### PR TITLE
Revert "Do byref liveness updates for same register GPR moves (#53684)"

### DIFF
--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -299,11 +299,7 @@ struct insGroup
     unsigned igStkLvl; // stack level on entry
 #endif
     regMaskSmall  igGCregs; // set of registers with live GC refs
-    unsigned char igInsCnt; // # of instructions in this group
-
-#if defined(DEBUG)
-    unsigned char igZeroSzCnt; // # of zero size instructions in this group
-#endif                         // DEBUG
+    unsigned char igInsCnt; // # of instructions  in this group
 
 #else // REGMASK_BITS
 
@@ -318,11 +314,7 @@ struct insGroup
     unsigned igStkLvl; // stack level on entry
 #endif
 
-    unsigned char igInsCnt;    // # of instructions in this group
-
-#if defined(DEBUG)
-    unsigned char igZeroSzCnt; // # of zero size instructions in this group
-#endif // DEBUG
+    unsigned char igInsCnt; // # of instructions  in this group
 
 #endif // REGMASK_BITS
 
@@ -928,7 +920,7 @@ protected:
                     break;
             }
 
-            return (idIns() != INS_mov_eliminated) ? size : 0;
+            return size;
         }
 
 #elif defined(TARGET_ARM)
@@ -940,7 +932,7 @@ protected:
         unsigned idCodeSize() const
         {
             unsigned result = (_idInsSize == ISZ_16BIT) ? 2 : (_idInsSize == ISZ_32BIT) ? 4 : 6;
-            return (idIns() != INS_mov_eliminated) ? result : 0;
+            return result;
         }
         insSize idInsSize() const
         {
@@ -1801,10 +1793,6 @@ private:
     UNATIVE_OFFSET emitCurCodeOffset; // current code offset within group
     UNATIVE_OFFSET emitTotalCodeSize; // bytes of code in entire method
 
-#if defined(DEBUG) || EMITTER_STATS
-    unsigned emitCurIGZeroSzCnt; // # of zero size instr's in buffer
-#endif                           // DEBUG || EMITTER_STATS
-
     insGroup* emitFirstColdIG; // first cold instruction group
 
     void emitSetFirstColdIGCookie(void* bbEmitCookie)
@@ -1901,7 +1889,6 @@ private:
     }
 
     instrDesc* emitLastIns;
-    instrDesc* emitLastEmittedIns;
 
 #ifdef DEBUG
     void emitCheckIGoffsets();
@@ -2330,16 +2317,14 @@ public:
 
     static unsigned emitTotalInsCnt;
 
-    static unsigned emitCurPrologInsCnt;    // current number of prolog instrDescs
-    static unsigned emitCurPrologZeroSzCnt; // current number of elided prolog instrDescs
-    static size_t   emitCurPrologIGSize;    // current size of prolog instrDescs
-    static unsigned emitMaxPrologInsCnt;    // maximum number of prolog instrDescs
-    static size_t   emitMaxPrologIGSize;    // maximum size of prolog instrDescs
+    static unsigned emitCurPrologInsCnt; // current number of prolog instrDescs
+    static size_t   emitCurPrologIGSize; // current size of prolog instrDescs
+    static unsigned emitMaxPrologInsCnt; // maximum number of prolog instrDescs
+    static size_t   emitMaxPrologIGSize; // maximum size of prolog instrDescs
 
     static unsigned emitTotalIGcnt;   // total number of insGroup allocated
     static unsigned emitTotalPhIGcnt; // total number of insPlaceholderGroupData allocated
     static unsigned emitTotalIGicnt;
-    static unsigned emitTotalIGZeroSzCnt;
     static size_t   emitTotalIGsize;
     static unsigned emitTotalIGmcnt;   // total method count
     static unsigned emitTotalIGExtend; // total number of 'emitExtend' (typically overflow) groups
