### PR TITLE
Add unsigned variants for BitConverter float bit APIs

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Variant.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Variant.cs
@@ -198,7 +198,7 @@ namespace System
         {
             _objref = null;
             _flags = CV_R4;
-            _data = (uint)BitConverter.SingleToInt32Bits(val);
+            _data = BitConverter.SingleToUInt32Bits(val);
         }
 
         public Variant(double val)
@@ -328,7 +328,7 @@ namespace System
                 CV_U4 => (uint)_data,
                 CV_I8 => _data,
                 CV_U8 => (ulong)_data,
-                CV_R4 => BitConverter.Int32BitsToSingle((int)_data),
+                CV_R4 => BitConverter.UInt32BitsToSingle((uint)_data),
                 CV_R8 => BitConverter.Int64BitsToDouble(_data),
                 CV_DATETIME => new DateTime(_data),
                 CV_TIMESPAN => new TimeSpan(_data),

--- a/src/libraries/Common/tests/System/RealParserTestsBase.cs
+++ b/src/libraries/Common/tests/System/RealParserTestsBase.cs
@@ -410,7 +410,7 @@ namespace System.Tests
             for (int i = start; i != end; i++)
             {
                 double d = Math.Pow(b, i);
-                ulong bits = (ulong)BitConverter.DoubleToInt64Bits(d);
+                ulong bits = BitConverter.DoubleToUInt64Bits(d);
 
                 TestRoundTripDouble(bits - 1);
                 TestRoundTripDouble(bits);
@@ -594,7 +594,7 @@ namespace System.Tests
             for (int i = start; i != end; ++i)
             {
                 float f = MathF.Pow(b, i);
-                uint bits = (uint)BitConverter.SingleToInt32Bits(f);
+                uint bits = BitConverter.SingleToUInt32Bits(f);
 
                 TestRoundTripSingle(bits - 1);
                 TestRoundTripSingle(bits);
@@ -604,7 +604,7 @@ namespace System.Tests
 
         private void CheckOneDouble(string s, ulong expectedBits)
         {
-            CheckOneDouble(s, BitConverter.Int64BitsToDouble((long)(expectedBits)));
+            CheckOneDouble(s, BitConverter.UInt64BitsToDouble(expectedBits));
         }
 
         private void CheckOneDouble(string s, double expected)
@@ -620,7 +620,7 @@ namespace System.Tests
 
         private void CheckOneSingle(string s, uint expectedBits)
         {
-            CheckOneSingle(s, BitConverter.Int32BitsToSingle((int)(expectedBits)));
+            CheckOneSingle(s, BitConverter.UInt32BitsToSingle(expectedBits));
         }
 
         private void CheckOneSingle(string s, float expected)
@@ -642,7 +642,7 @@ namespace System.Tests
 
         private void TestRoundTripDouble(ulong bits)
         {
-            double d = BitConverter.Int64BitsToDouble((long)(bits));
+            double d = BitConverter.UInt64BitsToDouble(bits);
 
             if (double.IsFinite(d))
             {
@@ -659,7 +659,7 @@ namespace System.Tests
 
         private void TestRoundTripSingle(uint bits)
         {
-            float d = BitConverter.Int32BitsToSingle((int)(bits));
+            float d = BitConverter.UInt32BitsToSingle(bits);
 
             if (float.IsFinite(d))
             {

--- a/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
@@ -848,12 +848,112 @@ namespace System
         }
 
         /// <summary>
-        /// Converts the specified 16-bit signed integer to a half-precision floating point number.
+        /// Converts the specified 16-bit unsigned integer to a half-precision floating point number.
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>A half-precision floating point number whose bits are identical to <paramref name="value"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe Half Int16BitsToHalf(short value)
+        {
+            return *(Half*)&value;
+        }
+
+        /// <summary>
+        /// Converts the specified double-precision floating point number to a 64-bit unsigned integer.
+        /// </summary>
+        /// <param name="value">The number to convert.</param>
+        /// <returns>A 64-bit unsigned integer whose bits are identical to <paramref name="value"/>.</returns>
+        [CLSCompliant(false)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe ulong DoubleToUInt64Bits(double value)
+        {
+            // Workaround for https://github.com/dotnet/runtime/issues/11413
+            if (Sse2.X64.IsSupported)
+            {
+                Vector128<ulong> vec = Vector128.CreateScalarUnsafe(value).AsUInt64();
+                return Sse2.X64.ConvertToUInt64(vec);
+            }
+
+            return *((ulong*)&value);
+        }
+
+        /// <summary>
+        /// Converts the specified 64-bit unsigned integer to a double-precision floating point number.
+        /// </summary>
+        /// <param name="value">The number to convert.</param>
+        /// <returns>A double-precision floating point number whose bits are identical to <paramref name="value"/>.</returns>
+        [CLSCompliant(false)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe double UInt64BitsToDouble(ulong value)
+        {
+            // Workaround for https://github.com/dotnet/runtime/issues/11413
+            if (Sse2.X64.IsSupported)
+            {
+                Vector128<double> vec = Vector128.CreateScalarUnsafe(value).AsDouble();
+                return vec.ToScalar();
+            }
+
+            return *((double*)&value);
+        }
+
+        /// <summary>
+        /// Converts the specified single-precision floating point number to a 32-bit unsigned integer.
+        /// </summary>
+        /// <param name="value">The number to convert.</param>
+        /// <returns>A 32-bit unsigned integer whose bits are identical to <paramref name="value"/>.</returns>
+        [CLSCompliant(false)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe uint SingleToUInt32Bits(float value)
+        {
+            // Workaround for https://github.com/dotnet/runtime/issues/11413
+            if (Sse2.IsSupported)
+            {
+                Vector128<uint> vec = Vector128.CreateScalarUnsafe(value).AsUInt32();
+                return Sse2.ConvertToUInt32(vec);
+            }
+
+            return *((uint*)&value);
+        }
+
+        /// <summary>
+        /// Converts the specified 32-bit unsigned integer to a single-precision floating point number.
+        /// </summary>
+        /// <param name="value">The number to convert.</param>
+        /// <returns>A single-precision floating point number whose bits are identical to <paramref name="value"/>.</returns>
+        [CLSCompliant(false)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe float UInt32BitsToSingle(uint value)
+        {
+            // Workaround for https://github.com/dotnet/runtime/issues/11413
+            if (Sse2.IsSupported)
+            {
+                Vector128<float> vec = Vector128.CreateScalarUnsafe(value).AsSingle();
+                return vec.ToScalar();
+            }
+
+            return *((float*)&value);
+        }
+
+        /// <summary>
+        /// Converts the specified half-precision floating point number to a 16-bit unsigned integer.
+        /// </summary>
+        /// <param name="value">The number to convert.</param>
+        /// <returns>A 16-bit unsigned integer whose bits are identical to <paramref name="value"/>.</returns>
+        [CLSCompliant(false)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe ushort HalfToUInt16Bits(Half value)
+        {
+            return *((ushort*)&value);
+        }
+
+        /// <summary>
+        /// Converts the specified 16-bit unsigned integer to a half-precision floating point number.
+        /// </summary>
+        /// <param name="value">The number to convert.</param>
+        /// <returns>A half-precision floating point number whose bits are identical to <paramref name="value"/>.</returns>
+        [CLSCompliant(false)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe Half UInt16BitsToHalf(ushort value)
         {
             return *(Half*)&value;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
@@ -874,7 +874,7 @@ namespace System
         /// <returns>A double-precision floating point number whose bits are identical to <paramref name="value"/>.</returns>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe double UInt64BitsToDouble(ulong value) => Int64BitsToDouble((ulong)value);
+        public static unsafe double UInt64BitsToDouble(ulong value) => Int64BitsToDouble((long)value);
 
         /// <summary>
         /// Converts the specified single-precision floating point number to a 32-bit unsigned integer.

--- a/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
@@ -865,17 +865,7 @@ namespace System
         /// <returns>A 64-bit unsigned integer whose bits are identical to <paramref name="value"/>.</returns>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe ulong DoubleToUInt64Bits(double value)
-        {
-            // Workaround for https://github.com/dotnet/runtime/issues/11413
-            if (Sse2.X64.IsSupported)
-            {
-                Vector128<ulong> vec = Vector128.CreateScalarUnsafe(value).AsUInt64();
-                return Sse2.X64.ConvertToUInt64(vec);
-            }
-
-            return *((ulong*)&value);
-        }
+        public static unsafe ulong DoubleToUInt64Bits(double value) => (ulong)DoubleToInt64Bits(value);
 
         /// <summary>
         /// Converts the specified 64-bit unsigned integer to a double-precision floating point number.
@@ -884,17 +874,7 @@ namespace System
         /// <returns>A double-precision floating point number whose bits are identical to <paramref name="value"/>.</returns>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe double UInt64BitsToDouble(ulong value)
-        {
-            // Workaround for https://github.com/dotnet/runtime/issues/11413
-            if (Sse2.X64.IsSupported)
-            {
-                Vector128<double> vec = Vector128.CreateScalarUnsafe(value).AsDouble();
-                return vec.ToScalar();
-            }
-
-            return *((double*)&value);
-        }
+        public static unsafe double UInt64BitsToDouble(ulong value) => Int64BitsToDouble((ulong)value);
 
         /// <summary>
         /// Converts the specified single-precision floating point number to a 32-bit unsigned integer.
@@ -903,17 +883,7 @@ namespace System
         /// <returns>A 32-bit unsigned integer whose bits are identical to <paramref name="value"/>.</returns>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe uint SingleToUInt32Bits(float value)
-        {
-            // Workaround for https://github.com/dotnet/runtime/issues/11413
-            if (Sse2.IsSupported)
-            {
-                Vector128<uint> vec = Vector128.CreateScalarUnsafe(value).AsUInt32();
-                return Sse2.ConvertToUInt32(vec);
-            }
-
-            return *((uint*)&value);
-        }
+        public static unsafe uint SingleToUInt32Bits(float value) => (uint)SingleToInt32Bits(value);
 
         /// <summary>
         /// Converts the specified 32-bit unsigned integer to a single-precision floating point number.
@@ -922,17 +892,7 @@ namespace System
         /// <returns>A single-precision floating point number whose bits are identical to <paramref name="value"/>.</returns>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe float UInt32BitsToSingle(uint value)
-        {
-            // Workaround for https://github.com/dotnet/runtime/issues/11413
-            if (Sse2.IsSupported)
-            {
-                Vector128<float> vec = Vector128.CreateScalarUnsafe(value).AsSingle();
-                return vec.ToScalar();
-            }
-
-            return *((float*)&value);
-        }
+        public static unsafe float UInt32BitsToSingle(uint value) => Int32BitsToSingle((int)value);
 
         /// <summary>
         /// Converts the specified half-precision floating point number to a 16-bit unsigned integer.
@@ -941,10 +901,7 @@ namespace System
         /// <returns>A 16-bit unsigned integer whose bits are identical to <paramref name="value"/>.</returns>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe ushort HalfToUInt16Bits(Half value)
-        {
-            return *((ushort*)&value);
-        }
+        public static unsafe ushort HalfToUInt16Bits(Half value) => (ushort)HalfToInt16Bits(value);
 
         /// <summary>
         /// Converts the specified 16-bit unsigned integer to a half-precision floating point number.
@@ -953,9 +910,6 @@ namespace System
         /// <returns>A half-precision floating point number whose bits are identical to <paramref name="value"/>.</returns>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe Half UInt16BitsToHalf(ushort value)
-        {
-            return *(Half*)&value;
-        }
+        public static unsafe Half UInt16BitsToHalf(ushort value) => Int16BitsToHalf((short)value);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/BitConverter.cs
@@ -848,7 +848,7 @@ namespace System
         }
 
         /// <summary>
-        /// Converts the specified 16-bit unsigned integer to a half-precision floating point number.
+        /// Converts the specified 16-bit signed integer to a half-precision floating point number.
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>A half-precision floating point number whose bits are identical to <paramref name="value"/>.</returns>

--- a/src/libraries/System.Private.CoreLib/src/System/Half.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Half.cs
@@ -491,7 +491,7 @@ namespace System
         {
             const int SingleMaxExponent = 0xFF;
 
-            uint floatInt = (uint)BitConverter.SingleToInt32Bits(value);
+            uint floatInt = BitConverter.SingleToUInt32Bits(value);
             bool sign = (floatInt & float.SignMask) >> float.SignShift != 0;
             int exp = (int)(floatInt & float.ExponentMask) >> float.ExponentShift;
             uint sig = floatInt & float.SignificandMask;
@@ -519,7 +519,7 @@ namespace System
         {
             const int DoubleMaxExponent = 0x7FF;
 
-            ulong doubleInt = (ulong)BitConverter.DoubleToInt64Bits(value);
+            ulong doubleInt = BitConverter.DoubleToUInt64Bits(value);
             bool sign = (doubleInt & double.SignMask) >> double.SignShift != 0;
             int exp = (int)((doubleInt & double.ExponentMask) >> double.ExponentShift);
             ulong sig = doubleInt & double.SignificandMask;
@@ -561,7 +561,7 @@ namespace System
             {
                 if (sig == 0)
                 {
-                    return BitConverter.Int32BitsToSingle((int)(sign ? float.SignMask : 0)); // Positive / Negative zero
+                    return BitConverter.UInt32BitsToSingle(sign ? float.SignMask : 0); // Positive / Negative zero
                 }
                 (exp, sig) = NormSubnormalF16Sig(sig);
                 exp -= 1;
@@ -589,7 +589,7 @@ namespace System
             {
                 if (sig == 0)
                 {
-                    return BitConverter.Int64BitsToDouble((long)(sign ? double.SignMask : 0)); // Positive / Negative zero
+                    return BitConverter.UInt64BitsToDouble(sign ? double.SignMask : 0); // Positive / Negative zero
                 }
                 (exp, sig) = NormSubnormalF16Sig(sig);
                 exp -= 1;
@@ -621,7 +621,7 @@ namespace System
             uint signInt = (sign ? 1U : 0U) << SignShift;
             uint sigInt = (uint)(significand >> 54);
 
-            return BitConverter.Int16BitsToHalf((short)(signInt | NaNBits | sigInt));
+            return BitConverter.UInt16BitsToHalf((ushort)(signInt | NaNBits | sigInt));
         }
 
         private static ushort RoundPackToHalf(bool sign, short exp, ushort sig)
@@ -670,7 +670,7 @@ namespace System
             uint signInt = (sign ? 1U : 0U) << float.SignShift;
             uint sigInt = (uint)(significand >> 41);
 
-            return BitConverter.Int32BitsToSingle((int)(signInt | NaNBits | sigInt));
+            return BitConverter.UInt32BitsToSingle(signInt | NaNBits | sigInt);
         }
 
         private static double CreateDoubleNaN(bool sign, ulong significand)
@@ -680,14 +680,14 @@ namespace System
             ulong signInt = (sign ? 1UL : 0UL) << double.SignShift;
             ulong sigInt = significand >> 12;
 
-            return BitConverter.Int64BitsToDouble((long)(signInt | NaNBits | sigInt));
+            return BitConverter.UInt64BitsToDouble(signInt | NaNBits | sigInt);
         }
 
         private static float CreateSingle(bool sign, byte exp, uint sig)
-            => BitConverter.Int32BitsToSingle((int)(((sign ? 1U : 0U) << float.SignShift) + ((uint)exp << float.ExponentShift) + sig));
+            => BitConverter.UInt32BitsToSingle(((sign ? 1U : 0U) << float.SignShift) + ((uint)exp << float.ExponentShift) + sig);
 
         private static double CreateDouble(bool sign, ushort exp, ulong sig)
-            => BitConverter.Int64BitsToDouble((long)(((sign ? 1UL : 0UL) << double.SignShift) + ((ulong)exp << double.ExponentShift) + sig));
+            => BitConverter.UInt64BitsToDouble(((sign ? 1UL : 0UL) << double.SignShift) + ((ulong)exp << double.ExponentShift) + sig);
 
         #endregion
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Math.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Math.cs
@@ -1175,7 +1175,7 @@ namespace System
 
             // This is based on the 'Berkeley SoftFloat Release 3e' algorithm
 
-            ulong bits = (ulong)BitConverter.DoubleToInt64Bits(a);
+            ulong bits = BitConverter.DoubleToUInt64Bits(a);
             int exponent = double.ExtractExponentFromBits(bits);
 
             if (exponent <= 0x03FE)
@@ -1231,7 +1231,7 @@ namespace System
                 bits &= ~roundBitsMask;
             }
 
-            return BitConverter.Int64BitsToDouble((long)bits);
+            return BitConverter.UInt64BitsToDouble(bits);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/MathF.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MathF.cs
@@ -325,7 +325,7 @@ namespace System
 
             // This is based on the 'Berkeley SoftFloat Release 3e' algorithm
 
-            uint bits = (uint)BitConverter.SingleToInt32Bits(x);
+            uint bits = BitConverter.SingleToUInt32Bits(x);
             int exponent = float.ExtractExponentFromBits(bits);
 
             if (exponent <= 0x7E)
@@ -381,7 +381,7 @@ namespace System
                 bits &= ~roundBitsMask;
             }
 
-            return BitConverter.Int32BitsToSingle((int)bits);
+            return BitConverter.UInt32BitsToSingle(bits);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
@@ -2629,7 +2629,7 @@ namespace System
 
         private static ulong ExtractFractionAndBiasedExponent(double value, out int exponent)
         {
-            ulong bits = (ulong)(BitConverter.DoubleToInt64Bits(value));
+            ulong bits = BitConverter.DoubleToUInt64Bits(value);
             ulong fraction = (bits & 0xFFFFFFFFFFFFF);
             exponent = ((int)(bits >> 52) & 0x7FF);
 
@@ -2661,7 +2661,7 @@ namespace System
 
         private static ushort ExtractFractionAndBiasedExponent(Half value, out int exponent)
         {
-            ushort bits = (ushort)BitConverter.HalfToInt16Bits(value);
+            ushort bits = BitConverter.HalfToUInt16Bits(value);
             ushort fraction = (ushort)(bits & 0x3FF);
             exponent = ((int)(bits >> 10) & 0x1F);
 
@@ -2693,7 +2693,7 @@ namespace System
 
         private static uint ExtractFractionAndBiasedExponent(float value, out int exponent)
         {
-            uint bits = (uint)(BitConverter.SingleToInt32Bits(value));
+            uint bits = BitConverter.SingleToUInt32Bits(value);
             uint fraction = (bits & 0x7FFFFF);
             exponent = ((int)(bits >> 23) & 0xFF);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Number.NumberToFloatingPointBits.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.NumberToFloatingPointBits.cs
@@ -388,7 +388,7 @@ namespace System
                     result *= scale;
                 }
 
-                return (ulong)(BitConverter.DoubleToInt64Bits(result));
+                return BitConverter.DoubleToUInt64Bits(result);
             }
 
             return NumberToFloatingPointBitsSlow(ref number, in info, positiveExponent, integerDigitsPresent, fractionalDigitsPresent);
@@ -450,7 +450,7 @@ namespace System
                     result *= scale;
                 }
 
-                return (ushort)(BitConverter.HalfToInt16Bits((Half)result));
+                return BitConverter.HalfToUInt16Bits((Half)result);
             }
 
             if ((totalDigits <= 15) && (fastExponent <= 22))
@@ -467,7 +467,7 @@ namespace System
                     result *= scale;
                 }
 
-                return (ushort)(BitConverter.HalfToInt16Bits((Half)(result)));
+                return BitConverter.HalfToUInt16Bits((Half)(result));
             }
 
             return (ushort)NumberToFloatingPointBitsSlow(ref number, in info, positiveExponent, integerDigitsPresent, fractionalDigitsPresent);
@@ -529,7 +529,7 @@ namespace System
                     result *= scale;
                 }
 
-                return (uint)(BitConverter.SingleToInt32Bits(result));
+                return BitConverter.SingleToUInt32Bits(result);
             }
 
             if ((totalDigits <= 15) && (fastExponent <= 22))
@@ -546,7 +546,7 @@ namespace System
                     result *= scale;
                 }
 
-                return (uint)(BitConverter.SingleToInt32Bits((float)(result)));
+                return BitConverter.SingleToUInt32Bits((float)(result));
             }
 
             return (uint)NumberToFloatingPointBitsSlow(ref number, in info, positiveExponent, integerDigitsPresent, fractionalDigitsPresent);

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Parsing.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Parsing.cs
@@ -2143,7 +2143,7 @@ namespace System
             else
             {
                 ulong bits = NumberToDoubleFloatingPointBits(ref number, in FloatingPointInfo.Double);
-                result = BitConverter.Int64BitsToDouble((long)(bits));
+                result = BitConverter.UInt64BitsToDouble(bits);
             }
 
             return number.IsNegative ? -result : result;
@@ -2187,7 +2187,7 @@ namespace System
             else
             {
                 uint bits = NumberToSingleFloatingPointBits(ref number, in FloatingPointInfo.Single);
-                result = BitConverter.Int32BitsToSingle((int)(bits));
+                result = BitConverter.UInt32BitsToSingle(bits);
             }
 
             return number.IsNegative ? -result : result;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPathConvert.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPathConvert.cs
@@ -21,12 +21,12 @@ namespace System.Xml.Xsl
     {
         public static uint DblHi(double dbl)
         {
-            return (uint)(BitConverter.DoubleToInt64Bits(dbl) >> 32);
+            return (uint)(BitConverter.DoubleToUInt64Bits(dbl) >> 32);
         }
 
         public static uint DblLo(double dbl)
         {
-            return unchecked((uint)BitConverter.DoubleToInt64Bits(dbl));
+            return unchecked((uint)BitConverter.DoubleToUInt64Bits(dbl));
         }
 
         // Returns true if value is infinite or NaN (exponent bits are all ones)
@@ -659,7 +659,7 @@ namespace System.Xml.Xsl
                         AddU(ref dblHi, 1);
                     }
                 }
-                return BitConverter.Int64BitsToDouble((long)dblHi << 32 | dblLo);
+                return BitConverter.UInt64BitsToDouble((ulong)dblHi << 32 | dblLo);
             }
 
             // Lop off the integer part and return it.
@@ -1112,7 +1112,7 @@ namespace System.Xml.Xsl
                     dblHi = DblHi(dblT);
                     dblHi &= 0x000FFFFF;
                     dblHi |= 0x3FF00000;
-                    dblT = BitConverter.Int64BitsToDouble((long)dblHi << 32 | DblLo(dblT));
+                    dblT = BitConverter.UInt64BitsToDouble((ulong)dblHi << 32 | DblLo(dblT));
 
                     // Adjust wExp2 because we don't have the implicit bit.
                     wExp2++;
@@ -1123,7 +1123,7 @@ namespace System.Xml.Xsl
                     // First multiply by a power of 2 to get a normalized value.
                     dblHi &= 0x000FFFFF;
                     dblHi |= 0x3FF00000;
-                    dblT = BitConverter.Int64BitsToDouble((long)dblHi << 32 | dblLo);
+                    dblT = BitConverter.UInt64BitsToDouble((ulong)dblHi << 32 | dblLo);
 
                     // This is the power of 2.
                     w1 = wExp2 + 52;
@@ -2307,7 +2307,7 @@ namespace System.Xml.Xsl
                         }
                     }
                 }
