### PR TITLE
Improve morphing of comparisons

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6148,6 +6148,7 @@ private:
     GenTree* fgMorphForRegisterFP(GenTree* tree);
     GenTree* fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac = nullptr);
     GenTree* fgOptimizeEqualityComparisonWithConst(GenTreeOp* cmp);
+    GenTree* fgOptimizeRelationalComparisonWithConst(GenTreeOp* cmp);
     GenTree* fgMorphRetInd(GenTreeUnOp* tree);
     GenTree* fgMorphModToSubMulDiv(GenTreeOp* tree);
     GenTree* fgMorphSmpOpOptional(GenTreeOp* tree);

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -3051,6 +3051,7 @@ struct GenTreeIntConCommon : public GenTree
     inline ssize_t IconValue() const;
     inline void SetIconValue(ssize_t val);
     inline INT64 IntegralValue() const;
+    inline void SetIntegralValue(int64_t value);
 
     template <typename T>
     inline void SetValueTruncating(T value);
@@ -3245,6 +3246,23 @@ inline INT64 GenTreeIntConCommon::IntegralValue() const
     return LngValue();
 #else
     return gtOper == GT_CNS_LNG ? LngValue() : (INT64)IconValue();
+#endif // TARGET_64BIT
+}
+
+inline void GenTreeIntConCommon::SetIntegralValue(int64_t value)
+{
+#ifdef TARGET_64BIT
+    SetIconValue(value);
+#else
+    if (OperIs(GT_CNS_LNG))
+    {
+        SetLngValue(value);
+    }
+    else
+    {
+        assert(FitsIn<int32_t>(value));
+        SetIconValue(static_cast<int32_t>(value));
+    }
 #endif // TARGET_64BIT
 }
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -14244,6 +14244,13 @@ GenTree* Compiler::fgOptimizeRelationalComparisonWithConst(GenTreeOp* cmp)
                 oper = (oper == GT_LE) ? GT_EQ : GT_NE;
                 cmp->gtFlags &= ~GTF_UNSIGNED;
             }
+            // LE_UN/GT_UN(expr, int/long.MaxValue) => GE/LT(expr, 0).
+            else if (((op1->TypeIs(TYP_LONG) && (op2Value == INT64_MAX))) ||
+                     ((genActualType(op1) == TYP_INT) && (op2Value == INT32_MAX)))
+            {
+                oper = (oper == GT_LE) ? GT_GE : GT_LT;
+                cmp->gtFlags &= ~GTF_UNSIGNED;
+            }
         }
     }
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13879,7 +13879,7 @@ GenTree* Compiler::fgOptimizeRelationalComparisonWithConst(GenTreeOp* cmp)
             }
             // LE_UN/GT_UN(expr, int/long.MaxValue) => GE/LT(expr, 0).
             else if (((op1->TypeIs(TYP_LONG) && (op2Value == INT64_MAX))) ||
-                ((genActualType(op1) == TYP_INT) && (op2Value == INT32_MAX)))
+                     ((genActualType(op1) == TYP_INT) && (op2Value == INT32_MAX)))
             {
                 oper = (oper == GT_LE) ? GT_GE : GT_LT;
                 cmp->gtFlags &= ~GTF_UNSIGNED;

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13801,6 +13801,107 @@ SKIP:
     return cmp;
 }
 
+//------------------------------------------------------------------------
+// fgOptimizeRelationalComparisonWithConst: optimizes a comparison operation.
+//
+// Recognizes comparisons against various constant operands and morphs
+// them, if possible, into comparisons against zero.
+//
+// Arguments:
+//   cmp - the GT_LE/GT_LT/GT_GE/GT_GT tree to morph.
+//
+// Return Value:
+//   The "cmp" tree, possibly with a modified oper.
+//   The second operand's constant value may be modified as well.
+//
+// Assumptions:
+//   The operands have been swapped so that any constants are on the right.
+//   The second operand is an integral constant.
+//
+GenTree* Compiler::fgOptimizeRelationalComparisonWithConst(GenTreeOp* cmp)
+{
+    assert(cmp->OperIs(GT_LE, GT_LT, GT_GE, GT_GT));
+    assert(cmp->gtGetOp2()->IsIntegralConst());
+    assert(!gtIsActiveCSE_Candidate(cmp->gtGetOp2()));
+
+    GenTree*             op1 = cmp->gtGetOp1();
+    GenTreeIntConCommon* op2 = cmp->gtGetOp2()->AsIntConCommon();
+
+    assert(genActualType(op1) == genActualType(op2));
+
+    genTreeOps oper     = cmp->OperGet();
+    int64_t    op2Value = op2->IntegralValue();
+
+    if (op2Value == 1)
+    {
+        // Check for "expr >= 1".
+        if (oper == GT_GE)
+        {
+            // Change to "expr != 0" for unsigned and "expr > 0" for signed.
+            oper = cmp->IsUnsigned() ? GT_NE : GT_GT;
+        }
+        // Check for "expr < 1".
+        else if (oper == GT_LT)
+        {
+            // Change to "expr == 0" for unsigned and "expr <= 0".
+            oper = cmp->IsUnsigned() ? GT_EQ : GT_LE;
+        }
+    }
+    // Check for "expr relop -1".
+    else if (!cmp->IsUnsigned() && (op2Value == -1))
+    {
+        // Check for "expr <= -1".
+        if (oper == GT_LE)
+        {
+            // Change to "expr < 0".
+            oper = GT_LT;
+        }
+        // Check for "expr > -1".
+        else if (oper == GT_GT)
+        {
+            // Change to "expr >= 0".
+            oper = GT_GE;
+        }
+    }
+    else if (cmp->IsUnsigned())
+    {
+        if ((oper == GT_LE) || (oper == GT_GT))
+        {
+            if (op2Value == 0)
+            {
+                // IL doesn't have a cne instruction so compilers use cgt.un instead. The JIT
+                // recognizes certain patterns that involve GT_NE (e.g (x & 4) != 0) and fails
+                // if GT_GT is used instead. Transform (x GT_GT.unsigned 0) into (x GT_NE 0)
+                // and (x GT_LE.unsigned 0) into (x GT_EQ 0). The later case is rare, it sometimes
+                // occurs as a result of branch inversion.
+                oper = (oper == GT_LE) ? GT_EQ : GT_NE;
+                cmp->gtFlags &= ~GTF_UNSIGNED;
+            }
+            // LE_UN/GT_UN(expr, int/long.MaxValue) => GE/LT(expr, 0).
+            else if (((op1->TypeIs(TYP_LONG) && (op2Value == INT64_MAX))) ||
+                ((genActualType(op1) == TYP_INT) && (op2Value == INT32_MAX)))
+            {
+                oper = (oper == GT_LE) ? GT_GE : GT_LT;
+                cmp->gtFlags &= ~GTF_UNSIGNED;
+            }
+        }
+    }
+
+    if (!cmp->OperIs(oper))
+    {
+        // Keep the old ValueNumber for 'tree' as the new expr
+        // will still compute the same value as before.
+        cmp->SetOper(oper, GenTree::PRESERVE_VN);
+        op2->SetIntegralValue(0);
+        if (vnStore != nullptr)
+        {
+            fgValueNumberTreeConst(op2);
+        }
+    }
+
+    return cmp;
+}
+
 //----------------------------------------------------------------------------------------------
 // fgMorphRetInd: Try to get rid of extra IND(ADDR()) pairs in a return tree.
 //
@@ -14166,107 +14267,6 @@ GenTree* Compiler::fgMorphSmpOpOptional(GenTreeOp* tree)
             break;
     }
     return tree;
-}
-
-//------------------------------------------------------------------------
-// fgOptimizeRelationalComparisonWithConst: optimizes a comparison operation.
-//
-// Recognizes comparisons against various constant operands and morphs
-// them, if possible, into comparisons against zero.
-//
-// Arguments:
-//   cmp - the GT_LE/GT_LT/GT_GE/GT_GT tree to morph.
-//
-// Return Value:
-//   The "cmp" tree, possibly with a modified oper.
-//   The second operand's constant value may be modified as well.
-//
-// Assumptions:
-//   The operands have been swapped so that any constants are on the right.
-//   The second operand is an integral constant.
-//
-GenTree* Compiler::fgOptimizeRelationalComparisonWithConst(GenTreeOp* cmp)
-{
-    assert(cmp->OperIs(GT_LE, GT_LT, GT_GE, GT_GT));
-    assert(cmp->gtGetOp2()->IsIntegralConst());
-    assert(!gtIsActiveCSE_Candidate(cmp->gtGetOp2()));
-
-    GenTree*             op1 = cmp->gtGetOp1();
-    GenTreeIntConCommon* op2 = cmp->gtGetOp2()->AsIntConCommon();
-
-    assert(genActualType(op1) == genActualType(op2));
-
-    genTreeOps oper     = cmp->OperGet();
-    int64_t    op2Value = op2->IntegralValue();
-
-    if (op2Value == 1)
-    {
-        // Check for "expr >= 1".
-        if (oper == GT_GE)
-        {
-            // Change to "expr != 0" for unsigned and "expr > 0" for signed.
-            oper = cmp->IsUnsigned() ? GT_NE : GT_GT;
-        }
-        // Check for "expr < 1".
-        else if (oper == GT_LT)
-        {
-            // Change to "expr == 0" for unsigned and "expr <= 0".
-            oper = cmp->IsUnsigned() ? GT_EQ : GT_LE;
-        }
-    }
-    // Check for "expr relop -1".
-    else if (!cmp->IsUnsigned() && (op2Value == -1))
-    {
-        // Check for "expr <= -1".
-        if (oper == GT_LE)
-        {
-            // Change to "expr < 0".
-            oper = GT_LT;
-        }
-        // Check for "expr > -1".
-        else if (oper == GT_GT)
-        {
-            // Change to "expr >= 0".
-            oper = GT_GE;
-        }
-    }
-    else if (cmp->IsUnsigned())
-    {
-        if ((oper == GT_LE) || (oper == GT_GT))
-        {
-            if (op2Value == 0)
-            {
-                // IL doesn't have a cne instruction so compilers use cgt.un instead. The JIT
-                // recognizes certain patterns that involve GT_NE (e.g (x & 4) != 0) and fails
-                // if GT_GT is used instead. Transform (x GT_GT.unsigned 0) into (x GT_NE 0)
-                // and (x GT_LE.unsigned 0) into (x GT_EQ 0). The later case is rare, it sometimes
-                // occurs as a result of branch inversion.
-                oper = (oper == GT_LE) ? GT_EQ : GT_NE;
-                cmp->gtFlags &= ~GTF_UNSIGNED;
-            }
-            // LE_UN/GT_UN(expr, int/long.MaxValue) => GE/LT(expr, 0).
-            else if (((op1->TypeIs(TYP_LONG) && (op2Value == INT64_MAX))) ||
-                     ((genActualType(op1) == TYP_INT) && (op2Value == INT32_MAX)))
-            {
-                oper = (oper == GT_LE) ? GT_GE : GT_LT;
-                cmp->gtFlags &= ~GTF_UNSIGNED;
-            }
-        }
-    }
-
-    if (!cmp->OperIs(oper))
-    {
-        // Keep the old ValueNumber for 'tree' as the new expr
-        // will still compute the same value as before.
-        cmp->SetOper(oper, GenTree::PRESERVE_VN);
-        op2->SetIntegralValue(0);
-        if (vnStore != nullptr)
-        {
-            fgValueNumberTreeConst(op2);
-        }
-    }
-
-    return cmp;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13893,10 +13893,7 @@ GenTree* Compiler::fgOptimizeRelationalComparisonWithConst(GenTreeOp* cmp)
         // will still compute the same value as before.
         cmp->SetOper(oper, GenTree::PRESERVE_VN);
         op2->SetIntegralValue(0);
-        if (vnStore != nullptr)
-        {
-            fgValueNumberTreeConst(op2);
-        }
+        fgUpdateConstTreeValueNumber(op2);
     }
 
     return cmp;

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12193,7 +12193,8 @@ DONE_MORPHING_CHILDREN:
         case GT_GE:
         case GT_GT:
 
-            if (op2->OperIs(GT_CNS_INT))
+            // op2's value may be changed, so it cannot be a CSE candidate.
+            if (op2->OperIs(GT_CNS_INT) && !gtIsActiveCSE_Candidate(op2))
             {
                 tree = fgOptimizeRelationalComparisonWithConst(tree->AsOp());
                 oper = tree->OperGet();
@@ -14188,6 +14189,7 @@ GenTree* Compiler::fgOptimizeRelationalComparisonWithConst(GenTreeOp* cmp)
 {
     assert(cmp->OperIs(GT_LE, GT_LT, GT_GE, GT_GT));
     assert(cmp->gtGetOp2()->OperIs(GT_CNS_INT));
+    assert(!gtIsActiveCSE_Candidate(cmp->gtGetOp2()));
 
     GenTree*             op1 = cmp->gtGetOp1();
     GenTreeIntConCommon* op2 = cmp->gtGetOp2()->AsIntConCommon();

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12193,75 +12193,13 @@ DONE_MORPHING_CHILDREN:
         case GT_GE:
         case GT_GT:
 
-            if (op2->gtOper == GT_CNS_INT)
+            if (op2->OperIs(GT_CNS_INT))
             {
-                cns2 = op2;
-                /* Check for "expr relop 1" */
-                if (cns2->IsIntegralConst(1))
-                {
-                    /* Check for "expr >= 1" */
-                    if (oper == GT_GE)
-                    {
-                        /* Change to "expr != 0" for unsigned and "expr > 0" for signed */
-                        oper = (tree->IsUnsigned()) ? GT_NE : GT_GT;
-                        goto SET_OPER;
-                    }
-                    /* Check for "expr < 1" */
-                    else if (oper == GT_LT)
-                    {
-                        /* Change to "expr == 0" for unsigned and "expr <= 0" for signed */
-                        oper = (tree->IsUnsigned()) ? GT_EQ : GT_LE;
-                        goto SET_OPER;
-                    }
-                }
-                /* Check for "expr relop -1" */
-                else if (!tree->IsUnsigned() && cns2->IsIntegralConst(-1))
-                {
-                    /* Check for "expr <= -1" */
-                    if (oper == GT_LE)
-                    {
-                        /* Change to "expr < 0" */
-                        oper = GT_LT;
-                        goto SET_OPER;
-                    }
-                    /* Check for "expr > -1" */
-                    else if (oper == GT_GT)
-                    {
-                        /* Change to "expr >= 0" */
-                        oper = GT_GE;
+                tree = fgOptimizeRelationalComparisonWithConst(tree->AsOp());
+                oper = tree->OperGet();
 
-                    SET_OPER:
-                        // IF we get here we should be changing 'oper'
-                        assert(tree->OperGet() != oper);
-
-                        // Keep the old ValueNumber for 'tree' as the new expr
-                        // will still compute the same value as before
-                        tree->SetOper(oper, GenTree::PRESERVE_VN);
-                        cns2->AsIntCon()->gtIconVal = 0;
-
-                        // vnStore is null before the ValueNumber phase has run
-                        if (vnStore != nullptr)
-                        {
-                            // Update the ValueNumber for 'cns2', as we just changed it to 0
-                            fgValueNumberTreeConst(cns2);
-                        }
-                        op2 = tree->AsOp()->gtOp2 = gtFoldExpr(op2);
-                    }
-                }
-                else if (tree->IsUnsigned() && op2->IsIntegralConst(0))
-                {
-                    if ((oper == GT_GT) || (oper == GT_LE))
-                    {
-                        // IL doesn't have a cne instruction so compilers use cgt.un instead. The JIT
-                        // recognizes certain patterns that involve GT_NE (e.g (x & 4) != 0) and fails
-                        // if GT_GT is used instead. Transform (x GT_GT.unsigned 0) into (x GT_NE 0)
-                        // and (x GT_LE.unsigned 0) into (x GT_EQ 0). The later case is rare, it sometimes
-                        // occurs as a result of branch inversion.
-                        oper = (oper == GT_LE) ? GT_EQ : GT_NE;
-                        tree->SetOper(oper, GenTree::PRESERVE_VN);
-                        tree->gtFlags &= ~GTF_UNSIGNED;
-                    }
-                }
+                assert(op1 == tree->AsOp()->gtGetOp1());
+                assert(op2 == tree->AsOp()->gtGetOp2());
             }
 
         COMPARE:
@@ -14227,6 +14165,99 @@ GenTree* Compiler::fgMorphSmpOpOptional(GenTreeOp* tree)
             break;
     }
     return tree;
+}
+
+//------------------------------------------------------------------------
+// fgOptimizeRelationalComparisonWithConst: optimizes a comparison operation.
+//
+// Recognizes comparisons against various constant operands and morphs
+// them, if possible, into comparisons against zero.
+//
+// Arguments:
+//   cmp - the GT_LE/GT_LT/GT_GE/GT_GT tree to morph.
+//
+// Return Value:
+//   The "cmp" tree, possibly with a modified oper.
+//   The second operand's constant value may be modified as well.
+//
+// Assumptions:
+//   The operands have been swapped so that any constants are on the right.
+//   The second operand is an integral constant.
+//
+GenTree* Compiler::fgOptimizeRelationalComparisonWithConst(GenTreeOp* cmp)
+{
+    assert(cmp->OperIs(GT_LE, GT_LT, GT_GE, GT_GT));
+    assert(cmp->gtGetOp2()->OperIs(GT_CNS_INT));
+
+    GenTree*             op1 = cmp->gtGetOp1();
+    GenTreeIntConCommon* op2 = cmp->gtGetOp2()->AsIntConCommon();
+
+    assert(genActualType(op1) == genActualType(op2));
+
+    genTreeOps oper     = cmp->OperGet();
+    int64_t    op2Value = op2->IntegralValue();
+
+    if (op2Value == 1)
+    {
+        // Check for "expr >= 1".
+        if (oper == GT_GE)
+        {
+            // Change to "expr != 0" for unsigned and "expr > 0" for signed.
+            oper = cmp->IsUnsigned() ? GT_NE : GT_GT;
+        }
+        // Check for "expr < 1".
+        else if (oper == GT_LT)
+        {
+            // Change to "expr == 0" for unsigned and "expr <= 0".
+            oper = cmp->IsUnsigned() ? GT_EQ : GT_LE;
+        }
+    }
+    // Check for "expr relop -1".
+    else if (!cmp->IsUnsigned() && (op2Value == -1))
+    {
+        // Check for "expr <= -1".
+        if (oper == GT_LE)
+        {
+            // Change to "expr < 0".
+            oper = GT_LT;
+        }
+        // Check for "expr > -1".
+        else if (oper == GT_GT)
+        {
+            // Change to "expr >= 0".
+            oper = GT_GE;
+        }
+    }
+    else if (cmp->IsUnsigned())
+    {
+        if ((oper == GT_LE) || (oper == GT_GT))
+        {
+            if (op2Value == 0)
+            {
+                // IL doesn't have a cne instruction so compilers use cgt.un instead. The JIT
+                // recognizes certain patterns that involve GT_NE (e.g (x & 4) != 0) and fails
+                // if GT_GT is used instead. Transform (x GT_GT.unsigned 0) into (x GT_NE 0)
+                // and (x GT_LE.unsigned 0) into (x GT_EQ 0). The later case is rare, it sometimes
+                // occurs as a result of branch inversion.
+                oper = (oper == GT_LE) ? GT_EQ : GT_NE;
+                cmp->gtFlags &= ~GTF_UNSIGNED;
+            }
+        }
+    }
+
+    if (!cmp->OperIs(oper))
+    {
+        // Keep the old ValueNumber for 'tree' as the new expr
+        // will still compute the same value as before.
+        cmp->SetOper(oper, GenTree::PRESERVE_VN);
+        op2->SetIntegralValue(0);
+        if (vnStore != nullptr)
+        {
+            fgValueNumberTreeConst(op2);
+        }
+    }
+
+    return cmp;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12194,7 +12194,7 @@ DONE_MORPHING_CHILDREN:
         case GT_GT:
 
             // op2's value may be changed, so it cannot be a CSE candidate.
-            if (op2->OperIs(GT_CNS_INT) && !gtIsActiveCSE_Candidate(op2))
+            if (op2->IsIntegralConst() && !gtIsActiveCSE_Candidate(op2))
             {
                 tree = fgOptimizeRelationalComparisonWithConst(tree->AsOp());
                 oper = tree->OperGet();
@@ -14188,7 +14188,7 @@ GenTree* Compiler::fgMorphSmpOpOptional(GenTreeOp* tree)
 GenTree* Compiler::fgOptimizeRelationalComparisonWithConst(GenTreeOp* cmp)
 {
     assert(cmp->OperIs(GT_LE, GT_LT, GT_GE, GT_GT));
-    assert(cmp->gtGetOp2()->OperIs(GT_CNS_INT));
+    assert(cmp->gtGetOp2()->IsIntegralConst());
     assert(!gtIsActiveCSE_Candidate(cmp->gtGetOp2()));
 
     GenTree*             op1 = cmp->gtGetOp1();


### PR DESCRIPTION
A couple changes to this part of `fgMorphSmpOp`:

1\) Refactored post-order morphing of `GT_LE\GT_LT\GT_GE\GT_GT` into its own method (verified no-diff).
2\) Made the new method handle `GT_CNS_LNG`.
3\) Fixed a missed `gtIsActiveCSE_Candidate` condition.
4\) Added a new optimization (primarily code size for x86/x64, but also allows to omit one `mov` on ARM/ARM64).

