### PR TITLE
Allow restricting cultures creation with any arbitrary names in Globalization Invariant Mode

### DIFF
--- a/docs/workflow/trimming/feature-switches.md
+++ b/docs/workflow/trimming/feature-switches.md
@@ -13,7 +13,7 @@ configurations but their defaults might vary as any SDK can set the defaults dif
 | EnableUnsafeBinaryFormatterSerialization | System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization | BinaryFormatter serialization support is trimmed when set to false |
 | EventSourceSupport | System.Diagnostics.Tracing.EventSource.IsSupported | Any EventSource related code or logic is trimmed when set to false |
 | InvariantGlobalization | System.Globalization.Invariant | All globalization specific code and data is trimmed when set to true |
-| PredefinedCulturesOnly | System.Globalization.PredefinedCulturesOnly |  Don't allow creating a made-up cultures when the platform does not carry data for it |
+| PredefinedCulturesOnly | System.Globalization.PredefinedCulturesOnly |  Don't allow creating a culture for which the platform does not have data |
 | UseSystemResourceKeys | System.Resources.UseSystemResourceKeys |  Any localizable resources for system assemblies is trimmed when set to true |
 | HttpActivityPropagationSupport | System.Net.Http.EnableActivityPropagation | Any dependency related to diagnostics support for System.Net.Http is trimmed when set to false |
 | UseNativeHttpHandler | System.Net.Http.UseNativeHttpHandler | HttpClient uses by default platform native implementation of HttpMessageHandler if set to true. |

--- a/docs/workflow/trimming/feature-switches.md
+++ b/docs/workflow/trimming/feature-switches.md
@@ -13,6 +13,7 @@ configurations but their defaults might vary as any SDK can set the defaults dif
 | EnableUnsafeBinaryFormatterSerialization | System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization | BinaryFormatter serialization support is trimmed when set to false |
 | EventSourceSupport | System.Diagnostics.Tracing.EventSource.IsSupported | Any EventSource related code or logic is trimmed when set to false |
 | InvariantGlobalization | System.Globalization.Invariant | All globalization specific code and data is trimmed when set to true |
+| PredefinedCulturesOnly | System.Globalization.PredefinedCulturesOnly |  Don't allow creating a made-up cultures when the platform does not carry data for it |
 | UseSystemResourceKeys | System.Resources.UseSystemResourceKeys |  Any localizable resources for system assemblies is trimmed when set to true |
 | HttpActivityPropagationSupport | System.Net.Http.EnableActivityPropagation | Any dependency related to diagnostics support for System.Net.Http is trimmed when set to false |
 | UseNativeHttpHandler | System.Net.Http.UseNativeHttpHandler | HttpClient uses by default platform native implementation of HttpMessageHandler if set to true. |

--- a/src/libraries/System.Globalization/tests/CultureInfo/GetCultureInfo.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/GetCultureInfo.cs
@@ -153,8 +153,15 @@ namespace System.Globalization.Tests
             var psi = new ProcessStartInfo();
             psi.Environment.Clear();
 
