### PR TITLE
[release/6.0-preview6] Fix profiling R2R code on Windows x64

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/RuntimeFunctionsTableNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/RuntimeFunctionsTableNode.cs
@@ -67,6 +67,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 LayoutRuntimeFunctions();
 
             ObjectDataBuilder runtimeFunctionsBuilder = new ObjectDataBuilder(factory, relocsOnly);
+            runtimeFunctionsBuilder.RequireInitialAlignment(4);
 
             // Add the symbol representing this object node
             runtimeFunctionsBuilder.AddSymbol(this);


### PR DESCRIPTION
Backport of #54318 to release/6.0-preview6.

## Customer Impact

ReadyToRun code cannot be profiled on Windows x64, because the emitted function table may not be 4-byte aligned. In that case the kernel profiler ignores the function table and fails to unwind the stack. This is a regression caused by switching to Crossgen2 compiler.

## Testing

Verified that profiling works with this fix.

## Risk

Very low. The fix is a single line that ensures 4-byte alignment of the table.