### PR TITLE
allow late certificate with disabled renegotiation

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -914,11 +914,12 @@ namespace System.Net.Security
                             // If that happen before EncryptData() runs, _handshakeWaiter will be set to null
                             // and EncryptData() will work normally e.g. no waiting, just exclusion with DecryptData()
 
-                            if (_sslAuthenticationOptions!.AllowRenegotiation || SslProtocol == SslProtocols.Tls13)
+                            if (_sslAuthenticationOptions!.AllowRenegotiation || SslProtocol == SslProtocols.Tls13 || _nestedAuth != 0)
                             {
                                 // create TCS only if we plan to proceed. If not, we will throw in block bellow outside of the lock.
                                 // Tls1.3 does not have renegotiation. However on Windows this error code is used
                                 // for session management e.g. anything lsass needs to see.
+                                // We also allow it when explicitly requested using RenegotiateAsync().
                                 _handshakeWaiter = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                             }
                         }


### PR DESCRIPTION
Motivation: In the past we did not have API to trigger renegotiation so the `AllowRenegotiation` property really controlled behavior when renegotiation was requested by remote peer. HTTP/2 explicitly prohibits it so Kestrel would set it to `false` any time when HTTP/2 is possibility. However there is no way how to turn it back on when HTTP/1 is negotiated. That can break the late certificate per specific URL even if HTTP/1 is negotiated. 
With this change, we would allow renegotiation if explicitly requested on server side using `NegotiateClientCertificateAsync()`. Note, that this is only during that particular call e.g. when `NegotiateClientCertificateAsync` is finished we would again respect the properly and block renegotiation requested by peer as we used to. That should make intro with HTTP/2 easier. Since SslStream does not really care about application protocols it is up to the caller to decide if this is appropriate e.g. if HTTP/2 is used or not. (TLS RFC does not care) 

contributes to #49346 

cc: @Tratcher 