### PR TITLE
Missing `Dispose` after `RemoteExecutor.Invoke`

### DIFF
--- a/src/libraries/Microsoft.Win32.SystemEvents/tests/SystemEvents.InvokeOnEventsThread.cs
+++ b/src/libraries/Microsoft.Win32.SystemEvents/tests/SystemEvents.InvokeOnEventsThread.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Win32.SystemEventsTests
 
                 Assert.True(changing);
                 Assert.True(changed);
-            });
+            }).Dispose();
         }
     }
 }


### PR DESCRIPTION
Causes test failures when run locally.