### PR TITLE
Adapt more Mono profiler events into NativeRuntimeEvents.

### DIFF
--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -19,6 +19,7 @@
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/debug-internals.h>
 #include <mono/metadata/gc-internals.h>
+#include <mono/metadata/profiler-private.h>
 #include <mono/mini/mini-runtime.h>
 #include <runtime_version.h>
 #include <clretwallmain.h>
@@ -2229,8 +2230,16 @@ ep_rt_mono_write_event_exception_thrown (MonoObject *obj)
 			NULL,
 			NULL);
 
+		if (!mono_component_profiler_clauses_enabled ()) {
+			FireEtwExceptionThrownStop (
+				NULL,
+				NULL);
+		}
+
 		g_free (exception_message);
 		g_free (type_name);
+
+		mono_error_cleanup (error);
 	}
 
 	return true;
@@ -2243,6 +2252,9 @@ ep_rt_mono_write_event_exception_clause (
 	MonoExceptionEnum clause_type,
 	MonoObject *obj)
 {
+	if (!mono_component_profiler_clauses_enabled ())
+		return true;
+
 	if ((clause_type == MONO_EXCEPTION_CLAUSE_FAULT || clause_type == MONO_EXCEPTION_CLAUSE_NONE) && (!EventEnabledExceptionCatchStart() || !EventEnabledExceptionCatchStop()))
 		return true;
 
@@ -2268,6 +2280,10 @@ ep_rt_mono_write_event_exception_clause (
 			NULL);
 
 		FireEtwExceptionCatchStop (
+			NULL,
+			NULL);
+
+		FireEtwExceptionThrownStop (
 			NULL,
 			NULL);
 	}

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -2217,7 +2217,7 @@ ep_rt_mono_write_event_exception_thrown (MonoObject *obj)
 		if (mono_get_eh_callbacks ()->mono_walk_stack_with_ctx)
 			mono_get_eh_callbacks ()->mono_walk_stack_with_ctx (get_exception_ip_func, NULL, MONO_UNWIND_SIGNAL_SAFE, (void *)&ip);
 
