### PR TITLE
Consider reloadWeight while evaluating spill cost

### DIFF
--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -11258,21 +11258,26 @@ void LinearScan::RegisterSelection::try_SPILL_COST()
             continue;
         }
 
-        float currentSpillWeight = 0;
-        RefPosition* recentRefPosition = spillCandidateRegRecord->assignedInterval->recentRefPosition;
+        float        currentSpillWeight = 0;
+        RefPosition* recentRefPosition  = spillCandidateRegRecord->assignedInterval != nullptr
+                                              ? spillCandidateRegRecord->assignedInterval->recentRefPosition
+                                              : nullptr;
         if ((recentRefPosition != nullptr) && (recentRefPosition->RegOptional()) &&
             !(currentInterval->isLocalVar && recentRefPosition->IsActualRef()))
         {
             // We do not "spillAfter" if previous (recent) refPosition was regOptional or if it
             // is not an actual ref. In those cases, we will reload in future (next) refPosition.
             // For such cases, consider the spill cost of next refposition.
+            // See notes in "spillInterval()".
             RefPosition* reloadRefPosition = spillCandidateRegRecord->assignedInterval->getNextRefPosition();
             if (reloadRefPosition != nullptr)
             {
                 currentSpillWeight = linearScan->getWeight(reloadRefPosition);
             }
         }
-        else
+
+        // Only consider spillCost if we were not able to calculate weight of reloadRefPosition.
+        if (currentSpillWeight == 0)
         {
             currentSpillWeight = linearScan->spillCost[spillCandidateRegNum];
 #ifdef TARGET_ARM

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -11260,8 +11260,8 @@ void LinearScan::RegisterSelection::try_SPILL_COST()
 
         float        currentSpillWeight = 0;
         RefPosition* recentRefPosition  = spillCandidateRegRecord->assignedInterval != nullptr
-                                              ? spillCandidateRegRecord->assignedInterval->recentRefPosition
-                                              : nullptr;
+                                             ? spillCandidateRegRecord->assignedInterval->recentRefPosition
+                                             : nullptr;
         if ((recentRefPosition != nullptr) && (recentRefPosition->RegOptional()) &&
             !(currentInterval->isLocalVar && recentRefPosition->IsActualRef()))
         {


### PR DESCRIPTION
In `SPILL_COST` heuristics, we always check the spill cost of `recentRefPosition` (last ref position) where the register was allocated. Spill cost is essentially the ref count weight of a variable. However, later, we check if that `recentRefPosition` is not `RegOptional` and is actual ref. If it is not, we skip spill it at the `recentRefPosition` and would instead reload at the next `refPosition`. As such, when calculating the spill cost, we should take that factor into account and depending on if we we will spill at last location or reload at next location, take the cost of appropriate position.

Here is the sample diff:

Note below, that we spill a low weight variable on stack in favor of using register for higher weight variable.

![image](https://user-images.githubusercontent.com/12488060/121323015-516a5380-c8c4-11eb-9d4f-6bed5639143f.png)

![image](https://user-images.githubusercontent.com/12488060/121323025-53ccad80-c8c4-11eb-8c2c-fcd088a1843f.png)

Fixes: https://github.com/dotnet/runtime/issues/53703 
Related: https://github.com/dotnet/runtime/issues/52316