### PR TITLE
Special-case no attributes in GetCustomAttributeData

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -237,6 +237,10 @@ namespace System.Reflection
         private static IList<CustomAttributeData> GetCustomAttributes(RuntimeModule module, int tkTarget)
         {
             CustomAttributeRecord[] records = GetCustomAttributeRecords(module, tkTarget);
+            if (records.Length == 0)
+            {
+                return Array.Empty<CustomAttributeData>();
+            }
 
             CustomAttributeData[] customAttributes = new CustomAttributeData[records.Length];
             for (int i = 0; i < records.Length; i++)


### PR DESCRIPTION
It's common to ask for attribute information on members that don't have attributes (which you only discover by asking).

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Collections.Generic;
using System.Reflection;

[MemoryDiagnoser]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssemblies(new[] { typeof(Program).Assembly }).Run(args);

    private MethodInfo _mi = typeof(Program).GetMethod("MyMethod");

    public void MyMethod() { }

    [Benchmark]
    public IList<CustomAttributeData> Get() => _mi.GetCustomAttributesData();
}
```

| Method |         Toolchain |     Mean | Ratio | Allocated |
|------- |------------------ |---------:|------:|----------:|
|    Get | \main\corerun.exe | 77.13 ns |  1.00 |      48 B |
|    Get |   \pr\corerun.exe | 72.08 ns |  0.93 |         - |