### PR TITLE
Implement SinPi, CosPi and TanPi and inverses

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Math.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Math.cs
@@ -1449,5 +1449,59 @@ namespace System
             double u = BitConverter.Int64BitsToDouble(((long)(0x3ff + n) << 52));
             return y * u;
         }
+
+        /// <summary>
+        /// Returns the sine of the specified angle measured in half-turns.
+        /// </summary>
+        /// <param name="x">An angle, measured in half-turns.</param>
+        /// <returns>The sine of <paramref name="x"/>. If <paramref name="x"/> is equal to <see cref="double.NaN"/>, <see cref="double.PositiveInfinity"/>,
+        /// or <see cref="double.NegativeInfinity"/>, this method returns <see cref="double.NaN"/>. </returns>
+        /// <remarks>
+        /// This method is effectively Sin(x * PI), with higher precision.
+        /// It guarantees to return -1, 0, or 1 when <paramref name="x"/> is integer or half-integer.
+        /// </remarks>
+        public static double SinPi(double x)
+        {
+            // Implementation based on https://github.com/boostorg/math/blob/develop/include/boost/math/special_functions/sin_pi.hpp
+
+            if (x < 0)
+            {
+                return -SinPi(-x);
+            }
+
+            bool invert;
+            if (x < 0.5)
+            {
+                return Sin(x * PI);
+            }
+            if (x < 1)
+            {
+                invert = true;
+                x = -x;
+            }
+            else
+            {
+                invert = false;
+            }
+
+            double floor = Floor(x);
+            if (((int)floor & 1) != 0)
+            {
+                invert = !invert;
+            }
+
+            double rem = x - floor;
+            if (rem > 0.5)
+            {
+                rem = 1 - rem;
+            }
+            else if (rem == 0.5)
+            {
+                return invert ? -1 : 1;
+            }
+
+            double sin = Sin(rem * PI);
+            return invert ? -sin : sin;
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Math.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Math.cs
@@ -1621,8 +1621,8 @@ namespace System
             return invert ? -tan : tan;
         }
 
-        // We don't need to special case inverse-trigs as long as getting precise PI/2 and PI.
-        // Guarded in unit test.
+        // Double inverse-trigs pass all special value tests on all platforms.
+        // Keep them fast.
 
         /// <summary>
         /// Returns the angle measured in half-revolutions whose sine is the specified number.

--- a/src/libraries/System.Private.CoreLib/src/System/Math.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Math.cs
@@ -1549,5 +1549,17 @@ namespace System
             double cos = rem > 0.25 ? Cos(0.5 - rem) : Cos(rem);
             return invert ? -cos : cos;
         }
+
+        /// <summary>
+        /// Returns the tangent of the specified angle measured in half-turns.
+        /// </summary>
+        /// <param name="x">An angle, measured in half-turns.</param>
+        /// <returns>The tangent of <paramref name="x"/>. If <paramref name="x"/> is equal to <see cref="double.NaN"/>, <see cref="double.PositiveInfinity"/>,
+        /// or <see cref="double.NegativeInfinity"/>, this method returns <see cref="double.NaN"/>. </returns>
+        /// <remarks>
+        /// This method is effectively Tan(x * PI), with higher precision.
+        /// It guarantees to return 0, <see cref="double.PositiveInfinity"/> or <see cref="double.NegativeInfinity"/> when <paramref name="x"/> is integer or half-integer.
+        /// </remarks>
+        public static double TanPi(double x) => SinPi(x) / CosPi(x);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Math.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Math.cs
@@ -1620,5 +1620,68 @@ namespace System
             double tan = Tan(rem * PI);
             return invert ? -tan : tan;
         }
+
+        // We don't need to special case inverse-trigs as long as getting precise PI/2 and PI.
+        // Guarded in unit test.
+
+        /// <summary>
+        /// Returns the angle measured in half-turns whose sine is the specified number.
+        /// </summary>
+        /// <param name="x">A number representing a sine, where <paramref name="x"/> must be greater than or equal to -1, but
+        /// less than or equal to 1.</param>
+        /// <returns>An angle, θ, measured in half-turns, such that -0.5 ≤ θ ≤ 0.5.
+        /// -or-
+        /// <see cref="double.NaN"/> if <paramref name="x"/> &lt; -1 or <paramref name="x"/> &gt; 1
+        /// or <paramref name="x"/> equals <see cref="double.NaN"/>.</returns>
+        public static double AsinPi(double x) => Asin(x) / PI;
+
+        /// <summary>
+        /// Returns the angle measured in half-turns whose cosine is the specified number.
+        /// </summary>
+        /// <param name="x">A number representing a cosine, where <paramref name="x"/> must be greater than or equal to -1, but
+        /// less than or equal to 1.</param>
+        /// <returns>An angle, θ, measured in half-turns, such that -0.5 ≤ θ ≤ 0.5.
+        /// -or-
+        /// <see cref="double.NaN"/> if <paramref name="x"/> &lt; -1 or <paramref name="x"/> &gt; 1
+        /// or <paramref name="x"/> equals <see cref="double.NaN"/>.</returns>
+        public static double AcosPi(double x) => Acos(x) / PI;
+
+        /// <summary>
+        /// Returns the angle measured in half-turns whose tangent is the specified number.
+        /// </summary>
+        /// <param name="x">A number representing a tangent.</param>
+        /// <returns>An angle, θ, measured in half-turns, such that -0.5 ≤ θ ≤ 0.5.
+        /// -or-
+        /// <see cref="double.NaN"/> if <paramref name="x"/> equals <see cref="double.NaN"/>,
+        /// -0.5 if <paramref name="x"/> equals <see cref="double.NegativeInfinity"/>,
+        /// or 0.5 if <paramref name="x"/> equals <see cref="double.PositiveInfinity"/>.</returns>
+        public static double AtanPi(double x) => Atan(x) / PI;
+
+        /// <summary>
+        /// Returns the angle whose measured in half-turns tangent is the quotient of two specified numbers.
+        /// </summary>
+        /// <param name="y">The y coordinate of a point.</param>
+        /// <param name="x">The x coordinate of a point.</param>
+        /// <returns>An angle, θ, measured in half-turns, such that -1 ≤ θ ≤ 1, and tan(θ) = y / x,
+        /// where (x, y) is a point in the Cartesian plane. Observe the following:
+        /// <list type="bullet">
+        /// <item>For (x, y) in quadrant 1, 0 &lt; θ &lt; 0.5. </item>
+        /// <item>For (x, y) in quadrant 2, 0.5 &lt; θ ≤ 1. </item>
+        /// <item>For (x, y) in quadrant 3, -1 &lt; θ &lt; -0.5. </item>
+        /// <item>For (x, y) in quadrant 4, -0.5 &lt; θ &lt; 0. </item>
+        /// </list>
+        /// For points on the boundaries of the quadrants, the return value is the following:
+        /// <list type="bullet">
+        /// <item>If y is 0 and x is not negative, θ = 0.</item>
+        /// <item>If y is 0 and x is negative, θ = 1.</item>
+        /// <item>If y is positive and x is 0, θ = 0.5.</item>
+        /// <item>If y is negative and x is 0, θ = -0.5.</item>
+        /// <item>If y is 0 and x is 0, θ = 0.</item>
+        /// <item>If y is 0 and x is 0, θ = 0.</item>
+        /// </list>
+        /// If x or y is <see cref="double.NaN"/>, or if x and y are either
+        /// <see cref="double.PositiveInfinity"/> or <see cref="double.NegativeInfinity"/>,
+        /// the method returns <see cref="double.NaN"/>.</returns>
+        public static double Atan2Pi(double y, double x) => Atan2(y, x) / PI;
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Math.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Math.cs
@@ -1503,5 +1503,51 @@ namespace System
             double sin = Sin(rem * PI);
             return invert ? -sin : sin;
         }
+
+        /// <summary>
+        /// Returns the cosine of the specified angle measured in half-turns.
+        /// </summary>
+        /// <param name="x">An angle, measured in half-turns.</param>
+        /// <returns>The cosine of <paramref name="x"/>. If <paramref name="x"/> is equal to <see cref="double.NaN"/>, <see cref="double.PositiveInfinity"/>,
+        /// or <see cref="double.NegativeInfinity"/>, this method returns <see cref="double.NaN"/>. </returns>
+        /// <remarks>
+        /// This method is effectively Cos(x * PI), with higher precision.
+        /// It guarantees to return -1, 0, or 1 when <paramref name="x"/> is integer or half-integer.
+        /// </remarks>
+        public static double CosPi(double x)
+        {
+            // Implementation based on https://github.com/boostorg/math/blob/develop/include/boost/math/special_functions/cos_pi.hpp
+
+            if (Abs(x) < 0.25)
+            {
+                return Cos(x * PI);
+            }
+
+            if (x < 0)
+            {
+                x = -x;
+            }
+
+            bool invert = false;
+            double floor = Floor(x);
+            if (((int)floor & 1) != 0)
+            {
+                invert = !invert;
+            }
+
+            double rem = x - floor;
+            if (rem > 0.5)
+            {
+                rem = 1 - rem;
+                invert = !invert;
+            }
+            else if (rem == 0.5)
+            {
+                return 0;
+            }
+
+            double cos = rem > 0.25 ? Cos(0.5 - rem) : Cos(rem);
+            return invert ? -cos : cos;
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Math.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Math.cs
@@ -1451,9 +1451,9 @@ namespace System
         }
 
         /// <summary>
-        /// Returns the sine of the specified angle measured in half-turns.
+        /// Returns the sine of the specified angle measured in half-revolutions.
         /// </summary>
-        /// <param name="x">An angle, measured in half-turns.</param>
+        /// <param name="x">An angle, measured in half-revolutions.</param>
         /// <returns>The sine of <paramref name="x"/>. If <paramref name="x"/> is equal to <see cref="double.NaN"/>, <see cref="double.PositiveInfinity"/>,
         /// or <see cref="double.NegativeInfinity"/>, this method returns <see cref="double.NaN"/>. </returns>
         /// <remarks>
