### PR TITLE
rework SocketsHttpHandler request queue handling for HTTP/1.1 and HTTP/2

### DIFF
--- a/src/libraries/Common/src/System/Threading/Tasks/TaskCompletionSourceWithCancellation.cs
+++ b/src/libraries/Common/src/System/Threading/Tasks/TaskCompletionSourceWithCancellation.cs
@@ -21,5 +21,20 @@ namespace System.Threading.Tasks
                 return await Task.ConfigureAwait(false);
             }
         }
+
+        public T WaitWithCancellation(CancellationToken cancellationToken)
+        {
+            using (cancellationToken.UnsafeRegister(static (s, cancellationToken) => ((TaskCompletionSourceWithCancellation<T>)s!).TrySetCanceled(cancellationToken), this))
+            {
+                return Task.GetAwaiter().GetResult();
+            }
+        }
+
+        public ValueTask<T> WaitWithCancellationAsync(bool async, CancellationToken cancellationToken)
+        {
+            return async ?
+                WaitWithCancellationAsync(cancellationToken) :
+                new ValueTask<T>(WaitWithCancellation(cancellationToken));
+        }
     }
 }

--- a/src/libraries/Common/tests/System/Diagnostics/Tracing/ConsoleEventListener.cs
+++ b/src/libraries/Common/tests/System/Diagnostics/Tracing/ConsoleEventListener.cs
@@ -32,7 +32,7 @@ namespace System.Diagnostics.Tracing
         {
             lock (Console.Out)
             {
-                string text = $"[{eventData.EventSource.Name}-{eventData.EventId}]{(eventData.Payload != null ? $" ({string.Join(", ", eventData.Payload)})." : "")}";
+                string text = $"[{eventData.EventSource.Name}-{eventData.EventName}]{(eventData.Payload != null ? $" ({string.Join(", ", eventData.Payload)})." : "")}";
                 if (_eventFilter != null && text.Contains(_eventFilter))
                 {
                     ConsoleColor origForeground = Console.ForegroundColor;

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cookies.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cookies.cs
@@ -315,7 +315,7 @@ namespace System.Net.Http.Functional.Tests
                 using (HttpClient client = CreateHttpClient(handler))
                 {
                     client.DefaultRequestHeaders.ConnectionClose = true; // to avoid issues with connection pooling
-                    await client.GetAsync(url1);
+                        await client.GetAsync(url1);
                 }
             },
             async server =>

--- a/src/libraries/System.Net.Http/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Http/src/Resources/Strings.resx
@@ -540,6 +540,9 @@
   <data name="net_http_request_timedout" xml:space="preserve">
     <value>The request was canceled due to the configured HttpClient.Timeout of {0} seconds elapsing.</value>
   </data>
+  <data name="net_http_connect_timedout" xml:space="preserve">
+    <value>A connection could not be established within the configured ConnectTimeout.</value>
+  </data>
   <data name="net_quic_connectionaborted" xml:space="preserve">
     <value>Connection aborted by peer ({0}).</value>
   </data>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
@@ -63,8 +63,12 @@ namespace System.Net.Http
                         if (response.Headers.ConnectionClose.GetValueOrDefault())
                         {
                             // Server is closing the connection and asking us to authenticate on a new connection.
+
+                            // First, detach the current connection from the pool. This means it will no longer count against the connection limit.
+                            // Instead, it will be replaced by the new connection below.
+                            connection.DetachFromPool();
+
                             connection = await connectionPool.CreateHttp11ConnectionAsync(request, async, cancellationToken).ConfigureAwait(false);
-                            connectionPool.IncrementConnectionCount();
                             connection!.Acquire();
                             isNewConnection = true;
                             needDrain = false;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -243,10 +243,7 @@ namespace System.Net.Http
                     return default;
                 }
 
-                if (_shutdownWaiter is null)
-                {
-                    _shutdownWaiter = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-                }
+                _shutdownWaiter ??= new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 return new ValueTask(_shutdownWaiter.Task);
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -35,13 +35,11 @@ namespace System.Net.Http
         private readonly Dictionary<int, Http2Stream> _httpStreams;
 
         private readonly CreditManager _connectionWindow;
-        private readonly CreditManager _concurrentStreams;
         private RttEstimator _rttEstimator;
 
         private int _nextStream;
         private bool _expectingSettingsAck;
         private int _initialServerStreamWindowSize;
-        private int _maxConcurrentStreams;
         private int _pendingWindowUpdate;
         private long _idleSinceTickCount;
 
@@ -1511,7 +1509,7 @@ namespace System.Net.Http
                 // assigning the stream ID to ensure only one stream gets an ID, and it must be held
                 // across setting the initial window size (available credit) and storing the stream into
                 // collection such that window size updates are able to atomically affect all known streams.
-                http2Stream.Initialize(_nextStream, _initialWindowSize);
+                http2Stream.Initialize(_nextStream, _initialServerStreamWindowSize);
 
                 // Client-initiated streams are always odd-numbered, so increase by 2.
                 _nextStream += 2;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1025,6 +1025,9 @@ namespace System.Net.Http
             Debug.Assert(lastStreamId >= 0);
             Exception resetException = new Http2ConnectionException(errorCode);
 
+            // There is no point sending more PING frames for RTT estimation:
+            _rttEstimator.OnGoAwayReceived();
+
             List<Http2Stream> streamsToAbort = new List<Http2Stream>();
             lock (SyncObject)
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -15,11 +14,10 @@ using System.Text;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Internal;
 
 namespace System.Net.Http
 {
-    internal sealed partial class Http2Connection : HttpConnectionBase, IDisposable
+    internal sealed partial class Http2Connection : HttpConnectionBase
     {
         private readonly HttpConnectionPool _pool;
         private readonly Stream _stream;
@@ -47,25 +45,37 @@ namespace System.Net.Http
         private int _pendingWindowUpdate;
         private long _idleSinceTickCount;
 
+        private uint _maxConcurrentStreams;
+        private uint _streamsInUse;
+        private TaskCompletionSource<bool>? _availableStreamsWaiter;
+
         private readonly Channel<WriteQueueEntry> _writeChannel;
         private bool _lastPendingWriterShouldFlush;
 
-        // This means that the pool has disposed us, but there may still be
-        // requests in flight that will continue to be processed.
-        private bool _disposed;
+        // This will be set when we receive a GOAWAY.
+        // Requests currently in flight will continue to be processed, but no new requests can be initiated.
+        private bool _goingAway;
 
-        // This will be set when:
-        // (1) We receive GOAWAY -- will be set to the value sent in the GOAWAY frame
-        // (2) A connection IO error occurs -- will be set to int.MaxValue
-        //     (meaning we must assume all streams have been processed by the server)
-        private int _lastStreamId = -1;
+        // If this is set, the connection is aborting due to an IO failure (IOException) or a protocol violation (Http2ProtocolException).
+        // Requests in flight have been (or are being) failed.
+        private Exception? _abortException;
+
+        // If this is set, the connections is shutting down and cannot accept new requests.
+        // When this is true, one or more of the following is also true:
+        // (1) _goingAway
+        // (2) _abortException is not null
+        // (3) _nextStream == MaxStreamId
+        private bool _shutdown;
+        private TaskCompletionSource? _shutdownWaiter;
+
+        // This means that the pool has disposed us and will not submit further requests.
+        // Requests currently in flight will continue to be processed.
+        // When all requests have completed, the connection will be torn down.
+        private bool _disposed;
 
         private const int TelemetryStatus_Opened = 1;
         private const int TelemetryStatus_Closed = 2;
         private int _markedByTelemetryStatus;
-
-        // This will be set when a connection IO error occurs
-        private Exception? _abortException;
 
         private const int MaxStreamId = int.MaxValue;
 
@@ -125,6 +135,7 @@ namespace System.Net.Http
         {
             _pool = pool;
             _stream = stream;
+
             _incomingBuffer = new ArrayBuffer(InitialConnectionBufferSize);
             _outgoingBuffer = new ArrayBuffer(InitialConnectionBufferSize);
 
@@ -133,7 +144,6 @@ namespace System.Net.Http
             _httpStreams = new Dictionary<int, Http2Stream>();
 
             _connectionWindow = new CreditManager(this, nameof(_connectionWindow), DefaultInitialWindowSize);
-            _concurrentStreams = new CreditManager(this, nameof(_concurrentStreams), InitialMaxConcurrentStreams);
 
             _rttEstimator = RttEstimator.Create();
 
@@ -143,9 +153,10 @@ namespace System.Net.Http
             _initialServerStreamWindowSize = DefaultInitialWindowSize;
 
             _maxConcurrentStreams = InitialMaxConcurrentStreams;
+            _streamsInUse = 0;
+
             _pendingWindowUpdate = 0;
             _idleSinceTickCount = Environment.TickCount64;
-
 
             _keepAlivePingDelay = TimeSpanToMs(_pool.Settings._keepAlivePingDelay);
             _keepAlivePingTimeout = TimeSpanToMs(_pool.Settings._keepAlivePingTimeout);
@@ -169,8 +180,6 @@ namespace System.Net.Http
         ~Http2Connection() => Dispose();
 
         private object SyncObject => _httpStreams;
-
-        public bool CanAddNewStream => _concurrentStreams.IsCreditAvailable;
 
         public async ValueTask SetupAsync()
         {
@@ -220,6 +229,161 @@ namespace System.Net.Http
 
             _ = ProcessIncomingFramesAsync();
             _ = ProcessOutgoingFramesAsync();
+        }
+
+        // This will complete when the connection begins to shut down and cannot be used anymore, or if it is disposed.
+        public ValueTask WaitForShutdownAsync()
+        {
+            lock (SyncObject)
+            {
+                if (_disposed)
+                {
+                    Debug.Fail("As currently used, we don't expect to call this after disposing and we don't handle the ODE");
+                    throw new ObjectDisposedException(nameof(Http2Connection));
+                }
+
+                if (_shutdown)
+                {
+                    Debug.Assert(_shutdownWaiter is null);
+                    return default;
+                }
+
+                if (_shutdownWaiter is null)
+                {
+                    _shutdownWaiter = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                }
+
+                return new ValueTask(_shutdownWaiter.Task);
+            }
+        }
+
+        private void Shutdown()
+        {
+            if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(_shutdown)}={_shutdown}, {nameof(_goingAway)}={_goingAway}, {nameof(_abortException)}={_abortException}");
+
+            Debug.Assert(Monitor.IsEntered(SyncObject));
+
+            SignalAvailableStreamsWaiter(false);
+            SignalShutdownWaiter();
+
+            // Note _shutdown could already be set, but that's fine.
+            _shutdown = true;
+        }
+
+        private void SignalShutdownWaiter()
+        {
+            if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(_shutdownWaiter)}?={_shutdownWaiter is not null}");
+
+            Debug.Assert(Monitor.IsEntered(SyncObject));
+
+            if (_shutdownWaiter is not null)
+            {
+                Debug.Assert(!_disposed);
+                Debug.Assert(!_shutdown);
+                _shutdownWaiter.SetResult();
+                _shutdownWaiter = null;
+            }
+        }
+
+        public bool TryReserveStream()
+        {
+            lock (SyncObject)
+            {
+                if (_disposed)
+                {
+                    Debug.Fail("As currently used, we don't expect to call this after disposing and we don't handle the ODE");
+                    throw new ObjectDisposedException(nameof(Http2Connection));
+                }
+
+                if (_shutdown)
+                {
+                    return false;
+                }
+
+                if (_streamsInUse < _maxConcurrentStreams)
+                {
+                    _streamsInUse++;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        // Can be called by the HttpConnectionPool after TryReserveStream if the stream doesn't end up being used.
+        // Otherwise, will be called when the request is complete and stream is closed.
+        public void ReleaseStream()
+        {
+            lock (SyncObject)
+            {
+                if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(_streamsInUse)}={_streamsInUse}");
+
+                Debug.Assert(_availableStreamsWaiter is null || _streamsInUse >= _maxConcurrentStreams);
+
+                _streamsInUse--;
+
+                Debug.Assert(_streamsInUse >= _httpStreams.Count);
+
+                if (_streamsInUse < _maxConcurrentStreams)
+                {
+                    SignalAvailableStreamsWaiter(true);
+                }
+
+                if (_streamsInUse == 0)
+                {
+                    _idleSinceTickCount = Environment.TickCount64;
+
+                    if (_disposed)
+                    {
+                        FinalTeardown();
+                    }
+                }
+            }
+        }
+
+        // Returns true to indicate at least one stream is available
+        // Returns false to indicate that the connection is shutting down and cannot be used anymore
+        public ValueTask<bool> WaitForAvailableStreamsAsync()
+        {
+            lock (SyncObject)
+            {
+                if (_disposed)
+                {
+                    Debug.Fail("As currently used, we don't expect to call this after disposing and we don't handle the ODE");
+                    throw new ObjectDisposedException(nameof(Http2Connection));
+                }
+
+                Debug.Assert(_availableStreamsWaiter is null, "As used currently, shouldn't already have a waiter");
+
+                if (_shutdown)
+                {
+                    return ValueTask.FromResult(false);
+                }
+
+                if (_streamsInUse < _maxConcurrentStreams)
+                {
+                    return ValueTask.FromResult(true);
+                }
+
+                // Need to wait for streams to become available.
+                _availableStreamsWaiter = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                return new ValueTask<bool>(_availableStreamsWaiter.Task);
+            }
+        }
+
+        private void SignalAvailableStreamsWaiter(bool result)
+        {
+            if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(result)}={result}, {nameof(_availableStreamsWaiter)}?={_availableStreamsWaiter is not null}");
+
+            Debug.Assert(Monitor.IsEntered(SyncObject));
+
+            if (_availableStreamsWaiter is not null)
+            {
+                Debug.Assert(!_disposed);
+                Debug.Assert(!_shutdown);
+                _availableStreamsWaiter.SetResult(result);
+                _availableStreamsWaiter = null;
+            }
         }
 
         private async Task FlushOutgoingBytesAsync()
@@ -305,7 +469,6 @@ namespace System.Net.Http
 
             void ThrowMissingFrame() =>
                 throw new IOException(SR.net_http_invalid_response_missing_frame);
-
         }
 
         private async Task ProcessIncomingFramesAsync()
@@ -695,16 +858,18 @@ namespace System.Net.Http
 
         private void ChangeMaxConcurrentStreams(uint newValue)
         {
-            if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(newValue)}={newValue}");
+            lock (SyncObject)
+            {
+                if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(newValue)}={newValue}, {nameof(_streamsInUse)}={_streamsInUse}, {nameof(_availableStreamsWaiter)}?={_availableStreamsWaiter is not null}");
 
-            // The value is provided as a uint.
-            // Limit this to int.MaxValue since the CreditManager implementation only supports singed values.
-            // In practice, we should never reach this value.
-            int effectiveValue = newValue > (uint)int.MaxValue ? int.MaxValue : (int)newValue;
-            int delta = effectiveValue - _maxConcurrentStreams;
-            _maxConcurrentStreams = effectiveValue;
+                Debug.Assert(_availableStreamsWaiter is null || _streamsInUse >= _maxConcurrentStreams);
 
-            _concurrentStreams.AdjustCredit(delta);
+                _maxConcurrentStreams = newValue;
+                if (_streamsInUse < _maxConcurrentStreams)
+                {
+                    SignalAvailableStreamsWaiter(true);
+                }
+            }
         }
 
         private void ChangeInitialWindowSize(int newSize)
@@ -854,20 +1019,46 @@ namespace System.Net.Http
                 ThrowProtocolError(Http2ProtocolErrorCode.FrameSizeError);
             }
 
-            // GoAway frames always apply to the whole connection, never to a single stream.
-            // According to RFC 7540 section 6.8, this should be a connection error.
             if (frameHeader.StreamId != 0)
             {
                 ThrowProtocolError();
             }
 
