### PR TITLE
Disable STRESS_REGIONS

### DIFF
--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -63,7 +63,7 @@ inline void FATAL_GC_ERROR()
 // + creates some pins on our own
 // + creates some ro segs
 // We can add more mechanisms here.
-#define STRESS_REGIONS
+//#define STRESS_REGIONS
 #endif //USE_REGIONS
 
 // FEATURE_STRUCTALIGN was added by Midori. In CLR we are not interested


### PR DESCRIPTION
There are several tests (most of them under GC\\Scenarios\\DoublinkList) that fail because STRESS_REGIONS pins arbitrary objects and thus keeps them alive, and thus these objects are not finalized.

Let's disable STRESS_REGIONS in the checked-in source code, but investigate whether there are any failures with STRESS_REGIONS that are real issues.
