### PR TITLE
Replace Values with KeyValuePair enumerator in MemoryCache

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -316,8 +316,11 @@ namespace Microsoft.Extensions.Caching.Memory
         private static void ScanForExpiredItems(MemoryCache cache)
         {
             DateTimeOffset now = cache._lastExpirationScan = cache._options.Clock.UtcNow;
-            foreach (CacheEntry entry in cache._entries.Values)
+
+            foreach (KeyValuePair<object, CacheEntry> item in cache._entries)
             {
+                CacheEntry entry = item.Value;
+
                 if (entry.CheckExpired(now))
                 {
                     cache.RemoveEntry(entry);

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -402,7 +402,7 @@ namespace Microsoft.Extensions.Caching.Memory
 
             // Sort items by expired & priority status
             DateTimeOffset now = _options.Clock.UtcNow;
-            foreach (KeyValuePair<object, CacheEntry> item in cache._entries)
+            foreach (KeyValuePair<object, CacheEntry> item in _entries)
             {
                 CacheEntry entry = item.Value;
                 if (entry.CheckExpired(now))

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -402,8 +402,9 @@ namespace Microsoft.Extensions.Caching.Memory
 
             // Sort items by expired & priority status
             DateTimeOffset now = _options.Clock.UtcNow;
-            foreach (CacheEntry entry in _entries.Values)
+            foreach (KeyValuePair<object, CacheEntry> item in cache._entries)
             {
+                CacheEntry entry = item.Value;
                 if (entry.CheckExpired(now))
                 {
                     entriesToRemove.Add(entry);


### PR DESCRIPTION
ConcurrentDictionary.Values will lock all the locks in the MemoryCache internal _entries ConcurrentDictionary . 
However, using regular dictionary enumerator which returns a KeyValuePair<TKey, TValue> does not cause locking.
This is important in heavy throughput scenarios as accessing .Values could reduce write throughput for the MemoryCache.