### PR TITLE
Spanify a bit of header parsing code

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AltSvcHeaderParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AltSvcHeaderParser.cs
@@ -413,7 +413,7 @@ namespace System.Net.Http.Headers
                 int tokenLength = HttpRuleParser.GetTokenLength(value, startIndex);
 
                 readLength = tokenLength;
-                return HeaderUtilities.TryParseInt32(value, startIndex, tokenLength, out result);
+                return HeaderUtilities.TryParseInt32(value.AsSpan(startIndex, tokenLength), out result);
             }
 
             if (HttpRuleParser.GetQuotedStringLength(value, startIndex, out int quotedLength) == HttpParseResult.Parsed)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/CacheControlHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/CacheControlHeaderValue.cs
@@ -587,20 +587,13 @@ namespace System.Net.Http.Headers
         {
             Debug.Assert(nameValue != null);
 
-            if (nameValue.Value == null)
+            if (HeaderUtilities.TryParseInt32(nameValue.Value, out int seconds))
             {
-                return false;
+                timeSpan = new TimeSpan(0, 0, seconds);
+                return true;
             }
 
-            int seconds;
-            if (!HeaderUtilities.TryParseInt32(nameValue.Value, out seconds))
-            {
-                return false;
-            }
-
-            timeSpan = new TimeSpan(0, 0, seconds);
-
-            return true;
+            return false;
         }
 
         private static void AppendValueIfRequired(StringBuilder sb, bool appendValue, string value)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/ContentRangeHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/ContentRangeHeaderValue.cs
@@ -363,13 +363,13 @@ namespace System.Net.Http.Headers
             parsedValue = null;
 
             long from = 0;
-            if ((fromLength > 0) && !HeaderUtilities.TryParseInt64(input, fromStartIndex, fromLength, out from))
+            if ((fromLength > 0) && !HeaderUtilities.TryParseInt64(input.AsSpan(fromStartIndex, fromLength), out from))
             {
                 return false;
             }
 
             long to = 0;
-            if ((toLength > 0) && !HeaderUtilities.TryParseInt64(input, toStartIndex, toLength, out to))
+            if ((toLength > 0) && !HeaderUtilities.TryParseInt64(input.AsSpan(toStartIndex, toLength), out to))
             {
                 return false;
             }
@@ -381,7 +381,7 @@ namespace System.Net.Http.Headers
             }
 
             long length = 0;
-            if ((lengthLength > 0) && !HeaderUtilities.TryParseInt64(input, lengthStartIndex, lengthLength, out length))
+            if ((lengthLength > 0) && !HeaderUtilities.TryParseInt64(input.AsSpan(lengthStartIndex, lengthLength), out length))
             {
                 return false;
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderUtilities.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderUtilities.cs
@@ -317,30 +317,11 @@ namespace System.Net.Http.Headers
             return null;
         }
 
-        internal static bool TryParseInt32(string value, out int result) =>
-            int.TryParse(value, NumberStyles.None, provider: null, out result);
+        internal static bool TryParseInt32(ReadOnlySpan<char> value, out int result) =>
+            int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out result);
 
