### PR TITLE
Remove crossgen perf tests

### DIFF
--- a/eng/testing/performance/crossgen_perf.proj
+++ b/eng/testing/performance/crossgen_perf.proj
@@ -44,13 +44,6 @@
     <Composite Include="framework-r2r.dll.rsp"/>
   </ItemGroup>
 
-  <ItemGroup>
-    <CrossgenWorkItem Include="@(SingleAssembly)">
-      <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
-      <Command>$(Python) $(CrossgenDirectory)test.py crossgen --core-root $(CoreRoot) --test-name %(Identity)</Command>
-    </CrossgenWorkItem>
-  </ItemGroup>
-
   <ItemGroup> 
     <Crossgen2WorkItem Include="@(SingleAssembly)">
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
@@ -66,15 +59,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <CrossgenSizeOnDiskWorkItem Include="@(SingleAssembly)" Condition="'$(Architecture)' == 'x64'">
-      <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
-      <PreCommands>$(Python) $(CrossgenDirectory)pre.py crossgen --core-root $(CoreRoot) --single %(Identity) </PreCommands>
-      <Command>$(Python) $(CrossgenDirectory)test.py sod --scenario-name &quot;Crossgen %(Identity) Size&quot; --dirs ./crossgen.out/</Command>
-      <PostCommands>$(Python) $(CrossgenDirectory)post.py</PostCommands>
-    </CrossgenSizeOnDiskWorkItem>
-  </ItemGroup>
-
-  <ItemGroup>
     <Crossgen2SizeOnDiskWorkItem Include="@(SingleAssembly)" Condition="'$(Architecture)' == 'x64'">
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
       <PreCommands>$(Python) $(Crossgen2Directory)pre.py crossgen2 --core-root $(CoreRoot) --single %(Identity) </PreCommands>
@@ -84,10 +68,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Enable crossgen tests on Windows x64 and Windows x86 -->
-    <HelixWorkItem Include="@(CrossgenWorkItem -> 'Crossgen %(Identity)')" Condition="'$(AGENT_OS)' == 'Windows_NT'">
-      <Timeout>4:00</Timeout>
-    </HelixWorkItem>
     <!-- Enable crossgen2 tests on Windows x64 and Linux x64 -->
     <HelixWorkItem Include="@(Crossgen2WorkItem -> 'Crossgen2 %(Identity)')" Condition="'$(Architecture)' == 'x64'">
       <Timeout>4:00</Timeout>
@@ -99,9 +79,6 @@
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>	
       <Command>$(Python) $(Crossgen2Directory)test.py crossgen2 --core-root $(CoreRoot) --composite $(Crossgen2Directory)framework-r2r.dll.rsp</Command>
       <Timeout>1:00</Timeout>  
-    </HelixWorkItem>
-    <HelixWorkItem Include="@(CrossgenSizeOnDiskWorkItem -> 'Crossgen Size on Disk %(Identity)')" Condition="'$(Architecture)' == 'x64'">
-      <Timeout>4:00</Timeout>  
     </HelixWorkItem>
     <HelixWorkItem Include="@(Crossgen2SizeOnDiskWorkItem -> 'Crossgen2 Size on Disk %(Identity)')" Condition="'$(Architecture)' == 'x64'">
       <Timeout>4:00</Timeout>  


### PR DESCRIPTION
With the removal of crossgen from the build (#53458) these tests no longer work.