### PR TITLE
[wasm] Fix browser-bench sample build

### DIFF
--- a/src/mono/sample/wasm/browser-bench/Wasm.Browser.Sample.Bench.csproj
+++ b/src/mono/sample/wasm/browser-bench/Wasm.Browser.Sample.Bench.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <WasmCopyAppZipToHelixTestDir Condition="'$(ArchiveTests)' == 'true'">true</WasmCopyAppZipToHelixTestDir>
     <WasmMainJSPath>runtime.js</WasmMainJSPath>
+    <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Suppress the linker analysis in the browser-bench project until we can
use the new `JsonSerializable` attribute.

Context: https://github.com/dotnet/runtime/issues/54227
Context: https://github.com/dotnet/runtime/pull/54205