### PR TITLE
Avoid throwing in ToString() if the process has already exited

### DIFF
--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -1361,15 +1361,31 @@ namespace System.Diagnostics
 
         public override string ToString()
         {
-            if (Associated)
+            string result = base.ToString();
+
+            try
             {
-                string processName = ProcessName;
-                if (processName.Length != 0)
+                if (Associated)
                 {
-                    return $"{base.ToString()} ({processName})";
+                    _processInfo ??= ProcessManager.GetProcessInfo(_processId, _machineName);
+                    if (_processInfo is not null)
+                    {
+                        string processName = _processInfo.ProcessName;
+                        if (processName.Length != 0)
+                        {
+                            result = $"{result} ({processName})";
+                        }
+                    }
                 }
             }
-            return base.ToString();
+            catch
+            {
+                // Common contract for ToString methods is never throw.
+                // Handle cases where a process would terminates immediately after our checks
+                // and/or cause ProcessManager to throw an exception.
+            }
+
+            return result;
         }
 
         /// <devdoc>

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -474,14 +474,14 @@ namespace System.Diagnostics.Tests
             var name = p.ProcessName;
             Assert.Equal($"System.Diagnostics.Process ({name})", p.ToString());
 
-            p.KillWait();
+            KillWait(p);
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void TestToString_OnExitedProcess()
         {
             Process p = CreateDefaultProcess();
-            p.KillWait();
+            KillWait(p);
 
             // Ensure ToString does not throw an exception, but still returns
             // a representation of the object.

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -467,6 +467,27 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void TestToString_OnRunningProcess()
+        {
+            Process p = CreateDefaultProcess();
+            var name = p.ProcessName;
+            Assert.Equal($"System.Diagnostics.Process ({name})", p.ToString());
+
+            p.KillWait();
+        }
+
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void TestToString_OnExitedProcess()
+        {
+            Process p = CreateDefaultProcess();
+            p.KillWait();
+
+            // Ensure ToString does not throw an exception, but still returns
+            // a representation of the object.
+            Assert.Equal("System.Diagnostics.Process", p.ToString());
+        }
+
         [Fact]
         public void HasExited_GetNotStarted_ThrowsInvalidOperationException()
         {


### PR DESCRIPTION
Fixes #1520

Replace #43597

In #43597 was a test fail because we called a process property and initialized internal process cache. So I split the test - one for running process, (2) second for exited process without calling any properties/methods for the test process to avoid the cache initialization.