### PR TITLE
System.Text.Json: TimeSpan support

### DIFF
--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -63,6 +63,7 @@ namespace System.Text.Json
         public sbyte GetSByte() { throw null; }
         public float GetSingle() { throw null; }
         public string? GetString() { throw null; }
+        public System.TimeSpan GetTimeSpan() { throw null; }
         [System.CLSCompliantAttribute(false)]
         public ushort GetUInt16() { throw null; }
         [System.CLSCompliantAttribute(false)]
@@ -87,6 +88,7 @@ namespace System.Text.Json
         [System.CLSCompliantAttribute(false)]
         public bool TryGetSByte(out sbyte value) { throw null; }
         public bool TryGetSingle(out float value) { throw null; }
+        public bool TryGetTimeSpan(out System.TimeSpan value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public bool TryGetUInt16(out ushort value) { throw null; }
         [System.CLSCompliantAttribute(false)]
@@ -345,6 +347,7 @@ namespace System.Text.Json
         public sbyte GetSByte() { throw null; }
         public float GetSingle() { throw null; }
         public string? GetString() { throw null; }
+        public System.TimeSpan GetTimeSpan() { throw null; }
         [System.CLSCompliantAttribute(false)]
         public ushort GetUInt16() { throw null; }
         [System.CLSCompliantAttribute(false)]
@@ -366,6 +369,7 @@ namespace System.Text.Json
         [System.CLSCompliantAttribute(false)]
         public bool TryGetSByte(out sbyte value) { throw null; }
         public bool TryGetSingle(out float value) { throw null; }
+        public bool TryGetTimeSpan(out System.TimeSpan value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public bool TryGetUInt16(out ushort value) { throw null; }
         [System.CLSCompliantAttribute(false)]
@@ -477,6 +481,7 @@ namespace System.Text.Json
         public void WriteString(System.ReadOnlySpan<byte> utf8PropertyName, System.ReadOnlySpan<byte> utf8Value) { }
         public void WriteString(System.ReadOnlySpan<byte> utf8PropertyName, System.ReadOnlySpan<char> value) { }
         public void WriteString(System.ReadOnlySpan<byte> utf8PropertyName, string? value) { }
+        public void WriteString(System.ReadOnlySpan<byte> utf8PropertyName, System.TimeSpan value) { }
         public void WriteString(System.ReadOnlySpan<byte> utf8PropertyName, System.Text.Json.JsonEncodedText value) { }
         public void WriteString(System.ReadOnlySpan<char> propertyName, System.DateTime value) { }
         public void WriteString(System.ReadOnlySpan<char> propertyName, System.DateTimeOffset value) { }
@@ -484,6 +489,7 @@ namespace System.Text.Json
         public void WriteString(System.ReadOnlySpan<char> propertyName, System.ReadOnlySpan<byte> utf8Value) { }
         public void WriteString(System.ReadOnlySpan<char> propertyName, System.ReadOnlySpan<char> value) { }
         public void WriteString(System.ReadOnlySpan<char> propertyName, string? value) { }
+        public void WriteString(System.ReadOnlySpan<char> propertyName, System.TimeSpan value) { }
         public void WriteString(System.ReadOnlySpan<char> propertyName, System.Text.Json.JsonEncodedText value) { }
         public void WriteString(string propertyName, System.DateTime value) { }
         public void WriteString(string propertyName, System.DateTimeOffset value) { }
@@ -491,6 +497,7 @@ namespace System.Text.Json
         public void WriteString(string propertyName, System.ReadOnlySpan<byte> utf8Value) { }
         public void WriteString(string propertyName, System.ReadOnlySpan<char> value) { }
         public void WriteString(string propertyName, string? value) { }
+        public void WriteString(string propertyName, System.TimeSpan value) { }
         public void WriteString(string propertyName, System.Text.Json.JsonEncodedText value) { }
         public void WriteString(System.Text.Json.JsonEncodedText propertyName, System.DateTime value) { }
         public void WriteString(System.Text.Json.JsonEncodedText propertyName, System.DateTimeOffset value) { }
@@ -498,6 +505,7 @@ namespace System.Text.Json
         public void WriteString(System.Text.Json.JsonEncodedText propertyName, System.ReadOnlySpan<byte> utf8Value) { }
         public void WriteString(System.Text.Json.JsonEncodedText propertyName, System.ReadOnlySpan<char> value) { }
         public void WriteString(System.Text.Json.JsonEncodedText propertyName, string? value) { }
+        public void WriteString(System.Text.Json.JsonEncodedText propertyName, System.TimeSpan value) { }
         public void WriteString(System.Text.Json.JsonEncodedText propertyName, System.Text.Json.JsonEncodedText value) { }
         public void WriteStringValue(System.DateTime value) { }
         public void WriteStringValue(System.DateTimeOffset value) { }
@@ -505,6 +513,7 @@ namespace System.Text.Json
         public void WriteStringValue(System.ReadOnlySpan<byte> utf8Value) { }
         public void WriteStringValue(System.ReadOnlySpan<char> value) { }
         public void WriteStringValue(string? value) { }
+        public void WriteStringValue(System.TimeSpan value) { }
         public void WriteStringValue(System.Text.Json.JsonEncodedText value) { }
     }
 }
@@ -887,6 +896,7 @@ namespace System.Text.Json.Serialization.Metadata
         public static System.Text.Json.Serialization.JsonConverter<sbyte> SByteConverter { get { throw null; } }
         public static System.Text.Json.Serialization.JsonConverter<float> SingleConverter { get { throw null; } }
         public static System.Text.Json.Serialization.JsonConverter<string> StringConverter { get { throw null; } }
+        public static System.Text.Json.Serialization.JsonConverter<System.TimeSpan> TimeSpanConverter { get { throw null; } }
         [System.CLSCompliantAttribute(false)]
         public static System.Text.Json.Serialization.JsonConverter<ushort> UInt16Converter { get { throw null; } }
         [System.CLSCompliantAttribute(false)]

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -559,6 +559,7 @@ namespace System.Text.Json.Nodes
         public static explicit operator char (System.Text.Json.Nodes.JsonNode value) { throw null; }
         public static explicit operator System.DateTime (System.Text.Json.Nodes.JsonNode value) { throw null; }
         public static explicit operator System.DateTimeOffset (System.Text.Json.Nodes.JsonNode value) { throw null; }
+        public static explicit operator System.TimeSpan (System.Text.Json.Nodes.JsonNode value) { throw null; }
         public static explicit operator decimal (System.Text.Json.Nodes.JsonNode value) { throw null; }
         public static explicit operator double (System.Text.Json.Nodes.JsonNode value) { throw null; }
         public static explicit operator System.Guid (System.Text.Json.Nodes.JsonNode value) { throw null; }
@@ -570,6 +571,7 @@ namespace System.Text.Json.Nodes
         public static explicit operator char? (System.Text.Json.Nodes.JsonNode? value) { throw null; }
         public static explicit operator System.DateTimeOffset? (System.Text.Json.Nodes.JsonNode? value) { throw null; }
         public static explicit operator System.DateTime? (System.Text.Json.Nodes.JsonNode? value) { throw null; }
+        public static explicit operator System.TimeSpan? (System.Text.Json.Nodes.JsonNode? value) { throw null; }
         public static explicit operator decimal? (System.Text.Json.Nodes.JsonNode? value) { throw null; }
         public static explicit operator double? (System.Text.Json.Nodes.JsonNode? value) { throw null; }
         public static explicit operator System.Guid? (System.Text.Json.Nodes.JsonNode? value) { throw null; }
@@ -600,6 +602,7 @@ namespace System.Text.Json.Nodes
         public static implicit operator System.Text.Json.Nodes.JsonNode (char value) { throw null; }
         public static implicit operator System.Text.Json.Nodes.JsonNode (System.DateTime value) { throw null; }
         public static implicit operator System.Text.Json.Nodes.JsonNode (System.DateTimeOffset value) { throw null; }
