### PR TITLE
Change PathInternal.IsCaseSensitive to a constant

### DIFF
--- a/src/libraries/Common/src/System/IO/PathInternal.CaseSensitivity.cs
+++ b/src/libraries/Common/src/System/IO/PathInternal.CaseSensitivity.cs
@@ -39,33 +39,5 @@ namespace System.IO
             return !(OperatingSystem.IsWindows() || OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() || OperatingSystem.IsWatchOS());
 #endif
         }
-
-        /// <summary>
-        /// Determines whether the file system is case sensitive by creating a file in a temp folder and observing the result.
-        /// </summary>
-        /// <remarks>
-        /// Ideally we'd use something like pathconf with _PC_CASE_SENSITIVE, but that is non-portable,
-        /// not supported on Windows or Linux, etc. For now, this function creates a tmp file with capital letters
-        /// and then tests for its existence with lower-case letters.  This could return invalid results in corner
-        /// cases where, for example, different file systems are mounted with differing sensitivities.
-        /// </remarks>
-        private static bool GetIsCaseSensitiveByProbing()
-        {
-            try
-            {
-                string pathWithUpperCase = Path.Combine(Path.GetTempPath(), "CASESENSITIVETEST" + Guid.NewGuid().ToString("N"));
-                using (new FileStream(pathWithUpperCase, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, 0x1000, FileOptions.DeleteOnClose))
-                {
-                    string lowerCased = pathWithUpperCase.ToLowerInvariant();
-                    return !File.Exists(lowerCased);
-                }
-            }
-            catch
-            {
-                // In case something goes wrong (e.g. temp pointing to a privilieged directory), we don't
-                // want to fail just because of a casing test, so we assume case-insensitive-but-preserving.
-                return false;
-            }
-        }
     }
 }

--- a/src/libraries/Common/src/System/IO/PathInternal.CaseSensitivity.cs
+++ b/src/libraries/Common/src/System/IO/PathInternal.CaseSensitivity.cs
@@ -33,16 +33,11 @@ namespace System.IO
         /// </summary>
         private static bool GetIsCaseSensitive()
         {
-#if NET6_0_OR_GREATER
-            // Return a constant for mobile platforms without resorting to I/O
-            if (OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() || OperatingSystem.IsWatchOS())
-                return true;
-            if (OperatingSystem.IsBrowser())
-                return false;
-            if (OperatingSystem.IsAndroid())
-                return false;
+#if MS_IO_REDIST
+            return false; // Windows is always case-insensitive
+#else
+            return !(OperatingSystem.IsWindows() || OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() || OperatingSystem.IsWatchOS());
 #endif
-            return GetIsCaseSensitiveByProbing();
         }
 
         /// <summary>

--- a/src/libraries/Common/src/System/IO/PathInternal.CaseSensitivity.cs
+++ b/src/libraries/Common/src/System/IO/PathInternal.CaseSensitivity.cs
@@ -31,13 +31,28 @@ namespace System.IO
         /// <summary>
         /// Determines whether the file system is case sensitive.
         /// </summary>
+        private static bool GetIsCaseSensitive()
+        {
+            // Return a constant for mobile platforms without resorting to I/O
+            if (OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() || OperatingSystem.IsWatchOS())
+                return true;
+            if (OperatingSystem.IsBrowser())
+                return false;
+            if (OperatingSystem.IsAndroid())
+                return false;
+            return GetIsCaseSensitiveByProbing();
+        }
+
+        /// <summary>
+        /// Determines whether the file system is case sensitive by creating a file in a temp folder and observing the result.
+        /// </summary>
         /// <remarks>
         /// Ideally we'd use something like pathconf with _PC_CASE_SENSITIVE, but that is non-portable,
         /// not supported on Windows or Linux, etc. For now, this function creates a tmp file with capital letters
         /// and then tests for its existence with lower-case letters.  This could return invalid results in corner
         /// cases where, for example, different file systems are mounted with differing sensitivities.
         /// </remarks>
