### PR TITLE
Optionally capture a dump during generational aware analysis

### DIFF
--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -722,6 +722,7 @@ RETAIL_CONFIG_DWORD_INFO(INTERNAL_GCGenAnalysisGen, W("GCGenAnalysisGen"), 0, "T
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_GCGenAnalysisBytes, W("GCGenAnalysisBytes"), 0, "The number of bytes to trigger generational aware analysis")
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_GCGenAnalysisIndex, W("GCGenAnalysisIndex"), 0, "The gc index to trigger generational aware analysis")
 RETAIL_CONFIG_STRING_INFO(INTERNAL_GCGenAnalysisCmd, W("GCGenAnalysisCmd"), "An optional filter to match with the command line used to spawn the process")
+RETAIL_CONFIG_DWORD_INFO(INTERNAL_GCGenAnalysisDump, W("GCGenAnalysisDump"), 0, "Enable/Disable capturing a dump as well as the traces")
 
 //
 // Diagnostics Ports

--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -722,7 +722,8 @@ RETAIL_CONFIG_DWORD_INFO(INTERNAL_GCGenAnalysisGen, W("GCGenAnalysisGen"), 0, "T
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_GCGenAnalysisBytes, W("GCGenAnalysisBytes"), 0, "The number of bytes to trigger generational aware analysis")
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_GCGenAnalysisIndex, W("GCGenAnalysisIndex"), 0, "The gc index to trigger generational aware analysis")
 RETAIL_CONFIG_STRING_INFO(INTERNAL_GCGenAnalysisCmd, W("GCGenAnalysisCmd"), "An optional filter to match with the command line used to spawn the process")
-RETAIL_CONFIG_DWORD_INFO(INTERNAL_GCGenAnalysisDump, W("GCGenAnalysisDump"), 0, "Enable/Disable capturing a dump as well as the traces")
+RETAIL_CONFIG_DWORD_INFO(INTERNAL_GCGenAnalysisTrace, W("GCGenAnalysisTrace"), 1, "Enable/Disable capturing a trace")
+RETAIL_CONFIG_DWORD_INFO(INTERNAL_GCGenAnalysisDump, W("GCGenAnalysisDump"), 0, "Enable/Disable capturing a dump")
 
 //
 // Diagnostics Ports

