### PR TITLE
Disable BundleExtractToSpecificPath tests on Linux due to same problems

### DIFF
--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleExtractToSpecificPath.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleExtractToSpecificPath.cs
@@ -15,6 +15,7 @@ using Xunit;
 
 namespace AppHost.Bundle.Tests
 {
+    [Trait("category", "FlakyAppHostTests")]
     public class BundleExtractToSpecificPath : BundleTestBase, IClassFixture<BundleExtractToSpecificPath.SharedTestState>
     {
         private SharedTestState sharedTestState;
@@ -43,7 +44,7 @@ namespace AppHost.Bundle.Tests
             var extractBaseDir = BundleHelper.GetExtractionRootDir(fixture);
             extractBaseDir.Should().NotHaveDirectory(BundleHelper.GetAppBaseName(fixture));
 
-            // Run the bundled app for the first time, and extract files to 
+            // Run the bundled app for the first time, and extract files to
             // $DOTNET_BUNDLE_EXTRACT_BASE_DIR/<app>/bundle-id
             Command.Create(singleFile)
                 .CaptureStdErr()
@@ -115,7 +116,7 @@ namespace AppHost.Bundle.Tests
             // Create a directory for extraction.
             var extractBaseDir = BundleHelper.GetExtractionRootDir(fixture);
 
-            // Run the bunded app for the first time, and extract files to 
+            // Run the bunded app for the first time, and extract files to
             // $DOTNET_BUNDLE_EXTRACT_BASE_DIR/<app>/bundle-id
             Command.Create(singleFile)
                 .CaptureStdErr()
@@ -165,7 +166,7 @@ namespace AppHost.Bundle.Tests
             // Create a directory for extraction.
             var extractBaseDir = BundleHelper.GetExtractionRootDir(fixture);
 
-            // Run the bunded app for the first time, and extract files to 
+            // Run the bunded app for the first time, and extract files to
             // $DOTNET_BUNDLE_EXTRACT_BASE_DIR/<app>/bundle-id
             Command.Create(singleFile)
                 .CaptureStdErr()


### PR DESCRIPTION
Tracking issue is at https://github.com/dotnet/runtime/issues/44657.

Tests should still be running in the staging build so we can probably still investigate the issue there.