@@ -2374,7 +2359,6 @@ public:
     static unsigned emitSmallCns[SMALL_CNS_TSZ];
     static unsigned emitLargeCnsCnt;
     static unsigned emitTotalDescAlignCnt;
-    static unsigned emitTotalDescZeroSzCnt;
 
     static unsigned emitIFcounts[IF_COUNT];
 

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -4088,9 +4088,7 @@ void emitter::emitIns_Mov(
 
             if (IsRedundantMov(ins, size, dstReg, srcReg, canSkip))
             {
-                // TODO-ARM64: These instructions might have a side effect in the form of a
-                // byref liveness update, so we should preserve them but emit nothing
-
+                // These instructions have no side effect and can be skipped
                 return;
             }
 
@@ -4106,10 +4104,13 @@ void emitter::emitIns_Mov(
                     return emitIns_R_R_I(INS_mov, size, dstReg, srcReg, 0);
                 }
             }
-            else if (isVectorRegister(srcReg))
+            else
             {
-                assert(isGeneralRegister(dstReg));
-                return emitIns_R_R_I(INS_mov, size, dstReg, srcReg, 0);
+                if (isVectorRegister(srcReg))
+                {
+                    assert(isGeneralRegister(dstReg));
+                    return emitIns_R_R_I(INS_mov, size, dstReg, srcReg, 0);
+                }
             }
 
             // Is this a MOV to/from SP instruction?
@@ -10347,17 +10348,6 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 
     assert(REG_NA == (int)REG_NA);
 
-    if (ins == INS_mov_eliminated)
-    {
-        // Elideable moves are specified to have a zero size, but are carried
-        // in emit so we can still do the relevant byref liveness update
-
-        assert(id->idGCref() == GCT_BYREF);
-        assert(id->idCodeSize() == 0);
-
-        goto UPDATE_LIVENESS;
-    }
-
     /* What instruction format have we got? */
 
     switch (fmt)
@@ -11471,7 +11461,6 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             break;
     }
 
-UPDATE_LIVENESS:
     // Determine if any registers now hold GC refs, or whether a register that was overwritten held a GC ref.
     // We assume here that "id->idGCref()" is not GC_NONE only if the instruction described by "id" writes a
     // GC ref to register "id->idReg1()".  (It may, apparently, also not be GC_NONE in other cases, such as
@@ -11587,9 +11576,9 @@ UPDATE_LIVENESS:
     }
 #endif
 
-    /* All instructions, except eliminated moves, are expected to generate code */
+    /* All instructions are expected to generate code */
 
-    assert((*dp != dst) || (ins == INS_mov_eliminated));
+    assert(*dp != dst);
 
     *dp = dst;
 
