### PR TITLE
Use an untyped `Task` instead of a `Task<bool>` in `TimerQueueTimer`.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Timer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Timer.cs
@@ -440,7 +440,7 @@ namespace System.Threading
     // A timer in our TimerQueue.
     [DebuggerDisplay("{DisplayString,nq}")]
     [DebuggerTypeProxy(typeof(TimerDebuggerTypeProxy))]
-    internal sealed partial class TimerQueueTimer : IThreadPoolWorkItem
+    internal sealed class TimerQueueTimer : IThreadPoolWorkItem
     {
         // The associated timer queue.
         private readonly TimerQueue _associatedTimerQueue;
@@ -473,12 +473,12 @@ namespace System.Threading
         // after all pending callbacks are complete.  We set _canceled to prevent any callbacks that
         // are already queued from running.  We track the number of callbacks currently executing in
         // _callbacksRunning.  We set _notifyWhenNoCallbacksRunning only when _callbacksRunning
-        // reaches zero.  Same applies if Timer.DisposeAsync() is used, except with a Task<bool>
+        // reaches zero.  Same applies if Timer.DisposeAsync() is used, except with a Task
         // instead of with a provided WaitHandle.
         private int _callbacksRunning;
         private bool _canceled;
         internal bool _everQueued;
-        private object? _notifyWhenNoCallbacksRunning; // may be either WaitHandle or Task<bool>
+        private object? _notifyWhenNoCallbacksRunning; // may be either WaitHandle or Task
 
         internal TimerQueueTimer(TimerCallback timerCallback, object? state, uint dueTime, uint period, bool flowExecutionContext)
         {
@@ -626,20 +626,20 @@ namespace System.Threading
 
                 Debug.Assert(
                     notifyWhenNoCallbacksRunning == null ||
-                    notifyWhenNoCallbacksRunning is Task<bool>);
+                    notifyWhenNoCallbacksRunning is Task);
 
-                // There are callbacks queued or running, so we need to store a Task<bool>
+                // There are callbacks queued or running, so we need to store a Task
                 // that'll be used to signal the caller when all callbacks complete. Do so as long as
                 // there wasn't a previous CloseAsync call that did.
                 if (notifyWhenNoCallbacksRunning == null)
                 {
-                    var t = new Task<bool>((object?)null, TaskCreationOptions.RunContinuationsAsynchronously);
+                    var t = new Task((object?)null, TaskCreationOptions.RunContinuationsAsynchronously, true);
                     _notifyWhenNoCallbacksRunning = t;
                     return new ValueTask(t);
                 }
 
                 // A previous CloseAsync call already hooked up a task.  Just return it.
-                return new ValueTask((Task<bool>)notifyWhenNoCallbacksRunning);
+                return new ValueTask((Task)notifyWhenNoCallbacksRunning);
             }
         }
 
@@ -675,7 +675,7 @@ namespace System.Threading
         internal void SignalNoCallbacksRunning()
         {
             object? toSignal = _notifyWhenNoCallbacksRunning;
-            Debug.Assert(toSignal is WaitHandle || toSignal is Task<bool>);
+            Debug.Assert(toSignal is WaitHandle || toSignal is Task);
 
             if (toSignal is WaitHandle wh)
             {
@@ -683,7 +683,7 @@ namespace System.Threading
             }
             else
             {
-                ((Task<bool>)toSignal).TrySetResult(true);
+                ((Task)toSignal).TrySetResult();
             }
         }
 


### PR DESCRIPTION
When `TimerQueueTimer.CloseAsync` was about to complete asynchronously, it returns an untyped `ValueTask` backed by a `Task<bool>`. This PR changes it to return an untyped `Task`, saving one unused boolean value and using the correct semantics.

It also removes the unused `partial` designation from `TimerQueueTimer`.