### PR TITLE
[Tasks][MonoAOTCompiler] Update README.md to include option using UsingTask

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Runtime.MonoAOTCompiler.Task/README.md
+++ b/src/mono/nuget/Microsoft.NET.Runtime.MonoAOTCompiler.Task/README.md
@@ -40,7 +40,7 @@ Use `UsingTask` directly
 </ItemGroup>
 
 <UsingTask TaskName="MonoAOTCompiler"
-           AssemblyFile="$(PkgMicrosoft_NET_Runtime_MonoAOTCompiler_Task)/tools/$(TargetFramework)/MonoAOTCompiler.dll" />
+           AssemblyFile="$(PkgMicrosoft_NET_Runtime_MonoAOTCompiler_Task)/tools/<target-framework>/MonoAOTCompiler.dll" />
 
 <!-- Use the MonoAOTCompiler task in a target -->
 <Target>

--- a/src/mono/nuget/Microsoft.NET.Runtime.MonoAOTCompiler.Task/README.md
+++ b/src/mono/nuget/Microsoft.NET.Runtime.MonoAOTCompiler.Task/README.md
@@ -29,3 +29,27 @@ The `MonoAOTCompiler` MSBuild task is also useful outside the context of `dotnet
     </MonoAOTCompiler>
 </Target>
 ```
+
+------------
+Use `UsingTask` directly 
+## In the project file
+```
+<!-- Import the NuGet package into the project -->
+<ItemGroup>
+    <PackageReference Include="Microsoft.NET.Runtime.MonoAOTCompiler.Task" Version="<desired-dotnet-6-sdk-version>" GeneratePathProperty="true" />
+</ItemGroup>
+
+<UsingTask TaskName="MonoAOTCompiler"
+           AssemblyFile="$(PkgMicrosoft_NET_Runtime_MonoAOTCompiler_Task)/tools/$(TargetFramework)/MonoAOTCompiler.dll" />
+
+<!-- Use the MonoAOTCompiler task in a target -->
+<Target>
+    <MonoAOTCompiler 
+        CompilerBinaryPath="$(CompilerBinaryPath)"
+        Assemblies="@(Assemblies)"
+        <!-- Other parameters -->
+        >
+        <Output TaskParameter="CompiledAssemblies" ItemName="CompiledAssemblies" />
+    </MonoAOTCompiler>
+</Target>
+```

--- a/src/mono/nuget/Microsoft.NET.Runtime.MonoAOTCompiler.Task/README.md
+++ b/src/mono/nuget/Microsoft.NET.Runtime.MonoAOTCompiler.Task/README.md
@@ -31,7 +31,7 @@ The `MonoAOTCompiler` MSBuild task is also useful outside the context of `dotnet
 ```
 
 ------------
-Use `UsingTask` directly 
+Use `UsingTask` directly
 ## In the project file
 ```
 <!-- Import the NuGet package into the project -->


### PR DESCRIPTION
Though the MonoAOTCompiler Task is included in the SDK in https://github.com/dotnet/runtime/blob/main/src/mono/nuget/Microsoft.NET.Runtime.MonoAOTCompiler.Task/Sdk/Sdk.props and should be accessible when using the NuGet, adding the second option to the MonoAOTCompiler task README allows for greater visibility on how to directly implement one's own UsingTask. 

Fixes #47630