### PR TITLE
Fix for bug #53520, Entry point not found

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
@@ -139,7 +139,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 MemberReference memberRef = token.MetadataReader.GetMemberReference((MemberReferenceHandle)token.Handle);
                 EntityHandle owningTypeHandle = memberRef.Parent;
-                AddModuleTokenForType(method.OwningType, new ModuleToken(token.Module, owningTypeHandle));
+                object owningType = token.Module.GetObject(owningTypeHandle, NotFoundBehavior.ReturnNull);
+                if (owningType != null)
+                {
+                    AddModuleTokenForType((TypeDesc)owningType, new ModuleToken(token.Module, owningTypeHandle));
+                }
                 memberRef.DecodeMethodSignature<DummyTypeInfo, ModuleTokenResolver>(new TokenResolverProvider(this, token.Module), this);
             }
         }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
@@ -139,11 +139,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 MemberReference memberRef = token.MetadataReader.GetMemberReference((MemberReferenceHandle)token.Handle);
                 EntityHandle owningTypeHandle = memberRef.Parent;
-                object owningType = token.Module.GetObject(owningTypeHandle, NotFoundBehavior.ReturnNull);
-                if (owningType != null)
-                {
-                    AddModuleTokenForType((TypeDesc)owningType, new ModuleToken(token.Module, owningTypeHandle));
-                }
+                TypeDesc owningType = (TypeDesc)token.Module.GetObject(owningTypeHandle, NotFoundBehavior.Throw);
+                AddModuleTokenForType(owningType, new ModuleToken(token.Module, owningTypeHandle));
                 memberRef.DecodeMethodSignature<DummyTypeInfo, ModuleTokenResolver>(new TokenResolverProvider(this, token.Module), this);
             }
         }


### PR DESCRIPTION
Manish investigated this issue and he found out that the problem
is caused by the fact that in the method

Newtonsoft.Json.Utilities.ReflectionUtils.GetFields

Crossgen2 produces a NewObject fixup for the incorrect type

System.Collections.Generic.List`1<System.Type>

instead of the right type

System.Collections.Generic.List`1<System.Reflection.MemberInfo>

This was caused by a bug in the token harvesting logic; at some
point resolveToken was asked to resolve the token 0x0A02BA,

string [System.Runtime/*23000001*/]System.Type/*01000019*/::get_Name() /* 0A0002BA */

As part of the token harvesting logic we looked at the
MethodReference.Parent (01000019) and stored it in the harvesting
table along with the OwningType of the method. The problem is
that the translation of the MemberReference to MethodDesc
resolves the method on a base class,

string [System.Reflection/*23000009*/]System.Reflection.MemberInfo/*01000076*/::get_Name() /* 0A0002B5 */

As a result we were storing the incorrect [token - type] pair
[01000019 - System.Reflection.MemberInfo] into the type token
translation table and that confused the signature encoder because
01000019 is System.Type.

The trivial solution is to separately translate the memberref
parent entity handle to the owning type entity instead than
extracting it from the MethodDesc. I have verified using R2RDump
that I now see the correct NewObject fixup getting generated
in the method.

Thanks

Tomas

Fixes: #53520 
/cc @dotnet/crossgen-contrib 