### PR TITLE
make MsQuicStatusCodes platform specific

### DIFF
--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -15,7 +15,16 @@
     <Compile Include="System\Net\Quic\Implementations\Mock\*.cs" />
     <Compile Include="System\Net\Quic\Implementations\MsQuic\*.cs" />
     <Compile Include="System\Net\Quic\Implementations\MsQuic\Internal\*.cs" />
-    <Compile Include="System\Net\Quic\Implementations\MsQuic\Interop\*.cs" />
+    <Compile Include="System\Net\Quic\Implementations\MsQuic\Interop\MsQuicAlpnHelper.cs" />
+    <Compile Include="System\Net\Quic\Implementations\MsQuic\Interop\MsQuicEnums.cs" />
+    <Compile Include="System\Net\Quic\Implementations\MsQuic\Interop\MsQuicNativeMethods.cs" />
+    <Compile Include="System\Net\Quic\Implementations\MsQuic\Interop\MsQuicStatusCodes.cs" />
+    <Compile Include="System\Net\Quic\Implementations\MsQuic\Interop\MsQuicStatusHelper.cs" />
+    <Compile Include="System\Net\Quic\Implementations\MsQuic\Interop\SafeMsQuicConfigurationHandle.cs" />
+    <Compile Include="System\Net\Quic\Implementations\MsQuic\Interop\SafeMsQuicConnectionHandle.cs" />
+    <Compile Include="System\Net\Quic\Implementations\MsQuic\Interop\SafeMsQuicListenerHandle.cs" />
+    <Compile Include="System\Net\Quic\Implementations\MsQuic\Interop\SafeMsQuicRegistrationHandle.cs" />
+    <Compile Include="System\Net\Quic\Implementations\MsQuic\Interop\SafeMsQuicStreamHandle.cs" />
   </ItemGroup>
   <!-- System.Net common -->
   <ItemGroup Condition="'$(TargetsAnyOS)' != 'true'">
@@ -28,18 +37,23 @@
   <!-- Windows specific files -->
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true'">
     <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs" Link="Common\Interop\Windows\Interop.Libraries.cs" />
+    <Compile Include="System\Net\Quic\Implementations\MsQuic\Interop\MsQuicStatusCodes.Windows.cs" />
   </ItemGroup>
   <!-- Linux specific files -->
   <ItemGroup Condition="'$(TargetsLinux)' == 'true'">
     <Compile Include="$(CommonPath)Interop\Linux\Interop.Libraries.cs" Link="Common\Interop\Linux\Interop.Libraries.cs" />
+    <Compile Include="System\Net\Quic\Implementations\MsQuic\Interop\MsQuicStatusCodes.Linux.cs" />
   </ItemGroup>
   <!-- FreeBSD specific files -->
   <ItemGroup Condition="'$(TargetsFreeBSD)' == 'true' ">
     <Compile Include="$(CommonPath)Interop\FreeBSD\Interop.Libraries.cs" Link="Common\Interop\FreeBSD\Interop.Libraries.cs" />
+    <!-- Assume similarity with OSX for now -->
+    <Compile Include="System\Net\Quic\Implementations\MsQuic\Interop\MsQuicStatusCodes.OSX.cs" />
   </ItemGroup>
   <!-- OSX specific files -->
   <ItemGroup Condition=" '$(TargetsOSX)' == 'true'">
     <Compile Include="$(CommonPath)Interop\OSX\Interop.Libraries.cs" Link="Common\Interop\OSX\Interop.Libraries.cs" />
