### PR TITLE
Scope events to the execution of the entry point

### DIFF
--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/HostFactoryResolverTests.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/HostFactoryResolverTests.cs
@@ -6,14 +6,13 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Threading;
-using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
 namespace Microsoft.Extensions.Hosting.Tests
 {
     public class HostFactoryResolverTests
     {
-        public static bool RequirementsMet => RemoteExecutor.IsSupported && PlatformDetection.IsThreadingSupported;
+        public static bool RequirementsMet => PlatformDetection.IsThreadingSupported;
 
         private static readonly TimeSpan s_WaitTimeout = TimeSpan.FromSeconds(20);
 
@@ -130,158 +129,128 @@ namespace Microsoft.Extensions.Hosting.Tests
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(CreateHostBuilderInvalidSignature.Program))]
         public void CreateHostBuilderPattern__Invalid_CantFindServiceProvider()
         {
-            using var _ = RemoteExecutor.Invoke(() => 
-            {
-                var factory = HostFactoryResolver.ResolveServiceProviderFactory(typeof(CreateHostBuilderInvalidSignature.Program).Assembly, s_WaitTimeout);
+            var factory = HostFactoryResolver.ResolveServiceProviderFactory(typeof(CreateHostBuilderInvalidSignature.Program).Assembly, s_WaitTimeout);
 
-                Assert.NotNull(factory);
-                Assert.Throws<InvalidOperationException>(() => factory(Array.Empty<string>()));
-            });
+            Assert.NotNull(factory);
+            Assert.Throws<InvalidOperationException>(() => factory(Array.Empty<string>()));
         }
 
         [ConditionalFact(nameof(RequirementsMet))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(NoSpecialEntryPointPattern.Program))]
         public void NoSpecialEntryPointPattern()
         {
-            using var _ = RemoteExecutor.Invoke(() => 
-            {
-                var factory = HostFactoryResolver.ResolveServiceProviderFactory(typeof(NoSpecialEntryPointPattern.Program).Assembly, s_WaitTimeout);
+            var factory = HostFactoryResolver.ResolveServiceProviderFactory(typeof(NoSpecialEntryPointPattern.Program).Assembly, s_WaitTimeout);
 
-                Assert.NotNull(factory);
-                Assert.IsAssignableFrom<IServiceProvider>(factory(Array.Empty<string>()));
-            });
+            Assert.NotNull(factory);
+            Assert.IsAssignableFrom<IServiceProvider>(factory(Array.Empty<string>()));
         }
 
         [ConditionalFact(nameof(RequirementsMet))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(NoSpecialEntryPointPattern.Program))]
         public void NoSpecialEntryPointPatternHostBuilderConfigureHostBuilderCallbackIsCalled()
         {
-            using var _ = RemoteExecutor.Invoke(() => 
+            bool called = false;
+            void ConfigureHostBuilder(object hostBuilder)
             {
-                bool called = false;
-                void ConfigureHostBuilder(object hostBuilder)
-                {
-                    Assert.IsAssignableFrom<IHostBuilder>(hostBuilder);
-                    called = true;
-                }
+                Assert.IsAssignableFrom<IHostBuilder>(hostBuilder);
+                called = true;
+            }
 
-                var factory = HostFactoryResolver.ResolveHostFactory(typeof(NoSpecialEntryPointPattern.Program).Assembly, waitTimeout: s_WaitTimeout, configureHostBuilder: ConfigureHostBuilder);
+            var factory = HostFactoryResolver.ResolveHostFactory(typeof(NoSpecialEntryPointPattern.Program).Assembly, waitTimeout: s_WaitTimeout, configureHostBuilder: ConfigureHostBuilder);
 
-                Assert.NotNull(factory);
-                Assert.IsAssignableFrom<IHost>(factory(Array.Empty<string>()));
-                Assert.True(called);
-            });
+            Assert.NotNull(factory);
+            Assert.IsAssignableFrom<IHost>(factory(Array.Empty<string>()));
+            Assert.True(called);
         }
 
         [ConditionalFact(nameof(RequirementsMet))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(NoSpecialEntryPointPattern.Program))]
         public void NoSpecialEntryPointPatternBuildsThenThrowsCallsEntryPointCompletedCallback()
         {
-            using var _ = RemoteExecutor.Invoke(() => 
+            var wait = new ManualResetEventSlim(false);
+            Exception? entryPointException = null;
+            void EntryPointCompleted(Exception? exception)
             {
-                var wait = new ManualResetEventSlim(false);
-                Exception? entryPointException = null;
-                void EntryPointCompleted(Exception? exception)
-                {
-                    entryPointException = exception;
-                    wait.Set();
-                }
+                entryPointException = exception;
+                wait.Set();
+            }
 
-                var factory = HostFactoryResolver.ResolveHostFactory(typeof(NoSpecialEntryPointPattern.Program).Assembly, waitTimeout: s_WaitTimeout, stopApplication: false, entrypointCompleted: EntryPointCompleted);
+            var factory = HostFactoryResolver.ResolveHostFactory(typeof(NoSpecialEntryPointPattern.Program).Assembly, waitTimeout: s_WaitTimeout, stopApplication: false, entrypointCompleted: EntryPointCompleted);
 
-                Assert.NotNull(factory);
-                Assert.IsAssignableFrom<IHost>(factory(Array.Empty<string>()));
-                Assert.True(wait.Wait(s_WaitTimeout));
-                Assert.Null(entryPointException);
-            });
+            Assert.NotNull(factory);
+            Assert.IsAssignableFrom<IHost>(factory(Array.Empty<string>()));
+            Assert.True(wait.Wait(s_WaitTimeout));
+            Assert.Null(entryPointException);
         }
 
         [ConditionalFact(nameof(RequirementsMet))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(NoSpecialEntryPointPatternBuildsThenThrows.Program))]
         public void NoSpecialEntryPointPatternBuildsThenThrowsCallsEntryPointCompletedCallbackWithException()
         {
-            using var _ = RemoteExecutor.Invoke(() => 
+            var wait = new ManualResetEventSlim(false);
+            Exception? entryPointException = null;
+            void EntryPointCompleted(Exception? exception)
             {
-                var wait = new ManualResetEventSlim(false);
-                Exception? entryPointException = null;
-                void EntryPointCompleted(Exception? exception)
-                {
-                    entryPointException = exception;
-                    wait.Set();
-                }
+                entryPointException = exception;
+                wait.Set();
+            }
 
-                var factory = HostFactoryResolver.ResolveHostFactory(typeof(NoSpecialEntryPointPatternBuildsThenThrows.Program).Assembly, waitTimeout: s_WaitTimeout, stopApplication: false, entrypointCompleted: EntryPointCompleted);
+            var factory = HostFactoryResolver.ResolveHostFactory(typeof(NoSpecialEntryPointPatternBuildsThenThrows.Program).Assembly, waitTimeout: s_WaitTimeout, stopApplication: false, entrypointCompleted: EntryPointCompleted);
 
-                Assert.NotNull(factory);
-                Assert.IsAssignableFrom<IHost>(factory(Array.Empty<string>()));
-                Assert.True(wait.Wait(s_WaitTimeout));
-                Assert.NotNull(entryPointException);
-            });
+            Assert.NotNull(factory);
+            Assert.IsAssignableFrom<IHost>(factory(Array.Empty<string>()));
+            Assert.True(wait.Wait(s_WaitTimeout));
+            Assert.NotNull(entryPointException);
         }
 
         [ConditionalFact(nameof(RequirementsMet))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(NoSpecialEntryPointPatternThrows.Program))]
         public void NoSpecialEntryPointPatternThrows()
         {
-            using var _ = RemoteExecutor.Invoke(() => 
-            {
-                var factory = HostFactoryResolver.ResolveServiceProviderFactory(typeof(NoSpecialEntryPointPatternThrows.Program).Assembly, s_WaitTimeout);
+            var factory = HostFactoryResolver.ResolveServiceProviderFactory(typeof(NoSpecialEntryPointPatternThrows.Program).Assembly, s_WaitTimeout);
 
-                Assert.NotNull(factory);
-                Assert.Throws<Exception>(() => factory(Array.Empty<string>()));
-            });
+            Assert.NotNull(factory);
+            Assert.Throws<Exception>(() => factory(Array.Empty<string>()));
         }
 
         [ConditionalFact(nameof(RequirementsMet))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(NoSpecialEntryPointPatternExits.Program))]
         public void NoSpecialEntryPointPatternExits()
         {
-            using var _ = RemoteExecutor.Invoke(() => 
-            {
-                var factory = HostFactoryResolver.ResolveServiceProviderFactory(typeof(NoSpecialEntryPointPatternExits.Program).Assembly, s_WaitTimeout);
+            var factory = HostFactoryResolver.ResolveServiceProviderFactory(typeof(NoSpecialEntryPointPatternExits.Program).Assembly, s_WaitTimeout);
 
-                Assert.NotNull(factory);
-                Assert.Throws<InvalidOperationException>(() => factory(Array.Empty<string>()));
-            });
+            Assert.NotNull(factory);
+            Assert.Throws<InvalidOperationException>(() => factory(Array.Empty<string>()));
         }
 
         [ConditionalFact(nameof(RequirementsMet))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(NoSpecialEntryPointPatternHangs.Program))]
         public void NoSpecialEntryPointPatternHangs()
         {
-            using var _ = RemoteExecutor.Invoke(() => 
-            {
-                var factory = HostFactoryResolver.ResolveServiceProviderFactory(typeof(NoSpecialEntryPointPatternHangs.Program).Assembly, s_WaitTimeout);
+            var factory = HostFactoryResolver.ResolveServiceProviderFactory(typeof(NoSpecialEntryPointPatternHangs.Program).Assembly, s_WaitTimeout);
 
-                Assert.NotNull(factory);
-                Assert.Throws<InvalidOperationException>(() => factory(Array.Empty<string>()));
-            });
+            Assert.NotNull(factory);
+            Assert.Throws<InvalidOperationException>(() => factory(Array.Empty<string>()));
         }
 
         [ConditionalFact(nameof(RequirementsMet))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(NoSpecialEntryPointPatternMainNoArgs.Program))]
         public void NoSpecialEntryPointPatternMainNoArgs()
         {
-            using var _ = RemoteExecutor.Invoke(() => 
-            {
-                var factory = HostFactoryResolver.ResolveServiceProviderFactory(typeof(NoSpecialEntryPointPatternMainNoArgs.Program).Assembly, s_WaitTimeout);
+            var factory = HostFactoryResolver.ResolveServiceProviderFactory(typeof(NoSpecialEntryPointPatternMainNoArgs.Program).Assembly, s_WaitTimeout);
 
-                Assert.NotNull(factory);
-                Assert.IsAssignableFrom<IServiceProvider>(factory(Array.Empty<string>()));
-            });
+            Assert.NotNull(factory);
+            Assert.IsAssignableFrom<IServiceProvider>(factory(Array.Empty<string>()));
         }
 
         [ConditionalFact(nameof(RequirementsMet))]
         public void TopLevelStatements()
         {
-            using var _ = RemoteExecutor.Invoke(() => 
-            {
-                var assembly = Assembly.Load("TopLevelStatements");
-                var factory = HostFactoryResolver.ResolveServiceProviderFactory(assembly, s_WaitTimeout);
+            var assembly = Assembly.Load("TopLevelStatements");
+            var factory = HostFactoryResolver.ResolveServiceProviderFactory(assembly, s_WaitTimeout);
 
-                Assert.NotNull(factory);
-                Assert.IsAssignableFrom<IServiceProvider>(factory(Array.Empty<string>()));
-            });
+            Assert.NotNull(factory);
+            Assert.IsAssignableFrom<IServiceProvider>(factory(Array.Empty<string>()));
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/HostFactoryResolverTests.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/HostFactoryResolverTests.cs
@@ -12,8 +12,6 @@ namespace Microsoft.Extensions.Hosting.Tests
 {
     public class HostFactoryResolverTests
     {
-        public static bool RequirementsMet => PlatformDetection.IsThreadingSupported;
-
         private static readonly TimeSpan s_WaitTimeout = TimeSpan.FromSeconds(20);
 
         [Fact]
@@ -125,7 +123,7 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.Null(factory);
         }
 
-        [ConditionalFact(nameof(RequirementsMet))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(CreateHostBuilderInvalidSignature.Program))]
         public void CreateHostBuilderPattern__Invalid_CantFindServiceProvider()
         {
@@ -135,7 +133,7 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.Throws<InvalidOperationException>(() => factory(Array.Empty<string>()));
         }
 
-        [ConditionalFact(nameof(RequirementsMet))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(NoSpecialEntryPointPattern.Program))]
         public void NoSpecialEntryPointPattern()
         {
@@ -145,7 +143,7 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.IsAssignableFrom<IServiceProvider>(factory(Array.Empty<string>()));
         }
 