@@ -12199,17 +12188,6 @@ void emitter::emitDispInsHex(instrDesc* id, BYTE* code, size_t sz)
 void emitter::emitDispIns(
     instrDesc* id, bool isNew, bool doffs, bool asmfm, unsigned offset, BYTE* pCode, size_t sz, insGroup* ig)
 {
-    if (id->idIns() == INS_mov_eliminated)
-    {
-        // Elideable moves are specified to have a zero size, but are carried
-        // in emit so we can still do the relevant byref liveness update
-
-        assert(id->idGCref() == GCT_BYREF);
-        assert(id->idCodeSize() == 0);
-
-        return;
-    }
-
     if (EMITVERBOSE)
     {
         unsigned idNum =
@@ -15557,7 +15535,6 @@ bool emitter::IsMovInstruction(instruction ins)
     {
         case INS_fmov:
         case INS_mov:
-        case INS_mov_eliminated:
         case INS_sxtb:
         case INS_sxth:
         case INS_sxtw:
@@ -15640,24 +15617,23 @@ bool emitter::IsRedundantMov(instruction ins, emitAttr size, regNumber dst, regN
     bool isFirstInstrInBlock = (emitCurIGinsCnt == 0) && ((emitCurIG->igFlags & IGF_EXTEND) == 0);
 
     if (!isFirstInstrInBlock && // Don't optimize if instruction is not the first instruction in IG.
-        (emitLastEmittedIns != nullptr) &&
-        (emitLastEmittedIns->idIns() == INS_mov) && // Don't optimize if last instruction was not 'mov'.
-        (emitLastEmittedIns->idOpSize() == size))   // Don't optimize if operand size is different than previous
-                                                    // instruction.
+        (emitLastIns != nullptr) &&
+        (emitLastIns->idIns() == INS_mov) && // Don't optimize if last instruction was not 'mov'.
+        (emitLastIns->idOpSize() == size))   // Don't optimize if operand size is different than previous instruction.
     {
         // Check if we did same move in prev instruction except dst/src were switched.
-        regNumber prevDst    = emitLastEmittedIns->idReg1();
-        regNumber prevSrc    = emitLastEmittedIns->idReg2();
-        insFormat lastInsfmt = emitLastEmittedIns->idInsFmt();
+        regNumber prevDst    = emitLastIns->idReg1();
+        regNumber prevSrc    = emitLastIns->idReg2();
+        insFormat lastInsfmt = emitLastIns->idInsFmt();
 
         if ((prevDst == dst) && (prevSrc == src))
         {
-            assert(emitLastEmittedIns->idOpSize() == size);
+            assert(emitLastIns->idOpSize() == size);
             JITDUMP("\n -- suppressing mov because previous instruction already moved from src to dst register.\n");
             return true;
         }
 
-        // Sometimes emitLastEmittedIns can be a mov with single register e.g. "mov reg, #imm". So ensure to
+        // Sometimes emitLastIns can be a mov with single register e.g. "mov reg, #imm". So ensure to
         // optimize formats that does vector-to-vector or scalar-to-scalar register movs.
         bool isValidLastInsFormats = ((lastInsfmt == IF_DV_3C) || (lastInsfmt == IF_DR_2G) || (lastInsfmt == IF_DR_2E));
 
@@ -15720,17 +15696,16 @@ bool emitter::IsRedundantLdStr(
 {
     bool isFirstInstrInBlock = (emitCurIGinsCnt == 0) && ((emitCurIG->igFlags & IGF_EXTEND) == 0);
 
-    if (((ins != INS_ldr) && (ins != INS_str)) || (isFirstInstrInBlock) || (emitLastEmittedIns == nullptr))
+    if (((ins != INS_ldr) && (ins != INS_str)) || (isFirstInstrInBlock) || (emitLastIns == nullptr))
     {
         return false;
     }
 
-    regNumber prevReg1   = emitLastEmittedIns->idReg1();
-    regNumber prevReg2   = emitLastEmittedIns->idReg2();
-    insFormat lastInsfmt = emitLastEmittedIns->idInsFmt();
-    emitAttr  prevSize   = emitLastEmittedIns->idOpSize();
-    ssize_t   prevImm    = emitLastEmittedIns->idIsLargeCns() ? ((instrDescCns*)emitLastEmittedIns)->idcCnsVal
-                                                         : emitLastEmittedIns->idSmallCns();
+    regNumber prevReg1   = emitLastIns->idReg1();
+    regNumber prevReg2   = emitLastIns->idReg2();
+    insFormat lastInsfmt = emitLastIns->idInsFmt();
+    emitAttr  prevSize   = emitLastIns->idOpSize();
+    ssize_t prevImm = emitLastIns->idIsLargeCns() ? ((instrDescCns*)emitLastIns)->idcCnsVal : emitLastIns->idSmallCns();
 
     // Only optimize if:
     // 1. "base" or "base plus immediate offset" addressing modes.
@@ -15741,7 +15716,7 @@ bool emitter::IsRedundantLdStr(
         return false;
     }
 
-    if ((ins == INS_ldr) && (emitLastEmittedIns->idIns() == INS_str))
+    if ((ins == INS_ldr) && (emitLastIns->idIns() == INS_str))
     {
         // If reg1 is of size less than 8-bytes, then eliminating the 'ldr'
         // will not zero the upper bits of reg1.
@@ -15762,7 +15737,7 @@ bool emitter::IsRedundantLdStr(
             return true;
         }
     }
-    else if ((ins == INS_str) && (emitLastEmittedIns->idIns() == INS_ldr))
+    else if ((ins == INS_str) && (emitLastIns->idIns() == INS_ldr))
     {
         // Make sure src and dst registers are not same.
         //  ldr x0, [x0, #4]

--- a/src/coreclr/jit/instrsarm.h
+++ b/src/coreclr/jit/instrsarm.h
@@ -146,21 +146,20 @@ INST6(ldrsh,   "ldrsh",  0,LD, IF_EN6A,   0x5E00,    BAD_CODE,    0xF9300000,   
                                    //  ldrsh   Rt,[Rn+i12]       T2_K1     111110011011nnnn ttttiiiiiiiiiiii   F9B0 0000           imm(0-4095)
                                    //  ldrsh   Rt,[PC+i12]       T2_K4     11111001U0111111 ttttiiiiiiiiiiii   F93F 0000           imm(+-4095)
 
-//    enum            name      FP LD/ST          Rd, Rm     Rd,Rm        Rd,i8       Rd,+i8<<i4   S / Rn,Rm{,sh}
-//                                                 T1_E       T1_D0        T1_J0       T2_L1/L2     T2_C3/C8
-INST5(mov,            "mov",            0, 0, IF_EN5A,   0x0000,    0x4600,      0x2000,      0xF04F0000,  0xEA5F0000)
-                                                  //  movs    Rd,Rm             T1_E      0000000000mmmddd                    0000        low
-                                                  //  mov     Rd,Rm             T1_D0     01000110Dmmmmddd                    4600        high
-                                                  //  movs    Rd,i8             T1_J0     00100dddiiiiiiii                    2000        low     imm(0-255)
-                                                  //  mov{s}  Rd,+i8<<i4        T2_L1     11110i00010S1111 0iiiddddiiiiiiii   F04F 0000           imm(i8<<i4)
-                                                  //  mov{s}  Rd,Rm             T2_C3     1110101001011111 0000dddd0000mmmm   EA5F 0000
-INST5(mov_eliminated, "mov_eliminated", 0, 0, IF_EN5A,   0x0000,    0x4600,      0x2000,      0xF04F0000,  0xEA5F0000)
-INST5(cmp,            "cmp",            0,CMP,IF_EN5B,   0x4280,    0x4500,      0x2800,      0xF1B00F00,  0xEBB00F00)
-                                                  //  cmp     Rn,Rm             T1_E      0100001010mmmnnn                    4280        low
-                                                  //  cmp     Rn,Rm             T1_D0     01000101Nmmmmnnn                    4500        high
-                                                  //  cmp     Rn,i8             T1_J0     00101nnniiiiiiii                    2800        low     imm(0-255)
-                                                  //  cmp     Rn,+i8<<i4        T2_L2     11110i011011nnnn 0iii1111iiiiiiii   F1B0 0F00           imm(i8<<i4)
-                                                  //  cmp     Rn,Rm{,sh}        T2_C8     111010111011nnnn 0iii1111iishmmmm   EBB0 0F00
+//    enum     name      FP LD/ST          Rd, Rm     Rd,Rm        Rd,i8       Rd,+i8<<i4   S / Rn,Rm{,sh}
+//                                          T1_E       T1_D0        T1_J0       T2_L1/L2     T2_C3/C8
+INST5(mov,     "mov",    0, 0, IF_EN5A,   0x0000,    0x4600,      0x2000,      0xF04F0000,  0xEA5F0000)
+                                   //  movs    Rd,Rm             T1_E      0000000000mmmddd                    0000        low
+                                   //  mov     Rd,Rm             T1_D0     01000110Dmmmmddd                    4600        high
+                                   //  movs    Rd,i8             T1_J0     00100dddiiiiiiii                    2000        low     imm(0-255)
+                                   //  mov{s}  Rd,+i8<<i4        T2_L1     11110i00010S1111 0iiiddddiiiiiiii   F04F 0000           imm(i8<<i4)
+                                   //  mov{s}  Rd,Rm             T2_C3     1110101001011111 0000dddd0000mmmm   EA5F 0000
+INST5(cmp,     "cmp",    0,CMP,IF_EN5B,   0x4280,    0x4500,      0x2800,      0xF1B00F00,  0xEBB00F00)
+                                   //  cmp     Rn,Rm             T1_E      0100001010mmmnnn                    4280        low
+                                   //  cmp     Rn,Rm             T1_D0     01000101Nmmmmnnn                    4500        high
+                                   //  cmp     Rn,i8             T1_J0     00101nnniiiiiiii                    2800        low     imm(0-255)
+                                   //  cmp     Rn,+i8<<i4        T2_L2     11110i011011nnnn 0iii1111iiiiiiii   F1B0 0F00           imm(i8<<i4)
+                                   //  cmp     Rn,Rm{,sh}        T2_C8     111010111011nnnn 0iii1111iishmmmm   EBB0 0F00
 
 //    enum     name      FP LD/ST          Rdn, Rn    Rd,Rn,i5     Rd,Rn,Rm     Rd,Rn,i5
 //                                          T1_E       T2_C         T2_C4        T2_C2

--- a/src/coreclr/jit/instrsarm64.h
+++ b/src/coreclr/jit/instrsarm64.h
@@ -58,18 +58,17 @@
 // clang-format off
 INST9(invalid,     "INVALID",      0,      IF_NONE,   BAD_CODE,    BAD_CODE,    BAD_CODE,    BAD_CODE,    BAD_CODE,    BAD_CODE,    BAD_CODE,    BAD_CODE,    BAD_CODE)
 
-//    enum            name              info               DR_2E        DR_2G        DI_1B        DI_1D        DV_3C        DV_2B        DV_2C        DV_2E        DV_2F
-INST9(mov,            "mov",            0,      IF_EN9,    0x2A0003E0,  0x11000000,  0x52800000,  0x320003E0,  0x0EA01C00,  0x0E003C00,  0x4E001C00,  0x5E000400,  0x6E000400)
-                                        //  mov     Rd,Rm                DR_2E  X0101010000mmmmm 00000011111ddddd   2A00 03E0
-                                        //  mov     Rd,Rn                DR_2G  X001000100000000 000000nnnnnddddd   1100 0000   mov to/from SP only
-                                        //  mov     Rd,imm(i16,hw)       DI_1B  X10100101hwiiiii iiiiiiiiiiiddddd   5280 0000   imm(i16,hw)
-                                        //  mov     Rd,imm(N,r,s)        DI_1D  X01100100Nrrrrrr ssssss11111ddddd   3200 03E0   imm(N,r,s)
-                                        //  mov     Vd,Vn                DV_3C  0Q001110101nnnnn 000111nnnnnddddd   0EA0 1C00   Vd,Vn
-                                        //  mov     Rd,Vn[0]             DV_2B  0Q001110000iiiii 001111nnnnnddddd   0E00 3C00   Rd,Vn[]   (to general)
-                                        //  mov     Vd[],Rn              DV_2C  01001110000iiiii 000111nnnnnddddd   4E00 1C00   Vd[],Rn   (from general)
-                                        //  mov     Vd,Vn[]              DV_2E  01011110000iiiii 000001nnnnnddddd   5E00 0400   Vd,Vn[]   (scalar by element)
-                                        //  mov     Vd[],Vn[]            DV_2F  01101110000iiiii 0jjjj1nnnnnddddd   6E00 0400   Vd[],Vn[] (from/to elem)
-INST9(mov_eliminated, "mov_eliminated", 0,      IF_EN9,    0x2A0003E0,  0x11000000,  0x52800000,  0x320003E0,  0x0EA01C00,  0x0E003C00,  0x4E001C00,  0x5E000400,  0x6E000400)
+//    enum         name            info               DR_2E        DR_2G        DI_1B        DI_1D        DV_3C        DV_2B        DV_2C        DV_2E        DV_2F
+INST9(mov,         "mov",          0,      IF_EN9,    0x2A0003E0,  0x11000000,  0x52800000,  0x320003E0,  0x0EA01C00,  0x0E003C00,  0x4E001C00,  0x5E000400,  0x6E000400)
+                                   //  mov     Rd,Rm                DR_2E  X0101010000mmmmm 00000011111ddddd   2A00 03E0
+                                   //  mov     Rd,Rn                DR_2G  X001000100000000 000000nnnnnddddd   1100 0000   mov to/from SP only
+                                   //  mov     Rd,imm(i16,hw)       DI_1B  X10100101hwiiiii iiiiiiiiiiiddddd   5280 0000   imm(i16,hw)
+                                   //  mov     Rd,imm(N,r,s)        DI_1D  X01100100Nrrrrrr ssssss11111ddddd   3200 03E0   imm(N,r,s)
+                                   //  mov     Vd,Vn                DV_3C  0Q001110101nnnnn 000111nnnnnddddd   0EA0 1C00   Vd,Vn
+                                   //  mov     Rd,Vn[0]             DV_2B  0Q001110000iiiii 001111nnnnnddddd   0E00 3C00   Rd,Vn[]   (to general)
+                                   //  mov     Vd[],Rn              DV_2C  01001110000iiiii 000111nnnnnddddd   4E00 1C00   Vd[],Rn   (from general)
+                                   //  mov     Vd,Vn[]              DV_2E  01011110000iiiii 000001nnnnnddddd   5E00 0400   Vd,Vn[]   (scalar by element)
+                                   //  mov     Vd[],Vn[]            DV_2F  01101110000iiiii 0jjjj1nnnnnddddd   6E00 0400   Vd[],Vn[] (from/to elem)
 
 //    enum         name            info               DR_3A        DR_3B        DR_3C        DI_2A        DV_3A        DV_3E
 INST6(add,         "add",          0,      IF_EN6A,   0x0B000000,  0x0B000000,  0x0B200000,  0x11000000,  0x0E208400,  0x5EE08400)

--- a/src/coreclr/jit/instrsxarch.h
+++ b/src/coreclr/jit/instrsxarch.h
@@ -79,7 +79,6 @@ INST4(xor,              "xor",              IUM_RW, 0x000030,     0x003080,     
 INST4(cmp,              "cmp",              IUM_RD, 0x000038,     0x003880,     0x00003A,     0x00003C,                  Writes_OF      | Writes_SF     | Writes_ZF     | Writes_AF     | Writes_PF     | Writes_CF     )
 INST4(test,             "test",             IUM_RD, 0x000084,     0x0000F6,     0x000084,     0x0000A8,                  Resets_OF      | Writes_SF     | Writes_ZF     | Undefined_AF  | Writes_PF     | Resets_CF     )
 INST4(mov,              "mov",              IUM_WR, 0x000088,     0x0000C6,     0x00008A,     0x0000B0,                  INS_FLAGS_None )
-INST4(mov_eliminated,   "mov_eliminated",   IUM_WR, 0x000088,     0x0000C6,     0x00008A,     0x0000B0,                  INS_FLAGS_None)
 
 INST4(lea,              "lea",              IUM_WR, BAD_CODE,     BAD_CODE,     0x00008D,     BAD_CODE,                  INS_FLAGS_None )
 


### PR DESCRIPTION
This reverts commit 7df92fd478aef22d4d98693e64d93730bc513e29 to resolve https://github.com/dotnet/runtime/issues/53940

The original PR ran outerloop and gc stress, but apparently there is some remaining issue under jit stress.