-        private static bool GetIsCaseSensitive()
+        private static bool GetIsCaseSensitiveByProbing()
         {
             try
             {

--- a/src/libraries/Common/src/System/IO/PathInternal.CaseSensitivity.cs
+++ b/src/libraries/Common/src/System/IO/PathInternal.CaseSensitivity.cs
@@ -33,6 +33,7 @@ namespace System.IO
         /// </summary>
         private static bool GetIsCaseSensitive()
         {
+#if NET6_0_OR_GREATER
             // Return a constant for mobile platforms without resorting to I/O
             if (OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() || OperatingSystem.IsWatchOS())
                 return true;
@@ -40,6 +41,7 @@ namespace System.IO
                 return false;
             if (OperatingSystem.IsAndroid())
                 return false;
+#endif
             return GetIsCaseSensitiveByProbing();
         }
 

--- a/src/libraries/Common/src/System/IO/PathInternal.CaseSensitivity.cs
+++ b/src/libraries/Common/src/System/IO/PathInternal.CaseSensitivity.cs
@@ -12,32 +12,28 @@ namespace System.IO
     /// <summary>Contains internal path helpers that are shared between many projects.</summary>
     internal static partial class PathInternal
     {
-        private static readonly bool s_isCaseSensitive = GetIsCaseSensitive();
-
         /// <summary>Returns a comparison that can be used to compare file and directory names for equality.</summary>
         internal static StringComparison StringComparison
         {
             get
             {
-                return s_isCaseSensitive ?
+                return IsCaseSensitive ?
                     StringComparison.Ordinal :
                     StringComparison.OrdinalIgnoreCase;
             }
         }
 
         /// <summary>Gets whether the system is case-sensitive.</summary>
-        internal static bool IsCaseSensitive { get { return s_isCaseSensitive; } }
-
-        /// <summary>
-        /// Determines whether the file system is case sensitive.
-        /// </summary>
-        private static bool GetIsCaseSensitive()
+        internal static bool IsCaseSensitive
         {
+            get
+            {
 #if MS_IO_REDIST
-            return false; // Windows is always case-insensitive
+                return false; // Windows is always case-insensitive
 #else
-            return !(OperatingSystem.IsWindows() || OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() || OperatingSystem.IsWatchOS());
+                return !(OperatingSystem.IsWindows() || OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() || OperatingSystem.IsWatchOS());
 #endif
+            }
         }
     }
 }

--- a/src/libraries/System.IO.FileSystem/tests/FileSystemTest.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileSystemTest.cs
@@ -139,21 +139,12 @@ namespace System.IO.Tests
         /// </remarks>
         protected static bool GetIsCaseSensitiveByProbing(string probingDirectory)
         {
-            try
-            {
-                string pathWithUpperCase = Path.Combine(probingDirectory, "CASESENSITIVETEST" + Guid.NewGuid().ToString("N"));
-                using (new FileStream(pathWithUpperCase, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, 0x1000, FileOptions.DeleteOnClose))
-                {
-                    string lowerCased = pathWithUpperCase.ToLowerInvariant();
-                    return !File.Exists(lowerCased);
-                }
-            }
-            catch
-            {
-                // In case something goes wrong (e.g. temp pointing to a privilieged directory), we don't
-                // want to fail just because of a casing test, so we assume case-insensitive-but-preserving.
-                return false;
-            }
+	    string pathWithUpperCase = Path.Combine(probingDirectory, "CASESENSITIVETEST" + Guid.NewGuid().ToString("N"));
+	    using (new FileStream(pathWithUpperCase, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, 0x1000, FileOptions.DeleteOnClose))
+	    {
+		string lowerCased = pathWithUpperCase.ToLowerInvariant();
+		return !File.Exists(lowerCased);
+	    }
         }
     }
 }

