### PR TITLE
[wasm][testing] Avoid using crypto in WASM HTTP unit tests

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.RemoteServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.RemoteServer.cs
@@ -346,7 +346,7 @@ namespace System.Net.Http.Functional.Tests
                 string data = "Test String";
                 var content = new StringContent(data, Encoding.UTF8);
 
-                if(PlatformDetection.IsBrowser)
+                if (PlatformDetection.IsBrowser)
                 {
                     // [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
                     content.Headers.Add("Content-MD5-Skip", "browser");
@@ -364,7 +364,7 @@ namespace System.Net.Http.Functional.Tests
 
                 // Repeat call.
                 content = new StringContent(data, Encoding.UTF8);
-                if(PlatformDetection.IsBrowser)
+                if (PlatformDetection.IsBrowser)
                 {
                     // [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
                     content.Headers.Add("Content-MD5-Skip", "browser");
@@ -389,7 +389,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 string data = "\ub4f1\uffc7\u4e82\u67ab4\uc6d4\ud1a0\uc694\uc77c\uffda3\u3155\uc218\uffdb";
                 var content = new StringContent(data, Encoding.UTF8);
-                if(PlatformDetection.IsBrowser)
+                if (PlatformDetection.IsBrowser)
                 {
                     // [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
                     content.Headers.Add("Content-MD5-Skip", "browser");
@@ -412,7 +412,7 @@ namespace System.Net.Http.Functional.Tests
         {
             using (HttpClient client = CreateHttpClientForRemoteServer(remoteServer))
             {
-                if(PlatformDetection.IsBrowser)
+                if (PlatformDetection.IsBrowser)
                 {
                     // [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
                     content.Headers.Add("Content-MD5-Skip", "browser");
@@ -711,7 +711,7 @@ namespace System.Net.Http.Functional.Tests
                 var content = new StreamContent(fs);
 
                 // Compute MD5 of request body data. This will be verified by the server when it receives the request.
-                if(PlatformDetection.IsBrowser)
+                if (PlatformDetection.IsBrowser)
                 {
                     // [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
                     content.Headers.Add("Content-MD5-Skip", "browser");
@@ -737,7 +737,7 @@ namespace System.Net.Http.Functional.Tests
                     if (expectRedirectToPost)
                     {
                         // [ActiveIssue("https://github.com/dotnet/runtime/issues/53668", TestPlatforms.Browser)] 
-                        if(!PlatformDetection.IsBrowser)
+                        if (!PlatformDetection.IsBrowser)
                         {
                             IEnumerable<string> headerValue = response.Headers.GetValues("X-HttpRequest-Method");
                             Assert.Equal("POST", headerValue.First());

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.RemoteServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.RemoteServer.cs
@@ -736,12 +736,8 @@ namespace System.Net.Http.Functional.Tests
 
                     if (expectRedirectToPost)
                     {
-                        // [ActiveIssue("https://github.com/dotnet/runtime/issues/53668", TestPlatforms.Browser)] 
-                        if (!PlatformDetection.IsBrowser)
-                        {
-                            IEnumerable<string> headerValue = response.Headers.GetValues("X-HttpRequest-Method");
-                            Assert.Equal("POST", headerValue.First());
-                        }
+                        IEnumerable<string> headerValue = response.Headers.GetValues("X-HttpRequest-Method");
+                        Assert.Equal("POST", headerValue.First());
                     }
                 }
             }

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.RemoteServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.RemoteServer.cs
@@ -113,7 +113,6 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task GetAsync_ResponseContentAfterClientAndHandlerDispose_Success(Configuration.Http.RemoteServer remoteServer)
         {
             using (HttpClient client = CreateHttpClientForRemoteServer(remoteServer))
@@ -289,7 +288,6 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task GetAsync_ResponseHeadersRead_ReadFromEachIterativelyDoesntDeadlock(Configuration.Http.RemoteServer remoteServer)
         {
             using (HttpClient client = CreateHttpClientForRemoteServer(remoteServer))
@@ -315,7 +313,6 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task SendAsync_HttpRequestMsgResponseHeadersRead_StatusCodeOK(Configuration.Http.RemoteServer remoteServer)
         {
             // Sync API supported only up to HTTP/1.1
@@ -342,14 +339,23 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task PostAsync_CallMethodTwice_StringContent(Configuration.Http.RemoteServer remoteServer)
         {
             using (HttpClient client = CreateHttpClientForRemoteServer(remoteServer))
             {
                 string data = "Test String";
                 var content = new StringContent(data, Encoding.UTF8);
-                content.Headers.ContentMD5 = TestHelper.ComputeMD5Hash(data);
+
+                if(PlatformDetection.IsBrowser)
+                {
+                    // [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
+                    content.Headers.Add("Content-MD5-Skip", "browser");
+                }
+                else
+                {
+                    content.Headers.ContentMD5 = TestHelper.ComputeMD5Hash(data);
+                }
+
                 HttpResponseMessage response;
                 using (response = await client.PostAsync(remoteServer.VerifyUploadUri, content))
                 {
@@ -358,7 +364,16 @@ namespace System.Net.Http.Functional.Tests
 
                 // Repeat call.
                 content = new StringContent(data, Encoding.UTF8);
-                content.Headers.ContentMD5 = TestHelper.ComputeMD5Hash(data);
+                if(PlatformDetection.IsBrowser)
+                {
+                    // [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
+                    content.Headers.Add("Content-MD5-Skip", "browser");
+                }
+                else
+                {
+                    content.Headers.ContentMD5 = TestHelper.ComputeMD5Hash(data);
+                }
+
                 using (response = await client.PostAsync(remoteServer.VerifyUploadUri, content))
                 {
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -368,14 +383,21 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task PostAsync_CallMethod_UnicodeStringContent(Configuration.Http.RemoteServer remoteServer)
         {
             using (HttpClient client = CreateHttpClientForRemoteServer(remoteServer))
             {
                 string data = "\ub4f1\uffc7\u4e82\u67ab4\uc6d4\ud1a0\uc694\uc77c\uffda3\u3155\uc218\uffdb";
                 var content = new StringContent(data, Encoding.UTF8);
-                content.Headers.ContentMD5 = TestHelper.ComputeMD5Hash(data);
+                if(PlatformDetection.IsBrowser)
+                {
+                    // [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
+                    content.Headers.Add("Content-MD5-Skip", "browser");
+                }
+                else
+                {
+                    content.Headers.ContentMD5 = TestHelper.ComputeMD5Hash(data);
+                }
 
                 using (HttpResponseMessage response = await client.PostAsync(remoteServer.VerifyUploadUri, content))
                 {
@@ -386,12 +408,19 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory, MemberData(nameof(VerifyUploadServersStreamsAndExpectedData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)] 
         public async Task PostAsync_CallMethod_StreamContent(Configuration.Http.RemoteServer remoteServer, HttpContent content, byte[] expectedData)
         {
             using (HttpClient client = CreateHttpClientForRemoteServer(remoteServer))
             {
-                content.Headers.ContentMD5 = TestHelper.ComputeMD5Hash(expectedData);
+                if(PlatformDetection.IsBrowser)
+                {
+                    // [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
+                    content.Headers.Add("Content-MD5-Skip", "browser");
+                }
+                else
+                {
+                    content.Headers.ContentMD5 = TestHelper.ComputeMD5Hash(expectedData);
+                }
 
                 using (HttpResponseMessage response = await client.PostAsync(remoteServer.VerifyUploadUri, content))
                 {
@@ -526,7 +555,6 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task PostAsync_CallMethod_NullContent(Configuration.Http.RemoteServer remoteServer)
         {
             using (HttpClient client = CreateHttpClientForRemoteServer(remoteServer))
@@ -548,7 +576,6 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task PostAsync_CallMethod_EmptyContent(Configuration.Http.RemoteServer remoteServer)
         {
             using (HttpClient client = CreateHttpClientForRemoteServer(remoteServer))
@@ -641,7 +668,6 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task PostAsync_RedirectWith307_LargePayload(Configuration.Http.RemoteServer remoteServer)
         {
             if (remoteServer.HttpVersion == new Version(2, 0))
@@ -657,7 +683,6 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task PostAsync_RedirectWith302_LargePayload(Configuration.Http.RemoteServer remoteServer)
         {
             await PostAsync_Redirect_LargePayload_Helper(remoteServer, 302, false);
@@ -686,7 +711,15 @@ namespace System.Net.Http.Functional.Tests
                 var content = new StreamContent(fs);
 
                 // Compute MD5 of request body data. This will be verified by the server when it receives the request.
-                content.Headers.ContentMD5 = TestHelper.ComputeMD5Hash(contentBytes);
+                if(PlatformDetection.IsBrowser)
+                {
+                    // [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
+                    content.Headers.Add("Content-MD5-Skip", "browser");
+                }
+                else
+                {
+                    content.Headers.ContentMD5 = TestHelper.ComputeMD5Hash(contentBytes);
+                }
 
                 using (HttpClient client = CreateHttpClientForRemoteServer(remoteServer))
                 using (HttpResponseMessage response = await client.PostAsync(redirectUri, content))
@@ -703,8 +736,12 @@ namespace System.Net.Http.Functional.Tests
 
                     if (expectRedirectToPost)
                     {
-                        IEnumerable<string> headerValue = response.Headers.GetValues("X-HttpRequest-Method");
-                        Assert.Equal("POST", headerValue.First());
+                        // [ActiveIssue("https://github.com/dotnet/runtime/issues/53668", TestPlatforms.Browser)] 
+                        if(!PlatformDetection.IsBrowser)
+                        {
+                            IEnumerable<string> headerValue = response.Headers.GetValues("X-HttpRequest-Method");
+                            Assert.Equal("POST", headerValue.First());
+                        }
                     }
                 }
             }
@@ -713,7 +750,6 @@ namespace System.Net.Http.Functional.Tests
 #if !NETFRAMEWORK
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task PostAsync_ReuseRequestContent_Success(Configuration.Http.RemoteServer remoteServer)
         {
             const string ContentString = "This is the content string.";
@@ -759,12 +795,16 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory, MemberData(nameof(HttpMethodsThatAllowContent))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/53591", TestPlatforms.Browser)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task SendAsync_SendRequestUsingMethodToEchoServerWithContent_Success(
             string method,
             Uri serverUri)
         {
+            if (method == "GET" && PlatformDetection.IsBrowser)
+            {
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/53591", TestPlatforms.Browser)]
+                return;
+            }
+
             using (HttpClient client = CreateHttpClient())
             {
                 var request = new HttpRequestMessage(

--- a/src/libraries/Common/tests/System/Net/Http/PostScenarioTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/PostScenarioTest.cs
@@ -249,7 +249,7 @@ namespace System.Net.Http.Functional.Tests
 
                     // Compute MD5 of request body data. This will be verified by the server when it
                     // receives the request.
-                    if(PlatformDetection.IsBrowser)
+                    if (PlatformDetection.IsBrowser)
                     {
                         // [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
                         requestContent.Headers.Add("Content-MD5-Skip", "browser");

--- a/src/libraries/Common/tests/System/Net/Http/PostScenarioTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/PostScenarioTest.cs
@@ -30,7 +30,6 @@ namespace System.Net.Http.Functional.Tests
 #if !NETFRAMEWORK
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task PostRewindableStreamContentMultipleTimes_StreamContentFullySent(Configuration.Http.RemoteServer remoteServer)
         {
             const string requestBody = "ABC";
@@ -56,7 +55,6 @@ namespace System.Net.Http.Functional.Tests
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [MemberData(nameof(RemoteServersMemberData))]
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsBrowserDomSupportedOrNotBrowser))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task PostNoContentUsingContentLengthSemantics_Success(Configuration.Http.RemoteServer remoteServer)
         {
             await PostHelper(remoteServer, string.Empty, null,
@@ -65,7 +63,6 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task PostEmptyContentUsingContentLengthSemantics_Success(Configuration.Http.RemoteServer remoteServer)
         {
             await PostHelper(remoteServer, string.Empty, new StringContent(string.Empty),
@@ -74,7 +71,6 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task PostEmptyContentUsingChunkedEncoding_Success(Configuration.Http.RemoteServer remoteServer)
         {
             await PostHelper(remoteServer, string.Empty, new StringContent(string.Empty),
@@ -83,7 +79,6 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task PostEmptyContentUsingConflictingSemantics_Success(Configuration.Http.RemoteServer remoteServer)
         {
             await PostHelper(remoteServer, string.Empty, new StringContent(string.Empty),
@@ -92,7 +87,6 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task PostUsingContentLengthSemantics_Success(Configuration.Http.RemoteServer remoteServer)
         {
             await PostHelper(remoteServer, ExpectedContent, new StringContent(ExpectedContent),
@@ -101,7 +95,6 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task PostUsingChunkedEncoding_Success(Configuration.Http.RemoteServer remoteServer)
         {
             await PostHelper(remoteServer, ExpectedContent, new StringContent(ExpectedContent),
@@ -110,7 +103,6 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task PostSyncBlockingContentUsingChunkedEncoding_Success(Configuration.Http.RemoteServer remoteServer)
         {
             await PostHelper(remoteServer, ExpectedContent, new SyncBlockingContent(ExpectedContent),
@@ -119,7 +111,6 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task PostRepeatedFlushContentUsingChunkedEncoding_Success(Configuration.Http.RemoteServer remoteServer)
         {
             await PostHelper(remoteServer, ExpectedContent, new RepeatedFlushContent(ExpectedContent),
@@ -128,7 +119,6 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task PostUsingUsingConflictingSemantics_UsesChunkedSemantics(Configuration.Http.RemoteServer remoteServer)
         {
             await PostHelper(remoteServer, ExpectedContent, new StringContent(ExpectedContent),
@@ -137,7 +127,6 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task PostUsingNoSpecifiedSemantics_UsesChunkedSemantics(Configuration.Http.RemoteServer remoteServer)
         {
             await PostHelper(remoteServer, ExpectedContent, new StringContent(ExpectedContent),
@@ -157,7 +146,6 @@ namespace System.Net.Http.Functional.Tests
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory]
         [MemberData(nameof(RemoteServersAndLargeContentSizes))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task PostLargeContentUsingContentLengthSemantics_Success(Configuration.Http.RemoteServer remoteServer, int contentLength)
         {
             var rand = new Random(42);
@@ -226,7 +214,6 @@ namespace System.Net.Http.Functional.Tests
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [MemberData(nameof(RemoteServersMemberData))]
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsBrowserDomSupportedOrNotBrowser))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task PostAsync_EmptyContent_ContentTypeHeaderNotSent(Configuration.Http.RemoteServer remoteServer)
         {
             using (HttpClient client = CreateHttpClientForRemoteServer(remoteServer))
@@ -262,7 +249,15 @@ namespace System.Net.Http.Functional.Tests
 
                     // Compute MD5 of request body data. This will be verified by the server when it
                     // receives the request.
-                    requestContent.Headers.ContentMD5 = TestHelper.ComputeMD5Hash(requestBody);
+                    if(PlatformDetection.IsBrowser)
+                    {
+                        // [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
+                        requestContent.Headers.Add("Content-MD5-Skip", "browser");
+                    }
+                    else
+                    {
+                        requestContent.Headers.ContentMD5 = TestHelper.ComputeMD5Hash(requestBody);
+                    }
                 }
 
                 if (useChunkedEncodingUpload)

--- a/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/ResponseStreamTest.cs
@@ -128,7 +128,6 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task GetAsync_UseResponseHeadersReadAndCallLoadIntoBuffer_Success(Configuration.Http.RemoteServer remoteServer)
         {
             using (HttpClient client = CreateHttpClientForRemoteServer(remoteServer))
@@ -148,7 +147,6 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task GetAsync_UseResponseHeadersReadAndCopyToMemoryStream_Success(Configuration.Http.RemoteServer remoteServer)
         {
             using (HttpClient client = CreateHttpClientForRemoteServer(remoteServer))

--- a/src/libraries/Common/tests/System/Net/Http/TestHelper.cs
+++ b/src/libraries/Common/tests/System/Net/Http/TestHelper.cs
@@ -41,9 +41,13 @@ namespace System.Net.Http.Functional.Tests
             bool chunkedUpload,
             string requestBody)
         {
-            // Verify that response body from the server was corrected received by comparing MD5 hash.
-            byte[] actualMD5Hash = ComputeMD5Hash(responseContent);
-            Assert.Equal(expectedMD5Hash, actualMD5Hash);
+            // https://github.com/dotnet/runtime/issues/37669
+            if(!PlatformDetection.IsBrowser)
+            {
+                // Verify that response body from the server was corrected received by comparing MD5 hash.
+                byte[] actualMD5Hash = ComputeMD5Hash(responseContent);
+                Assert.Equal(expectedMD5Hash, actualMD5Hash);
+            }
 
             // Verify upload semantics: 'Content-Length' vs. 'Transfer-Encoding: chunked'.
             if (requestBody != null)
@@ -66,6 +70,11 @@ namespace System.Net.Http.Functional.Tests
 
         public static void VerifyRequestMethod(HttpResponseMessage response, string expectedMethod)
         {
+            if(PlatformDetection.IsBrowser)
+            {
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/53668", TestPlatforms.Browser)] 
+                return;
+            }
            IEnumerable<string> values = response.Headers.GetValues("X-HttpRequest-Method");
            foreach (string value in values)
            {

--- a/src/libraries/Common/tests/System/Net/Http/TestHelper.cs
+++ b/src/libraries/Common/tests/System/Net/Http/TestHelper.cs
@@ -70,11 +70,6 @@ namespace System.Net.Http.Functional.Tests
 
         public static void VerifyRequestMethod(HttpResponseMessage response, string expectedMethod)
         {
-            if(PlatformDetection.IsBrowser)
-            {
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/53668", TestPlatforms.Browser)] 
-                return;
-            }
            IEnumerable<string> values = response.Headers.GetValues("X-HttpRequest-Method");
            foreach (string value in values)
            {

--- a/src/libraries/Common/tests/System/Net/Http/TestHelper.cs
+++ b/src/libraries/Common/tests/System/Net/Http/TestHelper.cs
@@ -41,8 +41,8 @@ namespace System.Net.Http.Functional.Tests
             bool chunkedUpload,
             string requestBody)
         {
-            // https://github.com/dotnet/runtime/issues/37669
-            if(!PlatformDetection.IsBrowser)
+            // [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
+            if (!PlatformDetection.IsBrowser)
             {
                 // Verify that response body from the server was corrected received by comparing MD5 hash.
                 byte[] actualMD5Hash = ComputeMD5Hash(responseContent);

--- a/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/Handlers/VerifyUploadHandler.cs
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/Handlers/VerifyUploadHandler.cs
@@ -32,7 +32,8 @@ namespace NetCoreServer
             // Get request body.
             byte[] requestBodyBytes = await ReadAllRequestBytesAsync(context);
 
-            // Skip MD5 checksum for empty request body or for requests which opt to skip it.
+            // Skip MD5 checksum for empty request body 
+            // or for requests which opt to skip it due to [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
             if (requestBodyBytes.Length == 0 || !string.IsNullOrEmpty(context.Request.Headers["Content-MD5-Skip"]))
             {
                 context.Response.StatusCode = 200;

--- a/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/Handlers/VerifyUploadHandler.cs
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/Handlers/VerifyUploadHandler.cs
@@ -35,31 +35,40 @@ namespace NetCoreServer
             // Check MD5 checksum for non-empty request body.
             if (requestBodyBytes.Length > 0)
             {
-                // Get expected MD5 hash of request body.
-                string expectedHash = context.Request.Headers["Content-MD5"];
-                if (string.IsNullOrEmpty(expectedHash))
-                {
-                    context.Response.StatusCode = 400;
-                    context.Response.SetStatusDescription("Missing 'Content-MD5' request header");
-                    return;
-                }
-
-                // Compute MD5 hash of received request body.
-                string actualHash;
-                using (MD5 md5 = MD5.Create())
-                {
-                    byte[] hash = md5.ComputeHash(requestBodyBytes);
-                    actualHash = Convert.ToBase64String(hash);
-                }
-
-                if (expectedHash == actualHash)
+                string skip = context.Request.Headers["Content-MD5-Skip"];
+                if(!string.IsNullOrEmpty(skip)) 
                 {
                     context.Response.StatusCode = 200;
                 }
                 else
                 {
-                    context.Response.StatusCode = 400;
-                    context.Response.SetStatusDescription("Received request body fails MD5 checksum");
+                    // Get expected MD5 hash of request body.
+                    string expectedHash = context.Request.Headers["Content-MD5"];
+
+                    if (string.IsNullOrEmpty(expectedHash))
+                    {
+                        context.Response.StatusCode = 400;
+                        context.Response.SetStatusDescription("Missing 'Content-MD5' request header");
+                        return;
+                    }
+
+                    // Compute MD5 hash of received request body.
+                    string actualHash;
+                    using (MD5 md5 = MD5.Create())
+                    {
+                        byte[] hash = md5.ComputeHash(requestBodyBytes);
+                        actualHash = Convert.ToBase64String(hash);
+                    }
+
+                    if (expectedHash == actualHash)
+                    {
+                        context.Response.StatusCode = 200;
+                    }
+                    else
+                    {
+                        context.Response.StatusCode = 400;
+                        context.Response.SetStatusDescription("Received request body fails MD5 checksum");
+                    }
                 }
             }
             else

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
@@ -361,8 +361,8 @@ namespace System.Net.Http.Functional.Tests
             }
 
             var m = new HttpRequestMessage(HttpMethod.Get, Configuration.Http.SecureRemoteEchoServer) { Version = UseVersion };
-            m.Headers.Host = !PlatformDetection.LocalEchoServerIsAvailable && withPort 
-                                ? Configuration.Http.SecureHost + ":" + Configuration.Http.SecurePort 
+            m.Headers.Host = !PlatformDetection.LocalEchoServerIsAvailable && withPort
+                                ? Configuration.Http.SecureHost + ":" + Configuration.Http.SecurePort
                                 : Configuration.Http.SecureHost;
 
             using (HttpClient client = CreateHttpClient())

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
@@ -347,7 +347,6 @@ namespace System.Net.Http.Functional.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         public async Task SendAsync_GetWithValidHostHeader_Success(bool withPort)
         {
             if (UseVersion == HttpVersion.Version30)
@@ -362,7 +361,9 @@ namespace System.Net.Http.Functional.Tests
             }
 
             var m = new HttpRequestMessage(HttpMethod.Get, Configuration.Http.SecureRemoteEchoServer) { Version = UseVersion };
-            m.Headers.Host = withPort ? Configuration.Http.SecureHost + ":" + Configuration.Http.SecurePort : Configuration.Http.SecureHost;
+            m.Headers.Host = !PlatformDetection.LocalEchoServerIsAvailable && withPort 
+                                ? Configuration.Http.SecureHost + ":" + Configuration.Http.SecurePort 
+                                : Configuration.Http.SecureHost;
 
             using (HttpClient client = CreateHttpClient())
             using (HttpResponseMessage response = await client.SendAsync(TestAsync, m))


### PR DESCRIPTION
On WASM platform existing POST/PUT tests are blocked by current [lack of crypto](https://github.com/dotnet/runtime/issues/37669) in WASM.
By skipping content checksum validation in the tests for Browser, we could enable about 130 tests of other HTTP features.

- send `Content-MD5-Skip` header instead of `Content-MD5` header from browser
- on the server side (hosted in XHarness) skip request MD5 validation when `Content-MD5-Skip` is present
- on the client side skip `Content-MD5` response validation
- `SendAsync_SendRequestUsingMethodToEchoServerWithContent_Success` more granular active issue https://github.com/dotnet/runtime/issues/53591
- fix for port handling on `SendAsync_GetWithValidHostHeader_Success`