### PR TITLE
Don't enable DllImport generator for shims

### DIFF
--- a/eng/generators.targets
+++ b/eng/generators.targets
@@ -20,6 +20,7 @@
 
   <Target Name="EnableDllImportGeneratorForNetCoreApp"
           Condition="'$(EnableDllImportGenerator)' == ''
+                        and '$(IsFrameworkSupportFacade)' != 'true'
                         and ('$(IsNetCoreAppSrc)' == 'true' or '$(MSBuildProjectName)' == 'System.Private.CoreLib')
                         and '$(MSBuildProjectExtension)' == '.csproj'">
     <PropertyGroup>


### PR DESCRIPTION
Having it enabled was resulting in the attributes for triggering/configuration generation being added to the shims.

cc @AaronRobinsonMSFT @jkoritzinsky 