### PR TITLE
Backport bugfixes, infrastructural changes and perf improvements from the polymorphism feature branch

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -312,7 +312,9 @@ namespace System.Text.Json.Serialization.Converters
 
                         if (!jsonPropertyInfo.GetMemberAndWriteJson(objectValue!, ref state, writer))
                         {
-                            Debug.Assert(jsonPropertyInfo.ConverterBase.ConverterStrategy != ConverterStrategy.Value);
+                            Debug.Assert(jsonPropertyInfo.ConverterBase.ConverterStrategy != ConverterStrategy.Value ||
+                                         jsonPropertyInfo.ConverterBase.TypeToConvert == JsonTypeInfo.ObjectType);
+
                             return false;
                         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -220,7 +220,12 @@ namespace System.Text.Json.Serialization
             // Remember if we were a continuation here since Push() may affect IsContinuation.
             bool wasContinuation = state.IsContinuation;
 
+#if DEBUG
+            // DEBUG: ensure push/pop operations preserve stack integrity
+            JsonTypeInfo originalJsonTypeInfo = state.Current.JsonTypeInfo;
+#endif
             state.Push();
+            Debug.Assert(TypeToConvert.IsAssignableFrom(state.Current.JsonTypeInfo.Type));
 
 #if !DEBUG
             // For performance, only perform validation on internal converters on debug builds.
@@ -257,6 +262,9 @@ namespace System.Text.Json.Serialization
 
                         value = default;
                         state.Pop(true);
+#if DEBUG
+                        Debug.Assert(ReferenceEquals(originalJsonTypeInfo, state.Current.JsonTypeInfo));
+#endif
                         return true;
                     }
 
@@ -288,6 +296,9 @@ namespace System.Text.Json.Serialization
             }
 
             state.Pop(success);
+#if DEBUG
+            Debug.Assert(ReferenceEquals(originalJsonTypeInfo, state.Current.JsonTypeInfo));
+#endif
             return success;
         }
 
@@ -298,6 +309,9 @@ namespace System.Text.Json.Serialization
             return success;
         }
 
+        /// <summary>
+        /// Overridden by the nullable converter to prevent boxing of values by the JIT.
+        /// </summary>
         internal virtual bool IsNull(in T value) => value == null;
 
         internal bool TryWrite(Utf8JsonWriter writer, in T value, JsonSerializerOptions options, ref WriteStack state)
@@ -416,7 +430,12 @@ namespace System.Text.Json.Serialization
 
             bool isContinuation = state.IsContinuation;
 
+#if DEBUG
+            // DEBUG: ensure push/pop operations preserve stack integrity
+            JsonTypeInfo originalJsonTypeInfo = state.Current.JsonTypeInfo;
+#endif
             state.Push();
+            Debug.Assert(TypeToConvert.IsAssignableFrom(state.Current.JsonTypeInfo.Type));
 
             if (!isContinuation)
             {
@@ -432,6 +451,9 @@ namespace System.Text.Json.Serialization
             }
 
             state.Pop(success);
+#if DEBUG
+            Debug.Assert(ReferenceEquals(originalJsonTypeInfo, state.Current.JsonTypeInfo));
+#endif
 
             if (ignoreCyclesPopReference)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -22,7 +22,7 @@ namespace System.Text.Json.Serialization
             // In the future, this will be check for !IsSealed (and excluding value types).
             CanBePolymorphic = TypeToConvert == JsonTypeInfo.ObjectType;
             IsValueType = TypeToConvert.IsValueType;
-            CanBeNull = !IsValueType || TypeToConvert.IsNullableOfT();
+            CanBeNull = default(T) is null;
             IsInternalConverter = GetType().Assembly == typeof(JsonConverter).Assembly;
 
             if (HandleNull)
@@ -321,7 +321,7 @@ namespace System.Text.Json.Serialization
                 ThrowHelper.ThrowJsonException_SerializerCycleDetected(options.EffectiveMaxDepth);
             }
 