-            int lastValidStream = (int)(BinaryPrimitives.ReadUInt32BigEndian(_incomingBuffer.ActiveSpan) & 0x7FFFFFFF);
-            var errorCode = (Http2ProtocolErrorCode)BinaryPrimitives.ReadInt32BigEndian(_incomingBuffer.ActiveSpan.Slice(sizeof(int)));
-            if (NetEventSource.Log.IsEnabled()) Trace(frameHeader.StreamId, $"{nameof(lastValidStream)}={lastValidStream}, {nameof(errorCode)}={errorCode}");
-
-            StartTerminatingConnection(lastValidStream, new Http2ConnectionException(errorCode));
+            int lastStreamId = (int)(BinaryPrimitives.ReadUInt32BigEndian(_incomingBuffer.ActiveSpan) & 0x7FFFFFFF);
+            Http2ProtocolErrorCode errorCode = (Http2ProtocolErrorCode)BinaryPrimitives.ReadInt32BigEndian(_incomingBuffer.ActiveSpan.Slice(sizeof(int)));
+            if (NetEventSource.Log.IsEnabled()) Trace(frameHeader.StreamId, $"{nameof(lastStreamId)}={lastStreamId}, {nameof(errorCode)}={errorCode}");
 
             _incomingBuffer.Discard(frameHeader.PayloadLength);
+
+            Debug.Assert(lastStreamId >= 0);
+            Exception resetException = new Http2ConnectionException(errorCode);
+
+            List<Http2Stream> streamsToAbort = new List<Http2Stream>();
+            lock (SyncObject)
+            {
+                // Note, we can received multiple GOAWAYs from the server, so this may already be true.
+                // We still want to process the frame and abort streams because the lastStreamId may be less than previous one.
+                _goingAway = true;
+
+                Shutdown();
+
+                foreach (KeyValuePair<int, Http2Stream> kvp in _httpStreams)
+                {
+                    int streamId = kvp.Key;
+                    Debug.Assert(streamId == kvp.Value.StreamId);
+
+                    if (streamId > lastStreamId)
+                    {
+                        streamsToAbort.Add(kvp.Value);
+                    }
+                }
+            }
+
+            // Avoid calling OnReset under the lock, as it may cause the Http2Stream to call back in to RemoveStream
+            foreach (Http2Stream s in streamsToAbort)
+            {
+                s.OnReset(resetException, canRetry: true);
+            }
         }
 
         internal Task FlushAsync(CancellationToken cancellationToken) =>
@@ -924,8 +1115,16 @@ namespace System.Net.Http
 
             if (!_writeChannel.Writer.TryWrite(writeEntry))
             {
-                Debug.Assert(_abortException is not null);
-                return Task.FromException(GetRequestAbortedException(_abortException));
+                if (_abortException is not null)
+                {
+                    return Task.FromException(GetRequestAbortedException(_abortException));
+                }
+
+                // We must be trying to send something asynchronously (like RST_STREAM or a PING or a SETTINGS ACK) and it has raced with the connection tear down.
+                // As such, it should not matter that we were not able to actually send the frame.
+                // But just in case, throw ObjectDisposedException. Asynchronous callers will ignore the failure.
+                Debug.Assert(_disposed && _streamsInUse == 0);
+                return Task.FromException(new ObjectDisposedException(nameof(Http2Connection)));
             }
 
             return writeEntry.Task;
@@ -994,9 +1193,6 @@ namespace System.Net.Http
                         await FlushOutgoingBytesAsync().ConfigureAwait(false);
                     }
                 }
-
-                // Connection should be aborting at this point.
-                Debug.Assert(_abortException is not null);
             }
             catch (Exception e)
             {
@@ -1297,83 +1493,44 @@ namespace System.Net.Http
             }
         }
 
-        [DoesNotReturn]
-        private void ThrowShutdownException()
+        private void AddStream(Http2Stream http2Stream)
         {
-            Debug.Assert(Monitor.IsEntered(SyncObject));
-
-            if (_abortException != null)
+            lock (SyncObject)
             {
-                // We had an IO failure on the connection. Don't retry in this case.
-                throw new HttpRequestException(SR.net_http_client_execution_error, _abortException);
-            }
+                if (_nextStream == MaxStreamId)
+                {
+                    // We have exhausted StreamIds. Shut down the connection.
+                    Shutdown();
+                }
 
-            // Connection is being gracefully shutdown. Allow the request to be retried.
-            Exception innerException;
-            if (_lastStreamId != -1)
-            {
-                // We must have received a GOAWAY.
-                innerException = new IOException(SR.net_http_server_shutdown);
-            }
-            else
-            {
-                // We must either be disposed or out of stream IDs.
-                Debug.Assert(_disposed || _nextStream == MaxStreamId);
+                if (_shutdown)
+                {
+                    // The connection has shut down. Throw a retryable exception so that this request will be handled on another connection.
+                    ThrowRetry(SR.net_http_server_shutdown);
+                }
 
-                innerException = new ObjectDisposedException(nameof(Http2Connection));
-            }
+                if (_streamsInUse > _maxConcurrentStreams)
+                {
+                    // The server must have sent a downward adjustment to SETTINGS_MAX_CONCURRENT_STREAMS, so our previous stream reservation is no longer valid.
+                    // We might want a better exception message here, but in general the user shouldn't see this anyway since it will be retried.
+                    ThrowRetry(SR.net_http_request_aborted);
+                }
 
-            ThrowRetry(SR.net_http_client_execution_error, innerException);
+                // Now that we're holding the lock, configure the stream.  The lock must be held while
+                // assigning the stream ID to ensure only one stream gets an ID, and it must be held
+                // across setting the initial window size (available credit) and storing the stream into
+                // collection such that window size updates are able to atomically affect all known streams.
+                http2Stream.Initialize(_nextStream, _initialWindowSize);
+
+                // Client-initiated streams are always odd-numbered, so increase by 2.
+                _nextStream += 2;
+
+                _httpStreams.Add(http2Stream.StreamId, http2Stream);
+            }
         }
 
         private async ValueTask<Http2Stream> SendHeadersAsync(HttpRequestMessage request, CancellationToken cancellationToken, bool mustFlush)
         {
-            // Enforce MAX_CONCURRENT_STREAMS setting value.  We do this before anything else, e.g. renting buffers to serialize headers,
-            // in order to avoid consuming resources in potentially many requests waiting for access.
-            try
-            {
-                if (!_concurrentStreams.TryRequestCreditNoWait(1))
-                {
-                    if (_pool.EnableMultipleHttp2Connections)
-                    {
-                        throw new HttpRequestException(null, null, RequestRetryType.RetryOnStreamLimitReached);
-                    }
-
-                    if (HttpTelemetry.Log.IsEnabled())
-                    {
-                        // Only log Http20RequestLeftQueue if we spent time waiting on the queue
-                        ValueStopwatch stopwatch = ValueStopwatch.StartNew();
-                        await _concurrentStreams.RequestCreditAsync(1, cancellationToken).ConfigureAwait(false);
-                        HttpTelemetry.Log.Http20RequestLeftQueue(stopwatch.GetElapsedTime().TotalMilliseconds);
-                    }
-                    else
-                    {
-                        await _concurrentStreams.RequestCreditAsync(1, cancellationToken).ConfigureAwait(false);
-                    }
-                }
-            }
-            catch (ObjectDisposedException)
-            {
-                // We have race condition between shutting down and initiating new requests.
-                // When we are shutting down the connection (e.g. due to receiving GOAWAY, etc)
-                // we will wait until the stream count goes to 0, and then we will close the connetion
-                // and perform clean up, including disposing _concurrentStreams.
-                // So if we get ObjectDisposedException here, we must have shut down the connection.
-                // Throw a retryable request exception if this is not result of some other error.
-                // This will cause retry logic to kick in and perform another connection attempt.
-                // The user should never see this exception.  See similar handling below.
-                // Throw a retryable request exception if this is not result of some other error.
-                // This will cause retry logic to kick in and perform another connection attempt.
-                // The user should never see this exception.  See also below.
-                lock (SyncObject)
-                {
-                    Debug.Assert(_disposed || _lastStreamId != -1);
-                    Debug.Assert(_httpStreams.Count == 0);
-                    ThrowShutdownException();
-                    throw; // unreachable
-                }
-            }
-
             ArrayBuffer headerBuffer = default;
             try
             {
@@ -1402,32 +1559,7 @@ namespace System.Net.Http
                 {
                     if (NetEventSource.Log.IsEnabled()) s.thisRef.Trace(s.http2Stream.StreamId, $"Started writing. Total header bytes={s.headerBytes.Length}");
 
-                    // Allocate the next available stream ID. Note that if we fail before sending the headers,
-                    // we'll just skip this stream ID, which is fine.
-                    lock (s.thisRef.SyncObject)
-                    {
-                        if (s.thisRef._nextStream == MaxStreamId || s.thisRef._disposed || s.thisRef._lastStreamId != -1)
-                        {
-                            // We ran out of stream IDs or we raced between acquiring the connection from the pool and shutting down.
-                            // Throw a retryable request exception. This will cause retry logic to kick in
-                            // and perform another connection attempt. The user should never see this exception.
-                            s.thisRef.ThrowShutdownException();
-                        }
-
-                        // Now that we're holding the lock, configure the stream.  The lock must be held while
-                        // assigning the stream ID to ensure only one stream gets an ID, and it must be held
-                        // across setting the initial window size (available credit) and storing the stream into
-                        // collection such that window size updates are able to atomically affect all known streams.
-                        s.http2Stream.Initialize(s.thisRef._nextStream, s.thisRef._initialServerStreamWindowSize);
-
-                        // Client-initiated streams are always odd-numbered, so increase by 2.
-                        s.thisRef._nextStream += 2;
-
-                        // We're about to flush the HEADERS frame, so add the stream to the dictionary now.
-                        // The lifetime of the stream is now controlled by the stream itself and the connection.
-                        // This can fail if the connection is shutting down, in which case we will cancel sending this frame.
-                        s.thisRef._httpStreams.Add(s.http2Stream.StreamId, s.http2Stream);
-                    }
+                    s.thisRef.AddStream(s.http2Stream);
 
                     Span<byte> span = writeBuffer.Span;
 
@@ -1466,7 +1598,7 @@ namespace System.Net.Http
             }
             catch
             {
-                _concurrentStreams.AdjustCredit(1);
+                ReleaseStream();
                 throw;
             }
             finally
@@ -1572,94 +1704,33 @@ namespace System.Net.Http
             LogExceptions(SendWindowUpdateAsync(0, windowUpdateSize));
         }
 
+        public override long GetIdleTicks(long nowTicks)
+        {
+            lock (SyncObject)
+            {
+                return _streamsInUse == 0 ? _idleSinceTickCount - nowTicks : 0;
+            }
+        }
+
         /// <summary>Abort all streams and cause further processing to fail.</summary>
         /// <param name="abortException">Exception causing Abort to be called.</param>
         private void Abort(Exception abortException)
         {
-            // The connection has failed, e.g. failed IO or a connection-level frame error.
-            bool alreadyAborting = false;
-            lock (SyncObject)
-            {
-                if (_abortException is null)
-                {
-                    _abortException = abortException;
-                }
-                else
-                {
-                    alreadyAborting = true;
-                }
-            }
+            if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(abortException)}=={abortException}");
 
-            if (alreadyAborting)
-            {
-                if (NetEventSource.Log.IsEnabled()) Trace($"Abort called while already aborting. {nameof(abortException)}=={abortException}");
-
-                return;
-            }
-
-            if (NetEventSource.Log.IsEnabled()) Trace($"Abort initiated. {nameof(abortException)}=={abortException}");
-
-            _writeChannel.Writer.Complete();
-
-            AbortStreams(_abortException);
-        }
-
-        /// <summary>Gets whether the connection exceeded any of the connection limits.</summary>
-        /// <param name="nowTicks">The current tick count.  Passed in to amortize the cost of calling Environment.TickCount64.</param>
-        /// <param name="connectionLifetime">How long a connection can be open to be considered reusable.</param>
-        /// <param name="connectionIdleTimeout">How long a connection can have been idle in the pool to be considered reusable.</param>
-        /// <returns>
-        /// true if we believe the connection is expired; otherwise, false.  There is an inherent race condition here,
-        /// in that the server could terminate the connection or otherwise make it unusable immediately after we check it,
-        /// but there's not much difference between that and starting to use the connection and then having the server
-        /// terminate it, which would be considered a failure, so this race condition is largely benign and inherent to
-        /// the nature of connection pooling.
-        /// </returns>
-        public bool IsExpired(long nowTicks,
-                              TimeSpan connectionLifetime,
-                              TimeSpan connectionIdleTimeout)
-        {
-            if (_disposed)
-            {
-                return true;
-            }
-
-            // Check idle timeout when there are not pending requests for a while.
-            if ((connectionIdleTimeout != Timeout.InfiniteTimeSpan) &&
-                (_httpStreams.Count == 0) &&
-                ((nowTicks - _idleSinceTickCount) > connectionIdleTimeout.TotalMilliseconds))
-            {
-                if (NetEventSource.Log.IsEnabled()) Trace($"HTTP/2 connection no longer usable. Idle {TimeSpan.FromMilliseconds(nowTicks - _idleSinceTickCount)} > {connectionIdleTimeout}.");
-
-                return true;
-            }
-
-            if (LifetimeExpired(nowTicks, connectionLifetime))
-            {
-                if (NetEventSource.Log.IsEnabled()) Trace($"HTTP/2 connection no longer usable. Lifetime {TimeSpan.FromMilliseconds(nowTicks - CreationTickCount)} > {connectionLifetime}.");
-
-                return true;
-            }
-
-            return false;
-        }
-
-        private void AbortStreams(Exception abortException)
-        {
-            if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(abortException)}={abortException}");
-
-            // Invalidate outside of lock to avoid race with HttpPool Dispose()
-            // We should not try to grab pool lock while holding connection lock as on disposing pool,
-            // we could hold pool lock while trying to grab connection lock in Dispose().
-            _pool.InvalidateHttp2Connection(this);
-
+            // The connection has failed, e.g. failed IO or a connection-level protocol error.
             List<Http2Stream> streamsToAbort = new List<Http2Stream>();
-
             lock (SyncObject)
             {
-                // Set _lastStreamId to int.MaxValue to indicate that we are shutting down
-                // and we must assume all active streams have been processed by the server
-                _lastStreamId = int.MaxValue;
+                if (_abortException is not null)
+                {
+                    if (NetEventSource.Log.IsEnabled()) Trace($"Abort called while already aborting. {nameof(abortException)}={abortException}");
+                    return;
+                }
+
+                _abortException = abortException;
+
+                Shutdown();
 
                 foreach (KeyValuePair<int, Http2Stream> kvp in _httpStreams)
                 {
@@ -1668,91 +1739,28 @@ namespace System.Net.Http
 
                     streamsToAbort.Add(kvp.Value);
                 }
-
-                CheckForShutdown();
             }
 
-            // Avoid calling OnAbort under the lock, as it may cause the Http2Stream
-            // to call back in to RemoveStream
+            // Avoid calling OnReset under the lock, as it may cause the Http2Stream to call back in to RemoveStream
             foreach (Http2Stream s in streamsToAbort)
             {
-                s.OnReset(abortException);
+                s.OnReset(_abortException);
             }
         }
 
