### PR TITLE
Implement descr_generations_to_profiler for regions

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -15503,9 +15503,9 @@ int bgc_allocate_spin(size_t min_gc_size, size_t bgc_begin_size, size_t bgc_size
         return 0;
     }
 
-    if (((bgc_begin_size / end_size) >= 2) || (bgc_size_increased >= bgc_begin_size))
+    if ((bgc_begin_size >= (2 * end_size)) || (bgc_size_increased >= bgc_begin_size))
     {
-        if ((bgc_begin_size / end_size) >= 2)
+        if (bgc_begin_size >= (2 * end_size))
         {
             dprintf (3, ("alloc-ed too much before bgc started"));
         }
@@ -39704,9 +39704,6 @@ go_through_refs:
 
 void gc_heap::descr_generations_to_profiler (gen_walk_fn fn, void *context)
 {
-#ifdef USE_REGIONS
-    assert (!"not impl!!");
-#else
 #ifdef MULTIPLE_HEAPS
     for (int i = 0; i < n_heaps; i++)
     {
@@ -39725,6 +39722,16 @@ void gc_heap::descr_generations_to_profiler (gen_walk_fn fn, void *context)
         {
             generation* gen = hp->generation_of (curr_gen_number);
             heap_segment* seg = generation_start_segment (gen);
+#ifdef USE_REGIONS
+            while (seg)
+            {
+                fn(context, curr_gen_number, heap_segment_mem (seg),
+                                              heap_segment_allocated (seg),
+                                              heap_segment_reserved (seg));
+
+                seg = heap_segment_next (seg);
+            }
+#else
             while (seg && (seg != hp->ephemeral_heap_segment))
             {
                 assert (curr_gen_number > 0);
@@ -39777,9 +39784,9 @@ void gc_heap::descr_generations_to_profiler (gen_walk_fn fn, void *context)
                                                   heap_segment_reserved (hp->ephemeral_heap_segment) );
                 }
             }
+#endif //USE_REGIONS
         }
     }
-#endif //USE_REGIONS
 }
 
 #ifdef TRACE_GC

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -843,9 +843,9 @@ void __stdcall UpdateGenerationBounds()
             RETURN;
         newGenerationTable->count = 0;
         newGenerationTable->capacity = GenerationTable::defaultCapacity;
-        // if there is already a current table, use its count as a guess for the capacity
+        // if there is already a current table, use its capacity as a guess for the capacity
         if (s_currentGenerationTable != NULL)
-            newGenerationTable->capacity = s_currentGenerationTable->count;
+            newGenerationTable->capacity = s_currentGenerationTable->capacity;
         newGenerationTable->prev = NULL;
         newGenerationTable->genDescTable = new (nothrow) GenerationDesc[newGenerationTable->capacity];
         if (newGenerationTable->genDescTable == NULL)

--- a/src/tests/profiler/native/gcbasicprofiler/gcbasicprofiler.cpp
+++ b/src/tests/profiler/native/gcbasicprofiler/gcbasicprofiler.cpp
@@ -50,9 +50,6 @@ HRESULT GCBasicProfiler::Shutdown()
     return S_OK;
 }
 