-                return BitConverter.Int64BitsToDouble((long)dblHi << 32 | dblLo);
+                return BitConverter.UInt64BitsToDouble((ulong)dblHi << 32 | dblLo);
             }
 #endif
         };

--- a/src/libraries/System.Runtime.Extensions/tests/System/BitConverter.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/BitConverter.cs
@@ -295,5 +295,35 @@ namespace System.Tests
             Half roundtripped = BitConverter.Int16BitsToHalf(result);
             Assert.Equal(input, roundtripped);
         }
+
+        [Fact]
+        public static void DoubleToUInt64Bits()
+        {
+            double input = 123456.3234;
+            ulong result = BitConverter.DoubleToUInt64Bits(input);
+            Assert.Equal(4683220267154373240UL, result);
+            double roundtripped = BitConverter.UInt64BitsToDouble(result);
+            Assert.Equal(input, roundtripped);
+        }
+
+        [Fact]
+        public static void SingleToUInt32Bits()
+        {
+            float input = 12345.63f;
+            uint result = BitConverter.SingleToUInt32Bits(input);
+            Assert.Equal(1178658437U, result);
+            float roundtripped = BitConverter.UInt32BitsToSingle(result);
+            Assert.Equal(input, roundtripped);
+        }
+
+        [Fact]
+        public static void HalfToUInt16Bits()
+        {
+            Half input = (Half)12.34;
+            ushort result = BitConverter.HalfToUInt16Bits(input);
+            Assert.Equal((ushort)18988, result);
+            Half roundtripped = BitConverter.UInt16BitsToHalf(result);
+            Assert.Equal(input, roundtripped);
+        }
     }
 }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -600,6 +600,18 @@ namespace System
         public static float Int32BitsToSingle(int value) { throw null; }
         public static double Int64BitsToDouble(long value) { throw null; }
         public static int SingleToInt32Bits(float value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static ulong DoubleToUInt64Bits(double value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static double UInt64BitsToDouble(ulong value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static uint SingleToUInt32Bits(float value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static float UInt32BitsToSingle(uint value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static ushort HalfToUInt16Bits(System.Half value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static System.Half UInt16BitsToHalf(ushort value) { throw null; }
         public static bool ToBoolean(byte[] value, int startIndex) { throw null; }
         public static bool ToBoolean(System.ReadOnlySpan<byte> value) { throw null; }
         public static char ToChar(byte[] value, int startIndex) { throw null; }

--- a/src/libraries/System.Runtime/tests/System/DoubleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DoubleTests.cs
@@ -13,11 +13,6 @@ namespace System.Tests
     {
         // NOTE: Consider duplicating any tests added here in SingleTests.cs
 
-        private static ulong DoubleToUInt64Bits(double value)
-        {
-            return (ulong)(BitConverter.DoubleToInt64Bits(value));
-        }
-
         [Theory]
         [InlineData("a")]
         [InlineData(234.0f)]
@@ -103,7 +98,7 @@ namespace System.Tests
         public static void Epsilon()
         {
             Assert.Equal(4.9406564584124654E-324, double.Epsilon);
-            Assert.Equal(0x00000000_00000001u, DoubleToUInt64Bits(double.Epsilon));
+            Assert.Equal(0x00000000_00000001u, BitConverter.DoubleToUInt64Bits(double.Epsilon));
         }
 
         [Theory]
@@ -221,28 +216,28 @@ namespace System.Tests
         public static void MaxValue()
         {
             Assert.Equal(1.7976931348623157E+308, double.MaxValue);
-            Assert.Equal(0x7FEFFFFF_FFFFFFFFu, DoubleToUInt64Bits(double.MaxValue));
+            Assert.Equal(0x7FEFFFFF_FFFFFFFFu, BitConverter.DoubleToUInt64Bits(double.MaxValue));
         }
 
         [Fact]
         public static void MinValue()
         {
             Assert.Equal(-1.7976931348623157E+308, double.MinValue);
-            Assert.Equal(0xFFEFFFFF_FFFFFFFFu, DoubleToUInt64Bits(double.MinValue));
+            Assert.Equal(0xFFEFFFFF_FFFFFFFFu, BitConverter.DoubleToUInt64Bits(double.MinValue));
         }
 
         [Fact]
         public static void NaN()
         {
             Assert.Equal(0.0 / 0.0, double.NaN);
-            Assert.Equal(0xFFF80000_00000000u, DoubleToUInt64Bits(double.NaN));
+            Assert.Equal(0xFFF80000_00000000u, BitConverter.DoubleToUInt64Bits(double.NaN));
         }
 
         [Fact]
         public static void NegativeInfinity()
         {
             Assert.Equal(-1.0 / 0.0, double.NegativeInfinity);
-            Assert.Equal(0xFFF00000_00000000u, DoubleToUInt64Bits(double.NegativeInfinity));
+            Assert.Equal(0xFFF00000_00000000u, BitConverter.DoubleToUInt64Bits(double.NegativeInfinity));
         }
 
         public static IEnumerable<object[]> Parse_Valid_TestData()
@@ -474,7 +469,7 @@ namespace System.Tests
         public static void PositiveInfinity()
         {
             Assert.Equal(1.0 / 0.0, double.PositiveInfinity);
-            Assert.Equal(0x7FF00000_00000000u, DoubleToUInt64Bits(double.PositiveInfinity));
+            Assert.Equal(0x7FF00000_00000000u, BitConverter.DoubleToUInt64Bits(double.PositiveInfinity));
         }
 
         public static IEnumerable<object[]> ToString_TestData()

--- a/src/libraries/System.Runtime/tests/System/HalfTests.cs
+++ b/src/libraries/System.Runtime/tests/System/HalfTests.cs
@@ -10,74 +10,64 @@ namespace System.Tests
 {
     public partial class HalfTests
     {
-        private static ushort HalfToUInt16Bits(Half value)
-        {
-            return (ushort)BitConverter.HalfToInt16Bits(value);
-        }
-
-        private static Half UInt16BitsToHalf(ushort value)
-        {
-            return BitConverter.Int16BitsToHalf((short)value);
-        }
-
         [Fact]
         public static void Epsilon()
         {
-            Assert.Equal(0x0001u, HalfToUInt16Bits(Half.Epsilon));
+            Assert.Equal(0x0001u, BitConverter.HalfToUInt16Bits(Half.Epsilon));
         }
 
         [Fact]
         public static void PositiveInfinity()
         {
-            Assert.Equal(0x7C00u, HalfToUInt16Bits(Half.PositiveInfinity));
+            Assert.Equal(0x7C00u, BitConverter.HalfToUInt16Bits(Half.PositiveInfinity));
         }
 
         [Fact]
         public static void NegativeInfinity()
         {
-            Assert.Equal(0xFC00u, HalfToUInt16Bits(Half.NegativeInfinity));
+            Assert.Equal(0xFC00u, BitConverter.HalfToUInt16Bits(Half.NegativeInfinity));
         }
 
         [Fact]
         public static void NaN()
         {
-            Assert.Equal(0xFE00u, HalfToUInt16Bits(Half.NaN));
+            Assert.Equal(0xFE00u, BitConverter.HalfToUInt16Bits(Half.NaN));
         }
 
         [Fact]
         public static void MinValue()
         {
-            Assert.Equal(0xFBFFu, HalfToUInt16Bits(Half.MinValue));
+            Assert.Equal(0xFBFFu, BitConverter.HalfToUInt16Bits(Half.MinValue));
         }
 
         [Fact]
         public static void MaxValue()
         {
-            Assert.Equal(0x7BFFu, HalfToUInt16Bits(Half.MaxValue));
+            Assert.Equal(0x7BFFu, BitConverter.HalfToUInt16Bits(Half.MaxValue));
         }
 
         [Fact]
         public static void Ctor_Empty()
         {
             var value = new Half();
-            Assert.Equal(0x0000, HalfToUInt16Bits(value));
+            Assert.Equal(0x0000, BitConverter.HalfToUInt16Bits(value));
         }
 
         public static IEnumerable<object[]> IsFinite_TestData()
         {
-            yield return new object[] { Half.NegativeInfinity, false };     // Negative Infinity
-            yield return new object[] { Half.MinValue, true };              // Min Negative Normal
-            yield return new object[] { UInt16BitsToHalf(0x8400), true };   // Max Negative Normal
-            yield return new object[] { UInt16BitsToHalf(0x83FF), true };   // Min Negative Subnormal
-            yield return new object[] { UInt16BitsToHalf(0x8001), true };   // Max Negative Subnormal
-            yield return new object[] { UInt16BitsToHalf(0x8000), true };   // Negative Zero
-            yield return new object[] { Half.NaN, false };                  // NaN
-            yield return new object[] { UInt16BitsToHalf(0x0000), true };   // Positive Zero
-            yield return new object[] { Half.Epsilon, true };               // Min Positive Subnormal
-            yield return new object[] { UInt16BitsToHalf(0x03FF), true };   // Max Positive Subnormal
-            yield return new object[] { UInt16BitsToHalf(0x0400), true };   // Min Positive Normal
-            yield return new object[] { Half.MaxValue, true };              // Max Positive Normal
-            yield return new object[] { Half.PositiveInfinity, false };     // Positive Infinity
+            yield return new object[] { Half.NegativeInfinity, false };                  // Negative Infinity
+            yield return new object[] { Half.MinValue, true };                           // Min Negative Normal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8400), true };   // Max Negative Normal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x83FF), true };   // Min Negative Subnormal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8001), true };   // Max Negative Subnormal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8000), true };   // Negative Zero
+            yield return new object[] { Half.NaN, false };                               // NaN
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x0000), true };   // Positive Zero
+            yield return new object[] { Half.Epsilon, true };                            // Min Positive Subnormal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x03FF), true };   // Max Positive Subnormal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x0400), true };   // Min Positive Normal
+            yield return new object[] { Half.MaxValue, true };                           // Max Positive Normal
+            yield return new object[] { Half.PositiveInfinity, false };                  // Positive Infinity
         }
 
         [Theory]
@@ -89,19 +79,19 @@ namespace System.Tests
 
         public static IEnumerable<object[]> IsInfinity_TestData()
         {
-            yield return new object[] { Half.NegativeInfinity, true };      // Negative Infinity
-            yield return new object[] { Half.MinValue, false };             // Min Negative Normal
-            yield return new object[] { UInt16BitsToHalf(0x8400), false };  // Max Negative Normal
-            yield return new object[] { UInt16BitsToHalf(0x83FF), false };  // Min Negative Subnormal
-            yield return new object[] { UInt16BitsToHalf(0x8001), false };  // Max Negative Subnormal (Negative Epsilon)
-            yield return new object[] { UInt16BitsToHalf(0x8000), false };  // Negative Zero
-            yield return new object[] { Half.NaN, false };                  // NaN
-            yield return new object[] { UInt16BitsToHalf(0x0000), false };  // Positive Zero
-            yield return new object[] { Half.Epsilon, false };              // Min Positive Subnormal (Positive Epsilon)
-            yield return new object[] { UInt16BitsToHalf(0x03FF), false };  // Max Positive Subnormal
-            yield return new object[] { UInt16BitsToHalf(0x0400), false };  // Min Positive Normal
-            yield return new object[] { Half.MaxValue, false };             // Max Positive Normal
-            yield return new object[] { Half.PositiveInfinity, true };      // Positive Infinity
+            yield return new object[] { Half.NegativeInfinity, true };                   // Negative Infinity
+            yield return new object[] { Half.MinValue, false };                          // Min Negative Normal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8400), false };  // Max Negative Normal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x83FF), false };  // Min Negative Subnormal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8001), false };  // Max Negative Subnormal (Negative Epsilon)
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8000), false };  // Negative Zero
+            yield return new object[] { Half.NaN, false };                               // NaN
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x0000), false };  // Positive Zero
+            yield return new object[] { Half.Epsilon, false };                           // Min Positive Subnormal (Positive Epsilon)
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x03FF), false };  // Max Positive Subnormal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x0400), false };  // Min Positive Normal
+            yield return new object[] { Half.MaxValue, false };                          // Max Positive Normal
+            yield return new object[] { Half.PositiveInfinity, true };                   // Positive Infinity
         }
 
         [Theory]
@@ -113,19 +103,19 @@ namespace System.Tests
 
         public static IEnumerable<object[]> IsNaN_TestData()
         {
-            yield return new object[] { Half.NegativeInfinity, false };     // Negative Infinity
-            yield return new object[] { Half.MinValue, false };             // Min Negative Normal
-            yield return new object[] { UInt16BitsToHalf(0x8400), false };  // Max Negative Normal
-            yield return new object[] { UInt16BitsToHalf(0x83FF), false };  // Min Negative Subnormal
-            yield return new object[] { UInt16BitsToHalf(0x8001), false };  // Max Negative Subnormal (Negative Epsilon)
-            yield return new object[] { UInt16BitsToHalf(0x8000), false };  // Negative Zero
-            yield return new object[] { Half.NaN, true };                   // NaN
-            yield return new object[] { UInt16BitsToHalf(0x0000), false };  // Positive Zero
-            yield return new object[] { Half.Epsilon, false };              // Min Positive Subnormal (Positive Epsilon)
-            yield return new object[] { UInt16BitsToHalf(0x03FF), false };  // Max Positive Subnormal
-            yield return new object[] { UInt16BitsToHalf(0x0400), false };  // Min Positive Normal
-            yield return new object[] { Half.MaxValue, false };             // Max Positive Normal
-            yield return new object[] { Half.PositiveInfinity, false };     // Positive Infinity
+            yield return new object[] { Half.NegativeInfinity, false };                  // Negative Infinity
+            yield return new object[] { Half.MinValue, false };                          // Min Negative Normal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8400), false };  // Max Negative Normal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x83FF), false };  // Min Negative Subnormal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8001), false };  // Max Negative Subnormal (Negative Epsilon)
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8000), false };  // Negative Zero
+            yield return new object[] { Half.NaN, true };                                // NaN
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x0000), false };  // Positive Zero
+            yield return new object[] { Half.Epsilon, false };                           // Min Positive Subnormal (Positive Epsilon)
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x03FF), false };  // Max Positive Subnormal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x0400), false };  // Min Positive Normal
+            yield return new object[] { Half.MaxValue, false };                          // Max Positive Normal
+            yield return new object[] { Half.PositiveInfinity, false };                  // Positive Infinity
         }
 
         [Theory]
