### PR TITLE
[wasm] Disable unsupported Stacktrace test, on AOT

### DIFF
--- a/src/libraries/System.Runtime.Extensions/tests/System/Environment.StackTrace.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Environment.StackTrace.cs
@@ -68,6 +68,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/51676", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
         public void StackTraceDoesNotStartWithInternalFrame()
         {
              string stackTrace = Environment.StackTrace;


### PR DESCRIPTION
```
[22:22:31] fail: [FAIL] System.Tests.EnvironmentStackTrace.StackTraceDoesNotStartWithInternalFrame
[22:22:31] info: System.NullReferenceException : Object reference not set to an instance of an object.
[22:22:31] info:    at System.Reflection.RuntimeMethodInfo.Invoke(Object , BindingFlags , Binder , Object[] , CultureInfo )
```

Issue: https://github.com/dotnet/runtime/issues/51676