@@ -1506,9 +1506,9 @@ namespace System
         }
 
         /// <summary>
-        /// Returns the cosine of the specified angle measured in half-turns.
+        /// Returns the cosine of the specified angle measured in half-revolutions.
         /// </summary>
-        /// <param name="x">An angle, measured in half-turns.</param>
+        /// <param name="x">An angle, measured in half-revolutions.</param>
         /// <returns>The cosine of <paramref name="x"/>. If <paramref name="x"/> is equal to <see cref="double.NaN"/>, <see cref="double.PositiveInfinity"/>,
         /// or <see cref="double.NegativeInfinity"/>, this method returns <see cref="double.NaN"/>. </returns>
         /// <remarks>
@@ -1561,9 +1561,9 @@ namespace System
         }
 
         /// <summary>
-        /// Returns the tangent of the specified angle measured in half-turns.
+        /// Returns the tangent of the specified angle measured in half-revolutions.
         /// </summary>
-        /// <param name="x">An angle, measured in half-turns.</param>
+        /// <param name="x">An angle, measured in half-revolutions.</param>
         /// <returns>The tangent of <paramref name="x"/>. If <paramref name="x"/> is equal to <see cref="double.NaN"/>, <see cref="double.PositiveInfinity"/>,
         /// or <see cref="double.NegativeInfinity"/>, this method returns <see cref="double.NaN"/>. </returns>
         /// <remarks>
@@ -1625,32 +1625,32 @@ namespace System
         // Guarded in unit test.
 
         /// <summary>
-        /// Returns the angle measured in half-turns whose sine is the specified number.
+        /// Returns the angle measured in half-revolutions whose sine is the specified number.
         /// </summary>
         /// <param name="x">A number representing a sine, where <paramref name="x"/> must be greater than or equal to -1, but
         /// less than or equal to 1.</param>
-        /// <returns>An angle, θ, measured in half-turns, such that -0.5 ≤ θ ≤ 0.5.
+        /// <returns>An angle, θ, measured in half-revolutions, such that -0.5 ≤ θ ≤ 0.5.
         /// -or-
         /// <see cref="double.NaN"/> if <paramref name="x"/> &lt; -1 or <paramref name="x"/> &gt; 1
         /// or <paramref name="x"/> equals <see cref="double.NaN"/>.</returns>
         public static double AsinPi(double x) => Asin(x) / PI;
 
         /// <summary>
-        /// Returns the angle measured in half-turns whose cosine is the specified number.
+        /// Returns the angle measured in half-revolutions whose cosine is the specified number.
         /// </summary>
         /// <param name="x">A number representing a cosine, where <paramref name="x"/> must be greater than or equal to -1, but
         /// less than or equal to 1.</param>
-        /// <returns>An angle, θ, measured in half-turns, such that -0.5 ≤ θ ≤ 0.5.
+        /// <returns>An angle, θ, measured in half-revolutions, such that -0.5 ≤ θ ≤ 0.5.
         /// -or-
         /// <see cref="double.NaN"/> if <paramref name="x"/> &lt; -1 or <paramref name="x"/> &gt; 1
         /// or <paramref name="x"/> equals <see cref="double.NaN"/>.</returns>
         public static double AcosPi(double x) => Acos(x) / PI;
 
         /// <summary>
-        /// Returns the angle measured in half-turns whose tangent is the specified number.
+        /// Returns the angle measured in half-revolutions whose tangent is the specified number.
         /// </summary>
         /// <param name="x">A number representing a tangent.</param>
-        /// <returns>An angle, θ, measured in half-turns, such that -0.5 ≤ θ ≤ 0.5.
+        /// <returns>An angle, θ, measured in half-revolutions, such that -0.5 ≤ θ ≤ 0.5.
         /// -or-
         /// <see cref="double.NaN"/> if <paramref name="x"/> equals <see cref="double.NaN"/>,
         /// -0.5 if <paramref name="x"/> equals <see cref="double.NegativeInfinity"/>,
@@ -1658,11 +1658,11 @@ namespace System
         public static double AtanPi(double x) => Atan(x) / PI;
 
         /// <summary>
-        /// Returns the angle whose measured in half-turns tangent is the quotient of two specified numbers.
+        /// Returns the angle whose measured in half-revolutions tangent is the quotient of two specified numbers.
         /// </summary>
         /// <param name="y">The y coordinate of a point.</param>
         /// <param name="x">The x coordinate of a point.</param>
-        /// <returns>An angle, θ, measured in half-turns, such that -1 ≤ θ ≤ 1, and tan(θ) = y / x,
+        /// <returns>An angle, θ, measured in half-revolutions, such that -1 ≤ θ ≤ 1, and tan(θ) = y / x,
         /// where (x, y) is a point in the Cartesian plane. Observe the following:
         /// <list type="bullet">
         /// <item>For (x, y) in quadrant 1, 0 &lt; θ &lt; 0.5. </item>

--- a/src/libraries/System.Private.CoreLib/src/System/MathF.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MathF.cs
@@ -573,5 +573,51 @@ namespace System
             float sin = Sin(rem * PI);
             return invert ? -sin : sin;
         }
+
+        /// <summary>
+        /// Returns the cosine of the specified angle measured in half-turns.
+        /// </summary>
+        /// <param name="x">An angle, measured in half-turns.</param>
+        /// <returns>The cosine of <paramref name="x"/>. If <paramref name="x"/> is equal to <see cref="float.NaN"/>, <see cref="double.PositiveInfinity"/>,
+        /// or <see cref="float.NegativeInfinity"/>, this method returns <see cref="float.NaN"/>. </returns>
+        /// <remarks>
+        /// This method is effectively Cos(x * PI), with higher precision.
+        /// It guarantees to return -1, 0, or 1 when <paramref name="x"/> is integer or half-integer.
+        /// </remarks>
+        public static float CosPi(float x)
+        {
+            // Implementation based on https://github.com/boostorg/math/blob/develop/include/boost/math/special_functions/cos_pi.hpp
+
+            if (Abs(x) < 0.25f)
+            {
+                return Cos(x * PI);
+            }
+
+            if (x < 0)
+            {
+                x = -x;
+            }
+
+            bool invert = false;
+            float floor = Floor(x);
+            if (((int)floor & 1) != 0)
+            {
+                invert = !invert;
+            }
+
+            float rem = x - floor;
+            if (rem > 0.5f)
+            {
+                rem = 1 - rem;
+                invert = !invert;
+            }
+            else if (rem == 0.5f)
+            {
+                return 0;
+            }
+
+            float cos = rem > 0.25f ? Cos(0.5f - rem) : Cos(rem);
+            return invert ? -cos : cos;
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/MathF.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MathF.cs
@@ -619,5 +619,17 @@ namespace System
             float cos = rem > 0.25f ? Cos(0.5f - rem) : Cos(rem);
             return invert ? -cos : cos;
         }
+
+        /// <summary>
+        /// Returns the tangent of the specified angle measured in half-turns.
+        /// </summary>
+        /// <param name="x">An angle, measured in half-turns.</param>
+        /// <returns>The tangent of <paramref name="x"/>. If <paramref name="x"/> is equal to <see cref="float.NaN"/>, <see cref="double.PositiveInfinity"/>,
+        /// or <see cref="float.NegativeInfinity"/>, this method returns <see cref="float.NaN"/>. </returns>
+        /// <remarks>
+        /// This method is effectively Tan(x * PI), with higher precision.
+        /// It guarantees to return 0, <see cref="float.PositiveInfinity"/> or <see cref="float.NegativeInfinity"/> when <paramref name="x"/> is integer or half-integer.
+        /// </remarks>
+        public static float TanPi(float x) => SinPi(x) / CosPi(x);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/MathF.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MathF.cs
@@ -419,45 +419,45 @@ namespace System
                     // Rounds to the nearest value; if the number falls midway,
                     // it is rounded to the nearest value with an even least significant digit
                     case MidpointRounding.ToEven:
-                    {
-                        x = Round(x);
-                        break;
-                    }
+                        {
+                            x = Round(x);
+                            break;
+                        }
                     // Rounds to the nearest value; if the number falls midway,
                     // it is rounded to the nearest value above (for positive numbers) or below (for negative numbers)
                     case MidpointRounding.AwayFromZero:
-                    {
-                        float fraction = ModF(x, &x);
-
-                        if (Abs(fraction) >= 0.5f)
                         {
-                            x += Sign(fraction);
-                        }
+                            float fraction = ModF(x, &x);
 
-                        break;
-                    }
+                            if (Abs(fraction) >= 0.5f)
+                            {
+                                x += Sign(fraction);
+                            }
+
+                            break;
+                        }
                     // Directed rounding: Round to the nearest value, toward to zero
                     case MidpointRounding.ToZero:
-                    {
-                        x = Truncate(x);
-                        break;
-                    }
+                        {
+                            x = Truncate(x);
+                            break;
+                        }
                     // Directed Rounding: Round down to the next value, toward negative infinity
                     case MidpointRounding.ToNegativeInfinity:
-                    {
-                        x = Floor(x);
-                        break;
-                    }
+                        {
+                            x = Floor(x);
+                            break;
+                        }
                     // Directed rounding: Round up to the next value, toward positive infinity
                     case MidpointRounding.ToPositiveInfinity:
-                    {
-                        x = Ceiling(x);
-                        break;
-                    }
+                        {
+                            x = Ceiling(x);
+                            break;
+                        }
                     default:
-                    {
-                        throw new ArgumentException(SR.Format(SR.Argument_InvalidEnumValue, mode, nameof(MidpointRounding)), nameof(mode));
-                    }
+                        {
+                            throw new ArgumentException(SR.Format(SR.Argument_InvalidEnumValue, mode, nameof(MidpointRounding)), nameof(mode));
+                        }
                 }
 
                 x /= power10;
@@ -692,8 +692,8 @@ namespace System
             return invert ? -tan : tan;
         }
 