--- a/src/libraries/System.IO.FileSystem/tests/FileSystemTest.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileSystemTest.cs
@@ -137,14 +137,14 @@ namespace System.IO.Tests
         /// and then tests for its existence with lower-case letters.  This could return invalid results in corner
         /// cases where, for example, different file systems are mounted with differing sensitivities.
         /// </remarks>
-    protected static bool GetIsCaseSensitiveByProbing(string probingDirectory)
-    {
-        string pathWithUpperCase = Path.Combine(probingDirectory, "CASESENSITIVETEST" + Guid.NewGuid().ToString("N"));
-        using (new FileStream(pathWithUpperCase, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, 0x1000, FileOptions.DeleteOnClose))
+        protected static bool GetIsCaseSensitiveByProbing(string probingDirectory)
         {
-            string lowerCased = pathWithUpperCase.ToLowerInvariant();
-            return !File.Exists(lowerCased);
+            string pathWithUpperCase = Path.Combine(probingDirectory, "CASESENSITIVETEST" + Guid.NewGuid().ToString("N"));
+            using (new FileStream(pathWithUpperCase, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, 0x1000, FileOptions.DeleteOnClose))
+            {
+                string lowerCased = pathWithUpperCase.ToLowerInvariant();
+                return !File.Exists(lowerCased);
+            }
         }
-    }
     }
 }

--- a/src/libraries/System.IO.FileSystem/tests/FileSystemTest.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileSystemTest.cs
@@ -127,5 +127,33 @@ namespace System.IO.Tests
                 Assert.Equal(0, AdminHelpers.RunAsSudo($"umount {readOnlyDirectory}"));
             }
         }
+
+        /// <summary>
+        /// Determines whether the file system is case sensitive by creating a file in the specified folder and observing the result.
+        /// </summary>
+        /// <remarks>
+        /// Ideally we'd use something like pathconf with _PC_CASE_SENSITIVE, but that is non-portable,
+        /// not supported on Windows or Linux, etc. For now, this function creates a tmp file with capital letters
+        /// and then tests for its existence with lower-case letters.  This could return invalid results in corner
+        /// cases where, for example, different file systems are mounted with differing sensitivities.
+        /// </remarks>
+        protected static bool GetIsCaseSensitiveByProbing(string probingDirectory)
+        {
+            try
+            {
+                string pathWithUpperCase = Path.Combine(probingDirectory, "CASESENSITIVETEST" + Guid.NewGuid().ToString("N"));
+                using (new FileStream(pathWithUpperCase, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, 0x1000, FileOptions.DeleteOnClose))
+                {
+                    string lowerCased = pathWithUpperCase.ToLowerInvariant();
+                    return !File.Exists(lowerCased);
+                }
+            }
+            catch
+            {
+                // In case something goes wrong (e.g. temp pointing to a privilieged directory), we don't
+                // want to fail just because of a casing test, so we assume case-insensitive-but-preserving.
+                return false;
+            }
+        }
     }
 }

--- a/src/libraries/System.IO.FileSystem/tests/FileSystemTest.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileSystemTest.cs
@@ -137,14 +137,14 @@ namespace System.IO.Tests
         /// and then tests for its existence with lower-case letters.  This could return invalid results in corner
         /// cases where, for example, different file systems are mounted with differing sensitivities.
         /// </remarks>
-        protected static bool GetIsCaseSensitiveByProbing(string probingDirectory)
+    protected static bool GetIsCaseSensitiveByProbing(string probingDirectory)
+    {
+        string pathWithUpperCase = Path.Combine(probingDirectory, "CASESENSITIVETEST" + Guid.NewGuid().ToString("N"));
+        using (new FileStream(pathWithUpperCase, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, 0x1000, FileOptions.DeleteOnClose))
         {
-	    string pathWithUpperCase = Path.Combine(probingDirectory, "CASESENSITIVETEST" + Guid.NewGuid().ToString("N"));
-	    using (new FileStream(pathWithUpperCase, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, 0x1000, FileOptions.DeleteOnClose))
-	    {
-		string lowerCased = pathWithUpperCase.ToLowerInvariant();
-		return !File.Exists(lowerCased);
-	    }
+            string lowerCased = pathWithUpperCase.ToLowerInvariant();
+            return !File.Exists(lowerCased);
         }
+    }
     }
 }

