### PR TITLE
Remove unintended line wrap

### DIFF
--- a/src/installer/pkg/sfx/installers/rpm_scripts/host/after_remove.sh
+++ b/src/installer/pkg/sfx/installers/rpm_scripts/host/after_remove.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 if [[ -L /usr/local/bin/dotnet ]]; then
-  rm /usr/local/bin/dotnet && \
+  rm /usr/local/bin/dotnet
 fi
 


### PR DESCRIPTION
This removes the unintended line wrap from dotnet host script for symlink removal.

I'm unsure how it got in the original PR: https://github.com/dotnet/runtime/pull/53705