### PR TITLE
Remove AOT exclusion for full PGO runs

### DIFF
--- a/eng/testing/performance/performance-setup.ps1
+++ b/eng/testing/performance/performance-setup.ps1
@@ -88,7 +88,6 @@ elseif($DynamicPGO)
 elseif($FullPGO)
 {
     $Configurations += " PGOType=fullpgo"
-    $ExtraBenchmarkDotNetArguments = "--category-exclusion-filter NoAOT"
 }
 
 # FIX ME: This is a workaround until we get this from the actual pipeline


### PR DESCRIPTION
This was left in by mistake from the earlier change, and we do not need to use this exclusion any more