--- a/src/libraries/System.IO.FileSystem/tests/Net5CompatTests/System.IO.FileSystem.Net5Compat.Tests.csproj
+++ b/src/libraries/System.IO.FileSystem/tests/Net5CompatTests/System.IO.FileSystem.Net5Compat.Tests.csproj
@@ -37,6 +37,8 @@
     <Compile Include="$(CommonTestPath)System\IO\TempFile.cs" Link="Common\System\IO\TempFile.cs" />
     <Compile Include="$(CommonTestPath)System\IO\PathFeatures.cs" Link="Common\System\IO\PathFeatures.cs" />
     <Content Include="..\DirectoryInfo\test-dir\dummy.txt" Link="test-dir\dummy.txt" />
+    <Compile Include="$(CommonPath)System\IO\PathInternal.CaseSensitivity.cs"
+             Link="Common\System\IO\PathInternal.CaseSensitivity.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)StreamConformanceTests\StreamConformanceTests.csproj" />

--- a/src/libraries/System.IO.FileSystem/tests/PathInternalTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/PathInternalTests.cs
@@ -11,7 +11,7 @@ namespace System.IO.Tests
         [OuterLoop]
         public void PathInternalIsCaseSensitiveMatchesProbing()
         {
-            var probingDirectory = TestDirectory;
+            string probingDirectory = TestDirectory;
             Assert.Equal(GetIsCaseSensitiveByProbing(probingDirectory), PathInternal.IsCaseSensitive);
         }
     }

--- a/src/libraries/System.IO.FileSystem/tests/PathInternalTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/PathInternalTests.cs
@@ -8,6 +8,7 @@ namespace System.IO.Tests
     public class PathInternalTests : FileSystemTest
     {
         [Fact]
+        [OuterLoop]
         public void PathInternalIsCaseSensitiveMatchesProbing()
         {
             var probingDirectory = TestDirectory;

--- a/src/libraries/System.IO.FileSystem/tests/PathInternalTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/PathInternalTests.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class PathInternalTests : FileSystemTest
+    {
+        [Fact]
+        public void PathInternalIsCaseSensitiveMatchesProbing()
+        {
+            var probingDirectory = TestDirectory;
+            Assert.Equal(GetIsCaseSensitiveByProbing(probingDirectory), PathInternal.IsCaseSensitive);
+        }
+    }
+}

--- a/src/libraries/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/libraries/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Enumeration\ExampleTests.cs" />
     <Compile Include="Enumeration\RemovedDirectoryTests.cs" />
     <Compile Include="Enumeration\SymbolicLinksTests.cs" />
+    <Compile Include="PathInternalTests.cs" />
     <Compile Include="RandomAccess\Base.cs" />
     <Compile Include="RandomAccess\GetLength.cs" />
     <Compile Include="RandomAccess\Read.cs" />
@@ -191,6 +192,8 @@
     <Compile Include="$(CommonTestPath)System\IO\TempFile.cs" Link="Common\System\IO\TempFile.cs" />
     <Compile Include="$(CommonTestPath)System\IO\PathFeatures.cs" Link="Common\System\IO\PathFeatures.cs" />
     <Content Include="DirectoryInfo\test-dir\dummy.txt" Link="test-dir\dummy.txt" />
+    <Compile Include="$(CommonPath)System\IO\PathInternal.CaseSensitivity.cs"
+             Link="Common\System\IO\PathInternal.CaseSensitivity.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)StreamConformanceTests\StreamConformanceTests.csproj" />

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
@@ -129,17 +129,5 @@ namespace System.IO
             return IsPathRooted(path) ? PathInternal.DirectorySeparatorCharAsString.AsSpan() : ReadOnlySpan<char>.Empty;
         }
 
