### PR TITLE
Remove System.Security.Cryptography.Cng from ASP.NET transport package

### DIFF
--- a/src/libraries/System.Security.Cryptography.Cng/Directory.Build.props
+++ b/src/libraries/System.Security.Cryptography.Cng/Directory.Build.props
@@ -2,7 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IsAspNetCoreApp>true</IsAspNetCoreApp>
     <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/54427

We should also port to Preview6