### PR TITLE
Move the "do not zero-extend setcc" optimization to lower

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -116,7 +116,7 @@ GenTree* Lowering::LowerNode(GenTree* node)
             break;
 
         case GT_STOREIND:
-            LowerStoreIndirCommon(node->AsIndir());
+            LowerStoreIndirCommon(node->AsStoreInd());
             break;
 
         case GT_ADD:
@@ -3548,7 +3548,7 @@ void Lowering::LowerStoreSingleRegCallStruct(GenTreeBlk* store)
     {
         store->ChangeType(regType);
         store->SetOper(GT_STOREIND);
-        LowerStoreIndirCommon(store);
+        LowerStoreIndirCommon(store->AsStoreInd());
         return;
     }
     else
@@ -4088,7 +4088,7 @@ void Lowering::InsertPInvokeMethodProlog()
         // The init routine sets InlinedCallFrame's m_pNext, so we just set the thead's top-of-stack
         GenTree* frameUpd = CreateFrameLinkUpdate(PushFrame);
         firstBlockRange.InsertBefore(insertionPoint, LIR::SeqTree(comp, frameUpd));
-        ContainCheckStoreIndir(frameUpd->AsIndir());
+        ContainCheckStoreIndir(frameUpd->AsStoreInd());
         DISPTREERANGE(firstBlockRange, frameUpd);
     }
 #endif // TARGET_64BIT
@@ -4151,7 +4151,7 @@ void Lowering::InsertPInvokeMethodEpilog(BasicBlock* returnBB DEBUGARG(GenTree* 
     {
         GenTree* frameUpd = CreateFrameLinkUpdate(PopFrame);
         returnBlockRange.InsertBefore(insertionPoint, LIR::SeqTree(comp, frameUpd));
-        ContainCheckStoreIndir(frameUpd->AsIndir());
+        ContainCheckStoreIndir(frameUpd->AsStoreInd());
     }
 }
 
@@ -4313,7 +4313,7 @@ void Lowering::InsertPInvokeCallProlog(GenTreeCall* call)
         // Stubs do this once per stub, not once per call.
         GenTree* frameUpd = CreateFrameLinkUpdate(PushFrame);
         BlockRange().InsertBefore(insertBefore, LIR::SeqTree(comp, frameUpd));
-        ContainCheckStoreIndir(frameUpd->AsIndir());
+        ContainCheckStoreIndir(frameUpd->AsStoreInd());
     }
 #endif // TARGET_64BIT
 
@@ -4323,7 +4323,7 @@ void Lowering::InsertPInvokeCallProlog(GenTreeCall* call)
     //  [tcb + offsetOfGcState] = 0
     GenTree* storeGCState = SetGCState(0);
     BlockRange().InsertBefore(insertBefore, LIR::SeqTree(comp, storeGCState));
-    ContainCheckStoreIndir(storeGCState->AsIndir());
+    ContainCheckStoreIndir(storeGCState->AsStoreInd());
 
     // Indicate that codegen has switched this thread to preemptive GC.
     // This tree node doesn't generate any code, but impacts LSRA and gc reporting.
@@ -4369,7 +4369,7 @@ void Lowering::InsertPInvokeCallEpilog(GenTreeCall* call)
 
     GenTree* tree = SetGCState(1);
     BlockRange().InsertBefore(insertionPoint, LIR::SeqTree(comp, tree));
-    ContainCheckStoreIndir(tree->AsIndir());
+    ContainCheckStoreIndir(tree->AsStoreInd());
 
     tree = CreateReturnTrapSeq();
     BlockRange().InsertBefore(insertionPoint, LIR::SeqTree(comp, tree));
@@ -4384,7 +4384,7 @@ void Lowering::InsertPInvokeCallEpilog(GenTreeCall* call)
     {
         tree = CreateFrameLinkUpdate(PopFrame);
         BlockRange().InsertBefore(insertionPoint, LIR::SeqTree(comp, tree));
-        ContainCheckStoreIndir(tree->AsIndir());
+        ContainCheckStoreIndir(tree->AsStoreInd());
     }
 #else
     const CORINFO_EE_INFO::InlinedCallFrameInfo& callFrameInfo = comp->eeGetEEInfo()->inlinedCallFrameInfo;
@@ -6376,7 +6376,7 @@ void Lowering::ContainCheckNode(GenTree* node)
             ContainCheckReturnTrap(node->AsOp());
             break;
         case GT_STOREIND:
-            ContainCheckStoreIndir(node->AsIndir());
+            ContainCheckStoreIndir(node->AsStoreInd());
             break;
         case GT_IND:
             ContainCheckIndir(node->AsIndir());
