### PR TITLE
Make some Brotli p/invokes blittable

### DIFF
--- a/src/libraries/Common/src/Interop/Interop.Brotli.cs
+++ b/src/libraries/Common/src/Interop/Interop.Brotli.cs
@@ -19,32 +19,32 @@ internal static partial class Interop
             ref nuint availableOut, byte** nextOut, out nuint totalOut);
 
         [DllImport(Libraries.CompressionNative)]
-        internal static extern unsafe int BrotliDecoderDecompress(nuint availableInput, byte* inBytes, nuint* availableOutput, byte* outBytes);
+        internal static extern unsafe BOOL BrotliDecoderDecompress(nuint availableInput, byte* inBytes, nuint* availableOutput, byte* outBytes);
 
         [DllImport(Libraries.CompressionNative)]
         internal static extern void BrotliDecoderDestroyInstance(IntPtr state);
 
         [DllImport(Libraries.CompressionNative)]
-        internal static extern bool BrotliDecoderIsFinished(SafeBrotliDecoderHandle state);
+        internal static extern BOOL BrotliDecoderIsFinished(SafeBrotliDecoderHandle state);
 
         [DllImport(Libraries.CompressionNative)]
         internal static extern SafeBrotliEncoderHandle BrotliEncoderCreateInstance(IntPtr allocFunc, IntPtr freeFunc, IntPtr opaque);
 
         [DllImport(Libraries.CompressionNative)]
-        internal static extern bool BrotliEncoderSetParameter(SafeBrotliEncoderHandle state, BrotliEncoderParameter parameter, uint value);
+        internal static extern BOOL BrotliEncoderSetParameter(SafeBrotliEncoderHandle state, BrotliEncoderParameter parameter, uint value);
 
         [DllImport(Libraries.CompressionNative)]
-        internal static extern unsafe bool BrotliEncoderCompressStream(
+        internal static extern unsafe BOOL BrotliEncoderCompressStream(
             SafeBrotliEncoderHandle state, BrotliEncoderOperation op, ref nuint availableIn,
             byte** nextIn, ref nuint availableOut, byte** nextOut, out nuint totalOut);
 
         [DllImport(Libraries.CompressionNative)]
-        internal static extern bool BrotliEncoderHasMoreOutput(SafeBrotliEncoderHandle state);
+        internal static extern BOOL BrotliEncoderHasMoreOutput(SafeBrotliEncoderHandle state);
 
         [DllImport(Libraries.CompressionNative)]
         internal static extern void BrotliEncoderDestroyInstance(IntPtr state);
 
         [DllImport(Libraries.CompressionNative)]
-        internal static extern unsafe int BrotliEncoderCompress(int quality, int window, int v, nuint availableInput, byte* inBytes, nuint* availableOutput, byte* outBytes);
+        internal static extern unsafe BOOL BrotliEncoderCompress(int quality, int window, int v, nuint availableInput, byte* inBytes, nuint* availableOutput, byte* outBytes);
     }
 }

--- a/src/libraries/Common/src/Interop/Interop.Brotli.cs
+++ b/src/libraries/Common/src/Interop/Interop.Brotli.cs
@@ -19,7 +19,7 @@ internal static partial class Interop
             ref nuint availableOut, byte** nextOut, out nuint totalOut);
 
         [DllImport(Libraries.CompressionNative)]
-        internal static extern unsafe bool BrotliDecoderDecompress(nuint availableInput, byte* inBytes, ref nuint availableOutput, byte* outBytes);
+        internal static extern unsafe int BrotliDecoderDecompress(nuint availableInput, byte* inBytes, nuint* availableOutput, byte* outBytes);
 
         [DllImport(Libraries.CompressionNative)]
         internal static extern void BrotliDecoderDestroyInstance(IntPtr state);
@@ -45,6 +45,6 @@ internal static partial class Interop
         internal static extern void BrotliEncoderDestroyInstance(IntPtr state);
 
         [DllImport(Libraries.CompressionNative)]