-        [ConditionalFact(nameof(RequirementsMet))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(NoSpecialEntryPointPattern.Program))]
         public void NoSpecialEntryPointPatternHostBuilderConfigureHostBuilderCallbackIsCalled()
         {
@@ -163,7 +161,7 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.True(called);
         }
 
-        [ConditionalFact(nameof(RequirementsMet))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(NoSpecialEntryPointPattern.Program))]
         public void NoSpecialEntryPointPatternBuildsThenThrowsCallsEntryPointCompletedCallback()
         {
@@ -183,7 +181,7 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.Null(entryPointException);
         }
 
-        [ConditionalFact(nameof(RequirementsMet))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(NoSpecialEntryPointPatternBuildsThenThrows.Program))]
         public void NoSpecialEntryPointPatternBuildsThenThrowsCallsEntryPointCompletedCallbackWithException()
         {
@@ -203,7 +201,7 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.NotNull(entryPointException);
         }
 
-        [ConditionalFact(nameof(RequirementsMet))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(NoSpecialEntryPointPatternThrows.Program))]
         public void NoSpecialEntryPointPatternThrows()
         {
@@ -213,7 +211,7 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.Throws<Exception>(() => factory(Array.Empty<string>()));
         }
 
-        [ConditionalFact(nameof(RequirementsMet))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(NoSpecialEntryPointPatternExits.Program))]
         public void NoSpecialEntryPointPatternExits()
         {
@@ -223,7 +221,7 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.Throws<InvalidOperationException>(() => factory(Array.Empty<string>()));
         }
 
