### PR TITLE
Disable two Interop tests failing in outerloop under crossgen2

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -123,6 +123,12 @@
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/eventsvalidation/ThreadPool/*">
             <Issue>https://github.com/dotnet/runtime/issues/48727</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/COM/NETClients/ComDisabled/NETClientComDisabled/*">
+            <Issue>https://github.com/dotnet/runtime/issues/54379</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/LayoutClass/LayoutClassTest/*">
+            <Issue>https://github.com/dotnet/runtime/issues/54316</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- All Unix targets on all runtimes -->


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/54379
https://github.com/dotnet/runtime/issues/54316