### PR TITLE
[release/5.0] Remove unneeded NuGet.config file

### DIFF
--- a/src/coreclr/tests/NuGet.config
+++ b/src/coreclr/tests/NuGet.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="dotnet-experimental" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
This either needs to have a `<clear />` or needs to be removed.