### PR TITLE
Rename wasm/browser-bench sample to match others, so it gets built on CI

### DIFF
--- a/src/mono/sample/wasm/browser-bench/Makefile
+++ b/src/mono/sample/wasm/browser-bench/Makefile
@@ -6,6 +6,6 @@ ifneq ($(AOT),)
 override MSBUILD_ARGS+=/p:RunAOTCompilation=true
 endif
 
-PROJECT_NAME=Wasm.Browser.Sample.Bench.csproj
+PROJECT_NAME=Wasm.Browser.Bench.Sample.csproj
 
 run: run-browser

--- a/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
+++ b/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <_SampleProject>Wasm.Browser.Sample.Bench.csproj</_SampleProject>
+    <_SampleProject>Wasm.Browser.Bench.Sample.csproj</_SampleProject>
   </PropertyGroup>
 
   <Target Name="RunSample" DependsOnTargets="RunSampleWithBrowser" />

--- a/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
+++ b/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <WasmCopyAppZipToHelixTestDir Condition="'$(ArchiveTests)' == 'true'">true</WasmCopyAppZipToHelixTestDir>
     <WasmMainJSPath>runtime.js</WasmMainJSPath>
+    <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/mono/sample/wasm/browser-bench/index.html
+++ b/src/mono/sample/wasm/browser-bench/index.html
@@ -35,7 +35,7 @@
       };
 
       function yieldBench () {
-        let ret = BINDING.call_static_method("[Wasm.Browser.Sample.Bench] Sample.Test:RunBenchmark", []);
+        let ret = BINDING.call_static_method("[Wasm.Browser.Bench.Sample] Sample.Test:RunBenchmark", []);
         document.getElementById("out").innerHTML += ret;
         if (ret.length > 0) {
           document.getElementById("out").innerHTML += "<br>";


### PR DESCRIPTION
Radek found build issues with this sample due to which it is being built with system assemblies, instead of the in-tree ones (#54226).
Also, the same currently, has trimming errors, which are being worked around here. The issue is tracked at https://github.com/dotnet/runtime/issues/54227.

Radek:
```
Suppress the linker analysis in the browser-bench project until we can
use the new JsonSerializable attribute.

Context: #54227
Context: #54205
```