### PR TITLE
Add support for multi-arch install locations

### DIFF
--- a/src/installer/tests/HostActivation.Tests/CommandExtensions.cs
+++ b/src/installer/tests/HostActivation.Tests/CommandExtensions.cs
@@ -37,12 +37,17 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
         public static Command DotNetRoot(this Command command, string dotNetRoot, string architecture = null)
         {
+            if (!string.IsNullOrEmpty(architecture))
+            {
+                command = command
+                    .EnvironmentVariable($"DOTNET_ROOT_{architecture.ToUpper()}", dotNetRoot);
+
+                return command;
+            }
+
             command = command
                 .EnvironmentVariable("DOTNET_ROOT", dotNetRoot)
                 .EnvironmentVariable("DOTNET_ROOT(x86)", dotNetRoot);
-            if (!string.IsNullOrEmpty(architecture))
-                command = command
-                    .EnvironmentVariable($"DOTNET_ROOT_{architecture.ToUpper()}", dotNetRoot);
 
             return command;
         }

--- a/src/installer/tests/HostActivation.Tests/CommandExtensions.cs
+++ b/src/installer/tests/HostActivation.Tests/CommandExtensions.cs
@@ -35,11 +35,16 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .CaptureStdErr();
         }
 
-        public static Command DotNetRoot(this Command command, string dotNetRoot)
+        public static Command DotNetRoot(this Command command, string dotNetRoot, string architecture = null)
         {
-            return command
+            command = command
                 .EnvironmentVariable("DOTNET_ROOT", dotNetRoot)
                 .EnvironmentVariable("DOTNET_ROOT(x86)", dotNetRoot);
+            if (!string.IsNullOrEmpty(architecture))
+                command = command
+                    .EnvironmentVariable($"DOTNET_ROOT_{architecture.ToUpper()}", dotNetRoot);
+
+            return command;
         }
 
         public static Command MultilevelLookup(this Command command, bool enable)

--- a/src/installer/tests/HostActivation.Tests/CommandExtensions.cs
+++ b/src/installer/tests/HostActivation.Tests/CommandExtensions.cs
@@ -38,18 +38,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         public static Command DotNetRoot(this Command command, string dotNetRoot, string architecture = null)
         {
             if (!string.IsNullOrEmpty(architecture))
-            {
-                command = command
-                    .EnvironmentVariable($"DOTNET_ROOT_{architecture.ToUpper()}", dotNetRoot);
+                return command.EnvironmentVariable($"DOTNET_ROOT_{architecture.ToUpper()}", dotNetRoot);
 
-                return command;
-            }
-
-            command = command
+            return command
                 .EnvironmentVariable("DOTNET_ROOT", dotNetRoot)
                 .EnvironmentVariable("DOTNET_ROOT(x86)", dotNetRoot);
-
-            return command;
         }
 
         public static Command MultilevelLookup(this Command command, bool enable)

--- a/src/installer/tests/HostActivation.Tests/InstallLocationCommandResultExtensions.cs
+++ b/src/installer/tests/HostActivation.Tests/InstallLocationCommandResultExtensions.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Build.Framework;
+using Microsoft.DotNet.CoreSetup.Test;
+
+namespace HostActivation.Tests
+{
+    internal static class InstallLocationCommandResultExtensions
+    {
+        private static bool IsRunningInWoW64() => OperatingSystem.IsWindows() && !Environment.Is64BitProcess && Environment.Is64BitOperatingSystem;
+
+        public static AndConstraint<CommandResultAssertions> HaveUsedDotNetRootInstallLocation(this CommandResultAssertions assertion, string installLocation)
+        {
+            return assertion.HaveUsedDotNetRootInstallLocation(null, installLocation);
+        }
+
+        public static AndConstraint<CommandResultAssertions> HaveUsedDotNetRootInstallLocation(this CommandResultAssertions assertion, string arch, string installLocation)
+        {
+            string expectedEnvironmentVariable = !string.IsNullOrEmpty(arch) ? $"DOTNET_ROOT_{arch.ToUpper()}" : IsRunningInWoW64() ? "DOTNET_ROOT(x86)" : "DOTNET_ROOT";
+
+            return assertion.HaveStdErrContaining($"Using environment variable {expectedEnvironmentVariable}=[{installLocation}] as runtime location.");
+        }
+
+        public static AndConstraint<CommandResultAssertions> HaveUsedConfigFileInstallLocation(this CommandResultAssertions assertion, string installLocation)
+        {
+            return assertion.HaveStdErrContaining($"Using install location '{installLocation}'.");
+        }
+
+        public static AndConstraint<CommandResultAssertions> HaveUsedGlobalInstallLocation(this CommandResultAssertions assertion, string installLocation)
+        {
+            return assertion.HaveStdErrContaining($"Using global installation location [{installLocation}]");
+        }
+
+        public static AndConstraint<CommandResultAssertions> HaveFoundDefaultInstallLocationInConfigFile(this CommandResultAssertions assertion, string installLocation)
+        {
+            return assertion.HaveStdErrContaining($"Found install location path '{installLocation}'.");
+        }
+
+        public static AndConstraint<CommandResultAssertions> HaveFoundArchSpecificInstallLocationInConfigFile(this CommandResultAssertions assertion, string arch, string installLocation)
+        {
+            return assertion.HaveStdErrContaining($"Found architecture-specific install location path: '{installLocation}' ('{arch}').");
+        }
+    }
+}

--- a/src/installer/tests/HostActivation.Tests/InstallLocationCommandResultExtensions.cs
+++ b/src/installer/tests/HostActivation.Tests/InstallLocationCommandResultExtensions.cs
@@ -12,16 +12,20 @@ namespace HostActivation.Tests
 {
     internal static class InstallLocationCommandResultExtensions
     {
-        private static bool IsRunningInWoW64() => OperatingSystem.IsWindows() && !Environment.Is64BitProcess;
+        private static bool IsRunningInWoW64(string rid) => OperatingSystem.IsWindows() && Environment.Is64BitOperatingSystem && rid.Equals("win-x86");
 
         public static AndConstraint<CommandResultAssertions> HaveUsedDotNetRootInstallLocation(this CommandResultAssertions assertion, string installLocation)
         {
-            return assertion.HaveUsedDotNetRootInstallLocation(null, installLocation);
+            return assertion.HaveUsedDotNetRootInstallLocation(installLocation, null, null);
         }
 
-        public static AndConstraint<CommandResultAssertions> HaveUsedDotNetRootInstallLocation(this CommandResultAssertions assertion, string arch, string installLocation)
+        public static AndConstraint<CommandResultAssertions> HaveUsedDotNetRootInstallLocation(this CommandResultAssertions assertion,
+            string installLocation,
+            string arch,
+            string rid)
         {
-            string expectedEnvironmentVariable = !string.IsNullOrEmpty(arch) ? $"DOTNET_ROOT_{arch.ToUpper()}" : IsRunningInWoW64() ? "DOTNET_ROOT(x86)" : "DOTNET_ROOT";
+            string expectedEnvironmentVariable = !string.IsNullOrEmpty(arch) ? $"DOTNET_ROOT_{arch.ToUpper()}" :
+                IsRunningInWoW64(rid) ? "DOTNET_ROOT(x86)" : "DOTNET_ROOT";
 
             return assertion.HaveStdErrContaining($"Using environment variable {expectedEnvironmentVariable}=[{installLocation}] as runtime location.");
         }
@@ -41,7 +45,7 @@ namespace HostActivation.Tests
             return assertion.HaveStdErrContaining($"Found install location path '{installLocation}'.");
         }
 
-        public static AndConstraint<CommandResultAssertions> HaveFoundArchSpecificInstallLocationInConfigFile(this CommandResultAssertions assertion, string arch, string installLocation)
+        public static AndConstraint<CommandResultAssertions> HaveFoundArchSpecificInstallLocationInConfigFile(this CommandResultAssertions assertion, string installLocation, string arch)
         {
             return assertion.HaveStdErrContaining($"Found architecture-specific install location path: '{installLocation}' ('{arch}').");
         }

--- a/src/installer/tests/HostActivation.Tests/InstallLocationCommandResultExtensions.cs
+++ b/src/installer/tests/HostActivation.Tests/InstallLocationCommandResultExtensions.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using FluentAssertions;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Microsoft.DotNet.CoreSetup.Test;
+using Xunit;
 
 namespace HostActivation.Tests
 {
@@ -14,16 +15,20 @@ namespace HostActivation.Tests
     {
         private static bool IsRunningInWoW64(string rid) => OperatingSystem.IsWindows() && Environment.Is64BitOperatingSystem && rid.Equals("win-x86");
 
-        public static AndConstraint<CommandResultAssertions> HaveUsedDotNetRootInstallLocation(this CommandResultAssertions assertion, string installLocation)
+        public static AndConstraint<CommandResultAssertions> HaveUsedDotNetRootInstallLocation(this CommandResultAssertions assertion, string installLocation, string rid)
         {
-            return assertion.HaveUsedDotNetRootInstallLocation(installLocation, null, null);
+            return assertion.HaveUsedDotNetRootInstallLocation(installLocation, rid, null);
         }
 
         public static AndConstraint<CommandResultAssertions> HaveUsedDotNetRootInstallLocation(this CommandResultAssertions assertion,
             string installLocation,
-            string arch,
-            string rid)
+            string rid,
+            string arch)
         {
+            // If no arch is passed and we are on Windows, we need the used RID for determining whether or not we are running on WoW64.
+            if (string.IsNullOrEmpty(arch))
+                Assert.NotNull(rid);
+
             string expectedEnvironmentVariable = !string.IsNullOrEmpty(arch) ? $"DOTNET_ROOT_{arch.ToUpper()}" :
                 IsRunningInWoW64(rid) ? "DOTNET_ROOT(x86)" : "DOTNET_ROOT";
 

--- a/src/installer/tests/HostActivation.Tests/InstallLocationCommandResultExtensions.cs
+++ b/src/installer/tests/HostActivation.Tests/InstallLocationCommandResultExtensions.cs
@@ -12,7 +12,7 @@ namespace HostActivation.Tests
 {
     internal static class InstallLocationCommandResultExtensions
     {
-        private static bool IsRunningInWoW64() => OperatingSystem.IsWindows() && !Environment.Is64BitProcess && Environment.Is64BitOperatingSystem;
+        private static bool IsRunningInWoW64() => OperatingSystem.IsWindows() && !Environment.Is64BitProcess;
 
         public static AndConstraint<CommandResultAssertions> HaveUsedDotNetRootInstallLocation(this CommandResultAssertions assertion, string installLocation)
         {

--- a/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
+++ b/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
@@ -1,0 +1,126 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Cli.Build.Framework;
+using Microsoft.DotNet.CoreSetup.Test;
+using Microsoft.DotNet.CoreSetup.Test.HostActivation;
+using Xunit;
+
+namespace HostActivation.Tests
+{
+    public class MultiArchInstallLocation : IClassFixture<MultiArchInstallLocation.SharedTestState>
+    {
+        private string InstallLocationFile => Path.Combine(sharedTestState.InstallLocation, "install_location");
+
+        private SharedTestState sharedTestState;
+
+        public MultiArchInstallLocation(SharedTestState fixture)
+        {
+            sharedTestState = fixture;
+        }
+
+        [Fact]
+        public void GlobalInstallation_CurrentArchitectureIsUsedIfEnvVarSet()
+        {
+            var fixture = sharedTestState.PortableAppFixture
+                .Copy();
+
+            var appExe = fixture.TestProject.AppExe;
+            var arch = fixture.RepoDirProvider.BuildArchitecture.ToUpper();
+            Command.Create(appExe)
+                .EnvironmentVariable("COREHOST_TRACE", "1")
+                .EnvironmentVariable($"DOTNET_ROOT_{arch}", fixture.SdkDotnet.BinPath)
+                .CaptureStdErr()
+                .Execute()
+                .Should().HaveStdErrContaining($"DOTNET_ROOT_{arch}");
+        }
+
+        [Fact]
+        public void GlobalInstallation_IfNoArchSpecificEnvVarIsFoundDotnetRootIsUed()
+        {
+            var fixture = sharedTestState.PortableAppFixture
+                .Copy();
+
+            var appExe = fixture.TestProject.AppExe;
+            Command.Create(appExe)
+                .EnableTracingAndCaptureOutputs()
+                .Execute()
+                .Should().HaveStdErrContaining($"DOTNET_ROOT");
+        }
+
+        [Fact]
+        public void GlobalInstallation_ArchSpecificDotnetRootIsUsedOverDotnetRoot()
+        {
+            var fixture = sharedTestState.PortableAppFixture
+                .Copy();
+
+            var appExe = fixture.TestProject.AppExe;
+            var arch = fixture.RepoDirProvider.BuildArchitecture.ToUpper();
+            Command.Create(appExe)
+                .EnableTracingAndCaptureOutputs()
+                .EnvironmentVariable("DOTNET_ROOT", "non_existent_path")
+                .EnvironmentVariable($"DOTNET_ROOT_{arch}", fixture.SdkDotnet.BinPath)
+                .Execute()
+                .Should().HaveStdErrContaining($"DOTNET_ROOT_{arch}")
+                .And.NotHaveStdErrContaining("[DOTNET_ROOT] directory");
+        }
+
+        [Fact]
+        [SkipOnPlatform(TestPlatforms.Windows, "This test targets the install_location config file which is only used on Linux and macOS.")]
+        public void InstallLocationFile_ArchSpecificLocationIsPickedFirst()
+        {
+            var fixture = sharedTestState.PortableAppFixture
+                .Copy();
+
+            var dotnet = fixture.BuiltDotnet;
+            var appDll = fixture.TestProject.AppDll;
+            using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(InstallLocationFile))
+            {
+                registeredInstallLocationOverride.SetInstallLocation(("x/y/z", fixture.RepoDirProvider.BuildArchitecture));
+                dotnet.Exec(appDll)
+                    .EnableTracingAndCaptureOutputs()
+                    .ApplyRegisteredInstallLocationOverride(registeredInstallLocationOverride)
+                    .EnvironmentVariable(Constants.TestOnlyEnvironmentVariables.DefaultInstallPath, InstallLocationFile)
+                    .DotNetRoot(null)
+                    .Execute()
+                    .Should().Pass()
+                    .And.HaveStdErrContaining("");
+            }
+        }
+
+        public class SharedTestState : IDisposable
+        {
+            public string BaseDirectory { get; }
+            public TestProjectFixture PortableAppFixture { get; }
+            public RepoDirectoriesProvider RepoDirectories { get; }
+            public string InstallLocation { get; }
+
+            public SharedTestState()
+            {
+                RepoDirectories = new RepoDirectoriesProvider();
+                var fixture = new TestProjectFixture("PortableApp", RepoDirectories);
+                fixture
+                    .EnsureRestored()
+                    .BuildProject();
+
+                PortableAppFixture = fixture;
+                BaseDirectory = Path.GetDirectoryName(PortableAppFixture.SdkDotnet.GreatestVersionHostFxrFilePath);
+                var install_location_dir = Path.Combine(fixture.TestProject.Location, "install_location");
+                Directory.CreateDirectory(install_location_dir);
+                InstallLocation = install_location_dir;
+            }
+
+            public void Dispose()
+            {
+                PortableAppFixture.Dispose();
+            }
+        }
+    }
+}

--- a/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
+++ b/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
@@ -89,7 +89,7 @@ namespace HostActivation.Tests
                 registeredInstallLocationOverride.SetInstallLocation(new (string, string)[] {
                     (string.Empty, path1),
                     (arch1, path1),
-                    (arch2, path2)
+                    (arch2, path2)EnvironmentVariable_IfNoArchSpecificEnvVarIsFoundDotnetR
                 });
 
                 Command.Create(appExe)
@@ -99,7 +99,6 @@ namespace HostActivation.Tests
                     .Execute()
                     .Should().HaveFoundDefaultInstallLocationInConfigFile(path1)
                     .And.HaveFoundArchSpecificInstallLocationInConfigFile(arch1, path1)
-                    .And.HaveFoundArchSpecificInstallLocationInConfigFile(arch2, path1)
                     .And.HaveFoundArchSpecificInstallLocationInConfigFile(arch2, path2)
                     .And.HaveUsedGlobalInstallLocation(path2);
             }

--- a/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
+++ b/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
@@ -111,10 +111,10 @@ namespace HostActivation.Tests
                 .Copy();
 
             var appExe = fixture.TestProject.AppExe;
-            var arch1 = fixture.RepoDirProvider.BuildArchitecture;
-            var path1 = "a/b/c";
-            var arch2 = "someArch";
-            var path2 = "x/y/z";
+            var arch1 = "someArch";
+            var path1 = "x/y/z";
+            var arch2 = fixture.RepoDirProvider.BuildArchitecture;
+            var path2 = "a/b/c";
 
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(appExe))
             {
@@ -123,6 +123,7 @@ namespace HostActivation.Tests
                     (arch1, path1),
                     (arch2, path2)
                 });
+
                 Command.Create(appExe)
                     .EnableTracingAndCaptureOutputs()
                     .ApplyRegisteredInstallLocationOverride(registeredInstallLocationOverride)
@@ -130,9 +131,9 @@ namespace HostActivation.Tests
                     .Execute()
                     .Should().HaveStdErrContaining($"Found install location path '{path1}'.")
                     .And.HaveStdErrContaining($"Found architecture-specific install location path: '{path1}' ('{arch1}').")
-                    .And.HaveStdErrContaining($"Found architecture-specific install location path matching the current OS architecture ('{arch1}'): '{path1}'.")
                     .And.HaveStdErrContaining($"Found architecture-specific install location path: '{path2}' ('{arch2}').")
-                    .And.HaveStdErrContaining($"Using global installation location [{path1}] as runtime location.");
+                    .And.HaveStdErrContaining($"Found architecture-specific install location path matching the current OS architecture ('{arch2}'): '{path2}'.")
+                    .And.HaveStdErrContaining($"Using global installation location [{path2}] as runtime location.");
             }
         }
 