-        private void StartTerminatingConnection(int lastValidStream, Exception abortException)
+        private void FinalTeardown()
         {
-            Debug.Assert(lastValidStream >= 0);
+            if (NetEventSource.Log.IsEnabled()) Trace("");
 
-            // Invalidate outside of lock to avoid race with HttpPool Dispose()
-            // We should not try to grab pool lock while holding connection lock as on disposing pool,
-            // we could hold pool lock while trying to grab connection lock in Dispose().
-            _pool.InvalidateHttp2Connection(this);
-
-            // There is no point sending more PING frames for RTT estimation:
-            _rttEstimator.OnGoAwayReceived();
-
-            List<Http2Stream> streamsToAbort = new List<Http2Stream>();
-
-            lock (SyncObject)
-            {
-                if (_lastStreamId == -1)
-                {
-                    _lastStreamId = lastValidStream;
-                }
-                else
-                {
-                    // We have already received GOAWAY before
-                    // In this case the smaller valid stream is used
-                    _lastStreamId = Math.Min(_lastStreamId, lastValidStream);
-                }
-
-                if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(lastValidStream)}={lastValidStream}, {nameof(_lastStreamId)}={_lastStreamId}");
-
-                foreach (KeyValuePair<int, Http2Stream> kvp in _httpStreams)
-                {
-                    int streamId = kvp.Key;
-                    Debug.Assert(streamId == kvp.Value.StreamId);
-
-                    if (streamId > _lastStreamId)
-                    {
-                        streamsToAbort.Add(kvp.Value);
-                    }
-                    else
-                    {
-                        if (NetEventSource.Log.IsEnabled()) Trace($"Found {nameof(streamId)} {streamId} <= {_lastStreamId}.");
-                    }
-                }
-
-                CheckForShutdown();
-            }
-
-            // Avoid calling OnAbort under the lock, as it may cause the Http2Stream
-            // to call back in to RemoveStream
-            foreach (Http2Stream s in streamsToAbort)
-            {
-                s.OnReset(abortException, canRetry: true);
-            }
-        }
-
-        private void CheckForShutdown()
-        {
-            Debug.Assert(_disposed || _lastStreamId != -1);
-            Debug.Assert(Monitor.IsEntered(SyncObject));
-
-            // Check if dictionary has become empty
-            if (_httpStreams.Count != 0)
-            {
-                return;
-            }
+            Debug.Assert(_disposed);
+            Debug.Assert(_streamsInUse == 0);
 
             GC.SuppressFinalize(this);
 
-            // Do shutdown.
             _stream.Dispose();
 
             _connectionWindow.Dispose();
-            _concurrentStreams.Dispose();
+            _writeChannel.Writer.Complete();
 
             if (HttpTelemetry.Log.IsEnabled())
             {
@@ -1763,15 +1771,23 @@ namespace System.Net.Http
             }
         }
 
-        public void Dispose()
+        public override void Dispose()
         {
             lock (SyncObject)
             {
+                if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(_disposed)}={_disposed}, {nameof(_streamsInUse)}={_streamsInUse}");
+
                 if (!_disposed)
                 {
+                    SignalAvailableStreamsWaiter(false);
+                    SignalShutdownWaiter();
+
                     _disposed = true;
 
-                    CheckForShutdown();
+                    if (_streamsInUse == 0)
+                    {
+                        FinalTeardown();
+                    }
                 }
             }
         }
@@ -1885,7 +1901,7 @@ namespace System.Net.Http
 
         // Note that this is safe to be called concurrently by multiple threads.
 
-        public sealed override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
         {
             Debug.Assert(async);
             if (NetEventSource.Log.IsEnabled()) Trace($"{request}");
@@ -1969,7 +1985,6 @@ namespace System.Net.Http
         private void RemoveStream(Http2Stream http2Stream)
         {
             if (NetEventSource.Log.IsEnabled()) Trace(http2Stream.StreamId, "");
-            Debug.Assert(http2Stream != null);
 
             lock (SyncObject)
             {
@@ -1978,20 +1993,9 @@ namespace System.Net.Http
                     Debug.Fail($"Stream {http2Stream.StreamId} not found in dictionary during RemoveStream???");
                     return;
                 }
-
-                if (_httpStreams.Count == 0)
-                {
-                    // If this was last pending request, get timestamp so we can monitor idle time.
-                    _idleSinceTickCount = Environment.TickCount64;
-
-                    if (_disposed || _lastStreamId != -1)
-                    {
-                        CheckForShutdown();
-                    }
-                }
             }
 
-            _concurrentStreams.AdjustCredit(1);
+            ReleaseStream();
         }
 
         private void RefreshPingTimestamp()
@@ -2023,7 +2027,10 @@ namespace System.Net.Http
             {
                 lock (SyncObject)
                 {
-                    if (_httpStreams.Count == 0) return;
+                    if (_streamsInUse == 0)
+                    {
+                        return;
+                    }
                 }
             }
 
@@ -2067,7 +2074,7 @@ namespace System.Net.Http
                 message);                     // message
 
         [DoesNotReturn]
-        private static void ThrowRetry(string message, Exception innerException) =>
+        private static void ThrowRetry(string message, Exception? innerException = null) =>
             throw new HttpRequestException(message, innerException, allowRetry: RequestRetryType.RetryOnConnectionFailure);
 
         private static Exception GetRequestAbortedException(Exception? innerException = null) =>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -18,7 +18,7 @@ namespace System.Net.Http
     [SupportedOSPlatform("windows")]
     [SupportedOSPlatform("linux")]
     [SupportedOSPlatform("macos")]
-    internal sealed class Http3Connection : HttpConnectionBase, IDisposable
+    internal sealed class Http3Connection : HttpConnectionBase
     {
         // TODO: once HTTP/3 is standardized, create APIs for this.
         public static readonly SslApplicationProtocol Http3ApplicationProtocol29 = new SslApplicationProtocol("h3-29");
@@ -92,7 +92,7 @@ namespace System.Net.Http
         /// <summary>
         /// Starts shutting down the <see cref="Http3Connection"/>. Final cleanup will happen when there are no more active requests.
         /// </summary>
-        public void Dispose()
+        public override void Dispose()
         {
             lock (SyncObj)
             {
@@ -155,7 +155,7 @@ namespace System.Net.Http
             }
         }
 
-        public override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
         {
             Debug.Assert(async);
 
@@ -328,6 +328,8 @@ namespace System.Net.Http
                 }
             }
         }
+
+        public override long GetIdleTicks(long nowTicks) => throw new NotImplementedException("We aren't scavenging HTTP3 connections yet");
 
         public override void Trace(string message, [CallerMemberName] string? memberName = null) =>
             Trace(0, message, memberName);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -17,7 +17,7 @@ using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
-    internal sealed partial class HttpConnection : HttpConnectionBase, IDisposable
+    internal sealed partial class HttpConnection : HttpConnectionBase
     {
         /// <summary>Default size of the read buffer used for the connection.</summary>
         private const int InitialReadBufferSize =
@@ -61,7 +61,9 @@ namespace System.Net.Http
         private int _readOffset;
         private int _readLength;
 
+        private long _idleSinceTickCount;
         private bool _inUse;
+        private bool _detachedFromPool;
         private bool _canRetry;
         private bool _startedSendingRequestBody;
         private bool _connectionClose; // Connection: close was seen on last response
@@ -90,6 +92,8 @@ namespace System.Net.Http
 
             _weakThisRef = new WeakReference<HttpConnection>(this);
 
+            _idleSinceTickCount = Environment.TickCount64;
+
             if (HttpTelemetry.Log.IsEnabled())
             {
                 HttpTelemetry.Log.Http11ConnectionEstablished();
@@ -101,7 +105,7 @@ namespace System.Net.Http
 
         ~HttpConnection() => Dispose(disposing: false);
 
-        public void Dispose() => Dispose(disposing: true);
+        public override void Dispose() => Dispose(disposing: true);
 
         private void Dispose(bool disposing)
         {
@@ -118,7 +122,10 @@ namespace System.Net.Http
                     HttpTelemetry.Log.Http11ConnectionClosed();
                 }
 
-                _pool.DecrementConnectionCount();
+                if (!_detachedFromPool)
+                {
+                    _pool.InvalidateHttp11Connection(this);
+                }
 
                 if (disposing)
                 {
@@ -187,7 +194,7 @@ namespace System.Net.Http
 
         /// <summary>Check whether a currently idle connection is still usable, or should be scavenged.</summary>
         /// <returns>True if connection can be used, false if it is invalid due to receiving EOF or unexpected data.</returns>
-        public bool CheckUsabilityOnScavenge()
+        public override bool CheckUsabilityOnScavenge()
         {
             // We may already have a read-ahead task if we did a previous scavenge and haven't used the connection since.
             if (_readAheadTask is null)
@@ -230,6 +237,8 @@ namespace System.Net.Http
             // by someone else who will consume the task.
             return null;
         }
+
+        public override long GetIdleTicks(long nowTicks) => nowTicks - _idleSinceTickCount;
 
         public TransportContext? TransportContext => _transportContext;
 
@@ -802,7 +811,7 @@ namespace System.Net.Http
             }
         }
 
-        public sealed override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken) =>
+        public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken) =>
             SendAsyncCore(request, async, cancellationToken);
 
         private bool MapSendException(Exception exception, CancellationToken cancellationToken, out Exception mappedException)
@@ -1932,6 +1941,17 @@ namespace System.Net.Http
             }
         }
 
+        /// <summary>
+        /// Detach the connection from the pool, so it is no longer counted against the connection limit.
+        /// This is used when we are creating a replacement connection for NT auth challenges.
+        /// </summary>
+        internal void DetachFromPool()
+        {
+            Debug.Assert(_inUse);
+
+            _detachedFromPool = true;
+        }
+
         private void CompleteResponse()
         {
             Debug.Assert(_currentRequest != null, "Expected the connection to be associated with a request.");
@@ -2015,8 +2035,12 @@ namespace System.Net.Http
             }
             else
             {
+                Debug.Assert(!_detachedFromPool, "Should not be detached from pool unless _connectionClose is true");
+
+                _idleSinceTickCount = Environment.TickCount64;
+
                 // Put connection back in the pool.
-                _pool.ReturnConnection(this);
+                _pool.ReturnHttp11Connection(this);
             }
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -13,7 +13,7 @@ using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
-    internal abstract class HttpConnectionBase : IHttpTrace
+    internal abstract class HttpConnectionBase : IDisposable, IHttpTrace
     {
         /// <summary>Cached string for the last Date header received on this connection.</summary>
         private string? _lastDateHeaderValue;
@@ -39,7 +39,6 @@ namespace System.Net.Http
             }
         }
 
-        public abstract Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken);
         public abstract void Trace(string message, [CallerMemberName] string? memberName = null);
 
         protected void TraceConnection(Stream stream)
@@ -60,14 +59,15 @@ namespace System.Net.Http
             }
         }
 
-        public long CreationTickCount { get; } = Environment.TickCount64;
+        private readonly long _creationTickCount = Environment.TickCount64;
 
-        // Check if lifetime expired on connection.
-        public bool LifetimeExpired(long nowTicks, TimeSpan lifetime)
-        {
-            return lifetime != Timeout.InfiniteTimeSpan &&
-                (lifetime == TimeSpan.Zero || (nowTicks - CreationTickCount) > lifetime.TotalMilliseconds);
-        }
+        public long GetLifetimeTicks(long nowTicks) => nowTicks - _creationTickCount;
+
+        public abstract long GetIdleTicks(long nowTicks);
+
+        /// <summary>Check whether a connection is still usable, or should be scavenged.</summary>
+        /// <returns>True if connection can be used.</returns>
+        public virtual bool CheckUsabilityOnScavenge() => true;
 
         internal static bool IsDigit(byte c) => (uint)(c - '0') <= '9' - '0';
 
@@ -126,5 +126,7 @@ namespace System.Net.Http
                 if (NetEventSource.Log.IsEnabled()) connection.Trace($"Exception from asynchronous processing: {e}");
             }
         }
+
+        public abstract void Dispose();
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -13,7 +13,7 @@ using System.Net.Quic;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+using System.Runtime.ExceptionServices;
 using System.Runtime.Versioning;
 using System.Security.Authentication;
 using System.Text;
@@ -64,15 +64,31 @@ namespace System.Net.Http
         /// <summary>The time, in milliseconds, that an authority should remain in <see cref="_altSvcBlocklist"/>.</summary>
         private const int AltSvcBlocklistTimeoutInMilliseconds = 10 * 60 * 1000;
 
-        /// <summary>List of idle connections stored in the pool.</summary>
-        private readonly List<CachedConnection> _idleConnections = new List<CachedConnection>();
-        /// <summary>The maximum number of connections allowed to be associated with the pool.</summary>
-        private readonly int _maxConnections;
+        // HTTP/1.1 connection pool
+
+        /// <summary>List of available HTTP/1.1 connections stored in the pool.</summary>
+        private readonly List<HttpConnection> _availableHttp11Connections = new List<HttpConnection>();
+        /// <summary>The maximum number of HTTP/1.1 connections allowed to be associated with the pool.</summary>
+        private readonly int _maxHttp11Connections;
+        /// <summary>The number of HTTP/1.1 connections associated with the pool, including in use, available, and pending.</summary>
+        private int _associatedHttp11ConnectionCount;
+        /// <summary>The number of HTTP/1.1 connections that are in the process of being established.</summary>
+        private int _pendingHttp11ConnectionCount;
+        /// <summary>Queue of requests waiting for an HTTP/1.1 connection.</summary>
+        private RequestQueue<HttpConnection> _http11RequestQueue;
+
+        // HTTP/2 connection pool
+
+        /// <summary>List of available HTTP/2 connections stored in the pool.</summary>
+        private List<Http2Connection>? _availableHttp2Connections;
+        /// <summary>The number of HTTP/2 connections associated with the pool, including in use, available, and pending.</summary>
+        private int _associatedHttp2ConnectionCount;
+        /// <summary>Indicates whether an HTTP/2 connection is in the process of being established.</summary>
+        private bool _pendingHttp2Connection;
+        /// <summary>Queue of requests waiting for an HTTP/2 connection.</summary>
+        private RequestQueue<Http2Connection?> _http2RequestQueue;
 
         private bool _http2Enabled;
-        // This array must be treated as immutable. It can only be replaced with a new value in AddHttp2Connection method.
-        private volatile Http2Connection[]? _http2Connections;
-        private SemaphoreSlim? _http2ConnectionCreateLock;
         private byte[]? _http2AltSvcOriginUri;
         internal readonly byte[]? _http2EncodedAuthorityHostHeader;
         private readonly bool _http3Enabled;
@@ -88,11 +104,6 @@ namespace System.Net.Http
         private readonly SslClientAuthenticationOptions? _sslOptionsHttp2Only;
         private readonly SslClientAuthenticationOptions? _sslOptionsHttp3;
 
-        /// <summary>Queue of waiters waiting for a connection.  Created on demand.</summary>
-        private Queue<TaskCompletionSourceWithCancellation<HttpConnection?>>? _waiters;
-
-        /// <summary>The number of connections associated with the pool.  Some of these may be in <see cref="_idleConnections"/>, others may be in use.</summary>
-        private int _associatedConnectionCount;
         /// <summary>Whether the pool has been used since the last time a cleanup occurred.</summary>
         private bool _usedSinceLastCleanup = true;
         /// <summary>Whether the pool has been disposed.</summary>
@@ -113,7 +124,7 @@ namespace System.Net.Http
             _poolManager = poolManager;
             _kind = kind;
             _proxyUri = proxyUri;
-            _maxConnections = Settings._maxConnectionsPerServer;
+            _maxHttp11Connections = Settings._maxConnectionsPerServer;
 
             if (host != null)
             {
@@ -183,7 +194,7 @@ namespace System.Net.Http
                     // Don't enforce the max connections limit on proxy tunnels; this would mean that connections to different origin servers
                     // would compete for the same limited number of connections.
                     // We will still enforce this limit on the user of the tunnel (i.e. ProxyTunnel or SslProxyTunnel).
-                    _maxConnections = int.MaxValue;
+                    _maxHttp11Connections = int.MaxValue;
 
                     _http2Enabled = false;
                     _http3Enabled = false;
@@ -364,10 +375,45 @@ namespace System.Net.Http
             }
         }
 
-        public bool EnableMultipleHttp2Connections => _poolManager.Settings.EnableMultipleHttp2Connections;
+        private bool EnableMultipleHttp2Connections => _poolManager.Settings.EnableMultipleHttp2Connections;
 
         /// <summary>Object used to synchronize access to state in the pool.</summary>
