### PR TITLE
Add polymorphic serialization to System.Text.Json

### DIFF
--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -267,6 +267,7 @@ namespace System.Text.Json
         public bool IncludeFields { get { throw null; } set { } }
         public int MaxDepth { get { throw null; } set { } }
         public System.Text.Json.Serialization.JsonNumberHandling NumberHandling { get { throw null; } set { } }
+        public System.Func<Type, bool> SupportedPolymorphicTypes { get { throw null; } set { } }
         public bool PropertyNameCaseInsensitive { get { throw null; } set { } }
         public System.Text.Json.JsonNamingPolicy? PropertyNamingPolicy { get { throw null; } set { } }
         public System.Text.Json.JsonCommentHandling ReadCommentHandling { get { throw null; } set { } }
@@ -795,6 +796,11 @@ namespace System.Text.Json.Serialization
     {
         public JsonNumberHandlingAttribute(System.Text.Json.Serialization.JsonNumberHandling handling) { }
         public System.Text.Json.Serialization.JsonNumberHandling Handling { get { throw null; } }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
+    public sealed partial class JsonPolymorphicTypeAttribute : System.Text.Json.Serialization.JsonAttribute
+    {
+        public JsonPolymorphicTypeAttribute() { }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Property, AllowMultiple=false)]
     public sealed partial class JsonPropertyNameAttribute : System.Text.Json.Serialization.JsonAttribute

