### PR TITLE
Fix memory corruption after free in EventPipe streaming thread.

### DIFF
--- a/src/native/eventpipe/ep-session.c
+++ b/src/native/eventpipe/ep-session.c
@@ -71,10 +71,10 @@ EP_RT_DEFINE_THREAD_FUNC (streaming_thread)
 		ep_rt_wait_event_set (&session->rt_thread_shutdown_event);
 	EP_GCX_PREEMP_EXIT
 
+	session->streaming_thread = NULL;
+
 	if (!success)
 		ep_disable ((EventPipeSessionID)session);
-
-	session->streaming_thread = NULL;
 
 	return (ep_rt_thread_start_func_return_t)0;
 }


### PR DESCRIPTION
If streaming thread was aborted with an error it will disable the session. This is not the normal scenario, since most tools will explicit ask to close session, but if there is a network connectivity causing failures to write to stream, session will first be disabled and then it will write NULL into freed memory, causing heap corruption.

Fix makes sure we reset streaming_thread before we eventually disable session, making sure it won't write into freed memory.