### PR TITLE
Add name of corrupted certificate to CryptographicException on Mac

### DIFF
--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X509.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X509.cs
@@ -82,9 +82,9 @@ internal static partial class Interop
                 cert,
                 out subjectSummary);
 
-            if (ret == 1)
+            using (subjectSummary)
             {
-                using (subjectSummary)
+                if (ret == 1)
                 {
                     return CoreFoundation.CFStringToString(subjectSummary);
                 }

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X509.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X509.cs
@@ -21,6 +21,11 @@ internal static partial class Interop
             out int pOSStatus);
 
         [DllImport(Libraries.AppleCryptoNative)]
+        private static extern int AppleCryptoNative_X509GetSubjectSummary(
+            SafeSecCertificateHandle cert,
+            out SafeCFStringHandle cfSubjectSummaryOut);
+
+        [DllImport(Libraries.AppleCryptoNative)]
         private static extern int AppleCryptoNative_X509GetPublicKey(SafeSecCertificateHandle cert, out SafeSecKeyRefHandle publicKey, out int pOSStatus);
 
         internal static X509ContentType X509GetContentType(ReadOnlySpan<byte> data)
@@ -66,6 +71,30 @@ internal static partial class Interop
             }
 
             Debug.Fail($"Unexpected return value {ret}");
+            throw new CryptographicException();
+        }
+
+        internal static string X509GetSubjectSummary(SafeSecCertificateHandle cert)
+        {
+            SafeCFStringHandle subjectSummary;
+
+            int ret = AppleCryptoNative_X509GetSubjectSummary(
+                cert,
+                out subjectSummary);
+
+            if (ret == 1)
+            {
+                using (subjectSummary)
+                {
+                    return CoreFoundation.CFStringToString(subjectSummary);
+                }
+            }
+
+            if (ret != 0)
+            {
+                Debug.Fail($"Unexpected return value {ret}");
+            }
+
             throw new CryptographicException();
         }
 

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X509.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X509.cs
@@ -74,7 +74,7 @@ internal static partial class Interop
             throw new CryptographicException();
         }
 
-        internal static string X509GetSubjectSummary(SafeSecCertificateHandle cert)
+        internal static string? X509GetSubjectSummary(SafeSecCertificateHandle cert)
         {
             SafeCFStringHandle subjectSummary;
 
@@ -90,11 +90,12 @@ internal static partial class Interop
                 }
             }
 
-            if (ret != 0)
+            if (ret == 0)
             {
-                Debug.Fail($"Unexpected return value {ret}");
+                return null;
             }
 
+            Debug.Fail($"Unexpected return value {ret}");
             throw new CryptographicException();
         }
 

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/entrypoints.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/entrypoints.c
@@ -106,6 +106,7 @@ static const Entry s_cryptoAppleNative[] =
     DllImportEntry(AppleCryptoNative_GetOSStatusForChainStatus)
     DllImportEntry(AppleCryptoNative_X509ChainSetTrustAnchorCertificates)
     DllImportEntry(AppleCryptoNative_Pbkdf2)
+    DllImportEntry(AppleCryptoNative_X509GetSubjectSummary)
 };
 
 EXTERN_C const void* CryptoAppleResolveDllImport(const char* name);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509.c
@@ -230,3 +230,15 @@ int32_t AppleCryptoNative_X509GetRawData(SecCertificateRef cert, CFDataRef* ppDa
     *pOSStatus = *ppDataOut == NULL ? errSecParam : noErr;
     return (*pOSStatus == noErr);
 }
+
+int32_t AppleCryptoNative_X509GetSubjectSummary(SecCertificateRef cert, CFStringRef* ppSummaryOut)
+{
+    if (ppSummaryOut != NULL)
+        *ppSummaryOut = NULL;
+
+    if (cert == NULL || ppSummaryOut == NULL)
+        return kErrorBadInput;
+
+    *ppSummaryOut = SecCertificateCopySubjectSummary(cert);
+    return (*ppSummaryOut != NULL);
+}

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509.h
@@ -72,3 +72,13 @@ ppDataOut: Receives a CFDataRef with the exported blob
 pOSStatus: Receives the result of SecItemExport
 */
 PALEXPORT int32_t AppleCryptoNative_X509GetRawData(SecCertificateRef cert, CFDataRef* ppDataOut, int32_t* pOSStatus);