@@ -6557,9 +6557,8 @@ void Lowering::ContainCheckBitCast(GenTree* node)
 // Arguments:
 //    ind - the store indirection node we are lowering.
 //
-void Lowering::LowerStoreIndirCommon(GenTreeIndir* ind)
+void Lowering::LowerStoreIndirCommon(GenTreeStoreInd* ind)
 {
-    assert(ind->OperIs(GT_STOREIND));
     assert(ind->TypeGet() != TYP_STRUCT);
     TryCreateAddrMode(ind->Addr(), true);
     if (!comp->codeGen->gcInfo.gcIsWriteBarrierStoreIndNode(ind))
@@ -6759,6 +6758,6 @@ bool Lowering::TryTransformStoreObjAsStoreInd(GenTreeBlk* blkNode)
     {
         assert(src->TypeIs(regType) || src->IsCnsIntOrI() || src->IsCall());
     }
-    LowerStoreIndirCommon(blkNode);
+    LowerStoreIndirCommon(blkNode->AsStoreInd());
     return true;
 }

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -89,7 +89,7 @@ private:
     void ContainCheckBitCast(GenTree* node);
     void ContainCheckCallOperands(GenTreeCall* call);
     void ContainCheckIndir(GenTreeIndir* indirNode);
-    void ContainCheckStoreIndir(GenTreeIndir* indirNode);
+    void ContainCheckStoreIndir(GenTreeStoreInd* indirNode);
     void ContainCheckMul(GenTreeOp* node);
     void ContainCheckShiftRotate(GenTreeOp* node);
     void ContainCheckStoreLoc(GenTreeLclVarCommon* storeLoc) const;
@@ -292,9 +292,9 @@ private:
 #endif // defined(TARGET_XARCH)
 
     // Per tree node member functions
-    void LowerStoreIndirCommon(GenTreeIndir* ind);
+    void LowerStoreIndirCommon(GenTreeStoreInd* ind);
     void LowerIndir(GenTreeIndir* ind);
-    void LowerStoreIndir(GenTreeIndir* node);
+    void LowerStoreIndir(GenTreeStoreInd* node);
     GenTree* LowerAdd(GenTreeOp* node);
     bool LowerUnsignedDivOrMod(GenTreeOp* divMod);
     GenTree* LowerConstIntDivOrMod(GenTree* node);

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -1379,8 +1379,8 @@ void Lowering::ContainCheckCallOperands(GenTreeCall* call)
 void Lowering::ContainCheckStoreIndir(GenTreeStoreInd* node)
 {
 #ifdef TARGET_ARM64
-    GenTree* src = node->AsOp()->gtOp2;
-    if (!varTypeIsFloating(src->TypeGet()) && src->IsIntegralConst(0))
+    GenTree* src = node->Data();
+    if (src->IsIntegralConst(0))
     {
         // an integer zero for 'src' can be contained.
         MakeSrcContained(node, src);

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -218,7 +218,7 @@ void Lowering::LowerStoreLoc(GenTreeLclVarCommon* storeLoc)
 // Return Value:
 //    None.
 //
-void Lowering::LowerStoreIndir(GenTreeIndir* node)
+void Lowering::LowerStoreIndir(GenTreeStoreInd* node)
 {
     ContainCheckStoreIndir(node);
 }
@@ -1376,7 +1376,7 @@ void Lowering::ContainCheckCallOperands(GenTreeCall* call)
 // Arguments:
 //    node - pointer to the node
 //
-void Lowering::ContainCheckStoreIndir(GenTreeIndir* node)
+void Lowering::ContainCheckStoreIndir(GenTreeStoreInd* node)
 {
 #ifdef TARGET_ARM64
     GenTree* src = node->AsOp()->gtOp2;

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -110,7 +110,7 @@ void Lowering::LowerStoreLoc(GenTreeLclVarCommon* storeLoc)
 // Return Value:
 //    None.
 //
-void Lowering::LowerStoreIndir(GenTreeIndir* node)
+void Lowering::LowerStoreIndir(GenTreeStoreInd* node)
 {
     // Mark all GT_STOREIND nodes to indicate that it is not known
     // whether it represents a RMW memory op.
@@ -4575,7 +4575,7 @@ void Lowering::ContainCheckIndir(GenTreeIndir* node)
 // Arguments:
 //    node - pointer to the node
 //
-void Lowering::ContainCheckStoreIndir(GenTreeIndir* node)
+void Lowering::ContainCheckStoreIndir(GenTreeStoreInd* node)
 {
     // If the source is a containable immediate, make it contained, unless it is
     // an int-size or larger store of zero to memory, because we can generate smaller code

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -163,6 +163,12 @@ void Lowering::LowerStoreIndir(GenTreeStoreInd* node)
         }
     }
 
+    // Optimization: do not unnecessarily zero-extend the result of setcc.
+    if (varTypeIsByte(node) && (node->Data()->OperIsCompare() || node->Data()->OperIs(GT_SETCC)))
+    {
+        node->Data()->ChangeType(TYP_BYTE);
+    }
+
     ContainCheckStoreIndir(node);
 }
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13637,9 +13637,6 @@ DONE_MORPHING_CHILDREN:
                         gtReverseCond(op1);
                     }
 
-                    /* Propagate gtType of tree into op1 in case it is TYP_BYTE for setcc optimization */
-                    op1->gtType = tree->gtType;
-
                     noway_assert((op1->gtFlags & GTF_RELOP_JMP_USED) == 0);
                     op1->gtFlags |= tree->gtFlags & (GTF_RELOP_JMP_USED | GTF_RELOP_QMARK | GTF_DONT_CSE);
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13394,23 +13394,8 @@ DONE_MORPHING_CHILDREN:
                         tree->AsOp()->gtOp2 = op2 = op2->AsCast()->CastOp();
                     }
                 }
