### PR TITLE
[Test] Move leakwheel to Pri1

### DIFF
--- a/src/tests/GC/Scenarios/LeakWheel/leakwheel.csproj
+++ b/src/tests/GC/Scenarios/LeakWheel/leakwheel.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="leakwheel.cs" />

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1696,9 +1696,6 @@
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/jit64/localloc/ehverify/eh07_large/**">
             <Issue>https://github.com/dotnet/runtime/issues/54395</Issue>
         </ExcludeList>
-        <ExcludeList Include = "$(XunitTestBinBase)/GC/Scenarios/LeakWheel/leakwheel/**">
-            <Issue>needs triage</Issue>
-        </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/jit64/verif/sniff/fg/ver_fg_13/**">
             <Issue>https://github.com/dotnet/runtime/issues/54396</Issue>
         </ExcludeList>
@@ -3148,9 +3145,6 @@
         </ExcludeList>
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/Regression/JitBlue/DevDiv_461649/DevDiv_461649/**">
             <Issue>https://github.com/dotnet/runtime/issues/53353</Issue>
-        </ExcludeList>
-        <ExcludeList Include = "$(XunitTestBinBase)/GC/Scenarios/LeakWheel/leakwheel/**">
-            <Issue>long running test https://github.com/dotnet/runtime/issues/53386</Issue>
         </ExcludeList>
     </ItemGroup>
 


### PR DESCRIPTION
Fixes #53386

GC test leakwheel contains random number generator
https://github.com/dotnet/runtime/blob/main/src/tests/GC/Scenarios/LeakWheel/leakwheel.cs#L158

Half of the time it ran out of time on Android x64. I am moving this test to Pri1, due to its randomness.