-            if (enableInvariant)     { psi.Environment.Add("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "true"); }
-            if (declarePredefinedCulturesOnly) { psi.Environment.Add("DOTNET_SYSTEM_GLOBALIZATION_PREDEFINED_CULTURES_ONLY", predefinedCulturesOnly ? "true" : "false"); }
+            if (enableInvariant)
+            {
+                psi.Environment.Add("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "true");
+            }
+
+            if (declarePredefinedCulturesOnly)
+            {
+                psi.Environment.Add("DOTNET_SYSTEM_GLOBALIZATION_PREDEFINED_CULTURES_ONLY", predefinedCulturesOnly ? "true" : "false");
+            }
 
             bool restricted = enableInvariant && (declarePredefinedCulturesOnly ? predefinedCulturesOnly : true);
 

--- a/src/libraries/System.Globalization/tests/CultureInfo/GetCultureInfo.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/GetCultureInfo.cs
@@ -154,11 +154,11 @@ namespace System.Globalization.Tests
             if (enableInvariant)     { psi.Environment.Add("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT",              "true"); }
             if (enableInvariantOnly) { psi.Environment.Add("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT_CULTURE_ONLY", "true"); }
 
-            RemoteExecutor.Invoke((invarintEnabled, invariantOnlyEnabled) =>
+            RemoteExecutor.Invoke((invariantEnabled, invariantOnlyEnabled) =>
             {
-                bool restrictedMode = bool.Parse(invarintEnabled) && bool.Parse(invariantOnlyEnabled);
+                bool restrictedMode = bool.Parse(invariantEnabled) && bool.Parse(invariantOnlyEnabled);
 
-                // First ensure we can create the current cultures regaldless of the mode we are in
+                // First ensure we can create the current cultures regardless of the mode we are in
                 Assert.NotNull(CultureInfo.CurrentCulture);
                 Assert.NotNull(CultureInfo.CurrentUICulture);
 

--- a/src/libraries/System.Globalization/tests/CultureInfo/GetCultureInfo.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/GetCultureInfo.cs
@@ -193,6 +193,15 @@ namespace System.Globalization.Tests
                     Assert.Equal("en", new CultureInfo("en").Name);
                     Assert.Equal("es", new CultureInfo("es").Name);
                 }
+
+                // Ensure the Invariant Mode functionality still work
+                if (bool.Parse(invariantEnabled))
+                {
+                    Assert.True(CultureInfo.CurrentCulture.Calendar is GregorianCalendar);
+                    Assert.True("abcd".Equals("ABCD", StringComparison.CurrentCultureIgnoreCase));
+                    Assert.Equal("Invariant Language (Invariant Country)", CultureInfo.CurrentCulture.NativeName);
+                }
+
             }, enableInvariant.ToString(), enableInvariantOnly.ToString(), new RemoteInvokeOptions { StartInfo = psi }).Dispose();
         }
     }

--- a/src/libraries/System.Globalization/tests/Invariant/InvariantMode.cs
+++ b/src/libraries/System.Globalization/tests/Invariant/InvariantMode.cs
@@ -14,7 +14,7 @@ namespace System.Globalization.Tests
 {
     public class InvariantModeTests
     {
-        private static bool PredefinedCulturesOnlyIsDisabled => !PredefinedCulturesOnly();
+        private static bool PredefinedCulturesOnlyIsDisabled { get; } = !PredefinedCulturesOnly();
         private static bool PredefinedCulturesOnly()
         {
             bool ret;

--- a/src/libraries/System.Globalization/tests/Invariant/InvariantMode.cs
+++ b/src/libraries/System.Globalization/tests/Invariant/InvariantMode.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Reflection;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
@@ -13,6 +14,23 @@ namespace System.Globalization.Tests
 {
     public class InvariantModeTests
     {
+        private static bool PredefinedCulturesOnlyIsDisabled => !PredefinedCulturesOnly();
+        private static bool PredefinedCulturesOnly()
+        {
+            bool ret;
+
+            try
+            {
+                ret = (bool) typeof(object).Assembly.GetType("System.Globalization.GlobalizationMode").GetProperty("PredefinedCulturesOnly", BindingFlags.Static | BindingFlags.NonPublic).GetValue(null);
+            }
+            catch
+            {
+                ret = false;
+            }
+
+            return ret;
+        }
+
         public static IEnumerable<object[]> Cultures_TestData()
         {
             yield return new object[] { "en-US" };
@@ -490,13 +508,13 @@ namespace System.Globalization.Tests
             yield return new object[] { "xn--de-jg4avhby1noc0d", 0, 21, "\u30D1\u30D5\u30A3\u30FC\u0064\u0065\u30EB\u30F3\u30D0" };
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PredefinedCulturesOnlyIsDisabled))]
         public static void IcuShouldNotBeLoaded()
         {
             Assert.False(PlatformDetection.IsIcuGlobalization);
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(PredefinedCulturesOnlyIsDisabled))]
         [MemberData(nameof(Cultures_TestData))]
         public void TestCultureData(string cultureName)
         {
@@ -636,7 +654,7 @@ namespace System.Globalization.Tests
             Assert.True(cultureName.Equals(ci.CompareInfo.Name, StringComparison.OrdinalIgnoreCase));
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(PredefinedCulturesOnlyIsDisabled))]
         [MemberData(nameof(Cultures_TestData))]
         public void SetCultureData(string cultureName)
         {
@@ -652,13 +670,13 @@ namespace System.Globalization.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => ci.DateTimeFormat.Calendar = new TaiwanCalendar());
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PredefinedCulturesOnlyIsDisabled))]
         public void TestEnum()
         {
             Assert.Equal(new CultureInfo[1] { CultureInfo.InvariantCulture }, CultureInfo.GetCultures(CultureTypes.AllCultures));
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(PredefinedCulturesOnlyIsDisabled))]
         [MemberData(nameof(Cultures_TestData))]
         public void TestSortVersion(string cultureName)
         {
@@ -670,7 +688,7 @@ namespace System.Globalization.Tests
             Assert.Equal(version, new CultureInfo(cultureName).CompareInfo.Version);
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(PredefinedCulturesOnlyIsDisabled))]
         [InlineData(0, 0)]
         [InlineData(1, 2)]
         [InlineData(100_000, 200_000)]
@@ -683,7 +701,7 @@ namespace System.Globalization.Tests
             Assert.Equal(expectedSortKeyLength, CultureInfo.InvariantCulture.CompareInfo.GetSortKeyLength(dummySpan));
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(PredefinedCulturesOnlyIsDisabled))]
         [InlineData(0x4000_0000)]
         [InlineData(int.MaxValue)]
         public unsafe void TestGetSortKeyLength_OverlongArgument(int inputLength)
@@ -698,7 +716,7 @@ namespace System.Globalization.Tests
             });
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(PredefinedCulturesOnlyIsDisabled))]
         [InlineData("Hello", CompareOptions.None, "Hello")]
         [InlineData("Hello", CompareOptions.IgnoreWidth, "Hello")]
         [InlineData("Hello", CompareOptions.IgnoreCase, "HELLO")]
