### PR TITLE
Enable more LDAP TLS tests on linux

### DIFF
--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Linux.cs
@@ -9,7 +9,21 @@ namespace System.DirectoryServices.Protocols
     {
         private static void PALCertFreeCRLContext(IntPtr certPtr) { /* No op */ }
 
-        public bool SecureSocketLayer { get; set; }
+        private bool _secureSocketLayer;
+
+        public bool SecureSocketLayer
+        {
+            get
+            {
+                if (_connection._disposed) throw new ObjectDisposedException(GetType().Name);
+                return _secureSocketLayer;
+            }
+            set
+            {
+                if (_connection._disposed) throw new ObjectDisposedException(GetType().Name);
+                _secureSocketLayer = value;
+            }
+        }
 
         public int ProtocolVersion
         {

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Windows.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Windows.cs
@@ -9,7 +9,6 @@ namespace System.DirectoryServices.Protocols
     {
         private static void PALCertFreeCRLContext(IntPtr certPtr) => Interop.Ldap.CertFreeCRLContext(certPtr);
 
-        [SupportedOSPlatform("windows")]
         public bool SecureSocketLayer
         {
             get

--- a/src/libraries/System.DirectoryServices.Protocols/tests/LdapSessionOptionsTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/LdapSessionOptionsTests.cs
@@ -64,7 +64,6 @@ namespace System.DirectoryServices.Protocols.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
         public void SecureSocketLayer_GetSetWhenDisposed_ThrowsObjectDisposedException()
         {
             var connection = new LdapConnection("server");


### PR DESCRIPTION
As a follow up to #52904, this removes the `SupportedOsPlatform("windows")` attribute from LdapSessionOptions.SecureSocketLayer, which was causing weird Intellisense issues in VS Code on Linux.

It also enables some tests for `LdapSessionOptions.SecureSocketsLayer` for Linux that were missed in the previous PR.