-                else if (op2->OperIsCompare() && varTypeIsByte(effectiveOp1->TypeGet()))
-                {
-                    /* We don't need to zero extend the setcc instruction */
-                    op2->gtType = TYP_BYTE;
-                }
             }
-            // If we introduced a CSE we may need to undo the optimization above
-            // (i.e. " op2->gtType = TYP_BYTE;" which depends upon op1 being a GT_IND of a byte type)
-            // When we introduce the CSE we remove the GT_IND and subsitute a GT_LCL_VAR in it place.
-            else if (op2->OperIsCompare() && (op2->gtType == TYP_BYTE) && (op1->gtOper == GT_LCL_VAR))
-            {
-                unsigned   varNum = op1->AsLclVarCommon()->GetLclNum();
-                LclVarDsc* varDsc = &lvaTable[varNum];
 
-                /* We again need to zero extend the setcc instruction */
-                op2->gtType = varDsc->TypeGet();
-            }
             fgAssignSetVarDef(tree);
 
             /* We can't CSE the LHS of an assignment */


### PR DESCRIPTION
It is XARCH-specific and moving it eliminates questionable code that is trying to compensate for CSE changing the store. Also removes a case where a node that actually produces `TYP_INT` has a small type in HIR.

Also, use strongly-typed trees (and related helpers) for the lowering functions that deal with `GT_STOREIND` to improve the clarity of code.

I was not looking for CQ improvements with this change, but there were, apparently, some cases that morph missed:

<details>
<summary>Windows x64 diffs</summary>