--- a/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
+++ b/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
@@ -2,12 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Microsoft.DotNet.CoreSetup.Test;
 using Microsoft.DotNet.CoreSetup.Test.HostActivation;
@@ -15,6 +10,7 @@ using Xunit;
 
 namespace HostActivation.Tests
 {
+
     public class MultiArchInstallLocation : IClassFixture<MultiArchInstallLocation.SharedTestState>
     {
         private SharedTestState sharedTestState;

--- a/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
+++ b/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
@@ -181,7 +181,7 @@ namespace HostActivation.Tests
 
             public void Dispose()
             {
-                // StandaloneAppFixture.Dispose();
+                StandaloneAppFixture.Dispose();
             }
         }
     }

--- a/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
+++ b/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
@@ -33,7 +33,7 @@ namespace HostActivation.Tests
                 .DotNetRoot(fixture.BuiltDotnet.BinPath, arch)
                 .Execute()
                 .Should().Pass()
-                .And.HaveUsedDotNetRootInstallLocation(fixture.BuiltDotnet.BinPath, arch, fixture.CurrentRid);
+                .And.HaveUsedDotNetRootInstallLocation(fixture.BuiltDotnet.BinPath, fixture.CurrentRid, arch);
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace HostActivation.Tests
                 .DotNetRoot(fixture.BuiltDotnet.BinPath)
                 .Execute()
                 .Should().Pass()
-                .And.HaveUsedDotNetRootInstallLocation(fixture.BuiltDotnet.BinPath);
+                .And.HaveUsedDotNetRootInstallLocation(fixture.BuiltDotnet.BinPath, fixture.CurrentRid);
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace HostActivation.Tests
                 .DotNetRoot(dotnet, arch)
                 .Execute()
                 .Should().Pass()
-                .And.HaveUsedDotNetRootInstallLocation(dotnet, arch, fixture.CurrentRid)
+                .And.HaveUsedDotNetRootInstallLocation(dotnet, fixture.CurrentRid, arch)
                 .And.NotHaveStdErrContaining("Using environment variable DOTNET_ROOT=");
         }
 

--- a/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
+++ b/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
@@ -33,7 +33,7 @@ namespace HostActivation.Tests
                 .DotNetRoot(fixture.BuiltDotnet.BinPath, arch)
                 .Execute()
                 .Should().Pass()
-                .And.HaveUsedDotNetRootInstallLocation(arch, fixture.BuiltDotnet.BinPath);
+                .And.HaveUsedDotNetRootInstallLocation(fixture.BuiltDotnet.BinPath, arch, fixture.CurrentRid);
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace HostActivation.Tests
                 .DotNetRoot(dotnet, arch)
                 .Execute()
                 .Should().Pass()
-                .And.HaveUsedDotNetRootInstallLocation(arch, dotnet)
+                .And.HaveUsedDotNetRootInstallLocation(dotnet, arch, fixture.CurrentRid)
                 .And.NotHaveStdErrContaining("Using environment variable DOTNET_ROOT=");
         }
 
@@ -98,8 +98,8 @@ namespace HostActivation.Tests
                     .DotNetRoot(null)
                     .Execute()
                     .Should().HaveFoundDefaultInstallLocationInConfigFile(path1)
-                    .And.HaveFoundArchSpecificInstallLocationInConfigFile(arch1, path1)
-                    .And.HaveFoundArchSpecificInstallLocationInConfigFile(arch2, path2)
+                    .And.HaveFoundArchSpecificInstallLocationInConfigFile(path1, arch1)
+                    .And.HaveFoundArchSpecificInstallLocationInConfigFile(path2, arch2)
                     .And.HaveUsedGlobalInstallLocation(path2);
             }
         }

--- a/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
+++ b/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
@@ -89,7 +89,7 @@ namespace HostActivation.Tests
                 registeredInstallLocationOverride.SetInstallLocation(new (string, string)[] {
                     (string.Empty, path1),
                     (arch1, path1),
-                    (arch2, path2)EnvironmentVariable_IfNoArchSpecificEnvVarIsFoundDotnetR
+                    (arch2, path2)
                 });
 
                 Command.Create(appExe)

--- a/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
+++ b/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
@@ -51,7 +51,7 @@ namespace HostActivation.Tests
                 .Execute();
 
             result.Should().Pass();
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && RuntimeInformation.OSArchitecture == Architecture.X86)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && arch == "X86")
                 result.Should().HaveStdErrContaining($"Using environment variable DOTNET_ROOT(x86)=");
             else
                 result.Should().HaveStdErrContaining($"Using environment variable DOTNET_ROOT=");

--- a/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
+++ b/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
@@ -45,12 +45,16 @@ namespace HostActivation.Tests
 
             var appExe = fixture.TestProject.AppExe;
             var arch = fixture.RepoDirProvider.BuildArchitecture.ToUpper();
-            Command.Create(appExe)
+            var result = Command.Create(appExe)
                 .EnableTracingAndCaptureOutputs()
                 .DotNetRoot(fixture.BuiltDotnet.BinPath)
-                .Execute()
-                .Should().Pass()
-                .And.HaveStdErrContaining($"Using environment variable DOTNET_ROOT=");
+                .Execute();
+
+            result.Should().Pass();
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && RuntimeInformation.OSArchitecture == Architecture.X86)
+                result.Should().HaveStdErrContaining($"Using environment variable DOTNET_ROOT(x86)=");
+            else
+                result.Should().HaveStdErrContaining($"Using environment variable DOTNET_ROOT=");
         }
 
         [Fact]