+
+/*
+Extract a string that contains a human-readable summary of the contents of the certificate
+
+Returns 1 on success, 0 on failure, any other value indicates invalid state.
+
+Output:
+ppSummaryOut: Receives a CFDataRef with the exported blob
+*/
+PALEXPORT int32_t AppleCryptoNative_X509GetSubjectSummary(SecCertificateRef cert, CFStringRef* ppSummaryOut);

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.cs
@@ -399,7 +399,21 @@ namespace Internal.Cryptography.Pal
                 return;
 
             Debug.Assert(!_certHandle.IsInvalid);
-            _certData = new CertificateData(Interop.AppleCrypto.X509GetRawData(_certHandle));
+            string subjectSummary = Interop.AppleCrypto.X509GetSubjectSummary(_certHandle);
+
+            try
+            {
+                _certData = new CertificateData(Interop.AppleCrypto.X509GetRawData(_certHandle));
+            }
+            catch (CryptographicException e)
+            {
+                string message = SR.Format(
+                SR.Cryptography_X509_CertificateCorrupted,
+                subjectSummary);
+
+                throw new CryptographicException(message, e);
+            }
+
             _readCertData = true;
         }
     }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.cs
@@ -399,13 +399,13 @@ namespace Internal.Cryptography.Pal
                 return;
 
             Debug.Assert(!_certHandle.IsInvalid);
-            string subjectSummary = Interop.AppleCrypto.X509GetSubjectSummary(_certHandle);
+            string? subjectSummary = Interop.AppleCrypto.X509GetSubjectSummary(_certHandle);
 
             try
             {
                 _certData = new CertificateData(Interop.AppleCrypto.X509GetRawData(_certHandle));
             }
-            catch (CryptographicException e)
+            catch (CryptographicException e) when (subjectSummary != null)
             {
                 string message = SR.Format(
                 SR.Cryptography_X509_CertificateCorrupted,

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.cs
@@ -408,8 +408,8 @@ namespace Internal.Cryptography.Pal
             catch (CryptographicException e) when (subjectSummary != null)
             {
                 string message = SR.Format(
-                SR.Cryptography_X509_CertificateCorrupted,
-                subjectSummary);
+                    SR.Cryptography_X509_CertificateCorrupted,
+                    subjectSummary);
 
                 throw new CryptographicException(message, e);
             }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.cs
@@ -411,7 +411,7 @@ namespace Internal.Cryptography.Pal
                 {
                     throw;
                 }
-                
+
                 string message = SR.Format(
                     SR.Cryptography_X509_CertificateCorrupted,
                     subjectSummary);

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.cs
@@ -405,8 +405,13 @@ namespace Internal.Cryptography.Pal
             {
                 _certData = new CertificateData(Interop.AppleCrypto.X509GetRawData(_certHandle));
             }
-            catch (CryptographicException e) when (subjectSummary != null)
+            catch (CryptographicException e)
             {
+                if (subjectSummary is null)
+                {
+                    throw;
+                }
+                
                 string message = SR.Format(
                     SR.Cryptography_X509_CertificateCorrupted,
                     subjectSummary);

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -331,6 +331,9 @@
   <data name="Cryptography_X509_NoOrMismatchedPemKey" xml:space="preserve">
     <value>The key contents do not contain a PEM, the content is malformed, or the key does not match the certificate.</value>
   </data>
+  <data name="Cryptography_X509_CertificateCorrupted" xml:space="preserve">
+    <value>Certificate '{0}' is corrupted.</value>
+  </data>
   <data name="InvalidOperation_EnumNotStarted" xml:space="preserve">
     <value>Enumeration has not started. Call MoveNext.</value>
   </data>


### PR DESCRIPTION
When trying to create a CertificateData out of raw X509 byte array it might throw if the data is corrupted. The existing exception message does not provide any information which might help the user identify the corrupted certificate and fix it.

This change, makes a native call to SecCertificateCopySubjectSummary which will provide a human readable summary of the certificate, and will generate an exception message using this string.

fix #54336