### PR TITLE
Remove an erroneous check

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -28669,11 +28669,6 @@ heap_segment* gc_heap::relocate_advance_to_non_sip (heap_segment* region)
                             {
                                 dprintf (4444, ("SIP %Ix(%Ix)->%Ix->%Ix(%Ix)", 
                                     x, (uint8_t*)pval, child, *pval, method_table (child)));
-
-                                if (method_table (child) == 0)
-                                {
-                                    FATAL_GC_ERROR();
-                                }
                             }
                         });
                     }


### PR DESCRIPTION
Fixes #53401

I claim that the check I removed is erroneous. The check is performed during the `relocate_advance_to_non_sip`, which is part of `relocate_phase`.

In the earlier plan phase, if we discovered a non-pinned plug that is too close to the earlier pinned plug, we would like to be able to relocate this plug, but then we have no space to store the relocation data. In that case, we will temporarily overwrite the last plug's end to store the relocation data after backing it up. The backup will be restored later (either after compact or sweep)

Therefore, it is possible that a pointer in the swept in plan region points to a location where it was temporarily overwritten by the relocation data at that point in time. In that case, the pointer might not be pointing to a valid method table pointer, and that why the check fails.

This explains why the bug does not repro if we do not define `STRESS_REGIONS`, the chances for that to happen is significantly reduced without it.

I ran the test that repro it in a loop for an hour and nothing bad happened with it, I believe this fix is good to go.