### PR TITLE
Avoid sending EndStream after RST_STREAM with dedicated lock

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -387,7 +387,6 @@ namespace System.Net.Http
                 // When cancellation propagates, SendRequestBodyAsync will set _requestCompletionState to Failed
                 requestBodyCancellationSource?.Cancel();
 
-                // SendReset must be called under a lock and after a cancellation of requestBodyCancellationSource.
                 lock (SyncObject)
                 {
                     if (sendReset)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -325,7 +325,6 @@ namespace System.Net.Http
 
             private void SendReset()
             {
-                Debug.Assert(!Monitor.IsEntered(SyncObject));
                 Debug.Assert(_requestCompletionState != StreamCompletionState.InProgress);
                 Debug.Assert(_responseCompletionState != StreamCompletionState.InProgress);
                 Debug.Assert(_requestCompletionState == StreamCompletionState.Failed || _responseCompletionState == StreamCompletionState.Failed,


### PR DESCRIPTION
A race condition between sending RST_STREAM and checking conditions for sending EndStream was discovered during stress testing. It happens to be possible that in time after Http2Stream [checked the _responseCompletionState](https://github.com/dotnet/runtime/blob/183c4d100f68fb6c177a1fe71809d581aa25e47b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs#L275) and [actually send EndStream](https://github.com/dotnet/runtime/blob/183c4d100f68fb6c177a1fe71809d581aa25e47b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs#L288), a concurrent call to [Cancel method sends a RST_STREAM frame](https://github.com/dotnet/runtime/blob/183c4d100f68fb6c177a1fe71809d581aa25e47b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs#L389). Such reordering is disallowed by HTTP/2 protocol.

Note: The issue and fix were verified manually under the debugger because currently it's not clear how to reliably simulate that situation.

Fixes #42200 