### PR TITLE
Fix bug of FastReducer used in BigInteger.ModPow

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.FastReducer.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.FastReducer.cs
@@ -35,11 +35,11 @@ namespace System.Numerics
                 _mu = Divide(r, modulus);
                 _modulus = modulus;
 
-                // Allocate memory for quotients once
-                _q1 = new uint[modulus.Length * 2 + 2];
-                _q2 = new uint[modulus.Length * 2 + 1];
-
                 _muLength = ActualLength(_mu);
+
+                // Allocate memory for quotients once
+                _q1 = new uint[_muLength + modulus.Length + 1];
+                _q2 = new uint[_muLength + modulus.Length];
             }
 
             public int Reduce(uint[] value, int length)

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.FastReducer.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.FastReducer.cs
@@ -60,9 +60,10 @@ namespace System.Numerics
                 int l2 = DivMul(_q1, l1, _modulus, _modulus.Length,
                                 _q2, _modulus.Length + 1);
 
-                // Let v = (v - q2) % (2^32)^(k+1) - i*m
+                // Let v = (v - q2) % (2^32)^k
+                // while m <= v: Let v = v - m
                 return SubMod(value, length, _q2, l2,
-                              _modulus, _modulus.Length + 1);
+                              _modulus, _modulus.Length);
             }
 
             private static unsafe int DivMul(uint[] left, int leftLength,

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.FastReducer.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.FastReducer.cs
@@ -130,7 +130,7 @@ namespace System.Numerics
 
                 fixed (uint* l = left, r = right, m = modulus)
                 {
-                    SubtractSelf(l, leftLength, r, rightLength);
+                    OverFlowableSubtractSelf(l, leftLength, r, rightLength);
                     leftLength = ActualLength(left, leftLength);
 
                     while (Compare(l, leftLength, m, modulus.Length) >= 0)
@@ -143,6 +143,34 @@ namespace System.Numerics
                 Array.Clear(left, leftLength, left.Length - leftLength);
 
                 return leftLength;
+            }
+
+            private static unsafe void OverFlowableSubtractSelf(uint* left, int leftLength,
+                                                                uint* right, int rightLength)
+            {
+                Debug.Assert(leftLength >= 0);
+                Debug.Assert(rightLength >= 0);
+                Debug.Assert(leftLength >= rightLength);
+
+                // Executes the "grammar-school" algorithm for computing z = a - b.
+                // Same as above, but we're writing the result directly to a and
+                // stop execution, if we're out of b and c is already 0.
+
+                int i = 0;
+                long carry = 0L;
+
+                for (; i < rightLength; i++)
+                {
+                    long digit = (left[i] + carry) - right[i];
+                    left[i] = unchecked((uint)digit);
+                    carry = digit >> 32;
+                }
+                for (; carry != 0 && i < leftLength; i++)
+                {
+                    long digit = left[i] + carry;
+                    left[i] = (uint)digit;
+                    carry = digit >> 32;
+                }
             }
         }
     }

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.FastReducer.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.FastReducer.cs
@@ -27,11 +27,11 @@ namespace System.Numerics
             {
                 Debug.Assert(modulus != null);
 
-                // Let r = 4^k, with 2^k > m
+                // Let r = (2^32)^(2k), with (2^32)^k > m
                 uint[] r = new uint[modulus.Length * 2 + 1];
                 r[r.Length - 1] = 1;
 
-                // Let mu = 4^k / m
+                // Let mu = r / m
                 _mu = Divide(r, modulus);
                 _modulus = modulus;
 
@@ -52,15 +52,15 @@ namespace System.Numerics
                 if (length < _modulus.Length)
                     return length;
 
-                // Let q1 = v/2^(k-1) * mu
+                // Let q1 = v/(2^32)^(k-1) * mu
                 int l1 = DivMul(value, length, _mu, _muLength,
                                 _q1, _modulus.Length - 1);
 
-                // Let q2 = q1/2^(k+1) * m
+                // Let q2 = q1/(2^32)^(k+1) * m
                 int l2 = DivMul(_q1, l1, _modulus, _modulus.Length,
                                 _q2, _modulus.Length + 1);
 
-                // Let v = (v - q2) % 2^(k+1) - i*m
+                // Let v = (v - q2) % (2^32)^(k+1) - i*m
                 return SubMod(value, length, _q2, l2,
                               _modulus, _modulus.Length + 1);
             }

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/modpow.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/modpow.cs
@@ -295,12 +295,22 @@ namespace System.Numerics.Tests
                 byte[] tempByteArray1 = new byte[40];
                 byte[] tempByteArray2 = new byte[40];
                 byte[] tempByteArray3 = new byte[40];
