### PR TITLE
Don't return null target methods in GetInterfaceMap for abstract classes, or classes using DIMs

### DIFF
--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -2526,6 +2526,23 @@ fail:
 }
 
 static gboolean
+method_is_reabstracted (MonoMethod *method)
+{
+	/* only on interfaces */
+	/* method is marked "final abstract" */
+	/* FIXME: we need some other way to detect reabstracted methods.  "final" is an incidental detail of the spec. */
+	return method->flags & METHOD_ATTRIBUTE_FINAL && method->flags & METHOD_ATTRIBUTE_ABSTRACT;
+}
+
+static gboolean
+method_is_dim (MonoMethod *method)
+{
+	/* only valid on interface methods*/
+	/* method is marked "virtual" but not "virtual abstract" */
+	return method->flags & method->flags & METHOD_ATTRIBUTE_VIRTUAL && !(method->flags & METHOD_ATTRIBUTE_ABSTRACT);
+}
+
+static gboolean
 set_interface_map_data_method_object (MonoMethod *method, MonoClass *iclass, int ioffset, MonoClass *klass, MonoArrayHandle targets, MonoArrayHandle methods, int i, MonoError *error)
 {
 	HANDLE_FUNCTION_ENTER ();
@@ -2558,9 +2575,26 @@ set_interface_map_data_method_object (MonoMethod *method, MonoClass *iclass, int
 		}
 	}
 
-	if (foundMethod->flags & METHOD_ATTRIBUTE_ABSTRACT)
+	/*
+	 * if the iterface method is reabstracted, and either the found implementation method is abstract, or the found
+	 * implementation method is from another DIM (meaning neither klass nor any of its ancestor classes implemented
+	 * the method), then say the target method is null.
+	 */
+	if (method_is_reabstracted (method) &&
+	    ((foundMethod->flags & METHOD_ATTRIBUTE_ABSTRACT) ||
+	     (mono_class_is_interface (foundMethod->klass) && method_is_dim (foundMethod))
+		    ))
 		MONO_HANDLE_ARRAY_SETREF (targets, i, NULL_HANDLE);
-	else {
+	else if (mono_class_is_interface (foundMethod->klass) && method_is_reabstracted (foundMethod) && !m_class_is_abstract (klass)) {
+		/* if the method we found is a reabstracted DIM method, but the class isn't abstract, return NULL */
+		/*
+		 * (C# doesn't seem to allow constructing such types, it requires the whole class to be abstract - in
+		 * which case we are supposed to return the reabstracted interface method.  But in IL we can make a
+		 * non-abstract class with reabstracted interface methods - which is supposed to fail with an
+		 * EntryPointNotFoundException at invoke time, but does not prevent the class from loading.)
+		 */
+		MONO_HANDLE_ARRAY_SETREF (targets, i, NULL_HANDLE);
+	} else {
 		MONO_HANDLE_ASSIGN (member, mono_method_get_object_handle (foundMethod, mono_class_is_interface (foundMethod->klass) ? foundMethod->klass : klass, error));
 		goto_if_nok (error, leave);
 		MONO_HANDLE_ARRAY_SETREF (targets, i, member);


### PR DESCRIPTION
If the interface method is reabstracted, and either the found implementation method is abstract, or the found implementation method is from another DIM (meaning neither klass nor any of its ancestor classes implemented the
method), then say the target method is null.  Otherwise return the found implementation method, even if it is abstract.

Fixes https://github.com/dotnet/runtime/issues/53933
