### PR TITLE
[Android] Fix crash in startup when running below API Level 24

### DIFF
--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Ssl.cs
@@ -80,7 +80,7 @@ internal static partial class Interop
         {
             int ret = SSLStreamSetTargetHostImpl(sslHandle, targetHost);
             if (ret == UNSUPPORTED_API_LEVEL)
-                throw new PlatformNotSupportedException("The operation is not supported on this API level");
+                throw new PlatformNotSupportedException(SR.net_android_ssl_api_level_unsupported);
             else if (ret != SUCCESS)
                 throw new SslException();
         }

--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Ssl.cs
@@ -17,6 +17,8 @@ internal static partial class Interop
 {
     internal static partial class AndroidCrypto
     {
+        private const int UNSUPPORTED_API_LEVEL = 2;
+
         internal unsafe delegate PAL_SSLStreamStatus SSLReadCallback(byte* data, int* length);
         internal unsafe delegate void SSLWriteCallback(byte* data, int length);
 
@@ -77,7 +79,9 @@ internal static partial class Interop
             string targetHost)
         {
             int ret = SSLStreamSetTargetHostImpl(sslHandle, targetHost);
-            if (ret != SUCCESS)
+            if (ret == UNSUPPORTED_API_LEVEL)
+                throw new PlatformNotSupportedException("The operation is not supported on this API level");
+            else if (ret != SUCCESS)
                 throw new SslException();
         }
 

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -705,7 +705,6 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
     g_SSLParametersClass =                      GetClassGRef(env, "javax/net/ssl/SSLParameters");
     g_SSLParametersGetProtocols =               GetMethod(env, false,  g_SSLParametersClass, "getProtocols", "()[Ljava/lang/String;");
     g_SSLParametersSetApplicationProtocols =    GetOptionalMethod(env, false,  g_SSLParametersClass, "setApplicationProtocols", "([Ljava/lang/String;)V");
-    g_SSLParametersSetServerNames =             GetOptionalMethod(env, false,  g_SSLParametersClass, "setServerNames", "(Ljava/util/List;)V");
 
     g_sslCtxClass =                     GetClassGRef(env, "javax/net/ssl/SSLContext");
     g_sslCtxGetDefaultMethod =          GetMethod(env, true,  g_sslCtxClass, "getDefault", "()Ljavax/net/ssl/SSLContext;");
@@ -961,7 +960,8 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
     g_SNIHostName = GetOptionalClassGRef(env, "javax/net/ssl/SNIHostName");
     if (g_SNIHostName != NULL)
     {
-        g_SNIHostNameCtor = GetMethod(env, false, g_SNIHostName, "<init>", "(Ljava/lang/String;)V");
+        g_SNIHostNameCtor =                 GetMethod(env, false, g_SNIHostName, "<init>", "(Ljava/lang/String;)V");
+        g_SSLParametersSetServerNames =     GetOptionalMethod(env, false,  g_SSLParametersClass, "setServerNames", "(Ljava/util/List;)V");
     }
 
     g_SSLEngine =                       GetClassGRef(env, "javax/net/ssl/SSLEngine");

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -484,7 +484,6 @@ void ReleaseLRef(JNIEnv *env, jobject lref)
 ARGS_NON_NULL_ALL static bool TryGetClassGRef(JNIEnv *env, const char* name, jclass* out)
 {
     *out = NULL;
-    LOG_DEBUG("Finding %s class", name);
     jclass klass = (*env)->FindClass (env, name);
     if (klass == NULL)
         return false;
@@ -568,7 +567,6 @@ void SaveTo(uint8_t* src, uint8_t** dst, size_t len, bool overwrite)
 
 jmethodID GetMethod(JNIEnv *env, bool isStatic, jclass klass, const char* name, const char* sig)
 {
-    LOG_DEBUG("Finding %s method", name);
     jmethodID mid = isStatic ? (*env)->GetStaticMethodID(env, klass, name, sig) : (*env)->GetMethodID(env, klass, name, sig);
     abort_unless(mid != NULL, "method %s %s was not found", name, sig);
     return mid;
@@ -576,7 +574,6 @@ jmethodID GetMethod(JNIEnv *env, bool isStatic, jclass klass, const char* name, 
 
 jmethodID GetOptionalMethod(JNIEnv *env, bool isStatic, jclass klass, const char* name, const char* sig)
 {
-    LOG_DEBUG("Finding %s method", name);
     jmethodID mid = isStatic ? (*env)->GetStaticMethodID(env, klass, name, sig) : (*env)->GetMethodID(env, klass, name, sig);
     if (!mid) {
         LOG_INFO("optional method %s %s was not found", name, sig);
@@ -588,7 +585,6 @@ jmethodID GetOptionalMethod(JNIEnv *env, bool isStatic, jclass klass, const char
 
 jfieldID GetField(JNIEnv *env, bool isStatic, jclass klass, const char* name, const char* sig)
 {
-    LOG_DEBUG("Finding %s field", name);
     jfieldID fid = isStatic ? (*env)->GetStaticFieldID(env, klass, name, sig) : (*env)->GetFieldID(env, klass, name, sig);
     abort_unless(fid != NULL, "field %s %s was not found", name, sig);
     return fid;
@@ -709,7 +705,7 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
     g_SSLParametersClass =                      GetClassGRef(env, "javax/net/ssl/SSLParameters");
     g_SSLParametersGetProtocols =               GetMethod(env, false,  g_SSLParametersClass, "getProtocols", "()[Ljava/lang/String;");
     g_SSLParametersSetApplicationProtocols =    GetOptionalMethod(env, false,  g_SSLParametersClass, "setApplicationProtocols", "([Ljava/lang/String;)V");
-    g_SSLParametersSetServerNames =             GetMethod(env, false,  g_SSLParametersClass, "setServerNames", "(Ljava/util/List;)V");
+    g_SSLParametersSetServerNames =             GetOptionalMethod(env, false,  g_SSLParametersClass, "setServerNames", "(Ljava/util/List;)V");
 
     g_sslCtxClass =                     GetClassGRef(env, "javax/net/ssl/SSLContext");
     g_sslCtxGetDefaultMethod =          GetMethod(env, true,  g_sslCtxClass, "getDefault", "()Ljavax/net/ssl/SSLContext;");
@@ -961,8 +957,12 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
     g_KeyManagerFactoryInit =           GetMethod(env, false, g_KeyManagerFactory, "init", "(Ljava/security/KeyStore;[C)V");
     g_KeyManagerFactoryGetKeyManagers = GetMethod(env, false, g_KeyManagerFactory, "getKeyManagers", "()[Ljavax/net/ssl/KeyManager;");
 
-    g_SNIHostName =     GetClassGRef(env, "javax/net/ssl/SNIHostName");
-    g_SNIHostNameCtor = GetMethod(env, false, g_SNIHostName, "<init>", "(Ljava/lang/String;)V");
+    // Supported on API Level 24 and above
+    g_SNIHostName = GetOptionalClassGRef(env, "javax/net/ssl/SNIHostName");
+    if (g_SNIHostName != NULL)
+    {
+        g_SNIHostNameCtor = GetMethod(env, false, g_SNIHostName, "<init>", "(Ljava/lang/String;)V");
+    }
 
     g_SSLEngine =                       GetClassGRef(env, "javax/net/ssl/SSLEngine");
     g_SSLEngineBeginHandshake =         GetMethod(env, false, g_SSLEngine, "beginHandshake", "()V");

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_jni.h
@@ -10,6 +10,7 @@
 
 #define FAIL 0
 #define SUCCESS 1
+#define UNSUPPORTED_API_LEVEL  2
 #define INSUFFICIENT_BUFFER -1
 
 extern JavaVM* gJvm;

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_sslstream.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_sslstream.c
@@ -493,27 +493,21 @@ int32_t AndroidCryptoNative_SSLStreamSetTargetHost(SSLStream* sslStream, char* t
     // ArrayList<SNIServerName> nameList = new ArrayList<SNIServerName>();
     // SNIHostName hostName = new SNIHostName(targetHost);
     // nameList.add(hostName);
-    if (g_SNIHostName != NULL)
-    {
-        loc[hostStr] = make_java_string(env, targetHost);
-        loc[nameList] = (*env)->NewObject(env, g_ArrayListClass, g_ArrayListCtor);
-        ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
-        loc[hostName] = (*env)->NewObject(env, g_SNIHostName, g_SNIHostNameCtor, loc[hostStr]);
-        ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
-        (*env)->CallBooleanMethod(env, loc[nameList], g_ArrayListAdd, loc[hostName]);
-        ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
-    }
+    loc[hostStr] = make_java_string(env, targetHost);
+    loc[nameList] = (*env)->NewObject(env, g_ArrayListClass, g_ArrayListCtor);
+    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
+    loc[hostName] = (*env)->NewObject(env, g_SNIHostName, g_SNIHostNameCtor, loc[hostStr]);
+    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
+    (*env)->CallBooleanMethod(env, loc[nameList], g_ArrayListAdd, loc[hostName]);
+    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
 
     // SSLParameters params = sslEngine.getSSLParameters();
     // params.setServerNames(nameList);
     // sslEngine.setSSLParameters(params);
-    if (g_SSLParametersSetServerNames != NULL)
-    {
-        loc[params] = (*env)->CallObjectMethod(env, sslStream->sslEngine, g_SSLEngineGetSSLParameters);
-        ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
-        (*env)->CallVoidMethod(env, loc[params], g_SSLParametersSetServerNames, loc[nameList]);
-        (*env)->CallVoidMethod(env, sslStream->sslEngine, g_SSLEngineSetSSLParameters, loc[params]);
-    }
+    loc[params] = (*env)->CallObjectMethod(env, sslStream->sslEngine, g_SSLEngineGetSSLParameters);
+    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
+    (*env)->CallVoidMethod(env, loc[params], g_SSLParametersSetServerNames, loc[nameList]);
+    (*env)->CallVoidMethod(env, sslStream->sslEngine, g_SSLEngineSetSSLParameters, loc[params]);
 
     ret = SUCCESS;
 

--- a/src/libraries/System.Net.Security/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Security/src/Resources/Strings.resx
@@ -455,4 +455,7 @@
   <data name="net_ssl_renegotiate_data" xml:space="preserve">
     <value>Received data during renegotiation.</value>
   </data>
+  <data name="net_android_ssl_api_level_unsupported" xml:space="preserve">
+    <value>Setting an SNI hostname is not supported on this API level.</value>
+  </data>
 </root>


### PR DESCRIPTION
This change fixes a crash when running below API Level 24 due to SNIHostName and SSLParameters.setServerNames not being available.  We will now throw a PlatformNotSupportedException to make things a little more apparent.

Fixes https://github.com/dotnet/runtime/issues/54182