### PR TITLE
Remove uses of Rijndael from EncryptedXml where possible

### DIFF
--- a/src/libraries/System.Security.Cryptography.Xml/src/System.Security.Cryptography.Xml.csproj
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System.Security.Cryptography.Xml.csproj
@@ -6,8 +6,6 @@
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>
     <IsPartialFacadeAssembly Condition="'$(TargetFramework)' == 'net461'">true</IsPartialFacadeAssembly>
-    <!-- RijndaelManaged' is obsolete: 'The Rijndael and RijndaelManaged types are obsolete. Use Aes instead. https://github.com/dotnet/runtime/issues/54145. -->
-    <NoWarn Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">$(NoWarn);SYSLIB0022</NoWarn>
   </PropertyGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <Compile Include="System\Security\Cryptography\Xml\AncestralNamespaceContextManager.cs" />

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/EncryptedXml.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/EncryptedXml.cs
@@ -546,13 +546,13 @@ namespace System.Security.Cryptography.Xml
                 ek.KeyInfo.AddClause(new KeyInfoX509Data(certificate));
 
                 // Create a random AES session key and encrypt it with the public key associated with the certificate.
-                RijndaelManaged rijn = new RijndaelManaged();
-                ek.CipherData.CipherValue = EncryptedXml.EncryptKey(rijn.Key, rsaPublicKey, false);
+                Aes aes = Aes.Create();
+                ek.CipherData.CipherValue = EncryptedXml.EncryptKey(aes.Key, rsaPublicKey, false);
 
                 // Encrypt the input element with the random session key that we've created above.
                 KeyInfoEncryptedKey kek = new KeyInfoEncryptedKey(ek);
                 ed.KeyInfo.AddClause(kek);
-                ed.CipherData.CipherValue = EncryptData(inputElement, rijn, false);
+                ed.CipherData.CipherValue = EncryptData(inputElement, aes, false);
 
                 return ed;
             }
@@ -595,7 +595,9 @@ namespace System.Security.Cryptography.Xml
                 // CMS Triple DES Key Wrap
                 encryptionMethod = EncryptedXml.XmlEncTripleDESKeyWrapUrl;
             }
+#pragma warning disable SYSLIB0022 // Rijndael types are obsolete
             else if (symKey is Rijndael || symKey is Aes)
+#pragma warning restore SYSLIB0022
             {
                 // FIPS AES Key Wrap
                 switch (symKey.KeySize)
@@ -621,13 +623,13 @@ namespace System.Security.Cryptography.Xml
             ek.KeyInfo.AddClause(new KeyInfoName(keyName));
 
             // Create a random AES session key and encrypt it with the public key associated with the certificate.
-            RijndaelManaged rijn = new RijndaelManaged();
-            ek.CipherData.CipherValue = (symKey == null ? EncryptedXml.EncryptKey(rijn.Key, rsa, false) : EncryptedXml.EncryptKey(rijn.Key, symKey));
+            Aes aes = Aes.Create();
+            ek.CipherData.CipherValue = (symKey == null ? EncryptedXml.EncryptKey(aes.Key, rsa, false) : EncryptedXml.EncryptKey(aes.Key, symKey));
 
             // Encrypt the input element with the random session key that we've created above.
             KeyInfoEncryptedKey kek = new KeyInfoEncryptedKey(ek);
             ed.KeyInfo.AddClause(kek);
-            ed.CipherData.CipherValue = EncryptData(inputElement, rijn, false);
+            ed.CipherData.CipherValue = EncryptData(inputElement, aes, false);
 
             return ed;
         }
@@ -868,7 +870,9 @@ namespace System.Security.Cryptography.Xml
                 // CMS Triple DES Key Wrap
                 return SymmetricKeyWrap.TripleDESKeyWrapEncrypt(symmetricAlgorithm.Key, keyData);
             }
