### PR TITLE
Add Dependency for wcf projects to compat pack

### DIFF
--- a/src/libraries/pkg/Microsoft.Windows.Compatibility/Microsoft.Windows.Compatibility.pkgproj
+++ b/src/libraries/pkg/Microsoft.Windows.Compatibility/Microsoft.Windows.Compatibility.pkgproj
@@ -91,6 +91,8 @@
 
   <ItemGroup>
     <Dependency Include="@(ExternalLibraryPackage)"
+                TargetFramework="net6.0" />
+    <Dependency Include="@(ExternalLibraryPackage)"
                 TargetFramework="netcoreapp3.1" />
     <Dependency Include="@(ExternalLibraryPackage)"
                 TargetFramework="netstandard2.0" />


### PR DESCRIPTION
Missed that in https://github.com/dotnet/runtime/commit/663c40dbc4ccedf82e38e96391c28695da0e418f