### PR TITLE
Switch Windows Checked build to `-O2` from `-O1`

### DIFF
--- a/eng/native/configureoptimization.cmake
+++ b/eng/native/configureoptimization.cmake
@@ -1,6 +1,6 @@
 if(CLR_CMAKE_HOST_WIN32)
     add_compile_options($<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<CONFIG:Debug>>:/Od>)
-    add_compile_options($<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<CONFIG:Checked>>:/O1>)
+    add_compile_options($<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<CONFIG:Checked>>:/O2>)
     add_compile_options($<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<CONFIG:Release>>:/Ox>)
     add_compile_options($<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<CONFIG:RelWithDebInfo>>:/O2>)
 elseif(CLR_CMAKE_HOST_UNIX)


### PR DESCRIPTION
That is, optimize for speed, not for size.

Related: https://github.com/dotnet/runtime/issues/53849
