### PR TITLE
Add SupportedOSPlatform to X509Certificate2 members.

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.cs
@@ -238,9 +238,9 @@ namespace System.Security.Cryptography.X509Certificates
         public X509Certificate2(string fileName, System.Security.SecureString? password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
         public X509Certificate2(string fileName, string? password) { }
         public X509Certificate2(string fileName, string? password, System.Security.Cryptography.X509Certificates.X509KeyStorageFlags keyStorageFlags) { }
-        public bool Archived { get { throw null; } set { } }
+        public bool Archived { get { throw null; } [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] set { } }
         public System.Security.Cryptography.X509Certificates.X509ExtensionCollection Extensions { get { throw null; } }
-        public string FriendlyName { get { throw null; } set { } }
+        public string FriendlyName { get { throw null; } [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] set { } }
         public bool HasPrivateKey { get { throw null; } }
         public System.Security.Cryptography.X509Certificates.X500DistinguishedName IssuerName { get { throw null; } }
         public System.DateTime NotAfter { get { throw null; } }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Formats.Asn1;
 using System.IO;
 using System.Runtime.Serialization;
+using System.Runtime.Versioning;
 using System.Security;
 using System.Security.Cryptography.X509Certificates.Asn1;
 using System.Text;
@@ -170,6 +171,7 @@ namespace System.Security.Cryptography.X509Certificates
                 return Pal.Archived;
             }
 
+            [SupportedOSPlatform("windows")]
             set
             {
                 ThrowIfInvalid();
@@ -216,6 +218,7 @@ namespace System.Security.Cryptography.X509Certificates
                 return Pal.FriendlyName;
             }
 
+            [SupportedOSPlatform("windows")]
             set
             {
                 ThrowIfInvalid();


### PR DESCRIPTION
Archived and FriendlyName's setters are only supported on Windows.

Contributes to #47977.