-        /// <summary>Gets whether the system is case-sensitive.</summary>
-        internal static bool IsCaseSensitive
-        {
-            get
-            {
-                #if TARGET_OSX || TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
-                    return false;
-                #else
-                    return true;
-                #endif
-            }
-        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Windows.cs
@@ -230,9 +230,6 @@ namespace System.IO
             return pathRoot <= 0 ? ReadOnlySpan<char>.Empty : path.Slice(0, pathRoot);
         }
 
-        /// <summary>Gets whether the system is case-sensitive.</summary>
-        internal static bool IsCaseSensitive => false;
-
         /// <summary>
         /// Returns the volume name for dos, UNC and device paths.
         /// </summary>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
@@ -957,11 +957,11 @@ namespace System.IO
             return sb.ToString();
         }
 
+        /// <summary>Gets whether the system is case-sensitive.</summary>
+        internal static bool IsCaseSensitive => PathInternal.IsCaseSensitive;
+
         /// <summary>Returns a comparison that can be used to compare file and directory names for equality.</summary>
-        internal static StringComparison StringComparison =>
-            IsCaseSensitive ?
-                StringComparison.Ordinal :
-                StringComparison.OrdinalIgnoreCase;
+        internal static StringComparison StringComparison => PathInternal.StringComparison;
 
         /// <summary>
         /// Trims one trailing directory separator beyond the root of the path.

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
@@ -860,7 +860,7 @@ namespace System.IO
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="relativeTo"/> or <paramref name="path"/> is <c>null</c> or an empty string.</exception>
         public static string GetRelativePath(string relativeTo, string path)
         {
-            return GetRelativePath(relativeTo, path, StringComparison);
+            return GetRelativePath(relativeTo, path, PathInternal.StringComparison);
         }
 
         private static string GetRelativePath(string relativeTo, string path, StringComparison comparisonType)
@@ -956,12 +956,6 @@ namespace System.IO
 
             return sb.ToString();
         }
-
-        /// <summary>Gets whether the system is case-sensitive.</summary>
-        internal static bool IsCaseSensitive => PathInternal.IsCaseSensitive;
-
-        /// <summary>Returns a comparison that can be used to compare file and directory names for equality.</summary>
-        internal static StringComparison StringComparison => PathInternal.StringComparison;
 
         /// <summary>
         /// Trims one trailing directory separator beyond the root of the path.

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -781,7 +781,7 @@ namespace System.Runtime.Loader
             string assemblyPath = Path.Combine(parentDirectory, assemblyName.CultureName!, $"{assemblyName.Name}.dll");
 
             bool exists = System.IO.FileSystem.FileExists(assemblyPath);
-            if (!exists && Path.IsCaseSensitive)
+            if (!exists && PathInternal.IsCaseSensitive)
             {
 #if CORECLR
                 if (AssemblyLoadContext.IsTracingEnabled())


### PR DESCRIPTION
See https://github.com/dotnet/runtime/issues/54313#issuecomment-863347311 and https://github.com/dotnet/maui/issues/822#issuecomment-863323985

The code that initialized `System.IO.PathInternal.s_isCaseSensitive` did I/O in the temp folder to check for case sensitivity.  This is a startup perf hit on Android where low-end devices may have very slow storage. It also returns results that may be misleading since different paths on Unix may have different filesystems mounted that have different case sensitivity (a common case on Android is ext4 for internal storage and exFAT for the SD card).

Instead, return a constant value based on the common platform behavior - case insensitive on Windows and Apple platforms, case sensitive elsewhere.

Also remove `Path.IsCaseSensitive` and `Path.StringComparison` - callers should use `PathInternal` properties directly.

Fixes https://github.com/dotnet/runtime/issues/54339