-        private object SyncObj => _idleConnections;
+        private object SyncObj => _availableHttp11Connections;
+
+        // Overview of connection management (mostly HTTP version independent):
+        //
+        // Each version of HTTP (1.1, 2, 3) has its own connection pool, and each of these work in a similar manner,
+        // allowing for differences between the versions (most notably, HTTP/1.1 is not multiplexed.)
+        //
+        // When a request is submitted for a particular version (e.g. HTTP/1.1), we first look in the pool for available connections.
+        // An "available" connection is one that is (hopefully) usable for a new request.
+        //      For HTTP/1.1, this is just an idle connection.
+        //      For HTTP2/3, this is a connection that (hopefully) has available streams to use for new requests.
+        // If we find an available connection, we will attempt to validate it and then use it.
+        //      We check the lifetime of the connection and discard it if the lifetime is exceeded.
+        //      We check that the connection has not shut down; if so we discard it.
+        //      For HTTP2/3, we reserve a stream on the connection. If this fails, we cannot use the connection right now.
+        // If validation fails, we will attempt to find a different available connection.
+        //
+        // Once we have found a usable connection, we use it to process the request.
+        //      For HTTP/1.1, a connection can handle only a single request at a time, thus it is immediately removed from the list of available connections.
+        //      For HTTP2/3, a connection is only removed from the available list when it has no more available streams.
+        //      In either case, the connection still counts against the total associated connection count for the pool.
+        //
+        // If we cannot find a usable available connection, then the request is added the to the request queue for the appropriate version.
+        //
+        // Whenever a request is queued, or an existing connection shuts down, we will check to see if we should inject a new connection.
+        // Injection policy depends on both user settings and some simple heuristics.
+        // See comments on the relevant routines for details on connection injection policy.
+        //
+        // When a new connection is successfully created, or an existing unavailable connection becomes available again,
+        // we will attempt to use this connection to handle any queued requests (subject to lifetime restrictions on existing connections).
+        // This may result in the connection becoming unavailable again, because it cannot handle any more requests at the moment.
+        // If not, we will return the connection to the pool as an available connection for use by new requests.
+        //
+        // When a connection shuts down, either gracefully (e.g. GOAWAY) or abortively (e.g. IOException),
+        // we will remove it from the list of available connections, if it is present there.
+        // If not, then it must be unavailable at the moment; we will detect this and ensure it is not added back to the available pool.
 
         private static HttpRequestException GetVersionException(HttpRequestMessage request, int desiredVersion)
         {
@@ -376,288 +422,369 @@ namespace System.Net.Http
             return new HttpRequestException(SR.Format(SR.net_http_requested_version_cannot_establish, request.Version, request.VersionPolicy, desiredVersion));
         }
 
