### PR TITLE
Logging Generator: messaging fix

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
@@ -323,7 +323,7 @@ namespace Microsoft.Extensions.Logging.Generators
 
                                                 if (!found)
                                                 {
-                                                    Diag(DiagnosticDescriptors.TemplateHasNoCorrespondingArgument, ma.GetLocation(), t);
+                                                    Diag(DiagnosticDescriptors.TemplateHasNoCorrespondingArgument, ma.GetLocation(), t.Key);
                                                 }
                                             }
                                         }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/Strings.resx
@@ -177,7 +177,7 @@
     <value>Argument is not referenced from the logging message</value>
   </data>
   <data name="TemplateHasNoCorrespondingArgumentMessage" xml:space="preserve">
-    <value>Template {0} is not provided as argument to the logging method</value>
+    <value>Template '{0}' is not provided as argument to the logging method</value>
   </data>
   <data name="TemplateHasNoCorrespondingArgumentTitle" xml:space="preserve">
     <value>Logging template has no corresponding method argument</value>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.cs.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.cs.xlf
@@ -153,8 +153,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateHasNoCorrespondingArgumentMessage">
-        <source>Template {0} is not provided as argument to the logging method</source>
-        <target state="new">Template {0} is not provided as argument to the logging method</target>
+        <source>Template '{0}' is not provided as argument to the logging method</source>
+        <target state="new">Template '{0}' is not provided as argument to the logging method</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateHasNoCorrespondingArgumentTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.de.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.de.xlf
@@ -153,8 +153,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateHasNoCorrespondingArgumentMessage">
-        <source>Template {0} is not provided as argument to the logging method</source>
-        <target state="new">Template {0} is not provided as argument to the logging method</target>
+        <source>Template '{0}' is not provided as argument to the logging method</source>
+        <target state="new">Template '{0}' is not provided as argument to the logging method</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateHasNoCorrespondingArgumentTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.es.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.es.xlf
@@ -153,8 +153,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateHasNoCorrespondingArgumentMessage">
-        <source>Template {0} is not provided as argument to the logging method</source>
-        <target state="new">Template {0} is not provided as argument to the logging method</target>
+        <source>Template '{0}' is not provided as argument to the logging method</source>
+        <target state="new">Template '{0}' is not provided as argument to the logging method</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateHasNoCorrespondingArgumentTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.fr.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.fr.xlf
@@ -153,8 +153,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateHasNoCorrespondingArgumentMessage">
-        <source>Template {0} is not provided as argument to the logging method</source>
-        <target state="new">Template {0} is not provided as argument to the logging method</target>
+        <source>Template '{0}' is not provided as argument to the logging method</source>
+        <target state="new">Template '{0}' is not provided as argument to the logging method</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateHasNoCorrespondingArgumentTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.it.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.it.xlf
@@ -153,8 +153,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateHasNoCorrespondingArgumentMessage">
-        <source>Template {0} is not provided as argument to the logging method</source>
-        <target state="new">Template {0} is not provided as argument to the logging method</target>
+        <source>Template '{0}' is not provided as argument to the logging method</source>
+        <target state="new">Template '{0}' is not provided as argument to the logging method</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateHasNoCorrespondingArgumentTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.ja.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.ja.xlf
@@ -153,8 +153,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateHasNoCorrespondingArgumentMessage">
-        <source>Template {0} is not provided as argument to the logging method</source>
-        <target state="new">Template {0} is not provided as argument to the logging method</target>
+        <source>Template '{0}' is not provided as argument to the logging method</source>
+        <target state="new">Template '{0}' is not provided as argument to the logging method</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateHasNoCorrespondingArgumentTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.ko.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.ko.xlf
@@ -153,8 +153,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateHasNoCorrespondingArgumentMessage">
-        <source>Template {0} is not provided as argument to the logging method</source>
-        <target state="new">Template {0} is not provided as argument to the logging method</target>
+        <source>Template '{0}' is not provided as argument to the logging method</source>
+        <target state="new">Template '{0}' is not provided as argument to the logging method</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateHasNoCorrespondingArgumentTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.pl.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.pl.xlf
@@ -153,8 +153,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateHasNoCorrespondingArgumentMessage">
-        <source>Template {0} is not provided as argument to the logging method</source>
-        <target state="new">Template {0} is not provided as argument to the logging method</target>
+        <source>Template '{0}' is not provided as argument to the logging method</source>
+        <target state="new">Template '{0}' is not provided as argument to the logging method</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateHasNoCorrespondingArgumentTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.pt-BR.xlf
@@ -153,8 +153,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateHasNoCorrespondingArgumentMessage">
-        <source>Template {0} is not provided as argument to the logging method</source>
-        <target state="new">Template {0} is not provided as argument to the logging method</target>
+        <source>Template '{0}' is not provided as argument to the logging method</source>
+        <target state="new">Template '{0}' is not provided as argument to the logging method</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateHasNoCorrespondingArgumentTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.ru.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.ru.xlf
@@ -153,8 +153,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateHasNoCorrespondingArgumentMessage">
-        <source>Template {0} is not provided as argument to the logging method</source>
-        <target state="new">Template {0} is not provided as argument to the logging method</target>
+        <source>Template '{0}' is not provided as argument to the logging method</source>
+        <target state="new">Template '{0}' is not provided as argument to the logging method</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateHasNoCorrespondingArgumentTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.tr.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.tr.xlf
@@ -153,8 +153,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateHasNoCorrespondingArgumentMessage">
-        <source>Template {0} is not provided as argument to the logging method</source>
-        <target state="new">Template {0} is not provided as argument to the logging method</target>
+        <source>Template '{0}' is not provided as argument to the logging method</source>
+        <target state="new">Template '{0}' is not provided as argument to the logging method</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateHasNoCorrespondingArgumentTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.zh-Hans.xlf
@@ -153,8 +153,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateHasNoCorrespondingArgumentMessage">
-        <source>Template {0} is not provided as argument to the logging method</source>
-        <target state="new">Template {0} is not provided as argument to the logging method</target>
+        <source>Template '{0}' is not provided as argument to the logging method</source>
+        <target state="new">Template '{0}' is not provided as argument to the logging method</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateHasNoCorrespondingArgumentTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Resources/xlf/Strings.zh-Hant.xlf
@@ -153,8 +153,8 @@
         <note />
       </trans-unit>
       <trans-unit id="TemplateHasNoCorrespondingArgumentMessage">
-        <source>Template {0} is not provided as argument to the logging method</source>
-        <target state="new">Template {0} is not provided as argument to the logging method</target>
+        <source>Template '{0}' is not provided as argument to the logging method</source>
+        <target state="new">Template '{0}' is not provided as argument to the logging method</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplateHasNoCorrespondingArgumentTitle">

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorParserTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorParserTests.cs
@@ -93,6 +93,7 @@ namespace Microsoft.Extensions.Logging.Generators.Tests
 
             Assert.Single(diagnostics);
             Assert.Equal(DiagnosticDescriptors.TemplateHasNoCorrespondingArgument.Id, diagnostics[0].Id);
+            Assert.Contains("Template 'foo' is not provided as argument to the logging method", diagnostics[0].GetMessage(), StringComparison.InvariantCulture);
         }
 
         [Fact]


### PR DESCRIPTION
Update TemplateHasNoCorrespondingArgument diag message to contain Template name instead of key value pair.  Also updated String Resources to add quotes around the template name to be consistent with ArgumentHasNoCorrespondingTemplateMessage.  Updated test case to check for diag message contents.  

Fixes #54008 