@@ -137,19 +127,19 @@ namespace System.Tests
 
         public static IEnumerable<object[]> IsNegative_TestData()
         {
-            yield return new object[] { Half.NegativeInfinity, true };      // Negative Infinity
-            yield return new object[] { Half.MinValue, true };              // Min Negative Normal
-            yield return new object[] { UInt16BitsToHalf(0x8400), true };   // Max Negative Normal
-            yield return new object[] { UInt16BitsToHalf(0x83FF), true };   // Min Negative Subnormal
-            yield return new object[] { UInt16BitsToHalf(0x8001), true };   // Max Negative Subnormal
-            yield return new object[] { UInt16BitsToHalf(0x8000), true };   // Negative Zero
-            yield return new object[] { Half.NaN, true };                   // NaN
-            yield return new object[] { UInt16BitsToHalf(0x0000), false };  // Positive Zero
-            yield return new object[] { Half.Epsilon, false };              // Min Positive Subnormal
-            yield return new object[] { UInt16BitsToHalf(0x03FF), false };  // Max Positive Subnormal
-            yield return new object[] { UInt16BitsToHalf(0x0400), false };  // Min Positive Normal
-            yield return new object[] { Half.MaxValue, false };             // Max Positive Normal
-            yield return new object[] { Half.PositiveInfinity, false };     // Positive Infinity
+            yield return new object[] { Half.NegativeInfinity, true };                   // Negative Infinity
+            yield return new object[] { Half.MinValue, true };                           // Min Negative Normal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8400), true };   // Max Negative Normal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x83FF), true };   // Min Negative Subnormal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8001), true };   // Max Negative Subnormal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8000), true };   // Negative Zero
+            yield return new object[] { Half.NaN, true };                                // NaN
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x0000), false };  // Positive Zero
+            yield return new object[] { Half.Epsilon, false };                           // Min Positive Subnormal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x03FF), false };  // Max Positive Subnormal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x0400), false };  // Min Positive Normal
+            yield return new object[] { Half.MaxValue, false };                          // Max Positive Normal
+            yield return new object[] { Half.PositiveInfinity, false };                  // Positive Infinity
         }
 
         [Theory]
