### PR TITLE
Eliminate intermediate casts to double on ARM64

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -262,7 +262,7 @@ GenTree* Compiler::fgMorphCast(GenTree* tree)
     // AArch, unlike x86/amd64, has instructions that can cast directly from
     // all integers (except for longs on AArch32 of course) to floats.
     // Because there is no IL instruction conv.r4.un, uint/ulong -> float
-    // casts are always inported as CAST(float <- CAST(double <- uint/ulong)).
+    // casts are always imported as CAST(float <- CAST(double <- uint/ulong)).
     // We can eliminate the redundant intermediate cast as an optimization.
     else if ((dstType == TYP_FLOAT) && (srcType == TYP_DOUBLE) && oper->OperIs(GT_CAST)
 #ifdef TARGET_ARM

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -258,17 +258,26 @@ GenTree* Compiler::fgMorphCast(GenTree* tree)
     }
 #endif //! TARGET_64BIT
 
+#ifdef TARGET_ARMARCH
+    // AArch, unlike x86/amd64, has instructions that can cast directly from
+    // all integers (except for longs on AArch32 of course) to floats.
+    // Because there is no IL instruction conv.r4.un, uint/ulong -> float
+    // casts are always inported as CAST(float <- CAST(double <- uint/ulong)).
+    // We can eliminate the redundant intermediate cast as an optimization.
+    else if ((dstType == TYP_FLOAT) && (srcType == TYP_DOUBLE) && oper->OperIs(GT_CAST)
 #ifdef TARGET_ARM
-    else if ((dstType == TYP_FLOAT) && (srcType == TYP_DOUBLE) && (oper->gtOper == GT_CAST) &&
-             !varTypeIsLong(oper->AsCast()->CastOp()))
+             && !varTypeIsLong(oper->AsCast()->CastOp())
+#endif
+                 )
     {
-        // optimization: conv.r4(conv.r8(?)) -> conv.r4(d)
-        // except when the ultimate source is a long because there is no long-to-float helper, so it must be 2 step.
-        // This happens semi-frequently because there is no IL 'conv.r4.un'
         oper->gtType       = TYP_FLOAT;
         oper->CastToType() = TYP_FLOAT;
+
         return fgMorphTree(oper);
     }
