### PR TITLE
Add HashCode.AddBytes(ReadOnlySpan<byte>)

### DIFF
--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/CborConformanceLevel.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/CborConformanceLevel.cs
@@ -207,8 +207,9 @@ namespace System.Formats.Cbor
         public static int GetKeyEncodingHashCode(ReadOnlySpan<byte> encoding)
         {
             HashCode hash = default;
-
-            // TODO: Use https://github.com/dotnet/runtime/issues/48702 if/when it's available
+#if NET6_0_OR_GREATER
+            hash.Add(encoding);
+#else
             while (encoding.Length >= sizeof(int))
             {
                 hash.Add(MemoryMarshal.Read<int>(encoding));
@@ -219,7 +220,7 @@ namespace System.Formats.Cbor
             {
                 hash.Add(b);
             }
-
+#endif
             return hash.ToHashCode();
         }
 

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/CborConformanceLevel.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/CborConformanceLevel.cs
@@ -208,7 +208,7 @@ namespace System.Formats.Cbor
         {
             HashCode hash = default;
 #if NET6_0_OR_GREATER
-            hash.Add(encoding);
+            hash.AddBytes(encoding);
 #else
             while (encoding.Length >= sizeof(int))
             {

--- a/src/libraries/System.Private.CoreLib/src/System/HashCode.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/HashCode.cs
@@ -310,17 +310,16 @@ namespace System
         /// <summary>Adds a span of bytes to the hash code.</summary>
         /// <param name="value">The span.</param>
         /// <remarks>
-        /// While the implementation guarantees that the added span will result in the same
-        /// behavior within the same process, it does not guarantee that the result would match
-        /// instead adding each byte value individually.
+        /// This method does not guarantee that the result of adding a span of bytes will match
+        /// the result of adding the same bytes individually.
         /// </remarks>
-        public void Add(ReadOnlySpan<byte> value)
+        public void AddBytes(ReadOnlySpan<byte> value)
         {
             ref byte pos = ref MemoryMarshal.GetReference(value);
             ref byte end = ref Unsafe.Add(ref pos, value.Length);
 
             // Add four bytes at a time until the input has fewer than four bytes remaining.
-            while ((int)Unsafe.ByteOffset(ref pos, ref end) >= sizeof(int))
+            while ((nint)Unsafe.ByteOffset(ref pos, ref end) >= sizeof(int))
             {
                 Add(Unsafe.ReadUnaligned<int>(ref pos));
                 pos = ref Unsafe.Add(ref pos, sizeof(int));
@@ -329,7 +328,7 @@ namespace System
             // Add the remaining bytes a single byte at a time.
             while (Unsafe.IsAddressLessThan(ref pos, ref end))
             {
-                Add(pos);
+                Add((int)pos);
                 pos = ref Unsafe.Add(ref pos, 1);
             }
         }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -2355,6 +2355,7 @@ namespace System
         private int _dummyPrimitive;
         public void Add<T>(T value) { }
         public void Add<T>(T value, System.Collections.Generic.IEqualityComparer<T>? comparer) { }
+        public void Add(System.ReadOnlySpan<byte> value) { }
         public static int Combine<T1>(T1 value1) { throw null; }
         public static int Combine<T1, T2>(T1 value1, T2 value2) { throw null; }
         public static int Combine<T1, T2, T3>(T1 value1, T2 value2, T3 value3) { throw null; }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -2355,7 +2355,7 @@ namespace System
         private int _dummyPrimitive;
         public void Add<T>(T value) { }
         public void Add<T>(T value, System.Collections.Generic.IEqualityComparer<T>? comparer) { }
-        public void Add(System.ReadOnlySpan<byte> value) { }
+        public void AddBytes(System.ReadOnlySpan<byte> value) { }
         public static int Combine<T1>(T1 value1) { throw null; }
         public static int Combine<T1, T2>(T1 value1, T2 value2) { throw null; }
         public static int Combine<T1, T2, T3>(T1 value1, T2 value2, T3 value3) { throw null; }

--- a/src/libraries/System.Runtime/tests/System/HashCodeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/HashCodeTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Xunit;
 
 public static class HashCodeTests
@@ -123,40 +124,35 @@ public static class HashCodeTests
     }
 
     [Fact]
-    public static void HashCode_Add_Span_AllValuesHashed()
+    public static void HashCode_AddBytes_AllValuesHashed()
     {
-        static void Populate(ref HashCode hc, int length)
-        {
-            byte[] data = Enumerable.Range(1, length).Select(i => (byte)i).ToArray();
-            hc.Add((ReadOnlySpan<byte>)data);
-        }
+        // This code depends on HashCode having a private _length field that maps to the number
+        // of Int32 values Add'd, as well as exactly how AddBytes partitions the incoming bytes.
+        // If the implementation changes, this test may need to be updated accordingly.
 
+        FieldInfo lengthField = typeof(HashCode).GetField("_length", BindingFlags.Instance | BindingFlags.NonPublic);
+        int expectedLength = 0;
         HashCode hc = default;
-        Populate(ref hc, 1);
-
-        int last = hc.ToHashCode();
-        for (int i = 2; i < 100; i++)
+        for (int i = 1; i < 100; i++)
         {
-            hc = default;
-            Populate(ref hc, i);
-            int value = hc.ToHashCode();
-            Assert.NotEqual(last, value);
-            last = value;
+            hc.AddBytes(Enumerable.Range(1, i).Select(i => (byte)i).ToArray());
+            expectedLength += Math.DivRem(i, 4, out int remainder) + remainder;
+            Assert.Equal(expectedLength, (int)(uint)lengthField.GetValue(hc));
         }
     }
 
     [Fact]
-    public static void HashCode_Add_Span_VariousLengthsHashed()
+    public static void HashCode_AddBytes_VariousLengthsHashed()
     {
         static void Populate(ref HashCode hc)
         {
-            hc.Add((ReadOnlySpan<byte>)new byte[0]);
-            hc.Add((ReadOnlySpan<byte>)new byte[] { 1 });
-            hc.Add((ReadOnlySpan<byte>)new byte[] { 1, 2 });
-            hc.Add((ReadOnlySpan<byte>)new byte[] { 1, 2, 3 });
-            hc.Add((ReadOnlySpan<byte>)new byte[] { 1, 2, 3, 4 });
-            hc.Add((ReadOnlySpan<byte>)new byte[] { 1, 2, 3, 4, 5 });
-            hc.Add((ReadOnlySpan<byte>)Enumerable.Range(0, 10_000).Select(i => (byte)i).ToArray());
+            hc.AddBytes(new byte[0]);
+            hc.AddBytes(new byte[] { 1 });
+            hc.AddBytes(new byte[] { 1, 2 });
+            hc.AddBytes(new byte[] { 1, 2, 3 });
+            hc.AddBytes(new byte[] { 1, 2, 3, 4 });
+            hc.AddBytes(new byte[] { 1, 2, 3, 4, 5 });
+            hc.AddBytes(Enumerable.Range(0, 10_000).Select(i => (byte)i).ToArray());
         }
 
         var hc1 = new HashCode();
@@ -169,7 +165,7 @@ public static class HashCodeTests
     }
 
     [Fact]
-    public static void HashCode_Add_Span_AlignmentDoesntImpactResult()
+    public static void HashCode_AddBytes_AlignmentDoesntImpactResult()
     {
         byte[] data = Enumerable.Range(0, 32).Select(_ => (byte)42).ToArray();
         for (int length = 1; length < 10; length++)
@@ -178,7 +174,7 @@ public static class HashCodeTests
             for (int i = 0; i < data.Length - length; i++)
             {
                 var hc = new HashCode();
-                hc.Add(new ReadOnlySpan<byte>(data, i, length));
+                hc.AddBytes(new ReadOnlySpan<byte>(data, i, length));
                 if (result is null)
                 {
                     result = hc.ToHashCode();


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/48702
cc: @GrabYourPitchforks 