### PR TITLE
Add a test for Expression.Property and its handling of property accessors

### DIFF
--- a/src/libraries/System.Linq.Expressions/tests/TrimmingTests/ExpressionPropertyTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/TrimmingTests/ExpressionPropertyTests.cs
@@ -21,8 +21,6 @@ internal class Program
 
         result = LambdaCreation.Test();
 
-        Type.GetType("foo");
-
         return result;
     }
 

--- a/src/libraries/System.Linq.Expressions/tests/TrimmingTests/ExpressionPropertyTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/TrimmingTests/ExpressionPropertyTests.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+/// <summary>
+/// Tests that the System.Linq.Expressions.Expression.Property will correctly preserve both
+/// accessors even if only one is referenced by MethodInfo.
+/// </summary>
+internal class Program
+{
+    class TestType
+    {
+        public bool _testPropertyValue;
+
+        public bool TestProperty { 
+            get => _testPropertyValue;
+            set { _testPropertyValue = value; }
+        }
+    }
+
+    static int Main(string[] args)
+    {
+        var obj = new TestType();
+        var param = Expression.Parameter(typeof(TestType));
+        var prop = Expression.Property(param, typeof(TestType).GetMethod("get_TestProperty"));
+        ((PropertyInfo)prop.Member).SetValue(obj, true);
+        if (obj._testPropertyValue != true)
+            return -1;
+
+        return 100;
+    }
+}

--- a/src/libraries/System.Linq.Expressions/tests/TrimmingTests/ExpressionPropertyTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/TrimmingTests/ExpressionPropertyTests.cs
@@ -13,25 +13,67 @@ using System.Reflection;
 /// </summary>
 internal class Program
 {
-    class TestType
+    static int Main(string[] args)
     {
-        public bool _testPropertyValue;
+        int result = ExplicitCreation.Test();
+        if (result != 100)
+            return result;
 
-        public bool TestProperty { 
-            get => _testPropertyValue;
-            set { _testPropertyValue = value; }
+        result = LambdaCreation.Test();
+
+        Type.GetType("foo");
+
+        return result;
+    }
+
+    class ExplicitCreation
+    {
+        class TestType
+        {
+            public bool _testPropertyValue;
+
+            public bool TestProperty { 
+                get => _testPropertyValue;
+                set { _testPropertyValue = value; }
+            }
+        }
+
+        public static int Test()
+        {
+            var obj = new TestType();
+            var param = Expression.Parameter(typeof(TestType));
+            var prop = Expression.Property(param, typeof(TestType).GetMethod("get_TestProperty"));
+            ((PropertyInfo)prop.Member).SetValue(obj, true);
+            if (obj._testPropertyValue != true)
+                return -1;
+
+            return 100;
         }
     }
 
-    static int Main(string[] args)
+    class LambdaCreation
     {
-        var obj = new TestType();
-        var param = Expression.Parameter(typeof(TestType));
-        var prop = Expression.Property(param, typeof(TestType).GetMethod("get_TestProperty"));
-        ((PropertyInfo)prop.Member).SetValue(obj, true);
-        if (obj._testPropertyValue != true)
-            return -1;
+        class TestType
+        {
+            public bool _testPropertyValue;
 
-        return 100;
+            public bool TestProperty { 
+                get => _testPropertyValue;
+                set { _testPropertyValue = value; }
+            }
+        }
+
+        public static int Test()
+        {
+            var obj = new TestType ();
+            Expression<Func<TestType, bool>> expression = t => t.TestProperty;
+            var prop = ((MemberExpression)expression.Body);
+            ((PropertyInfo)prop.Member).SetValue(obj, true);
+
+            if (obj._testPropertyValue != true)
+                return -2;
+
+            return 100;
+        }
     }
 }


### PR DESCRIPTION
This mostly a linker test as this effectively validates linker feature from https://github.com/mono/linker/pull/1880.

But having a clean trimming tests here is better validation for this specific case.