+#endif // TARGET_ARMARCH
+
+#ifdef TARGET_ARM
     // converts long/ulong --> float/double casts into helper calls.
     else if (varTypeIsFloating(dstType) && varTypeIsLong(srcType))
     {


### PR DESCRIPTION
In rewriting `fgMorphCast`, I've noticed there was a minor missed optimization opportunity.

This enables the same optimization that has been there for a while for AArch32 for AArch64 too.
```
// AArch, unlike x86/amd64, has instructions that can cast directly from
// all integers (except for longs on AArch32 of course) to floats.
// Because there is no IL instruction conv.r4.un, uint/ulong -> float
// casts are always imported as CAST(float <- CAST(double <- uint/ulong)).
// We can eliminate the redundant intermediate cast as an optimization.
```
Some minor positive diffs for this change on `linux-arm64`:
<details>
<summary>Linux ARM64 SPMI run</summary>

```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 2158532
Total bytes of diff: 2148788
Total bytes of delta: -9744 (-0.45% of base)
    diff is an improvement.


Top method regressions (bytes):
        1352 ( 8.27% of base) - lclfldadd:Main():int
         752 ( 4.44% of base) - lclfldsub:Main():int
         488 ( 2.57% of base) - lclflddiv:Main():int

Top method improvements (bytes):
        -896 (-0.89% of base) - r4rem:Main():int
        -896 (-0.92% of base) - r4div:Main():int
        -712 (-3.81% of base) - lclfldsub:Main():int
        -672 (-0.52% of base) - u8rem:Main():int
        -672 (-0.55% of base) - u4div:Main():int
        -672 (-0.60% of base) - u8div:Main():int
        -672 (-0.47% of base) - u4rem:Main():int
        -660 (-0.50% of base) - r4rem:Main():int
        -644 (-0.52% of base) - r4div:Main():int
        -640 (-3.66% of base) - lclfldmul:Main():int
        -616 (-0.46% of base) - u8div:Main():int
        -616 (-3.65% of base) - lclfldadd:Main():int
        -612 (-0.43% of base) - u4div:Main():int
        -604 (-0.38% of base) - u4rem:Main():int
        -600 (-0.40% of base) - u8rem:Main():int
        -388 (-2.24% of base) - lclfldmul:Main():int
        -160 (-0.34% of base) - lclfldrem:Main():int
        -160 (-0.38% of base) - lclflddiv:Main():int
        -160 (-0.41% of base) - lclfldmul:Main():int
        -160 (-0.41% of base) - lclfldsub:Main():int

Top method regressions (percentages):
        1352 ( 8.27% of base) - lclfldadd:Main():int
         752 ( 4.44% of base) - lclfldsub:Main():int
         488 ( 2.57% of base) - lclflddiv:Main():int

Top method improvements (percentages):
          -8 (-28.57% of base) - TestApp:test_0_10(float,AA,AA):float
          -8 (-28.57% of base) - TestApp:test_0_10(float,AA,AA):float
          -8 (-28.57% of base) - TestApp:test_7_10(float,long,long):float
          -8 (-28.57% of base) - TestApp:test_1_10(float,byref,byref):float
          -8 (-25.00% of base) - TestApp:test_1_10(float,byref,byref):float
          -8 (-18.18% of base) - TestApp:test_4_10(float):float
          -4 (-16.67% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ConvertToSingle(int):float
          -8 (-14.29% of base) - CC:Static3(short):float
          -8 (-12.50% of base) - TestApp:test_4_10(float):float
          -4 (-9.09% of base) - PrimitiveVT.VT2B:op_Division(PrimitiveVT.VT2A,PrimitiveVT.VT2B):float
          -8 (-7.14% of base) - TestApp:test_2_10(float):float
          -4 (-7.14% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ConvertToSingle(int):float
          -8 (-6.90% of base) - TestApp:test_2_10(float):float
          -8 (-6.67% of base) - Vector:Norm(Vector):Vector
          -8 (-5.71% of base) - Sphere:Normal(Vector):Vector:this
          -4 (-5.00% of base) - ILGEN_0x5c49cb7e:Method_0x19bd6d70(long):float
          -4 (-4.00% of base) - PrimitiveVT.VT2B:op_Division(PrimitiveVT.VT2A,PrimitiveVT.VT2B):float
        -712 (-3.81% of base) - lclfldsub:Main():int
          -8 (-3.77% of base) - TestApp:test_3_10(float):float
          -8 (-3.77% of base) - TestApp:test_3_10(float):float

86 total methods with Code Size differences (83 improved, 3 regressed), 4 unchanged.

Running asm diffs of libraries.crossgen.Linux.arm64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 12092
Total bytes of diff: 12020
Total bytes of delta: -72 (-0.60% of base)
    diff is an improvement.


Top file improvements (bytes):
         -16 : 79825.dasm (-0.91% of base)
          -8 : 52260.dasm (-0.14% of base)
          -8 : 5508.dasm (-0.51% of base)
          -4 : 86971.dasm (-0.54% of base)
          -4 : 87248.dasm (-3.45% of base)
          -4 : 89917.dasm (-2.94% of base)
          -4 : 86970.dasm (-0.50% of base)
          -4 : 89417.dasm (-7.69% of base)
          -4 : 85524.dasm (-7.69% of base)
          -4 : 89382.dasm (-7.69% of base)
          -4 : 85526.dasm (-7.69% of base)
          -4 : 8809.dasm (-0.83% of base)
          -4 : 8815.dasm (-0.69% of base)

13 total files with Code Size differences (13 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -16 (-0.91% of base) - Microsoft.VisualBasic.CompilerServices.Conversions:ToSingle(System.Object,System.Globalization.NumberFormatInfo):float
          -8 (-0.14% of base) - Microsoft.CodeAnalysis.CSharp.Binder:DoUncheckedConversion(byte,Microsoft.CodeAnalysis.ConstantValue):System.Object
          -8 (-0.51% of base) - System.Data.Common.SqlConvert:ConvertToSqlSingle(System.Object):System.Data.SqlTypes.SqlSingle
          -4 (-0.54% of base) - System.Number:NumberToSingleFloatingPointBits(byref,byref):int
          -4 (-3.45% of base) - XoshiroImpl:NextSingle():float:this
          -4 (-2.94% of base) - System.Numerics.Vector:ConvertToSingle(System.Numerics.Vector`1[UInt32]):System.Numerics.Vector`1[Single]
          -4 (-0.50% of base) - System.Number:NumberToHalfFloatingPointBits(byref,byref):ushort
          -4 (-7.69% of base) - System.UInt64:System.IConvertible.ToSingle(System.IFormatProvider):float:this
          -4 (-7.69% of base) - System.Convert:ToSingle(int):float
          -4 (-7.69% of base) - System.UInt32:System.IConvertible.ToSingle(System.IFormatProvider):float:this
          -4 (-7.69% of base) - System.Convert:ToSingle(long):float
          -4 (-0.83% of base) - Unchecked:ConvertUInt64(long):System.Object:this
          -4 (-0.69% of base) - Checked:ConvertUInt64(long):System.Object:this

Top method improvements (percentages):
          -4 (-7.69% of base) - System.UInt64:System.IConvertible.ToSingle(System.IFormatProvider):float:this
          -4 (-7.69% of base) - System.Convert:ToSingle(int):float
          -4 (-7.69% of base) - System.UInt32:System.IConvertible.ToSingle(System.IFormatProvider):float:this
          -4 (-7.69% of base) - System.Convert:ToSingle(long):float
          -4 (-3.45% of base) - XoshiroImpl:NextSingle():float:this
          -4 (-2.94% of base) - System.Numerics.Vector:ConvertToSingle(System.Numerics.Vector`1[UInt32]):System.Numerics.Vector`1[Single]
         -16 (-0.91% of base) - Microsoft.VisualBasic.CompilerServices.Conversions:ToSingle(System.Object,System.Globalization.NumberFormatInfo):float
          -4 (-0.83% of base) - Unchecked:ConvertUInt64(long):System.Object:this
          -4 (-0.69% of base) - Checked:ConvertUInt64(long):System.Object:this
          -4 (-0.54% of base) - System.Number:NumberToSingleFloatingPointBits(byref,byref):int
          -8 (-0.51% of base) - System.Data.Common.SqlConvert:ConvertToSqlSingle(System.Object):System.Data.SqlTypes.SqlSingle
          -4 (-0.50% of base) - System.Number:NumberToHalfFloatingPointBits(byref,byref):ushort
          -8 (-0.14% of base) - Microsoft.CodeAnalysis.CSharp.Binder:DoUncheckedConversion(byte,Microsoft.CodeAnalysis.ConstantValue):System.Object

13 total methods with Code Size differences (13 improved, 0 regressed), 0 unchanged.

Running asm diffs of libraries.crossgen2.Linux.arm64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 13332
Total bytes of diff: 13252
Total bytes of delta: -80 (-0.60% of base)
    diff is an improvement.


Top file improvements (bytes):
         -16 : 135423.dasm (-0.90% of base)
          -8 : 140996.dasm (-0.63% of base)
          -8 : 117524.dasm (-0.14% of base)
          -8 : 1591.dasm (-0.51% of base)
          -4 : 19473.dasm (-0.68% of base)
          -4 : 85055.dasm (-7.69% of base)
          -4 : 19480.dasm (-0.84% of base)
          -4 : 83419.dasm (-3.45% of base)
          -4 : 83684.dasm (-0.49% of base)
          -4 : 81367.dasm (-7.69% of base)
          -4 : 80901.dasm (-2.70% of base)
          -4 : 85053.dasm (-7.69% of base)
          -4 : 83683.dasm (-0.53% of base)
          -4 : 81334.dasm (-7.69% of base)

14 total files with Code Size differences (14 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -16 (-0.90% of base) - Microsoft.VisualBasic.CompilerServices.Conversions:ToSingle(System.Object,System.Globalization.NumberFormatInfo):float
          -8 (-0.63% of base) - Microsoft.VisualBasic.CompilerServices.Conversions:ToSingle(System.Object):float
          -8 (-0.14% of base) - Microsoft.CodeAnalysis.CSharp.Binder:DoUncheckedConversion(byte,Microsoft.CodeAnalysis.ConstantValue):System.Object
          -8 (-0.51% of base) - System.Data.Common.SqlConvert:ConvertToSqlSingle(System.Object):System.Data.SqlTypes.SqlSingle
          -4 (-0.68% of base) - Checked:ConvertUInt64(long):System.Object:this
          -4 (-7.69% of base) - System.Convert:ToSingle(int):float
          -4 (-0.84% of base) - Unchecked:ConvertUInt64(long):System.Object:this
          -4 (-3.45% of base) - XoshiroImpl:NextSingle():float:this
          -4 (-0.49% of base) - System.Number:NumberToHalfFloatingPointBits(byref,byref):ushort
          -4 (-7.69% of base) - System.UInt32:System.IConvertible.ToSingle(System.IFormatProvider):float:this
          -4 (-2.70% of base) - System.Numerics.Vector:ConvertToSingle(System.Numerics.Vector`1[System.UInt32]):System.Numerics.Vector`1[System.Single]
          -4 (-7.69% of base) - System.Convert:ToSingle(long):float
          -4 (-0.53% of base) - System.Number:NumberToSingleFloatingPointBits(byref,byref):int
          -4 (-7.69% of base) - System.UInt64:System.IConvertible.ToSingle(System.IFormatProvider):float:this

Top method improvements (percentages):
          -4 (-7.69% of base) - System.Convert:ToSingle(int):float
          -4 (-7.69% of base) - System.UInt32:System.IConvertible.ToSingle(System.IFormatProvider):float:this
          -4 (-7.69% of base) - System.Convert:ToSingle(long):float
          -4 (-7.69% of base) - System.UInt64:System.IConvertible.ToSingle(System.IFormatProvider):float:this
          -4 (-3.45% of base) - XoshiroImpl:NextSingle():float:this
          -4 (-2.70% of base) - System.Numerics.Vector:ConvertToSingle(System.Numerics.Vector`1[System.UInt32]):System.Numerics.Vector`1[System.Single]
         -16 (-0.90% of base) - Microsoft.VisualBasic.CompilerServices.Conversions:ToSingle(System.Object,System.Globalization.NumberFormatInfo):float
          -4 (-0.84% of base) - Unchecked:ConvertUInt64(long):System.Object:this
          -4 (-0.68% of base) - Checked:ConvertUInt64(long):System.Object:this
          -8 (-0.63% of base) - Microsoft.VisualBasic.CompilerServices.Conversions:ToSingle(System.Object):float
          -4 (-0.53% of base) - System.Number:NumberToSingleFloatingPointBits(byref,byref):int
          -8 (-0.51% of base) - System.Data.Common.SqlConvert:ConvertToSqlSingle(System.Object):System.Data.SqlTypes.SqlSingle
          -4 (-0.49% of base) - System.Number:NumberToHalfFloatingPointBits(byref,byref):ushort
          -8 (-0.14% of base) - Microsoft.CodeAnalysis.CSharp.Binder:DoUncheckedConversion(byte,Microsoft.CodeAnalysis.ConstantValue):System.Object

14 total methods with Code Size differences (14 improved, 0 regressed), 0 unchanged.

Running asm diffs of libraries.pmi.Linux.arm64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 9908
Total bytes of diff: 9860
Total bytes of delta: -48 (-0.48% of base)
    diff is an improvement.


Top file improvements (bytes):
         -16 : 82345.dasm (-1.17% of base)
          -8 : 137843.dasm (-0.84% of base)
          -8 : 22594.dasm (-0.15% of base)
          -8 : 77758.dasm (-0.62% of base)
          -4 : 89757.dasm (-0.74% of base)
          -4 : 89750.dasm (-0.90% of base)

6 total files with Code Size differences (6 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -16 (-1.17% of base) - Microsoft.VisualBasic.CompilerServices.Conversions:ToSingle(System.Object,System.Globalization.NumberFormatInfo):float
          -8 (-0.84% of base) - Microsoft.VisualBasic.CompilerServices.Conversions:ToSingle(System.Object):float
          -8 (-0.15% of base) - Microsoft.CodeAnalysis.CSharp.Binder:DoUncheckedConversion(byte,Microsoft.CodeAnalysis.ConstantValue):System.Object
          -8 (-0.62% of base) - System.Data.Common.SqlConvert:ConvertToSqlSingle(System.Object):System.Data.SqlTypes.SqlSingle
          -4 (-0.74% of base) - Checked:ConvertUInt64(long):System.Object:this
          -4 (-0.90% of base) - Unchecked:ConvertUInt64(long):System.Object:this

Top method improvements (percentages):
         -16 (-1.17% of base) - Microsoft.VisualBasic.CompilerServices.Conversions:ToSingle(System.Object,System.Globalization.NumberFormatInfo):float
          -4 (-0.90% of base) - Unchecked:ConvertUInt64(long):System.Object:this
          -8 (-0.84% of base) - Microsoft.VisualBasic.CompilerServices.Conversions:ToSingle(System.Object):float
          -4 (-0.74% of base) - Checked:ConvertUInt64(long):System.Object:this
          -8 (-0.62% of base) - System.Data.Common.SqlConvert:ConvertToSqlSingle(System.Object):System.Data.SqlTypes.SqlSingle
          -8 (-0.15% of base) - Microsoft.CodeAnalysis.CSharp.Binder:DoUncheckedConversion(byte,Microsoft.CodeAnalysis.ConstantValue):System.Object

6 total methods with Code Size differences (6 improved, 0 regressed), 0 unchanged.

Running asm diffs of libraries_tests.pmi.Linux.arm64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 13276
Total bytes of diff: 13184
Total bytes of delta: -92 (-0.69% of base)
    diff is an improvement.


Top file improvements (bytes):
          -8 : 253764.dasm (-2.33% of base)
          -8 : 192350.dasm (-0.84% of base)
          -4 : 36527.dasm (-1.45% of base)
          -4 : 38114.dasm (-1.30% of base)
          -4 : 38121.dasm (-1.45% of base)
          -4 : 36528.dasm (-1.30% of base)
          -4 : 38077.dasm (-0.98% of base)
          -4 : 38122.dasm (-1.30% of base)
          -4 : 36536.dasm (-1.30% of base)
          -4 : 36491.dasm (-0.98% of base)
          -4 : 36535.dasm (-1.45% of base)
          -4 : 88927.dasm (-0.19% of base)
          -4 : 36492.dasm (-1.16% of base)
          -4 : 38078.dasm (-1.16% of base)
          -4 : 36499.dasm (-1.00% of base)
          -4 : 38085.dasm (-1.00% of base)
          -4 : 5754.dasm (-0.13% of base)
          -4 : 38086.dasm (-1.18% of base)
          -4 : 88926.dasm (-0.28% of base)
          -4 : 36500.dasm (-1.18% of base)

21 total files with Code Size differences (21 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
          -8 (-2.33% of base) - System.Numerics.Tests.GenericVectorTests:ConvertUInt32ToSingle():this
          -8 (-0.84% of base) - Microsoft.VisualBasic.CompilerServices.Conversions:ToSingle(System.Object):float
          -4 (-1.45% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedULongToFloat(long,bool)
          -4 (-1.30% of base) - System.Linq.Expressions.Tests.ConvertTests:VerifyULongToNullableFloat(long,bool)
          -4 (-1.45% of base) - System.Linq.Expressions.Tests.ConvertTests:VerifyUIntToFloat(int,bool)
          -4 (-1.30% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedULongToNullableFloat(long,bool)
          -4 (-0.98% of base) - System.Linq.Expressions.Tests.ConvertTests:VerifyNullableULongToFloat(System.Nullable`1[UInt64],bool)
          -4 (-1.30% of base) - System.Linq.Expressions.Tests.ConvertTests:VerifyUIntToNullableFloat(int,bool)
          -4 (-1.30% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedUIntToNullableFloat(int,bool)
          -4 (-0.98% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableULongToFloat(System.Nullable`1[UInt64],bool)
          -4 (-1.45% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedUIntToFloat(int,bool)
          -4 (-0.19% of base) - System.Dynamic.Runtime.Tests.Test:CalledFrom_ForExpressionConditions()
          -4 (-1.16% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableULongToNullableFloat(System.Nullable`1[UInt64],bool)
          -4 (-1.16% of base) - System.Linq.Expressions.Tests.ConvertTests:VerifyNullableULongToNullableFloat(System.Nullable`1[UInt64],bool)
          -4 (-1.00% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableUIntToFloat(System.Nullable`1[UInt32],bool)
          -4 (-1.00% of base) - System.Linq.Expressions.Tests.ConvertTests:VerifyNullableUIntToFloat(System.Nullable`1[UInt32],bool)
          -4 (-0.13% of base) - System.Text.Json.Tests.JsonDocumentTests:ReadLargeInteger(long)
          -4 (-1.18% of base) - System.Linq.Expressions.Tests.ConvertTests:VerifyNullableUIntToNullableFloat(System.Nullable`1[UInt32],bool)
          -4 (-0.28% of base) - System.Dynamic.Runtime.Tests.Test:CalledFrom_ForExpressionBody()
          -4 (-1.18% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableUIntToNullableFloat(System.Nullable`1[UInt32],bool)

Top method improvements (percentages):
          -8 (-2.33% of base) - System.Numerics.Tests.GenericVectorTests:ConvertUInt32ToSingle():this
          -4 (-1.45% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedULongToFloat(long,bool)
          -4 (-1.45% of base) - System.Linq.Expressions.Tests.ConvertTests:VerifyUIntToFloat(int,bool)
          -4 (-1.45% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedUIntToFloat(int,bool)
          -4 (-1.45% of base) - System.Linq.Expressions.Tests.ConvertTests:VerifyULongToFloat(long,bool)
          -4 (-1.30% of base) - System.Linq.Expressions.Tests.ConvertTests:VerifyULongToNullableFloat(long,bool)
          -4 (-1.30% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedULongToNullableFloat(long,bool)
          -4 (-1.30% of base) - System.Linq.Expressions.Tests.ConvertTests:VerifyUIntToNullableFloat(int,bool)
          -4 (-1.30% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedUIntToNullableFloat(int,bool)
          -4 (-1.18% of base) - System.Linq.Expressions.Tests.ConvertTests:VerifyNullableUIntToNullableFloat(System.Nullable`1[UInt32],bool)
          -4 (-1.18% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableUIntToNullableFloat(System.Nullable`1[UInt32],bool)
          -4 (-1.16% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableULongToNullableFloat(System.Nullable`1[UInt64],bool)
          -4 (-1.16% of base) - System.Linq.Expressions.Tests.ConvertTests:VerifyNullableULongToNullableFloat(System.Nullable`1[UInt64],bool)
          -4 (-1.00% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableUIntToFloat(System.Nullable`1[UInt32],bool)
          -4 (-1.00% of base) - System.Linq.Expressions.Tests.ConvertTests:VerifyNullableUIntToFloat(System.Nullable`1[UInt32],bool)
          -4 (-0.98% of base) - System.Linq.Expressions.Tests.ConvertTests:VerifyNullableULongToFloat(System.Nullable`1[UInt64],bool)
          -4 (-0.98% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableULongToFloat(System.Nullable`1[UInt64],bool)
          -8 (-0.84% of base) - Microsoft.VisualBasic.CompilerServices.Conversions:ToSingle(System.Object):float
          -4 (-0.28% of base) - System.Dynamic.Runtime.Tests.Test:CalledFrom_ForExpressionBody()
          -4 (-0.19% of base) - System.Dynamic.Runtime.Tests.Test:CalledFrom_ForExpressionConditions()

21 total methods with Code Size differences (21 improved, 0 regressed), 0 unchanged.
```
</details>

The regressions (and maybe some improvements too 😄) in tests are because of #53773.