### PR TITLE
Use HMAC one-shot where appropriate

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/HashOneShotHelpers.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/HashOneShotHelpers.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace System.Security.Cryptography
+{
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5350", Justification = "Weak algorithms are used as instructed by the caller")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5351", Justification = "Weak algorithms are used as instructed by the caller")]
+    internal static class HashOneShotHelpers
+    {
+        public static int MacData(
+            HashAlgorithmName hashAlgorithm,
+            ReadOnlySpan<byte> key,
+            ReadOnlySpan<byte> source,
+            Span<byte> destination)
+        {
+            if (hashAlgorithm == HashAlgorithmName.SHA256)
+            {
+                return HMACSHA256.HashData(key, source, destination);
+            }
+            else if (hashAlgorithm == HashAlgorithmName.SHA1)
+            {
+                return HMACSHA1.HashData(key, source, destination);
+            }
+            else if (hashAlgorithm == HashAlgorithmName.SHA512)
+            {
+                return HMACSHA512.HashData(key, source, destination);
+            }
+            else if (hashAlgorithm == HashAlgorithmName.SHA384)
+            {
+                return HMACSHA384.HashData(key, source, destination);
+            }
+            else if (hashAlgorithm == HashAlgorithmName.MD5)
+            {
+                return HMACMD5.HashData(key, source, destination);
+            }
+
+            throw new CryptographicException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithm.Name));
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -126,6 +126,8 @@
              Link="Common\System\Security\Cryptography\EccKeyFormatHelper.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\KeyBlobHelpers.cs"
              Link="Common\System\Security\Cryptography\KeyBlobHelpers.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\HashOneShotHelpers.cs"
+             Link="Common\System\Security\Cryptography\HashOneShotHelpers.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\KeyFormatHelper.cs"
              Link="Common\System\Security\Cryptography\KeyFormatHelper.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\KeySizeHelpers.cs"

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HKDF.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/HKDF.cs
@@ -67,12 +67,8 @@ namespace System.Security.Cryptography
         private static void Extract(HashAlgorithmName hashAlgorithmName, int hashLength, ReadOnlySpan<byte> ikm, ReadOnlySpan<byte> salt, Span<byte> prk)
         {
             Debug.Assert(HashLength(hashAlgorithmName) == hashLength);
-
-            using (IncrementalHash hmac = IncrementalHash.CreateHMAC(hashAlgorithmName, salt))
-            {
-                hmac.AppendData(ikm);
-                GetHashAndReset(hmac, prk);
-            }
+            int written = HashOneShotHelpers.MacData(hashAlgorithmName, salt, ikm, prk);
+            Debug.Assert(written == prk.Length, $"Bytes written is {written} bytes which does not match output length ({prk.Length} bytes)");
         }
 
         /// <summary>


### PR DESCRIPTION
Update to use the HMAC one shots where appropriate.

Most other places that use HMAC either A: Require appending (So `IncrementalHash` is the natural choice) or B: target downlevel frameworks.