### PR TITLE
Fix NTLM authentication from macOS to Windows machines

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
@@ -119,7 +119,7 @@ namespace System.Net.Http
                         }
 
                         ChannelBinding? channelBinding = connection.TransportContext?.GetChannelBinding(ChannelBindingKind.Endpoint);
-                        NTAuthentication authContext = new NTAuthentication(isServer: false, challenge.SchemeName, challenge.Credential, spn, ContextFlagsPal.Connection, channelBinding);
+                        NTAuthentication authContext = new NTAuthentication(isServer: false, challenge.SchemeName, challenge.Credential, spn, ContextFlagsPal.Connection | ContextFlagsPal.InitIntegrity, channelBinding);
                         string? challengeData = challenge.ChallengeData;
                         try
                         {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/NtAuthTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/NtAuthTests.cs
@@ -167,7 +167,7 @@ namespace System.Net.Http.Functional.Tests
         public async Task AuthTest(string authType)
         {
             var testUri = new Uri("http://emclientntlm.westus.cloudapp.azure.com/");
-            var networkCredential = new NetworkCredential("user1", "PLACEHOLDERcorrect20", "emclientntlm");
+            var networkCredential = new NetworkCredential("user1", "PLACEHOLDERcorrect20", "emclientntlm.westus.cloudapp.azure.com");
 
             using var socketsHandler = new SocketsHttpHandler();
             var credentialCache = new CredentialCache();

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/NtAuthTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/NtAuthTests.cs
@@ -160,23 +160,5 @@ namespace System.Net.Http.Functional.Tests
                 }
             }
         }
-
-        [Theory]
-        [InlineData("NTLM")]
-        [InlineData("Negotiate")]
-        public async Task AuthTest(string authType)
-        {
-            var testUri = new Uri("http://emclientntlm.westus.cloudapp.azure.com/");
-            var networkCredential = new NetworkCredential("user1", "PLACEHOLDERcorrect20", "emclientntlm");
-
-            using var socketsHandler = new SocketsHttpHandler();
-            var credentialCache = new CredentialCache();
-            credentialCache.Add(testUri, authType, networkCredential);
-            socketsHandler.Credentials = credentialCache;
-
-            using var client = new HttpClient(socketsHandler);
-            var result = await client.GetAsync(testUri);
-            Assert.True(result.IsSuccessStatusCode);
-        }
     }
 }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/NtAuthTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/NtAuthTests.cs
@@ -160,5 +160,23 @@ namespace System.Net.Http.Functional.Tests
                 }
             }
         }
+
+        [Theory]
+        [InlineData("NTLM")]
+        [InlineData("Negotiate")]
+        public async Task AuthTest(string authType)
+        {
+            var testUri = new Uri("http://emclientntlm.westus.cloudapp.azure.com/");
+            var networkCredential = new NetworkCredential("user1", "PLACEHOLDERcorrect20", "emclientntlm");
+
+            using var socketsHandler = new SocketsHttpHandler();
+            var credentialCache = new CredentialCache();
+            credentialCache.Add(testUri, authType, networkCredential);
+            socketsHandler.Credentials = credentialCache;
+
+            using var client = new HttpClient(socketsHandler);
+            var result = await client.GetAsync(testUri);
+            Assert.True(result.IsSuccessStatusCode);
+        }
     }
 }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/NtAuthTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/NtAuthTests.cs
@@ -167,7 +167,7 @@ namespace System.Net.Http.Functional.Tests
         public async Task AuthTest(string authType)
         {
             var testUri = new Uri("http://emclientntlm.westus.cloudapp.azure.com/");
-            var networkCredential = new NetworkCredential("user1", "PLACEHOLDERcorrect20", "emclientntlm.westus.cloudapp.azure.com");
+            var networkCredential = new NetworkCredential("user1", "PLACEHOLDERcorrect20", "emclientntlm");
 
             using var socketsHandler = new SocketsHttpHandler();
             var credentialCache = new CredentialCache();


### PR DESCRIPTION
The GSSAPI implementation on macOS has partially broken NTLM implementation. It only supports NTLMv2 with the message integrity code (MIC) as specified by the [MS-NLMP specification](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/b38c36ed-2804-4868-a9ff-8dd3182128e4). The MIC is calculated using HMAC-MD5 authentication code over the exchanged NTLM messages with a key named `ExportedSessionKey`. The proper generation of `ExportedSessionKey` requires the implementation to negotiate correct capabilities, namely `NTLMSSP_NEGOTIATE_KEY_EXCH` and at least one of `NTLMSSP_NEGOTIATE_SIGN` or `NTLMSSP_NEGOTIATE_SEAL` flags. By default the macOS implementation negotiates `NTLMSSP_NEGOTIATE_KEY_EXCH` and sends MIC but fails to set one of the additional flags that would make the key exchange valid. This results in violation of the following part of the NTLM specification:

> A session key MUST always exist to generate the MIC (section 3.1.5.1.2) in the authenticate message. NTLMSSP_NEGOTIATE_ALWAYS_SIGN MUST be set in the NEGOTIATE_MESSAGE to the server and the CHALLENGE_MESSAGE to the client.

Adding the `GSS_C_INTEG_FLAG` flag forces macOS to properly [negotiate all the necessary flags](https://github.com/apple-opensource/Heimdal/blob/dfcffe7531e8175ccea972bd0965de241befd205/lib/gssapi/ntlm/init_sec_context.c#L215-L218) (`NTLMSSP_NEGOTIATE_ALWAYS_SIGN` and `NTLMSSP_NEGOTIATE_SIGN`) to make the MIC exchange valid. This in turn enables the whole NTLM exchange to be recognized as valid by Windows server side.

The gss-ntlmssp package on Linux [interprets the `GSS_C_INTEG_FLAG` flag as additional negotiation of `NTLMSSP_NEGOTIATE_SIGN` and `NTLMSSP_NEGOTIATE_KEY_EXCH`](https://github.com/gssapi/gss-ntlmssp/blob/9b6493b1419d615e347d67c636fd238aa4d0f780/src/gss_sec_ctx.c#L132-L137). That should not hurt anything and in fact it may improve security depending on specific configuration. The flag was already specified when NTLM was used by `System.Net.Mail.SmtpClient`.

Fixes #887