+    <Compile Include="System\Net\Quic\Implementations\MsQuic\Interop\MsQuicStatusCodes.OSX.cs" />
   </ItemGroup>
   <!-- Project references -->
   <ItemGroup>

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicStatusCodes.Linux.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicStatusCodes.Linux.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Net.Quic.Implementations.MsQuic.Internal
+{
+    internal static partial class MsQuicStatusCodes
+    {
+        internal const uint Success = 0;
+        internal const uint Pending = unchecked((uint)-2);
+        internal const uint Continue = unchecked((uint)-1);
+        internal const uint OutOfMemory = 12;           // ENOMEM
+        internal const uint InvalidParameter = 22;      // EINVAL
+        internal const uint InvalidState = 1;           // EPERM
+        internal const uint NotSupported = 95;          // EOPNOTSUPP
+        internal const uint NotFound = 2;               // ENOENT
+        internal const uint BufferTooSmall = 75;        // EOVERFLOW
+        internal const uint HandshakeFailure = 103;     // ECONNABORTED
+        internal const uint Aborted = 125;              // ECANCELED
+        internal const uint AddressInUse = 98;          // EADDRINUSE
+        internal const uint ConnectionTimeout = 110;    // ETIMEDOUT
+        internal const uint ConnectionIdle = 62;        // ETIME
+        internal const uint HostUnreachable = 113;      // EHOSTUNREACH
+        internal const uint InternalError = 5;          // EIO
+        internal const uint ConnectionRefused = 111;    // ECONNREFUSED
+        internal const uint ProtocolError = 71;         // EPROTO
+        internal const uint VerNegError = 93;           // EPROTONOSUPPORT
+        internal const uint TlsError = 126;             // ENOKEY
+        internal const uint UserCanceled = 130;         // EOWNERDEAD
+        internal const uint AlpnNegotiationFailure = 92;// ENOPROTOOPT
+        internal const uint StreamLimit = 86;           // ESTRPIPE
+    }
+}

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicStatusCodes.OSX.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicStatusCodes.OSX.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Net.Quic.Implementations.MsQuic.Internal
+{
+    internal static partial class MsQuicStatusCodes
+    {
+        internal const uint Success = 0;
+        internal const uint Pending = unchecked((uint)-2);
+        internal const uint Continue = unchecked((uint)-1);
+        internal const uint OutOfMemory = 12;           // ENOMEM
+        internal const uint InvalidParameter = 22;      // EINVAL
+        internal const uint InvalidState = 1;           // EPERM
+        internal const uint NotSupported = 102;         // EOPNOTSUPP
+        internal const uint NotFound = 2;               // ENOENT
+        internal const uint BufferTooSmall = 84;        // EOVERFLOW
+        internal const uint HandshakeFailure = 53;      // ECONNABORTED
+        internal const uint Aborted = 89;               // ECANCELED
+        internal const uint AddressInUse = 48;          // EADDRINUSE
+        internal const uint ConnectionTimeout = 60;     // ETIMEDOUT
+        internal const uint ConnectionIdle = 101;       // ETIME
+        internal const uint HostUnreachable = 65;       // EHOSTUNREACH
+        internal const uint InternalError = 5;          // EIO
+        internal const uint ConnectionRefused = 61;     // ECONNREFUSED
+        internal const uint ProtocolError = 100;        // EPROTO
+        internal const uint VerNegError = 43;           // EPROTONOSUPPORT
+        internal const uint TlsError = 126;             // ENOKEY Linux value
+        internal const uint UserCanceled = 105;         // EOWNERDEAD
+        internal const uint AlpnNegotiationFailure = 42;// ENOPROTOOPT
+        internal const uint StreamLimit = 86;           // ESTRPIPE Linux value
+    }
+}

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicStatusCodes.Windows.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicStatusCodes.Windows.cs
@@ -27,5 +27,6 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         internal const uint TlsError = 0x80072B18;
         internal const uint UserCanceled = 0x80410002;
         internal const uint AlpnNegotiationFailure = 0x80410007;
+        internal const uint StreamLimit = 0x80410008;
     }
 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicStatusCodes.Windows.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicStatusCodes.Windows.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Net.Quic.Implementations.MsQuic.Internal
+{
+    internal static partial class MsQuicStatusCodes
+    {
+        internal const uint Success = 0;
+        internal const uint Pending = 0x703E5;
+        internal const uint Continue = 0x704DE;
+        internal const uint OutOfMemory = 0x8007000E;
+        internal const uint InvalidParameter = 0x80070057;
+        internal const uint InvalidState = 0x8007139F;
+        internal const uint NotSupported = 0x80004002;
+        internal const uint NotFound = 0x80070490;
+        internal const uint BufferTooSmall = 0x8007007A;
+        internal const uint HandshakeFailure = 0x80410000;
+        internal const uint Aborted = 0x80004004;
+        internal const uint AddressInUse = 0x80072740;
+        internal const uint ConnectionTimeout = 0x80410006;
+        internal const uint ConnectionIdle = 0x80410005;
+        internal const uint HostUnreachable = 0x800704D0;
+        internal const uint InternalError = 0x80410003;
+        internal const uint ConnectionRefused = 0x800704C9;
+        internal const uint ProtocolError = 0x80410004;
+        internal const uint VerNegError = 0x80410001;
+        internal const uint TlsError = 0x80072B18;
+        internal const uint UserCanceled = 0x80410002;
+        internal const uint AlpnNegotiationFailure = 0x80410007;
+    }
+}

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicStatusCodes.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicStatusCodes.cs
@@ -32,6 +32,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
                 TlsError => "TLS_ERROR",
                 UserCanceled => "USER_CANCELED",
                 AlpnNegotiationFailure => "ALPN_NEG_FAILURE",
