### PR TITLE
Use GeneratedDllImport in System.Security.AccessControl

### DIFF
--- a/src/libraries/System.Security.AccessControl/src/System.Security.AccessControl.csproj
+++ b/src/libraries/System.Security.AccessControl/src/System.Security.AccessControl.csproj
@@ -83,6 +83,7 @@
     <Reference Include="System.Collections" />
     <Reference Include="System.Collections.NonGeneric" />
     <Reference Include="System.Diagnostics.Debug" />
+    <Reference Include="System.Memory" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Memory" />
     <Reference Include="System.Runtime" />


### PR DESCRIPTION
|     | Original (B) | Converted (B) | + (B) | + (%) |
| --- | -----------: | ------------: | ----: | ----: |
| windows | 83968 | 91648 | 7680 | 9.15 |
| windows R2R | 204288 | 223744 | 19456 | 9.52 |

Turned out the p/invokes all overlapped with `Microsoft.Win32.Registry`, which @AaronRobinsonMSFT already did, so all this project needed was the reference to `System.Memory`.

cc @AaronRobinsonMSFT @jkoritzinsky 