### PR TITLE
Change implemantation of ImmutableQueue<T> to real-time queue

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System.Collections.Immutable.csproj
+++ b/src/libraries/System.Collections.Immutable/src/System.Collections.Immutable.csproj
@@ -58,6 +58,8 @@
     <Compile Include="System\Collections\Immutable\ImmutableQueue.cs" />
     <Compile Include="System\Collections\Immutable\ImmutableQueue_1.cs" />
     <Compile Include="System\Collections\Immutable\ImmutableQueue_1.Enumerator.cs" />
+    <Compile Include="System\Collections\Immutable\ImmutableQueue_1.LazyStack.cs" />
+    <Compile Include="System\Collections\Immutable\ImmutableQueue_1.LazyStack.Enumerator.cs" />
     <Compile Include="System\Collections\Immutable\ImmutableSortedDictionary.cs" />
     <Compile Include="System\Collections\Immutable\ImmutableSortedDictionary_2.Builder.cs" />
     <Compile Include="System\Collections\Immutable\ImmutableSortedDictionary_2.cs" />
@@ -80,8 +82,7 @@
     <Compile Include="System\Linq\ImmutableArrayExtensions.cs" />
     <Compile Include="Validation\Requires.cs" />
     <Compile Include="Validation\ValidatedNotNullAttribute.cs" />
-    <Compile Include="$(CommonPath)System\Runtime\Versioning\NonVersionableAttribute.cs"
-             Link="Common\System\Runtime\Versioning\NonVersionableAttribute.cs" />
+    <Compile Include="$(CommonPath)System\Runtime\Versioning\NonVersionableAttribute.cs" Link="Common\System\Runtime\Versioning\NonVersionableAttribute.cs" />
     <None Include="Interfaces.cd" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
@@ -99,7 +100,7 @@
     <Reference Include="System.Threading" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
-    <PackageReference Include="System.Memory"  Version="$(SystemMemoryVersion)" />
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != '$(NetCoreAppCurrent)'">
     <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.CompilerServices.Unsafe\src\System.Runtime.CompilerServices.Unsafe.ilproj" />

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue.cs
@@ -53,15 +53,14 @@ namespace System.Collections.Immutable
                     return ImmutableQueue<T>.Empty;
                 }
 
-                var forwards = ImmutableStack.Create(e.Current);
-                var backwards = ImmutableStack<T>.Empty;
+                var queue = ImmutableQueue<T>.Empty.Enqueue(e.Current);
 
                 while (e.MoveNext())
                 {
-                    backwards = backwards.Push(e.Current);
+                    queue = queue.Enqueue(e.Current);
                 }
 
-                return new ImmutableQueue<T>(forwards: forwards, backwards: backwards);
+                return queue;
             }
         }
 
@@ -75,19 +74,14 @@ namespace System.Collections.Immutable
         {
             Requires.NotNull(items, nameof(items));
 
-            if (items.Length == 0)
+            var queue = ImmutableQueue<T>.Empty;
+
+            for (int i = 0; i < items.Length; i++)
             {
-                return ImmutableQueue<T>.Empty;
+                queue = queue.Enqueue(items[i]);
             }
 
-            var forwards = ImmutableStack<T>.Empty;
-
-            for (int i = items.Length - 1; i >= 0; i--)
-            {
-                forwards = forwards.Push(items[i]);
-            }
-
-            return new ImmutableQueue<T>(forwards: forwards, backwards: ImmutableStack<T>.Empty);
+            return queue;
         }
 
         /// <summary>

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue_1.Enumerator.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue_1.Enumerator.cs
@@ -22,7 +22,7 @@ namespace System.Collections.Immutable
             /// <summary>
             /// The remaining forwards stack of the queue being enumerated.
             /// </summary>
-            private ImmutableStack<T>? _remainingForwardsStack;
+            private ImmutableQueue<T>.LazyStack? _remainingForwardsStack;
 
             /// <summary>
             /// The remaining backwards stack of the queue being enumerated.
@@ -111,7 +111,7 @@ namespace System.Collections.Immutable
             /// <summary>
             /// The remaining forwards stack of the queue being enumerated.
             /// </summary>
