### PR TITLE
Support NoGC for regions

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -20551,24 +20551,19 @@ void gc_heap::allocate_for_no_gc_after_gc()
                 required -= commit;
                 while (required > 0)
                 {
-                    uint8_t* start;
-                    uint8_t* end;
-                    bool allocated_p = global_region_allocator.allocate_basic_region (&start, &end);
-                    if (!allocated_p)
+                    heap_segment* seg = get_new_region (0);
+                    if (seg == nullptr)
                     {
                         no_gc_oom_p = true;
                         break;
                     }
-                    size_t region_size = end - start;
-                    seg = make_heap_segment (start, region_size, __this, 0);
-                    size_t usable_size = end - heap_segment_allocated (seg);
+                    size_t usable_size = heap_segment_reserved (seg) - heap_segment_allocated (seg);
                     commit = min (required, usable_size);
                     if (!grow_heap_segment (seg, heap_segment_allocated (seg) + commit))
                     {
                         no_gc_oom_p = true;
                         break;
                     }
-                    return_free_region (seg);
                     required -= commit;
                 }
             }

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -20026,7 +20026,14 @@ start_no_gc_region_status gc_heap::prepare_for_no_gc_region (uint64_t total_size
     }
 
     int soh_align_const = get_alignment_constant (TRUE);
+#ifdef USE_REGIONS
+    // With regions, we 'could' extend the SOH as large as we wanted by chaining the
+    // regions together. However, it probably does not make sense to have a huge SOH
+    // the next ephemeral GC will suffer badly otherwise.
+    size_t max_soh_allocated = (size_t)1 << min_segment_size_shr;
+#else
     size_t max_soh_allocated = soh_segment_size - segment_info_size - eph_gen_starts_size;