-            if (CanBeNull && !HandleNullOnWrite && IsNull(value))
+            if (default(T) is null && !HandleNullOnWrite && IsNull(value))
             {
                 // We do not pass null values to converters unless HandleNullOnWrite is true. Null values for properties were
                 // already handled in GetMemberAndWriteJson() so we don't need to check for IgnoreNullValues here.
@@ -331,81 +331,76 @@ namespace System.Text.Json.Serialization
 
             bool ignoreCyclesPopReference = false;
 
-            if (options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.IgnoreCycles &&
-                // .NET types that are serialized as JSON primitive values don't need to be tracked for cycle detection e.g: string.
-                ConverterStrategy != ConverterStrategy.Value &&
-                !IsValueType && !IsNull(value))
+            if (
+#if NET6_0_OR_GREATER
+                !typeof(T).IsValueType && // treated as a constant by recent versions of the JIT.
+#else
+                !IsValueType &&
+#endif
+                value is not null)
             {
-                // Custom (user) converters shall not track references
-                //  it is responsibility of the user to break cycles in case there's any
-                //  if we compare against Preserve, objects don't get preserved when a custom converter exists
-                //  given that the custom converter executes prior to the preserve logic.
-                Debug.Assert(IsInternalConverter);
-                Debug.Assert(value != null);
 
-                ReferenceResolver resolver = state.ReferenceResolver;
-
-                // Write null to break reference cycles.
-                if (resolver.ContainsReferenceForCycleDetection(value))
+                if (options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.IgnoreCycles &&
+                    // .NET types that are serialized as JSON primitive values don't need to be tracked for cycle detection e.g: string.
+                    ConverterStrategy != ConverterStrategy.Value)
                 {
-                    writer.WriteNullValue();
-                    return true;
-                }
+                    // Custom (user) converters shall not track references
+                    //  it is responsibility of the user to break cycles in case there's any
+                    //  if we compare against Preserve, objects don't get preserved when a custom converter exists
+                    //  given that the custom converter executes prior to the preserve logic.
+                    Debug.Assert(IsInternalConverter);
 
-                // For boxed reference types: do not push when boxed in order to avoid false positives
-                //   when we run the ContainsReferenceForCycleDetection check for the converter of the unboxed value.
-                Debug.Assert(!CanBePolymorphic);
-                resolver.PushReferenceForCycleDetection(value);
-                ignoreCyclesPopReference = true;
-            }
+                    ReferenceResolver resolver = state.ReferenceResolver;
 
-            if (CanBePolymorphic)
-            {
-                if (value == null)
-                {
-                    Debug.Assert(ConverterStrategy == ConverterStrategy.Value);
-                    Debug.Assert(!state.IsContinuation);
-                    Debug.Assert(HandleNullOnWrite);
-
-                    int originalPropertyDepth = writer.CurrentDepth;
-                    Write(writer, value, options);
-                    VerifyWrite(originalPropertyDepth, writer);
-
-                    return true;
-                }
-
-                Type type = value.GetType();
-                if (type == JsonTypeInfo.ObjectType)
-                {
-                    writer.WriteStartObject();
-                    writer.WriteEndObject();
-                    return true;
-                }
-
-                if (type != TypeToConvert && IsInternalConverter)
-                {
-                    // For internal converter only: Handle polymorphic case and get the new converter.
-                    // Custom converter, even though polymorphic converter, get called for reading AND writing.
-                    JsonConverter jsonConverter = state.Current.InitializeReEntry(type, options);
-                    Debug.Assert(jsonConverter != this);
-
-                    if (options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.IgnoreCycles &&
-                        jsonConverter.IsValueType)
+                    // Write null to break reference cycles.
+                    if (resolver.ContainsReferenceForCycleDetection(value))
                     {
-                        // For boxed value types: push the value before it gets unboxed on TryWriteAsObject.
-                        state.ReferenceResolver.PushReferenceForCycleDetection(value);
-                        ignoreCyclesPopReference = true;
+                        writer.WriteNullValue();
+                        return true;
                     }
 
-                    // We found a different converter; forward to that.
-                    bool success2 = jsonConverter.TryWriteAsObject(writer, value, options, ref state);
+                    // For boxed reference types: do not push when boxed in order to avoid false positives
+                    //   when we run the ContainsReferenceForCycleDetection check for the converter of the unboxed value.
+                    Debug.Assert(!CanBePolymorphic);
+                    resolver.PushReferenceForCycleDetection(value);
+                    ignoreCyclesPopReference = true;
+                }
 
-                    if (ignoreCyclesPopReference)
+                if (CanBePolymorphic)
+                {
+                    Type type = value.GetType();
+                    if (type == JsonTypeInfo.ObjectType)
                     {
-                        state.ReferenceResolver.PopReferenceForCycleDetection();
+                        writer.WriteStartObject();
+                        writer.WriteEndObject();
+                        return true;
                     }
 
-                    return success2;
+                    if (type != TypeToConvert && IsInternalConverter)
+                    {
+                        // For internal converter only: Handle polymorphic case and get the new converter.
+                        // Custom converter, even though polymorphic converter, get called for reading AND writing.
+                        JsonConverter jsonConverter = state.Current.InitializeReEntry(type, options);
+                        Debug.Assert(jsonConverter != this);
+
+                        if (options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.IgnoreCycles &&
+                            jsonConverter.IsValueType)
+                        {
+                            // For boxed value types: push the value before it gets unboxed on TryWriteAsObject.
+                            state.ReferenceResolver.PushReferenceForCycleDetection(value);
+                            ignoreCyclesPopReference = true;
+                        }
+
+                        // We found a different converter; forward to that.
+                        bool success2 = jsonConverter.TryWriteAsObject(writer, value, options, ref state);
+
+                        if (ignoreCyclesPopReference)
+                        {
+                            state.ReferenceResolver.PopReferenceForCycleDetection();
+                        }
+
+                        return success2;
+                    }
                 }
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -476,6 +476,7 @@ namespace System.Text.Json.Serialization
 
             // Ignore the naming policy for extension data.
             state.Current.IgnoreDictionaryKeyPolicy = true;
+            state.Current.DeclaredJsonPropertyInfo = state.Current.JsonTypeInfo.ElementTypeInfo!.PropertyInfoForTypeInfo;
 
             success = dictionaryConverter.OnWriteResume(writer, value, options, ref state);
             if (success)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.String.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.String.cs
@@ -125,9 +125,6 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(jsonTypeInfo));
             }
 