--- a/src/installer/tests/HostActivation.Tests/MultilevelSDKLookup.cs
+++ b/src/installer/tests/HostActivation.Tests/MultilevelSDKLookup.cs
@@ -501,7 +501,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(DotNet.GreatestVersionHostFxrFilePath))
             {
-                registeredInstallLocationOverride.SetInstallLocation(_regDir, RepoDirectories.BuildArchitecture);
+                registeredInstallLocationOverride.SetInstallLocation(new string[] { _regDir }, RepoDirectories.BuildArchitecture);
 
                 // Add SDK versions
                 AddAvailableSdkVersions(_regSdkBaseDir, "9999.0.4");

--- a/src/installer/tests/HostActivation.Tests/MultilevelSDKLookup.cs
+++ b/src/installer/tests/HostActivation.Tests/MultilevelSDKLookup.cs
@@ -501,7 +501,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(DotNet.GreatestVersionHostFxrFilePath))
             {
-                registeredInstallLocationOverride.SetInstallLocation(new string[] { _regDir }, RepoDirectories.BuildArchitecture);
+                registeredInstallLocationOverride.SetInstallLocation(new (string, string)[] { (RepoDirectories.BuildArchitecture, _regDir) });
 
                 // Add SDK versions
                 AddAvailableSdkVersions(_regSdkBaseDir, "9999.0.4");

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/ComhostSideBySide.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/ComhostSideBySide.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
             CommandResult result = Command.Create(sharedState.ComSxsPath, args)
                 .EnableTracingAndCaptureOutputs()
-                .DotNetRoot(sharedState.ComLibraryFixture.BuiltDotnet.BinPath, sharedState.RepoDirectories.BuildArchitecture)
+                .DotNetRoot(sharedState.ComLibraryFixture.BuiltDotnet.BinPath)
                 .MultilevelLookup(false)
                 .Execute();
 
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
             CommandResult result = Command.Create(sharedState.ComSxsPath, args)
                 .EnableTracingAndCaptureOutputs()
-                .DotNetRoot(sharedState.ComLibraryFixture.BuiltDotnet.BinPath, sharedState.RepoDirectories.BuildArchitecture)
+                .DotNetRoot(sharedState.ComLibraryFixture.BuiltDotnet.BinPath)
                 .MultilevelLookup(false)
                 .Execute();
 

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/ComhostSideBySide.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/ComhostSideBySide.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
             CommandResult result = Command.Create(sharedState.ComSxsPath, args)
                 .EnableTracingAndCaptureOutputs()
-                .DotNetRoot(sharedState.ComLibraryFixture.BuiltDotnet.BinPath)
+                .DotNetRoot(sharedState.ComLibraryFixture.BuiltDotnet.BinPath, sharedState.RepoDirectories.BuildArchitecture)
                 .MultilevelLookup(false)
                 .Execute();
 
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
             CommandResult result = Command.Create(sharedState.ComSxsPath, args)
                 .EnableTracingAndCaptureOutputs()
-                .DotNetRoot(sharedState.ComLibraryFixture.BuiltDotnet.BinPath)
+                .DotNetRoot(sharedState.ComLibraryFixture.BuiltDotnet.BinPath, sharedState.RepoDirectories.BuildArchitecture)
                 .MultilevelLookup(false)
                 .Execute();
 

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/Nethost.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/Nethost.cs
@@ -180,21 +180,32 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
         [Theory]
         [SkipOnPlatform(TestPlatforms.Windows, "This test targets the install_location config file which is only used on Linux and macOS.")]
-        [InlineData("{0}", true)]
-        [InlineData("{0}\n", true)]
-        [InlineData("{0}\nSome other text", true)]
-        [InlineData("", false)]
-        [InlineData("\n{0}", false)]
-        [InlineData(" {0}", false)]
-        [InlineData("{0} \n", false)]
-        [InlineData("{0} ", false)]
-        public void GetHostFxrPath_InstallLocationFile(string value, bool shouldPass)
+        [InlineData("{0}", false, true)]
+        [InlineData("{0}\n", false, true)]
+        [InlineData("{0}\nSome other text", false, true)]
+        [InlineData("", false, false)]
+        [InlineData("\n{0}", false, false)]
+        [InlineData(" {0}", false, false)]
+        [InlineData("{0} \n", false, false)]
+        [InlineData("{0} ", false, false)]
+        [InlineData("{0}", true, true)]
+        [InlineData("{0}\n", true, true)]
+        [InlineData("{0}\nSome other text", true, true)]
+        [InlineData("", true, false)]
+        [InlineData("\n{0}", true, false)]
+        [InlineData(" {0}", true, false)]
+        [InlineData("{0} \n", true, false)]
+        [InlineData("{0} ", true, false)]
+        public void GetHostFxrPath_InstallLocationFile(string value, bool shouldUseArchSpecificInstallLocation, bool shouldPass)
         {
             string installLocation = Path.Combine(sharedState.ValidInstallRoot, "dotnet");
 
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(sharedState.NethostPath))
             {
-                registeredInstallLocationOverride.SetInstallLocation((sharedState.RepoDirectories.BuildArchitecture, string.Format(value, installLocation)));
+                if (shouldUseArchSpecificInstallLocation)
+                    registeredInstallLocationOverride.SetInstallLocation((sharedState.RepoDirectories.BuildArchitecture, string.Format(value, installLocation)));
+                else
+                    registeredInstallLocationOverride.SetInstallLocation((string.Empty, string.Format(value, installLocation)));
 
                 CommandResult result = Command.Create(sharedState.NativeHostPath, GetHostFxrPath)
                     .EnableTracingAndCaptureOutputs()

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/Nethost.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/Nethost.cs
@@ -116,7 +116,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             {
                 if (useRegisteredLocation)
                 {
-                    registeredInstallLocationOverride.SetInstallLocation(new string[] { installLocation }, sharedState.RepoDirectories.BuildArchitecture);
+                    registeredInstallLocationOverride.SetInstallLocation((sharedState.RepoDirectories.BuildArchitecture, installLocation));
                 }
 
                 result = Command.Create(sharedState.NativeHostPath, $"{GetHostFxrPath} {explicitLoad} {(useAssemblyPath ? sharedState.TestAssemblyPath : string.Empty)}")
@@ -179,6 +179,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Theory]
+        [SkipOnPlatform(TestPlatforms.Windows, "This test targets the install_location config file which is only used on Linux and macOS.")]
         [InlineData("{0}", true)]
         [InlineData("{0}\n", true)]
         [InlineData("{0}\nSome other text", true)]
@@ -189,15 +190,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         [InlineData("{0} ", false)]
         public void GetHostFxrPath_InstallLocationFile(string value, bool shouldPass)
         {
-            // This test targets the install_location config file which is only used on Linux and macOS.
-            if (OperatingSystem.IsWindows())
-                return;
-
             string installLocation = Path.Combine(sharedState.ValidInstallRoot, "dotnet");
 
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(sharedState.NethostPath))
             {
-                registeredInstallLocationOverride.SetInstallLocation(new string[] { string.Format(value, installLocation) }, sharedState.RepoDirectories.BuildArchitecture);
+                registeredInstallLocationOverride.SetInstallLocation((sharedState.RepoDirectories.BuildArchitecture, string.Format(value, installLocation)));
 
                 CommandResult result = Command.Create(sharedState.NativeHostPath, GetHostFxrPath)
                     .EnableTracingAndCaptureOutputs()
@@ -227,16 +224,15 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Windows, "This test targets the install_location config file which is only used on Linux and macOS.")]
         public void GetHostFxrPath_GlobalInstallation_HasMoreThanOneDefaultInstallationPath()
         {
-            // This test targets the install_location config file which is only used on Linux and macOS.
-            if (OperatingSystem.IsWindows())
-                return;
-
             string installLocation = Path.Combine(sharedState.ValidInstallRoot, "dotnet");
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(sharedState.NethostPath))
             {
-                registeredInstallLocationOverride.SetInstallLocation(new string[] { installLocation, installLocation }, sharedState.RepoDirectories.BuildArchitecture);
+                registeredInstallLocationOverride.SetInstallLocation(new (string, string)[] {
+                    (string.Empty, installLocation), (string.Empty, installLocation)
+                });
 
                 CommandResult result = Command.Create(sharedState.NativeHostPath, GetHostFxrPath)
                     .EnableTracingAndCaptureOutputs()
@@ -257,19 +253,16 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Windows, "This test targets the install_location config file which is only used on Linux and macOS.")]
         public void GetHostFxrPath_GlobalInstallation_HasNoDefaultInstallationPath()
         {
-            // This test targets the install_location config file which is only used on Linux and macOS.
-            if (OperatingSystem.IsWindows())
-                return;
-
             string installLocation = Path.Combine(sharedState.ValidInstallRoot, "dotnet");
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(sharedState.NethostPath))
             {
-                registeredInstallLocationOverride.SetInstallLocation(new string[] {
-                    $"{sharedState.RepoDirectories.BuildArchitecture.ToLower()}={installLocation}",
-                    $"someOtherArch={installLocation}/invalid"
-                }, sharedState.RepoDirectories.BuildArchitecture);
+                registeredInstallLocationOverride.SetInstallLocation(new (string, string)[] {
+                    (sharedState.RepoDirectories.BuildArchitecture, installLocation),
+                    ("someOtherArch", $"{installLocation}/invalid")
+                });
 
                 CommandResult result = Command.Create(sharedState.NativeHostPath, GetHostFxrPath)
                     .EnableTracingAndCaptureOutputs()
@@ -290,19 +283,16 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Windows, "This test targets the install_location config file which is only used on Linux and macOS.")]
         public void GetHostFxrPath_GlobalInstallation_ArchitectureSpecificPathIsPickedOverDefaultPath()
         {
-            // This test targets the install_location config file which is only used on Linux and macOS.
-            if (OperatingSystem.IsWindows())
-                return;
-
             string installLocation = Path.Combine(sharedState.ValidInstallRoot, "dotnet");
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(sharedState.NethostPath))
             {
-                registeredInstallLocationOverride.SetInstallLocation(new string[] {
-                    $"{installLocation}/a/b/c",
-                    $"{sharedState.RepoDirectories.BuildArchitecture.ToLower()}={installLocation}",
-                }, sharedState.RepoDirectories.BuildArchitecture);
+                registeredInstallLocationOverride.SetInstallLocation(new (string, string)[] {
+                    (string.Empty, $"{installLocation}/a/b/c"),
+                    (sharedState.RepoDirectories.BuildArchitecture, installLocation)
+                });
 
                 CommandResult result = Command.Create(sharedState.NativeHostPath, GetHostFxrPath)
                     .EnableTracingAndCaptureOutputs()

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/Nethost.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/Nethost.cs
@@ -276,7 +276,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 result.Should().Pass()
                     .And.HaveStdErrContaining($"Looking for install_location file in '{registeredInstallLocationOverride.PathValueOverride}'.")
                     .And.HaveStdErrContaining($"Found architecture-specific install location path: '{installLocation}' ('{sharedState.RepoDirectories.BuildArchitecture.ToLower()}').")
-                    .And.HaveStdErrContaining($"Found architecture-specific install location path: '{installLocation}/invalid' ('someOtherArch').")
                     .And.HaveStdErrContaining($"Using install location '{installLocation}'.")
                     .And.HaveStdOutContaining($"hostfxr_path: {sharedState.HostFxrPath}".ToLower());
             }

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/Nethost.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/Nethost.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             string dotNetRoot = isValid ? Path.Combine(sharedState.ValidInstallRoot, "dotnet") : sharedState.InvalidInstallRoot;
             CommandResult result = Command.Create(sharedState.NativeHostPath, $"{GetHostFxrPath} {explicitLoad} {(useAssemblyPath ? sharedState.TestAssemblyPath : string.Empty)}")
                 .EnableTracingAndCaptureOutputs()
-                .DotNetRoot(dotNetRoot, sharedState.RepoDirectories.BuildArchitecture)
+                .DotNetRoot(dotNetRoot)
                 .Execute();
 
             result.Should().HaveStdErrContaining("Using environment variable");

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/Nethost.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/Nethost.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             string dotNetRoot = isValid ? Path.Combine(sharedState.ValidInstallRoot, "dotnet") : sharedState.InvalidInstallRoot;
             CommandResult result = Command.Create(sharedState.NativeHostPath, $"{GetHostFxrPath} {explicitLoad} {(useAssemblyPath ? sharedState.TestAssemblyPath : string.Empty)}")
                 .EnableTracingAndCaptureOutputs()
-                .DotNetRoot(dotNetRoot)
+                .DotNetRoot(dotNetRoot, sharedState.RepoDirectories.BuildArchitecture)
                 .Execute();
 
             result.Should().HaveStdErrContaining("Using environment variable");
@@ -179,7 +179,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Theory]
-        [SkipOnPlatform(TestPlatforms.Windows, "This test targets the install_location config file which is only used on Linux and macOS.")]
         [InlineData("{0}", true)]
         [InlineData("{0}\n", true)]
         [InlineData("{0}\nSome other text", true)]
@@ -190,11 +189,15 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         [InlineData("{0} ", false)]
         public void GetHostFxrPath_InstallLocationFile(string value, bool shouldPass)
         {
+            // This test targets the install_location config file which is only used on Linux and macOS.
+            if (OperatingSystem.IsWindows())
+                return;
+
             string installLocation = Path.Combine(sharedState.ValidInstallRoot, "dotnet");
 
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(sharedState.NethostPath))
             {
-                registeredInstallLocationOverride.SetInstallLocation(new string[] { string.Format(value, installLocation) });
+                registeredInstallLocationOverride.SetInstallLocation(new string[] { string.Format(value, installLocation) }, sharedState.RepoDirectories.BuildArchitecture);
 
                 CommandResult result = Command.Create(sharedState.NativeHostPath, GetHostFxrPath)
                     .EnableTracingAndCaptureOutputs()
@@ -224,14 +227,16 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.Windows, "This test targets the install_location config file which is only used on Linux and macOS.")]
         public void GetHostFxrPath_GlobalInstallation_HasMoreThanOneDefaultInstallationPath()
         {
-            string installLocation = Path.Combine(sharedState.ValidInstallRoot, "dotnet");
+            // This test targets the install_location config file which is only used on Linux and macOS.
+            if (OperatingSystem.IsWindows())
+                return;
 
+            string installLocation = Path.Combine(sharedState.ValidInstallRoot, "dotnet");
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(sharedState.NethostPath))
             {
-                registeredInstallLocationOverride.SetInstallLocation(new string[] { installLocation, installLocation });
+                registeredInstallLocationOverride.SetInstallLocation(new string[] { installLocation, installLocation }, sharedState.RepoDirectories.BuildArchitecture);
 
                 CommandResult result = Command.Create(sharedState.NativeHostPath, GetHostFxrPath)
                     .EnableTracingAndCaptureOutputs()
@@ -252,17 +257,19 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.Windows, "This test targets the install_location config file which is only used on Linux and macOS.")]
         public void GetHostFxrPath_GlobalInstallation_HasNoDefaultInstallationPath()
         {
-            string installLocation = Path.Combine(sharedState.ValidInstallRoot, "dotnet");
+            // This test targets the install_location config file which is only used on Linux and macOS.
+            if (OperatingSystem.IsWindows())
+                return;
 
+            string installLocation = Path.Combine(sharedState.ValidInstallRoot, "dotnet");
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(sharedState.NethostPath))
             {
                 registeredInstallLocationOverride.SetInstallLocation(new string[] {
                     $"{sharedState.RepoDirectories.BuildArchitecture.ToLower()}={installLocation}",
                     $"someOtherArch={installLocation}/invalid"
-                });
+                }, sharedState.RepoDirectories.BuildArchitecture);
 
                 CommandResult result = Command.Create(sharedState.NativeHostPath, GetHostFxrPath)
                     .EnableTracingAndCaptureOutputs()
