### PR TITLE
Set the async local just before execution

### DIFF
--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
@@ -194,10 +194,6 @@ namespace Microsoft.Extensions.Hosting
 
             public object CreateHost()
             {
-                // Set the async local to the instance of the HostingListener so we can filter events that
-                // aren't scoped to this execution of the entry point.
-                _currentListener.Value = this;
-
                 using var subscription = DiagnosticListener.AllListeners.Subscribe(this);
 
                 // Kick off the entry point on a new thread so we don't block the current one
@@ -208,6 +204,10 @@ namespace Microsoft.Extensions.Hosting
 
                     try
                     {
+                        // Set the async local to the instance of the HostingListener so we can filter events that
+                        // aren't scoped to this execution of the entry point.
+                        _currentListener.Value = this;
+
                         var parameters = _entryPoint.GetParameters();
                         if (parameters.Length == 0)
                         {

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/NoSpecialEntryPointPatternHangs/Program.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/NoSpecialEntryPointPatternHangs/Program.cs
@@ -9,7 +9,7 @@ namespace NoSpecialEntryPointPatternHangs
     {
         public static void Main(string[] args)
         {
-            Console.ReadLine();
+            System.Threading.Thread.Sleep(-1);
         }
     }
 }


### PR DESCRIPTION
- Subscribing to `DiagnosticListener.AllListeners` [replays all created `DiagnosticListener` instances](https://github.com/dotnet/runtime/blob/5bf0a3f4b30814c65faa380bff83fdc105ef9323/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs#L349). Because of this, we need to set the async local just before the execution of the entry point so that we only collect the events that are relevant to the call. Right now, it's also firing with the async local set pre-maturely, which makes this race when there are many concurrent executions happening.
- Wrote a concurrency test to make sure it's safe to instantiate the factory in parallel.


Follow up to https://github.com/dotnet/runtime/pull/54090