-        private ValueTask<HttpConnection?> GetOrReserveHttp11ConnectionAsync(bool async, CancellationToken cancellationToken)
+        private bool CheckExpirationOnGet(HttpConnectionBase connection)
         {
-            long nowTicks = Environment.TickCount64;
+            TimeSpan pooledConnectionLifetime = _poolManager.Settings._pooledConnectionLifetime;
+            if (pooledConnectionLifetime != Timeout.InfiniteTimeSpan)
+            {
+                return connection.GetLifetimeTicks(Environment.TickCount64) > pooledConnectionLifetime.TotalMilliseconds;
+            }
 
+            return false;
+        }
+
+        private static Exception CreateConnectTimeoutException(OperationCanceledException oce)
+        {
+            // The pattern for request timeouts (on HttpClient) is to throw an OCE with an inner exception of TimeoutException.
+            // Do the same for ConnectTimeout-based timeouts.
+            TimeoutException te = new TimeoutException(SR.net_http_connect_timedout, oce.InnerException);
+            Exception newException = CancellationHelper.CreateOperationCanceledException(te, oce.CancellationToken);
+            ExceptionDispatchInfo.SetCurrentStackTrace(newException);
+            return newException;
+        }
+
+        private async Task AddHttp11Connection(HttpRequestMessage request)
+        {
+            if (NetEventSource.Log.IsEnabled()) Trace("Creating new HTTP/1.1 connection for pool.");
+
+            HttpConnection connection;
+            using (CancellationTokenSource cts = GetConnectTimeoutCancellationTokenSource())
+            {
+                try
+                {
+                    connection = await CreateHttp11ConnectionAsync(request, false, cts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException oce) when (oce.CancellationToken == cts.Token)
+                {
+                    HandleHttp11ConnectionFailure(CreateConnectTimeoutException(oce));
+                    return;
+                }
+                catch (Exception e)
+                {
+                    HandleHttp11ConnectionFailure(e);
+                    return;
+                }
+            }
+
+            // Add the established connection to the pool.
+            ReturnHttp11Connection(connection, isNewConnection: true);
+        }
+
+        private void CheckForHttp11ConnectionInjection()
+        {
+            Debug.Assert(Monitor.IsEntered(SyncObj));
+
+            if (!_http11RequestQueue.TryPeekNextRequest(out HttpRequestMessage? request))
+            {
+                return;
+            }
+
+            // Determine if we can and should add a new connection to the pool.
+            if (_availableHttp11Connections.Count == 0 &&                           // No available connections
+                _http11RequestQueue.Count > _pendingHttp11ConnectionCount &&        // More requests queued than pending connections
+                _associatedHttp11ConnectionCount < _maxHttp11Connections)           // Under the connection limit
+            {
+                _associatedHttp11ConnectionCount++;
+                _pendingHttp11ConnectionCount++;
+
+                Task.Run(() => AddHttp11Connection(request));
+            }
+        }
+
+        private async ValueTask<HttpConnection> GetHttp11ConnectionAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
+        {
             // Look for a usable idle connection.
-            TaskCompletionSourceWithCancellation<HttpConnection?> waiter;
+            TaskCompletionSourceWithCancellation<HttpConnection> waiter;
             while (true)
             {
-                HttpConnection connection;
+                HttpConnection? connection = null;
                 lock (SyncObj)
                 {
-                    int idleConnectionCount = _idleConnections.Count;
-                    if (idleConnectionCount > 0)
+                    _usedSinceLastCleanup = true;
+
+                    int availableConnectionCount = _availableHttp11Connections.Count;
+                    if (availableConnectionCount > 0)
                     {
-                        // We have an idle connection that we can attempt to use.
+                        // We have a connection that we can attempt to use.
                         // Validate it below outside the lock, to avoid doing expensive operations while holding the lock.
-                        connection = _idleConnections[idleConnectionCount - 1]._connection;
-                        _idleConnections.RemoveAt(idleConnectionCount - 1);
+                        connection = _availableHttp11Connections[availableConnectionCount - 1];
+                        _availableHttp11Connections.RemoveAt(availableConnectionCount - 1);
                     }
                     else
                     {
-                        // No available idle connections.
-                        if (_associatedConnectionCount < _maxConnections)
-                        {
-                            // We are under the connection limit, so just increment the count and return null
-                            // to indicate to the caller that they should create a new connection.
-                            IncrementConnectionCountNoLock();
-                            return new ValueTask<HttpConnection?>((HttpConnection?)null);
-                        }
-                        else
-                        {
-                            // We've reached the connection limit and need to wait for an existing connection
-                            // to become available, or to be closed so that we can create a new connection.
-                            // Enqueue a waiter that will be signalled when this happens.
-                            // Break out of the loop and then do the actual wait below.
-                            waiter = EnqueueWaiter();
-                            break;
-                        }
+                        // No available connections. Add to the request queue.
+                        waiter = _http11RequestQueue.EnqueueRequest(request);
 
-                        // Note that we don't check for _disposed.  We may end up disposing the
-                        // created connection when it's returned, but we don't want to block use
-                        // of the pool if it's already been disposed, as there's a race condition
-                        // between getting a pool and someone disposing of it, and we don't want
-                        // to complicate the logic about trying to get a different pool when the
-                        // retrieved one has been disposed of.  In the future we could alternatively
-                        // try returning such connections to whatever pool is currently considered
-                        // current for that endpoint, if there is one.
+                        CheckForHttp11ConnectionInjection();
+
+                        // Break out of the loop and continue processing below.
+                        break;
                     }
                 }
 
-                if (connection.LifetimeExpired(nowTicks, _poolManager.Settings._pooledConnectionLifetime))
+                if (CheckExpirationOnGet(connection))
                 {
-                    if (NetEventSource.Log.IsEnabled()) connection.Trace("Found expired connection in pool.");
+                    if (NetEventSource.Log.IsEnabled()) connection.Trace("Found expired HTTP/1.1 connection in pool.");
                     connection.Dispose();
                     continue;
                 }
 
                 if (!connection.PrepareForReuse(async))
                 {
-                    if (NetEventSource.Log.IsEnabled()) connection.Trace("Found invalid connection in pool.");
+                    if (NetEventSource.Log.IsEnabled()) connection.Trace("Found invalid HTTP/1.1 connection in pool.");
                     connection.Dispose();
                     continue;
                 }
 
-                if (NetEventSource.Log.IsEnabled()) connection.Trace("Found usable connection in pool.");
-                return new ValueTask<HttpConnection?>(connection);
-            }
-
-            // We are at the connection limit. Wait for an available connection or connection count.
-            if (NetEventSource.Log.IsEnabled()) Trace($"{(async ? "As" : "S")}ynchronous request. Connection limit reached, waiting for available connection.");
-
-            if (HttpTelemetry.Log.IsEnabled())
-            {
-                return WaitOnWaiterWithTelemetryAsync(waiter, async, cancellationToken);
-            }
-            else
-            {
-                return waiter.WaitWithCancellationAsync(cancellationToken);
-            }
-
-            static async ValueTask<HttpConnection?> WaitOnWaiterWithTelemetryAsync(TaskCompletionSourceWithCancellation<HttpConnection?> waiter, bool async, CancellationToken cancellationToken)
-            {
-                ValueStopwatch stopwatch = ValueStopwatch.StartNew();
-
-                HttpConnection? connection = await waiter.WaitWithCancellationAsync(cancellationToken).ConfigureAwait(false);
-
-                HttpTelemetry.Log.Http11RequestLeftQueue(stopwatch.GetElapsedTime().TotalMilliseconds);
+                if (NetEventSource.Log.IsEnabled()) connection.Trace("Found usable HTTP/1.1 connection in pool.");
                 return connection;
+            }
+
+            // There were no available idle connections. This request has been added to the request queue.
+            if (NetEventSource.Log.IsEnabled()) Trace($"No available HTTP/1.1 connections; request queued.");
+
+            ValueStopwatch stopwatch = ValueStopwatch.StartNew();
+            try
+            {
+                return await waiter.WaitWithCancellationAsync(async, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                if (HttpTelemetry.Log.IsEnabled())
+                {
+                    HttpTelemetry.Log.Http11RequestLeftQueue(stopwatch.GetElapsedTime().TotalMilliseconds);
+                }
             }
         }
 
-        // Returns null if HTTP2 cannot be used
+        private async Task HandleHttp11Downgrade(HttpRequestMessage request, Socket? socket, Stream stream, TransportContext? transportContext, CancellationToken cancellationToken)
+        {
+            if (NetEventSource.Log.IsEnabled()) Trace("Server does not support HTTP2; disabling HTTP2 use and proceeding with HTTP/1.1 connection");
+
+            bool canUse = true;
+            lock (SyncObj)
+            {
+                Debug.Assert(_pendingHttp2Connection);
+                Debug.Assert(_associatedHttp2ConnectionCount > 0);
+
+                // Server does not support HTTP2. Disable further HTTP2 attempts.
+                _http2Enabled = false;
+                _associatedHttp2ConnectionCount--;
+                _pendingHttp2Connection = false;
+
+                // Signal to any queued HTTP2 requests that they must downgrade.
+                while (_http2RequestQueue.TryDequeueNextRequest(null))
+                    ;
+
+                if (_associatedHttp11ConnectionCount < _maxHttp11Connections)
+                {
+                    _associatedHttp11ConnectionCount++;
+                    _pendingHttp11ConnectionCount++;
+                }
+                else
+                {
+                    // We are already at the limit for HTTP/1.1 connections, so do not proceed with this connection.
+                    canUse = false;
+                }
+            }
+
+            if (!canUse)
+            {
+                if (NetEventSource.Log.IsEnabled()) Trace("Discarding downgraded HTTP/1.1 connection because HTTP/1.1 connection limit is exceeded");
+                stream.Dispose();
+            }
+
+            HttpConnection http11Connection;
+            try
+            {
+                // Note, the same CancellationToken from the original HTTP2 connection establishment still applies here.
+                http11Connection = await ConstructHttp11ConnectionAsync(false, socket, stream, transportContext, request, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException oce) when (oce.CancellationToken == cancellationToken)
+            {
+                HandleHttp11ConnectionFailure(CreateConnectTimeoutException(oce));
+                return;
+            }
+            catch (Exception e)
+            {
+                HandleHttp11ConnectionFailure(e);
+                return;
+            }
+
+            ReturnHttp11Connection(http11Connection, isNewConnection: true);
+        }
+
+        private async Task AddHttp2Connection(HttpRequestMessage request)
+        {
+            if (NetEventSource.Log.IsEnabled()) Trace("Creating new HTTP/2 connection for pool.");
+
+            Http2Connection connection;
+            using (CancellationTokenSource cts = GetConnectTimeoutCancellationTokenSource())
+            {
+                try
+                {
+                    (Socket? socket, Stream stream, TransportContext? transportContext) = await ConnectAsync(request, false, cts.Token).ConfigureAwait(false);
+
+                    if (IsSecure)
+                    {
+                        SslStream sslStream = (SslStream)stream;
+
+                        if (sslStream.NegotiatedApplicationProtocol == SslApplicationProtocol.Http2)
+                        {
+                            // The server accepted our request for HTTP2.
+
+                            if (sslStream.SslProtocol < SslProtocols.Tls12)
+                            {
+                                stream.Dispose();
+                                throw new HttpRequestException(SR.Format(SR.net_ssl_http2_requires_tls12, sslStream.SslProtocol));
+                            }
+
+                            connection = await ConstructHttp2ConnectionAsync(stream, request, cts.Token).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            // We established an SSL connection, but the server denied our request for HTTP2.
+                            await HandleHttp11Downgrade(request, socket, stream, transportContext, cts.Token).ConfigureAwait(false);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        connection = await ConstructHttp2ConnectionAsync(stream, request, cts.Token).ConfigureAwait(false);
+                    }
+                }
+                catch (OperationCanceledException oce) when (oce.CancellationToken == cts.Token)
+                {
+                    HandleHttp2ConnectionFailure(CreateConnectTimeoutException(oce));
+                    return;
+                }
+                catch (Exception e)
+                {
+                    HandleHttp2ConnectionFailure(e);
+                    return;
+                }
+            }
+
+            // Register for shutdown notification.
+            // Do this before we return the connection to the pool, because that may result in it being disposed.
+            ValueTask shutdownTask = connection.WaitForShutdownAsync();
+
+            // Add the new connection to the pool.
+            ReturnHttp2Connection(connection, isNewConnection: true);
+
+            // Wait for connection shutdown.
+            await shutdownTask.ConfigureAwait(false);
+
+            InvalidateHttp2Connection(connection);
+        }
+
+        private void CheckForHttp2ConnectionInjection()
+        {
+            Debug.Assert(Monitor.IsEntered(SyncObj));
+
+            if (!_http2RequestQueue.TryPeekNextRequest(out HttpRequestMessage? request))
+            {
+                return;
+            }
+
+            // Determine if we can and should add a new connection to the pool.
+            if ((_availableHttp2Connections?.Count ?? 0) == 0 &&                            // No available connections
+                !_pendingHttp2Connection &&                                                 // Only allow one pending HTTP2 connection at a time
+                (_associatedHttp2ConnectionCount == 0 || EnableMultipleHttp2Connections))   // We allow multiple connections, or don't have a connection currently
+            {
+                _associatedHttp2ConnectionCount++;
+                _pendingHttp2Connection = true;
+
+                Task.Run(() => AddHttp2Connection(request));
+            }
+        }
+
         private async ValueTask<Http2Connection?> GetHttp2ConnectionAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
         {
             Debug.Assert(_kind == HttpConnectionKind.Https || _kind == HttpConnectionKind.SslProxyTunnel || _kind == HttpConnectionKind.Http || _kind == HttpConnectionKind.SocksTunnel || _kind == HttpConnectionKind.SslSocksTunnel);
 
-            // See if we have an HTTP2 connection
-            Http2Connection? http2Connection = GetExistingHttp2Connection();
-
-            if (http2Connection != null)
+            // Look for a usable connection.
+            TaskCompletionSourceWithCancellation<Http2Connection?> waiter;
+            while (true)
             {
-                // Connection exists and it is still good to use.
-                if (NetEventSource.Log.IsEnabled()) Trace("Using existing HTTP2 connection.");
-                _usedSinceLastCleanup = true;
-                return http2Connection;
-            }
-
-            // Ensure that the connection creation semaphore is created
-            if (_http2ConnectionCreateLock == null)
-            {
+                Http2Connection connection;
                 lock (SyncObj)
                 {
-                    if (_http2ConnectionCreateLock == null)
+                    _usedSinceLastCleanup = true;
+
+                    if (!_http2Enabled)
                     {
-                        _http2ConnectionCreateLock = new SemaphoreSlim(1);
-                    }
-                }
-            }
-
-            // Try to establish an HTTP2 connection
-            Socket? socket = null;
-            Stream? stream = null;
-            SslStream? sslStream = null;
-            TransportContext? transportContext = null;
-
-            // Serialize creation attempt
-            await _http2ConnectionCreateLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-            try
-            {
-                http2Connection = GetExistingHttp2Connection();
-                if (http2Connection != null)
-                {
-                    return http2Connection;
-                }
-
-                // Recheck if HTTP2 has been disabled by a previous attempt.
-                if (_http2Enabled)
-                {
-                    if (NetEventSource.Log.IsEnabled())
-                    {
-                        Trace("Attempting new HTTP2 connection.");
+                        return null;
                     }
 
-                    (socket, stream, transportContext) =
-                        await ConnectAsync(request, async, cancellationToken).ConfigureAwait(false);
-
-                    Debug.Assert(stream != null);
-
-                    sslStream = stream as SslStream;
-
-                    if (!IsSecure)
+                    int availableConnectionCount = _availableHttp2Connections?.Count ?? 0;
+                    if (availableConnectionCount > 0)
                     {
-                        http2Connection = await ConstructHttp2ConnectionAsync(stream, request, cancellationToken).ConfigureAwait(false);
-
-                        if (NetEventSource.Log.IsEnabled())
-                        {
-                            Trace("New unencrypted HTTP2 connection established.");
-                        }
-
-                        return http2Connection;
-                    }
-
-                    Debug.Assert(sslStream != null);
-
-                    if (sslStream.NegotiatedApplicationProtocol == SslApplicationProtocol.Http2)
-                    {
-                        // The server accepted our request for HTTP2.
-
-                        if (sslStream.SslProtocol < SslProtocols.Tls12)
-                        {
-                            sslStream.Dispose();
-                            throw new HttpRequestException(SR.Format(SR.net_ssl_http2_requires_tls12, sslStream.SslProtocol));
-                        }
-
-                        http2Connection = await ConstructHttp2ConnectionAsync(stream, request, cancellationToken).ConfigureAwait(false);
-
-                        if (NetEventSource.Log.IsEnabled())
-                        {
-                            Trace("New HTTP2 connection established.");
-                        }
-
-                        return http2Connection;
-                    }
-                }
-            }
-            finally
-            {
-                _http2ConnectionCreateLock.Release();
-            }
-
-            if (sslStream != null)
-            {
-                // We established an SSL connection, but the server denied our request for HTTP2.
-                // Try to establish a 1.1 connection instead and add it to the pool.
-
-                if (NetEventSource.Log.IsEnabled())
-                {
-                    Trace("Server does not support HTTP2; disabling HTTP2 use and proceeding with HTTP/1.1 connection");
-                }
-
-                bool canUse = true;
-                lock (SyncObj)
-                {
-                    // Server does not support HTTP2. Disable further HTTP2 attempts.
-                    _http2Enabled = false;
-
-                    if (_associatedConnectionCount < _maxConnections)
-                    {
-                        IncrementConnectionCountNoLock();
+                        // We have a connection that we can attempt to use.
+                        // Validate it below outside the lock, to avoid doing expensive operations while holding the lock.
+                        connection = _availableHttp2Connections![availableConnectionCount - 1];
                     }
                     else
                     {
-                        // We are already at the limit for HTTP/1.1 connections, so do not proceed with this connection.
-                        canUse = false;
+                        // No available connections. Add to the request queue.
+                        waiter = _http2RequestQueue.EnqueueRequest(request);
+
+                        CheckForHttp2ConnectionInjection();
+
+                        // Break out of the loop and continue processing below.
+                        break;
                     }
                 }
 
-                if (canUse)
+                if (CheckExpirationOnGet(connection))
                 {
-                    HttpConnection http11Connection = await ConstructHttp11ConnectionAsync(async, socket, stream!, transportContext, request, cancellationToken).ConfigureAwait(false);
-                    ReturnConnection(http11Connection);
+                    if (NetEventSource.Log.IsEnabled()) connection.Trace("Found expired HTTP/2 connection in pool.");
+
+                    InvalidateHttp2Connection(connection);
+                    continue;
                 }
-                else
+
+                if (!connection.TryReserveStream())
                 {
-                    if (NetEventSource.Log.IsEnabled())
+                    if (NetEventSource.Log.IsEnabled()) connection.Trace("Found HTTP/2 connection in pool without available streams.");
+
+                    bool found = false;
+                    lock (SyncObj)
                     {
-                        Trace("Discarding downgraded HTTP/1.1 connection because connection limit is exceeded");
+                        int index = _availableHttp2Connections.IndexOf(connection);
+                        if (index != -1)
+                        {
+                            found = true;
+                            _availableHttp2Connections.RemoveAt(index);
+                        }
                     }
 
-                    stream!.Dispose();
+                    // If we didn't find the connection, then someone beat us to removing it (or it shut down)
+                    if (found)
+                    {
+                        DisableHttp2Connection(connection);
+                    }
+                    continue;
                 }
+
+                if (NetEventSource.Log.IsEnabled()) connection.Trace("Found usable HTTP/2 connection in pool.");
+                return connection;
             }
 
-            // We are unable to use HTTP2.
-            return null;
-        }
+            // There were no available connections. This request has been added to the request queue.
+            if (NetEventSource.Log.IsEnabled()) Trace($"No available HTTP/2 connections; request queued.");
 
-        private Http2Connection? GetExistingHttp2Connection()
-        {
-            Http2Connection[]? localConnections = _http2Connections;
-
-            if (localConnections == null)
+            ValueStopwatch stopwatch = ValueStopwatch.StartNew();
+            try
             {
-                return null;
+                return await waiter.WaitWithCancellationAsync(async, cancellationToken).ConfigureAwait(false);
             }
-
-            for (int i = 0; i < localConnections.Length; i++)
+            finally
             {
-                Http2Connection http2Connection = localConnections[i];
-
-                TimeSpan pooledConnectionLifetime = _poolManager.Settings._pooledConnectionLifetime;
-                if (http2Connection.LifetimeExpired(Environment.TickCount64, pooledConnectionLifetime))
+                if (HttpTelemetry.Log.IsEnabled())
                 {
-                    // Connection expired.
-                    if (NetEventSource.Log.IsEnabled()) http2Connection.Trace("Found expired HTTP2 connection.");
-                    http2Connection.Dispose();
-                    InvalidateHttp2Connection(http2Connection);
+                    HttpTelemetry.Log.Http20RequestLeftQueue(stopwatch.GetElapsedTime().TotalMilliseconds);
                 }
-                else if (!EnableMultipleHttp2Connections || http2Connection.CanAddNewStream)
-                {
-                    return http2Connection;
-                }
-            }
-
-            return null;
-        }
-
-        private void AddHttp2Connection(Http2Connection newConnection)
-        {
-            lock (SyncObj)
-            {
-                Http2Connection[]? localHttp2Connections = _http2Connections;
-                int newCollectionSize = localHttp2Connections == null ? 1 : localHttp2Connections.Length + 1;
-                Http2Connection[] newHttp2Connections = new Http2Connection[newCollectionSize];
-                newHttp2Connections[0] = newConnection;
-
-                if (localHttp2Connections != null)
-                {
-                    Array.Copy(localHttp2Connections, 0, newHttp2Connections, 1, localHttp2Connections.Length);
-                }
-
-                _http2Connections = newHttp2Connections;
             }
         }
 
@@ -673,8 +800,7 @@ namespace System.Net.Http
 
             if (http3Connection != null)
             {
-                TimeSpan pooledConnectionLifetime = _poolManager.Settings._pooledConnectionLifetime;
-                if (http3Connection.LifetimeExpired(Environment.TickCount64, pooledConnectionLifetime) || http3Connection.Authority != authority)
+                if (CheckExpirationOnGet(http3Connection) || http3Connection.Authority != authority)
                 {
                     // Connection expired.
                     if (NetEventSource.Log.IsEnabled()) http3Connection.Trace("Found expired HTTP3 connection.");
@@ -831,21 +957,7 @@ namespace System.Net.Http
 
         private async ValueTask<HttpResponseMessage> SendUsingHttp11Async(HttpRequestMessage request, bool async, bool doRequestAuth, CancellationToken cancellationToken)
         {
-            HttpConnection? connection = await GetOrReserveHttp11ConnectionAsync(async, cancellationToken).ConfigureAwait(false);
-            if (connection is null)
-            {
-                if (NetEventSource.Log.IsEnabled()) Trace("Creating new HTTP/1.1 connection for pool.");
-
-                try
-                {
-                    connection = await CreateHttp11ConnectionAsync(request, async, cancellationToken).ConfigureAwait(false);
-                }
-                catch
-                {
-                    DecrementConnectionCount();
-                    throw;
-                }
-            }
+            HttpConnection connection = await GetHttp11ConnectionAsync(request, async, cancellationToken).ConfigureAwait(false);
 
             // In case we are doing Windows (i.e. connection-based) auth, we need to ensure that we hold on to this specific connection while auth is underway.
             connection.Acquire();
@@ -1235,68 +1347,53 @@ namespace System.Net.Http
             return SendWithProxyAuthAsync(request, async, doRequestAuth, cancellationToken);
         }
 
+        private CancellationTokenSource GetConnectTimeoutCancellationTokenSource() => new CancellationTokenSource(Settings._connectTimeout);
+
         private async ValueTask<(Socket?, Stream, TransportContext?)> ConnectAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
         {
-            // If a non-infinite connect timeout has been set, create and use a new CancellationToken that will be canceled
-            // when either the original token is canceled or a connect timeout occurs.
-            CancellationTokenSource? cancellationWithConnectTimeout = null;
-            if (Settings._connectTimeout != Timeout.InfiniteTimeSpan)
+            Stream? stream = null;
+            Socket? socket = null;
+            switch (_kind)
             {
-                cancellationWithConnectTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                cancellationWithConnectTimeout.CancelAfter(Settings._connectTimeout);
-                cancellationToken = cancellationWithConnectTimeout.Token;
+                case HttpConnectionKind.Http:
+                case HttpConnectionKind.Https:
+                case HttpConnectionKind.ProxyConnect:
+                    Debug.Assert(_originAuthority != null);
+                    (socket, stream) = await ConnectToTcpHostAsync(_originAuthority.IdnHost, _originAuthority.Port, request, async, cancellationToken).ConfigureAwait(false);
+                    break;
+
+                case HttpConnectionKind.Proxy:
+                    (socket, stream) = await ConnectToTcpHostAsync(_proxyUri!.IdnHost, _proxyUri.Port, request, async, cancellationToken).ConfigureAwait(false);
+                    break;
+
+                case HttpConnectionKind.ProxyTunnel:
+                case HttpConnectionKind.SslProxyTunnel:
+                    stream = await EstablishProxyTunnelAsync(async, request.HasHeaders ? request.Headers : null, cancellationToken).ConfigureAwait(false);
+                    break;
+
+                case HttpConnectionKind.SocksTunnel:
+                case HttpConnectionKind.SslSocksTunnel:
+                    (socket, stream) = await EstablishSocksTunnel(request, async, cancellationToken).ConfigureAwait(false);
+                break;
             }
 
-            try
+            Debug.Assert(stream != null);
+            if (socket is null && stream is NetworkStream ns)
             {
-                Stream? stream = null;
-                Socket? socket = null;
-                switch (_kind)
-                {
-                    case HttpConnectionKind.Http:
-                    case HttpConnectionKind.Https:
-                    case HttpConnectionKind.ProxyConnect:
-                        Debug.Assert(_originAuthority != null);
-                        (socket, stream) = await ConnectToTcpHostAsync(_originAuthority.IdnHost, _originAuthority.Port, request, async, cancellationToken).ConfigureAwait(false);
-                        break;
-
-                    case HttpConnectionKind.Proxy:
-                        (socket, stream) = await ConnectToTcpHostAsync(_proxyUri!.IdnHost, _proxyUri.Port, request, async, cancellationToken).ConfigureAwait(false);
-                        break;
-
-                    case HttpConnectionKind.ProxyTunnel:
-                    case HttpConnectionKind.SslProxyTunnel:
-                        stream = await EstablishProxyTunnelAsync(async, request.HasHeaders ? request.Headers : null, cancellationToken).ConfigureAwait(false);
-                        break;
-
-                    case HttpConnectionKind.SocksTunnel:
-                    case HttpConnectionKind.SslSocksTunnel:
-                        (socket, stream) = await EstablishSocksTunnel(request, async, cancellationToken).ConfigureAwait(false);
-                        break;
-                }
-
-                Debug.Assert(stream != null);
-                if (socket is null && stream is NetworkStream ns)
-                {
-                    // We weren't handed a socket directly.  But if we're able to extract one, do so.
-                    // Most likely case here is a ConnectCallback was used and returned a NetworkStream.
-                    socket = ns.Socket;
-                }
-
-                TransportContext? transportContext = null;
-                if (IsSecure)
-                {
-                    SslStream sslStream = await ConnectHelper.EstablishSslConnectionAsync(GetSslOptionsForRequest(request), request, async, stream, cancellationToken).ConfigureAwait(false);
-                    transportContext = sslStream.TransportContext;
-                    stream = sslStream;
-                }
-
-                return (socket, stream, transportContext);
+                // We weren't handed a socket directly.  But if we're able to extract one, do so.
+                // Most likely case here is a ConnectCallback was used and returned a NetworkStream.
+                socket = ns.Socket;
             }
-            finally
+
+            TransportContext? transportContext = null;
+            if (IsSecure)
             {
-                cancellationWithConnectTimeout?.Dispose();
+                SslStream sslStream = await ConnectHelper.EstablishSslConnectionAsync(GetSslOptionsForRequest(request), request, async, stream, cancellationToken).ConfigureAwait(false);
+                transportContext = sslStream.TransportContext;
+                stream = sslStream;
             }
+
+            return (socket, stream, transportContext);
         }
 
         private async ValueTask<(Socket?, Stream)> ConnectToTcpHostAsync(string host, int port, HttpRequestMessage initialRequest, bool async, CancellationToken cancellationToken)
@@ -1357,8 +1454,7 @@ namespace System.Net.Http
 
         internal async ValueTask<HttpConnection> CreateHttp11ConnectionAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
         {
-            (Socket? socket, Stream? stream, TransportContext? transportContext) =
-                await ConnectAsync(request, async, cancellationToken).ConfigureAwait(false);
+            (Socket? socket, Stream stream, TransportContext? transportContext) = await ConnectAsync(request, async, cancellationToken).ConfigureAwait(false);
 
             return await ConstructHttp11ConnectionAsync(async, socket, stream!, transportContext, request, cancellationToken).ConfigureAwait(false);
         }
@@ -1403,6 +1499,11 @@ namespace System.Net.Http
 
                 newStream = await streamTask.ConfigureAwait(false);
             }
+            catch (OperationCanceledException oce) when (oce.CancellationToken == cancellationToken)
+            {
+                stream.Dispose();
+                throw;
+            }
             catch (Exception e)
             {
                 stream.Dispose();
@@ -1443,8 +1544,6 @@ namespace System.Net.Http
                 // Note, SetupAsync will dispose the connection if there is an exception.
                 throw new HttpRequestException(SR.net_http_client_execution_error, e);
             }
-
-            AddHttp2Connection(http2Connection);
 
             return http2Connection;
         }
@@ -1501,133 +1600,133 @@ namespace System.Net.Http
             return (socket, stream);
         }
 
-        /// <summary>Enqueues a waiter to the waiters list.</summary>
-        private TaskCompletionSourceWithCancellation<HttpConnection?> EnqueueWaiter()
+        private void HandleHttp11ConnectionFailure(Exception e)
         {
-            Debug.Assert(Monitor.IsEntered(SyncObj));
-            Debug.Assert(Settings._maxConnectionsPerServer != int.MaxValue);
-            Debug.Assert(_idleConnections.Count == 0, $"With {_idleConnections.Count} idle connections, we shouldn't have a waiter.");
+            if (NetEventSource.Log.IsEnabled()) Trace("HTTP/1.1 connection failed");
 
-            if (_waiters == null)
+            lock (SyncObj)
             {
-                _waiters = new Queue<TaskCompletionSourceWithCancellation<HttpConnection?>>();
+                Debug.Assert(_associatedHttp11ConnectionCount > 0);
+                Debug.Assert(_pendingHttp11ConnectionCount > 0);
+
+                _associatedHttp11ConnectionCount--;
+                _pendingHttp11ConnectionCount--;
+
+                // Fail the next queued request (if any) with this error.
+                _http11RequestQueue.TryFailNextRequest(e);
+
+                CheckForHttp11ConnectionInjection();
             }
-
-            var waiter = new TaskCompletionSourceWithCancellation<HttpConnection?>();
-            _waiters.Enqueue(waiter);
-            return waiter;
         }
 
-        private void IncrementConnectionCountNoLock()
+        private void HandleHttp2ConnectionFailure(Exception e)
         {
-            Debug.Assert(Monitor.IsEntered(SyncObj), $"Expected to be holding {nameof(SyncObj)}");
+            if (NetEventSource.Log.IsEnabled()) Trace("HTTP2 connection failed");
 
-            if (NetEventSource.Log.IsEnabled()) Trace(null);
-            _usedSinceLastCleanup = true;
+            lock (SyncObj)
+            {
+                Debug.Assert(_associatedHttp2ConnectionCount > 0);
+                Debug.Assert(_pendingHttp2Connection);
 
-            Debug.Assert(
-                _associatedConnectionCount >= 0 && _associatedConnectionCount < _maxConnections,
-                $"Expected 0 <= {_associatedConnectionCount} < {_maxConnections}");
-            _associatedConnectionCount++;
+                _associatedHttp2ConnectionCount--;
+                _pendingHttp2Connection = false;
+
+                // Fail the next queued request (if any) with this error.
+                _http2RequestQueue.TryFailNextRequest(e);
+
+                CheckForHttp2ConnectionInjection();
+            }
         }
 
-        internal void IncrementConnectionCount()
+        /// <summary>
+        /// Called when an HttpConnection from this pool is no longer usable.
+        /// Note, this is always called from HttpConnection.Dispose, which is a bit different than how HTTP2 works.
+        /// </summary>
+        public void InvalidateHttp11Connection(HttpConnection connection)
         {
             lock (SyncObj)
             {
-                IncrementConnectionCountNoLock();
+                _associatedHttp11ConnectionCount--;
+
+                CheckForHttp11ConnectionInjection();
             }
         }
 
-        private bool TransferConnection(HttpConnection? connection)
+        /// <summary>
+        /// Called when an Http2Connection from this pool is no longer usable.
+        /// </summary>
+        public void InvalidateHttp2Connection(Http2Connection connection)
         {
-            Debug.Assert(Monitor.IsEntered(SyncObj));
+            if (NetEventSource.Log.IsEnabled()) connection.Trace("");
 
-            if (_waiters == null)
+            bool found = false;
+            lock (SyncObj)
             {
-                return false;
-            }
-
-            Debug.Assert(_maxConnections != int.MaxValue, "_waiters queue is allocated but no connection limit is set??");
-
-            while (_waiters.TryDequeue(out TaskCompletionSourceWithCancellation<HttpConnection?>? waiter))
-            {
-                Debug.Assert(_idleConnections.Count == 0, $"With {_idleConnections.Count} idle connections, we shouldn't have a waiter.");
-
-                // Try to complete the task. If it's been cancelled already, this will fail.
-                if (waiter.TrySetResult(connection))
+                if (_availableHttp2Connections is not null)
                 {
-                    return true;
+                    Debug.Assert(_associatedHttp2ConnectionCount >= _availableHttp2Connections.Count);
+
+                    int index = _availableHttp2Connections.IndexOf(connection);
+                    if (index != -1)
+                    {
+                        found = true;
+                        _availableHttp2Connections.RemoveAt(index);
+                        _associatedHttp2ConnectionCount--;
+                    }
                 }
 
-                // Couldn't transfer to that waiter because it was cancelled. Try again.
-                Debug.Assert(waiter.Task.IsCanceled);
+                CheckForHttp2ConnectionInjection();
+            }
+
+            // If we found the connection in the available list, then dispose it now.
+            // Otherwise, when we try to put it back in the pool, we will see it is shut down and dispose it (and adjust connection counts).
+            if (found)
+            {
+                connection.Dispose();
+            }
+        }
+
+        private bool CheckExpirationOnReturn(HttpConnectionBase connection)
+        {
+            TimeSpan lifetime = _poolManager.Settings._pooledConnectionLifetime;
+            if (lifetime != Timeout.InfiniteTimeSpan)
+            {
+                return lifetime == TimeSpan.Zero || connection.GetLifetimeTicks(Environment.TickCount64) > lifetime.TotalMilliseconds;
             }
 
             return false;
         }
 
-        /// <summary>
-        /// Decrements the number of connections associated with the pool.
-        /// If there are waiters on the pool due to having reached the maximum,
-        /// this will instead try to transfer the count to one of them.
-        /// </summary>
-        public void DecrementConnectionCount()
+        public void ReturnHttp11Connection(HttpConnection connection, bool isNewConnection = false)
         {
-            if (NetEventSource.Log.IsEnabled()) Trace(null);
-            lock (SyncObj)
+            if (NetEventSource.Log.IsEnabled()) connection.Trace($"{nameof(isNewConnection)}={isNewConnection}");
+
+            if (!isNewConnection && CheckExpirationOnReturn(connection))
             {
-                Debug.Assert(_associatedConnectionCount > 0 && _associatedConnectionCount <= _maxConnections,
-                    $"Expected 0 < {_associatedConnectionCount} <= {_maxConnections}");
-
-                // Mark the pool as not being stale.
-                _usedSinceLastCleanup = true;
-
-                if (TransferConnection(null))
-                {
-                    if (NetEventSource.Log.IsEnabled()) Trace("Transferred connection count to waiter.");
-                    return;
-                }
-
-                // There are no waiters to which the count should logically be transferred,
-                // so simply decrement the count.
-                _associatedConnectionCount--;
-            }
-        }
-
-        /// <summary>Returns the connection to the pool for subsequent reuse.</summary>
-        /// <param name="connection">The connection to return.</param>
-        public void ReturnConnection(HttpConnection connection)
-        {
-            if (connection.LifetimeExpired(Environment.TickCount64, _poolManager.Settings._pooledConnectionLifetime))
-            {
-                if (NetEventSource.Log.IsEnabled()) connection.Trace("Disposing connection return to pool. Connection lifetime expired.");
+                if (NetEventSource.Log.IsEnabled()) connection.Trace("Disposing HTTP/1.1 connection return to pool. Connection lifetime expired.");
                 connection.Dispose();
                 return;
             }
 
-            List<CachedConnection> list = _idleConnections;
             lock (SyncObj)
             {
-                Debug.Assert(list.Count <= _maxConnections, $"Expected {list.Count} <= {_maxConnections}");
+                Debug.Assert(!_availableHttp11Connections.Contains(connection));
 
-                // Mark the pool as still being active.
-                _usedSinceLastCleanup = true;
-
-                // If there's someone waiting for a connection and this one's still valid, simply transfer this one to them rather than pooling it.
-                // Note that while we checked connection lifetime above, we don't check idle timeout, as even if idle timeout
-                // is zero, we consider a connection that's just handed from one use to another to never actually be idle.
-                if (TransferConnection(connection))
+                if (isNewConnection)
                 {
-                    if (NetEventSource.Log.IsEnabled()) connection.Trace("Transferred connection to waiter.");
+                    Debug.Assert(_pendingHttp11ConnectionCount > 0);
+                    _pendingHttp11ConnectionCount--;
+                }
+
+                if (_http11RequestQueue.TryDequeueNextRequest(connection))
+                {
+                    Debug.Assert(_availableHttp11Connections.Count == 0, $"With {_availableHttp11Connections.Count} available HTTP/1.1 connections, we shouldn't have a waiter.");
+
+                    if (NetEventSource.Log.IsEnabled()) connection.Trace("Dequeued waiting HTTP/1.1 request.");
                     return;
                 }
 
-                if (_poolManager.Settings._pooledConnectionIdleTimeout == TimeSpan.Zero)
-                {
-                    if (NetEventSource.Log.IsEnabled()) connection.Trace("Disposing connection returned to pool. Zero idle timeout.");
-                }
-                else if (_disposed)
+                if (_disposed)
                 {
                     // If the pool has been disposed of, dispose the connection being returned,
                     // as the pool is being deactivated. We do this after the above in order to
@@ -1637,55 +1736,148 @@ namespace System.Net.Http
                 }
                 else
                 {
-                    // Pool the connection by adding it to the list.
-                    list.Add(new CachedConnection(connection));
-                    if (NetEventSource.Log.IsEnabled()) connection.Trace("Stored connection in pool.");
+                    // Add connection to the pool.
+                    _availableHttp11Connections.Add(connection);
+                    Debug.Assert(_availableHttp11Connections.Count <= _maxHttp11Connections, $"Expected {_availableHttp11Connections.Count} <= {_maxHttp11Connections}");
+                    if (NetEventSource.Log.IsEnabled()) connection.Trace("Put connection in pool.");
                     return;
                 }
             }
 
+            // We determined that the connection is no longer usable.
             connection.Dispose();
         }
 
-        public void InvalidateHttp2Connection(Http2Connection connection)
+        public void ReturnHttp2Connection(Http2Connection connection, bool isNewConnection)
         {
+            if (NetEventSource.Log.IsEnabled()) connection.Trace($"{nameof(isNewConnection)}={isNewConnection}");
+
+            if (!isNewConnection && CheckExpirationOnReturn(connection))
+            {
+                lock (SyncObj)
+                {
+                    Debug.Assert(_associatedHttp2ConnectionCount > (_availableHttp2Connections?.Count ?? 0));
+                    _associatedHttp2ConnectionCount--;
+                }
+
+                if (NetEventSource.Log.IsEnabled()) connection.Trace("Disposing HTTP/2 connection return to pool. Connection lifetime expired.");
+                connection.Dispose();
+                return;
+            }
+
+            bool usable = true;
+            bool poolDisposed = false;
             lock (SyncObj)
             {
-                Http2Connection[]? localHttp2Connections = _http2Connections;
+                Debug.Assert(_availableHttp2Connections is null || !_availableHttp2Connections.Contains(connection));
 
-                if (localHttp2Connections == null)
+                if (isNewConnection)
                 {
-                    return;
+                    Debug.Assert(_pendingHttp2Connection);
+                    _pendingHttp2Connection = false;
                 }
 
-                if (localHttp2Connections.Length == 1)
+                while (!_http2RequestQueue.IsEmpty)
                 {
-                    // Fast shortcut for the most common case.
-                    if (localHttp2Connections[0] == connection)
+                    Debug.Assert((_availableHttp2Connections?.Count ?? 0) == 0, $"With {_availableHttp11Connections.Count} available HTTP2 connections, we shouldn't have a waiter.");
+
+                    if (!connection.TryReserveStream())
                     {
-                        _http2Connections = null;
+                        usable = false;
+                        if (isNewConnection)
+                        {
+                            // The new connection could not handle even one request, either because it shut down before we could use it for any requests,
+                            // or because it immediately set the max concurrent streams limit to 0.
+                            // We don't want to get stuck in a loop where we keep trying to create new connections for the same request.
+                            // Fail the next request, if any.
+                            HttpRequestException hre = new HttpRequestException(SR.net_http_http2_connection_not_established);
+                            ExceptionDispatchInfo.SetCurrentStackTrace(hre);
+                            _http2RequestQueue.TryFailNextRequest(hre);
+                        }
+                        break;
                     }
-                    return;
+
+                    isNewConnection = false;
+
+                    if (!_http2RequestQueue.TryDequeueNextRequest(connection))
+                    {
+                        connection.ReleaseStream();
+                        break;
+                    }
+
+                    if (NetEventSource.Log.IsEnabled()) connection.Trace("Dequeued waiting HTTP/2 request.");
                 }
 
-                int invalidatedIndex = Array.IndexOf(localHttp2Connections, connection);
-                if (invalidatedIndex >= 0)
+                if (_disposed)
                 {
-                    Http2Connection[] newHttp2Connections = new Http2Connection[localHttp2Connections.Length - 1];
-
-                    if (invalidatedIndex > 0)
+                    // If the pool has been disposed of, we want to dispose the connection being returned, as the pool is being deactivated.
+                    // We do this after the above in order to satisfy any requests that were queued before the pool was disposed of.
+                    Debug.Assert(_associatedHttp2ConnectionCount > (_availableHttp2Connections?.Count ?? 0));
+                    _associatedHttp2ConnectionCount--;
+                    poolDisposed = true;
+                }
+                else if (usable)
+                {
+                    if (_availableHttp2Connections is null)
                     {
-                        Array.Copy(localHttp2Connections, newHttp2Connections, invalidatedIndex);
+                        _availableHttp2Connections = new List<Http2Connection>();
                     }
 
-                    if (invalidatedIndex < localHttp2Connections.Length - 1)
-                    {
-                        Array.Copy(localHttp2Connections, invalidatedIndex + 1, newHttp2Connections, invalidatedIndex, newHttp2Connections.Length - invalidatedIndex);
-                    }
-
-                    _http2Connections = newHttp2Connections;
+                    // Add connection to the pool.
+                    _availableHttp2Connections.Add(connection);
+                    if (NetEventSource.Log.IsEnabled()) connection.Trace("Put HTTP/2 connection in pool.");
+                    return;
                 }
             }
+
+            if (poolDisposed)
+            {
+                if (NetEventSource.Log.IsEnabled()) connection.Trace("Disposing HTTP/2 connection returned to pool. Pool was disposed.");
+                connection.Dispose();
+                return;
+            }
+
+            Debug.Assert(!usable);
+
+            // We need to wait until the connection is usable again.
+            DisableHttp2Connection(connection);
+        }
+
+        /// <summary>
+        /// Disable usage of the specified connection because it cannot handle any more streams at the moment.
+        /// We will register to be notified when it can handle more streams (or becomes permanently unusable).
+        /// </summary>
+        private void DisableHttp2Connection(Http2Connection connection)
+        {
+            if (NetEventSource.Log.IsEnabled()) connection.Trace("");
+
+            Task.Run(async () =>
+            {
+                bool usable = await connection.WaitForAvailableStreamsAsync().ConfigureAwait(false);
+
+                if (NetEventSource.Log.IsEnabled()) connection.Trace($"WaitForAvailableStreamsAsync completed, {nameof(usable)}={usable}");
+
+                if (usable)
+                {
+                    ReturnHttp2Connection(connection, isNewConnection: false);
+                }
+                else
+                {
+                    // Connection has shut down.
+                    lock (SyncObj)
+                    {
+                        Debug.Assert(_availableHttp2Connections is null || !_availableHttp2Connections.Contains(connection));
+                        Debug.Assert(_associatedHttp2ConnectionCount > 0);
+
+                        _associatedHttp2ConnectionCount--;
+
+                        CheckForHttp2ConnectionInjection();
+                    }
+
+                    if (NetEventSource.Log.IsEnabled()) connection.Trace("HTTP2 connection no longer usable");
+                    connection.Dispose();
+                }
+            });
         }
 
         public void InvalidateHttp3Connection(Http3Connection connection)
@@ -1705,24 +1897,24 @@ namespace System.Net.Http
         /// </summary>
         public void Dispose()
         {
-            List<CachedConnection> list = _idleConnections;
             lock (SyncObj)
             {
                 if (!_disposed)
                 {
                     if (NetEventSource.Log.IsEnabled()) Trace("Disposing pool.");
-                    _disposed = true;
-                    list.ForEach(c => c._connection.Dispose());
-                    list.Clear();
 
-                    if (_http2Connections != null)
-                    {
-                        for (int i = 0; i < _http2Connections.Length; i++)
-                        {
-                            _http2Connections[i].Dispose();
-                        }
-                        _http2Connections = null;
-                    }
+                    _disposed = true;
+
+                    Debug.Assert(_associatedHttp11ConnectionCount >= _availableHttp11Connections.Count,
+                        $"Expected {nameof(_associatedHttp11ConnectionCount)}={_associatedHttp11ConnectionCount} >= {nameof(_availableHttp11Connections)}.Count={_availableHttp11Connections.Count}");
+                    _associatedHttp11ConnectionCount -= _availableHttp11Connections.Count;
+                    _availableHttp11Connections.ForEach(c => c.Dispose());
+                    _availableHttp11Connections.Clear();
+
+                    Debug.Assert(_associatedHttp2ConnectionCount >= (_availableHttp11Connections?.Count ?? 0));
+                    _associatedHttp11ConnectionCount -= (_availableHttp11Connections?.Count ?? 0);
+                    _availableHttp2Connections?.ForEach(c => c.Dispose());
+                    _availableHttp2Connections?.Clear();
 
                     if (_authorityExpireTimer != null)
                     {
@@ -1737,7 +1929,9 @@ namespace System.Net.Http
                         _altSvcBlocklistTimerCancellation = null;
                     }
                 }
-                Debug.Assert(list.Count == 0, $"Expected {nameof(list)}.{nameof(list.Count)} == 0");
+
+                Debug.Assert(_availableHttp11Connections!.Count == 0, $"Expected {nameof(_availableHttp11Connections)}.{nameof(_availableHttp11Connections.Count)} == 0");
+                Debug.Assert((_availableHttp2Connections?.Count ?? 0) == 0, $"Expected {nameof(_availableHttp2Connections)}.{nameof(_availableHttp2Connections.Count)} == 0");
             }
         }
 
@@ -1753,69 +1947,45 @@ namespace System.Net.Http
             TimeSpan pooledConnectionLifetime = _poolManager.Settings._pooledConnectionLifetime;
             TimeSpan pooledConnectionIdleTimeout = _poolManager.Settings._pooledConnectionIdleTimeout;
 
-            List<CachedConnection> list = _idleConnections;
-            List<HttpConnection>? toDispose = null;
-            bool tookLock = false;
+            List<HttpConnectionBase>? toDispose = null;
 
-            try
+            lock (SyncObj)
             {
-                if (NetEventSource.Log.IsEnabled()) Trace("Cleaning pool.");
-                Monitor.Enter(SyncObj, ref tookLock);
-
-                // Get the current time.  This is compared against each connection's last returned
-                // time to determine whether a connection is too old and should be closed.
-                long nowTicks = Environment.TickCount64;
-                // Copy the reference to a local variable to simplify the removal logic below.
-                Http2Connection[]? localHttp2Connections = _http2Connections;
-
-                if (localHttp2Connections != null)
+                // If there are now no connections associated with this pool, we can dispose of it. We
+                // avoid aggressively cleaning up pools that have recently been used but currently aren't;
+                // if a pool was used since the last time we cleaned up, give it another chance. New pools
+                // start out saying they've recently been used, to give them a bit of breathing room and time
+                // for the initial collection to be added to it.
+                if (!_usedSinceLastCleanup && _associatedHttp11ConnectionCount == 0 && _associatedHttp2ConnectionCount == 0)
                 {
-                    Http2Connection[]? newHttp2Connections = null;
-                    int newIndex = 0;
-                    for (int i = 0; i < localHttp2Connections.Length; i++)
-                    {
-                        Http2Connection http2Connection = localHttp2Connections[i];
-                        if (http2Connection.IsExpired(nowTicks, pooledConnectionLifetime, pooledConnectionIdleTimeout))
-                        {
-                            http2Connection.Dispose();
-
-                            if (newHttp2Connections == null)
-                            {
-                                newHttp2Connections = new Http2Connection[localHttp2Connections.Length];
-                                if (i > 0)
-                                {
-                                    // Copy valid connections residing at the beggining of the current collection.
-                                    Array.Copy(localHttp2Connections, newHttp2Connections, i);
-                                    newIndex = i;
-                                }
-                            }
-                        }
-                        else if (newHttp2Connections != null)
-                        {
-                            newHttp2Connections[newIndex] = localHttp2Connections[i];
-                            newIndex++;
-                        }
-                    }
-
-                    if (newHttp2Connections != null)
-                    {
-                        //Some connections have been removed, so _http2Connections must be replaced.
-                        if (newIndex > 0)
-                        {
-                            Array.Resize(ref newHttp2Connections, newIndex);
-                            _http2Connections = newHttp2Connections;
-                        }
-                        else
-                        {
-                            // All connections expired.
-                            _http2Connections = null;
-                        }
-                    }
+                    _disposed = true;
+                    return true; // Pool is disposed of.  It should be removed.
                 }
 
-                // Find the first item which needs to be removed.
+                // Reset the cleanup flag.  Any pools that are empty and not used since the last cleanup
+                // will be purged next time around.
+                _usedSinceLastCleanup = false;
+
+                long nowTicks = Environment.TickCount64;
+
+                ScavengeConnectionList(_availableHttp11Connections, ref toDispose, nowTicks, pooledConnectionLifetime, pooledConnectionIdleTimeout);
+                if (_availableHttp2Connections is not null)
+                {
+                    ScavengeConnectionList(_availableHttp2Connections, ref toDispose, nowTicks, pooledConnectionLifetime, pooledConnectionIdleTimeout);
+                }
+            }
+
+            // Dispose the stale connections outside the pool lock, to avoid holding the lock too long.
+            toDispose?.ForEach(c => c.Dispose());
+
+            // Pool is active.  Should not be removed.
+            return false;
+
+            static void ScavengeConnectionList<T>(List<T> list, ref List<HttpConnectionBase>? toDispose, long nowTicks, TimeSpan pooledConnectionLifetime, TimeSpan pooledConnectionIdleTimeout)
+                where T : HttpConnectionBase
+            {
                 int freeIndex = 0;
-                while (freeIndex < list.Count && list[freeIndex].IsUsable(nowTicks, pooledConnectionLifetime, pooledConnectionIdleTimeout))
+                while (freeIndex < list.Count && IsUsableConnection(list[freeIndex], nowTicks, pooledConnectionLifetime, pooledConnectionIdleTimeout))
                 {
                     freeIndex++;
                 }
@@ -1825,7 +1995,7 @@ namespace System.Net.Http
                 if (freeIndex < list.Count)
                 {
                     // We know the connection at freeIndex is unusable, so dispose of it.
-                    toDispose = new List<HttpConnection> { list[freeIndex]._connection };
+                    toDispose ??= new List<HttpConnectionBase> { list[freeIndex] };
 
                     // Find the first item after the one to be removed that should be kept.
                     int current = freeIndex + 1;
@@ -1833,9 +2003,9 @@ namespace System.Net.Http
                     {
                         // Look for the first item to be kept.  Along the way, any
                         // that shouldn't be kept are disposed of.
-                        while (current < list.Count && !list[current].IsUsable(nowTicks, pooledConnectionLifetime, pooledConnectionIdleTimeout))
+                        while (current < list.Count && !IsUsableConnection(list[current], nowTicks, pooledConnectionLifetime, pooledConnectionIdleTimeout))
                         {
-                            toDispose.Add(list[current]._connection);
+                            toDispose.Add(list[current]);
                             current++;
                         }
 
@@ -1852,37 +2022,41 @@ namespace System.Net.Http
                     // At this point, good connections have been moved below freeIndex, and garbage connections have
                     // been added to the dispose list, so clear the end of the list past freeIndex.
                     list.RemoveRange(freeIndex, list.Count - freeIndex);
+                }
+            }
 
-                    // If there are now no connections associated with this pool, we can dispose of it. We
-                    // avoid aggressively cleaning up pools that have recently been used but currently aren't;
-                    // if a pool was used since the last time we cleaned up, give it another chance. New pools
-                    // start out saying they've recently been used, to give them a bit of breathing room and time
-                    // for the initial collection to be added to it.
-                    if (_associatedConnectionCount == 0 && !_usedSinceLastCleanup && _http2Connections == null)
+            static bool IsUsableConnection(HttpConnectionBase connection, long nowTicks, TimeSpan pooledConnectionLifetime, TimeSpan pooledConnectionIdleTimeout)
+            {
+                // Validate that the connection hasn't been idle in the pool for longer than is allowed.
+                if (pooledConnectionIdleTimeout != Timeout.InfiniteTimeSpan)
+                {
+                    long idleTicks = connection.GetIdleTicks(nowTicks);
+                    if (idleTicks > pooledConnectionIdleTimeout.TotalMilliseconds)
                     {
-                        Debug.Assert(list.Count == 0, $"Expected {nameof(list)}.{nameof(list.Count)} == 0");
-                        _disposed = true;
-                        return true; // Pool is disposed of.  It should be removed.
+                        if (NetEventSource.Log.IsEnabled()) connection.Trace($"Scavenging connection. Idle {TimeSpan.FromMilliseconds(idleTicks)} > {pooledConnectionIdleTimeout}.");
+                        return false;
                     }
                 }
 
-                // Reset the cleanup flag.  Any pools that are empty and not used since the last cleanup
-                // will be purged next time around.
-                _usedSinceLastCleanup = false;
-            }
-            finally
-            {
-                if (tookLock)
+                // Validate that the connection lifetime has not been exceeded.
+                if (pooledConnectionLifetime != Timeout.InfiniteTimeSpan)
                 {
-                    Monitor.Exit(SyncObj);
+                    long lifetimeTicks = connection.GetLifetimeTicks(nowTicks);
+                    if (lifetimeTicks > pooledConnectionLifetime.TotalMilliseconds)
+                    {
+                        if (NetEventSource.Log.IsEnabled()) connection.Trace($"Scavenging connection. Lifetime {TimeSpan.FromMilliseconds(lifetimeTicks)} > {pooledConnectionLifetime}.");
+                        return false;
+                    }
                 }
 
-                // Dispose the stale connections outside the pool lock.
-                toDispose?.ForEach(c => c.Dispose());
-            }
+                if (!connection.CheckUsabilityOnScavenge())
+                {
+                    if (NetEventSource.Log.IsEnabled()) connection.Trace($"Scavenging connection. Unexpected data or EOF received.");
+                    return false;
+                }
 
-            // Pool is active.  Should not be removed.
-            return false;
+                return true;
+            }
         }
 
         /// <summary>Gets whether we're running on Windows 7 or Windows 2008 R2.</summary>
@@ -1900,8 +2074,13 @@ namespace System.Net.Http
 
         internal void HeartBeat()
         {
-            Http2Connection[]? localHttp2Connections = _http2Connections;
-            if (localHttp2Connections != null)
+            Http2Connection[]? localHttp2Connections;
+            lock (SyncObj)
+            {
+                localHttp2Connections = _availableHttp2Connections?.ToArray();
+            }
+
+            if (localHttp2Connections is not null)
             {
                 foreach (Http2Connection http2Connection in localHttp2Connections)
                 {
@@ -1909,7 +2088,6 @@ namespace System.Net.Http
                 }
             }
         }
-
 
         // For diagnostic purposes
         public override string ToString() =>
@@ -1930,67 +2108,89 @@ namespace System.Net.Http
                 memberName,                  // method name
                 message);                    // message
 
-        /// <summary>A cached idle connection and metadata about it.</summary>
-        [StructLayout(LayoutKind.Auto)]
-        private readonly struct CachedConnection : IEquatable<CachedConnection>
+        private struct RequestQueue<T>
         {
-            /// <summary>The cached connection.</summary>
-            internal readonly HttpConnection _connection;
-            /// <summary>The last tick count at which the connection was used.</summary>
-            internal readonly long _returnedTickCount;
-
-            /// <summary>Initializes the cached connection and its associated metadata.</summary>
-            /// <param name="connection">The connection.</param>
-            public CachedConnection(HttpConnection connection)
+            private struct QueueItem
             {
-                Debug.Assert(connection != null);
-                _connection = connection;
-                _returnedTickCount = Environment.TickCount64;
+                public HttpRequestMessage Request;
+                public TaskCompletionSourceWithCancellation<T> Waiter;
             }
 
-            /// <summary>Gets whether the connection is currently usable.</summary>
-            /// <param name="nowTicks">The current tick count.  Passed in to amortize the cost of calling Environment.TickCount.</param>
-            /// <param name="pooledConnectionLifetime">How long a connection can be open to be considered reusable.</param>
-            /// <param name="pooledConnectionIdleTimeout">How long a connection can have been idle in the pool to be considered reusable.</param>
-            /// <returns>
-            /// true if we believe the connection can be reused; otherwise, false.  There is an inherent race condition here,
-            /// in that the server could terminate the connection or otherwise make it unusable immediately after we check it,
-            /// but there's not much difference between that and starting to use the connection and then having the server
-            /// terminate it, which would be considered a failure, so this race condition is largely benign and inherent to
-            /// the nature of connection pooling.
-            /// </returns>
-            public bool IsUsable(
-                long nowTicks,
-                TimeSpan pooledConnectionLifetime,
-                TimeSpan pooledConnectionIdleTimeout)
+            private Queue<QueueItem>? _queue;
+
+            public TaskCompletionSourceWithCancellation<T> EnqueueRequest(HttpRequestMessage request)
             {
-                // Validate that the connection hasn't been idle in the pool for longer than is allowed.
-                if ((pooledConnectionIdleTimeout != Timeout.InfiniteTimeSpan) &&
-                    ((nowTicks - _returnedTickCount) > pooledConnectionIdleTimeout.TotalMilliseconds))
+                if (_queue is null)
                 {
-                    if (NetEventSource.Log.IsEnabled()) _connection.Trace($"Scavenging connection. Idle {TimeSpan.FromMilliseconds((nowTicks - _returnedTickCount))} > {pooledConnectionIdleTimeout}.");
-                    return false;
+                    _queue = new Queue<QueueItem>();
                 }
 
-                // Validate that the connection lifetime has not been exceeded.
-                if (_connection.LifetimeExpired(nowTicks, pooledConnectionLifetime))
-                {
-                    if (NetEventSource.Log.IsEnabled()) _connection.Trace($"Scavenging connection. Lifetime {TimeSpan.FromMilliseconds((nowTicks - _connection.CreationTickCount))} > {pooledConnectionLifetime}.");
-                    return false;
-                }
-
-                if (!_connection.CheckUsabilityOnScavenge())
-                {
-                    if (NetEventSource.Log.IsEnabled()) _connection.Trace($"Scavenging connection. Unexpected data or EOF received.");
-                    return false;
-                }
-
-                return true;
+                TaskCompletionSourceWithCancellation<T> waiter = new TaskCompletionSourceWithCancellation<T>();
+                _queue.Enqueue(new QueueItem { Request = request, Waiter = waiter });
+                return waiter;
             }
 
-            public bool Equals(CachedConnection other) => ReferenceEquals(other._connection, _connection);
-            public override bool Equals([NotNullWhen(true)] object? obj) => obj is CachedConnection && Equals((CachedConnection)obj);
-            public override int GetHashCode() => _connection?.GetHashCode() ?? 0;
+            public bool TryFailNextRequest(Exception e)
+            {
+                Debug.Assert(e is HttpRequestException or OperationCanceledException, "Unexpected exception type for connection failure");
+
+                if (_queue is not null)
+                {
+                    // Fail the next queued request (if any) with this error.
+                    while (_queue.TryDequeue(out QueueItem item))
+                    {
+                        // Try to complete the waiter task. If it's been cancelled already, this will fail.
+                        if (item.Waiter.TrySetException(e))
+                        {
+                            return true;
+                        }
+
+                        // Couldn't transfer to that waiter because it was cancelled. Try again.
+                        Debug.Assert(item.Waiter.Task.IsCanceled);
+                    }
+                }
+
+                return false;
+            }
+
+            public bool TryDequeueNextRequest(T connection)
+            {
+                if (_queue is not null)
+                {
+                    while (_queue.TryDequeue(out QueueItem item))
+                    {
+                        // Try to complete the task. If it's been cancelled already, this will return false.
+                        if (item.Waiter.TrySetResult(connection))
+                        {
+                            return true;
+                        }
+
+                        // Couldn't transfer to that waiter because it was cancelled. Try again.
+                        Debug.Assert(item.Waiter.Task.IsCanceled);
+                    }
+                }
+
+                return false;
+            }
+
+            public bool TryPeekNextRequest([NotNullWhen(true)] out HttpRequestMessage? request)
+            {
+                if (_queue is not null)
+                {
+                    if (_queue.TryPeek(out QueueItem item))
+                    {
+                        request = item.Request;
+                        return true;
+                    }
+                }
+
+                request = null;
+                return false;
+            }
+
+            public bool IsEmpty => Count == 0;
+
+            public int Count => (_queue?.Count ?? 0);
         }
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -443,7 +443,7 @@ namespace System.Net.Http
             return newException;
         }
 
