### PR TITLE
Dispose transient CFData in Interop.AppleCrypto.X509GetRawData

### DIFF
--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X509.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X509.cs
@@ -57,7 +57,14 @@ internal static partial class Interop
 
             if (ret == 1)
             {
-                return CoreFoundation.CFGetData(data);
+                try
+                {
+                    return CoreFoundation.CFGetData(data);
+                }
+                finally
+                {
+                    data.Dispose();
+                }
             }
 
             if (ret == 0)

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X509.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X509.cs
@@ -55,25 +55,21 @@ internal static partial class Interop
                 out data,
                 out osStatus);
 
-            if (ret == 1)
+            using (data)
             {
-                try
+                if (ret == 1)
                 {
                     return CoreFoundation.CFGetData(data);
                 }
-                finally
+
+                if (ret == 0)
                 {
-                    data.Dispose();
+                    throw CreateExceptionForOSStatus(osStatus);
                 }
-            }
 
-            if (ret == 0)
-            {
-                throw CreateExceptionForOSStatus(osStatus);
+                Debug.Fail($"Unexpected return value {ret}");
+                throw new CryptographicException();
             }
-
-            Debug.Fail($"Unexpected return value {ret}");
-            throw new CryptographicException();
         }
 
         internal static SafeSecKeyRefHandle X509GetPrivateKeyFromIdentity(SafeSecIdentityHandle identity)


### PR DESCRIPTION
Added missing dispose of the CFData object created

Fix #54489