### PR TITLE
Make JsonSerializer work when IsDynamicCodeSupported is false.

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -559,7 +559,12 @@ namespace System.Text.Json
             {
                 if (_memberAccessorStrategy == null)
                 {
-#if NETFRAMEWORK || NETCOREAPP
+#if NETCOREAPP
+                    // if dynamic code isn't supported, fallback to reflection
+                    _memberAccessorStrategy = RuntimeFeature.IsDynamicCodeSupported ?
+                        new ReflectionEmitMemberAccessor() :
+                        new ReflectionMemberAccessor();
+#elif NETFRAMEWORK
                     _memberAccessorStrategy = new ReflectionEmitMemberAccessor();
 #else
                     _memberAccessorStrategy = new ReflectionMemberAccessor();


### PR DESCRIPTION
Use the non-Emit codepath if IsDynamicCodeSupported is false.

This is basically a port of https://github.com/dotnet/runtimelab/pull/584.

cc @marek-safar 