@@ -161,19 +151,19 @@ namespace System.Tests
 
         public static IEnumerable<object[]> IsNegativeInfinity_TestData()
         {
-            yield return new object[] { Half.NegativeInfinity, true };      // Negative Infinity
-            yield return new object[] { Half.MinValue, false };             // Min Negative Normal
-            yield return new object[] { UInt16BitsToHalf(0x8400), false };  // Max Negative Normal
-            yield return new object[] { UInt16BitsToHalf(0x83FF), false };  // Min Negative Subnormal
-            yield return new object[] { UInt16BitsToHalf(0x8001), false };  // Max Negative Subnormal (Negative Epsilon)
-            yield return new object[] { UInt16BitsToHalf(0x8000), false };  // Negative Zero
-            yield return new object[] { Half.NaN, false };                  // NaN
-            yield return new object[] { UInt16BitsToHalf(0x0000), false };  // Positive Zero
-            yield return new object[] { Half.Epsilon, false };              // Min Positive Subnormal (Positive Epsilon)
-            yield return new object[] { UInt16BitsToHalf(0x03FF), false };  // Max Positive Subnormal
-            yield return new object[] { UInt16BitsToHalf(0x0400), false };  // Min Positive Normal
-            yield return new object[] { Half.MaxValue, false };             // Max Positive Normal
-            yield return new object[] { Half.PositiveInfinity, false };     // Positive Infinity
+            yield return new object[] { Half.NegativeInfinity, true };                   // Negative Infinity
+            yield return new object[] { Half.MinValue, false };                          // Min Negative Normal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8400), false };  // Max Negative Normal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x83FF), false };  // Min Negative Subnormal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8001), false };  // Max Negative Subnormal (Negative Epsilon)
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8000), false };  // Negative Zero
+            yield return new object[] { Half.NaN, false };                               // NaN
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x0000), false };  // Positive Zero
+            yield return new object[] { Half.Epsilon, false };                           // Min Positive Subnormal (Positive Epsilon)
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x03FF), false };  // Max Positive Subnormal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x0400), false };  // Min Positive Normal
+            yield return new object[] { Half.MaxValue, false };                          // Max Positive Normal
+            yield return new object[] { Half.PositiveInfinity, false };                  // Positive Infinity
         }
 
         [Theory]
@@ -185,19 +175,19 @@ namespace System.Tests
 
         public static IEnumerable<object[]> IsNormal_TestData()
         {
-            yield return new object[] { Half.NegativeInfinity, false };     // Negative Infinity
-            yield return new object[] { Half.MinValue, true };              // Min Negative Normal
-            yield return new object[] { UInt16BitsToHalf(0x8400), true };   // Max Negative Normal
-            yield return new object[] { UInt16BitsToHalf(0x83FF), false };  // Min Negative Subnormal
-            yield return new object[] { UInt16BitsToHalf(0x8001), false };  // Max Negative Subnormal
-            yield return new object[] { UInt16BitsToHalf(0x8000), false };  // Negative Zero
-            yield return new object[] { Half.NaN, false };                  // NaN
-            yield return new object[] { UInt16BitsToHalf(0x0000), false };  // Positive Zero
-            yield return new object[] { Half.Epsilon, false };              // Min Positive Subnormal
-            yield return new object[] { UInt16BitsToHalf(0x03FF), false };  // Max Positive Subnormal
-            yield return new object[] { UInt16BitsToHalf(0x0400), true };   // Min Positive Normal
-            yield return new object[] { Half.MaxValue, true };              // Max Positive Normal
-            yield return new object[] { Half.PositiveInfinity, false };     // Positive Infinity
+            yield return new object[] { Half.NegativeInfinity, false };                  // Negative Infinity
+            yield return new object[] { Half.MinValue, true };                           // Min Negative Normal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8400), true };   // Max Negative Normal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x83FF), false };  // Min Negative Subnormal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8001), false };  // Max Negative Subnormal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8000), false };  // Negative Zero
+            yield return new object[] { Half.NaN, false };                               // NaN
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x0000), false };  // Positive Zero
+            yield return new object[] { Half.Epsilon, false };                           // Min Positive Subnormal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x03FF), false };  // Max Positive Subnormal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x0400), true };   // Min Positive Normal
+            yield return new object[] { Half.MaxValue, true };                           // Max Positive Normal
+            yield return new object[] { Half.PositiveInfinity, false };                  // Positive Infinity
         }
 
         [Theory]
@@ -209,19 +199,19 @@ namespace System.Tests
 
         public static IEnumerable<object[]> IsPositiveInfinity_TestData()
         {
-            yield return new object[] { Half.NegativeInfinity, false };     // Negative Infinity
-            yield return new object[] { Half.MinValue, false };             // Min Negative Normal
-            yield return new object[] { UInt16BitsToHalf(0x8400), false };  // Max Negative Normal
-            yield return new object[] { UInt16BitsToHalf(0x83FF), false };  // Min Negative Subnormal
-            yield return new object[] { UInt16BitsToHalf(0x8001), false };  // Max Negative Subnormal (Negative Epsilon)
-            yield return new object[] { UInt16BitsToHalf(0x8000), false };  // Negative Zero
-            yield return new object[] { Half.NaN, false };                  // NaN
-            yield return new object[] { UInt16BitsToHalf(0x0000), false };  // Positive Zero
-            yield return new object[] { Half.Epsilon, false };              // Min Positive Subnormal (Positive Epsilon)
-            yield return new object[] { UInt16BitsToHalf(0x03FF), false };  // Max Positive Subnormal
-            yield return new object[] { UInt16BitsToHalf(0x0400), false };  // Min Positive Normal
-            yield return new object[] { Half.MaxValue, false };             // Max Positive Normal
-            yield return new object[] { Half.PositiveInfinity, true };      // Positive Infinity
+            yield return new object[] { Half.NegativeInfinity, false };                  // Negative Infinity
+            yield return new object[] { Half.MinValue, false };                          // Min Negative Normal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8400), false };  // Max Negative Normal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x83FF), false };  // Min Negative Subnormal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8001), false };  // Max Negative Subnormal (Negative Epsilon)
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8000), false };  // Negative Zero
+            yield return new object[] { Half.NaN, false };                               // NaN
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x0000), false };  // Positive Zero
+            yield return new object[] { Half.Epsilon, false };                           // Min Positive Subnormal (Positive Epsilon)
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x03FF), false };  // Max Positive Subnormal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x0400), false };  // Min Positive Normal
+            yield return new object[] { Half.MaxValue, false };                          // Max Positive Normal
+            yield return new object[] { Half.PositiveInfinity, true };                   // Positive Infinity
         }
 
         [Theory]
@@ -233,19 +223,19 @@ namespace System.Tests
 
         public static IEnumerable<object[]> IsSubnormal_TestData()
         {
-            yield return new object[] { Half.NegativeInfinity, false };     // Negative Infinity
-            yield return new object[] { Half.MinValue, false };             // Min Negative Normal
-            yield return new object[] { UInt16BitsToHalf(0x8400), false };  // Max Negative Normal
-            yield return new object[] { UInt16BitsToHalf(0x83FF), true };   // Min Negative Subnormal
-            yield return new object[] { UInt16BitsToHalf(0x8001), true };   // Max Negative Subnormal
-            yield return new object[] { UInt16BitsToHalf(0x8000), false };  // Negative Zero
-            yield return new object[] { Half.NaN, false };                  // NaN
-            yield return new object[] { UInt16BitsToHalf(0x0000), false };  // Positive Zero
-            yield return new object[] { Half.Epsilon, true };               // Min Positive Subnormal
-            yield return new object[] { UInt16BitsToHalf(0x03FF), true };   // Max Positive Subnormal
-            yield return new object[] { UInt16BitsToHalf(0x0400), false };  // Min Positive Normal
-            yield return new object[] { Half.MaxValue, false };             // Max Positive Normal
-            yield return new object[] { Half.PositiveInfinity, false };     // Positive Infinity
+            yield return new object[] { Half.NegativeInfinity, false };                  // Negative Infinity
+            yield return new object[] { Half.MinValue, false };                          // Min Negative Normal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8400), false };  // Max Negative Normal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x83FF), true };   // Min Negative Subnormal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8001), true };   // Max Negative Subnormal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8000), false };  // Negative Zero
+            yield return new object[] { Half.NaN, false };                               // NaN
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x0000), false };  // Positive Zero
+            yield return new object[] { Half.Epsilon, true };                            // Min Positive Subnormal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x03FF), true };   // Max Positive Subnormal
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x0400), false };  // Min Positive Normal
+            yield return new object[] { Half.MaxValue, false };                          // Max Positive Normal
+            yield return new object[] { Half.PositiveInfinity, false };                  // Positive Infinity
         }
 
         [Theory]
@@ -272,19 +262,19 @@ namespace System.Tests
         {
             yield return new object[] { Half.MaxValue, Half.MaxValue, 0 };
             yield return new object[] { Half.MaxValue, Half.MinValue, 1 };
-            yield return new object[] { Half.Epsilon, UInt16BitsToHalf(0x8001), 1 };
-            yield return new object[] { Half.MaxValue, UInt16BitsToHalf(0x0000), 1 };
+            yield return new object[] { Half.Epsilon, BitConverter.UInt16BitsToHalf(0x8001), 1 };
+            yield return new object[] { Half.MaxValue, BitConverter.UInt16BitsToHalf(0x0000), 1 };
             yield return new object[] { Half.MaxValue, Half.Epsilon, 1 };
             yield return new object[] { Half.MaxValue, Half.PositiveInfinity, -1 };
             yield return new object[] { Half.MinValue, Half.MaxValue, -1 };
             yield return new object[] { Half.MaxValue, Half.NaN, 1 };
             yield return new object[] { Half.NaN, Half.NaN, 0 };
-            yield return new object[] { Half.NaN, UInt16BitsToHalf(0x0000), -1 };
+            yield return new object[] { Half.NaN, BitConverter.UInt16BitsToHalf(0x0000), -1 };
             yield return new object[] { Half.MaxValue, null, 1 };
             yield return new object[] { Half.MinValue, Half.NegativeInfinity, 1 };
             yield return new object[] { Half.NegativeInfinity, Half.MinValue, -1 };
-            yield return new object[] { UInt16BitsToHalf(0x8000), Half.NegativeInfinity, 1 }; // Negative zero
-            yield return new object[] { Half.NegativeInfinity, UInt16BitsToHalf(0x8000), -1 }; // Negative zero
+            yield return new object[] { BitConverter.UInt16BitsToHalf(0x8000), Half.NegativeInfinity, 1 }; // Negative zero
+            yield return new object[] { Half.NegativeInfinity, BitConverter.UInt16BitsToHalf(0x8000), -1 }; // Negative zero
         }
 
         [Theory]
