### PR TITLE
Remove HarvestVersionValidation from pkg testing

### DIFF
--- a/src/libraries/pkg/test/testPackages.proj
+++ b/src/libraries/pkg/test/testPackages.proj
@@ -216,7 +216,7 @@
     <Exec Command="$(TestBuildCommand) &quot;$(TestProject)&quot;" EnvironmentVariables="@(CliEnvironment)" StandardOutputImportance="High" />
   </Target>
 
-  <Target Name="Build" DependsOnTargets="BuildProjects;HarvestVersionValidation;ArchiveHelixItems" />
+  <Target Name="Build" DependsOnTargets="BuildProjects;ArchiveHelixItems" />
 
   <!-- define test to do nothing, for this project Build does all the testing -->
   <Target Name="Test" />

--- a/src/libraries/pkg/test/testPackages.proj
+++ b/src/libraries/pkg/test/testPackages.proj
@@ -8,9 +8,6 @@
   <ItemGroup>
     <PackagesToTest Condition="'$(PackagesToTest)' != ''" Include="$(PackagesToTest)" />
 
-    <PackageReports Condition="'@(PackagesToTest)' == ''" Include="$(PackageReportDir)*.json" Exclude="@(ExcludePackages->'$(PackageReportDir)%(Identity).json')"/>
-    <PackageReports Condition="'@(PackagesToTest)' != ''" Include="@(PackagesToTest->'$(PackageReportDir)%(Identity).json')" />
-
     <!-- support override via commandline -->
     <RuntimesToInclude Condition="'$(RuntimesToInclude)' != ''" Include="$(RuntimesToInclude)" />
     <TargetFrameworksToInclude Condition="'$(TargetFrameworksToInclude)' != ''" Include="$(TargetFrameworksToInclude)" />
@@ -217,15 +214,6 @@
     <Message Importance="High" Text="*** Testing *** %(SupportedPackage.Identity)" />
     <Message Importance="High" Text="$(TestBuildCommand) &quot;$(TestProject)&quot;" />
     <Exec Command="$(TestBuildCommand) &quot;$(TestProject)&quot;" EnvironmentVariables="@(CliEnvironment)" StandardOutputImportance="High" />
-  </Target>
-
-  <UsingTask TaskName="ValidateHarvestVersionIsLatestForRelease" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-  <Target Name="HarvestVersionValidation">
-    <!-- This target will validate that all packages that are harvesting assets will be doing it from the right package version.
-         If an error is detected, the task will print out the command needed in order to fix the problem. This test requires
-         network access, as what it does is ensure that the harvest version we are using is the latest stable available for that
-         specific package release. -->
-    <ValidateHarvestVersionIsLatestForRelease PackageReports="@(PackageReports)" />
   </Target>
 
   <Target Name="Build" DependsOnTargets="BuildProjects;HarvestVersionValidation;ArchiveHelixItems" />


### PR DESCRIPTION
As packages assets aren't redistributed anymore, harvesting doesn't need to rely on exact versions and thus the task isn't necessary anymore.