### PR TITLE
[wasm][aot][tests] Disable tests causing crash - System.Text.Encoding…

### DIFF
--- a/src/libraries/System.Text.Encodings.Web/tests/TextEncoderSettingsTests.cs
+++ b/src/libraries/System.Text.Encodings.Web/tests/TextEncoderSettingsTests.cs
@@ -31,6 +31,7 @@ namespace System.Text.Encodings.Web.Tests
         }
     }
 
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/50965", TestPlatforms.Browser)]
     public class TextEncoderSettingsTests
     {
         [Fact]

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -258,9 +258,6 @@
     <!-- Issue: https://github.com/dotnet/runtime/issues/51677 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Tasks.Parallel/tests/System.Threading.Tasks.Parallel.Tests.csproj" />
 
-    <!-- Issue: https://github.com/dotnet/runtime/issues/50965 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Encodings.Web\tests\System.Text.Encodings.Web.Tests.csproj" />
-
     <!-- Issue: https://github.com/dotnet/runtime/issues/51678 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Loader\tests\System.Runtime.Loader.Tests.csproj" />
 


### PR DESCRIPTION
…s.Web.Tests

With these tests disabled, the test run doesn't crash, and can be
reenabled for AOT.

Issue: https://github.com/dotnet/runtime/issues/50965