@@ -741,7 +759,7 @@ namespace System.Globalization.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PredefinedCulturesOnlyIsDisabled))]
         public void TestSortKey_ZeroWeightCodePoints()
         {
             // In the invariant globalization mode, there's no such thing as a zero-weight code point,
@@ -753,7 +771,7 @@ namespace System.Globalization.Tests
             Assert.NotEqual(0, SortKey.Compare(sortKeyForEmptyString, sortKeyForZeroWidthJoiner));
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(PredefinedCulturesOnlyIsDisabled))]
         [InlineData("", "", 0)]
         [InlineData("", "not-empty", -1)]
         [InlineData("not-empty", "", 1)]
@@ -794,7 +812,7 @@ namespace System.Globalization.Tests
             return sc;
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(PredefinedCulturesOnlyIsDisabled))]
         [MemberData(nameof(IndexOf_TestData))]
         public void TestIndexOf(string source, string value, int startIndex, int count, CompareOptions options, int result)
         {
@@ -841,7 +859,7 @@ namespace System.Globalization.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(PredefinedCulturesOnlyIsDisabled))]
         [MemberData(nameof(LastIndexOf_TestData))]
         public void TestLastIndexOf(string source, string value, int startIndex, int count, CompareOptions options, int result)
         {
@@ -901,7 +919,7 @@ namespace System.Globalization.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(PredefinedCulturesOnlyIsDisabled))]
         [MemberData(nameof(IsPrefix_TestData))]
         public void TestIsPrefix(string source, string value, CompareOptions options, bool result)
         {
@@ -936,7 +954,7 @@ namespace System.Globalization.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(PredefinedCulturesOnlyIsDisabled))]
         [MemberData(nameof(IsSuffix_TestData))]
         public void TestIsSuffix(string source, string value, CompareOptions options, bool result)
         {
@@ -971,7 +989,7 @@ namespace System.Globalization.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(PredefinedCulturesOnlyIsDisabled))]
         [InlineData("", false)]
         [InlineData('x', true)]
         [InlineData('\ud800', true)] // standalone high surrogate
@@ -988,7 +1006,7 @@ namespace System.Globalization.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(PredefinedCulturesOnlyIsDisabled))]
         [MemberData(nameof(Compare_TestData))]
         public void TestCompare(string source, string value, CompareOptions options, int result)
         {
@@ -1019,7 +1037,7 @@ namespace System.Globalization.Tests
         }
 
 
-        [Theory]
+        [ConditionalTheory(nameof(PredefinedCulturesOnlyIsDisabled))]
         [MemberData(nameof(ToLower_TestData))]
         public void TestToLower(string upper, string lower, bool result)
         {
@@ -1030,7 +1048,7 @@ namespace System.Globalization.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(PredefinedCulturesOnlyIsDisabled))]
         [MemberData(nameof(ToUpper_TestData))]
         public void TestToUpper(string lower, string upper, bool result)
         {
@@ -1041,7 +1059,7 @@ namespace System.Globalization.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(PredefinedCulturesOnlyIsDisabled))]
         [InlineData("", NormalizationForm.FormC)]
         [InlineData("\uFB01", NormalizationForm.FormC)]
         [InlineData("\uFB01", NormalizationForm.FormD)]
@@ -1063,7 +1081,7 @@ namespace System.Globalization.Tests
             Assert.Equal(s, s.Normalize(form));
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(PredefinedCulturesOnlyIsDisabled))]
         [MemberData(nameof(GetAscii_TestData))]
         public void GetAscii(string unicode, int index, int count, string expected)
         {
@@ -1078,7 +1096,7 @@ namespace System.Globalization.Tests
             Assert.Equal(expected, new IdnMapping().GetAscii(unicode, index, count));
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(PredefinedCulturesOnlyIsDisabled))]
         [MemberData(nameof(GetUnicode_TestData))]
         public void GetUnicode(string ascii, int index, int count, string expected)
         {
@@ -1093,7 +1111,7 @@ namespace System.Globalization.Tests
             Assert.Equal(expected, new IdnMapping().GetUnicode(ascii, index, count));
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PredefinedCulturesOnlyIsDisabled))]
         public void TestHashing()
         {
             StringComparer cultureComparer = StringComparer.Create(CultureInfo.GetCultureInfo("tr-TR"), true);
@@ -1102,7 +1120,7 @@ namespace System.Globalization.Tests
             Assert.Equal(ordinalComparer.GetHashCode(turkishString), cultureComparer.GetHashCode(turkishString));
         }
 
-        [Theory]
+        [ConditionalTheory(nameof(PredefinedCulturesOnlyIsDisabled))]
         [InlineData('a', 'A', 'a')]
         [InlineData('A', 'A', 'a')]
         [InlineData('i', 'I', 'i')] // to verify that we don't special-case the Turkish I in the invariant globalization mode
@@ -1121,7 +1139,7 @@ namespace System.Globalization.Tests
             Assert.Equal(expectedToLower, Rune.ToLower(originalRune, CultureInfo.GetCultureInfo("tr-TR")).Value);
         }
 