-        // We don't need to special case inverse-trigs as long as getting precise PI/2 and PI.
-        // Guarded in unit test.
+        // Double inverse-trigs fail special value tests on some platforms.
+        // Special case them.
 
         /// <summary>
         /// Returns the angle measured in half-revolutions whose sine is the specified number.
@@ -715,7 +715,15 @@ namespace System
         /// -or-
         /// <see cref="float.NaN"/> if <paramref name="x"/> &lt; -1 or <paramref name="x"/> &gt; 1
         /// or <paramref name="x"/> equals <see cref="float.NaN"/>.</returns>
-        public static float AcosPi(float x) => Acos(x) / PI;
+        public static float AcosPi(float x)
+        {
+            if (x == 0)
+            {
+                return 0.5f;
+            }
+
+            return x > 0 ? Acos(x) / PI : 1 - Acos(-x) / PI;
+        }
 
         /// <summary>
         /// Returns the angle measured in half-revolutions whose tangent is the specified number.
@@ -726,7 +734,21 @@ namespace System
         /// <see cref="float.NaN"/> if <paramref name="x"/> equals <see cref="float.NaN"/>,
         /// -0.5 if <paramref name="x"/> equals <see cref="float.NegativeInfinity"/>,
         /// or 0.5 if <paramref name="x"/> equals <see cref="float.PositiveInfinity"/>.</returns>
-        public static float AtanPi(float x) => Atan(x) / PI;
+        public static float AtanPi(float x)
+        {
+            if (float.IsPositiveInfinity(x))
+            {
+                return 0.5f;
+            }
+            else if (float.IsNegativeInfinity(x))
+            {
+                return -0.5f;
+            }
+            else
+            {
+                return Atan(x) / PI;
+            }
+        }
 
         /// <summary>
         /// Returns the angle whose measured in half-revolutions tangent is the quotient of two specified numbers.

--- a/src/libraries/System.Private.CoreLib/src/System/MathF.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MathF.cs
@@ -419,45 +419,45 @@ namespace System
                     // Rounds to the nearest value; if the number falls midway,
                     // it is rounded to the nearest value with an even least significant digit
                     case MidpointRounding.ToEven:
-                        {
-                            x = Round(x);
-                            break;
-                        }
+                    {
+                        x = Round(x);
+                        break;
+                    }
                     // Rounds to the nearest value; if the number falls midway,
                     // it is rounded to the nearest value above (for positive numbers) or below (for negative numbers)
                     case MidpointRounding.AwayFromZero:
+                    {
+                        float fraction = ModF(x, &x);
+
+                        if (Abs(fraction) >= 0.5f)
                         {
-                            float fraction = ModF(x, &x);
-
-                            if (Abs(fraction) >= 0.5f)
-                            {
-                                x += Sign(fraction);
-                            }
-
-                            break;
+                            x += Sign(fraction);
                         }
+
+                        break;
+                    }
                     // Directed rounding: Round to the nearest value, toward to zero
                     case MidpointRounding.ToZero:
-                        {
-                            x = Truncate(x);
-                            break;
-                        }
+                    {
+                        x = Truncate(x);
+                        break;
+                    }
                     // Directed Rounding: Round down to the next value, toward negative infinity
                     case MidpointRounding.ToNegativeInfinity:
-                        {
-                            x = Floor(x);
-                            break;
-                        }
+                    {
+                        x = Floor(x);
+                        break;
+                    }
                     // Directed rounding: Round up to the next value, toward positive infinity
                     case MidpointRounding.ToPositiveInfinity:
-                        {
-                            x = Ceiling(x);
-                            break;
-                        }
+                    {
+                        x = Ceiling(x);
+                        break;
+                    }
                     default:
-                        {
-                            throw new ArgumentException(SR.Format(SR.Argument_InvalidEnumValue, mode, nameof(MidpointRounding)), nameof(mode));
-                        }
+                    {
+                        throw new ArgumentException(SR.Format(SR.Argument_InvalidEnumValue, mode, nameof(MidpointRounding)), nameof(mode));
+                    }
                 }
 
                 x /= power10;
@@ -692,7 +692,7 @@ namespace System
             return invert ? -tan : tan;
         }
 
-        // Double inverse-trigs fail special value tests on some platforms.
+        // Float inverse-trigs fail special value tests on some platforms.
         // Special case them.
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/MathF.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MathF.cs
@@ -519,5 +519,59 @@ namespace System
             float u = BitConverter.Int32BitsToSingle(((int)(0x7f + n) << 23));
             return y * u;
         }
+
+        /// <summary>
+        /// Returns the sine of the specified angle measured in half-turns.
+        /// </summary>
+        /// <param name="x">An angle, measured in half-turns.</param>
+        /// <returns>The sine of <paramref name="x"/>. If <paramref name="x"/> is equal to <see cref="float.NaN"/>, <see cref="float.PositiveInfinity"/>,
+        /// or <see cref="float.NegativeInfinity"/>, this method returns <see cref="float.NaN"/>. </returns>
+        /// <remarks>
+        /// This method is effectively Sin(x * PI), with higher precision.
+        /// It guarantees to return -1, 0, or 1 when <paramref name="x"/> is integer or half-integer.
+        /// </remarks>
+        public static float SinPi(float x)
+        {
+            // Implementation based on https://github.com/boostorg/math/blob/develop/include/boost/math/special_functions/sin_pi.hpp
+
+            if (x < 0)
+            {
+                return -SinPi(-x);
+            }
+
+            bool invert;
+            if (x < 0.5f)
+            {
+                return Sin(x * PI);
+            }
+            if (x < 1)
+            {
+                invert = true;
+                x = -x;
+            }
+            else
+            {
+                invert = false;
+            }
+
+            float floor = Floor(x);
+            if (((int)floor & 1) != 0)
+            {
+                invert = !invert;
+            }
+
+            float rem = x - floor;
+            if (rem > 0.5f)
+            {
+                rem = 1 - rem;
+            }
+            else if (rem == 0.5f)
+            {
+                return invert ? -1 : 1;
+            }
+
+            float sin = Sin(rem * PI);
+            return invert ? -sin : sin;
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/MathF.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MathF.cs
@@ -521,9 +521,9 @@ namespace System
         }
 
         /// <summary>
-        /// Returns the sine of the specified angle measured in half-turns.
+        /// Returns the sine of the specified angle measured in half-revolutions.
         /// </summary>
-        /// <param name="x">An angle, measured in half-turns.</param>
+        /// <param name="x">An angle, measured in half-revolutions.</param>
         /// <returns>The sine of <paramref name="x"/>. If <paramref name="x"/> is equal to <see cref="float.NaN"/>, <see cref="float.PositiveInfinity"/>,
         /// or <see cref="float.NegativeInfinity"/>, this method returns <see cref="float.NaN"/>. </returns>
         /// <remarks>
@@ -576,9 +576,9 @@ namespace System
         }
 
         /// <summary>
-        /// Returns the cosine of the specified angle measured in half-turns.
+        /// Returns the cosine of the specified angle measured in half-revolutions.
         /// </summary>
-        /// <param name="x">An angle, measured in half-turns.</param>
+        /// <param name="x">An angle, measured in half-revolutions.</param>
         /// <returns>The cosine of <paramref name="x"/>. If <paramref name="x"/> is equal to <see cref="float.NaN"/>, <see cref="double.PositiveInfinity"/>,
         /// or <see cref="float.NegativeInfinity"/>, this method returns <see cref="float.NaN"/>. </returns>
         /// <remarks>
@@ -631,9 +631,9 @@ namespace System
         }
 
         /// <summary>
-        /// Returns the tangent of the specified angle measured in half-turns.
+        /// Returns the tangent of the specified angle measured in half-revolutions.
         /// </summary>
-        /// <param name="x">An angle, measured in half-turns.</param>
+        /// <param name="x">An angle, measured in half-revolutions.</param>
         /// <returns>The tangent of <paramref name="x"/>. If <paramref name="x"/> is equal to <see cref="float.NaN"/>, <see cref="double.PositiveInfinity"/>,
         /// or <see cref="float.NegativeInfinity"/>, this method returns <see cref="float.NaN"/>. </returns>
         /// <remarks>
@@ -696,32 +696,32 @@ namespace System
         // Guarded in unit test.
 
         /// <summary>
-        /// Returns the angle measured in half-turns whose sine is the specified number.
+        /// Returns the angle measured in half-revolutions whose sine is the specified number.
         /// </summary>
         /// <param name="x">A number representing a sine, where <paramref name="x"/> must be greater than or equal to -1, but
         /// less than or equal to 1.</param>
-        /// <returns>An angle, θ, measured in half-turns, such that -0.5 ≤ θ ≤ 0.5.
+        /// <returns>An angle, θ, measured in half-revolutions, such that -0.5 ≤ θ ≤ 0.5.
         /// -or-
         /// <see cref="float.NaN"/> if <paramref name="x"/> &lt; -1 or <paramref name="x"/> &gt; 1
         /// or <paramref name="x"/> equals <see cref="float.NaN"/>.</returns>
         public static float AsinPi(float x) => Asin(x) / PI;
 
         /// <summary>
-        /// Returns the angle measured in half-turns whose cosine is the specified number.
+        /// Returns the angle measured in half-revolutions whose cosine is the specified number.
         /// </summary>
         /// <param name="x">A number representing a cosine, where <paramref name="x"/> must be greater than or equal to -1, but
         /// less than or equal to 1.</param>
-        /// <returns>An angle, θ, measured in half-turns, such that -0.5 ≤ θ ≤ 0.5.
+        /// <returns>An angle, θ, measured in half-revolutions, such that -0.5 ≤ θ ≤ 0.5.
         /// -or-
         /// <see cref="float.NaN"/> if <paramref name="x"/> &lt; -1 or <paramref name="x"/> &gt; 1
         /// or <paramref name="x"/> equals <see cref="float.NaN"/>.</returns>
         public static float AcosPi(float x) => Acos(x) / PI;
 
         /// <summary>
-        /// Returns the angle measured in half-turns whose tangent is the specified number.
+        /// Returns the angle measured in half-revolutions whose tangent is the specified number.
         /// </summary>
         /// <param name="x">A number representing a tangent.</param>
