### PR TITLE
[wasm] tentative fix - mono_wasm_convert_return_value interop

### DIFF
--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -1674,8 +1674,9 @@ var BindingSupportLib = {
 
 		},
 		mono_wasm_convert_return_value: function (ret) {
+			var res = this.js_to_mono_obj (ret);
 			this.mono_wasm_unwind_LMF();
-			return this.js_to_mono_obj (ret);
+			return res;
 		},
 	},
 


### PR DESCRIPTION
I'm not 100% sure what `LMF` does, but the original code look suspect.
How could this be tested ?