Diffs for this change (improvements on 32 bit are both because of the new optimization and `GT_CNS_LNG` handling, only regression on ARM is due to different register allocation):

<details>
<summary>Windows x64</summary>

```
Running asm diffs of benchmarks.run.windows.x64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 41309
Total bytes of diff: 40898
Total bytes of delta: -411 (-0.99% of base)
    diff is an improvement.


Top file improvements (bytes):
         -23 : 17200.dasm (-0.68% of base)
         -22 : 4355.dasm (-1.89% of base)
         -15 : 4354.dasm (-2.38% of base)
         -14 : 2735.dasm (-1.16% of base)
         -14 : 23174.dasm (-1.06% of base)
         -14 : 371.dasm (-0.93% of base)
         -12 : 21800.dasm (-1.88% of base)
         -11 : 4583.dasm (-1.01% of base)
         -10 : 21463.dasm (-0.85% of base)
         -10 : 3506.dasm (-1.40% of base)
         -10 : 19013.dasm (-0.85% of base)
         -10 : 5277.dasm (-0.82% of base)
         -10 : 1088.dasm (-0.75% of base)
         -10 : 167.dasm (-0.85% of base)
         -10 : 27.dasm (-0.83% of base)
         -10 : 8730.dasm (-0.89% of base)
         -10 : 18003.dasm (-0.85% of base)
         -10 : 11079.dasm (-0.85% of base)
         -10 : 37.dasm (-1.56% of base)
          -9 : 21491.dasm (-0.84% of base)

47 total files with Code Size differences (47 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -23 (-0.68% of base) - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.Lexer:ScanNumericLiteral(byref):bool:this
         -22 (-1.89% of base) - System.Collections.Generic.HashSet`1[Int32][System.Int32]:AddIfNotPresent(int,byref):bool:this
         -15 (-2.38% of base) - System.Collections.Generic.HashSet`1[Int32][System.Int32]:FindItemIndex(int):int:this
         -14 (-1.16% of base) - System.Collections.Generic.HashSet`1[Char][System.Char]:AddIfNotPresent(ushort,byref):bool:this
         -14 (-1.06% of base) - System.Collections.Generic.HashSet`1[ValueTuple`2][System.ValueTuple`2[System.Int32,System.Int32]]:AddIfNotPresent(System.ValueTuple`2[Int32,Int32],byref):bool:this
         -14 (-0.93% of base) - System.Collections.Generic.HashSet`1[__Canon][System.__Canon]:AddIfNotPresent(System.__Canon,byref):bool:this
         -12 (-1.88% of base) - System.Numerics.BigInteger:GreatestCommonDivisor(System.Numerics.BigInteger,System.Numerics.BigInteger):System.Numerics.BigInteger
         -11 (-1.01% of base) - System.Collections.Generic.Dictionary`2[Int32,ValueTuple`4][System.Int32,System.ValueTuple`4[System.Int64,System.Int64,System.Int64,System.Int64]]:TryInsert(int,System.ValueTuple`4[Int64,Int64,Int64,Int64],ubyte):bool:this
         -10 (-0.85% of base) - System.Collections.Generic.Dictionary`2[__Canon,Boolean][System.__Canon,System.Boolean]:TryInsert(System.__Canon,bool,ubyte):bool:this
         -10 (-1.40% of base) - System.Collections.Generic.Dictionary`2[ValueTuple`2,__Canon][System.ValueTuple`2[System.__Canon,System.__Canon],System.__Canon]:FindValue(System.ValueTuple`2[__Canon,__Canon]):byref:this
         -10 (-0.85% of base) - System.Collections.Generic.Dictionary`2[__Canon,UInt32][System.__Canon,System.UInt32]:TryInsert(System.__Canon,int,ubyte):bool:this
         -10 (-0.82% of base) - System.Collections.Generic.Dictionary`2[ValueTuple`2,__Canon][System.ValueTuple`2[System.Int32,System.Int32],System.__Canon]:TryInsert(System.ValueTuple`2[Int32,Int32],System.__Canon,ubyte):bool:this
         -10 (-0.75% of base) - System.Collections.Generic.Dictionary`2[__Canon,ResourceLocator][System.__Canon,System.Resources.ResourceLocator]:TryInsert(System.__Canon,System.Resources.ResourceLocator,ubyte):bool:this
         -10 (-0.85% of base) - System.Collections.Generic.Dictionary`2[__Canon,HostSignal][System.__Canon,BenchmarkDotNet.Engines.HostSignal]:TryInsert(System.__Canon,int,ubyte):bool:this
         -10 (-0.83% of base) - System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]:TryInsert(System.__Canon,System.__Canon,ubyte):bool:this
         -10 (-0.89% of base) - System.Collections.Generic.Dictionary`2[Char,__Canon][System.Char,System.__Canon]:TryInsert(ushort,System.__Canon,ubyte):bool:this
         -10 (-0.85% of base) - System.Collections.Generic.Dictionary`2[__Canon,SpecialType][System.__Canon,Microsoft.CodeAnalysis.SpecialType]:TryInsert(System.__Canon,byte,ubyte):bool:this
         -10 (-0.85% of base) - System.Collections.Generic.Dictionary`2[__Canon,Int64][System.__Canon,System.Int64]:TryInsert(System.__Canon,long,ubyte):bool:this
         -10 (-1.56% of base) - System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]:FindValue(System.__Canon):byref:this
          -9 (-0.84% of base) - System.Collections.Generic.Dictionary`2[UInt64,__Canon][System.UInt64,System.__Canon]:TryInsert(long,System.__Canon,ubyte):bool:this

Top method improvements (percentages):
          -3 (-3.30% of base) - System.Threading.TimeoutHelper:UpdateTimeOut(int,int):int
          -8 (-2.70% of base) - System.Text.Json.PooledByteBufferWriter:CheckAndResizeBuffer(int):this
         -15 (-2.38% of base) - System.Collections.Generic.HashSet`1[Int32][System.Int32]:FindItemIndex(int):int:this
         -22 (-1.89% of base) - System.Collections.Generic.HashSet`1[Int32][System.Int32]:AddIfNotPresent(int,byref):bool:this
         -12 (-1.88% of base) - System.Numerics.BigInteger:GreatestCommonDivisor(System.Numerics.BigInteger,System.Numerics.BigInteger):System.Numerics.BigInteger
          -4 (-1.87% of base) - System.Buffers.ArrayBufferWriter`1[Byte][System.Byte]:CheckAndResizeBuffer(int):this
         -10 (-1.56% of base) - System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]:FindValue(System.__Canon):byref:this
         -10 (-1.40% of base) - System.Collections.Generic.Dictionary`2[ValueTuple`2,__Canon][System.ValueTuple`2[System.__Canon,System.__Canon],System.__Canon]:FindValue(System.ValueTuple`2[__Canon,__Canon]):byref:this
          -8 (-1.39% of base) - System.Collections.Generic.Dictionary`2[TypeDefinitionHandle,ImmutableArray`1][System.Reflection.Metadata.TypeDefinitionHandle,System.Collections.Immutable.ImmutableArray`1[System.Reflection.Metadata.TypeDefinitionHandle]]:FindValue(System.Reflection.Metadata.TypeDefinitionHandle):byref:this
          -8 (-1.39% of base) - System.Collections.Generic.Dictionary`2[Int32,ValueTuple`4][System.Int32,System.ValueTuple`4[System.Int64,System.Int64,System.Int64,System.Int64]]:FindValue(int):byref:this
          -5 (-1.37% of base) - System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]:CopyEntries(System.Collections.Generic.Dictionary`2+Entry[System.__Canon,System.__Canon][],int):this
          -5 (-1.34% of base) - System.Collections.Generic.Dictionary`2[Int32,Int32][System.Int32,System.Int32]:CopyEntries(System.Collections.Generic.Dictionary`2+Entry[System.Int32,System.Int32][],int):this
          -9 (-1.33% of base) - System.Collections.Generic.HashSet`1[Char][System.Char]:FindItemIndex(ushort):int:this
          -9 (-1.20% of base) - System.Collections.Generic.HashSet`1[__Canon][System.__Canon]:FindItemIndex(System.__Canon):int:this
          -5 (-1.19% of base) - System.Marvin:ComputeHash32OrdinalIgnoreCase(byref,int,int,int):int
         -14 (-1.16% of base) - System.Collections.Generic.HashSet`1[Char][System.Char]:AddIfNotPresent(ushort,byref):bool:this
          -4 (-1.15% of base) - System.Numerics.BigInteger:GreatestCommonDivisor(System.UInt32[],System.UInt32[]):System.Numerics.BigInteger
          -9 (-1.13% of base) - System.Text.ASCIIUtility:GetIndexOfFirstNonAsciiChar_Sse2(long,long):long
         -14 (-1.06% of base) - System.Collections.Generic.HashSet`1[ValueTuple`2][System.ValueTuple`2[System.Int32,System.Int32]]:AddIfNotPresent(System.ValueTuple`2[Int32,Int32],byref):bool:this
         -11 (-1.01% of base) - System.Collections.Generic.Dictionary`2[Int32,ValueTuple`4][System.Int32,System.ValueTuple`4[System.Int64,System.Int64,System.Int64,System.Int64]]:TryInsert(int,System.ValueTuple`4[Int64,Int64,Int64,Int64],ubyte):bool:this

47 total methods with Code Size differences (47 improved, 0 regressed), 0 unchanged.

Running asm diffs of coreclr_tests.pmi.windows.x64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 2148
Total bytes of diff: 2139
Total bytes of delta: -9 (-0.42% of base)
    diff is an improvement.


Top file improvements (bytes):
          -9 : 166940.dasm (-0.42% of base)