-        /// <returns>An angle, θ, measured in half-turns, such that -0.5 ≤ θ ≤ 0.5.
+        /// <returns>An angle, θ, measured in half-revolutions, such that -0.5 ≤ θ ≤ 0.5.
         /// -or-
         /// <see cref="float.NaN"/> if <paramref name="x"/> equals <see cref="float.NaN"/>,
         /// -0.5 if <paramref name="x"/> equals <see cref="float.NegativeInfinity"/>,
@@ -729,11 +729,11 @@ namespace System
         public static float AtanPi(float x) => Atan(x) / PI;
 
         /// <summary>
-        /// Returns the angle whose measured in half-turns tangent is the quotient of two specified numbers.
+        /// Returns the angle whose measured in half-revolutions tangent is the quotient of two specified numbers.
         /// </summary>
         /// <param name="y">The y coordinate of a point.</param>
         /// <param name="x">The x coordinate of a point.</param>
-        /// <returns>An angle, θ, measured in half-turns, such that -1 ≤ θ ≤ 1, and tan(θ) = y / x,
+        /// <returns>An angle, θ, measured in half-revolutions, such that -1 ≤ θ ≤ 1, and tan(θ) = y / x,
         /// where (x, y) is a point in the Cartesian plane. Observe the following:
         /// <list type="bullet">
         /// <item>For (x, y) in quadrant 1, 0 &lt; θ &lt; 0.5. </item>

--- a/src/libraries/System.Private.CoreLib/src/System/MathF.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MathF.cs
@@ -704,7 +704,19 @@ namespace System
         /// -or-
         /// <see cref="float.NaN"/> if <paramref name="x"/> &lt; -1 or <paramref name="x"/> &gt; 1
         /// or <paramref name="x"/> equals <see cref="float.NaN"/>.</returns>
-        public static float AsinPi(float x) => Asin(x) / PI;
+        public static float AsinPi(float x)
+        {
+            if (x == 1)
+            {
+                return 0.5f;
+            }
+            if (x == -1)
+            {
+                return -0.5f;
+            }
+
+            return Asin(x) / PI;
+        }
 
         /// <summary>
         /// Returns the angle measured in half-revolutions whose cosine is the specified number.
@@ -777,18 +789,16 @@ namespace System
         /// the method returns <see cref="float.NaN"/>.</returns>
         public static float Atan2Pi(float y, float x)
         {
-            // There are many special values specified by IEEE754:2019
-            // involving +0/-0 which are not easy to handle
-            // To simplify, only special case failures in tests
-            if (float.IsPositiveInfinity(y) && float.IsFinite(x))
+            float atan = Atan2(y, x) / PI;
+
+            // if x or y is 0 or inf, it's a special value required by IEEE754:2019
+            // rounding to nearist quarter-integer (keeps +0/-0)
+            if (x == 0 || y == 0 || float.IsInfinity(x) || float.IsInfinity(y))
             {
-                return 0.5f;
+                return Round(atan * 4) / 4;
             }
-            if (float.IsNegativeInfinity(y) && float.IsFinite(x))
-            {
-                return -0.5f;
-            }
-            return Atan2(y, x) / PI;
+
+            return atan;
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/MathF.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MathF.cs
@@ -775,6 +775,20 @@ namespace System
         /// If x or y is <see cref="float.NaN"/>, or if x and y are either
         /// <see cref="float.PositiveInfinity"/> or <see cref="float.NegativeInfinity"/>,
         /// the method returns <see cref="float.NaN"/>.</returns>
-        public static float Atan2Pi(float y, float x) => Atan2(y, x) / PI;
+        public static float Atan2Pi(float y, float x)
+        {
+            // There are many special values specified by IEEE754:2019
+            // involving +0/-0 which are not easy to handle
+            // To simplify, only special case failures in tests
+            if (float.IsPositiveInfinity(y) && float.IsFinite(x))
+            {
+                return 0.5f;
+            }
+            if (float.IsNegativeInfinity(y) && float.IsFinite(x))
+            {
+                return -0.5f;
+            }
+            return Atan2(y, x) / PI;
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/MathF.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MathF.cs
@@ -691,5 +691,68 @@ namespace System
             float tan = Tan(rem * PI);
             return invert ? -tan : tan;
         }
+
+        // We don't need to special case inverse-trigs as long as getting precise PI/2 and PI.
+        // Guarded in unit test.
+
+        /// <summary>
+        /// Returns the angle measured in half-turns whose sine is the specified number.
+        /// </summary>
+        /// <param name="x">A number representing a sine, where <paramref name="x"/> must be greater than or equal to -1, but
+        /// less than or equal to 1.</param>
+        /// <returns>An angle, θ, measured in half-turns, such that -0.5 ≤ θ ≤ 0.5.
+        /// -or-
+        /// <see cref="float.NaN"/> if <paramref name="x"/> &lt; -1 or <paramref name="x"/> &gt; 1
+        /// or <paramref name="x"/> equals <see cref="float.NaN"/>.</returns>
+        public static float AsinPi(float x) => Asin(x) / PI;
+
+        /// <summary>
+        /// Returns the angle measured in half-turns whose cosine is the specified number.
+        /// </summary>
+        /// <param name="x">A number representing a cosine, where <paramref name="x"/> must be greater than or equal to -1, but
+        /// less than or equal to 1.</param>
+        /// <returns>An angle, θ, measured in half-turns, such that -0.5 ≤ θ ≤ 0.5.
+        /// -or-
+        /// <see cref="float.NaN"/> if <paramref name="x"/> &lt; -1 or <paramref name="x"/> &gt; 1
+        /// or <paramref name="x"/> equals <see cref="float.NaN"/>.</returns>
+        public static float AcosPi(float x) => Acos(x) / PI;
+
+        /// <summary>
+        /// Returns the angle measured in half-turns whose tangent is the specified number.
+        /// </summary>
+        /// <param name="x">A number representing a tangent.</param>
+        /// <returns>An angle, θ, measured in half-turns, such that -0.5 ≤ θ ≤ 0.5.
+        /// -or-
+        /// <see cref="float.NaN"/> if <paramref name="x"/> equals <see cref="float.NaN"/>,
+        /// -0.5 if <paramref name="x"/> equals <see cref="float.NegativeInfinity"/>,
+        /// or 0.5 if <paramref name="x"/> equals <see cref="float.PositiveInfinity"/>.</returns>
+        public static float AtanPi(float x) => Atan(x) / PI;
+
+        /// <summary>
+        /// Returns the angle whose measured in half-turns tangent is the quotient of two specified numbers.
+        /// </summary>
+        /// <param name="y">The y coordinate of a point.</param>
+        /// <param name="x">The x coordinate of a point.</param>
+        /// <returns>An angle, θ, measured in half-turns, such that -1 ≤ θ ≤ 1, and tan(θ) = y / x,
+        /// where (x, y) is a point in the Cartesian plane. Observe the following:
+        /// <list type="bullet">
+        /// <item>For (x, y) in quadrant 1, 0 &lt; θ &lt; 0.5. </item>
+        /// <item>For (x, y) in quadrant 2, 0.5 &lt; θ ≤ 1. </item>
+        /// <item>For (x, y) in quadrant 3, -1 &lt; θ &lt; -0.5. </item>
+        /// <item>For (x, y) in quadrant 4, -0.5 &lt; θ &lt; 0. </item>
+        /// </list>
+        /// For points on the boundaries of the quadrants, the return value is the following:
+        /// <list type="bullet">
+        /// <item>If y is 0 and x is not negative, θ = 0.</item>
+        /// <item>If y is 0 and x is negative, θ = 1.</item>
+        /// <item>If y is positive and x is 0, θ = 0.5.</item>
+        /// <item>If y is negative and x is 0, θ = -0.5.</item>
+        /// <item>If y is 0 and x is 0, θ = 0.</item>
+        /// <item>If y is 0 and x is 0, θ = 0.</item>
+        /// </list>
+        /// If x or y is <see cref="float.NaN"/>, or if x and y are either
+        /// <see cref="float.PositiveInfinity"/> or <see cref="float.NegativeInfinity"/>,
+        /// the method returns <see cref="float.NaN"/>.</returns>
+        public static float Atan2Pi(float y, float x) => Atan2(y, x) / PI;
     }
 }

--- a/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
@@ -3290,5 +3290,29 @@ namespace System.Tests
             AssertEqual(0.0f, MathF.TanPi(0.6789f) + MathF.TanPi(-0.6789f), 0.0f);
             AssertEqual(0.0f, MathF.TanPi(1.2345f) + MathF.TanPi(-1.2345f), 0.0f);
         }
+
+        [Theory]
+        [InlineData(0.1234)]
+        [InlineData(0.6789)]
+        [InlineData(1.2345)]
+        [InlineData(1.9876)]
+        public static void TriPi_Double_Correctness(double x)
+        {
+            AssertEqual(Math.Sin(x * Math.PI), Math.SinPi(x), CrossPlatformMachineEpsilonForEstimates);
+            AssertEqual(Math.Cos(x * Math.PI), Math.CosPi(x), CrossPlatformMachineEpsilonForEstimates);
+            AssertEqual(Math.Tan(x * Math.PI), Math.TanPi(x), CrossPlatformMachineEpsilonForEstimates);
+        }
+
+        [Theory]
+        [InlineData(0.1234f)]
+        [InlineData(0.6789f)]
+        [InlineData(1.2345f)]
+        [InlineData(1.9876f)]
+        public static void TriPi_Float_Correctness(float x)
+        {
+            AssertEqual(MathF.Sin(x * MathF.PI), MathF.SinPi(x), (float)CrossPlatformMachineEpsilonForEstimates);
+            AssertEqual(MathF.Cos(x * MathF.PI), MathF.CosPi(x), (float)CrossPlatformMachineEpsilonForEstimates);
+            AssertEqual(MathF.Tan(x * MathF.PI), MathF.TanPi(x), (float)CrossPlatformMachineEpsilonForEstimates);
+        }
     }
 }