--- a/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ds-rt-coreclr.h
@@ -195,20 +195,10 @@ ds_rt_generate_core_dump (DiagnosticsGenerateCoreDumpCommandPayload *payload)
 	ds_ipc_result_t result = DS_IPC_E_FAIL;
 	EX_TRY
 	{
-#ifdef HOST_WIN32
-		if (GenerateCrashDump (reinterpret_cast<LPCWSTR>(ds_generate_core_dump_command_payload_get_dump_name (payload)),
+		if (GenerateDump (reinterpret_cast<LPCWSTR>(ds_generate_core_dump_command_payload_get_dump_name (payload)),
 			static_cast<int32_t>(ds_generate_core_dump_command_payload_get_dump_type (payload)),
 			(ds_generate_core_dump_command_payload_get_diagnostics (payload) != 0) ? true : false))
 			result = DS_IPC_S_OK;
-#else
-		MAKE_UTF8PTR_FROMWIDE_NOTHROW (dump_name, reinterpret_cast<LPCWSTR>(ds_generate_core_dump_command_payload_get_dump_name (payload)));
-		if (dump_name != nullptr) {
-			if (PAL_GenerateCoreDump (dump_name,
-				static_cast<int32_t>(ds_generate_core_dump_command_payload_get_dump_type (payload)),
-				(ds_generate_core_dump_command_payload_get_diagnostics (payload) != 0) ? true : false))
-				result = DS_IPC_S_OK;
-		}
-#endif
 	}
 	EX_CATCH {}
 	EX_END_CATCH(SwallowAllExceptions);

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -4193,7 +4193,7 @@ bool GenerateDump(
     }
 #else // TARGET_UNIX
     return GenerateCrashDump(dumpName, dumpType, diag);
-#endif
+#endif // TARGET_UNIX
 }
 
 //************************************************************************************

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -4176,6 +4176,26 @@ InitializeCrashDump()
 
 #endif // HOST_WINDOWS
 
+bool GenerateDump(
+    LPCWSTR dumpName,
+    int dumpType,
+    bool diag)
+{
+#ifdef TARGET_UNIX
+    MAKE_UTF8PTR_FROMWIDE_NOTHROW (dumpNameUtf8, dumpName);
+    if (dumpNameUtf8 == nullptr)
+    {
+        return false;
+    }
+    else
+    {
+        return PAL_GenerateCoreDump(dumpNameUtf8, dumpType, diag);
+    }
+#else // TARGET_UNIX
+    return GenerateCrashDump(dumpName, dumpType, diag);
+#endif
+}
+
 //************************************************************************************
 // Create crash dump if enabled and terminate process. Generates crash dumps for both
 // Windows and Linux if enabled. For Linux, it happens in TerminateProcess in the PAL.

--- a/src/coreclr/vm/excep.h
+++ b/src/coreclr/vm/excep.h
@@ -196,9 +196,9 @@ enum UnhandledExceptionLocation
 
 #ifdef HOST_WINDOWS
 void InitializeCrashDump();
-bool GenerateCrashDump(LPCWSTR dumpName, int dumpType, bool diag);
 void CreateCrashDumpIfEnabled(bool stackoverflow = false);
 #endif
+bool GenerateDump(LPCWSTR dumpName, int dumpType, bool diag);
 
 // Generates crash dumps if enabled for both Windows and Linux
 void CrashDumpAndTerminateProcess(UINT exitCode);

--- a/src/coreclr/vm/finalizerthread.cpp
+++ b/src/coreclr/vm/finalizerthread.cpp
@@ -274,14 +274,15 @@ VOID FinalizerThread::FinalizerThreadWorker(void *args)
         if (gcGenAnalysisState == GcGenAnalysisState::Done)
         {
             gcGenAnalysisState = GcGenAnalysisState::Disabled;
-            EventPipeAdapter::Disable(gcGenAnalysisEventPipeSessionId);
+            if (gcGenAnalysisTrace)
+            {
+                EventPipeAdapter::Disable(gcGenAnalysisEventPipeSessionId);
+#ifdef GEN_ANALYSIS_STRESS
+                GenAnalysis::EnableGenerationalAwareSession();
+#endif
+            }
             // Writing an empty file to indicate completion
             fclose(fopen(GENAWARE_COMPLETION_FILE_NAME,"w+"));
-#ifdef GEN_ANALYSIS_STRESS
-            {
-                GenAnalysis::EnableGenerationalAwareSession();
-            }
-#endif
         }
 
         if (!bPriorityBoosted)

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -1655,11 +1655,7 @@ void GCToEEInterface::AnalyzeSurvivorsFinished(size_t gcIndex, int condemnedGene
             {
                 EX_TRY
                 {
-#ifdef HOST_WIN32
-                    GenerateCrashDump (GENAWARE_DUMP_FILE_NAME, 2, false);
-#else
-                    PAL_GenerateCoreDump (GENAWARE_DUMP_FILE_NAME, 2, false);
-#endif
+                    GenerateDump (GENAWARE_DUMP_FILE_NAME, 2, false);
                 }
                 EX_CATCH {}
                 EX_END_CATCH(SwallowAllExceptions);

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -1651,6 +1651,19 @@ void GCToEEInterface::AnalyzeSurvivorsFinished(size_t gcIndex, int condemnedGene
             s_forcedGCInProgress = false;
             reportGenerationBounds();
             FireEtwGenAwareEnd((int)gcIndex, GetClrInstanceId());
+            if (gcGenAnalysisDump)
+            {
+                EX_TRY
+                {
+#ifdef HOST_WIN32
+                    GenerateCrashDump (GENAWARE_DUMP_FILE_NAME, 2, false);
+#else
+                    PAL_GenerateCoreDump (GENAWARE_DUMP_FILE_NAME, 2, false);
+#endif
+                }
+                EX_CATCH {}
+                EX_END_CATCH(SwallowAllExceptions);
+            }
             EventPipeAdapter::PauseSession(gcGenAnalysisEventPipeSession);
             gcGenAnalysisState = GcGenAnalysisState::Done;
             EnableFinalization(true);

--- a/src/coreclr/vm/genanalysis.cpp
+++ b/src/coreclr/vm/genanalysis.cpp
@@ -13,6 +13,7 @@ int64_t gcGenAnalysisGen = -1;
 int64_t gcGenAnalysisBytes = 0;
 int64_t gcGenAnalysisIndex = 0;
 uint32_t gcGenAnalysisBufferMB = 0;
+bool gcGenAnalysisDump = false;
 
 /* static */ void GenAnalysis::Initialize()
 {
@@ -41,6 +42,7 @@ uint32_t gcGenAnalysisBufferMB = 0;
             gcGenAnalysisGen = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_GCGenAnalysisGen);
             gcGenAnalysisIndex = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_GCGenAnalysisIndex);
             gcGenAnalysisBufferMB = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_EventPipeCircularMB);
+            gcGenAnalysisDump = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_GCGenAnalysisDump);
             gcGenAnalysisConfigured = GcGenAnalysisState::Enabled;
         }
         else
