### PR TITLE
Fix the slot calculation for multiple services

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
@@ -77,6 +77,17 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             }
         }
 
+        // For unit testing
+        internal int? GetSlot(ServiceDescriptor serviceDescriptor)
+        {
+            if (_descriptorLookup.TryGetValue(serviceDescriptor.ServiceType, out ServiceDescriptorCacheItem item))
+            {
+                return item.GetSlot(serviceDescriptor);
+            }
+
+            return null;
+        }
+
         internal ServiceCallSite GetCallSite(Type serviceType, CallSiteChain callSiteChain) =>
             _callSiteCache.TryGetValue(new ServiceCacheKey(serviceType, DefaultSlot), out ServiceCallSite site) ? site :
             CreateCallSite(serviceType, callSiteChain);
@@ -537,7 +548,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     int index = _items.IndexOf(descriptor);
                     if (index != -1)
                     {
-                        return Count - index + 1;
+                        return _items.Count - (index + 1);
                     }
                 }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceLookup/CallSiteFactoryTest.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceLookup/CallSiteFactoryTest.cs
@@ -557,6 +557,41 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         }
 
         [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        public void GetSlotTests(int numberOfServices)
+        {
+            var serviceDescriptors = new[] {
+                ServiceDescriptor.Singleton<ICustomService, CustomService1>(),
+                ServiceDescriptor.Singleton<ICustomService, CustomService2>(),
+                ServiceDescriptor.Singleton<ICustomService, CustomService3>(),
+                ServiceDescriptor.Singleton<ICustomService, CustomService4>(),
+                ServiceDescriptor.Singleton<ICustomService, CustomService5>()
+            };
+
+            var callsiteFactory = new CallSiteFactory(serviceDescriptors.Take(numberOfServices));
+
+            for (int i = 0; i < numberOfServices; i++)
+            {
+                Assert.Equal(numberOfServices - i - 1, callsiteFactory.GetSlot(serviceDescriptors[i]));
+            }
+        }
+
+        interface ICustomService
+        {
+
+        }
+
+        class CustomService1 : ICustomService { }
+        class CustomService2 : ICustomService { }
+        class CustomService3 : ICustomService { }
+        class CustomService4 : ICustomService { }
+        class CustomService5 : ICustomService { }
+
+        [Theory]
         [InlineData(typeof(TypeWithMultipleParameterizedConstructors))]
         [InlineData(typeof(TypeWithSupersetConstructors))]
         public void CreateCallSite_ThrowsIfTypeHasNoConstructurWithResolvableParameters(Type type)

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderContainerTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.DependencyInjection.Fakes;
 using Microsoft.Extensions.DependencyInjection.Specification;
 using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
@@ -81,6 +82,70 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         }
 
         [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        public void MultipleServicesAreOrdered(int numberOfServices)
+        {
+            // Arrange
+            var collection = new ServiceCollection();
+
+            var serviceDescriptors = new[] {
+                ServiceDescriptor.Singleton<ICustomService, CustomService1>(),
+                ServiceDescriptor.Singleton<ICustomService, CustomService2>(),
+                ServiceDescriptor.Singleton<ICustomService, CustomService3>(),
+                ServiceDescriptor.Singleton<ICustomService, CustomService4>(),
+                ServiceDescriptor.Singleton<ICustomService, CustomService5>(),
+                ServiceDescriptor.Singleton<ICustomService, CustomService6>()
+            };
+
+            var serviceTypes = new[]
+            {
+                typeof(CustomService1),
+                typeof(CustomService2),
+                typeof(CustomService3),
+                typeof(CustomService4),
+                typeof(CustomService5),
+                typeof(CustomService6),
+            };
+
+            foreach (var sd in serviceDescriptors.Take(numberOfServices))
+            {
+                collection.Add(sd);
+            }
+
+            var provider = collection.BuildServiceProvider(new ServiceProviderOptions
+            {
+                ValidateOnBuild = true
+            });
+
+            // Act and Assert
+            var customServices = provider.GetService<IEnumerable<ICustomService>>().ToArray();
+
+            Assert.Equal(numberOfServices, customServices.Length);
+
+            for (int i = 0; i < numberOfServices; i++)
+            {
+                Assert.IsAssignableFrom(serviceTypes[i], customServices[i]);
+            }
+        }
+
+        interface ICustomService
+        {
+
+        }
+
+        class CustomService1 : ICustomService { }
+        class CustomService2 : ICustomService { }
+        class CustomService3 : ICustomService { }
+        class CustomService4 : ICustomService { }
+        class CustomService5 : ICustomService { }
+        class CustomService6 : ICustomService { }
+
+        [Theory]
         // GenericTypeDefintion, Abstract GenericTypeDefintion
         [InlineData(typeof(IFakeOpenGenericService<>), typeof(AbstractFakeOpenGenericService<>))]
         // GenericTypeDefintion, Interface GenericTypeDefintion
@@ -121,11 +186,11 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         {
             get
             {
-				Type serviceType = typeof(IFakeOpenGenericService<>);
-				// Service type is GenericTypeDefintion, implementation type is ConstructedGenericType
-                yield return new object[] {serviceType, typeof(ClassWithNoConstraints<string>), $"Open generic service type '{serviceType}' requires registering an open generic implementation type."};
-				// Service type is GenericTypeDefintion, implementation type has different generic type definition arity
-                yield return new object[] {serviceType, typeof(FakeOpenGenericServiceWithTwoTypeArguments<,>), $"Arity of open generic service type '{serviceType}' does not equal arity of open generic implementation type '{typeof(FakeOpenGenericServiceWithTwoTypeArguments<,>)}'."};
+                Type serviceType = typeof(IFakeOpenGenericService<>);
+                // Service type is GenericTypeDefintion, implementation type is ConstructedGenericType
+                yield return new object[] { serviceType, typeof(ClassWithNoConstraints<string>), $"Open generic service type '{serviceType}' requires registering an open generic implementation type." };
+                // Service type is GenericTypeDefintion, implementation type has different generic type definition arity
+                yield return new object[] { serviceType, typeof(FakeOpenGenericServiceWithTwoTypeArguments<,>), $"Arity of open generic service type '{serviceType}' does not equal arity of open generic implementation type '{typeof(FakeOpenGenericServiceWithTwoTypeArguments<,>)}'." };
             }
         }
 
@@ -566,8 +631,8 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
                         sb.Append("4");
                     }
 
