### PR TITLE
[QUIC] Add Windows version check to QUIC initialization

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
@@ -131,7 +131,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
 
                 if (NetEventSource.Log.IsEnabled())
                 {
-                    NetEventSource.Info(null, $"Current Windows version is not supported by QUIC. Minimal supported version is {MinWindowsVersion}");
+                    NetEventSource.Info(null, $"Current Windows version ({Environment.OSVersion}) is not supported by QUIC. Minimal supported version is {MinWindowsVersion}");
                 }
 
                 return;

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
@@ -121,6 +121,12 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
 
         static MsQuicApi()
         {
+            if (OperatingSystem.IsWindows() && !OperatingSystem.IsWindowsVersionAtLeast(10, 0, 20145, 1000))
+            {
+                IsQuicSupported = false;
+                return;
+            }
+
             // TODO: Consider updating all of these delegates to instead use function pointers.
             if (NativeLibrary.TryLoad(Interop.Libraries.MsQuic, typeof(MsQuicApi).Assembly, DllImportSearchPath.AssemblyDirectory, out IntPtr msQuicHandle))
             {

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
@@ -126,6 +126,12 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
             if (OperatingSystem.IsWindows() && !IsWindowsVersionSupported())
             {
                 IsQuicSupported = false;
+
+                if (NetEventSource.Log.IsEnabled())
+                {
+                    NetEventSource.Info(null, $"Current Windows version is not supported by QUIC. Minimal supported version is {MinWindowsVersion}");
+                }
+
                 return;
             }
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
@@ -9,6 +9,8 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
 {
     internal unsafe sealed class MsQuicApi
     {
+        private static readonly Version MinWindowsVersion = new Version(10, 0, 20145, 1000);
+
         public SafeMsQuicRegistrationHandle Registration { get; }
 
         // This is workaround for a bug in ILTrimmer.
@@ -121,7 +123,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
 
         static MsQuicApi()
         {
-            if (OperatingSystem.IsWindows() && !OperatingSystem.IsWindowsVersionAtLeast(10, 0, 20145, 1000))
+            if (OperatingSystem.IsWindows() && !IsWindowsVersionSupported())
             {
                 IsQuicSupported = false;
                 return;
@@ -153,6 +155,9 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
                 }
             }
         }
+
+        private static bool IsWindowsVersionSupported() => OperatingSystem.IsWindowsVersionAtLeast(MinWindowsVersion.Major,
+            MinWindowsVersion.Minor, MinWindowsVersion.Build, MinWindowsVersion.Revision);
 
         internal RegistrationOpenDelegate RegistrationOpenDelegate { get; }
         internal RegistrationCloseDelegate RegistrationCloseDelegate { get; }


### PR DESCRIPTION
I took the version number from [our QUIC readme](https://github.com/dotnet/runtime/tree/ca3c11d64516217134430d04354ac770b07c91ef/src/libraries/System.Net.Quic#windows) (OS Build 20145.1000)

Fixes #32575