-        [Fact]
+        [ConditionalFact(nameof(PredefinedCulturesOnlyIsDisabled))]
         public void TestGetCultureInfo_PredefinedOnly_ReturnsSame()
         {
             Assert.Equal(CultureInfo.GetCultureInfo("en-US"), CultureInfo.GetCultureInfo("en-US", predefinedOnly: true));

--- a/src/libraries/System.Globalization/tests/Invariant/runtimeconfig.template.json
+++ b/src/libraries/System.Globalization/tests/Invariant/runtimeconfig.template.json
@@ -1,5 +1,6 @@
 {
   "configProperties": {
-    "System.Globalization.Invariant": true
+    "System.Globalization.Invariant": true,
+    "System.Globalization.PredefinedCulturesOnly": false
   }
 }

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.Shared.xml
@@ -10,6 +10,7 @@
          to be trimmed when Invariant=true, and allows for the Settings static cctor (on Unix) to be preserved when Invariant=false. -->
     <type fullname="System.Globalization.GlobalizationMode">
       <method signature="System.Boolean get_Invariant()" body="stub" value="true" feature="System.Globalization.Invariant" featurevalue="true" />
+      <method signature="System.Boolean get_PredefinedCulturesOnly()" body="stub" value="true" feature="System.Globalization.PredefinedCulturesOnly" featurevalue="true" />
     </type>
     <type fullname="System.Globalization.GlobalizationMode/Settings">
       <method signature="System.Boolean get_Invariant()" body="stub" value="false" feature="System.Globalization.Invariant" featurevalue="false" />

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -957,6 +957,9 @@
   <data name="Argument_CultureNotSupported" xml:space="preserve">
     <value>Culture is not supported.</value>
   </data>
+  <data name="Argument_CultureNotSupportedInInvariantMode" xml:space="preserve">
+    <value>Globalization Invariant mode is enabled which limit the cultures that can be created. Either turn off the Invariant mode or use only the Invariant culture. Consult the link https://aka.ms/GlobalizationInvariantMode for more information.</value>
+  </data>
   <data name="Argument_CustomAssemblyLoadContextRequestedNameMismatch" xml:space="preserve">
     <value>Resolved assembly's simple name should be the same as of the requested assembly.</value>
   </data>

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -958,7 +958,7 @@
     <value>Culture is not supported.</value>
   </data>
   <data name="Argument_CultureNotSupportedInInvariantMode" xml:space="preserve">
-    <value>Globalization Invariant mode is enabled which limit the cultures that can be created. Either turn off the Invariant mode or use only the Invariant culture. Consult the link https://aka.ms/GlobalizationInvariantMode for more information.</value>
+    <value>Only the invariant culture is supported in globalization-invariant mode. See https://aka.ms/GlobalizationInvariantMode for more information.</value>
   </data>
   <data name="Argument_CustomAssemblyLoadContextRequestedNameMismatch" xml:space="preserve">
     <value>Resolved assembly's simple name should be the same as of the requested assembly.</value>

--- a/src/libraries/System.Private.CoreLib/src/System/AppContextConfigHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContextConfigHelper.cs
@@ -10,15 +10,12 @@ namespace System
         internal static bool GetBooleanConfig(string configName, bool defaultValue) =>
             AppContext.TryGetSwitch(configName, out bool value) ? value : defaultValue;
 
-        internal static bool GetBooleanConfig(string switchName, string envVariable)
+        internal static bool GetBooleanConfig(string switchName, string envVariable, bool defaultValue = false)
         {
             if (!AppContext.TryGetSwitch(switchName, out bool ret))
             {
                 string? switchValue = Environment.GetEnvironmentVariable(envVariable);
-                if (switchValue != null)
-                {
-                    ret = bool.IsTrueStringIgnoreCase(switchValue) || switchValue.Equals("1");
-                }
+                ret = switchValue != null ? (bool.IsTrueStringIgnoreCase(switchValue) || switchValue.Equals("1")) : defaultValue;
             }
 
             return ret;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -669,7 +669,7 @@ namespace System.Globalization
                 return CultureData.Invariant;
             }
 
-            if (GlobalizationMode.AllowInvariantCultureOnly)
+            if (GlobalizationMode.Invariant && GlobalizationMode.PredefinedCulturesOnly)
             {
                 return null;
             }
@@ -870,7 +870,7 @@ namespace System.Globalization
             if (GlobalizationMode.Invariant)
             {
                 // LCID is not supported in the InvariantMode
-                throw new CultureNotFoundException(nameof(culture), culture, SR.Argument_CultureNotSupported);
+                throw new CultureNotFoundException(nameof(culture), culture, SR.Argument_CultureNotSupportedInInvariantMode);
             }
 
             // Convert the lcid to a name, then use that

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -669,6 +669,11 @@ namespace System.Globalization
                 return CultureData.Invariant;
             }
 
+            if (GlobalizationMode.AllowInvariantCultureOnly)
+            {
+                return null;
+            }
+
             if (GlobalizationMode.PredefinedCulturesOnly)
             {
                 Debug.Assert(!GlobalizationMode.Invariant);

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -669,15 +669,9 @@ namespace System.Globalization
                 return CultureData.Invariant;
             }
 
