### PR TITLE
Remove allocation from MsQuicAddressHelpers.IPEndPointToINet

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicAddressHelpers.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicAddressHelpers.cs
@@ -24,7 +24,6 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         internal static unsafe SOCKADDR_INET IPEndPointToINet(IPEndPoint endpoint)
         {
             SOCKADDR_INET socketAddress = default;
-            byte[] buffer = endpoint.Address.GetAddressBytes();
             if (endpoint.Address != IPAddress.Any && endpoint.Address != IPAddress.IPv6Any)
             {
                 switch (endpoint.Address.AddressFamily)


### PR DESCRIPTION
Assuming that GetAddressBytes() does not have side effects, this call should not be needed.

Clean up from dotnet/runtime#53461