-            WriteStack state = default;
-            state.Initialize(jsonTypeInfo, supportContinuation: false);
-
             JsonSerializerOptions options = jsonTypeInfo.Options;
 
             using (var output = new PooledByteBufferWriter(options.DefaultBufferSize))

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
@@ -234,11 +234,17 @@ namespace System.Text.Json.Serialization.Metadata
         {
             T value = Get!(obj);
 
-            if (Options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.IgnoreCycles &&
-                value != null &&
+            if (
+#if NET6_0_OR_GREATER
+                !typeof(T).IsValueType && // treated as a constant by recent versions of the JIT.
+#else
+                !Converter.IsValueType &&
+#endif
+                Options.ReferenceHandlingStrategy == ReferenceHandlingStrategy.IgnoreCycles &&
+                value is not null &&
                 // .NET types that are serialized as JSON primitive values don't need to be tracked for cycle detection e.g: string.
                 // However JsonConverter<object> that uses ConverterStrategy == Value is an exception.
-                (Converter.CanBePolymorphic || (!Converter.IsValueType && ConverterStrategy != ConverterStrategy.Value)) &&
+                (Converter.CanBePolymorphic || ConverterStrategy != ConverterStrategy.Value) &&
                 state.ReferenceResolver.ContainsReferenceForCycleDetection(value))
             {
                 // If a reference cycle is detected, treat value as null.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -16,16 +16,24 @@ namespace System.Text.Json
         internal static readonly char[] SpecialCharacters = { '.', ' ', '\'', '/', '"', '[', ']', '(', ')', '\t', '\n', '\r', '\f', '\b', '\\', '\u0085', '\u2028', '\u2029' };
 
         /// <summary>
-        /// The number of stack frames when the continuation started.
+        /// Exposes the stackframe that is currently active.
         /// </summary>
-        private int _continuationCount;
+        public ReadStackFrame Current;
 
         /// <summary>
-        /// The number of stack frames including Current. _previous will contain _count-1 higher frames.
+        /// Buffer containing all frames in the stack. For performance it is only populated for serialization depths > 1.
+        /// </summary>
+        private ReadStackFrame[] _stack;
+
+        /// <summary>
+        /// Tracks the current depth of the stack.
         /// </summary>
         private int _count;
 
-        private List<ReadStackFrame> _previous;
+        /// <summary>
+        /// If not zero, indicates that the stack is part of a re-entrant continuation of given depth.
+        /// </summary>
+        private int _continuationCount;
 
         // State cache when deserializing objects with parameterized constructors.
         private List<ArgumentState>? _ctorArgStateCache;
@@ -35,11 +43,10 @@ namespace System.Text.Json
         /// </summary>
         public long BytesConsumed;
 
-        // A field is used instead of a property to avoid value semantics.
-        public ReadStackFrame Current;
-
+        /// <summary>
+        /// Indicates that the state still contains suspended frames waiting re-entry.
+        /// </summary>
         public bool IsContinuation => _continuationCount != 0;
-        public bool IsLastContinuation => _continuationCount == _count;
 
         /// <summary>
         /// Internal flag to let us know that we need to read ahead in the inner read loop.
@@ -59,25 +66,19 @@ namespace System.Text.Json
         /// </summary>
         public bool UseFastPath;
 
-        private void AddCurrent()
+        /// <summary>
+        /// Ensures that the stack buffer has sufficient capacity to hold an additional frame.
+        /// </summary>
+        private void EnsurePushCapacity()
         {
-            if (_previous == null)
+            if (_stack is null)
             {
-                _previous = new List<ReadStackFrame>();
+                _stack = new ReadStackFrame[4];
             }
-
-            if (_count > _previous.Count)
+            else if (_count - 1 == _stack.Length)
             {
-                // Need to allocate a new array element.
-                _previous.Add(Current);
+                Array.Resize(ref _stack, 2 * _stack.Length);
             }
-            else
-            {
-                // Use a previously allocated slot.
-                _previous[_count - 1] = Current;
-            }
-
-            _count++;
         }
 
         public void Initialize(Type type, JsonSerializerOptions options, bool supportContinuation)
@@ -143,8 +144,10 @@ namespace System.Text.Json
                         jsonTypeInfo = Current.JsonTypeInfo.ElementTypeInfo!;
                     }
 
-                    AddCurrent();
-                    Current.Reset();
+                    EnsurePushCapacity();
+                    _stack[_count - 1] = Current;
+                    Current = default;
+                    _count++;
 
                     Current.JsonTypeInfo = jsonTypeInfo;
                     Current.JsonPropertyInfo = jsonTypeInfo.PropertyInfoForTypeInfo;
@@ -152,25 +155,18 @@ namespace System.Text.Json
                     Current.NumberHandling = numberHandling ?? Current.JsonPropertyInfo.NumberHandling;
                 }
             }