@@ -283,17 +290,19 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.Windows, "This test targets the install_location config file which is only used on Linux and macOS.")]
         public void GetHostFxrPath_GlobalInstallation_ArchitectureSpecificPathIsPickedOverDefaultPath()
         {
-            string installLocation = Path.Combine(sharedState.ValidInstallRoot, "dotnet");
+            // This test targets the install_location config file which is only used on Linux and macOS.
+            if (OperatingSystem.IsWindows())
+                return;
 
+            string installLocation = Path.Combine(sharedState.ValidInstallRoot, "dotnet");
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(sharedState.NethostPath))
             {
                 registeredInstallLocationOverride.SetInstallLocation(new string[] {
                     $"{installLocation}/a/b/c",
                     $"{sharedState.RepoDirectories.BuildArchitecture.ToLower()}={installLocation}",
-                });
+                }, sharedState.RepoDirectories.BuildArchitecture);
 
                 CommandResult result = Command.Create(sharedState.NativeHostPath, GetHostFxrPath)
                     .EnableTracingAndCaptureOutputs()

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/Nethost.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/Nethost.cs
@@ -244,7 +244,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
                 result.Should().Pass()
                     .And.HaveStdErrContaining($"Looking for install_location file in '{registeredInstallLocationOverride.PathValueOverride}'.")
-                    .And.HaveStdOutContaining($"Found install location path '{installLocation}'.")
+                    .And.HaveStdErrContaining($"Found install location path '{installLocation}'.")
                     .And.HaveStdErrContaining($"Only the first line in '{registeredInstallLocationOverride.PathValueOverride}' may not have an architecture prefix.")
                     .And.HaveStdErrContaining($"Using install location '{installLocation}'.")
                     .And.HaveStdOutContaining($"hostfxr_path: {sharedState.HostFxrPath}".ToLower());
@@ -261,7 +261,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             {
                 registeredInstallLocationOverride.SetInstallLocation(new string[] {
                     $"{sharedState.RepoDirectories.BuildArchitecture.ToLower()}={installLocation}",
-                    $"someOtherArch={installLocation}/invalid/"
+                    $"someOtherArch={installLocation}/invalid"
                 });
 
                 CommandResult result = Command.Create(sharedState.NativeHostPath, GetHostFxrPath)
@@ -275,7 +275,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
                 result.Should().Pass()
                     .And.HaveStdErrContaining($"Looking for install_location file in '{registeredInstallLocationOverride.PathValueOverride}'.")
-                    .And.HaveStdOutContaining($"Found architecture-specific install logcation path: '{installLocation}' ('{sharedState.RepoDirectories.BuildArchitecture.ToLower()}').")
+                    .And.HaveStdErrContaining($"Found architecture-specific install location path: '{installLocation}' ('{sharedState.RepoDirectories.BuildArchitecture.ToLower()}').")
+                    .And.HaveStdErrContaining($"Found architecture-specific install location path: '{installLocation}/invalid' ('someOtherArch').")
                     .And.HaveStdErrContaining($"Using install location '{installLocation}'.")
                     .And.HaveStdOutContaining($"hostfxr_path: {sharedState.HostFxrPath}".ToLower());
             }
@@ -305,8 +306,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
                 result.Should().Pass()
                     .And.HaveStdErrContaining($"Looking for install_location file in '{registeredInstallLocationOverride.PathValueOverride}'.")
-                    .And.HaveStdOutContaining($"Found install location path '{installLocation}/a/b/c'.")
-                    .And.HaveStdOutContaining($"Found architecture-specific install logcation path: '{installLocation}' ('{sharedState.RepoDirectories.BuildArchitecture.ToLower()}').")
+                    .And.HaveStdErrContaining($"Found install location path '{installLocation}/a/b/c'.")
+                    .And.HaveStdErrContaining($"Found architecture-specific install location path: '{installLocation}' ('{sharedState.RepoDirectories.BuildArchitecture.ToLower()}').")
                     .And.HaveStdErrContaining($"Using install location '{installLocation}'.")
                     .And.HaveStdOutContaining($"hostfxr_path: {sharedState.HostFxrPath}".ToLower());
             }

--- a/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
@@ -300,7 +300,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 string architecture = fixture.CurrentRid.Split('-')[1];
                 if (useRegisteredLocation)
                 {
-                    registeredInstallLocationOverride.SetInstallLocation(new string[] { builtDotnet }, architecture);
+                    registeredInstallLocationOverride.SetInstallLocation(new (string, string)[] { (architecture, builtDotnet) });
                 }
 
                 // Verify running with the default working directory

--- a/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
@@ -257,7 +257,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             Command.Create(appExe)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .DotNetRoot(builtDotnet)
+                .DotNetRoot(builtDotnet, sharedTestState.RepoDirectories.BuildArchitecture)
                 .MultilevelLookup(false)
                 .Execute()
                 .Should().Pass()
@@ -268,7 +268,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             // Verify running from within the working directory
             Command.Create(appExe)
                 .WorkingDirectory(fixture.TestProject.OutputDirectory)
-                .DotNetRoot(builtDotnet)
+                .DotNetRoot(builtDotnet, sharedTestState.RepoDirectories.BuildArchitecture)
                 .MultilevelLookup(false)
                 .CaptureStdErr()
                 .CaptureStdOut()