--- a/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
@@ -3212,5 +3212,41 @@ namespace System.Tests
             Assert.Equal(0, MathF.SinPi(0.6789f) + MathF.SinPi(-0.6789f));
             Assert.Equal(0, MathF.SinPi(1.2345f) + MathF.SinPi(-1.2345f));
         }
+
+        [Fact]
+        public static void CosPi_Double_Precision()
+        {
+            Assert.Equal( 1, Math.CosPi( 0.0));
+            Assert.Equal( 0, Math.CosPi( 0.5));
+            Assert.Equal( 0, Math.CosPi(-0.5));
+            Assert.Equal(-1, Math.CosPi( 1.0));
+            Assert.Equal(-1, Math.CosPi(-1.0));
+            Assert.Equal( 0, Math.CosPi( 1.5));
+            Assert.Equal( 0, Math.CosPi(-1.5));
+            Assert.Equal( 1, Math.CosPi( 2.0));
+            Assert.Equal( 1, Math.CosPi(-2.0));
+
+            Assert.Equal(0, Math.CosPi(0.1234) - Math.CosPi(-0.1234));
+            Assert.Equal(0, Math.CosPi(0.6789) - Math.CosPi(-0.6789));
+            Assert.Equal(0, Math.CosPi(1.2345) - Math.CosPi(-1.2345));
+        }
+
+        [Fact]
+        public static void CosPi_Float_Precision()
+        {
+            Assert.Equal( 1, MathF.CosPi( 0.0f));
+            Assert.Equal( 0, MathF.CosPi( 0.5f));
+            Assert.Equal( 0, MathF.CosPi(-0.5f));
+            Assert.Equal(-1, MathF.CosPi( 1.0f));
+            Assert.Equal(-1, MathF.CosPi(-1.0f));
+            Assert.Equal( 0, MathF.CosPi( 1.5f));
+            Assert.Equal( 0, MathF.CosPi(-1.5f));
+            Assert.Equal( 1, MathF.CosPi( 2.0f));
+            Assert.Equal( 1, MathF.CosPi(-2.0f));
+
+            Assert.Equal(0, MathF.CosPi(0.1234f) - MathF.CosPi(-0.1234f));
+            Assert.Equal(0, MathF.CosPi(0.6789f) - MathF.CosPi(-0.6789f));
+            Assert.Equal(0, MathF.CosPi(1.2345f) - MathF.CosPi(-1.2345f));
+        }
     }
 }

--- a/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
@@ -3361,50 +3361,52 @@ namespace System.Tests
             AssertEqual(-0.5f, MathF.AtanPi(float.NegativeInfinity), 0.0f);
         }
 
-        [Fact]
-        public static void Atan2Pi_Double_Precision()
+        [Theory]
+        [InlineData( 0.0, -0.0,  1.0)]
+        [InlineData(-0.0, -0.0, -1.0)]
+        [InlineData( 0.0, -1.0,  1.0)]
+        [InlineData(-0.0, -1.0, -1.0)]
+        [InlineData(-1.0,  0.0, -0.5)]
+        [InlineData(-1.0, -0.0, -0.5)]
+        [InlineData( 1.0,  0.0,  0.5)]
+        [InlineData( 1.0, -0.0,  0.5)]
+        [InlineData( 1.0, double.NegativeInfinity,  1.0)]
+        [InlineData(-1.0, double.NegativeInfinity, -1.0)]
+        [InlineData(double.PositiveInfinity,  1.0,  0.5)]
+        [InlineData(double.PositiveInfinity, -1.0,  0.5)]
+        [InlineData(double.NegativeInfinity,  1.0, -0.5)]
+        [InlineData(double.NegativeInfinity, -1.0, -0.5)]
+        [InlineData(double.PositiveInfinity, double.NegativeInfinity,  0.75)]
+        [InlineData(double.NegativeInfinity, double.NegativeInfinity, -0.75)]
+        [InlineData(double.PositiveInfinity, double.PositiveInfinity,  0.25)]
+        [InlineData(double.NegativeInfinity, double.PositiveInfinity, -0.25)]
+        public static void Atan2Pi_Double_Precision(double y, double x, double expected)
         {
-            AssertEqual( 1.00, Math.Atan2Pi( 0.0, -0.0), 0.0);
-            AssertEqual(-1.00, Math.Atan2Pi(-0.0, -0.0), 0.0);
-            AssertEqual( 1.00, Math.Atan2Pi( 0.0, -1.0), 0.0);
-            AssertEqual(-1.00, Math.Atan2Pi(-0.0, -1.0), 0.0);
-            AssertEqual(-0.50, Math.Atan2Pi(-1.0,  0.0), 0.0);
-            AssertEqual(-0.50, Math.Atan2Pi(-1.0, -0.0), 0.0);
-            AssertEqual( 0.50, Math.Atan2Pi( 1.0,  0.0), 0.0);
-            AssertEqual( 0.50, Math.Atan2Pi( 1.0, -0.0), 0.0);
-            AssertEqual( 1.00, Math.Atan2Pi( 1.0, double.NegativeInfinity), 0.0);
-            AssertEqual(-1.00, Math.Atan2Pi(-1.0, double.NegativeInfinity), 0.0);
-            AssertEqual( 0.50, Math.Atan2Pi(double.PositiveInfinity,  1.0), 0.0);
-            AssertEqual( 0.50, Math.Atan2Pi(double.PositiveInfinity, -1.0), 0.0);
-            AssertEqual(-0.50, Math.Atan2Pi(double.NegativeInfinity,  1.0), 0.0);
-            AssertEqual(-0.50, Math.Atan2Pi(double.NegativeInfinity, -1.0), 0.0);
-            AssertEqual( 0.75, Math.Atan2Pi(double.PositiveInfinity, double.NegativeInfinity), 0.0);
-            AssertEqual(-0.75, Math.Atan2Pi(double.NegativeInfinity, double.NegativeInfinity), 0.0);
-            AssertEqual( 0.25, Math.Atan2Pi(double.PositiveInfinity, double.PositiveInfinity), 0.0);
-            AssertEqual(-0.25, Math.Atan2Pi(double.NegativeInfinity, double.PositiveInfinity), 0.0);
+            AssertEqual(expected, Math.Atan2Pi(y, x), 0.0);
         }
 
-        [Fact]
-        public static void Atan2Pi_Float_Precision()
+        [Theory]
+        [InlineData( 0.0f, -0.0f,  1.0f)]
+        [InlineData(-0.0f, -0.0f, -1.0f)]
+        [InlineData( 0.0f, -1.0f,  1.0f)]
+        [InlineData(-0.0f, -1.0f, -1.0f)]
+        [InlineData(-1.0f,  0.0f, -0.5f)]
+        [InlineData(-1.0f, -0.0f, -0.5f)]
+        [InlineData( 1.0f,  0.0f,  0.5f)]
+        [InlineData( 1.0f, -0.0f,  0.5f)]
+        [InlineData( 1.0f, float.NegativeInfinity,  1.0f)]
+        [InlineData(-1.0f, float.NegativeInfinity, -1.0f)]
+        [InlineData(float.PositiveInfinity,  1.0f,  0.5f)]
+        [InlineData(float.PositiveInfinity, -1.0f,  0.5f)]
+        [InlineData(float.NegativeInfinity,  1.0f, -0.5f)]
+        [InlineData(float.NegativeInfinity, -1.0f, -0.5f)]
+        [InlineData(float.PositiveInfinity, float.NegativeInfinity,  0.75f)]
+        [InlineData(float.NegativeInfinity, float.NegativeInfinity, -0.75f)]
+        [InlineData(float.PositiveInfinity, float.PositiveInfinity,  0.25f)]
+        [InlineData(float.NegativeInfinity, float.PositiveInfinity, -0.25f)]
+        public static void Atan2Pi_Float_Precision(float y, float x, float expected)
         {
-            AssertEqual( 1.00f, MathF.Atan2Pi( 0.0f, -0.0f), 0.0f);
-            AssertEqual(-1.00f, MathF.Atan2Pi(-0.0f, -0.0f), 0.0f);
-            AssertEqual( 1.00f, MathF.Atan2Pi( 0.0f, -1.0f), 0.0f);
-            AssertEqual(-1.00f, MathF.Atan2Pi(-0.0f, -1.0f), 0.0f);
-            AssertEqual(-0.50f, MathF.Atan2Pi(-1.0f,  0.0f), 0.0f);
-            AssertEqual(-0.50f, MathF.Atan2Pi(-1.0f, -0.0f), 0.0f);
-            AssertEqual( 0.50f, MathF.Atan2Pi( 1.0f,  0.0f), 0.0f);
-            AssertEqual( 0.50f, MathF.Atan2Pi( 1.0f, -0.0f), 0.0f);
-            AssertEqual( 1.00f, MathF.Atan2Pi( 1.0f, float.NegativeInfinity), 0.0f);
-            AssertEqual(-1.00f, MathF.Atan2Pi(-1.0f, float.NegativeInfinity), 0.0f);
-            AssertEqual( 0.50f, MathF.Atan2Pi(float.PositiveInfinity,  1.0f), 0.0f);
-            AssertEqual( 0.50f, MathF.Atan2Pi(float.PositiveInfinity, -1.0f), 0.0f);
-            AssertEqual(-0.50f, MathF.Atan2Pi(float.NegativeInfinity,  1.0f), 0.0f);
-            AssertEqual(-0.50f, MathF.Atan2Pi(float.NegativeInfinity, -1.0f), 0.0f);
-            AssertEqual( 0.75f, MathF.Atan2Pi(float.PositiveInfinity, float.NegativeInfinity), 0.0f);
-            AssertEqual(-0.75f, MathF.Atan2Pi(float.NegativeInfinity, float.NegativeInfinity), 0.0f);
-            AssertEqual( 0.25f, MathF.Atan2Pi(float.PositiveInfinity, float.PositiveInfinity), 0.0f);
-            AssertEqual(-0.25f, MathF.Atan2Pi(float.NegativeInfinity, float.PositiveInfinity), 0.0f);
+            AssertEqual(expected, MathF.Atan2Pi(y, x), 0.0f);
         }
     }
 }