-        internal static extern unsafe bool BrotliEncoderCompress(int quality, int window, int v, nuint availableInput, byte* inBytes, ref nuint availableOutput, byte* outBytes);
+        internal static extern unsafe int BrotliEncoderCompress(int quality, int window, int v, nuint availableInput, byte* inBytes, nuint* availableOutput, byte* outBytes);
     }
 }

--- a/src/libraries/System.IO.Compression.Brotli/src/System.IO.Compression.Brotli.csproj
+++ b/src/libraries/System.IO.Compression.Brotli/src/System.IO.Compression.Brotli.csproj
@@ -11,6 +11,8 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetsAnyOS)' != 'true'">
     <Compile Include="$(CommonPath)Interop\Interop.Brotli.cs" />
+    <!-- The native compression lib uses a BROTLI_BOOL type analogous to the Windows BOOL type -->
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.BOOL.cs" />
     <Compile Include="System\IO\Compression\enc\BrotliStream.Compress.cs" />
     <Compile Include="System\IO\Compression\dec\BrotliStream.Decompress.cs" />
     <Compile Include="System\IO\Compression\BrotliUtils.cs" />

--- a/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/dec/BrotliDecoder.cs
+++ b/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/dec/BrotliDecoder.cs
@@ -117,7 +117,7 @@ namespace System.IO.Compression
             fixed (byte* outBytes = &MemoryMarshal.GetReference(destination))
             {
                 nuint availableOutput = (nuint)destination.Length;
-                bool success = Interop.Brotli.BrotliDecoderDecompress((nuint)source.Length, inBytes, ref availableOutput, outBytes);
+                bool success = Interop.Brotli.BrotliDecoderDecompress((nuint)source.Length, inBytes, &availableOutput, outBytes) != 0;
 
                 Debug.Assert(success ? availableOutput <= (nuint)destination.Length : availableOutput == 0);
 

--- a/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/dec/BrotliDecoder.cs
+++ b/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/dec/BrotliDecoder.cs
@@ -59,7 +59,7 @@ namespace System.IO.Compression
 
             bytesConsumed = 0;
             bytesWritten = 0;
-            if (Interop.Brotli.BrotliDecoderIsFinished(_state))
+            if (Interop.Brotli.BrotliDecoderIsFinished(_state) != Interop.BOOL.FALSE)
                 return OperationStatus.Done;
             nuint availableOutput = (nuint)destination.Length;
             nuint availableInput = (nuint)source.Length;
@@ -117,7 +117,7 @@ namespace System.IO.Compression
             fixed (byte* outBytes = &MemoryMarshal.GetReference(destination))
             {
                 nuint availableOutput = (nuint)destination.Length;
-                bool success = Interop.Brotli.BrotliDecoderDecompress((nuint)source.Length, inBytes, &availableOutput, outBytes) != 0;
+                bool success = Interop.Brotli.BrotliDecoderDecompress((nuint)source.Length, inBytes, &availableOutput, outBytes) != Interop.BOOL.FALSE;
 
                 Debug.Assert(success ? availableOutput <= (nuint)destination.Length : availableOutput == 0);
 

--- a/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/enc/BrotliEncoder.cs
+++ b/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/enc/BrotliEncoder.cs
@@ -78,7 +78,7 @@ namespace System.IO.Compression
             {
                 throw new ArgumentOutOfRangeException(nameof(quality), SR.Format(SR.BrotliEncoder_Quality, quality, 0, BrotliUtils.Quality_Max));
             }
-            if (!Interop.Brotli.BrotliEncoderSetParameter(_state, BrotliEncoderParameter.Quality, (uint)quality))
+            if (Interop.Brotli.BrotliEncoderSetParameter(_state, BrotliEncoderParameter.Quality, (uint)quality) == Interop.BOOL.FALSE)
             {
                 throw new InvalidOperationException(SR.Format(SR.BrotliEncoder_InvalidSetParameter, "Quality"));
             }
@@ -96,7 +96,7 @@ namespace System.IO.Compression
             {
                 throw new ArgumentOutOfRangeException(nameof(window), SR.Format(SR.BrotliEncoder_Window, window, BrotliUtils.WindowBits_Min, BrotliUtils.WindowBits_Max));
             }
-            if (!Interop.Brotli.BrotliEncoderSetParameter(_state, BrotliEncoderParameter.LGWin, (uint)window))
+            if (Interop.Brotli.BrotliEncoderSetParameter(_state, BrotliEncoderParameter.LGWin, (uint)window) == Interop.BOOL.FALSE)
             {
                 throw new InvalidOperationException(SR.Format(SR.BrotliEncoder_InvalidSetParameter, "Window"));
             }
@@ -161,7 +161,7 @@ namespace System.IO.Compression
                     fixed (byte* inBytes = &MemoryMarshal.GetReference(source))
                     fixed (byte* outBytes = &MemoryMarshal.GetReference(destination))
                     {
-                        if (!Interop.Brotli.BrotliEncoderCompressStream(_state, operation, ref availableInput, &inBytes, ref availableOutput, &outBytes, out _))
+                        if (Interop.Brotli.BrotliEncoderCompressStream(_state, operation, ref availableInput, &inBytes, ref availableOutput, &outBytes, out _) == Interop.BOOL.FALSE)
                         {
                             return OperationStatus.InvalidData;
                         }
@@ -173,7 +173,7 @@ namespace System.IO.Compression
                         bytesWritten += destination.Length - (int)availableOutput;
 
                         // no bytes written, no remaining input to give to the encoder, and no output in need of retrieving means we are Done
-                        if ((int)availableOutput == destination.Length && !Interop.Brotli.BrotliEncoderHasMoreOutput(_state) && availableInput == 0)
+                        if ((int)availableOutput == destination.Length && Interop.Brotli.BrotliEncoderHasMoreOutput(_state) == Interop.BOOL.FALSE && availableInput == 0)
                         {
                             return OperationStatus.Done;
                         }
@@ -218,7 +218,7 @@ namespace System.IO.Compression
                 fixed (byte* outBytes = &MemoryMarshal.GetReference(destination))
                 {
                     nuint availableOutput = (nuint)destination.Length;
-                    bool success = Interop.Brotli.BrotliEncoderCompress(quality, window, /*BrotliEncoderMode*/ 0, (nuint)source.Length, inBytes, &availableOutput, outBytes) != 0;
+                    bool success = Interop.Brotli.BrotliEncoderCompress(quality, window, /*BrotliEncoderMode*/ 0, (nuint)source.Length, inBytes, &availableOutput, outBytes) != Interop.BOOL.FALSE;
 
                     Debug.Assert(success ? availableOutput <= (nuint)destination.Length : availableOutput == 0);
 

--- a/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/enc/BrotliEncoder.cs
+++ b/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/enc/BrotliEncoder.cs
@@ -218,7 +218,7 @@ namespace System.IO.Compression
                 fixed (byte* outBytes = &MemoryMarshal.GetReference(destination))
                 {
                     nuint availableOutput = (nuint)destination.Length;
-                    bool success = Interop.Brotli.BrotliEncoderCompress(quality, window, /*BrotliEncoderMode*/ 0, (nuint)source.Length, inBytes, ref availableOutput, outBytes);
+                    bool success = Interop.Brotli.BrotliEncoderCompress(quality, window, /*BrotliEncoderMode*/ 0, (nuint)source.Length, inBytes, &availableOutput, outBytes) != 0;
 
                     Debug.Assert(success ? availableOutput <= (nuint)destination.Length : availableOutput == 0);
 


### PR DESCRIPTION
Found that two of the Brotli p/invokes could easily be made blittable (inlinable during JIT) while prototyping a `DllImport` source generator.

cc @AaronRobinsonMSFT @jkoritzinsky 