### PR TITLE
Remove System.Drawing code that doesn't work

### DIFF
--- a/src/libraries/System.Drawing.Common/src/System/Drawing/macFunctions.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/macFunctions.cs
@@ -28,10 +28,8 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-#undef DEBUG_CLIPPING
 
 using System.Collections;
-using System.Reflection;
 using System.Runtime.InteropServices;
 
 namespace System.Drawing
@@ -40,31 +38,6 @@ namespace System.Drawing
     {
         internal static readonly Hashtable contextReference = new Hashtable();
         internal static readonly object lockobj = new object();
-        internal static readonly Delegate? hwnd_delegate = GetHwndDelegate();
-
-#if DEBUG_CLIPPING
-        internal static float red = 1.0f;
-        internal static float green = 0.0f;
-        internal static float blue = 0.0f;
-        internal static int debug_threshold = 1;
-#endif
-
-        private static Delegate? GetHwndDelegate()
-        {
-            foreach (Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
-            {
-                if (string.Equals(asm.GetName().Name, "System.Windows.Forms"))
-                {
-                    Type? driver_type = asm.GetType("System.Windows.Forms.XplatUICarbon");
-                    if (driver_type != null)
-                    {
-                        return (Delegate?)driver_type.GetField("HwndDelegate", BindingFlags.NonPublic | BindingFlags.Static)!.GetValue(null);
-                    }
-                }
-            }
-
-            return null;
-        }
 
         internal static CocoaContext GetCGContextForNSView(IntPtr handle)
         {
@@ -129,39 +102,10 @@ namespace System.Drawing
 
             CGContextSaveGState(context);
 
-            Rectangle[]? clip_rectangles = (Rectangle[]?)hwnd_delegate!.DynamicInvoke(new object[] { handle });
-            if (clip_rectangles != null && clip_rectangles.Length > 0)
-            {
-                int length = clip_rectangles.Length;
-
-                CGContextBeginPath(context);
-                CGContextAddRect(context, rc_clip);
-
-                for (int i = 0; i < length; i++)
-                {
-                    CGContextAddRect(context, new Rect(clip_rectangles[i].X, view_bounds.size.height - clip_rectangles[i].Y - clip_rectangles[i].Height, clip_rectangles[i].Width, clip_rectangles[i].Height));
-                }
-                CGContextClosePath(context);
-                CGContextEOClip(context);
-#if DEBUG_CLIPPING
-                if (clip_rectangles.Length >= debug_threshold) {
-                    CGContextSetRGBFillColor (context, red, green, blue, 0.5f);
-                    CGContextFillRect (context, rc_clip);
-                    CGContextFlush (context);
-                    System.Threading.Thread.Sleep (500);
-                    if (red == 1.0f) { red = 0.0f; blue = 1.0f; }
-                    else if (blue == 1.0f) { blue = 0.0f; green = 1.0f; }
-                    else if (green == 1.0f) { green = 0.0f; red = 1.0f; }
-                }
-#endif
-            }
-            else
-            {
-                CGContextBeginPath(context);
-                CGContextAddRect(context, rc_clip);
-                CGContextClosePath(context);
-                CGContextClip(context);
-            }
+            CGContextBeginPath(context);
+            CGContextAddRect(context, rc_clip);
+            CGContextClosePath(context);
+            CGContextClip(context);
 
             return new CarbonContext(port, context, (int)view_bounds.size.width, (int)view_bounds.size.height);
         }
@@ -285,13 +229,6 @@ namespace System.Drawing
         internal static extern void CGContextSaveGState(IntPtr context);
         [DllImport("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
         internal static extern void CGContextRestoreGState(IntPtr context);
-
-#if DEBUG_CLIPPING
-        [DllImport ("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern void CGContextSetRGBFillColor (IntPtr context, float red, float green, float blue, float alpha);
-        [DllImport ("/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon")]
-        internal static extern void CGContextFillRect (IntPtr context, Rect rect);
-#endif
     }
 
     internal struct CGSize


### PR DESCRIPTION
This code only runs on macOS, and expects mono's System.Windows.Forms assembly is loaded into the process. This is causing trim warnings, and it is easier just to delete this code than try to make ILLink happy.

This code is only called from Graphics.FromHwnd, which doesn't work because the Carbon.framework no longer exists on macOS. Issue https://github.com/dotnet/runtime/issues/22221 is tracking the test failures that use FromHwnd.

Tagging the mono runtime devs I think might be interested here: @lambdageek @vargaz @marek-safar @steveisok @lewing @SamMonoRT 