### PR TITLE
Possible leak of a weak handle in `Gen2GcCallback`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Gen2GcCallback.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Gen2GcCallback.cs
@@ -71,6 +71,7 @@ namespace System
                     if (!_callback1(targetObj))
                     {
                         // If the callback returns false, this callback object is no longer needed.
+                        _weakTargetObj.Free();
                         return;
                     }
                 }


### PR DESCRIPTION
I do not think we have an actual leak since no users of `Gen2GcCallback` ever return `false` from the callback.

If someone returns `false` though, I think we should free the handle, since we might not get another chance.