### PR TITLE
[libraries] Fix metadata name following arcade change to stop supporting multiple targets in helix sdk

### DIFF
--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -260,7 +260,7 @@
     <ItemGroup Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS' or '$(TargetOS)' == 'iOSSimulator' or '$(TargetOS)' == 'tvOSSimulator' or '$(TargetOS)' == 'MacCatalyst'">
       <!-- Create work items for test apps -->
       <XHarnessAppBundleToTest Include="$([System.IO.Directory]::GetDirectories('$(TestArchiveTestsRoot)', '*.app', System.IO.SearchOption.AllDirectories))">
-        <Targets>$(AppleTestTarget)</Targets>
+        <TestTarget>$(AppleTestTarget)</TestTarget>
       </XHarnessAppBundleToTest>
       <!-- Create work items for run-only apps -->
       <XHarnessAppBundleToTest Condition="Exists('$(TestArchiveRoot)runonly')" Include="$([System.IO.Directory]::GetDirectories('$(TestArchiveRoot)runonly', '*.app', System.IO.SearchOption.AllDirectories))" >
@@ -268,7 +268,7 @@
         <IncludesTestRunner>false</IncludesTestRunner>
         <!-- The sample's C# Main method returns 42 so it should be considered by xharness as a success -->
         <ExpectedExitCode>42</ExpectedExitCode>
-        <Targets>$(AppleTestTarget)</Targets>
+        <TestTarget>$(AppleTestTarget)</TestTarget>
       </XHarnessAppBundleToTest>
     </ItemGroup>
 


### PR DESCRIPTION
New errors for iOS/tvOS/MacCatalyst on `runtime-staging` began occurring as a result of https://github.com/dotnet/arcade/pull/7462

`/Users/runner/work/1/s/.packages/microsoft.dotnet.helix.sdk/6.0.0-beta.21304.1/tools/xharness-runner/XHarnessRunner.targets(105,5): 'Targets' metadata must be specified - expecting list of target device/simulator platforms to execute tests on (e.g. ios-simulator-64) [/Users/runner/work/1/s/src/libraries/sendtohelixhelp.proj]`

This PR looks to resolve the expected metadata discrepancy in iOS/tvOS/MacCatalyst XHarness bundles.