@@ -334,7 +324,7 @@ namespace System.Tests
         {
             yield return new object[] { Half.MaxValue, Half.MaxValue, true };
             yield return new object[] { Half.MaxValue, Half.MinValue, false };
-            yield return new object[] { Half.MaxValue, UInt16BitsToHalf(0x0000), false };
+            yield return new object[] { Half.MaxValue, BitConverter.UInt16BitsToHalf(0x0000), false };
             yield return new object[] { Half.NaN, Half.NaN, true };
             yield return new object[] { Half.MaxValue, 789.0f, false };
             yield return new object[] { Half.MaxValue, "789", false };
@@ -351,41 +341,41 @@ namespace System.Tests
         {
             (Half Original, float Expected)[] data = // Fraction is shifted left by 42, Exponent is -15 then +127 = +112
             {
-                (UInt16BitsToHalf(0b0_01111_0000000000), 1f), // 1
-                (UInt16BitsToHalf(0b1_01111_0000000000), -1f), // -1
+                (BitConverter.UInt16BitsToHalf(0b0_01111_0000000000), 1f), // 1
+                (BitConverter.UInt16BitsToHalf(0b1_01111_0000000000), -1f), // -1
                 (Half.MaxValue, 65504f), // 65500
                 (Half.MinValue, -65504f), // -65500
-                (UInt16BitsToHalf(0b0_01011_1001100110), 0.0999755859375f), // 0.1ish
-                (UInt16BitsToHalf(0b1_01011_1001100110), -0.0999755859375f), // -0.1ish
-                (UInt16BitsToHalf(0b0_10100_0101000000), 42f), // 42
-                (UInt16BitsToHalf(0b1_10100_0101000000), -42f), // -42
+                (BitConverter.UInt16BitsToHalf(0b0_01011_1001100110), 0.0999755859375f), // 0.1ish
+                (BitConverter.UInt16BitsToHalf(0b1_01011_1001100110), -0.0999755859375f), // -0.1ish
+                (BitConverter.UInt16BitsToHalf(0b0_10100_0101000000), 42f), // 42
+                (BitConverter.UInt16BitsToHalf(0b1_10100_0101000000), -42f), // -42
                 (Half.PositiveInfinity, float.PositiveInfinity), // PosInfinity
                 (Half.NegativeInfinity, float.NegativeInfinity), // NegInfinity
-                (UInt16BitsToHalf(0b0_11111_1000000000), BitConverter.Int32BitsToSingle(0x7FC00000)), // Positive Quiet NaN
+                (BitConverter.UInt16BitsToHalf(0b0_11111_1000000000), BitConverter.Int32BitsToSingle(0x7FC00000)), // Positive Quiet NaN
                 (Half.NaN, float.NaN), // Negative Quiet NaN
-                (UInt16BitsToHalf(0b0_11111_1010101010), BitConverter.Int32BitsToSingle(0x7FD54000)), // Positive Signalling NaN - Should preserve payload
-                (UInt16BitsToHalf(0b1_11111_1010101010), BitConverter.Int32BitsToSingle(unchecked((int)0xFFD54000))), // Negative Signalling NaN - Should preserve payload
+                (BitConverter.UInt16BitsToHalf(0b0_11111_1010101010), BitConverter.Int32BitsToSingle(0x7FD54000)), // Positive Signalling NaN - Should preserve payload
+                (BitConverter.UInt16BitsToHalf(0b1_11111_1010101010), BitConverter.Int32BitsToSingle(unchecked((int)0xFFD54000))), // Negative Signalling NaN - Should preserve payload
                 (Half.Epsilon, 1/16777216f), // PosEpsilon = 0.000000059605...
-                (UInt16BitsToHalf(0), 0), // 0
-                (UInt16BitsToHalf(0b1_00000_0000000000), -0f), // -0
-                (UInt16BitsToHalf(0b0_10000_1001001000), 3.140625f), // 3.140625
-                (UInt16BitsToHalf(0b1_10000_1001001000), -3.140625f), // -3.140625
-                (UInt16BitsToHalf(0b0_10000_0101110000), 2.71875f), // 2.71875
-                (UInt16BitsToHalf(0b1_10000_0101110000), -2.71875f), // -2.71875
-                (UInt16BitsToHalf(0b0_01111_1000000000), 1.5f), // 1.5
-                (UInt16BitsToHalf(0b1_01111_1000000000), -1.5f), // -1.5
-                (UInt16BitsToHalf(0b0_01111_1000000001), 1.5009765625f), // 1.5009765625
-                (UInt16BitsToHalf(0b1_01111_1000000001), -1.5009765625f), // -1.5009765625
-                (UInt16BitsToHalf(0b0_00001_0000000000), BitConverter.Int32BitsToSingle(0x38800000)), // smallest normal
-                (UInt16BitsToHalf(0b0_00000_1111111111), BitConverter.Int32BitsToSingle(0x387FC000)), // largest subnormal
-                (UInt16BitsToHalf(0b0_00000_1000000000), BitConverter.Int32BitsToSingle(0x38000000)), // middle subnormal
-                (UInt16BitsToHalf(0b0_00000_0111111111), BitConverter.Int32BitsToSingle(0x37FF8000)), // just below middle subnormal
-                (UInt16BitsToHalf(0b0_00000_0000000001), BitConverter.Int32BitsToSingle(0x33800000)), // smallest subnormal
-                (UInt16BitsToHalf(0b1_00000_0000000001), BitConverter.Int32BitsToSingle(unchecked((int)0xB3800000))), // highest negative subnormal
-                (UInt16BitsToHalf(0b1_00000_0111111111), BitConverter.Int32BitsToSingle(unchecked((int)0xB7FF8000))), // just above negative middle subnormal
-                (UInt16BitsToHalf(0b1_00000_1000000000), BitConverter.Int32BitsToSingle(unchecked((int)0xB8000000))), // negative middle subnormal
-                (UInt16BitsToHalf(0b1_00000_1111111111), BitConverter.Int32BitsToSingle(unchecked((int)0xB87FC000))), // lowest negative subnormal
-                (UInt16BitsToHalf(0b1_00001_0000000000), BitConverter.Int32BitsToSingle(unchecked((int)0xB8800000))) // highest negative normal
+                (BitConverter.UInt16BitsToHalf(0), 0), // 0
+                (BitConverter.UInt16BitsToHalf(0b1_00000_0000000000), -0f), // -0
+                (BitConverter.UInt16BitsToHalf(0b0_10000_1001001000), 3.140625f), // 3.140625
+                (BitConverter.UInt16BitsToHalf(0b1_10000_1001001000), -3.140625f), // -3.140625
+                (BitConverter.UInt16BitsToHalf(0b0_10000_0101110000), 2.71875f), // 2.71875
+                (BitConverter.UInt16BitsToHalf(0b1_10000_0101110000), -2.71875f), // -2.71875
+                (BitConverter.UInt16BitsToHalf(0b0_01111_1000000000), 1.5f), // 1.5
+                (BitConverter.UInt16BitsToHalf(0b1_01111_1000000000), -1.5f), // -1.5
+                (BitConverter.UInt16BitsToHalf(0b0_01111_1000000001), 1.5009765625f), // 1.5009765625
+                (BitConverter.UInt16BitsToHalf(0b1_01111_1000000001), -1.5009765625f), // -1.5009765625
+                (BitConverter.UInt16BitsToHalf(0b0_00001_0000000000), BitConverter.Int32BitsToSingle(0x38800000)), // smallest normal
+                (BitConverter.UInt16BitsToHalf(0b0_00000_1111111111), BitConverter.Int32BitsToSingle(0x387FC000)), // largest subnormal
+                (BitConverter.UInt16BitsToHalf(0b0_00000_1000000000), BitConverter.Int32BitsToSingle(0x38000000)), // middle subnormal
+                (BitConverter.UInt16BitsToHalf(0b0_00000_0111111111), BitConverter.Int32BitsToSingle(0x37FF8000)), // just below middle subnormal
+                (BitConverter.UInt16BitsToHalf(0b0_00000_0000000001), BitConverter.Int32BitsToSingle(0x33800000)), // smallest subnormal
+                (BitConverter.UInt16BitsToHalf(0b1_00000_0000000001), BitConverter.Int32BitsToSingle(unchecked((int)0xB3800000))), // highest negative subnormal
+                (BitConverter.UInt16BitsToHalf(0b1_00000_0111111111), BitConverter.Int32BitsToSingle(unchecked((int)0xB7FF8000))), // just above negative middle subnormal
+                (BitConverter.UInt16BitsToHalf(0b1_00000_1000000000), BitConverter.Int32BitsToSingle(unchecked((int)0xB8000000))), // negative middle subnormal
+                (BitConverter.UInt16BitsToHalf(0b1_00000_1111111111), BitConverter.Int32BitsToSingle(unchecked((int)0xB87FC000))), // lowest negative subnormal
+                (BitConverter.UInt16BitsToHalf(0b1_00001_0000000000), BitConverter.Int32BitsToSingle(unchecked((int)0xB8800000))) // highest negative normal
             };
 
             foreach ((Half original, float expected) in data)
@@ -406,41 +396,41 @@ namespace System.Tests
         {
             (Half Original, double Expected)[] data = // Fraction is shifted left by 42, Exponent is -15 then +127 = +112
             {
-                (UInt16BitsToHalf(0b0_01111_0000000000), 1d), // 1
-                (UInt16BitsToHalf(0b1_01111_0000000000), -1d), // -1
+                (BitConverter.UInt16BitsToHalf(0b0_01111_0000000000), 1d), // 1
+                (BitConverter.UInt16BitsToHalf(0b1_01111_0000000000), -1d), // -1
                 (Half.MaxValue, 65504d), // 65500
                 (Half.MinValue, -65504d), // -65500
-                (UInt16BitsToHalf(0b0_01011_1001100110), 0.0999755859375d), // 0.1ish
-                (UInt16BitsToHalf(0b1_01011_1001100110), -0.0999755859375d), // -0.1ish
-                (UInt16BitsToHalf(0b0_10100_0101000000), 42d), // 42
-                (UInt16BitsToHalf(0b1_10100_0101000000), -42d), // -42
+                (BitConverter.UInt16BitsToHalf(0b0_01011_1001100110), 0.0999755859375d), // 0.1ish
+                (BitConverter.UInt16BitsToHalf(0b1_01011_1001100110), -0.0999755859375d), // -0.1ish
+                (BitConverter.UInt16BitsToHalf(0b0_10100_0101000000), 42d), // 42
+                (BitConverter.UInt16BitsToHalf(0b1_10100_0101000000), -42d), // -42
                 (Half.PositiveInfinity, double.PositiveInfinity), // PosInfinity
                 (Half.NegativeInfinity, double.NegativeInfinity), // NegInfinity
-                (UInt16BitsToHalf(0b0_11111_1000000000), BitConverter.Int64BitsToDouble(0x7FF80000_00000000)), // Positive Quiet NaN
+                (BitConverter.UInt16BitsToHalf(0b0_11111_1000000000), BitConverter.Int64BitsToDouble(0x7FF80000_00000000)), // Positive Quiet NaN
                 (Half.NaN, double.NaN), // Negative Quiet NaN
-                (UInt16BitsToHalf(0b0_11111_1010101010), BitConverter.Int64BitsToDouble(0x7FFAA800_00000000)), // Positive Signalling NaN - Should preserve payload
-                (UInt16BitsToHalf(0b1_11111_1010101010), BitConverter.Int64BitsToDouble(unchecked((long)0xFFFAA800_00000000))), // Negative Signalling NaN - Should preserve payload
+                (BitConverter.UInt16BitsToHalf(0b0_11111_1010101010), BitConverter.Int64BitsToDouble(0x7FFAA800_00000000)), // Positive Signalling NaN - Should preserve payload
+                (BitConverter.UInt16BitsToHalf(0b1_11111_1010101010), BitConverter.Int64BitsToDouble(unchecked((long)0xFFFAA800_00000000))), // Negative Signalling NaN - Should preserve payload
                 (Half.Epsilon, 1/16777216d), // PosEpsilon = 0.000000059605...
-                (UInt16BitsToHalf(0), 0d), // 0
-                (UInt16BitsToHalf(0b1_00000_0000000000), -0d), // -0
-                (UInt16BitsToHalf(0b0_10000_1001001000), 3.140625d), // 3.140625
-                (UInt16BitsToHalf(0b1_10000_1001001000), -3.140625d), // -3.140625
-                (UInt16BitsToHalf(0b0_10000_0101110000), 2.71875d), // 2.71875
-                (UInt16BitsToHalf(0b1_10000_0101110000), -2.71875d), // -2.71875
-                (UInt16BitsToHalf(0b0_01111_1000000000), 1.5d), // 1.5
-                (UInt16BitsToHalf(0b1_01111_1000000000), -1.5d), // -1.5
-                (UInt16BitsToHalf(0b0_01111_1000000001), 1.5009765625d), // 1.5009765625
-                (UInt16BitsToHalf(0b1_01111_1000000001), -1.5009765625d), // -1.5009765625
-                (UInt16BitsToHalf(0b0_00001_0000000000), BitConverter.Int64BitsToDouble(0x3F10000000000000)), // smallest normal
-                (UInt16BitsToHalf(0b0_00000_1111111111), BitConverter.Int64BitsToDouble(0x3F0FF80000000000)), // largest subnormal
-                (UInt16BitsToHalf(0b0_00000_1000000000), BitConverter.Int64BitsToDouble(0x3F00000000000000)), // middle subnormal
-                (UInt16BitsToHalf(0b0_00000_0111111111), BitConverter.Int64BitsToDouble(0x3EFFF00000000000)), // just below middle subnormal
-                (UInt16BitsToHalf(0b0_00000_0000000001), BitConverter.Int64BitsToDouble(0x3E70000000000000)), // smallest subnormal
-                (UInt16BitsToHalf(0b1_00000_0000000001), BitConverter.Int64BitsToDouble(unchecked((long)0xBE70000000000000))), // highest negative subnormal
-                (UInt16BitsToHalf(0b1_00000_0111111111), BitConverter.Int64BitsToDouble(unchecked((long)0xBEFFF00000000000))), // just above negative middle subnormal
-                (UInt16BitsToHalf(0b1_00000_1000000000), BitConverter.Int64BitsToDouble(unchecked((long)0xBF00000000000000))), // negative middle subnormal
-                (UInt16BitsToHalf(0b1_00000_1111111111), BitConverter.Int64BitsToDouble(unchecked((long)0xBF0FF80000000000))), // lowest negative subnormal
-                (UInt16BitsToHalf(0b1_00001_0000000000), BitConverter.Int64BitsToDouble(unchecked((long)0xBF10000000000000))) // highest negative normal
+                (BitConverter.UInt16BitsToHalf(0), 0d), // 0
+                (BitConverter.UInt16BitsToHalf(0b1_00000_0000000000), -0d), // -0
+                (BitConverter.UInt16BitsToHalf(0b0_10000_1001001000), 3.140625d), // 3.140625
+                (BitConverter.UInt16BitsToHalf(0b1_10000_1001001000), -3.140625d), // -3.140625
+                (BitConverter.UInt16BitsToHalf(0b0_10000_0101110000), 2.71875d), // 2.71875
+                (BitConverter.UInt16BitsToHalf(0b1_10000_0101110000), -2.71875d), // -2.71875
+                (BitConverter.UInt16BitsToHalf(0b0_01111_1000000000), 1.5d), // 1.5
+                (BitConverter.UInt16BitsToHalf(0b1_01111_1000000000), -1.5d), // -1.5
+                (BitConverter.UInt16BitsToHalf(0b0_01111_1000000001), 1.5009765625d), // 1.5009765625
+                (BitConverter.UInt16BitsToHalf(0b1_01111_1000000001), -1.5009765625d), // -1.5009765625
+                (BitConverter.UInt16BitsToHalf(0b0_00001_0000000000), BitConverter.Int64BitsToDouble(0x3F10000000000000)), // smallest normal
+                (BitConverter.UInt16BitsToHalf(0b0_00000_1111111111), BitConverter.Int64BitsToDouble(0x3F0FF80000000000)), // largest subnormal
+                (BitConverter.UInt16BitsToHalf(0b0_00000_1000000000), BitConverter.Int64BitsToDouble(0x3F00000000000000)), // middle subnormal
+                (BitConverter.UInt16BitsToHalf(0b0_00000_0111111111), BitConverter.Int64BitsToDouble(0x3EFFF00000000000)), // just below middle subnormal
+                (BitConverter.UInt16BitsToHalf(0b0_00000_0000000001), BitConverter.Int64BitsToDouble(0x3E70000000000000)), // smallest subnormal
+                (BitConverter.UInt16BitsToHalf(0b1_00000_0000000001), BitConverter.Int64BitsToDouble(unchecked((long)0xBE70000000000000))), // highest negative subnormal
+                (BitConverter.UInt16BitsToHalf(0b1_00000_0111111111), BitConverter.Int64BitsToDouble(unchecked((long)0xBEFFF00000000000))), // just above negative middle subnormal
+                (BitConverter.UInt16BitsToHalf(0b1_00000_1000000000), BitConverter.Int64BitsToDouble(unchecked((long)0xBF00000000000000))), // negative middle subnormal
+                (BitConverter.UInt16BitsToHalf(0b1_00000_1111111111), BitConverter.Int64BitsToDouble(unchecked((long)0xBF0FF80000000000))), // lowest negative subnormal
+                (BitConverter.UInt16BitsToHalf(0b1_00001_0000000000), BitConverter.Int64BitsToDouble(unchecked((long)0xBF10000000000000))) // highest negative normal
             };
 
             foreach ((Half original, double expected) in data)
@@ -462,73 +452,73 @@ namespace System.Tests
         {
             (float, Half)[] data =
             {
-                (MathF.PI, UInt16BitsToHalf(0b0_10000_1001001000)), // 3.140625
-                (MathF.E, UInt16BitsToHalf(0b0_10000_0101110000)), // 2.71875
-                (-MathF.PI, UInt16BitsToHalf(0b1_10000_1001001000)), // -3.140625
-                (-MathF.E, UInt16BitsToHalf(0b1_10000_0101110000)), // -2.71875
+                (MathF.PI, BitConverter.UInt16BitsToHalf(0b0_10000_1001001000)), // 3.140625
+                (MathF.E, BitConverter.UInt16BitsToHalf(0b0_10000_0101110000)), // 2.71875
+                (-MathF.PI, BitConverter.UInt16BitsToHalf(0b1_10000_1001001000)), // -3.140625
+                (-MathF.E, BitConverter.UInt16BitsToHalf(0b1_10000_0101110000)), // -2.71875
                 (float.MaxValue, Half.PositiveInfinity), // Overflow
                 (float.MinValue, Half.NegativeInfinity), // Overflow
                 (float.PositiveInfinity, Half.PositiveInfinity), // Overflow
                 (float.NegativeInfinity, Half.NegativeInfinity), // Overflow
                 (float.NaN, Half.NaN), // Quiet Negative NaN
-                (BitConverter.Int32BitsToSingle(0x7FC00000), UInt16BitsToHalf(0b0_11111_1000000000)), // Quiet Positive NaN
+                (BitConverter.Int32BitsToSingle(0x7FC00000), BitConverter.UInt16BitsToHalf(0b0_11111_1000000000)), // Quiet Positive NaN
                 (BitConverter.Int32BitsToSingle(unchecked((int)0xFFD55555)),
-                    UInt16BitsToHalf(0b1_11111_1010101010)), // Signalling Negative NaN
-                (BitConverter.Int32BitsToSingle(0x7FD55555), UInt16BitsToHalf(0b0_11111_1010101010)), // Signalling Positive NaN
-                (float.Epsilon, UInt16BitsToHalf(0)), // Underflow
-                (-float.Epsilon, UInt16BitsToHalf(0b1_00000_0000000000)), // Underflow
-                (1f, UInt16BitsToHalf(0b0_01111_0000000000)), // 1
-                (-1f, UInt16BitsToHalf(0b1_01111_0000000000)), // -1
-                (0f, UInt16BitsToHalf(0)), // 0
-                (-0f, UInt16BitsToHalf(0b1_00000_0000000000)), // -0
-                (42f, UInt16BitsToHalf(0b0_10100_0101000000)), // 42
-                (-42f, UInt16BitsToHalf(0b1_10100_0101000000)), // -42
-                (0.1f, UInt16BitsToHalf(0b0_01011_1001100110)), // 0.0999755859375
-                (-0.1f, UInt16BitsToHalf(0b1_01011_1001100110)), // -0.0999755859375
-                (1.5f, UInt16BitsToHalf(0b0_01111_1000000000)), // 1.5
-                (-1.5f, UInt16BitsToHalf(0b1_01111_1000000000)), // -1.5
-                (1.5009765625f, UInt16BitsToHalf(0b0_01111_1000000001)), // 1.5009765625
-                (-1.5009765625f, UInt16BitsToHalf(0b1_01111_1000000001)), // -1.5009765625
-                (BitConverter.Int32BitsToSingle(0x38800000), UInt16BitsToHalf(0b0_00001_0000000000)), // smallest normal
-                (BitConverter.Int32BitsToSingle(0x387FC000), UInt16BitsToHalf(0b0_00000_1111111111)), // largest subnormal
-                (BitConverter.Int32BitsToSingle(0x38000000), UInt16BitsToHalf(0b0_00000_1000000000)), // middle subnormal
-                (BitConverter.Int32BitsToSingle(0x37FF8000), UInt16BitsToHalf(0b0_00000_0111111111)), // just below middle subnormal
-                (BitConverter.Int32BitsToSingle(0x33800000), UInt16BitsToHalf(0b0_00000_0000000001)), // smallest subnormal
+                    BitConverter.UInt16BitsToHalf(0b1_11111_1010101010)), // Signalling Negative NaN
+                (BitConverter.Int32BitsToSingle(0x7FD55555), BitConverter.UInt16BitsToHalf(0b0_11111_1010101010)), // Signalling Positive NaN
+                (float.Epsilon, BitConverter.UInt16BitsToHalf(0)), // Underflow
+                (-float.Epsilon, BitConverter.UInt16BitsToHalf(0b1_00000_0000000000)), // Underflow
+                (1f, BitConverter.UInt16BitsToHalf(0b0_01111_0000000000)), // 1
+                (-1f, BitConverter.UInt16BitsToHalf(0b1_01111_0000000000)), // -1
+                (0f, BitConverter.UInt16BitsToHalf(0)), // 0
+                (-0f, BitConverter.UInt16BitsToHalf(0b1_00000_0000000000)), // -0
+                (42f, BitConverter.UInt16BitsToHalf(0b0_10100_0101000000)), // 42
+                (-42f, BitConverter.UInt16BitsToHalf(0b1_10100_0101000000)), // -42
+                (0.1f, BitConverter.UInt16BitsToHalf(0b0_01011_1001100110)), // 0.0999755859375
+                (-0.1f, BitConverter.UInt16BitsToHalf(0b1_01011_1001100110)), // -0.0999755859375
+                (1.5f, BitConverter.UInt16BitsToHalf(0b0_01111_1000000000)), // 1.5
+                (-1.5f, BitConverter.UInt16BitsToHalf(0b1_01111_1000000000)), // -1.5
+                (1.5009765625f, BitConverter.UInt16BitsToHalf(0b0_01111_1000000001)), // 1.5009765625
+                (-1.5009765625f, BitConverter.UInt16BitsToHalf(0b1_01111_1000000001)), // -1.5009765625
+                (BitConverter.Int32BitsToSingle(0x38800000), BitConverter.UInt16BitsToHalf(0b0_00001_0000000000)), // smallest normal
+                (BitConverter.Int32BitsToSingle(0x387FC000), BitConverter.UInt16BitsToHalf(0b0_00000_1111111111)), // largest subnormal
+                (BitConverter.Int32BitsToSingle(0x38000000), BitConverter.UInt16BitsToHalf(0b0_00000_1000000000)), // middle subnormal
+                (BitConverter.Int32BitsToSingle(0x37FF8000), BitConverter.UInt16BitsToHalf(0b0_00000_0111111111)), // just below middle subnormal
+                (BitConverter.Int32BitsToSingle(0x33800000), BitConverter.UInt16BitsToHalf(0b0_00000_0000000001)), // smallest subnormal
                 (BitConverter.Int32BitsToSingle(unchecked((int)0xB3800000)),
-                    UInt16BitsToHalf(0b1_00000_0000000001)), // highest negative subnormal
+                    BitConverter.UInt16BitsToHalf(0b1_00000_0000000001)), // highest negative subnormal
                 (BitConverter.Int32BitsToSingle(unchecked((int)0xB7FF8000)),
-                    UInt16BitsToHalf(0b1_00000_0111111111)), // just above negative middle subnormal
+                    BitConverter.UInt16BitsToHalf(0b1_00000_0111111111)), // just above negative middle subnormal
                 (BitConverter.Int32BitsToSingle(unchecked((int)0xB8000000)),
-                    UInt16BitsToHalf(0b1_00000_1000000000)), // negative middle subnormal
+                    BitConverter.UInt16BitsToHalf(0b1_00000_1000000000)), // negative middle subnormal
                 (BitConverter.Int32BitsToSingle(unchecked((int)0xB87FC000)),
-                    UInt16BitsToHalf(0b1_00000_1111111111)), // lowest negative subnormal
+                    BitConverter.UInt16BitsToHalf(0b1_00000_1111111111)), // lowest negative subnormal
                 (BitConverter.Int32BitsToSingle(unchecked((int)0xB8800000)),
-                    UInt16BitsToHalf(0b1_00001_0000000000)), // highest negative normal
+                    BitConverter.UInt16BitsToHalf(0b1_00001_0000000000)), // highest negative normal
                 (BitConverter.Int32BitsToSingle(0b0_10001001_00000000111000000000001),
-                                  UInt16BitsToHalf(0b0_11001_0000000100)), // 1027.5+ULP rounds up
+                                  BitConverter.UInt16BitsToHalf(0b0_11001_0000000100)), // 1027.5+ULP rounds up
                 (BitConverter.Int32BitsToSingle(0b0_10001001_00000000111000000000000),
-                                  UInt16BitsToHalf(0b0_11001_0000000100)), // 1027.5 rounds to even
+                                  BitConverter.UInt16BitsToHalf(0b0_11001_0000000100)), // 1027.5 rounds to even
                 (BitConverter.Int32BitsToSingle(0b0_10001001_00000000110111111111111),
-                                  UInt16BitsToHalf(0b0_11001_0000000011)), // 1027.5-ULP rounds down
+                                  BitConverter.UInt16BitsToHalf(0b0_11001_0000000011)), // 1027.5-ULP rounds down
                 (BitConverter.Int32BitsToSingle(unchecked((int)0b1_10001001_00000000110111111111111)),
-                                                 UInt16BitsToHalf(0b1_11001_0000000011)), // -1027.5+ULP rounds towards zero
+                                                 BitConverter.UInt16BitsToHalf(0b1_11001_0000000011)), // -1027.5+ULP rounds towards zero
                 (BitConverter.Int32BitsToSingle(unchecked((int)0b1_10001001_00000000111000000000000)),
-                                                 UInt16BitsToHalf(0b1_11001_0000000100)), // -1027.5 rounds to even
+                                                 BitConverter.UInt16BitsToHalf(0b1_11001_0000000100)), // -1027.5 rounds to even
                 (BitConverter.Int32BitsToSingle(unchecked((int)0b1_10001001_00000000111000000000001)),
-                                                 UInt16BitsToHalf(0b1_11001_0000000100)), // -1027.5-ULP rounds away from zero
+                                                 BitConverter.UInt16BitsToHalf(0b1_11001_0000000100)), // -1027.5-ULP rounds away from zero
                 (BitConverter.Int32BitsToSingle(0b0_01110000_00000001110000000000001),
-                                 UInt16BitsToHalf(0b0_00000_1000000100)), // subnormal + ULP rounds up
+                                 BitConverter.UInt16BitsToHalf(0b0_00000_1000000100)), // subnormal + ULP rounds up
                 (BitConverter.Int32BitsToSingle(0b0_01110000_00000001110000000000000),
-                                 UInt16BitsToHalf(0b0_00000_1000000100)), // subnormal rounds to even
+                                 BitConverter.UInt16BitsToHalf(0b0_00000_1000000100)), // subnormal rounds to even
                 (BitConverter.Int32BitsToSingle(0b0_01110000_00000001101111111111111),
-                                 UInt16BitsToHalf(0b0_00000_1000000011)), // subnormal - ULP rounds down
+                                 BitConverter.UInt16BitsToHalf(0b0_00000_1000000011)), // subnormal - ULP rounds down
                 (BitConverter.Int32BitsToSingle(unchecked((int)0b1_01110000_00000001101111111111111)),
-                                                UInt16BitsToHalf(0b1_00000_1000000011)), // neg subnormal + ULP rounds higher
+                                                BitConverter.UInt16BitsToHalf(0b1_00000_1000000011)), // neg subnormal + ULP rounds higher
                 (BitConverter.Int32BitsToSingle(unchecked((int)0b1_01110000_00000001110000000000000)),
-                                                UInt16BitsToHalf(0b1_00000_1000000100)), // neg subnormal rounds to even
+                                                BitConverter.UInt16BitsToHalf(0b1_00000_1000000100)), // neg subnormal rounds to even
                 (BitConverter.Int32BitsToSingle(unchecked((int)0b1_01110000_00000001101111111111111)),
-                                                UInt16BitsToHalf(0b1_00000_1000000011)), // neg subnormal - ULP rounds lower,
-                (BitConverter.Int32BitsToSingle(0x33000000), UInt16BitsToHalf(0b0_00000_000000000)), // (half-precision minimum subnormal / 2) should underflow to zero
+                                                BitConverter.UInt16BitsToHalf(0b1_00000_1000000011)), // neg subnormal - ULP rounds lower,
+                (BitConverter.Int32BitsToSingle(0x33000000), BitConverter.UInt16BitsToHalf(0b0_00000_000000000)), // (half-precision minimum subnormal / 2) should underflow to zero
             };
 
             foreach ((float original, Half expected) in data)