-            if (GlobalizationMode.Invariant && GlobalizationMode.PredefinedCulturesOnly)
-            {
-                return null;
-            }
-
             if (GlobalizationMode.PredefinedCulturesOnly)
             {
-                Debug.Assert(!GlobalizationMode.Invariant);
-                if (GlobalizationMode.UseNls ? !NlsIsEnsurePredefinedLocaleName(cultureName): !IcuIsEnsurePredefinedLocaleName(cultureName))
+                if (GlobalizationMode.Invariant || (GlobalizationMode.UseNls ? !NlsIsEnsurePredefinedLocaleName(cultureName): !IcuIsEnsurePredefinedLocaleName(cultureName)))
                     return null;
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
@@ -174,7 +174,7 @@ namespace System.Globalization
 
             if (cultureData == null)
             {
-                throw new CultureNotFoundException(nameof(name), name, SR.Argument_CultureNotSupported);
+                throw new CultureNotFoundException(nameof(name), name, GlobalizationMode.Invariant ? SR.Argument_CultureNotSupportedInInvariantMode : SR.Argument_CultureNotSupported);
             }
 
             _cultureData = cultureData;
@@ -249,7 +249,7 @@ namespace System.Globalization
             }
 
             CultureData? cultureData = CultureData.GetCultureData(cultureName, false) ??
-                throw new CultureNotFoundException(nameof(cultureName), cultureName, SR.Argument_CultureNotSupported);
+                throw new CultureNotFoundException(nameof(cultureName), cultureName, GlobalizationMode.Invariant ? SR.Argument_CultureNotSupportedInInvariantMode : SR.Argument_CultureNotSupported);
 
             _cultureData = cultureData;
 
@@ -1060,7 +1060,7 @@ namespace System.Globalization
             }
             catch (ArgumentException)
             {
-                throw new CultureNotFoundException(nameof(culture), culture, SR.Argument_CultureNotSupported);
+                throw new CultureNotFoundException(nameof(culture), culture, GlobalizationMode.Invariant ? SR.Argument_CultureNotSupportedInInvariantMode : SR.Argument_CultureNotSupported);
             }
 
             lock (lcidTable)
@@ -1096,7 +1096,7 @@ namespace System.Globalization
             }
 
             result = CreateCultureInfoNoThrow(name, useUserOverride: false) ??
-                throw new CultureNotFoundException(nameof(name), name, SR.Argument_CultureNotSupported);
+                throw new CultureNotFoundException(nameof(name), name, GlobalizationMode.Invariant ? SR.Argument_CultureNotSupportedInInvariantMode : SR.Argument_CultureNotSupported);
             result._isReadOnly = true;
 
             // Remember our name as constructed.  Do NOT use alternate sort name versions because

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
@@ -158,6 +158,8 @@ namespace System.Globalization
             return s_userDefaultUICulture!;
         }
 
+        private static string GetCultureNotSupportedExceptionMessage() => GlobalizationMode.Invariant ? SR.Argument_CultureNotSupportedInInvariantMode : SR.Argument_CultureNotSupported;
+
         public CultureInfo(string name) : this(name, true)
         {
         }
@@ -174,7 +176,7 @@ namespace System.Globalization
 
             if (cultureData == null)
             {
-                throw new CultureNotFoundException(nameof(name), name, GlobalizationMode.Invariant ? SR.Argument_CultureNotSupportedInInvariantMode : SR.Argument_CultureNotSupported);
+                throw new CultureNotFoundException(nameof(name), name, GetCultureNotSupportedExceptionMessage());
             }
 
             _cultureData = cultureData;
@@ -249,7 +251,7 @@ namespace System.Globalization
             }
 
             CultureData? cultureData = CultureData.GetCultureData(cultureName, false) ??
-                throw new CultureNotFoundException(nameof(cultureName), cultureName, GlobalizationMode.Invariant ? SR.Argument_CultureNotSupportedInInvariantMode : SR.Argument_CultureNotSupported);
+                throw new CultureNotFoundException(nameof(cultureName), cultureName, GetCultureNotSupportedExceptionMessage());
 
             _cultureData = cultureData;
 
@@ -1060,7 +1062,7 @@ namespace System.Globalization
             }
             catch (ArgumentException)
             {
-                throw new CultureNotFoundException(nameof(culture), culture, GlobalizationMode.Invariant ? SR.Argument_CultureNotSupportedInInvariantMode : SR.Argument_CultureNotSupported);
+                throw new CultureNotFoundException(nameof(culture), culture, GetCultureNotSupportedExceptionMessage());
             }
 
             lock (lcidTable)
@@ -1096,7 +1098,7 @@ namespace System.Globalization
             }
 
             result = CreateCultureInfoNoThrow(name, useUserOverride: false) ??
-                throw new CultureNotFoundException(nameof(name), name, GlobalizationMode.Invariant ? SR.Argument_CultureNotSupportedInInvariantMode : SR.Argument_CultureNotSupported);
+                throw new CultureNotFoundException(nameof(name), name, GetCultureNotSupportedExceptionMessage());
             result._isReadOnly = true;
 
             // Remember our name as constructed.  Do NOT use alternate sort name versions because

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.cs
@@ -13,7 +13,6 @@ namespace System.Globalization
         {
             internal static readonly bool PredefinedCulturesOnly = AppContextConfigHelper.GetBooleanConfig("System.Globalization.PredefinedCulturesOnly", "DOTNET_SYSTEM_GLOBALIZATION_PREDEFINED_CULTURES_ONLY");
             internal static bool Invariant { get; } = GetInvariantSwitchValue();
-            internal static readonly bool AllowInvariantCultureOnly = AppContextConfigHelper.GetBooleanConfig("System.Globalization.AllowInvariantCultureOnly", "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT_CULTURE_ONLY");
         }
 
         // Note: Invariant=true and Invariant=false are substituted at different levels in the ILLink.Substitutions file.
