### PR TITLE
[wasm][aot] Enable tests that are passing now

### DIFF
--- a/src/libraries/System.Transactions.Local/tests/LTMEnlistmentTests.cs
+++ b/src/libraries/System.Transactions.Local/tests/LTMEnlistmentTests.cs
@@ -76,7 +76,6 @@ namespace System.Transactions.Tests
         }
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50969", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
         // This test needs to change once we have promotion support.
         // Right now any attempt to create a two phase durable enlistment will attempt to promote and will fail because promotion is not supported. This results in the transaction being
         // aborted.

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -255,9 +255,6 @@
     <!-- Issue: https://github.com/dotnet/runtime/issues/51722 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Linq\tests\System.Linq.Tests.csproj" />
 
-    <!-- Issue: https://github.com/dotnet/runtime/issues/51677 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Tasks.Parallel/tests/System.Threading.Tasks.Parallel.Tests.csproj" />
-
     <!-- Issue: https://github.com/dotnet/runtime/issues/50965 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Encodings.Web\tests\System.Text.Encodings.Web.Tests.csproj" />
 

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -299,10 +299,6 @@
     <!-- Issue: https://github.com/dotnet/runtime/issues/51708 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Linq.Expressions\tests\System.Linq.Expressions.Tests.csproj" />
 
-    <!-- Issue: https://github.com/dotnet/runtime/issues/51244 -->
-    <!-- Issue: https://github.com/dotnet/runtime/issues/51911 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml\tests\Xslt\XslCompiledTransformApi\System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj" />
-
     <!-- MarkTypeForDynamicallyAccessedMembers stack overflow https://github.com/mono/linker/issues/1881 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.ComponentModel.Annotations\tests\System.ComponentModel.Annotations.Tests.csproj" />
 


### PR DESCRIPTION
These don't reproduce on `main` anymore, after the exceptions fix.

`System.Reflection.Tests`          Fixes https://github.com/dotnet/runtime/issues/51673
`System.Transactions.Locals.Tests` Fixes https://github.com/dotnet/runtime/issues/50969
`System.Threading.Tasks.Parallel.Tests` Fixes https://github.com/dotnet/runtime/issues/51677