### PR TITLE
posix_fallocate should work on WASM now

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/FileStream/ctor_options_as.Browser.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/ctor_options_as.Browser.cs
@@ -1,11 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Xunit;
-
 namespace System.IO.Tests
 {
-    [PlatformSpecific(~TestPlatforms.Browser)]
     public partial class FileStream_ctor_options_as : FileStream_ctor_options_as_base
     {
         protected override long PreallocationSize => 10;

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.cs
@@ -39,7 +39,6 @@ namespace System.IO.Strategies
         internal static bool ShouldPreallocate(long preallocationSize, FileAccess access, FileMode mode)
             => preallocationSize > 0
                && (access & FileAccess.Write) != 0
-               && mode != FileMode.Open && mode != FileMode.Append
-               && !OperatingSystem.IsBrowser(); // WASM limitation
+               && mode != FileMode.Open && mode != FileMode.Append;
     }
 }


### PR DESCRIPTION
With #53927 it should be possible to call `posix_fallocate` now (signature: IILL)