### PR TITLE
Lazy-allocate ValidationState.CurPos

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/ValidationState.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/ValidationState.cs
@@ -42,7 +42,8 @@ namespace System.Xml.Schema
         public bool HasMatched;       // whether the element has been verified correctly
 
         //For NFAs
-        public BitSet[] CurPos = new BitSet[2];
+        private BitSet[]? _curPos;
+        public BitSet[] CurPos => _curPos ??= new BitSet[2];
 
         //For all
         public BitSet? AllElementsSet;


### PR DESCRIPTION
The array is only used for a subset of validators; no point in paying for this array for every ValidationState instance even if it's not going to be used.

With the same scenario as in https://github.com/dotnet/runtime/pull/54344, these drop from 5000 to 11:
![image](https://user-images.githubusercontent.com/2642209/122440214-5a18f480-cf6a-11eb-9046-a06e12d29070.png)