@@ -542,87 +532,87 @@ namespace System.Tests
         public static void ExplicitConversion_FromSingle(float f, Half expected) // Check the underlying bits for verifying NaNs
         {
             Half h = (Half)f;
-            Assert.Equal(HalfToUInt16Bits(expected), HalfToUInt16Bits(h));
+            Assert.Equal(BitConverter.HalfToUInt16Bits(expected), BitConverter.HalfToUInt16Bits(h));
         }
 
         public static IEnumerable<object[]> ExplicitConversion_FromDouble_TestData()
         {
             (double, Half)[] data =
             {
-                (Math.PI, UInt16BitsToHalf(0b0_10000_1001001000)), // 3.140625
-                (Math.E, UInt16BitsToHalf(0b0_10000_0101110000)), // 2.71875
-                (-Math.PI, UInt16BitsToHalf(0b1_10000_1001001000)), // -3.140625
-                (-Math.E, UInt16BitsToHalf(0b1_10000_0101110000)), // -2.71875
+                (Math.PI, BitConverter.UInt16BitsToHalf(0b0_10000_1001001000)), // 3.140625
+                (Math.E, BitConverter.UInt16BitsToHalf(0b0_10000_0101110000)), // 2.71875
+                (-Math.PI, BitConverter.UInt16BitsToHalf(0b1_10000_1001001000)), // -3.140625
+                (-Math.E, BitConverter.UInt16BitsToHalf(0b1_10000_0101110000)), // -2.71875
                 (double.MaxValue, Half.PositiveInfinity), // Overflow
                 (double.MinValue, Half.NegativeInfinity), // Overflow
                 (double.PositiveInfinity, Half.PositiveInfinity), // Overflow
                 (double.NegativeInfinity, Half.NegativeInfinity), // Overflow
                 (double.NaN, Half.NaN), // Quiet Negative NaN
                 (BitConverter.Int64BitsToDouble(0x7FF80000_00000000),
-                    UInt16BitsToHalf(0b0_11111_1000000000)), // Quiet Positive NaN
+                    BitConverter.UInt16BitsToHalf(0b0_11111_1000000000)), // Quiet Positive NaN
                 (BitConverter.Int64BitsToDouble(unchecked((long)0xFFFAAAAA_AAAAAAAA)),
-                    UInt16BitsToHalf(0b1_11111_1010101010)), // Signalling Negative NaN
+                    BitConverter.UInt16BitsToHalf(0b1_11111_1010101010)), // Signalling Negative NaN
                 (BitConverter.Int64BitsToDouble(0x7FFAAAAA_AAAAAAAA),
-                    UInt16BitsToHalf(0b0_11111_1010101010)), // Signalling Positive NaN
-                (double.Epsilon, UInt16BitsToHalf(0)), // Underflow
-                (-double.Epsilon, UInt16BitsToHalf(0b1_00000_0000000000)), // Underflow
-                (1d, UInt16BitsToHalf(0b0_01111_0000000000)), // 1
-                (-1d, UInt16BitsToHalf(0b1_01111_0000000000)), // -1
-                (0d, UInt16BitsToHalf(0)), // 0
-                (-0d, UInt16BitsToHalf(0b1_00000_0000000000)), // -0
-                (42d, UInt16BitsToHalf(0b0_10100_0101000000)), // 42
-                (-42d, UInt16BitsToHalf(0b1_10100_0101000000)), // -42
-                (0.1d, UInt16BitsToHalf(0b0_01011_1001100110)), // 0.0999755859375
-                (-0.1d, UInt16BitsToHalf(0b1_01011_1001100110)), // -0.0999755859375
-                (1.5d, UInt16BitsToHalf(0b0_01111_1000000000)), // 1.5
-                (-1.5d, UInt16BitsToHalf(0b1_01111_1000000000)), // -1.5
-                (1.5009765625d, UInt16BitsToHalf(0b0_01111_1000000001)), // 1.5009765625
-                (-1.5009765625d, UInt16BitsToHalf(0b1_01111_1000000001)), // -1.5009765625
+                    BitConverter.UInt16BitsToHalf(0b0_11111_1010101010)), // Signalling Positive NaN
+                (double.Epsilon, BitConverter.UInt16BitsToHalf(0)), // Underflow
+                (-double.Epsilon, BitConverter.UInt16BitsToHalf(0b1_00000_0000000000)), // Underflow
+                (1d, BitConverter.UInt16BitsToHalf(0b0_01111_0000000000)), // 1
+                (-1d, BitConverter.UInt16BitsToHalf(0b1_01111_0000000000)), // -1
+                (0d, BitConverter.UInt16BitsToHalf(0)), // 0
+                (-0d, BitConverter.UInt16BitsToHalf(0b1_00000_0000000000)), // -0
+                (42d, BitConverter.UInt16BitsToHalf(0b0_10100_0101000000)), // 42
+                (-42d, BitConverter.UInt16BitsToHalf(0b1_10100_0101000000)), // -42
+                (0.1d, BitConverter.UInt16BitsToHalf(0b0_01011_1001100110)), // 0.0999755859375
+                (-0.1d, BitConverter.UInt16BitsToHalf(0b1_01011_1001100110)), // -0.0999755859375
+                (1.5d, BitConverter.UInt16BitsToHalf(0b0_01111_1000000000)), // 1.5
+                (-1.5d, BitConverter.UInt16BitsToHalf(0b1_01111_1000000000)), // -1.5
+                (1.5009765625d, BitConverter.UInt16BitsToHalf(0b0_01111_1000000001)), // 1.5009765625
+                (-1.5009765625d, BitConverter.UInt16BitsToHalf(0b1_01111_1000000001)), // -1.5009765625
                 (BitConverter.Int64BitsToDouble(0x3F10000000000000),
-                    UInt16BitsToHalf(0b0_00001_0000000000)), // smallest normal
+                    BitConverter.UInt16BitsToHalf(0b0_00001_0000000000)), // smallest normal
                 (BitConverter.Int64BitsToDouble(0x3F0FF80000000000),
-                    UInt16BitsToHalf(0b0_00000_1111111111)), // largest subnormal
+                    BitConverter.UInt16BitsToHalf(0b0_00000_1111111111)), // largest subnormal
                 (BitConverter.Int64BitsToDouble(0x3f00000000000000),
-                    UInt16BitsToHalf(0b0_00000_1000000000)), // middle subnormal
+                    BitConverter.UInt16BitsToHalf(0b0_00000_1000000000)), // middle subnormal
                 (BitConverter.Int64BitsToDouble(0x3EFFF00000000000),
-                    UInt16BitsToHalf(0b0_00000_0111111111)), // just below middle subnormal
+                    BitConverter.UInt16BitsToHalf(0b0_00000_0111111111)), // just below middle subnormal
                 (BitConverter.Int64BitsToDouble(0x3E70000000000000),
-                    UInt16BitsToHalf(0b0_00000_0000000001)), // smallest subnormal
+                    BitConverter.UInt16BitsToHalf(0b0_00000_0000000001)), // smallest subnormal
                 (BitConverter.Int64BitsToDouble(unchecked((long)0xBE70000000000000)),
-                    UInt16BitsToHalf(0b1_00000_0000000001)), // highest negative subnormal
+                    BitConverter.UInt16BitsToHalf(0b1_00000_0000000001)), // highest negative subnormal
                 (BitConverter.Int64BitsToDouble(unchecked((long)0xBEFFF00000000000)),
-                    UInt16BitsToHalf(0b1_00000_0111111111)), // just above negative middle subnormal
+                    BitConverter.UInt16BitsToHalf(0b1_00000_0111111111)), // just above negative middle subnormal
                 (BitConverter.Int64BitsToDouble(unchecked((long)0xBF00000000000000)),
-                    UInt16BitsToHalf(0b1_00000_1000000000)), // negative middle subnormal
+                    BitConverter.UInt16BitsToHalf(0b1_00000_1000000000)), // negative middle subnormal
                 (BitConverter.Int64BitsToDouble(unchecked((long)0xBF0FF80000000000)),
-                    UInt16BitsToHalf(0b1_00000_1111111111)), // lowest negative subnormal
+                    BitConverter.UInt16BitsToHalf(0b1_00000_1111111111)), // lowest negative subnormal
                 (BitConverter.Int64BitsToDouble(unchecked((long)0xBF10000000000000)),
-                    UInt16BitsToHalf(0b1_00001_0000000000)), // highest negative normal
+                    BitConverter.UInt16BitsToHalf(0b1_00001_0000000000)), // highest negative normal
                 (BitConverter.Int64BitsToDouble(0x40900E0000000001),
-                    UInt16BitsToHalf(0b0_11001_0000000100)), // 1027.5+ULP rounds up
+                    BitConverter.UInt16BitsToHalf(0b0_11001_0000000100)), // 1027.5+ULP rounds up
                 (BitConverter.Int64BitsToDouble(0x40900E0000000000),
-                    UInt16BitsToHalf(0b0_11001_0000000100)), // 1027.5 rounds to even
+                    BitConverter.UInt16BitsToHalf(0b0_11001_0000000100)), // 1027.5 rounds to even
                 (BitConverter.Int64BitsToDouble(0x40900DFFFFFFFFFF),
-                    UInt16BitsToHalf(0b0_11001_0000000011)), // 1027.5-ULP rounds down
+                    BitConverter.UInt16BitsToHalf(0b0_11001_0000000011)), // 1027.5-ULP rounds down
                 (BitConverter.Int64BitsToDouble(unchecked((long)0xC0900DFFFFFFFFFF)),
-                    UInt16BitsToHalf(0b1_11001_0000000011)), // -1027.5+ULP rounds towards zero
+                    BitConverter.UInt16BitsToHalf(0b1_11001_0000000011)), // -1027.5+ULP rounds towards zero
                 (BitConverter.Int64BitsToDouble(unchecked((long)0xC0900E0000000000)),
-                    UInt16BitsToHalf(0b1_11001_0000000100)), // -1027.5 rounds to even
+                    BitConverter.UInt16BitsToHalf(0b1_11001_0000000100)), // -1027.5 rounds to even
                 (BitConverter.Int64BitsToDouble(unchecked((long)0xC0900E0000000001)),
-                    UInt16BitsToHalf(0b1_11001_0000000100)), // -1027.5-ULP rounds away from zero
+                    BitConverter.UInt16BitsToHalf(0b1_11001_0000000100)), // -1027.5-ULP rounds away from zero
                 (BitConverter.Int64BitsToDouble(0x3F001C0000000001),
-                    UInt16BitsToHalf(0b0_00000_1000000100)), // subnormal + ULP rounds up
+                    BitConverter.UInt16BitsToHalf(0b0_00000_1000000100)), // subnormal + ULP rounds up
                 (BitConverter.Int64BitsToDouble(0x3F001C0000000001),
-                    UInt16BitsToHalf(0b0_00000_1000000100)), // subnormal rounds to even
+                    BitConverter.UInt16BitsToHalf(0b0_00000_1000000100)), // subnormal rounds to even
                 (BitConverter.Int64BitsToDouble(0x3F001BFFFFFFFFFF),
-                    UInt16BitsToHalf(0b0_00000_1000000011)), // subnormal - ULP rounds down
+                    BitConverter.UInt16BitsToHalf(0b0_00000_1000000011)), // subnormal - ULP rounds down
                 (BitConverter.Int64BitsToDouble(unchecked((long)0xBF001BFFFFFFFFFF)),
-                    UInt16BitsToHalf(0b1_00000_1000000011)), // neg subnormal + ULP rounds higher
+                    BitConverter.UInt16BitsToHalf(0b1_00000_1000000011)), // neg subnormal + ULP rounds higher
                 (BitConverter.Int64BitsToDouble(unchecked((long)0xBF001C0000000000)),
-                    UInt16BitsToHalf(0b1_00000_1000000100)), // neg subnormal rounds to even
+                    BitConverter.UInt16BitsToHalf(0b1_00000_1000000100)), // neg subnormal rounds to even
                 (BitConverter.Int64BitsToDouble(unchecked((long)0xBF001C0000000001)),
-                    UInt16BitsToHalf(0b1_00000_1000000100)), // neg subnormal - ULP rounds lower
-                (BitConverter.Int64BitsToDouble(0x3E60000000000000), UInt16BitsToHalf(0b0_00000_000000000)), // (half-precision minimum subnormal / 2) should underflow to zero
+                    BitConverter.UInt16BitsToHalf(0b1_00000_1000000100)), // neg subnormal - ULP rounds lower
+                (BitConverter.Int64BitsToDouble(0x3E60000000000000), BitConverter.UInt16BitsToHalf(0b0_00000_000000000)), // (half-precision minimum subnormal / 2) should underflow to zero
             };
 
             foreach ((double original, Half expected) in data)
