### PR TITLE
Improve SuperPMI performance.

### DIFF
--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/compileresult.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/compileresult.cpp
@@ -1096,7 +1096,10 @@ void CompileResult::repRecordCallSite(ULONG instrOffset, CORINFO_SIG_INFO* callS
         // The most call site records have only `methodHandle`, so creating two separate maps give us better perfomance
         // and smaller memory consumption. Note: we are not reading values from these maps during a normal replay.
         RecordCallSiteWithSignature = new LightWeightMap<DWORD, Agnostic_RecordCallSite>();
-        RecordCallSiteWithoutSignature = new LightWeightMap<DWORD, DWORDLONG>();
+        if (recordCallSitesWithoutSig)
+        {
+            RecordCallSiteWithoutSignature = new LightWeightMap<DWORD, DWORDLONG>();
+        }
     }
 
     if (callSig != nullptr)
@@ -1107,7 +1110,7 @@ void CompileResult::repRecordCallSite(ULONG instrOffset, CORINFO_SIG_INFO* callS
         value.methodHandle = CastHandle(methodHandle);
         RecordCallSiteWithSignature->Add(instrOffset, value);
     }
-    else
+    else if (recordCallSitesWithoutSig)
     {
         RecordCallSiteWithoutSignature->Add(instrOffset, CastHandle(methodHandle));
     }

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/compileresult.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/compileresult.h
@@ -211,5 +211,7 @@ private:
     MemoryTracker*          memoryTracker;
     Capture_AllocMemDetails allocMemDets;
     allocGCInfoDetails      allocGCInfoDets;
+
+    const bool recordCallSitesWithoutSig = false; // Set it to true if you want to use CallUtils::GetRecordedCallSiteInfo.
 };
 #endif

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/lightweightmap.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/lightweightmap.h
@@ -385,11 +385,9 @@ public:
 
         if (numItems > 0)
         {
-            for (unsigned int i = numItems; i > insert; i--)
-            {
-                pKeys[i]  = pKeys[i - 1];
-                pItems[i] = pItems[i - 1];
-            }
+            int countToMove = (numItems - insert);
+            memmove(&pKeys[insert+1], &pKeys[insert], countToMove * sizeof(pKeys[insert]));
+            memmove(&pItems[insert+1], &pItems[insert], countToMove * sizeof(pItems[insert]));
         }
 
         pKeys[insert]  = key;


### PR DESCRIPTION
There were some methods where we had added too many records in this map that is not even used until you call https://github.com/dotnet/runtime/blob/ac87f000c90814a76f7891362b886569043bee12/src/coreclr/ToolBox/superpmi/superpmi-shared/callutils.cpp#L54
(no callers nowadays).

The overall replay time goes down to ~30% (without -p) on coreclr_tests.pmi.windows.x64.checked.mch.

but for some huge methods it goes down from 70 seconds to 5 so they stop becoming a bottleneck for -p replays.

Also, improve array shift in `bool Add(_Key key, _Item item)` from a simple sequential move to a `memmove`.