+                byte[] tempByteArray4 = new byte[40];
+                byte[] tempByteArray5 = new byte[40];
+                byte[] tempByteArray6 = new byte[40];
 
                 for (int i = 0; i < 32; i++)
                 {
                     tempByteArray2[i] = 0xff;
                 }
-                tempByteArray3[36] = 1;
+                tempByteArray3[0] = 1;
+                for (int i = 0; i < 36; i++)
+                {
+                    tempByteArray4[i] = 0xff;
+                }
+                tempByteArray5[36] = 1;
+                tempByteArray6[0] = 1;
+                tempByteArray6[36] = 1;
 
                 for (int i = 32; i < 40; i++)
                 {
@@ -308,10 +318,19 @@ namespace System.Numerics.Tests
                     {
                         tempByteArray1[i] = (byte)(1 << j);
                         tempByteArray2[i] |= (byte)(1 << j);
-                        VerifyModPowString(Print(tempByteArray3) + "2 " + Print(tempByteArray2) + "tModPow");
-                        VerifyModPowString(Print(tempByteArray3) + "2 " + Print(tempByteArray1) + "tModPow");
+                        tempByteArray3[i] = (byte)(1 << j);
+                        VerifyModPowString(Print(tempByteArray4) + "2 " + Print(tempByteArray1) + "tModPow");
+                        VerifyModPowString(Print(tempByteArray5) + "2 " + Print(tempByteArray1) + "tModPow");
+                        VerifyModPowString(Print(tempByteArray6) + "2 " + Print(tempByteArray1) + "tModPow");
+                        VerifyModPowString(Print(tempByteArray4) + "2 " + Print(tempByteArray2) + "tModPow");
+                        VerifyModPowString(Print(tempByteArray5) + "2 " + Print(tempByteArray2) + "tModPow");
+                        VerifyModPowString(Print(tempByteArray6) + "2 " + Print(tempByteArray2) + "tModPow");
+                        VerifyModPowString(Print(tempByteArray4) + "2 " + Print(tempByteArray3) + "tModPow");
+                        VerifyModPowString(Print(tempByteArray5) + "2 " + Print(tempByteArray3) + "tModPow");
+                        VerifyModPowString(Print(tempByteArray6) + "2 " + Print(tempByteArray3) + "tModPow");
                     }
                     tempByteArray1[i] = 0;
+                    tempByteArray3[i] = 0;
                 }
             });
         }

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/modpow.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/modpow.cs
@@ -286,6 +286,36 @@ namespace System.Numerics.Tests
             VerifyModPowString(Math.Pow(2, 35) + " " + Math.Pow(2, 33) + " 2 tModPow");
         }
 
