### PR TITLE
Exclude experimental projects from source-build

### DIFF
--- a/src/coreclr/.nuget/coreclr-packages.proj
+++ b/src/coreclr/.nuget/coreclr-packages.proj
@@ -5,11 +5,14 @@
     <ProjectReference Include="dotnet-ilverify\dotnet-ilverify.pkgproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
+    <ProjectReference Include="ILCompiler.Reflection.ReadyToRun.Experimental\ILCompiler.Reflection.ReadyToRun.Experimental.pkgproj" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="Microsoft.NETCore.TestHost\Microsoft.NETCore.TestHost.proj" />
     <ProjectReference Include="Microsoft.NETCore.ILAsm\Microsoft.NETCore.ILAsm.proj" />
     <ProjectReference Include="Microsoft.NETCore.ILDAsm\Microsoft.NETCore.ILDAsm.proj" />
-    <ProjectReference Include="ILCompiler.Reflection.ReadyToRun.Experimental\ILCompiler.Reflection.ReadyToRun.Experimental.pkgproj" />
   </ItemGroup>
 
   <Import Project="versioning.targets" />


### PR DESCRIPTION
This integrates [this source-build patch](https://github.com/dotnet/runtime/pull/53294/files#diff-478288142ea2a479ba3669443f3d1f285c79229be423d745b2530c277d774834).

Related to https://github.com/dotnet/source-build/issues/2052