### PR TITLE
Fix mismatch between morph and lower

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -8639,7 +8639,7 @@ void Compiler::fgMorphTailCallViaJitHelper(GenTreeCall* call)
         GenTree* objp       = call->gtCallThisArg->GetNode();
         call->gtCallThisArg = nullptr;
 
-        if ((call->IsDelegateInvoke() || call->IsVirtualVtable()) && !objp->IsLocal())
+        if ((call->IsDelegateInvoke() || call->IsVirtualVtable()) && !objp->OperIs(GT_LCL_VAR))
         {
             // tmp = "this"
             unsigned lclNum = lvaGrabTemp(true DEBUGARG("tail call thisptr"));


### PR DESCRIPTION
For x86 delegate invoke tailcall via helper calls,
Lower expects the `this` pointer in a LCL_VAR. Morph
(`fgMorphTailCallViaJitHelper`) was letting a LCL_FLD go through
instead of inserting a copy of the field to a temp local.

Simply change the condition in morph to match the condition in Lower.

Fixes #53568