@@ -22,7 +21,7 @@ namespace System.Globalization
         internal static bool Invariant => Settings.Invariant;
 
         internal static bool PredefinedCulturesOnly => !Invariant && Settings.PredefinedCulturesOnly;
-        internal static bool AllowInvariantCultureOnly => Invariant && Settings.AllowInvariantCultureOnly;
+        internal static bool AllowInvariantCultureOnly { get; } = Invariant && AppContextConfigHelper.GetBooleanConfig("System.Globalization.AllowInvariantCultureOnly", "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT_CULTURE_ONLY");
 
         private static bool GetInvariantSwitchValue() =>
             AppContextConfigHelper.GetBooleanConfig("System.Globalization.Invariant", "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT");

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.cs
@@ -13,6 +13,7 @@ namespace System.Globalization
         {
             internal static readonly bool PredefinedCulturesOnly = AppContextConfigHelper.GetBooleanConfig("System.Globalization.PredefinedCulturesOnly", "DOTNET_SYSTEM_GLOBALIZATION_PREDEFINED_CULTURES_ONLY");
             internal static bool Invariant { get; } = GetInvariantSwitchValue();
+            internal static readonly bool AllowInvariantCultureOnly = AppContextConfigHelper.GetBooleanConfig("System.Globalization.AllowInvariantCultureOnly", "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT_CULTURE_ONLY");
         }
 
         // Note: Invariant=true and Invariant=false are substituted at different levels in the ILLink.Substitutions file.
@@ -21,6 +22,7 @@ namespace System.Globalization
         internal static bool Invariant => Settings.Invariant;
 
         internal static bool PredefinedCulturesOnly => !Invariant && Settings.PredefinedCulturesOnly;
+        internal static bool AllowInvariantCultureOnly => Invariant && Settings.AllowInvariantCultureOnly;
 
         private static bool GetInvariantSwitchValue() =>
             AppContextConfigHelper.GetBooleanConfig("System.Globalization.Invariant", "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT");

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.cs
@@ -11,8 +11,8 @@ namespace System.Globalization
         // split from GlobalizationMode so the whole class can be trimmed when Invariant=true.
         private static partial class Settings
         {
-            internal static readonly bool PredefinedCulturesOnly = AppContextConfigHelper.GetBooleanConfig("System.Globalization.PredefinedCulturesOnly", "DOTNET_SYSTEM_GLOBALIZATION_PREDEFINED_CULTURES_ONLY");
             internal static bool Invariant { get; } = GetInvariantSwitchValue();
+            internal static readonly bool PredefinedCulturesOnly = AppContextConfigHelper.GetBooleanConfig("System.Globalization.PredefinedCulturesOnly", "DOTNET_SYSTEM_GLOBALIZATION_PREDEFINED_CULTURES_ONLY", Invariant);
         }
 
         // Note: Invariant=true and Invariant=false are substituted at different levels in the ILLink.Substitutions file.
@@ -20,8 +20,7 @@ namespace System.Globalization
         // static cctor (on Unix) to be preserved when Invariant=false.
         internal static bool Invariant => Settings.Invariant;
 
-        internal static bool PredefinedCulturesOnly => !Invariant && Settings.PredefinedCulturesOnly;
-        internal static bool AllowInvariantCultureOnly { get; } = Invariant && AppContextConfigHelper.GetBooleanConfig("System.Globalization.AllowInvariantCultureOnly", "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT_CULTURE_ONLY");
+        internal static bool PredefinedCulturesOnly => Settings.PredefinedCulturesOnly;
 
         private static bool GetInvariantSwitchValue() =>
             AppContextConfigHelper.GetBooleanConfig("System.Globalization.Invariant", "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT");

--- a/src/libraries/System.Private.CoreLib/src/System/Resources/ManifestBasedResourceGroveler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Resources/ManifestBasedResourceGroveler.cs
@@ -139,7 +139,7 @@ namespace System.Resources
             Debug.Assert(a != null, "assembly != null");
 
             NeutralResourcesLanguageAttribute? attr = a.GetCustomAttribute<NeutralResourcesLanguageAttribute>();