-            private ImmutableStack<T>? _remainingForwardsStack;
+            private ImmutableQueue<T>.LazyStack? _remainingForwardsStack;
 
             /// <summary>
             /// The remaining backwards stack of the queue being enumerated.

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue_1.LazyStack.Enumerator.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue_1.LazyStack.Enumerator.cs
@@ -1,0 +1,184 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace System.Collections.Immutable
+{
+    public sealed partial class ImmutableQueue<T>
+    {
+        /// <summary>
+        /// Enumerates a stack with no memory allocations.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        internal struct LazyStackEnumerator
+        {
+            /// <summary>
+            /// The original stack being enumerated.
+            /// </summary>
+            private readonly LazyStack _originalStack;
+
+            /// <summary>
+            /// The remaining stack not yet enumerated.
+            /// </summary>
+            private LazyStack? _remainingStack;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="LazyStackEnumerator"/> struct.
+            /// </summary>
+            /// <param name="stack">The stack to enumerator.</param>
+            internal LazyStackEnumerator(LazyStack stack)
+            {
+                Requires.NotNull(stack, nameof(stack));
+                _originalStack = stack;
+                _remainingStack = null;
+            }
+
+            /// <summary>
+            /// Gets the current element.
+            /// </summary>
+            public T Current
+            {
+                get
+                {
+                    if (_remainingStack == null || _remainingStack.IsEmpty)
+                    {
+                        throw new InvalidOperationException();
+                    }
+                    else
+                    {
+                        return _remainingStack.Peek();
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Moves to the first or next element.
+            /// </summary>
+            /// <returns>A value indicating whether there are any more elements.</returns>
+            public bool MoveNext()
+            {
+                if (_remainingStack == null)
+                {
+                    // initial move
+                    _remainingStack = _originalStack;
+                }
+                else if (!_remainingStack.IsEmpty)
+                {
+                    _remainingStack = _remainingStack.Pop();
+                }
+
+                return !_remainingStack.IsEmpty;
+            }
+        }
+
+        /// <summary>
+        /// Enumerates a stack with no memory allocations.
+        /// </summary>
+        private sealed class LazyStackEnumeratorObject : IEnumerator<T>
+        {
+            /// <summary>
+            /// The original stack being enumerated.
+            /// </summary>
+            private readonly LazyStack _originalStack;
+
+            /// <summary>
+            /// The remaining stack not yet enumerated.
+            /// </summary>
+            private LazyStack? _remainingStack;
+
+            /// <summary>
+            /// A flag indicating whether this enumerator has been disposed.
+            /// </summary>
+            private bool _disposed;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="LazyStackEnumeratorObject"/> class.
+            /// </summary>
+            /// <param name="stack">The stack to enumerator.</param>
+            internal LazyStackEnumeratorObject(LazyStack stack)
+            {
+                Requires.NotNull(stack, nameof(stack));
+                _originalStack = stack;
+            }
+
+            /// <summary>
+            /// Gets the current element.
+            /// </summary>
+            public T Current
+            {
+                get
+                {
+                    this.ThrowIfDisposed();
+                    if (_remainingStack == null || _remainingStack.IsEmpty)
+                    {
+                        throw new InvalidOperationException();
+                    }
+                    else
+                    {
+                        return _remainingStack.Peek();
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Gets the current element.
+            /// </summary>
+            object? IEnumerator.Current
+            {
+                get { return this.Current; }
+            }
+
+            /// <summary>
+            /// Moves to the first or next element.
+            /// </summary>
+            /// <returns>A value indicating whether there are any more elements.</returns>
+            public bool MoveNext()
+            {
+                this.ThrowIfDisposed();
+
+                if (_remainingStack == null)
+                {
+                    // initial move
+                    _remainingStack = _originalStack;
+                }
+                else if (!_remainingStack.IsEmpty)
+                {
+                    _remainingStack = _remainingStack.Pop();
+                }
+
+                return !_remainingStack.IsEmpty;
+            }
+
+            /// <summary>
+            /// Resets the position to just before the first element in the list.
+            /// </summary>
+            public void Reset()
+            {
+                this.ThrowIfDisposed();
+                _remainingStack = null;
+            }
+
+            /// <summary>
+            /// Disposes this instance.
+            /// </summary>
+            public void Dispose()
+            {
+                _disposed = true;
+            }
+
+            /// <summary>
+            /// Throws an <see cref="ObjectDisposedException"/> if this
+            /// enumerator has already been disposed.
+            /// </summary>
+            private void ThrowIfDisposed()
+            {
+                if (_disposed)
+                {
+                    Requires.FailObjectDisposed(this);
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue_1.LazyStack.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue_1.LazyStack.cs
@@ -1,0 +1,285 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace System.Collections.Immutable
+{
+    public sealed partial class ImmutableQueue<T>
+    {
+        /// <summary>
+        /// An immutable stack with lazy initialization.
+        /// </summary>
+        [DebuggerTypeProxy(typeof(ImmutableEnumerableDebuggerProxy<>))]
+        [DebuggerDisplay("IsEmpty = {IsEmpty}; Top = {_head}")]
+        internal class LazyStack : IImmutableStack<T>
+        {
+            /// <summary>
+            /// The singleton empty stack.
+            /// </summary>
+            /// <remarks>
+            /// Additional instances representing the empty stack may exist on deserialized stacks.
+            /// </remarks>
+            private static readonly LazyStack s_EmptyField = new LazyStack();
+
+            /// <summary>
+            /// The element on the top of the stack.
+            /// </summary>
+            private T? _head;
+
+            /// <summary>
+            /// A stack that contains the rest of the elements (under the top element).
+            /// </summary>
+            private LazyStack? _tail;
+
+
+            /// <summary>
+            /// A stack that contains the heads of the elements.
+            /// </summary>
+            private readonly LazyStack? _lazyHeads;
+
+            /// <summary>
+            /// A stack that contains the ends of the elements.
+            /// </summary>
+            private readonly ImmutableStack<T>? _lazyTails;
+
+            /// <summary>
+            /// A stack that contains the middle of the elements.
+            /// </summary>
+            private readonly LazyStack? _lazySchedule;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="LazyStack"/> class
+            /// that acts as the empty stack.
+            /// </summary>
+            private LazyStack()
+            {
+            }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="LazyStack"/> class.
+            /// </summary>
+            /// <param name="head">The head element on the stack.</param>
+            /// <param name="tail">The rest of the elements on the stack.</param>
+            internal LazyStack(T head, LazyStack tail)
+            {
+                Debug.Assert(tail is not null);
+
+                _head = head;
+                _tail = tail;
+            }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="LazyStack"/> class with lazy initialization.
+            /// </summary>
+            internal LazyStack(LazyStack heads, ImmutableStack<T> tails, LazyStack schedule)
+            {
+                _lazyHeads = heads;
+                _lazyTails = tails;
+                _lazySchedule = schedule;
+            }
+
+            /// <summary>
+            /// Gets the empty stack, upon which all stacks are built.
+            /// </summary>
+            public static LazyStack Empty
+            {
+                get
+                {
+                    Debug.Assert(s_EmptyField.IsEmpty);
+                    return s_EmptyField;
+                }
+            }
+
+            /// <summary>
+            /// Gets the empty stack, upon which all stacks are built.
+            /// </summary>
+            public LazyStack Clear()
+            {
+                Debug.Assert(s_EmptyField.IsEmpty);
+                return Empty;
+            }
+
+            /// <summary>
+            /// Gets an empty stack.
+            /// </summary>
+            IImmutableStack<T> IImmutableStack<T>.Clear()
+            {
+                return this.Clear();
+            }
+
+            /// <summary>
+            /// Gets a value indicating whether this instance is empty.
+            /// </summary>
+            /// <value>
+            ///   <c>true</c> if this instance is empty; otherwise, <c>false</c>.
+            /// </value>
+            public bool IsEmpty
+            {
+                get
+                {
+                    return _tail is null && _lazySchedule is null;
+                }
+            }
+
+            /// <summary>
+            /// Gets the element on the top of the stack.
+            /// </summary>
+            /// <returns>
+            /// The element on the top of the stack.
+            /// </returns>
+            /// <exception cref="InvalidOperationException">Thrown when the stack is empty.</exception>
+            public T Peek()
+            {
+                if (this.IsEmpty)
+                {
+                    throw new InvalidOperationException(SR.InvalidEmptyOperation);
+                }
+
+                Rotate();
+                return _head!;
+            }
+
+            /// <summary>
+            /// Gets a read-only reference to the element on the top of the stack.
+            /// </summary>
+            /// <returns>
+            /// A read-only reference to the element on the top of the stack.
+            /// </returns>
+            /// <exception cref="InvalidOperationException">Thrown when the stack is empty.</exception>
+            public ref readonly T PeekRef()
+            {
+                if (this.IsEmpty)
+                {
+                    throw new InvalidOperationException(SR.InvalidEmptyOperation);
+                }
+
+                Rotate();
+                return ref _head!;
+            }
+
+
+            /// <summary>
+            /// Pushes an element onto a stack and returns the new stack.
+            /// </summary>
+            /// <param name="value">The element to push onto the stack.</param>
+            /// <returns>The new stack.</returns>
+            public LazyStack Push(T value)
+            {
+                return new LazyStack(value, this);
+            }
+
+            /// <summary>
+            /// Pushes an element onto a stack and returns the new stack.
+            /// </summary>
+            /// <param name="value">The element to push onto the stack.</param>
+            /// <returns>The new stack.</returns>
+            IImmutableStack<T> IImmutableStack<T>.Push(T value)
+            {
+                return this.Push(value);
+            }
+
+            /// <summary>
+            /// Returns a stack that lacks the top element on this stack.
+            /// </summary>
+            /// <returns>A stack; never <c>null</c></returns>
+            /// <exception cref="InvalidOperationException">Thrown when the stack is empty.</exception>
+            public LazyStack Pop()
+            {
+                if (this.IsEmpty)
+                {
+                    throw new InvalidOperationException(SR.InvalidEmptyOperation);
+                }
+
+                Rotate();
+                Debug.Assert(_tail is not null);
+                return _tail;
+            }
+
+            /// <summary>
+            /// Returns a stack that lacks the top element on this stack.
+            /// </summary>
+            /// <returns>A stack; never <c>null</c></returns>
+            /// <exception cref="InvalidOperationException">Thrown when the stack is empty.</exception>
+            IImmutableStack<T> IImmutableStack<T>.Pop()
+            {
+                return this.Pop();
+            }
+
+            /// <summary>
+            /// Pops the top element off the stack.
+            /// </summary>
+            /// <param name="value">The value that was removed from the stack.</param>
+            /// <returns>
+            /// A stack; never <c>null</c>
+            /// </returns>
+            public LazyStack Pop(out T value)
+            {
+                Rotate();
+                value = this.Peek();
+                return this.Pop();
+            }
+
+            internal void Rotate()
+            {
+                if (_tail is not null || _lazySchedule is null)
+                {
+                    return;
+                }
+                Debug.Assert(_lazyHeads is not null);
+                Debug.Assert(_lazyTails is not null);
+                Debug.Assert(_lazySchedule is not null);
+
+                if (_lazyHeads.IsEmpty)
+                {
+                    _head = _lazyTails.Peek();
+                    _tail = _lazySchedule;
+                }
+                else
+                {
+                    var heads = _lazyHeads.Pop(out _head);
+                    var tails = _lazyTails.Pop(out T tailValue);
+                    var schedule = _lazySchedule.Push(tailValue);
+                    _tail = new LazyStack(heads, tails, schedule);
+                }
+            }
+
+            /// <summary>
+            /// Returns an enumerator that iterates through the collection.
+            /// </summary>
+            /// <returns>
+            /// An <see cref="LazyStackEnumerator"/> that can be used to iterate through the collection.
+            /// </returns>
+            public LazyStackEnumerator GetEnumerator()
+            {
+                return new LazyStackEnumerator(this);
+            }
+
+            /// <summary>
+            /// Returns an enumerator that iterates through the collection.
+            /// </summary>
+            /// <returns>
+            /// A <see cref="IEnumerator{T}"/> that can be used to iterate through the collection.
+            /// </returns>
+            IEnumerator<T> IEnumerable<T>.GetEnumerator()
+            {
+                return this.IsEmpty ?
+                    Enumerable.Empty<T>().GetEnumerator() :
+                    new LazyStackEnumeratorObject(this);
+            }
+
+            /// <summary>
+            /// Returns an enumerator that iterates through a collection.
+            /// </summary>
+            /// <returns>
+            /// An <see cref="IEnumerator"/> object that can be used to iterate through the collection.
+            /// </returns>
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return new LazyStackEnumeratorObject(this);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fix #53902

In worst case, ImmutableQueue<T> takes O(n) now.
Real-time queue takes O(1).

**reference**
https://www.cs.cmu.edu/~rwh/theses/okasaki.pdf

## pros & cons

### pros:

It takes O(1) no matter what kind of operation is performed.

### cons:

Due to overhead, it may be a bit slower than the current implimentation. 

## Benchmark

ImmutableQueue is .NET 5 implementation.
RealTimeQueue is my implementation.

### Benchmark result

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-4790 CPU 3.60GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=6.0.100-preview.4.21255.9
  [Host]     : .NET Core 5.0.7 (CoreCLR 5.0.721.25508, CoreFX 5.0.721.25508), X64 RyuJIT
  Job-QIKQBU : .NET Core 5.0.7 (CoreCLR 5.0.721.25508, CoreFX 5.0.721.25508), X64 RyuJIT

Toolchain=.NET Core 5.0  

```
|      Method |     N |           Type |               Mean |            Error |            StdDev |        Gen 0 |       Gen 1 |       Gen 2 |   Allocated |
|------------ |------ |--------------- |-------------------:|-----------------:|------------------:|-------------:|------------:|------------:|------------:|
|     **UseMany** |    **50** | **ImmutableQueue** |         **3,620.0 ns** |         **70.41 ns** |          **89.04 ns** |       **3.2387** |           **-** |           **-** |    **13.23 KB** |
|     **UseMany** |    **50** |  **RealTimeQueue** |         **1,535.4 ns** |         **28.80 ns** |          **55.49 ns** |       **1.2035** |           **-** |           **-** |     **4.92 KB** |
|     **UseMany** |   **500** | **ImmutableQueue** |       **268,553.1 ns** |      **2,197.03 ns** |       **1,947.61 ns** |     **246.5820** |           **-** |           **-** |  **1007.81 KB** |
|     **UseMany** |   **500** |  **RealTimeQueue** |        **15,992.2 ns** |        **119.46 ns** |          **99.75 ns** |      **11.9019** |           **-** |           **-** |    **48.66 KB** |
|     **UseMany** |  **5000** | **ImmutableQueue** |    **29,758,003.3 ns** |    **347,668.09 ns** |     **308,198.71 ns** |   **23937.5000** |     **62.5000** |           **-** | **97968.75 KB** |
|     **UseMany** |  **5000** |  **RealTimeQueue** |       **246,001.2 ns** |      **4,680.05 ns** |       **5,007.60 ns** |      **85.4492** |     **42.7246** |           **-** |   **512.73 KB** |
|     **UseMany** | **50000** | **ImmutableQueue** | **3,813,408,958.3 ns** | **52,385,180.85 ns** | **129,483,188.00 ns** | **1686000.0000** | **304000.0000** | **152000.0000** |  **9768750 KB** |
|     **UseMany** | **50000** |  **RealTimeQueue** |     **7,646,693.2 ns** |     **77,409.59 ns** |      **72,408.98 ns** |     **882.8125** |    **335.9375** |    **156.2500** |  **5306.75 KB** |
|             |       |                |                    |                  |                   |              |             |             |             |
|     **UseOnce** |    **50** | **ImmutableQueue** |           **989.0 ns** |         **19.75 ns** |          **28.32 ns** |       **0.9441** |           **-** |           **-** |     **3.86 KB** |
|     **UseOnce** |    **50** |  **RealTimeQueue** |         **1,990.1 ns** |         **37.70 ns** |          **38.72 ns** |       **1.5373** |           **-** |           **-** |     **6.29 KB** |
|     **UseOnce** |   **500** | **ImmutableQueue** |         **9,984.3 ns** |        **167.53 ns** |         **156.71 ns** |       **9.5520** |           **-** |           **-** |    **39.06 KB** |
|     **UseOnce** |   **500** |  **RealTimeQueue** |        **20,979.1 ns** |        **381.87 ns** |         **571.56 ns** |      **15.2588** |           **-** |           **-** |    **62.39 KB** |
|     **UseOnce** |  **5000** | **ImmutableQueue** |       **126,342.0 ns** |      **1,839.52 ns** |       **1,720.69 ns** |      **95.4590** |      **0.2441** |           **-** |   **390.63 KB** |
|     **UseOnce** |  **5000** |  **RealTimeQueue** |       **315,340.8 ns** |      **3,236.03 ns** |       **2,868.66 ns** |     **132.8125** |     **52.7344** |           **-** |   **673.89 KB** |
|     **UseOnce** | **50000** | **ImmutableQueue** |     **3,098,779.2 ns** |     **61,429.23 ns** |      **73,127.12 ns** |     **636.7188** |    **316.4063** |           **-** |  **3906.25 KB** |
|     **UseOnce** | **50000** |  **RealTimeQueue** |     **8,285,622.3 ns** |     **56,804.53 ns** |      **50,355.73 ns** |    **1093.7500** |    **468.7500** |    **156.2500** |  **6673.99 KB** |
|             |       |                |                    |                  |                   |              |             |             |             |
| **EnqueueMany** |    **50** | **ImmutableQueue** |           **815.5 ns** |         **15.97 ns** |          **17.75 ns** |       **0.8602** |           **-** |           **-** |     **3.52 KB** |
| **EnqueueMany** |    **50** |  **RealTimeQueue** |         **1,544.0 ns** |         **11.61 ns** |          **10.29 ns** |       **1.3046** |           **-** |           **-** |     **5.33 KB** |
| **EnqueueMany** |   **500** | **ImmutableQueue** |         **8,096.0 ns** |         **75.87 ns** |          **67.25 ns** |       **8.6060** |           **-** |           **-** |    **35.16 KB** |
| **EnqueueMany** |   **500** |  **RealTimeQueue** |        **16,601.9 ns** |        **321.31 ns** |         **300.55 ns** |      **12.8479** |      **0.0305** |           **-** |    **52.57 KB** |
| **EnqueueMany** |  **5000** | **ImmutableQueue** |       **114,007.4 ns** |      **1,793.75 ns** |       **1,677.88 ns** |      **86.0596** |      **0.1221** |           **-** |   **351.56 KB** |
| **EnqueueMany** |  **5000** |  **RealTimeQueue** |       **257,275.4 ns** |      **1,399.04 ns** |       **1,168.26 ns** |      **94.7266** |     **44.9219** |           **-** |   **551.79 KB** |
| **EnqueueMany** | **50000** | **ImmutableQueue** |     **3,080,481.2 ns** |     **21,465.44 ns** |      **19,028.55 ns** |     **574.2188** |    **285.1563** |     **54.6875** |  **3515.63 KB** |
| **EnqueueMany** | **50000** |  **RealTimeQueue** |     **8,120,688.3 ns** |    **152,113.27 ns** |     **142,286.85 ns** |     **984.3750** |    **359.3750** |    **140.6250** |   **5697.5 KB** |
|             |       |                |                    |                  |                   |              |             |             |             |
|   **Enumerate** |    **50** | **ImmutableQueue** |         **1,757.5 ns** |         **34.32 ns** |          **33.71 ns** |       **1.2455** |           **-** |           **-** |     **5.09 KB** |
|   **Enumerate** |    **50** |  **RealTimeQueue** |         **2,990.5 ns** |         **55.14 ns** |          **51.58 ns** |       **1.8730** |           **-** |           **-** |     **7.66 KB** |
|   **Enumerate** |   **500** | **ImmutableQueue** |        **17,488.4 ns** |        **115.87 ns** |         **108.39 ns** |      **12.4207** |      **0.0305** |           **-** |     **50.8 KB** |
|   **Enumerate** |   **500** |  **RealTimeQueue** |        **28,487.9 ns** |        **167.85 ns** |         **140.16 ns** |      **18.1580** |      **0.0305** |           **-** |    **74.22 KB** |
|   **Enumerate** |  **5000** | **ImmutableQueue** |       **221,659.8 ns** |      **4,280.32 ns** |       **4,003.81 ns** |     **122.0703** |      **8.5449** |           **-** |   **507.83 KB** |
|   **Enumerate** |  **5000** |  **RealTimeQueue** |       **471,760.5 ns** |      **3,289.16 ns** |       **2,746.60 ns** |     **151.3672** |     **61.0352** |           **-** |   **866.19 KB** |
|   **Enumerate** | **50000** | **ImmutableQueue** |     **3,578,473.0 ns** |     **24,655.79 ns** |      **21,856.71 ns** |     **980.4688** |    **472.6563** |           **-** |  **5078.14 KB** |
|   **Enumerate** | **50000** |  **RealTimeQueue** |     **9,030,936.9 ns** |     **59,085.44 ns** |      **52,377.71 ns** |    **1328.1250** |    **625.0000** |    **203.1250** |   **8027.9 KB** |


### Benchmark code

```csharp
using System;
using System.Collections;
using System.Collections.Generic;
using System.Collections.Immutable;
using System.Diagnostics;
using System.Linq;
using System.Runtime.CompilerServices;
using System.Runtime.InteropServices;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Configs;
using BenchmarkDotNet.Diagnosers;
using BenchmarkDotNet.Jobs;
using BenchmarkDotNet.Running;
using BenchmarkDotNet.Toolchains.CsProj;

_ = BenchmarkRunner.Run(typeof(Benchmark).Assembly);


public class BenchmarkConfig : ManualConfig
{
    public BenchmarkConfig()
    {
        AddDiagnoser(MemoryDiagnoser.Default);
        AddExporter(BenchmarkDotNet.Exporters.MarkdownExporter.GitHub);
        AddJob(Job.Default.WithToolchain(CsProjCoreToolchain.NetCoreApp50));
    }
}

[Config(typeof(BenchmarkConfig))]
[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByMethod)]
public class Benchmark
{
    [Params(50, 500, 5000, 50000)]
    public int N;

    [Params(QueueType.ImmutableQueue, QueueType.RealTimeQueue)]
    public QueueType Type;

    public readonly IImmutableQueue<int>[] Empties = new IImmutableQueue<int>[]
    {
        ImmutableQueue<int>.Empty,// .NET 5 implimentation.
        RealTimeQueue<int>.Empty, // my implimentation.
    };

    [Benchmark]
    public IImmutableQueue<int> UseMany()
    {
        var queue = Empties[(int)Type];
        for (int i = 0; i < N / 2; i++)
            queue = queue.Enqueue(i);
        var queue2 = queue;
        for (int i = N / 2; i < N; i++)
        {
            if (i % 2 == 0)
                queue = queue2.Enqueue(i);
            else
                queue = queue.Dequeue();
        }
        return queue;
    }
    [Benchmark]
    public IImmutableQueue<int> UseOnce()
    {
        var queue = Empties[(int)Type];
        for (int i = 0; i < N / 2; i++)
            queue = queue.Enqueue(i);
        for (int i = N / 2; i < N; i++)
        {
            if (i % 2 == 0)
                queue = queue.Enqueue(i);
            else
                queue = queue.Dequeue();
        }
        return queue;
    }

    [Benchmark]
    public IImmutableQueue<int> EnqueueMany()
    {
        var queue = Empties[(int)Type];
        for (int i = 0; i < N / 2; i++)
            queue = queue.Enqueue(i);
        var queue2 = queue;
        for (int i = N / 2; i < N; i++)
        {
            if (i % 2 == 0)
                queue = queue2.Enqueue(i);
            else
                queue = queue.Enqueue(i);
        }
        return queue;
    }
    [Benchmark]
    public int Enumerate()
    {
        var queue = Empties[(int)Type];
        for (int i = 0; i < N; i++)
            queue = queue.Enqueue(i);
        int num = 0;
        foreach (var item in queue)
            num ^= item;
        return num;
    }
    public enum QueueType
    {
        ImmutableQueue,
        RealTimeQueue,
    }
}
```