-        private async Task AddHttp11Connection(HttpRequestMessage request)
+        private async Task AddHttp11ConnectionAsync(HttpRequestMessage request)
         {
             if (NetEventSource.Log.IsEnabled()) Trace("Creating new HTTP/1.1 connection for pool.");
 
@@ -487,7 +487,7 @@ namespace System.Net.Http
                 _associatedHttp11ConnectionCount++;
                 _pendingHttp11ConnectionCount++;
 
-                Task.Run(() => AddHttp11Connection(request));
+                Task.Run(() => AddHttp11ConnectionAsync(request));
             }
         }
 
@@ -614,7 +614,7 @@ namespace System.Net.Http
             ReturnHttp11Connection(http11Connection, isNewConnection: true);
         }
 
-        private async Task AddHttp2Connection(HttpRequestMessage request)
+        private async Task AddHttp2ConnectionAsync(HttpRequestMessage request)
         {
             if (NetEventSource.Log.IsEnabled()) Trace("Creating new HTTP/2 connection for pool.");
 
@@ -695,7 +695,7 @@ namespace System.Net.Http
                 _associatedHttp2ConnectionCount++;
                 _pendingHttp2Connection = true;
 
-                Task.Run(() => AddHttp2Connection(request));
+                Task.Run(() => AddHttp2ConnectionAsync(request));
             }
         }
 
