### PR TITLE
small improvements to HTTP Cancellation Tests and rename

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.SocketsHttpHandler.cs
@@ -63,10 +63,10 @@ namespace System.Net.Http.Functional.Tests
             CreateHttpClientHandler(Version.Parse(useVersionString));
 
 
-        protected static object GetUnderlyingSocketsHttpHandler(HttpClientHandler handler)
+        protected static SocketsHttpHandler GetUnderlyingSocketsHttpHandler(HttpClientHandler handler)
         {
             FieldInfo field = typeof(HttpClientHandler).GetField("_underlyingHandler", BindingFlags.Instance | BindingFlags.NonPublic);
-            return field?.GetValue(handler);
+            return (SocketsHttpHandler)field?.GetValue(handler);
         }
 
         protected static HttpRequestMessage CreateRequest(HttpMethod method, Uri uri, Version version, bool exactVersion = false) =>

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Cancellation.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Cancellation.cs
@@ -1,13 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Net.Test.Common;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -15,45 +11,78 @@ using Xunit.Abstractions;
 
 namespace System.Net.Http.Functional.Tests
 {
-    public abstract class HttpClientHandler_Http11_Cancellation_Test : HttpClientHandler_Cancellation_Test
+    public abstract class SocketsHttpHandler_Cancellation_Test : HttpClientHandler_Cancellation_Test
     {
-        protected HttpClientHandler_Http11_Cancellation_Test(ITestOutputHelper output) : base(output) { }
+        protected SocketsHttpHandler_Cancellation_Test(ITestOutputHelper output) : base(output) { }
+
+        private async Task ValidateConnectTimeout(HttpMessageInvoker invoker, Uri uri)
+        {
+            var sw = Stopwatch.StartNew();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                invoker.SendAsync(TestAsync, new HttpRequestMessage(HttpMethod.Get, uri) { Version = UseVersion }, default));
+            sw.Stop();
+
+            Assert.InRange(sw.ElapsedMilliseconds, 500, 85_000);
+        }
 
         [OuterLoop]
         [Fact]
         public async Task ConnectTimeout_TimesOutSSLAuth_Throws()
         {
             var releaseServer = new TaskCompletionSource();
-            await LoopbackServer.CreateClientAndServerAsync(async uri =>
+            await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
             {
                 using (var handler = new SocketsHttpHandler())
                 using (var invoker = new HttpMessageInvoker(handler))
                 {
                     handler.ConnectTimeout = TimeSpan.FromSeconds(1);
 
-                    var sw = Stopwatch.StartNew();
-                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
-                        invoker.SendAsync(TestAsync, new HttpRequestMessage(HttpMethod.Get,
-                            new UriBuilder(uri) { Scheme = "https" }.ToString()) { Version = UseVersion }, default));
-                    sw.Stop();
+                    await ValidateConnectTimeout(invoker, new UriBuilder(uri) { Scheme = "https" }.Uri);
 
-                    Assert.InRange(sw.ElapsedMilliseconds, 500, 85_000);
                     releaseServer.SetResult();
                 }
             }, server => releaseServer.Task); // doesn't establish SSL connection
+        }
+
+        private static async Task WaitForCancellationAsync(CancellationToken token)
+        {
+            TaskCompletionSource tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            using (token.Register(() => tcs.SetCanceled(token)))
+            {
+                await tcs.Task;
+            }
+        }
+
+        [OuterLoop]
+        [Fact]
+        public async Task ConnectTimeout_ConnectCallbackTimesOut_Throws()
+        {
+            await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
+            {
+                using (var handler = CreateHttpClientHandler())
+                using (var invoker = new HttpMessageInvoker(handler))
+                {
+                    var socketsHandler = GetUnderlyingSocketsHttpHandler(handler);
+                    socketsHandler.ConnectTimeout = TimeSpan.FromSeconds(1);
+                    socketsHandler.ConnectCallback = async (context, token) => { await WaitForCancellationAsync(token); return null; };
+
+                    await ValidateConnectTimeout(invoker, uri);
+                }
+            }, server => Task.CompletedTask); // doesn't actually connect to server
         }
 
         [OuterLoop("Incurs significant delay")]
         [Fact]
         public async Task Expect100Continue_WaitsExpectedPeriodOfTimeBeforeSendingContent()
         {
-            await LoopbackServer.CreateClientAndServerAsync(async uri =>
+            await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
             {
-                using (var handler = new SocketsHttpHandler())
+                using (var handler = CreateHttpClientHandler())
                 using (var invoker = new HttpMessageInvoker(handler))
                 {
+                    var socketsHandler = GetUnderlyingSocketsHttpHandler(handler);
                     TimeSpan delay = TimeSpan.FromSeconds(3);
-                    handler.Expect100ContinueTimeout = delay;
+                    socketsHandler.Expect100ContinueTimeout = delay;
 
                     var tcs = new TaskCompletionSource<bool>();
                     var content = new SetTcsContent(new MemoryStream(new byte[1]), tcs);
@@ -69,9 +98,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 await server.AcceptConnectionAsync(async connection =>
                 {
-                    await connection.ReadRequestHeaderAsync();
-                    await connection.ReadAsync(new byte[1], 0, 1);
-                    await connection.SendResponseAsync();
+                    await connection.HandleRequestAsync();
                 });
             });
         }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -1024,9 +1024,9 @@ namespace System.Net.Http.Functional.Tests
     }
 
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-    public sealed class SocketsHttpHandler_HttpClientHandler_Cancellation_Test : HttpClientHandler_Http11_Cancellation_Test
+    public sealed class SocketsHttpHandler_HttpClientHandler_Http11_Cancellation_Test : SocketsHttpHandler_Cancellation_Test
     {
-        public SocketsHttpHandler_HttpClientHandler_Cancellation_Test(ITestOutputHelper output) : base(output) { }
+        public SocketsHttpHandler_HttpClientHandler_Http11_Cancellation_Test(ITestOutputHelper output) : base(output) { }
 
         [Fact]
         public void ConnectTimeout_Default()
@@ -3064,7 +3064,7 @@ namespace System.Net.Http.Functional.Tests
     }
 
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
-    public sealed class SocketsHttpHandler_HttpClientHandler_Cancellation_Test_Http2 : HttpClientHandler_Cancellation_Test
+    public sealed class SocketsHttpHandler_HttpClientHandler_Cancellation_Test_Http2 : SocketsHttpHandler_Cancellation_Test
     {
         public SocketsHttpHandler_HttpClientHandler_Cancellation_Test_Http2(ITestOutputHelper output) : base(output) { }
         protected override Version UseVersion => HttpVersion.Version20;
@@ -3138,7 +3138,7 @@ namespace System.Net.Http.Functional.Tests
     // TODO: Many cancellation tests are failing for HTTP3.
     [ActiveIssue("https://github.com/dotnet/runtime/issues/53093")]
     [ConditionalClass(typeof(HttpClientHandlerTestBase), nameof(IsMsQuicSupported))]
-    public sealed class SocketsHttpHandler_HttpClientHandler_Cancellation_Test_Http3_MsQuic : HttpClientHandler_Cancellation_Test
+    public sealed class SocketsHttpHandler_HttpClientHandler_Cancellation_Test_Http3_MsQuic : SocketsHttpHandler_Cancellation_Test
     {
         public SocketsHttpHandler_HttpClientHandler_Cancellation_Test_Http3_MsQuic(ITestOutputHelper output) : base(output) { }
         protected override Version UseVersion => HttpVersion.Version30;
@@ -3147,7 +3147,7 @@ namespace System.Net.Http.Functional.Tests
 
     [ActiveIssue("https://github.com/dotnet/runtime/issues/53093")]
     [ConditionalClass(typeof(HttpClientHandlerTestBase), nameof(IsMsQuicSupported))]
-    public sealed class SocketsHttpHandler_HttpClientHandler_Cancellation_Test_Http3_Mock : HttpClientHandler_Cancellation_Test
+    public sealed class SocketsHttpHandler_HttpClientHandler_Cancellation_Test_Http3_Mock : SocketsHttpHandler_Cancellation_Test
     {
         public SocketsHttpHandler_HttpClientHandler_Cancellation_Test_Http3_Mock(ITestOutputHelper output) : base(output) { }
         protected override Version UseVersion => HttpVersion.Version30;

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SyncHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SyncHttpHandlerTest.cs
@@ -83,7 +83,7 @@ namespace System.Net.Http.Functional.Tests
     }
 
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
-    public sealed class SyncHttpHandler_HttpClientHandler_Cancellation_Test : HttpClientHandler_Http11_Cancellation_Test
+    public sealed class SyncHttpHandler_HttpClientHandler_Cancellation_Test : SocketsHttpHandler_Cancellation_Test
     {
         public SyncHttpHandler_HttpClientHandler_Cancellation_Test(ITestOutputHelper output) : base(output) { }
         protected override bool TestAsync => false;

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -116,7 +116,7 @@
     <Compile Include="$(CommonTestPath)System\Net\Http\HttpClientHandlerTest.DefaultProxyCredentials.cs"
              Link="Common\System\Net\Http\HttpClientHandlerTest.DefaultProxyCredentials.cs" />
     <Compile Include="HttpClientHandlerTest.AltSvc.cs" />
-    <Compile Include="HttpClientHandlerTest.Cancellation.cs" />
+    <Compile Include="SocketsHttpHandlerTest.Cancellation.cs" />
     <Compile Include="HttpClientHandlerTest.Connect.cs" />
     <Compile Include="HttpClientHandlerTest.Finalization.cs" />
     <Compile Include="HttpClientHandlerTest.Headers.cs" />


### PR DESCRIPTION
(1) Rename the file and class from "HttpClientHandlerTest.Cancellation.cs" to "SocketsHttpHandlerTest.Cancellation.cs" to avoid conflict with file in Common with the same name
(2) Make these tests run for HTTP2 as well, since they are not specific to HTTP/1.1
(3) Add another ConnectTimeout variation to ensure the ConnectTimeout applies to ConnectCallback