@@ -636,7 +626,7 @@ namespace System.Tests
         public static void ExplicitConversion_FromDouble(double d, Half expected) // Check the underlying bits for verifying NaNs
         {
             Half h = (Half)d;
-            Assert.Equal(HalfToUInt16Bits(expected), HalfToUInt16Bits(h));
+            Assert.Equal(BitConverter.HalfToUInt16Bits(expected), BitConverter.HalfToUInt16Bits(h));
         }
 
         public static IEnumerable<object[]> Parse_Valid_TestData()
@@ -1033,16 +1023,16 @@ namespace System.Tests
             yield return new object[] { Half.MaxValue };
             yield return new object[] { Half.PositiveInfinity };
 
-            yield return new object[] { (UInt16BitsToHalf(0b0_00001_0000000000)) }; // smallest normal
-            yield return new object[] { (UInt16BitsToHalf(0b0_00000_1111111111)) }; // largest subnormal
-            yield return new object[] { (UInt16BitsToHalf(0b0_00000_1000000000)) }; // middle subnormal
-            yield return new object[] { (UInt16BitsToHalf(0b0_00000_0111111111)) }; // just below middle subnormal
-            yield return new object[] { (UInt16BitsToHalf(0b0_00000_0000000001)) }; // smallest subnormal
-            yield return new object[] { (UInt16BitsToHalf(0b1_00000_0000000001)) }; // highest negative subnormal
-            yield return new object[] { (UInt16BitsToHalf(0b1_00000_0111111111)) }; // just above negative middle subnormal
-            yield return new object[] { (UInt16BitsToHalf(0b1_00000_1000000000)) }; // negative middle subnormal
-            yield return new object[] { (UInt16BitsToHalf(0b1_00000_1111111111)) }; // lowest negative subnormal
-            yield return new object[] { (UInt16BitsToHalf(0b1_00001_0000000000)) }; // highest negative normal
+            yield return new object[] { (BitConverter.UInt16BitsToHalf(0b0_00001_0000000000)) }; // smallest normal
+            yield return new object[] { (BitConverter.UInt16BitsToHalf(0b0_00000_1111111111)) }; // largest subnormal
+            yield return new object[] { (BitConverter.UInt16BitsToHalf(0b0_00000_1000000000)) }; // middle subnormal
+            yield return new object[] { (BitConverter.UInt16BitsToHalf(0b0_00000_0111111111)) }; // just below middle subnormal
+            yield return new object[] { (BitConverter.UInt16BitsToHalf(0b0_00000_0000000001)) }; // smallest subnormal
+            yield return new object[] { (BitConverter.UInt16BitsToHalf(0b1_00000_0000000001)) }; // highest negative subnormal
+            yield return new object[] { (BitConverter.UInt16BitsToHalf(0b1_00000_0111111111)) }; // just above negative middle subnormal
+            yield return new object[] { (BitConverter.UInt16BitsToHalf(0b1_00000_1000000000)) }; // negative middle subnormal
+            yield return new object[] { (BitConverter.UInt16BitsToHalf(0b1_00000_1111111111)) }; // lowest negative subnormal
+            yield return new object[] { (BitConverter.UInt16BitsToHalf(0b1_00001_0000000000)) }; // highest negative normal
         }
 
         [Theory]