-// filler for empty generations: x86 - 0xc; ia64 - 0x18
-#define GEN_FILLER 0x18
-
 HRESULT GCBasicProfiler::GarbageCollectionStarted(int cGenerations, BOOL generationCollected[], COR_PRF_GC_REASON reason)
 {
     SHUTDOWNGUARD();
@@ -80,43 +77,11 @@ HRESULT GCBasicProfiler::GarbageCollectionStarted(int cGenerations, BOOL generat
             return S_OK;
         }
 
-        // Assuming an initial gc heap like this.
-        //
-        // Generation: 3	Start: 1ee1000	Length: 2030	Reserved: fff000	// big objects
-        // Generation: 2	Start: 7a8d0bbc Length: 1fd1c	Reserved: 1fd1c		// frozen objects (per module)
-        // Generation: 2	Start: 3120004	Length: c		Reserved: c			// debug build only, internal
-        // Generation: 2	Start: 5ba29b7c	Length: 465f0	Reserved: 465f0		// frozen objects (per module)
-        // Generation: 2	Start: ee1000	Length: c		Reserved: c			// empty, with filler
-        // Generation: 1	Start: ee100c	Length: c		Reserved: c			// empty, with filler
-        // Generation: 0	Start: ee1018	Length: 15b8	Reserved: ffefe8	// new objects
-
-        // loop through generations from 0 to 3
+        // loop through all ranges
         for (int i = nObjectRanges - 1; i >= 0; i--)
         {
-            switch (objectRanges[i].generation)
+            if (0 > objectRanges[i].generation || objectRanges[i].generation > 4)
             {
-            case 0:
-            case 3:
-            case 4:
-                // no useful verification
-                break;
-            case 1:
-                if (objectRanges[i].rangeLength > GEN_FILLER)
-                {
-                    _failures++;
-                    printf("GCBasicProfiler::GarbageCollectionStarted: FAIL: Expected initial gen1 rangeLength <= 0x%x. rangeLength=0x%p\n",
-                        GEN_FILLER, (void*)objectRanges[i].rangeLength);
-                }
-                if (objectRanges[i].rangeLengthReserved > GEN_FILLER)
-                {
-                    _failures++;
-                    printf("GCBasicProfiler::GarbageCollectionStarted: FAIL: Expected initial gen1 rangeLengthReserved <= 0x%x. rangeLengthReserved=0x%p\n",
-                        GEN_FILLER, (void*)objectRanges[i].rangeLengthReserved);
-                }
-                break;
-            case 2:
-                break;
-            default:
                 _failures++;
                 printf("GCBasicProfiler::GarbageCollectionStarted: FAIL: invalid generation: %d\n",objectRanges[i].generation);
             }

--- a/src/tests/profiler/native/gcbasicprofiler/gcbasicprofiler.cpp
+++ b/src/tests/profiler/native/gcbasicprofiler/gcbasicprofiler.cpp
@@ -76,7 +76,6 @@ HRESULT GCBasicProfiler::GarbageCollectionStarted(int cGenerations, BOOL generat
             printf("GCBasicProfiler::GarbageCollectionStarted: FAIL: GetGenerationBounds hr=0x%x\n", hr);
             return S_OK;
         }
-
         // loop through all ranges
         for (int i = nObjectRanges - 1; i >= 0; i--)
         {
@@ -86,7 +85,16 @@ HRESULT GCBasicProfiler::GarbageCollectionStarted(int cGenerations, BOOL generat
                 printf("GCBasicProfiler::GarbageCollectionStarted: FAIL: invalid generation: %d\n",objectRanges[i].generation);
             }
         }
+        if (nObjectRanges > 3 && objectRanges[2].generation == 2 && objectRanges[2].rangeLength == 0x18 && objectRanges[2].generation == 1)
+        {
+            if (objectRanges[3].rangeLength != 0x18)
+            {
+                _failures++;
+                printf("GCBasicProfiler::GarbageCollectionStarted: FAIL: in the first GC for the segment case, gen 1 should have size 0x18");
+            }
+        }
     }
+
     return S_OK;
 }
 


### PR DESCRIPTION
In this change, I made the `gcbasic` profiler test work under `USE_REGIONS`. There are a few changes:

- In `bgc_allocate_spin`, if we happen to have an empty LOH, it is possible that `end_size` is 0 and the subsequent code will fail with a division by 0 error. This happens deterministically for the `gcbasic` profiler test.

- I provided an implementation to `descr_generations_to_profiler`, this is straightforward.

- In `UpdateGenerationBounds`, I changed the heuristic from using the last `count` as the `capacity` to use the last `capacity` as the `capacity` instead. (See explanation below)

- I eliminated the `FILLER` check in the `gcbasic` test case. The check is no longer valid for regions. By default, we allocate an empty region to gen 1. I am not sure the value of that check, so I just deleted it to unblock myself. That check is still valid in the segments' case. If we could easily figure out which case we are in, we might be able to keep the check.

The capacity change is a bit tricky to explain, let's consider this case:

Someone allocated a large object, the GC will create a new region. It will call `UpdateGenerationBounds`.
Suppose we have just got the 41st region when the table has a capacity of 40, the table's capacity will be doubled to 80 and the count will turn 41.

Next time around, when someone allocated a large object again, the GC will create another region. This time the table will be initialized with the last count (which is 41) and we need to store 42 regions into it, so the table's capacity will be doubled to 82 and the count will turn 42.

In this way, every future allocation will lead to the doubling work code path, and that's not ideal.

The system doesn't like more than one label, so I will add the GC team here.
@dotnet/gc 