@@ -1911,8 +1911,8 @@ namespace System.Net.Http
                     _availableHttp11Connections.ForEach(c => c.Dispose());
                     _availableHttp11Connections.Clear();
 
-                    Debug.Assert(_associatedHttp2ConnectionCount >= (_availableHttp11Connections?.Count ?? 0));
-                    _associatedHttp11ConnectionCount -= (_availableHttp11Connections?.Count ?? 0);
+                    Debug.Assert(_associatedHttp2ConnectionCount >= (_availableHttp2Connections?.Count ?? 0));
+                    _associatedHttp2ConnectionCount -= (_availableHttp2Connections?.Count ?? 0);
                     _availableHttp2Connections?.ForEach(c => c.Dispose());
                     _availableHttp2Connections?.Clear();
 
@@ -1930,7 +1930,7 @@ namespace System.Net.Http
                     }
                 }
 
-                Debug.Assert(_availableHttp11Connections!.Count == 0, $"Expected {nameof(_availableHttp11Connections)}.{nameof(_availableHttp11Connections.Count)} == 0");
+                Debug.Assert(_availableHttp11Connections.Count == 0, $"Expected {nameof(_availableHttp11Connections)}.{nameof(_availableHttp11Connections.Count)} == 0");
                 Debug.Assert((_availableHttp2Connections?.Count ?? 0) == 0, $"Expected {nameof(_availableHttp2Connections)}.{nameof(_availableHttp2Connections.Count)} == 0");
             }
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1651,12 +1651,12 @@ namespace System.Net.Http
         /// Called when an HttpConnection from this pool is no longer usable.
         /// Note, this is always called from HttpConnection.Dispose, which is a bit different than how HTTP2 works.
         /// </summary>