+                StreamLimit => "STREAM_LIMIT_REACHED",
                 _ => $"0x{status:X8}"
             };
         }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicStatusCodes.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicStatusCodes.cs
@@ -3,134 +3,37 @@
 
 namespace System.Net.Quic.Implementations.MsQuic.Internal
 {
-    internal static class MsQuicStatusCodes
+    internal static partial class MsQuicStatusCodes
     {
-        internal static uint Success => OperatingSystem.IsWindows() ? Windows.Success : Posix.Success;
-        internal static uint Pending => OperatingSystem.IsWindows() ? Windows.Pending : Posix.Pending;
-        internal static uint InternalError => OperatingSystem.IsWindows() ? Windows.InternalError : Posix.InternalError;
-        internal static uint InvalidState => OperatingSystem.IsWindows() ? Windows.InvalidState : Posix.InvalidState;
-        internal static uint HandshakeFailure => OperatingSystem.IsWindows() ? Windows.HandshakeFailure : Posix.HandshakeFailure;
-        internal static uint UserCanceled => OperatingSystem.IsWindows() ? Windows.UserCanceled : Posix.UserCanceled;
-
         // TODO return better error messages here.
-        public static string GetError(uint status) => OperatingSystem.IsWindows() ? Windows.GetError(status) : Posix.GetError(status);
-
-        private static class Windows
+        public static string GetError(uint status)
         {
-            internal const uint Success = 0;
-            internal const uint Pending = 0x703E5;
-            internal const uint Continue = 0x704DE;
-            internal const uint OutOfMemory = 0x8007000E;
-            internal const uint InvalidParameter = 0x80070057;
-            internal const uint InvalidState = 0x8007139F;
-            internal const uint NotSupported = 0x80004002;
-            internal const uint NotFound = 0x80070490;
-            internal const uint BufferTooSmall = 0x8007007A;
-            internal const uint HandshakeFailure = 0x80410000;
-            internal const uint Aborted = 0x80004004;
-            internal const uint AddressInUse = 0x80072740;
-            internal const uint ConnectionTimeout = 0x80410006;
-            internal const uint ConnectionIdle = 0x80410005;
-            internal const uint HostUnreachable = 0x800704D0;
-            internal const uint InternalError = 0x80410003;
-            internal const uint ConnectionRefused = 0x800704C9;
-            internal const uint ProtocolError = 0x80410004;
-            internal const uint VerNegError = 0x80410001;
-            internal const uint TlsError = 0x80072B18;
-            internal const uint UserCanceled = 0x80410002;
-            internal const uint AlpnNegotiationFailure = 0x80410007;
-
-            // TODO return better error messages here.
-            public static string GetError(uint status)
+            return status switch
             {
-                return status switch
-                {
-                    Success => "SUCCESS",
-                    Pending => "PENDING",
-                    Continue => "CONTINUE",
-                    OutOfMemory => "OUT_OF_MEMORY",
-                    InvalidParameter => "INVALID_PARAMETER",
-                    InvalidState => "INVALID_STATE",
-                    NotSupported => "NOT_SUPPORTED",
-                    NotFound => "NOT_FOUND",
-                    BufferTooSmall => "BUFFER_TOO_SMALL",
-                    HandshakeFailure => "HANDSHAKE_FAILURE",
-                    Aborted => "ABORTED",
-                    AddressInUse => "ADDRESS_IN_USE",
-                    ConnectionTimeout => "CONNECTION_TIMEOUT",
-                    ConnectionIdle => "CONNECTION_IDLE",
-                    HostUnreachable => "UNREACHABLE",
-                    InternalError => "INTERNAL_ERROR",
-                    ConnectionRefused => "CONNECTION_REFUSED",
-                    ProtocolError => "PROTOCOL_ERROR",
-                    VerNegError => "VER_NEG_ERROR",
-                    TlsError => "TLS_ERROR",
-                    UserCanceled => "USER_CANCELED",
-                    AlpnNegotiationFailure => "ALPN_NEG_FAILURE",
-                    _ => $"0x{status:X8}"
-                };
-            }
-        }
-
-        private static class Posix
-        {
-            internal const uint Success = 0;
-            internal const uint Pending = unchecked((uint)-2);
-            internal const uint Continue = unchecked((uint)-1);
-            internal const uint OutOfMemory = 12;
-            internal const uint InvalidParameter = 22;
-            internal const uint InvalidState = 200000002;
-            internal const uint NotSupported = 95;
-            internal const uint NotFound = 2;
-            internal const uint BufferTooSmall = 75;
-            internal const uint HandshakeFailure = 200000009;
-            internal const uint Aborted = 200000008;
-            internal const uint AddressInUse = 98;
-            internal const uint ConnectionTimeout = 110;
-            internal const uint ConnectionIdle = 200000011;
-            internal const uint InternalError = 200000012;
-            internal const uint ConnectionRefused = 200000007;
-            internal const uint ProtocolError = 200000013;
-            internal const uint VerNegError = 200000014;
-            internal const uint EpollError = 200000015;
-            internal const uint DnsResolutionError = 200000016;
-            internal const uint SocketError = 200000017;
-            internal const uint TlsError = 200000018;
-            internal const uint UserCanceled = 200000019;
-            internal const uint AlpnNegotiationFailure = 200000020;
-
-            // TODO return better error messages here.
-            public static string GetError(uint status)
-            {
-                return status switch
-                {
-                    Success => "SUCCESS",
-                    Pending => "PENDING",
-                    Continue => "CONTINUE",
-                    OutOfMemory => "OUT_OF_MEMORY",
-                    InvalidParameter => "INVALID_PARAMETER",
-                    InvalidState => "INVALID_STATE",
-                    NotSupported => "NOT_SUPPORTED",
-                    NotFound => "NOT_FOUND",
-                    BufferTooSmall => "BUFFER_TOO_SMALL",
-                    HandshakeFailure => "HANDSHAKE_FAILURE",
-                    Aborted => "ABORTED",
-                    AddressInUse => "ADDRESS_IN_USE",
-                    ConnectionTimeout => "CONNECTION_TIMEOUT",
-                    ConnectionIdle => "CONNECTION_IDLE",
-                    InternalError => "INTERNAL_ERROR",
-                    ConnectionRefused => "CONNECTION_REFUSED",
-                    ProtocolError => "PROTOCOL_ERROR",
-                    VerNegError => "VER_NEG_ERROR",
-                    EpollError => "EPOLL_ERROR",
-                    DnsResolutionError => "DNS_RESOLUTION_ERROR",
-                    SocketError => "SOCKET_ERROR",
-                    TlsError => "TLS_ERROR",
-                    UserCanceled => "USER_CANCELED",
-                    AlpnNegotiationFailure => "ALPN_NEG_FAILURE",
-                    _ => $"0x{status:X8}"
-                };
-            }
+                Success => "SUCCESS",
+                Pending => "PENDING",
+                Continue => "CONTINUE",
+                OutOfMemory => "OUT_OF_MEMORY",
+                InvalidParameter => "INVALID_PARAMETER",
+                InvalidState => "INVALID_STATE",
+                NotSupported => "NOT_SUPPORTED",
+                NotFound => "NOT_FOUND",
+                BufferTooSmall => "BUFFER_TOO_SMALL",
+                HandshakeFailure => "HANDSHAKE_FAILURE",
+                Aborted => "ABORTED",
+                AddressInUse => "ADDRESS_IN_USE",
+                ConnectionTimeout => "CONNECTION_TIMEOUT",
+                ConnectionIdle => "CONNECTION_IDLE",
+                HostUnreachable => "UNREACHABLE",
+                InternalError => "INTERNAL_ERROR",
+                ConnectionRefused => "CONNECTION_REFUSED",
+                ProtocolError => "PROTOCOL_ERROR",
+                VerNegError => "VER_NEG_ERROR",
+                TlsError => "TLS_ERROR",
+                UserCanceled => "USER_CANCELED",
+                AlpnNegotiationFailure => "ALPN_NEG_FAILURE",
+                _ => $"0x{status:X8}"
+            };
         }
     }
 }


### PR DESCRIPTION
https://github.com/microsoft/msquic/pull/1645/ introduced new status codes on non-windows platforms and this is reaction to it. Our old split to windows/posix no does not work since the actual errno values differ among OSes. 
The assumption about FreeBSD is rather weak but we can fix it later since MsQuic does not wok on FreeBSD anyway. 

fixes #53506
cc: @ThadHouse @nibanks
