### PR TITLE
enable ZeroByteRead_BlocksUntilDataAvailableOrNops test for quic

### DIFF
--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamConnectedStreamConformanceTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamConnectedStreamConformanceTests.cs
@@ -22,6 +22,7 @@ namespace System.Net.Quic.Tests
     {
         protected override QuicImplementationProvider Provider => QuicImplementationProviders.MsQuic;
         protected override bool UsableAfterCanceledReads => false;
+        protected override bool BlocksOnZeroByteReads => true;
 
         // TODO: These are all hanging, likely due to Stream close behavior.
         [ActiveIssue("https://github.com/dotnet/runtime/issues/756")]
@@ -42,8 +43,6 @@ namespace System.Net.Quic.Tests
         public override Task ReadWriteAsync_PrecanceledOperations_ThrowsCancellationException() => base.ReadWriteAsync_PrecanceledOperations_ThrowsCancellationException();
         [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
         public override Task Read_DataStoredAtDesiredOffset(ReadWriteMode mode) => base.Read_DataStoredAtDesiredOffset(mode);
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
-        public override Task ZeroByteRead_BlocksUntilDataAvailableOrNops(ReadWriteMode mode) => base.ZeroByteRead_BlocksUntilDataAvailableOrNops(mode);
         [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
         public override Task ReadAsync_DuringReadAsync_ThrowsIfUnsupported() => base.ReadAsync_DuringReadAsync_ThrowsIfUnsupported();
     }


### PR DESCRIPTION
We block until some data are received. (same as NetworkStream and SslStream) 