### PR TITLE
Be more verbose when processes spawned from tasks fail.

### DIFF
--- a/src/tasks/Common/Utils.cs
+++ b/src/tasks/Common/Utils.cs
@@ -97,7 +97,7 @@ internal static class Utils
                 throw new Exception("Error: Process returned non-zero exit code: " + outputBuilder);
         }
 
-        return silent ? new String() : outputBuilder.ToString().Trim('\r', '\n');
+        return silent ? String.Empty : outputBuilder.ToString().Trim('\r', '\n');
     }
 
 #if NETCOREAPP

--- a/src/tasks/Common/Utils.cs
+++ b/src/tasks/Common/Utils.cs
@@ -97,7 +97,7 @@ internal static class Utils
                 throw new Exception("Error: Process returned non-zero exit code: " + outputBuilder);
         }
 
-        return silent ? String.Empty : outputBuilder.ToString().Trim('\r', '\n');
+        return silent ? string.Empty : outputBuilder.ToString().Trim('\r', '\n');
     }
 
 #if NETCOREAPP

--- a/src/tasks/Common/Utils.cs
+++ b/src/tasks/Common/Utils.cs
@@ -33,7 +33,6 @@ internal static class Utils
     {
         LogInfo($"Running: {path} {args}", debugMessageImportance);
         var outputBuilder = new StringBuilder();
-        var errorBuilder = new StringBuilder();
         var processStartInfo = new ProcessStartInfo
         {
             FileName = path,
@@ -72,9 +71,8 @@ internal static class Utils
                 if (!silent)
                 {
                     LogWarning(e.Data);
-                    outputBuilder.AppendLine(e.Data);
                 }
-                errorBuilder.AppendLine(e.Data);
+                outputBuilder.AppendLine(e.Data);
             }
         };
         process.OutputDataReceived += (sender, e) =>
@@ -84,8 +82,8 @@ internal static class Utils
                 if (!silent)
                 {
                     LogInfo(e.Data, outputMessageImportance);
-                    outputBuilder.AppendLine(e.Data);
                 }
+                outputBuilder.AppendLine(e.Data);
             }
         };
         process.BeginOutputReadLine();
@@ -96,10 +94,10 @@ internal static class Utils
         {
             Logger?.LogMessage(MessageImportance.High, $"Exit code: {process.ExitCode}");
             if (!ignoreErrors)
-                throw new Exception("Error: Process returned non-zero exit code: " + errorBuilder);
+                throw new Exception("Error: Process returned non-zero exit code: " + outputBuilder);
         }
 
-        return outputBuilder.ToString().Trim('\r', '\n');
+        return silent ? new StringBuilder() : outputBuilder.ToString().Trim('\r', '\n');
     }
 
 #if NETCOREAPP

--- a/src/tasks/Common/Utils.cs
+++ b/src/tasks/Common/Utils.cs
@@ -97,7 +97,7 @@ internal static class Utils
                 throw new Exception("Error: Process returned non-zero exit code: " + outputBuilder);
         }
 
-        return silent ? new StringBuilder() : outputBuilder.ToString().Trim('\r', '\n');
+        return silent ? new String() : outputBuilder.ToString().Trim('\r', '\n');
     }
 
 #if NETCOREAPP


### PR DESCRIPTION
Right now, when a process fails (e.g. cmake or xcodebuild), all of the STDERR captured during that process run is dumped in the exception.

However, if silent is true, no STDOUT is captured at all, and we lose potentially vital debugging information contained within.

This PR merges the stdout and stderr capture, and instead of not capturing anything when silent is true, it always captures and only returns nothing when silent is true.

This should greatly ease debugging of failed tasks.