### PR TITLE
Move System.Object serialization to ObjectConverter

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ObjectConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ObjectConverter.cs
@@ -24,7 +24,10 @@ namespace System.Text.Json.Serialization.Converters
 
         public override void Write(Utf8JsonWriter writer, object? value, JsonSerializerOptions options)
         {
-            throw new InvalidOperationException();
+            Debug.Assert(value?.GetType() == typeof(object));
+
+            writer.WriteStartObject();
+            writer.WriteEndObject();
         }
 
         internal override object ReadWithQuotes(ref Utf8JsonReader reader)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfoOfT.cs
@@ -235,7 +235,7 @@ namespace System.Text.Json.Serialization.Metadata
             T value = Get!(obj);
 
             if (
-#if NET6_0_OR_GREATER
+#if NET5_0_OR_GREATER
                 !typeof(T).IsValueType && // treated as a constant by recent versions of the JIT.
 #else
                 !Converter.IsValueType &&

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CustomConverterTests/CustomConverterTests.Object.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CustomConverterTests/CustomConverterTests.Object.cs
@@ -307,7 +307,9 @@ namespace System.Text.Json.Serialization.Tests
 
             public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
             {
-                throw new InvalidOperationException("Should not get here.");
+                Assert.IsType<object>(value);
+                writer.WriteStartObject();
+                writer.WriteEndObject();
             }
         }
 
@@ -732,5 +734,34 @@ namespace System.Text.Json.Serialization.Tests
             options.Converters.Add(new SystemObjectNewtonsoftCompatibleConverter());
             Verify(options);
         }
+
+        [Fact]
+        public static void CanCustomizeSystemObjectSerialization()
+        {
+            var options = new JsonSerializerOptions { Converters = { new CustomSystemObjectConverter() } };
+
+            string expectedJson = "\"Object\"";
+            string actualJson = JsonSerializer.Serialize(new object(), options);
+            Assert.Equal(expectedJson, actualJson);
+        }
+
+        private class CustomSystemObjectConverter : JsonConverter<object>
+        {
+            public override object? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => throw new NotImplementedException();
+            public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
+            {
+                if (value?.GetType() == typeof(object))
+                {
+                    // check that serialization for values of
+                    // runtime type object can be customized.
+                    writer.WriteStringValue("Object");
+                }
+                else
+                {
+                    throw new NotSupportedException();
+                }
+            }
+        }
     }
+
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CustomConverterTests/CustomConverterTests.Object.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CustomConverterTests/CustomConverterTests.Object.cs
@@ -740,7 +740,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             var options = new JsonSerializerOptions { Converters = { new CustomSystemObjectConverter() } };
 
-            string expectedJson = "\"Object\"";
+            string expectedJson = "42";
             string actualJson = JsonSerializer.Serialize(new object(), options);
             Assert.Equal(expectedJson, actualJson);
         }
@@ -749,18 +749,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             public override object? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => throw new NotImplementedException();
             public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
-            {
-                if (value?.GetType() == typeof(object))
-                {
-                    // check that serialization for values of
-                    // runtime type object can be customized.
-                    writer.WriteStringValue("Object");
-                }
-                else
-                {
-                    throw new NotSupportedException();
-                }
-            }
+                => writer.WriteNumberValue(42);
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
@@ -328,12 +328,12 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void Options_GetConverterForObjectJsonElement_GivesCorrectConverter()
         {
-            GenericObjectOrJsonElementConverterTestHelper<object>("ObjectConverter", new object(), "[3]", true);
+            GenericObjectOrJsonElementConverterTestHelper<object>("ObjectConverter", new object(), "{}");
             JsonElement element = JsonDocument.Parse("[3]").RootElement;
-            GenericObjectOrJsonElementConverterTestHelper<JsonElement>("JsonElementConverter", element, "[3]", false);
+            GenericObjectOrJsonElementConverterTestHelper<JsonElement>("JsonElementConverter", element, "[3]");
         }
 
-        private static void GenericObjectOrJsonElementConverterTestHelper<T>(string converterName, object objectValue, string stringValue, bool throws)
+        private static void GenericObjectOrJsonElementConverterTestHelper<T>(string converterName, object objectValue, string stringValue)
         {
             var options = new JsonSerializerOptions();
 
@@ -347,10 +347,7 @@ namespace System.Text.Json.Serialization.Tests
 
             if (readValue is JsonElement element)
             {
-                Assert.Equal(JsonValueKind.Array, element.ValueKind);
-                JsonElement.ArrayEnumerator iterator = element.EnumerateArray();
-                Assert.True(iterator.MoveNext());
-                Assert.Equal(3, iterator.Current.GetInt32());
+                JsonTestHelper.AssertJsonEqual(stringValue, element.ToString());
             }
             else
             {
@@ -360,22 +357,14 @@ namespace System.Text.Json.Serialization.Tests
             using (var stream = new MemoryStream())
             using (var writer = new Utf8JsonWriter(stream))
             {
-                if (throws)
-                {
-                    Assert.Throws<InvalidOperationException>(() => converter.Write(writer, (T)objectValue, options));
-                    Assert.Throws<InvalidOperationException>(() => converter.Write(writer, (T)objectValue, null));
-                }
-                else
-                {
-                    converter.Write(writer, (T)objectValue, options);
-                    writer.Flush();
-                    Assert.Equal(stringValue, Encoding.UTF8.GetString(stream.ToArray()));
+                converter.Write(writer, (T)objectValue, options);
+                writer.Flush();
+                Assert.Equal(stringValue, Encoding.UTF8.GetString(stream.ToArray()));
 
-                    writer.Reset(stream);
-                    converter.Write(writer, (T)objectValue, null); // Test with null option
-                    writer.Flush();
-                    Assert.Equal(stringValue + stringValue, Encoding.UTF8.GetString(stream.ToArray()));
-                }
+                writer.Reset(stream);
+                converter.Write(writer, (T)objectValue, null); // Test with null option
+                writer.Flush();
+                Assert.Equal(stringValue + stringValue, Encoding.UTF8.GetString(stream.ToArray()));
             }
         }
 


### PR DESCRIPTION
Continuing the backporting efforts of #54420, this PR brings a change from #54328 that requires review in isolation:

## Potential breaking change

The changes introduce a deliberate breaking change when it comes to the handling of `new object()` values. The existing implementation will hardcode the serialization to `{}` _even if_ the user has subscribed a custom `JsonConverter<object>` that does something different. I would like to change this behavior for a few reasons:

* It can be surprising to users: custom object converters cannot be polymorphic _with the sole exception of_ `new object()` values. Users cannot specify a custom serialization format for `new object()` values.
* Keeping it requires maintaining [more complex logic in the serialization hot path](https://github.com/dotnet/runtime/commit/b14bcdf497def3996db1b480704504c986864aa8). The change makes the code simpler by delegating `object` instance serialization to the relevant converter.
* It is unlikely that `new object()` instances are being serialized in production applications.

The breaking change concerns the following scenario:
```csharp
using System;
using System.Text.Json;
using System.Text.Json.Serialization;

var options = new JsonSerializerOptions { Converters = { new CustomObjectConverter() } };
string json = JsonSerializer.Serialize(new object(), options);
Console.WriteLine(json);

public class CustomObjectConverter : JsonConverter<object>
{
    public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options) => writer.WriteNumberValue(42);
    public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => throw new NotSupportedException();
}
```
In .NET 5 the above would print `{}`, however under the new changes it would print `42`. This could break users with custom object converters who rely on the existing hardcoding behavior.