### PR TITLE
Fix profiling R2R code on Windows x64

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/RuntimeFunctionsTableNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/RuntimeFunctionsTableNode.cs
@@ -67,6 +67,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 LayoutRuntimeFunctions();
 
             ObjectDataBuilder runtimeFunctionsBuilder = new ObjectDataBuilder(factory, relocsOnly);
+            runtimeFunctionsBuilder.RequireInitialAlignment(4);
 
             // Add the symbol representing this object node
             runtimeFunctionsBuilder.AddSymbol(this);


### PR DESCRIPTION
The kernel requires the function table to be 4-byte aligned. Fixes #53743.