@@ -357,7 +357,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             if (useAppHost)
             {
                 command = Command.Create(sharedTestState.MockApp.AppExe)
-                    .DotNetRoot(sharedTestState.BuiltDotNet.BinPath);
+                    .DotNetRoot(sharedTestState.BuiltDotNet.BinPath, sharedTestState.RepoDirectories.BuildArchitecture);
             }
             else
             {
@@ -386,7 +386,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             if (useAppHost)
             {
                 command = Command.Create(app.AppExe)
-                    .DotNetRoot(sharedTestState.BuiltDotNet.BinPath);
+                    .DotNetRoot(sharedTestState.BuiltDotNet.BinPath, sharedTestState.RepoDirectories.BuildArchitecture);
             }
             else
             {
@@ -540,7 +540,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
                 Command command = Command.Create(appExe)
                     .EnableTracingAndCaptureOutputs()
-                    .DotNetRoot(dotnet.BinPath)
+                    .DotNetRoot(dotnet.BinPath, sharedTestState.RepoDirectories.BuildArchitecture)
                     .MultilevelLookup(false)
                     .Start();
 

--- a/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
@@ -297,7 +297,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(appExe))
             {
-                string architecture = fixture.CurrentRid.Split('-')[1];
+                string architecture = fixture.RepoDirProvider.BuildArchitecture;
                 if (useRegisteredLocation)
                 {
                     registeredInstallLocationOverride.SetInstallLocation(new (string, string)[] { (architecture, builtDotnet) });

--- a/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
@@ -300,7 +300,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 string architecture = fixture.CurrentRid.Split('-')[1];
                 if (useRegisteredLocation)
                 {
-                    registeredInstallLocationOverride.SetInstallLocation(builtDotnet, architecture);
+                    registeredInstallLocationOverride.SetInstallLocation(new string[] { builtDotnet }, architecture);
                 }
 
                 // Verify running with the default working directory

--- a/src/installer/tests/HostActivation.Tests/RegisteredInstallLocationOverride.cs
+++ b/src/installer/tests/HostActivation.Tests/RegisteredInstallLocationOverride.cs
@@ -65,18 +65,21 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
         public void SetInstallLocation(params (string Architecture, string Path)[] locations)
         {
-            var locationsList = locations.ToList();
-            Debug.Assert(locationsList.Count >= 1);
+            Debug.Assert(locations.Length >= 1);
             if (OperatingSystem.IsWindows())
             {
-                foreach (var location in locationsList)
+                foreach (var location in locations)
+                {
                     using (RegistryKey dotnetLocationKey = key.CreateSubKey($@"Setup\InstalledVersions\{location.Architecture}"))
+                    {
                         dotnetLocationKey.SetValue("InstallLocation", location.Path);
+                    }
+                }
             }
             else
             {
-                File.WriteAllText(PathValueOverride, string.Join (Environment.NewLine,
-                    locationsList.Select(l => string.Format("{0}{1}".ToLower(),
+                File.WriteAllText(PathValueOverride, string.Join(Environment.NewLine,
+                    locations.Select(l => string.Format("{0}{1}",
                         (!string.IsNullOrWhiteSpace(l.Architecture) ? l.Architecture + "=" : ""), l.Path))));
             }
         }

--- a/src/installer/tests/HostActivation.Tests/RegisteredInstallLocationOverride.cs
+++ b/src/installer/tests/HostActivation.Tests/RegisteredInstallLocationOverride.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         {
             if (OperatingSystem.IsWindows())
             {
-                Debug.Assert(installLocation.Length == 1 && !string.IsNullOrEmpty(architecture));
+                Debug.Assert(installLocation.Length >= 1 && !string.IsNullOrEmpty(architecture));
                 using (RegistryKey dotnetLocationKey = key.CreateSubKey($@"Setup\InstalledVersions\{architecture}"))
                 {
                     dotnetLocationKey.SetValue("InstallLocation", installLocation[0]);

--- a/src/installer/tests/HostActivation.Tests/RegisteredInstallLocationOverride.cs
+++ b/src/installer/tests/HostActivation.Tests/RegisteredInstallLocationOverride.cs
@@ -69,11 +69,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             Debug.Assert(locationsList.Count >= 1);
             if (OperatingSystem.IsWindows())
             {
-                // Only the first location is used on Windows
-                using (RegistryKey dotnetLocationKey = key.CreateSubKey($@"Setup\InstalledVersions\{locationsList[0].Architecture}"))
-                {
-                    dotnetLocationKey.SetValue("InstallLocation", locationsList[0].Path);
-                }
+                foreach (var location in locationsList)
+                    using (RegistryKey dotnetLocationKey = key.CreateSubKey($@"Setup\InstalledVersions\{location.Architecture}"))
+                        dotnetLocationKey.SetValue("InstallLocation", location.Path);
             }
             else
             {

--- a/src/installer/tests/HostActivation.Tests/RegisteredInstallLocationOverride.cs
+++ b/src/installer/tests/HostActivation.Tests/RegisteredInstallLocationOverride.cs
@@ -61,18 +61,19 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             }
         }
 
-        public void SetInstallLocation(string installLocation, string architecture)
+        public void SetInstallLocation(string[] installLocation, string architecture = "")
         {
             if (OperatingSystem.IsWindows())
             {
+                Debug.Assert(installLocation.Length == 1 && !string.IsNullOrEmpty(architecture));
                 using (RegistryKey dotnetLocationKey = key.CreateSubKey($@"Setup\InstalledVersions\{architecture}"))
                 {
-                    dotnetLocationKey.SetValue("InstallLocation", installLocation);
+                    dotnetLocationKey.SetValue("InstallLocation", installLocation[0]);
                 }
             }
             else
             {
-                File.WriteAllText(PathValueOverride, installLocation);
+                File.WriteAllText(PathValueOverride, string.Join (Environment.NewLine, installLocation));
             }
         }
 

--- a/src/installer/tests/HostActivation.Tests/StandaloneAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/StandaloneAppActivation.cs
@@ -204,8 +204,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             // self-contained layout since a flat layout of the shared framework is not supported.
             Command.Create(appExe)
                 .EnvironmentVariable("COREHOST_TRACE", "1")
-                .EnvironmentVariable("DOTNET_ROOT", newOutDir)
-                .EnvironmentVariable("DOTNET_ROOT(x86)", newOutDir)
+                .DotNetRoot(newOutDir)
                 .CaptureStdErr()
                 .CaptureStdOut()
                 .Execute(fExpectedToFail: true)

--- a/src/installer/tests/TestUtils/TestProjectFixture.cs
+++ b/src/installer/tests/TestUtils/TestProjectFixture.cs
@@ -358,7 +358,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         public TestProjectFixture EnsureRestored(params string[] fallbackSources)
         {
-            if ( ! TestProject.IsRestored())
+            if (!TestProject.IsRestored())
             {
                 RestoreProject(fallbackSources);
             }
@@ -368,7 +368,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         public TestProjectFixture EnsureRestoredForRid(string rid, params string[] fallbackSources)
         {
-            if ( ! TestProject.IsRestored())
+            if (!TestProject.IsRestored())
             {
                 string extraMSBuildProperties = $"/p:TestTargetRid={rid}";
                 RestoreProject(fallbackSources, extraMSBuildProperties);

--- a/src/native/corehost/deps_format.cpp
+++ b/src/native/corehost/deps_format.cpp
@@ -84,7 +84,7 @@ void deps_json_t::reconcile_libraries_with_targets(
                 size_t pos = lib_name.find(_X("/"));
                 entry.library_name = lib_name.substr(0, pos);
                 entry.library_version = lib_name.substr(pos + 1);
-                entry.library_type = pal::to_lower(library.value[_X("type")].GetString());
+                entry.library_type = to_lower(library.value[_X("type")].GetString());
                 entry.library_hash = hash;
                 entry.library_path = library_path;
                 entry.library_hash_path = library_hash_path;

--- a/src/native/corehost/fxr/command_line.cpp
+++ b/src/native/corehost/fxr/command_line.cpp
@@ -86,7 +86,7 @@ namespace
         while (arg_i < argc)
         {
             const pal::char_t* arg = argv[arg_i];
-            pal::string_t arg_lower = pal::to_lower(arg);
+            pal::string_t arg_lower = to_lower(arg);
             const auto &iter = std::find_if(known_opts.cbegin(), known_opts.cend(),
                 [&](const known_options &opt) { return arg_lower == get_host_option(opt).option; });
             if (iter == known_opts.cend())

--- a/src/native/corehost/fxr_resolver.cpp
+++ b/src/native/corehost/fxr_resolver.cpp
@@ -67,8 +67,8 @@ bool fxr_resolver::try_get_path(const pal::string_t& root_path, pal::string_t* o
 
     // For framework-dependent apps, use DOTNET_ROOT_<ARCH>
     pal::string_t default_install_location;
-    pal::string_t dotnet_root_env_var_name = get_dotnet_root_env_var_name();
-    if (get_file_path_from_env(dotnet_root_env_var_name.c_str(), out_dotnet_root))
+    pal::string_t dotnet_root_env_var_name;
+    if (get_dotnet_root_from_env(&dotnet_root_env_var_name, out_dotnet_root))
     {
         trace::info(_X("Using environment variable %s=[%s] as runtime location."), dotnet_root_env_var_name.c_str(), out_dotnet_root->c_str());
     }

--- a/src/native/corehost/fxr_resolver.cpp
+++ b/src/native/corehost/fxr_resolver.cpp
@@ -77,7 +77,7 @@ bool fxr_resolver::try_get_path(const pal::string_t& root_path, pal::string_t* o
         if (pal::get_dotnet_self_registered_dir(&default_install_location) || pal::get_default_installation_dir(&default_install_location))
         {
             trace::info(_X("Using global installation location [%s] as runtime location."), default_install_location.c_str());
-            out_dotnet_root->assign(default_install_location);
+            out_dotnet_root->assign(default_install_location.c_str());
         }
         else
         {
@@ -134,7 +134,7 @@ bool fxr_resolver::try_get_path(const pal::string_t& root_path, pal::string_t* o
 #endif // !FEATURE_APPHOST && !FEATURE_LIBHOST
 }
 
-bool fxr_resolver::try_get_path_from_dotnet_root(const pal::string_t &dotnet_root, pal::string_t *out_fxr_path)
+bool fxr_resolver::try_get_path_from_dotnet_root(const pal::string_t& dotnet_root, pal::string_t* out_fxr_path)
 {
     pal::string_t fxr_dir = dotnet_root;
     append_path(&fxr_dir, _X("host"));
@@ -148,7 +148,7 @@ bool fxr_resolver::try_get_path_from_dotnet_root(const pal::string_t &dotnet_roo
     return get_latest_fxr(std::move(fxr_dir), out_fxr_path);
 }
 
-bool fxr_resolver::try_get_existing_fxr(pal::dll_t *out_fxr, pal::string_t *out_fxr_path)
+bool fxr_resolver::try_get_existing_fxr(pal::dll_t* out_fxr, pal::string_t* out_fxr_path)
 {
     if (!pal::get_loaded_library(LIBFXR_NAME, "hostfxr_main", out_fxr, out_fxr_path))
         return false;

--- a/src/native/corehost/fxr_resolver.cpp
+++ b/src/native/corehost/fxr_resolver.cpp
@@ -77,7 +77,7 @@ bool fxr_resolver::try_get_path(const pal::string_t& root_path, pal::string_t* o
         if (pal::get_dotnet_self_registered_dir(&default_install_location) || pal::get_default_installation_dir(&default_install_location))
         {
             trace::info(_X("Using global installation location [%s] as runtime location."), default_install_location.c_str());
-            out_dotnet_root->assign(default_install_location.c_str());
+            out_dotnet_root->assign(default_install_location);
         }
         else
         {

--- a/src/native/corehost/fxr_resolver.cpp
+++ b/src/native/corehost/fxr_resolver.cpp
@@ -65,7 +65,7 @@ bool fxr_resolver::try_get_path(const pal::string_t& root_path, pal::string_t* o
         return true;
     }
 
-    // For framework-dependent apps, use DOTNET_ROOT
+    // For framework-dependent apps, use DOTNET_ROOT_<ARCH>
     pal::string_t default_install_location;
     pal::string_t dotnet_root_env_var_name = get_dotnet_root_env_var_name();
     if (get_file_path_from_env(dotnet_root_env_var_name.c_str(), out_dotnet_root))

--- a/src/native/corehost/hostmisc/pal.h
+++ b/src/native/corehost/hostmisc/pal.h
@@ -252,6 +252,7 @@ namespace pal
     string_t get_timestamp();
 
     bool getcwd(string_t* recv);
+    string_t to_lower(const string_t& in);
     string_t to_lower(const char_t* in);
 
 

--- a/src/native/corehost/hostmisc/pal.h
+++ b/src/native/corehost/hostmisc/pal.h
@@ -252,17 +252,6 @@ namespace pal
     string_t get_timestamp();
 
     bool getcwd(string_t* recv);
-    inline string_t to_lower(const char_t* in) {
-        pal::string_t ret = in;
-        std::transform(ret.begin(), ret.end(), ret.begin(), ::tolower);
-        return ret;
-    }
-
-    inline string_t to_upper(const char_t* in) {
-        pal::string_t ret = in;
-        std::transform(ret.begin(), ret.end(), ret.begin(), ::toupper);
-        return ret;
-    }
 
     inline void file_flush(FILE *f) { std::fflush(f); }
     inline void err_flush() { std::fflush(stderr); }

--- a/src/native/corehost/hostmisc/pal.h
+++ b/src/native/corehost/hostmisc/pal.h
@@ -237,9 +237,6 @@ namespace pal
     inline bool munmap(void* addr, size_t length) { return ::munmap(addr, length) == 0; }
     inline int get_pid() { return getpid(); }
     inline void sleep(uint32_t milliseconds) { usleep(milliseconds * 1000); }
-
-    bool get_line_from_file(FILE* pFile, pal::string_t& line);
-
 #endif
 
     inline int snwprintf(char_t* buffer, size_t count, const char_t* format, ...)

--- a/src/native/corehost/hostmisc/pal.h
+++ b/src/native/corehost/hostmisc/pal.h
@@ -252,9 +252,17 @@ namespace pal
     string_t get_timestamp();
 
     bool getcwd(string_t* recv);
-    string_t to_lower(const string_t& in);
-    string_t to_lower(const char_t* in);
+    inline string_t to_lower(const char_t* in) {
+        pal::string_t ret = in;
+        std::transform(ret.begin(), ret.end(), ret.begin(), ::tolower);
+        return ret;
+    }
 
+    inline string_t to_upper(const char_t* in) {
+        pal::string_t ret = in;
+        std::transform(ret.begin(), ret.end(), ret.begin(), ::toupper);
+        return ret;
+    }
 
     inline void file_flush(FILE *f) { std::fflush(f); }
     inline void err_flush() { std::fflush(stderr); }

--- a/src/native/corehost/hostmisc/pal.h
+++ b/src/native/corehost/hostmisc/pal.h
@@ -104,13 +104,13 @@
 namespace pal
 {
 #if defined(_WIN32)
-    #ifdef EXPORT_SHARED_API
-        #define SHARED_API extern "C" __declspec(dllexport)
-    #else
-        #define SHARED_API extern "C"
-    #endif
+#ifdef EXPORT_SHARED_API
+#define SHARED_API extern "C" __declspec(dllexport)
+#else
+#define SHARED_API extern "C"
+#endif
 
-    #define STDMETHODCALLTYPE __stdcall
+#define STDMETHODCALLTYPE __stdcall
 
     typedef wchar_t char_t;
     typedef std::wstring string_t;
@@ -151,13 +151,13 @@ namespace pal
     inline int strcasecmp(const char_t* str1, const char_t* str2) { return ::_wcsicmp(str1, str2); }
     inline int strncmp(const char_t* str1, const char_t* str2, size_t len) { return ::wcsncmp(str1, str2, len); }
     inline int strncasecmp(const char_t* str1, const char_t* str2, size_t len) { return ::_wcsnicmp(str1, str2, len); }
-    inline int pathcmp(const pal::string_t &path1, const pal::string_t &path2) { return strcasecmp(path1.c_str(), path2.c_str()); }
+    inline int pathcmp(const pal::string_t& path1, const pal::string_t& path2) { return strcasecmp(path1.c_str(), path2.c_str()); }
     inline string_t to_string(int value) { return std::to_wstring(value); }
 
     inline size_t strlen(const char_t* str) { return ::wcslen(str); }
 
 #pragma warning(suppress : 4996)  // error C4996: '_wfopen': This function or variable may be unsafe.
-    inline FILE * file_open(const string_t& path, const char_t* mode) { return ::_wfopen(path.c_str(), mode); }
+    inline FILE* file_open(const string_t& path, const char_t* mode) { return ::_wfopen(path.c_str(), mode); }
 
     inline void file_vprintf(FILE* f, const char_t* format, va_list vl) { ::vfwprintf(f, format, vl); ::fputwc(_X('\n'), f); }
     inline void err_fputs(const char_t* message) { ::fputws(message, stderr); ::fputwc(_X('\n'), stderr); }
@@ -170,32 +170,32 @@ namespace pal
     // Suppressing warning since the 'safe' version requires an input buffer that is unnecessary for
     // uses of this function.
 #pragma warning(suppress : 4996) //  error C4996: '_wcserror': This function or variable may be unsafe.
-    inline const char_t* strerror(int errnum){ return ::_wcserror(errnum); }
+    inline const char_t* strerror(int errnum) { return ::_wcserror(errnum); }
 
     bool pal_utf8string(const string_t& str, std::vector<char>* out);
     bool pal_clrstring(const string_t& str, std::vector<char>* out);
     bool clr_palstring(const char* cstr, string_t* out);
 
     inline bool mkdir(const char_t* dir, int mode) { return CreateDirectoryW(dir, NULL) != 0; }
-    inline bool rmdir (const char_t* path) { return RemoveDirectoryW(path) != 0; }
+    inline bool rmdir(const char_t* path) { return RemoveDirectoryW(path) != 0; }
     inline int rename(const char_t* old_name, const char_t* new_name) { return ::_wrename(old_name, new_name); }
     inline int remove(const char_t* path) { return ::_wremove(path); }
     inline bool munmap(void* addr, size_t length) { return UnmapViewOfFile(addr) != 0; }
     inline int get_pid() { return GetCurrentProcessId(); }
     inline void sleep(uint32_t milliseconds) { Sleep(milliseconds); }
 #else
-    #ifdef EXPORT_SHARED_API
-        #define SHARED_API extern "C" __attribute__((__visibility__("default")))
-    #else
-        #define SHARED_API extern "C"
-    #endif
+#ifdef EXPORT_SHARED_API
+#define SHARED_API extern "C" __attribute__((__visibility__("default")))
+#else
+#define SHARED_API extern "C"
+#endif
 
-    #define __cdecl    /* nothing */
-    #define __stdcall  /* nothing */
-    #if !defined(TARGET_FREEBSD)
-        #define __fastcall /* nothing */
-    #endif
-    #define STDMETHODCALLTYPE __stdcall
+#define __cdecl    /* nothing */
+#define __stdcall  /* nothing */
+#if !defined(TARGET_FREEBSD)
+#define __fastcall /* nothing */
+#endif
+#define STDMETHODCALLTYPE __stdcall
 
     typedef char char_t;
     typedef std::string string_t;
@@ -219,7 +219,7 @@ namespace pal
     inline string_t to_string(int value) { return std::to_string(value); }
 
     inline size_t strlen(const char_t* str) { return ::strlen(str); }
-    inline FILE * file_open(const string_t& path, const char_t* mode) { return fopen(path.c_str(), mode); }
+    inline FILE* file_open(const string_t& path, const char_t* mode) { return fopen(path.c_str(), mode); }
     inline void file_vprintf(FILE* f, const char_t* format, va_list vl) { ::vfprintf(f, format, vl); ::fputc('\n', f); }
     inline void err_fputs(const char_t* message) { ::fputs(message, stderr); ::fputc(_X('\n'), stderr); }
     inline void out_vprintf(const char_t* format, va_list vl) { ::vfprintf(stdout, format, vl); ::fputc('\n', stdout); }
@@ -238,6 +238,8 @@ namespace pal
     inline int get_pid() { return getpid(); }
     inline void sleep(uint32_t milliseconds) { usleep(milliseconds * 1000); }
 
+    bool get_line_from_file(FILE* pFile, pal::string_t& line);
+
 #endif
 
     inline int snwprintf(char_t* buffer, size_t count, const char_t* format, ...)
@@ -253,7 +255,7 @@ namespace pal
 
     bool getcwd(string_t* recv);
 
-    inline void file_flush(FILE *f) { std::fflush(f); }
+    inline void file_flush(FILE* f) { std::fflush(f); }
     inline void err_flush() { std::fflush(stderr); }
     inline void out_flush() { std::fflush(stdout); }
 
@@ -281,7 +283,7 @@ namespace pal
     bool get_own_module_path(string_t* recv);
     bool get_method_module_path(string_t* recv, void* method);
     bool get_module_path(dll_t mod, string_t* recv);
-    bool get_current_module(dll_t *mod);
+    bool get_current_module(dll_t* mod);
     bool getenv(const char_t* name, string_t* recv);
     bool get_default_servicing_directory(string_t* recv);
 
@@ -305,7 +307,7 @@ namespace pal
 
     int xtoi(const char_t* input);
 
-    bool get_loaded_library(const char_t *library_name, const char *symbol_name, /*out*/ dll_t *dll, /*out*/ string_t *path);
+    bool get_loaded_library(const char_t* library_name, const char* symbol_name, /*out*/ dll_t* dll, /*out*/ string_t* path);
     bool load_library(const string_t* path, dll_t* dll);
     proc_t get_symbol(dll_t library, const char* name);
     void unload_library(dll_t library);

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -68,7 +68,7 @@ bool pal::touch_file(const pal::string_t& path)
         trace::warning(_X("open(%s) failed in %s"), path.c_str(), _STRINGIFY(__FUNCTION__));
         return false;
     }
-    (void) close(fd);
+    (void)close(fd);
     return true;
 }
 
@@ -139,12 +139,12 @@ bool pal::getcwd(pal::string_t* recv)
 
 namespace
 {
-    bool get_loaded_library_from_proc_maps(const pal::char_t *library_name, pal::dll_t *dll, pal::string_t *path)
+    bool get_loaded_library_from_proc_maps(const pal::char_t* library_name, pal::dll_t* dll, pal::string_t* path)
     {
-        char *line = nullptr;
+        char* line = nullptr;
         size_t lineLen = 0;
         ssize_t read;
-        FILE *file = pal::file_open(_X("/proc/self/maps"), _X("r"));
+        FILE* file = pal::file_open(_X("/proc/self/maps"), _X("r"));
         if (file == nullptr)
             return false;
 
@@ -185,10 +185,10 @@ namespace
 }
 
 bool pal::get_loaded_library(
-    const char_t *library_name,
-    const char *symbol_name,
-    /*out*/ dll_t *dll,
-    /*out*/ pal::string_t *path)
+    const char_t* library_name,
+    const char* symbol_name,
+    /*out*/ dll_t* dll,
+    /*out*/ pal::string_t* path)
 {
     pal::string_t library_name_local;
 #if defined(TARGET_OSX)
@@ -333,7 +333,7 @@ bool pal::get_default_servicing_directory(string_t* recv)
 bool is_read_write_able_directory(pal::string_t& dir)
 {
     return pal::realpath(&dir) &&
-           (access(dir.c_str(), R_OK | W_OK | X_OK) == 0);
+        (access(dir.c_str(), R_OK | W_OK | X_OK) == 0);
 }
 
 bool get_extraction_base_parent_directory(pal::string_t& directory)
@@ -424,7 +424,7 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
     pal::string_t install_location;
     bool is_first_line = true, install_location_found = false;
 
-    while (get_line_from_file(install_location_file, install_location))
+    while (pal::get_line_from_file(install_location_file, install_location))
     {
         size_t arch_sep = install_location.find(_X('='));
         if (arch_sep == pal::string_t::npos)
@@ -459,6 +459,7 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
         is_first_line = false;
     }
 
+    fclose(install_location_file);
     if (!install_location_found)
     {
         trace::warning(_X("Did not find any install location in '%s'."), install_location_file_path.c_str());
@@ -466,7 +467,6 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
     }
 
     trace::verbose(_X("Using install location '%s'."), recv->c_str());
-    fclose(install_location_file);
     return true;
 }
 
@@ -482,17 +482,37 @@ bool pal::get_default_installation_dir(pal::string_t* recv)
     //  ***************************
 
 #if defined(TARGET_OSX)
-     recv->assign(_X("/usr/local/share/dotnet"));
+    recv->assign(_X("/usr/local/share/dotnet"));
 #else
-     recv->assign(_X("/usr/share/dotnet"));
+    recv->assign(_X("/usr/share/dotnet"));
 #endif
-     return true;
+    return true;
+}
+
+bool pal::get_line_from_file(FILE* pFile, pal::string_t& line)
+{
+    line = pal::string_t();
+    char buffer[256];
+    while (fgets(buffer, sizeof(buffer), pFile))
+    {
+        line += (pal::char_t*)buffer;
+        size_t len = line.length();
+
+        // fgets includes the newline character in the string - so remove it.
+        if (len > 0 && line[len - 1] == '\n')
+        {
+            line.pop_back();
+            break;
+        }
+    }
+
+    return !line.empty();
 }
 
 pal::string_t trim_quotes(pal::string_t stringToCleanup)
 {
-    pal::char_t quote_array[2] = {'\"', '\''};
-    for (size_t index = 0; index < sizeof(quote_array)/sizeof(quote_array[0]); index++)
+    pal::char_t quote_array[2] = { '\"', '\'' };
+    for (size_t index = 0; index < sizeof(quote_array) / sizeof(quote_array[0]); index++)
     {
         size_t pos = stringToCleanup.find(quote_array[index]);
         while (pos != std::string::npos)
@@ -568,11 +588,11 @@ pal::string_t pal::get_current_os_rid_platform()
 
     if (ret == 0)
     {
-        char *pos = strchr(str, '.');
+        char* pos = strchr(str, '.');
         if (pos)
         {
             ridOS.append(_X("freebsd."))
-                 .append(str, pos - str);
+                .append(str, pos - str);
         }
     }
 
@@ -604,7 +624,7 @@ pal::string_t pal::get_current_os_rid_platform()
     if (strncmp(utsname_obj.version, "omnios", strlen("omnios")) == 0)
     {
         ridOS.append(_X("omnios."))
-             .append(utsname_obj.version, strlen("omnios-r"), 2); // e.g. omnios.15
+            .append(utsname_obj.version, strlen("omnios-r"), 2); // e.g. omnios.15
     }
     else if (strncmp(utsname_obj.version, "illumos-", strlen("illumos-")) == 0)
     {
@@ -613,7 +633,7 @@ pal::string_t pal::get_current_os_rid_platform()
     else if (strncmp(utsname_obj.version, "joyent_", strlen("joyent_")) == 0)
     {
         ridOS.append(_X("smartos."))
-             .append(utsname_obj.version, strlen("joyent_"), 4); // e.g. smartos.2020
+            .append(utsname_obj.version, strlen("joyent_"), 4); // e.g. smartos.2020
     }
 
     return ridOS;
@@ -636,11 +656,11 @@ pal::string_t pal::get_current_os_rid_platform()
         return ridOS;
     }
 
-    char *pos = strchr(utsname_obj.version, '.');
+    char* pos = strchr(utsname_obj.version, '.');
     if (pos)
     {
         ridOS.append(_X("solaris."))
-             .append(utsname_obj.version, pos - utsname_obj.version); // e.g. solaris.11
+            .append(utsname_obj.version, pos - utsname_obj.version); // e.g. solaris.11
     }
 
     return ridOS;
@@ -786,7 +806,7 @@ bool pal::get_own_executable_path(pal::string_t* recv)
 bool pal::get_own_module_path(string_t* recv)
 {
     Dl_info info;
-    if (dladdr((void *)&pal::get_own_module_path, &info) == 0)
+    if (dladdr((void*)&pal::get_own_module_path, &info) == 0)
         return false;
 
     recv->assign(info.dli_fname);
@@ -808,7 +828,7 @@ bool pal::get_module_path(dll_t module, string_t* recv)
     return false;
 }
 
-bool pal::get_current_module(dll_t *mod)
+bool pal::get_current_module(dll_t* mod)
 {
     return false;
 }
@@ -891,31 +911,31 @@ static void readdir(const pal::string_t& path, const pal::string_t& pattern, boo
                 }
                 break;
 
-            // Handle symlinks and file systems that do not support d_type
+                // Handle symlinks and file systems that do not support d_type
             case DT_LNK:
             case DT_UNKNOWN:
+            {
+                struct stat sb;
+
+                if (fstatat(dirfd(dir), entry->d_name, &sb, 0) == -1)
                 {
-                    struct stat sb;
-
-                    if (fstatat(dirfd(dir), entry->d_name, &sb, 0) == -1)
-                    {
-                        continue;
-                    }
-
-                    if (onlydirectories)
-                    {
-                        if (!S_ISDIR(sb.st_mode))
-                        {
-                            continue;
-                        }
-                        break;
-                    }
-                    else if (!S_ISREG(sb.st_mode) && !S_ISDIR(sb.st_mode))
-                    {
-                        continue;
-                    }
+                    continue;
                 }
-                break;
+
+                if (onlydirectories)
+                {
+                    if (!S_ISDIR(sb.st_mode))
+                    {
+                        continue;
+                    }
+                    break;
+                }
+                else if (!S_ISREG(sb.st_mode) && !S_ISDIR(sb.st_mode))
+                {
+                    continue;
+                }
+            }
+            break;
 
             default:
                 continue;

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -448,7 +448,7 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
         }
 
         char* pDelimiter = strchr(buffer, '=');
-        if (pDelimiter == nullptr)
+        if (pDelimiter == nullptr && len > 0)
         {
             if (is_first_line)
             {
@@ -468,7 +468,7 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
         pal::string_t arch_prefix = pal::string_t(buffer).substr(0, delimiter_index);
         pal::string_t path_to_location = pal::string_t(buffer).substr(delimiter_index + 1);
 
-        trace::verbose(_X("Found architecture-specific install logcation path: '%s' ('%s')."), path_to_location.c_str(), arch_prefix.c_str());
+        trace::verbose(_X("Found architecture-specific install location path: '%s' ('%s')."), path_to_location.c_str(), arch_prefix.c_str());
         if (arch_prefix == get_arch())
         {
             architecture_install_location = path_to_location;

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -417,7 +417,7 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
     FILE* install_location_file = pal::file_open(install_location_file_path, "r");
     if (install_location_file == nullptr)
     {
-        trace::error(_X("The install_location file '%s' failed to open with error %d."), install_location_file_path.c_str(), errno);
+        trace::error(_X("The install_location file ['%s'] failed to open: %s."), install_location_file_path.c_str(), pal::strerror(errno));
         return false;
     }
 

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -381,13 +381,13 @@ bool pal::get_global_dotnet_dirs(std::vector<pal::string_t>* recv)
 
 bool pal::get_dotnet_self_registered_config_location(pal::string_t* recv)
 {
-    *recv = _X("/etc/dotnet/install_location");
+    recv->assign(_X("/etc/dotnet/install_location"));
 
     //  ***Used only for testing***
     pal::string_t environment_install_location_override;
     if (test_only_getenv(_X("_DOTNET_TEST_INSTALL_LOCATION_FILE_PATH"), &environment_install_location_override))
     {
-        *recv = environment_install_location_override;
+        recv->assign(environment_install_location_override);
     }
 
     return true;
@@ -431,7 +431,7 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
         {
             if (is_first_line)
             {
-                *recv = install_location;
+                recv->assign(install_location);
                 install_location_found = true;
                 trace::verbose(_X("Found install location path '%s'."), install_location.c_str());
             }
@@ -450,7 +450,7 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
         trace::verbose(_X("Found architecture-specific install location path: '%s' ('%s')."), path_to_location.c_str(), arch_prefix.c_str());
         if (arch_prefix == get_arch())
         {
-            *recv = path_to_location;
+            recv->assign(path_to_location);
             install_location_found = true;
             trace::verbose(_X("Found architecture-specific install location path matching the current OS architecture ('%s'): '%s'."), arch_prefix.c_str(), path_to_location.c_str());
             break;

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -417,7 +417,7 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
     FILE* install_location_file = pal::file_open(install_location_file_path, "r");
     if (install_location_file == nullptr)
     {
-        trace::error(_X("The install_location file '%s' failed to open with error %d.", install_location_file.c_str(), errno));
+        trace::error(_X("The install_location file '%s' failed to open with error %d."), install_location_file_path.c_str(), errno);
         return false;
     }
 

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -436,7 +436,7 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
     }
 
     char buffer[PATH_MAX];
-    pal::string_t install_location, arch_install_location;
+    pal::string_t install_location, architecture_install_location;
     bool is_first_line = true;
     while (fgets(buffer, sizeof(buffer), install_location_file))
     {
@@ -453,11 +453,11 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
             if (is_first_line)
             {
                 install_location = pal::string_t(buffer);
-                trace::verbose(_X("Found install location path '%s'.", install_location.c_str()))
+                trace::verbose(_X("Found install location path '%s'."), install_location.c_str());
             }
             else
             {
-                trace::error(_X("Only the first line in '%s' may not have an architecture prefix.", install_location_file_path.c_str()));
+                trace::error(_X("Only the first line in '%s' may not have an architecture prefix."), install_location_file_path.c_str());
             }
 
             is_first_line = false;
@@ -468,30 +468,31 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
         pal::string_t arch_prefix = pal::string_t(buffer).substr(0, delimiter_index);
         pal::string_t path_to_location = pal::string_t(buffer).substr(delimiter_index + 1);
 
-        trace::verbose(_X("Found architecture-specific install logcation path: '%s' ('%s').", path_to_location.c_str(), arch_prefix.c_str()));
+        trace::verbose(_X("Found architecture-specific install logcation path: '%s' ('%s')."), path_to_location.c_str(), arch_prefix.c_str());
         if (arch_prefix == get_arch())
         {
-            arch_install_location = path_to_location;
-            trace::verbose(_X("Found architecture-specific install location path matching the current OS architecture ('%s'): '%s'.", arch_prefix.c_str(), arch_install_location.c_str()));
+            architecture_install_location = path_to_location;
+            trace::verbose(_X("Found architecture-specific install location path matching the current OS architecture ('%s'): '%s'."), arch_prefix.c_str(), architecture_install_location.c_str());
         }
     }
 
-    if (architecture_prefixed_install_location != nullptr)
+    if (architecture_install_location != "")
     {
-        *recv = architecture_prefixed_install_location;
+        *recv = architecture_install_location;
     }
-    else if (install_location != nullptr)
+    else if (install_location != "")
     {
         *recv = install_location;
     }
     else
     {
-        trace::error(_X("Did not find any install location in '%s'", install_location_file_path.c_str()));
+        trace::error(_X("Did not find any install location in '%s'"), install_location_file_path.c_str());
         return false;
     }
 
+    trace::verbose(_X("Using install location '%s'."), (*recv).c_str());
     fclose(install_location_file);
-    return result;
+    return true;
 }
 
 bool pal::get_default_installation_dir(pal::string_t* recv)

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -393,6 +393,29 @@ bool pal::get_dotnet_self_registered_config_location(pal::string_t* recv)
     return true;
 }
 
+namespace
+{
+    bool get_line_from_file(FILE* pFile, pal::string_t& line)
+    {
+        line = pal::string_t();
+        char buffer[256];
+        while (fgets(buffer, sizeof(buffer), pFile))
+        {
+            line += (pal::char_t*)buffer;
+            size_t len = line.length();
+
+            // fgets includes the newline character in the string - so remove it.
+            if (len > 0 && line[len - 1] == '\n')
+            {
+                line.pop_back();
+                break;
+            }
+        }
+
+        return !line.empty();
+    }
+}
+
 bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
 {
     recv->clear();
@@ -425,7 +448,7 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
     int current_line = 0;
     bool is_first_line = true, install_location_found = false;
 
-    while (pal::get_line_from_file(install_location_file, install_location))
+    while (get_line_from_file(install_location_file, install_location))
     {
         current_line++;
         size_t arch_sep = install_location.find(_X('='));
@@ -451,7 +474,7 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
         pal::string_t path_to_location = install_location.substr(arch_sep + 1);
 
         trace::verbose(_X("Found architecture-specific install location path: '%s' ('%s')."), path_to_location.c_str(), arch_prefix.c_str());
-        if (strcasecmp(arch_prefix, get_arch()) == 0)
+        if (pal::strcasecmp(arch_prefix.c_str(), get_arch()) == 0)
         {
             recv->assign(path_to_location);
             install_location_found = true;
@@ -490,29 +513,6 @@ bool pal::get_default_installation_dir(pal::string_t* recv)
     recv->assign(_X("/usr/share/dotnet"));
 #endif
     return true;
-}
-
-namespace
-{
-    bool pal::get_line_from_file(FILE* pFile, pal::string_t& line)
-    {
-        line = pal::string_t();
-        char buffer[256];
-        while (fgets(buffer, sizeof(buffer), pFile))
-        {
-            line += (pal::char_t*)buffer;
-            size_t len = line.length();
-
-            // fgets includes the newline character in the string - so remove it.
-            if (len > 0 && line[len - 1] == '\n')
-            {
-                line.pop_back();
-                break;
-            }
-        }
-
-        return !line.empty();
-    }
 }
 
 pal::string_t trim_quotes(pal::string_t stringToCleanup)

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -50,20 +50,6 @@
 #error "Don't know how to obtain max path on this platform"
 #endif
 
-pal::string_t pal::to_lower(const pal::char_t* in)
-{
-    pal::string_t ret = in;
-    std::transform(ret.begin(), ret.end(), ret.begin(), ::tolower);
-    return ret;
-}
-
-pal::string_t pal::to_upper(const pal::string_t& in)
-{
-    pal::string_t ret = in;
-    std::transform(ret.begin(), ret.end(), ret.begin(), ::toupper);
-    return ret;
-}
-
 pal::string_t pal::get_timestamp()
 {
     std::time_t t = std::time(nullptr);

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -417,7 +417,7 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
     FILE* install_location_file = pal::file_open(install_location_file_path, "r");
     if (install_location_file == nullptr)
     {
-        trace::error(_X("The install_location file failed to open."));
+        trace::error(_X("The install_location file '%s' failed to open with error %d.", install_location_file.c_str(), errno));
         return false;
     }
 
@@ -472,7 +472,7 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
     }
     else
     {
-        trace::error(_X("Did not find any install location in '%s'"), install_location_file_path.c_str());
+        trace::error(_X("Did not find any install location in '%s'."), install_location_file_path.c_str());
         return false;
     }
 

--- a/src/native/corehost/hostmisc/pal.windows.cpp
+++ b/src/native/corehost/hostmisc/pal.windows.cpp
@@ -40,20 +40,6 @@ bool GetModuleHandleFromAddress(void *addr, HMODULE *hModule)
     return (res != FALSE);
 }
 
-pal::string_t pal::to_lower(const pal::char_t* in)
-{
-    pal::string_t ret = in;
-    std::transform(ret.begin(), ret.end(), ret.begin(), ::towlower);
-    return ret;
-}
-
-pal::string_t pal::to_upper(const pal::string_t& in)
-{
-    pal::string_t ret = in;
-    std::transform(ret.begin(), ret.end(), ret.begin(), ::toupper);
-    return ret;
-}
-
 pal::string_t pal::get_timestamp()
 {
     std::time_t t = std::time(nullptr);

--- a/src/native/corehost/hostmisc/pal.windows.cpp
+++ b/src/native/corehost/hostmisc/pal.windows.cpp
@@ -26,7 +26,7 @@ bool GetModuleFileNameWrapper(HMODULE hModule, pal::string_t* recv)
         return false;
 
     path.resize(dwModuleFileName);
-    *recv = path;
+    recv->assign(path);
     return true;
 }
 
@@ -332,7 +332,7 @@ bool pal::get_dotnet_self_registered_config_location(pal::string_t* recv)
     const pal::char_t* value;
     get_dotnet_install_location_registry_path(&key_hive, &sub_key, &value);
 
-    *recv = (key_hive == HKEY_CURRENT_USER ? _X("HKCU\\") : _X("HKLM\\")) + sub_key + _X("\\") + value;
+    recv->assign((key_hive == HKEY_CURRENT_USER ? _X("HKCU\\") : _X("HKLM\\")) + sub_key + _X("\\") + value);
     return true;
 #endif
 }

--- a/src/native/corehost/hostmisc/pal.windows.cpp
+++ b/src/native/corehost/hostmisc/pal.windows.cpp
@@ -47,6 +47,13 @@ pal::string_t pal::to_lower(const pal::char_t* in)
     return ret;
 }
 
+pal::string_t pal::to_upper(const pal::string_t& in)
+{
+    pal::string_t ret = in;
+    std::transform(ret.begin(), ret.end(), ret.begin(), ::toupper);
+    return ret;
+}
+
 pal::string_t pal::get_timestamp()
 {
     std::time_t t = std::time(nullptr);

--- a/src/native/corehost/hostmisc/utils.cpp
+++ b/src/native/corehost/hostmisc/utils.cpp
@@ -98,26 +98,6 @@ pal::string_t strip_file_ext(const pal::string_t& path)
     return path.substr(0, dot_pos);
 }
 
-bool get_line_from_file(FILE* pFile, pal::string_t& line)
-{
-    line = pal::string_t();
-    char buffer[256];
-    while (fgets(buffer, sizeof(buffer), pFile))
-    {
-        line += (pal::char_t*)buffer;
-        size_t len = line.length();
-
-        // fgets includes the newline character in the string - so remove it.
-        if (len > 0 && line[len - 1] == '\n')
-        {
-            line[len - 1] = '\0';
-            break;
-        }
-    }
-
-    return !line.empty();
-}
-
 pal::string_t get_filename_without_ext(const pal::string_t& path)
 {
     if (path.empty())
@@ -181,7 +161,7 @@ void remove_trailing_dir_seperator(pal::string_t* dir)
 
 void replace_char(pal::string_t* path, pal::char_t match, pal::char_t repl)
 {
-	size_t pos = 0;
+    size_t pos = 0;
     while ((pos = path->find(match, pos)) != pal::string_t::npos)
     {
         (*path)[pos] = repl;
@@ -190,7 +170,7 @@ void replace_char(pal::string_t* path, pal::char_t match, pal::char_t repl)
 
 pal::string_t get_replaced_char(const pal::string_t& path, pal::char_t match, pal::char_t repl)
 {
-	size_t pos = path.find(match);
+    size_t pos = path.find(match);
     if (pos == pal::string_t::npos)
     {
         return path;
@@ -261,7 +241,7 @@ bool get_env_shared_store_dirs(std::vector<pal::string_t>* dirs, const pal::stri
     return true;
 }
 
-bool get_global_shared_store_dirs(std::vector<pal::string_t>*  dirs, const pal::string_t& arch, const pal::string_t& tfm)
+bool get_global_shared_store_dirs(std::vector<pal::string_t>* dirs, const pal::string_t& arch, const pal::string_t& tfm)
 {
     std::vector<pal::string_t> global_dirs;
     if (!pal::get_global_dotnet_dirs(&global_dirs))
@@ -386,7 +366,7 @@ bool get_dotnet_root_from_env(pal::string_t* dotnet_root_env_var_name, pal::stri
 
     // If no architecture-specific environment variable was set
     // fallback to the default DOTNET_ROOT.
-    *dotnet_root_env_var_name = _X("DOTNET_ROOT");
+    * dotnet_root_env_var_name = _X("DOTNET_ROOT");
     return get_file_path_from_env(dotnet_root_env_var_name->c_str(), recv);
 }
 
@@ -434,7 +414,7 @@ void get_runtime_config_paths(const pal::string_t& path, const pal::string_t& na
     trace::verbose(_X("Runtime config is cfg=%s dev=%s"), cfg->c_str(), dev_cfg->c_str());
 }
 
-pal::string_t get_dotnet_root_from_fxr_path(const pal::string_t &fxr_path)
+pal::string_t get_dotnet_root_from_fxr_path(const pal::string_t& fxr_path)
 {
     // If coreclr exists next to hostfxr, assume everything is local (e.g. self-contained)
     pal::string_t fxr_dir = get_directory(fxr_path);
@@ -446,7 +426,7 @@ pal::string_t get_dotnet_root_from_fxr_path(const pal::string_t &fxr_path)
     return get_directory(get_directory(fxr_root));
 }
 
-pal::string_t get_download_url(const pal::char_t *framework_name, const pal::char_t *framework_version)
+pal::string_t get_download_url(const pal::char_t* framework_name, const pal::char_t* framework_version)
 {
     pal::string_t url = DOTNET_CORE_APPLAUNCH_URL _X("?");
     if (framework_name != nullptr && pal::strlen(framework_name) > 0)

--- a/src/native/corehost/hostmisc/utils.cpp
+++ b/src/native/corehost/hostmisc/utils.cpp
@@ -350,11 +350,20 @@ bool try_stou(const pal::string_t& str, unsigned* num)
 
 pal::string_t get_dotnet_root_env_var_name()
 {
+    pal::string_t dotnet_root_arch = _X("DOTNET_ROOT_"), path;
+    dotnet_root_arch.append(pal::to_upper(get_arch()));
+    if (pal::getenv(dotnet_root_arch.c_str(), &path))
+        return dotnet_root_arch;
+
+#if defined(WIN32)
     if (pal::is_running_in_wow64())
     {
         return pal::string_t(_X("DOTNET_ROOT(x86)"));
     }
+#endif
 
+    // If no architecture-specific environment variable was set
+    // fallback to the default DOTNET_ROOT.
     return pal::string_t(_X("DOTNET_ROOT"));
 }
 

--- a/src/native/corehost/hostmisc/utils.cpp
+++ b/src/native/corehost/hostmisc/utils.cpp
@@ -352,8 +352,8 @@ bool get_dotnet_root_from_env(pal::string_t* dotnet_root_env_var_name, pal::stri
 {
     *dotnet_root_env_var_name = _X("DOTNET_ROOT_");
     dotnet_root_env_var_name->append(to_upper(get_arch()));
-    if (get_file_path_from_env(dotnet_root_env_var_name->c_str(), recv))
-        return true;
+    if (pal::getenv(dotnet_root_env_var_name->c_str(), recv))
+        return pal::file_exists(*recv);
 
 #if defined(WIN32)
     if (pal::is_running_in_wow64())

--- a/src/native/corehost/hostmisc/utils.cpp
+++ b/src/native/corehost/hostmisc/utils.cpp
@@ -351,7 +351,7 @@ bool try_stou(const pal::string_t& str, unsigned* num)
 pal::string_t get_dotnet_root_env_var_name()
 {
     pal::string_t dotnet_root_arch = _X("DOTNET_ROOT_"), path;
-    dotnet_root_arch.append(pal::to_upper(get_arch()));
+    dotnet_root_arch.append(to_upper(get_arch()));
     if (pal::getenv(dotnet_root_arch.c_str(), &path))
         return dotnet_root_arch;
 
@@ -448,6 +448,18 @@ pal::string_t get_download_url(const pal::char_t *framework_name, const pal::cha
     url.append(rid);
 
     return url;
+}
+
+pal::string_t to_lower(const pal::char_t* in) {
+    pal::string_t ret = in;
+    std::transform(ret.begin(), ret.end(), ret.begin(), ::tolower);
+    return ret;
+}
+
+pal::string_t to_upper(const pal::char_t* in) {
+    pal::string_t ret = in;
+    std::transform(ret.begin(), ret.end(), ret.begin(), ::toupper);
+    return ret;
 }
 
 #define TEST_ONLY_MARKER "d38cc827-e34f-4453-9df4-1e796e9f1d07"

--- a/src/native/corehost/hostmisc/utils.cpp
+++ b/src/native/corehost/hostmisc/utils.cpp
@@ -366,7 +366,7 @@ bool get_dotnet_root_from_env(pal::string_t* dotnet_root_env_var_name, pal::stri
 
     // If no architecture-specific environment variable was set
     // fallback to the default DOTNET_ROOT.
-    * dotnet_root_env_var_name = _X("DOTNET_ROOT");
+    *dotnet_root_env_var_name = _X("DOTNET_ROOT");
     return get_file_path_from_env(dotnet_root_env_var_name->c_str(), recv);
 }
 

--- a/src/native/corehost/hostmisc/utils.cpp
+++ b/src/native/corehost/hostmisc/utils.cpp
@@ -348,23 +348,25 @@ bool try_stou(const pal::string_t& str, unsigned* num)
     return true;
 }
 
-pal::string_t get_dotnet_root_env_var_name()
+bool get_dotnet_root_from_env(pal::string_t* dotnet_root_env_var_name, pal::string_t* recv)
 {
-    pal::string_t dotnet_root_arch = _X("DOTNET_ROOT_"), path;
-    dotnet_root_arch.append(to_upper(get_arch()));
-    if (pal::getenv(dotnet_root_arch.c_str(), &path))
-        return dotnet_root_arch;
+    *dotnet_root_env_var_name = _X("DOTNET_ROOT_");
+    dotnet_root_env_var_name->append(to_upper(get_arch()));
+    if (get_file_path_from_env(dotnet_root_env_var_name->c_str(), recv))
+        return true;
 
 #if defined(WIN32)
     if (pal::is_running_in_wow64())
     {
-        return pal::string_t(_X("DOTNET_ROOT(x86)"));
+        *dotnet_root_env_var_name = _X("DOTNET_ROOT(x86)");
+        return get_file_path_from_env(dotnet_root_env_var_name->c_str(), recv);
     }
 #endif
 
     // If no architecture-specific environment variable was set
     // fallback to the default DOTNET_ROOT.
-    return pal::string_t(_X("DOTNET_ROOT"));
+    *dotnet_root_env_var_name = _X("DOTNET_ROOT");
+    return get_file_path_from_env(dotnet_root_env_var_name->c_str(), recv);
 }
 
 /**

--- a/src/native/corehost/hostmisc/utils.cpp
+++ b/src/native/corehost/hostmisc/utils.cpp
@@ -98,6 +98,22 @@ pal::string_t strip_file_ext(const pal::string_t& path)
     return path.substr(0, dot_pos);
 }
 
+bool get_line_from_file(FILE* pFile, pal::string_t& line)
+{
+    std::vector<pal::char_t> buffer;
+    char last_char;
+    while ((last_char = fgetc(pFile)))
+    {
+        if (last_char == '\n' || last_char == EOF)
+            break;
+
+        buffer.push_back((pal::char_t)last_char);
+    }
+
+    line = pal::string_t(buffer.begin(), buffer.end());
+    return buffer.size() != 0;
+}
+
 pal::string_t get_filename_without_ext(const pal::string_t& path)
 {
     if (path.empty())

--- a/src/native/corehost/hostmisc/utils.h
+++ b/src/native/corehost/hostmisc/utils.h
@@ -41,6 +41,7 @@ bool get_global_shared_store_dirs(std::vector<pal::string_t>* dirs, const pal::s
 bool multilevel_lookup_enabled();
 void get_framework_and_sdk_locations(const pal::string_t& dotnet_dir, std::vector<pal::string_t>* locations);
 bool get_file_path_from_env(const pal::char_t* env_key, pal::string_t* recv);
+bool get_line_from_file(FILE* pFile, pal::string_t& line);
 size_t index_of_non_numeric(const pal::string_t& str, size_t i);
 bool try_stou(const pal::string_t& str, unsigned* num);
 bool get_dotnet_root_from_env(pal::string_t* used_dotnet_root_env_var_name, pal::string_t* recv);

--- a/src/native/corehost/hostmisc/utils.h
+++ b/src/native/corehost/hostmisc/utils.h
@@ -54,6 +54,9 @@ pal::string_t get_dotnet_root_from_fxr_path(const pal::string_t &fxr_path);
 // If no framework is specified, a download URL for the runtime is returned
 pal::string_t get_download_url(const pal::char_t *framework_name = nullptr, const pal::char_t *framework_version = nullptr);
 
+pal::string_t to_lower(const pal::char_t* in);
+pal::string_t to_upper(const pal::char_t* in);
+
 // Retrieves environment variable which is only used for testing.
 // This will return the value of the variable only if the product binary is stamped
 // with test-only marker.

--- a/src/native/corehost/hostmisc/utils.h
+++ b/src/native/corehost/hostmisc/utils.h
@@ -43,7 +43,7 @@ void get_framework_and_sdk_locations(const pal::string_t& dotnet_dir, std::vecto
 bool get_file_path_from_env(const pal::char_t* env_key, pal::string_t* recv);
 size_t index_of_non_numeric(const pal::string_t& str, size_t i);
 bool try_stou(const pal::string_t& str, unsigned* num);
-pal::string_t get_dotnet_root_env_var_name();
+bool get_dotnet_root_from_env(pal::string_t* used_dotnet_root_env_var_name, pal::string_t* recv);
 pal::string_t get_deps_from_app_binary(const pal::string_t& app_base, const pal::string_t& app);
 pal::string_t get_runtime_config_path(const pal::string_t& path, const pal::string_t& name);
 pal::string_t get_runtime_config_dev_path(const pal::string_t& path, const pal::string_t& name);

--- a/src/native/corehost/hostmisc/utils.h
+++ b/src/native/corehost/hostmisc/utils.h
@@ -41,7 +41,6 @@ bool get_global_shared_store_dirs(std::vector<pal::string_t>* dirs, const pal::s
 bool multilevel_lookup_enabled();
 void get_framework_and_sdk_locations(const pal::string_t& dotnet_dir, std::vector<pal::string_t>* locations);
 bool get_file_path_from_env(const pal::char_t* env_key, pal::string_t* recv);
-bool get_line_from_file(FILE* pFile, pal::string_t& line);
 size_t index_of_non_numeric(const pal::string_t& str, size_t i);
 bool try_stou(const pal::string_t& str, unsigned* num);
 bool get_dotnet_root_from_env(pal::string_t* used_dotnet_root_env_var_name, pal::string_t* recv);
@@ -49,11 +48,11 @@ pal::string_t get_deps_from_app_binary(const pal::string_t& app_base, const pal:
 pal::string_t get_runtime_config_path(const pal::string_t& path, const pal::string_t& name);
 pal::string_t get_runtime_config_dev_path(const pal::string_t& path, const pal::string_t& name);
 void get_runtime_config_paths(const pal::string_t& path, const pal::string_t& name, pal::string_t* cfg, pal::string_t* dev_cfg);
-pal::string_t get_dotnet_root_from_fxr_path(const pal::string_t &fxr_path);
+pal::string_t get_dotnet_root_from_fxr_path(const pal::string_t& fxr_path);
 
 // Get a download URL for a specific framework and version
 // If no framework is specified, a download URL for the runtime is returned
-pal::string_t get_download_url(const pal::char_t *framework_name = nullptr, const pal::char_t *framework_version = nullptr);
+pal::string_t get_download_url(const pal::char_t* framework_name = nullptr, const pal::char_t* framework_version = nullptr);
 
 pal::string_t to_lower(const pal::char_t* in);
 pal::string_t to_upper(const pal::char_t* in);
@@ -67,7 +66,7 @@ bool test_only_getenv(const pal::char_t* name, pal::string_t* recv);
 class propagate_error_writer_t
 {
 public:
-    typedef trace::error_writer_fn(__cdecl *set_error_writer_fn)(trace::error_writer_fn error_writer);
+    typedef trace::error_writer_fn(__cdecl* set_error_writer_fn)(trace::error_writer_fn error_writer);
 
 private:
     set_error_writer_fn m_set_error_writer;

--- a/src/native/corehost/test/nativehost/nativehost.cpp
+++ b/src/native/corehost/test/nativehost/nativehost.cpp
@@ -40,7 +40,7 @@ int main(const int argc, const pal::char_t *argv[])
         // args: ... [<explicit_load>] [<assembly_path>] [<dotnet_root>] [<hostfxr_to_load>]
         bool explicit_load = false;
         if (argc >= 3)
-            explicit_load = pal::strcmp(pal::to_lower(argv[2]).c_str(), _X("true")) == 0;
+            explicit_load = pal::strcmp(to_lower(argv[2]).c_str(), _X("true")) == 0;
 
         const pal::char_t *assembly_path = nullptr;
         if (argc >= 4 && pal::strcmp(argv[3], _X("nullptr")) != 0)
@@ -117,7 +117,7 @@ int main(const int argc, const pal::char_t *argv[])
         if (static_cast<StatusCode>(res) == StatusCode::Success)
         {
             std::cout << "get_hostfxr_path succeeded" << std::endl;
-            std::cout << "hostfxr_path: " << tostr(pal::to_lower(fxr_path.c_str())).data() << std::endl;
+            std::cout << "hostfxr_path: " << tostr(to_lower(fxr_path.c_str())).data() << std::endl;
             return EXIT_SUCCESS;
         }
         else


### PR DESCRIPTION
This PR implements the accepted [design](https://github.com/dotnet/designs/blob/main/accepted/2021/install-location-per-architecture.md) for multi-arch install locations. It adds the ability for Unix users to specify architecture-specific install locations in the install location config file (located in `/etc/dotnet/install_location`); this file currently contains a single line pointing to the registered install location.

Changes in this PR evolve the format of the aforementioned config file so that users are now able to specify multiple architecture-specific install locations and, optionally, keep the first line as it currently is (i.e., without any architecture prefix) -- this will be needed for backcompat with previous apphosts and will also work as the fallback install location if none of the arch install locations can be resolved.

This PR also gives users the ability to set architecture-specific environment variables for specifying the location of the .NET runtime by extending the current format to `DOTNET_ROOT_ARCH`. The current format, `DOTNET_ROOT` (and `DOTNET_ROOT(x86)` on Windows), will continue to be supported and will work as a fallback when no arch-specific env vars are used.

Currently on Windows x86, the only environment variable that is looked for finding the install location is `DOTNET_ROOT(x86)`, changes in this PR will cause to fallback to `DOTNET_ROOT` whenever `DOTNET_ROOT(x86)` is not set in win-x86.