-                // Let Thread 1 over take Thread 2
-                Thing1 value = lazy.Value;
+                    // Let Thread 1 over take Thread 2
+                    Thing1 value = lazy.Value;
                     return value;
                 });
                 services.AddSingleton<Thing2>();
@@ -631,7 +696,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
                     sb.Append("3");
                     mreForThread2.Set();   // Now that thread 1 holds lazy lock, allow thread 2 to continue
 
-                thing3 = sp.GetRequiredService<Thing3>();
+                    thing3 = sp.GetRequiredService<Thing3>();
                     return new Thing4(thing3);
                 });
 
@@ -1012,7 +1077,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             }
         }
 
-        private class FakeMultipleServiceWithIEnumerableDependency: IFakeMultipleService
+        private class FakeMultipleServiceWithIEnumerableDependency : IFakeMultipleService
         {
             public FakeMultipleServiceWithIEnumerableDependency(IEnumerable<IFakeService> fakeServices)
             {
@@ -1125,7 +1190,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 
             Assert.Same(sp.GetRequiredService<IFakeOpenGenericService<A>>().Value, sp.GetRequiredService<A>());
         }
-        
+
         [Theory]
         [InlineData(ServiceProviderMode.Default)]
         [InlineData(ServiceProviderMode.Dynamic)]


### PR DESCRIPTION
- The slot calculation was not correct for more than 5 services.
- Added tests to verify the slot calculation and service resolution.

Fixes https://github.com/dotnet/runtime/issues/54407

PS: We should put this in preview6

Details:

When register multiple instances of the same service type (e.g. IFoo, Foo1 : IFoo, Foo2 : IFoo), that service type can be resolved as an `IEnumerable<T>` or `T`. When resolved as `T` we take the last registration, when resolved as `IEnumerable<T>` we take all in registration order. Slots are per service type and represent 2 things:
- The 0th slot is the service service descriptor that will be resolved when asking for specific service type (Foo2 in the above example)
- It's a way to disambiguate the cache key for the same service type for IEnumerable (Foo1 = (IFoo, slot = 1), Foo2 = (IFoo, slot = 0))

Looking at the examples above, the last service registered is slot 0 and the first service registered is slot N - 1, where N is the number of service descriptors with the same service type.

The bug:

These calculations show why things were broken for only >= 5 services when ValidateOnBuild was set. Most of the time, even though the slot calculation was incorrect, it was incorrect and outside of the valid range of slot values for the IEnumerable. So for example, the valid range for 5 items is 0-4 (think array indexes). At 5 or more services, the incorrect slot calculation began to overlap in the valid list of slot values.

1
GetSlot(CS1) = Slot 0

2
GetSlot(CS1) = Slot 1 
GetSlot(CS2) = Slot 3 -> invalid slot

3
GetSlot(CS1) = Slot 2
GetSlot(CS2) = Slot 4 -> invalid slot
GetSlot(CS3) = Slot 3 -> invalid slot

4
GetSlot(CS1) = Slot 3
GetSlot(CS2) = Slot 5 -> invalid slot
GetSlot(CS3) = Slot 4 -> invalid slot
GetSlot(CS4) = Slot 3 -> already correctly cached so it gets ignored

5
GetSlot(CS1) = Slot 4
GetSlot(CS2) = Slot 6 -> invalid slot
GetSlot(CS3) = Slot 5 -> invalid slot
GetSlot(CS4) = Slot 4 -> already correctly cached so it gets ignored
GetSlot(CS5) = Slot 3 -> This crosses into a valid slot 
