### PR TITLE
Change `pThisRef->GetMethodTable()` to `pThisMT` in `ObjectNative::Equals`.

### DIFF
--- a/src/coreclr/classlibnative/bcltype/objectnative.cpp
+++ b/src/coreclr/classlibnative/bcltype/objectnative.cpp
@@ -163,8 +163,8 @@ FCIMPL2(FC_BOOL_RET, ObjectNative::Equals, Object *pThisRef, Object *pCompareRef
         FC_RETURN_BOOL(FALSE);
 
     // Compare the contents (size - vtable - sync block index).
-    DWORD dwBaseSize = pThisRef->GetMethodTable()->GetBaseSize();
-    if(pThisRef->GetMethodTable() == g_pStringClass)
+    DWORD dwBaseSize = pThisMT->GetBaseSize();
+    if(pThisMT == g_pStringClass)
         dwBaseSize -= sizeof(WCHAR);
     BOOL ret = memcmp(
         (void *) (pThisRef+1),


### PR DESCRIPTION
I fixed the code `ObjectNative::Equals` that simply use `pThisMT` instead of `pThisRef->GetMethodTable()` in step of comparing the contents.
The related discussion: #53728