### PR TITLE
Fix GC heap walk for regions (failing test tracing\eventpipe\gcdump\gcdump)

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -44523,6 +44523,19 @@ void gc_heap::walk_heap_per_heap (walk_fn fn, void* context, int gen_number, BOO
                 end = heap_segment_allocated (seg);
                 continue;
             }
+#ifdef USE_REGIONS
+            else if (gen_number > 0)
+            {
+                // advance to next lower generation
+                gen_number--;
+                gen = gc_heap::generation_of (gen_number);
+                seg = generation_start_segment (gen);
+
+                x = heap_segment_mem (seg);
+                end = heap_segment_allocated (seg);
+                continue;
+            }
+#endif // USE_REGIONS
             else
             {
                 if (walk_large_object_heap_p)


### PR DESCRIPTION
In gc_heap::walk_heap_per_heap, we need to iterate through the SOH generations if USE_REGIONS is enabled - otherwise the lower SOH generations may be skipped.

