### PR TITLE
Remove some overhead from XmlNode.SelectSingleNode

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlNode.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlNode.cs
@@ -48,9 +48,17 @@ namespace System.Xml
         // Selects the first node that matches the xpath expression
         public XmlNode? SelectSingleNode(string xpath)
         {
-            XmlNodeList? list = SelectNodes(xpath);
-            // SelectNodes returns null for certain node types
-            return list != null ? list[0] : null;
+            if (CreateNavigator() is XPathNavigator navigator)
+            {
+                XPathNodeIterator nodeIterator = navigator.Select(xpath);
+                if (nodeIterator.MoveNext())
+                {
+                    Debug.Assert(nodeIterator.Current != null);
+                    return ((IHasXmlNode)nodeIterator.Current).GetNode();
+                }
+            }
+
+            return null;
         }
 
         // Selects the first node that matches the xpath expression and given namespace context.

--- a/src/libraries/System.Private.Xml/src/System/Xml/XPath/Internal/XPathScanner.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XPath/Internal/XPathScanner.cs
@@ -40,16 +40,18 @@ namespace MS.Internal.Xml.XPath
         private bool NextChar()
         {
             Debug.Assert(0 <= _xpathExprIndex && _xpathExprIndex <= _xpathExpr.Length);
-            if (_xpathExprIndex < _xpathExpr.Length)
+
+            string expr = _xpathExpr;
+            int index = _xpathExprIndex;
+            if ((uint)index < (uint)expr.Length)
             {
-                _currentChar = _xpathExpr[_xpathExprIndex++];
+                _currentChar = expr[index];
+                _xpathExprIndex = index + 1;
                 return true;
             }
-            else
-            {
-                _currentChar = '\0';
-                return false;
-            }
+
+            _currentChar = '\0';
+            return false;
         }
 
         public LexKind Kind { get { return _kind; } }

--- a/src/libraries/System.Private.Xml/src/System/Xml/XPath/Internal/XPathScanner.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XPath/Internal/XPathScanner.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Xml;
 using System.Xml.XPath;
 
@@ -107,9 +108,19 @@ namespace MS.Internal.Xml.XPath
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void SkipSpace()
         {
-            while (XmlCharType.IsWhiteSpace(CurrentChar) && NextChar()) ;
+            if (XmlCharType.IsWhiteSpace(CurrentChar))
+            {
+                SkipKnownSpace();
+            }
+        }
+
+        private void SkipKnownSpace()
+        {
+            Debug.Assert(XmlCharType.IsWhiteSpace(CurrentChar));
+            while (NextChar() && XmlCharType.IsWhiteSpace(CurrentChar));
         }
 
         public bool NextLex()

--- a/src/libraries/System.Private.Xml/src/System/Xml/XPath/Internal/XPathScanner.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XPath/Internal/XPathScanner.cs
@@ -9,7 +9,7 @@ using System.Xml.XPath;
 
 namespace MS.Internal.Xml.XPath
 {
-    internal sealed class XPathScanner
+    internal struct XPathScanner
     {
         private readonly string _xpathExpr;
         private int _xpathExprIndex;
@@ -18,16 +18,17 @@ namespace MS.Internal.Xml.XPath
         private string? _name;
         private string? _prefix;
         private string? _stringValue;
-        private double _numberValue = double.NaN;
+        private double _numberValue;
         private bool _canBeFunction;
 
-        public XPathScanner(string xpathExpr)
+        public XPathScanner(string xpathExpr) : this()
         {
             if (xpathExpr == null)
             {
                 throw XPathException.Create(SR.Xp_ExprExpected, string.Empty);
             }
             _xpathExpr = xpathExpr;
+            _numberValue = double.NaN;
             NextChar();
             NextLex();
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/XPath/Internal/XPathScanner.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XPath/Internal/XPathScanner.cs
@@ -313,23 +313,26 @@ namespace MS.Internal.Xml.XPath
 
         private string ScanName()
         {
-            Debug.Assert(XmlCharType.IsStartNCNameSingleChar(CurrentChar));
-            int start = _xpathExprIndex - 1;
-            int len = 0;
+            ReadOnlySpan<char> span = _xpathExpr.AsSpan(_xpathExprIndex - 1);
 
-            while (true)
+            Debug.Assert(!span.IsEmpty);
+            Debug.Assert(span[0] == CurrentChar);
+            Debug.Assert(XmlCharType.IsStartNCNameSingleChar(span[0]));
+            Debug.Assert(XmlCharType.IsNCNameSingleChar(span[0]));
+
+            int i;
+            for (i = 1; i < span.Length && XmlCharType.IsNCNameSingleChar(span[i]); i++);
+
+            if ((uint)i < (uint)span.Length)
             {
-                if (XmlCharType.IsNCNameSingleChar(CurrentChar))
-                {
-                    NextChar();
-                    len++;
-                }
-                else
-                {
-                    break;
-                }
+                _currentChar = span[i];
+                _xpathExprIndex += i;
+                return span.Slice(0, i).ToString();
             }
-            return _xpathExpr.Substring(start, len);
+
+            _currentChar = '\0';
+            _xpathExprIndex += i - 1;
+            return span.ToString();
         }
 
         public enum LexKind


### PR DESCRIPTION
Using the example from https://docs.microsoft.com/en-us/dotnet/api/system.xml.xmlnode.selectsinglenode?view=net-5.0#System_Xml_XmlNode_SelectSingleNode_System_String_ :

|           Method |         Toolchain |       Mean | Ratio | Allocated |
|----------------- |------------------ |-----------:|------:|----------:|
| SelectSingleNode | \main\CoreRun.exe | 1,238.4 ns |  1.00 |   2,312 B |
| SelectSingleNode |   \pr\CoreRun.exe | 1,120.9 ns |  0.91 |   2,080 B |