-            if (attr == null)
+            if (attr == null || GlobalizationMode.AllowInvariantCultureOnly)
             {
                 fallbackLocation = UltimateResourceFallbackLocation.MainAssembly;
                 return CultureInfo.InvariantCulture;

--- a/src/libraries/System.Private.CoreLib/src/System/Resources/ManifestBasedResourceGroveler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Resources/ManifestBasedResourceGroveler.cs
@@ -139,7 +139,7 @@ namespace System.Resources
             Debug.Assert(a != null, "assembly != null");
 
             NeutralResourcesLanguageAttribute? attr = a.GetCustomAttribute<NeutralResourcesLanguageAttribute>();
-            if (attr == null || GlobalizationMode.AllowInvariantCultureOnly)
+            if (attr == null || (GlobalizationMode.Invariant && GlobalizationMode.PredefinedCulturesOnly))
             {
                 fallbackLocation = UltimateResourceFallbackLocation.MainAssembly;
                 return CultureInfo.InvariantCulture;

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Win32.cs
@@ -846,15 +846,15 @@ namespace System
         /// If a localized resource file exists, we LoadString resource ID "123" and
         /// return it to our caller.
         /// </summary>
-        private static string GetLocalizedNameByMuiNativeResource(string resource, CultureInfo? cultureInfo = null)
+        private static string GetLocalizedNameByMuiNativeResource(string resource)
         {
-            if (string.IsNullOrEmpty(resource))
+            if (string.IsNullOrEmpty(resource) || (GlobalizationMode.Invariant && GlobalizationMode.PredefinedCulturesOnly))
             {
                 return string.Empty;
             }
 
             // Use the current UI culture when culture not specified
-            cultureInfo ??= CultureInfo.CurrentUICulture;
+            CultureInfo cultureInfo = CultureInfo.CurrentUICulture;
 
             // parse "@tzres.dll, -100"
             //

--- a/src/libraries/System.Runtime/tests/TrimmingTests/InvariantGlobalizationTrue.cs
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/InvariantGlobalizationTrue.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Globalization;
 using System.Reflection;
-using System.Threading;
 
 /// <summary>
 /// Ensures setting InvariantGlobalization = true still works in a trimmed app.
@@ -13,24 +12,13 @@ class Program
 {
     static int Main(string[] args)
     {
-        // since we are using Invariant GlobalizationMode = true, setting the culture doesn't matter.
-        // The app will always use Invariant mode, so even in the Turkish culture, 'i' ToUpper will be "I"
-        Thread.CurrentThread.CurrentCulture = new CultureInfo("tr-TR");
-        if ("i".ToUpper() != "I")
-        {
-            // 'i' ToUpper was not "I", so fail
-            return -1;
-        }
-
         // Ensure the internal GlobalizationMode class is trimmed correctly
         Type globalizationMode = GetCoreLibType("System.Globalization.GlobalizationMode");
         const BindingFlags allStatics = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
         foreach (MemberInfo member in globalizationMode.GetMembers(allStatics))
         {
             // properties and their backing getter methods are OK
-            if ((member is PropertyInfo || member.Name.StartsWith("get_")) ||
-                (member is FieldInfo && member.Name.Contains("AllowInvariantCultureOnly")) ||
-                (member is ConstructorInfo && member.Name.Contains(".cctor")))
+            if (member is PropertyInfo || member.Name.StartsWith("get_"))
             {
                 continue;
             }
@@ -46,7 +34,7 @@ class Program
 
             // Some unexpected member was left on GlobalizationMode, fail
             Console.WriteLine($"Member '{member.Name}' was not trimmed from GlobalizationMode, but should have been.");
-            return -2;
+            return -1;
         }
 
         return 100;

--- a/src/libraries/System.Runtime/tests/TrimmingTests/InvariantGlobalizationTrue.cs
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/InvariantGlobalizationTrue.cs
@@ -28,7 +28,9 @@ class Program
         foreach (MemberInfo member in globalizationMode.GetMembers(allStatics))
         {
             // properties and their backing getter methods are OK
-            if ((member is PropertyInfo || member.Name.StartsWith("get_")) || (member is FieldInfo && member.Name.Contains("AllowInvariantCultureOnly")))
+            if ((member is PropertyInfo || member.Name.StartsWith("get_")) ||
+                (member is FieldInfo && member.Name.Contains("AllowInvariantCultureOnly")) ||
+                (member is ConstructorInfo && member.Name.Contains(".cctor")))
             {
                 continue;
             }

--- a/src/libraries/System.Runtime/tests/TrimmingTests/InvariantGlobalizationTrue.cs
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/InvariantGlobalizationTrue.cs
@@ -15,6 +15,29 @@ class Program
         // Ensure the internal GlobalizationMode class is trimmed correctly
         Type globalizationMode = GetCoreLibType("System.Globalization.GlobalizationMode");
         const BindingFlags allStatics = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
+        bool predefinedCulturesOnly = (bool) globalizationMode.GetProperty("PredefinedCulturesOnly", allStatics).GetValue(null);
+
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
+            if (predefinedCulturesOnly)
+            {
+                return -1; // we expect new CultureInfo("tr-TR") to throw.
+            }
+        }
+        catch (CultureNotFoundException)
+        {
+            if (!predefinedCulturesOnly)
+            {
+                return -2; // It is not expected to have new CultureInfo("tr-TR") to throw.
+            }
+        }
+
+        if ("i".ToUpper() != "I")
+        {
+            return -3;
+        }
+
         foreach (MemberInfo member in globalizationMode.GetMembers(allStatics))
         {
             // properties and their backing getter methods are OK
@@ -34,7 +57,7 @@ class Program
 
             // Some unexpected member was left on GlobalizationMode, fail
             Console.WriteLine($"Member '{member.Name}' was not trimmed from GlobalizationMode, but should have been.");
-            return -1;
+            return -4;
         }
 
         return 100;

--- a/src/libraries/System.Runtime/tests/TrimmingTests/InvariantGlobalizationTrue.cs
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/InvariantGlobalizationTrue.cs
@@ -28,7 +28,7 @@ class Program
         foreach (MemberInfo member in globalizationMode.GetMembers(allStatics))
         {
             // properties and their backing getter methods are OK
-            if (member is PropertyInfo || member.Name.StartsWith("get_"))
+            if ((member is PropertyInfo || member.Name.StartsWith("get_")) || (member is FieldInfo && member.Name.Contains("AllowInvariantCultureOnly")))
             {
                 continue;
             }

--- a/src/libraries/System.Runtime/tests/TrimmingTests/InvariantGlobalizationTrue.cs
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/InvariantGlobalizationTrue.cs
@@ -15,22 +15,14 @@ class Program
         // Ensure the internal GlobalizationMode class is trimmed correctly
         Type globalizationMode = GetCoreLibType("System.Globalization.GlobalizationMode");
         const BindingFlags allStatics = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
-        bool predefinedCulturesOnly = (bool) globalizationMode.GetProperty("PredefinedCulturesOnly", allStatics).GetValue(null);
 
         try
         {
             CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
-            if (predefinedCulturesOnly)
-            {
-                return -1; // we expect new CultureInfo("tr-TR") to throw.
-            }
+            return -1; // we expect new CultureInfo("tr-TR") to throw.
         }
         catch (CultureNotFoundException)
         {
-            if (!predefinedCulturesOnly)
-            {
-                return -2; // It is not expected to have new CultureInfo("tr-TR") to throw.
-            }
         }
 
         if ("i".ToUpper() != "I")

--- a/src/libraries/System.Runtime/tests/TrimmingTests/System.Runtime.TrimmingTests.proj
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/System.Runtime.TrimmingTests.proj
@@ -15,7 +15,7 @@
       <ExtraTrimmerArgs>--feature System.Globalization.Invariant false</ExtraTrimmerArgs>
     </TestConsoleAppSourceFiles>
     <TestConsoleAppSourceFiles Include="InvariantGlobalizationTrue.cs">
-      <ExtraTrimmerArgs>--feature System.Globalization.Invariant true</ExtraTrimmerArgs>
+      <ExtraTrimmerArgs>--feature System.Globalization.Invariant true --feature System.Globalization.PredefinedCulturesOnly true</ExtraTrimmerArgs>
     </TestConsoleAppSourceFiles>
     <TestConsoleAppSourceFiles Include="StackFrameHelperTest.cs">
       <!-- There is a bug with the linker where it is corrupting the pdbs while trimming

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/InvariantGlobalizationTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/InvariantGlobalizationTests.cs
@@ -62,9 +62,17 @@ namespace Wasm.Build.Tests
                 public class TestClass {
                     public static int Main()
                     {
-                        var culture = new CultureInfo(""es-ES"", false);
+                        CultureInfo culture;
+                        try
+                        {
+                            culture = new CultureInfo(""es-ES"", false);
                         // https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md#cultures-and-culture-data
-                        Console.WriteLine($""{culture.LCID == 0x1000} - {culture.NativeName}"");
+                        }
+                        catch
+                        {
+                            culture = new CultureInfo("""", false);
+                        }
+                        Console.WriteLine($""{culture.LCID == CultureInfo.InvariantCulture.LCID} - {culture.NativeName}"");
                         return 42;
                     }
                 }";


### PR DESCRIPTION
This change addresses the second part of #43774

This change is forcing to throw exception when creating any culture other than Invariant culture when enabling the Globalization Invariant Mode. This will allow easier diagnosis of the failures when turning on the Globalization Invariant Mode. 
When turning on the [Invariant globalization mode](https://docs.microsoft.com/en-us/dotnet/core/run-time-config/globalization?ranMID=46131&ranEAID=a1LgFw09t88&ranSiteID=a1LgFw09t88-TL.gIntYvAARbx7QNuWPjg&epi=a1LgFw09t88-TL.gIntYvAARbx7QNuWPjg&irgwc=1&OCID=AID2000142_aff_7806_1243925&tduid=%28ir__mrdukhopi0kfqxeykk0sohzifv2xuvvxe2xvqk3y00%29%287806%29%281243925%29%28a1LgFw09t88-TL.gIntYvAARbx7QNuWPjg%29%28%29&irclickid=_mrdukhopi0kfqxeykk0sohzifv2xuvvxe2xvqk3y00#invariant-mode) the config switch `System.Globalization.PredefinedCulturesOnly` will be automatically turned on. If anyone for any reason want to get back to the old behavior which is allowing creating any cultures by providing Invariant culture data, can do that by explicitly turning off the `System.Globalization.PredefinedCulturesOnly` switch.

The breaking change doc is tracked by [Restrict Cultures Creation in Globalization Invariant Mode](https://github.com/dotnet/docs/issues/24849) issue.