-            else if (_continuationCount == 1)
-            {
-                // No need for a push since there is only one stack frame.
-                Debug.Assert(_count == 1);
-                _continuationCount = 0;
-            }
             else
             {
-                // A continuation; adjust the index.
-                Current = _previous[_count - 1];
+                // We are re-entering a continuation, adjust indices accordingly
+                if (_count++ > 0)
+                {
+                    Current = _stack[_count - 1];
+                }
 
-                // Check if we are done.
-                if (_count == _continuationCount)
+                // check if we are done
+                if (_continuationCount == _count)
                 {
                     _continuationCount = 0;
-                }
-                else
-                {
-                    _count++;
                 }
             }
 
@@ -189,41 +185,34 @@ namespace System.Text.Json
                 {
                     if (_count == 1)
                     {
-                        // No need for a continuation since there is only one stack frame.
+                        // No need to copy any frames here.
                         _continuationCount = 1;
-                    }
-                    else
-                    {
-                        AddCurrent();
-                        _count--;
-                        _continuationCount = _count;
-                        _count--;
-                        Current = _previous[_count - 1];
+                        _count = 0;
+                        return;
                     }
 
-                    return;
+                    // Need to push the Current frame to the stack,
+                    // ensure that we have sufficient capacity.
+                    EnsurePushCapacity();
+                    _continuationCount = _count--;
                 }
