### PR TITLE
Create dotnet symlink during RPM install

### DIFF
--- a/src/installer/pkg/sfx/installers/dotnet-host.proj
+++ b/src/installer/pkg/sfx/installers/dotnet-host.proj
@@ -17,6 +17,9 @@
     <IncludeVersionInMacOSComponentName>false</IncludeVersionInMacOSComponentName>
     <MacOSScriptsDirectory>osx_scripts/host</MacOSScriptsDirectory>
     <MacOSPackageDescription>The .NET Shared Host.</MacOSPackageDescription>
+    <RpmScriptsDirectory>$(MSBuildThisFileDirectory)rpm_scripts/host</RpmScriptsDirectory>
+    <RpmAfterInstallScript>$(RpmScriptsDirectory)/after_install.sh</RpmAfterInstallScript>
+    <RpmAfterRemoveScript>$(RpmScriptsDirectory)/after_remove.sh</RpmAfterRemoveScript>
   </PropertyGroup>
 
   <ItemGroup>
@@ -68,6 +71,8 @@
     <ItemGroup>
       <DebJsonProperty Include="symlinks" Object="{ &quot;dotnet&quot;: &quot;/usr/bin/dotnet&quot; }" />
       <RpmJsonProperty Include="directories" Object="[ &quot;/usr/share/dotnet&quot;, &quot;/usr/share/doc/dotnet-host&quot; ]" />
+      <RpmJsonProperty Include="after_install_source" Object="&quot;$(RpmAfterInstallScript)&quot;" />
+      <RpmJsonProperty Include="after_remove_source" Object="&quot;$(RpmAfterRemoveScript)&quot;" />
       <PackageConflictsProperty Include="package_conflicts" Object="[ &quot;dotnet&quot;, &quot;dotnet-nightly&quot; ]" />
       <DebJsonProperty Include="@(PackageConflictsProperty)" />
       <RpmJsonProperty Include="@(PackageConflictsProperty)" />

--- a/src/installer/pkg/sfx/installers/rpm_scripts/host/after_install.sh
+++ b/src/installer/pkg/sfx/installers/rpm_scripts/host/after_install.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [[ -L /usr/local/bin/dotnet ]]; then
+  rm /usr/local/bin/dotnet
+fi
+ln -s /usr/share/dotnet/dotnet /usr/local/bin/dotnet
+

--- a/src/installer/pkg/sfx/installers/rpm_scripts/host/after_remove.sh
+++ b/src/installer/pkg/sfx/installers/rpm_scripts/host/after_remove.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+if [[ -L /usr/local/bin/dotnet ]]; then
+  rm /usr/local/bin/dotnet && \
+fi
+


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/53543

RPM packages are not creating symlink for 'dotnet' command anymore. This PR adds 2 scripts, one that runs during package install, the other during package uninstall.