### PR TITLE
Import `cgt.un(op, 0)` as `NE(op, 0)`

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -13065,25 +13065,26 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 op1 = impPopStack().val;
 
 #ifdef TARGET_64BIT
-                if (varTypeIsI(op1->TypeGet()) && (genActualType(op2->TypeGet()) == TYP_INT))
+                // TODO-Casts: create a helper that upcasts int32 -> native int when necessary.
+                // See also identical code in impGetByRefResultType and STSFLD import.
+                if (varTypeIsI(op1) && (genActualType(op2) == TYP_INT))
                 {
-                    op2 = gtNewCastNode(TYP_I_IMPL, op2, uns, uns ? TYP_U_IMPL : TYP_I_IMPL);
+                    op2 = gtNewCastNode(TYP_I_IMPL, op2, uns, TYP_I_IMPL);
                 }
-                else if (varTypeIsI(op2->TypeGet()) && (genActualType(op1->TypeGet()) == TYP_INT))
+                else if (varTypeIsI(op2) && (genActualType(op1) == TYP_INT))
                 {
-                    op1 = gtNewCastNode(TYP_I_IMPL, op1, uns, uns ? TYP_U_IMPL : TYP_I_IMPL);
+                    op1 = gtNewCastNode(TYP_I_IMPL, op1, uns, TYP_I_IMPL);
                 }
 #endif // TARGET_64BIT
 
-                assertImp(genActualType(op1->TypeGet()) == genActualType(op2->TypeGet()) ||
-                          (varTypeIsI(op1->TypeGet()) && varTypeIsI(op2->TypeGet())) ||
-                          (varTypeIsFloating(op1->gtType) && varTypeIsFloating(op2->gtType)));
+                assertImp(genActualType(op1) == genActualType(op2) || (varTypeIsI(op1) && varTypeIsI(op2)) ||
+                          (varTypeIsFloating(op1) && varTypeIsFloating(op2)));
 
-                /* Create the comparison node */
+                // Create the comparison node.
 
                 op1 = gtNewOperNode(oper, TYP_INT, op1, op2);
 
-                /* TODO: setting both flags when only one is appropriate */
+                // TODO: setting both flags when only one is appropriate.
                 if (opcode == CEE_CGT_UN || opcode == CEE_CLT_UN)
                 {
                     op1->gtFlags |= GTF_RELOP_NAN_UN | GTF_UNSIGNED;

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -13064,6 +13064,14 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 op2 = impPopStack().val;
                 op1 = impPopStack().val;
 
+                // Recognize the IL idiom of CGT_UN(op1, 0) and normalize
+                // it so that downstream optimizations don't have to.
+                if ((opcode == CEE_CGT_UN) && op2->IsIntegralConst(0))
+                {
+                    oper = GT_NE;
+                    uns  = false;
+                }
+
 #ifdef TARGET_64BIT
                 // TODO-Casts: create a helper that upcasts int32 -> native int when necessary.
                 // See also identical code in impGetByRefResultType and STSFLD import.
@@ -13085,7 +13093,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 op1 = gtNewOperNode(oper, TYP_INT, op1, op2);
 
                 // TODO: setting both flags when only one is appropriate.
-                if (opcode == CEE_CGT_UN || opcode == CEE_CLT_UN)
+                if (uns)
                 {
                     op1->gtFlags |= GTF_RELOP_NAN_UN | GTF_UNSIGNED;
                 }


### PR DESCRIPTION
This is a pretty common IL idiom (e. g. for comparing against `null`). Today, morph transforms it into the equivalent "not equal" form, but doing it earlier in the importer, apparently, has CQ benefits.

In addition to the optimization this PR:
1\) Cleans up some importation code.
2\) And solves most of the regressions by being a bit smarter in morph.

There is also a `TODO` left in importer, for me, not to forget to unify the handling of upcasts - the way it is done currently has issues (like the fact redundant IR is created for constants).

This change will help avoid regressions for my next changes in morph, for post-order `NE/EQ` processing - there is a lot of questionable code there and correctness issues, so I want the refactoring and fixes to be zero-diff.

Diffs:

<details>
<summary>Windows x64</summary>

