### PR TITLE
Use InvariantCulture when parsing with NumberStyles.None/HexNumber

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderUtilities.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderUtilities.cs
@@ -156,7 +156,7 @@ namespace System.Net.Http.Headers
 
             if (HttpRuleParser.GetTokenLength(value, 0) != value.Length)
             {
-                throw new FormatException(SR.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_headers_invalid_value, value));
+                throw new FormatException(SR.Format(CultureInfo.InvariantCulture, SR.net_http_headers_invalid_value, value));
             }
         }
 
@@ -171,7 +171,7 @@ namespace System.Net.Http.Headers
             if ((HttpRuleParser.GetCommentLength(value, 0, out length) != HttpParseResult.Parsed) ||
                 (length != value.Length)) // no trailing spaces allowed
             {
-                throw new FormatException(SR.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_headers_invalid_value, value));
+                throw new FormatException(SR.Format(CultureInfo.InvariantCulture, SR.net_http_headers_invalid_value, value));
             }
         }
 
@@ -186,7 +186,7 @@ namespace System.Net.Http.Headers
             if ((HttpRuleParser.GetQuotedStringLength(value, 0, out length) != HttpParseResult.Parsed) ||
                 (length != value.Length)) // no trailing spaces allowed
             {
-                throw new FormatException(SR.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_headers_invalid_value, value));
+                throw new FormatException(SR.Format(CultureInfo.InvariantCulture, SR.net_http_headers_invalid_value, value));
             }
         }
 
@@ -318,7 +318,7 @@ namespace System.Net.Http.Headers
         }
 
         internal static bool TryParseInt32(string value, out int result) =>
-            int.TryParse(value, NumberStyles.None, provider: null, out result);
+            int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out result);
 
         internal static bool TryParseInt32(string value, int offset, int length, out int result)
         {
@@ -328,7 +328,7 @@ namespace System.Net.Http.Headers
                 return false;
             }
 
-            return int.TryParse(value.AsSpan(offset, length), NumberStyles.None, provider: null, out result);
+            return int.TryParse(value.AsSpan(offset, length), NumberStyles.None, CultureInfo.InvariantCulture, out result);
         }
 
         internal static bool TryParseInt64(string value, int offset, int length, out long result)
@@ -339,7 +339,7 @@ namespace System.Net.Http.Headers
                 return false;
             }
 
-            return long.TryParse(value.AsSpan(offset, length), NumberStyles.None, provider: null, out result);
+            return long.TryParse(value.AsSpan(offset, length), NumberStyles.None, CultureInfo.InvariantCulture, out result);
         }
 
         internal static void DumpHeaders(StringBuilder sb, params HttpHeaders?[] headers)

--- a/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerRequestUriBuilder.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerRequestUriBuilder.cs
@@ -242,7 +242,7 @@ namespace System.Net
             // http.sys only supports %uXXXX (4 hex-digits), even though unicode code points could have up to
             // 6 hex digits. Therefore we parse always 4 characters after %u and convert them to an int.
             int codePointValue;
-            if (!int.TryParse(codePoint, NumberStyles.HexNumber, null, out codePointValue))
+            if (!int.TryParse(codePoint, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out codePointValue))
             {
                 if (NetEventSource.Log.IsEnabled())
                     NetEventSource.Error(this, SR.Format(SR.net_log_listener_cant_convert_percent_value, codePoint));
@@ -274,7 +274,7 @@ namespace System.Net
         private bool AddPercentEncodedOctetToRawOctetsList(Encoding encoding, string escapedCharacter)
         {
             byte encodedValue;
-            if (!byte.TryParse(escapedCharacter, NumberStyles.HexNumber, null, out encodedValue))
+            if (!byte.TryParse(escapedCharacter, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out encodedValue))
             {
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, SR.Format(SR.net_log_listener_cant_convert_percent_value, escapedCharacter));
                 return false;

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Managed/ChunkStream.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Managed/ChunkStream.cs
@@ -274,7 +274,7 @@ namespace System.Net
                 {
                     if (_saved.Length > 0)
                     {
-                        _chunkSize = int.Parse(RemoveChunkExtension(_saved.ToString()), NumberStyles.HexNumber);
+                        _chunkSize = int.Parse(RemoveChunkExtension(_saved.ToString()), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
                     }
                 }
                 catch (Exception)
@@ -288,7 +288,7 @@ namespace System.Net
             _chunkRead = 0;
             try
             {
-                _chunkSize = int.Parse(RemoveChunkExtension(_saved.ToString()), NumberStyles.HexNumber);
+                _chunkSize = int.Parse(RemoveChunkExtension(_saved.ToString()), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
             }
             catch (Exception)
             {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -361,7 +361,7 @@ namespace System.Text.RegularExpressions
             else
             {
                 // Otherwise, try to parse it as a number.
-                return uint.TryParse(name, NumberStyles.None, provider: null, out uint result) && result < capsize ? (int)result : -1;
+                return uint.TryParse(name, NumberStyles.None, CultureInfo.InvariantCulture, out uint result) && result < capsize ? (int)result : -1;
             }
         }
 


### PR DESCRIPTION
The only time {U}Int{32/64}.TryParse needs to consult a culture is if it needs to look up the positive/negative symbol from it, and if NumberStyles.None or NumberStyles.HexNumber are passed, it won't ever do that.  All such call sites benefit from using CultureInfo.InvariantCulture explicitly, as it's just a static field read, whereas passing in null causes the implementation to access CultureInfo.CurrentCulture, which incurs a thread-static read.  Most of our usage already does this, but a few sites don't; this fixes those.