### PR TITLE
Reenable 48786

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -720,14 +720,6 @@
         </ExcludeList>
     </ItemGroup>
 
-    <!-- MacOS arm64 specific -->
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TargetOS)' == 'OSX' and '$(TargetArchitecture)' == 'arm64' and '$(RuntimeFlavor)' == 'coreclr'">
-        <!-- Tracing failures -->
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/eventsourceerror/eventsourceerror/*">
-            <Issue>https://github.com/dotnet/runtime/issues/48786</Issue>
-        </ExcludeList>
-    </ItemGroup>
-
     <!-- Tests that need to be triaged for vararg usage as that is not supported -->
     <!-- Note these will only be excluded for unix platforms on all runtimes -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TargetsWindows)' != 'true' ">


### PR DESCRIPTION
Reenable tests disabled for issue 48786

Per @sandreenko, this should be fixed now that we have moved to crossgen2.