-
-                if (_continuationCount == 1)
+                else if (--_count == 0)
                 {
-                    // No need for a pop since there is only one stack frame.
-                    Debug.Assert(_count == 1);
+                    // reached the root, no need to copy frames.
                     return;
                 }
 
-                // Update the list entry to the current value.
-                _previous[_count - 1] = Current;
-
-                Debug.Assert(_count > 0);
+                _stack[_count] = Current;
+                Current = _stack[_count - 1];
             }
             else
             {
                 Debug.Assert(_continuationCount == 0);
-            }
 
-            if (_count > 1)
-            {
-                Current = _previous[--_count -1];
+                if (--_count > 0)
+                {
+                    Current = _stack[_count - 1];
+                }
             }
 
             SetConstructorArgumentState();
@@ -241,20 +230,20 @@ namespace System.Text.Json
 
             for (int i = 0; i < count - 1; i++)
             {
-                AppendStackFrame(sb, _previous[i]);
+                AppendStackFrame(sb, ref _stack[i]);
             }
 
             if (_continuationCount == 0)
             {
-                AppendStackFrame(sb, Current);
+                AppendStackFrame(sb, ref Current);
             }
 
             return sb.ToString();
 
-            static void AppendStackFrame(StringBuilder sb, in ReadStackFrame frame)
+            static void AppendStackFrame(StringBuilder sb, ref ReadStackFrame frame)
             {
                 // Append the property name.
-                string? propertyName = GetPropertyName(frame);
+                string? propertyName = GetPropertyName(ref frame);
                 AppendPropertyName(sb, propertyName);
 
                 if (frame.JsonTypeInfo != null && frame.IsProcessingEnumerable())
@@ -276,7 +265,7 @@ namespace System.Text.Json
                 }
             }
 
-           static int GetCount(IEnumerable enumerable)
+            static int GetCount(IEnumerable enumerable)
             {
                 if (enumerable is ICollection collection)
                 {
@@ -311,7 +300,7 @@ namespace System.Text.Json
                 }
             }
 
-            static string? GetPropertyName(in ReadStackFrame frame)
+            static string? GetPropertyName(ref ReadStackFrame frame)
             {
                 string? propertyName = null;
 
@@ -350,10 +339,7 @@ namespace System.Text.Json
                 // A zero index indicates a new stack frame.
                 if (Current.CtorArgumentStateIndex == 0)
                 {
-                    if (_ctorArgStateCache == null)
-                    {
-                        _ctorArgStateCache = new List<ArgumentState>();
-                    }
+                    _ctorArgStateCache ??= new List<ArgumentState>();
 
                     var newState = new ArgumentState();
                     _ctorArgStateCache.Add(newState);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -258,8 +258,7 @@ namespace System.Text.Json
 
                 if (frame.JsonTypeInfo != null && frame.IsProcessingEnumerable())
                 {
-                    IEnumerable? enumerable = (IEnumerable?)frame.ReturnValue;
-                    if (enumerable == null)
+                    if (frame.ReturnValue is not IEnumerable enumerable)
                     {
                         return;
                     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -175,6 +175,7 @@ namespace System.Text.Json
             }
 
             SetConstructorArgumentState();
+            Debug.Assert(JsonPath() is not null);
         }
 
         public void Pop(bool success)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -171,7 +171,10 @@ namespace System.Text.Json
             }
 
             SetConstructorArgumentState();
-            Debug.Assert(JsonPath() is not null);
+#if DEBUG
+            // Ensure the method is always exercised in debug builds.
+            _ = JsonPath();
+#endif
         }
 
         public void Pop(bool success)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -89,20 +89,5 @@ namespace System.Text.Json
         {
             return (JsonTypeInfo.PropertyInfoForTypeInfo.ConverterStrategy & ConverterStrategy.Enumerable) != 0;
         }
-
-        public void Reset()
-        {
-            CtorArgumentStateIndex = 0;
-            CtorArgumentState = null;
-            JsonTypeInfo = null!;
-            ObjectState = StackFrameObjectState.None;
-            OriginalDepth = 0;
-            OriginalTokenType = JsonTokenType.None;
-            PropertyIndex = 0;
-            PropertyRefCache = null;
-            ReturnValue = null;
-
-            EndProperty();
-        }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -253,13 +253,10 @@ namespace System.Text.Json
             DisposeFrame(Current.CollectionEnumerator, ref exception);
 
             int stackSize = Math.Max(_count, _continuationCount);