+        [Fact]
+        [OuterLoop]
+        public static void ModPowFastReducerBoundary()
+        {
+            BigIntTools.Utils.RunWithFakeThreshold("ReducerThreshold", 8, () =>
+            {
+                byte[] tempByteArray1 = new byte[40];
+                byte[] tempByteArray2 = new byte[40];
+                byte[] tempByteArray3 = new byte[40];
+
+                for (int i = 0; i < 32; i++)
+                {
+                    tempByteArray2[i] = 0xff;
+                }
+                tempByteArray3[36] = 1;
+
+                for (int i = 32; i < 40; i++)
+                {
+                    for (int j = 0; j < 8; j++)
+                    {
+                        tempByteArray1[i] = (byte)(1 << j);
+                        tempByteArray2[i] |= (byte)(1 << j);
+                        VerifyModPowString(Print(tempByteArray3) + "2 " + Print(tempByteArray2) + "tModPow");
+                        VerifyModPowString(Print(tempByteArray3) + "2 " + Print(tempByteArray1) + "tModPow");
+                    }
+                    tempByteArray1[i] = 0;
+                }
+            });
+        }
+
         private static void VerifyModPowString(string opstring)
         {
             StackCalc sc = new StackCalc(opstring);


### PR DESCRIPTION
There is a bug in the current implementation of `FastReducer` that causes a runtime error when certain conditions described below are met.

 - Modulus is less than **or equal** to `base^{modulus.Length-1}`.
 - Length of divided value must be sufficiently large when call reduce (this length depending on the modulus).

When these conditions are met, the size of the buffers q1 and q2 used in the algorithm becomes insufficient, causing a assertion error on [BigIntegerCalculator.FastReducer.cs#L77](https://github.com/dotnet/runtime/blob/9a64a29c38319a3c7724894fbf3e1e14b6fa799e/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.FastReducer.cs#L77) in debug build, or `IndexOutOfRangeException` on [BigIntegerCalculator.PowMod.cs#L401](https://github.com/dotnet/runtime/blob/9a64a29c38319a3c7724894fbf3e1e14b6fa799e/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.PowMod.cs#L401) in Release build.

`FastReducer` is used only in `BigInteger.ModPow`, but the specific condition cause above error. Following code is one of the example.

```cs
BigInteger.ModPow(BigInteger.One << 1008, 2, BigInteger.One << 992);
```

This PR fixes this bug by changing the allocated size of the buffer. The validity of the change is explained below.

**Edit: After submitting this PR, I found a bug that is related but has a different cause, so I will fix that as well. See the below comments for details.**

# Explanation

Unless otherwise stated, all variables are non-negative and division is defined as truncated division.

Before we begin, we will define a few constants and functions.

```
               base := 2^32
      Length(value) := Length of the current array representing the value
ActualLength(value) := Minimum array length that needs to represent value
```

First, we will look at the algorithm of the constructor.

```
given m: uint array notation of modulus

let k := Length(m)
let r := base^(2k)

let mu := r / m
let muLength := ActualLength(mu)
```

Note: The variable `k` is implicitly defined and does not appear in the actual code.

The above corresponds to the following code.

https://github.com/dotnet/runtime/blob/949fef48fd465bca952a3f97dda99e5a1b12ea47/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.FastReducer.cs#L26-L43

Next, we will look at the algorithm of the Reduce function.

```
given V: value that ActualLength(V) is less than or equal 2k
      ⇔ V is less than base^(2k)

let q1 := V / base^(k-1) * mu
let q2 := q1 / base^(k+1) * m
```

The above corresponds to the following code.

https://github.com/dotnet/runtime/blob/949fef48fd465bca952a3f97dda99e5a1b12ea47/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.FastReducer.cs#L45-L66

Here, we will think about upper bound of `ActualLength(q1)`.
Since upper bound of `V` is `base^(2k)`, upper bound of `V / base^(k-1)` is `base^(k+1)`.
Since modulus should not be 0, `r` and `mu` can't be 0. So `mu` is less than `base^(muLength)`.
It is easy to show that an upper bound on the values of both `V` and `mu` can be achieved.
From these facts, we can see that the upper bound of `q1` is `base^(muLength + k + 1)`.

Same as `q1`, we can see that upper bound of `q2` is `base^(muLength + k)`

Now we have shown the upper bound of `q1` and `q2`. From these, we can see that the upper bound of length of the buffer required for `q1` and `q2` is: `ActualLength(q1) ≦ muLength + k + 1`, `ActualLength(q2) ≦ muLength + k`.

