### PR TITLE
Disable failing System.Reflection.Tests.ModuleTests.GetMethods

### DIFF
--- a/src/libraries/System.Runtime/tests/System/Reflection/ModuleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/ModuleTests.cs
@@ -232,6 +232,7 @@ namespace System.Reflection.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/51912", typeof(PlatformDetection), nameof(PlatformDetection.IsBuiltWithAggressiveTrimming), nameof(PlatformDetection.IsBrowser))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/50831")]
         public void GetMethods()
         {
             var methodNames = TestModule.GetMethods().Select(m => m.Name).ToArray();


### PR DESCRIPTION
Tracking: https://github.com/dotnet/runtime/issues/50831