-            if (stackSize > 1)
+            for (int i = 0; i < stackSize - 1; i++)
             {
-                for (int i = 0; i < stackSize - 1; i++)
-                {
-                    Debug.Assert(_previous[i].AsyncEnumerator is null);
-                    DisposeFrame(_previous[i].CollectionEnumerator, ref exception);
-                }
+                Debug.Assert(_previous[i].AsyncEnumerator is null);
+                DisposeFrame(_previous[i].CollectionEnumerator, ref exception);
             }
 
             if (exception is not null)
@@ -294,12 +291,9 @@ namespace System.Text.Json
             exception = await DisposeFrame(Current.CollectionEnumerator, Current.AsyncEnumerator, exception).ConfigureAwait(false);
 
             int stackSize = Math.Max(_count, _continuationCount);
-            if (stackSize > 1)
+            for (int i = 0; i < stackSize - 1; i++)
             {
-                for (int i = 0; i < stackSize - 1; i++)
-                {
-                    exception = await DisposeFrame(_previous[i].CollectionEnumerator, _previous[i].AsyncEnumerator, exception).ConfigureAwait(false);
-                }
+                exception = await DisposeFrame(_previous[i].CollectionEnumerator, _previous[i].AsyncEnumerator, exception).ConfigureAwait(false);
             }
 
             if (exception is not null)
@@ -353,7 +347,7 @@ namespace System.Text.Json
 
             return sb.ToString();
 
-            void AppendStackFrame(StringBuilder sb, in WriteStackFrame frame)
+            static void AppendStackFrame(StringBuilder sb, in WriteStackFrame frame)
             {
                 // Append the property name.
                 string? propertyName = frame.DeclaredJsonPropertyInfo?.MemberInfo?.Name;
@@ -366,7 +360,7 @@ namespace System.Text.Json
                 AppendPropertyName(sb, propertyName);
             }
 