--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -88,6 +88,7 @@
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonIgnoreAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonIncludeAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonNumberHandlingAttribute.cs" />
+    <Compile Include="System\Text\Json\Serialization\Attributes\JsonPolymorphicTypeAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonPropertyNameAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonSerializableAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\JsonMetadataServicesConverter.cs" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Attributes/JsonPolymorphicTypeAttribute.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Attributes/JsonPolymorphicTypeAttribute.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Text.Json.Serialization
+{
+    /// <summary>
+    /// When placed on a type declaration, indicates that instances of that type
+    /// should be serialized using the schema based on their derived runtime types.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
+    public sealed class JsonPolymorphicTypeAttribute : JsonAttribute
+    {
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ArrayConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ArrayConverter.cs
@@ -38,7 +38,7 @@ namespace System.Text.Json.Serialization.Converters
             int index = state.Current.EnumeratorIndex;
 
             JsonConverter<TElement> elementConverter = GetElementConverter(ref state);
-            if (elementConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling == null)
+            if (GetElementTypeInfo(ref state).CanUseDirectWrite && state.Current.NumberHandling == null)
             {
                 // Fast path that avoids validation and extra indirection.
                 for (; index < array.Length; index++)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
@@ -67,7 +67,7 @@ namespace System.Text.Json.Serialization.Converters
                 CreateCollection(ref reader, ref state);
 
                 _valueConverter ??= GetConverter<TValue>(elementTypeInfo);
-                if (_valueConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling == null)
+                if (elementTypeInfo.CanUseDirectRead && state.Current.NumberHandling == null)
                 {
                     // Process all elements.
                     while (true)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryOfTKeyTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryOfTKeyTValueConverter.cs
@@ -55,7 +55,7 @@ namespace System.Text.Json.Serialization.Converters
             _keyConverter ??= GetConverter<TKey>(typeInfo.KeyTypeInfo!);
             _valueConverter ??= GetConverter<TValue>(typeInfo.ElementTypeInfo!);
 
-            if (!state.SupportContinuation && _valueConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling == null)
+            if (!state.SupportContinuation && typeInfo.ElementTypeInfo!.CanUseDirectWrite && state.Current.NumberHandling == null)
             {
                 // Fast path that avoids validation and extra indirection.
                 do

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
@@ -33,6 +33,14 @@ namespace System.Text.Json.Serialization.Converters
             return converter;
         }
 
+        protected static JsonTypeInfo GetElementTypeInfo(ref WriteStack state)
+        {
+            JsonTypeInfo typeInfo = state.Current.DeclaredJsonPropertyInfo!.RuntimeTypeInfo;
+            Debug.Assert(typeInfo != null); // It should not be possible to have a null JsonTypeInfo
+
+            return typeInfo;
+        }
+
         internal override bool OnTryRead(
             ref Utf8JsonReader reader,
             Type typeToConvert,
@@ -54,7 +62,7 @@ namespace System.Text.Json.Serialization.Converters
                 CreateCollection(ref reader, ref state, options);
 
                 JsonConverter<TElement> elementConverter = GetElementConverter(elementTypeInfo);
-                if (elementConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling == null)
+                if (elementTypeInfo.CanUseDirectRead && state.Current.NumberHandling == null)
                 {
                     // Fast path that avoids validation and extra indirection.
                     while (true)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IListConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IListConverter.cs
@@ -61,7 +61,7 @@ namespace System.Text.Json.Serialization.Converters
             int index = state.Current.EnumeratorIndex;
             JsonConverter<object?> elementConverter = GetElementConverter(ref state);
 
-            if (elementConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling == null)
+            if (GetElementTypeInfo(ref state).CanUseDirectWrite && state.Current.NumberHandling == null)
             {
                 // Fast path that avoids validation and extra indirection.
                 for (; index < list.Count; index++)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ListOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ListOfTConverter.cs
@@ -33,7 +33,7 @@ namespace System.Text.Json.Serialization.Converters
             int index = state.Current.EnumeratorIndex;
             JsonConverter<TElement> elementConverter = GetElementConverter(ref state);
 
-            if (elementConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling == null)
+            if (GetElementTypeInfo(ref state).CanUseDirectWrite && state.Current.NumberHandling == null)
             {
                 // Fast path that avoids validation and extra indirection.
                 for (; index < list.Count; index++)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -312,7 +312,9 @@ namespace System.Text.Json.Serialization.Converters
 
                         if (!jsonPropertyInfo.GetMemberAndWriteJson(objectValue!, ref state, writer))
                         {
-                            Debug.Assert(jsonPropertyInfo.ConverterBase.ConverterStrategy != ConverterStrategy.Value);
+                            Debug.Assert(jsonPropertyInfo.ConverterBase.ConverterStrategy != ConverterStrategy.Value ||
+                                         jsonPropertyInfo.ConverterBase.TypeToConvert == JsonTypeInfo.ObjectType);
+
                             return false;
                         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ObjectConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ObjectConverter.cs
@@ -24,7 +24,10 @@ namespace System.Text.Json.Serialization.Converters
 
         public override void Write(Utf8JsonWriter writer, object? value, JsonSerializerOptions options)
         {
-            throw new InvalidOperationException();
+            Debug.Assert(value?.GetType() == typeof(object));
+
+            writer.WriteStartObject();
+            writer.WriteEndObject();
         }
 
         internal override object ReadWithQuotes(ref Utf8JsonReader reader)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -23,16 +23,9 @@ namespace System.Text.Json.Serialization
         internal abstract ConverterStrategy ConverterStrategy { get; }
 
         /// <summary>
-        /// Can direct Read or Write methods be called (for performance).
-        /// </summary>
-        internal bool CanUseDirectReadOrWrite { get; set; }
-
-        /// <summary>
         /// Can the converter have $id metadata.
         /// </summary>
         internal virtual bool CanHaveIdMetadata => true;
-
-        internal bool CanBePolymorphic { get; set; }
 
         /// <summary>
         /// Used to support JsonObject as an extension property in a loosely-typed, trimmable manner.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonResumableConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonResumableConverterOfT.cs
@@ -33,10 +33,18 @@ namespace System.Text.Json.Serialization
             }
 
             WriteStack state = default;
-            state.Initialize(typeof(T), options, supportContinuation: false);
+            JsonConverter converter = state.Initialize(value, options, supportContinuation: false);
+
             try
             {
-                TryWrite(writer, value, options, ref state);
+                if (converter is JsonConverter<T> conv)
+                {
+                    conv.TryWrite(writer, value, options, ref state);
+                }
+                else
+                {
+                    converter.TryWriteAsObject(writer, value, options, ref state);
+                }
             }
             catch
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
@@ -47,11 +47,9 @@ namespace System.Text.Json
             else
             {
                 WriteStack state = default;
-                state.Initialize(jsonTypeInfo, supportContinuation: false);
+                JsonConverter converter = state.Initialize(value, jsonTypeInfo, supportContinuation: false);
 
-                JsonConverter converter = jsonTypeInfo.PropertyInfoForTypeInfo.ConverterBase;
                 Debug.Assert(converter != null);
-
                 Debug.Assert(jsonTypeInfo.Options != null);
 
                 WriteCore(converter, writer, value, jsonTypeInfo.Options, ref state);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -194,7 +194,7 @@ namespace System.Text.Json
             using (var writer = new Utf8JsonWriter(bufferWriter, writerOptions))
             {
                 WriteStack state = new WriteStack { CancellationToken = cancellationToken };
-                JsonConverter converter = state.Initialize(jsonTypeInfo, supportContinuation: true);
+                JsonConverter converter = state.Initialize(value, jsonTypeInfo, supportContinuation: true);
 
                 bool isFinalBlock;
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.String.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.String.cs
@@ -125,9 +125,6 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(jsonTypeInfo));
             }
 
-            WriteStack state = default;
-            state.Initialize(jsonTypeInfo, supportContinuation: false);
-
             JsonSerializerOptions options = jsonTypeInfo.Options;
 
             using (var output = new PooledByteBufferWriter(options.DefaultBufferSize))

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -39,6 +39,7 @@ namespace System.Text.Json
         private JsonNamingPolicy? _jsonPropertyNamingPolicy;
         private JsonCommentHandling _readCommentHandling;
         private ReferenceHandler? _referenceHandler;
+        private Func<Type, bool>? _supportedPolymorphicTypes;
         private JavaScriptEncoder? _encoder;
         private JsonIgnoreCondition _defaultIgnoreCondition;
         private JsonNumberHandling _numberHandling;
@@ -82,6 +83,7 @@ namespace System.Text.Json
             _dictionaryKeyPolicy = options._dictionaryKeyPolicy;
             _jsonPropertyNamingPolicy = options._jsonPropertyNamingPolicy;
             _readCommentHandling = options._readCommentHandling;
+            _supportedPolymorphicTypes = options._supportedPolymorphicTypes;
             _referenceHandler = options._referenceHandler;
             _encoder = options._encoder;
             _defaultIgnoreCondition = options._defaultIgnoreCondition;
@@ -547,6 +549,20 @@ namespace System.Text.Json
                 VerifyMutable();
                 _referenceHandler = value;
                 ReferenceHandlingStrategy = value?.HandlingStrategy ?? ReferenceHandlingStrategy.None;
+            }
+        }
+
+        /// <summary>
+        /// Type predicate configuring what types should be serialized polymorphically.
+        /// Note that this abstraction only governs serialization and offers no support for deserialization.
+        /// </summary>
+        public Func<Type, bool> SupportedPolymorphicTypes
+        {
+            get => _supportedPolymorphicTypes ??= static type => type == JsonTypeInfo.ObjectType;
+            set
+            {
+                VerifyMutable();
+                _supportedPolymorphicTypes = value;
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -551,8 +551,9 @@ namespace System.Text.Json.Serialization.Metadata
 
             // Resolve polymorphic serialization configuration
             CanBeWritePolymorphic =
+                isInternalConverter && !Type.IsValueType && !Type.IsSealed &&
                 Type == JsonTypeInfo.ObjectType ||
-                !Type.IsValueType && !Type.IsSealed && converterStrategy != ConverterStrategy.Value &&
+                converterStrategy != ConverterStrategy.Value &&
                     (Options?.SupportedPolymorphicTypes(Type) == true ||
                      Type.GetCustomAttribute<JsonPolymorphicTypeAttribute>(inherit: false) is not null);
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -258,8 +258,7 @@ namespace System.Text.Json
 
                 if (frame.JsonTypeInfo != null && frame.IsProcessingEnumerable())
                 {
-                    IEnumerable? enumerable = (IEnumerable?)frame.ReturnValue;
-                    if (enumerable == null)
+                    if (frame.ReturnValue is not IEnumerable enumerable)
                     {
                         return;
                     }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CustomConverterTests/CustomConverterTests.Object.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CustomConverterTests/CustomConverterTests.Object.cs
@@ -307,7 +307,9 @@ namespace System.Text.Json.Serialization.Tests
 
             public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
             {
-                throw new InvalidOperationException("Should not get here.");
+                Assert.IsType<object>(value);
+                writer.WriteStartObject();
+                writer.WriteEndObject();
             }
         }
 
@@ -732,5 +734,34 @@ namespace System.Text.Json.Serialization.Tests
             options.Converters.Add(new SystemObjectNewtonsoftCompatibleConverter());
             Verify(options);
         }
+
+        [Fact]
+        public static void CanCustomizeSystemObjectSerialization()
+        {
+            var options = new JsonSerializerOptions { Converters = { new CustomSystemObjectConverter() } };
+
+            string expectedJson = "\"Object\"";
+            string actualJson = JsonSerializer.Serialize(new object(), options);
+            Assert.Equal(expectedJson, actualJson);
+        }
+
+        private class CustomSystemObjectConverter : JsonConverter<object>
+        {
+            public override object? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => throw new NotImplementedException();
+            public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
+            {
+                if (value?.GetType() == typeof(object))
+                {
+                    // check that serialization for values of
+                    // runtime type object can be customized.
+                    writer.WriteStringValue("Object");
+                }
+                else
+                {
+                    throw new NotSupportedException();
+                }
+            }
+        }
     }
+
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
@@ -328,12 +328,12 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void Options_GetConverterForObjectJsonElement_GivesCorrectConverter()
         {
-            GenericObjectOrJsonElementConverterTestHelper<object>("ObjectConverter", new object(), "[3]", true);
+            GenericObjectOrJsonElementConverterTestHelper<object>("ObjectConverter", new object(), "{}");
             JsonElement element = JsonDocument.Parse("[3]").RootElement;
-            GenericObjectOrJsonElementConverterTestHelper<JsonElement>("JsonElementConverter", element, "[3]", false);
+            GenericObjectOrJsonElementConverterTestHelper<JsonElement>("JsonElementConverter", element, "[3]");
         }
 
-        private static void GenericObjectOrJsonElementConverterTestHelper<T>(string converterName, object objectValue, string stringValue, bool throws)
+        private static void GenericObjectOrJsonElementConverterTestHelper<T>(string converterName, object objectValue, string stringValue)
         {
             var options = new JsonSerializerOptions();
 
@@ -347,10 +347,7 @@ namespace System.Text.Json.Serialization.Tests
 
             if (readValue is JsonElement element)
             {
-                Assert.Equal(JsonValueKind.Array, element.ValueKind);
-                JsonElement.ArrayEnumerator iterator = element.EnumerateArray();
-                Assert.True(iterator.MoveNext());
-                Assert.Equal(3, iterator.Current.GetInt32());
+                JsonTestHelper.AssertJsonEqual(stringValue, element.ToString());
             }
             else
             {
@@ -360,22 +357,14 @@ namespace System.Text.Json.Serialization.Tests
             using (var stream = new MemoryStream())
             using (var writer = new Utf8JsonWriter(stream))
             {
-                if (throws)
-                {
-                    Assert.Throws<InvalidOperationException>(() => converter.Write(writer, (T)objectValue, options));
-                    Assert.Throws<InvalidOperationException>(() => converter.Write(writer, (T)objectValue, null));
-                }
-                else
-                {
-                    converter.Write(writer, (T)objectValue, options);
-                    writer.Flush();
-                    Assert.Equal(stringValue, Encoding.UTF8.GetString(stream.ToArray()));
+                converter.Write(writer, (T)objectValue, options);
+                writer.Flush();
+                Assert.Equal(stringValue, Encoding.UTF8.GetString(stream.ToArray()));
 
-                    writer.Reset(stream);
-                    converter.Write(writer, (T)objectValue, null); // Test with null option
-                    writer.Flush();
-                    Assert.Equal(stringValue + stringValue, Encoding.UTF8.GetString(stream.ToArray()));
-                }
+                writer.Reset(stream);
+                converter.Write(writer, (T)objectValue, null); // Test with null option
+                writer.Flush();
+                Assert.Equal(stringValue + stringValue, Encoding.UTF8.GetString(stream.ToArray()));
             }
         }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
@@ -587,6 +587,10 @@ namespace System.Text.Json.Serialization.Tests
                 {
                     options.ReferenceHandler = ReferenceHandler.Preserve;
                 }
+                else if (propertyType == typeof(Func<Type, bool>))
+                {
+                    options.SupportedPolymorphicTypes = static type => type == typeof(object);
+                }
                 else if (propertyType.IsValueType)
                 {
                     options.ReadCommentHandling = JsonCommentHandling.Disallow;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/PolymorphicTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/PolymorphicTests.cs
@@ -512,6 +512,361 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(Expected, json);
         }
 
+        [Fact]
+        public async Task ConcreteClass_RootValue_PolymorphismDisabled_ShouldSerializeAsBase()
+        {
+            var options = new JsonSerializerOptions { SupportedPolymorphicTypes = _ => false };
+            ConcreteClass value = new DerivedClass { Boolean = true, Number = 42 };
+            string expectedJson = @"{""Boolean"":true}";
+
+            string actualJson = await Serializer.SerializeWrapper(value, options);
+
+            Assert.Equal(expectedJson, actualJson);
+        }
+
+        [Fact]
+        public async Task ConcreteClass_RootValue_PolymorphismEnabled_ShouldSerializePolymorphically()
+        {
+            var options = new JsonSerializerOptions { SupportedPolymorphicTypes = type => type == typeof(ConcreteClass) };
+            ConcreteClass value = new DerivedClass { Boolean = true, Number = 42 };
+            string expectedJson = @"{""Number"":42,""Boolean"":true}";
+
+            string actualJson = await Serializer.SerializeWrapper(value, options);
+
+            Assert.Equal(expectedJson, actualJson);
+        }
+
+        [Fact]
+        public void ConcreteClass_RootValue_PolymorphismEnabled_ShouldDeserializeAsBase()
+        {
+            var options = new JsonSerializerOptions { SupportedPolymorphicTypes = type => type == typeof(ConcreteClass) };
+            string json = @"{""Number"":42,""Boolean"":true}";
+
+            ConcreteClass result = JsonSerializer.Deserialize<ConcreteClass>(json, options);
+
+            Assert.IsType<ConcreteClass>(result);
+            Assert.True(result.Boolean);
+        }
+
+        [Fact]
+        public async Task ConcreteClass_NestedValue_PolymorphismDisabled_ShouldSerializeAsBase()
+        {
+            var options = new JsonSerializerOptions { SupportedPolymorphicTypes = _ => false };
+            List<ConcreteClass> value = new() { new DerivedClass { Boolean = true, Number = 42 } };
+            string expectedJson = @"[{""Boolean"":true}]";
+
+            string actualJson = await Serializer.SerializeWrapper(value);
+            Assert.Equal(expectedJson, actualJson);
+        }
+
+        [Fact]
+        public async Task ConcreteClass_NestedValue_PolymorphismEnabled_ShouldSerializePolymorphically()
+        {
+            var options = new JsonSerializerOptions { SupportedPolymorphicTypes = type => type == typeof(ConcreteClass) };
+            List<ConcreteClass> value = new() { new DerivedClass { Boolean = true, Number = 42 } };
+            string expectedJson = @"[{""Number"":42,""Boolean"":true}]";
+
+            string actualJson = await Serializer.SerializeWrapper(value, options);
+            Assert.Equal(expectedJson, actualJson);
+        }
+
+        [Fact]
+        public void ConcreteClass_NestedValue_PolymorphismEnabled_ShouldDeserializeAsBase()
+        {
+            var options = new JsonSerializerOptions { SupportedPolymorphicTypes = type => type == typeof(ConcreteClass) };
+            string json = @"[{""Number"":42,""Boolean"":true}]";
+
+            List<ConcreteClass> result = JsonSerializer.Deserialize<List<ConcreteClass>>(json, options);
+
+            Assert.Equal(1, result.Count);
+            Assert.IsType<ConcreteClass>(result[0]);
+            Assert.True(result[0].Boolean);
+        }
+
+        [Fact]
+        public async Task AbstractClass_RootValue_PolymorphismDisabled_ShouldSerializeAsBase()
+        {
+            var options = new JsonSerializerOptions { SupportedPolymorphicTypes = _ => false };
+            AbstractClass value = new ConcreteClass { Boolean = true };
+            string expectedJson = @"{}";
+
+            string actualJson = await Serializer.SerializeWrapper(value, options);
+
+            Assert.Equal(expectedJson, actualJson);
+        }
+
+        [Fact]
+        public async Task AbstractClass_RootValue_PolymorphismEnabled_ShouldSerializePolymorphically()
+        {
+            var options = new JsonSerializerOptions { SupportedPolymorphicTypes = type => type == typeof(AbstractClass) };
+            AbstractClass value = new ConcreteClass { Boolean = true };
+            string expectedJson = @"{""Boolean"":true}";
+
+            string actualJson = await Serializer.SerializeWrapper(value, options);
+
+            Assert.Equal(expectedJson, actualJson);
+        }
+
+        [Fact]
+        public void AbstractClass_RootValue_PolymorphismEnabled_ShouldFailDeserialization()
+        {
+            var options = new JsonSerializerOptions { SupportedPolymorphicTypes = type => type == typeof(AbstractClass) };
+            string json = @"{""Boolean"":true}";
+
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<AbstractClass>(json, options));
+        }
+
+        [Fact]
+        public async Task AbstractClass_NestedValue_PolymorphismDisabled_ShouldSerializeAsBase()
+        {
+            var options = new JsonSerializerOptions { SupportedPolymorphicTypes = _ => false };
+            List<AbstractClass> value = new() { new ConcreteClass { Boolean = true } };
+            string expectedJson = @"[{}]";
+
+            string actualJson = await Serializer.SerializeWrapper(value);
+            Assert.Equal(expectedJson, actualJson);
+        }
+
+        [Fact]
+        public async Task AbstractClass_NestedValue_PolymorphismEnabled_ShouldSerializePolymorphically()
+        {
+            var options = new JsonSerializerOptions { SupportedPolymorphicTypes = type => type == typeof(AbstractClass) };
+            List<AbstractClass> value = new() { new ConcreteClass { Boolean = true } };
+            string expectedJson = @"[{""Boolean"":true}]";
+
+            string actualJson = await Serializer.SerializeWrapper(value, options);
+            Assert.Equal(expectedJson, actualJson);
+        }
+
+        [Fact]
+        public void AbstractClass_NestedValue_PolymorphismEnabled_ShouldFailDeserialization()
+        {
+            var options = new JsonSerializerOptions { SupportedPolymorphicTypes = type => type == typeof(AbstractClass) };
+            string json = @"[{""Boolean"":true}]";
+
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<List<AbstractClass>>(json, options));
+        }
+
+        [Fact]
+        public async Task Interface_RootValue_PolymorphismDisabled_ShouldSerializeAsBase()
+        {
+            var options = new JsonSerializerOptions { SupportedPolymorphicTypes = _ => false };
+            IThing value = new MyOtherThing { Number = 42, OtherNumber = 24 };
+            string expectedJson = @"{""Number"":42}";
+
+            string actualJson = await Serializer.SerializeWrapper(value, options);
+            Assert.Equal(expectedJson, actualJson);
+        }
+
+        [Fact]
+        public async Task Interface_RootValue_PolymorphismEnabled_ShouldSerializePolymorphically()
+        {
+            var options = new JsonSerializerOptions { SupportedPolymorphicTypes = type => type == typeof(IThing) };
+            IThing value = new MyOtherThing { Number = 42, OtherNumber = 24 };
+            string expectedJson = @"{""Number"":42,""OtherNumber"":24}";
+
+            string actualJson = await Serializer.SerializeWrapper(value, options);
+            Assert.Equal(expectedJson, actualJson);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetObjectsContainingNestedIThingValues))]
+        public async Task Interface_NestedValues_PolymorphismDisabled_ShouldSerializeAsBase<TValue>(TValue value, string expectedJson)
+        {
+            var options = new JsonSerializerOptions { SupportedPolymorphicTypes = _ => false };
+            string actualJson = await Serializer.SerializeWrapper(value, options);
+            Assert.NotEqual(expectedJson, actualJson);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetObjectsContainingNestedIThingValues))]
+        public async Task Interface_NestedValues_PolymorphismEnabled_ShouldSerializePolymorphically<TValue>(TValue value, string expectedJson)
+        {
+            var options = new JsonSerializerOptions { SupportedPolymorphicTypes = type => type == typeof(IThing) };
+            string actualJson = await Serializer.SerializeWrapper(value, options);
+            Assert.Equal(expectedJson, actualJson);
+        }
+
+        [Fact]
+        public void Interface_RootValue_PolymorphismEnabled_ShouldFailDeserialization()
+        {
+            var options = new JsonSerializerOptions { SupportedPolymorphicTypes = type => type == typeof(IThing) };
+            string json = @"{""Number"":42,""OtherNumber"":24}";
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<IThing>(json, options));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetObjectsContainingNestedIThingValues))]
+        public void Interface_NestedValues_PolymorphismEnabled_ShouldFailDeserialization<TValue>(TValue value, string json)
+        {
+            _ = value;
+            var options = new JsonSerializerOptions { SupportedPolymorphicTypes = type => type == typeof(IThing) };
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<TValue>(json, options));
+        }
+
+        [Fact]
+        public async Task PolymorphismEnabledForAllTypes_ShouldSerializeAllValuesPolymorphically()
+        {
+            var options = new JsonSerializerOptions { SupportedPolymorphicTypes = _ => true };
+            object[] value = new object[]
+            {
+                42,
+                "string",
+                CreateList<IThing>(new MyOtherThing { Number = 42, OtherNumber = -1 }),
+                CreateList<AbstractClass>(new DerivedClass { Number = 42, Boolean = true }, new ConcreteClass { Boolean = false }),
+                CreateList<ConcreteClass>(new DerivedClass { Number = 42, Boolean = true }),
+            };
+
+            string expectedJson = @"[42,""string"",[{""Number"":42,""OtherNumber"":-1}],[{""Number"":42,""Boolean"":true},{""Boolean"":false}],[{""Number"":42,""Boolean"":true}]]";
+            string actualJson = await Serializer.SerializeWrapper(value, options);
+
+            Assert.Equal(expectedJson, actualJson);
+
+            static List<T> CreateList<T>(params T[] values) => new(values);
+        }
+
+
+        [Fact]
+        public async Task ClassWithCustomConverter_RootValue_ShouldNotBePolymorphic()
+        {
+            var options = new JsonSerializerOptions
+            {
+                Converters = { new CustomIThingConverter() },
+                SupportedPolymorphicTypes = type => type == typeof(IThing)
+            };
+
+            IThing value = new MyOtherThing { Number = 42, OtherNumber = 21 };
+
+            string expectedJson = "42";
+            string actualJson = await Serializer.SerializeWrapper(value, options);
+
+            Assert.Equal(expectedJson, actualJson);
+        }
+
+        [Fact]
+        public async Task ClassWithCustomConverter_NestedValue_ShouldNotBePolymorphic()
+        {
+            var options = new JsonSerializerOptions
+            {
+                Converters = { new CustomIThingConverter() },
+                SupportedPolymorphicTypes = type => type == typeof(IThing)
+            };
+
+            var value = new { Value = (IThing)new MyOtherThing { Number = 42, OtherNumber = 21 } };
+
+            string expectedJson = @"{""Value"":42}";
+            string actualJson = await Serializer.SerializeWrapper(value, options);
+
+            Assert.Equal(expectedJson, actualJson);
+        }
+
+        [Fact]
+        public async Task RootObjectValue_PolymorphismCannotBeDisabled()
+        {
+            var options = new JsonSerializerOptions
+            {
+                SupportedPolymorphicTypes = type => false
+            };
+
+            object value = new { Value = 42 };
+
+            string expectedJson = @"{""Value"":42}";
+            string actualJson = await Serializer.SerializeWrapper(value, options);
+
+            Assert.Equal(expectedJson, actualJson);
+        }
+
+        [Fact]
+        public async Task NestedObjectValue_PolymorphismCannotBeDisabled()
+        {
+            var options = new JsonSerializerOptions
+            {
+                SupportedPolymorphicTypes = type => false
+            };
+
+            var value = new { Value = (object)new { Value = 42 } };
+
+            string expectedJson = @"{""Value"":{""Value"":42}}";
+            string actualJson = await Serializer.SerializeWrapper(value, options);
+
+            Assert.Equal(expectedJson, actualJson);
+        }
+
+        [Fact]
+        public async Task JsonPolymorphicTypeAttribute_Class()
+        {
+            PolymorphicAnnotatedClass value = new DerivedFromPolymorphicAnnotatedClass { A = 1, B = 2, C = 3 };
+            string expectedJson = @"{""A"":1,""B"":2,""C"":3}";
+
+            string json = await Serializer.SerializeWrapper(value);
+            JsonTestHelper.AssertJsonEqual(expectedJson, json);
+        }
+
+        [Fact]
+        public async Task JsonPolymorphicTypeAttribute_Interface()
+        {
+            IPolymorphicAnnotatedInterface value = new DerivedFromPolymorphicAnnotatedClass { A = 1, B = 2, C = 3 };
+            string expectedJson = @"{""A"":1,""B"":2,""C"":3}";
+
+            string json = await Serializer.SerializeWrapper(value);
+            JsonTestHelper.AssertJsonEqual(expectedJson, json);
+        }
+
+        [Fact]
+        public async Task JsonPolymorphicTypeAttribute_IsNotInheritedByDerivedTypes()
+        {
+            DerivedFromPolymorphicAnnotatedClass value = new DerivedFromDerivedFromPolymorphicAnnotatedClass { A = 1, B = 2, C = 3, D = 4 };
+            string expectedJson = @"{""A"":1,""B"":2,""C"":3}";
+
+            string json = await Serializer.SerializeWrapper(value);
+            JsonTestHelper.AssertJsonEqual(expectedJson, json);
+        }
+
+        public static IEnumerable<object[]> GetObjectsContainingNestedIThingValues()
+        {
+            yield return WrapArgs<MyThingCollection>(
+                new() { new MyThing { Number = -1 }, new MyOtherThing { Number = 42, OtherNumber = 24 } },
+                @"[{""Number"":-1},{""Number"":42,""OtherNumber"":24}]"
+            );
+
+            yield return WrapArgs<MyClass>(
+                new() { Value = "value", Thing = new MyOtherThing { Number = 42, OtherNumber = 24 } },
+                @"{""Value"":""value"",""Thing"":{""Number"":42,""OtherNumber"":24}}"
+            );
+
+            yield return WrapArgs<MyThingDictionary>(
+                new()
+                {
+                    ["key1"] = new MyOtherThing { Number = 42, OtherNumber = 24 },
+                    ["key2"] = new MyThing { Number = -1 }
+                },
+                @"{""key1"":{""Number"":42,""OtherNumber"":24},""key2"":{""Number"":-1}}"
+            );
+
+            static object[] WrapArgs<TValue>(TValue value, string expectedJson) => new object[] { value, expectedJson };
+        }
+
+        [Fact]
+
+        public async Task PolymorphicCyclicObjectGraphs_CycleDetectionEnabled()
+        {
+            var options = new JsonSerializerOptions { ReferenceHandler = ReferenceHandler.IgnoreCycles };
+
+            IBinTree tree = new BinTree<int>
+            {
+                Value = 0,
+                Left = new BinTree<int> { Value = -1 },
+            };
+
+            tree.Left.Left = tree;
+            tree.Left.Right = tree.Left;
+            tree.Right = tree;
+
+            string expectedJson = @"{""Value"":0,""Left"":{""Value"":-1,""Left"":null,""Right"":null},""Right"":null}";
+            string actualJson = await Serializer.SerializeWrapper(tree, options);
+            Assert.Equal(expectedJson, actualJson);
+        }
+
         class MyClass
         {
             public string Value { get; set; }
@@ -528,8 +883,74 @@ namespace System.Text.Json.Serialization.Tests
             public int Number { get; set; }
         }
 