+        public static implicit operator System.Text.Json.Nodes.JsonNode (System.TimeSpan value) { throw null; }
         public static implicit operator System.Text.Json.Nodes.JsonNode (decimal value) { throw null; }
         public static implicit operator System.Text.Json.Nodes.JsonNode (double value) { throw null; }
         public static implicit operator System.Text.Json.Nodes.JsonNode (System.Guid value) { throw null; }
@@ -611,6 +614,7 @@ namespace System.Text.Json.Nodes
         public static implicit operator System.Text.Json.Nodes.JsonNode? (char? value) { throw null; }
         public static implicit operator System.Text.Json.Nodes.JsonNode? (System.DateTimeOffset? value) { throw null; }
         public static implicit operator System.Text.Json.Nodes.JsonNode? (System.DateTime? value) { throw null; }
+        public static implicit operator System.Text.Json.Nodes.JsonNode? (System.TimeSpan? value) { throw null; }
         public static implicit operator System.Text.Json.Nodes.JsonNode? (decimal? value) { throw null; }
         public static implicit operator System.Text.Json.Nodes.JsonNode? (double? value) { throw null; }
         public static implicit operator System.Text.Json.Nodes.JsonNode? (System.Guid? value) { throw null; }
@@ -681,6 +685,7 @@ namespace System.Text.Json.Nodes
         public static System.Text.Json.Nodes.JsonValue Create(char value, System.Text.Json.Nodes.JsonNodeOptions? options = default(System.Text.Json.Nodes.JsonNodeOptions?)) { throw null; }
         public static System.Text.Json.Nodes.JsonValue Create(System.DateTime value, System.Text.Json.Nodes.JsonNodeOptions? options = default(System.Text.Json.Nodes.JsonNodeOptions?)) { throw null; }
         public static System.Text.Json.Nodes.JsonValue Create(System.DateTimeOffset value, System.Text.Json.Nodes.JsonNodeOptions? options = default(System.Text.Json.Nodes.JsonNodeOptions?)) { throw null; }
+        public static System.Text.Json.Nodes.JsonValue Create(System.TimeSpan value, System.Text.Json.Nodes.JsonNodeOptions? options = default(System.Text.Json.Nodes.JsonNodeOptions?)) { throw null; }
         public static System.Text.Json.Nodes.JsonValue Create(decimal value, System.Text.Json.Nodes.JsonNodeOptions? options = default(System.Text.Json.Nodes.JsonNodeOptions?)) { throw null; }
         public static System.Text.Json.Nodes.JsonValue Create(double value, System.Text.Json.Nodes.JsonNodeOptions? options = default(System.Text.Json.Nodes.JsonNodeOptions?)) { throw null; }
         public static System.Text.Json.Nodes.JsonValue Create(System.Guid value, System.Text.Json.Nodes.JsonNodeOptions? options = default(System.Text.Json.Nodes.JsonNodeOptions?)) { throw null; }
@@ -692,6 +697,7 @@ namespace System.Text.Json.Nodes
         public static System.Text.Json.Nodes.JsonValue? Create(char? value, System.Text.Json.Nodes.JsonNodeOptions? options = default(System.Text.Json.Nodes.JsonNodeOptions?)) { throw null; }
         public static System.Text.Json.Nodes.JsonValue? Create(System.DateTimeOffset? value, System.Text.Json.Nodes.JsonNodeOptions? options = default(System.Text.Json.Nodes.JsonNodeOptions?)) { throw null; }
         public static System.Text.Json.Nodes.JsonValue? Create(System.DateTime? value, System.Text.Json.Nodes.JsonNodeOptions? options = default(System.Text.Json.Nodes.JsonNodeOptions?)) { throw null; }
+        public static System.Text.Json.Nodes.JsonValue? Create(System.TimeSpan? value, System.Text.Json.Nodes.JsonNodeOptions? options = default(System.Text.Json.Nodes.JsonNodeOptions?)) { throw null; }
         public static System.Text.Json.Nodes.JsonValue? Create(decimal? value, System.Text.Json.Nodes.JsonNodeOptions? options = default(System.Text.Json.Nodes.JsonNodeOptions?)) { throw null; }
         public static System.Text.Json.Nodes.JsonValue? Create(double? value, System.Text.Json.Nodes.JsonNodeOptions? options = default(System.Text.Json.Nodes.JsonNodeOptions?)) { throw null; }
         public static System.Text.Json.Nodes.JsonValue? Create(System.Guid? value, System.Text.Json.Nodes.JsonNodeOptions? options = default(System.Text.Json.Nodes.JsonNodeOptions?)) { throw null; }

--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -318,6 +318,9 @@
   <data name="FormatDateTimeOffset" xml:space="preserve">
     <value>The JSON value is not in a supported DateTimeOffset format.</value>
   </data>
+  <data name="FormatTimeSpan" xml:space="preserve">
+    <value>The JSON value is not in a supported TimeSpan format.</value>
+  </data>
   <data name="FormatGuid" xml:space="preserve">
     <value>The JSON value is not in a supported Guid format.</value>
   </data>

--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -50,6 +50,7 @@
     <Compile Include="System\Text\Json\JsonHelpers.cs" />
     <Compile Include="System\Text\Json\JsonHelpers.Date.cs" />
     <Compile Include="System\Text\Json\JsonHelpers.Escaping.cs" />
+    <Compile Include="System\Text\Json\JsonHelpers.TimeSpan.cs" />
     <Compile Include="System\Text\Json\JsonTokenType.cs" />
     <Compile Include="System\Text\Json\Nodes\JsonArray.cs" />
     <Compile Include="System\Text\Json\Nodes\JsonArray.IList.cs" />
@@ -165,6 +166,7 @@
     <Compile Include="System\Text\Json\Serialization\Converters\Value\SByteConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Value\SingleConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Value\StringConverter.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\Value\TimeSpanConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Value\UInt16Converter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Value\UInt32Converter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Value\UInt64Converter.cs" />
@@ -245,6 +247,7 @@
     <Compile Include="System\Text\Json\Writer\Utf8JsonWriter.WriteProperties.Literal.cs" />
     <Compile Include="System\Text\Json\Writer\Utf8JsonWriter.WriteProperties.SignedNumber.cs" />
     <Compile Include="System\Text\Json\Writer\Utf8JsonWriter.WriteProperties.String.cs" />
+    <Compile Include="System\Text\Json\Writer\Utf8JsonWriter.WriteProperties.TimeSpan.cs" />
     <Compile Include="System\Text\Json\Writer\Utf8JsonWriter.WriteProperties.UnsignedNumber.cs" />
     <Compile Include="System\Text\Json\Writer\Utf8JsonWriter.WriteValues.Bytes.cs" />
     <Compile Include="System\Text\Json\Writer\Utf8JsonWriter.WriteValues.Comment.cs" />
@@ -259,6 +262,7 @@
     <Compile Include="System\Text\Json\Writer\Utf8JsonWriter.WriteValues.Literal.cs" />
     <Compile Include="System\Text\Json\Writer\Utf8JsonWriter.WriteValues.SignedNumber.cs" />
     <Compile Include="System\Text\Json\Writer\Utf8JsonWriter.WriteValues.String.cs" />
+    <Compile Include="System\Text\Json\Writer\Utf8JsonWriter.WriteValues.TimeSpan.cs" />
     <Compile Include="System\Text\Json\Writer\Utf8JsonWriter.WriteValues.UnsignedNumber.cs" />
     <Compile Include="System\TypeExtensions.cs" />
     <Compile Include="$(CommonPath)System\Obsoletions.cs" Link="Common\System\Obsoletions.cs" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
@@ -1096,6 +1096,57 @@ namespace System.Text.Json
         }
 
         /// <summary>