-            void AppendPropertyName(StringBuilder sb, string? propertyName)
+            static void AppendPropertyName(StringBuilder sb, string? propertyName)
             {
                 if (propertyName != null)
                 {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -16,14 +16,24 @@ namespace System.Text.Json
     internal struct WriteStack
     {
         /// <summary>
-        /// The number of stack frames when the continuation started.
+        /// Exposes the stackframe that is currently active.
         /// </summary>
-        private int _continuationCount;
+        public WriteStackFrame Current;
 
         /// <summary>
-        /// The number of stack frames including Current. _previous will contain _count-1 higher frames.
+        /// Buffer containing all frames in the stack. For performance it is only populated for serialization depths > 1.
+        /// </summary>
+        private WriteStackFrame[] _stack;
+
+        /// <summary>
+        /// Tracks the current depth of the stack.
         /// </summary>
         private int _count;
+
+        /// <summary>
+        /// If not zero, indicates that the stack is part of a re-entrant continuation of given depth.
+        /// </summary>
+        private int _continuationCount;
 
         /// <summary>
         /// Cancellation token used by converters performing async serialization (e.g. IAsyncEnumerable)
@@ -41,17 +51,15 @@ namespace System.Text.Json
         /// </summary>
         public List<IAsyncDisposable>? PendingAsyncDisposables;
 
-        private List<WriteStackFrame> _previous;
-
-        // A field is used instead of a property to avoid value semantics.
-        public WriteStackFrame Current;
-
         /// <summary>
         /// The amount of bytes to write before the underlying Stream should be flushed and the
         /// current buffer adjusted to remove the processed bytes.
         /// </summary>
         public int FlushThreshold;
 
+        /// <summary>
+        /// Indicates that the state still contains suspended frames waiting re-entry.
+        /// </summary>
         public bool IsContinuation => _continuationCount != 0;
 
         // The bag of preservable references.
@@ -62,25 +70,16 @@ namespace System.Text.Json
         /// </summary>
         public bool SupportContinuation;
 
-        private void AddCurrent()
+        private void EnsurePushCapacity()
         {
-            if (_previous == null)
+            if (_stack is null)
             {
-                _previous = new List<WriteStackFrame>();
+                _stack = new WriteStackFrame[4];
             }
-
-            if (_count > _previous.Count)
+            else if (_count - 1 == _stack.Length)
             {
-                // Need to allocate a new array element.
-                _previous.Add(Current);
+                Array.Resize(ref _stack, 2 * _stack.Length);
             }
-            else
-            {
-                // Use a previously allocated slot.
-                _previous[_count - 1] = Current;
-            }
-
-            _count++;
         }
 
         /// <summary>
@@ -125,8 +124,10 @@ namespace System.Text.Json
                     JsonTypeInfo jsonTypeInfo = Current.GetPolymorphicJsonPropertyInfo().RuntimeTypeInfo;
                     JsonNumberHandling? numberHandling = Current.NumberHandling;
 
-                    AddCurrent();
-                    Current.Reset();
+                    EnsurePushCapacity();
+                    _stack[_count - 1] = Current;
+                    Current = default;
+                    _count++;
 
                     Current.JsonTypeInfo = jsonTypeInfo;
                     Current.DeclaredJsonPropertyInfo = jsonTypeInfo.PropertyInfoForTypeInfo;
@@ -134,25 +135,18 @@ namespace System.Text.Json
                     Current.NumberHandling = numberHandling ?? Current.DeclaredJsonPropertyInfo.NumberHandling;
                 }
             }
-            else if (_continuationCount == 1)
-            {
-                // No need for a push since there is only one stack frame.
-                Debug.Assert(_count == 1);
-                _continuationCount = 0;
-            }
             else
             {
-                // A continuation, adjust the index.
-                Current = _previous[_count - 1];
+                // We are re-entering a continuation, adjust indices accordingly
+                if (_count++ > 0)
+                {
+                    Current = _stack[_count - 1];
+                }
 
-                // Check if we are done.
-                if (_count == _continuationCount)
+                // check if we are done
+                if (_continuationCount == _count)
                 {
                     _continuationCount = 0;
-                }
-                else
-                {
-                    _count++;
                 }
             }
 
@@ -170,33 +164,25 @@ namespace System.Text.Json
                 {
                     if (_count == 1)
                     {
-                        // No need for a continuation since there is only one stack frame.
+                        // No need to copy any frames here.
                         _continuationCount = 1;
-                        _count = 1;
-                    }
-                    else
-                    {
-                        AddCurrent();
-                        _count--;
-                        _continuationCount = _count;
-                        _count--;
-                        Current = _previous[_count - 1];
+                        _count = 0;
+                        return;
                     }
 
-                    return;
+                    // Need to push the Current frame to the stack,
+                    // ensure that we have sufficient capacity.
+                    EnsurePushCapacity();
+                    _continuationCount = _count--;
                 }
-
-                if (_continuationCount == 1)
+                else if (--_count == 0)
                 {
-                    // No need for a pop since there is only one stack frame.
-                    Debug.Assert(_count == 1);
+                    // reached the root, no need to copy frames.
                     return;
                 }
 
-                // Update the list entry to the current value.
-                _previous[_count - 1] = Current;
-
-                Debug.Assert(_count > 0);
+                _stack[_count] = Current;
+                Current = _stack[_count - 1];
             }
             else
             {
@@ -209,11 +195,11 @@ namespace System.Text.Json
                     PendingAsyncDisposables ??= new List<IAsyncDisposable>();
                     PendingAsyncDisposables.Add(Current.AsyncEnumerator);
                 }
-            }
 
-            if (_count > 1)
-            {
-                Current = _previous[--_count - 1];
+                if (--_count > 0)
+                {
+                    Current = _stack[_count - 1];
+                }
             }
         }
 
@@ -257,8 +243,8 @@ namespace System.Text.Json
             int stackSize = Math.Max(_count, _continuationCount);
             for (int i = 0; i < stackSize - 1; i++)
             {
-                Debug.Assert(_previous[i].AsyncEnumerator is null);
-                DisposeFrame(_previous[i].CollectionEnumerator, ref exception);
+                Debug.Assert(_stack[i].AsyncEnumerator is null);
+                DisposeFrame(_stack[i].CollectionEnumerator, ref exception);
             }
 
             if (exception is not null)