+#pragma warning disable SYSLIB0022 // Rijndael types are obsolete
             else if (symmetricAlgorithm is Rijndael || symmetricAlgorithm is Aes)
+#pragma warning restore SYSLIB0022
             {
                 // FIPS AES Key Wrap
                 return SymmetricKeyWrap.AESKeyWrapEncrypt(symmetricAlgorithm.Key, keyData);
@@ -912,7 +916,9 @@ namespace System.Security.Cryptography.Xml
                 // CMS Triple DES Key Wrap
                 return SymmetricKeyWrap.TripleDESKeyWrapDecrypt(symmetricAlgorithm.Key, keyData);
             }
+#pragma warning disable SYSLIB0022 // Rijndael types are obsolete
             else if (symmetricAlgorithm is Rijndael || symmetricAlgorithm is Aes)
+#pragma warning restore SYSLIB0022
             {
                 // FIPS AES Key Wrap
                 return SymmetricKeyWrap.AESKeyWrapDecrypt(symmetricAlgorithm.Key, keyData);

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/EncryptedXml.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/EncryptedXml.cs
@@ -546,13 +546,15 @@ namespace System.Security.Cryptography.Xml
                 ek.KeyInfo.AddClause(new KeyInfoX509Data(certificate));
 
                 // Create a random AES session key and encrypt it with the public key associated with the certificate.
-                Aes aes = Aes.Create();
-                ek.CipherData.CipherValue = EncryptedXml.EncryptKey(aes.Key, rsaPublicKey, false);
+                using (Aes aes = Aes.Create())
+                {
+                    ek.CipherData.CipherValue = EncryptedXml.EncryptKey(aes.Key, rsaPublicKey, false);
 
-                // Encrypt the input element with the random session key that we've created above.
-                KeyInfoEncryptedKey kek = new KeyInfoEncryptedKey(ek);
-                ed.KeyInfo.AddClause(kek);
-                ed.CipherData.CipherValue = EncryptData(inputElement, aes, false);
+                    // Encrypt the input element with the random session key that we've created above.
+                    KeyInfoEncryptedKey kek = new KeyInfoEncryptedKey(ek);
+                    ed.KeyInfo.AddClause(kek);
+                    ed.CipherData.CipherValue = EncryptData(inputElement, aes, false);
+                }
 
                 return ed;
             }
@@ -623,13 +625,15 @@ namespace System.Security.Cryptography.Xml
             ek.KeyInfo.AddClause(new KeyInfoName(keyName));
 
             // Create a random AES session key and encrypt it with the public key associated with the certificate.
-            Aes aes = Aes.Create();
-            ek.CipherData.CipherValue = (symKey == null ? EncryptedXml.EncryptKey(aes.Key, rsa, false) : EncryptedXml.EncryptKey(aes.Key, symKey));
+            using (Aes aes = Aes.Create())
+            {
+                ek.CipherData.CipherValue = (symKey == null ? EncryptedXml.EncryptKey(aes.Key, rsa, false) : EncryptedXml.EncryptKey(aes.Key, symKey));
 
-            // Encrypt the input element with the random session key that we've created above.
-            KeyInfoEncryptedKey kek = new KeyInfoEncryptedKey(ek);
-            ed.KeyInfo.AddClause(kek);
-            ed.CipherData.CipherValue = EncryptData(inputElement, aes, false);
+                // Encrypt the input element with the random session key that we've created above.
+                KeyInfoEncryptedKey kek = new KeyInfoEncryptedKey(ek);
+                ed.KeyInfo.AddClause(kek);
+                ed.CipherData.CipherValue = EncryptData(inputElement, aes, false);
+            }
 
             return ed;
         }


### PR DESCRIPTION
This removes uses of RijndaelManaged and replaces it with Aes since as of .NET Core, the Rijndael types were a simple shim to the AES types, anyway.

This removes the project-level warning ignore and adds targeted error supressions.

Closes #54145.