### PR TITLE
Fix2 for Trim HW

### DIFF
--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -1505,7 +1505,14 @@ void SystemDomain::LoadBaseSystemClasses()
     g_pThreadClass = CoreLibBinder::GetClass(CLASS__THREAD);
 
 #ifdef FEATURE_COMINTEROP
-    g_pBaseCOMObject = CoreLibBinder::GetClass(CLASS__COM_OBJECT);
+    if (g_pConfig->IsBuiltInCOMSupported())
+    {
+        g_pBaseCOMObject = CoreLibBinder::GetClass(CLASS__COM_OBJECT);
+    }
+    else
+    {
+        g_pBaseCOMObject = NULL;
+    }
 #endif
 
     g_pIDynamicInterfaceCastableInterface = CoreLibBinder::GetClass(CLASS__IDYNAMICINTERFACECASTABLE);

--- a/src/coreclr/vm/cominterfacemarshaler.cpp
+++ b/src/coreclr/vm/cominterfacemarshaler.cpp
@@ -400,6 +400,7 @@ VOID COMInterfaceMarshaler::InitializeObjectClass(IUnknown *pIncomingIP)
         // This was previously provided by IProvideClassinfo. If the type handle isn't
         // set fallback to the opaque __ComObject type.
         m_typeHandle = TypeHandle(g_pBaseCOMObject);
+        _ASSERTE(!m_typeHandle.IsNull());
     }
 }
 

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -202,6 +202,7 @@ DEFINE_CLASS(VARIANT_WRAPPER,       Interop,                VariantWrapper)
 #endif // FEATURE_COMINTEROP
 END_ILLINK_FEATURE_SWITCH()
 
+BEGIN_ILLINK_FEATURE_SWITCH(System.Runtime.InteropServices.BuiltInComInterop.IsSupported, true, true)
 #ifdef FEATURE_COMINTEROP
 DEFINE_CLASS_U(System,                 __ComObject,            ComObject)
 DEFINE_FIELD_U(m_ObjectToDataMap,      ComObject,              m_ObjectToDataMap)
@@ -211,14 +212,12 @@ DEFINE_METHOD(COM_OBJECT,           GET_EVENT_PROVIDER,     GetEventProvider,   
 #ifdef FOR_ILLINK
 DEFINE_METHOD(COM_OBJECT,           CTOR,                   .ctor,                      IM_RetVoid)
 #endif
-#endif // FEATURE_COMINTEROP
 
-BEGIN_ILLINK_FEATURE_SWITCH(System.Runtime.InteropServices.BuiltInComInterop.IsSupported, true, true)
-#ifdef FEATURE_COMINTEROP
 DEFINE_CLASS(LICENSE_INTEROP_PROXY,  InternalInteropServices, LicenseInteropProxy)
 DEFINE_METHOD(LICENSE_INTEROP_PROXY, CREATE,                  Create,                  SM_RetObj)
 DEFINE_METHOD(LICENSE_INTEROP_PROXY, GETCURRENTCONTEXTINFO,   GetCurrentContextInfo,   IM_RuntimeTypeHandle_RefBool_RefIntPtr_RetVoid)
 DEFINE_METHOD(LICENSE_INTEROP_PROXY, SAVEKEYINCURRENTCONTEXT, SaveKeyInCurrentContext, IM_IntPtr_RetVoid)
+
 #endif // FEATURE_COMINTEROP
 END_ILLINK_FEATURE_SWITCH()
 

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -1524,20 +1524,12 @@ MethodTableBuilder::BuildMethodTableThrowing(
             BuildMethodTableThrowException(IDS_CLASSLOAD_COMIMPCANNOTHAVELAYOUT);
         }
 
-        if (pMTParent == g_pObjectClass)
-        {
-            // ComImport classes ultimately extend from our __ComObject or RuntimeClass class
-            MethodTable *pCOMMT = g_pBaseCOMObject;
-
-            _ASSERTE(pCOMMT);
-
-            // We could have had COM interop classes derive from System._ComObject,
-            // but instead we have them derive from System.Object, have them set the
-            // ComImport bit in the type attributes, and then we swap out the parent
-            // type under the covers.
-            bmtInternal->pType->SetParentType(CreateTypeChain(pCOMMT, Substitution()));
-            bmtInternal->pParentMT = pCOMMT;
-        }
+        // We could have had COM interop classes derive from System._ComObject,
+        // but instead we have them derive from System.Object, have them set the
+        // ComImport bit in the type attributes, and then we swap out the parent
+        // type under the covers.
+        bmtInternal->pType->SetParentType(CreateTypeChain(g_pBaseCOMObject, Substitution()));
+        bmtInternal->pParentMT = g_pBaseCOMObject;
 #endif
         // if the current class is imported
         bmtProp->fIsComObjectType = true;


### PR DESCRIPTION
Even though `__ComObject` is under the `FEATURE_COMINTEROP `flag, we pull this class during CLR initialization. The correct fix as recommended by the interop team is to set `g_baseCOMObject` to `NULL `if built-in COM is disabled. The earlier fix, #53912, works but does not fully disable built-in COM since we keep `__ComObject`

Fixes #53898