```
Running asm diffs of benchmarks.run.windows.x64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 624
Total bytes of diff: 605
Total bytes of delta: -19 (-3.04% of base)
    diff is an improvement.


Top file improvements (bytes):
         -16 : 26199.dasm (-2.72% of base)
          -3 : 2478.dasm (-8.33% of base)

2 total files with Code Size differences (2 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -16 (-2.72% of base) - Benchstone.BenchI.NDhrystone:Proc0()
          -3 (-8.33% of base) - Utf8Json.Internal.UnsafeMemory:.cctor()

Top method improvements (percentages):
          -3 (-8.33% of base) - Utf8Json.Internal.UnsafeMemory:.cctor()
         -16 (-2.72% of base) - Benchstone.BenchI.NDhrystone:Proc0()

2 total methods with Code Size differences (2 improved, 0 regressed), 0 unchanged.

Running asm diffs of coreclr_tests.pmi.windows.x64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 4897
Total bytes of diff: 4837
Total bytes of delta: -60 (-1.23% of base)
    diff is an improvement.


Top file improvements (bytes):
          -6 : 253256.dasm (-2.37% of base)
          -3 : 239999.dasm (-3.30% of base)
          -3 : 83958.dasm (-0.79% of base)
          -3 : 240000.dasm (-2.63% of base)
          -3 : 242054.dasm (-8.57% of base)
          -3 : 239996.dasm (-3.26% of base)
          -3 : 251116.dasm (-0.71% of base)
          -3 : 239966.dasm (-3.26% of base)
          -3 : 83952.dasm (-0.68% of base)
          -3 : 239021.dasm (-0.53% of base)
          -3 : 83956.dasm (-0.74% of base)
          -3 : 85847.dasm (-5.45% of base)
          -3 : 239995.dasm (-3.30% of base)
          -3 : 83955.dasm (-0.71% of base)
          -3 : 83959.dasm (-0.87% of base)
          -3 : 239998.dasm (-4.17% of base)
          -3 : 83719.dasm (-0.71% of base)
          -3 : 239997.dasm (-2.16% of base)
          -3 : 83951.dasm (-0.65% of base)

19 total files with Code Size differences (19 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
          -6 (-2.37% of base) - ParallelCrash:Main(System.String[]):int
          -3 (-3.30% of base) - OneStructOneInt:.ctor(OneInt):this
          -3 (-0.79% of base) - LocallocTest:unwindTest1()
          -3 (-2.63% of base) - OneStructOneRtTH:.ctor(OneRtTH):this
          -3 (-8.57% of base) - OVFTest:.cctor()
          -3 (-3.26% of base) - OneBool:.ctor(bool):this
          -3 (-0.71% of base) - Test:Main(System.String[]):int
          -3 (-3.26% of base) - OneString:.ctor(System.String):this
          -3 (-0.68% of base) - LocallocTest:unwindTest2(int,int,int,int,int,int,int,int,int):this
          -3 (-0.53% of base) - Benchstone.BenchI.NDhrystone:Proc0()
          -3 (-0.74% of base) - LocallocTest:unwindTest2(int,int,int,int,int,int,int,int,int):this
          -3 (-5.45% of base) - TestClass:sel():bool
          -3 (-3.30% of base) - OneInt:.ctor(int):this
          -3 (-0.71% of base) - LocallocTest:unwindTest1()
          -3 (-0.87% of base) - LocallocTest:unwindTest2(int,int,int,int,int,int,int,int,int):this
          -3 (-4.17% of base) - OneStructOneString:.ctor(OneString):this
          -3 (-0.71% of base) - ILGEN_0x57cc69ce:Method_0x183df1b1():int
          -3 (-2.16% of base) - OneRtTH:.ctor(System.RuntimeTypeHandle):this
          -3 (-0.65% of base) - LocallocTest:unwindTest1()

Top method improvements (percentages):
          -3 (-8.57% of base) - OVFTest:.cctor()
          -3 (-5.45% of base) - TestClass:sel():bool
          -3 (-4.17% of base) - OneStructOneString:.ctor(OneString):this
          -3 (-3.30% of base) - OneStructOneInt:.ctor(OneInt):this
          -3 (-3.30% of base) - OneInt:.ctor(int):this
          -3 (-3.26% of base) - OneBool:.ctor(bool):this
          -3 (-3.26% of base) - OneString:.ctor(System.String):this
          -3 (-2.63% of base) - OneStructOneRtTH:.ctor(OneRtTH):this
          -6 (-2.37% of base) - ParallelCrash:Main(System.String[]):int
          -3 (-2.16% of base) - OneRtTH:.ctor(System.RuntimeTypeHandle):this
          -3 (-0.87% of base) - LocallocTest:unwindTest2(int,int,int,int,int,int,int,int,int):this
          -3 (-0.79% of base) - LocallocTest:unwindTest1()
          -3 (-0.74% of base) - LocallocTest:unwindTest2(int,int,int,int,int,int,int,int,int):this
          -3 (-0.71% of base) - Test:Main(System.String[]):int
          -3 (-0.71% of base) - LocallocTest:unwindTest1()
          -3 (-0.71% of base) - ILGEN_0x57cc69ce:Method_0x183df1b1():int
          -3 (-0.68% of base) - LocallocTest:unwindTest2(int,int,int,int,int,int,int,int,int):this
          -3 (-0.65% of base) - LocallocTest:unwindTest1()
          -3 (-0.53% of base) - Benchstone.BenchI.NDhrystone:Proc0()

19 total methods with Code Size differences (19 improved, 0 regressed), 0 unchanged.

Running asm diffs of libraries.crossgen.windows.x64.checked.mch

Running asm diffs of libraries.crossgen2.windows.x64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 163
Total bytes of diff: 160
Total bytes of delta: -3 (-1.84% of base)
    diff is an improvement.


Top file improvements (bytes):
          -3 : 131232.dasm (-1.84% of base)

1 total files with Code Size differences (1 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
          -3 (-1.84% of base) - BitArrayEnumeratorSimple:MoveNext():bool:this

Top method improvements (percentages):
          -3 (-1.84% of base) - BitArrayEnumeratorSimple:MoveNext():bool:this

1 total methods with Code Size differences (1 improved, 0 regressed), 0 unchanged.

Running asm diffs of libraries.pmi.windows.x64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 4762
Total bytes of diff: 4744
Total bytes of delta: -18 (-0.38% of base)
    diff is an improvement.


Top file improvements (bytes):
          -3 : 215927.dasm (-2.94% of base)
          -3 : 166865.dasm (-0.62% of base)
          -3 : 166023.dasm (-0.08% of base)
          -3 : 176854.dasm (-8.33% of base)
          -3 : 155365.dasm (-1.67% of base)
          -3 : 215926.dasm (-2.94% of base)

6 total files with Code Size differences (6 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
          -3 (-2.94% of base) - System.Security.Cryptography.Xml.SignedXmlDebugLog:get_VerboseLoggingEnabled():bool
          -3 (-0.62% of base) - System.Data.Common.ADP:.cctor()
          -3 (-0.08% of base) - System.Data.OleDb.ODB:.cctor()
          -3 (-8.33% of base) - System.IO.Compression.ZipArchiveEntry:.cctor()
          -3 (-1.67% of base) - BitArrayEnumeratorSimple:MoveNext():bool:this
          -3 (-2.94% of base) - System.Security.Cryptography.Xml.SignedXmlDebugLog:get_InformationLoggingEnabled():bool

Top method improvements (percentages):
          -3 (-8.33% of base) - System.IO.Compression.ZipArchiveEntry:.cctor()
          -3 (-2.94% of base) - System.Security.Cryptography.Xml.SignedXmlDebugLog:get_VerboseLoggingEnabled():bool
          -3 (-2.94% of base) - System.Security.Cryptography.Xml.SignedXmlDebugLog:get_InformationLoggingEnabled():bool
          -3 (-1.67% of base) - BitArrayEnumeratorSimple:MoveNext():bool:this
          -3 (-0.62% of base) - System.Data.Common.ADP:.cctor()
          -3 (-0.08% of base) - System.Data.OleDb.ODB:.cctor()

6 total methods with Code Size differences (6 improved, 0 regressed), 0 unchanged.

Running asm diffs of libraries_tests.pmi.windows.x64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 4647
Total bytes of diff: 4497
Total bytes of delta: -150 (-3.23% of base)
    diff is an improvement.


Top file improvements (bytes):
          -9 : 2587.dasm (-5.45% of base)
          -9 : 2601.dasm (-4.13% of base)
          -6 : 117781.dasm (-4.51% of base)
          -3 : 190531.dasm (-8.57% of base)
          -3 : 199520.dasm (-6.12% of base)
          -3 : 219914.dasm (-8.57% of base)
          -3 : 224218.dasm (-8.57% of base)
          -3 : 26189.dasm (-3.30% of base)
          -3 : 296193.dasm (-8.57% of base)
          -3 : 5051.dasm (-5.36% of base)
          -3 : 120465.dasm (-3.41% of base)
          -3 : 218435.dasm (-8.57% of base)
          -3 : 291444.dasm (-8.57% of base)
          -3 : 309112.dasm (-8.57% of base)
          -3 : 93739.dasm (-0.65% of base)
          -3 : 117774.dasm (-4.84% of base)
          -3 : 2030.dasm (-1.04% of base)
          -3 : 221066.dasm (-8.57% of base)
          -3 : 24160.dasm (-0.63% of base)
          -3 : 26212.dasm (-3.45% of base)

45 total files with Code Size differences (45 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
          -9 (-5.45% of base) - Microsoft.Build.Internal.Utilities:RefreshInternalEnvironmentValues()
          -9 (-4.13% of base) - Microsoft.Build.Internal.Utilities:.cctor()
          -6 (-4.51% of base) - Microsoft.Build.Tasks.Copy:.cctor()
          -3 (-8.57% of base) - System.Net.Tests.HttpListenerContextTests:.cctor()
          -3 (-6.12% of base) - System.Security.Cryptography.X509Certificates.Tests.Common.RevocationResponder:.cctor()
          -3 (-8.57% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-8.57% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-3.30% of base) - <>c__DisplayClass4_0:<Get_InvalidIndex_ThrowsArgumentOutOfRangeException>b__1():System.Object:this
          -3 (-8.57% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-5.36% of base) - Microsoft.Build.BackEnd.Logging.TargetLoggingContext:.cctor()
          -3 (-3.41% of base) - Microsoft.Build.Shared.ErrorUtilities:.cctor()
          -3 (-8.57% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-8.57% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-8.57% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-0.65% of base) - System.Text.Json.Tests.Utf8JsonWriterTests:.cctor()
          -3 (-4.84% of base) - Microsoft.Build.Tasks.Copy:RefreshInternalEnvironmentValues()
          -3 (-1.04% of base) - Microsoft.Build.Evaluation.Project:.cctor()
          -3 (-8.57% of base) - System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests.DecryptTests:.cctor()
          -3 (-0.63% of base) - System.Collections.Tests.BitArray_GetSetTests:GetEnumerator(System.Boolean[])
          -3 (-3.45% of base) - <>c__DisplayClass13_0:<Length_Set>b__0():System.Object:this

Top method improvements (percentages):
          -3 (-8.57% of base) - System.Net.Tests.HttpListenerContextTests:.cctor()
          -3 (-8.57% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-8.57% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-8.57% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-8.57% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-8.57% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-8.57% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-8.57% of base) - System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests.DecryptTests:.cctor()
          -3 (-8.57% of base) - System.Net.Tests.HttpListenerWebSocketTests:.cctor()
          -3 (-8.57% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-8.57% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-8.57% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-8.57% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-8.57% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-8.57% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-8.57% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-8.57% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-8.57% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-8.33% of base) - System.Text.Json.Serialization.Tests.WriteValueTests:.cctor()
          -3 (-8.33% of base) - System.Composition.TypedParts.Tests.ReflectionTests:.cctor()

45 total methods with Code Size differences (45 improved, 0 regressed), 0 unchanged.
```
</details>

