### PR TITLE
Set DLL flag on R2R binaries

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/CodeGen/ReadyToRunObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/CodeGen/ReadyToRunObjectWriter.cs
@@ -198,11 +198,7 @@ namespace ILCompiler.DependencyAnalysis
 
                 if (_nodeFactory.CompilationModuleGroup.IsCompositeBuildMode && _componentModule == null)
                 {
-                    headerBuilder = PEHeaderProvider.Create(
-                        imageCharacteristics: Characteristics.ExecutableImage | Characteristics.Dll,
-                        dllCharacteristics: default(DllCharacteristics),
-                        Subsystem.Unknown,
-                        _nodeFactory.Target);
+                    headerBuilder = PEHeaderProvider.Create(Subsystem.Unknown, _nodeFactory.Target);
                     peIdProvider = new Func<IEnumerable<Blob>, BlobContentId>(content => BlobContentId.FromHash(CryptographicHashProvider.ComputeSourceHash(content)));
                     timeDateStamp = null;
                     r2rHeaderExportSymbol = _nodeFactory.Header;
@@ -210,7 +206,7 @@ namespace ILCompiler.DependencyAnalysis
                 else
                 {
                     PEReader inputPeReader = (_componentModule != null ? _componentModule.PEReader : _nodeFactory.CompilationModuleGroup.CompilationModuleSet.First().PEReader);
-                    headerBuilder = PEHeaderProvider.Copy(inputPeReader.PEHeaders, _nodeFactory.Target);
+                    headerBuilder = PEHeaderProvider.Create(inputPeReader.PEHeaders.PEHeader.Subsystem, _nodeFactory.Target);
                     timeDateStamp = inputPeReader.PEHeaders.CoffHeader.TimeDateStamp;
                     r2rHeaderExportSymbol = null;
                 }


### PR DESCRIPTION
Always set the IMAGE_FILE_DLL flag on output assemblies with ReadyToRun code even if the corresponding input IL assembly misses it. This is required for R2R relocations to be processed by the OS loader on Windows 7 and Windows 8.1. Fixes #54440. @dotnet/crossgen-contrib

The corresponding code in the old Crossgen: https://github.com/dotnet/runtime/blob/8a20ae03566e3aabb0c95d2bb206a9ee780db4fd/src/coreclr/zap/zapwriter.cpp#L479-L482
where `m_isDll` is unconditionally set to `true` in `ZapWriter::Initialize`: https://github.com/dotnet/runtime/blob/8a20ae03566e3aabb0c95d2bb206a9ee780db4fd/src/coreclr/zap/zapwriter.cpp#L51