--- a/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
@@ -3314,5 +3314,97 @@ namespace System.Tests
             AssertEqual(MathF.Cos(x * MathF.PI), MathF.CosPi(x), (float)CrossPlatformMachineEpsilonForEstimates);
             AssertEqual(MathF.Tan(x * MathF.PI), MathF.TanPi(x), (float)CrossPlatformMachineEpsilonForEstimates);
         }
+
+        [Fact]
+        public static void AsinPi_Double_Precision()
+        {
+            AssertEqual( 0.5, Math.AsinPi( 1.0), 0.0);
+            AssertEqual(-0.5, Math.AsinPi(-1.0), 0.0);
+        }
+
+        [Fact]
+        public static void AsinPi_Float_Precision()
+        {
+            AssertEqual( 0.5f, MathF.AsinPi( 1.0f), 0.0f);
+            AssertEqual(-0.5f, MathF.AsinPi(-1.0f), 0.0f);
+        }
+
+        [Fact]
+        public static void AcosPi_Double_Precision()
+        {
+            AssertEqual( 0.5, Math.AcosPi( 0.0), 0.0);
+            AssertEqual( 0.5, Math.AcosPi(-0.0), 0.0);
+            AssertEqual( 0.0, Math.AcosPi( 1.0), 0.0);
+            AssertEqual( 1.0, Math.AcosPi(-1.0), 0.0);
+        }
+
+        [Fact]
+        public static void AcosPi_Float_Precision()
+        {
+            AssertEqual( 0.5f, MathF.AcosPi( 0.0f), 0.0f);
+            AssertEqual( 0.5f, MathF.AcosPi(-0.0f), 0.0f);
+            AssertEqual( 0.0f, MathF.AcosPi( 1.0f), 0.0f);
+            AssertEqual( 1.0f, MathF.AcosPi(-1.0f), 0.0f);
+        }
+
+        [Fact]
+        public static void AtanPi_Double_Precision()
+        {
+            AssertEqual( 0.5, Math.AtanPi(double.PositiveInfinity), 0.0);
+            AssertEqual(-0.5, Math.AtanPi(double.NegativeInfinity), 0.0);
+        }
+
+        [Fact]
+        public static void AtanPi_Float_Precision()
+        {
+            AssertEqual( 0.5f, MathF.AtanPi(float.PositiveInfinity), 0.0f);
+            AssertEqual(-0.5f, MathF.AtanPi(float.NegativeInfinity), 0.0f);
+        }
+
+        [Fact]
+        public static void Atan2Pi_Double_Precision()
+        {
+            AssertEqual( 1.00, Math.Atan2Pi( 0.0, -0.0), 0.0);
+            AssertEqual(-1.00, Math.Atan2Pi(-0.0, -0.0), 0.0);
+            AssertEqual( 1.00, Math.Atan2Pi( 0.0, -1.0), 0.0);
+            AssertEqual(-1.00, Math.Atan2Pi(-0.0, -1.0), 0.0);
+            AssertEqual(-0.50, Math.Atan2Pi(-1.0,  0.0), 0.0);
+            AssertEqual(-0.50, Math.Atan2Pi(-1.0, -0.0), 0.0);
+            AssertEqual( 0.50, Math.Atan2Pi( 1.0,  0.0), 0.0);
+            AssertEqual( 0.50, Math.Atan2Pi( 1.0, -0.0), 0.0);
+            AssertEqual( 1.00, Math.Atan2Pi( 1.0, double.NegativeInfinity), 0.0);
+            AssertEqual(-1.00, Math.Atan2Pi(-1.0, double.NegativeInfinity), 0.0);
+            AssertEqual( 0.50, Math.Atan2Pi(double.PositiveInfinity,  1.0), 0.0);
+            AssertEqual( 0.50, Math.Atan2Pi(double.PositiveInfinity, -1.0), 0.0);
+            AssertEqual(-0.50, Math.Atan2Pi(double.NegativeInfinity,  1.0), 0.0);
+            AssertEqual(-0.50, Math.Atan2Pi(double.NegativeInfinity, -1.0), 0.0);
+            AssertEqual( 0.75, Math.Atan2Pi(double.PositiveInfinity, double.NegativeInfinity), 0.0);
+            AssertEqual(-0.75, Math.Atan2Pi(double.NegativeInfinity, double.NegativeInfinity), 0.0);
+            AssertEqual( 0.25, Math.Atan2Pi(double.PositiveInfinity, double.PositiveInfinity), 0.0);
+            AssertEqual(-0.25, Math.Atan2Pi(double.NegativeInfinity, double.PositiveInfinity), 0.0);
+        }
+
+        [Fact]
+        public static void Atan2Pi_Float_Precision()
+        {
+            AssertEqual( 1.00f, MathF.Atan2Pi( 0.0f, -0.0f), 0.0f);
+            AssertEqual(-1.00f, MathF.Atan2Pi(-0.0f, -0.0f), 0.0f);
+            AssertEqual( 1.00f, MathF.Atan2Pi( 0.0f, -1.0f), 0.0f);
+            AssertEqual(-1.00f, MathF.Atan2Pi(-0.0f, -1.0f), 0.0f);
+            AssertEqual(-0.50f, MathF.Atan2Pi(-1.0f,  0.0f), 0.0f);
+            AssertEqual(-0.50f, MathF.Atan2Pi(-1.0f, -0.0f), 0.0f);
+            AssertEqual( 0.50f, MathF.Atan2Pi( 1.0f,  0.0f), 0.0f);
+            AssertEqual( 0.50f, MathF.Atan2Pi( 1.0f, -0.0f), 0.0f);
+            AssertEqual( 1.00f, MathF.Atan2Pi( 1.0f, float.NegativeInfinity), 0.0f);
+            AssertEqual(-1.00f, MathF.Atan2Pi(-1.0f, float.NegativeInfinity), 0.0f);
+            AssertEqual( 0.50f, MathF.Atan2Pi(float.PositiveInfinity,  1.0f), 0.0f);
+            AssertEqual( 0.50f, MathF.Atan2Pi(float.PositiveInfinity, -1.0f), 0.0f);
+            AssertEqual(-0.50f, MathF.Atan2Pi(float.NegativeInfinity,  1.0f), 0.0f);
+            AssertEqual(-0.50f, MathF.Atan2Pi(float.NegativeInfinity, -1.0f), 0.0f);
+            AssertEqual( 0.75f, MathF.Atan2Pi(float.PositiveInfinity, float.NegativeInfinity), 0.0f);
+            AssertEqual(-0.75f, MathF.Atan2Pi(float.NegativeInfinity, float.NegativeInfinity), 0.0f);
+            AssertEqual( 0.25f, MathF.Atan2Pi(float.PositiveInfinity, float.PositiveInfinity), 0.0f);
+            AssertEqual(-0.25f, MathF.Atan2Pi(float.NegativeInfinity, float.PositiveInfinity), 0.0f);
+        }
     }
 }

--- a/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
@@ -3248,5 +3248,33 @@ namespace System.Tests
             Assert.Equal(0, MathF.CosPi(0.6789f) - MathF.CosPi(-0.6789f));
             Assert.Equal(0, MathF.CosPi(1.2345f) - MathF.CosPi(-1.2345f));
         }
+
+        [Fact]
+        public static void TanPi_Double_Precision()
+        {
+            Assert.Equal(                      0, Math.TanPi( 0.0));
+            Assert.Equal(double.PositiveInfinity, Math.TanPi( 0.5));
+            Assert.Equal(double.NegativeInfinity, Math.TanPi(-0.5));
+            Assert.Equal(                      0, Math.TanPi( 1.0));
+            Assert.Equal(                      0, Math.TanPi(-1.0));
+            Assert.Equal(double.NegativeInfinity, Math.TanPi( 1.5));
+            Assert.Equal(double.PositiveInfinity, Math.TanPi(-1.5));
+            Assert.Equal(                      0, Math.TanPi( 2.0));
+            Assert.Equal(                      0, Math.TanPi(-2.0));
+        }
+
+        [Fact]
+        public static void TanPi_Float_Precision()
+        {
+            Assert.Equal(                     0, MathF.TanPi( 0.0f));
+            Assert.Equal(float.PositiveInfinity, MathF.TanPi( 0.5f));
+            Assert.Equal(float.NegativeInfinity, MathF.TanPi(-0.5f));
+            Assert.Equal(                     0, MathF.TanPi( 1.0f));
+            Assert.Equal(                     0, MathF.TanPi(-1.0f));
+            Assert.Equal(float.NegativeInfinity, MathF.TanPi( 1.5f));
+            Assert.Equal(float.PositiveInfinity, MathF.TanPi(-1.5f));
+            Assert.Equal(                     0, MathF.TanPi( 2.0f));
+            Assert.Equal(                     0, MathF.TanPi(-2.0f));
+        }
     }
 }

