### PR TITLE
[release/5.0] Stop including static libraries in Linux runtime pack

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -180,7 +180,6 @@
       <LibrariesRuntimeFiles Include="
         $(LibrariesNativeArtifactsPath)*.dll;
         $(LibrariesNativeArtifactsPath)*.dylib;
-        $(LibrariesNativeArtifactsPath)*.a;
         $(LibrariesNativeArtifactsPath)*.so;
         $(LibrariesNativeArtifactsPath)*.dbg;
         $(LibrariesNativeArtifactsPath)*.dwarf;

--- a/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -29,21 +29,15 @@
   <ItemGroup>
     <_pastShimFiles Include="System.Globalization.Native.dylib" />
     <_pastShimFiles Include="System.Globalization.Native.so" />
-    <_pastShimFiles Include="System.IO.Compression.Native.a" />
     <_pastShimFiles Include="System.IO.Compression.Native.dylib" />
     <_pastShimFiles Include="System.IO.Compression.Native.so" />
-    <_pastShimFiles Include="System.Native.a" />
     <_pastShimFiles Include="System.Native.dylib" />
     <_pastShimFiles Include="System.Native.so" />
-    <_pastShimFiles Include="System.Net.Http.Native.a" />
     <_pastShimFiles Include="System.Net.Http.Native.dylib" />
     <_pastShimFiles Include="System.Net.Http.Native.so" />
-    <_pastShimFiles Include="System.Net.Security.Native.a" />
     <_pastShimFiles Include="System.Net.Security.Native.dylib" />
     <_pastShimFiles Include="System.Net.Security.Native.so" />
-    <_pastShimFiles Include="System.Security.Cryptography.Native.Apple.a" />
     <_pastShimFiles Include="System.Security.Cryptography.Native.Apple.dylib" />
-    <_pastShimFiles Include="System.Security.Cryptography.Native.OpenSsl.a" />
     <_pastShimFiles Include="System.Security.Cryptography.Native.OpenSsl.dylib" />
     <_pastShimFiles Include="System.Security.Cryptography.Native.OpenSsl.so" />
     <SharedFrameworkRuntimeFiles Include="@(_pastShimFiles)" TargetPath="runtimes/" />

--- a/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -29,15 +29,25 @@
   <ItemGroup>
     <_pastShimFiles Include="System.Globalization.Native.dylib" />
     <_pastShimFiles Include="System.Globalization.Native.so" />
+    <_pastShimFiles Include="System.IO.Compression.Native.a" />
+    <_pastShimFiles Include="libSystem.IO.Compression.Native.a" />
     <_pastShimFiles Include="System.IO.Compression.Native.dylib" />
     <_pastShimFiles Include="System.IO.Compression.Native.so" />
+    <_pastShimFiles Include="System.Native.a" />
+    <_pastShimFiles Include="libSystem.Native.a" />
     <_pastShimFiles Include="System.Native.dylib" />
     <_pastShimFiles Include="System.Native.so" />
+    <_pastShimFiles Include="System.Net.Http.Native.a" />
     <_pastShimFiles Include="System.Net.Http.Native.dylib" />
     <_pastShimFiles Include="System.Net.Http.Native.so" />
+    <_pastShimFiles Include="System.Net.Security.Native.a" />
+    <_pastShimFiles Include="libSystem.Net.Security.Native.a" />
     <_pastShimFiles Include="System.Net.Security.Native.dylib" />
     <_pastShimFiles Include="System.Net.Security.Native.so" />
+    <_pastShimFiles Include="System.Security.Cryptography.Native.Apple.a" />
     <_pastShimFiles Include="System.Security.Cryptography.Native.Apple.dylib" />
+    <_pastShimFiles Include="System.Security.Cryptography.Native.OpenSsl.a" />
+    <_pastShimFiles Include="libSystem.Security.Cryptography.Native.OpenSsl.a" />
     <_pastShimFiles Include="System.Security.Cryptography.Native.OpenSsl.dylib" />
     <_pastShimFiles Include="System.Security.Cryptography.Native.OpenSsl.so" />
     <SharedFrameworkRuntimeFiles Include="@(_pastShimFiles)" TargetPath="runtimes/" />


### PR DESCRIPTION
The native libraries are used to build the singlefilehost, but aren't
needed afterwards, especially in the runtimepack where they will get
included in any self-contained publish.

Fixes #47564