### PR TITLE
Fix missing ClearStateUponCompletion call in AsyncTaskMethodBuilder

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -329,6 +329,11 @@ namespace System.Runtime.CompilerServices
                     }
                 }
 
+                if (IsCompleted)
+                {
+                    ClearStateUponCompletion();
+                }
+
                 if (loggingOn)
                 {
                     TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);


### PR DESCRIPTION
This was accidentally removed as part of a previous refactoring.  The lack of it means primarily that we're not always removing async method tasks from the s_currentActiveTasks dictionary when the debugger is attached (we didn't notice it because awaiting the resulting task also causes it to be removed).  It also means we're not clearing out some state we intended to in order to minimize extending lifetime of objects referenced by the state machine if the task is held onto for a prolonged period.

@mangod9, this is a fix for the issue @timmydo alluded to yesterday.

cc: @kouvel