### PR TITLE
Return false for SocketsHttpHandler.IsSupported on Browser

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -43,7 +43,11 @@ namespace System.Net.Http
         /// Gets a value that indicates whether the handler is supported on the current platform.
         /// </summary>
         [UnsupportedOSPlatformGuard("browser")]
+#if TARGET_BROWSER
+        public static bool IsSupported => false;
+#else
         public static bool IsSupported => true;
+#endif
 
         public bool UseCookies
         {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -43,11 +43,7 @@ namespace System.Net.Http
         /// Gets a value that indicates whether the handler is supported on the current platform.
         /// </summary>
         [UnsupportedOSPlatformGuard("browser")]
-#if TARGET_BROWSER
-        public static bool IsSupported => false;
-#else
-        public static bool IsSupported => true;
-#endif
+        public static bool IsSupported => !OperatingSystem.IsBrowser();
 
         public bool UseCookies
         {


### PR DESCRIPTION
We were returning true even though sockets don't work on Browser.