-        public void InvalidateHttp11Connection(HttpConnection connection)
+        public void InvalidateHttp11Connection(HttpConnection connection, bool disposing = true)
         {
             lock (SyncObj)
             {
                 Debug.Assert(_associatedHttp11ConnectionCount > 0);
-                Debug.Assert(!_availableHttp11Connections.Contains(connection));
+                Debug.Assert(!disposing || !_availableHttp11Connections.Contains(connection));
 
                 _associatedHttp11ConnectionCount--;
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -129,7 +129,7 @@ namespace System.Net.Http.Functional.Tests
                 DataFrame invalidFrame = new DataFrame(new byte[10], FrameFlags.Padded, 10, 1);
                 await connection.WriteFrameAsync(invalidFrame);
 
-                await AssertProtocolErrorAsync(sendTask, ProtocolErrors.PROTOCOL_ERROR);
+                await Assert.ThrowsAsync<HttpRequestException>(() => sendTask);
             }
         }
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -244,10 +244,10 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ConditionalTheory(nameof(SupportsAlpn))]
-        [InlineData(SettingId.MaxFrameSize, 16383, ProtocolErrors.PROTOCOL_ERROR)]
-        [InlineData(SettingId.MaxFrameSize, 162777216, ProtocolErrors.PROTOCOL_ERROR)]
-        [InlineData(SettingId.InitialWindowSize, 0x80000000, ProtocolErrors.FLOW_CONTROL_ERROR)]
-        public async Task Http2_ServerSendsInvalidSettingsValue_Error(SettingId settingId, uint value, ProtocolErrors expectedError)
+        [InlineData(SettingId.MaxFrameSize, 16383)]
+        [InlineData(SettingId.MaxFrameSize, 162777216)]
+        [InlineData(SettingId.InitialWindowSize, 0x80000000)]
+        public async Task Http2_ServerSendsInvalidSettingsValue_Error(SettingId settingId, uint value)
         {
             using (Http2LoopbackServer server = Http2LoopbackServer.CreateServer())
             using (HttpClient client = CreateHttpClient())
@@ -257,7 +257,7 @@ namespace System.Net.Http.Functional.Tests
                 // Send invalid initial SETTINGS value
                 Http2LoopbackConnection connection = await server.EstablishConnectionAsync(new SettingsEntry { SettingId = settingId, Value = value });
 
-                await AssertProtocolErrorAsync(sendTask, expectedError);
+                await Assert.ThrowsAsync<HttpRequestException>(() => sendTask);
 
                 connection.Dispose();
             }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -3383,16 +3383,15 @@ namespace System.Net.Http.Functional.Tests
                         options.ServerCertificate = Net.Test.Common.Configuration.Certificates.GetServerCertificate();
                         options.ApplicationProtocols = new List<SslApplicationProtocol>() { SslApplicationProtocol.Http2 };
                         options.ApplicationProtocols.Add(SslApplicationProtocol.Http2);
+
                         // Negotiate TLS.
                         await sslStream.AuthenticateAsServerAsync(options, CancellationToken.None).ConfigureAwait(false);
+
                         // Send back HTTP/1.1 response
                         await sslStream.WriteAsync(Encoding.ASCII.GetBytes("HTTP/1.1 400 Unrecognized request\r\n\r\n"), CancellationToken.None);
                     });
 
-
                     Exception e = await Assert.ThrowsAsync<HttpRequestException>(() => requestTask);
-                    Assert.NotNull(e.InnerException);
-                    Assert.False(e.InnerException is ObjectDisposedException);
                 });
             }
         }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Cancellation.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Cancellation.cs
@@ -84,6 +84,12 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(false)]
         public async Task ConnectTimeout_PlaintextStreamFilterTimesOut_Throws(bool useSsl)
         {
+            if (UseVersion == HttpVersion.Version30)
+            {
+                // HTTP3 does not support PlaintextStreamFilter
+                return;
+            }
+
             var releaseServer = new TaskCompletionSource();
             await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
             {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Cancellation.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Cancellation.cs
@@ -18,10 +18,11 @@ namespace System.Net.Http.Functional.Tests
         private async Task ValidateConnectTimeout(HttpMessageInvoker invoker, Uri uri, int minElapsed, int maxElapsed)
         {
             var sw = Stopwatch.StartNew();
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            var oce = await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
                 invoker.SendAsync(TestAsync, new HttpRequestMessage(HttpMethod.Get, uri) { Version = UseVersion }, default));
             sw.Stop();
 
+            Assert.IsType<TimeoutException>(oce.InnerException);
             Assert.InRange(sw.ElapsedMilliseconds, minElapsed, maxElapsed);
         }
 
@@ -51,8 +52,10 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [OuterLoop]
-        [Fact]
-        public async Task ConnectTimeout_ConnectCallbackTimesOut_Throws()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ConnectTimeout_ConnectCallbackTimesOut_Throws(bool useSsl)
         {
             if (UseVersion == HttpVersion.Version30)
             {
@@ -71,7 +74,43 @@ namespace System.Net.Http.Functional.Tests
 
                     await ValidateConnectTimeout(invoker, uri, 500, 85_000);
                 }
-            }, server => Task.CompletedTask); // doesn't actually connect to server
+            }, server => Task.CompletedTask, // doesn't actually connect to server
+            options: new GenericLoopbackOptions() { UseSsl = useSsl });
+        }
+
+        [OuterLoop]
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ConnectTimeout_PlaintextStreamFilterTimesOut_Throws(bool useSsl)
+        {
+            var releaseServer = new TaskCompletionSource();
+            await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
+            {
+                using (var handler = CreateHttpClientHandler())
+                using (var invoker = new HttpMessageInvoker(handler))
+                {
+                    handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
+                    var socketsHandler = GetUnderlyingSocketsHttpHandler(handler);
+                    socketsHandler.ConnectTimeout = TimeSpan.FromSeconds(1);
+                    socketsHandler.PlaintextStreamFilter = async (context, token) => { await Task.Delay(-1, token); return null; };
+
+                    await ValidateConnectTimeout(invoker, uri, 500, 85_000);
+
+                    releaseServer.SetResult();
+                }
+            },
+            async server =>
+            {
+                try
+                {
+                    await server.AcceptConnectionAsync(async c =>
+                    {
+                        await releaseServer.Task;
+                    });
+                }
+                catch (Exception) { } // Eat exception from client timing out
+            }, options: new GenericLoopbackOptions() { UseSsl = useSsl });
         }
 
         [OuterLoop("Incurs significant delay")]

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
@@ -552,10 +552,6 @@ namespace System.Net.Http.Functional.Tests
                 Assert.Contains(http11requestQueueDurations, d => d > 0);
                 Assert.All(http11requestQueueDurations, d => Assert.True(d >= 0));
             }
-            else
-            {
-                Assert.All(http11requestQueueDurations, d => Assert.True(d == 0));
-            }
 
             Assert.True(eventCounters.TryGetValue("http20-requests-queue-duration", out double[] http20requestQueueDurations));
             Assert.Equal(0, http20requestQueueDurations[^1]);
@@ -563,10 +559,6 @@ namespace System.Net.Http.Functional.Tests
             {
                 Assert.Contains(http20requestQueueDurations, d => d > 0);
                 Assert.All(http20requestQueueDurations, d => Assert.True(d >= 0));
-            }
-            else
-            {
-                Assert.All(http20requestQueueDurations, d => Assert.True(d == 0));
             }
         }
 
@@ -655,12 +647,19 @@ namespace System.Net.Http.Functional.Tests
 
                 ValidateConnectionEstablishedClosed(events, version);
 
-                (EventWrittenEventArgs requestLeftQueue, Guid requestLeftQueueId) = Assert.Single(events, e => e.Event.EventName == "RequestLeftQueue");
-                Assert.Equal(3, requestLeftQueue.Payload.Count);
-                Assert.True((double)requestLeftQueue.Payload.Count > 0); // timeSpentOnQueue
-                Assert.Equal(version.Major, (byte)requestLeftQueue.Payload[1]);
-                Assert.Equal(version.Minor, (byte)requestLeftQueue.Payload[2]);
+                var requestLeftEvents = events.Where(e => e.Event.EventName == "RequestLeftQueue");
+                Assert.Equal(2, requestLeftEvents.Count());
 
+                foreach (var (e, _) in requestLeftEvents)
+                {
+                    Assert.Equal(3, e.Payload.Count);
+                    Assert.True((double)e.Payload[0] > 0); // timeSpentOnQueue
+                    Assert.Equal(version.Major, (byte)e.Payload[1]);
+                    Assert.Equal(version.Minor, (byte)e.Payload[2]);
+
+                }
+
+                Guid requestLeftQueueId = requestLeftEvents.Last().ActivityId;
                 Assert.Equal(requestLeftQueueId, events.Where(e => e.Event.EventName == "RequestStart").Last().ActivityId);
 
                 ValidateRequestResponseStartStopEvents(events, requestContentLength: null, responseContentLength: 0, count: 3);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/44818
Fixes https://github.com/dotnet/runtime/issues/47484

This is a significant change to connection pooling and request queuing in SocketsHttpHandler. The primary goal is to address https://github.com/dotnet/runtime/issues/44818 -- that is, allow a request to be satisfied by any connection that becomes available while the request is waiting for a connection. The secondary goals are:
 
(1) Provide consistency in connection pooling across HTTP versions. Where possible, code is shared and reused. In other cases, we provide parallel but distinct implementations for different HTTP versions.
(2) Separate pool policy from connection state, where possible, to allow in the future the ability to use connections directly without being associated with a pool. This is a work in progress; the HTTP2 logic is closer to enabling this goal than the HTTP/1.1 logic.

Details:

Previously, a new connection attempt (HTTP1.1 or HTTP2) was always associated with a specific request.

In the simplest case of HTTP/1.1, no connection limit, and no connection currently available, this would always result in a new connection attempt for the request, and the request would always wait for this connection to be established, even if other connections became available sooner.

For HTTP/1.1 with a connection limit, when the limit was hit, we would queue requests to the HTTP/1.1 request queue instead of initiating a new connection. When an existing connection became available, it would try to satisfy one of the queued requests, if any. If an existing connection became unusable, then it would allow a new connection to be created -- but again, this connection would be associated with a specific request (the one that happened to be at the top of the HTTP.1/1 request queue at the time).

The HTTP/2 model was very different. By default, it would only allow a single HTTP/2 connection at a time. During connection establishment, requests would be queued by the `_http2ConnectionCreateLock`. After the HTTP/2 connection was established, requests were subject to queuing by the `_concurrentStreams` CreditManger on the Http2Connection, which would queue requests when necessary to enforce the HTTP2 MAX_CONCURRENT_STREAMS setting from the server.

When the `EnableMultipleHttp2Connections` setting was set to true, HTTP/2 behavior would change so that we would no longer queue on the connection to enforce MAX_CONCURRENT_STREAMS. Instead, we would create a new HTTP2 connection to satisfy requests. However, like HTTP/1.1, new requests would always wait for the new connection to be established instead of using existing connections if/when they became available for use.

This PR implements a uniform request queuing model for HTTP/1.1 and HTTP/2 that is used for all requests when no connections are immediately usable. When connections (new or existing) become usable, they dequeue requests from the queue and process them.

Simple connection injection policy is used to determine if/when to create a connections. Specifically:

For HTTP/1.1: 
We will inject a new connection whenever we are:
(a) below the connection limit (if any), and 
(b) have more requests in the queue than pending connections.

For HTTP/2:
We only inject a single HTTP/2 connection at a time. 
Before use, an HTTP/2 connection is checked to see if it has available streams. If not, we will not attempt to use it; instead we will register to be notified when streams become available. There is no longer any connection-level queuing of requests.
If `EnableMultipleHttp2Connections` is true, we will inject a new connection any time we do not have a pending connection, and we have queued requests.

Additionally, this PR contains some cleanup/clarification to related issues such as HTTP2 connection shutdown, connection scavenging, managing of idle time and lifetime, etc.

@dotnet/ncl Please take a look.
@stephentoub You implemented most of the HTTP/1.1 connection pooling logic originally
@scalablecory
@alnikola You are most familiar with the HTTP/2 connection management
@ManickaP You are most familiar with https://github.com/dotnet/runtime/issues/47484