### PR TITLE
Don't use `lvDoNotEnregister` in `optCopyProp_LclVarScore`.

### DIFF
--- a/src/coreclr/jit/copyprop.cpp
+++ b/src/coreclr/jit/copyprop.cpp
@@ -97,16 +97,6 @@ int Compiler::optCopyProp_LclVarScore(LclVarDsc* lclVarDsc, LclVarDsc* copyVarDs
         score -= 4;
     }
 
-    if (lclVarDsc->lvDoNotEnregister)
-    {
-        score += 4;
-    }
-
-    if (copyVarDsc->lvDoNotEnregister)
-    {
-        score -= 4;
-    }
-
 #ifdef TARGET_X86
     // For doubles we also prefer to change parameters into non-parameter local variables
     if (lclVarDsc->lvType == TYP_DOUBLE)


### PR DESCRIPTION
The value of `lvDoNotEnregister` is not finalized when we call `optCopyProp_LclVarScore` during global morph, so we should not rely on it.

It causes many asm diffs when we change what we mark as `lvDoNotEnregister` so I want to avoid this noise by merging this first.

Note: there is another call to `optCopyProp_LclVarScore` during `optCopyProp` where such check could make sense but it is guarded with 
https://github.com/dotnet/runtime/blob/bfb8d6bfd3c708e148755caa3e3ae916cdef7ed9/src/coreclr/jit/copyprop.cpp#L199-L202
so also not needed.

The diffs are small and are mostly noise.
<details>
  <summary>SuperPMI diffs</summary>

```
benchmarks.run.windows.x64.checked.mch
Total bytes of delta: 32
1 total files with Code Size differences (0 improved, 1 regressed)

libraries.pmi.windows.x64.checked.mch
Total bytes of delta: 3
27 total files with Code Size differences (16 improved, 11 regressed)

libraries_tests.pmi.windows.x64.checked.mch
Total bytes of delta: -26
2 total files with Code Size differences (2 improved, 0 regressed)

coreclr_tests.pmi.Linux.arm64.checked.mch
Total bytes of delta: -8
1 total files with Code Size differences (1 improved, 0 regressed)

libraries.pmi.Linux.arm64.checked.mch
Total bytes of delta: -20
27 total files with Code Size differences (16 improved, 11 regressed)

libraries_tests.pmi.Linux.arm64.checked.mch
Total bytes of delta: -56
9 total files with Code Size differences (7 improved, 2 regressed)

coreclr_tests.pmi.Linux.x64.checked.mch
Total bytes of delta: -3
2 total files with Code Size differences (1 improved, 1 regressed)

libraries.pmi.Linux.x64.checked.mch
Total bytes of delta: -21
29 total files with Code Size differences (18 improved, 11 regressed)

libraries_tests.pmi.Linux.x64.checked.mch
Total bytes of delta: -107
11 total files with Code Size differences (9 improved, 2 regressed)

coreclr_tests.pmi.windows.arm64.checked.mch
Total bytes of delta: -8
1 total files with Code Size differences (1 improved, 0 regressed)

libraries.pmi.windows.arm64.checked.mch
Total bytes of delta: -20
27 total files with Code Size differences (16 improved, 11 regressed)

libraries_tests.pmi.windows.arm64.checked.mch
Total bytes of delta: -44
9 total files with Code Size differences (7 improved, 2 regressed)

benchmarks.run.windows.x86.checked.mch
Total bytes of delta: -734
17 total files with Code Size differences (16 improved, 1 regressed)

coreclr_tests.pmi.windows.x86.checked.mch
Total bytes of delta: -111
35 total files with Code Size differences (11 improved, 24 regressed)

libraries.pmi.windows.x86.checked.mch
Total bytes of delta: 86
5 total files with Code Size differences (0 improved, 5 regressed)

libraries_tests.pmi.windows.x86.checked.mch
Total bytes of delta: -1748
80 total files with Code Size differences (78 improved, 2 regressed)

libraries.pmi.Linux.arm.checked.mch
Total bytes of delta: -10
32 total files with Code Size differences (17 improved, 15 regressed)

libraries_tests.pmi.Linux.arm.checked.mch
Total bytes of delta: -56
7 total files with Code Size differences (6 improved, 1 regressed)
```

</details>
