### PR TITLE
Remove unused usings

### DIFF
--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
@@ -7,8 +7,6 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 
 #nullable enable
 


### PR DESCRIPTION
This is a shared source package and I forgot to remove these usings in this [PR](https://github.com/dotnet/runtime/pull/53757/) which is causing this dependency flow to break https://github.com/dotnet/aspnetcore/pull/33397.