### PR TITLE
Add args descriptions for VNF_MapStore and VNF_MapSelect

### DIFF
--- a/src/coreclr/jit/valuenumfuncs.h
+++ b/src/coreclr/jit/valuenumfuncs.h
@@ -6,8 +6,8 @@
 // <is-shared-static>)
 
 // clang-format off
-ValueNumFuncDef(MapStore, 3, false, false, false)
-ValueNumFuncDef(MapSelect, 2, false, false, false)
+ValueNumFuncDef(MapStore, 3, false, false, false)   // Args: 0: map, 1: index (e. g. field handle), 2: value being stored.
+ValueNumFuncDef(MapSelect, 2, false, false, false)  // Args: 0: map, 1: key.
 
 ValueNumFuncDef(FieldSeq, 2, false, false, false)   // Sequence (VN of null == empty) of (VN's of) field handles.
 ValueNumFuncDef(NotAField, 0, false, false, false)  // Value number function for FieldSeqStore::NotAField.


### PR DESCRIPTION
For the first-time readers of `VNForMapSelectWork`'s code (like myself), it can be non-obvious why e. g. `select(store(m, i, v), i) == v`.