### PR TITLE
Disable RegisterFromSTAThreadThatGoesAway_MessageStillDelivered test on Mono on Windows

### DIFF
--- a/src/libraries/Microsoft.Win32.SystemEvents/tests/SystemEvents.InvokeOnEventsThread.cs
+++ b/src/libraries/Microsoft.Win32.SystemEvents/tests/SystemEvents.InvokeOnEventsThread.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Win32.SystemEventsTests
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoNorServerCore))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/34360", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public void RegisterFromSTAThreadThatGoesAway_MessageStillDelivered()
         {
             RemoteExecutor.Invoke(() => // to ensure no one has registered for any events before


### PR DESCRIPTION
It started failing after https://github.com/dotnet/runtime/pull/53700 because the missing Dispose() caused the failure to not be reported.