### PR TITLE
HTTP/3: Fix header field length calculation

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/QPack/HeaderField.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/QPack/HeaderField.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+using System.Text;
+
 namespace System.Net.Http.QPack
 {
     internal readonly struct HeaderField
@@ -11,6 +14,8 @@ namespace System.Net.Http.QPack
 
         public HeaderField(byte[] name, byte[] value)
         {
+            Debug.Assert(name.Length > 0);
+
             Name = name;
             Value = value;
         }
@@ -19,6 +24,20 @@ namespace System.Net.Http.QPack
 
         public byte[] Value { get; }
 
-        public int Length => Name.Length + Value.Length;
+        public int Length => GetLength(Name.Length, Value.Length);
+
+        public static int GetLength(int nameLength, int valueLength) => nameLength + valueLength + RfcOverhead;
+
+        public override string ToString()
+        {
+            if (Name != null)
+            {
+                return Encoding.ASCII.GetString(Name) + ": " + Encoding.ASCII.GetString(Value);
+            }
+            else
+            {
+                return "<empty>";
+            }
+        }
     }
 }


### PR DESCRIPTION
https://quicwg.org/base-drafts/draft-ietf-quic-qpack.html#section-3.2.1

> The size of an entry is the sum of its name's length in bytes, its value's length in bytes, and 32 additional bytes. The size of an entry is calculated using the length of its name and value without Huffman encoding applied.

Makes type consistent with HPack type - https://github.com/dotnet/runtime/blob/3174651b1ed15a2cdd9789ac2282601925428e55/src/libraries/Common/src/System/Net/Http/aspnetcore/Http2/Hpack/HeaderField.cs