--- a/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
@@ -3180,101 +3180,115 @@ namespace System.Tests
         [Fact]
         public static void SinPi_Double_Precision()
         {
-            Assert.Equal( 0, Math.SinPi( 0.0));
-            Assert.Equal( 1, Math.SinPi( 0.5));
-            Assert.Equal(-1, Math.SinPi(-0.5));
-            Assert.Equal( 0, Math.SinPi( 1.0));
-            Assert.Equal( 0, Math.SinPi(-1.0));
-            Assert.Equal(-1, Math.SinPi( 1.5));
-            Assert.Equal( 1, Math.SinPi(-1.5));
-            Assert.Equal( 0, Math.SinPi( 2.0));
-            Assert.Equal( 0, Math.SinPi(-2.0));
+            AssertEqual( 0.0, Math.SinPi( 0.0), 0.0);
+            AssertEqual(-0.0, Math.SinPi(-0.0), 0.0);
+            AssertEqual( 1.0, Math.SinPi( 0.5), 0.0);
+            AssertEqual(-1.0, Math.SinPi(-0.5), 0.0);
+            AssertEqual( 0.0, Math.SinPi( 1.0), 0.0);
+            AssertEqual(-0.0, Math.SinPi(-1.0), 0.0);
+            AssertEqual(-1.0, Math.SinPi( 1.5), 0.0);
+            AssertEqual( 1.0, Math.SinPi(-1.5), 0.0);
+            AssertEqual( 0.0, Math.SinPi( 2.0), 0.0);
+            AssertEqual(-0.0, Math.SinPi(-2.0), 0.0);
 
-            Assert.Equal(0, Math.SinPi(0.1234) + Math.SinPi(-0.1234));
-            Assert.Equal(0, Math.SinPi(0.6789) + Math.SinPi(-0.6789));
-            Assert.Equal(0, Math.SinPi(1.2345) + Math.SinPi(-1.2345));
+            AssertEqual(0.0, Math.SinPi(0.1234) + Math.SinPi(-0.1234), 0.0);
+            AssertEqual(0.0, Math.SinPi(0.6789) + Math.SinPi(-0.6789), 0.0);
+            AssertEqual(0.0, Math.SinPi(1.2345) + Math.SinPi(-1.2345), 0.0);
         }
 
         [Fact]
         public static void SinPi_Float_Precision()
         {
-            Assert.Equal( 0, MathF.SinPi( 0.0f));
-            Assert.Equal( 1, MathF.SinPi( 0.5f));
-            Assert.Equal(-1, MathF.SinPi(-0.5f));
-            Assert.Equal( 0, MathF.SinPi( 1.0f));
-            Assert.Equal( 0, MathF.SinPi(-1.0f));
-            Assert.Equal(-1, MathF.SinPi( 1.5f));
-            Assert.Equal( 1, MathF.SinPi(-1.5f));
-            Assert.Equal( 0, MathF.SinPi( 2.0f));
-            Assert.Equal( 0, MathF.SinPi(-2.0f));
+            AssertEqual( 0.0f, MathF.SinPi( 0.0f), 0.0f);
+            AssertEqual(-0.0f, MathF.SinPi(-0.0f), 0.0f);
+            AssertEqual( 1.0f, MathF.SinPi( 0.5f), 0.0f);
+            AssertEqual(-1.0f, MathF.SinPi(-0.5f), 0.0f);
+            AssertEqual( 0.0f, MathF.SinPi( 1.0f), 0.0f);
+            AssertEqual(-0.0f, MathF.SinPi(-1.0f), 0.0f);
+            AssertEqual(-1.0f, MathF.SinPi( 1.5f), 0.0f);
+            AssertEqual( 1.0f, MathF.SinPi(-1.5f), 0.0f);
+            AssertEqual( 0.0f, MathF.SinPi( 2.0f), 0.0f);
+            AssertEqual(-0.0f, MathF.SinPi(-2.0f), 0.0f);
 
-            Assert.Equal(0, MathF.SinPi(0.1234f) + MathF.SinPi(-0.1234f));
-            Assert.Equal(0, MathF.SinPi(0.6789f) + MathF.SinPi(-0.6789f));
-            Assert.Equal(0, MathF.SinPi(1.2345f) + MathF.SinPi(-1.2345f));
+            AssertEqual(0.0f, MathF.SinPi(0.1234f) + MathF.SinPi(-0.1234f), 0.0f);
+            AssertEqual(0.0f, MathF.SinPi(0.6789f) + MathF.SinPi(-0.6789f), 0.0f);
+            AssertEqual(0.0f, MathF.SinPi(1.2345f) + MathF.SinPi(-1.2345f), 0.0f);
         }
 
         [Fact]
         public static void CosPi_Double_Precision()
         {
-            Assert.Equal( 1, Math.CosPi( 0.0));
-            Assert.Equal( 0, Math.CosPi( 0.5));
-            Assert.Equal( 0, Math.CosPi(-0.5));
-            Assert.Equal(-1, Math.CosPi( 1.0));
-            Assert.Equal(-1, Math.CosPi(-1.0));
-            Assert.Equal( 0, Math.CosPi( 1.5));
-            Assert.Equal( 0, Math.CosPi(-1.5));
-            Assert.Equal( 1, Math.CosPi( 2.0));
-            Assert.Equal( 1, Math.CosPi(-2.0));
+            AssertEqual( 1.0, Math.CosPi( 0.0), 0.0);
+            AssertEqual( 1.0, Math.CosPi(-0.0), 0.0);
+            AssertEqual( 0.0, Math.CosPi( 0.5), 0.0);
+            AssertEqual( 0.0, Math.CosPi(-0.5), 0.0);
+            AssertEqual(-1.0, Math.CosPi( 1.0), 0.0);
+            AssertEqual(-1.0, Math.CosPi(-1.0), 0.0);
+            AssertEqual( 0.0, Math.CosPi( 1.5), 0.0);
+            AssertEqual( 0.0, Math.CosPi(-1.5), 0.0);
+            AssertEqual( 1.0, Math.CosPi( 2.0), 0.0);
+            AssertEqual( 1.0, Math.CosPi(-2.0), 0.0);
 
-            Assert.Equal(0, Math.CosPi(0.1234) - Math.CosPi(-0.1234));
-            Assert.Equal(0, Math.CosPi(0.6789) - Math.CosPi(-0.6789));
-            Assert.Equal(0, Math.CosPi(1.2345) - Math.CosPi(-1.2345));
+            AssertEqual(0.0, Math.CosPi(0.1234) - Math.CosPi(-0.1234), 0.0);
+            AssertEqual(0.0, Math.CosPi(0.6789) - Math.CosPi(-0.6789), 0.0);
+            AssertEqual(0.0, Math.CosPi(1.2345) - Math.CosPi(-1.2345), 0.0);
         }
 
         [Fact]
         public static void CosPi_Float_Precision()
         {
-            Assert.Equal( 1, MathF.CosPi( 0.0f));
-            Assert.Equal( 0, MathF.CosPi( 0.5f));
-            Assert.Equal( 0, MathF.CosPi(-0.5f));
-            Assert.Equal(-1, MathF.CosPi( 1.0f));
-            Assert.Equal(-1, MathF.CosPi(-1.0f));
-            Assert.Equal( 0, MathF.CosPi( 1.5f));
-            Assert.Equal( 0, MathF.CosPi(-1.5f));
-            Assert.Equal( 1, MathF.CosPi( 2.0f));
-            Assert.Equal( 1, MathF.CosPi(-2.0f));
+            AssertEqual( 1.0f, MathF.CosPi( 0.0f), 0.0f);
+            AssertEqual( 1.0f, MathF.CosPi(-0.0f), 0.0f);
+            AssertEqual( 0.0f, MathF.CosPi( 0.5f), 0.0f);
+            AssertEqual( 0.0f, MathF.CosPi(-0.5f), 0.0f);
+            AssertEqual(-1.0f, MathF.CosPi( 1.0f), 0.0f);
+            AssertEqual(-1.0f, MathF.CosPi(-1.0f), 0.0f);
+            AssertEqual( 0.0f, MathF.CosPi( 1.5f), 0.0f);
+            AssertEqual( 0.0f, MathF.CosPi(-1.5f), 0.0f);
+            AssertEqual( 1.0f, MathF.CosPi( 2.0f), 0.0f);
+            AssertEqual( 1.0f, MathF.CosPi(-2.0f), 0.0f);
 
-            Assert.Equal(0, MathF.CosPi(0.1234f) - MathF.CosPi(-0.1234f));
-            Assert.Equal(0, MathF.CosPi(0.6789f) - MathF.CosPi(-0.6789f));
-            Assert.Equal(0, MathF.CosPi(1.2345f) - MathF.CosPi(-1.2345f));
+            AssertEqual(0.0f, MathF.CosPi(0.1234f) - MathF.CosPi(-0.1234f), 0.0f);
+            AssertEqual(0.0f, MathF.CosPi(0.6789f) - MathF.CosPi(-0.6789f), 0.0f);
+            AssertEqual(0.0f, MathF.CosPi(1.2345f) - MathF.CosPi(-1.2345f), 0.0f);
         }
 
         [Fact]
         public static void TanPi_Double_Precision()
         {
-            Assert.Equal(                      0, Math.TanPi( 0.0));
-            Assert.Equal(double.PositiveInfinity, Math.TanPi( 0.5));
-            Assert.Equal(double.NegativeInfinity, Math.TanPi(-0.5));
-            Assert.Equal(                      0, Math.TanPi( 1.0));
-            Assert.Equal(                      0, Math.TanPi(-1.0));
-            Assert.Equal(double.NegativeInfinity, Math.TanPi( 1.5));
-            Assert.Equal(double.PositiveInfinity, Math.TanPi(-1.5));
-            Assert.Equal(                      0, Math.TanPi( 2.0));
-            Assert.Equal(                      0, Math.TanPi(-2.0));
+            AssertEqual(                    0.0, Math.TanPi( 0.0), 0.0);
+            AssertEqual(                   -0.0, Math.TanPi(-0.0), 0.0);
+            AssertEqual(double.PositiveInfinity, Math.TanPi( 0.5), 0.0);
+            AssertEqual(double.NegativeInfinity, Math.TanPi(-0.5), 0.0);
+            AssertEqual(                   -0.0, Math.TanPi( 1.0), 0.0);
+            AssertEqual(                    0.0, Math.TanPi(-1.0), 0.0);
+            AssertEqual(double.NegativeInfinity, Math.TanPi( 1.5), 0.0);
+            AssertEqual(double.PositiveInfinity, Math.TanPi(-1.5), 0.0);
+            AssertEqual(                    0.0, Math.TanPi( 2.0), 0.0);
+            AssertEqual(                   -0.0, Math.TanPi(-2.0), 0.0);
+
+            AssertEqual(0.0, Math.TanPi(0.1234) + Math.TanPi(-0.1234), 0.0);
+            AssertEqual(0.0, Math.TanPi(0.6789) + Math.TanPi(-0.6789), 0.0);
+            AssertEqual(0.0, Math.TanPi(1.2345) + Math.TanPi(-1.2345), 0.0);
         }
 
         [Fact]
         public static void TanPi_Float_Precision()
         {
-            Assert.Equal(                     0, MathF.TanPi( 0.0f));
-            Assert.Equal(float.PositiveInfinity, MathF.TanPi( 0.5f));
-            Assert.Equal(float.NegativeInfinity, MathF.TanPi(-0.5f));
-            Assert.Equal(                     0, MathF.TanPi( 1.0f));
-            Assert.Equal(                     0, MathF.TanPi(-1.0f));
-            Assert.Equal(float.NegativeInfinity, MathF.TanPi( 1.5f));
-            Assert.Equal(float.PositiveInfinity, MathF.TanPi(-1.5f));
-            Assert.Equal(                     0, MathF.TanPi( 2.0f));
-            Assert.Equal(                     0, MathF.TanPi(-2.0f));
+            AssertEqual(                  0.0f, MathF.TanPi( 0.0f), 0.0f);
+            AssertEqual(                 -0.0f, MathF.TanPi(-0.0f), 0.0f);
+            AssertEqual(float.PositiveInfinity, MathF.TanPi( 0.5f), 0.0f);
+            AssertEqual(float.NegativeInfinity, MathF.TanPi(-0.5f), 0.0f);
+            AssertEqual(                 -0.0f, MathF.TanPi( 1.0f), 0.0f);
+            AssertEqual(                  0.0f, MathF.TanPi(-1.0f), 0.0f);
+            AssertEqual(float.NegativeInfinity, MathF.TanPi( 1.5f), 0.0f);
+            AssertEqual(float.PositiveInfinity, MathF.TanPi(-1.5f), 0.0f);
+            AssertEqual(                  0.0f, MathF.TanPi( 2.0f), 0.0f);
+            AssertEqual(                 -0.0f, MathF.TanPi(-2.0f), 0.0f);
+
+            AssertEqual(0.0f, MathF.TanPi(0.1234f) + MathF.TanPi(-0.1234f), 0.0f);
+            AssertEqual(0.0f, MathF.TanPi(0.6789f) + MathF.TanPi(-0.6789f), 0.0f);
+            AssertEqual(0.0f, MathF.TanPi(1.2345f) + MathF.TanPi(-1.2345f), 0.0f);
         }
     }
 }