1 total files with Code Size differences (1 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
          -9 (-0.42% of base) - Internal.TypeSystem.Ecma.EcmaType:GetClassLayout():Internal.TypeSystem.ClassLayoutMetadata:this

Top method improvements (percentages):
          -9 (-0.42% of base) - Internal.TypeSystem.Ecma.EcmaType:GetClassLayout():Internal.TypeSystem.ClassLayoutMetadata:this

1 total methods with Code Size differences (1 improved, 0 regressed), 0 unchanged.

Running asm diffs of libraries.crossgen.windows.x64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 49666
Total bytes of diff: 49127
Total bytes of delta: -539 (-1.09% of base)
    diff is an improvement.


Top file improvements (bytes):
         -35 : 137722.dasm (-6.93% of base)
         -20 : 28774.dasm (-0.88% of base)
         -15 : 26274.dasm (-0.97% of base)
         -13 : 81044.dasm (-4.11% of base)
         -12 : 166099.dasm (-1.89% of base)
         -10 : 26168.dasm (-1.60% of base)
         -10 : 26243.dasm (-1.35% of base)
         -10 : 26507.dasm (-1.61% of base)
         -10 : 26554.dasm (-1.64% of base)
         -10 : 26610.dasm (-0.84% of base)
         -10 : 106816.dasm (-1.24% of base)
         -10 : 78459.dasm (-3.92% of base)
         -10 : 80058.dasm (-0.54% of base)
         -10 : 26553.dasm (-0.84% of base)
         -10 : 113744.dasm (-6.45% of base)
         -10 : 26819.dasm (-1.60% of base)
         -10 : 81447.dasm (-18.87% of base)
         -10 : 26581.dasm (-0.84% of base)
         -10 : 73934.dasm (-6.17% of base)
         -10 : 78414.dasm (-3.28% of base)

76 total files with Code Size differences (76 improved, 0 regressed), 4 unchanged.

Top method improvements (bytes):
         -35 (-6.93% of base) - System.IO.Compression.ZipArchive:TryReadZip64EndOfCentralDirectory(System.IO.Compression.ZipEndOfCentralDirectoryBlock,long):this
         -20 (-0.88% of base) - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.Lexer:ScanNumericLiteral(byref):bool:this
         -15 (-0.97% of base) - System.Collections.Generic.HashSet`1[__Canon][System.__Canon]:AddIfNotPresent(System.__Canon,byref):bool:this
         -13 (-4.11% of base) - System.Xml.ValueHandle:ToLong():long:this
         -12 (-1.89% of base) - System.Numerics.BigInteger:GreatestCommonDivisor(System.Numerics.BigInteger,System.Numerics.BigInteger):System.Numerics.BigInteger
         -10 (-1.60% of base) - System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]:FindValue(System.__Canon):byref:this
         -10 (-1.35% of base) - System.Collections.Generic.HashSet`1[__Canon][System.__Canon]:FindItemIndex(System.__Canon):int:this
         -10 (-1.61% of base) - System.Collections.Generic.Dictionary`2[UInt64,__Canon][System.UInt64,System.__Canon]:FindValue(long):byref:this
         -10 (-1.64% of base) - System.Collections.Generic.Dictionary`2[Int32,__Canon][System.Int32,System.__Canon]:FindValue(int):byref:this
         -10 (-0.84% of base) - System.Collections.Generic.Dictionary`2[__Canon,Boolean][System.__Canon,System.Boolean]:TryInsert(System.__Canon,bool,ubyte):bool:this
         -10 (-1.24% of base) - Microsoft.CSharp.RuntimeBinder.Semantics.ExpressionBinder:isConstantInRange(Microsoft.CSharp.RuntimeBinder.Semantics.ExprConstant,Microsoft.CSharp.RuntimeBinder.Semantics.CType,bool):bool
         -10 (-3.92% of base) - System.Data.SqlTypes.SqlMoney:.ctor(System.Decimal):this
         -10 (-0.54% of base) - System.Data.Common.TimeSpanStorage:Aggregate(System.Int32[],int):System.Object:this
         -10 (-0.84% of base) - System.Collections.Generic.Dictionary`2[__Canon,Int32][System.__Canon,System.Int32]:TryInsert(System.__Canon,int,ubyte):bool:this
         -10 (-6.45% of base) - Newtonsoft.Json.Bson.BsonDataWriter:WriteValue(long):this
         -10 (-1.60% of base) - System.Collections.Generic.Dictionary`2[UInt64,Char][System.UInt64,System.Char]:FindValue(long):byref:this
         -10 (-18.87% of base) - System.Xml.XmlBinaryNodeWriter:WriteUInt64Text(long):this
         -10 (-0.84% of base) - System.Collections.Generic.Dictionary`2[__Canon,IntPtr][System.__Canon,System.IntPtr]:TryInsert(System.__Canon,long,ubyte):bool:this
         -10 (-6.17% of base) - Newtonsoft.Json.Bson.BsonWriter:WriteValue(long):this
         -10 (-3.28% of base) - System.Data.SqlTypes.SqlInt64:op_Explicit(System.Data.SqlTypes.SqlDecimal):System.Data.SqlTypes.SqlInt64

Top method improvements (percentages):
         -10 (-18.87% of base) - System.Xml.XmlBinaryNodeWriter:WriteUInt64Text(long):this
         -35 (-6.93% of base) - System.IO.Compression.ZipArchive:TryReadZip64EndOfCentralDirectory(System.IO.Compression.ZipEndOfCentralDirectoryBlock,long):this
         -10 (-6.45% of base) - Newtonsoft.Json.Bson.BsonDataWriter:WriteValue(long):this
         -10 (-6.17% of base) - Newtonsoft.Json.Bson.BsonWriter:WriteValue(long):this
          -4 (-5.63% of base) - System.Numerics.BigInteger:op_Implicit(int):System.Numerics.BigInteger
          -4 (-4.82% of base) - System.Buffers.ArrayMemoryPool`1[__Canon][System.__Canon]:Rent(int):System.Buffers.IMemoryOwner`1[__Canon]:this
          -4 (-4.49% of base) - System.Numerics.BigInteger:.ctor(int):this
          -3 (-4.17% of base) - System.Collections.Concurrent.BlockingCollection`1[__Canon][System.__Canon]:UpdateTimeOut(int,int):int
         -13 (-4.11% of base) - System.Xml.ValueHandle:ToLong():long:this
          -5 (-4.03% of base) - System.Collections.HashHelpers:FastMod(int,int,long):int
         -10 (-3.92% of base) - System.Data.SqlTypes.SqlMoney:.ctor(System.Decimal):this
          -4 (-3.42% of base) - System.Threading.ThreadPool:UnsafeRegisterWaitForSingleObject(System.Threading.WaitHandle,System.Threading.WaitOrTimerCallback,System.Object,int,bool):System.Threading.RegisteredWaitHandle
          -4 (-3.36% of base) - System.Threading.ThreadPool:RegisterWaitForSingleObject(System.Threading.WaitHandle,System.Threading.WaitOrTimerCallback,System.Object,int,bool):System.Threading.RegisteredWaitHandle
         -10 (-3.28% of base) - System.Data.SqlTypes.SqlInt64:op_Explicit(System.Data.SqlTypes.SqlDecimal):System.Data.SqlTypes.SqlInt64
          -3 (-3.23% of base) - System.Threading.TimeoutHelper:UpdateTimeOut(int,int):int
          -5 (-3.18% of base) - System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]:GetBucket(int):byref:this
          -5 (-3.18% of base) - System.Collections.Generic.HashSet`1[__Canon][System.__Canon]:GetBucketRef(int):byref:this
          -5 (-3.09% of base) - System.Reflection.Metadata.FieldDefinition:GetOffset():int:this
          -8 (-3.08% of base) - System.Text.Json.PooledByteBufferWriter:CheckAndResizeBuffer(int):this
          -8 (-3.08% of base) - System.Text.Json.PooledByteBufferWriter:CheckAndResizeBuffer(int):this

76 total methods with Code Size differences (76 improved, 0 regressed), 4 unchanged.

Running asm diffs of libraries.crossgen2.windows.x64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 43761
Total bytes of diff: 43279
Total bytes of delta: -482 (-1.10% of base)
    diff is an improvement.


Top file improvements (bytes):
         -35 : 168893.dasm (-7.07% of base)
         -23 : 85581.dasm (-1.09% of base)
         -15 : 7990.dasm (-0.98% of base)
         -12 : 141131.dasm (-1.94% of base)
         -12 : 152122.dasm (-5.17% of base)
         -10 : 31818.dasm (-0.52% of base)
         -10 : 8097.dasm (-0.81% of base)
         -10 : 8099.dasm (-1.58% of base)
         -10 : 26837.dasm (-0.84% of base)
         -10 : 27148.dasm (-1.58% of base)
         -10 : 8021.dasm (-1.33% of base)
         -10 : 26582.dasm (-1.61% of base)
         -10 : 26851.dasm (-1.58% of base)
         -10 : 26545.dasm (-1.57% of base)
         -10 : 99476.dasm (-6.37% of base)
         -10 : 26571.dasm (-0.84% of base)
         -10 : 26941.dasm (-0.77% of base)
         -10 : 26419.dasm (-0.84% of base)
          -9 : 15690.dasm (-1.13% of base)
          -9 : 26850.dasm (-0.81% of base)

70 total files with Code Size differences (70 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -35 (-7.07% of base) - System.IO.Compression.ZipArchive:TryReadZip64EndOfCentralDirectory(System.IO.Compression.ZipEndOfCentralDirectoryBlock,long):this
         -23 (-1.09% of base) - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.Lexer:ScanNumericLiteral(byref):bool:this
         -15 (-0.98% of base) - System.Collections.Generic.HashSet`1:AddIfNotPresent(System.__Canon,byref):bool:this
         -12 (-1.94% of base) - System.Numerics.BigInteger:GreatestCommonDivisor(System.Numerics.BigInteger,System.Numerics.BigInteger):System.Numerics.BigInteger
         -12 (-5.17% of base) - System.Formats.Asn1.Asn1Tag:TryDecode(System.ReadOnlySpan`1[System.Byte],byref,byref):bool
         -10 (-0.52% of base) - System.Data.Common.TimeSpanStorage:Aggregate(System.Int32[],int):System.Object:this
         -10 (-0.81% of base) - System.Collections.Generic.Dictionary`2:TryInsert(System.__Canon,System.__Canon,ubyte):bool:this
         -10 (-1.58% of base) - System.Collections.Generic.Dictionary`2:FindValue(System.__Canon):byref:this
         -10 (-0.84% of base) - System.Collections.Generic.Dictionary`2:TryInsert(System.__Canon,int,ubyte):bool:this
         -10 (-1.58% of base) - System.Collections.Generic.Dictionary`2:FindValue(long):byref:this
         -10 (-1.33% of base) - System.Collections.Generic.HashSet`1:FindItemIndex(System.__Canon):int:this
         -10 (-1.61% of base) - System.Collections.Generic.Dictionary`2:FindValue(int):byref:this
         -10 (-1.58% of base) - System.Collections.Generic.Dictionary`2:FindValue(long):byref:this
         -10 (-1.57% of base) - System.Collections.Generic.Dictionary`2:FindValue(long):byref:this
         -10 (-6.37% of base) - Newtonsoft.Json.Bson.BsonWriter:WriteValue(long):this
         -10 (-0.84% of base) - System.Collections.Generic.Dictionary`2:TryInsert(System.__Canon,long,ubyte):bool:this
         -10 (-0.77% of base) - System.Collections.Generic.Dictionary`2:TryInsert(System.__Canon,System.Resources.ResourceLocator,ubyte):bool:this
         -10 (-0.84% of base) - System.Collections.Generic.Dictionary`2:TryInsert(System.__Canon,bool,ubyte):bool:this
          -9 (-1.13% of base) - System.Text.ASCIIUtility:GetIndexOfFirstNonAsciiChar_Sse2(long,long):long
          -9 (-0.81% of base) - System.Collections.Generic.Dictionary`2:TryInsert(long,System.__Canon,ubyte):bool:this

Top method improvements (percentages):
         -35 (-7.07% of base) - System.IO.Compression.ZipArchive:TryReadZip64EndOfCentralDirectory(System.IO.Compression.ZipEndOfCentralDirectoryBlock,long):this
         -10 (-6.37% of base) - Newtonsoft.Json.Bson.BsonWriter:WriteValue(long):this
          -4 (-5.63% of base) - System.Numerics.BigInteger:op_Implicit(int):System.Numerics.BigInteger
         -12 (-5.17% of base) - System.Formats.Asn1.Asn1Tag:TryDecode(System.ReadOnlySpan`1[System.Byte],byref,byref):bool
          -4 (-4.82% of base) - System.Buffers.ArrayMemoryPool`1:Rent(int):System.Buffers.IMemoryOwner`1[System.__Canon]:this
          -4 (-4.44% of base) - System.Numerics.BigInteger:.ctor(int):this
          -3 (-4.17% of base) - System.Collections.Concurrent.BlockingCollection`1:UpdateTimeOut(int,int):int
          -5 (-4.03% of base) - System.Collections.HashHelpers:FastMod(int,int,long):int
          -4 (-3.57% of base) - System.Threading.ThreadPool:UnsafeRegisterWaitForSingleObject(System.Threading.WaitHandle,System.Threading.WaitOrTimerCallback,System.Object,int,bool):System.Threading.RegisteredWaitHandle
          -4 (-3.51% of base) - System.Threading.ThreadPool:RegisterWaitForSingleObject(System.Threading.WaitHandle,System.Threading.WaitOrTimerCallback,System.Object,int,bool):System.Threading.RegisteredWaitHandle
          -3 (-3.23% of base) - System.Threading.TimeoutHelper:UpdateTimeOut(int,int):int
          -8 (-3.17% of base) - System.Text.Json.PooledByteBufferWriter:CheckAndResizeBuffer(int):this
          -5 (-3.16% of base) - System.Collections.Generic.HashSet`1:GetBucketRef(int):byref:this
          -5 (-3.16% of base) - System.Collections.Generic.Dictionary`2:GetBucket(int):byref:this
          -5 (-3.16% of base) - System.Collections.Generic.Dictionary`2:GetBucket(int):byref:this
          -5 (-3.09% of base) - System.Reflection.Metadata.FieldDefinition:GetOffset():int:this
          -4 (-2.70% of base) - Newtonsoft.Json.Bson.BsonWriter:WriteValue(int):this
          -4 (-2.61% of base) - System.Net.Http.Http2Connection:ChangeMaxConcurrentStreams(int):this
          -3 (-2.50% of base) - System.Formats.Asn1.AsnDecoder:ParseNonNegativeInt(System.ReadOnlySpan`1[System.Byte]):int
          -4 (-1.97% of base) - CfgSerializedHeader:IsCfg(System.IO.Stream,byref):bool

70 total methods with Code Size differences (70 improved, 0 regressed), 0 unchanged.

Running asm diffs of libraries.pmi.windows.x64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 59798
Total bytes of diff: 59147
Total bytes of delta: -651 (-1.09% of base)
    diff is an improvement.


Top file improvements (bytes):
         -31 : 176807.dasm (-5.37% of base)
         -23 : 32968.dasm (-0.98% of base)
         -18 : 20125.dasm (-3.03% of base)
         -14 : 20291.dasm (-1.19% of base)
         -14 : 20355.dasm (-1.19% of base)
         -14 : 20341.dasm (-1.14% of base)
         -14 : 20332.dasm (-1.18% of base)
         -14 : 20348.dasm (-1.06% of base)
         -13 : 20156.dasm (-1.25% of base)
         -12 : 209700.dasm (-1.88% of base)
         -12 : 20127.dasm (-1.16% of base)
         -11 : 20146.dasm (-1.05% of base)
         -10 : 112137.dasm (-3.29% of base)
         -10 : 146535.dasm (-5.46% of base)
         -10 : 109504.dasm (-2.72% of base)
         -10 : 139001.dasm (-1.26% of base)
         -10 : 104669.dasm (-5.46% of base)
         -10 : 20176.dasm (-0.85% of base)
         -10 : 112550.dasm (-25.00% of base)
         -10 : 20186.dasm (-0.95% of base)

89 total files with Code Size differences (89 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -31 (-5.37% of base) - System.IO.Compression.ZipArchive:TryReadZip64EndOfCentralDirectory(System.IO.Compression.ZipEndOfCentralDirectoryBlock,long):this
         -23 (-0.98% of base) - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.Lexer:ScanNumericLiteral(byref):bool:this
         -18 (-3.03% of base) - System.Collections.Generic.Dictionary`2[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:FindValue(ubyte):byref:this
         -14 (-1.19% of base) - System.Collections.Generic.HashSet`1[Byte][System.Byte]:AddIfNotPresent(ubyte,byref):bool:this
         -14 (-1.19% of base) - System.Collections.Generic.HashSet`1[Int64][System.Int64]:AddIfNotPresent(long,byref):bool:this
         -14 (-1.14% of base) - System.Collections.Generic.HashSet`1[Double][System.Double]:AddIfNotPresent(double,byref):bool:this
         -14 (-1.18% of base) - System.Collections.Generic.HashSet`1[Int16][System.Int16]:AddIfNotPresent(short,byref):bool:this
         -14 (-1.06% of base) - System.Collections.Generic.HashSet`1[Vector`1][System.Numerics.Vector`1[System.Single]]:AddIfNotPresent(System.Numerics.Vector`1[Single],byref):bool:this
         -13 (-1.25% of base) - System.Collections.Generic.Dictionary`2[Int32,Nullable`1][System.Int32,System.Nullable`1[System.Int32]]:TryInsert(int,System.Nullable`1[Int32],ubyte):bool:this
         -12 (-1.88% of base) - System.Numerics.BigInteger:GreatestCommonDivisor(System.Numerics.BigInteger,System.Numerics.BigInteger):System.Numerics.BigInteger
         -12 (-1.16% of base) - System.Collections.Generic.Dictionary`2[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:TryInsert(ubyte,System.Nullable`1[Int32],ubyte):bool:this
         -11 (-1.05% of base) - System.Collections.Generic.Dictionary`2[Int16,Nullable`1][System.Int16,System.Nullable`1[System.Int32]]:TryInsert(short,System.Nullable`1[Int32],ubyte):bool:this
         -10 (-3.29% of base) - System.Xml.ValueHandle:ToLong():long:this
         -10 (-5.46% of base) - Newtonsoft.Json.Bson.BsonDataWriter:WriteValue(long):this
         -10 (-2.72% of base) - System.Data.SqlTypes.SqlInt64:op_Explicit(System.Data.SqlTypes.SqlDecimal):System.Data.SqlTypes.SqlInt64
         -10 (-1.26% of base) - Microsoft.CSharp.RuntimeBinder.Semantics.ExpressionBinder:isConstantInRange(Microsoft.CSharp.RuntimeBinder.Semantics.ExprConstant,Microsoft.CSharp.RuntimeBinder.Semantics.CType,bool):bool
         -10 (-5.46% of base) - Newtonsoft.Json.Bson.BsonWriter:WriteValue(long):this
         -10 (-0.85% of base) - System.Collections.Generic.Dictionary`2[Vector`1,Nullable`1][System.Numerics.Vector`1[System.Single],System.Nullable`1[System.Int32]]:TryInsert(System.Numerics.Vector`1[Single],System.Nullable`1[Int32],ubyte):bool:this
         -10 (-25.00% of base) - System.Xml.XmlBinaryNodeWriter:WriteUInt64Text(long):this
         -10 (-0.95% of base) - System.Collections.Generic.Dictionary`2[Int64,Nullable`1][System.Int64,System.Nullable`1[System.Int32]]:TryInsert(long,System.Nullable`1[Int32],ubyte):bool:this

Top method improvements (percentages):
         -10 (-25.00% of base) - System.Xml.XmlBinaryNodeWriter:WriteUInt64Text(long):this
         -10 (-5.46% of base) - Newtonsoft.Json.Bson.BsonDataWriter:WriteValue(long):this
         -10 (-5.46% of base) - Newtonsoft.Json.Bson.BsonWriter:WriteValue(long):this
         -31 (-5.37% of base) - System.IO.Compression.ZipArchive:TryReadZip64EndOfCentralDirectory(System.IO.Compression.ZipEndOfCentralDirectoryBlock,long):this
          -4 (-5.19% of base) - System.Buffers.ArrayMemoryPool`1[Byte][System.Byte]:Rent(int):System.Buffers.IMemoryOwner`1[Byte]:this
          -4 (-5.06% of base) - System.Numerics.BigInteger:op_Implicit(int):System.Numerics.BigInteger
          -4 (-5.00% of base) - System.Buffers.ArrayMemoryPool`1[__Canon][System.__Canon]:Rent(int):System.Buffers.IMemoryOwner`1[__Canon]:this
          -3 (-4.29% of base) - System.Collections.Concurrent.BlockingCollection`1[Byte][System.Byte]:UpdateTimeOut(int,int):int
          -3 (-4.23% of base) - System.Collections.Concurrent.BlockingCollection`1[__Canon][System.__Canon]:UpdateTimeOut(int,int):int
          -4 (-4.12% of base) - System.Numerics.BigInteger:.ctor(int):this
         -10 (-3.56% of base) - System.Data.SqlTypes.SqlMoney:.ctor(System.Decimal):this
         -10 (-3.29% of base) - System.Xml.ValueHandle:ToLong():long:this
          -5 (-3.12% of base) - System.Reflection.Metadata.FieldDefinition:GetOffset():int:this
         -18 (-3.03% of base) - System.Collections.Generic.Dictionary`2[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:FindValue(ubyte):byref:this
          -5 (-2.98% of base) - System.Collections.Generic.Dictionary`2[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:GetBucket(int):byref:this
          -5 (-2.98% of base) - System.Collections.Generic.HashSet`1[Byte][System.Byte]:GetBucketRef(int):byref:this
         -10 (-2.72% of base) - System.Data.SqlTypes.SqlInt64:op_Explicit(System.Data.SqlTypes.SqlDecimal):System.Data.SqlTypes.SqlInt64
          -8 (-2.33% of base) - System.Text.Json.PooledByteBufferWriter:CheckAndResizeBuffer(int):this
          -8 (-2.33% of base) - System.Text.Json.PooledByteBufferWriter:CheckAndResizeBuffer(int):this
          -4 (-2.30% of base) - Newtonsoft.Json.Bson.BsonDataWriter:WriteValue(int):this

89 total methods with Code Size differences (89 improved, 0 regressed), 0 unchanged.

Running asm diffs of libraries_tests.pmi.windows.x64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 24850
Total bytes of diff: 24632
Total bytes of delta: -218 (-0.88% of base)
    diff is an improvement.


Top file improvements (bytes):
         -16 : 214953.dasm (-0.84% of base)
         -15 : 53748.dasm (-3.34% of base)
         -15 : 53742.dasm (-3.31% of base)
         -12 : 53743.dasm (-2.73% of base)
         -10 : 53779.dasm (-2.51% of base)
         -10 : 53721.dasm (-2.51% of base)
         -10 : 53778.dasm (-2.86% of base)
         -10 : 53720.dasm (-2.86% of base)
         -10 : 214975.dasm (-0.31% of base)
          -9 : 53749.dasm (-2.14% of base)
          -8 : 214936.dasm (-1.06% of base)
          -8 : 214966.dasm (-0.99% of base)
          -8 : 53754.dasm (-1.75% of base)
          -7 : 53755.dasm (-1.60% of base)
          -7 : 53813.dasm (-1.60% of base)
          -7 : 206146.dasm (-1.40% of base)
          -6 : 188224.dasm (-1.31% of base)
          -6 : 187640.dasm (-1.08% of base)
          -4 : 190256.dasm (-0.70% of base)
          -4 : 53785.dasm (-1.04% of base)

30 total files with Code Size differences (30 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -16 (-0.84% of base) - System.Numerics.Tests.ComparisonTest:VerifyComparison(System.Numerics.BigInteger,int,int)
         -15 (-3.34% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableULongToLong(System.Nullable`1[UInt64],bool)
         -15 (-3.31% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableULongToEnumLong(System.Nullable`1[UInt64],bool)
         -12 (-2.73% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableULongToNullableEnumLong(System.Nullable`1[UInt64],bool)
         -10 (-2.51% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedULongToNullableEnumLong(long,bool)
         -10 (-2.51% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedULongToNullableLong(long,bool)
         -10 (-2.86% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedULongToEnumLong(long,bool)
         -10 (-2.86% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedULongToLong(long,bool)
         -10 (-0.31% of base) - System.Numerics.Tests.BigIntegerConstructorTest:RunCtorByteArrayTests()
          -9 (-2.14% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableULongToNullableLong(System.Nullable`1[UInt64],bool)
          -8 (-1.06% of base) - System.Numerics.Tests.cast_toTest:VerifyUInt32ImplicitCastToBigInteger(int)
          -8 (-0.99% of base) - System.Numerics.Tests.BigIntegerConstructorTest:VerifyCtorUInt32(int)
          -8 (-1.75% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableUIntToInt(System.Nullable`1[UInt32],bool)
          -7 (-1.60% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableUIntToNullableInt(System.Nullable`1[UInt32],bool)
          -7 (-1.60% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableUIntToNullableEnum(System.Nullable`1[UInt32],bool)
          -7 (-1.40% of base) - System.Reflection.Metadata.Tests.MetadataReaderTests:ValidateFieldLayoutTable():this
          -6 (-1.31% of base) - System.SpanTests.SpanTests:IndexOverflow()
          -6 (-1.08% of base) - System.SpanTests.ReadOnlySpanTests:IndexOverflow()
          -4 (-0.70% of base) - <>c__DisplayClass2_0`1[__Canon][System.__Canon]:<TwoGiBOverflowHelper>b__0(System.Buffers.Text.Tests.ParserTestData`1[__Canon]):this
          -4 (-1.04% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedUIntToNullableEnum(int,bool)

Top method improvements (percentages):
         -15 (-3.34% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableULongToLong(System.Nullable`1[UInt64],bool)
         -15 (-3.31% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableULongToEnumLong(System.Nullable`1[UInt64],bool)
          -4 (-2.94% of base) - System.Numerics.Tests.cast_fromTest:VerifyUInt32ExplicitCastFromBigInteger(int)
         -10 (-2.86% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedULongToEnumLong(long,bool)
         -10 (-2.86% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedULongToLong(long,bool)
         -12 (-2.73% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableULongToNullableEnumLong(System.Nullable`1[UInt64],bool)
         -10 (-2.51% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedULongToNullableEnumLong(long,bool)
         -10 (-2.51% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedULongToNullableLong(long,bool)
          -9 (-2.14% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableULongToNullableLong(System.Nullable`1[UInt64],bool)
          -8 (-1.75% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableUIntToInt(System.Nullable`1[UInt32],bool)
          -7 (-1.60% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableUIntToNullableInt(System.Nullable`1[UInt32],bool)
          -7 (-1.60% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableUIntToNullableEnum(System.Nullable`1[UInt32],bool)
          -7 (-1.40% of base) - System.Reflection.Metadata.Tests.MetadataReaderTests:ValidateFieldLayoutTable():this
          -6 (-1.31% of base) - System.SpanTests.SpanTests:IndexOverflow()
          -4 (-1.18% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedUIntToEnum(int,bool)
          -4 (-1.18% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedUIntToInt(int,bool)
          -6 (-1.08% of base) - System.SpanTests.ReadOnlySpanTests:IndexOverflow()
          -8 (-1.06% of base) - System.Numerics.Tests.cast_toTest:VerifyUInt32ImplicitCastToBigInteger(int)
          -4 (-1.04% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedUIntToNullableEnum(int,bool)
          -4 (-1.04% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedUIntToNullableInt(int,bool)

30 total methods with Code Size differences (30 improved, 0 regressed), 0 unchanged.
```
</details>

<details>
<summary>Windows x86</summary>

```
Running asm diffs of benchmarks.run.windows.x86.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 55571
Total bytes of diff: 54937
Total bytes of delta: -634 (-1.14% of base)
    diff is an improvement.


Top file improvements (bytes):
         -91 : 5250.dasm (-3.46% of base)
         -90 : 10194.dasm (-0.59% of base)
         -71 : 5245.dasm (-2.00% of base)
         -70 : 5222.dasm (-4.46% of base)
         -40 : 6991.dasm (-1.64% of base)
         -18 : 5716.dasm (-10.47% of base)
         -18 : 6988.dasm (-2.86% of base)
         -15 : 20041.dasm (-3.02% of base)
         -14 : 5616.dasm (-5.15% of base)
         -14 : 5619.dasm (-5.15% of base)
         -13 : 6997.dasm (-5.96% of base)
         -12 : 1968.dasm (-0.36% of base)
         -12 : 4257.dasm (-4.46% of base)
         -11 : 15739.dasm (-0.39% of base)
         -10 : 5219.dasm (-1.10% of base)
          -8 : 20083.dasm (-0.24% of base)
          -8 : 9735.dasm (-5.93% of base)
          -8 : 5846.dasm (-3.70% of base)
          -7 : 5223.dasm (-0.21% of base)
          -7 : 5241.dasm (-1.05% of base)

45 total files with Code Size differences (45 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -91 (-3.46% of base) - System.Uri:GetCanonicalPath(byref,int):this
         -90 (-0.59% of base) - System.Reflection.Metadata.MetadataReader:InitializeTableReaders(System.Reflection.Internal.MemoryBlock,ubyte,System.Int32[],System.Int32[]):this
         -71 (-2.00% of base) - System.Uri:ReCreateParts(int,ushort,int):System.String:this
         -70 (-4.46% of base) - System.Uri:PrivateParseMinimal():int:this
         -40 (-1.64% of base) - System.Uri:GetUriPartsFromUserString(int):System.String:this
         -18 (-10.47% of base) - System.Text.Json.Utf8JsonWriter:ValidateEnd(ubyte):this
         -18 (-2.86% of base) - System.Uri:ResolveHelper(System.Uri,System.Uri,byref,byref):System.Uri
         -15 (-3.02% of base) - System.Numerics.BigInteger:GreatestCommonDivisor(System.Numerics.BigInteger,System.Numerics.BigInteger):System.Numerics.BigInteger
         -14 (-5.15% of base) - System.Text.Json.Utf8JsonReader:EndArray():this
         -14 (-5.15% of base) - System.Text.Json.Utf8JsonReader:EndObject():this
         -13 (-5.96% of base) - System.Uri:GetEscapedParts(int):System.String:this
         -12 (-0.36% of base) - System.Globalization.TimeSpanFormat:TryFormatStandard(System.TimeSpan,int,System.String,System.Span`1[Char],byref):bool
         -12 (-4.46% of base) - System.Number:RightShiftWithRounding(long,int,bool):long
         -11 (-0.39% of base) - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.Lexer:ScanNumericLiteral(byref):bool:this
         -10 (-1.10% of base) - System.Uri:InitializeUri(int,int,byref):this
          -8 (-0.24% of base) - DecCalc:VarDecDiv(byref,byref)
          -8 (-5.93% of base) - System.Uri:get_Port():int:this
          -8 (-3.70% of base) - System.Text.Json.PooledByteBufferWriter:CheckAndResizeBuffer(int):this
          -7 (-0.21% of base) - System.Uri:CheckAuthorityHelper(int,int,int,byref,byref,System.UriParser,byref):int:this
          -7 (-1.05% of base) - System.Uri:CreateHostString():this

Top method improvements (percentages):
          -4 (-13.79% of base) - System.Uri:get_IsDosPath():bool:this
          -4 (-13.79% of base) - System.Uri:get_IsImplicitFile():bool:this
          -4 (-13.79% of base) - System.Uri:get_UserDrivenParsing():bool:this
          -4 (-13.79% of base) - System.Uri:get_IsUncOrDosPath():bool:this
          -4 (-12.12% of base) - System.Xml.XmlReader:CanReadContentAs(int):bool
         -18 (-10.47% of base) - System.Text.Json.Utf8JsonWriter:ValidateEnd(ubyte):this
          -4 (-6.35% of base) - System.Reflection.Metadata.Ecma335.MetadataSizes:IsPresent(ubyte):bool:this
          -4 (-6.15% of base) - System.Uri:EnsureHostString(bool):this
         -13 (-5.96% of base) - System.Uri:GetEscapedParts(int):System.String:this
          -8 (-5.93% of base) - System.Uri:get_Port():int:this
         -14 (-5.15% of base) - System.Text.Json.Utf8JsonReader:EndArray():this
         -14 (-5.15% of base) - System.Text.Json.Utf8JsonReader:EndObject():this
         -70 (-4.46% of base) - System.Uri:PrivateParseMinimal():int:this
         -12 (-4.46% of base) - System.Number:RightShiftWithRounding(long,int,bool):long
          -3 (-4.11% of base) - System.Threading.TimeoutHelper:UpdateTimeOut(int,int):int
          -8 (-3.70% of base) - System.Text.Json.PooledByteBufferWriter:CheckAndResizeBuffer(int):this
         -91 (-3.46% of base) - System.Uri:GetCanonicalPath(byref,int):this
         -15 (-3.02% of base) - System.Numerics.BigInteger:GreatestCommonDivisor(System.Numerics.BigInteger,System.Numerics.BigInteger):System.Numerics.BigInteger
         -18 (-2.86% of base) - System.Uri:ResolveHelper(System.Uri,System.Uri,byref,byref):System.Uri
          -4 (-2.60% of base) - DiyFp:Normalize():DiyFp:this

45 total methods with Code Size differences (45 improved, 0 regressed), 0 unchanged.

Running asm diffs of coreclr_tests.pmi.windows.x86.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 98508
Total bytes of diff: 98398
Total bytes of delta: -110 (-0.11% of base)
    diff is an improvement.


Top file improvements (bytes):
         -32 : 225408.dasm (-0.08% of base)
         -32 : 225420.dasm (-0.07% of base)
         -10 : 239996.dasm (-0.75% of base)
          -8 : 249034.dasm (-0.93% of base)
          -4 : 212829.dasm (-3.25% of base)
          -4 : 249036.dasm (-1.57% of base)
          -4 : 245782.dasm (-7.02% of base)
          -4 : 245783.dasm (-6.56% of base)
          -4 : 85757.dasm (-0.73% of base)
          -4 : 86120.dasm (-1.64% of base)
          -4 : 166885.dasm (-0.20% of base)

11 total files with Code Size differences (11 improved, 0 regressed), 46 unchanged.

Top method improvements (bytes):
         -32 (-0.08% of base) - longMDArrTest:Main():int
         -32 (-0.07% of base) - ulongMDArrTest:Main():int
         -10 (-0.75% of base) - AA:Static5(System.Double[],byref,byref,ushort,System.Boolean[][],byref,System.UInt32[][,,],long):System.SByte[,][]
          -8 (-0.93% of base) - Threading.Tests.OSThreadId:Main(System.String[]):int
          -4 (-3.25% of base) - TestUnsafeCasts:PrimFromLPrim2()
          -4 (-1.57% of base) - Threading.Tests.OSThreadId:ThreadProc(System.Object)
          -4 (-7.02% of base) - Program:I8_BT_reg_reg(long,int):bool
          -4 (-6.56% of base) - Program:I8_BT_mem_reg(byref,int):bool
          -4 (-0.73% of base) - ILGEN_0x14dd78f4:Method_0xb96ba46d(long,short):int
          -4 (-1.64% of base) - ILGEN_CLASS:ILGEN_METHOD(ubyte,long,int):long
          -4 (-0.20% of base) - Internal.TypeSystem.Ecma.EcmaType:GetClassLayout():Internal.TypeSystem.ClassLayoutMetadata:this

Top method improvements (percentages):
          -4 (-7.02% of base) - Program:I8_BT_reg_reg(long,int):bool
          -4 (-6.56% of base) - Program:I8_BT_mem_reg(byref,int):bool
          -4 (-3.25% of base) - TestUnsafeCasts:PrimFromLPrim2()
          -4 (-1.64% of base) - ILGEN_CLASS:ILGEN_METHOD(ubyte,long,int):long
          -4 (-1.57% of base) - Threading.Tests.OSThreadId:ThreadProc(System.Object)
          -8 (-0.93% of base) - Threading.Tests.OSThreadId:Main(System.String[]):int
         -10 (-0.75% of base) - AA:Static5(System.Double[],byref,byref,ushort,System.Boolean[][],byref,System.UInt32[][,,],long):System.SByte[,][]
          -4 (-0.73% of base) - ILGEN_0x14dd78f4:Method_0xb96ba46d(long,short):int
          -4 (-0.20% of base) - Internal.TypeSystem.Ecma.EcmaType:GetClassLayout():Internal.TypeSystem.ClassLayoutMetadata:this
         -32 (-0.08% of base) - longMDArrTest:Main():int
         -32 (-0.07% of base) - ulongMDArrTest:Main():int

11 total methods with Code Size differences (11 improved, 0 regressed), 46 unchanged.

Running asm diffs of libraries.crossgen.windows.x86.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 91025
Total bytes of diff: 89861
Total bytes of delta: -1164 (-1.28% of base)
    diff is an improvement.


Top file improvements (bytes):
        -119 : 166021.dasm (-5.83% of base)
         -90 : 125175.dasm (-0.60% of base)
         -38 : 166013.dasm (-2.08% of base)
         -18 : 166044.dasm (-2.79% of base)
         -16 : 72806.dasm (-1.34% of base)
         -15 : 169954.dasm (-2.99% of base)
         -14 : 131147.dasm (-5.13% of base)
         -14 : 166004.dasm (-1.54% of base)
         -14 : 130816.dasm (-13.73% of base)
         -14 : 131579.dasm (-6.48% of base)
         -14 : 131148.dasm (-10.07% of base)
         -14 : 93921.dasm (-0.74% of base)
         -14 : 131145.dasm (-5.13% of base)
         -13 : 166011.dasm (-5.86% of base)
         -12 : 16029.dasm (-0.38% of base)
         -12 : 15698.dasm (-0.30% of base)
         -12 : 11292.dasm (-4.41% of base)
         -12 : 51111.dasm (-4.48% of base)
         -11 : 166047.dasm (-4.93% of base)
          -9 : 153196.dasm (-1.97% of base)

175 total files with Code Size differences (175 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
        -119 (-5.83% of base) - System.Uri:GetCanonicalPath(byref,int):this
         -90 (-0.60% of base) - System.Reflection.Metadata.MetadataReader:InitializeTableReaders(System.Reflection.Internal.MemoryBlock,ubyte,System.Int32[],System.Int32[]):this
         -38 (-2.08% of base) - System.Uri:GetUriPartsFromUserString(int):System.String:this
         -18 (-2.79% of base) - System.Uri:ResolveHelper(System.Uri,System.Uri,byref,byref):System.Uri
         -16 (-1.34% of base) - Microsoft.VisualBasic.CompilerServices.Conversions:ToBoolean(System.Object):bool
         -15 (-2.99% of base) - System.Numerics.BigInteger:GreatestCommonDivisor(System.Numerics.BigInteger,System.Numerics.BigInteger):System.Numerics.BigInteger
         -14 (-5.13% of base) - System.Text.Json.Utf8JsonReader:EndArray():this
         -14 (-1.54% of base) - System.Uri:Equals(System.Object):bool:this
         -14 (-13.73% of base) - System.Text.Json.BitStack:Pop():bool:this
         -14 (-6.48% of base) - System.Text.Json.Utf8JsonWriter:ValidateEnd(ubyte):this
         -14 (-10.07% of base) - System.Text.Json.Utf8JsonReader:UpdateBitStackOnEndToken():this
         -14 (-0.74% of base) - System.Drawing.Icon:Initialize(int,int):this
         -14 (-5.13% of base) - System.Text.Json.Utf8JsonReader:EndObject():this
         -13 (-5.86% of base) - System.Uri:GetEscapedParts(int):System.String:this
         -12 (-0.38% of base) - System.Buffers.Text.Utf8Formatter:TryFormat(System.TimeSpan,System.Span`1[Byte],byref,System.Buffers.StandardFormat):bool
         -12 (-0.30% of base) - System.Globalization.TimeSpanFormat:TryFormatStandard(System.TimeSpan,int,System.String,System.Span`1[Char],byref):bool
         -12 (-4.41% of base) - System.Number:RightShiftWithRounding(long,int,bool):long
         -12 (-4.48% of base) - Microsoft.CodeAnalysis.RealParser:RightShiftWithRounding(long,int,bool):long
         -11 (-4.93% of base) - System.Uri:CreateThisFromUri(System.Uri):this
          -9 (-1.97% of base) - System.IO.Compression.ZipArchive:TryReadZip64EndOfCentralDirectory(System.IO.Compression.ZipEndOfCentralDirectoryBlock,long):this

Top method improvements (percentages):
          -4 (-25.00% of base) - Microsoft.Extensions.Internal.ValueStopwatch:get_IsActive():bool:this
          -4 (-25.00% of base) - Microsoft.Extensions.Internal.ValueStopwatch:get_IsActive():bool:this
          -4 (-25.00% of base) - Microsoft.Extensions.Internal.ValueStopwatch:get_IsActive():bool:this
          -4 (-25.00% of base) - Microsoft.Extensions.Internal.ValueStopwatch:get_IsActive():bool:this
          -4 (-25.00% of base) - System.Threading.Tasks.Dataflow.DataflowMessageHeader:get_IsValid():bool:this
          -4 (-21.05% of base) - System.Threading.Tasks.Dataflow.WriteOnceBlock`1[__Canon][System.__Canon]:get_HasValue():bool:this
          -4 (-19.05% of base) - System.Diagnostics.SharedPerformanceCounter:IsMisaligned(int):bool
          -4 (-19.05% of base) - System.Threading.Tasks.Dataflow.WriteOnceBlock`1[__Canon][System.__Canon]:get_Value():System.__Canon:this
          -4 (-16.67% of base) - DebugView[__Canon][System.__Canon]:get_HasValue():bool:this
          -4 (-14.81% of base) - System.Convert:ToBoolean(long):bool
          -4 (-14.81% of base) - System.Convert:ToBoolean(long):bool
          -4 (-14.29% of base) - System.UInt64:System.IConvertible.ToBoolean(System.IFormatProvider):bool:this
          -4 (-14.29% of base) - System.Int64:System.IConvertible.ToBoolean(System.IFormatProvider):bool:this
          -4 (-13.79% of base) - System.Uri:get_IsDosPath():bool:this
          -4 (-13.79% of base) - System.Uri:get_UserEscaped():bool:this
          -4 (-13.79% of base) - System.Uri:get_IsUncPath():bool:this
          -4 (-13.79% of base) - System.Uri:get_UserDrivenParsing():bool:this
          -4 (-13.79% of base) - System.Uri:get_IsImplicitFile():bool:this
          -4 (-13.79% of base) - System.Uri:get_IsUncOrDosPath():bool:this
         -14 (-13.73% of base) - System.Text.Json.BitStack:Pop():bool:this

175 total methods with Code Size differences (175 improved, 0 regressed), 0 unchanged.

Running asm diffs of libraries.crossgen2.windows.x86.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 89725
Total bytes of diff: 88623
Total bytes of delta: -1102 (-1.23% of base)
    diff is an improvement.


Top file improvements (bytes):
        -127 : 179009.dasm (-5.83% of base)
         -90 : 152135.dasm (-0.60% of base)
         -38 : 179017.dasm (-2.08% of base)
         -18 : 178985.dasm (-2.78% of base)
         -17 : 169705.dasm (-3.84% of base)
         -16 : 1782.dasm (-1.35% of base)
         -15 : 174303.dasm (-2.99% of base)
         -14 : 179025.dasm (-1.54% of base)
         -13 : 179019.dasm (-5.83% of base)
         -12 : 31777.dasm (-0.30% of base)
         -12 : 90069.dasm (-4.41% of base)
         -12 : 31443.dasm (-0.38% of base)
         -12 : 36074.dasm (-4.41% of base)
         -11 : 178982.dasm (-4.91% of base)
          -9 : 85506.dasm (-7.26% of base)
          -9 : 150706.dasm (-3.86% of base)
          -9 : 131230.dasm (-0.48% of base)
          -9 : 10572.dasm (-0.67% of base)
          -9 : 179050.dasm (-9.57% of base)
          -8 : 192928.dasm (-3.69% of base)

171 total files with Code Size differences (171 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
        -127 (-5.83% of base) - System.Uri:GetCanonicalPath(byref,int):this
         -90 (-0.60% of base) - System.Reflection.Metadata.MetadataReader:InitializeTableReaders(System.Reflection.Internal.MemoryBlock,ubyte,System.Int32[],System.Int32[]):this
         -38 (-2.08% of base) - System.Uri:GetUriPartsFromUserString(int):System.String:this
         -18 (-2.78% of base) - System.Uri:ResolveHelper(System.Uri,System.Uri,byref,byref):System.Uri
         -17 (-3.84% of base) - System.IO.Compression.ZipArchive:TryReadZip64EndOfCentralDirectory(System.IO.Compression.ZipEndOfCentralDirectoryBlock,long):this
         -16 (-1.35% of base) - Microsoft.VisualBasic.CompilerServices.Conversions:ToBoolean(System.Object):bool
         -15 (-2.99% of base) - System.Numerics.BigInteger:GreatestCommonDivisor(System.Numerics.BigInteger,System.Numerics.BigInteger):System.Numerics.BigInteger
         -14 (-1.54% of base) - System.Uri:Equals(System.Object):bool:this
         -13 (-5.83% of base) - System.Uri:GetEscapedParts(int):System.String:this
         -12 (-0.30% of base) - System.Globalization.TimeSpanFormat:TryFormatStandard(System.TimeSpan,int,System.String,System.Span`1[System.Char],byref):bool
         -12 (-4.41% of base) - Microsoft.CodeAnalysis.RealParser:RightShiftWithRounding(long,int,bool):long
         -12 (-0.38% of base) - System.Buffers.Text.Utf8Formatter:TryFormat(System.TimeSpan,System.Span`1[System.Byte],byref,System.Buffers.StandardFormat):bool
         -12 (-4.41% of base) - System.Number:RightShiftWithRounding(long,int,bool):long
         -11 (-4.91% of base) - System.Uri:CreateThisFromUri(System.Uri):this
          -9 (-7.26% of base) - Roslyn.Utilities.DecimalUtilities:GetBits(System.Decimal,byref,byref,byref,byref,byref)
          -9 (-3.86% of base) - System.Reflection.Internal.DecimalUtilities:GetBits(System.Decimal,byref,byref,byref,byref,byref)
          -9 (-0.48% of base) - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.Lexer:ScanNumericLiteral(byref):bool:this
          -9 (-0.67% of base) - System.Linq.Expressions.Compiler.ILGen:EmitDecimal(System.Reflection.Emit.ILGenerator,System.Decimal)
          -9 (-9.57% of base) - System.Uri:get_IsLoopback():bool:this
          -8 (-3.69% of base) - System.Formats.Asn1.Asn1Tag:TryDecode(System.ReadOnlySpan`1[System.Byte],byref,byref):bool

Top method improvements (percentages):
          -4 (-25.00% of base) - Microsoft.Extensions.Internal.ValueStopwatch:get_IsActive():bool:this
          -4 (-25.00% of base) - Microsoft.Extensions.Internal.ValueStopwatch:get_IsActive():bool:this
          -4 (-25.00% of base) - Microsoft.Extensions.Internal.ValueStopwatch:get_IsActive():bool:this
          -4 (-25.00% of base) - Microsoft.Extensions.Internal.ValueStopwatch:get_IsActive():bool:this
          -4 (-25.00% of base) - System.Threading.Tasks.Dataflow.DataflowMessageHeader:get_IsValid():bool:this
          -4 (-21.05% of base) - System.Threading.Tasks.Dataflow.WriteOnceBlock`1:get_HasValue():bool:this
          -4 (-19.05% of base) - System.Threading.Tasks.Dataflow.WriteOnceBlock`1:get_Value():System.__Canon:this
          -4 (-19.05% of base) - System.Diagnostics.SharedPerformanceCounter:IsMisaligned(int):bool
          -4 (-16.67% of base) - DebugView:get_HasValue():bool:this
          -4 (-14.81% of base) - System.Convert:ToBoolean(long):bool
          -4 (-14.81% of base) - System.Convert:ToBoolean(long):bool
          -4 (-14.29% of base) - System.UInt64:System.IConvertible.ToBoolean(System.IFormatProvider):bool:this
          -4 (-14.29% of base) - System.Int64:System.IConvertible.ToBoolean(System.IFormatProvider):bool:this
          -4 (-13.79% of base) - System.Uri:get_IsUncPath():bool:this
          -4 (-13.79% of base) - System.Uri:get_IsImplicitFile():bool:this
          -4 (-13.79% of base) - System.Uri:get_IsUncOrDosPath():bool:this
          -4 (-13.79% of base) - System.Uri:get_UserEscaped():bool:this
          -4 (-13.79% of base) - System.Uri:get_IsDosPath():bool:this
          -4 (-13.79% of base) - System.Uri:get_UserDrivenParsing():bool:this
          -4 (-12.90% of base) - System.Reflection.Metadata.MetadataReader:IsDeclaredSorted(long):bool:this

171 total methods with Code Size differences (171 improved, 0 regressed), 0 unchanged.

Running asm diffs of libraries.pmi.windows.x86.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 147247
Total bytes of diff: 145512
Total bytes of delta: -1735 (-1.18% of base)
    diff is an improvement.


Top file improvements (bytes):
         -97 : 208099.dasm (-3.64% of base)
         -90 : 156767.dasm (-0.59% of base)
         -73 : 208141.dasm (-2.04% of base)
         -70 : 208133.dasm (-4.46% of base)
         -40 : 208142.dasm (-1.63% of base)
         -18 : 208084.dasm (-2.86% of base)
         -18 : 163804.dasm (-10.47% of base)
         -16 : 102710.dasm (-1.39% of base)
         -16 : 129177.dasm (-1.16% of base)
         -15 : 208078.dasm (-1.40% of base)
         -15 : 212127.dasm (-3.02% of base)
         -14 : 208128.dasm (-1.58% of base)
         -14 : 162997.dasm (-5.15% of base)
         -14 : 163000.dasm (-10.22% of base)
         -14 : 162568.dasm (-14.29% of base)
         -14 : 162999.dasm (-5.15% of base)
         -13 : 208159.dasm (-1.49% of base)
         -13 : 208139.dasm (-5.96% of base)
         -12 : 75361.dasm (-4.46% of base)
         -11 : 208089.dasm (-5.00% of base)

288 total files with Code Size differences (288 improved, 0 regressed), 3 unchanged.

Top method improvements (bytes):
         -97 (-3.64% of base) - System.Uri:GetCanonicalPath(byref,int):this
         -90 (-0.59% of base) - System.Reflection.Metadata.MetadataReader:InitializeTableReaders(System.Reflection.Internal.MemoryBlock,ubyte,System.Int32[],System.Int32[]):this
         -73 (-2.04% of base) - System.Uri:ReCreateParts(int,ushort,int):System.String:this
         -70 (-4.46% of base) - System.Uri:PrivateParseMinimal():int:this
         -40 (-1.63% of base) - System.Uri:GetUriPartsFromUserString(int):System.String:this
         -18 (-2.86% of base) - System.Uri:ResolveHelper(System.Uri,System.Uri,byref,byref):System.Uri
         -18 (-10.47% of base) - System.Text.Json.Utf8JsonWriter:ValidateEnd(ubyte):this
         -16 (-1.39% of base) - Microsoft.VisualBasic.CompilerServices.Conversions:ToBoolean(System.Object):bool
         -16 (-1.16% of base) - System.Linq.Expressions.Compiler.ILGen:EmitDecimal(System.Reflection.Emit.ILGenerator,System.Decimal)
         -15 (-1.40% of base) - System.Uri:InternalIsWellFormedOriginalString():bool:this
         -15 (-3.02% of base) - System.Numerics.BigInteger:GreatestCommonDivisor(System.Numerics.BigInteger,System.Numerics.BigInteger):System.Numerics.BigInteger
         -14 (-1.58% of base) - System.Uri:Equals(System.Object):bool:this
         -14 (-5.15% of base) - System.Text.Json.Utf8JsonReader:EndObject():this
         -14 (-10.22% of base) - System.Text.Json.Utf8JsonReader:UpdateBitStackOnEndToken():this
         -14 (-14.29% of base) - System.Text.Json.BitStack:Pop():bool:this
         -14 (-5.15% of base) - System.Text.Json.Utf8JsonReader:EndArray():this
         -13 (-1.49% of base) - System.Uri:GetLocalPath():System.String:this
         -13 (-5.96% of base) - System.Uri:GetEscapedParts(int):System.String:this
         -12 (-4.46% of base) - Microsoft.CodeAnalysis.RealParser:RightShiftWithRounding(long,int,bool):long
         -11 (-5.00% of base) - System.Uri:CreateThisFromUri(System.Uri):this

Top method improvements (percentages):
          -4 (-25.00% of base) - Microsoft.Extensions.Internal.ValueStopwatch:get_IsActive():bool:this
          -4 (-25.00% of base) - Microsoft.Extensions.Internal.ValueStopwatch:get_IsActive():bool:this
          -4 (-25.00% of base) - Microsoft.Extensions.Internal.ValueStopwatch:get_IsActive():bool:this
          -4 (-25.00% of base) - System.Threading.Tasks.Dataflow.DataflowMessageHeader:get_IsValid():bool:this
          -4 (-25.00% of base) - Microsoft.Extensions.Internal.ValueStopwatch:get_IsActive():bool:this
          -4 (-21.05% of base) - System.Threading.Tasks.Dataflow.WriteOnceBlock`1[__Canon][System.__Canon]:get_HasValue():bool:this
          -4 (-21.05% of base) - System.Threading.Tasks.Dataflow.WriteOnceBlock`1[Byte][System.Byte]:get_HasValue():bool:this
          -4 (-19.05% of base) - System.Diagnostics.SharedPerformanceCounter:IsMisaligned(int):bool
          -4 (-19.05% of base) - System.Threading.Tasks.Dataflow.WriteOnceBlock`1[Int32][System.Int32]:get_Value():int:this
          -4 (-19.05% of base) - System.Threading.Tasks.Dataflow.WriteOnceBlock`1[__Canon][System.__Canon]:get_Value():System.__Canon:this
          -4 (-18.18% of base) - System.Threading.Tasks.Dataflow.WriteOnceBlock`1[Int16][System.Int16]:get_Value():short:this
          -4 (-18.18% of base) - System.Threading.Tasks.Dataflow.WriteOnceBlock`1[Byte][System.Byte]:get_Value():ubyte:this
          -4 (-16.67% of base) - DebugView[__Canon][System.__Canon]:get_HasValue():bool:this
          -4 (-16.67% of base) - DebugView[Byte][System.Byte]:get_HasValue():bool:this
          -4 (-14.29% of base) - System.Threading.Tasks.Dataflow.WriteOnceBlock`1[Int64][System.Int64]:get_Value():long:this
         -14 (-14.29% of base) - System.Text.Json.BitStack:Pop():bool:this
          -4 (-13.79% of base) - System.Uri:get_IsUncPath():bool:this
          -4 (-13.79% of base) - System.Uri:get_UserDrivenParsing():bool:this
          -4 (-13.79% of base) - System.Uri:get_IsUncOrDosPath():bool:this
          -4 (-13.79% of base) - System.Uri:get_IsDosPath():bool:this

288 total methods with Code Size differences (288 improved, 0 regressed), 3 unchanged.

Running asm diffs of libraries_tests.pmi.windows.x86.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 63180
Total bytes of diff: 62565
Total bytes of delta: -615 (-0.97% of base)
    diff is an improvement.


Top file improvements (bytes):
         -32 : 121410.dasm (-12.70% of base)
         -32 : 92215.dasm (-3.21% of base)
         -24 : 93113.dasm (-1.04% of base)
         -16 : 213932.dasm (-0.90% of base)
         -16 : 92217.dasm (-1.13% of base)
         -14 : 87751.dasm (-14.29% of base)
         -12 : 93168.dasm (-0.63% of base)
         -12 : 71581.dasm (-1.13% of base)
         -12 : 227550.dasm (-1.43% of base)
         -12 : 93167.dasm (-0.81% of base)
         -10 : 302204.dasm (-1.17% of base)
         -10 : 302207.dasm (-1.16% of base)
         -10 : 302203.dasm (-1.22% of base)
         -10 : 302206.dasm (-1.14% of base)
          -9 : 213679.dasm (-1.26% of base)
          -9 : 8805.dasm (-7.20% of base)
          -9 : 126158.dasm (-3.54% of base)
          -9 : 86264.dasm (-1.26% of base)
          -9 : 213675.dasm (-1.95% of base)
          -9 : 205208.dasm (-1.90% of base)

94 total files with Code Size differences (94 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -32 (-12.70% of base) - <>c:<get_UInt64TestSubtractions>b__125_1(long,long):System.Object[]:this
         -32 (-3.21% of base) - System.Text.Json.Tests.BitStackTests:SetResetFirstBit()
         -24 (-1.04% of base) - System.Text.Json.Tests.Utf8JsonWriterTests:ResetChangeOutputMode(bool,bool):this
         -16 (-0.90% of base) - System.Numerics.Tests.ComparisonTest:VerifyComparison(System.Numerics.BigInteger,int,int)
         -16 (-1.13% of base) - System.Text.Json.Tests.BitStackTests:BitStackPushPopLarge(int)
         -14 (-14.29% of base) - System.Text.Json.BitStack:Pop():bool:this
         -12 (-0.63% of base) - System.Text.Json.Tests.Utf8JsonWriterTests:ResetWithSameOutput(bool,bool):this
         -12 (-1.13% of base) - System.Runtime.Serialization.Formatters.Tests.EqualityExtensions:IsEqual(System.Uri,System.Uri,bool)
         -12 (-1.43% of base) - System.Threading.Tasks.Dataflow.Tests.DataflowBlockExtensionsTests:TestDataflowMessageHeader():this
         -12 (-0.81% of base) - System.Text.Json.Tests.Utf8JsonWriterTests:Reset(bool,bool):this
         -10 (-1.17% of base) - System.PrivateUri.Tests.UriTests:TestCtor_Uri_String()
         -10 (-1.16% of base) - System.PrivateUri.Tests.UriTests:TestTryCreate_String_UriKind()
         -10 (-1.22% of base) - System.PrivateUri.Tests.UriTests:TestCtor_String()
         -10 (-1.14% of base) - System.PrivateUri.Tests.UriTests:TestCtor_Uri_Uri()
          -9 (-1.26% of base) - <>c__DisplayClass9_0:<Path_Query_Fragment>b__0(System.Uri):this
          -9 (-7.20% of base) - Roslyn.Utilities.DecimalUtilities:GetBits(System.Decimal,byref,byref,byref,byref,byref)
          -9 (-3.54% of base) - Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery.SyntaxTreeExtensions:IsFieldNameDeclarationContext(Microsoft.CodeAnalysis.SyntaxTree,int,Microsoft.CodeAnalysis.SyntaxToken,System.Threading.CancellationToken):bool
          -9 (-1.26% of base) - <>c__DisplayClass9_0:<Path_Query_Fragment>b__0(System.Uri):this
          -9 (-1.95% of base) - <>c__DisplayClass7_0:<Scheme_Authority_IdnHost>b__0(System.Uri):this
          -9 (-1.90% of base) - System.Reflection.Metadata.Tests.MetadataReaderTests:ValidateFieldLayoutTable():this

Top method improvements (percentages):
          -5 (-27.78% of base) - Microsoft.CodeAnalysis.VisualBasic.Utilities.ModifierCollectionFacts:CouldApplyToOneOf(int):bool:this
          -4 (-21.05% of base) - <>c:<get_UInt64TestDivisions>b__105_2(<>f__AnonymousType0`2[UInt64,UInt64]):bool:this
         -14 (-14.29% of base) - System.Text.Json.BitStack:Pop():bool:this
         -32 (-12.70% of base) - <>c:<get_UInt64TestSubtractions>b__125_1(long,long):System.Object[]:this
          -4 (-12.50% of base) - System.Text.Unicode.UnicodeData:IsWhiteSpace(int):bool
          -4 (-10.26% of base) - HashBucket[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:IsInUse(int):bool:this
          -4 (-10.26% of base) - HashBucket[__Canon,Nullable`1][System.__Canon,System.Nullable`1[System.Int32]]:IsInUse(int):bool:this
          -9 (-7.20% of base) - Roslyn.Utilities.DecimalUtilities:GetBits(System.Decimal,byref,byref,byref,byref,byref)
          -4 (-6.67% of base) - System.IO.Tests.FileInfo_GetSetTimes:HasNonZeroNanoseconds(System.DateTime):bool
          -4 (-6.67% of base) - System.IO.Tests.FileInfo_GetSetTimes:HasNonZeroNanoseconds(System.DateTime):bool
          -4 (-6.56% of base) - Microsoft.CodeAnalysis.BitVector:IsTrue(long,int):bool
          -4 (-6.06% of base) - Microsoft.Diagnostics.Runtime.DacInterface.CommonMethodTables:Validate():bool:this
          -4 (-4.35% of base) - System.Numerics.Tests.cast_fromTest:VerifyUInt32ExplicitCastFromBigInteger(int)
          -4 (-4.17% of base) - System.Numerics.Tests.BitOperationsTests:BitOps_IsPow2_ulong(long,bool)
          -9 (-3.54% of base) - Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery.SyntaxTreeExtensions:IsFieldNameDeclarationContext(Microsoft.CodeAnalysis.SyntaxTree,int,Microsoft.CodeAnalysis.SyntaxToken,System.Threading.CancellationToken):bool
          -4 (-3.42% of base) - Microsoft.Diagnostics.Runtime.DacInterface.SOSDac:GetAppDomainData(long,byref):bool:this
         -32 (-3.21% of base) - System.Text.Json.Tests.BitStackTests:SetResetFirstBit()
          -4 (-2.84% of base) - CRC:make_crc_table()
          -4 (-2.84% of base) - CRC:make_crc_table()
          -4 (-2.72% of base) - Microsoft.CodeAnalysis.BitVector:get_Item(int):bool:this

94 total methods with Code Size differences (94 improved, 0 regressed), 0 unchanged.
```
</details>

<details>
<summary>Linux ARM64</summary>

```
Running asm diffs of coreclr_tests.pmi.Linux.arm64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 1708
Total bytes of diff: 1704
Total bytes of delta: -4 (-0.23% of base)
    diff is an improvement.


Top file improvements (bytes):
          -4 : 158623.dasm (-0.23% of base)

1 total files with Code Size differences (1 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
          -4 (-0.23% of base) - Internal.TypeSystem.Ecma.EcmaType:GetClassLayout():Internal.TypeSystem.ClassLayoutMetadata:this

Top method improvements (percentages):
          -4 (-0.23% of base) - Internal.TypeSystem.Ecma.EcmaType:GetClassLayout():Internal.TypeSystem.ClassLayoutMetadata:this

1 total methods with Code Size differences (1 improved, 0 regressed), 0 unchanged.

Running asm diffs of libraries.crossgen.Linux.arm64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 63796
Total bytes of diff: 63368
Total bytes of delta: -428 (-0.67% of base)
    diff is an improvement.


Top file improvements (bytes):
         -12 : 102198.dasm (-0.66% of base)
         -12 : 156780.dasm (-1.56% of base)
         -12 : 168598.dasm (-1.70% of base)
          -8 : 102094.dasm (-0.47% of base)
          -8 : 102416.dasm (-0.53% of base)
          -8 : 102467.dasm (-0.49% of base)
          -8 : 102496.dasm (-0.56% of base)
          -8 : 102468.dasm (-0.94% of base)
          -8 : 102599.dasm (-0.91% of base)
          -8 : 102455.dasm (-0.47% of base)
          -8 : 102167.dasm (-0.82% of base)
          -8 : 102417.dasm (-0.53% of base)
          -8 : 102494.dasm (-0.54% of base)
          -8 : 102523.dasm (-0.49% of base)
          -8 : 102742.dasm (-0.94% of base)
          -8 : 49411.dasm (-0.26% of base)
          -8 : 102423.dasm (-0.53% of base)
          -8 : 114125.dasm (-2.13% of base)
          -8 : 171511.dasm (-2.11% of base)
          -8 : 102092.dasm (-0.89% of base)

81 total files with Code Size differences (81 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -12 (-0.66% of base) - System.Collections.Generic.HashSet`1[__Canon][System.__Canon]:AddIfNotPresent(System.__Canon,byref):bool:this
         -12 (-1.56% of base) - System.Numerics.BigInteger:GreatestCommonDivisor(System.Numerics.BigInteger,System.Numerics.BigInteger):System.Numerics.BigInteger
         -12 (-1.70% of base) - System.IO.Compression.ZipArchive:TryReadZip64EndOfCentralDirectory(System.IO.Compression.ZipEndOfCentralDirectoryBlock,long):this
          -8 (-0.47% of base) - System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]:TryInsert(System.__Canon,System.__Canon,ubyte):bool:this
          -8 (-0.53% of base) - System.Collections.Generic.Dictionary`2[IntPtr,__Canon][System.IntPtr,System.__Canon]:TryInsert(long,System.__Canon,ubyte):bool:this
          -8 (-0.49% of base) - System.Collections.Generic.Dictionary`2[__Canon,Int32][System.__Canon,System.Int32]:TryInsert(System.__Canon,int,ubyte):bool:this
          -8 (-0.56% of base) - System.Collections.Generic.Dictionary`2[UInt64,Char][System.UInt64,System.Char]:TryInsert(long,ushort,ubyte):bool:this
          -8 (-0.94% of base) - System.Collections.Generic.Dictionary`2[Int32,__Canon][System.Int32,System.__Canon]:FindValue(int):byref:this
          -8 (-0.91% of base) - System.Collections.Generic.Dictionary`2[Char,__Canon][System.Char,System.__Canon]:FindValue(ushort):byref:this
          -8 (-0.47% of base) - System.Collections.Generic.Dictionary`2[__Canon,ResourceLocator][System.__Canon,System.Resources.ResourceLocator]:TryInsert(System.__Canon,System.Resources.ResourceLocator,ubyte):bool:this
          -8 (-0.82% of base) - System.Collections.Generic.HashSet`1[__Canon][System.__Canon]:FindItemIndex(System.__Canon):int:this
          -8 (-0.53% of base) - System.Collections.Generic.Dictionary`2[Char,__Canon][System.Char,System.__Canon]:TryInsert(ushort,System.__Canon,ubyte):bool:this
          -8 (-0.54% of base) - System.Collections.Generic.Dictionary`2[Int32,__Canon][System.Int32,System.__Canon]:TryInsert(int,System.__Canon,ubyte):bool:this
          -8 (-0.49% of base) - System.Collections.Generic.Dictionary`2[__Canon,Boolean][System.__Canon,System.Boolean]:TryInsert(System.__Canon,bool,ubyte):bool:this
          -8 (-0.94% of base) - System.Collections.Generic.Dictionary`2[IntPtr,__Canon][System.IntPtr,System.__Canon]:FindValue(long):byref:this
          -8 (-0.26% of base) - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.Lexer:ScanNumericLiteral(byref):bool:this
          -8 (-0.53% of base) - System.Collections.Generic.Dictionary`2[UInt64,__Canon][System.UInt64,System.__Canon]:TryInsert(long,System.__Canon,ubyte):bool:this
          -8 (-2.13% of base) - System.Text.Json.PooledByteBufferWriter:CheckAndResizeBuffer(int):this
          -8 (-2.11% of base) - System.Text.Json.PooledByteBufferWriter:CheckAndResizeBuffer(int):this
          -8 (-0.89% of base) - System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]:FindValue(System.__Canon):byref:this

Top method improvements (percentages):
          -4 (-5.00% of base) - System.Xml.XmlBinaryNodeWriter:WriteUInt64Text(long):this
          -4 (-4.00% of base) - System.AppDomain:get_MonitoringTotalProcessorTime():System.TimeSpan:this
          -4 (-3.70% of base) - System.Numerics.BigInteger:op_Implicit(int):System.Numerics.BigInteger
          -4 (-3.12% of base) - System.Collections.Concurrent.BlockingCollection`1[__Canon][System.__Canon]:UpdateTimeOut(int,int):int
          -4 (-2.78% of base) - System.Buffers.ArrayMemoryPool`1[__Canon][System.__Canon]:Rent(int):System.Buffers.IMemoryOwner`1[__Canon]:this
          -4 (-2.78% of base) - System.Numerics.BigInteger:.ctor(int):this
          -4 (-2.44% of base) - System.Threading.TimeoutHelper:UpdateTimeOut(int,int):int
          -4 (-2.38% of base) - System.Threading.ThreadPool:UnsafeRegisterWaitForSingleObject(System.Threading.WaitHandle,System.Threading.WaitOrTimerCallback,System.Object,int,bool):System.Threading.RegisteredWaitHandle
          -4 (-2.38% of base) - System.Threading.ThreadPool:RegisterWaitForSingleObject(System.Threading.WaitHandle,System.Threading.WaitOrTimerCallback,System.Object,int,bool):System.Threading.RegisteredWaitHandle
          -4 (-2.22% of base) - System.Formats.Asn1.AsnDecoder:ParseNonNegativeInt(System.ReadOnlySpan`1[Byte]):int
          -4 (-2.13% of base) - System.Diagnostics.Process:GetWorkingSetLimits(byref,byref):this
          -8 (-2.13% of base) - System.Text.Json.PooledByteBufferWriter:CheckAndResizeBuffer(int):this
          -8 (-2.11% of base) - System.Text.Json.PooledByteBufferWriter:CheckAndResizeBuffer(int):this
          -4 (-1.89% of base) - System.Collections.HashHelpers:FastMod(int,int,long):int
         -12 (-1.70% of base) - System.IO.Compression.ZipArchive:TryReadZip64EndOfCentralDirectory(System.IO.Compression.ZipEndOfCentralDirectoryBlock,long):this
          -4 (-1.69% of base) - System.Reflection.Metadata.FieldDefinition:GetOffset():int:this
          -4 (-1.64% of base) - System.Formats.Asn1.Asn1Tag:TryDecode(System.ReadOnlySpan`1[Byte],byref,byref):bool
          -4 (-1.64% of base) - Newtonsoft.Json.Bson.BsonDataWriter:WriteValue(long):this
          -4 (-1.64% of base) - Newtonsoft.Json.Bson.BsonDataWriter:WriteValue(int):this
          -4 (-1.59% of base) - System.Collections.Generic.HashSet`1[__Canon][System.__Canon]:GetBucketRef(int):byref:this

81 total methods with Code Size differences (81 improved, 0 regressed), 0 unchanged.

Running asm diffs of libraries.crossgen2.Linux.arm64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 69552
Total bytes of diff: 69120
Total bytes of delta: -432 (-0.62% of base)
    diff is an improvement.


Top file improvements (bytes):
         -12 : 172040.dasm (-1.55% of base)
         -12 : 175083.dasm (-1.49% of base)
         -12 : 69177.dasm (-0.65% of base)
          -8 : 69284.dasm (-0.47% of base)
          -8 : 88331.dasm (-0.52% of base)
          -8 : 88077.dasm (-0.46% of base)
          -8 : 88269.dasm (-0.52% of base)
          -8 : 88274.dasm (-0.91% of base)
          -8 : 69208.dasm (-0.79% of base)
          -8 : 87972.dasm (-0.48% of base)
          -8 : 69286.dasm (-0.86% of base)
          -8 : 87396.dasm (-0.48% of base)
          -8 : 87631.dasm (-0.48% of base)
          -8 : 87985.dasm (-0.52% of base)
          -8 : 87986.dasm (-0.91% of base)
          -8 : 9830.dasm (-2.04% of base)
          -8 : 87641.dasm (-0.53% of base)
          -8 : 87642.dasm (-0.91% of base)
          -8 : 88354.dasm (-0.88% of base)
          -8 : 106581.dasm (-0.25% of base)

82 total files with Code Size differences (82 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -12 (-1.55% of base) - System.Numerics.BigInteger:GreatestCommonDivisor(System.Numerics.BigInteger,System.Numerics.BigInteger):System.Numerics.BigInteger
         -12 (-1.49% of base) - System.IO.Compression.ZipArchive:TryReadZip64EndOfCentralDirectory(System.IO.Compression.ZipEndOfCentralDirectoryBlock,long):this
         -12 (-0.65% of base) - System.Collections.Generic.HashSet`1:AddIfNotPresent(System.__Canon,byref):bool:this
          -8 (-0.47% of base) - System.Collections.Generic.Dictionary`2:TryInsert(System.__Canon,System.__Canon,ubyte):bool:this
          -8 (-0.52% of base) - System.Collections.Generic.Dictionary`2:TryInsert(ushort,System.__Canon,ubyte):bool:this
          -8 (-0.46% of base) - System.Collections.Generic.Dictionary`2:TryInsert(System.__Canon,System.Resources.ResourceLocator,ubyte):bool:this
          -8 (-0.52% of base) - System.Collections.Generic.Dictionary`2:TryInsert(long,System.__Canon,ubyte):bool:this
          -8 (-0.91% of base) - System.Collections.Generic.Dictionary`2:FindValue(long):byref:this
          -8 (-0.79% of base) - System.Collections.Generic.HashSet`1:FindItemIndex(System.__Canon):int:this
          -8 (-0.48% of base) - System.Collections.Generic.Dictionary`2:TryInsert(System.__Canon,int,ubyte):bool:this
          -8 (-0.86% of base) - System.Collections.Generic.Dictionary`2:FindValue(System.__Canon):byref:this
          -8 (-0.48% of base) - System.Collections.Generic.Dictionary`2:TryInsert(System.__Canon,bool,ubyte):bool:this
          -8 (-0.48% of base) - System.Collections.Generic.Dictionary`2:TryInsert(System.__Canon,long,ubyte):bool:this
          -8 (-0.52% of base) - System.Collections.Generic.Dictionary`2:TryInsert(long,System.__Canon,ubyte):bool:this
          -8 (-0.91% of base) - System.Collections.Generic.Dictionary`2:FindValue(long):byref:this
          -8 (-2.04% of base) - System.Text.Json.PooledByteBufferWriter:CheckAndResizeBuffer(int):this
          -8 (-0.53% of base) - System.Collections.Generic.Dictionary`2:TryInsert(int,System.__Canon,ubyte):bool:this
          -8 (-0.91% of base) - System.Collections.Generic.Dictionary`2:FindValue(int):byref:this
          -8 (-0.88% of base) - System.Collections.Generic.Dictionary`2:FindValue(ushort):byref:this
          -8 (-0.25% of base) - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.Lexer:ScanNumericLiteral(byref):bool:this

Top method improvements (percentages):
          -4 (-5.00% of base) - System.Xml.XmlBinaryNodeWriter:WriteUInt64Text(long):this
          -4 (-3.57% of base) - System.AppDomain:get_MonitoringTotalProcessorTime():System.TimeSpan:this
          -4 (-3.33% of base) - System.Numerics.BigInteger:op_Implicit(int):System.Numerics.BigInteger
          -4 (-3.12% of base) - System.Collections.Concurrent.BlockingCollection`1:UpdateTimeOut(int,int):int
          -4 (-2.78% of base) - System.Buffers.ArrayMemoryPool`1:Rent(int):System.Buffers.IMemoryOwner`1[System.__Canon]:this
          -4 (-2.56% of base) - System.Numerics.BigInteger:.ctor(int):this
          -4 (-2.44% of base) - System.Threading.TimeoutHelper:UpdateTimeOut(int,int):int
          -4 (-2.13% of base) - System.Threading.ThreadPool:RegisterWaitForSingleObject(System.Threading.WaitHandle,System.Threading.WaitOrTimerCallback,System.Object,int,bool):System.Threading.RegisteredWaitHandle
          -4 (-2.13% of base) - System.Threading.ThreadPool:UnsafeRegisterWaitForSingleObject(System.Threading.WaitHandle,System.Threading.WaitOrTimerCallback,System.Object,int,bool):System.Threading.RegisteredWaitHandle
          -4 (-2.13% of base) - System.Diagnostics.Process:GetWorkingSetLimits(byref,byref):this
          -8 (-2.04% of base) - System.Text.Json.PooledByteBufferWriter:CheckAndResizeBuffer(int):this
          -8 (-2.04% of base) - System.Text.Json.PooledByteBufferWriter:CheckAndResizeBuffer(int):this
          -4 (-1.89% of base) - System.Formats.Asn1.AsnDecoder:ParseNonNegativeInt(System.ReadOnlySpan`1[System.Byte]):int
          -4 (-1.79% of base) - System.Collections.HashHelpers:FastMod(int,int,long):int
          -4 (-1.69% of base) - System.Reflection.Metadata.FieldDefinition:GetOffset():int:this
          -4 (-1.56% of base) - System.Net.Http.Http2Connection:ChangeMaxConcurrentStreams(int):this
         -12 (-1.55% of base) - System.Numerics.BigInteger:GreatestCommonDivisor(System.Numerics.BigInteger,System.Numerics.BigInteger):System.Numerics.BigInteger
          -4 (-1.49% of base) - System.Formats.Asn1.Asn1Tag:TryDecode(System.ReadOnlySpan`1[System.Byte],byref,byref):bool
         -12 (-1.49% of base) - System.IO.Compression.ZipArchive:TryReadZip64EndOfCentralDirectory(System.IO.Compression.ZipEndOfCentralDirectoryBlock,long):this
          -4 (-1.45% of base) - System.Collections.Generic.Dictionary`2:GetBucket(int):byref:this

82 total methods with Code Size differences (82 improved, 0 regressed), 0 unchanged.

Running asm diffs of libraries.pmi.Linux.arm64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 66440
Total bytes of diff: 65912
Total bytes of delta: -528 (-0.79% of base)
    diff is an improvement.


Top file improvements (bytes):
         -24 : 166215.dasm (-0.87% of base)
         -24 : 172852.dasm (-0.87% of base)
         -12 : 10094.dasm (-0.86% of base)
         -12 : 191193.dasm (-1.86% of base)
         -12 : 10053.dasm (-0.86% of base)
         -12 : 10117.dasm (-0.89% of base)
         -12 : 10103.dasm (-0.87% of base)
         -12 : 10110.dasm (-0.87% of base)
         -12 : 200897.dasm (-2.03% of base)
          -8 : 10066.dasm (-0.98% of base)
          -8 : 84160.dasm (-1.98% of base)
          -8 : 9906.dasm (-1.06% of base)
          -8 : 9916.dasm (-1.08% of base)
          -8 : 9917.dasm (-0.65% of base)
          -8 : 10113.dasm (-0.97% of base)
          -8 : 34293.dasm (-0.28% of base)
          -8 : 9888.dasm (-0.67% of base)
          -8 : 10120.dasm (-1.01% of base)
          -8 : 9886.dasm (-1.06% of base)
          -8 : 9926.dasm (-1.00% of base)

88 total files with Code Size differences (88 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -24 (-0.87% of base) - ECDiffieHellmanOpenSsl:DeriveSecretAgreement(System.Security.Cryptography.ECDiffieHellmanPublicKey,System.Security.Cryptography.IncrementalHash):System.Byte[]:this
         -24 (-0.87% of base) - System.Security.Cryptography.ECDiffieHellmanOpenSsl:DeriveSecretAgreement(System.Security.Cryptography.ECDiffieHellmanPublicKey,System.Security.Cryptography.IncrementalHash):System.Byte[]:this
         -12 (-0.86% of base) - System.Collections.Generic.HashSet`1[Int16][System.Int16]:AddIfNotPresent(short,byref):bool:this
         -12 (-1.86% of base) - System.Numerics.BigInteger:GreatestCommonDivisor(System.Numerics.BigInteger,System.Numerics.BigInteger):System.Numerics.BigInteger
         -12 (-0.86% of base) - System.Collections.Generic.HashSet`1[Byte][System.Byte]:AddIfNotPresent(ubyte,byref):bool:this
         -12 (-0.89% of base) - System.Collections.Generic.HashSet`1[Int64][System.Int64]:AddIfNotPresent(long,byref):bool:this
         -12 (-0.87% of base) - System.Collections.Generic.HashSet`1[Double][System.Double]:AddIfNotPresent(double,byref):bool:this
         -12 (-0.87% of base) - System.Collections.Generic.HashSet`1[Vector`1][System.Numerics.Vector`1[System.Single]]:AddIfNotPresent(System.Numerics.Vector`1[Single],byref):bool:this
         -12 (-2.03% of base) - System.IO.Compression.ZipArchive:TryReadZip64EndOfCentralDirectory(System.IO.Compression.ZipEndOfCentralDirectoryBlock,long):this
          -8 (-0.98% of base) - System.Collections.Generic.HashSet`1[Byte][System.Byte]:FindItemIndex(ubyte):int:this
          -8 (-1.98% of base) - System.Text.Json.PooledByteBufferWriter:CheckAndResizeBuffer(int):this
          -8 (-1.06% of base) - System.Collections.Generic.Dictionary`2[Int16,Nullable`1][System.Int16,System.Nullable`1[System.Int32]]:FindValue(short):byref:this
          -8 (-1.08% of base) - System.Collections.Generic.Dictionary`2[Int32,Nullable`1][System.Int32,System.Nullable`1[System.Int32]]:FindValue(int):byref:this
          -8 (-0.65% of base) - System.Collections.Generic.Dictionary`2[Int32,Nullable`1][System.Int32,System.Nullable`1[System.Int32]]:TryInsert(int,System.Nullable`1[Int32],ubyte):bool:this
          -8 (-0.97% of base) - System.Collections.Generic.HashSet`1[Vector`1][System.Numerics.Vector`1[System.Single]]:FindItemIndex(System.Numerics.Vector`1[Single]):int:this
          -8 (-0.28% of base) - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.Lexer:ScanNumericLiteral(byref):bool:this
          -8 (-0.67% of base) - System.Collections.Generic.Dictionary`2[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:TryInsert(ubyte,System.Nullable`1[Int32],ubyte):bool:this
          -8 (-1.01% of base) - System.Collections.Generic.HashSet`1[Int64][System.Int64]:FindItemIndex(long):int:this
          -8 (-1.06% of base) - System.Collections.Generic.Dictionary`2[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:FindValue(ubyte):byref:this
          -8 (-1.00% of base) - System.Collections.Generic.Dictionary`2[Double,Nullable`1][System.Double,System.Nullable`1[System.Int32]]:FindValue(double):byref:this

Top method improvements (percentages):
          -4 (-6.25% of base) - System.Xml.XmlBinaryNodeWriter:WriteUInt64Text(long):this
          -4 (-4.00% of base) - System.Buffers.ArrayMemoryPool`1[Byte][System.Byte]:Rent(int):System.Buffers.IMemoryOwner`1[Byte]:this
          -4 (-3.70% of base) - System.Buffers.ArrayMemoryPool`1[__Canon][System.__Canon]:Rent(int):System.Buffers.IMemoryOwner`1[__Canon]:this
          -4 (-3.70% of base) - System.Numerics.BigInteger:op_Implicit(int):System.Numerics.BigInteger
          -4 (-3.45% of base) - System.Collections.Concurrent.BlockingCollection`1[__Canon][System.__Canon]:UpdateTimeOut(int,int):int
          -4 (-3.45% of base) - System.Collections.Concurrent.BlockingCollection`1[Byte][System.Byte]:UpdateTimeOut(int,int):int
          -4 (-3.03% of base) - System.Diagnostics.Process:GetWorkingSetLimits(byref,byref):this
          -4 (-3.03% of base) - System.Numerics.BigInteger:.ctor(int):this
          -4 (-2.44% of base) - System.Formats.Asn1.AsnDecoder:ParseNonNegativeInt(System.ReadOnlySpan`1[Byte]):int
         -12 (-2.03% of base) - System.IO.Compression.ZipArchive:TryReadZip64EndOfCentralDirectory(System.IO.Compression.ZipEndOfCentralDirectoryBlock,long):this
          -8 (-1.98% of base) - System.Text.Json.PooledByteBufferWriter:CheckAndResizeBuffer(int):this
          -8 (-1.98% of base) - System.Text.Json.PooledByteBufferWriter:CheckAndResizeBuffer(int):this
          -4 (-1.89% of base) - System.Reflection.Metadata.FieldDefinition:GetOffset():int:this
         -12 (-1.86% of base) - System.Numerics.BigInteger:GreatestCommonDivisor(System.Numerics.BigInteger,System.Numerics.BigInteger):System.Numerics.BigInteger
          -4 (-1.85% of base) - Newtonsoft.Json.Bson.BsonDataWriter:WriteValue(int):this
          -4 (-1.85% of base) - Newtonsoft.Json.Bson.BsonDataWriter:WriteValue(long):this
          -4 (-1.85% of base) - Newtonsoft.Json.Bson.BsonWriter:WriteValue(int):this
          -4 (-1.85% of base) - Newtonsoft.Json.Bson.BsonWriter:WriteValue(long):this
          -4 (-1.75% of base) - System.Collections.Generic.HashSet`1[Byte][System.Byte]:GetBucketRef(int):byref:this
          -4 (-1.75% of base) - System.Collections.Generic.Dictionary`2[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:GetBucket(int):byref:this

88 total methods with Code Size differences (88 improved, 0 regressed), 0 unchanged.

Running asm diffs of libraries_tests.pmi.Linux.arm64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 24320
Total bytes of diff: 24188
Total bytes of delta: -132 (-0.54% of base)
    diff is an improvement.


Top file improvements (bytes):
         -16 : 230811.dasm (-0.95% of base)
          -8 : 230794.dasm (-1.20% of base)
          -8 : 230824.dasm (-1.12% of base)
          -4 : 203707.dasm (-0.12% of base)
          -4 : 36538.dasm (-0.94% of base)
          -4 : 36559.dasm (-0.83% of base)
          -4 : 116817.dasm (-0.70% of base)
          -4 : 36496.dasm (-0.88% of base)
          -4 : 36525.dasm (-1.01% of base)
          -4 : 36532.dasm (-0.94% of base)
          -4 : 132814.dasm (-0.88% of base)
          -4 : 36501.dasm (-0.78% of base)
          -4 : 36531.dasm (-1.01% of base)
          -4 : 132875.dasm (-0.12% of base)
          -4 : 36526.dasm (-0.97% of base)
          -4 : 36560.dasm (-0.83% of base)
          -4 : 117401.dasm (-0.79% of base)
          -4 : 230748.dasm (-0.31% of base)
          -4 : 230833.dasm (-0.13% of base)
          -4 : 36489.dasm (-0.79% of base)

28 total files with Code Size differences (28 improved, 0 regressed), 2 unchanged.

Top method improvements (bytes):
         -16 (-0.95% of base) - System.Numerics.Tests.ComparisonTest:VerifyComparison(System.Numerics.BigInteger,int,int)
          -8 (-1.20% of base) - System.Numerics.Tests.cast_toTest:VerifyUInt32ImplicitCastToBigInteger(int)
          -8 (-1.12% of base) - System.Numerics.Tests.BigIntegerConstructorTest:VerifyCtorUInt32(int)
          -4 (-0.12% of base) - System.Data.SqlClient.TdsParser:TdsLogin(System.Data.SqlClient.SqlLogin,int,System.Data.SqlClient.SessionData,System.Nullable`1[FederatedAuthenticationFeatureExtensionData]):this
          -4 (-0.94% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedUIntToNullableInt(int,bool)
          -4 (-0.83% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableUIntToEnum(System.Nullable`1[UInt32],bool)
          -4 (-0.70% of base) - System.SpanTests.ReadOnlySpanTests:IndexOverflow()
          -4 (-0.88% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableULongToNullableLong(System.Nullable`1[UInt64],bool)
          -4 (-1.01% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedULongToEnumLong(long,bool)
          -4 (-0.94% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedUIntToNullableEnum(int,bool)
          -4 (-0.88% of base) - System.Data.SqlClient.TdsParser:LoadSSPILibrary():this
          -4 (-0.78% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableUIntToInt(System.Nullable`1[UInt32],bool)
          -4 (-1.01% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedUIntToEnum(int,bool)
          -4 (-0.12% of base) - System.Data.SqlClient.TdsParser:TdsLogin(System.Data.SqlClient.SqlLogin,int,System.Data.SqlClient.SessionData,System.Nullable`1[FederatedAuthenticationFeatureExtensionData]):this
          -4 (-0.97% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedULongToNullableEnumLong(long,bool)
          -4 (-0.83% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableUIntToNullableEnum(System.Nullable`1[UInt32],bool)
          -4 (-0.79% of base) - System.SpanTests.SpanTests:IndexOverflow()
          -4 (-0.31% of base) - System.Numerics.Tests.cast_fromTest:RunUInt32ExplicitCastFromBigIntegerTests()
          -4 (-0.13% of base) - System.Numerics.Tests.BigIntegerConstructorTest:RunCtorByteArrayTests()
          -4 (-0.79% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableULongToEnumLong(System.Nullable`1[UInt64],bool)

Top method improvements (percentages):
          -4 (-2.63% of base) - System.Numerics.Tests.cast_fromTest:VerifyUInt32ExplicitCastFromBigInteger(int)
          -8 (-1.20% of base) - System.Numerics.Tests.cast_toTest:VerifyUInt32ImplicitCastToBigInteger(int)
          -8 (-1.12% of base) - System.Numerics.Tests.BigIntegerConstructorTest:VerifyCtorUInt32(int)
          -4 (-1.01% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedULongToEnumLong(long,bool)
          -4 (-1.01% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedUIntToEnum(int,bool)
          -4 (-1.01% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedUIntToInt(int,bool)
          -4 (-1.01% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedULongToLong(long,bool)
          -4 (-0.97% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedULongToNullableEnumLong(long,bool)
          -4 (-0.97% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedULongToNullableLong(long,bool)
         -16 (-0.95% of base) - System.Numerics.Tests.ComparisonTest:VerifyComparison(System.Numerics.BigInteger,int,int)
          -4 (-0.94% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedUIntToNullableInt(int,bool)
          -4 (-0.94% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedUIntToNullableEnum(int,bool)
          -4 (-0.88% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableULongToNullableLong(System.Nullable`1[UInt64],bool)
          -4 (-0.88% of base) - System.Data.SqlClient.TdsParser:LoadSSPILibrary():this
          -4 (-0.85% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableULongToNullableEnumLong(System.Nullable`1[UInt64],bool)
          -4 (-0.83% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableUIntToNullableEnum(System.Nullable`1[UInt32],bool)
          -4 (-0.83% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableUIntToNullableInt(System.Nullable`1[UInt32],bool)
          -4 (-0.83% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableUIntToEnum(System.Nullable`1[UInt32],bool)
          -4 (-0.79% of base) - System.SpanTests.SpanTests:IndexOverflow()
          -4 (-0.79% of base) - System.Linq.Expressions.Tests.ConvertCheckedTests:VerifyCheckedNullableULongToEnumLong(System.Nullable`1[UInt64],bool)

28 total methods with Code Size differences (28 improved, 0 regressed), 2 unchanged.
```
</details>

<details>
<summary>Linux ARM</summary>

```
Running asm diffs of coreclr_tests.pmi.Linux.arm.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 94586
Total bytes of diff: 94188
Total bytes of delta: -398 (-0.42% of base)
    diff is an improvement.


Top file improvements (bytes):
         -32 : 233530.dasm (-0.08% of base)
         -32 : 227923.dasm (-0.08% of base)
         -12 : 250764.dasm (-1.00% of base)
         -10 : 246849.dasm (-0.69% of base)
          -6 : 109229.dasm (-3.66% of base)
          -6 : 14683.dasm (-3.19% of base)
          -6 : 152516.dasm (-3.66% of base)
          -6 : 182908.dasm (-3.19% of base)
          -6 : 202199.dasm (-3.66% of base)
          -6 : 254375.dasm (-9.68% of base)
          -6 : 43721.dasm (-3.66% of base)
          -6 : 115798.dasm (-3.19% of base)
          -6 : 11593.dasm (-3.19% of base)
          -6 : 181911.dasm (-3.19% of base)
          -6 : 194691.dasm (-3.19% of base)
          -6 : 208717.dasm (-3.19% of base)
          -6 : 58911.dasm (-3.19% of base)
          -6 : 9578.dasm (-3.19% of base)
          -6 : 109228.dasm (-3.19% of base)
          -6 : 14684.dasm (-3.66% of base)

58 total files with Code Size differences (58 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -32 (-0.08% of base) - ulongMDArrTest:Main():int
         -32 (-0.08% of base) - longMDArrTest:Main():int
         -12 (-1.00% of base) - Threading.Tests.OSThreadId:Main(System.String[]):int
         -10 (-0.69% of base) - AA:Static5(System.Double[],byref,byref,ushort,System.Boolean[][],byref,System.UInt32[][,,],long):System.SByte[,][]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.19% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[Int64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.19% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[Int64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-9.68% of base) - Program:I8_BT_mem_reg(byref,int):bool
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.19% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[Int64,Boolean]
          -6 (-3.19% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[Int64,Boolean]
          -6 (-3.19% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[Int64,Boolean]
          -6 (-3.19% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[Int64,Boolean]
          -6 (-3.19% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[Int64,Boolean]
          -6 (-3.19% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[Int64,Boolean]
          -6 (-3.19% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[Int64,Boolean]
          -6 (-3.19% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[Int64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]

Top method improvements (percentages):
          -6 (-9.68% of base) - Program:I8_BT_mem_reg(byref,int):bool
          -6 (-8.57% of base) - Program:I8_BT_reg_reg(long,int):bool
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]

58 total methods with Code Size differences (58 improved, 0 regressed), 0 unchanged.

Running asm diffs of libraries.crossgen.Linux.arm.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 90768
Total bytes of diff: 89722
Total bytes of delta: -1046 (-1.15% of base)
    diff is an improvement.


Top method regressions (bytes):
          48 ( 1.72% of base) - System.Uri:CheckAuthorityHelper(int,int,int,byref,byref,System.UriParser,byref):int:this

Top method improvements (bytes):
        -104 (-0.84% of base) - System.Reflection.Metadata.MetadataReader:InitializeTableReaders(System.Reflection.Internal.MemoryBlock,ubyte,System.Int32[],System.Int32[]):this
         -78 (-2.96% of base) - System.Uri:GetCanonicalPath(byref,int):this
         -38 (-1.91% of base) - System.Uri:GetUriPartsFromUserString(int):System.String:this
         -20 (-0.67% of base) - System.Globalization.TimeSpanFormat:TryFormatStandard(System.TimeSpan,int,System.String,System.Span`1[Char],byref):bool
         -20 (-7.58% of base) - System.Number:RightShiftWithRounding(long,int,bool):long
         -20 (-7.58% of base) - Microsoft.CodeAnalysis.RealParser:RightShiftWithRounding(long,int,bool):long
         -20 (-0.81% of base) - System.Buffers.Text.Utf8Formatter:TryFormat(System.TimeSpan,System.Span`1[Byte],byref,System.Buffers.StandardFormat):bool
         -18 (-2.18% of base) - System.Uri:ResolveHelper(System.Uri,System.Uri,byref,byref):System.Uri
         -16 (-1.03% of base) - Microsoft.VisualBasic.CompilerServices.Conversions:ToBoolean(System.Object):bool
         -14 (-5.98% of base) - System.Uri:GetEscapedParts(int):System.String:this
         -12 (-6.12% of base) - RangeUInt64@5422-2:System.Collections.IEnumerator.MoveNext():bool:this
         -12 (-4.51% of base) - System.Uri:CreateThisFromUri(System.Uri):this
         -12 (-4.05% of base) - System.Uri:TryCreate(System.Uri,System.Uri,byref):bool
         -12 (-2.29% of base) - BroadcastingSourceCore`1[__Canon,__Canon][System.__Canon,System.__Canon]:OfferToTargets():bool:this
         -12 (-1.92% of base) - System.Numerics.BigInteger:GreatestCommonDivisor(System.Numerics.BigInteger,System.Numerics.BigInteger):System.Numerics.BigInteger
         -12 (-1.20% of base) - System.Uri:Equals(System.Object):bool:this
         -12 (-10.00% of base) - System.Text.Json.BitStack:Pop():bool:this
         -12 (-3.61% of base) - System.Text.Json.Utf8JsonReader:EndObject():this
         -12 (-3.61% of base) - System.Text.Json.Utf8JsonReader:EndArray():this
         -12 (-7.50% of base) - System.Text.Json.Utf8JsonReader:UpdateBitStackOnEndToken():this

Top method regressions (percentages):
          48 ( 1.72% of base) - System.Uri:CheckAuthorityHelper(int,int,int,byref,byref,System.UriParser,byref):int:this

Top method improvements (percentages):
          -4 (-18.18% of base) - Microsoft.Extensions.Internal.ValueStopwatch:get_IsActive():bool:this
          -4 (-18.18% of base) - Microsoft.Extensions.Internal.ValueStopwatch:get_IsActive():bool:this
          -4 (-18.18% of base) - System.Threading.Tasks.Dataflow.DataflowMessageHeader:get_IsValid():bool:this
          -4 (-18.18% of base) - Microsoft.Extensions.Internal.ValueStopwatch:get_IsActive():bool:this
          -4 (-18.18% of base) - Microsoft.Extensions.Internal.ValueStopwatch:get_IsActive():bool:this
          -4 (-16.67% of base) - System.Threading.Tasks.Dataflow.WriteOnceBlock`1[__Canon][System.__Canon]:get_HasValue():bool:this
          -4 (-15.38% of base) - System.Threading.Tasks.Dataflow.WriteOnceBlock`1[__Canon][System.__Canon]:get_Value():System.__Canon:this
          -4 (-14.29% of base) - DebugView[__Canon][System.__Canon]:get_HasValue():bool:this
          -6 (-14.29% of base) - System.Xml.XmlReader:IsTextualNode(int):bool
          -6 (-13.64% of base) - System.Uri:StaticInFact(long,long):bool
          -6 (-13.04% of base) - System.Xml.XmlReader:CanReadContentAs(int):bool
          -6 (-13.04% of base) - System.Xml.XmlReader:HasValueInternal(int):bool
          -4 (-12.50% of base) - System.Uri:get_IsUncPath():bool:this
          -4 (-12.50% of base) - System.Uri:get_IsUnixPath():bool:this
          -4 (-12.50% of base) - System.Uri:get_IsDosPath():bool:this
          -4 (-12.50% of base) - System.Uri:get_UserEscaped():bool:this
          -4 (-12.50% of base) - System.Uri:get_IsImplicitFile():bool:this
          -4 (-12.50% of base) - System.Uri:get_IsUncOrDosPath():bool:this
          -4 (-12.50% of base) - System.Uri:get_UserDrivenParsing():bool:this
          -4 (-11.11% of base) - System.Xml.UniqueId:get_IsGuid():bool:this

161 total methods with Code Size differences (160 improved, 1 regressed), 1 unchanged.

Running asm diffs of libraries.crossgen2.Linux.arm.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 96846
Total bytes of diff: 95776
Total bytes of delta: -1070 (-1.10% of base)
    diff is an improvement.


Top method regressions (bytes):
          48 ( 1.72% of base) - System.Uri:CheckAuthorityHelper(int,int,int,byref,byref,System.UriParser,byref):int:this

Top method improvements (bytes):
        -104 (-0.83% of base) - System.Reflection.Metadata.MetadataReader:InitializeTableReaders(System.Reflection.Internal.MemoryBlock,ubyte,System.Int32[],System.Int32[]):this
         -78 (-2.88% of base) - System.Uri:GetCanonicalPath(byref,int):this
         -38 (-1.90% of base) - System.Uri:GetUriPartsFromUserString(int):System.String:this
         -20 (-7.58% of base) - Microsoft.CodeAnalysis.RealParser:RightShiftWithRounding(long,int,bool):long
         -20 (-0.81% of base) - System.Buffers.Text.Utf8Formatter:TryFormat(System.TimeSpan,System.Span`1[System.Byte],byref,System.Buffers.StandardFormat):bool
         -20 (-0.67% of base) - System.Globalization.TimeSpanFormat:TryFormatStandard(System.TimeSpan,int,System.String,System.Span`1[System.Char],byref):bool
         -20 (-7.58% of base) - System.Number:RightShiftWithRounding(long,int,bool):long
         -18 (-2.16% of base) - System.Uri:ResolveHelper(System.Uri,System.Uri,byref,byref):System.Uri
         -16 (-1.02% of base) - Microsoft.VisualBasic.CompilerServices.Conversions:ToBoolean(System.Object):bool
         -16 (-4.37% of base) - System.Text.Json.Utf8JsonReader:EndArray():this
         -16 (-4.37% of base) - System.Text.Json.Utf8JsonReader:EndObject():this
         -14 (-5.74% of base) - System.Uri:GetEscapedParts(int):System.String:this
         -12 (-6.12% of base) - RangeUInt64@5422-2:System.Collections.IEnumerator.MoveNext():bool:this
         -12 (-4.35% of base) - System.Uri:CreateThisFromUri(System.Uri):this
         -12 (-4.05% of base) - System.Uri:TryCreate(System.Uri,System.Uri,byref):bool
         -12 (-10.00% of base) - System.Text.Json.BitStack:Pop():bool:this
         -12 (-1.19% of base) - System.Uri:Equals(System.Object):bool:this
         -12 (-2.21% of base) - BroadcastingSourceCore`1:OfferToTargets():bool:this
         -12 (-4.84% of base) - System.Text.Json.Utf8JsonWriter:ValidateEnd(ubyte):this
         -12 (-7.50% of base) - System.Text.Json.Utf8JsonReader:UpdateBitStackOnEndToken():this

Top method regressions (percentages):
          48 ( 1.72% of base) - System.Uri:CheckAuthorityHelper(int,int,int,byref,byref,System.UriParser,byref):int:this

Top method improvements (percentages):
          -4 (-18.18% of base) - Microsoft.Extensions.Internal.ValueStopwatch:get_IsActive():bool:this
          -4 (-18.18% of base) - Microsoft.Extensions.Internal.ValueStopwatch:get_IsActive():bool:this
          -4 (-18.18% of base) - Microsoft.Extensions.Internal.ValueStopwatch:get_IsActive():bool:this
          -4 (-18.18% of base) - System.Threading.Tasks.Dataflow.DataflowMessageHeader:get_IsValid():bool:this
          -4 (-18.18% of base) - Microsoft.Extensions.Internal.ValueStopwatch:get_IsActive():bool:this
          -4 (-16.67% of base) - System.Threading.Tasks.Dataflow.WriteOnceBlock`1:get_HasValue():bool:this
          -4 (-15.38% of base) - System.Threading.Tasks.Dataflow.WriteOnceBlock`1:get_Value():System.__Canon:this
          -4 (-14.29% of base) - DebugView:get_HasValue():bool:this
          -6 (-14.29% of base) - System.Xml.XmlReader:IsTextualNode(int):bool
          -6 (-13.64% of base) - System.Uri:StaticInFact(long,long):bool
          -6 (-13.04% of base) - System.Xml.XmlReader:CanReadContentAs(int):bool
          -6 (-13.04% of base) - System.Xml.XmlReader:HasValueInternal(int):bool
          -4 (-12.50% of base) - System.Uri:get_IsImplicitFile():bool:this
          -4 (-12.50% of base) - System.Uri:get_UserDrivenParsing():bool:this
          -4 (-12.50% of base) - System.Uri:get_UserEscaped():bool:this
          -4 (-12.50% of base) - System.Uri:get_IsUncPath():bool:this
          -4 (-12.50% of base) - System.Uri:get_IsDosPath():bool:this
          -4 (-12.50% of base) - System.Uri:get_IsUncOrDosPath():bool:this
          -4 (-12.50% of base) - System.Uri:get_IsUnixPath():bool:this
          -4 (-11.11% of base) - System.Xml.UniqueId:get_IsGuid():bool:this

163 total methods with Code Size differences (162 improved, 1 regressed), 3 unchanged.

Running asm diffs of libraries.pmi.Linux.arm.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 152124
Total bytes of diff: 150494
Total bytes of delta: -1630 (-1.07% of base)
    diff is an improvement.


Top method regressions (bytes):
          86 ( 3.23% of base) - System.Uri:CheckAuthorityHelper(int,int,int,byref,byref,System.UriParser,byref):int:this

Top method improvements (bytes):
        -104 (-0.91% of base) - System.Reflection.Metadata.MetadataReader:InitializeTableReaders(System.Reflection.Internal.MemoryBlock,ubyte,System.Int32[],System.Int32[]):this
         -92 (-2.40% of base) - System.Uri:ReCreateParts(int,ushort,int):System.String:this
         -76 (-2.42% of base) - System.Uri:GetCanonicalPath(byref,int):this
         -38 (-1.49% of base) - System.Uri:GetUriPartsFromUserString(int):System.String:this
         -34 (-2.38% of base) - System.Uri:PrivateParseMinimal():int:this
         -30 (-3.17% of base) - System.Uri:InternalIsWellFormedOriginalString():bool:this
         -22 (-2.19% of base) - System.Uri:InitializeUri(int,int,byref):this
         -20 (-7.94% of base) - Microsoft.CodeAnalysis.RealParser:RightShiftWithRounding(long,int,bool):long
         -16 (-1.13% of base) - Microsoft.VisualBasic.CompilerServices.Conversions:ToBoolean(System.Object):bool
         -16 (-2.27% of base) - System.Uri:ResolveHelper(System.Uri,System.Uri,byref,byref):System.Uri
         -14 (-6.54% of base) - System.Uri:GetEscapedParts(int):System.String:this
         -12 (-3.70% of base) - System.Text.Json.Utf8JsonReader:EndArray():this
         -12 (-0.43% of base) - System.Security.Cryptography.ECDiffieHellmanOpenSsl:DeriveSecretAgreement(System.Security.Cryptography.ECDiffieHellmanPublicKey,System.Security.Cryptography.IncrementalHash):System.Byte[]:this
         -12 (-0.90% of base) - System.Linq.Expressions.Compiler.ILGen:EmitDecimal(System.Reflection.Emit.ILGenerator,System.Decimal)
         -12 (-6.45% of base) - System.Text.Json.Utf8JsonWriter:ValidateEnd(ubyte):this
         -12 (-7.69% of base) - System.Text.Json.Utf8JsonReader:UpdateBitStackOnEndToken():this
         -12 (-2.26% of base) - BroadcastingSourceCore`1[__Canon,Nullable`1][System.__Canon,System.Nullable`1[System.Int32]]:OfferToTargets():bool:this
         -12 (-0.43% of base) - ECDiffieHellmanOpenSsl:DeriveSecretAgreement(System.Security.Cryptography.ECDiffieHellmanPublicKey,System.Security.Cryptography.IncrementalHash):System.Byte[]:this
         -12 (-2.14% of base) - System.Numerics.BigInteger:GreatestCommonDivisor(System.Numerics.BigInteger,System.Numerics.BigInteger):System.Numerics.BigInteger
         -12 (-4.72% of base) - System.Uri:CreateThisFromUri(System.Uri):this

Top method regressions (percentages):
          86 ( 3.23% of base) - System.Uri:CheckAuthorityHelper(int,int,int,byref,byref,System.UriParser,byref):int:this

Top method improvements (percentages):
          -4 (-18.18% of base) - System.Threading.Tasks.Dataflow.DataflowMessageHeader:get_IsValid():bool:this
          -4 (-18.18% of base) - Microsoft.Extensions.Internal.ValueStopwatch:get_IsActive():bool:this
          -4 (-18.18% of base) - Microsoft.Extensions.Internal.ValueStopwatch:get_IsActive():bool:this
          -4 (-18.18% of base) - Microsoft.Extensions.Internal.ValueStopwatch:get_IsActive():bool:this
          -4 (-18.18% of base) - Microsoft.Extensions.Internal.ValueStopwatch:get_IsActive():bool:this
          -4 (-16.67% of base) - System.Threading.Tasks.Dataflow.WriteOnceBlock`1[Byte][System.Byte]:get_HasValue():bool:this
          -4 (-16.67% of base) - System.Threading.Tasks.Dataflow.WriteOnceBlock`1[__Canon][System.__Canon]:get_HasValue():bool:this
          -4 (-15.38% of base) - System.Threading.Tasks.Dataflow.WriteOnceBlock`1[Byte][System.Byte]:get_Value():ubyte:this
          -4 (-15.38% of base) - System.Threading.Tasks.Dataflow.WriteOnceBlock`1[__Canon][System.__Canon]:get_Value():System.__Canon:this
          -4 (-15.38% of base) - System.Threading.Tasks.Dataflow.WriteOnceBlock`1[Int32][System.Int32]:get_Value():int:this
          -8 (-15.38% of base) - System.Threading.Tasks.Dataflow.WriteOnceBlock`1[Vector`1][System.Numerics.Vector`1[System.Single]]:get_Value():System.Numerics.Vector`1[Single]:this
          -4 (-14.29% of base) - System.Threading.Tasks.Dataflow.WriteOnceBlock`1[Int16][System.Int16]:get_Value():short:this
          -4 (-14.29% of base) - DebugView[__Canon][System.__Canon]:get_HasValue():bool:this
          -4 (-14.29% of base) - DebugView[Byte][System.Byte]:get_HasValue():bool:this
          -6 (-14.29% of base) - System.Xml.XmlReader:IsTextualNode(int):bool
          -6 (-13.64% of base) - System.Uri:StaticInFact(long,long):bool
          -6 (-13.04% of base) - System.Xml.XmlReader:CanReadContentAs(int):bool
          -6 (-13.04% of base) - System.Xml.XmlReader:HasValueInternal(int):bool
          -4 (-12.50% of base) - System.Uri:get_IsUncOrDosPath():bool:this
          -4 (-12.50% of base) - System.Uri:get_IsDosPath():bool:this

275 total methods with Code Size differences (274 improved, 1 regressed), 1 unchanged.

Running asm diffs of libraries_tests.pmi.Linux.arm.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 71778
Total bytes of diff: 71204
Total bytes of delta: -574 (-0.80% of base)
    diff is an improvement.


Top file improvements (bytes):
         -48 : 18767.dasm (-3.95% of base)
         -30 : 213839.dasm (-9.09% of base)
         -24 : 19681.dasm (-0.99% of base)
         -24 : 18769.dasm (-1.60% of base)
         -16 : 131663.dasm (-0.91% of base)
         -12 : 19736.dasm (-0.57% of base)
         -12 : 13999.dasm (-10.71% of base)
         -12 : 179752.dasm (-0.42% of base)
         -12 : 18768.dasm (-1.23% of base)
         -12 : 19735.dasm (-0.73% of base)
         -10 : 106627.dasm (-2.05% of base)
         -10 : 264379.dasm (-1.10% of base)
         -10 : 38073.dasm (-0.68% of base)
         -10 : 127961.dasm (-2.05% of base)
         -10 : 40734.dasm (-7.94% of base)
          -8 : 223186.dasm (-0.79% of base)
          -8 : 249181.dasm (-0.57% of base)
          -8 : 131646.dasm (-1.12% of base)
          -8 : 224093.dasm (-2.30% of base)
          -8 : 131676.dasm (-1.03% of base)

84 total files with Code Size differences (84 improved, 0 regressed), 2 unchanged.

Top method improvements (bytes):
         -48 (-3.95% of base) - System.Text.Json.Tests.BitStackTests:SetResetFirstBit()
         -30 (-9.09% of base) - <>c:<get_UInt64TestSubtractions>b__125_1(long,long):System.Object[]:this
         -24 (-0.99% of base) - System.Text.Json.Tests.Utf8JsonWriterTests:ResetChangeOutputMode(bool,bool):this
         -24 (-1.60% of base) - System.Text.Json.Tests.BitStackTests:BitStackPushPopLarge(int)
         -16 (-0.91% of base) - System.Numerics.Tests.ComparisonTest:VerifyComparison(System.Numerics.BigInteger,int,int)
         -12 (-0.57% of base) - System.Text.Json.Tests.Utf8JsonWriterTests:ResetWithSameOutput(bool,bool):this
         -12 (-10.71% of base) - System.Text.Json.BitStack:Pop():bool:this
         -12 (-0.42% of base) - System.Reflection.Metadata.Tests.BlobReaderTests:ReadFromMemoryBlock():this
         -12 (-1.23% of base) - System.Text.Json.Tests.BitStackTests:BitStackPushPop(int)
         -12 (-0.73% of base) - System.Text.Json.Tests.Utf8JsonWriterTests:Reset(bool,bool):this
         -10 (-2.05% of base) - System.Data.SqlClient.SqlCachedBuffer:TryCreate(System.Data.SqlClient.SqlMetaDataPriv,System.Data.SqlClient.TdsParser,System.Data.SqlClient.TdsParserStateObject,byref):bool
         -10 (-1.10% of base) - System.Threading.Tasks.Dataflow.Tests.DataflowBlockExtensionsTests:TestDataflowMessageHeader():this
         -10 (-0.68% of base) - System.Runtime.Serialization.Formatters.Tests.EqualityExtensions:IsEqual(System.Uri,System.Uri,bool)
         -10 (-2.05% of base) - System.Data.SqlClient.SqlCachedBuffer:TryCreate(System.Data.SqlClient.SqlMetaDataPriv,System.Data.SqlClient.TdsParser,System.Data.SqlClient.TdsParserStateObject,byref):bool
         -10 (-7.94% of base) - Roslyn.Utilities.DecimalUtilities:GetBits(System.Decimal,byref,byref,byref,byref,byref)
          -8 (-0.79% of base) - Microsoft.VisualBasic.CompilerServices.Conversions:ToBoolean(System.Object):bool
          -8 (-0.57% of base) - System.IO.Tests.FileInfo_GetSetTimes:GetNonZeroNanoseconds():System.IO.FileInfo:this
          -8 (-1.12% of base) - System.Numerics.Tests.cast_toTest:VerifyUInt32ImplicitCastToBigInteger(int)
          -8 (-2.30% of base) - Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery.SyntaxTreeExtensions:IsFieldNameDeclarationContext(Microsoft.CodeAnalysis.SyntaxTree,int,Microsoft.CodeAnalysis.SyntaxToken,System.Threading.CancellationToken):bool
          -8 (-1.03% of base) - System.Numerics.Tests.BigIntegerConstructorTest:VerifyCtorUInt32(int)

Top method improvements (percentages):
          -6 (-23.08% of base) - Microsoft.CodeAnalysis.VisualBasic.Utilities.ModifierCollectionFacts:CouldApplyToOneOf(int):bool:this
          -4 (-15.38% of base) - <>c:<get_UInt64TestDivisions>b__105_2(<>f__AnonymousType0`2[UInt64,UInt64]):bool:this
          -6 (-15.00% of base) - HashBucket[__Canon,Nullable`1][System.__Canon,System.Nullable`1[System.Int32]]:IsInUse(int):bool:this
          -6 (-15.00% of base) - HashBucket[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:IsInUse(int):bool:this
         -12 (-10.71% of base) - System.Text.Json.BitStack:Pop():bool:this
          -4 (-9.52% of base) - System.Text.Unicode.UnicodeData:IsWhiteSpace(int):bool
          -6 (-9.09% of base) - Microsoft.CodeAnalysis.BitVector:IsTrue(long,int):bool
         -30 (-9.09% of base) - <>c:<get_UInt64TestSubtractions>b__125_1(long,long):System.Object[]:this
         -10 (-7.94% of base) - Roslyn.Utilities.DecimalUtilities:GetBits(System.Decimal,byref,byref,byref,byref,byref)
          -4 (-6.06% of base) - System.IO.Tests.FileInfo_GetSetTimes:HasNonZeroNanoseconds(System.DateTime):bool
          -4 (-4.88% of base) - Microsoft.Diagnostics.Runtime.DacInterface.CommonMethodTables:Validate():bool:this
         -48 (-3.95% of base) - System.Text.Json.Tests.BitStackTests:SetResetFirstBit()
          -6 (-3.61% of base) - Microsoft.CodeAnalysis.BitVector:get_Item(int):bool:this
          -6 (-3.33% of base) - CRC:make_crc_table()
          -6 (-3.33% of base) - CRC:make_crc_table()
          -4 (-3.17% of base) - System.Numerics.Tests.BitOperationsTests:BitOps_IsPow2_ulong(long,bool)
          -6 (-3.09% of base) - Roslyn.Utilities.ObjectReader:ReadBooleanArrayElements(System.Boolean[]):System.Boolean[]:this
          -4 (-3.03% of base) - Microsoft.Diagnostics.Runtime.DacInterface.SOSDac:GetAppDomainData(long,byref):bool:this
          -4 (-2.99% of base) - System.Numerics.Tests.cast_fromTest:VerifyUInt32ExplicitCastFromBigInteger(int)
          -4 (-2.41% of base) - TestTime:FromMilliseconds(System.DateTimeOffset,long):TestTime

84 total methods with Code Size differences (84 improved, 0 regressed), 2 unchanged.
```
</details>