### PR TITLE
add pre-cancellation check and enable ReadWriteAsync_PrecanceledOperations_ThrowsCancellationException for QUIC

### DIFF
--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamConnectedStreamConformanceTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamConnectedStreamConformanceTests.cs
@@ -40,8 +40,6 @@ namespace System.Net.Quic.Tests
 
         // TODO: new additions, find out the actual reason for hanging
         [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
-        public override Task ReadWriteAsync_PrecanceledOperations_ThrowsCancellationException() => base.ReadWriteAsync_PrecanceledOperations_ThrowsCancellationException();
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
         public override Task Read_DataStoredAtDesiredOffset(ReadWriteMode mode) => base.Read_DataStoredAtDesiredOffset(mode);
         [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
         public override Task ReadAsync_DuringReadAsync_ThrowsIfUnsupported() => base.ReadAsync_DuringReadAsync_ThrowsIfUnsupported();


### PR DESCRIPTION
As discussed with @stephentoub off-line the test makes assumption that the first cancellation leaves Stream in usable state and perhaps deserves updated. However since no other Stream needs the change I decided to proceed only with the product change and check cancellation status beforehand like we do in other streams. 