### PR TITLE
HTTP/3: Remove ASP.NET Core specific code from QPackEncoder

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/QPack/QPackEncoder.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/QPack/QPackEncoder.cs
@@ -9,10 +9,8 @@ using System.Text;
 
 namespace System.Net.Http.QPack
 {
-    internal sealed class QPackEncoder
+    internal static class QPackEncoder
     {
-        private IEnumerator<KeyValuePair<string, string>>? _enumerator;
-
         // https://tools.ietf.org/html/draft-ietf-quic-qpack-11#section-4.5.2
         //   0   1   2   3   4   5   6   7
         // +---+---+---+---+---+---+---+---+
@@ -402,94 +400,6 @@ namespace System.Net.Http.QPack
             bytesWritten += length;
 
             return true;
-        }
-
-        public bool BeginEncode(IEnumerable<KeyValuePair<string, string>> headers, Span<byte> buffer, out int length)
-        {
-            _enumerator = headers.GetEnumerator();
-
-            bool hasValue = _enumerator.MoveNext();
-            Debug.Assert(hasValue == true);
-
-            buffer[0] = 0;
-            buffer[1] = 0;
-
-            bool doneEncode = Encode(buffer.Slice(2), out length);
-
-            // Add two for the first two bytes.
-            length += 2;
-            return doneEncode;
-        }
-
-        public bool BeginEncode(int statusCode, IEnumerable<KeyValuePair<string, string>> headers, Span<byte> buffer, out int length)
-        {
-            _enumerator = headers.GetEnumerator();
-
-            bool hasValue = _enumerator.MoveNext();
-            Debug.Assert(hasValue == true);
-
-            // https://quicwg.org/base-drafts/draft-ietf-quic-qpack.html#header-prefix
-            buffer[0] = 0;
-            buffer[1] = 0;
-
-            int statusCodeLength = EncodeStatusCode(statusCode, buffer.Slice(2));
-            bool done = Encode(buffer.Slice(statusCodeLength + 2), throwIfNoneEncoded: false, out int headersLength);
-            length = statusCodeLength + headersLength + 2;
-
-            return done;
-        }
-
-        public bool Encode(Span<byte> buffer, out int length)
-        {
-            return Encode(buffer, throwIfNoneEncoded: true, out length);
-        }
-
-        private bool Encode(Span<byte> buffer, bool throwIfNoneEncoded, out int length)
-        {
-            length = 0;
-
-            do
-            {
-                if (!EncodeLiteralHeaderFieldWithoutNameReference(_enumerator!.Current.Key, _enumerator.Current.Value, buffer.Slice(length), out int headerLength))
-                {
-                    if (length == 0 && throwIfNoneEncoded)
-                    {
-                        throw new QPackEncodingException("TODO sync with corefx" /* CoreStrings.HPackErrorNotEnoughBuffer */);
-                    }
-                    return false;
-                }
-
-                length += headerLength;
-            } while (_enumerator.MoveNext());
-
-            return true;
-        }
-
-        private int EncodeStatusCode(int statusCode, Span<byte> buffer)
-        {
-            switch (statusCode)
-            {
-                case 200:
-                case 204:
-                case 206:
-                case 304:
-                case 400:
-                case 404:
-                case 500:
-                    EncodeStaticIndexedHeaderField(H3StaticTable.StatusIndex[statusCode], buffer, out var bytesWritten);
-                    return bytesWritten;
-                default:
-                    // https://tools.ietf.org/html/draft-ietf-quic-qpack-21#section-4.5.4
-                    // Index is 63 - :status
-                    buffer[0] = 0b01011111;
-                    buffer[1] = 0b00110000;
-
-                    ReadOnlySpan<byte> statusBytes = StatusCodes.ToStatusBytes(statusCode);
-                    buffer[2] = (byte)statusBytes.Length;
-                    statusBytes.CopyTo(buffer.Slice(3));
-
-                    return 3 + statusBytes.Length;
-            }
         }
     }
 }


### PR DESCRIPTION
This PR removes the non-static members from shared QPackEncoder. These methods are only used by ASP.NET Core. It is easier to have them in a non-shared file in the ASP.NET Core repo so changes don't need to be synced.

This change makes QPackEncoder consistent with [HPackEncoder](https://github.com/dotnet/runtime/blob/main/src/libraries/Common/src/System/Net/Http/aspnetcore/Http2/Hpack/HPackEncoder.cs) which is also static and the ASP.NET Core specific methods [are in a different file in the ASP.NET Core repo](https://github.com/dotnet/aspnetcore/blob/main/src/Servers/Kestrel/Core/src/Internal/Http2/HPackHeaderWriter.cs).