-		type_name = mono_type_get_name_full (m_class_get_byval_arg (mono_object_get_class (obj)), MONO_TYPE_NAME_FORMAT_IL);
+		type_name = mono_type_get_name_full (m_class_get_byval_arg (mono_object_class (obj)), MONO_TYPE_NAME_FORMAT_IL);
 
 		FireEtwExceptionThrown_V1 (
 			type_name,

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -2190,6 +2190,13 @@ bool
 ep_rt_mono_write_event_exception_thrown (MonoObject *object);
 
 bool
+ep_rt_mono_write_event_exception_clause (
+	MonoMethod *method,
+	uint32_t clause_num,
+	MonoExceptionEnum clause_type,
+	MonoObject *obj);
+
+bool
 ep_rt_write_event_threadpool_worker_thread_start (
 	uint32_t active_thread_count,
 	uint32_t retired_worker_thread_count,

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -2166,7 +2166,13 @@ bool
 ep_rt_mono_write_event_module_load (MonoImage *image);
 
 bool
+ep_rt_mono_write_event_module_unload (MonoImage *image);
+
+bool
 ep_rt_mono_write_event_assembly_load (MonoAssembly *assembly);
+
+bool
+ep_rt_mono_write_event_assembly_unload (MonoAssembly *assembly);
 
 bool
 ep_rt_write_event_threadpool_worker_thread_start (

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -2175,6 +2175,12 @@ bool
 ep_rt_mono_write_event_assembly_unload (MonoAssembly *assembly);
 
 bool
+ep_rt_mono_write_event_thread_created (ep_rt_thread_id_t tid);
+
+bool
+ep_rt_mono_write_event_thread_terminated (ep_rt_thread_id_t tid);
+
+bool
 ep_rt_write_event_threadpool_worker_thread_start (
 	uint32_t active_thread_count,
 	uint32_t retired_worker_thread_count,

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -2181,6 +2181,12 @@ bool
 ep_rt_mono_write_event_thread_terminated (ep_rt_thread_id_t tid);
 
 bool
+ep_rt_mono_write_event_type_load_start (MonoType *type);
+
+bool
+ep_rt_mono_write_event_type_load_stop (MonoType *type);
+
+bool
 ep_rt_write_event_threadpool_worker_thread_start (
 	uint32_t active_thread_count,
 	uint32_t retired_worker_thread_count,

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -2197,20 +2197,11 @@ ep_rt_mono_write_event_exception_clause (
 	MonoExceptionEnum clause_type,
 	MonoObject *obj);
 
- typedef enum {
-	EP_MONITOR_CONTENTION_FLAGS_MANAGED = 0,
-	EP_MONITOR_CONTENTION_FLAGS_NATIVE = 1
-} EventPipeMonitorContentionFlags;
+bool
+ep_rt_mono_write_event_monitor_contention_start (MonoObject *obj);
 
 bool
-ep_rt_mono_write_event_monitor_contention_start (
-	MonoObject *obj,
-	EventPipeMonitorContentionFlags flags);
-
-bool
-ep_rt_mono_write_event_monitor_contention_stop (
-	MonoObject *obj,
-	EventPipeMonitorContentionFlags flags);
+ep_rt_mono_write_event_monitor_contention_stop (MonoObject *obj);
 
 bool
 ep_rt_mono_write_event_method_jit_memory_allocated_for_code (

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -23,6 +23,7 @@
 #include <mono/metadata/w32file.h>
 #include <mono/metadata/w32event.h>
 #include <mono/metadata/environment-internals.h>
+#include <mono/metadata/profiler.h>
 
 #undef EP_ARRAY_SIZE
 #define EP_ARRAY_SIZE(expr) G_N_ELEMENTS(expr)
@@ -2210,6 +2211,13 @@ bool
 ep_rt_mono_write_event_monitor_contention_stop (
 	MonoObject *obj,
 	EventPipeMonitorContentionFlags flags);
+
+bool
+ep_rt_mono_write_event_method_jit_memory_allocated_for_code (
+	const uint8_t *buffer,
+	uint64_t size,
+	MonoProfilerCodeBufferType type,
+	const void *data);
 
 bool
 ep_rt_write_event_threadpool_worker_thread_start (

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -2196,6 +2196,21 @@ ep_rt_mono_write_event_exception_clause (
 	MonoExceptionEnum clause_type,
 	MonoObject *obj);
 
+ typedef enum {
+	EP_MONITOR_CONTENTION_FLAGS_MANAGED = 0,
+	EP_MONITOR_CONTENTION_FLAGS_NATIVE = 1
+} EventPipeMonitorContentionFlags;
+
+bool
+ep_rt_mono_write_event_monitor_contention_start (
+	MonoObject *obj,
+	EventPipeMonitorContentionFlags flags);
+
+bool
+ep_rt_mono_write_event_monitor_contention_stop (
+	MonoObject *obj,
+	EventPipeMonitorContentionFlags flags);
+
 bool
 ep_rt_write_event_threadpool_worker_thread_start (
 	uint32_t active_thread_count,

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -2187,6 +2187,9 @@ bool
 ep_rt_mono_write_event_type_load_stop (MonoType *type);
 
 bool
+ep_rt_mono_write_event_exception_thrown (MonoObject *object);
+
+bool
 ep_rt_write_event_threadpool_worker_thread_start (
 	uint32_t active_thread_count,
 	uint32_t retired_worker_thread_count,

--- a/src/mono/mono/eventpipe/gen-eventing-event-inc.lst
+++ b/src/mono/mono/eventpipe/gen-eventing-event-inc.lst
@@ -4,6 +4,8 @@ AppDomainDCEnd_V1
 AssemblyDCEnd_V1
 AssemblyLoad_V1
 AssemblyUnload_V1
+ContentionStart_V1
+ContentionStop
 DCEndComplete_V1
 DCEndInit_V1
 DomainModuleDCEnd_V1

--- a/src/mono/mono/eventpipe/gen-eventing-event-inc.lst
+++ b/src/mono/mono/eventpipe/gen-eventing-event-inc.lst
@@ -23,6 +23,7 @@ MethodDCEndILToNativeMap
 MethodDCEnd_V1
 MethodDCEndVerbose_V1
 MethodILToNativeMap
+MethodJitMemoryAllocatedForCode
 MethodJittingStarted_V1
 MethodLoad_V1
 MethodLoadVerbose_V1

--- a/src/mono/mono/eventpipe/gen-eventing-event-inc.lst
+++ b/src/mono/mono/eventpipe/gen-eventing-event-inc.lst
@@ -32,3 +32,5 @@ ThreadPoolWorkerThreadStop
 ThreadPoolWorkerThreadWait
 ThreadPoolWorkingThreadCount
 ThreadTerminated
+TypeLoadStart
+TypeLoadStop

--- a/src/mono/mono/eventpipe/gen-eventing-event-inc.lst
+++ b/src/mono/mono/eventpipe/gen-eventing-event-inc.lst
@@ -3,6 +3,7 @@
 AppDomainDCEnd_V1
 AssemblyDCEnd_V1
 AssemblyLoad_V1
+AssemblyUnload_V1
 DCEndComplete_V1
 DCEndInit_V1
 DomainModuleDCEnd_V1
@@ -18,7 +19,9 @@ MethodLoad_V1
 MethodLoadVerbose_V1
 ModuleDCEnd_V2
 ModuleLoad_V2
+ModuleUnload_V2
 RuntimeInformationDCStart
+ThreadCreated
 ThreadPoolIODequeue
 ThreadPoolIOEnqueue
 ThreadPoolWorkerThreadAdjustmentAdjustment
@@ -28,3 +31,4 @@ ThreadPoolWorkerThreadStart
 ThreadPoolWorkerThreadStop
 ThreadPoolWorkerThreadWait
 ThreadPoolWorkingThreadCount
+ThreadTerminated

--- a/src/mono/mono/eventpipe/gen-eventing-event-inc.lst
+++ b/src/mono/mono/eventpipe/gen-eventing-event-inc.lst
@@ -10,6 +10,7 @@ DomainModuleDCEnd_V1
 DomainModuleLoad_V1
 EEStartupStart_V1
 ExecutionCheckpointDCEnd
+ExceptionThrown_V1
 MethodDCEndILToNativeMap
 MethodDCEnd_V1
 MethodDCEndVerbose_V1

--- a/src/mono/mono/eventpipe/gen-eventing-event-inc.lst
+++ b/src/mono/mono/eventpipe/gen-eventing-event-inc.lst
@@ -19,6 +19,7 @@ ExceptionFilterStop
 ExceptionFinallyStart
 ExceptionFinallyStop
 ExceptionThrown_V1
+ExceptionThrownStop
 MethodDCEndILToNativeMap
 MethodDCEnd_V1
 MethodDCEndVerbose_V1

--- a/src/mono/mono/eventpipe/gen-eventing-event-inc.lst
+++ b/src/mono/mono/eventpipe/gen-eventing-event-inc.lst
@@ -9,7 +9,13 @@ DCEndInit_V1
 DomainModuleDCEnd_V1
 DomainModuleLoad_V1
 EEStartupStart_V1
+ExceptionCatchStart
+ExceptionCatchStop
 ExecutionCheckpointDCEnd
+ExceptionFilterStart
+ExceptionFilterStop
+ExceptionFinallyStart
+ExceptionFinallyStop
 ExceptionThrown_V1
 MethodDCEndILToNativeMap
 MethodDCEnd_V1

--- a/src/mono/mono/metadata/gc-internals.h
+++ b/src/mono/mono/metadata/gc-internals.h
@@ -86,7 +86,7 @@ extern void mono_gc_set_stack_end (void *stack_end);
  * Not exported in public headers, but can be linked to (unsupported).
  */
 gboolean mono_object_is_alive (MonoObject* obj);
-gboolean mono_gc_is_finalizer_thread (MonoThread *thread);
+MONO_COMPONENT_API gboolean mono_gc_is_finalizer_thread (MonoThread *thread);
 
 void mono_gchandle_set_target (MonoGCHandle gchandle, MonoObject *obj);
 

--- a/src/mono/mono/metadata/object-internals.h
+++ b/src/mono/mono/metadata/object-internals.h
@@ -1751,7 +1751,7 @@ mono_object_clone_checked (MonoObject *obj, MonoError *error);
 MonoObjectHandle
 mono_object_clone_handle (MonoObjectHandle obj, MonoError *error);
 
-MonoObject *
+MONO_COMPONENT_API MonoObject *
 mono_object_isinst_checked (MonoObject *obj, MonoClass *klass, MonoError *error);
 
 MonoObjectHandle

--- a/src/mono/mono/metadata/profiler-private.h
+++ b/src/mono/mono/metadata/profiler-private.h
@@ -157,6 +157,9 @@ mono_profiler_clauses_enabled (void)
 	return mono_profiler_state.clauses;
 }
 
+MONO_COMPONENT_API gboolean
+mono_component_profiler_clauses_enabled (void);
+
 #define _MONO_PROFILER_EVENT(name, ...) \
 	ICALL_EXPORT void mono_profiler_raise_ ## name (__VA_ARGS__);
 #define MONO_PROFILER_EVENT_0(name, type) \

--- a/src/mono/mono/metadata/profiler.c
+++ b/src/mono/mono/metadata/profiler.c
@@ -595,6 +595,12 @@ mono_profiler_enable_clauses (void)
 	return mono_profiler_state.clauses = TRUE;
 }
 
+gboolean
+mono_component_profiler_clauses_enabled (void)
+{
+	return mono_profiler_clauses_enabled ();
+}
+
 /**
  * mono_profiler_set_call_instrumentation_filter_callback:
  *


### PR DESCRIPTION
Mono profiler event | NativeRuntimeEvent
------------ | -------------
image_unloaded | FireEtwModuleUnload_V2
assembly_unloaded | FireEtwAssemblyUnload_V1
thread_started | FireEtwThreadCreated
thread_stopped | FireEtwThreadTerminated
class_loading | FireEtwTypeLoadStart
class_failed | FireEtwTypeLoadStop
class_loaded | FireEtwTypeLoadStop
exception_throw | FireEtwExceptionThrown_V1
exception_clause (MONO_EXCEPTION_CLAUSE_FAULT or MONO_EXCEPTION_CLAUSE_FAULT) | FireEtwExceptionCatchStart + FireEtwExceptionCatchStop
exception_clause (MONO_EXCEPTION_CLAUSE_FILTER) | FireEtwExceptionFilterStart + FireEtwExceptionFilterStop
exception_clause (MONO_EXCEPTION_CLAUSE_FINALLY) | FireEtwExceptionFinallyStart + FireEtwExceptionFinallyStop
monitor_contention | FireEtwContentionStart_V1
monitor_acquired | FireEtwContentionStop
monitor_failed | FireEtwContentionStop
jit_code_buffer | FireEtwMethodJitMemoryAllocatedForCode

New events gives even more metrics into nettrace file. Using added metrics it is now possible to look at what methods loads most types, throws most exceptions, JIT most methods, etc in perfview:

![image](https://user-images.githubusercontent.com/11529140/120662650-9e47c780-c489-11eb-9347-c5e9b9d5758e.png)

It is also possible to look at callstacks/threads with most monitor contention:

![image](https://user-images.githubusercontent.com/11529140/120663061-fc74aa80-c489-11eb-873a-6c523bc49407.png)

as well as getting even more detailed flame graphs:

![image](https://user-images.githubusercontent.com/11529140/120663421-4a89ae00-c48a-11eb-9d76-fbda32371796.png)

Just to name a few ways to use additional profiling data.