### PR TITLE
Allow disabling LDAP referral chasing on Linux.

### DIFF
--- a/src/libraries/Common/src/Interop/Linux/OpenLdap/Interop.Ldap.cs
+++ b/src/libraries/Common/src/Interop/Linux/OpenLdap/Interop.Ldap.cs
@@ -86,6 +86,9 @@ internal static partial class Interop
         public static extern IntPtr ldap_get_dn([In] ConnectionHandle ldapHandle, [In] IntPtr result);
 
         [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_get_option", CharSet = CharSet.Ansi)]
+        public static extern int ldap_get_option_bool([In] ConnectionHandle ldapHandle, [In] LdapOption option, ref bool outValue);
+
+        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_get_option", CharSet = CharSet.Ansi)]
         public static extern int ldap_get_option_secInfo([In] ConnectionHandle ldapHandle, [In] LdapOption option, [In, Out] SecurityPackageContextConnectionInformation outValue);
 
         [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_get_option", CharSet = CharSet.Ansi)]
@@ -111,6 +114,9 @@ internal static partial class Interop
 
         [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_search_ext", CharSet = CharSet.Ansi)]
         public static extern int ldap_search([In] ConnectionHandle ldapHandle, string dn, int scope, string filter, IntPtr attributes, bool attributeOnly, IntPtr servercontrol, IntPtr clientcontrol, int timelimit, int sizelimit, ref int messageNumber);
+
+        [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_set_option", CharSet = CharSet.Ansi, SetLastError = true)]
+        public static extern int ldap_set_option_bool([In] ConnectionHandle ld, [In] LdapOption option, bool value);
 
         [DllImport(Libraries.OpenLdap, EntryPoint = "ldap_set_option", CharSet = CharSet.Ansi)]
         public static extern int ldap_set_option_clientcert([In] ConnectionHandle ldapHandle, [In] LdapOption option, QUERYCLIENTCERT outValue);

--- a/src/libraries/System.DirectoryServices.Protocols/src/Resources/Strings.resx
+++ b/src/libraries/System.DirectoryServices.Protocols/src/Resources/Strings.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -491,5 +491,8 @@
   </data>
   <data name="QuotaControlNotSupported" xml:space="preserve">
     <value>System.DirectoryServices.Protocols.QuotaControl is not supported on this platform.</value>
+  </data>
+  <data name="ReferralChasingOptionsNotSupported" xml:space="preserve">
+    <value>Only ReferralChasingOptions.None and ReferralChasingOptions.All are supported on Linux.</value>
   </data>
 </root>

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/LdapPal.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/Interop/LdapPal.Linux.cs
@@ -41,6 +41,8 @@ namespace System.DirectoryServices.Protocols
             return result;
         }
 
+        internal static int GetBoolOption(ConnectionHandle ldapHandle, LdapOption option, ref bool outValue) => Interop.Ldap.ldap_get_option_bool(ldapHandle, option, ref outValue);
+
         internal static int GetIntOption(ConnectionHandle ldapHandle, LdapOption option, ref int outValue) => Interop.Ldap.ldap_get_option_int(ldapHandle, option, ref outValue);
 
         internal static int GetPtrOption(ConnectionHandle ldapHandle, LdapOption option, ref IntPtr outValue) => Interop.Ldap.ldap_get_option_ptr(ldapHandle, option, ref outValue);
@@ -84,6 +86,8 @@ namespace System.DirectoryServices.Protocols
 
         internal static int SearchDirectory(ConnectionHandle ldapHandle, string dn, int scope, string filter, IntPtr attributes, bool attributeOnly, IntPtr servercontrol, IntPtr clientcontrol, int timelimit, int sizelimit, ref int messageNumber) =>
                                 Interop.Ldap.ldap_search(ldapHandle, dn, scope, filter, attributes, attributeOnly, servercontrol, clientcontrol, timelimit, sizelimit, ref messageNumber);
+
+        internal static int SetBoolOption(ConnectionHandle ld, LdapOption option, bool value) => Interop.Ldap.ldap_set_option_bool(ld, option, value);
 
         // This option is not supported in Linux, so it would most likely throw.
         internal static int SetClientCertOption(ConnectionHandle ldapHandle, LdapOption option, QUERYCLIENTCERT outValue) => Interop.Ldap.ldap_set_option_clientcert(ldapHandle, option, outValue);

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Linux.cs
@@ -31,7 +31,7 @@ namespace System.DirectoryServices.Protocols
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ReferralChasingOptions));
                 }
-                if (!(value == ReferralChasingOptions.None || value == ReferralChasingOptions.All))
+                if (value != ReferralChasingOptions.None || value != ReferralChasingOptions.All)
                 {
                     throw new PlatformNotSupportedException(SR.ReferralChasingOptionsNotSupported);
                 }

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Linux.cs
@@ -31,7 +31,7 @@ namespace System.DirectoryServices.Protocols
                 {
                     throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ReferralChasingOptions));
                 }