-        internal static bool TryParseInt32(string value, int offset, int length, out int result)
-        {
-            if (offset < 0 || length < 0 || offset > value.Length - length)
-            {
-                result = 0;
-                return false;
-            }
-
-            return int.TryParse(value.AsSpan(offset, length), NumberStyles.None, provider: null, out result);
-        }
-
-        internal static bool TryParseInt64(string value, int offset, int length, out long result)
-        {
-            if (offset < 0 || length < 0 || offset > value.Length - length)
-            {
-                result = 0;
-                return false;
-            }
-
-            return long.TryParse(value.AsSpan(offset, length), NumberStyles.None, provider: null, out result);
-        }
+        internal static bool TryParseInt64(ReadOnlySpan<char> value, out long result) =>
+            long.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out result);
 
         internal static void DumpHeaders(StringBuilder sb, params HttpHeaders?[] headers)
         {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/Int32NumberHeaderParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/Int32NumberHeaderParser.cs
@@ -31,23 +31,15 @@ namespace System.Net.Http.Headers
         protected override int GetParsedValueLength(string value, int startIndex, object? storeValue,
             out object? parsedValue)
         {
+            ReadOnlySpan<char> span = value.AsSpan(startIndex).Trim();
+            if (HeaderUtilities.TryParseInt32(span, out int result))
+            {
+                parsedValue = result;
+                return span.Length;
+            }
+
             parsedValue = null;
-
-            int numberLength = HttpRuleParser.GetNumberLength(value, startIndex, false);
-
-            if ((numberLength == 0) || (numberLength > HttpRuleParser.MaxInt32Digits))
-            {
-                return 0;
-            }
-
-            int result = 0;
-            if (!HeaderUtilities.TryParseInt32(value, startIndex, numberLength, out result))
-            {
-                return 0;
-            }
-
-            parsedValue = result;
-            return numberLength;
+            return 0;
         }
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/Int32NumberHeaderParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/Int32NumberHeaderParser.cs
@@ -2,44 +2,70 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 namespace System.Net.Http.Headers
 {
-    internal sealed class Int32NumberHeaderParser : BaseHeaderParser
+    internal sealed class Int32NumberHeaderParser : HttpHeaderParser
     {
         // Note that we don't need a custom comparer even though we have a value type that gets boxed (comparing two
         // equal boxed value types returns 'false' since the object instances used for boxing the two values are
         // different). The reason is that the comparer is only used by HttpHeaders when comparing values in a collection.
-        // Value types are never used in collections (in fact HttpHeaderValueCollection expects T to be a reference
-        // type).
+        // Value types are never used in collections (in fact HttpHeaderValueCollection expects T to be a reference type).
 
         internal static readonly Int32NumberHeaderParser Parser = new Int32NumberHeaderParser();
 
-        private Int32NumberHeaderParser()
-            : base(false)
+        private Int32NumberHeaderParser() : base(false)
         {
         }
 
         public override string ToString(object value)
         {
             Debug.Assert(value is int);
-
             return ((int)value).ToString(NumberFormatInfo.InvariantInfo);
         }
 
-        protected override int GetParsedValueLength(string value, int startIndex, object? storeValue,
-            out object? parsedValue)
+        public override bool TryParseValue(string? value, object? storeValue, ref int index, [NotNullWhen(true)] out object? parsedValue)
         {
-            ReadOnlySpan<char> span = value.AsSpan(startIndex).Trim();
-            if (HeaderUtilities.TryParseInt32(span, out int result))
+            if (TryParseInt32Value(value, ref index, out int result))
             {
                 parsedValue = result;
-                return span.Length;
+                return true;
             }
 
             parsedValue = null;
-            return 0;
+            return false;
+        }
+
+        internal static bool TryParseInt32Value(string? value, ref int index, out int parsedValue)
+        {
+            ReadOnlySpan<char> span = value.AsSpan(index);
+
+            // Skip past valid starting whitespace
+            int startingWhitespaceLength = HttpRuleParser.GetWhitespaceLength(span);
+            if (startingWhitespaceLength != 0)
+            {
+                span = span.Slice(startingWhitespaceLength);
+            }
+
+            // Parse everything until the ending whitespace
+            ReadOnlySpan<char> spanTrimmed = span.TrimEnd();
+            if (HeaderUtilities.TryParseInt32(spanTrimmed, out int result))
+            {
+                // If there wasn't ending whitespace or it was valid, give back the successfully parsed value.
+                ReadOnlySpan<char> remainingSpace = span.Slice(spanTrimmed.Length);
+                if (remainingSpace.IsEmpty || HttpRuleParser.GetWhitespaceLength(remainingSpace) == remainingSpace.Length)
+                {
+                    parsedValue = result;
+                    index = value!.Length;
+                    return true;
+                }
+            }
+
+            // Invalid.
+            parsedValue = 0;
+            return false;
         }
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/Int64NumberHeaderParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/Int64NumberHeaderParser.cs
@@ -2,44 +2,58 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 namespace System.Net.Http.Headers
 {
-    internal sealed class Int64NumberHeaderParser : BaseHeaderParser
+    internal sealed class Int64NumberHeaderParser : HttpHeaderParser
     {
         // Note that we don't need a custom comparer even though we have a value type that gets boxed (comparing two
         // equal boxed value types returns 'false' since the object instances used for boxing the two values are
         // different). The reason is that the comparer is only used by HttpHeaders when comparing values in a collection.
-        // Value types are never used in collections (in fact HttpHeaderValueCollection expects T to be a reference
-        // type).
+        // Value types are never used in collections (in fact HttpHeaderValueCollection expects T to be a reference type).
 
         internal static readonly Int64NumberHeaderParser Parser = new Int64NumberHeaderParser();
 
-        private Int64NumberHeaderParser()
-            : base(false)
+        private Int64NumberHeaderParser() : base(supportsMultipleValues: false)
         {
         }
 
         public override string ToString(object value)
         {
             Debug.Assert(value is long);
-
             return ((long)value).ToString(NumberFormatInfo.InvariantInfo);
         }
 
-        protected override int GetParsedValueLength(string value, int startIndex, object? storeValue,
-            out object? parsedValue)
+        public override bool TryParseValue(string? value, object? storeValue, ref int index, [NotNullWhen(true)] out object? parsedValue)
         {
-            ReadOnlySpan<char> span = value.AsSpan(startIndex).Trim();
-            if (HeaderUtilities.TryParseInt64(span, out long result))
+            ReadOnlySpan<char> span = value.AsSpan(index);
+
+            // Skip past valid starting whitespace
+            int startingWhitespaceLength = HttpRuleParser.GetWhitespaceLength(span);
+            if (startingWhitespaceLength != 0)
             {
-                parsedValue = result;
-                return span.Length;
+                span = span.Slice(startingWhitespaceLength);
             }
 
+            // Parse everything until the ending whitespace
+            ReadOnlySpan<char> spanTrimmed = span.TrimEnd();
+            if (HeaderUtilities.TryParseInt64(spanTrimmed, out long result))
+            {
+                // If there wasn't ending whitespace or it was valid, give back the successfully parsed value.
+                ReadOnlySpan<char> remainingSpace = span.Slice(spanTrimmed.Length);
+                if (remainingSpace.IsEmpty || HttpRuleParser.GetWhitespaceLength(remainingSpace) == remainingSpace.Length)
+                {
+                    parsedValue = result;
+                    index = value!.Length;
+                    return true;
+                }
+            }
+
+            // Invalid.
             parsedValue = null;
-            return 0;
+            return false;
         }
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/Int64NumberHeaderParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/Int64NumberHeaderParser.cs
@@ -31,23 +31,15 @@ namespace System.Net.Http.Headers
         protected override int GetParsedValueLength(string value, int startIndex, object? storeValue,
             out object? parsedValue)
         {
+            ReadOnlySpan<char> span = value.AsSpan(startIndex).Trim();
+            if (HeaderUtilities.TryParseInt64(span, out long result))
+            {
+                parsedValue = result;
+                return span.Length;
+            }
+
             parsedValue = null;
-
-            int numberLength = HttpRuleParser.GetNumberLength(value, startIndex, false);
-
-            if ((numberLength == 0) || (numberLength > HttpRuleParser.MaxInt64Digits))
-            {
-                return 0;
-            }
-
-            long result = 0;
-            if (!HeaderUtilities.TryParseInt64(value, startIndex, numberLength, out result))
-            {
-                return 0;
-            }
-
-            parsedValue = result;
-            return numberLength;
+            return 0;
         }
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/RangeItemHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/RangeItemHeaderValue.cs
@@ -207,14 +207,14 @@ namespace System.Net.Http.Headers
 
             // Try convert first value to int64
             long from = 0;
-            if ((fromLength > 0) && !HeaderUtilities.TryParseInt64(input, fromStartIndex, fromLength, out from))
+            if ((fromLength > 0) && !HeaderUtilities.TryParseInt64(input.AsSpan(fromStartIndex, fromLength), out from))
             {
                 return 0;
             }
 
             // Try convert second value to int64
             long to = 0;
-            if ((toLength > 0) && !HeaderUtilities.TryParseInt64(input, toStartIndex, toLength, out to))
+            if ((toLength > 0) && !HeaderUtilities.TryParseInt64(input.AsSpan(toStartIndex, toLength), out to))
             {
                 return 0;
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/RetryConditionHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/RetryConditionHeaderValue.cs
@@ -146,7 +146,7 @@ namespace System.Net.Http.Headers
                     return 0;
                 }
 
-                if (!HeaderUtilities.TryParseInt32(input, deltaStartIndex, deltaLength, out deltaSeconds))
+                if (!HeaderUtilities.TryParseInt32(input.AsSpan(deltaStartIndex, deltaLength), out deltaSeconds))
                 {
                     return 0; // int.TryParse() may return 'false' if the value has 10 digits and is > Int32.MaxValue.
                 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/TimeSpanHeaderParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/TimeSpanHeaderParser.cs
@@ -25,23 +25,15 @@ namespace System.Net.Http.Headers
         protected override int GetParsedValueLength(string value, int startIndex, object? storeValue,
             out object? parsedValue)
         {
+            ReadOnlySpan<char> span = value.AsSpan(startIndex).Trim();
+            if (HeaderUtilities.TryParseInt32(span, out int result))
+            {
+                parsedValue = new TimeSpan(0, 0, result);
+                return span.Length;
+            }
+
             parsedValue = null;
-
-            int numberLength = HttpRuleParser.GetNumberLength(value, startIndex, false);
-
-            if ((numberLength == 0) || (numberLength > HttpRuleParser.MaxInt32Digits))
-            {
-                return 0;
-            }
-
-            int result = 0;
-            if (!HeaderUtilities.TryParseInt32(value, startIndex, numberLength, out result))
-            {
-                return 0;
-            }
-
-            parsedValue = new TimeSpan(0, 0, result);
-            return numberLength;
+            return 0;
         }
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/TimeSpanHeaderParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/TimeSpanHeaderParser.cs
@@ -2,38 +2,35 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 namespace System.Net.Http.Headers
 {
-    internal sealed class TimeSpanHeaderParser : BaseHeaderParser
+    internal sealed class TimeSpanHeaderParser : HttpHeaderParser
     {
         internal static readonly TimeSpanHeaderParser Parser = new TimeSpanHeaderParser();
 
-        private TimeSpanHeaderParser()
-            : base(false)
+        private TimeSpanHeaderParser() : base(supportsMultipleValues: false)
         {
         }
 
         public override string ToString(object value)
         {
             Debug.Assert(value is TimeSpan);
-
             return ((int)((TimeSpan)value).TotalSeconds).ToString(NumberFormatInfo.InvariantInfo);
         }
 
-        protected override int GetParsedValueLength(string value, int startIndex, object? storeValue,
-            out object? parsedValue)
+        public override bool TryParseValue(string? value, object? storeValue, ref int index, [NotNullWhen(true)] out object? parsedValue)
         {
-            ReadOnlySpan<char> span = value.AsSpan(startIndex).Trim();
-            if (HeaderUtilities.TryParseInt32(span, out int result))
+            if (Int32NumberHeaderParser.TryParseInt32Value(value, ref index, out int result))
             {
                 parsedValue = new TimeSpan(0, 0, result);
-                return span.Length;
+                return true;
             }
 
             parsedValue = null;
-            return 0;
+            return false;
         }
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/WarningHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/WarningHeaderValue.cs
@@ -236,7 +236,7 @@ namespace System.Net.Http.Headers
                 return false;
             }
 
-            if (!HeaderUtilities.TryParseInt32(input, current, codeLength, out code))
+            if (!HeaderUtilities.TryParseInt32(input.AsSpan(current, codeLength), out code))
             {
                 Debug.Fail("Unable to parse value even though it was parsed as <=3 digits string. Input: '" +
                     input + "', Current: " + current + ", CodeLength: " + codeLength);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRuleParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRuleParser.cs
@@ -119,47 +119,38 @@ namespace System.Net.Http
             return Encoding.ASCII.GetString(input);
         }
 
-        internal static int GetWhitespaceLength(string input, int startIndex)
+        internal static int GetWhitespaceLength(string input, int startIndex) =>
+            GetWhitespaceLength(input.AsSpan(startIndex));
+
+        internal static int GetWhitespaceLength(ReadOnlySpan<char> input)
         {
-            Debug.Assert(input != null);
-
-            if (startIndex >= input.Length)
+            for (int i = 0; i < input.Length; i++)
             {
-                return 0;
-            }
+                char c = input[i];
 
-            int current = startIndex;
-
-            char c;
-            while (current < input.Length)
-            {
-                c = input[current];
-
-                if ((c == ' ') || (c == '\t'))
+                if (c == ' ' || c == '\t')
                 {
-                    current++;
                     continue;
                 }
 
                 if (c == '\r')
                 {
                     // If we have a #13 char, it must be followed by #10 and then at least one SP or HT.
-                    if ((current + 2 < input.Length) && (input[current + 1] == '\n'))
+                    if (i + 2 < input.Length && input[i + 1] == '\n')
                     {
-                        char spaceOrTab = input[current + 2];
-                        if ((spaceOrTab == ' ') || (spaceOrTab == '\t'))
+                        char spaceOrTab = input[i + 2];
+                        if (spaceOrTab == ' ' || spaceOrTab == '\t')
                         {
-                            current += 3;
+                            i += 2;
                             continue;
                         }
                     }
                 }
 
-                return current - startIndex;
+                return i;
             }
 
-            // All characters between startIndex and the end of the string are LWS characters.
-            return input.Length - startIndex;
+            return input.Length;
         }
 
         internal static bool ContainsInvalidNewLine(string value)

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/Int32NumberHeaderParserTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/Int32NumberHeaderParserTest.cs
@@ -89,6 +89,14 @@ namespace System.Net.Http.Tests
             CheckInvalidParsedValue("-123", 0);
             CheckInvalidParsedValue("123456789012345678901234567890", 0); // value >> Int32.MaxValue
             CheckInvalidParsedValue("2147483648", 0); // value = Int32.MaxValue + 1
+            for (int i = 0; i <= char.MaxValue; i++)
+            {
+                if (char.IsWhiteSpace((char)i) && i != ' ' && i != '\t')
+                {
+                    CheckInvalidParsedValue("123" + (char)i, 0);
+                    CheckInvalidParsedValue((char)i + "123", 0);
+                }
+            }
         }
 
         [Fact]

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/Int64NumberHeaderParserTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/Int64NumberHeaderParserTest.cs
@@ -88,6 +88,14 @@ namespace System.Net.Http.Tests
             CheckInvalidParsedValue("-123", 0);
             CheckInvalidParsedValue("123456789012345678901234567890", 0); // value >> Int64.MaxValue
             CheckInvalidParsedValue("9223372036854775808", 0); // value = Int64.MaxValue + 1
+            for (int i = 0; i <= char.MaxValue; i++)
+            {
+                if (char.IsWhiteSpace((char)i) && i != ' ' && i != '\t')
+                {
+                    CheckInvalidParsedValue("123" + (char)i, 0);
+                    CheckInvalidParsedValue((char)i + "123", 0);
+                }
+            }
         }
 
         [Fact]

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/TimeSpanHeaderParserTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/TimeSpanHeaderParserTest.cs
@@ -88,6 +88,14 @@ namespace System.Net.Http.Tests
             CheckInvalidParsedValue("-123", 0);
             CheckInvalidParsedValue("123456789012345678901234567890", 0); // value >> Int32.MaxValue
             CheckInvalidParsedValue("2147483648", 0); // value = Int32.MaxValue + 1
+            for (int i = 0; i <= char.MaxValue; i++)
+            {
+                if (char.IsWhiteSpace((char)i) && i != ' ' && i != '\t')
+                {
+                    CheckInvalidParsedValue("123" + (char)i, 0);
+                    CheckInvalidParsedValue((char)i + "123", 0);
+                }
+            }
         }
 
         [Fact]


### PR DESCRIPTION
To delete some code which appears superfluous, in particular the GetNumberLength calls.  Is there any reason those checks need to be done rather than just leaving it up to int/long.TryParse as this is doing?

|           Method |         Toolchain |     Mean |  Ratio | Allocated |
|----------------- |------------------ |---------:|-------:|----------:|
| GetContentLength | \main\CoreRun.exe | 164.1 ns |   1.00 |      64 B |
| GetContentLength |   \pr\CoreRun.exe | 148.3 ns |   0.90 |      64 B |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Net.Http;
using System.Net.Http.Headers;

[MemoryDiagnoser]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssemblies(new[] { typeof(Program).Assembly }).Run(args);

    private HttpContentHeaders _headers = new ByteArrayContent(new byte[1]).Headers;

    [Benchmark]
    public long? GetContentLength()
    {
        _headers.Clear();
        _headers.TryAddWithoutValidation("Content-Length", "12345");
        return _headers.ContentLength;
    }
}
```