```
Running asm diffs of benchmarks.run.windows.x64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 57001
Total bytes of diff: 56493
Total bytes of delta: -508 (-0.89% of base)
Total relative delta: -2.16
    diff is an improvement.
    relative diff is an improvement.


Top method regressions (bytes):
          72 ( 3.71% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceOrdinaryMethodSymbol:CheckModifiers(bool,Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           3 ( 1.15% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol:CheckModifiersForBody(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           2 ( 0.25% of base) - System.Text.ASCIIUtility:GetIndexOfFirstNonAsciiChar_Sse2(long,long):long

Top method improvements (bytes):
         -49 (-24.62% of base) - System.IO.Strategies.AsyncWindowsFileStreamStrategy:Write(System.Byte[],int,int):this
         -41 (-1.06% of base) - System.Uri:ReCreateParts(int,ushort,int):System.String:this
         -40 (-16.39% of base) - System.Threading.Tasks.UnwrapPromise`1[VoidTaskResult][System.Threading.Tasks.VoidTaskResult]:.ctor(System.Threading.Tasks.Task,bool):this
         -38 (-0.31% of base) - System.Reflection.Metadata.MetadataReader:InitializeTableReaders(System.Reflection.Internal.MemoryBlock,ubyte,System.Int32[],System.Int32[]):this
         -32 (-2.75% of base) - System.Uri:PrivateParseMinimal():int:this
         -25 (-0.91% of base) - System.Uri:GetUriPartsFromUserString(int):System.String:this
         -24 (-2.28% of base) - System.Uri:CreateUriInfo(long):this
         -19 (-2.78% of base) - System.Buffer:Memmove(byref,byref,long)
         -17 (-2.41% of base) - System.Uri:CreateHostString():this
         -15 (-0.57% of base) - System.Uri:GetCanonicalPath(byref,int):this
         -15 (-1.61% of base) - System.Uri:InitializeUri(int,int,byref):this
         -14 (-2.35% of base) - System.Net.Security.SafeDeleteContext:MustRunInitializeSecurityContext(byref,bool,long,int,int,long,System.Net.Security.SafeDeleteContext,byref,byref,System.Net.Security.SafeFreeContextBuffer):int
         -14 (-2.44% of base) - System.Net.Security.SafeDeleteContext:MustRunAcceptSecurityContext_SECURITY(byref,bool,long,int,int,System.Net.Security.SafeDeleteContext,byref,byref,System.Net.Security.SafeFreeContextBuffer):int
         -12 (-2.04% of base) - System.IO.Strategies.AsyncWindowsFileStreamStrategy:Read(System.Byte[],int,int):int:this
         -10 (-1.47% of base) - System.Uri:get_IdnHost():System.String:this
          -9 (-0.94% of base) - System.Text.RegularExpressions.RegexCharClass:ToStringClass(byref):this
          -8 (-1.70% of base) - Microsoft.CodeAnalysis.CSharp.ControlFlowPass:Analyze(Microsoft.CodeAnalysis.CSharp.CSharpCompilation,Microsoft.CodeAnalysis.CSharp.Symbol,Microsoft.CodeAnalysis.CSharp.BoundBlock,Microsoft.CodeAnalysis.DiagnosticBag):bool
          -8 (-2.04% of base) - System.Drawing.Graphics:Dispose(bool):this
          -8 (-1.64% of base) - Microsoft.Extensions.Internal.ParameterDefaultValue:TryGetDefaultValue(System.Reflection.ParameterInfo,byref):bool
          -8 (-1.87% of base) - System.Net.Sockets.NetworkStream:Read(System.Span`1[Byte]):int:this

Top method regressions (percentages):
          72 ( 3.71% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceOrdinaryMethodSymbol:CheckModifiers(bool,Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           3 ( 1.15% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol:CheckModifiersForBody(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           2 ( 0.25% of base) - System.Text.ASCIIUtility:GetIndexOfFirstNonAsciiChar_Sse2(long,long):long

Top method improvements (percentages):
         -49 (-24.62% of base) - System.IO.Strategies.AsyncWindowsFileStreamStrategy:Write(System.Byte[],int,int):this
          -4 (-22.22% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol:get_IsAbstract():bool:this
          -4 (-22.22% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol:get_IsAbstract():bool:this
          -4 (-17.39% of base) - System.Xml.XmlReader:CanReadContentAs(int):bool
         -40 (-16.39% of base) - System.Threading.Tasks.UnwrapPromise`1[VoidTaskResult][System.Threading.Tasks.VoidTaskResult]:.ctor(System.Threading.Tasks.Task,bool):this
          -2 (-11.76% of base) - System.Uri:EnsureParseRemaining():this
          -1 (-6.67% of base) - System.Uri:get_UserDrivenParsing():bool:this
          -1 (-6.67% of base) - System.Uri:get_IsUncOrDosPath():bool:this
          -1 (-6.67% of base) - System.Uri:get_IsImplicitFile():bool:this
          -1 (-6.67% of base) - System.Uri:get_IsDosPath():bool:this
          -8 (-5.48% of base) - System.Text.Json.Utf8JsonWriter:ValidateEnd(ubyte):this
          -2 (-5.00% of base) - System.Uri:EnsureUriInfo():UriInfo:this
          -6 (-3.64% of base) - System.Reflection.Metadata.MetadataReader:ComputeCodedTokenSize(int,System.Int32[],long):int:this
         -19 (-2.78% of base) - System.Buffer:Memmove(byref,byref,long)
         -32 (-2.75% of base) - System.Uri:PrivateParseMinimal():int:this
         -14 (-2.44% of base) - System.Net.Security.SafeDeleteContext:MustRunAcceptSecurityContext_SECURITY(byref,bool,long,int,int,System.Net.Security.SafeDeleteContext,byref,byref,System.Net.Security.SafeFreeContextBuffer):int
         -17 (-2.41% of base) - System.Uri:CreateHostString():this
         -14 (-2.35% of base) - System.Net.Security.SafeDeleteContext:MustRunInitializeSecurityContext(byref,bool,long,int,int,long,System.Net.Security.SafeDeleteContext,byref,byref,System.Net.Security.SafeFreeContextBuffer):int
          -8 (-2.30% of base) - System.Drawing.Pen:Dispose(bool):this
         -24 (-2.28% of base) - System.Uri:CreateUriInfo(long):this

63 total methods with Code Size differences (60 improved, 3 regressed), 4 unchanged.

Running asm diffs of coreclr_tests.pmi.windows.x64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3304059
Total bytes of diff: 3304183
Total bytes of delta: 124 (0.00% of base)
Total relative delta: -0.16
    diff is a regression.
    relative diff is an improvement.


Top method regressions (bytes):
           4 ( 0.02% of base) - Program:TestCase0002()
           4 ( 0.02% of base) - Program:TestCase0002()
           4 ( 0.02% of base) - Program:TestCase0017()
           4 ( 0.02% of base) - Program:TestCase0005()
           4 ( 0.02% of base) - Program:TestCase0005()
           4 ( 0.02% of base) - Program:TestCase0017()
           4 ( 0.02% of base) - Program:TestCase0011()
           4 ( 0.02% of base) - Program:TestCase0011()
           2 ( 0.01% of base) - Program:TestCase0016()
           2 ( 0.01% of base) - Program:TestCase0006()
           2 ( 0.02% of base) - Program:TestCase0015()
           2 ( 0.02% of base) - Program:TestCase0016()
           2 ( 0.02% of base) - Program:TestCase0031()
           2 ( 0.02% of base) - Program:TestCase0011()
           2 ( 0.02% of base) - Program:TestCase0012()
           2 ( 0.02% of base) - Program:TestCase0027()
           2 ( 0.02% of base) - Program:TestCase0028()
           2 ( 0.01% of base) - Program:TestCase0006()
           2 ( 0.01% of base) - Program:TestCase0013()
           2 ( 0.01% of base) - Program:TestCase0003()

Top method improvements (bytes):
          -9 (-0.94% of base) - System.Text.RegularExpressions.RegexCharClass:ToStringClass(byref):this
          -8 (-3.90% of base) - PInvokeTest.Test:FromFilter():bool
          -8 (-3.59% of base) - C:Test1Inner():int
          -8 (-4.21% of base) - C:Test5(int):int
          -8 (-3.98% of base) - C:Test6(int):int
          -2 (-0.02% of base) - Program:TestCase0032()
          -1 (-0.01% of base) - TestApp:Main():int
          -1 (-0.01% of base) - TestApp:Main():int
          -1 (-0.01% of base) - TestApp:Main():int
          -1 (-0.01% of base) - TestApp:Main():int
          -1 (-1.11% of base) - Internal.IL.EcmaMethodIL:GetObject(int,int):System.Object:this

Top method regressions (percentages):
           2 ( 0.06% of base) - Program:TestCase0003()
           2 ( 0.06% of base) - Program:TestCase0003()
           2 ( 0.03% of base) - Program:TestCase0002()
           2 ( 0.03% of base) - Program:TestCase0002()
           2 ( 0.03% of base) - Program:TestCase0005()
           2 ( 0.03% of base) - Program:TestCase0005()
           4 ( 0.02% of base) - Program:TestCase0002()
           4 ( 0.02% of base) - Program:TestCase0017()
           4 ( 0.02% of base) - Program:TestCase0005()
           4 ( 0.02% of base) - Program:TestCase0011()
           4 ( 0.02% of base) - Program:TestCase0002()
           4 ( 0.02% of base) - Program:TestCase0017()
           4 ( 0.02% of base) - Program:TestCase0011()
           4 ( 0.02% of base) - Program:TestCase0005()
           2 ( 0.02% of base) - Program:TestCase0003()
           2 ( 0.02% of base) - Program:TestCase0014()
           2 ( 0.02% of base) - Program:TestCase0007()
           2 ( 0.02% of base) - Program:TestCase0027()
           2 ( 0.02% of base) - Program:TestCase0006()
           2 ( 0.02% of base) - Program:TestCase0026()

Top method improvements (percentages):
          -8 (-4.21% of base) - C:Test5(int):int
          -8 (-3.98% of base) - C:Test6(int):int
          -8 (-3.90% of base) - PInvokeTest.Test:FromFilter():bool
          -8 (-3.59% of base) - C:Test1Inner():int
          -1 (-1.11% of base) - Internal.IL.EcmaMethodIL:GetObject(int,int):System.Object:this
          -9 (-0.94% of base) - System.Text.RegularExpressions.RegexCharClass:ToStringClass(byref):this
          -2 (-0.02% of base) - Program:TestCase0032()
          -1 (-0.01% of base) - TestApp:Main():int
          -1 (-0.01% of base) - TestApp:Main():int
          -1 (-0.01% of base) - TestApp:Main():int
          -1 (-0.01% of base) - TestApp:Main():int

89 total methods with Code Size differences (11 improved, 78 regressed), 146 unchanged.

Running asm diffs of libraries.crossgen.windows.x64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 134332
Total bytes of diff: 131778
Total bytes of delta: -2554 (-1.90% of base)
Total relative delta: -9.58
    diff is an improvement.
    relative diff is an improvement.


Top method regressions (bytes):
          12 ( 1.22% of base) - System.Text.Latin1Utility:GetIndexOfFirstNonLatin1Char_Sse2(long,long):long
          11 ( 4.33% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMethodSymbol:CheckModifiersForBody(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           5 ( 0.51% of base) - System.Text.ASCIIUtility:GetIndexOfFirstNonAsciiChar_Sse2(long,long):long
           3 ( 2.68% of base) - System.Net.HttpResponseStreamAsyncResult:GetChunkHeader(int,byref):System.Byte[]
           1 ( 0.16% of base) - MethodDataEnumerator:.ctor(System.Management.ManagementObject):this
           1 ( 0.41% of base) - System.Management.MethodData:RefreshMethodInfo():this
           1 ( 0.23% of base) - System.Management.MethodDataCollection:Add(System.String,System.Management.ManagementBaseObject,System.Management.ManagementBaseObject):this
           1 ( 0.37% of base) - System.Management.MethodDataCollection:Remove(System.String):this
           1 ( 0.18% of base) - System.Management.MethodDataCollection:get_Count():int:this

Top method improvements (bytes):
        -153 (-6.49% of base) - <WaitUntilCountOrTimeoutAsync>d__31:MoveNext():this
         -77 (-24.29% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:OnCompleted(System.Action):this
         -77 (-24.76% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:UnsafeOnCompleted(System.Action):this
         -77 (-24.29% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Int32][System.Int32]:OnCompleted(System.Action):this
         -77 (-24.76% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Int32][System.Int32]:UnsafeOnCompleted(System.Action):this
         -58 (-22.48% of base) - System.IO.Stream:EndRead(System.IAsyncResult):int:this
         -54 (-4.66% of base) - <WriteAsyncInternal>d__61:MoveNext():this
         -50 (-2.82% of base) - <WriteAsyncInternal>d__65:MoveNext():this
         -48 (-11.51% of base) - ConfiguredValueTaskAwaiter[Int32][System.Int32]:OnCompleted(System.Action):this
         -48 (-9.11% of base) - <OutputTabsAsync>d__22:MoveNext():this
         -48 (-11.79% of base) - ConfiguredValueTaskAwaiter[Int32][System.Int32]:UnsafeOnCompleted(System.Action):this
         -47 (-17.67% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:FlushWriteBuffer(bool):this
         -43 (-22.05% of base) - System.IO.Strategies.AsyncWindowsFileStreamStrategy:Write(System.Byte[],int,int):this
         -41 (-19.81% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:Read(System.Byte[],int,int):int:this
         -40 (-38.83% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult)
         -39 (-13.09% of base) - System.IO.Stream:EndWrite(System.IAsyncResult):this
         -38 (-13.33% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[__Canon][System.__Canon]:UnsafeOnCompleted(System.Action):this
         -38 (-13.06% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[__Canon][System.__Canon]:OnCompleted(System.Action):this
         -38 (-28.36% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):int
         -38 (-0.31% of base) - System.Reflection.Metadata.MetadataReader:InitializeTableReaders(System.Reflection.Internal.MemoryBlock,ubyte,System.Int32[],System.Int32[]):this

Top method regressions (percentages):
          11 ( 4.33% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMethodSymbol:CheckModifiersForBody(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           3 ( 2.68% of base) - System.Net.HttpResponseStreamAsyncResult:GetChunkHeader(int,byref):System.Byte[]
          12 ( 1.22% of base) - System.Text.Latin1Utility:GetIndexOfFirstNonLatin1Char_Sse2(long,long):long
           5 ( 0.51% of base) - System.Text.ASCIIUtility:GetIndexOfFirstNonAsciiChar_Sse2(long,long):long
           1 ( 0.41% of base) - System.Management.MethodData:RefreshMethodInfo():this
           1 ( 0.37% of base) - System.Management.MethodDataCollection:Remove(System.String):this
           1 ( 0.23% of base) - System.Management.MethodDataCollection:Add(System.String,System.Management.ManagementBaseObject,System.Management.ManagementBaseObject):this
           1 ( 0.18% of base) - System.Management.MethodDataCollection:get_Count():int:this
           1 ( 0.16% of base) - MethodDataEnumerator:.ctor(System.Management.ManagementObject):this

Top method improvements (percentages):
         -40 (-38.83% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult)
         -38 (-28.36% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):int
         -31 (-26.96% of base) - System.Buffers.MemoryManager`1[__Canon][System.__Canon]:get_Memory():System.Memory`1[__Canon]:this
         -31 (-26.96% of base) - System.Buffers.MemoryManager`1[Byte][System.Byte]:get_Memory():System.Memory`1[Byte]:this
         -77 (-24.76% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:UnsafeOnCompleted(System.Action):this
         -77 (-24.76% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Int32][System.Int32]:UnsafeOnCompleted(System.Action):this
         -77 (-24.29% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:OnCompleted(System.Action):this
         -77 (-24.29% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Int32][System.Int32]:OnCompleted(System.Action):this
         -58 (-22.48% of base) - System.IO.Stream:EndRead(System.IAsyncResult):int:this
          -4 (-22.22% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol:get_IsAbstract():bool:this
          -4 (-22.22% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMethodSymbol:get_IsAbstract():bool:this
          -4 (-22.22% of base) - PEFile.IMAGE_RESOURCE_DIRECTORY_ENTRY:get_IsLeaf():bool:this
         -43 (-22.05% of base) - System.IO.Strategies.AsyncWindowsFileStreamStrategy:Write(System.Byte[],int,int):this
         -41 (-19.81% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:Read(System.Byte[],int,int):int:this
         -47 (-17.67% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:FlushWriteBuffer(bool):this
          -4 (-17.39% of base) - System.Xml.XmlReader:IsTextualNode(int):bool
          -4 (-17.39% of base) - System.Xml.XmlReader:CanReadContentAs(int):bool
          -4 (-17.39% of base) - System.Xml.XmlReader:HasValueInternal(int):bool
         -37 (-16.74% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:FillReadBufferForReadByte():int:this
         -35 (-14.40% of base) - System.Threading.Tasks.UnwrapPromise`1[__Canon][System.__Canon]:.ctor(System.Threading.Tasks.Task,bool):this

212 total methods with Code Size differences (203 improved, 9 regressed), 2 unchanged.

Running asm diffs of libraries.crossgen2.windows.x64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 130417
Total bytes of diff: 128244
Total bytes of delta: -2173 (-1.67% of base)
Total relative delta: -7.97
    diff is an improvement.
    relative diff is an improvement.


Top method regressions (bytes):
          69 ( 4.41% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol:CheckModifiers(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
          11 ( 1.38% of base) - System.Text.Latin1Utility:GetIndexOfFirstNonLatin1Char_Sse2(long,long):long
           7 ( 2.21% of base) - System.Text.Encodings.Web.OptimizedInboxTextEncoder:GetIndexOfFirstByteToEncodeSsse3(long,long):long:this
           7 ( 0.87% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceUserDefinedOperatorSymbolBase:.ctor(int,System.String,Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol,Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.SyntaxReference,Microsoft.CodeAnalysis.SyntaxReference,Microsoft.CodeAnalysis.SyntaxTokenList,Microsoft.CodeAnalysis.DiagnosticBag,bool):this
           4 ( 0.50% of base) - System.Text.ASCIIUtility:GetIndexOfFirstNonAsciiChar_Sse2(long,long):long
           3 ( 1.24% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMethodSymbol:CheckModifiersForBody(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           3 ( 0.25% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceCustomEventAccessorSymbol:.ctor(Microsoft.CodeAnalysis.CSharp.Symbols.SourceEventSymbol,Microsoft.CodeAnalysis.CSharp.Syntax.AccessorDeclarationSyntax,Microsoft.CodeAnalysis.CSharp.Symbols.EventSymbol,System.String,Microsoft.CodeAnalysis.DiagnosticBag):this
           3 ( 0.88% of base) - System.Text.Encodings.Web.OptimizedInboxTextEncoder:GetIndexOfFirstCharToEncodeSsse3(long,long):long:this
           3 ( 2.68% of base) - System.Net.HttpResponseStreamAsyncResult:GetChunkHeader(int,byref):System.Byte[]
           1 ( 0.16% of base) - MethodDataEnumerator:.ctor(System.Management.ManagementObject):this
           1 ( 0.23% of base) - System.Management.MethodDataCollection:Add(System.String,System.Management.ManagementBaseObject,System.Management.ManagementBaseObject):this
           1 ( 0.41% of base) - System.Management.MethodData:RefreshMethodInfo():this
           1 ( 0.19% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourcePropertyAccessorSymbol:CheckModifiers(Microsoft.CodeAnalysis.Location,bool,Microsoft.CodeAnalysis.DiagnosticBag):this
           1 ( 0.37% of base) - System.Management.MethodDataCollection:Remove(System.String):this
           1 ( 0.18% of base) - System.Management.MethodDataCollection:get_Count():int:this

Top method improvements (bytes):
        -153 (-6.49% of base) - <WaitUntilCountOrTimeoutAsync>d__31:MoveNext():this
         -77 (-24.29% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:OnCompleted(System.Action):this
         -77 (-24.76% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:UnsafeOnCompleted(System.Action):this
         -58 (-22.48% of base) - System.IO.Stream:EndRead(System.IAsyncResult):int:this
         -54 (-4.65% of base) - <WriteAsyncInternal>d__61:MoveNext():this
         -50 (-2.81% of base) - <WriteAsyncInternal>d__65:MoveNext():this
         -48 (-9.07% of base) - <OutputTabsAsync>d__22:MoveNext():this
         -48 (-11.79% of base) - ConfiguredValueTaskAwaiter:UnsafeOnCompleted(System.Action):this
         -48 (-11.51% of base) - ConfiguredValueTaskAwaiter:OnCompleted(System.Action):this
         -47 (-17.67% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:FlushWriteBuffer(bool):this
         -43 (-22.05% of base) - System.IO.Strategies.AsyncWindowsFileStreamStrategy:Write(System.Byte[],int,int):this
         -41 (-19.81% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:Read(System.Byte[],int,int):int:this
         -40 (-38.83% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult)
         -39 (-13.09% of base) - System.IO.Stream:EndWrite(System.IAsyncResult):this
         -38 (-0.31% of base) - System.Reflection.Metadata.MetadataReader:InitializeTableReaders(System.Reflection.Internal.MemoryBlock,ubyte,System.Int32[],System.Int32[]):this
         -38 (-13.06% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1:OnCompleted(System.Action):this
         -38 (-30.16% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):int
         -38 (-13.33% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1:UnsafeOnCompleted(System.Action):this
         -37 (-16.74% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:FillReadBufferForReadByte():int:this
         -37 (-6.68% of base) - System.IO.Strategies.AsyncWindowsFileStreamStrategy:Read(System.Byte[],int,int):int:this

Top method regressions (percentages):
          69 ( 4.41% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol:CheckModifiers(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           3 ( 2.68% of base) - System.Net.HttpResponseStreamAsyncResult:GetChunkHeader(int,byref):System.Byte[]
           7 ( 2.21% of base) - System.Text.Encodings.Web.OptimizedInboxTextEncoder:GetIndexOfFirstByteToEncodeSsse3(long,long):long:this
          11 ( 1.38% of base) - System.Text.Latin1Utility:GetIndexOfFirstNonLatin1Char_Sse2(long,long):long
           3 ( 1.24% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMethodSymbol:CheckModifiersForBody(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           3 ( 0.88% of base) - System.Text.Encodings.Web.OptimizedInboxTextEncoder:GetIndexOfFirstCharToEncodeSsse3(long,long):long:this
           7 ( 0.87% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceUserDefinedOperatorSymbolBase:.ctor(int,System.String,Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol,Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.SyntaxReference,Microsoft.CodeAnalysis.SyntaxReference,Microsoft.CodeAnalysis.SyntaxTokenList,Microsoft.CodeAnalysis.DiagnosticBag,bool):this
           4 ( 0.50% of base) - System.Text.ASCIIUtility:GetIndexOfFirstNonAsciiChar_Sse2(long,long):long
           1 ( 0.41% of base) - System.Management.MethodData:RefreshMethodInfo():this
           1 ( 0.37% of base) - System.Management.MethodDataCollection:Remove(System.String):this
           3 ( 0.25% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceCustomEventAccessorSymbol:.ctor(Microsoft.CodeAnalysis.CSharp.Symbols.SourceEventSymbol,Microsoft.CodeAnalysis.CSharp.Syntax.AccessorDeclarationSyntax,Microsoft.CodeAnalysis.CSharp.Symbols.EventSymbol,System.String,Microsoft.CodeAnalysis.DiagnosticBag):this
           1 ( 0.23% of base) - System.Management.MethodDataCollection:Add(System.String,System.Management.ManagementBaseObject,System.Management.ManagementBaseObject):this
           1 ( 0.19% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourcePropertyAccessorSymbol:CheckModifiers(Microsoft.CodeAnalysis.Location,bool,Microsoft.CodeAnalysis.DiagnosticBag):this
           1 ( 0.18% of base) - System.Management.MethodDataCollection:get_Count():int:this
           1 ( 0.16% of base) - MethodDataEnumerator:.ctor(System.Management.ManagementObject):this

Top method improvements (percentages):
         -40 (-38.83% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult)
         -38 (-30.16% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):int
         -31 (-25.83% of base) - System.Buffers.MemoryManager`1:get_Memory():System.Memory`1[System.__Canon]:this
         -31 (-25.83% of base) - System.Buffers.MemoryManager`1:get_Memory():System.Memory`1[System.Char]:this
         -77 (-24.76% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:UnsafeOnCompleted(System.Action):this
         -77 (-24.29% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:OnCompleted(System.Action):this
         -58 (-22.48% of base) - System.IO.Stream:EndRead(System.IAsyncResult):int:this
          -4 (-22.22% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMethodSymbol:get_IsAbstract():bool:this
          -4 (-22.22% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol:get_IsAbstract():bool:this
          -4 (-22.22% of base) - PEFile.IMAGE_RESOURCE_DIRECTORY_ENTRY:get_IsLeaf():bool:this
         -43 (-22.05% of base) - System.IO.Strategies.AsyncWindowsFileStreamStrategy:Write(System.Byte[],int,int):this
         -41 (-19.81% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:Read(System.Byte[],int,int):int:this
         -47 (-17.67% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:FlushWriteBuffer(bool):this
          -4 (-17.39% of base) - System.Xml.XmlReader:CanReadContentAs(int):bool
          -4 (-17.39% of base) - System.Xml.XmlReader:IsTextualNode(int):bool
          -4 (-17.39% of base) - System.Xml.XmlReader:HasValueInternal(int):bool
         -37 (-16.74% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:FillReadBufferForReadByte():int:this
         -35 (-14.40% of base) - System.Threading.Tasks.UnwrapPromise`1:.ctor(System.Threading.Tasks.Task,bool):this
         -35 (-14.40% of base) - System.Threading.Tasks.UnwrapPromise`1:.ctor(System.Threading.Tasks.Task,bool):this
          -2 (-13.33% of base) - System.Reflection.Metadata.Ecma335.TokenTypeIds:IsValidRowId(int):bool

192 total methods with Code Size differences (177 improved, 15 regressed), 3 unchanged.

Running asm diffs of libraries.pmi.windows.x64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 161905
Total bytes of diff: 159918
Total bytes of delta: -1987 (-1.23% of base)
Total relative delta: -7.99
    diff is an improvement.
    relative diff is an improvement.


Top method regressions (bytes):
          69 ( 4.34% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol:CheckModifiers(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           7 ( 0.84% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceUserDefinedOperatorSymbolBase:.ctor(int,System.String,Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol,Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.SyntaxReference,Microsoft.CodeAnalysis.SyntaxReference,Microsoft.CodeAnalysis.SyntaxTokenList,Microsoft.CodeAnalysis.DiagnosticBag,bool):this
           4 ( 0.74% of base) - System.Text.ASCIIUtility:GetIndexOfFirstNonAsciiByte_Default(long,long):long
           3 ( 1.15% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMethodSymbol:CheckModifiersForBody(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           3 ( 0.37% of base) - System.Uri:GetHostViaCustomSyntax():this
           3 ( 2.48% of base) - System.Net.HttpResponseStreamAsyncResult:GetChunkHeader(int,byref):System.Byte[]
           2 ( 0.37% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourcePropertyAccessorSymbol:CheckModifiers(Microsoft.CodeAnalysis.Location,bool,Microsoft.CodeAnalysis.DiagnosticBag):this
           1 ( 0.40% of base) - System.Management.MethodData:RefreshMethodInfo():this
           1 ( 0.17% of base) - System.Management.MethodDataCollection:get_Count():int:this
           1 ( 0.09% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceCustomEventAccessorSymbol:.ctor(Microsoft.CodeAnalysis.CSharp.Symbols.SourceEventSymbol,Microsoft.CodeAnalysis.CSharp.Syntax.AccessorDeclarationSyntax,Microsoft.CodeAnalysis.CSharp.Symbols.EventSymbol,System.String,Microsoft.CodeAnalysis.DiagnosticBag):this
           1 ( 0.24% of base) - System.Management.MethodDataCollection:Add(System.String,System.Management.ManagementBaseObject,System.Management.ManagementBaseObject):this
           1 ( 0.35% of base) - System.Management.MethodDataCollection:Remove(System.String):this
           1 ( 0.14% of base) - MethodDataEnumerator:.ctor(System.Management.ManagementObject):this

Top method improvements (bytes):
        -166 (-30.63% of base) - Internal.JitInterface.InstructionSetFlags:Set64BitInstructionSetVariants(int):this
         -54 (-4.32% of base) - Internal.JitInterface.InstructionSetFlags:ExpandInstructionSetByImplicationHelper(int,Internal.JitInterface.InstructionSetFlags):Internal.JitInterface.InstructionSetFlags
         -48 (-14.41% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Byte][System.Byte]:OnCompleted(System.Action):this
         -48 (-14.68% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Byte][System.Byte]:UnsafeOnCompleted(System.Action):this
         -47 (-9.87% of base) - ConfiguredValueTaskAwaiter[Byte][System.Byte]:OnCompleted(System.Action):this
         -47 (-10.09% of base) - ConfiguredValueTaskAwaiter[Byte][System.Byte]:UnsafeOnCompleted(System.Action):this
         -43 (-30.71% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):ubyte
         -43 (-30.50% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):short
         -43 (-30.50% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):double
         -43 (-31.16% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):long
         -41 (-1.06% of base) - System.Uri:ReCreateParts(int,ushort,int):System.String:this
         -40 (-15.04% of base) - System.Threading.Tasks.UnwrapPromise`1[Byte][System.Byte]:.ctor(System.Threading.Tasks.Task,bool):this
         -38 (-0.31% of base) - System.Reflection.Metadata.MetadataReader:InitializeTableReaders(System.Reflection.Internal.MemoryBlock,ubyte,System.Int32[],System.Int32[]):this
         -37 (-18.05% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):System.Numerics.Vector`1[Single]
         -33 (-3.72% of base) - Internal.JitInterface.InstructionSetFlags:ExpandInstructionSetByReverseImplicationHelper(int,Internal.JitInterface.InstructionSetFlags):Internal.JitInterface.InstructionSetFlags
         -32 (-2.75% of base) - System.Uri:PrivateParseMinimal():int:this
         -30 (-26.79% of base) - System.Buffers.MemoryManager`1[Int16][System.Int16]:get_Memory():System.Memory`1[Int16]:this
         -24 (-2.28% of base) - System.Uri:CreateUriInfo(long):this
         -17 (-2.41% of base) - System.Uri:CreateHostString():this
         -16 (-1.13% of base) - System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest:ProcessResponse(System.ReadOnlyMemory`1[Byte],byref,byref,byref,bool):bool:this

Top method regressions (percentages):
          69 ( 4.34% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol:CheckModifiers(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           3 ( 2.48% of base) - System.Net.HttpResponseStreamAsyncResult:GetChunkHeader(int,byref):System.Byte[]
           3 ( 1.15% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMethodSymbol:CheckModifiersForBody(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           7 ( 0.84% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceUserDefinedOperatorSymbolBase:.ctor(int,System.String,Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol,Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.SyntaxReference,Microsoft.CodeAnalysis.SyntaxReference,Microsoft.CodeAnalysis.SyntaxTokenList,Microsoft.CodeAnalysis.DiagnosticBag,bool):this
           4 ( 0.74% of base) - System.Text.ASCIIUtility:GetIndexOfFirstNonAsciiByte_Default(long,long):long
           1 ( 0.40% of base) - System.Management.MethodData:RefreshMethodInfo():this
           3 ( 0.37% of base) - System.Uri:GetHostViaCustomSyntax():this
           2 ( 0.37% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourcePropertyAccessorSymbol:CheckModifiers(Microsoft.CodeAnalysis.Location,bool,Microsoft.CodeAnalysis.DiagnosticBag):this
           1 ( 0.35% of base) - System.Management.MethodDataCollection:Remove(System.String):this
           1 ( 0.24% of base) - System.Management.MethodDataCollection:Add(System.String,System.Management.ManagementBaseObject,System.Management.ManagementBaseObject):this
           1 ( 0.17% of base) - System.Management.MethodDataCollection:get_Count():int:this
           1 ( 0.14% of base) - MethodDataEnumerator:.ctor(System.Management.ManagementObject):this
           1 ( 0.09% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceCustomEventAccessorSymbol:.ctor(Microsoft.CodeAnalysis.CSharp.Symbols.SourceEventSymbol,Microsoft.CodeAnalysis.CSharp.Syntax.AccessorDeclarationSyntax,Microsoft.CodeAnalysis.CSharp.Symbols.EventSymbol,System.String,Microsoft.CodeAnalysis.DiagnosticBag):this

Top method improvements (percentages):
         -43 (-31.16% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):long
         -43 (-30.71% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):ubyte
        -166 (-30.63% of base) - Internal.JitInterface.InstructionSetFlags:Set64BitInstructionSetVariants(int):this
         -43 (-30.50% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):short
         -43 (-30.50% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):double
         -30 (-26.79% of base) - System.Buffers.MemoryManager`1[Int16][System.Int16]:get_Memory():System.Memory`1[Int16]:this
          -4 (-22.22% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMethodSymbol:get_IsAbstract():bool:this
          -4 (-22.22% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol:get_IsAbstract():bool:this
          -4 (-22.22% of base) - PEFile.IMAGE_RESOURCE_DIRECTORY_ENTRY:get_IsLeaf():bool:this
         -37 (-18.05% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):System.Numerics.Vector`1[Single]
          -4 (-17.39% of base) - System.Xml.XmlReader:IsTextualNode(int):bool
          -4 (-17.39% of base) - System.Xml.XmlReader:CanReadContentAs(int):bool
          -4 (-17.39% of base) - System.Xml.XmlReader:HasValueInternal(int):bool
         -40 (-15.04% of base) - System.Threading.Tasks.UnwrapPromise`1[Byte][System.Byte]:.ctor(System.Threading.Tasks.Task,bool):this
         -48 (-14.68% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Byte][System.Byte]:UnsafeOnCompleted(System.Action):this
         -48 (-14.41% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Byte][System.Byte]:OnCompleted(System.Action):this
          -2 (-13.33% of base) - System.Reflection.Metadata.Ecma335.TokenTypeIds:IsValidRowId(int):bool
          -8 (-11.94% of base) - System.Text.Json.BitStack:Pop():bool:this
          -2 (-11.76% of base) - System.Uri:EnsureParseRemaining():this
          -2 (-11.76% of base) - System.Data.SqlTypes.SqlInt32:SameSignInt(int,int):bool

226 total methods with Code Size differences (213 improved, 13 regressed), 7 unchanged.

Running asm diffs of libraries_tests.pmi.windows.x64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 54733
Total bytes of diff: 53602
Total bytes of delta: -1131 (-2.07% of base)
Total relative delta: -8.80
    diff is an improvement.
    relative diff is an improvement.


Top file improvements (bytes):
         -68 : 202990.dasm (-4.45% of base)
         -66 : 202992.dasm (-4.31% of base)
         -57 : 263241.dasm (-98.28% of base)
         -40 : 188191.dasm (-9.05% of base)
         -35 : 321604.dasm (-38.46% of base)
         -33 : 177496.dasm (-1.68% of base)
         -33 : 173229.dasm (-1.68% of base)
         -30 : 189174.dasm (-65.22% of base)
         -30 : 173235.dasm (-1.33% of base)
         -30 : 189171.dasm (-65.22% of base)
         -30 : 177502.dasm (-1.33% of base)
         -30 : 187657.dasm (-8.20% of base)
         -30 : 189173.dasm (-65.22% of base)
         -30 : 189172.dasm (-65.22% of base)
         -28 : 321623.dasm (-31.11% of base)
         -28 : 65553.dasm (-32.56% of base)
         -28 : 47804.dasm (-32.56% of base)
         -28 : 200813.dasm (-32.56% of base)
         -28 : 171937.dasm (-32.56% of base)
         -28 : 173823.dasm (-31.11% of base)

67 total files with Code Size differences (67 improved, 0 regressed), 3 unchanged.

Top method improvements (bytes):
         -68 (-4.45% of base) - <ReceiveAsync>d__2:MoveNext():this
         -66 (-4.31% of base) - <SendAsync>d__3:MoveNext():this
         -57 (-98.28% of base) - Microsoft.Extensions.Primitives.StringSegmentTest:StringSegment_Value_Invalid():this
         -40 (-9.05% of base) - System.SpanTests.SpanTests:SequenceCompareToNoMatch_Bool()
         -35 (-38.46% of base) - WindowsImplementation`1[Byte][System.Byte]:get_Memory():System.Memory`1[Byte]:this
         -33 (-1.68% of base) - <ReadAsyncMemory_WrapsNative_DelegatesToReadAsyncArrayWithPool_Success>d__3:MoveNext():this
         -33 (-1.68% of base) - <ReadAsyncMemory_WrapsNative_DelegatesToReadAsyncArrayWithPool_Success>d__3:MoveNext():this
         -30 (-65.22% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__7():System.Object:this
         -30 (-1.33% of base) - <WriteAsyncMemory_WrapsNative_DelegatesToWrite_Success>d__5:MoveNext():this
         -30 (-65.22% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__4():System.Object:this
         -30 (-1.33% of base) - <WriteAsyncMemory_WrapsNative_DelegatesToWrite_Success>d__5:MoveNext():this
         -30 (-8.20% of base) - System.SpanTests.ReadOnlySpanTests:SequenceCompareToNoMatch_Bool()
         -30 (-65.22% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__6():System.Object:this
         -30 (-65.22% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__5():System.Object:this
         -28 (-31.11% of base) - BoundedMemoryManager[Byte][System.Byte]:get_Memory():System.Memory`1[Byte]:this
         -28 (-32.56% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -28 (-32.56% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -28 (-32.56% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -28 (-32.56% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -28 (-31.11% of base) - DisposeTrackingMemoryManager:get_Memory():System.Memory`1[Byte]:this

Top method improvements (percentages):
         -57 (-98.28% of base) - Microsoft.Extensions.Primitives.StringSegmentTest:StringSegment_Value_Invalid():this
         -30 (-65.22% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__7():System.Object:this
         -30 (-65.22% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__4():System.Object:this
         -30 (-65.22% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__6():System.Object:this
         -30 (-65.22% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__5():System.Object:this
          -9 (-47.37% of base) - <>c:<Find>b__102_2(int):bool:this
         -35 (-38.46% of base) - WindowsImplementation`1[Byte][System.Byte]:get_Memory():System.Memory`1[Byte]:this
          -5 (-33.33% of base) - Microsoft.CodeAnalysis.VisualBasic.Utilities.ModifierCollectionFacts:CouldApplyToOneOf(int):bool:this
         -28 (-32.56% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -28 (-32.56% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -28 (-32.56% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -28 (-32.56% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -28 (-32.56% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -28 (-32.56% of base) - NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -28 (-31.11% of base) - BoundedMemoryManager[Byte][System.Byte]:get_Memory():System.Memory`1[Byte]:this
         -28 (-31.11% of base) - DisposeTrackingMemoryManager:get_Memory():System.Memory`1[Byte]:this
          -4 (-22.22% of base) - Microsoft.Diagnostics.Runtime.Utilities.IMAGE_RESOURCE_DIRECTORY_ENTRY:get_IsLeaf():bool:this
          -8 (-11.94% of base) - System.Text.Json.BitStack:Pop():bool:this
          -2 (-9.52% of base) - System.IO.Win32Marshal:MakeHRFromErrorCode(int):int
         -40 (-9.05% of base) - System.SpanTests.SpanTests:SequenceCompareToNoMatch_Bool()

67 total methods with Code Size differences (67 improved, 0 regressed), 3 unchanged.
```
</details>

<details>
<summary>Windows x86</summary>

```
Running asm diffs of benchmarks.run.windows.x86.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 60939
Total bytes of diff: 58799
Total bytes of delta: -2140 (-3.51% of base)
Total relative delta: -6.27
    diff is an improvement.
    relative diff is an improvement.


Top method regressions (bytes):
          59 ( 4.27% of base) - System.Threading.Tasks.Task:RunContinuations(System.Object):this
          28 ( 1.74% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceOrdinaryMethodSymbol:CheckModifiers(bool,Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this

Top method improvements (bytes):
        -338 (-18.74% of base) - ProtoBuf.ProtoReader:TryReadUInt64VariantWithoutMoving(byref):int:this
        -272 (-7.68% of base) - System.Uri:ReCreateParts(int,ushort,int):System.String:this
        -234 (-7.02% of base) - System.Uri:CheckAuthorityHelper(int,int,int,byref,byref,System.UriParser,byref):int:this
        -201 (-7.65% of base) - System.Uri:GetCanonicalPath(byref,int):this
        -181 (-1.19% of base) - System.Reflection.Metadata.MetadataReader:InitializeTableReaders(System.Reflection.Internal.MemoryBlock,ubyte,System.Int32[],System.Int32[]):this
        -135 (-5.55% of base) - System.Uri:GetUriPartsFromUserString(int):System.String:this
        -107 (-6.82% of base) - System.Uri:PrivateParseMinimal():int:this
         -46 (-7.31% of base) - System.Uri:ResolveHelper(System.Uri,System.Uri,byref,byref):System.Uri
         -32 (-18.60% of base) - System.Text.Json.Utf8JsonWriter:ValidateEnd(ubyte):this
         -32 (-2.89% of base) - System.Uri:CreateUriInfo(long):this
         -31 (-14.22% of base) - System.Uri:GetEscapedParts(int):System.String:this
         -30 (-20.69% of base) - System.IO.Strategies.AsyncWindowsFileStreamStrategy:Write(System.Byte[],int,int):this
         -30 (-3.31% of base) - System.Uri:InitializeUri(int,int,byref):this
         -29 (-14.80% of base) - System.Reflection.Metadata.MetadataReader:ComputeCodedTokenSize(int,System.Int32[],long):int:this
         -28 (-10.29% of base) - System.Text.Json.Utf8JsonReader:EndArray():this
         -28 (-4.46% of base) - System.Convert:TryDecodeFromUtf16(System.ReadOnlySpan`1[Char],System.Span`1[Byte],byref,byref):bool
         -28 (-10.29% of base) - System.Text.Json.Utf8JsonReader:EndObject():this
         -26 (-13.90% of base) - System.Threading.Tasks.UnwrapPromise`1[VoidTaskResult][System.Threading.Tasks.VoidTaskResult]:.ctor(System.Threading.Tasks.Task,bool):this
         -24 (-4.15% of base) - System.Uri:get_IdnHost():System.String:this
         -20 (-4.71% of base) - System.Net.Security.SafeDeleteContext:MustRunInitializeSecurityContext(byref,bool,int,int,int,int,System.Net.Security.SafeDeleteContext,byref,byref,System.Net.Security.SafeFreeContextBuffer):int

Top method regressions (percentages):
          59 ( 4.27% of base) - System.Threading.Tasks.Task:RunContinuations(System.Object):this
          28 ( 1.74% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceOrdinaryMethodSymbol:CheckModifiers(bool,Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this

Top method improvements (percentages):
         -15 (-51.72% of base) - System.Uri:get_IsImplicitFile():bool:this
         -15 (-51.72% of base) - System.Uri:get_UserDrivenParsing():bool:this
         -15 (-51.72% of base) - System.Uri:get_IsDosPath():bool:this
         -15 (-51.72% of base) - System.Uri:get_IsUncOrDosPath():bool:this
         -14 (-42.42% of base) - System.Xml.XmlReader:CanReadContentAs(int):bool
          -8 (-34.78% of base) - System.Uri:EnsureParseRemaining():this
          -4 (-23.53% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol:get_IsAbstract():bool:this
          -4 (-23.53% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol:get_IsAbstract():bool:this
         -15 (-23.08% of base) - System.Uri:EnsureHostString(bool):this
         -30 (-20.69% of base) - System.IO.Strategies.AsyncWindowsFileStreamStrategy:Write(System.Byte[],int,int):this
        -338 (-18.74% of base) - ProtoBuf.ProtoReader:TryReadUInt64VariantWithoutMoving(byref):int:this
         -32 (-18.60% of base) - System.Text.Json.Utf8JsonWriter:ValidateEnd(ubyte):this
         -29 (-14.80% of base) - System.Reflection.Metadata.MetadataReader:ComputeCodedTokenSize(int,System.Int32[],long):int:this
         -31 (-14.22% of base) - System.Uri:GetEscapedParts(int):System.String:this
         -26 (-13.90% of base) - System.Threading.Tasks.UnwrapPromise`1[VoidTaskResult][System.Threading.Tasks.VoidTaskResult]:.ctor(System.Threading.Tasks.Task,bool):this
         -16 (-11.85% of base) - System.Uri:get_Port():int:this
         -28 (-10.29% of base) - System.Text.Json.Utf8JsonReader:EndArray():this
         -28 (-10.29% of base) - System.Text.Json.Utf8JsonReader:EndObject():this
          -3 (-8.57% of base) - System.Uri:EnsureUriInfo():UriInfo:this
        -272 (-7.68% of base) - System.Uri:ReCreateParts(int,ushort,int):System.String:this

63 total methods with Code Size differences (61 improved, 2 regressed), 3 unchanged.

Running asm diffs of coreclr_tests.pmi.windows.x86.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 2991323
Total bytes of diff: 2991294
Total bytes of delta: -29 (-0.00% of base)
Total relative delta: -0.53
    diff is an improvement.
    relative diff is an improvement.


Top method regressions (bytes):
           4 ( 0.02% of base) - Program:TestCase0002()
           4 ( 0.02% of base) - Program:TestCase0005()
           4 ( 0.02% of base) - Program:TestCase0017()
           4 ( 0.02% of base) - Program:TestCase0017()
           4 ( 0.02% of base) - Program:TestCase0011()
           4 ( 0.02% of base) - Program:TestCase0002()
           4 ( 0.02% of base) - Program:TestCase0005()
           4 ( 0.02% of base) - Program:TestCase0011()
           2 ( 0.01% of base) - Program:TestCase0013()
           2 ( 0.01% of base) - Program:TestCase0003()
           2 ( 0.01% of base) - Program:TestCase0013()
           2 ( 0.02% of base) - Program:TestCase0036()
           2 ( 0.02% of base) - Program:TestCase0011()
           2 ( 0.02% of base) - Program:TestCase0012()
           2 ( 0.02% of base) - Program:TestCase0026()
           2 ( 0.02% of base) - Program:TestCase0005()
           2 ( 0.02% of base) - Program:TestCase0006()
           2 ( 0.01% of base) - Program:TestCase0015()
           2 ( 0.01% of base) - Program:TestCase0016()
           2 ( 0.02% of base) - Program:TestCase0013()

Top method improvements (bytes):
         -32 (-0.08% of base) - longMDArrTest:Main():int
         -32 (-0.07% of base) - ulongMDArrTest:Main():int
         -10 (-0.75% of base) - AA:Static5(System.Double[],byref,byref,ushort,System.Boolean[][],byref,System.UInt32[][,,],long):System.SByte[,][]
          -8 (-5.88% of base) - PInvokeTest.Test:FromFilter():bool
          -8 (-5.76% of base) - C:Test1Inner():int
          -8 (-7.34% of base) - C:Test5(int):int
          -8 (-6.67% of base) - C:Test6(int):int
          -8 (-0.93% of base) - Threading.Tests.OSThreadId:Main(System.String[]):int
          -6 (-0.05% of base) - TestApp:Main():int
          -6 (-0.05% of base) - TestApp:Main():int
          -6 (-0.05% of base) - TestApp:Main():int
          -6 (-0.05% of base) - TestApp:Main():int
          -5 (-6.02% of base) - Internal.IL.EcmaMethodIL:GetObject(int,int):System.Object:this
          -4 (-7.02% of base) - Program:I8_BT_reg_reg(long,int):bool
          -4 (-6.56% of base) - Program:I8_BT_mem_reg(byref,int):bool
          -4 (-1.64% of base) - ILGEN_CLASS:ILGEN_METHOD(ubyte,long,int):long
          -4 (-1.57% of base) - Threading.Tests.OSThreadId:ThreadProc(System.Object)
          -4 (-3.25% of base) - TestUnsafeCasts:PrimFromLPrim2()
          -2 (-0.02% of base) - Program:TestCase0019()
          -2 (-0.02% of base) - Program:TestCase0028()

Top method regressions (percentages):
           2 ( 0.04% of base) - Program:TestCase0002()
           2 ( 0.04% of base) - Program:TestCase0002()
           2 ( 0.04% of base) - Program:TestCase0005()
           2 ( 0.04% of base) - Program:TestCase0005()
           4 ( 0.02% of base) - Program:TestCase0017()
           4 ( 0.02% of base) - Program:TestCase0002()
           4 ( 0.02% of base) - Program:TestCase0011()
           4 ( 0.02% of base) - Program:TestCase0005()
           4 ( 0.02% of base) - Program:TestCase0005()
           4 ( 0.02% of base) - Program:TestCase0017()
           4 ( 0.02% of base) - Program:TestCase0002()
           4 ( 0.02% of base) - Program:TestCase0011()
           2 ( 0.02% of base) - Program:TestCase0014()
           2 ( 0.02% of base) - Program:TestCase0006()
           2 ( 0.02% of base) - Program:TestCase0007()
           2 ( 0.02% of base) - Program:TestCase0003()
           2 ( 0.02% of base) - Program:TestCase0012()
           2 ( 0.02% of base) - Program:TestCase0006()
           2 ( 0.02% of base) - Program:TestCase0014()
           2 ( 0.02% of base) - Program:TestCase0003()

Top method improvements (percentages):
          -8 (-7.34% of base) - C:Test5(int):int
          -4 (-7.02% of base) - Program:I8_BT_reg_reg(long,int):bool
          -8 (-6.67% of base) - C:Test6(int):int
          -4 (-6.56% of base) - Program:I8_BT_mem_reg(byref,int):bool
          -5 (-6.02% of base) - Internal.IL.EcmaMethodIL:GetObject(int,int):System.Object:this
          -8 (-5.88% of base) - PInvokeTest.Test:FromFilter():bool
          -8 (-5.76% of base) - C:Test1Inner():int
          -4 (-3.25% of base) - TestUnsafeCasts:PrimFromLPrim2()
          -4 (-1.64% of base) - ILGEN_CLASS:ILGEN_METHOD(ubyte,long,int):long
          -4 (-1.57% of base) - Threading.Tests.OSThreadId:ThreadProc(System.Object)
          -8 (-0.93% of base) - Threading.Tests.OSThreadId:Main(System.String[]):int
         -10 (-0.75% of base) - AA:Static5(System.Double[],byref,byref,ushort,System.Boolean[][],byref,System.UInt32[][,,],long):System.SByte[,][]
         -32 (-0.08% of base) - longMDArrTest:Main():int
         -32 (-0.07% of base) - ulongMDArrTest:Main():int
          -2 (-0.07% of base) - Program:TestCase0003()
          -2 (-0.07% of base) - Program:TestCase0003()
          -6 (-0.05% of base) - TestApp:Main():int
          -6 (-0.05% of base) - TestApp:Main():int
          -6 (-0.05% of base) - TestApp:Main():int
          -6 (-0.05% of base) - TestApp:Main():int

95 total methods with Code Size differences (27 improved, 68 regressed), 194 unchanged.

Running asm diffs of libraries.crossgen.windows.x86.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 147326
Total bytes of diff: 142764
Total bytes of delta: -4562 (-3.10% of base)
Total relative delta: -24.97
    diff is an improvement.
    relative diff is an improvement.


Top method regressions (bytes):
          13 ( 7.03% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMethodSymbol:CheckModifiersForBody(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           9 ( 4.71% of base) - System.Reflection.Metadata.MetadataReader:ComputeCodedTokenSize(int,System.Int32[],long):int:this
           5 ( 4.81% of base) - System.Net.HttpResponseStreamAsyncResult:GetChunkHeader(int,byref):System.Byte[]

Top method improvements (bytes):
        -241 (-13.12% of base) - <WriteAsyncInternal>d__65:MoveNext():this
        -235 (-6.98% of base) - System.Uri:CheckAuthorityHelper(int,int,int,byref,byref,System.UriParser,byref):int:this
        -207 (-10.14% of base) - System.Uri:GetCanonicalPath(byref,int):this
        -181 (-1.21% of base) - System.Reflection.Metadata.MetadataReader:InitializeTableReaders(System.Reflection.Internal.MemoryBlock,ubyte,System.Int32[],System.Int32[]):this
        -135 (-7.39% of base) - System.Uri:GetUriPartsFromUserString(int):System.String:this
         -89 (-4.51% of base) - <WaitUntilCountOrTimeoutAsync>d__31:MoveNext():this
         -80 (-31.37% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:OnCompleted(System.Action):this
         -80 (-31.37% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:UnsafeOnCompleted(System.Action):this
         -80 (-31.37% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Int32][System.Int32]:OnCompleted(System.Action):this
         -80 (-31.37% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Int32][System.Int32]:UnsafeOnCompleted(System.Action):this
         -52 (-24.53% of base) - System.IO.Stream:EndRead(System.IAsyncResult):int:this
         -47 (-20.43% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:Write(System.Byte[],int,int):this
         -46 (-7.12% of base) - System.Uri:ResolveHelper(System.Uri,System.Uri,byref,byref):System.Uri
         -39 (-2.23% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:ReadAsyncInternal(System.Memory`1[Byte],System.Threading.CancellationToken,byref):System.Threading.Tasks.Task`1[Int32]:this
         -38 (-17.67% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:FlushWriteBuffer(bool):this
         -37 (-22.42% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:Read(System.Byte[],int,int):int:this
         -37 (-10.88% of base) - ConfiguredValueTaskAwaiter[Int32][System.Int32]:OnCompleted(System.Action):this
         -37 (-10.98% of base) - ConfiguredValueTaskAwaiter[Int32][System.Int32]:UnsafeOnCompleted(System.Action):this
         -36 (-14.52% of base) - System.IO.Stream:EndWrite(System.IAsyncResult):this
         -35 (-39.77% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult)

Top method regressions (percentages):
          13 ( 7.03% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMethodSymbol:CheckModifiersForBody(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           5 ( 4.81% of base) - System.Net.HttpResponseStreamAsyncResult:GetChunkHeader(int,byref):System.Byte[]
           9 ( 4.71% of base) - System.Reflection.Metadata.MetadataReader:ComputeCodedTokenSize(int,System.Int32[],long):int:this

Top method improvements (percentages):
         -15 (-51.72% of base) - System.Uri:get_IsImplicitFile():bool:this
         -15 (-51.72% of base) - System.Uri:get_IsUncOrDosPath():bool:this
         -15 (-51.72% of base) - System.Uri:get_UserDrivenParsing():bool:this
         -15 (-51.72% of base) - System.Uri:get_IsDosPath():bool:this
         -15 (-51.72% of base) - System.Uri:get_IsUncPath():bool:this
         -15 (-51.72% of base) - System.Uri:get_UserEscaped():bool:this
         -14 (-42.42% of base) - System.Xml.XmlReader:CanReadContentAs(int):bool
         -14 (-42.42% of base) - System.Xml.XmlReader:IsTextualNode(int):bool
         -14 (-42.42% of base) - System.Xml.XmlReader:HasValueInternal(int):bool
         -35 (-39.77% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult)
          -8 (-38.10% of base) - System.Diagnostics.SharedPerformanceCounter:IsMisaligned(int):bool
          -8 (-33.33% of base) - System.Uri:EnsureParseRemaining():this
          -6 (-31.58% of base) - System.Reflection.Metadata.Ecma335.TokenTypeIds:IsValidRowId(int):bool
         -80 (-31.37% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:OnCompleted(System.Action):this
         -80 (-31.37% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:UnsafeOnCompleted(System.Action):this
         -80 (-31.37% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Int32][System.Int32]:OnCompleted(System.Action):this
         -80 (-31.37% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Int32][System.Int32]:UnsafeOnCompleted(System.Action):this
         -29 (-30.21% of base) - System.Buffers.MemoryManager`1[Byte][System.Byte]:get_Memory():System.Memory`1[Byte]:this
         -29 (-30.21% of base) - System.Buffers.MemoryManager`1[__Canon][System.__Canon]:get_Memory():System.Memory`1[__Canon]:this
          -6 (-30.00% of base) - PEFile.IMAGE_RESOURCE_DIRECTORY_ENTRY:get_IsLeaf():bool:this

298 total methods with Code Size differences (295 improved, 3 regressed), 0 unchanged.

Running asm diffs of libraries.crossgen2.windows.x86.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 148483
Total bytes of diff: 144222
Total bytes of delta: -4261 (-2.87% of base)
Total relative delta: -23.69
    diff is an improvement.
    relative diff is an improvement.


Top method regressions (bytes):
          35 ( 5.80% of base) - Microsoft.CodeAnalysis.VisualBasic.DocumentationCommentCrefBinder:BindNameInsideCrefReferenceInLegacyMode(Microsoft.CodeAnalysis.VisualBasic.Syntax.TypeSyntax,bool,byref):System.Collections.Immutable.ImmutableArray`1[Microsoft.CodeAnalysis.VisualBasic.Symbol]:this
          28 ( 2.08% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol:CheckModifiers(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           9 ( 4.69% of base) - System.Reflection.Metadata.MetadataReader:ComputeCodedTokenSize(int,System.Int32[],long):int:this
           5 ( 4.81% of base) - System.Net.HttpResponseStreamAsyncResult:GetChunkHeader(int,byref):System.Byte[]
           2 ( 0.32% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceUserDefinedOperatorSymbolBase:.ctor(int,System.String,Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol,Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.SyntaxReference,Microsoft.CodeAnalysis.SyntaxReference,Microsoft.CodeAnalysis.SyntaxTokenList,Microsoft.CodeAnalysis.DiagnosticBag,bool):this
           1 ( 0.23% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourcePropertyAccessorSymbol:CheckModifiers(Microsoft.CodeAnalysis.Location,bool,Microsoft.CodeAnalysis.DiagnosticBag):this

Top method improvements (bytes):
        -235 (-6.97% of base) - System.Uri:CheckAuthorityHelper(int,int,int,byref,byref,System.UriParser,byref):int:this
        -230 (-10.55% of base) - System.Uri:GetCanonicalPath(byref,int):this
        -217 (-11.97% of base) - <WriteAsyncInternal>d__65:MoveNext():this
        -181 (-1.21% of base) - System.Reflection.Metadata.MetadataReader:InitializeTableReaders(System.Reflection.Internal.MemoryBlock,ubyte,System.Int32[],System.Int32[]):this
        -135 (-7.39% of base) - System.Uri:GetUriPartsFromUserString(int):System.String:this
         -89 (-4.50% of base) - <WaitUntilCountOrTimeoutAsync>d__31:MoveNext():this
         -80 (-31.37% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:UnsafeOnCompleted(System.Action):this
         -80 (-31.37% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:OnCompleted(System.Action):this
         -52 (-24.53% of base) - System.IO.Stream:EndRead(System.IAsyncResult):int:this
         -47 (-20.43% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:Write(System.Byte[],int,int):this
         -46 (-7.11% of base) - System.Uri:ResolveHelper(System.Uri,System.Uri,byref,byref):System.Uri
         -39 (-2.23% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:ReadAsyncInternal(System.Memory`1[System.Byte],System.Threading.CancellationToken,byref):System.Threading.Tasks.Task`1[System.Int32]:this
         -38 (-17.67% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:FlushWriteBuffer(bool):this
         -37 (-10.88% of base) - ConfiguredValueTaskAwaiter:OnCompleted(System.Action):this
         -37 (-10.98% of base) - ConfiguredValueTaskAwaiter:UnsafeOnCompleted(System.Action):this
         -37 (-22.42% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:Read(System.Byte[],int,int):int:this
         -36 (-14.52% of base) - System.IO.Stream:EndWrite(System.IAsyncResult):this
         -35 (-39.77% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult)
         -35 (-22.73% of base) - System.IO.Strategies.AsyncWindowsFileStreamStrategy:Write(System.Byte[],int,int):this
         -34 (-3.37% of base) - <WriteAsyncInternal>d__61:MoveNext():this

Top method regressions (percentages):
          35 ( 5.80% of base) - Microsoft.CodeAnalysis.VisualBasic.DocumentationCommentCrefBinder:BindNameInsideCrefReferenceInLegacyMode(Microsoft.CodeAnalysis.VisualBasic.Syntax.TypeSyntax,bool,byref):System.Collections.Immutable.ImmutableArray`1[Microsoft.CodeAnalysis.VisualBasic.Symbol]:this
           5 ( 4.81% of base) - System.Net.HttpResponseStreamAsyncResult:GetChunkHeader(int,byref):System.Byte[]
           9 ( 4.69% of base) - System.Reflection.Metadata.MetadataReader:ComputeCodedTokenSize(int,System.Int32[],long):int:this
          28 ( 2.08% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol:CheckModifiers(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           2 ( 0.32% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceUserDefinedOperatorSymbolBase:.ctor(int,System.String,Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol,Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.SyntaxReference,Microsoft.CodeAnalysis.SyntaxReference,Microsoft.CodeAnalysis.SyntaxTokenList,Microsoft.CodeAnalysis.DiagnosticBag,bool):this
           1 ( 0.23% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourcePropertyAccessorSymbol:CheckModifiers(Microsoft.CodeAnalysis.Location,bool,Microsoft.CodeAnalysis.DiagnosticBag):this

Top method improvements (percentages):
         -15 (-51.72% of base) - System.Uri:get_IsDosPath():bool:this
         -15 (-51.72% of base) - System.Uri:get_IsUncOrDosPath():bool:this
         -15 (-51.72% of base) - System.Uri:get_IsImplicitFile():bool:this
         -15 (-51.72% of base) - System.Uri:get_UserDrivenParsing():bool:this
         -15 (-51.72% of base) - System.Uri:get_IsUncPath():bool:this
         -15 (-51.72% of base) - System.Uri:get_UserEscaped():bool:this
         -14 (-42.42% of base) - System.Xml.XmlReader:HasValueInternal(int):bool
         -14 (-42.42% of base) - System.Xml.XmlReader:CanReadContentAs(int):bool
         -14 (-42.42% of base) - System.Xml.XmlReader:IsTextualNode(int):bool
         -35 (-39.77% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult)
          -8 (-38.10% of base) - System.Diagnostics.SharedPerformanceCounter:IsMisaligned(int):bool
          -8 (-33.33% of base) - System.Uri:EnsureParseRemaining():this
          -6 (-31.58% of base) - System.Reflection.Metadata.Ecma335.TokenTypeIds:IsValidRowId(int):bool
         -80 (-31.37% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:UnsafeOnCompleted(System.Action):this
         -80 (-31.37% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:OnCompleted(System.Action):this
         -29 (-30.21% of base) - System.Buffers.MemoryManager`1:get_Memory():System.Memory`1[System.__Canon]:this
         -29 (-30.21% of base) - System.Buffers.MemoryManager`1:get_Memory():System.Memory`1[System.Char]:this
          -6 (-30.00% of base) - PEFile.IMAGE_RESOURCE_DIRECTORY_ENTRY:get_IsLeaf():bool:this
         -31 (-28.70% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):int
          -6 (-28.57% of base) - System.Data.SqlTypes.SqlInt32:SameSignInt(int,int):bool

301 total methods with Code Size differences (295 improved, 6 regressed), 3 unchanged.

Running asm diffs of libraries.pmi.windows.x86.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 209849
Total bytes of diff: 205305
Total bytes of delta: -4544 (-2.17% of base)
Total relative delta: -23.84
    diff is an improvement.
    relative diff is an improvement.


Top method regressions (bytes):
          28 ( 2.12% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol:CheckModifiers(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           9 ( 4.52% of base) - System.Reflection.Metadata.MetadataReader:ComputeCodedTokenSize(int,System.Int32[],long):int:this
           5 ( 4.63% of base) - System.Net.HttpResponseStreamAsyncResult:GetChunkHeader(int,byref):System.Byte[]
           2 ( 0.30% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceUserDefinedOperatorSymbolBase:.ctor(int,System.String,Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol,Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.SyntaxReference,Microsoft.CodeAnalysis.SyntaxReference,Microsoft.CodeAnalysis.SyntaxTokenList,Microsoft.CodeAnalysis.DiagnosticBag,bool):this
           1 ( 0.10% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceCustomEventAccessorSymbol:.ctor(Microsoft.CodeAnalysis.CSharp.Symbols.SourceEventSymbol,Microsoft.CodeAnalysis.CSharp.Syntax.AccessorDeclarationSyntax,Microsoft.CodeAnalysis.CSharp.Symbols.EventSymbol,System.String,Microsoft.CodeAnalysis.DiagnosticBag):this
           1 ( 0.22% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourcePropertyAccessorSymbol:CheckModifiers(Microsoft.CodeAnalysis.Location,bool,Microsoft.CodeAnalysis.DiagnosticBag):this

Top method improvements (bytes):
        -278 (-7.77% of base) - System.Uri:ReCreateParts(int,ushort,int):System.String:this
        -234 (-7.02% of base) - System.Uri:CheckAuthorityHelper(int,int,int,byref,byref,System.UriParser,byref):int:this
        -195 (-7.32% of base) - System.Uri:GetCanonicalPath(byref,int):this
        -181 (-1.19% of base) - System.Reflection.Metadata.MetadataReader:InitializeTableReaders(System.Reflection.Internal.MemoryBlock,ubyte,System.Int32[],System.Int32[]):this
        -143 (-13.31% of base) - System.Uri:InternalIsWellFormedOriginalString():bool:this
        -135 (-5.50% of base) - System.Uri:GetUriPartsFromUserString(int):System.String:this
        -107 (-6.82% of base) - System.Uri:PrivateParseMinimal():int:this
         -85 (-31.72% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Byte][System.Byte]:OnCompleted(System.Action):this
         -85 (-31.72% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Byte][System.Byte]:UnsafeOnCompleted(System.Action):this
         -46 (-7.31% of base) - System.Uri:ResolveHelper(System.Uri,System.Uri,byref,byref):System.Uri
         -38 (-4.36% of base) - System.Uri:GetLocalPath():System.String:this
         -32 (-2.89% of base) - System.Uri:CreateUriInfo(long):this
         -32 (-9.36% of base) - ConfiguredValueTaskAwaiter[Byte][System.Byte]:UnsafeOnCompleted(System.Action):this
         -32 (-3.60% of base) - System.Uri:Equals(System.Object):bool:this
         -32 (-18.60% of base) - System.Text.Json.Utf8JsonWriter:ValidateEnd(ubyte):this
         -32 (-9.28% of base) - ConfiguredValueTaskAwaiter[Byte][System.Byte]:OnCompleted(System.Action):this
         -31 (-14.22% of base) - System.Uri:GetEscapedParts(int):System.String:this
         -30 (-3.31% of base) - System.Uri:InitializeUri(int,int,byref):this
         -28 (-10.29% of base) - System.Text.Json.Utf8JsonReader:EndObject():this
         -28 (-10.29% of base) - System.Text.Json.Utf8JsonReader:EndArray():this

Top method regressions (percentages):
           5 ( 4.63% of base) - System.Net.HttpResponseStreamAsyncResult:GetChunkHeader(int,byref):System.Byte[]
           9 ( 4.52% of base) - System.Reflection.Metadata.MetadataReader:ComputeCodedTokenSize(int,System.Int32[],long):int:this
          28 ( 2.12% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol:CheckModifiers(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           2 ( 0.30% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceUserDefinedOperatorSymbolBase:.ctor(int,System.String,Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol,Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.SyntaxReference,Microsoft.CodeAnalysis.SyntaxReference,Microsoft.CodeAnalysis.SyntaxTokenList,Microsoft.CodeAnalysis.DiagnosticBag,bool):this
           1 ( 0.22% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourcePropertyAccessorSymbol:CheckModifiers(Microsoft.CodeAnalysis.Location,bool,Microsoft.CodeAnalysis.DiagnosticBag):this
           1 ( 0.10% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceCustomEventAccessorSymbol:.ctor(Microsoft.CodeAnalysis.CSharp.Symbols.SourceEventSymbol,Microsoft.CodeAnalysis.CSharp.Syntax.AccessorDeclarationSyntax,Microsoft.CodeAnalysis.CSharp.Symbols.EventSymbol,System.String,Microsoft.CodeAnalysis.DiagnosticBag):this

Top method improvements (percentages):
         -15 (-51.72% of base) - System.Uri:get_UserDrivenParsing():bool:this
         -15 (-51.72% of base) - System.Uri:get_IsDosPath():bool:this
         -15 (-51.72% of base) - System.Uri:get_IsUncPath():bool:this
         -15 (-51.72% of base) - System.Uri:get_IsImplicitFile():bool:this
         -15 (-51.72% of base) - System.Uri:get_IsUncOrDosPath():bool:this
         -15 (-51.72% of base) - System.Uri:get_UserEscaped():bool:this
         -14 (-42.42% of base) - System.Xml.XmlReader:HasValueInternal(int):bool
         -14 (-42.42% of base) - System.Xml.XmlReader:IsTextualNode(int):bool
         -14 (-42.42% of base) - System.Xml.XmlReader:CanReadContentAs(int):bool
          -8 (-38.10% of base) - System.Diagnostics.SharedPerformanceCounter:IsMisaligned(int):bool
          -8 (-34.78% of base) - System.Uri:EnsureParseRemaining():this
         -85 (-31.72% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Byte][System.Byte]:OnCompleted(System.Action):this
         -85 (-31.72% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Byte][System.Byte]:UnsafeOnCompleted(System.Action):this
          -6 (-31.58% of base) - System.Reflection.Metadata.Ecma335.TokenTypeIds:IsValidRowId(int):bool
          -6 (-30.00% of base) - PEFile.IMAGE_RESOURCE_DIRECTORY_ENTRY:get_IsLeaf():bool:this
          -6 (-28.57% of base) - System.Data.SqlTypes.SqlInt32:SameSignInt(int,int):bool
         -28 (-28.57% of base) - System.Text.Json.BitStack:Pop():bool:this
         -24 (-26.97% of base) - System.Buffers.MemoryManager`1[Int16][System.Int16]:get_Memory():System.Memory`1[Int16]:this
          -4 (-25.00% of base) - Microsoft.Extensions.Internal.ValueStopwatch:get_IsActive():bool:this
          -4 (-25.00% of base) - System.Threading.Tasks.Dataflow.DataflowMessageHeader:get_IsValid():bool:this

403 total methods with Code Size differences (397 improved, 6 regressed), 3 unchanged.

Running asm diffs of libraries_tests.pmi.windows.x86.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 63630
Total bytes of diff: 62153
Total bytes of delta: -1477 (-2.32% of base)
Total relative delta: -11.95
    diff is an improvement.
    relative diff is an improvement.


Top file improvements (bytes):
        -112 : 92215.dasm (-11.24% of base)
         -72 : 92217.dasm (-5.07% of base)
         -70 : 202041.dasm (-5.98% of base)
         -58 : 202043.dasm (-4.85% of base)
         -39 : 262123.dasm (-88.64% of base)
         -29 : 176571.dasm (-2.00% of base)
         -29 : 172307.dasm (-2.00% of base)
         -28 : 171016.dasm (-43.08% of base)
         -28 : 65114.dasm (-43.08% of base)
         -28 : 92216.dasm (-3.36% of base)
         -28 : 172901.dasm (-41.18% of base)
         -28 : 47380.dasm (-43.08% of base)
         -28 : 187759.dasm (-43.08% of base)
         -28 : 199864.dasm (-43.08% of base)
         -28 : 271037.dasm (-43.08% of base)
         -28 : 320350.dasm (-41.18% of base)
         -28 : 87751.dasm (-28.57% of base)
         -26 : 320331.dasm (-37.68% of base)
         -24 : 93113.dasm (-1.04% of base)
         -22 : 188228.dasm (-61.11% of base)

104 total files with Code Size differences (104 improved, 0 regressed), 4 unchanged.

Top method improvements (bytes):
        -112 (-11.24% of base) - System.Text.Json.Tests.BitStackTests:SetResetFirstBit()
         -72 (-5.07% of base) - System.Text.Json.Tests.BitStackTests:BitStackPushPopLarge(int)
         -70 (-5.98% of base) - <ReceiveAsync>d__2:MoveNext():this
         -58 (-4.85% of base) - <SendAsync>d__3:MoveNext():this
         -39 (-88.64% of base) - Microsoft.Extensions.Primitives.StringSegmentTest:StringSegment_Value_Invalid():this
         -29 (-2.00% of base) - <ReadAsyncMemory_WrapsNative_DelegatesToReadAsyncArrayWithPool_Success>d__3:MoveNext():this
         -29 (-2.00% of base) - <ReadAsyncMemory_WrapsNative_DelegatesToReadAsyncArrayWithPool_Success>d__3:MoveNext():this
         -28 (-43.08% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -28 (-43.08% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -28 (-3.36% of base) - System.Text.Json.Tests.BitStackTests:BitStackPushPop(int)
         -28 (-41.18% of base) - DisposeTrackingMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -28 (-43.08% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -28 (-43.08% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -28 (-43.08% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -28 (-43.08% of base) - NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -28 (-41.18% of base) - BoundedMemoryManager[Byte][System.Byte]:get_Memory():System.Memory`1[Byte]:this
         -28 (-28.57% of base) - System.Text.Json.BitStack:Pop():bool:this
         -26 (-37.68% of base) - WindowsImplementation`1[Byte][System.Byte]:get_Memory():System.Memory`1[Byte]:this
         -24 (-1.04% of base) - System.Text.Json.Tests.Utf8JsonWriterTests:ResetChangeOutputMode(bool,bool):this
         -22 (-61.11% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__7():System.Object:this

Top method improvements (percentages):
         -39 (-88.64% of base) - Microsoft.Extensions.Primitives.StringSegmentTest:StringSegment_Value_Invalid():this
         -22 (-61.11% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__7():System.Object:this
         -22 (-61.11% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__6():System.Object:this
         -22 (-61.11% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__5():System.Object:this
         -22 (-61.11% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__4():System.Object:this
          -9 (-47.37% of base) - <>c:<Find>b__102_2(int):bool:this
          -8 (-44.44% of base) - Microsoft.CodeAnalysis.VisualBasic.Utilities.ModifierCollectionFacts:CouldApplyToOneOf(int):bool:this
         -28 (-43.08% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -28 (-43.08% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -28 (-43.08% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -28 (-43.08% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -28 (-43.08% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -28 (-43.08% of base) - NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -28 (-41.18% of base) - DisposeTrackingMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -28 (-41.18% of base) - BoundedMemoryManager[Byte][System.Byte]:get_Memory():System.Memory`1[Byte]:this
         -26 (-37.68% of base) - WindowsImplementation`1[Byte][System.Byte]:get_Memory():System.Memory`1[Byte]:this
          -6 (-30.00% of base) - Microsoft.Diagnostics.Runtime.Utilities.IMAGE_RESOURCE_DIRECTORY_ENTRY:get_IsLeaf():bool:this
         -28 (-28.57% of base) - System.Text.Json.BitStack:Pop():bool:this
          -6 (-24.00% of base) - System.IO.Win32Marshal:MakeHRFromErrorCode(int):int
          -4 (-21.05% of base) - <>c:<get_UInt64TestDivisions>b__105_2(<>f__AnonymousType0`2[UInt64,UInt64]):bool:this

104 total methods with Code Size differences (104 improved, 0 regressed), 4 unchanged.
```
</details>

<details>
<summary>Linux ARM64</summary>

```
Running asm diffs of coreclr_tests.pmi.Linux.arm64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3338328
Total bytes of diff: 3338284
Total bytes of delta: -44 (-0.00% of base)
Total relative delta: -0.18
    diff is an improvement.
    relative diff is an improvement.


Top file improvements (bytes):
          -8 : 245840.dasm (-3.23% of base)
          -8 : 245854.dasm (-3.70% of base)
          -8 : 245857.dasm (-3.45% of base)
          -8 : 248962.dasm (-3.51% of base)
          -8 : 83747.dasm (-0.42% of base)
          -4 : 158844.dasm (-3.70% of base)

6 total files with Code Size differences (6 improved, 0 regressed), 230 unchanged.

Top method improvements (bytes):
          -8 (-3.23% of base) - C:Test1Inner():int
          -8 (-3.70% of base) - C:Test5(int):int
          -8 (-3.45% of base) - C:Test6(int):int
          -8 (-3.51% of base) - PInvokeTest.Test:FromFilter():bool
          -8 (-0.42% of base) - System.Net.Sockets.Socket:Dispose(bool):this
          -4 (-3.70% of base) - Internal.IL.EcmaMethodIL:GetObject(int,int):System.Object:this

Top method improvements (percentages):
          -8 (-3.70% of base) - C:Test5(int):int
          -4 (-3.70% of base) - Internal.IL.EcmaMethodIL:GetObject(int,int):System.Object:this
          -8 (-3.51% of base) - PInvokeTest.Test:FromFilter():bool
          -8 (-3.45% of base) - C:Test6(int):int
          -8 (-3.23% of base) - C:Test1Inner():int
          -8 (-0.42% of base) - System.Net.Sockets.Socket:Dispose(bool):this

6 total methods with Code Size differences (6 improved, 0 regressed), 230 unchanged.

Running asm diffs of libraries.crossgen.Linux.arm64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 134364
Total bytes of diff: 131628
Total bytes of delta: -2736 (-2.04% of base)
Total relative delta: -6.89
    diff is an improvement.
    relative diff is an improvement.


Top method regressions (bytes):
           8 ( 3.45% of base) - System.Uri:CreateThisFromUri(System.Uri):this
           4 ( 1.09% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMethodSymbol:CheckModifiersForBody(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           4 ( 0.13% of base) - System.Uri:CheckAuthorityHelper(long,int,int,byref,byref,System.UriParser,byref):int:this
           4 ( 1.85% of base) - System.Uri:get_DnsSafeHost():System.String:this

Top method improvements (bytes):
        -156 (-5.02% of base) - <WaitUntilCountOrTimeoutAsync>d__31:MoveNext():this
        -116 (-24.79% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Boolean][System.Boolean]:OnCompleted(System.Action):this
        -116 (-24.79% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Boolean][System.Boolean]:UnsafeOnCompleted(System.Action):this
        -116 (-24.79% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:OnCompleted(System.Action):this
        -116 (-24.79% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:UnsafeOnCompleted(System.Action):this
         -88 (-3.75% of base) - <WriteAsyncInternal>d__65:MoveNext():this
         -80 (-18.87% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:Write(System.Byte[],int,int):this
         -68 (-5.15% of base) - <<WriteLineAsync>g__WriteLineAsyncCore|66_0>d:MoveNext():this
         -68 (-4.24% of base) - <InternalWriteAllTextAsync>d__82:MoveNext():this
         -64 (-15.09% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[__Canon][System.__Canon]:OnCompleted(System.Action):this
         -64 (-15.09% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[__Canon][System.__Canon]:UnsafeOnCompleted(System.Action):this
         -64 (-34.78% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult)
         -64 (-21.05% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:Read(System.Byte[],int,int):int:this
         -64 (-16.67% of base) - System.IO.Stream:EndRead(System.IAsyncResult):int:this
         -60 (-11.28% of base) - ConfiguredValueTaskAwaiter[Int32][System.Int32]:UnsafeOnCompleted(System.Action):this
         -60 (-25.42% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):int
         -60 (-11.19% of base) - ConfiguredValueTaskAwaiter[Int32][System.Int32]:OnCompleted(System.Action):this
         -60 (-4.70% of base) - <<ReadAsync>g__FinishReadAsync|44_0>d:MoveNext():this
         -60 (-8.72% of base) - <OutputTabsAsync>d__22:MoveNext():this
         -56 (-3.49% of base) - <InternalWriteAllLinesAsync>d__81:MoveNext():this

Top method regressions (percentages):
           8 ( 3.45% of base) - System.Uri:CreateThisFromUri(System.Uri):this
           4 ( 1.85% of base) - System.Uri:get_DnsSafeHost():System.String:this
           4 ( 1.09% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMethodSymbol:CheckModifiersForBody(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           4 ( 0.13% of base) - System.Uri:CheckAuthorityHelper(long,int,int,byref,byref,System.UriParser,byref):int:this

Top method improvements (percentages):
         -64 (-34.78% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult)
         -48 (-30.77% of base) - System.Buffers.MemoryManager`1[Char][System.Char]:get_Memory():System.Memory`1[Char]:this
         -48 (-30.77% of base) - System.Buffers.MemoryManager`1[__Canon][System.__Canon]:get_Memory():System.Memory`1[__Canon]:this
         -60 (-25.42% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):int
        -116 (-24.79% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Boolean][System.Boolean]:OnCompleted(System.Action):this
        -116 (-24.79% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Boolean][System.Boolean]:UnsafeOnCompleted(System.Action):this
        -116 (-24.79% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:OnCompleted(System.Action):this
        -116 (-24.79% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:UnsafeOnCompleted(System.Action):this
         -64 (-21.05% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:Read(System.Byte[],int,int):int:this
         -80 (-18.87% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:Write(System.Byte[],int,int):this
         -64 (-16.67% of base) - System.IO.Stream:EndRead(System.IAsyncResult):int:this
         -64 (-15.09% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[__Canon][System.__Canon]:OnCompleted(System.Action):this
         -64 (-15.09% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[__Canon][System.__Canon]:UnsafeOnCompleted(System.Action):this
          -4 (-14.29% of base) - System.Reflection.Metadata.Ecma335.TokenTypeIds:IsValidRowId(int):bool
         -56 (-13.21% of base) - System.Threading.Tasks.UnwrapPromise`1[VoidTaskResult][System.Threading.Tasks.VoidTaskResult]:.ctor(System.Threading.Tasks.Task,bool):this
         -56 (-13.21% of base) - System.Threading.Tasks.UnwrapPromise`1[__Canon][System.__Canon]:.ctor(System.Threading.Tasks.Task,bool):this
          -4 (-12.50% of base) - PEFile.IMAGE_RESOURCE_DIRECTORY_ENTRY:get_IsLeaf():bool:this
          -4 (-12.50% of base) - System.Data.SqlTypes.SqlInt32:SameSignInt(int,int):bool
         -52 (-11.82% of base) - System.IO.Stream:EndWrite(System.IAsyncResult):this
         -60 (-11.28% of base) - ConfiguredValueTaskAwaiter[Int32][System.Int32]:UnsafeOnCompleted(System.Action):this

153 total methods with Code Size differences (149 improved, 4 regressed), 23 unchanged.

Running asm diffs of libraries.crossgen2.Linux.arm64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 150168
Total bytes of diff: 147580
Total bytes of delta: -2588 (-1.72% of base)
Total relative delta: -6.51
    diff is an improvement.
    relative diff is an improvement.


Top method regressions (bytes):
          16 ( 0.72% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol:CheckModifiers(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           8 ( 3.28% of base) - System.Uri:CreateThisFromUri(System.Uri):this
           4 ( 0.13% of base) - System.Uri:CheckAuthorityHelper(long,int,int,byref,byref,System.UriParser,byref):int:this
           4 ( 1.69% of base) - System.Uri:get_DnsSafeHost():System.String:this

Top method improvements (bytes):
        -156 (-4.99% of base) - <WaitUntilCountOrTimeoutAsync>d__31:MoveNext():this
        -116 (-24.79% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:UnsafeOnCompleted(System.Action):this
        -116 (-24.79% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:OnCompleted(System.Action):this
         -88 (-3.74% of base) - <WriteAsyncInternal>d__65:MoveNext():this
         -80 (-18.87% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:Write(System.Byte[],int,int):this
         -68 (-4.21% of base) - <InternalWriteAllLinesAsync>d__81:MoveNext():this
         -68 (-4.16% of base) - <InternalWriteAllTextAsync>d__82:MoveNext():this
         -68 (-5.14% of base) - <<WriteLineAsync>g__WriteLineAsyncCore|66_0>d:MoveNext():this
         -64 (-15.09% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1:UnsafeOnCompleted(System.Action):this
         -64 (-15.09% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1:OnCompleted(System.Action):this
         -64 (-16.67% of base) - System.IO.Stream:EndRead(System.IAsyncResult):int:this
         -64 (-34.78% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult)
         -64 (-21.05% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:Read(System.Byte[],int,int):int:this
         -60 (-8.72% of base) - <OutputTabsAsync>d__22:MoveNext():this
         -60 (-11.28% of base) - ConfiguredValueTaskAwaiter:UnsafeOnCompleted(System.Action):this
         -60 (-26.79% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):int
         -60 (-4.66% of base) - <<ReadAsync>g__FinishReadAsync|44_0>d:MoveNext():this
         -60 (-11.19% of base) - ConfiguredValueTaskAwaiter:OnCompleted(System.Action):this
         -56 (-13.21% of base) - System.Threading.Tasks.UnwrapPromise`1:.ctor(System.Threading.Tasks.Task,bool):this
         -56 (-13.21% of base) - System.Threading.Tasks.UnwrapPromise`1:.ctor(System.Threading.Tasks.Task,bool):this

Top method regressions (percentages):
           8 ( 3.28% of base) - System.Uri:CreateThisFromUri(System.Uri):this
           4 ( 1.69% of base) - System.Uri:get_DnsSafeHost():System.String:this
          16 ( 0.72% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol:CheckModifiers(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           4 ( 0.13% of base) - System.Uri:CheckAuthorityHelper(long,int,int,byref,byref,System.UriParser,byref):int:this

Top method improvements (percentages):
         -64 (-34.78% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult)
         -48 (-30.00% of base) - System.Buffers.MemoryManager`1:get_Memory():System.Memory`1[System.__Canon]:this
         -48 (-30.00% of base) - System.Buffers.MemoryManager`1:get_Memory():System.Memory`1[System.Char]:this
         -60 (-26.79% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):int
        -116 (-24.79% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:UnsafeOnCompleted(System.Action):this
        -116 (-24.79% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:OnCompleted(System.Action):this
         -64 (-21.05% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:Read(System.Byte[],int,int):int:this
         -80 (-18.87% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:Write(System.Byte[],int,int):this
         -64 (-16.67% of base) - System.IO.Stream:EndRead(System.IAsyncResult):int:this
         -64 (-15.09% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1:UnsafeOnCompleted(System.Action):this
         -64 (-15.09% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1:OnCompleted(System.Action):this
          -4 (-14.29% of base) - System.Reflection.Metadata.Ecma335.TokenTypeIds:IsValidRowId(int):bool
         -56 (-13.21% of base) - System.Threading.Tasks.UnwrapPromise`1:.ctor(System.Threading.Tasks.Task,bool):this
         -56 (-13.21% of base) - System.Threading.Tasks.UnwrapPromise`1:.ctor(System.Threading.Tasks.Task,bool):this
          -4 (-12.50% of base) - System.Data.SqlTypes.SqlInt32:SameSignInt(int,int):bool
          -4 (-12.50% of base) - PEFile.IMAGE_RESOURCE_DIRECTORY_ENTRY:get_IsLeaf():bool:this
         -52 (-11.82% of base) - System.IO.Stream:EndWrite(System.IAsyncResult):this
         -60 (-11.28% of base) - ConfiguredValueTaskAwaiter:UnsafeOnCompleted(System.Action):this
         -60 (-11.19% of base) - ConfiguredValueTaskAwaiter:OnCompleted(System.Action):this
          -4 (-11.11% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol:get_IsAbstract():bool:this

161 total methods with Code Size differences (157 improved, 4 regressed), 29 unchanged.

Running asm diffs of libraries.pmi.Linux.arm64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 126180
Total bytes of diff: 124864
Total bytes of delta: -1316 (-1.04% of base)
Total relative delta: -5.19
    diff is an improvement.
    relative diff is an improvement.


Top method regressions (bytes):
          16 ( 1.69% of base) - System.Uri:InitializeUri(int,int,byref):this
          16 ( 0.98% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol:CheckModifiers(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           8 ( 4.08% of base) - System.Uri:CreateThisFromUri(System.Uri):this
           4 ( 2.27% of base) - System.Uri:get_DnsSafeHost():System.String:this
           4 ( 0.27% of base) - System.Uri:PrivateParseMinimal():int:this
           4 ( 0.15% of base) - System.Uri:CheckAuthorityHelper(long,int,int,byref,byref,System.UriParser,byref):int:this
           4 ( 0.37% of base) - System.Uri:InternalIsWellFormedOriginalString():bool:this
           4 ( 0.59% of base) - System.Uri:get_IdnHost():System.String:this

Top method improvements (bytes):
         -60 (-15.79% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Byte][System.Byte]:OnCompleted(System.Action):this
         -60 (-15.79% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Byte][System.Byte]:UnsafeOnCompleted(System.Action):this
         -56 (-11.57% of base) - ConfiguredValueTaskAwaiter[Byte][System.Byte]:UnsafeOnCompleted(System.Action):this
         -56 (-11.48% of base) - ConfiguredValueTaskAwaiter[Byte][System.Byte]:OnCompleted(System.Action):this
         -48 (-27.91% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):long
         -48 (-27.91% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):double
         -48 (-27.27% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):ubyte
         -48 (-27.27% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):short
         -44 (-12.64% of base) - System.Threading.Tasks.UnwrapPromise`1[Byte][System.Byte]:.ctor(System.Threading.Tasks.Task,bool):this
         -40 (-17.24% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):System.Numerics.Vector`1[Single]
         -32 (-25.81% of base) - System.Buffers.MemoryManager`1[Int16][System.Int16]:get_Memory():System.Memory`1[Int16]:this
         -28 (-2.46% of base) - System.Uri:CreateUriInfo(long):this
         -16 (-1.45% of base) - System.IO.Ports.SerialStream:.ctor(System.String,int,int,int,int,int,int,int,bool,bool,bool,ubyte):this
         -16 (-1.16% of base) - System.Security.Cryptography.Pkcs.Rfc3161TimestampRequest:ProcessResponse(System.ReadOnlyMemory`1[Byte],byref,byref,byref,bool):bool:this
         -12 (-0.41% of base) - System.Uri:GetCanonicalPath(byref,int):this
          -8 (-4.17% of base) - System.Drawing.Region:Dispose(bool):this
          -8 (-4.26% of base) - System.Drawing.Text.PrivateFontCollection:Dispose(bool):this
          -8 (-0.08% of base) - <ReceiveAsyncPrivate>d__68`1[Byte][System.Byte]:MoveNext():this
          -8 (-1.34% of base) - System.Net.WebClient:DownloadFileAsync(System.Uri,System.String,System.Object):this
          -8 (-1.15% of base) - System.Net.WebClient:UploadStringAsync(System.Uri,System.String,System.String,System.Object):this

Top method regressions (percentages):
           8 ( 4.08% of base) - System.Uri:CreateThisFromUri(System.Uri):this
           4 ( 2.27% of base) - System.Uri:get_DnsSafeHost():System.String:this
          16 ( 1.69% of base) - System.Uri:InitializeUri(int,int,byref):this
          16 ( 0.98% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol:CheckModifiers(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           4 ( 0.59% of base) - System.Uri:get_IdnHost():System.String:this
           4 ( 0.37% of base) - System.Uri:InternalIsWellFormedOriginalString():bool:this
           4 ( 0.27% of base) - System.Uri:PrivateParseMinimal():int:this
           4 ( 0.15% of base) - System.Uri:CheckAuthorityHelper(long,int,int,byref,byref,System.UriParser,byref):int:this

Top method improvements (percentages):
         -48 (-27.91% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):long
         -48 (-27.91% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):double
         -48 (-27.27% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):ubyte
         -48 (-27.27% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):short
         -32 (-25.81% of base) - System.Buffers.MemoryManager`1[Int16][System.Int16]:get_Memory():System.Memory`1[Int16]:this
         -40 (-17.24% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):System.Numerics.Vector`1[Single]
         -60 (-15.79% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Byte][System.Byte]:OnCompleted(System.Action):this
         -60 (-15.79% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Byte][System.Byte]:UnsafeOnCompleted(System.Action):this
          -4 (-14.29% of base) - System.Reflection.Metadata.Ecma335.TokenTypeIds:IsValidRowId(int):bool
         -44 (-12.64% of base) - System.Threading.Tasks.UnwrapPromise`1[Byte][System.Byte]:.ctor(System.Threading.Tasks.Task,bool):this
          -4 (-12.50% of base) - PEFile.IMAGE_RESOURCE_DIRECTORY_ENTRY:get_IsLeaf():bool:this
          -4 (-12.50% of base) - System.Data.SqlTypes.SqlInt32:SameSignInt(int,int):bool
         -56 (-11.57% of base) - ConfiguredValueTaskAwaiter[Byte][System.Byte]:UnsafeOnCompleted(System.Action):this
         -56 (-11.48% of base) - ConfiguredValueTaskAwaiter[Byte][System.Byte]:OnCompleted(System.Action):this
          -4 (-11.11% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol:get_IsAbstract():bool:this
          -4 (-11.11% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMethodSymbol:get_IsAbstract():bool:this
          -4 (-10.00% of base) - System.Xml.XmlReader:IsTextualNode(int):bool
          -4 (-9.09% of base) - System.Xml.XmlReader:HasValueInternal(int):bool
          -4 (-9.09% of base) - System.Xml.XmlReader:CanReadContentAs(int):bool
          -4 (-7.69% of base) - System.Uri:EnsureUriInfo():UriInfo:this

136 total methods with Code Size differences (128 improved, 8 regressed), 35 unchanged.

Running asm diffs of libraries_tests.pmi.Linux.arm64.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 49836
Total bytes of diff: 49060
Total bytes of delta: -776 (-1.56% of base)
Total relative delta: -7.38
    diff is an improvement.
    relative diff is an improvement.


Top method regressions (bytes):
          56 ( 2.53% of base) - <WriteAsyncMemory_WrapsNative_DelegatesToWrite_Success>d__5:MoveNext():this
          20 ( 0.99% of base) - <ReadAsyncMemory_WrapsNative_DelegatesToReadAsyncArrayWithPool_Success>d__3:MoveNext():this
          16 ( 1.55% of base) - System.Text.Json.Tests.BitStackTests:SetResetFirstBit()
           8 ( 0.52% of base) - System.Text.Json.Tests.BitStackTests:BitStackPushPopLarge(int)
           4 ( 0.39% of base) - System.Text.Json.Tests.BitStackTests:BitStackPushPop(int)

Top method improvements (bytes):
         -56 (-77.78% of base) - Microsoft.Extensions.Primitives.StringSegmentTest:StringSegment_Value_Invalid():this
         -44 (-40.74% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -44 (-40.74% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -44 (-39.29% of base) - BoundedMemoryManager[Byte][System.Byte]:get_Memory():System.Memory`1[Byte]:this
         -44 (-40.74% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -44 (-40.74% of base) - NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -44 (-40.74% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -44 (-39.29% of base) - DisposeTrackingMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -40 (-35.71% of base) - WindowsImplementation`1[Byte][System.Byte]:get_Memory():System.Memory`1[Byte]:this
         -40 (-38.46% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -32 (-57.14% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__4():System.Object:this
         -32 (-57.14% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__6():System.Object:this
         -32 (-57.14% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__7():System.Object:this
         -32 (-57.14% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__5():System.Object:this
         -16 (-0.96% of base) - <ReceiveAsync>d__2:MoveNext():this
         -12 (-1.73% of base) - System.Net.Security.SafeDeleteContext:MustRunInitializeSecurityContext(byref,bool,long,int,int,long,System.Net.Security.SafeDeleteContext,byref,byref,System.Net.Security.SafeFreeContextBuffer):int
         -12 (-1.82% of base) - System.Net.Security.SafeDeleteContext:MustRunAcceptSecurityContext_SECURITY(byref,bool,long,int,int,System.Net.Security.SafeDeleteContext,byref,byref,System.Net.Security.SafeFreeContextBuffer):int
         -12 (-0.73% of base) - <SendAsync>d__3:MoveNext():this
          -8 (-1.65% of base) - Microsoft.VisualBasic.CompilerServices.Conversions:ParseDecimal(System.String,System.Globalization.NumberFormatInfo):System.Decimal
          -8 (-1.92% of base) - Microsoft.VisualBasic.CompilerServices.Conversions:ParseDouble(System.String):double

Top method regressions (percentages):
          56 ( 2.53% of base) - <WriteAsyncMemory_WrapsNative_DelegatesToWrite_Success>d__5:MoveNext():this
          16 ( 1.55% of base) - System.Text.Json.Tests.BitStackTests:SetResetFirstBit()
          20 ( 0.99% of base) - <ReadAsyncMemory_WrapsNative_DelegatesToReadAsyncArrayWithPool_Success>d__3:MoveNext():this
           8 ( 0.52% of base) - System.Text.Json.Tests.BitStackTests:BitStackPushPopLarge(int)
           4 ( 0.39% of base) - System.Text.Json.Tests.BitStackTests:BitStackPushPop(int)

Top method improvements (percentages):
         -56 (-77.78% of base) - Microsoft.Extensions.Primitives.StringSegmentTest:StringSegment_Value_Invalid():this
         -32 (-57.14% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__4():System.Object:this
         -32 (-57.14% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__6():System.Object:this
         -32 (-57.14% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__7():System.Object:this
         -32 (-57.14% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__5():System.Object:this
         -44 (-40.74% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -44 (-40.74% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -44 (-40.74% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -44 (-40.74% of base) - NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -44 (-40.74% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -44 (-39.29% of base) - BoundedMemoryManager[Byte][System.Byte]:get_Memory():System.Memory`1[Byte]:this
         -44 (-39.29% of base) - DisposeTrackingMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -40 (-38.46% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -40 (-35.71% of base) - WindowsImplementation`1[Byte][System.Byte]:get_Memory():System.Memory`1[Byte]:this
          -8 (-22.22% of base) - Microsoft.CodeAnalysis.VisualBasic.Utilities.ModifierCollectionFacts:CouldApplyToOneOf(int):bool:this
          -4 (-12.50% of base) - Microsoft.Diagnostics.Runtime.Utilities.IMAGE_RESOURCE_DIRECTORY_ENTRY:get_IsLeaf():bool:this
          -8 (-4.65% of base) - <>c__DisplayClass74_0:<ExecuteSubmission>b__0():this
          -8 (-3.28% of base) - System.IO.Tests.File_ReadWriteAllBytes:ProcFs_EqualsReadAllText(System.String):this
          -8 (-2.33% of base) - <>c__DisplayClass73_0:<ExecuteSubmission>b__0():this
          -4 (-2.22% of base) - Roslyn.Utilities.DecimalUtilities:GetBits(System.Decimal,byref,byref,byref,byref,byref)

58 total methods with Code Size differences (53 improved, 5 regressed), 4 unchanged.
```
</details>

<details>
<summary>Linux ARM</summary>

```
Running asm diffs of coreclr_tests.pmi.Linux.arm.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3870988
Total bytes of diff: 3870698
Total bytes of delta: -290 (-0.01% of base)
Total relative delta: -2.06
    diff is an improvement.
    relative diff is an improvement.


Top method regressions (bytes):
           4 ( 0.02% of base) - Program:TestCase0011()
           4 ( 0.02% of base) - Program:TestCase0005()
           4 ( 0.02% of base) - Program:TestCase0005()
           4 ( 0.02% of base) - Program:TestCase0002()
           4 ( 0.02% of base) - Program:TestCase0017()
           4 ( 0.02% of base) - Program:TestCase0002()
           4 ( 0.02% of base) - Program:TestCase0011()
           4 ( 0.02% of base) - Program:TestCase0017()
           2 ( 0.02% of base) - Program:TestCase0036()
           2 ( 0.02% of base) - Program:TestCase0007()
           2 ( 0.02% of base) - Program:TestCase0015()
           2 ( 0.02% of base) - Program:TestCase0022()
           2 ( 0.01% of base) - Program:TestCase0006()
           2 ( 0.01% of base) - Program:TestCase0007()
           2 ( 0.03% of base) - Program:TestCase0005()
           2 ( 0.03% of base) - Program:TestCase0002()
           2 ( 0.02% of base) - Program:TestCase0016()
           2 ( 0.02% of base) - Program:TestCase0017()
           2 ( 0.02% of base) - Program:TestCase0018()
           2 ( 0.02% of base) - Program:TestCase0002()

Top method improvements (bytes):
         -32 (-0.08% of base) - longMDArrTest:Main():int
         -32 (-0.08% of base) - ulongMDArrTest:Main():int
         -12 (-1.00% of base) - Threading.Tests.OSThreadId:Main(System.String[]):int
         -10 (-5.21% of base) - C:Test6(int):int
         -10 (-4.55% of base) - PInvokeTest.Test:FromFilter():bool
         -10 (-0.69% of base) - AA:Static5(System.Double[],byref,byref,ushort,System.Boolean[][],byref,System.UInt32[][,,],long):System.SByte[,][]
         -10 (-4.31% of base) - C:Test1Inner():int
         -10 (-5.56% of base) - C:Test5(int):int
         -10 (-0.56% of base) - System.Net.Sockets.Socket:Dispose(bool):this
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.19% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[Int64,Boolean]
          -6 (-3.19% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[Int64,Boolean]
          -6 (-3.19% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[Int64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.19% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[Int64,Boolean]
          -6 (-3.19% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[Int64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.19% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[Int64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]

Top method regressions (percentages):
           2 ( 0.05% of base) - Program:TestCase0002()
           2 ( 0.05% of base) - Program:TestCase0002()
           2 ( 0.03% of base) - Program:TestCase0002()
           2 ( 0.03% of base) - Program:TestCase0005()
           2 ( 0.03% of base) - Program:TestCase0005()
           2 ( 0.03% of base) - Program:TestCase0002()
           4 ( 0.02% of base) - Program:TestCase0017()
           4 ( 0.02% of base) - Program:TestCase0011()
           4 ( 0.02% of base) - Program:TestCase0005()
           4 ( 0.02% of base) - Program:TestCase0002()
           4 ( 0.02% of base) - Program:TestCase0017()
           4 ( 0.02% of base) - Program:TestCase0005()
           4 ( 0.02% of base) - Program:TestCase0002()
           4 ( 0.02% of base) - Program:TestCase0011()
           2 ( 0.02% of base) - Program:TestCase0007()
           2 ( 0.02% of base) - Program:TestCase0015()
           2 ( 0.02% of base) - Program:TestCase0022()
           2 ( 0.02% of base) - Program:TestCase0014()
           2 ( 0.02% of base) - Program:TestCase0021()
           2 ( 0.02% of base) - Program:TestCase0003()

Top method improvements (percentages):
          -6 (-9.68% of base) - Program:I8_BT_mem_reg(byref,int):bool
          -6 (-8.57% of base) - Program:I8_BT_reg_reg(long,int):bool
         -10 (-5.56% of base) - C:Test5(int):int
         -10 (-5.21% of base) - C:Test6(int):int
         -10 (-4.55% of base) - PInvokeTest.Test:FromFilter():bool
          -4 (-4.44% of base) - Internal.IL.EcmaMethodIL:GetObject(int,int):System.Object:this
         -10 (-4.31% of base) - C:Test1Inner():int
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]
          -6 (-3.66% of base) - JIT.HardwareIntrinsics.Arm.Helpers:ShiftOvf(long,int):System.ValueTuple`2[UInt64,Boolean]

158 total methods with Code Size differences (74 improved, 84 regressed), 132 unchanged.

Running asm diffs of libraries.crossgen.Linux.arm.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 135192
Total bytes of diff: 131546
Total bytes of delta: -3646 (-2.70% of base)
Total relative delta: -16.77
    diff is an improvement.
    relative diff is an improvement.


Top method regressions (bytes):
          22 ( 0.79% of base) - System.Uri:CheckAuthorityHelper(int,int,int,byref,byref,System.UriParser,byref):int:this
           6 ( 1.97% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMethodSymbol:CheckModifiersForBody(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this

Top method improvements (bytes):
        -186 (-1.49% of base) - System.Reflection.Metadata.MetadataReader:InitializeTableReaders(System.Reflection.Internal.MemoryBlock,ubyte,System.Int32[],System.Int32[]):this
        -154 (-6.56% of base) - <WaitUntilCountOrTimeoutAsync>d__31:MoveNext():this
        -146 (-5.55% of base) - System.Uri:GetCanonicalPath(byref,int):this
        -120 (-6.04% of base) - System.Uri:GetUriPartsFromUserString(int):System.String:this
         -88 (-25.73% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:UnsafeOnCompleted(System.Action):this
         -88 (-25.73% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Boolean][System.Boolean]:OnCompleted(System.Action):this
         -88 (-25.73% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Boolean][System.Boolean]:UnsafeOnCompleted(System.Action):this
         -88 (-25.73% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:OnCompleted(System.Action):this
         -78 (-4.52% of base) - <WriteAsyncInternal>d__65:MoveNext():this
         -54 (-12.80% of base) - ConfiguredValueTaskAwaiter[Int32][System.Int32]:OnCompleted(System.Action):this
         -54 (-12.92% of base) - ConfiguredValueTaskAwaiter[Int32][System.Int32]:UnsafeOnCompleted(System.Action):this
         -54 (-18.12% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:Write(System.Byte[],int,int):this
         -52 (-18.44% of base) - System.IO.Stream:EndRead(System.IAsyncResult):int:this
         -52 (-38.81% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult)
         -50 (-15.53% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[__Canon][System.__Canon]:OnCompleted(System.Action):this
         -50 (-29.41% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):int
         -50 (-15.53% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[__Canon][System.__Canon]:UnsafeOnCompleted(System.Action):this
         -50 (-5.52% of base) - <<ReadAsync>g__FinishReadAsync|44_0>d:MoveNext():this
         -50 (-21.01% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:Read(System.Byte[],int,int):int:this
         -48 (-14.91% of base) - System.Threading.Tasks.UnwrapPromise`1[VoidTaskResult][System.Threading.Tasks.VoidTaskResult]:.ctor(System.Threading.Tasks.Task,bool):this

Top method regressions (percentages):
           6 ( 1.97% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMethodSymbol:CheckModifiersForBody(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
          22 ( 0.79% of base) - System.Uri:CheckAuthorityHelper(int,int,int,byref,byref,System.UriParser,byref):int:this

Top method improvements (percentages):
         -52 (-38.81% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult)
         -12 (-37.50% of base) - System.Uri:get_IsUncOrDosPath():bool:this
         -12 (-37.50% of base) - System.Uri:get_IsDosPath():bool:this
         -12 (-37.50% of base) - System.Uri:get_UserDrivenParsing():bool:this
         -12 (-37.50% of base) - System.Uri:get_IsImplicitFile():bool:this
         -12 (-37.50% of base) - System.Uri:get_IsUncPath():bool:this
         -12 (-37.50% of base) - System.Uri:get_UserEscaped():bool:this
         -40 (-33.33% of base) - System.Buffers.MemoryManager`1[__Canon][System.__Canon]:get_Memory():System.Memory`1[__Canon]:this
         -40 (-33.33% of base) - System.Buffers.MemoryManager`1[Char][System.Char]:get_Memory():System.Memory`1[Char]:this
         -50 (-29.41% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):int
         -12 (-28.57% of base) - System.Xml.XmlReader:IsTextualNode(int):bool
         -10 (-27.78% of base) - Microsoft.FSharp.Text.StructuredPrintfImpl.LayoutTag:GetHashCode():int:this
         -10 (-27.78% of base) - ShowMode:GetHashCode():int:this
         -10 (-27.78% of base) - TupleType:GetHashCode():int:this
         -12 (-26.09% of base) - System.Xml.XmlReader:CanReadContentAs(int):bool
         -12 (-26.09% of base) - System.Xml.XmlReader:HasValueInternal(int):bool
         -88 (-25.73% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:UnsafeOnCompleted(System.Action):this
         -88 (-25.73% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Boolean][System.Boolean]:OnCompleted(System.Action):this
         -88 (-25.73% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Boolean][System.Boolean]:UnsafeOnCompleted(System.Action):this
         -88 (-25.73% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:OnCompleted(System.Action):this

237 total methods with Code Size differences (235 improved, 2 regressed), 3 unchanged.

Running asm diffs of libraries.crossgen2.Linux.arm.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 147094
Total bytes of diff: 143538
Total bytes of delta: -3556 (-2.42% of base)
Total relative delta: -16.39
    diff is an improvement.
    relative diff is an improvement.


Top method regressions (bytes):
          22 ( 0.79% of base) - System.Uri:CheckAuthorityHelper(int,int,int,byref,byref,System.UriParser,byref):int:this
           8 ( 0.42% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol:CheckModifiers(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           4 ( 0.45% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceUserDefinedOperatorSymbolBase:.ctor(int,System.String,Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol,Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.SyntaxReference,Microsoft.CodeAnalysis.SyntaxReference,Microsoft.CodeAnalysis.SyntaxTokenList,Microsoft.CodeAnalysis.DiagnosticBag,bool):this
           2 ( 0.66% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMethodSymbol:CheckModifiersForBody(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this

Top method improvements (bytes):
        -186 (-1.49% of base) - System.Reflection.Metadata.MetadataReader:InitializeTableReaders(System.Reflection.Internal.MemoryBlock,ubyte,System.Int32[],System.Int32[]):this
        -154 (-6.56% of base) - <WaitUntilCountOrTimeoutAsync>d__31:MoveNext():this
        -146 (-5.38% of base) - System.Uri:GetCanonicalPath(byref,int):this
        -120 (-6.01% of base) - System.Uri:GetUriPartsFromUserString(int):System.String:this
         -88 (-25.73% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:OnCompleted(System.Action):this
         -88 (-25.73% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:UnsafeOnCompleted(System.Action):this
         -78 (-4.49% of base) - <WriteAsyncInternal>d__65:MoveNext():this
         -54 (-18.12% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:Write(System.Byte[],int,int):this
         -54 (-12.92% of base) - ConfiguredValueTaskAwaiter:UnsafeOnCompleted(System.Action):this
         -54 (-12.80% of base) - ConfiguredValueTaskAwaiter:OnCompleted(System.Action):this
         -52 (-38.81% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult)
         -52 (-18.44% of base) - System.IO.Stream:EndRead(System.IAsyncResult):int:this
         -50 (-5.34% of base) - <<ReadAsync>g__FinishReadAsync|44_0>d:MoveNext():this
         -50 (-21.01% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:Read(System.Byte[],int,int):int:this
         -50 (-15.53% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1:UnsafeOnCompleted(System.Action):this
         -50 (-30.12% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):int
         -50 (-15.53% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1:OnCompleted(System.Action):this
         -50 (-6.72% of base) - <<WriteAsync>g__WriteAsyncCore|60_0>d:MoveNext():this
         -48 (-14.91% of base) - System.Threading.Tasks.UnwrapPromise`1:.ctor(System.Threading.Tasks.Task,bool):this
         -48 (-14.91% of base) - System.Threading.Tasks.UnwrapPromise`1:.ctor(System.Threading.Tasks.Task,bool):this

Top method regressions (percentages):
          22 ( 0.79% of base) - System.Uri:CheckAuthorityHelper(int,int,int,byref,byref,System.UriParser,byref):int:this
           2 ( 0.66% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMethodSymbol:CheckModifiersForBody(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           4 ( 0.45% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceUserDefinedOperatorSymbolBase:.ctor(int,System.String,Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol,Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.SyntaxReference,Microsoft.CodeAnalysis.SyntaxReference,Microsoft.CodeAnalysis.SyntaxTokenList,Microsoft.CodeAnalysis.DiagnosticBag,bool):this
           8 ( 0.42% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol:CheckModifiers(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this

Top method improvements (percentages):
         -52 (-38.81% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult)
         -12 (-37.50% of base) - System.Uri:get_IsUncPath():bool:this
         -12 (-37.50% of base) - System.Uri:get_IsDosPath():bool:this
         -12 (-37.50% of base) - System.Uri:get_IsUncOrDosPath():bool:this
         -12 (-37.50% of base) - System.Uri:get_IsImplicitFile():bool:this
         -12 (-37.50% of base) - System.Uri:get_UserDrivenParsing():bool:this
         -12 (-37.50% of base) - System.Uri:get_UserEscaped():bool:this
         -50 (-30.12% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):int
         -12 (-28.57% of base) - System.Xml.XmlReader:IsTextualNode(int):bool
         -36 (-28.12% of base) - System.Buffers.MemoryManager`1:get_Memory():System.Memory`1[System.Char]:this
         -36 (-28.12% of base) - System.Buffers.MemoryManager`1:get_Memory():System.Memory`1[System.__Canon]:this
         -10 (-27.78% of base) - ShowMode:GetHashCode():int:this
         -10 (-27.78% of base) - TupleType:GetHashCode():int:this
         -10 (-27.78% of base) - Microsoft.FSharp.Text.StructuredPrintfImpl.LayoutTag:GetHashCode():int:this
         -12 (-26.09% of base) - System.Xml.XmlReader:CanReadContentAs(int):bool
         -12 (-26.09% of base) - System.Xml.XmlReader:HasValueInternal(int):bool
         -88 (-25.73% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:OnCompleted(System.Action):this
         -88 (-25.73% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter:UnsafeOnCompleted(System.Action):this
          -8 (-22.22% of base) - System.Uri:EnsureParseRemaining():this
         -50 (-21.01% of base) - System.IO.Strategies.Net5CompatFileStreamStrategy:Read(System.Byte[],int,int):int:this

247 total methods with Code Size differences (243 improved, 4 regressed), 7 unchanged.

Running asm diffs of libraries.pmi.Linux.arm.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 194692
Total bytes of diff: 191160
Total bytes of delta: -3532 (-1.81% of base)
Total relative delta: -16.81
    diff is an improvement.
    relative diff is an improvement.


Top method regressions (bytes):
          60 ( 2.25% of base) - System.Uri:CheckAuthorityHelper(int,int,int,byref,byref,System.UriParser,byref):int:this
          20 ( 1.26% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol:CheckModifiers(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           4 ( 0.50% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceUserDefinedOperatorSymbolBase:.ctor(int,System.String,Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol,Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.SyntaxReference,Microsoft.CodeAnalysis.SyntaxReference,Microsoft.CodeAnalysis.SyntaxTokenList,Microsoft.CodeAnalysis.DiagnosticBag,bool):this

Top method improvements (bytes):
        -186 (-1.62% of base) - System.Reflection.Metadata.MetadataReader:InitializeTableReaders(System.Reflection.Internal.MemoryBlock,ubyte,System.Int32[],System.Int32[]):this
        -184 (-4.81% of base) - System.Uri:ReCreateParts(int,ushort,int):System.String:this
        -168 (-5.35% of base) - System.Uri:GetCanonicalPath(byref,int):this
        -120 (-4.71% of base) - System.Uri:GetUriPartsFromUserString(int):System.String:this
        -100 (-10.57% of base) - System.Uri:InternalIsWellFormedOriginalString():bool:this
         -66 (-20.62% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Byte][System.Byte]:OnCompleted(System.Action):this
         -66 (-20.62% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Byte][System.Byte]:UnsafeOnCompleted(System.Action):this
         -42 (-5.95% of base) - System.Uri:ResolveHelper(System.Uri,System.Uri,byref,byref):System.Uri
         -42 (-2.94% of base) - System.Uri:PrivateParseMinimal():int:this
         -38 (-25.68% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):short
         -38 (-26.03% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):double
         -38 (-24.68% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):long
         -38 (-25.68% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):ubyte
         -38 (-3.81% of base) - System.Uri:CreateUriInfo(long):this
         -36 (-9.18% of base) - ConfiguredValueTaskAwaiter[Byte][System.Byte]:OnCompleted(System.Action):this
         -36 (-9.28% of base) - ConfiguredValueTaskAwaiter[Byte][System.Byte]:UnsafeOnCompleted(System.Action):this
         -36 (-4.04% of base) - System.Uri:GetLocalPath():System.String:this
         -36 (-24.00% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):System.Numerics.Vector`1[Single]
         -36 (-12.59% of base) - System.Threading.Tasks.UnwrapPromise`1[Byte][System.Byte]:.ctor(System.Threading.Tasks.Task,bool):this
         -32 (-31.37% of base) - System.Buffers.MemoryManager`1[Int16][System.Int16]:get_Memory():System.Memory`1[Int16]:this

Top method regressions (percentages):
          60 ( 2.25% of base) - System.Uri:CheckAuthorityHelper(int,int,int,byref,byref,System.UriParser,byref):int:this
          20 ( 1.26% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberMethodSymbol:CheckModifiers(Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.DiagnosticBag):this
           4 ( 0.50% of base) - Microsoft.CodeAnalysis.CSharp.Symbols.SourceUserDefinedOperatorSymbolBase:.ctor(int,System.String,Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberContainerTypeSymbol,Microsoft.CodeAnalysis.Location,Microsoft.CodeAnalysis.SyntaxReference,Microsoft.CodeAnalysis.SyntaxReference,Microsoft.CodeAnalysis.SyntaxTokenList,Microsoft.CodeAnalysis.DiagnosticBag,bool):this

Top method improvements (percentages):
         -12 (-37.50% of base) - System.Uri:get_IsImplicitFile():bool:this
         -12 (-37.50% of base) - System.Uri:get_IsUncOrDosPath():bool:this
         -12 (-37.50% of base) - System.Uri:get_UserDrivenParsing():bool:this
         -12 (-37.50% of base) - System.Uri:get_IsDosPath():bool:this
         -12 (-37.50% of base) - System.Uri:get_IsUncPath():bool:this
         -12 (-37.50% of base) - System.Uri:get_UserEscaped():bool:this
         -32 (-31.37% of base) - System.Buffers.MemoryManager`1[Int16][System.Int16]:get_Memory():System.Memory`1[Int16]:this
         -12 (-28.57% of base) - System.Xml.XmlReader:IsTextualNode(int):bool
         -12 (-26.09% of base) - System.Xml.XmlReader:CanReadContentAs(int):bool
         -12 (-26.09% of base) - System.Xml.XmlReader:HasValueInternal(int):bool
         -38 (-26.03% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):double
         -38 (-25.68% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):short
         -38 (-25.68% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):ubyte
          -8 (-25.00% of base) - System.Uri:EnsureParseRemaining():this
         -10 (-25.00% of base) - Microsoft.FSharp.Text.StructuredPrintfImpl.LayoutTag:GetHashCode():int:this
         -10 (-25.00% of base) - ShowMode:GetHashCode():int:this
         -10 (-25.00% of base) - TupleType:GetHashCode():int:this
         -38 (-24.68% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):long
         -36 (-24.00% of base) - System.Threading.Tasks.TaskToApm:End(System.IAsyncResult):System.Numerics.Vector`1[Single]
         -66 (-20.62% of base) - System.Runtime.CompilerServices.ValueTaskAwaiter`1[Byte][System.Byte]:OnCompleted(System.Action):this

342 total methods with Code Size differences (339 improved, 3 regressed), 5 unchanged.

Running asm diffs of libraries_tests.pmi.Linux.arm.checked.mch

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 60060
Total bytes of diff: 58786
Total bytes of delta: -1274 (-2.12% of base)
Total relative delta: -8.88
    diff is an improvement.
    relative diff is an improvement.


Top file improvements (bytes):
         -96 : 18767.dasm (-7.91% of base)
         -56 : 158520.dasm (-4.06% of base)
         -56 : 304735.dasm (-84.85% of base)
         -48 : 18769.dasm (-3.19% of base)
         -46 : 158522.dasm (-3.43% of base)
         -28 : 115176.dasm (-56.00% of base)
         -28 : 115175.dasm (-56.00% of base)
         -28 : 115178.dasm (-56.00% of base)
         -28 : 115177.dasm (-56.00% of base)
         -26 : 114684.dasm (-31.71% of base)
         -26 : 188212.dasm (-31.71% of base)
         -26 : 189299.dasm (-1.47% of base)
         -26 : 234063.dasm (-31.71% of base)
         -26 : 156336.dasm (-31.71% of base)
         -26 : 7378.dasm (-31.71% of base)
         -26 : 222123.dasm (-30.95% of base)
         -26 : 247975.dasm (-31.71% of base)
         -26 : 277039.dasm (-30.95% of base)
         -24 : 277020.dasm (-28.57% of base)
         -24 : 19681.dasm (-0.99% of base)

86 total files with Code Size differences (86 improved, 0 regressed), 2 unchanged.

Top method improvements (bytes):
         -96 (-7.91% of base) - System.Text.Json.Tests.BitStackTests:SetResetFirstBit()
         -56 (-4.06% of base) - <ReceiveAsync>d__2:MoveNext():this
         -56 (-84.85% of base) - Microsoft.Extensions.Primitives.StringSegmentTest:StringSegment_Value_Invalid():this
         -48 (-3.19% of base) - System.Text.Json.Tests.BitStackTests:BitStackPushPopLarge(int)
         -46 (-3.43% of base) - <SendAsync>d__3:MoveNext():this
         -28 (-56.00% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__5():System.Object:this
         -28 (-56.00% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__4():System.Object:this
         -28 (-56.00% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__7():System.Object:this
         -28 (-56.00% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__6():System.Object:this
         -26 (-31.71% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -26 (-31.71% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -26 (-1.47% of base) - <ReadAsyncMemory_WrapsNative_DelegatesToReadAsyncArrayWithPool_Success>d__3:MoveNext():this
         -26 (-31.71% of base) - NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -26 (-31.71% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -26 (-31.71% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -26 (-30.95% of base) - DisposeTrackingMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -26 (-31.71% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -26 (-30.95% of base) - BoundedMemoryManager[Byte][System.Byte]:get_Memory():System.Memory`1[Byte]:this
         -24 (-28.57% of base) - WindowsImplementation`1[Byte][System.Byte]:get_Memory():System.Memory`1[Byte]:this
         -24 (-0.99% of base) - System.Text.Json.Tests.Utf8JsonWriterTests:ResetChangeOutputMode(bool,bool):this

Top method improvements (percentages):
         -56 (-84.85% of base) - Microsoft.Extensions.Primitives.StringSegmentTest:StringSegment_Value_Invalid():this
         -28 (-56.00% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__5():System.Object:this
         -28 (-56.00% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__4():System.Object:this
         -28 (-56.00% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__7():System.Object:this
         -28 (-56.00% of base) - <>c__DisplayClass78_0:<MemoryManagerMemoryCtorInvalid>b__6():System.Object:this
         -26 (-31.71% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -26 (-31.71% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -26 (-31.71% of base) - NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -26 (-31.71% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -26 (-31.71% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -26 (-31.71% of base) - System.Buffers.NativeMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -26 (-30.95% of base) - DisposeTrackingMemoryManager:get_Memory():System.Memory`1[Byte]:this
         -26 (-30.95% of base) - BoundedMemoryManager[Byte][System.Byte]:get_Memory():System.Memory`1[Byte]:this
          -8 (-30.77% of base) - Microsoft.CodeAnalysis.VisualBasic.Utilities.ModifierCollectionFacts:CouldApplyToOneOf(int):bool:this
         -24 (-28.57% of base) - WindowsImplementation`1[Byte][System.Byte]:get_Memory():System.Memory`1[Byte]:this
         -20 (-17.86% of base) - System.Text.Json.BitStack:Pop():bool:this
          -4 (-15.38% of base) - <>c:<get_UInt64TestDivisions>b__105_2(<>f__AnonymousType0`2[UInt64,UInt64]):bool:this
          -6 (-15.00% of base) - HashBucket[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:IsInUse(int):bool:this
          -6 (-15.00% of base) - HashBucket[__Canon,Nullable`1][System.__Canon,System.Nullable`1[System.Int32]]:IsInUse(int):bool:this
          -4 (-13.33% of base) - <>c__DisplayClass0_0:<InvalidArgs_Throws>b__1():System.Object:this

86 total methods with Code Size differences (86 improved, 0 regressed), 2 unchanged.
```
</details>

Almost all regressions are caused by now missing CSEs as morph changes more trees. The small tests regressions are because of slightly different register allocation. I think, given the overall positive impact, the regressions are acceptable.


~~I still need to drill down into what's causing such CQ improvements.~~
Done, see below.