<details>
<summary>Windows x86 diffs</summary>

```
Running asm diffs of benchmarks.run.windows.x86.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 447
Total bytes of diff: 444
Total bytes of delta: -3 (-0.67% of base)
    diff is an improvement.


Top file improvements (bytes):
          -3 : 2466.dasm (-12.50% of base)

1 total files with Code Size differences (1 improved, 0 regressed), 1 unchanged.

Top method improvements (bytes):
          -3 (-12.50% of base) - Utf8Json.Internal.UnsafeMemory:.cctor()

Top method improvements (percentages):
          -3 (-12.50% of base) - Utf8Json.Internal.UnsafeMemory:.cctor()

1 total methods with Code Size differences (1 improved, 0 regressed), 1 unchanged.

Running asm diffs of coreclr_tests.pmi.windows.x86.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3573
Total bytes of diff: 3503
Total bytes of delta: -70 (-1.96% of base)
    diff is an improvement.


Top file improvements (bytes):
          -7 : 83941.dasm (-2.15% of base)
          -7 : 83945.dasm (-2.39% of base)
          -7 : 83948.dasm (-2.68% of base)
          -6 : 252844.dasm (-3.09% of base)
          -3 : 239630.dasm (-4.41% of base)
          -3 : 83708.dasm (-0.76% of base)
          -3 : 239600.dasm (-4.69% of base)
          -3 : 85834.dasm (-7.32% of base)
          -3 : 239631.dasm (-2.86% of base)
          -3 : 250711.dasm (-0.96% of base)
          -3 : 239629.dasm (-4.48% of base)
          -3 : 239632.dasm (-5.56% of base)
          -3 : 241687.dasm (-13.04% of base)
          -3 : 83947.dasm (-1.28% of base)
          -3 : 238800.dasm (-0.74% of base)
          -3 : 83940.dasm (-0.99% of base)
          -3 : 239633.dasm (-4.48% of base)
          -3 : 83944.dasm (-1.10% of base)
          -1 : 239634.dasm (-1.16% of base)

19 total files with Code Size differences (19 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
          -7 (-2.15% of base) - LocallocTest:unwindTest2(int,int,int,int,int,int,int,int,int):this
          -7 (-2.39% of base) - LocallocTest:unwindTest2(int,int,int,int,int,int,int,int,int):this
          -7 (-2.68% of base) - LocallocTest:unwindTest2(int,int,int,int,int,int,int,int,int):this
          -6 (-3.09% of base) - ParallelCrash:Main(System.String[]):int
          -3 (-4.41% of base) - OneBool:.ctor(bool):this
          -3 (-0.76% of base) - ILGEN_0x57cc69ce:Method_0x183df1b1():int
          -3 (-4.69% of base) - OneString:.ctor(System.String):this
          -3 (-7.32% of base) - TestClass:sel():bool
          -3 (-2.86% of base) - OneRtTH:.ctor(System.RuntimeTypeHandle):this
          -3 (-0.96% of base) - Test:Main(System.String[]):int
          -3 (-4.48% of base) - OneInt:.ctor(int):this
          -3 (-5.56% of base) - OneStructOneString:.ctor(OneString):this
          -3 (-13.04% of base) - OVFTest:.cctor()
          -3 (-1.28% of base) - LocallocTest:unwindTest1()
          -3 (-0.74% of base) - Benchstone.BenchI.NDhrystone:Proc0()
          -3 (-0.99% of base) - LocallocTest:unwindTest1()
          -3 (-4.48% of base) - OneStructOneInt:.ctor(OneInt):this
          -3 (-1.10% of base) - LocallocTest:unwindTest1()
          -1 (-1.16% of base) - OneStructOneRtTH:.ctor(OneRtTH):this

Top method improvements (percentages):
          -3 (-13.04% of base) - OVFTest:.cctor()
          -3 (-7.32% of base) - TestClass:sel():bool
          -3 (-5.56% of base) - OneStructOneString:.ctor(OneString):this
          -3 (-4.69% of base) - OneString:.ctor(System.String):this
          -3 (-4.48% of base) - OneInt:.ctor(int):this
          -3 (-4.48% of base) - OneStructOneInt:.ctor(OneInt):this
          -3 (-4.41% of base) - OneBool:.ctor(bool):this
          -6 (-3.09% of base) - ParallelCrash:Main(System.String[]):int
          -3 (-2.86% of base) - OneRtTH:.ctor(System.RuntimeTypeHandle):this
          -7 (-2.68% of base) - LocallocTest:unwindTest2(int,int,int,int,int,int,int,int,int):this
          -7 (-2.39% of base) - LocallocTest:unwindTest2(int,int,int,int,int,int,int,int,int):this
          -7 (-2.15% of base) - LocallocTest:unwindTest2(int,int,int,int,int,int,int,int,int):this
          -3 (-1.28% of base) - LocallocTest:unwindTest1()
          -1 (-1.16% of base) - OneStructOneRtTH:.ctor(OneRtTH):this
          -3 (-1.10% of base) - LocallocTest:unwindTest1()
          -3 (-0.99% of base) - LocallocTest:unwindTest1()
          -3 (-0.96% of base) - Test:Main(System.String[]):int
          -3 (-0.76% of base) - ILGEN_0x57cc69ce:Method_0x183df1b1():int
          -3 (-0.74% of base) - Benchstone.BenchI.NDhrystone:Proc0()

19 total methods with Code Size differences (19 improved, 0 regressed), 0 unchanged.

Running asm diffs of libraries.crossgen.windows.x86.checked.mch

Running asm diffs of libraries.crossgen2.windows.x86.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 141
Total bytes of diff: 138
Total bytes of delta: -3 (-2.13% of base)
    diff is an improvement.


Top file improvements (bytes):
          -3 : 201795.dasm (-2.13% of base)

1 total files with Code Size differences (1 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
          -3 (-2.13% of base) - BitArrayEnumeratorSimple:MoveNext():bool:this

Top method improvements (percentages):
          -3 (-2.13% of base) - BitArrayEnumeratorSimple:MoveNext():bool:this

1 total methods with Code Size differences (1 improved, 0 regressed), 0 unchanged.

Running asm diffs of libraries.pmi.windows.x86.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3515
Total bytes of diff: 3497
Total bytes of delta: -18 (-0.51% of base)
    diff is an improvement.


Top file improvements (bytes):
          -3 : 121617.dasm (-0.74% of base)
          -3 : 181737.dasm (-2.01% of base)
          -3 : 120761.dasm (-0.11% of base)
          -3 : 217941.dasm (-3.61% of base)
          -3 : 217942.dasm (-3.61% of base)
          -3 : 191973.dasm (-12.50% of base)

6 total files with Code Size differences (6 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
          -3 (-0.74% of base) - System.Data.Common.ADP:.cctor()
          -3 (-2.01% of base) - BitArrayEnumeratorSimple:MoveNext():bool:this
          -3 (-0.11% of base) - System.Data.OleDb.ODB:.cctor()
          -3 (-3.61% of base) - System.Security.Cryptography.Xml.SignedXmlDebugLog:get_InformationLoggingEnabled():bool
          -3 (-3.61% of base) - System.Security.Cryptography.Xml.SignedXmlDebugLog:get_VerboseLoggingEnabled():bool
          -3 (-12.50% of base) - System.IO.Compression.ZipArchiveEntry:.cctor()

Top method improvements (percentages):
          -3 (-12.50% of base) - System.IO.Compression.ZipArchiveEntry:.cctor()
          -3 (-3.61% of base) - System.Security.Cryptography.Xml.SignedXmlDebugLog:get_InformationLoggingEnabled():bool
          -3 (-3.61% of base) - System.Security.Cryptography.Xml.SignedXmlDebugLog:get_VerboseLoggingEnabled():bool
          -3 (-2.01% of base) - BitArrayEnumeratorSimple:MoveNext():bool:this
          -3 (-0.74% of base) - System.Data.Common.ADP:.cctor()
          -3 (-0.11% of base) - System.Data.OleDb.ODB:.cctor()

6 total methods with Code Size differences (6 improved, 0 regressed), 0 unchanged.

Running asm diffs of libraries_tests.pmi.windows.x86.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3486
Total bytes of diff: 3336
Total bytes of delta: -150 (-4.30% of base)
    diff is an improvement.


Top file improvements (bytes):
          -9 : 2590.dasm (-5.56% of base)
          -9 : 2576.dasm (-6.87% of base)
          -6 : 116942.dasm (-5.61% of base)
          -3 : 119626.dasm (-5.08% of base)
          -3 : 197149.dasm (-13.04% of base)
          -3 : 198571.dasm (-10.34% of base)
          -3 : 217414.dasm (-13.04% of base)
          -3 : 221681.dasm (-8.33% of base)
          -3 : 24072.dasm (-0.72% of base)
          -3 : 26093.dasm (-3.95% of base)
          -3 : 26116.dasm (-4.11% of base)
          -3 : 307409.dasm (-13.04% of base)
          -3 : 307838.dasm (-13.04% of base)
          -3 : 118779.dasm (-5.08% of base)
          -3 : 296390.dasm (-13.04% of base)
          -3 : 194302.dasm (-13.04% of base)
          -3 : 2020.dasm (-1.47% of base)
          -3 : 218893.dasm (-13.04% of base)
          -3 : 220710.dasm (-13.04% of base)
          -3 : 223197.dasm (-13.04% of base)

45 total files with Code Size differences (45 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
          -9 (-5.56% of base) - Microsoft.Build.Internal.Utilities:.cctor()
          -9 (-6.87% of base) - Microsoft.Build.Internal.Utilities:RefreshInternalEnvironmentValues()
          -6 (-5.61% of base) - Microsoft.Build.Tasks.Copy:.cctor()
          -3 (-5.08% of base) - Microsoft.Build.Shared.ErrorUtilities:.cctor()
          -3 (-13.04% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-10.34% of base) - System.Security.Cryptography.X509Certificates.Tests.Common.RevocationResponder:.cctor()
          -3 (-13.04% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-8.33% of base) - System.Security.Cryptography.X509Certificates.Tests.TestEnvironmentConfiguration:.cctor()
          -3 (-0.72% of base) - System.Collections.Tests.BitArray_GetSetTests:GetEnumerator(System.Boolean[])
          -3 (-3.95% of base) - <>c__DisplayClass4_0:<Get_InvalidIndex_ThrowsArgumentOutOfRangeException>b__1():System.Object:this
          -3 (-4.11% of base) - <>c__DisplayClass13_0:<Length_Set>b__0():System.Object:this
          -3 (-13.04% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-13.04% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-5.08% of base) - Microsoft.Build.Shared.ErrorUtilities:.cctor()
          -3 (-13.04% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-13.04% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-1.47% of base) - Microsoft.Build.Evaluation.Project:.cctor()
          -3 (-13.04% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-13.04% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-13.04% of base) - Test.Cryptography.PlatformSupport:.cctor()

Top method improvements (percentages):
          -3 (-13.04% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-13.04% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-13.04% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-13.04% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-13.04% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-13.04% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-13.04% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-13.04% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-13.04% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-13.04% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-13.04% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-13.04% of base) - System.Net.Tests.HttpListenerWebSocketTests:.cctor()
          -3 (-13.04% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-13.04% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-13.04% of base) - System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests.DecryptTests:.cctor()
          -3 (-13.04% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-13.04% of base) - Test.Cryptography.PlatformSupport:.cctor()
          -3 (-13.04% of base) - System.Net.Tests.HttpListenerContextTests:.cctor()
          -3 (-12.50% of base) - System.Tests.GCTests:.cctor()
          -3 (-12.50% of base) - System.Composition.TypedParts.Tests.ReflectionTests:.cctor()

45 total methods with Code Size differences (45 improved, 0 regressed), 0 unchanged.
```
</details>

As expected, this is a no-diff change for ARMARCH - verified via replaying `linux-arm` and `linux-arm64` collections.

Depending on the merge order, this might conflict with #53667 (that's fine, just mentioning it for completeness).