### PR TITLE
Add code to flush JSON writer after root-level fast-path serialization

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
@@ -43,6 +43,7 @@ namespace System.Text.Json
                 typedInfo.Options._context?.CanUseSerializationLogic == true)
             {
                 typedInfo.Serialize(writer, value);
+                writer.Flush();
             }
             else
             {

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/SerializationLogicTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/SerializationLogicTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Text.Encodings.Web;
 using System.Text.Json.Serialization;
 using Xunit;
@@ -110,6 +111,17 @@ namespace System.Text.Json.SourceGeneration.Tests
             yield return new object[] { new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase } };
             yield return new object[] { new JsonSerializerOptions(s_compatibleOptions) { DefaultIgnoreCondition = JsonIgnoreCondition.Never } };
             yield return new object[] { new JsonSerializerOptions(s_compatibleOptions) { IgnoreReadOnlyFields = true } };
+        }
+
+        [Fact]
+        public static void WriterIsFlushedAtRootCall()
+        {
+            using MemoryStream ms = new();
+            using Utf8JsonWriter writer = new(ms);
+
+            JsonSerializer.Serialize(writer, new HighLowTemps(), SerializationContext.Default.HighLowTemps);
+            Assert.Equal(18, writer.BytesCommitted);
+            Assert.Equal(0, writer.BytesPending);
         }
     }
 }


### PR DESCRIPTION
Helps avoid code patterns like this: https://github.com/aspnet/Benchmarks/pull/1683#discussion_r654862756.