### PR TITLE
Disable failing test BasicTestWithMcj under GCStress

### DIFF
--- a/src/tests/baseservices/TieredCompilation/BasicTestWithMcj.csproj
+++ b/src/tests/baseservices/TieredCompilation/BasicTestWithMcj.csproj
@@ -4,6 +4,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>
     <CLRTestPriority>0</CLRTestPriority>
+    <!-- Disable test for GCStress. Tracking: https://github.com/dotnet/runtime/issues/54203 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
     <!-- Generated shell script and corresponding assembly have different names -->
     <CLRTestTargetUnsupported Condition="'$(TargetOS)' == 'Android'">true</CLRTestTargetUnsupported>
   </PropertyGroup>


### PR DESCRIPTION
Tracking: https://github.com/dotnet/runtime/issues/54203