### PR TITLE
Remove crossgen from test build and run scripts

### DIFF
--- a/src/tests/build.sh
+++ b/src/tests/build.sh
@@ -133,8 +133,7 @@ generate_layout()
     build_MSBuild_projects "Tests_Overlay_Managed" "$__RepoRootDir/src/tests/run.proj" "Creating test overlay" "/t:CreateTestOverlay"
 
     # Precompile framework assemblies with crossgen if required
-    if [[ "$__DoCrossgen" != 0 || "$__DoCrossgen2" != 0 ]]; then
-        chmod +x "$__CrossgenExe"
+    if [[ "$__DoCrossgen2" != 0 ]]; then
         if [[ "$__SkipCrossgenFramework" == 0 ]]; then
             precompile_coreroot_fx
         fi
@@ -171,11 +170,7 @@ precompile_coreroot_fx()
         crossgenDir="$crossgenDir/$__HostArch"
     fi
 
-    if [[ "$__DoCrossgen" != 0 ]]; then
-        crossgenCmd="$crossgenCmd --crossgen --nocrossgen2 --crossgen-path \"$crossgenDir/crossgen\""
-    else
-        crossgenCmd="$crossgenCmd --verify-type-and-field-layout --crossgen2-path \"$crossgenDir/crossgen2/crossgen2.dll\""
-    fi
+    crossgenCmd="$crossgenCmd --verify-type-and-field-layout --crossgen2-path \"$crossgenDir/crossgen2/crossgen2.dll\""
 
     echo "Running $crossgenCmd"
     eval $crossgenCmd