+        ///   Attempts to represent the current JSON string as a <see cref="TimeSpan"/>.
+        /// </summary>
+        /// <param name="value">Receives the value.</param>
+        /// <remarks>
+        ///   This method does not create a TimeSpan representation of values other than JSON strings.
+        /// </remarks>
+        /// <returns>
+        ///   <see langword="true"/> if the string can be represented as a <see cref="TimeSpan"/>,
+        ///   <see langword="false"/> otherwise.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        ///   This value's <see cref="ValueKind"/> is not <see cref="JsonValueKind.String"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   The parent <see cref="JsonDocument"/> has been disposed.
+        /// </exception>
+        public bool TryGetTimeSpan(out TimeSpan value)
+        {
+            CheckValidInstance();
+
+            return _parent.TryGetValue(_idx, out value);
+        }
+
+        /// <summary>
+        ///   Gets the value of the element as a <see cref="TimeSpan"/>.
+        /// </summary>
+        /// <remarks>
+        ///   This method does not create a TimeSpan representation of values other than JSON strings.
+        /// </remarks>
+        /// <returns>The value of the element as a <see cref="TimeSpan"/>.</returns>
+        /// <exception cref="InvalidOperationException">
+        ///   This value's <see cref="ValueKind"/> is not <see cref="JsonValueKind.String"/>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///   The value cannot be represented as a <see cref="TimeSpan"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   The parent <see cref="JsonDocument"/> has been disposed.
+        /// </exception>
+        /// <seealso cref="ToString"/>
+        public TimeSpan GetTimeSpan()
+        {
+            if (TryGetTimeSpan(out TimeSpan value))
+            {
+                return value;
+            }
+
+            throw ThrowHelper.GetFormatException();
+        }
+
+        /// <summary>
         ///   Attempts to represent the current JSON string as a <see cref="Guid"/>.
         /// </summary>
         /// <param name="value">Receives the value.</param>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonConstants.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonConstants.cs
@@ -87,6 +87,9 @@ namespace System.Text.Json
             (DateTimeParseNumFractionDigits - DateTimeNumFractionDigits)); // Like StandardFormat 'O' for DateTimeOffset, but allowing 9 additional (up to 16) fraction digits.
         public const int MinimumDateTimeParseLength = 10; // YYYY-MM-DD
         public const int MaximumEscapedDateTimeOffsetParseLength = MaxExpansionFactorWhileEscaping * MaximumDateTimeOffsetParseLength;
