### PR TITLE
Use GeneratedDllImport in System.IO.FileSystem.Watcher

### DIFF
--- a/src/libraries/Common/src/Interop/Linux/System.Native/Interop.INotify.cs
+++ b/src/libraries/Common/src/Interop/Linux/System.Native/Interop.INotify.cs
@@ -10,14 +10,14 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_INotifyInit", SetLastError = true)]
-        internal static extern SafeFileHandle INotifyInit();
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_INotifyInit", SetLastError = true)]
+        internal static partial SafeFileHandle INotifyInit();
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_INotifyAddWatch", SetLastError = true)]
-        internal static extern int INotifyAddWatch(SafeFileHandle fd, string pathName, uint mask);
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_INotifyAddWatch", SetLastError = true, CharSet = CharSet.Ansi)]
+        internal static partial int INotifyAddWatch(SafeFileHandle fd, string pathName, uint mask);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_INotifyRemoveWatch", SetLastError = true)]
-        private static extern int INotifyRemoveWatch_private(SafeFileHandle fd, int wd);
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_INotifyRemoveWatch", SetLastError = true)]
+        private static partial int INotifyRemoveWatch_private(SafeFileHandle fd, int wd);
 
         internal static int INotifyRemoveWatch(SafeFileHandle fd, int wd)
         {

--- a/src/libraries/Common/src/Interop/OSX/Interop.EventStream.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.EventStream.cs
@@ -99,8 +99,8 @@ internal static partial class Interop
         /// <param name="flags">Flags to say what kind of events should be sent through this stream.</param>
         /// <returns>On success, returns a pointer to an FSEventStream object; otherwise, returns IntPtr.Zero</returns>
         /// <remarks>For *nix systems, the CLR maps ANSI to UTF-8, so be explicit about that</remarks>
-        [DllImport(Interop.Libraries.CoreServicesLibrary, CharSet = CharSet.Ansi)]
-        internal static extern unsafe SafeEventStreamHandle FSEventStreamCreate(
+        [GeneratedDllImport(Interop.Libraries.CoreServicesLibrary, CharSet = CharSet.Ansi)]
+        internal static unsafe partial SafeEventStreamHandle FSEventStreamCreate(
             IntPtr                      allocator,
             delegate* unmanaged<FSEventStreamRef, IntPtr, size_t, byte**, FSEventStreamEventFlags*, FSEventStreamEventId*, void> callback,
             FSEventStreamContext*       context,
@@ -115,8 +115,8 @@ internal static partial class Interop
         /// <param name="streamRef">The stream to attach to the RunLoop</param>
         /// <param name="runLoop">The RunLoop to attach the stream to</param>
         /// <param name="runLoopMode">The mode of the RunLoop; this should usually be kCFRunLoopDefaultMode. See the documentation for RunLoops for more info.</param>
-        [DllImport(Interop.Libraries.CoreServicesLibrary)]
-        internal static extern void FSEventStreamScheduleWithRunLoop(
+        [GeneratedDllImport(Interop.Libraries.CoreServicesLibrary)]
+        internal static partial void FSEventStreamScheduleWithRunLoop(
             SafeEventStreamHandle   streamRef,
             CFRunLoopRef            runLoop,
             SafeCreateHandle        runLoopMode);
@@ -126,15 +126,15 @@ internal static partial class Interop
         /// </summary>
         /// <param name="streamRef">The stream to receive events on.</param>
         /// <returns>Returns true if the stream was started; otherwise, returns false and no events will be received.</returns>
-        [DllImport(Interop.Libraries.CoreServicesLibrary)]
-        internal static extern bool FSEventStreamStart(SafeEventStreamHandle streamRef);
+        [GeneratedDllImport(Interop.Libraries.CoreServicesLibrary)]
+        internal static partial bool FSEventStreamStart(SafeEventStreamHandle streamRef);
 
         /// <summary>
         /// Stops receiving events on the specified stream. The stream can be restarted and not miss any events.
         /// </summary>
         /// <param name="streamRef">The stream to stop receiving events on.</param>
-        [DllImport(Interop.Libraries.CoreServicesLibrary)]
-        internal static extern void FSEventStreamStop(SafeEventStreamHandle streamRef);
+        [GeneratedDllImport(Interop.Libraries.CoreServicesLibrary)]
+        internal static partial void FSEventStreamStop(SafeEventStreamHandle streamRef);
 
         /// <summary>
         /// Stops receiving events on the specified stream. The stream can be restarted and not miss any events.
@@ -157,8 +157,8 @@ internal static partial class Interop
         /// <param name="streamRef">The stream to remove from the RunLoop</param>
         /// <param name="runLoop">The RunLoop to remove the stream from.</param>
         /// <param name="runLoopMode">The mode of the RunLoop; this should usually be kCFRunLoopDefaultMode. See the documentation for RunLoops for more info.</param>
-        [DllImport(Interop.Libraries.CoreServicesLibrary)]
-        internal static extern void FSEventStreamUnscheduleFromRunLoop(
+        [GeneratedDllImport(Interop.Libraries.CoreServicesLibrary)]
+        internal static partial void FSEventStreamUnscheduleFromRunLoop(
             SafeEventStreamHandle   streamRef,
             CFRunLoopRef            runLoop,
             SafeCreateHandle        runLoopMode);

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.RealPath.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.RealPath.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
         /// </summary>
         /// <param name="path">The path to the file system object</param>
         /// <returns>Returns the result string on success and null on failure</returns>
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_RealPath", SetLastError = true)]
-        internal static extern string RealPath(string path);
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_RealPath", SetLastError = true, CharSet = CharSet.Ansi)]
+        internal static partial string RealPath(string path);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ReadDirectoryChangesW.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ReadDirectoryChangesW.cs
@@ -10,8 +10,8 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, EntryPoint = "ReadDirectoryChangesW", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern unsafe bool ReadDirectoryChangesW(
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "ReadDirectoryChangesW", CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static unsafe partial bool ReadDirectoryChangesW(
             SafeFileHandle hDirectory,
             byte[] lpBuffer,
             uint nBufferLength,


### PR DESCRIPTION
|     | Original (B) | Converted (B) | + (B) | + (%) |
| --- | -----------: | ------------: | ----: | ----: |
| linux | 40448 | 43008 | 2560 | 6.33 |
| windows | 30720 | 32768 | 2048 | 6.67 |
| linux R2R | 87552 | 94720 | 7168 | 8.19 |
| windows R2R | 62464 | 67072 | 4608 | 7.38 |

cc @AaronRobinsonMSFT @jkoritzinsky 