### PR TITLE
Follow the same failure behavior for [ComImport] classes on Windows with built-in COM disabled as non-Windows.

### DIFF
--- a/src/coreclr/vm/ecall.cpp
+++ b/src/coreclr/vm/ecall.cpp
@@ -430,11 +430,16 @@ PCODE ECall::GetFCallImpl(MethodDesc * pMD, BOOL * pfSharedOrDynamicFCallImpl /*
     // COM imported classes have special constructors
     if (pMT->IsComObjectType()
 #ifdef FEATURE_COMINTEROP
-        && pMT != g_pBaseCOMObject
+        && (g_pBaseCOMObject == NULL || pMT != g_pBaseCOMObject)
 #endif // FEATURE_COMINTEROP
     )
     {
 #ifdef FEATURE_COMINTEROP
+        if (g_pBaseCOMObject == NULL)
+        {
+            COMPlusThrow(kPlatformNotSupportedException, IDS_EE_ERROR_COM);
+        }
+
         if (pfSharedOrDynamicFCallImpl)
             *pfSharedOrDynamicFCallImpl = TRUE;
 

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -1511,7 +1511,7 @@ MethodTableBuilder::BuildMethodTableThrowing(
     if (IsComImport() && !IsEnum() && !IsInterface() && !IsValueClass() && !IsDelegate())
     {
 #ifdef FEATURE_COMINTEROP
-        // ComImport classes must either extend from Object
+        // ComImport classes must extend from Object
         MethodTable* pMTParent = GetParentMethodTable();
         if ((pMTParent == NULL) || (pMTParent != g_pObjectClass))
         {
@@ -1524,12 +1524,15 @@ MethodTableBuilder::BuildMethodTableThrowing(
             BuildMethodTableThrowException(IDS_CLASSLOAD_COMIMPCANNOTHAVELAYOUT);
         }
 
-        // We could have had COM interop classes derive from System._ComObject,
-        // but instead we have them derive from System.Object, have them set the
-        // ComImport bit in the type attributes, and then we swap out the parent
-        // type under the covers.
-        bmtInternal->pType->SetParentType(CreateTypeChain(g_pBaseCOMObject, Substitution()));
-        bmtInternal->pParentMT = g_pBaseCOMObject;
+        if (g_pBaseCOMObject != NULL)
+        {
+            // We could have had COM interop classes derive from System._ComObject,
+            // but instead we have them derive from System.Object, have them set the
+            // ComImport bit in the type attributes, and then we swap out the parent
+            // type under the covers.
+            bmtInternal->pType->SetParentType(CreateTypeChain(g_pBaseCOMObject, Substitution()));
+            bmtInternal->pParentMT = g_pBaseCOMObject;
+        }
 #endif
         // if the current class is imported
         bmtProp->fIsComObjectType = true;
@@ -6307,13 +6310,13 @@ MethodTableBuilder::PlaceMethodImpls()
             {
                 // The declaration is on the type being built
                 bmtMDMethod * pCurDeclMethod = hDeclMethod.AsMDMethod();
-    
+
                 mdToken mdef = pCurDeclMethod->GetMethodSignature().GetToken();
                 if (bmtMethodImpl->IsBody(mdef))
                 {   // A method declared on this class cannot be both a decl and an impl
                     BuildMethodTableThrowException(IDS_CLASSLOAD_MI_MULTIPLEOVERRIDES, mdef);
                 }
-    
+
                 if (IsInterface())
                 {
                     // Throws
@@ -6340,7 +6343,7 @@ MethodTableBuilder::PlaceMethodImpls()
             else
             {
                 bmtRTMethod * pCurDeclMethod = hDeclMethod.AsRTMethod();
-    
+
                 if (IsInterface())
                 {
                     // Throws

--- a/src/tests/Interop/COM/NETClients/ComDisabled/App.manifest
+++ b/src/tests/Interop/COM/NETClients/ComDisabled/App.manifest
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity
+    type="win32"
+    name="NetPrimitivesClient"
+    version="1.0.0.0" />
+
+  <dependency>
+    <dependentAssembly>
+      <!-- RegFree COM -->
+      <assemblyIdentity
+          type="win32"
+          name="COMNativeServer.X"
+          version="1.0.0.0"/>
+    </dependentAssembly>
+  </dependency>
+
+</assembly>

--- a/src/tests/Interop/COM/NETClients/ComDisabled/NETClientComDisabled.csproj
+++ b/src/tests/Interop/COM/NETClients/ComDisabled/NETClientComDisabled.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <ApplicationManifest>App.manifest</ApplicationManifest>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="../../ServerContracts/Server.CoClasses.cs" />
+    <Compile Include="../../ServerContracts/Server.Contracts.cs" />
+    <Compile Include="../../ServerContracts/ServerGuids.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../NativeServer/CMakeLists.txt" />
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Runtime.InteropServices.BuiltInComInterop.IsSupported" Value="false" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Interop/COM/NETClients/ComDisabled/Program.cs
+++ b/src/tests/Interop/COM/NETClients/ComDisabled/Program.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace NetClient
+{
+    using System;
+    using System.Threading;
+    using System.Runtime.InteropServices;
+    using System.Runtime.CompilerServices;
+
+    class Program
+    {
+        static int Main(string[] doNotUse)
+        {
+            // RegFree COM is not supported on Windows Nano
+            if (TestLibrary.Utilities.IsWindowsNanoServer)
+            {
+                return 100;
+            }
+
+            try
+            {
+                ActivateServer();
+            }
+            catch (PlatformNotSupportedException ex)
+            {
+                return 100;
+            }
+
+            return 101;
+        }
+
+        // Mark as NoInlining to make sure the failure is observed while running Main,
+        // not while JITing Main and trying to resolve the target of the constructor call.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ActivateServer()
+        {
+            var server = (Server.Contract.Servers.NumericTesting)new Server.Contract.Servers.NumericTestingClass();
+        }
+    }
+}


### PR DESCRIPTION
On non-Windows, CoreCLR sets a flag on a class with `[ComImport]` so that we remember that it is a `[ComImport]` type and it allows the type to be loaded. Then, when the constructor is called, CoreCLR throws a `PlatformNotSupportedException`.

This PR enables the same behavior on Windows when the `__ComObject` type is not present (the disabled built-in COM scenario).