### PR TITLE
Make the ZLib P/Invokes all blittable

### DIFF
--- a/src/libraries/Common/src/Interop/Interop.zlib.cs
+++ b/src/libraries/Common/src/Interop/Interop.zlib.cs
@@ -9,8 +9,8 @@ internal static partial class Interop
     internal static partial class zlib
     {
         [DllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_DeflateInit2_")]
-        internal static extern ZLibNative.ErrorCode DeflateInit2_(
-            ref ZLibNative.ZStream stream,
+        internal static extern unsafe ZLibNative.ErrorCode DeflateInit2_(
+            ZLibNative.ZStream* stream,
             ZLibNative.CompressionLevel level,
             ZLibNative.CompressionMethod method,
             int windowBits,
@@ -18,25 +18,25 @@ internal static partial class Interop
             ZLibNative.CompressionStrategy strategy);
 
         [DllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_Deflate")]
-        internal static extern ZLibNative.ErrorCode Deflate(ref ZLibNative.ZStream stream, ZLibNative.FlushCode flush);
+        internal static extern unsafe ZLibNative.ErrorCode Deflate(ZLibNative.ZStream* stream, ZLibNative.FlushCode flush);
 
         [DllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_DeflateReset")]
-        internal static extern ZLibNative.ErrorCode DeflateReset(ref ZLibNative.ZStream stream);
+        internal static extern unsafe ZLibNative.ErrorCode DeflateReset(ZLibNative.ZStream* stream);
 
         [DllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_DeflateEnd")]
-        internal static extern ZLibNative.ErrorCode DeflateEnd(ref ZLibNative.ZStream stream);
+        internal static extern unsafe ZLibNative.ErrorCode DeflateEnd(ZLibNative.ZStream* stream);
 
         [DllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_InflateInit2_")]
-        internal static extern ZLibNative.ErrorCode InflateInit2_(ref ZLibNative.ZStream stream, int windowBits);
+        internal static extern unsafe ZLibNative.ErrorCode InflateInit2_(ZLibNative.ZStream* stream, int windowBits);
 
         [DllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_Inflate")]
-        internal static extern ZLibNative.ErrorCode Inflate(ref ZLibNative.ZStream stream, ZLibNative.FlushCode flush);
+        internal static extern unsafe ZLibNative.ErrorCode Inflate(ZLibNative.ZStream* stream, ZLibNative.FlushCode flush);
 
         [DllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_InflateReset")]
-        internal static extern ZLibNative.ErrorCode InflateReset(ref ZLibNative.ZStream stream);
+        internal static extern unsafe ZLibNative.ErrorCode InflateReset(ZLibNative.ZStream* stream);
 
         [DllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_InflateEnd")]
-        internal static extern ZLibNative.ErrorCode InflateEnd(ref ZLibNative.ZStream stream);
+        internal static extern unsafe ZLibNative.ErrorCode InflateEnd(ZLibNative.ZStream* stream);
 
         [DllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_Crc32")]
         internal static extern unsafe uint crc32(uint crc, byte* buffer, int len);

--- a/src/libraries/Common/src/System/IO/Compression/ZLibNative.cs
+++ b/src/libraries/Common/src/System/IO/Compression/ZLibNative.cs
@@ -283,7 +283,9 @@ namespace System.IO.Compression
                 EnsureState(State.InitializedForDeflate);
 
                 fixed (ZStream* stream = &_zStream)
+                {
                     return Interop.zlib.Deflate(stream, flush);
+                }
             }
 
 
@@ -293,7 +295,9 @@ namespace System.IO.Compression
                 EnsureState(State.InitializedForDeflate);
 
                 fixed (ZStream* stream = &_zStream)
+                {
                     return Interop.zlib.DeflateReset(stream);
+                }
             }
 
             public unsafe ErrorCode DeflateEnd()
@@ -332,7 +336,9 @@ namespace System.IO.Compression
                 EnsureState(State.InitializedForInflate);
 
                 fixed (ZStream* stream = &_zStream)
+                {
                     return Interop.zlib.Inflate(stream, flush);
+                }
             }
 
 
@@ -342,7 +348,9 @@ namespace System.IO.Compression
                 EnsureState(State.InitializedForInflate);
 
                 fixed (ZStream* stream = &_zStream)
+                {
                     return Interop.zlib.InflateReset(stream);
+                }
             }
 
             public unsafe ErrorCode InflateEnd()

--- a/src/libraries/Common/src/System/IO/Compression/ZLibNative.cs
+++ b/src/libraries/Common/src/System/IO/Compression/ZLibNative.cs
@@ -262,81 +262,101 @@ namespace System.IO.Compression
             }
 
 
-            public ErrorCode DeflateInit2_(CompressionLevel level, int windowBits, int memLevel, CompressionStrategy strategy)
+            public unsafe ErrorCode DeflateInit2_(CompressionLevel level, int windowBits, int memLevel, CompressionStrategy strategy)
             {
                 EnsureNotDisposed();
                 EnsureState(State.NotInitialized);
 
-                ErrorCode errC = Interop.zlib.DeflateInit2_(ref _zStream, level, CompressionMethod.Deflated, windowBits, memLevel, strategy);
-                _initializationState = State.InitializedForDeflate;
+                fixed (ZStream* stream = &_zStream)
+                {
+                    ErrorCode errC = Interop.zlib.DeflateInit2_(stream, level, CompressionMethod.Deflated, windowBits, memLevel, strategy);
+                    _initializationState = State.InitializedForDeflate;
 
-                return errC;
+                    return errC;
+                }
             }
 
 
-            public ErrorCode Deflate(FlushCode flush)
-            {
-                EnsureNotDisposed();
-                EnsureState(State.InitializedForDeflate);
-                return Interop.zlib.Deflate(ref _zStream, flush);
-            }
-
-
-            public ErrorCode DeflateReset()
-            {
-                EnsureNotDisposed();
-                EnsureState(State.InitializedForDeflate);
-                return Interop.zlib.DeflateReset(ref _zStream);
-            }
-
-            public ErrorCode DeflateEnd()
+            public unsafe ErrorCode Deflate(FlushCode flush)
             {
                 EnsureNotDisposed();
                 EnsureState(State.InitializedForDeflate);
 
-                ErrorCode errC = Interop.zlib.DeflateEnd(ref _zStream);
-                _initializationState = State.Disposed;
-
-                return errC;
+                fixed (ZStream* stream = &_zStream)
+                    return Interop.zlib.Deflate(stream, flush);
             }
 
 
-            public ErrorCode InflateInit2_(int windowBits)
+            public unsafe ErrorCode DeflateReset()
+            {
+                EnsureNotDisposed();
+                EnsureState(State.InitializedForDeflate);
+
+                fixed (ZStream* stream = &_zStream)
+                    return Interop.zlib.DeflateReset(stream);
+            }
+
+            public unsafe ErrorCode DeflateEnd()
+            {
+                EnsureNotDisposed();
+                EnsureState(State.InitializedForDeflate);
+
+                fixed (ZStream* stream = &_zStream)
+                {
+                    ErrorCode errC = Interop.zlib.DeflateEnd(stream);
+                    _initializationState = State.Disposed;
+
+                    return errC;
+                }
+            }
+
+
+            public unsafe ErrorCode InflateInit2_(int windowBits)
             {
                 EnsureNotDisposed();
                 EnsureState(State.NotInitialized);
 
-                ErrorCode errC = Interop.zlib.InflateInit2_(ref _zStream, windowBits);
-                _initializationState = State.InitializedForInflate;
+                fixed (ZStream* stream = &_zStream)
+                {
+                    ErrorCode errC = Interop.zlib.InflateInit2_(stream, windowBits);
+                    _initializationState = State.InitializedForInflate;
 
-                return errC;
+                    return errC;
+                }
             }
 
 
-            public ErrorCode Inflate(FlushCode flush)
-            {
-                EnsureNotDisposed();
-                EnsureState(State.InitializedForInflate);
-                return Interop.zlib.Inflate(ref _zStream, flush);
-            }
-
-
-            public ErrorCode InflateReset()
-            {
-                EnsureNotDisposed();
-                EnsureState(State.InitializedForInflate);
-                return Interop.zlib.InflateReset(ref _zStream);
-            }
-
-            public ErrorCode InflateEnd()
+            public unsafe ErrorCode Inflate(FlushCode flush)
             {
                 EnsureNotDisposed();
                 EnsureState(State.InitializedForInflate);
 
-                ErrorCode errC = Interop.zlib.InflateEnd(ref _zStream);
-                _initializationState = State.Disposed;
+                fixed (ZStream* stream = &_zStream)
+                    return Interop.zlib.Inflate(stream, flush);
+            }
 
-                return errC;
+
+            public unsafe ErrorCode InflateReset()
+            {
+                EnsureNotDisposed();
+                EnsureState(State.InitializedForInflate);
+
+                fixed (ZStream* stream = &_zStream)
+                    return Interop.zlib.InflateReset(stream);
+            }
+
+            public unsafe ErrorCode InflateEnd()
+            {
+                EnsureNotDisposed();
+                EnsureState(State.InitializedForInflate);
+
+                fixed (ZStream* stream = &_zStream)
+                {
+                    ErrorCode errC = Interop.zlib.InflateEnd(stream);
+                    _initializationState = State.Disposed;
+
+                    return errC;
+                }
             }
 
             // This can work even after XxflateEnd().


### PR DESCRIPTION
While prototyping a `DllImport` source generator it was observed the ZLib P/Invokes can all be converted to be blittable and thus inlinable during JIT.

/cc @elinor-fung 