@@ -1051,7 +1041,7 @@ namespace System.Tests
         {
             float value = o_value is float floatValue ? floatValue : (float)(Half)o_value;
             Half result = Half.Parse(value.ToString());
-            Assert.Equal(HalfToUInt16Bits((Half)value), HalfToUInt16Bits(result));
+            Assert.Equal(BitConverter.HalfToUInt16Bits((Half)value), BitConverter.HalfToUInt16Bits(result));
         }
 
         [Theory]
@@ -1060,7 +1050,7 @@ namespace System.Tests
         {
             float value = o_value is float floatValue ? floatValue : (float)(Half)o_value;
             Half result = Half.Parse(value.ToString("R"));
-            Assert.Equal(HalfToUInt16Bits((Half)value), HalfToUInt16Bits(result));
+            Assert.Equal(BitConverter.HalfToUInt16Bits((Half)value), BitConverter.HalfToUInt16Bits(result));
         }
 
         public static IEnumerable<object[]> RoundTripFloat_CornerCases()

--- a/src/libraries/System.Runtime/tests/System/SingleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/SingleTests.cs
@@ -15,11 +15,6 @@ namespace System.Tests
     {
         // NOTE: Consider duplicating any tests added here in DoubleTests.cs
 
-        private static uint SingleToUInt32Bits(float value)
-        {
-            return Unsafe.As<float, uint>(ref value);
-        }
-
         [Theory]
         [InlineData("a")]
         [InlineData(234.0)]
@@ -105,7 +100,7 @@ namespace System.Tests
         public static void Epsilon()
         {
             Assert.Equal(1.40129846E-45f, float.Epsilon);
-            Assert.Equal(0x00000001u, SingleToUInt32Bits(float.Epsilon));
+            Assert.Equal(0x00000001u, BitConverter.SingleToUInt32Bits(float.Epsilon));
         }
 
         [Theory]
@@ -223,28 +218,28 @@ namespace System.Tests
         public static void MaxValue()
         {
             Assert.Equal(3.40282347E+38f, float.MaxValue);
-            Assert.Equal(0x7F7FFFFFu, SingleToUInt32Bits(float.MaxValue));
+            Assert.Equal(0x7F7FFFFFu, BitConverter.SingleToUInt32Bits(float.MaxValue));
         }
 
         [Fact]
         public static void MinValue()
         {
             Assert.Equal(-3.40282347E+38f, float.MinValue);
-            Assert.Equal(0xFF7FFFFFu, SingleToUInt32Bits(float.MinValue));
+            Assert.Equal(0xFF7FFFFFu, BitConverter.SingleToUInt32Bits(float.MinValue));
         }
 
         [Fact]
         public static void NaN()
         {
             Assert.Equal(0.0f / 0.0f, float.NaN);
-            Assert.Equal(0xFFC00000u, SingleToUInt32Bits(float.NaN));
+            Assert.Equal(0xFFC00000u, BitConverter.SingleToUInt32Bits(float.NaN));
         }
 
         [Fact]
         public static void NegativeInfinity()
         {
             Assert.Equal(-1.0f / 0.0f, float.NegativeInfinity);
-            Assert.Equal(0xFF800000u, SingleToUInt32Bits(float.NegativeInfinity));
+            Assert.Equal(0xFF800000u, BitConverter.SingleToUInt32Bits(float.NegativeInfinity));
         }
 
         public static IEnumerable<object[]> Parse_Valid_TestData()
@@ -479,7 +474,7 @@ namespace System.Tests
         public static void PositiveInfinity()
         {
             Assert.Equal(1.0f / 0.0f, float.PositiveInfinity);
-            Assert.Equal(0x7F800000u, SingleToUInt32Bits(float.PositiveInfinity));
+            Assert.Equal(0x7F800000u, BitConverter.SingleToUInt32Bits(float.PositiveInfinity));
         }
 
         public static IEnumerable<object[]> ToString_TestData()


### PR DESCRIPTION
Adds DoubleToUInt64Bits, UInt64BitsToDouble, SingleToUInt32Bits,
UInt32BitsToSingle, HalfToUInt16Bits and UInt16BitsToHalf.

Implementations were based on existing signed integer variants.

Convert usages of existing APIs to unsigned variants when appropriate.

Fix #36469

The changes build on my machine, but I was unable to run the unit tests, running all of them made the test process hang for 4 hours, so I'm opening this to see what happens on the CI.