-                if (value != ReferralChasingOptions.None || value != ReferralChasingOptions.All)
+                if (value != ReferralChasingOptions.None && value != ReferralChasingOptions.All)
                 {
                     throw new PlatformNotSupportedException(SR.ReferralChasingOptionsNotSupported);
                 }

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Linux.cs
@@ -33,7 +33,7 @@ namespace System.DirectoryServices.Protocols
                 }
                 if (!(value == ReferralChasingOptions.None || value == ReferralChasingOptions.All))
                 {
-                    throw new PlatformNotSupportedException($"Only {nameof(ReferralChasingOptions.None)} and {nameof(ReferralChasingOptions.All)} are supported in Linux.");
+                    throw new PlatformNotSupportedException(SR.ReferralChasingOptionsNotSupported);
                 }
 
                 SetBoolValueHelper(LdapOption.LDAP_OPT_REFERRALS, value == ReferralChasingOptions.All);

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Linux.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
-using System.Runtime.InteropServices;
-using System.Runtime.Versioning;
 
 namespace System.DirectoryServices.Protocols
 {

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Windows.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Windows.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel;
 using System.Runtime.Versioning;
 
 namespace System.DirectoryServices.Protocols
@@ -28,6 +29,24 @@ namespace System.DirectoryServices.Protocols
         {
             get => GetIntValueHelper(LdapOption.LDAP_OPT_VERSION);
             set => SetIntValueHelper(LdapOption.LDAP_OPT_VERSION, value);
+        }
+
+        public ReferralChasingOptions ReferralChasing
+        {
+            get
+            {
+                int result = GetIntValueHelper(LdapOption.LDAP_OPT_REFERRALS);
+                return result == 1 ? ReferralChasingOptions.All : (ReferralChasingOptions)result;
+            }
+            set
+            {
+                if (((value) & (~ReferralChasingOptions.All)) != 0)
+                {
+                    throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ReferralChasingOptions));
+                }
+
+                SetIntValueHelper(LdapOption.LDAP_OPT_REFERRALS, (int)value);
+            }
         }
     }
 }

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.cs
@@ -136,24 +136,6 @@ namespace System.DirectoryServices.Protocols
             _serverCertificateRoutine = new VERIFYSERVERCERT(ProcessServerCertificate);
         }
 
-        public ReferralChasingOptions ReferralChasing
-        {
-            get
-            {
-                int result = GetIntValueHelper(LdapOption.LDAP_OPT_REFERRALS);
-                return result == 1 ? ReferralChasingOptions.All : (ReferralChasingOptions)result;
-            }
-            set
-            {
-                if (((value) & (~ReferralChasingOptions.All)) != 0)
-                {
-                    throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ReferralChasingOptions));
-                }
-
-                SetIntValueHelper(LdapOption.LDAP_OPT_REFERRALS, (int)value);
-            }
-        }
-
         public int ReferralHopLimit
         {
             get => GetIntValueHelper(LdapOption.LDAP_OPT_REFERRAL_HOP_LIMIT);

--- a/src/libraries/System.DirectoryServices.Protocols/tests/LdapSessionOptionsTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/LdapSessionOptionsTests.cs
@@ -14,7 +14,23 @@ namespace System.DirectoryServices.Protocols.Tests
         [PlatformSpecific(TestPlatforms.Windows)]
         [InlineData(ReferralChasingOptions.None)]
         [InlineData(ReferralChasingOptions.External)]
-        public void ReferralChasing_Set_GetReturnsExpected(ReferralChasingOptions value)
+        public void ReferralChasing_Set_GetReturnsExpected_On_Windows(ReferralChasingOptions value)
+        {
+            using (var connection = new LdapConnection("server"))
+            {
+                LdapSessionOptions options = connection.SessionOptions;
+                Assert.Equal(ReferralChasingOptions.All, options.ReferralChasing);
+
+                options.ReferralChasing = value;
+                Assert.Equal(value, options.ReferralChasing);
+            }
+        }
+
+        [Theory]
+        [PlatformSpecific(TestPlatforms.Linux)]
+        [InlineData(ReferralChasingOptions.None)]
+        [InlineData(ReferralChasingOptions.All)]
+        public void ReferralChasing_Set_GetReturnsExpected_On_Linux(ReferralChasingOptions value)
         {
             using (var connection = new LdapConnection("server"))
             {


### PR DESCRIPTION
Before this, changing SessionOptions.ReferralChasing on Linux was ineffective, since we were passing `ref int` to OpenLDAP, which does not follow the pointer passed and interprets any non-zero value as "enabled".

This passes a boolean directly instead, which the library is able to detect properly.

This is a little bit of a hack, since it relies on the fact that [OpenLDAP doesn't actually check for the correct value of `LDAP_OPT_ON`](https://git.openldap.org/openldap/openldap/-/blob/OPENLDAP_REL_ENG_2_4_58/libraries/libldap/options.c#L470-477), which changes every time the program is run. Instead, it compares whether the passed value is 0 when cast to `int *`, which makes it `false`; passing any other value evaluates to `true`. Actually getting the correct value of LDAP_OPT_ON, I think would require a putting a get_ldap_opt_on() function in a native shim for OpenLDAP, which seems a little overkill. The [documentation](https://www.openldap.org/software/man.cgi?query=ldap_get_option&sektion=3&apropos=0&manpath=OpenLDAP+2.4-Release) says

>  its value should either be `LDAP_OPT_OFF` or `LDAP_OPT_ON`

but maybe it's ok to fudge that.

Fixes #44826.