### PR TITLE
Root ComActivator for hosting

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Windows.xml
+++ b/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Windows.xml
@@ -4,5 +4,7 @@
     <type fullname="System.Runtime.InteropServices.IDispatch" />
     <type fullname="System.Runtime.InteropServices.IMarshal" />
     <type fullname="Internal.Runtime.InteropServices.IClassFactory2" />
+    <!-- ComActivator is needed for native host operations -->
+    <type fullname="Internal.Runtime.InteropServices.ComActivator" />
   </assembly>
 </linker>

--- a/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Windows.xml
+++ b/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Windows.xml
@@ -5,6 +5,10 @@
     <type fullname="System.Runtime.InteropServices.IMarshal" />
     <type fullname="Internal.Runtime.InteropServices.IClassFactory2" />
     <!-- ComActivator is needed for native host operations -->
-    <type fullname="Internal.Runtime.InteropServices.ComActivator" />
+    <type fullname="Internal.Runtime.InteropServices.ComActivator" >
+      <method name="GetClassFactoryForTypeInternal" />
+      <method name="RegisterClassForTypeInternal" />
+      <method name="UnregisterClassForTypeInternal" />
+    </type>
   </assembly>
 </linker>


### PR DESCRIPTION
`ComActivator `is a special type for the following reasons

- Its a COM helper class: We have guards on public methods (we throw `NotSupportedException `if built-in COM is disabled)
- Its referred in [hostpolicy](https://github.com/dotnet/runtime/blob/116aae9255c217c6cddc54190c2435fc44e3f426/src/installer/corehost/cli/hostpolicy/hostpolicy.cpp#L476-L481)

The above means that we trim the whole type away in the following scenarios and will give a less than ideal experience for callers from native code.

- The application code does not refer to it
- Built-in COM is disabled (default for net core applications)

This change will root the type globally (not under a feature switch) similar to other native hosts (`EnableCppCLIHostActivation`, `_EnableConsumingManagedCodeFromNativeHosting`) so that the type will always be there. If `BuiltInComInteropSupport `is disabled, we will only have the throw code and users from the native side will get an error that gives more information (built-in COM is disabled and a url link)

Fixes #43606 