### PR TITLE
Avoid Attribute.GetCustomAttributes overheads when inherit==true is useless

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
@@ -304,9 +304,11 @@ namespace System.Reflection
                 // Now copy over the parameter info's and change their
                 // owning member info to the current property info.
 
-                ParameterInfo[] propParams = new ParameterInfo[numParams];
+                ParameterInfo[] propParams = numParams != 0 ?
+                    new ParameterInfo[numParams] :
+                    Array.Empty<ParameterInfo>();
 
-                for (int i = 0; i < numParams; i++)
+                for (int i = 0; i < propParams.Length; i++)
                     propParams[i] = new RuntimeParameterInfo((RuntimeParameterInfo)methParams![i], this);
 
                 m_parameters = propParams;


### PR DESCRIPTION
Just stop doing unnecessary work.

| Method |         Toolchain |     Mean | Ratio | Allocated |
|------- |------------------ |---------:|------:|----------:|
|    Get | \main\corerun.exe | 826.7 ns |  1.00 |     664 B |
|    Get |   \pr\corerun.exe | 488.1 ns |  0.59 |     104 B |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System;
using System.Reflection;

[MemoryDiagnoser]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssemblies(new[] { typeof(Program).Assembly }).Run(args);

    private PropertyInfo _prop = typeof(B).GetProperty("MyProp");

    [Benchmark]
    public Attribute[] Get() => Attribute.GetCustomAttributes(_prop, inherit: true);
}

class A { }

class B : A
{
    [My]
    public int MyProp { get; set; }
}

class MyAttribute : Attribute { }
```