+        class MyOtherThing : IThing
+        {
+            public int Number { get; set; }
+            public int OtherNumber { get; set; }
+        }
+
+        abstract class AbstractClass
+        {
+        }
+
+        class ConcreteClass : AbstractClass
+        {
+            public bool Boolean { get; set; }
+        }
+
+        class DerivedClass : ConcreteClass
+        {
+            public int Number { get; set; }
+        }
+
         class MyThingCollection : List<IThing> { }
 
         class MyThingDictionary : Dictionary<string, IThing> { }
+
+        [JsonPolymorphicType]
+        public class IPolymorphicAnnotatedInterface
+        {
+            int A { get; set; }
+        }
+
+        [JsonPolymorphicType]
+        public class PolymorphicAnnotatedClass : IPolymorphicAnnotatedInterface
+        {
+            public int A { get; set; }
+            public int B { get; set; }
+        }
+
+        public class DerivedFromPolymorphicAnnotatedClass : PolymorphicAnnotatedClass
+        {
+            public int C { get; set; }
+        }
+
+        public class DerivedFromDerivedFromPolymorphicAnnotatedClass : DerivedFromPolymorphicAnnotatedClass
+        {
+            public int D { get; set; }
+        }
+
+        [JsonPolymorphicType]
+        public interface IBinTree
+        {
+            public IBinTree? Left { get; set; }
+            public IBinTree? Right { get; set; }
+        }
+
+        public class BinTree<T> : IBinTree
+        {
+            public T Value { get; set; }
+            public IBinTree? Left { get; set; }
+            public IBinTree? Right { get; set; }
+        }
+
+        class CustomIThingConverter : JsonConverter<IThing>
+        {
+            public override IThing? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => throw new NotImplementedException();
+            public override void Write(Utf8JsonWriter writer, IThing value, JsonSerializerOptions options)
+            {
+                writer.WriteNumberValue(value.Number);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #29937. Based on the prototype in #53882 which incorporates #30083. API design pending approval.

## Infrastructural Changes

Here is a high-level overview of the infrastructural changes being made:

* The `CanBePolymorphic` and `CanUseDirectReadOrWrite` properties from `JsonConverter` have been moved to `JsonTypeInfo`, since the value of these flags can now be influenced by user configuration or attributes.
* Rewrites the `WriteStack` struct to support polymorphism:
    - Adds a `WriteStack.NextValueCanBePolymorphic` property which replaces `JsonConverter.CanBePolymorphic`.
    - Use an array instead of a list for storing previous stackframes.
    - Infrastructural changes in anticipation of #30083.
* Reworks the `ReferenceResolver.IgnoreCycles` implementation: the current implementation contains bespoke code to avoid polymorphic converters triggering false negatives. I have refactored the code slightly so that the cycle detection logic is combined with the polymorphic serialization infrastructure.

## Potential breaking change

The changes isolated in https://github.com/dotnet/runtime/commit/b14bcdf497def3996db1b480704504c986864aa8 introduce a deliberate breaking change when it comes to the handling of `new object()` values. The existing implementation will hardcode the serialization to `{}` _even if_ the user has subscribed a custom `JsonConverter<object>` that does something different. I would like to change this behavior for a few reasons:

* It can be surprising to users: custom object converters cannot be polymorphic _with the sole exception of_ `new object()` values. Users cannot specify a custom serialization format for `new object()` values.
* Keeping it requires maintaining [more complex logic in the serialization hot path](https://github.com/dotnet/runtime/commit/b14bcdf497def3996db1b480704504c986864aa8). The change makes the code simpler by delegating `object` instance serialization to the relevant converter.
* It is unlikely that `new object()` instances are being serialized in production applications.

The breaking change concerns the following scenario:
```csharp
using System;
using System.Text.Json;
using System.Text.Json.Serialization;

var options = new JsonSerializerOptions { Converters = { new CustomObjectConverter() } };
string json = JsonSerializer.Serialize(new object(), options);
Console.WriteLine(json);

public class CustomObjectConverter : JsonConverter<object>
{
    public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options) => writer.WriteNumberValue(42);
    public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => throw new NotSupportedException();
}
```
In .NET 5 the above would print `{}`, however under the new changes it would print `42`. This could break users with custom object converters who rely on the existing hardcoding behavior.

## Performance

When benchmarked against `main` using statistical testing with 5% threshold, performance of the feature branch is largely equivalent. It should be noted however that certain polymorphism-heavy scenaria (e.g. `WriteJson<ArrayList>`) do record a slight regression (which can be observed when applying thresholds < 3%). After profiling the code I can confirm that this regression is in part attributable to the additional work required by computing the `WriteStack.NextValueCanBePolymorphic` property.