### PR TITLE
[release/5.0] Remove the sealed blittable layoutclass correctness fix because of backcompat.

### DIFF
--- a/src/coreclr/src/vm/classlayoutinfo.cpp
+++ b/src/coreclr/src/vm/classlayoutinfo.cpp
@@ -653,12 +653,8 @@ VOID EEClassLayoutInfo::CollectLayoutFieldMetadataThrowing(
         DEBUGARG(szName)
         );
 
-    // Type is blittable only if parent is also blittable and is not empty.
-    if (isBlittable && fHasNonTrivialParent)
-    {
-        isBlittable = pParentMT->IsBlittable()  // Check parent
-            && (!pParentLayoutInfo || !pParentLayoutInfo->IsZeroSized()); // Ensure non-zero size
-    }
+    // Type is blittable only if parent is also blittable
+    isBlittable = isBlittable && (fHasNonTrivialParent ? pParentMT->IsBlittable() : TRUE);
     pEEClassLayoutInfoOut->SetIsBlittable(isBlittable);
 
     S_UINT32 cbSortArraySize = S_UINT32(cTotalFields) * S_UINT32(sizeof(LayoutRawFieldInfo*));

--- a/src/coreclr/src/vm/mlinfo.cpp
+++ b/src/coreclr/src/vm/mlinfo.cpp
@@ -1231,8 +1231,6 @@ MarshalInfo::MarshalInfo(Module* pModule,
     m_pMT                           = NULL;
     m_pMD                           = pMD;
     m_onInstanceMethod              = onInstanceMethod;
-    // [Compat] For backward compatibility reasons, some marshalers imply [In, Out] behavior when marked as [In], [Out], or not marked with either.
-    BOOL byValAlwaysInOut           = FALSE;
 
 #ifdef FEATURE_COMINTEROP
     m_fDispItf                      = FALSE;
@@ -2009,7 +2007,6 @@ MarshalInfo::MarshalInfo(Module* pModule,
                     }
                     m_type = IsFieldScenario() ? MARSHAL_TYPE_BLITTABLE_LAYOUTCLASS : MARSHAL_TYPE_BLITTABLEPTR;
                     m_args.m_pMT = m_pMT;
-                    byValAlwaysInOut = TRUE;
                 }
                 else if (m_pMT->HasLayout())
                 {
@@ -2517,13 +2514,7 @@ lExit:
             }
         }
 
-        if (!m_byref && byValAlwaysInOut)
-        {
-            // Some marshalers expect [In, Out] behavior with [In], [Out], or no directional attributes.
-            m_in = TRUE;
-            m_out = TRUE;
-        }
-        else if (!m_in && !m_out)
+        if (!m_in && !m_out)
         {
             // If neither IN nor OUT are true, this signals the URT to use the default
             // rules.

--- a/src/tests/Interop/LayoutClass/LayoutClassNative.cpp
+++ b/src/tests/Interop/LayoutClass/LayoutClassNative.cpp
@@ -97,6 +97,12 @@ DLL_EXPORT BOOL STDMETHODCALLTYPE SimpleNestedLayoutClassByValue(NestedLayoutCla
 }
 
 extern "C"
+DLL_EXPORT BOOL STDMETHODCALLTYPE PointersEqual(void* ptr, void* ptr2)
+{
+    return ptr == ptr2 ? TRUE : FALSE;
+}
+
+extern "C"
 DLL_EXPORT void __cdecl Invalid(...)
 {
 }

--- a/src/tests/Interop/LayoutClass/LayoutClassTest.cs
+++ b/src/tests/Interop/LayoutClass/LayoutClassTest.cs
@@ -155,6 +155,12 @@ namespace PInvokeTests
         [DllImport("LayoutClassNative")]
         private static extern bool SimpleNestedLayoutClassByValue(NestedLayout p);
 
+        [DllImport("LayoutClassNative")]
+        private static extern bool PointersEqual(SealedBlittable obj, ref int field);
+
+        [DllImport("LayoutClassNative")]
+        private static extern bool PointersEqual(Blittable obj, ref int field);
+
         [DllImport("LayoutClassNative", EntryPoint = "Invalid")]
         private static extern void RecursiveNativeLayoutInvalid(RecursiveTestStruct str);
 
@@ -264,6 +270,20 @@ namespace PInvokeTests
             Assert.Throws<TypeLoadException>(() => RecursiveNativeLayoutInvalid(new RecursiveTestStruct()));
         }
 
+        public static void SealedBlittablePinned()
+        {
+            Console.WriteLine($"Running {nameof(SealedBlittablePinned)}...");
+            var blittable = new SealedBlittable(1);
+            Assert.IsTrue(PointersEqual(blittable, ref blittable.a));
+        }
+
+        public static void BlittablePinned()
+        {
+            Console.WriteLine($"Running {nameof(BlittablePinned)}...");
+            var blittable = new Blittable(1);
+            Assert.IsTrue(PointersEqual(blittable, ref blittable.a));
+        }
+
         public static int Main(string[] argv)
         {
             try
@@ -279,6 +299,8 @@ namespace PInvokeTests
                 SealedBlittableClassByOutAttr();
                 NestedLayoutClass();
                 RecursiveNativeLayout();
+                SealedBlittablePinned();
+                BlittablePinned();
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Port of #54235

## Customer Impact
Copying data for a non-sealed blittable layout class instead of pinning leads to a use-after-free bug of code on the native heap in NAudio on .NET 5.0.7.

NAudio pins the layoutclass object in managed code and uses the same memory address across multiple native calls. When the fix in #50882 changed the layoutclass marshaller to have some extra safety and not pass non-sealed blittable layout classes by pinning and instead allocate memory and copy, the assumption NAudio made around the object's native representation's address being constant while the managed object is pinned with a pinned GC handle became untrue.

## Testing
Testing added in PR.

Fix validated by users.

## Risk
Low. This puts our behavior fully 100% in line with 3.1 for our layout class marshalling with no observable differences in behavior for any scenario we know about. I know I said the same thing in https://github.com/dotnet/runtime/pull/50882, but at the time I did not realize that there was a mechanism to become dependent on the pinning optimization occurring outside of the data marshalling around the call (which #50882 included compat behavior to preserve).

## Regression
This is a regression introduced in https://github.com/dotnet/runtime/pull/50882
