### PR TITLE
Fix packaging test use of Stream.Read

### DIFF
--- a/src/libraries/System.IO.Packaging/tests/Tests.cs
+++ b/src/libraries/System.IO.Packaging/tests/Tests.cs
@@ -3823,9 +3823,15 @@ namespace System.IO.Packaging.Tests
                         byte[] readBuffer = new byte[buffer.Length];
                         for (long i = 0; i < SizeInMb; i++)
                         {
-                            int actualRead = partStream.Read(readBuffer, 0, readBuffer.Length);
+                            int totalRead = 0;
+                            while (totalRead < readBuffer.Length)
+                            {
+                                int actualRead = partStream.Read(readBuffer, totalRead, readBuffer.Length - totalRead);
+                                Assert.InRange(actualRead, 1, readBuffer.Length - totalRead);
+                                totalRead += actualRead;
+                            }
 
-                            Assert.Equal(actualRead, readBuffer.Length);
+                            Assert.Equal(readBuffer.Length, totalRead);
                             Assert.True(buffer.AsSpan().SequenceEqual(readBuffer));
                         }
                     }


### PR DESCRIPTION
Read returning the number of bytes requested is not guaranteed.
Fix https://github.com/dotnet/runtime/issues/54208