--- a/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
@@ -3176,5 +3176,41 @@ namespace System.Tests
             Assert.Equal( 4, MathF.Round( 3.5f, MidpointRounding.AwayFromZero));
             Assert.Equal(-4, MathF.Round(-3.5f, MidpointRounding.AwayFromZero));
         }
+
+        [Fact]
+        public static void SinPi_Double_Precision()
+        {
+            Assert.Equal( 0, Math.SinPi( 0.0));
+            Assert.Equal( 1, Math.SinPi( 0.5));
+            Assert.Equal(-1, Math.SinPi(-0.5));
+            Assert.Equal( 0, Math.SinPi( 1.0));
+            Assert.Equal( 0, Math.SinPi(-1.0));
+            Assert.Equal(-1, Math.SinPi( 1.5));
+            Assert.Equal( 1, Math.SinPi(-1.5));
+            Assert.Equal( 0, Math.SinPi( 2.0));
+            Assert.Equal( 0, Math.SinPi(-2.0));
+
+            Assert.Equal(0, Math.SinPi(0.1234) + Math.SinPi(-0.1234));
+            Assert.Equal(0, Math.SinPi(0.6789) + Math.SinPi(-0.6789));
+            Assert.Equal(0, Math.SinPi(1.2345) + Math.SinPi(-1.2345));
+        }
+
+        [Fact]
+        public static void SinPi_Float_Precision()
+        {
+            Assert.Equal( 0, MathF.SinPi( 0.0f));
+            Assert.Equal( 1, MathF.SinPi( 0.5f));
+            Assert.Equal(-1, MathF.SinPi(-0.5f));
+            Assert.Equal( 0, MathF.SinPi( 1.0f));
+            Assert.Equal( 0, MathF.SinPi(-1.0f));
+            Assert.Equal(-1, MathF.SinPi( 1.5f));
+            Assert.Equal( 1, MathF.SinPi(-1.5f));
+            Assert.Equal( 0, MathF.SinPi( 2.0f));
+            Assert.Equal( 0, MathF.SinPi(-2.0f));
+
+            Assert.Equal(0, MathF.SinPi(0.1234f) + MathF.SinPi(-0.1234f));
+            Assert.Equal(0, MathF.SinPi(0.6789f) + MathF.SinPi(-0.6789f));
+            Assert.Equal(0, MathF.SinPi(1.2345f) + MathF.SinPi(-1.2345f));
+        }
     }
 }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -2880,6 +2880,7 @@ namespace System
         public static double Sqrt(double d) { throw null; }
         public static double Tan(double a) { throw null; }
         public static double Tanh(double value) { throw null; }
+        public static double TanPi(double x) { throw null; }
         public static decimal Truncate(decimal d) { throw null; }
         public static double Truncate(double d) { throw null; }
     }
@@ -2933,6 +2934,7 @@ namespace System
         public static float Sqrt(float x) { throw null; }
         public static float Tan(float x) { throw null; }
         public static float Tanh(float x) { throw null; }
+        public static float TanPi(float x) { throw null; }
         public static float Truncate(float x) { throw null; }
     }
     public partial class MemberAccessException : System.SystemException

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -2751,11 +2751,15 @@ namespace System
         public static float Abs(float value) { throw null; }
         public static double Acos(double d) { throw null; }
         public static double Acosh(double d) { throw null; }
+        public static double AcosPi(double x) { throw null; }
         public static double Asin(double d) { throw null; }
         public static double Asinh(double d) { throw null; }
+        public static double AsinPi(double x) { throw null; }
         public static double Atan(double d) { throw null; }
         public static double Atan2(double y, double x) { throw null; }
+        public static double Atan2Pi(double y, double x) { throw null; }
         public static double Atanh(double d) { throw null; }
+        public static double AtanPi(double x) { throw null; }
         public static long BigMul(int a, int b) { throw null; }
         public static long BigMul(long a, long b, out long low) { throw null; }
         [System.CLSCompliantAttribute(false)]
@@ -2892,11 +2896,15 @@ namespace System
         public static float Abs(float x) { throw null; }
         public static float Acos(float x) { throw null; }
         public static float Acosh(float x) { throw null; }
+        public static float AcosPi(float x) { throw null; }
         public static float Asin(float x) { throw null; }
         public static float Asinh(float x) { throw null; }
+        public static float AsinPi(float x) { throw null; }
         public static float Atan(float x) { throw null; }
         public static float Atan2(float y, float x) { throw null; }
+        public static float Atan2Pi(float y, float x) { throw null; }
         public static float Atanh(float x) { throw null; }
+        public static float AtanPi(float x) { throw null; }
         public static float BitDecrement(float x) { throw null; }
         public static float BitIncrement(float x) { throw null; }
         public static float Cbrt(float x) { throw null; }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -2873,6 +2873,7 @@ namespace System
         public static int Sign(sbyte value) { throw null; }
         public static int Sign(float value) { throw null; }
         public static double Sin(double a) { throw null; }
+        public static double SinPi(double x) { throw null; }
         public static (double Sin, double Cos) SinCos(double x) { throw null; }
         public static double Sinh(double value) { throw null; }
         public static double Sqrt(double d) { throw null; }
@@ -2924,6 +2925,7 @@ namespace System
         public static float ScaleB(float x, int n) { throw null; }
         public static int Sign(float x) { throw null; }
         public static float Sin(float x) { throw null; }
+        public static float SinPi(float x) { throw null; }
         public static (float Sin, float Cos) SinCos(float x) { throw null; }
         public static float Sinh(float x) { throw null; }
         public static float Sqrt(float x) { throw null; }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -2786,6 +2786,7 @@ namespace System
         public static double CopySign(double x, double y) { throw null; }
         public static double Cos(double d) { throw null; }
         public static double Cosh(double value) { throw null; }
+        public static double CosPi(double x) { throw null; }
         public static int DivRem(int a, int b, out int result) { throw null; }
         public static long DivRem(long a, long b, out long result) { throw null; }
         public static (byte Quotient, byte Remainder) DivRem(byte left, byte right) { throw null; }
@@ -2873,9 +2874,9 @@ namespace System
         public static int Sign(sbyte value) { throw null; }
         public static int Sign(float value) { throw null; }
         public static double Sin(double a) { throw null; }
-        public static double SinPi(double x) { throw null; }
         public static (double Sin, double Cos) SinCos(double x) { throw null; }
         public static double Sinh(double value) { throw null; }
+        public static double SinPi(double x) { throw null; }
         public static double Sqrt(double d) { throw null; }
         public static double Tan(double a) { throw null; }
         public static double Tanh(double value) { throw null; }
@@ -2902,6 +2903,7 @@ namespace System
         public static float CopySign(float x, float y) { throw null; }
         public static float Cos(float x) { throw null; }
         public static float Cosh(float x) { throw null; }
+        public static float CosPi(float x) { throw null; }
         public static float Exp(float x) { throw null; }
         public static float Floor(float x) { throw null; }
         public static float FusedMultiplyAdd(float x, float y, float z) { throw null; }
@@ -2925,9 +2927,9 @@ namespace System
         public static float ScaleB(float x, int n) { throw null; }
         public static int Sign(float x) { throw null; }
         public static float Sin(float x) { throw null; }
-        public static float SinPi(float x) { throw null; }
         public static (float Sin, float Cos) SinCos(float x) { throw null; }
         public static float Sinh(float x) { throw null; }
+        public static float SinPi(float x) { throw null; }
         public static float Sqrt(float x) { throw null; }
         public static float Tan(float x) { throw null; }
         public static float Tanh(float x) { throw null; }


### PR DESCRIPTION
Part of #20137

Implementations are copied from boost/math. However, I can't find AsinPi/AcosPi/AtanPi implementation there. It feels better to add them together.

Question: IEEE754 spec explicitly specifies +0 and -0. Do we need to test it?