### PR TITLE
Update SuppressGCTransition test to work in single file

### DIFF
--- a/src/tests/Interop/SuppressGCTransition/SuppressGCTransitionTest.cs
+++ b/src/tests/Interop/SuppressGCTransition/SuppressGCTransitionTest.cs
@@ -94,7 +94,7 @@ unsafe static class SuppressGCTransitionNative
             $"lib{nameof(SuppressGCTransitionNative)}.dylib",
         };
 
-        string binDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        string binDir = AppContext.BaseDirectory;
         foreach (var ln in libNames)
         {
             if (NativeLibrary.TryLoad(Path.Combine(binDir, ln), out IntPtr mod))


### PR DESCRIPTION
Assembly.Location is an empty string when published as a single file.