### PR TITLE
Fix unboxing datetime instances

### DIFF
--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -441,7 +441,7 @@ var BindingSupportLib = {
 				case 18:
 					throw new Error ("Marshalling of primitive arrays are not supported.  Use the corresponding TypedArray instead.");
 				case 20: // clr .NET DateTime
-					var dateValue = this.call_method(this.get_date_value, null, "md", [ mono_obj ]);
+					var dateValue = this.call_method(this.get_date_value, null, "m", [ mono_obj ]);
 					return new Date(dateValue);
 				case 21: // clr .NET DateTimeOffset
 					var dateoffsetValue = this._object_to_string (mono_obj);


### PR DESCRIPTION
This is fixed as part of the new marshaler API PR, but it turns out that unboxing datetimes is actually just broken currently under certain circumstances. So if we don't land the new marshaler API, we need to land this. I noticed it while writing some new benchmark tests. (The new marshaler API PR also adds more test coverage here)