-        [ConditionalFact(nameof(RequirementsMet))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(NoSpecialEntryPointPatternHangs.Program))]
         public void NoSpecialEntryPointPatternHangs()
         {
@@ -233,7 +231,7 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.Throws<InvalidOperationException>(() => factory(Array.Empty<string>()));
         }
 
-        [ConditionalFact(nameof(RequirementsMet))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(NoSpecialEntryPointPatternMainNoArgs.Program))]
         public void NoSpecialEntryPointPatternMainNoArgs()
         {
@@ -243,7 +241,7 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.IsAssignableFrom<IServiceProvider>(factory(Array.Empty<string>()));
         }
 
-        [ConditionalFact(nameof(RequirementsMet))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void TopLevelStatements()
         {
             var assembly = Assembly.Load("TopLevelStatements");

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/Microsoft.Extensions.HostFactoryResolver.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/Microsoft.Extensions.HostFactoryResolver.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);net461</TargetFrameworks>
-    <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Today we're using the global event source and events that fire in the app domain get captured and this can result in capturing the wrong instances. This fix uses an async local to scope the events for the HostingEventListener to the execution of the application's entry point.
- Removed the RemoteExecutor as a result of this change.

Fixes https://github.com/dotnet/aspnetcore/issues/33494

PS: This doesn't try to handle multiple instances being created on the same execution context.