### PR TITLE
[CrossGen] Condition MibcArgs for source-build

### DIFF
--- a/src/coreclr/crossgen-corelib.proj
+++ b/src/coreclr/crossgen-corelib.proj
@@ -96,7 +96,8 @@
       <CrossGenDllCmd>$(CrossGenDllCmd) -o:$(CoreLibOutputPath)</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) -r:$([MSBuild]::NormalizePath('$(BinDir)', 'IL', '*.dll'))</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) --targetarch:$(TargetArchitecture)</CrossGenDllCmd>
-      <CrossGenDllCmd Condition="'$(UsingToolIbcOptimization)' != 'true' and '$(EnableNgenOptimization)' == 'true'">$(CrossGenDllCmd) -m:$(MergedMibcPath) --embed-pgo-data</CrossGenDllCmd>
+      <MibcArgs>@(OptimizationMibcFiles->'-m:$(MergedMibcPath)', ' ')</MibcArgs>
+      <CrossGenDllCmd Condition="'$(UsingToolIbcOptimization)' != 'true' and '$(EnableNgenOptimization)' == 'true'">$(CrossGenDllCmd) $(MibcArgs) --embed-pgo-data</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) -O</CrossGenDllCmd>
       <CrossGenDllCmd  Condition="'$(Configuration)' == 'Debug' or '$(Configuration)' == 'Checked'">$(CrossGenDllCmd) --verify-type-and-field-layout</CrossGenDllCmd>
       <CrossGenDllCmd>$(CrossGenDllCmd) $(CoreLibInputPath)</CrossGenDllCmd>


### PR DESCRIPTION
This integrates [this source-build patch](https://github.com/dotnet/runtime/pull/53294/files#diff-bf3e916014b9d055da59301a72b55b1b4adbd68e128a122eb6749d478b6fd6b6).

This is reverting this [change](https://github.com/dotnet/runtime/pull/50536/files#diff-c1a5c8175c3239289802166cc67bc704e8a0e282e7eba0f4de26fd0062d5fcf5L87) made in https://github.com/dotnet/runtime/pull/50536.  For source builds, there is no optimization data therefore the `MibcArgs` need to be excluded to avoid build errors.

Related to https://github.com/dotnet/source-build/issues/2052