### PR TITLE
[wasm] Make assertion exit with -1

### DIFF
--- a/src/mono/mono/eglib/goutput.c
+++ b/src/mono/mono/eglib/goutput.c
@@ -207,7 +207,7 @@ g_assertion_message (const gchar *format, ...)
 	failure_assertion = g_logv_nofree (G_LOG_DOMAIN, G_LOG_LEVEL_ERROR, format, args);
 
 	va_end (args);
-	exit (0);
+	exit (-1);
 }
 
 // Emscriptem emulates varargs, and fails to stack pack multiple outgoing varargs areas,


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/issues/53588

This change makes the test in above issue fail:

    fail: console.error: * Assertion at C:/Users/rodo/git/wa-main/src/mono/mono/mini/mini-exceptions.c:3957, condition `<disabled>' not met

    fail:

    info: console.info: Arguments: --run,WasmTestRunner.dll,System.Buffers.Tests.dll,-notrait,category=OuterLoop,-notrait,category=failing
    info: console.debug: MONO_WASM: Initializing mono runtime
    info: console.debug: MONO_WASM: ICU data archive(s) loaded, disabling invariant mode
    info: console.debug: mono_wasm_runtime_ready fe00e07a-5519-4dfe-b35a-f867dbaf2e28
    info: console.info: Initializing.....
    info: Discovering: System.Buffers.Tests.dll (method display = ClassAndMethod, method display options = None)
    info: Discovered:  System.Buffers.Tests.dll (found 42 of 44 test cases)
    info: Starting:    System.Buffers.Tests.dll
    info: Process v8.cmd exited with -1

    fail: Application has finished with exit code -1 but 0 was expected
    XHarness exit code: 71 (GENERAL_FAILURE)