### PR TITLE
[wasm] Fix NRE caused by WeakReference collected on JS interop boundary.

### DIFF
--- a/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
+++ b/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
@@ -70,6 +70,7 @@ internal static partial class Interop
             object res = CompileFunction(snippet, out int exception);
             if (exception != 0)
                 throw new JSException((string)res);
+            ReleaseInFlight(res);
             return res as System.Runtime.InteropServices.JavaScript.Function;
         }
 
@@ -97,6 +98,7 @@ internal static partial class Interop
             if (exception != 0)
                 throw new JSException($"Error obtaining a handle to global {str}");
 
+            ReleaseInFlight(globalHandle);
             return globalHandle;
         }
 
@@ -120,6 +122,12 @@ internal static partial class Interop
                 var module = (JSObject)Runtime.GetGlobalObject("Module");
                 module.SetObjectProperty("aot_profile_data", Uint8Array.From(span));
             }
+        }
+
+        public static void ReleaseInFlight(object? obj)
+        {
+            JSObject? jsObj = obj as JSObject;
+            jsObj?.ReleaseInFlight();
         }
     }
 }

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.RemoteServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.RemoteServer.cs
@@ -178,7 +178,6 @@ namespace System.Net.Http.Functional.Tests
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory]
         [MemberData(nameof(RemoteServersAndHeaderEchoUrisMemberData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/53872", TestPlatforms.Browser)]
         public async Task GetAsync_RequestHeadersAddCustomHeaders_HeaderAndEmptyValueSent(Configuration.Http.RemoteServer remoteServer, Uri uri)
         {
             if (IsWinHttpHandler && !PlatformDetection.IsWindows10Version1709OrGreater)

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -577,7 +577,6 @@ namespace System.Net.Http.Functional.Tests
 
         [Theory]
         [MemberData(nameof(GetAsync_ManyDifferentResponseHeaders_ParsedCorrectly_MemberData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/54655", TestPlatforms.Browser)]
         public async Task GetAsync_ManyDifferentResponseHeaders_ParsedCorrectly(string newline, string fold, bool dribble)
         {
             if (LoopbackServerFactory.Version >= HttpVersion20.Value)

--- a/src/libraries/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
@@ -217,7 +217,6 @@ namespace System.Net.WebSockets.Client.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/53957", TestPlatforms.Browser)]
         public async Task ReceiveAsync_MultipleOutstandingReceiveOperations_Throws(Uri server)
         {
             using (ClientWebSocket cws = await WebSocketHelper.GetConnectedWebSocket(server, TimeOutMilliseconds, _output))
@@ -321,7 +320,6 @@ namespace System.Net.WebSockets.Client.Tests
 
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/53957", TestPlatforms.Browser)]
         public async Task SendReceive_VaryingLengthBuffers_Success(Uri server)
         {
             using (ClientWebSocket cws = await WebSocketHelper.GetConnectedWebSocket(server, TimeOutMilliseconds, _output))

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Array.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Array.cs
@@ -86,6 +86,7 @@ namespace System.Runtime.InteropServices.JavaScript
 
                 if (exception != 0)
                     throw new JSException((string)indexValue);
+                Interop.Runtime.ReleaseInFlight(indexValue);
                 return indexValue;
             }
             set

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
@@ -73,6 +73,7 @@ namespace System.Runtime.InteropServices.JavaScript
             object res = Interop.Runtime.InvokeJSWithArgs(JSHandle, method, args, out int exception);
             if (exception != 0)
                 throw new JSException((string)res);
+            Interop.Runtime.ReleaseInFlight(res);
             return res;
         }
 
@@ -103,6 +104,7 @@ namespace System.Runtime.InteropServices.JavaScript
             object propertyValue = Interop.Runtime.GetObjectProperty(JSHandle, name, out int exception);
             if (exception != 0)
                 throw new JSException((string)propertyValue);
+            Interop.Runtime.ReleaseInFlight(propertyValue);
             return propertyValue;
         }
 

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -91,6 +91,8 @@ namespace System.Runtime.InteropServices.JavaScript
                 }
             }
 
+            target.AddInFlight();
+
             return target.Int32Handle;
         }
 
@@ -236,12 +238,21 @@ namespace System.Runtime.InteropServices.JavaScript
             return jsObject?.JSHandle ?? -1;
         }
 
-        public static object? GetDotNetObject(int gcHandle)
+        /// <param name="gcHandle"></param>
+        /// <param name="shouldAddInflight">when true, we would create Normal GCHandle to the JSObject, so that it would not get collected before passing it back to managed code</param>
+        public static object? GetDotNetObject(int gcHandle, int shouldAddInflight)
         {
             GCHandle h = (GCHandle)(IntPtr)gcHandle;
 
-            return h.Target is JSObject js ?
-                js.GetWrappedObject() ?? h.Target : h.Target;
+            if (h.Target is JSObject jso)
+            {
+                if (shouldAddInflight != 0)
+                {
+                    jso.AddInFlight();
+                }
+                return jso.GetWrappedObject() ?? jso;
+            }
+            return h.Target;
         }
 
         public static bool IsSimpleArray(object a)


### PR DESCRIPTION
- Added GCHandle Normal while JSObject is in flight over JS/Managed interop boundary
- Added new unit test for iterator.

Fixes https://github.com/dotnet/runtime/issues/53872
Fixes https://github.com/dotnet/runtime/issues/53957
Fixes https://github.com/dotnet/runtime/issues/54655

