### PR TITLE
fix some failing quic tests

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -515,9 +515,9 @@ namespace System.Net.Quic.Implementations.MsQuic
             byte[] rentedBuffer = ArrayPool<byte>.Shared.Rent(buffer.Length);
             try
             {
-                int reqdLength = ReadAsync(new Memory<byte>(rentedBuffer, 0, buffer.Length)).AsTask().GetAwaiter().GetResult();
-                rentedBuffer.AsSpan().Slice(0, reqdLength).CopyTo(buffer);
-                return reqdLength;
+                int readLength = ReadAsync(new Memory<byte>(rentedBuffer, 0, buffer.Length)).AsTask().GetAwaiter().GetResult();
+                rentedBuffer.AsSpan(0, readLength).CopyTo(buffer);
+                return readLength;
             }
             finally
             {

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -512,8 +512,17 @@ namespace System.Net.Quic.Implementations.MsQuic
         internal override int Read(Span<byte> buffer)
         {
             ThrowIfDisposed();
-
-            return ReadAsync(buffer.ToArray()).AsTask().GetAwaiter().GetResult();
+            byte[] rentedBuffer = ArrayPool<byte>.Shared.Rent(buffer.Length);
+            try
+            {
+                int reqdLength = ReadAsync(new Memory<byte>(rentedBuffer, 0, buffer.Length)).AsTask().GetAwaiter().GetResult();
+                rentedBuffer.AsSpan().Slice(0, reqdLength).CopyTo(buffer);
+                return reqdLength;
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rentedBuffer);
+            }
         }
 
         internal override void Write(ReadOnlySpan<byte> buffer)

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamConnectedStreamConformanceTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamConnectedStreamConformanceTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.IO.Tests;
 using System.Net.Quic.Implementations;
 using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -37,59 +38,42 @@ namespace System.Net.Quic.Tests
 
         // TODO: new additions, find out the actual reason for hanging
         [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
-        public override Task ReadTimeout_Expires_Throws() => base.ReadTimeout_Expires_Throws();
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
-        public override Task ConcurrentBidirectionalReadsWrites_Success() => base.ConcurrentBidirectionalReadsWrites_Success();
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
-        public override Task ArgumentValidation_ThrowsExpectedException() => base.ArgumentValidation_ThrowsExpectedException();
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
         public override Task ReadWriteAsync_PrecanceledOperations_ThrowsCancellationException() => base.ReadWriteAsync_PrecanceledOperations_ThrowsCancellationException();
         [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
         public override Task Read_DataStoredAtDesiredOffset(ReadWriteMode mode) => base.Read_DataStoredAtDesiredOffset(mode);
         [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
         public override Task ReadAsync_CancelPendingRead_DoesntImpactSubsequentReads() => base.ReadAsync_CancelPendingRead_DoesntImpactSubsequentReads();
         [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
-        public override Task Disposed_ThrowsObjectDisposedException() => base.Disposed_ThrowsObjectDisposedException();
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
-        public override Task Timeout_Roundtrips() => base.Timeout_Roundtrips();
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
-        public override Task ZeroByteWrite_OtherDataReceivedSuccessfully(ReadWriteMode mode) => base.ZeroByteWrite_OtherDataReceivedSuccessfully(mode);
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
-        public override Task ReadAsync_ContinuesOnCurrentTaskSchedulerIfDesired(bool flowExecutionContext, bool? continueOnCapturedContext) => base.ReadAsync_ContinuesOnCurrentTaskSchedulerIfDesired(flowExecutionContext, continueOnCapturedContext);
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
         public override Task ZeroByteRead_BlocksUntilDataAvailableOrNops(ReadWriteMode mode) => base.ZeroByteRead_BlocksUntilDataAvailableOrNops(mode);
         [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
-        public override Task ReadAsync_CancelPendingTask_ThrowsCancellationException() => base.ReadAsync_CancelPendingTask_ThrowsCancellationException();
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
-        public override Task ReadAsync_ContinuesOnCurrentSynchronizationContextIfDesired(bool flowExecutionContext, bool? continueOnCapturedContext) => base.ReadAsync_ContinuesOnCurrentSynchronizationContextIfDesired(flowExecutionContext, continueOnCapturedContext);
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
-        public override Task ReadWriteByte_Success() => base.ReadWriteByte_Success();
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
-        public override Task ReadWrite_Success(ReadWriteMode mode, int writeSize, bool startWithFlush) => base.ReadWrite_Success(mode, writeSize, startWithFlush);
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
-        public override Task ReadWrite_Success_Large(ReadWriteMode mode, int writeSize, bool startWithFlush) => base.ReadWrite_Success_Large(mode, writeSize, startWithFlush);
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
-        public override Task Flush_ValidOnWriteableStreamWithNoData_Success() => base.Flush_ValidOnWriteableStreamWithNoData_Success();
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
-        public override Task ReadAsync_CancelPendingValueTask_ThrowsCancellationException() => base.ReadAsync_CancelPendingValueTask_ThrowsCancellationException();
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
         public override Task ReadAsync_DuringReadAsync_ThrowsIfUnsupported() => base.ReadAsync_DuringReadAsync_ThrowsIfUnsupported();
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
-        public override Task ReadWrite_CustomMemoryManager_Success(bool useAsync) => base.ReadWrite_CustomMemoryManager_Success(useAsync);
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
-        public override Task Flush_ValidOnReadableStream_Success() => base.Flush_ValidOnReadableStream_Success();
-
     }
 
     public abstract class QuicStreamConformanceTests : ConnectedStreamConformanceTests
     {
+        public X509Certificate2 ServerCertificate = System.Net.Test.Common.Configuration.Certificates.GetServerCertificate();
+
+        public bool RemoteCertificateValidationCallback(object sender, X509Certificate? certificate, X509Chain? chain, SslPolicyErrors sslPolicyErrors)
+        {
+            Assert.Equal(ServerCertificate.GetCertHash(), certificate?.GetCertHash());
+            return true;
+        }
+
         public SslServerAuthenticationOptions GetSslServerAuthenticationOptions()
         {
             return new SslServerAuthenticationOptions()
             {
                 ApplicationProtocols = new List<SslApplicationProtocol>() { new SslApplicationProtocol("quictest") },
-                // TODO: use a cert. MsQuic currently only allows certs that are trusted.
-                ServerCertificate = System.Net.Test.Common.Configuration.Certificates.GetServerCertificate()
+                ServerCertificate = ServerCertificate
+            };
+        }
+
+        public SslClientAuthenticationOptions GetSslClientAuthenticationOptions()
+        {
+            return new SslClientAuthenticationOptions()
+            {
+                ApplicationProtocols = new List<SslApplicationProtocol>() { new SslApplicationProtocol("quictest") },
+                RemoteCertificateValidationCallback = RemoteCertificateValidationCallback
             };
         }
 
@@ -98,30 +82,30 @@ namespace System.Net.Quic.Tests
         protected override async Task<StreamPair> CreateConnectedStreamsAsync()
         {
             QuicImplementationProvider provider = Provider;
-            var protocol = new SslApplicationProtocol("quictest");
-
             var listener = new QuicListener(
                 provider,
                 new IPEndPoint(IPAddress.Loopback, 0),
                 GetSslServerAuthenticationOptions());
 
+            byte[] buffer = new byte[1] { 42 };
             QuicConnection connection1 = null, connection2 = null;
             QuicStream stream1 = null, stream2 = null;
-
             await WhenAllOrAnyFailed(
                 Task.Run(async () =>
                 {
                     connection1 = await listener.AcceptConnectionAsync();
                     stream1 = await connection1.AcceptStreamAsync();
+                    Assert.Equal(1, await stream1.ReadAsync(buffer));
                 }),
                 Task.Run(async () =>
                 {
                     connection2 = new QuicConnection(
                         provider,
                         listener.ListenEndPoint,
-                        new SslClientAuthenticationOptions() { ApplicationProtocols = new List<SslApplicationProtocol>() { protocol } });
+                        GetSslClientAuthenticationOptions());
                     await connection2.ConnectAsync();
                     stream2 = connection2.OpenBidirectionalStream();
+                    await stream2.WriteAsync(buffer);
                 }));
 
             var result = new StreamPairWithOtherDisposables(stream1, stream2);

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamConnectedStreamConformanceTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamConnectedStreamConformanceTests.cs
@@ -105,6 +105,8 @@ namespace System.Net.Quic.Tests
                         GetSslClientAuthenticationOptions());
                     await connection2.ConnectAsync();
                     stream2 = connection2.OpenBidirectionalStream();
+                    // OpenBidirectionalStream only allocates ID. We will force stream opening
+                    // by Writing there and receiving data on the other side.
                     await stream2.WriteAsync(buffer);
                 }));
 


### PR DESCRIPTION
I start looking at newly failing `ReadWrite_MessagesSmallerThanReadBuffer_Success` worrying this is another evil test @stephentoub wrote. It turned out that out setup was bused so the test was primarily failing failing because it was not disabled like other one. ;(

It is somewhat confusing as `connection2.OpenBidirectionalStream()` does not really create connected stream - but it only allocates ID. With that the `CreateConnectedStreamsAsync` was failing to do what it claims. I added read/write to get truly connected stream with verification. Further more, the was issue with client options as we use untrusted certificate so we need to force the validation via RemoteCertificateValidationCallback.

I also noticed some tests failing with the "sync" variant. With closer look at 
```c#
return ReadAsync(buffer.ToArray()).AsTask().GetAwaiter().GetResult();
```

the wrapper would read data to newly allocated array but the actual data would never make it back to the original Span.
There may be better way to fix it but for now I rent transient buffer from pool and than copy read bytes over.

contributes to #49157