+#endif
     size_t size_per_heap = 0;
     const double scale_factor = 1.05;
 

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -20543,23 +20543,23 @@ void gc_heap::allocate_for_no_gc_after_gc()
         {
 #ifdef USE_REGIONS
             size_t required = soh_allocation_no_gc;
-            heap_segment* seg = generation_allocation_segment (generation_of (0));
-            size_t available = heap_segment_reserved (seg) - heap_segment_allocated (seg);
+            heap_segment* region = generation_allocation_segment (generation_of (0));
+            size_t available = heap_segment_reserved (region) - heap_segment_allocated (region);
             size_t commit = min (available, required);
-            if (grow_heap_segment (seg, heap_segment_allocated (seg) + commit))
+            if (grow_heap_segment (region, heap_segment_allocated (region) + commit))
             {
                 required -= commit;
                 while (required > 0)
                 {
-                    heap_segment* seg = get_new_region (0);
-                    if (seg == nullptr)
+                    heap_segment* region = get_new_region (0);
+                    if (region == nullptr)
                     {
                         no_gc_oom_p = true;
                         break;
                     }
-                    size_t usable_size = heap_segment_reserved (seg) - heap_segment_allocated (seg);
+                    size_t usable_size = heap_segment_reserved (region) - heap_segment_allocated (region);
                     commit = min (required, usable_size);
-                    if (!grow_heap_segment (seg, heap_segment_allocated (seg) + commit))
+                    if (!grow_heap_segment (region, heap_segment_allocated (region) + commit))
                     {
                         no_gc_oom_p = true;
                         break;
@@ -20572,7 +20572,7 @@ void gc_heap::allocate_for_no_gc_after_gc()
                 no_gc_oom_p = true;
             }
             
-#else 
+#else
             if (((size_t)(heap_segment_reserved (ephemeral_heap_segment) - heap_segment_allocated (ephemeral_heap_segment)) < soh_allocation_no_gc) ||
                 (!grow_heap_segment (ephemeral_heap_segment, (heap_segment_allocated (ephemeral_heap_segment) + soh_allocation_no_gc))))
             {

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -20570,10 +20570,10 @@ int gc_heap::extend_soh_for_no_gc()
 {
     size_t required = soh_allocation_no_gc;
     heap_segment* region = generation_allocation_segment (generation_of (0));
-    // TODO: Do we need to worry about alloc_allocated here?
-    size_t available = heap_segment_reserved (region) - heap_segment_allocated (region);
+    uint8_t* allocated = (region == ephemeral_heap_segment) ? alloc_allocated : heap_segment_allocated (region);
+    size_t available = heap_segment_reserved (region) - allocated;
     size_t commit = min (available, required);
-    if (grow_heap_segment (region, heap_segment_allocated (region) + commit))
+    if (grow_heap_segment (region, allocated + commit))
     {
         required -= commit;
         while (required > 0)

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -20566,6 +20566,7 @@ void gc_heap::check_and_set_no_gc_oom()
 #endif //MULTIPLE_HEAPS
 }
 
+#ifdef USE_REGIONS
 int gc_heap::extend_soh_for_no_gc()
 {
     size_t required = soh_allocation_no_gc;
@@ -20598,6 +20599,7 @@ int gc_heap::extend_soh_for_no_gc()
     }
     return false;
 }
+#endif //USE_REGIONS
 
 void gc_heap::allocate_for_no_gc_after_gc()
 {

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -1667,6 +1667,12 @@ protected:
     PER_HEAP
     void allocate_for_no_gc_after_gc();
 
+#ifdef USE_REGIONS
+    // TODO, enum
+    PER_HEAP
+    int extend_soh_for_no_gc();
+#endif //USE_REGIONS
+
     PER_HEAP
     void set_loh_allocations_for_no_gc();
 

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -1498,8 +1498,10 @@ public:
     void get_and_reset_loh_alloc_info();
 #endif //BGC_SERVO_TUNING
 
+#ifndef USE_REGIONS
     PER_HEAP
     BOOL expand_soh_with_minimal_gc();
+#endif //!USE_REGIONS
 
     // EE is always suspended when this method is called.
     // returning FALSE means we actually didn't do a GC. This happens
@@ -1668,9 +1670,8 @@ protected:
     void allocate_for_no_gc_after_gc();
 
 #ifdef USE_REGIONS
-    // TODO, enum
     PER_HEAP
-    int extend_soh_for_no_gc();
+    bool extend_soh_for_no_gc();
 #endif //USE_REGIONS
 
     PER_HEAP

--- a/src/tests/GC/API/NoGCRegion/NoGC.cs
+++ b/src/tests/GC/API/NoGCRegion/NoGC.cs
@@ -52,8 +52,8 @@ public class Test
     static bool TestAllocInNoGCRegion(int sizeMB, int sizeMBLOH, bool disallowFullBlockingGC)
     {
         bool isCurrentTestPassed = false;
-        Console.WriteLine("=====allocating {0}mb {1} full blocking GC first=====", 
-            sizeMB, (disallowFullBlockingGC ? "disallowing" : "allowing"));
+        Console.WriteLine("=====allocating {0}mb/{1}mb {2} full blocking GC first=====", 
+            sizeMB, sizeMBLOH, (disallowFullBlockingGC ? "disallowing" : "allowing"));
             
         DoAlloc();
 


### PR DESCRIPTION
This change enables the NoGC regions support in regions.

**Idea:**
There are 3 phases when we try to start a No GC region

1. Computing the expected allocation sizes in `prepare_for_no_gc_region`. In this phase, most of the logic is shared with the segment case. 
> Since the SOH can be extended by chaining regions, there isn't an upper bound.on how much allocation we could do in the SOH during NoGC, therefore we set the size to be `SIZE_T_MAX`, this is consistent with the behavior for LOH.
2. Determine if we need to perform a GC to enter the No GC region by `should_proceed_for_no_gc`. In this phase, we reused the LOH part for simplicity. For the SOH part, we leverage the fact that the SOH can be extended by concatenating regions after it, so we simply try to extend it to satisfy the request. If that works, we avoid doing a GC.
> As we have a smaller region size for LOH, we might want to reconsider whether or not we need something different in case that becomes a problem, but I would like to get this change in first to unblock testing.
3. If we did perform a GC, then after the GC we would like to preallocate the memory through `allocate_for_no_gc_after_gc`. This will reuse the same function that we used to extend the SOH in `should_proceed_for_no_gc`.

**Testing:**
Testing is done by running the NoGC test on Windows only. All tests passed under workstation GC. In server GC, the allocating 8192 MB test case failed and performed a GC during the NoGC region. I guess that has to do with the fact that my machine don't have that much memory, the same test case failed in the segment case as well.