### PR TITLE
Make `System.Net.Http.HPack.IntegerDecoder` a struct

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Http2/Hpack/HPackDecoder.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Http2/Hpack/HPackDecoder.cs
@@ -83,7 +83,7 @@ namespace System.Net.Http.HPack
         private readonly int _maxDynamicTableSize;
         private readonly int _maxHeadersLength;
         private readonly DynamicTable _dynamicTable;
-        private readonly IntegerDecoder _integerDecoder = new IntegerDecoder();
+        private IntegerDecoder _integerDecoder;
         private byte[] _stringOctets;
         private byte[] _headerNameOctets;
         private byte[] _headerValueOctets;

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Http2/Hpack/IntegerDecoder.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Http2/Hpack/IntegerDecoder.cs
@@ -6,7 +6,7 @@ using System.Numerics;
 
 namespace System.Net.Http.HPack
 {
-    internal sealed class IntegerDecoder
+    internal struct IntegerDecoder
     {
         private int _i;
         private int _m;

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/QPack/QPackDecoder.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/QPack/QPackDecoder.cs
@@ -123,7 +123,7 @@ namespace System.Net.Http.QPack
         private int _headerValueLength;
         private int _stringLength;
         private int _stringIndex;
-        private readonly IntegerDecoder _integerDecoder = new IntegerDecoder();
+        private IntegerDecoder _integerDecoder;
 
         private static ArrayPool<byte> Pool => ArrayPool<byte>.Shared;
 


### PR DESCRIPTION
# Description

`System.Net.Http.HPack.IntegerDecoder` is a mutable reference type containing two signed 32-bit integers. This PR makes it a struct, eliminating one small allocation per HTTP/2 or 3 connection and providing better locality. On 64-bit platforms the classes that use `IntegerDecoder` have no size difference while on 32-bit ones they will gain four additional bytes.

If it gets accepted, I will also file a corresponding PR on `aspnetcore`.

# Customer Impact

An allocation of 24/16 bytes per HTTP/2 or 3 connection, on 64/32-bit platforms.

# Regression

No

# Testing

N/A

# Risk

The risk is minimal; there is no behavior change. Future code should be careful to not store `IntegerDecoder` on a `readonly` field; existing uses were updated.
