### PR TITLE
[release/5.0] Port #54070: Ensure debugger can parse VEX 256 instructions

### DIFF
--- a/src/coreclr/src/debug/ee/controller.cpp
+++ b/src/coreclr/src/debug/ee/controller.cpp
@@ -4415,8 +4415,9 @@ DebuggerPatchSkip::DebuggerPatchSkip(Thread *thread,
         }
         else
         {
+            _ASSERTE(m_instrAttrib.m_cOperandSize <= SharedPatchBypassBuffer::cbBufferBypass);
             // Copy the data into our buffer.
-            memcpy(bufferBypass, patch->address + m_instrAttrib.m_cbInstr + dwOldDisp, SharedPatchBypassBuffer::cbBufferBypass);
+            memcpy(bufferBypass, patch->address + m_instrAttrib.m_cbInstr + dwOldDisp, m_instrAttrib.m_cOperandSize);
 
             if (m_instrAttrib.m_fIsWrite)
             {

--- a/src/coreclr/src/debug/ee/controller.h
+++ b/src/coreclr/src/debug/ee/controller.h
@@ -288,7 +288,7 @@ public:
     // "PatchBypass" must be the first field of this class for alignment to be correct.
     BYTE    PatchBypass[MAX_INSTRUCTION_LENGTH];
 #if defined(TARGET_AMD64)
-    const static int cbBufferBypass = 0x10;
+    const static int cbBufferBypass = 0x20;
     BYTE    BypassBuffer[cbBufferBypass];
 
     UINT_PTR                RipTargetFixup;


### PR DESCRIPTION
## Customer Impact

Stepping over any breakpoint that VEX instruction that sets the L bit and uses IP relative encoding would corrupt the underlying memory.  This may impact any customer sdebugging Vector related code.

var v = Vector256.Create(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f);      //<1, 2, 3, 4, 5, 6, 7, 8>
    v = Vector256.Create(1.0f);                                                    //<1, 1, 1, 1, 0, 0, 0, 7.17E-43>
    v = Vector256.Create(-1.0f, -2.0f, -3.0f, -4.0f, -5.0f, -6.0f, -7.0f, -8.0f);  //<-1, -2, -3, -4, -5, -6, -7, -8>
    v = Vector256.Create(1.0f);   

## Testing

Ran over a few different types of vector operations and all successfully got redirected.

## Risk

Very low. At most this extends the memory consumption under a debugger per breakpoint by 16 bytes. In fact, this is even more conservative about reads than prior versions.