@@ -52,13 +54,13 @@ uint32_t gcGenAnalysisBufferMB = 0;
 #endif
     {
         EnableGenerationalAwareSession();
-    }    
+    }
 }
 
 /* static */ void GenAnalysis::EnableGenerationalAwareSession()
 {
     LPCWSTR outputPath = nullptr;
-    outputPath = GENAWARE_FILE_NAME;
+    outputPath = GENAWARE_TRACE_FILE_NAME;
     NewArrayHolder<COR_PRF_EVENTPIPE_PROVIDER_CONFIG> pProviders;
     int providerCnt = 1;
     pProviders = new COR_PRF_EVENTPIPE_PROVIDER_CONFIG[providerCnt];

--- a/src/coreclr/vm/genanalysis.cpp
+++ b/src/coreclr/vm/genanalysis.cpp
@@ -13,6 +13,7 @@ int64_t gcGenAnalysisGen = -1;
 int64_t gcGenAnalysisBytes = 0;
 int64_t gcGenAnalysisIndex = 0;
 uint32_t gcGenAnalysisBufferMB = 0;
+bool gcGenAnalysisTrace = true;
 bool gcGenAnalysisDump = false;
 
 /* static */ void GenAnalysis::Initialize()
@@ -42,6 +43,7 @@ bool gcGenAnalysisDump = false;
             gcGenAnalysisGen = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_GCGenAnalysisGen);
             gcGenAnalysisIndex = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_GCGenAnalysisIndex);
             gcGenAnalysisBufferMB = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_EventPipeCircularMB);
+            gcGenAnalysisTrace = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_GCGenAnalysisTrace);
             gcGenAnalysisDump = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_GCGenAnalysisDump);
             gcGenAnalysisConfigured = GcGenAnalysisState::Enabled;
         }
@@ -53,7 +55,14 @@ bool gcGenAnalysisDump = false;
     if ((gcGenAnalysisConfigured == GcGenAnalysisState::Enabled) && (gcGenAnalysisState == GcGenAnalysisState::Uninitialized))
 #endif
     {
-        EnableGenerationalAwareSession();
+        if (gcGenAnalysisTrace)
+        {
+            EnableGenerationalAwareSession();
+        }
+        if (gcGenAnalysisDump)
+        {
+            gcGenAnalysisState = GcGenAnalysisState::Enabled;
+        }
     }
 }
 

--- a/src/coreclr/vm/genanalysis.h
+++ b/src/coreclr/vm/genanalysis.h
@@ -30,6 +30,7 @@ extern GcGenAnalysisState gcGenAnalysisConfigured;
 extern int64_t gcGenAnalysisGen;
 extern int64_t gcGenAnalysisBytes;
 extern int64_t gcGenAnalysisIndex;
+extern bool gcGenAnalysisTrace;
 extern bool gcGenAnalysisDump;
 
 class GenAnalysis

--- a/src/coreclr/vm/genanalysis.h
+++ b/src/coreclr/vm/genanalysis.h
@@ -18,7 +18,8 @@ enum GcGenAnalysisState
     Done = 3,
 };
 
-#define GENAWARE_FILE_NAME W("gcgenaware.nettrace")
+#define GENAWARE_TRACE_FILE_NAME W("gcgenaware.nettrace")
+#define GENAWARE_DUMP_FILE_NAME W("gcgenaware.dmp")
 #define GENAWARE_COMPLETION_FILE_NAME "gcgenaware.nettrace.completed"
 
 extern bool s_forcedGCInProgress;
@@ -29,6 +30,7 @@ extern GcGenAnalysisState gcGenAnalysisConfigured;
 extern int64_t gcGenAnalysisGen;
 extern int64_t gcGenAnalysisBytes;
 extern int64_t gcGenAnalysisIndex;
+extern bool gcGenAnalysisDump;
 
 class GenAnalysis
 {


### PR DESCRIPTION
This change introduces an extra option to allow generational aware analysis to capture a dump in addition to the trace files.

The trace file contains information about the type of object that held the young objects alive, but very often, we also need to know the exact instance. This is particularly useful when the young objects are leaked by a delegate, where we would like to know which callback is causing the problem.

@dotnet/dotnet-diag 