@@ -295,7 +281,7 @@ namespace System.Text.Json
             int stackSize = Math.Max(_count, _continuationCount);
             for (int i = 0; i < stackSize - 1; i++)
             {
-                exception = await DisposeFrame(_previous[i].CollectionEnumerator, _previous[i].AsyncEnumerator, exception).ConfigureAwait(false);
+                exception = await DisposeFrame(_stack[i].CollectionEnumerator, _stack[i].AsyncEnumerator, exception).ConfigureAwait(false);
             }
 
             if (exception is not null)
@@ -339,17 +325,17 @@ namespace System.Text.Json
 
             for (int i = 0; i < count - 1; i++)
             {
-                AppendStackFrame(sb, _previous[i]);
+                AppendStackFrame(sb, ref _stack[i]);
             }
 
             if (_continuationCount == 0)
             {
-                AppendStackFrame(sb, Current);
+                AppendStackFrame(sb, ref Current);
             }
 
             return sb.ToString();
 
-            static void AppendStackFrame(StringBuilder sb, in WriteStackFrame frame)
+            static void AppendStackFrame(StringBuilder sb, ref WriteStackFrame frame)
             {
                 // Append the property name.
                 string? propertyName = frame.DeclaredJsonPropertyInfo?.MemberInfo?.Name;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -150,7 +150,10 @@ namespace System.Text.Json
                 }
             }
 
-            Debug.Assert(PropertyPath() is not null);
+#if DEBUG
+            // Ensure the method is always exercised in debug builds.
+            _ = PropertyPath();
+#endif
         }
 
         public void Pop(bool success)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -155,6 +155,8 @@ namespace System.Text.Json
                     _count++;
                 }
             }
+
+            Debug.Assert(PropertyPath() is not null);
         }
 
         public void Pop(bool success)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
@@ -120,20 +120,5 @@ namespace System.Text.Json
 
             return PolymorphicJsonPropertyInfo.ConverterBase;
         }
-
-        public void Reset()
-        {
-            CollectionEnumerator = null;
-            EnumeratorIndex = 0;
-            AsyncEnumerator = null;
-            AsyncEnumeratorIsPendingCompletion = false;
-            IgnoreDictionaryKeyPolicy = false;
-            JsonTypeInfo = null!;
-            OriginalDepth = 0;
-            ProcessedStartToken = false;
-            ProcessedEndToken = false;
-
-            EndProperty();
-        }
     }
 }


### PR DESCRIPTION
This PR backports a selection of bugfixes, infrastructural changes and perf improvements that were made as part of the polymorphism feature branch in #53882. I have layered the changes into separate commits that should ideally be reviewed independently:

1. https://github.com/dotnet/runtime/commit/a858d3b11d9ae6e2a1fed8198ed564fd4a8e82b7 fixes a series of bugs that were discovered while prototyping.
2. https://github.com/dotnet/runtime/commit/99529f71f9467675f277db33fb2c29f30ab420d5 adds debug assertions around `Push()` and `Pop()` operations that assist in early detection of stack-corrupting bugs.
3. https://github.com/dotnet/runtime/commit/4ba2497f0282f0ef25c278db92cff234930ed6e4 reworks and simplifies the `WriteStack` and `ReadStack` implementations to
    - Use arrays instead of lists for storing previous stackframes: previous frames can now be passed by reference where needed.
    - Ensures that the `_count` field always accurately reflects the current stack depth.
    - Removes the `StackFrame.Reset()` methods and instead clears `Current` by assigning it to a `default` instance. This eliminates a class of bugs caused by dirty frames being reused in new contexts.
4. https://github.com/dotnet/runtime/commit/cb594301e1fa57bd1d47f011392a00b67bc2a873 takes advantage of recently added JIT optimizations (e.g. optimizing `typeof(T).IsValueType` expressions #1157) in the serialization hot path methods.

The changes should make it easier to incorporate the polymorphism infrastructural changes in the future. Overall the changes result in a slight increase in serialization performance, on average between 4-8% faster in our benchmark suite.