### PR TITLE
fix MsQuicStream counting on failure

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -74,7 +74,6 @@ namespace System.Net.Quic.Implementations.MsQuic
         internal MsQuicStream(MsQuicConnection.State connectionState, SafeMsQuicStreamHandle streamHandle, QUIC_STREAM_OPEN_FLAGS flags)
         {
             _state.Handle = streamHandle;
-            _state.ConnectionState = connectionState;
             _canRead = true;
             _canWrite = !flags.HasFlag(QUIC_STREAM_OPEN_FLAGS.UNIDIRECTIONAL);
             _started = true;
@@ -99,6 +98,8 @@ namespace System.Net.Quic.Implementations.MsQuic
                 throw new ObjectDisposedException(nameof(QuicConnection));
             }
 
+            _state.ConnectionState = connectionState;
+
             if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Info(
@@ -113,10 +114,8 @@ namespace System.Net.Quic.Implementations.MsQuic
         {
             Debug.Assert(connectionState.Handle != null);
 
-            _state.ConnectionState = connectionState;
             _canRead = !flags.HasFlag(QUIC_STREAM_OPEN_FLAGS.UNIDIRECTIONAL);
             _canWrite = true;
-
             _stateHandle = GCHandle.Alloc(_state);
             try
             {
@@ -145,6 +144,8 @@ namespace System.Net.Quic.Implementations.MsQuic
                 _stateHandle.Free();
                 throw new ObjectDisposedException(nameof(QuicConnection));
             }
+
+            _state.ConnectionState = connectionState;
 
             if (NetEventSource.Log.IsEnabled())
             {
@@ -569,7 +570,6 @@ namespace System.Net.Quic.Implementations.MsQuic
             Marshal.FreeHGlobal(_state.SendQuicBuffers);
             if (_stateHandle.IsAllocated) _stateHandle.Free();
             CleanupSendState(_state);
-            Debug.Assert(_state.ConnectionState != null);
             _state.ConnectionState?.RemoveStream(this);
 
             if (NetEventSource.Log.IsEnabled())

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -116,7 +116,6 @@ namespace System.Net.Quic.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/52048")]
         public async Task WaitForAvailableUnidirectionStreamsAsyncWorks()
         {
             using QuicListener listener = CreateQuicListener(maxUnidirectionalStreams: 1);
@@ -126,7 +125,7 @@ namespace System.Net.Quic.Tests
             using QuicConnection serverConnection = await listener.AcceptConnectionAsync();
             await clientTask;
 
-            // No stream openned yet, should return immediately.
+            // No stream opened yet, should return immediately.
             Assert.True(clientConnection.WaitForAvailableUnidirectionalStreamsAsync().IsCompletedSuccessfully);
 
             // Open one stream, should wait till it closes.
@@ -141,7 +140,6 @@ namespace System.Net.Quic.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/52048")]
         public async Task WaitForAvailableBidirectionStreamsAsyncWorks()
         {
             using QuicListener listener = CreateQuicListener(maxBidirectionalStreams: 1);
@@ -151,7 +149,7 @@ namespace System.Net.Quic.Tests
             using QuicConnection serverConnection = await listener.AcceptConnectionAsync();
             await clientTask;
 
-            // No stream openned yet, should return immediately.
+            // No stream opened yet, should return immediately.
             Assert.True(clientConnection.WaitForAvailableBidirectionalStreamsAsync().IsCompletedSuccessfully);
 
             // Open one stream, should wait till it closes.


### PR DESCRIPTION
This is follow-up on #52800
When we throw in MsQuicStream,  the finalizer would still run and that would call Dispose() and that would try to decrement StreamCount and we may hit Debug.Assert on negative number for stream we never added. 
Since the Dispose is already using `_state.ConnectionState?.RemoveStream(this);` the fix is to defer assignment of `ConnectionState` until after `TryAddStream` is successfully finished. 

enabling two more tests   #52800 missed. 