+        public const int MinimumTimeSpanParseLength = 8; // hh:mm:ss
+        public const int MaximumTimeSpanParseLength = 28; // -dddddddddd.hh:mm:ss.fffffff
+        public const int MaximumEscapedTimeSpanParseLength = MaxExpansionFactorWhileEscaping * MaximumTimeSpanParseLength;
 
         // Encoding Helpers
         public const char HighSurrogateStart = '\ud800';

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.TimeSpan.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.TimeSpan.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers.Text;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace System.Text.Json
+{
+    internal static partial class JsonHelpers
+    {
+        public static bool TryParseAsConstantFormat(ReadOnlySpan<char> source, out TimeSpan value)
+        {
+            if (!IsValidTimeSpanParseLength(source.Length))
+            {
+                value = default;
+                return false;
+            }
+
+            int maxLength = checked(source.Length * JsonConstants.MaxExpansionFactorWhileTranscoding);
+
+            Span<byte> bytes = maxLength <= JsonConstants.StackallocThreshold
+                ? stackalloc byte[JsonConstants.StackallocThreshold]
+                : new byte[maxLength];
+
+            int length = JsonReaderHelper.GetUtf8FromText(source, bytes);
+
+            bytes = bytes.Slice(0, length);
+
+            if (bytes.IndexOf(JsonConstants.BackSlash) != -1)
+            {
+                return JsonReaderHelper.TryGetEscapedTimeSpan(bytes, out value);
+            }
+
+            Debug.Assert(bytes.IndexOf(JsonConstants.BackSlash) == -1);
+
+            if (TryParseAsConstantFormat(bytes, out TimeSpan tmp))
+            {
+                value = tmp;
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsValidTimeSpanParseLength(int length)
+        {
+            return IsInRangeInclusive(length, JsonConstants.MinimumTimeSpanParseLength, JsonConstants.MaximumEscapedTimeSpanParseLength);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsValidTimeSpanParseLength(long length)
+        {
+            return IsInRangeInclusive(length, JsonConstants.MinimumTimeSpanParseLength, JsonConstants.MaximumEscapedTimeSpanParseLength);
+        }
+
+        /// <summary>
+        /// Parse the given UTF-8 <paramref name="source"/> as TimeSpan constant ("c") format.
+        /// </summary>
+        /// <param name="source">UTF-8 source to parse.</param>
+        /// <param name="value">The parsed <see cref="TimeSpan"/> if successful.</param>
+        /// <returns>"true" if successfully parsed.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryParseAsConstantFormat(ReadOnlySpan<byte> source, out TimeSpan value)
+        {
+            return Utf8Parser.TryParse(source, out value, out int _, 'c');
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.TimeSpan.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.TimeSpan.cs
@@ -65,7 +65,21 @@ namespace System.Text.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryParseAsConstantFormat(ReadOnlySpan<byte> source, out TimeSpan value)
         {
-            return Utf8Parser.TryParse(source, out value, out int _, 'c');
+            bool result = Utf8Parser.TryParse(source, out TimeSpan tmpValue, out int bytesConsumed, 'c');
+
+            // Note: Utf8Parser.TryParse will return true for invalid input so
+            // long as it starts with an integer. Example: "2021-06-08" or
+            // "1$$$$$$$$$$". We need to check bytesConsumed to know if the
+            // entire source was actually valid.
+
+            if (result && source.Length == bytesConsumed)
+            {
+                value = tmpValue;
+                return true;
+            }
+
+            value = default;
+            return false;
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.Operators.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.Operators.cs
@@ -66,6 +66,18 @@ namespace System.Text.Json.Nodes
         public static implicit operator JsonNode?(DateTimeOffset? value) => JsonValue.Create(value);
 
         /// <summary>
+        ///   Defines an implicit conversion of a given <see cref="TimeSpan"/> to a <see cref="JsonNode"/>.
+        /// </summary>
+        /// <param name="value">A <see cref="TimeSpan"/> to implicitly convert.</param>
+        public static implicit operator JsonNode(TimeSpan value) => JsonValue.Create(value);
+
+        /// <summary>
+        ///   Defines an implicit conversion of a given <see cref="TimeSpan"/> to a <see cref="JsonNode"/>.
+        /// </summary>
+        /// <param name="value">A <see cref="TimeSpan"/> to implicitly convert.</param>
+        public static implicit operator JsonNode?(TimeSpan? value) => JsonValue.Create(value);
+
+        /// <summary>
         ///   Defines an implicit conversion of a given <see cref="decimal"/> to a <see cref="JsonNode"/>.
         /// </summary>
         /// <param name="value">A <see cref="decimal"/> to implicitly convert.</param>
@@ -270,6 +282,18 @@ namespace System.Text.Json.Nodes
         /// </summary>
         /// <param name="value">A <see cref="DateTimeOffset"/> to implicitly convert.</param>
         public static explicit operator DateTimeOffset?(JsonNode? value) => value?.GetValue<DateTimeOffset>();
+
+        /// <summary>
+        ///   Defines an explicit conversion of a given <see cref="TimeSpan"/> to a <see cref="JsonNode"/>.
+        /// </summary>
+        /// <param name="value">A <see cref="TimeSpan"/> to implicitly convert.</param>
+        public static explicit operator TimeSpan(JsonNode value) => value.GetValue<TimeSpan>();
+
+        /// <summary>
+        ///   Defines an explicit conversion of a given <see cref="TimeSpan"/> to a <see cref="JsonNode"/>.
+        /// </summary>
+        /// <param name="value">A <see cref="TimeSpan"/> to implicitly convert.</param>
+        public static explicit operator TimeSpan?(JsonNode? value) => value?.GetValue<TimeSpan>();
 
         /// <summary>
         ///   Defines an explicit conversion of a given <see cref="decimal"/> to a <see cref="JsonNode"/>.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.CreateOverloads.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.CreateOverloads.cs
@@ -93,6 +93,22 @@ namespace System.Text.Json.Nodes
         /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
         /// <param name="options">Options to control the behavior.</param>
         /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
+        public static JsonValue Create(TimeSpan value, JsonNodeOptions? options = null) => new JsonValueTrimmable<TimeSpan>(value, JsonMetadataServices.TimeSpanConverter);
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
+        /// </summary>
+        /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
+        /// <param name="options">Options to control the behavior.</param>
+        /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
+        public static JsonValue? Create(TimeSpan? value, JsonNodeOptions? options = null) => value.HasValue ? new JsonValueTrimmable<TimeSpan>(value.Value, JsonMetadataServices.TimeSpanConverter) : null;
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="JsonValue"/> class that contains the specified value.
+        /// </summary>
+        /// <param name="value">The underlying value of the new <see cref="JsonValue"/> instance.</param>
+        /// <param name="options">Options to control the behavior.</param>
+        /// <returns>The new instance of the <see cref="JsonValue"/> class that contains the specified value.</returns>
         public static JsonValue Create(decimal value, JsonNodeOptions? options = null) => new JsonValueTrimmable<decimal>(value, JsonMetadataServices.DecimalConverter);
 
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfT.cs
@@ -152,6 +152,11 @@ namespace System.Text.Json.Nodes
                         return (TypeToConvert)(object)element.GetDateTimeOffset();
                     }
 
+                    if (typeof(TypeToConvert) == typeof(TimeSpan) || typeof(TypeToConvert) == typeof(TimeSpan?))
+                    {
+                        return (TypeToConvert)(object)element.GetTimeSpan();
+                    }
+
                     if (typeof(TypeToConvert) == typeof(Guid) || typeof(TypeToConvert) == typeof(Guid?))
                     {
                         return (TypeToConvert)(object)element.GetGuid();
@@ -288,6 +293,13 @@ namespace System.Text.Json.Nodes
                     if (typeof(TypeToConvert) == typeof(DateTimeOffset) || typeof(TypeToConvert) == typeof(DateTimeOffset?))
                     {
                         success = element.TryGetDateTimeOffset(out DateTimeOffset value);
+                        result = (TypeToConvert)(object)value;
+                        return success;
+                    }
+
+                    if (typeof(TypeToConvert) == typeof(TimeSpan) || typeof(TypeToConvert) == typeof(TimeSpan?))
+                    {
+                        success = element.TryGetTimeSpan(out TimeSpan value);
                         result = (TypeToConvert)(object)value;
                         return success;
                     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/TimeSpanConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/TimeSpanConverter.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Text.Json.Serialization.Converters
+{
+    internal sealed class TimeSpanConverter : JsonConverter<TimeSpan>
+    {
+        public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return reader.GetTimeSpan();
+        }
+
+        public override void Write(Utf8JsonWriter writer, TimeSpan value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value);
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -49,7 +49,7 @@ namespace System.Text.Json
 
         private static Dictionary<Type, JsonConverter> GetDefaultSimpleConverters()
         {
-            const int NumberOfSimpleConverters = 23;
+            const int NumberOfSimpleConverters = 24;
             var converters = new Dictionary<Type, JsonConverter>(NumberOfSimpleConverters);
 
             // Use a dictionary for simple converters.
@@ -72,6 +72,7 @@ namespace System.Text.Json
             Add(JsonMetadataServices.SByteConverter);
             Add(JsonMetadataServices.SingleConverter);
             Add(JsonMetadataServices.StringConverter);
+            Add(JsonMetadataServices.TimeSpanConverter);
             Add(JsonMetadataServices.UInt16Converter);
             Add(JsonMetadataServices.UInt32Converter);
             Add(JsonMetadataServices.UInt64Converter);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Converters.cs
@@ -111,6 +111,12 @@ namespace System.Text.Json.Serialization.Metadata
         private static JsonConverter<string>? s_stringConverter;
 
         /// <summary>
+        /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="TimeSpan"/> values.
+        /// </summary>
+        public static JsonConverter<TimeSpan> TimeSpanConverter => s_timeSpanConverter ??= new TimeSpanConverter();
+        private static JsonConverter<TimeSpan>? s_timeSpanConverter;
+
+        /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="ushort"/> values.
         /// </summary>
         [CLSCompliant(false)]

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
@@ -636,6 +636,9 @@ namespace System.Text.Json
                 case DataType.DateTimeOffset:
                     message = SR.FormatDateTimeOffset;
                     break;
+                case DataType.TimeSpan:
+                    message = SR.FormatTimeSpan;
+                    break;
                 case DataType.Base64String:
                     message = SR.CannotDecodeInvalidBase64;
                     break;
@@ -723,6 +726,7 @@ namespace System.Text.Json
         Boolean,
         DateTime,
         DateTimeOffset,
+        TimeSpan,
         Base64String,
         Guid,
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.TimeSpan.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.TimeSpan.cs
@@ -1,0 +1,388 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.Buffers.Text;
+using System.Diagnostics;
+
+namespace System.Text.Json
+{
+    public sealed partial class Utf8JsonWriter
+    {
+        /// <summary>
+        /// Writes the pre-encoded property name and <see cref="TimeSpan"/> value (as a JSON string) as part of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="propertyName">The JSON-encoded name of the property to write.</param>
+        /// <param name="value">The value to write.</param>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this would result in invalid JSON being written (while validation is enabled).
+        /// </exception>
+        /// <remarks>
+        /// Writes the <see cref="TimeSpan"/> using the constant ('c') <see cref="StandardFormat"/> , for example: 10:02:35.
+        /// The property name should already be escaped when the instance of <see cref="JsonEncodedText"/> was created.
+        /// </remarks>
+        public void WriteString(JsonEncodedText propertyName, TimeSpan value)
+        {
+            ReadOnlySpan<byte> utf8PropertyName = propertyName.EncodedUtf8Bytes;
+            Debug.Assert(utf8PropertyName.Length <= JsonConstants.MaxUnescapedTokenSize);
+
+            WriteStringByOptions(utf8PropertyName, value);
+
+            SetFlagToAddListSeparatorBeforeNextItem();
+            _tokenType = JsonTokenType.String;
+        }
+
+        /// <summary>
+        /// Writes the property name and <see cref="TimeSpan"/> value (as a JSON string) as part of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="propertyName">The name of the property to write.</param>
+        /// <param name="value">The value to write.</param>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the specified property name is too large.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref name="propertyName"/> parameter is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this would result in invalid JSON being written (while validation is enabled).
+        /// </exception>
+        /// <remarks>
+        /// Writes the <see cref="TimeSpan"/> using the constant ('c') <see cref="StandardFormat"/> , for example: 10:02:35.
+        /// The property name is escaped before writing.
+        /// </remarks>
+        public void WriteString(string propertyName, TimeSpan value)
+            => WriteString((propertyName ?? throw new ArgumentNullException(nameof(propertyName))).AsSpan(), value);
+
+        /// <summary>
+        /// Writes the property name and <see cref="TimeSpan"/> value (as a JSON string) as part of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="propertyName">The name of the property to write.</param>
+        /// <param name="value">The value to write.</param>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the specified property name is too large.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this would result in invalid JSON being written (while validation is enabled).
+        /// </exception>
+        /// <remarks>
+        /// Writes the <see cref="TimeSpan"/> using the constant ('c') <see cref="StandardFormat"/> , for example: 10:02:35.
+        /// The property name is escaped before writing.
+        /// </remarks>
+        public void WriteString(ReadOnlySpan<char> propertyName, TimeSpan value)
+        {
+            JsonWriterHelper.ValidateProperty(propertyName);
+
+            WriteStringEscape(propertyName, value);
+
+            SetFlagToAddListSeparatorBeforeNextItem();
+            _tokenType = JsonTokenType.String;
+        }
+
+        /// <summary>
+        /// Writes the property name and <see cref="TimeSpan"/> value (as a JSON string) as part of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="utf8PropertyName">The UTF-8 encoded name of the property to write.</param>
+        /// <param name="value">The value to write.</param>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the specified property name is too large.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this would result in invalid JSON being written (while validation is enabled).
+        /// </exception>
+        /// <remarks>
+        /// Writes the <see cref="TimeSpan"/> using the constant ('c') <see cref="StandardFormat"/> , for example: 10:02:35.
+        /// The property name is escaped before writing.
+        /// </remarks>
+        public void WriteString(ReadOnlySpan<byte> utf8PropertyName, TimeSpan value)
+        {
+            JsonWriterHelper.ValidateProperty(utf8PropertyName);
+
+            WriteStringEscape(utf8PropertyName, value);
+
+            SetFlagToAddListSeparatorBeforeNextItem();
+            _tokenType = JsonTokenType.String;
+        }
+
+        private void WriteStringEscape(ReadOnlySpan<char> propertyName, TimeSpan value)
+        {
+            int propertyIdx = JsonWriterHelper.NeedsEscaping(propertyName, _options.Encoder);
+
+            Debug.Assert(propertyIdx >= -1 && propertyIdx < propertyName.Length);
+
+            if (propertyIdx != -1)
+            {
+                WriteStringEscapeProperty(propertyName, value, propertyIdx);
+            }
+            else
+            {
+                WriteStringByOptions(propertyName, value);
+            }
+        }
+
+        private void WriteStringEscape(ReadOnlySpan<byte> utf8PropertyName, TimeSpan value)
+        {
+            int propertyIdx = JsonWriterHelper.NeedsEscaping(utf8PropertyName, _options.Encoder);
+
+            Debug.Assert(propertyIdx >= -1 && propertyIdx < utf8PropertyName.Length);
+
+            if (propertyIdx != -1)
+            {
+                WriteStringEscapeProperty(utf8PropertyName, value, propertyIdx);
+            }
+            else
+            {
+                WriteStringByOptions(utf8PropertyName, value);
+            }
+        }
+
+        private void WriteStringEscapeProperty(ReadOnlySpan<char> propertyName, TimeSpan value, int firstEscapeIndexProp)
+        {
+            Debug.Assert(int.MaxValue / JsonConstants.MaxExpansionFactorWhileEscaping >= propertyName.Length);
+            Debug.Assert(firstEscapeIndexProp >= 0 && firstEscapeIndexProp < propertyName.Length);
+
+            char[]? propertyArray = null;
+
+            int length = JsonWriterHelper.GetMaxEscapedLength(propertyName.Length, firstEscapeIndexProp);
+
+            Span<char> escapedPropertyName = length <= JsonConstants.StackallocThreshold ?
+                stackalloc char[length] :
+                (propertyArray = ArrayPool<char>.Shared.Rent(length));
+
+            JsonWriterHelper.EscapeString(propertyName, escapedPropertyName, firstEscapeIndexProp, _options.Encoder, out int written);
+
+            WriteStringByOptions(escapedPropertyName.Slice(0, written), value);
+
+            if (propertyArray != null)
+            {
+                ArrayPool<char>.Shared.Return(propertyArray);
+            }
+        }
+
+        private void WriteStringEscapeProperty(ReadOnlySpan<byte> utf8PropertyName, TimeSpan value, int firstEscapeIndexProp)
+        {
+            Debug.Assert(int.MaxValue / JsonConstants.MaxExpansionFactorWhileEscaping >= utf8PropertyName.Length);
+            Debug.Assert(firstEscapeIndexProp >= 0 && firstEscapeIndexProp < utf8PropertyName.Length);
+
+            byte[]? propertyArray = null;
+
+            int length = JsonWriterHelper.GetMaxEscapedLength(utf8PropertyName.Length, firstEscapeIndexProp);
+
+            Span<byte> escapedPropertyName = length <= JsonConstants.StackallocThreshold ?
+                stackalloc byte[length] :
+                (propertyArray = ArrayPool<byte>.Shared.Rent(length));
+
+            JsonWriterHelper.EscapeString(utf8PropertyName, escapedPropertyName, firstEscapeIndexProp, _options.Encoder, out int written);
+
+            WriteStringByOptions(escapedPropertyName.Slice(0, written), value);
+
+            if (propertyArray != null)
+            {
+                ArrayPool<byte>.Shared.Return(propertyArray);
+            }
+        }
+
+        private void WriteStringByOptions(ReadOnlySpan<char> propertyName, TimeSpan value)
+        {
+            ValidateWritingProperty();
+            if (_options.Indented)
+            {
+                WriteStringIndented(propertyName, value);
+            }
+            else
+            {
+                WriteStringMinimized(propertyName, value);
+            }
+        }
+
+        private void WriteStringByOptions(ReadOnlySpan<byte> utf8PropertyName, TimeSpan value)
+        {
+            ValidateWritingProperty();
+            if (_options.Indented)
+            {
+                WriteStringIndented(utf8PropertyName, value);
+            }
+            else
+            {
+                WriteStringMinimized(utf8PropertyName, value);
+            }
+        }
+
+        private void WriteStringMinimized(ReadOnlySpan<char> escapedPropertyName, TimeSpan value)
+        {
+            Debug.Assert(escapedPropertyName.Length < (int.MaxValue / JsonConstants.MaxExpansionFactorWhileTranscoding) - JsonConstants.MaximumTimeSpanParseLength - 6);
+
+            // All ASCII, 2 quotes for property name, 2 quotes for timespan, and 1 colon => escapedPropertyName.Length + JsonConstants.MaximumTimeSpanParseLength + 5
+            // Optionally, 1 list separator, and up to 3x growth when transcoding
+            int maxRequired = (escapedPropertyName.Length * JsonConstants.MaxExpansionFactorWhileTranscoding) + JsonConstants.MaximumTimeSpanParseLength + 6;
+
+            if (_memory.Length - BytesPending < maxRequired)
+            {
+                Grow(maxRequired);
+            }
+
+            Span<byte> output = _memory.Span;
+
+            if (_currentDepth < 0)
+            {
+                output[BytesPending++] = JsonConstants.ListSeparator;
+            }
+            output[BytesPending++] = JsonConstants.Quote;
+
+            TranscodeAndWrite(escapedPropertyName, output);
+
+            output[BytesPending++] = JsonConstants.Quote;
+            output[BytesPending++] = JsonConstants.KeyValueSeperator;
+
+            output[BytesPending++] = JsonConstants.Quote;
+
+            bool result = Utf8Formatter.TryFormat(value, output.Slice(BytesPending), out int bytesWritten, 'c');
+            Debug.Assert(result);
+            BytesPending += bytesWritten;
+
+            output[BytesPending++] = JsonConstants.Quote;
+        }
+
+        private void WriteStringMinimized(ReadOnlySpan<byte> escapedPropertyName, TimeSpan value)
+        {
+            Debug.Assert(escapedPropertyName.Length < int.MaxValue - JsonConstants.MaximumTimeSpanParseLength - 6);
+
+            int minRequired = escapedPropertyName.Length + JsonConstants.MaximumTimeSpanParseLength + 5; // 2 quotes for property name, 2 quotes for timespan, and 1 colon
+            int maxRequired = minRequired + 1; // Optionally, 1 list separator
+
+            if (_memory.Length - BytesPending < maxRequired)
+            {
+                Grow(maxRequired);
+            }
+
+            Span<byte> output = _memory.Span;
+
+            if (_currentDepth < 0)
+            {
+                output[BytesPending++] = JsonConstants.ListSeparator;
+            }
+            output[BytesPending++] = JsonConstants.Quote;
+
+            escapedPropertyName.CopyTo(output.Slice(BytesPending));
+            BytesPending += escapedPropertyName.Length;
+
+            output[BytesPending++] = JsonConstants.Quote;
+            output[BytesPending++] = JsonConstants.KeyValueSeperator;
+
+            output[BytesPending++] = JsonConstants.Quote;
+
+            bool result = Utf8Formatter.TryFormat(value, output.Slice(BytesPending), out int bytesWritten, 'c');
+            Debug.Assert(result);
+            BytesPending += bytesWritten;
+
+            output[BytesPending++] = JsonConstants.Quote;
+        }
+
+        private void WriteStringIndented(ReadOnlySpan<char> escapedPropertyName, TimeSpan value)
+        {
+            int indent = Indentation;
+            Debug.Assert(indent <= 2 * JsonConstants.MaxWriterDepth);
+
+            Debug.Assert(escapedPropertyName.Length < (int.MaxValue / JsonConstants.MaxExpansionFactorWhileTranscoding) - indent - JsonConstants.MaximumTimeSpanParseLength - 7 - s_newLineLength);
+
+            // All ASCII, 2 quotes for property name, 2 quotes for timespan, 1 colon, and 1 space => escapedPropertyName.Length + JsonConstants.MaximumTimeSpanParseLength + 6
+            // Optionally, 1 list separator, 1-2 bytes for new line, and up to 3x growth when transcoding
+            int maxRequired = indent + (escapedPropertyName.Length * JsonConstants.MaxExpansionFactorWhileTranscoding) + JsonConstants.MaximumTimeSpanParseLength + 7 + s_newLineLength;
+
+            if (_memory.Length - BytesPending < maxRequired)
+            {
+                Grow(maxRequired);
+            }
+
+            Span<byte> output = _memory.Span;
+
+            if (_currentDepth < 0)
+            {
+                output[BytesPending++] = JsonConstants.ListSeparator;
+            }
+
+            Debug.Assert(_options.SkipValidation || _tokenType != JsonTokenType.PropertyName);
+
+            if (_tokenType != JsonTokenType.None)
+            {
+                WriteNewLine(output);
+            }
+
+            JsonWriterHelper.WriteIndentation(output.Slice(BytesPending), indent);
+            BytesPending += indent;
+
+            output[BytesPending++] = JsonConstants.Quote;
+
+            TranscodeAndWrite(escapedPropertyName, output);
+
+            output[BytesPending++] = JsonConstants.Quote;
+            output[BytesPending++] = JsonConstants.KeyValueSeperator;
+            output[BytesPending++] = JsonConstants.Space;
+
+            output[BytesPending++] = JsonConstants.Quote;
+
+            bool result = Utf8Formatter.TryFormat(value, output.Slice(BytesPending), out int bytesWritten, 'c');
+            Debug.Assert(result);
+            BytesPending += bytesWritten;
+
+            output[BytesPending++] = JsonConstants.Quote;
+        }
+
+        private void WriteStringIndented(ReadOnlySpan<byte> escapedPropertyName, TimeSpan value)
+        {
+            int indent = Indentation;
+            Debug.Assert(indent <= 2 * JsonConstants.MaxWriterDepth);
+
+            Debug.Assert(escapedPropertyName.Length < int.MaxValue - indent - JsonConstants.MaximumTimeSpanParseLength - 7 - s_newLineLength);
+
+            int minRequired = indent + escapedPropertyName.Length + JsonConstants.MaximumTimeSpanParseLength + 6; // 2 quotes for property name, 2 quotes for timespan, 1 colon, and 1 space
+            int maxRequired = minRequired + 1 + s_newLineLength; // Optionally, 1 list separator and 1-2 bytes for new line
+
+            if (_memory.Length - BytesPending < maxRequired)
+            {
+                Grow(maxRequired);
+            }
+
+            Span<byte> output = _memory.Span;
+
+            if (_currentDepth < 0)
+            {
+                output[BytesPending++] = JsonConstants.ListSeparator;
+            }
+
+            Debug.Assert(_options.SkipValidation || _tokenType != JsonTokenType.PropertyName);
+
+            if (_tokenType != JsonTokenType.None)
+            {
+                WriteNewLine(output);
+            }
+
+            JsonWriterHelper.WriteIndentation(output.Slice(BytesPending), indent);
+            BytesPending += indent;
+
+            output[BytesPending++] = JsonConstants.Quote;
+
+            escapedPropertyName.CopyTo(output.Slice(BytesPending));
+            BytesPending += escapedPropertyName.Length;
+
+            output[BytesPending++] = JsonConstants.Quote;
+            output[BytesPending++] = JsonConstants.KeyValueSeperator;
+            output[BytesPending++] = JsonConstants.Space;
+
+            output[BytesPending++] = JsonConstants.Quote;
+
+            bool result = Utf8Formatter.TryFormat(value, output.Slice(BytesPending), out int bytesWritten, 'c');
+            Debug.Assert(result);
+            BytesPending += bytesWritten;
+
+            output[BytesPending++] = JsonConstants.Quote;
+        }
+
+        internal void WritePropertyName(TimeSpan value)
+        {
+            Span<byte> buffer = stackalloc byte[JsonConstants.MaximumTimeSpanParseLength];
+            bool result = Utf8Formatter.TryFormat(value, buffer, out int bytesWritten, 'c');
+            Debug.Assert(result);
+            WritePropertyNameUnescaped(buffer.Slice(0, bytesWritten));
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.TimeSpan.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.TimeSpan.cs
@@ -1,0 +1,106 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.Buffers.Text;
+using System.Diagnostics;
+
+namespace System.Text.Json
+{
+    public sealed partial class Utf8JsonWriter
+    {
+        /// <summary>
+        /// Writes the <see cref="TimeSpan"/> value (as a JSON string) as an element of a JSON array.
+        /// </summary>
+        /// <param name="value">The value to write.</param>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this would result in invalid JSON being written (while validation is enabled).
+        /// </exception>
+        /// <remarks>
+        /// Writes the <see cref="TimeSpan"/> using the constant ('c') <see cref="StandardFormat"/> , for example: 10:02:35.
+        /// </remarks>
+        public void WriteStringValue(TimeSpan value)
+        {
+            if (!_options.SkipValidation)
+            {
+                ValidateWritingValue();
+            }
+
+            if (_options.Indented)
+            {
+                WriteStringValueIndented(value);
+            }
+            else
+            {
+                WriteStringValueMinimized(value);
+            }
+
+            SetFlagToAddListSeparatorBeforeNextItem();
+            _tokenType = JsonTokenType.String;
+        }
+
+        private void WriteStringValueMinimized(TimeSpan value)
+        {
+            int maxRequired = JsonConstants.MaximumTimeSpanParseLength + 3; // 2 quotes, and optionally, 1 list separator
+
+            if (_memory.Length - BytesPending < maxRequired)
+            {
+                Grow(maxRequired);
+            }
+
+            Span<byte> output = _memory.Span;
+
+            if (_currentDepth < 0)
+            {
+                output[BytesPending++] = JsonConstants.ListSeparator;
+            }
+
+            output[BytesPending++] = JsonConstants.Quote;
+
+            bool result = Utf8Formatter.TryFormat(value, output.Slice(BytesPending), out int bytesWritten, 'c');
+            Debug.Assert(result);
+            BytesPending += bytesWritten;
+
+            output[BytesPending++] = JsonConstants.Quote;
+        }
+
+        private void WriteStringValueIndented(TimeSpan value)
+        {
+            int indent = Indentation;
+            Debug.Assert(indent <= 2 * JsonConstants.MaxWriterDepth);
+
+            // 2 quotes, and optionally, 1 list separator and 1-2 bytes for new line
+            int maxRequired = indent + JsonConstants.MaximumTimeSpanParseLength + 3 + s_newLineLength;
+
+            if (_memory.Length - BytesPending < maxRequired)
+            {
+                Grow(maxRequired);
+            }
+
+            Span<byte> output = _memory.Span;
+
+            if (_currentDepth < 0)
+            {
+                output[BytesPending++] = JsonConstants.ListSeparator;
+            }
+
+            if (_tokenType != JsonTokenType.PropertyName)
+            {
+                if (_tokenType != JsonTokenType.None)
+                {
+                    WriteNewLine(output);
+                }
+                JsonWriterHelper.WriteIndentation(output.Slice(BytesPending), indent);
+                BytesPending += indent;
+            }
+
+            output[BytesPending++] = JsonConstants.Quote;
+
+            bool result = Utf8Formatter.TryFormat(value, output.Slice(BytesPending), out int bytesWritten, 'c');
+            Debug.Assert(result);
+            BytesPending += bytesWritten;
+
+            output[BytesPending++] = JsonConstants.Quote;
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonDocumentTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonDocumentTests.cs
@@ -1433,6 +1433,36 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
+        [InlineData("11:18:00", true)]
+        [InlineData("11:18", false)]
+        public static void ReadTimeSpan(string testString, bool expectedValid)
+        {
+            byte[] dataUtf8 = Encoding.UTF8.GetBytes($"\"{testString}\"");
+
+            using (JsonDocument doc = JsonDocument.Parse(dataUtf8, default))
+            {
+                JsonElement root = doc.RootElement;
+
+                TimeSpan expectedTimeSpan = TimeSpan.Parse(testString);
+
+                Assert.Equal(JsonValueKind.String, root.ValueKind);
+
+                bool result = root.TryGetTimeSpan(out TimeSpan TimeSpanVal);
+                Assert.Equal(expectedValid, result);
+                Assert.Equal(expectedValid ? expectedTimeSpan : default, TimeSpanVal);
+
+                if (expectedValid)
+                {
+                    Assert.Equal(expectedTimeSpan, root.GetTimeSpan());
+                }
+                else
+                {
+                    Assert.Throws<FormatException>(() => root.GetTimeSpan());
+                }
+            }
+        }
+
+        [Theory]
         [MemberData(nameof(JsonGuidTestData.ValidGuidTests), MemberType = typeof(JsonGuidTestData))]
         [MemberData(nameof(JsonGuidTestData.ValidHexGuidTests), MemberType = typeof(JsonGuidTestData))]
         public static void ReadGuid(string jsonString, string expectedStr)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonNodeOperatorTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonNodeOperatorTests.cs
@@ -26,7 +26,8 @@ namespace System.Text.Json.Nodes.Tests
                 @"""MyDecimal"":3.3," +
                 @"""MyDateTime"":""2019-01-30T12:01:02Z""," +
                 @"""MyDateTimeOffset"":""2019-01-30T12:01:02+01:00""," +
-                @"""MyGuid"":""1b33498a-7b7d-4dda-9c13-f6aa4ab449a6""" + // note lowercase
+                @"""MyGuid"":""1b33498a-7b7d-4dda-9c13-f6aa4ab449a6""," + // note lowercase
+                @"""MyTimeSpan"":""23:59:59.9999999""" +
                 @"}";
 
         [Fact]
@@ -51,6 +52,7 @@ namespace System.Text.Json.Nodes.Tests
             jObject["MyDateTime"] = new DateTime(2019, 1, 30, 12, 1, 2, DateTimeKind.Utc);
             jObject["MyDateTimeOffset"] = new DateTimeOffset(2019, 1, 30, 12, 1, 2, new TimeSpan(1, 0, 0));
             jObject["MyGuid"] = new Guid("1B33498A-7B7D-4DDA-9C13-F6AA4AB449A6");
+            jObject["MyTimeSpan"] = TimeSpan.Parse("23:59:59.9999999");
 
             string expected = ExpectedPrimitiveJson;
 
@@ -84,6 +86,7 @@ namespace System.Text.Json.Nodes.Tests
             Assert.Equal(new DateTime(2019, 1, 30, 12, 1, 2, DateTimeKind.Utc), (DateTime)jObject["MyDateTime"]);
             Assert.Equal(new DateTimeOffset(2019, 1, 30, 12, 1, 2, new TimeSpan(1, 0, 0)), (DateTimeOffset)jObject["MyDateTimeOffset"]);
             Assert.Equal(new Guid("1B33498A-7B7D-4DDA-9C13-F6AA4AB449A6"), (Guid)jObject["MyGuid"]);
+            Assert.Equal(TimeSpan.Parse("23:59:59.9999999"), (TimeSpan)jObject["MyTimeSpan"]);
         }
 
         [Fact]
@@ -110,6 +113,8 @@ namespace System.Text.Json.Nodes.Tests
                 (DateTimeOffset)(JsonNode)new DateTimeOffset(2019, 1, 30, 12, 1, 2, new TimeSpan(1, 0, 0)));
             Assert.Equal(new Guid("1B33498A-7B7D-4DDA-9C13-F6AA4AB449A6"),
                 (Guid)(JsonNode)new Guid("1B33498A-7B7D-4DDA-9C13-F6AA4AB449A6"));
+            Assert.Equal(TimeSpan.Parse("23:59:59.9999999"),
+                (TimeSpan)(JsonNode)TimeSpan.Parse("23:59:59.9999999"));
         }
 
         [Fact]
@@ -132,6 +137,7 @@ namespace System.Text.Json.Nodes.Tests
             Assert.Null((DateTime?)(JsonValue)null);
             Assert.Null((DateTimeOffset?)(JsonValue)null);
             Assert.Null((Guid?)(JsonValue)null);
+            Assert.Null((TimeSpan?)(JsonValue)null);
         }
 
         [Fact]
@@ -154,6 +160,7 @@ namespace System.Text.Json.Nodes.Tests
             Assert.NotNull((DateTime?)(JsonValue)new DateTime(2019, 1, 30, 12, 1, 2, DateTimeKind.Utc));
             Assert.NotNull((DateTimeOffset?)(JsonValue)new DateTimeOffset(2019, 1, 30, 12, 1, 2, new TimeSpan(1, 0, 0)));
             Assert.NotNull((Guid?)(JsonValue)new Guid("1B33498A-7B7D-4DDA-9C13-F6AA4AB449A6"));
+            Assert.NotNull((TimeSpan?)(JsonValue)TimeSpan.Parse("23:59:59.9999999"));
         }
 
         [Fact]
@@ -176,6 +183,7 @@ namespace System.Text.Json.Nodes.Tests
             Assert.Null((JsonValue?)(DateTime?)null);
             Assert.Null((JsonValue?)(DateTimeOffset?)null);
             Assert.Null((JsonValue?)(Guid?)null);
+            Assert.Null((JsonValue?)(TimeSpan?)null);
         }
 
         [Fact]
@@ -197,6 +205,7 @@ namespace System.Text.Json.Nodes.Tests
             Assert.NotNull((JsonValue?)(DateTime?)new DateTime(2019, 1, 30, 12, 1, 2, DateTimeKind.Utc));
             Assert.NotNull((JsonValue?)(DateTimeOffset?)new DateTimeOffset(2019, 1, 30, 12, 1, 2, new TimeSpan(1, 0, 0)));
             Assert.NotNull((JsonValue?)(Guid?)new Guid("1B33498A-7B7D-4DDA-9C13-F6AA4AB449A6"));
+            Assert.NotNull((JsonValue?)(TimeSpan?)TimeSpan.Parse("23:59:59.9999999"));
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonValueTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonValueTests.cs
@@ -124,6 +124,7 @@ namespace System.Text.Json.Nodes.Tests
             Assert.False(jValue.TryGetValue(out DateTime _));
             Assert.False(jValue.TryGetValue(out DateTimeOffset _));
             Assert.False(jValue.TryGetValue(out Guid _));
+            Assert.False(jValue.TryGetValue(out TimeSpan _));
         }
 
         [Fact]
@@ -148,6 +149,7 @@ namespace System.Text.Json.Nodes.Tests
             Assert.False(jValue.TryGetValue(out DateTime _));
             Assert.False(jValue.TryGetValue(out DateTimeOffset _));
             Assert.False(jValue.TryGetValue(out Guid _));
+            Assert.False(jValue.TryGetValue(out TimeSpan _));
         }
 
         [Fact]
@@ -172,6 +174,7 @@ namespace System.Text.Json.Nodes.Tests
             Assert.False(jValue.TryGetValue(out bool _));
             Assert.False(jValue.TryGetValue(out DateTime _));
             Assert.False(jValue.TryGetValue(out DateTimeOffset _));
+            Assert.False(jValue.TryGetValue(out TimeSpan _));
         }
 
         [Theory]
@@ -198,6 +201,7 @@ namespace System.Text.Json.Nodes.Tests
             Assert.False(jValue.TryGetValue(out decimal _));
             Assert.False(jValue.TryGetValue(out bool _));
             Assert.False(jValue.TryGetValue(out Guid _));
+            Assert.False(jValue.TryGetValue(out TimeSpan _));
         }
 
         [Fact]
@@ -219,6 +223,32 @@ namespace System.Text.Json.Nodes.Tests
             Assert.False(jValue.TryGetValue(out decimal _));
             Assert.False(jValue.TryGetValue(out string _));
             Assert.False(jValue.TryGetValue(out char _));
+            Assert.False(jValue.TryGetValue(out DateTime _));
+            Assert.False(jValue.TryGetValue(out DateTimeOffset _));
+            Assert.False(jValue.TryGetValue(out Guid _));
+            Assert.False(jValue.TryGetValue(out TimeSpan _));
+        }
+
+        [Fact]
+        public static void TryGetValue_FromTimeSpan()
+        {
+            JsonValue jValue = JsonNode.Parse("\"1:18:00.1\"").AsValue();
+
+            Assert.True(jValue.TryGetValue(out TimeSpan _));
+            Assert.True(jValue.TryGetValue(out string _));
+            Assert.False(jValue.TryGetValue(out char _));
+            Assert.False(jValue.TryGetValue(out byte _));
+            Assert.False(jValue.TryGetValue(out short _));
+            Assert.False(jValue.TryGetValue(out int _));
+            Assert.False(jValue.TryGetValue(out long _));
+            Assert.False(jValue.TryGetValue(out sbyte _));
+            Assert.False(jValue.TryGetValue(out ushort _));
+            Assert.False(jValue.TryGetValue(out uint _));
+            Assert.False(jValue.TryGetValue(out ulong _));
+            Assert.False(jValue.TryGetValue(out float _));
+            Assert.False(jValue.TryGetValue(out double _));
+            Assert.False(jValue.TryGetValue(out decimal _));
+            Assert.False(jValue.TryGetValue(out bool _));
             Assert.False(jValue.TryGetValue(out DateTime _));
             Assert.False(jValue.TryGetValue(out DateTimeOffset _));
             Assert.False(jValue.TryGetValue(out Guid _));

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/ParseTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/ParseTests.cs
@@ -49,6 +49,13 @@ namespace System.Text.Json.Nodes.Tests
             Assert.Equal(2, dtOffset.Minute);
             Assert.Equal(3, dtOffset.Second);
             Assert.Equal(new TimeSpan(1,15,0), dtOffset.Offset);
+
+            TimeSpan ts = JsonNode.Parse("\"10.12:18:00\"").GetValue<TimeSpan>();
+            Assert.Equal(10, ts.Days);
+            Assert.Equal(12, ts.Hours);
+            Assert.Equal(18, ts.Minutes);
+            Assert.Equal(0, ts.Seconds);
+            Assert.Equal(new TimeSpan(10, 12, 18, 0), ts);
         }
 
         [Fact]
@@ -102,11 +109,13 @@ namespace System.Text.Json.Nodes.Tests
             Assert.True(JsonNode.Parse("\"2020-07-08T00:00:00\"").AsValue().TryGetValue(out DateTime? _));
             Assert.True(JsonNode.Parse("\"ed957609-cdfe-412f-88c1-02daca1b4f51\"").AsValue().TryGetValue(out Guid? _));
             Assert.True(JsonNode.Parse("\"2020-07-08T01:02:03+01:15\"").AsValue().TryGetValue(out DateTimeOffset? _));
+            Assert.True(JsonNode.Parse("\"-100.23:59:59\"").AsValue().TryGetValue(out TimeSpan? _));
 
             JsonValue? jValue = JsonNode.Parse("\"Hello!\"").AsValue();
             Assert.False(jValue.TryGetValue(out int _));
             Assert.False(jValue.TryGetValue(out DateTime _));
             Assert.False(jValue.TryGetValue(out DateTimeOffset _));
+            Assert.False(jValue.TryGetValue(out TimeSpan _));
             Assert.False(jValue.TryGetValue(out Guid _));
         }
 


### PR DESCRIPTION
Fixes #29932

## Description

Adds `TimeSpan` support to System.Text.Json (Utf8JsonReader, Utf8JsonWriter, JsonElement, JsonSerializer, & JsonNode/JsonValue).

Uses [Utf8Parser.TryParse](https://docs.microsoft.com/en-us/dotnet/api/system.buffers.text.utf8parser.tryparse?view=net-5.0#System_Buffers_Text_Utf8Parser_TryParse_System_ReadOnlySpan_System_Byte__System_TimeSpan__System_Int32__System_Char_) & [Utf8Formatter.TryFormat](https://docs.microsoft.com/en-us/dotnet/api/system.buffers.text.utf8formatter.tryformat?view=net-5.0#System_Buffers_Text_Utf8Formatter_TryFormat_System_TimeSpan_System_Span_System_Byte__System_Int32__System_Buffers_StandardFormat_) for the heavy lifting.

## Public API Changes

```csharp
    public readonly partial struct JsonElement
    {
       public System.TimeSpan GetTimeSpan() { throw null; }
       public bool TryGetTimeSpan(out System.TimeSpan value) { throw null; }
    }

    public ref partial struct Utf8JsonReader
    {
       public System.TimeSpan GetTimeSpan() { throw null; }
       public bool TryGetTimeSpan(out System.TimeSpan value) { throw null; }
    }

    public sealed partial class Utf8JsonWriter
    {
       public void WriteString(System.ReadOnlySpan<byte> utf8PropertyName, System.TimeSpan value) { }
       public void WriteString(System.ReadOnlySpan<char> propertyName, System.TimeSpan value) { }
       public void WriteString(string propertyName, System.TimeSpan value) { }
       public void WriteString(System.Text.Json.JsonEncodedText propertyName, System.TimeSpan value) { }
       public void WriteStringValue(System.TimeSpan value) { }
    }

    public abstract partial class JsonNode
    {
       public static explicit operator System.TimeSpan (System.Text.Json.Nodes.JsonNode value) { throw null; }
       public static explicit operator System.TimeSpan? (System.Text.Json.Nodes.JsonNode? value) { throw null; }
       public static implicit operator System.Text.Json.Nodes.JsonNode (System.TimeSpan value) { throw null; }
       public static implicit operator System.Text.Json.Nodes.JsonNode? (System.TimeSpan? value) { throw null; }
    }

    public abstract partial class JsonValue
    {
       public static System.Text.Json.Nodes.JsonValue Create(System.TimeSpan value, System.Text.Json.Nodes.JsonNodeOptions? options = default(System.Text.Json.Nodes.JsonNodeOptions?)) { throw null; }
       public static System.Text.Json.Nodes.JsonValue? Create(System.TimeSpan? value, System.Text.Json.Nodes.JsonNodeOptions? options = default(System.Text.Json.Nodes.JsonNodeOptions?)) { throw null; }
    }

    public static partial class JsonMetadataServices
    {
       public static System.Text.Json.Serialization.JsonConverter<System.TimeSpan> TimeSpanConverter { get { throw null; } }
    }
```

## Considerations

This is using the constant ("c") format. I think the general short format ("g") could compact things a bit, but not sure if that would round-trip with Newtonsoft and it is culture-sensitive.

/cc @layomia @eiriktsarpalis @JamesNK 