@@ -189,17 +184,6 @@ precompile_coreroot_fx()
     mv "$outputDir"/*.dll "$CORE_ROOT"
 
     return 0
-}
-
-declare -a skipCrossGenFiles
-
-function is_skip_crossgen_test {
-    for skip in "${skipCrossGenFiles[@]}"; do
-        if [[ "$1" == "$skip" ]]; then
-            return 0
-        fi
-    done
-    return 1
 }
 
 build_Tests()
@@ -447,7 +431,6 @@ usage_list+=("-buildtestwrappersonly: only build the test wrappers.")
 usage_list+=("-copynativeonly: Only copy the native test binaries to the managed output. Do not build the native or managed tests.")
 usage_list+=("-generatelayoutonly: only pull down dependencies and build coreroot.")
 
-usage_list+=("-crossgen: Precompiles the framework managed assemblies in coreroot.")
 usage_list+=("-crossgen2: Precompiles the framework managed assemblies in coreroot using the Crossgen2 compiler.")
 usage_list+=("-priority1: include priority=1 tests in the build.")
 usage_list+=("-allTargets: Build managed tests for all target platforms.")
@@ -478,11 +461,6 @@ handle_arguments_local() {
             __CopyNativeProjectsAfterCombinedTestBuild=true
             __SkipGenerateLayout=1
             __SkipCrossgenFramework=1
-            ;;
-
-        crossgen|-crossgen)
-            __DoCrossgen=1
-            __TestBuildMode=crossgen
             ;;
 
         crossgen2|-crossgen2)
@@ -559,9 +537,9 @@ __CopyNativeProjectsAfterCombinedTestBuild=true
 __CopyNativeTestBinaries=0
 __CrossBuild=0
 __DistroRid=""
-__DoCrossgen=0
 __DoCrossgen2=0
 __CompositeBuildMode=0
+__TestBuildMode=
 __DotNetCli="$__RepoRootDir/dotnet.sh"
 __GenerateLayoutOnly=
 __IsMSBuildOnNETCoreSupported=0
@@ -607,17 +585,8 @@ __TestDir="$__RepoRootDir/src/tests"
 __TestWorkingDir="$__RootBinDir/tests/coreclr/$__OSPlatformConfig"
 __IntermediatesDir="$__RootBinDir/obj/coreclr/$__OSPlatformConfig"
 __TestIntermediatesDir="$__RootBinDir/tests/coreclr/obj/$__OSPlatformConfig"
-__CrossComponentBinDir="$__BinDir"
 __CrossCompIntermediatesDir="$__IntermediatesDir/crossgen"
 __MonoBinDir="$__RootBinDir/bin/mono/$__OSPlatformConfig"
-
-__CrossArch="$__HostArch"
-if [[ "$__CrossBuild" == 1 ]]; then
-    __CrossComponentBinDir="$__CrossComponentBinDir/$__CrossArch"
-fi
-__CrossgenCoreLibLog="$__LogsDir/CrossgenCoreLib_$__TargetOS.$BuildArch.$__BuildType.log"
-__CrossgenExe="$__CrossComponentBinDir/crossgen"
-__Crossgen2Dll="$__CrossComponentBinDir/crossgen2/crossgen2.dll"
 
 # CI_SPECIFIC - On CI machines, $HOME may not be set. In such a case, create a subfolder and set the variable to it.
 # This is needed by CLI to function.

--- a/src/tests/run.cmd
+++ b/src/tests/run.cmd
@@ -26,8 +26,6 @@ set __msbuildExtraArgs=
 set __LongGCTests=
 set __GCSimulatorTests=
 set __IlasmRoundTrip=
-set __DoCrossgen=
-set __CrossgenAltJit=
 set __PrintLastResultsOnly=
 set RunInUnloadableContext=
 
@@ -50,13 +48,8 @@ if /i "%1" == "debug"                                   (set __BuildType=Debug&s
 if /i "%1" == "release"                                 (set __BuildType=Release&shift&goto Arg_Loop)
 if /i "%1" == "checked"                                 (set __BuildType=Checked&shift&goto Arg_Loop)
 
-if /i "%1" == "vs2017"                                  (set __VSVersion=%1&shift&goto Arg_Loop)
-if /i "%1" == "vs2019"                                  (set __VSVersion=%1&shift&goto Arg_Loop)
-
 if /i "%1" == "TestEnv"                                 (set __TestEnv=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "sequential"                              (set __Sequential=1&shift&goto Arg_Loop)
-if /i "%1" == "crossgen"                                (set __DoCrossgen=1&shift&goto Arg_Loop)
-if /i "%1" == "crossgenaltjit"                          (set __DoCrossgen=1&set __CrossgenAltJit=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "longgc"                                  (set __LongGCTests=1&shift&goto Arg_Loop)
 if /i "%1" == "gcsimulator"                             (set __GCSimulatorTests=1&shift&goto Arg_Loop)
 if /i "%1" == "jitstress"                               (set COMPlus_JitStress=%2&shift&shift&goto Arg_Loop)
@@ -66,10 +59,8 @@ if /i "%1" == "jitforcerelocs"                          (set COMPlus_ForceRelocs
 if /i "%1" == "ilasmroundtrip"                          (set __IlasmRoundTrip=1&shift&goto Arg_Loop)
 
 if /i "%1" == "printlastresultsonly"                    (set __PrintLastResultsOnly=1&shift&goto Arg_Loop)
-if /i "%1" == "runcrossgentests"                        (set RunCrossGen=true&shift&goto Arg_Loop)
 if /i "%1" == "runcrossgen2tests"                       (set RunCrossGen2=true&shift&goto Arg_Loop)
 REM This test feature is currently intentionally undocumented
-if /i "%1" == "runlargeversionbubblecrossgentests"      (set RunCrossGen=true&set CrossgenLargeVersionBubble=true&shift&goto Arg_Loop)
 if /i "%1" == "runlargeversionbubblecrossgen2tests"     (set RunCrossGen2=true&set CrossgenLargeVersionBubble=true&shift&goto Arg_Loop)
 if /i "%1" == "link"                                    (set DoLink=true&set ILLINK=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "gcname"                                  (set COMPlus_GCName=%2&shift&shift&goto Arg_Loop)
@@ -138,16 +129,8 @@ if defined __Sequential (
     set __RuntestPyArgs=%__RuntestPyArgs% --sequential
 )
 
-if defined RunCrossGen (
-    set __RuntestPyArgs=%__RuntestPyArgs% --run_crossgen_tests
-)
-
 if defined RunCrossGen2 (
     set __RuntestPyArgs=%__RuntestPyArgs% --run_crossgen2_tests
-)
-
-if defined __DoCrossgen (
-    set __RuntestPyArgs=%__RuntestPyArgs% --precompile_core_root
 )
 
 if defined CrossgenLargeVersionBubble (
@@ -242,14 +225,6 @@ call :SetTestEnvironment
 call :ResolveDependencies
 if errorlevel 1 exit /b 1
 
-if defined __DoCrossgen (
-    echo %__MsgPrefix%Running crossgen on framework assemblies
-    call :PrecompileFX
-)
-
-REM Delete the unecessary mscorlib.ni file.
-if exist %CORE_ROOT%\mscorlib.ni.dll del %CORE_ROOT%\mscorlib.ni.dll
-
 ::Check if the test Binaries are built
 if not exist %XunitTestBinBase% (
     echo %__MsgPrefix%Error: Ensure the Test Binaries are built and are present at %XunitTestBinBase%.
@@ -284,52 +259,6 @@ REM ============================================================================
 echo %__MsgPrefix%Test run successful. Finished at %TIME%. Refer to the log files for details:
 echo     %__TestRunHtmlLog%
 echo     %__TestRunXmlLog%
-exit /b 0
-
-REM =========================================================================================
-REM ===
-REM === Compile the managed assemblies in Core_ROOT before running the tests
-REM ===
-REM =========================================================================================
-
-:PrecompileAssembly
-
-REM Skip mscorlib since it is already precompiled.
-if /I "%3" == "mscorlib.dll" exit /b 0
-if /I "%3" == "mscorlib.ni.dll" exit /b 0
-
-"%1\crossgen.exe" /nologo /Platform_Assemblies_Paths "%CORE_ROOT%" "%2" >nul 2>nul
-set /a __exitCode = %errorlevel%
-if "%__exitCode%" == "-2146230517" (
-    echo %2 is not a managed assembly.
-    exit /b 0
-)
-
-if %__exitCode% neq 0 (
-    echo Unable to precompile %2
-    exit /b 0
-)
-
-echo %__MsgPrefix%Successfully precompiled %2
-exit /b 0
-
-:PrecompileFX
-setlocal
-
-if defined __CrossgenAltJit (
-    REM Set altjit flags for the crossgen run. Note that this entire crossgen section is within a setlocal/endlocal scope,
-    REM so we don't need to save or unset these afterwards.
-    echo %__MsgPrefix%Setting altjit environment variables for %__CrossgenAltJit%.
-    set COMPlus_AltJit=*
-    set COMPlus_AltJitNgen=*
-    set COMPlus_AltJitName=%__CrossgenAltJit%
-    set COMPlus_AltJitAssertOnNYI=1
-    set COMPlus_NoGuiOnAssert=1
-    set COMPlus_ContinueOnAssert=0
-)
-
-for %%F in (%CORE_ROOT%\*.dll) do call :PrecompileAssembly "%CORE_ROOT%" "%%F" %%~nF%%~xF
-endlocal
 exit /b 0
 
 REM =========================================================================================
@@ -447,12 +376,8 @@ echo.
 echo./? -? /h -h /help -help   - View this message.
 echo ^<build_architecture^>      - Specifies build architecture: x64, x86, arm, or arm64 ^(default: x64^).
 echo ^<build_type^>              - Specifies build type: Debug, Release, or Checked ^(default: Debug^).
-echo VSVersion ^<vs_version^>    - VS2017 or VS2019 ^(default: VS2019^).
 echo TestEnv ^<test_env_script^> - Run a custom script before every test to set custom test environment settings.
 echo sequential                - Run tests sequentially (no parallelism).
-echo crossgen                  - Precompile ^(crossgen^) the managed assemblies in CORE_ROOT before running the tests.
-echo crossgenaltjit ^<altjit^>   - Precompile ^(crossgen^) the managed assemblies in CORE_ROOT before running the tests, using the given altjit.
-echo RunCrossgenTests          - Runs ReadytoRun tests
 echo RunCrossgen2Tests         - Runs ReadytoRun tests compiled with Crossgen2
 echo jitstress ^<n^>             - Runs the tests with COMPlus_JitStress=n
 echo jitstressregs ^<n^>         - Runs the tests with COMPlus_JitStressRegs=n

--- a/src/tests/run.py
+++ b/src/tests/run.py
@@ -84,7 +84,6 @@ parser.add_argument("-test_location", dest="test_location", nargs="?", default=N
 parser.add_argument("-core_root", dest="core_root", nargs='?', default=None)
 parser.add_argument("-runtime_repo_location", dest="runtime_repo_location", default=os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
 parser.add_argument("-test_env", dest="test_env", default=None)
-parser.add_argument("-crossgen_altjit", dest="crossgen_altjit", default=None)
 
 # Optional arguments which change execution.
 
@@ -92,11 +91,9 @@ parser.add_argument("--il_link", dest="il_link", action="store_true", default=Fa
 parser.add_argument("--long_gc", dest="long_gc", action="store_true", default=False)
 parser.add_argument("--gcsimulator", dest="gcsimulator", action="store_true", default=False)
 parser.add_argument("--ilasmroundtrip", dest="ilasmroundtrip", action="store_true", default=False)
-parser.add_argument("--run_crossgen_tests", dest="run_crossgen_tests", action="store_true", default=False)
 parser.add_argument("--run_crossgen2_tests", dest="run_crossgen2_tests", action="store_true", default=False)
 parser.add_argument("--large_version_bubble", dest="large_version_bubble", action="store_true", default=False)
-parser.add_argument("--precompile_core_root", dest="precompile_core_root", action="store_true", default=False)
-parser.add_argument("--skip_test_run", dest="skip_test_run", action="store_true", default=False, help="Does not run tests. Useful in conjunction with --precompile_core_root")
+parser.add_argument("--skip_test_run", dest="skip_test_run", action="store_true", default=False, help="Does not run tests.")
 parser.add_argument("--sequential", dest="sequential", action="store_true", default=False)
 
 parser.add_argument("--analyze_results_only", dest="analyze_results_only", action="store_true", default=False)
@@ -842,9 +839,6 @@ def run_tests(args,
         test_env_script_path  : Path to script to use to set the test environment, if any.
     """
 
-    if args.precompile_core_root:
-        precompile_core_root(args)
-
     if args.skip_test_run:
         return
 
@@ -868,11 +862,6 @@ def run_tests(args,
         print("Running ILasm round trip.")
         print("Setting RunningIlasmRoundTrip=1")
         os.environ["RunningIlasmRoundTrip"] = "1"
-
-    if args.run_crossgen_tests:
-        print("Running tests R2R")
-        print("Setting RunCrossGen=true")
-        os.environ["RunCrossGen"] = "true"
 
     if args.run_crossgen2_tests:
         print("Running tests R2R (Crossgen2)")
@@ -963,11 +952,6 @@ def setup_args(args):
                               "Error setting analyze_results_only")
 
     coreclr_setup_args.verify(args,
-                              "crossgen_altjit",
-                              lambda arg: True,
-                              "Error setting crossgen_altjit")
-
-    coreclr_setup_args.verify(args,
                               "rid",
                               lambda arg: True,
                               "Error setting rid")
@@ -998,19 +982,9 @@ def setup_args(args):
                               "Error setting large_version_bubble")
 
     coreclr_setup_args.verify(args,
-                              "run_crossgen_tests",
-                              lambda arg: True,
-                              "Error setting run_crossgen_tests")
-
-    coreclr_setup_args.verify(args,
                               "run_crossgen2_tests",
                               lambda unused: True,
                               "Error setting run_crossgen2_tests")
-
-    coreclr_setup_args.verify(args,
-                              "precompile_core_root",
-                              lambda arg: True,
-                              "Error setting precompile_core_root")
 
     coreclr_setup_args.verify(args,
                               "skip_test_run",
@@ -1044,7 +1018,6 @@ def setup_args(args):
     print("core_root                : %s" % coreclr_setup_args.core_root)
     print("test_location            : %s" % coreclr_setup_args.test_location)
 
-    coreclr_setup_args.crossgen_path = os.path.join(coreclr_setup_args.core_root, "crossgen%s" % (".exe" if coreclr_setup_args.host_os == "windows" else ""))
     coreclr_setup_args.corerun_path = os.path.join(coreclr_setup_args.core_root, "corerun%s" % (".exe" if coreclr_setup_args.host_os == "windows" else ""))
     coreclr_setup_args.dotnetcli_script_path = os.path.join(coreclr_setup_args.runtime_repo_location, "dotnet%s" % (".cmd" if coreclr_setup_args.host_os == "windows" else ".sh"))
     coreclr_setup_args.coreclr_tests_dir = os.path.join(coreclr_setup_args.coreclr_dir, "tests")
@@ -1053,92 +1026,6 @@ def setup_args(args):
     coreclr_setup_args.logs_dir = os.path.join(coreclr_setup_args.artifacts_location, "log")
 
     return coreclr_setup_args
-
-def precompile_core_root(args):
-    """ Precompile all of the assemblies in the core_root directory
-
-    Args:
-        args
-    """
-
-    skip_list = [
-        ".*xunit.*",
-        ".*api-ms-win-core.*",
-        ".*api-ms-win.*",
-        ".*System.Private.CoreLib.*"
-    ]
-
-    unix_skip_list = [
-        ".*mscorlib.*",
-        ".*System.Runtime.WindowsRuntime.*",
-        ".*System.Runtime.WindowsRuntime.UI.Xaml.*",
-        ".*R2RDump.dll.*"
-    ]
-
-    arm64_unix_skip_list = [
-        ".*Microsoft.CodeAnalysis.VisualBasic.*",
-        ".*System.Net.NameResolution.*",
-        ".*System.Net.Sockets.*",
-        ".*System.Net.Primitives.*"
-    ]
-
-    if args.host_os != "windows":
-        skip_list += unix_skip_list
-
-        if args.arch == "arm64":
-            skip_list += arm64_unix_skip_list
-
-    assert os.path.isdir(args.test_location)
-    assert os.path.isdir(args.core_root)
-
-    def call_crossgen(file, env):
-        assert os.path.isfile(args.crossgen_path)
-        command = [args.crossgen_path, "/Platform_Assemblies_Paths", args.core_root, file]
-
-        proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
-        proc.communicate()
-
-        return_code = proc.returncode
-
-        if return_code == -2146230517:
-            print("%s is not a managed assembly." % file)
-            return False
-
-        if return_code != 0:
-            print("Unable to precompile %s (%d)" % (file, return_code))
-            return False
-
-        print("Successfully precompiled %s" % file)
-        return True
-
-    print("Precompiling all assemblies in %s" % args.core_root)
-    print("")
-
-    env = os.environ.copy()
-
-    if not args.crossgen_altjit is None:
-        env["COMPlus_AltJit"]="*"
-        env["COMPlus_AltJitNgen"]="*"
-        env["COMPlus_AltJitName"]=args.crossgen_altjit
-        env["COMPlus_AltJitAssertOnNYI"]="1"
-        env["COMPlus_NoGuiOnAssert"]="1"
-        env["COMPlus_ContinueOnAssert"]="0"
-
-    dlls = [os.path.join(args.core_root, item) for item in os.listdir(args.core_root) if item.endswith("dll") and "mscorlib" not in item]
-
-    def in_skip_list(item):
-        found = False
-        for skip_re in skip_list:
-            if re.match(skip_re, item.lower()) is not None:
-                found = True
-        return found
-
-    dlls = [dll for dll in dlls if not in_skip_list(dll)]
-
-    for dll in dlls:
-        call_crossgen(dll, env)
-
-    print("")
 
 if sys.version_info.major < 3:
     def to_unicode(s):

--- a/src/tests/run.sh
+++ b/src/tests/run.sh
@@ -17,8 +17,6 @@ function print_usage {
     echo '  --testRootDir=<path>             : Root directory of the test build (e.g. runtime/artifacts/tests/windows.x64.Debug).'
     echo '  --disableEventLogging            : Disable the events logged by both VM and Managed Code'
     echo '  --sequential                     : Run tests sequentially (default is to run in parallel).'
-    echo '  --crossgen                       : Precompiles the framework managed assemblies'
-    echo '  --runcrossgentests               : Runs the ReadyToRun tests' 
     echo '  --runcrossgen2tests              : Runs the ReadyToRun tests compiled with Crossgen2' 
     echo '  --jitstress=<n>                  : Runs the tests with COMPlus_JitStress=n'
     echo '  --jitstressregs=<n>              : Runs the tests with COMPlus_JitStressRegs=n'
@@ -94,7 +92,6 @@ limitedCoreDumps=
 
 # Handle arguments
 verbose=0
-doCrossgen=0
 ilasmroundtrip=
 printLastResultsOnly=
 runSequential=0
@@ -140,9 +137,6 @@ do
         --printLastResultsOnly)
             printLastResultsOnly=1
             ;;
-        --crossgen)
-            doCrossgen=1
-            ;;
         --jitstress=*)
             export COMPlus_JitStress=${i#*=}
             ;;
@@ -167,9 +161,6 @@ do
             ;;
         --disableEventLogging)
             ((disableEventLogging = 1))
-            ;;
-        --runcrossgentests)
-            export RunCrossGen=1
             ;;
         --runcrossgen2tests)
             export RunCrossGen2=1
@@ -281,16 +272,8 @@ if [ ! -z "$printLastResultsOnly" ]; then
     runtestPyArguments+=("--analyze_results_only")
 fi
 
-if [ ! -z "$RunCrossGen" ]; then
-    runtestPyArguments+=("--run_crossgen_tests")
-fi
-
 if [ ! -z "$RunCrossGen2" ]; then
     runtestPyArguments+=("--run_crossgen2_tests")
-fi
-
-if (($doCrossgen!=0)); then
-    runtestPyArguments+=("--precompile_core_root")
 fi
 
 if [ "$limitedCoreDumps" == "ON" ]; then


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/53458/ removed crossgen; this removes it from the test scripts.