### PR TITLE
Add UnixFilePermissions.xml for Mono AOT compilers

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.UnixFilePermissions.xml
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.UnixFilePermissions.xml
@@ -1,0 +1,5 @@
+<FileList>
+    <File Path="tools/mono-aot-cross" Permission="755" />
+    <File Path="tools/opt" Permission="755" />
+    <File Path="tools/llc" Permission="755" />
+</FileList>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.sfxproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <NativeRuntimeAsset Include="$(MonoAotCrossDir)$(TargetCrossRid)\**" TargetPath="tools/" />
     <NativeRuntimeAsset Include="$(MonoAotCrossDir)$(TargetCrossRid).Sdk.props" TargetPath="Sdk/Sdk.props" />
-    <NativeRuntimeAsset Include="Microsoft.NETCore.App.MonoCrossAOT.UnixFilePermissions.xml" TargetPath="data/UnixFilePermissions.xml" />
+    <NativeRuntimeAsset Condition="!$([MSBuild]::IsOsPlatform('Windows'))" Include="Microsoft.NETCore.App.MonoCrossAOT.UnixFilePermissions.xml" TargetPath="data/UnixFilePermissions.xml" />
   </ItemGroup>
 
   <Target Name="WriteAotSdkProps" BeforeTargets="ValidateProperties">

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.sfxproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <NativeRuntimeAsset Include="$(MonoAotCrossDir)$(TargetCrossRid)\**" TargetPath="tools/" />
     <NativeRuntimeAsset Include="$(MonoAotCrossDir)$(TargetCrossRid).Sdk.props" TargetPath="Sdk/Sdk.props" />
+    <NativeRuntimeAsset Include="Microsoft.NETCore.App.MonoCrossAOT.UnixFilePermissions.xml" TargetPath="data/UnixFilePermissions.xml" />
   </ItemGroup>
 
   <Target Name="WriteAotSdkProps" BeforeTargets="ValidateProperties">


### PR DESCRIPTION
As is, mono-aot-cross files installed to a system location via workloads are not executable by the end user:

```
-rwxr--r--  1 root  wheel    11M Jun  1 14:33 /usr/local/share/dotnet/packs/Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.browser-wasm/6.0.0-preview.5.21301.5/tools/mono-aot-cross
```

Ref: https://github.com/dotnet/runtime/issues/53545
Ref: https://github.com/dotnet/sdk/issues/16894
Ref: https://github.com/xamarin/xamarin-macios/pull/11869
Ref: https://github.com/xamarin/xamarin-android/pull/6010