### PR TITLE
Skip Split resolution for singledef

### DIFF
--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -7385,11 +7385,6 @@ void Compiler::lvaDumpEntry(unsigned lclNum, FrameLayoutState curState, size_t r
         printf(" HFA(%s) ", varTypeName(varDsc->GetHfaType()));
     }
 
-    if (varDsc->lvLiveInOutOfHndlr)
-    {
-        printf(" EH");
-    }
-
     if (varDsc->lvDoNotEnregister)
     {
         printf(" do-not-enreg[");
@@ -7479,6 +7474,10 @@ void Compiler::lvaDumpEntry(unsigned lclNum, FrameLayoutState curState, size_t r
     if (varDsc->lvLiveInOutOfHndlr)
     {
         printf(" EH-live");
+    }
+    if (varDsc->lvEhWriteThruCandidate)
+    {
+        printf(" single-def");
     }
 #ifndef TARGET_64BIT
     if (varDsc->lvStructDoubleAlign)

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -2021,6 +2021,7 @@ public:
 
     // True if this interval is associated with a lclVar that is written to memory at each definition.
     bool isWriteThru : 1;
+    bool isSingleDef : 1;
 
 #ifdef DEBUG
     unsigned int intervalIndex;


### PR DESCRIPTION
Prototype to skip the "Split" resolution if variable is a single-def.