### PR TITLE
[mono] Search for components using mono_dl_build_path

### DIFF
--- a/src/mono/mono/metadata/components.c
+++ b/src/mono/mono/metadata/components.c
@@ -140,14 +140,18 @@ try_load (const char* dir, const MonoComponentEntry *component, const char* comp
 {
 	MonoDl *lib = NULL;
 	char *path = NULL;
-	path = g_module_build_path (dir, component_base_lib);
-	if (path) {
+	void *iter = NULL;
+
+	while ((path = mono_dl_build_path (dir, component_base_lib, &iter))) {
 		char *error_msg = NULL;
 		lib = mono_dl_open (path, MONO_DL_EAGER | MONO_DL_LOCAL, &error_msg);
+		if (lib)
+			break;
 		if (!lib) {
 			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_DLLIMPORT, "Component %s not found: %s", component->name, error_msg);
 		}
 		g_free (error_msg);
+		g_free (path);
 	}
 	if (lib)
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_DLLIMPORT, "Component %s found at %s", component->name, path);


### PR DESCRIPTION
It knows how to try various combinations of prefixes and suffixes on various
platforms.  In particular it knows to look for .dylib files on Apple platforms.

Fixes iOS simulator component search