### PR TITLE
Fix infinite loop in Diagnostics CounterGroup OnTimer method.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -253,7 +253,7 @@ namespace System.Diagnostics.Tracing
                     _timeStampSinceCollectionStarted = now;
                     do
                     {
-                        _nextPollingTimeStamp += new TimeSpan(0, 0, 0, 0, _pollingIntervalInMilliseconds);
+                        _nextPollingTimeStamp += new TimeSpan(0, 0, 0, 0, (_pollingIntervalInMilliseconds > 0) ? _pollingIntervalInMilliseconds : 1);
                     } while (_nextPollingTimeStamp <= now);
                 }
             }


### PR DESCRIPTION
If a counter event source is disabled while in System.Diagnostics.Tracing.CounterGroup.OnTimer, thread could end up in infinite loop. This happens since _pollingIntervalInMilliseconds is set to 0 when disabled, meaning that we could fail to advance _nextPollingTimeStamp past now:

```
lock (s_counterGroupLock)
{
    _timeStampSinceCollectionStarted = now;
    do
    {
        _nextPollingTimeStamp += new TimeSpan(0, 0, 0, 0, _pollingIntervalInMilliseconds);
    } while (_nextPollingTimeStamp <= now);
}
```

Fix use the local copy of pollingIntervalInMilliseconds and also adds an additional safe quard to make sure it always gets advance event if disabled check on _eventSource.IsEnabled() and lock (s_counterGroupLock), since that case will set _pollingIntervalInMilliseconds to 0 as well even before loaded into local variable.