### PR TITLE
Modernize DiagnosticsHandler tests

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/FakeDiagnosticSourceListenerObserver.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/FakeDiagnosticSourceListenerObserver.cs
@@ -71,11 +71,6 @@ namespace System.Net.Http.Functional.Tests
             _writeObserverEnabled = writeObserverEnabled;
         }
 
-        public void Disable()
-        {
-            _writeObserverEnabled = (name, arg1, arg2) => false;
-        }
-
         private bool IsEnabled(string s, object arg1, object arg2)
         {
             return _writeObserverEnabled.Invoke(s, arg1, arg2);

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.SocketsHttpHandler.cs
@@ -78,6 +78,9 @@ namespace System.Net.Http.Functional.Tests
 
         protected LoopbackServerFactory LoopbackServerFactory => GetFactoryForVersion(UseVersion, UseQuicImplementationProvider);
 
+        protected static LoopbackServerFactory GetFactoryForVersion(string useVersion, QuicImplementationProvider quicImplementationProvider = null) =>
+            GetFactoryForVersion(Version.Parse(useVersion), quicImplementationProvider);
+
         protected static LoopbackServerFactory GetFactoryForVersion(Version useVersion, QuicImplementationProvider quicImplementationProvider = null)
         {
             return useVersion.Major switch

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -146,9 +146,9 @@ namespace System.Net.Http.Functional.Tests
         public SocketsHttpHandler_DiagnosticsTest_Http11(ITestOutputHelper output) : base(output) { }
     }
 
-    public sealed class SocketsHttpHandler_DiagnosticsTest_Http20 : DiagnosticsTest
+    public sealed class SocketsHttpHandler_DiagnosticsTest_Http2 : DiagnosticsTest
     {
-        public SocketsHttpHandler_DiagnosticsTest_Http20(ITestOutputHelper output) : base(output) { }
+        public SocketsHttpHandler_DiagnosticsTest_Http2(ITestOutputHelper output) : base(output) { }
         protected override Version UseVersion => HttpVersion.Version20;
     }
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -141,9 +141,15 @@ namespace System.Net.Http.Functional.Tests
         public SocketsHttpHandler_HttpProtocolTests_Dribble(ITestOutputHelper output) : base(output) { }
     }
 
-    public sealed class SocketsHttpHandler_DiagnosticsTest : DiagnosticsTest
+    public sealed class SocketsHttpHandler_DiagnosticsTest_Http11 : DiagnosticsTest
     {
-        public SocketsHttpHandler_DiagnosticsTest(ITestOutputHelper output) : base(output) { }
+        public SocketsHttpHandler_DiagnosticsTest_Http11(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class SocketsHttpHandler_DiagnosticsTest_Http20 : DiagnosticsTest
+    {
+        public SocketsHttpHandler_DiagnosticsTest_Http20(ITestOutputHelper output) : base(output) { }
+        protected override Version UseVersion => HttpVersion.Version20;
     }
 
     public sealed class SocketsHttpHandler_HttpClient_SelectedSites_Test : HttpClient_SelectedSites_Test


### PR DESCRIPTION
Effectively all tests here were in OuterLoop/disabled, even those that were not hitting any servers.

This PR:
- Replaces the Echo remote server with loopback
- Removes race conditions & busy waits (replaces `SpinWait.SpinUntil` with `SemaphoreSlim` where needed)
- Fixes some tests to test what the name suggests (e.g. `Hierarchical` format wasn't being tested)
- Flows UseVersion, TestAsync across tests
- Enables HTTP/2 tests

Fixes #23167 (re-enables the tests disabled against it)