### PR TITLE
[draft] Update AppleAppBuilder to use dynamic components on iOSSimulator

### DIFF
--- a/src/mono/sample/iOS/Program.cs
+++ b/src/mono/sample/iOS/Program.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Runtime.InteropServices;
@@ -35,7 +36,8 @@ public static class Program
             delegate* unmanaged<void> unmanagedPtr = &OnButtonClick;
             ios_register_button_click(unmanagedPtr);
         }
-        const string msg = "Hello World!\n.NET 5.0";
+	var mi = typeof(System.Reflection.Metadata.AssemblyExtensions).GetMethod ("GetApplyUpdateCapabilities", BindingFlags.Static | BindingFlags.NonPublic);
+        string msg = string.Format("Hello World!\nC:<{0}>", mi == null ? "null method" : mi.Invoke(null, Array.Empty<object>()));
         for (int i = 0; i < msg.Length; i++)
         {
             // a kind of an animation

--- a/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
+++ b/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
@@ -231,8 +231,9 @@ public class AppleAppBuilderTask : Task
             generator.EnableRuntimeLogging = EnableRuntimeLogging;
             generator.DiagnosticPorts = DiagnosticPorts;
 
+            bool preferDylibs = !isDevice;
             XcodeProjectPath = generator.GenerateXCode(ProjectName, MainLibraryFileName, assemblerFiles, assemblerFilesToLink,
-                AppDir, binDir, MonoRuntimeHeaders, !isDevice, UseConsoleUITemplate, ForceAOT, ForceInterpreter, InvariantGlobalization, Optimized, RuntimeComponents, NativeMainSource);
+                                                       AppDir, binDir, MonoRuntimeHeaders, preferDylibs, UseConsoleUITemplate, ForceAOT, ForceInterpreter, InvariantGlobalization, Optimized, RuntimeComponents, NativeMainSource);
 
             if (BuildAppBundle)
             {

--- a/src/tasks/AppleAppBuilder/Templates/CMakeLists.txt.template
+++ b/src/tasks/AppleAppBuilder/Templates/CMakeLists.txt.template
@@ -66,4 +66,11 @@ target_link_libraries(
     "-lc++"
     "-liconv"
 %NativeLibrariesToLink%
+    "-L.."
+    "-lmonosgen-2.0"
+)
+
+add_custom_command(
+  TARGET %ProjectName% POST_BUILD
+  COMMAND install_name_tool -add_rpath @executable_path/. "$<TARGET_FILE:%ProjectName%>"
 )


### PR DESCRIPTION
WIP.

We want to load components dynamically.

One issue is that we _must_ link against a dynamic libmonosgen-2.0.dylib so that the components can resolve the mono symbols.  (It's possible there's some way to use `install_name_tool` to change the reference to `@rpath/libmonosgen-2.0dylib` to the app instead).

---

Currently this just drops all the component dylibs into the app bundle, but we should instead only copy the ones that are specified in the `RuntimeComponents` task property.