### PR TITLE
Disable another flaky MemoryCache test

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/MemoryCacheSetAndRemoveTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/MemoryCacheSetAndRemoveTests.cs
@@ -594,6 +594,7 @@ namespace Microsoft.Extensions.Caching.Memory
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/33993")]
         public void AddAndReplaceEntries_AreThreadSafe()
         {
             var cache = new MemoryCache(new MemoryCacheOptions


### PR DESCRIPTION
relates to https://github.com/dotnet/runtime/issues/33993

This particular test is failing ~8 times a month

Execute: [Web](https://dataexplorer.azure.com/clusters/engsrvprod.kusto.windows.net/databases/engineeringdata?query=H4sIAAAAAAAEAG2OQWvCQBCF74H8h8GLLaRgvaegBSGCQjXQ87r7MGvMrOxMWgL98d2k1F4KAzNv5g3vqyF6gPRXFcqzL7oEz9R6dqVnRqT3ENtK0QkFvovK%2fevdhtNkS71yo%2bGzQQRtPHtp4OilJGcU6js8LBfL56fFWI9k2FE93EA2sBrPQrMduhCHV2MbHKErdoe0%2bECdaGU2PfxAU1nSfGP8dT7mhegSxmn4i3QQO7HeYrjA6v1S0Doatk0xJRe0gzYhbVfx3HdglYLeevTYm268JhDPvwIi5pyGoxrb1tFY5FmefQOQxEAqSgEAAA%3d%3d) | [Desktop](https://engsrvprod.kusto.windows.net/engineeringdata?query=H4sIAAAAAAAEAG2OQWvCQBCF74H8h8GLLaRgvaegBSGCQjXQ87r7MGvMrOxMWgL98d2k1F4KAzNv5g3vqyF6gPRXFcqzL7oEz9R6dqVnRqT3ENtK0QkFvovK%2fevdhtNkS71yo%2bGzQQRtPHtp4OilJGcU6js8LBfL56fFWI9k2FE93EA2sBrPQrMduhCHV2MbHKErdoe0%2bECdaGU2PfxAU1nSfGP8dT7mhegSxmn4i3QQO7HeYrjA6v1S0Doatk0xJRe0gzYhbVfx3HdglYLeevTYm268JhDPvwIi5pyGoxrb1tFY5FmefQOQxEAqSgEAAA%3d%3d&web=0) | [Web (Lens)](https://lens.msftcloudes.com/v2/#/discover/query//results?datasource=(cluster:engsrvprod.kusto.windows.net,database:engineeringdata,type:Kusto)&query=H4sIAAAAAAAEAG2OQWvCQBCF74H8h8GLLaRgvaegBSGCQjXQ87r7MGvMrOxMWgL98d2k1F4KAzNv5g3vqyF6gPRXFcqzL7oEz9R6dqVnRqT3ENtK0QkFvovK%2fevdhtNkS71yo%2bGzQQRtPHtp4OilJGcU6js8LBfL56fFWI9k2FE93EA2sBrPQrMduhCHV2MbHKErdoe0%2bECdaGU2PfxAU1nSfGP8dT7mhegSxmn4i3QQO7HeYrjA6v1S0Doatk0xJRe0gzYhbVfx3HdglYLeevTYm268JhDPvwIi5pyGoxrb1tFY5FmefQOQxEAqSgEAAA%3d%3d&runquery=1) | [Desktop (SAW)](https://engsrvprod.kusto.windows.net/engineeringdata?query=H4sIAAAAAAAEAG2OQWvCQBCF74H8h8GLLaRgvaegBSGCQjXQ87r7MGvMrOxMWgL98d2k1F4KAzNv5g3vqyF6gPRXFcqzL7oEz9R6dqVnRqT3ENtK0QkFvovK%2fevdhtNkS71yo%2bGzQQRtPHtp4OilJGcU6js8LBfL56fFWI9k2FE93EA2sBrPQrMduhCHV2MbHKErdoe0%2bECdaGU2PfxAU1nSfGP8dT7mhegSxmn4i3QQO7HeYrjA6v1S0Doatk0xJRe0gzYhbVfx3HdglYLeevTYm268JhDPvwIi5pyGoxrb1tFY5FmefQOQxEAqSgEAAA%3d%3d&saw=1)

https://engsrvprod.kusto.windows.net/engineeringdata
<!-- csl: https://engsrvprod.kusto.windows.net -->
```kusto
TestResults 
| join kind=inner WorkItems on WorkItemId 
| join kind=inner Jobs on JobId
| where Finished >= datetime(2021-01-01) and Type contains "MemoryCacheSetAndRemoveTests" and Result == 'Fail'
| order by Finished desc 
| project Finished, Branch, Type, Method, Arguments, QueueName, MachineName, Message, StackTrace
```
example results:
Message
Assert.Equal() Failure
Expected: 2
Actual:   4
Assert.Equal() Failure
Expected: 7
Actual:   8
Assert.Equal() Failure
Expected: 7
Actual:   9
Assert.Equal() Failure
Expected: 5
Actual:   7
Assert.Equal() Failure
Expected: 8
Actual:   9
Assert.Equal() Failure
Expected: 6
Actual:   10
Assert.Equal() Failure
Expected: 3
Actual:   7
Assert.Equal() Failure
Expected: 6
Actual:   9
Assert.Equal() Failure
Expected: 11
Actual:   14
Assert.Equal() Failure
Expected: 1
Actual:   4

I am not sure whether these issues are new in 6.0 or not: unfortunately there is not enough history and MemoryCacheSetAndRemoveTests tests do not fail enough to know.