### PR TITLE
Adjust composite build exclusion list

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.Composite.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.Composite.sfxproj
@@ -20,6 +20,7 @@
     <PlatformManifestFileEntry Include="Microsoft.NETCore.App.Composite.r2r.dll" IsNative="true" />
     <PublishReadyToRunCompositeExclusions Include="System.Reflection.Metadata.dll" />
     <PublishReadyToRunCompositeExclusions Include="System.Collections.Immutable.dll" />
+    <PublishReadyToRunCompositeExclusions Include="System.Runtime.CompilerServices.Unsafe.dll" />
   </ItemGroup>
 
  <ItemGroup>


### PR DESCRIPTION
Add System.Runtime.CompilerServices.Unsafe.dll to the list of dlls not part of the composite image to make roslyn work with the composite build
This will hopefully enable some sdk style scenarios for the composite container build experiments