### PR TITLE
Disable SynchronizationContextCurrent_NotUsedForAsyncOperations on Mono

### DIFF
--- a/src/libraries/System.Private.Xml/tests/XmlReader/Tests/AsyncReaderLateInitTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlReader/Tests/AsyncReaderLateInitTests.cs
@@ -93,6 +93,7 @@ namespace System.Xml.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/53987", TestRuntimes.Mono)]
         public static void SynchronizationContextCurrent_NotUsedForAsyncOperations()
         {
             Task.Run(() =>


### PR DESCRIPTION
It seems to hang for some reason.

https://github.com/dotnet/runtime/issues/53987