### PR TITLE
Remove outdated lock from ParseRawHeaderValues

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpRequestHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpRequestHeaders.cs
@@ -261,11 +261,6 @@ namespace System.Net.Http.Headers
         {
         }
 
-        internal HttpRequestHeaders(bool forceHeaderStoreItems)
-            : base(HttpHeaderType.General | HttpHeaderType.Request | HttpHeaderType.Custom, HttpHeaderType.Response, forceHeaderStoreItems)
-        {
-        }
-
         internal override void AddHeaders(HttpHeaders sourceHeaders)
         {
             base.AddHeaders(sourceHeaders);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -43,7 +43,7 @@ namespace System.Net.Http
         }
 
         public HttpRequestHeaders DefaultRequestHeaders =>
-            _defaultRequestHeaders ??= new HttpRequestHeaders(forceHeaderStoreItems: true);
+            _defaultRequestHeaders ??= new HttpRequestHeaders();
 
         public Version DefaultRequestVersion
         {


### PR DESCRIPTION
This lock existed to protect HttpClient.DefaultRequestHeaders.  While headers collections aren't meant to be thread-safe, out of necessity the design of DefaultRequestHeaders required this lock be in place, with multiple concurrent requests all potentially enumerating DefaultRequestHeaders in order to copy its contents into the outgoing request.  Such enumeration could trigger parsing, which could trigger the same object to be mutated from multiple threads to store the parsed result, hence the lock.  But as of https://github.com/dotnet/runtime/pull/49673, we no longer force parsing of the DefaultRequestHeaders, instead preferring to just transfer everything over as-is.  With that, there shouldn't be any concurrent mutation of these objects (and if there is, it's user error doing their own concurrent enumeration of a header collection).

Please quadruple check me on this :smile:
cc: @geoffkizer, @scalablecory 