### PR TITLE
Faster type load for scenarios made more common by generic math

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
@@ -257,12 +257,12 @@ namespace System.Runtime.CompilerServices
                 }
 
             extra:
-                if (mt->NonTrivialInterfaceCast)
+//                if (mt->NonTrivialInterfaceCast) Remove the NonTrivialInterfaceCast check for now as the uninstantiated interface being used for the curiously recurring pattern scenario makes more cases NonTrivial
                 {
                     goto slowPath;
                 }
 
-                obj = null;
+//                obj = null;
             }
 
         done:

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
@@ -257,12 +257,12 @@ namespace System.Runtime.CompilerServices
                 }
 
             extra:
-//                if (mt->NonTrivialInterfaceCast) Remove the NonTrivialInterfaceCast check for now as the uninstantiated interface being used for the curiously recurring pattern scenario makes more cases NonTrivial
+                if (mt->NonTrivialInterfaceCast)
                 {
                     goto slowPath;
                 }
 
-//                obj = null;
+                obj = null;
             }
 
         done:

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
@@ -408,7 +408,8 @@ namespace System.Runtime.CompilerServices
         private const uint enum_flag_NonTrivialInterfaceCast = 0x00080000 // enum_flag_Category_Array
                                                              | 0x40000000 // enum_flag_ComObject
                                                              | 0x00400000 // enum_flag_ICastable;
-                                                             | 0x00200000;// enum_flag_IDynamicInterfaceCastable;
+                                                             | 0x00200000 // enum_flag_IDynamicInterfaceCastable;
+                                                             | 0x00040000; // enum_flag_Category_ValueType
 
         private const int DebugClassNamePtr = // adjust for debug_m_szClassName
 #if DEBUG

--- a/src/coreclr/vm/amd64/asmconstants.h
+++ b/src/coreclr/vm/amd64/asmconstants.h
@@ -203,10 +203,6 @@ ASMCONSTANTS_C_ASSERT(METHODTABLE_EQUIVALENCE_FLAGS
 #define               METHODTABLE_EQUIVALENCE_FLAGS 0x0
 #endif
 
-#define               METHODTABLE_NONTRIVIALINTERFACECAST_FLAGS (0x00080000 + 0x40000000 + 0x00400000 + 0x00200000)
-ASMCONSTANTS_C_ASSERT(METHODTABLE_NONTRIVIALINTERFACECAST_FLAGS
-                    == MethodTable::enum_flag_NonTrivialInterfaceCast);
-
 #define               MethodTable__enum_flag_ContainsPointers 0x01000000
 ASMCONSTANTS_C_ASSERT(MethodTable__enum_flag_ContainsPointers
                     == MethodTable::enum_flag_ContainsPointers);

--- a/src/coreclr/vm/class.cpp
+++ b/src/coreclr/vm/class.cpp
@@ -1902,7 +1902,8 @@ TypeHandle MethodTable::GetDefItfForComClassItf()
     InterfaceMapIterator it = IterateInterfaceMap();
     if (it.Next())
     {
-        return TypeHandle(it.GetInterface());
+        // Can use GetInterfaceApprox, as there are no generic default interfaces
+        return TypeHandle(it.GetInterfaceApprox()); 
     }
     else
     {

--- a/src/coreclr/vm/classcompat.cpp
+++ b/src/coreclr/vm/classcompat.cpp
@@ -1242,7 +1242,7 @@ VOID MethodTableBuilder::BuildInteropVTable_ExpandInterface(InterfaceInfo_t *pIn
         MethodTable::InterfaceMapIterator it = pNewInterface->IterateInterfaceMap();
         while (it.Next()) {
             MethodTable *pItf = it.GetInterfaceApprox();
-            if (pItf->HasInstantiation() || pItf->IsGenericTypeDefinition())
+            if (pItf->HasInstantiation() || pItf->IsSpecialMarkerTypeForGenericCasting())
                 continue;
             
             BuildInteropVTable_ExpandInterface(pInterfaceMap, pItf,

--- a/src/coreclr/vm/classcompat.cpp
+++ b/src/coreclr/vm/classcompat.cpp
@@ -1241,7 +1241,11 @@ VOID MethodTableBuilder::BuildInteropVTable_ExpandInterface(InterfaceInfo_t *pIn
     if (pNewInterface->GetNumInterfaces() != 0) {
         MethodTable::InterfaceMapIterator it = pNewInterface->IterateInterfaceMap();
         while (it.Next()) {
-            BuildInteropVTable_ExpandInterface(pInterfaceMap, it.GetInterface(),
+            MethodTable *pItf = it.GetInterfaceApprox();
+            if (pItf->HasInstantiation() || pItf->IsGenericTypeDefinition())
+                continue;
+            
+            BuildInteropVTable_ExpandInterface(pInterfaceMap, pItf,
                                                pwInterfaceListSize, pdwMaxInterfaceMethods, FALSE);
         }
     }

--- a/src/coreclr/vm/clsload.cpp
+++ b/src/coreclr/vm/clsload.cpp
@@ -2281,7 +2281,8 @@ TypeHandle ClassLoader::LoadTypeDefOrRefOrSpecThrowing(Module *pModule,
                                                        LoadTypesFlag fLoadTypes/*=LoadTypes*/ ,
                                                        ClassLoadLevel level /* = CLASS_LOADED */,
                                                        BOOL dropGenericArgumentLevel /* = FALSE */,
-                                                       const Substitution *pSubst)
+                                                       const Substitution *pSubst,
+                                                       MethodTable *pMTInterfaceMapOwner)
 {
     CONTRACT(TypeHandle)
     {
@@ -2315,7 +2316,7 @@ TypeHandle ClassLoader::LoadTypeDefOrRefOrSpecThrowing(Module *pModule,
         }
         SigPointer sigptr(pSig, cSig);
         TypeHandle typeHnd = sigptr.GetTypeHandleThrowing(pModule, pTypeContext, fLoadTypes,
-                                                          level, dropGenericArgumentLevel, pSubst);
+                                                          level, dropGenericArgumentLevel, pSubst, (const ZapSig::Context *)0, pMTInterfaceMapOwner);
 #ifndef DACCESS_COMPILE
         if ((fNotFoundAction == ThrowIfNotFound) && typeHnd.IsNull())
             pModule->GetAssembly()->ThrowTypeLoadException(pInternalImport, typeDefOrRefOrSpec,
@@ -5294,7 +5295,7 @@ BOOL ClassLoader::CanAccessFamily(
             while (it.Next())
             {
                 // We only loosely check if they are of the same generic type
-                if (it.GetInterface()->HasSameTypeDefAs(pTargetClass))
+                if (it.HasSameTypeDefAs(pTargetClass))
                     return TRUE;
             }
         }

--- a/src/coreclr/vm/clsload.hpp
+++ b/src/coreclr/vm/clsload.hpp
@@ -680,7 +680,8 @@ public:
                                                      LoadTypesFlag fLoadTypes = LoadTypes,
                                                      ClassLoadLevel level = CLASS_LOADED,
                                                      BOOL dropGenericArgumentLevel = FALSE,
-                                                     const Substitution *pSubst = NULL /* substitution to apply if the token is a type spec with generic variables */ );
+                                                     const Substitution *pSubst = NULL /* substitution to apply if the token is a type spec with generic variables */,
+                                                     MethodTable *pMTInterfaceMapOwner = NULL);
 
     // Load constructed types by providing their constituents
     static TypeHandle LoadPointerOrByrefTypeThrowing(CorElementType typ,

--- a/src/coreclr/vm/comcallablewrapper.cpp
+++ b/src/coreclr/vm/comcallablewrapper.cpp
@@ -2520,12 +2520,13 @@ static IUnknown * GetComIPFromCCW_HandleExtendsCOMObject(
         MethodTable::InterfaceMapIterator intIt = pMT->IterateInterfaceMapFrom(intfIndex);
 
         // If the number of slots is 0, then no need to proceed
-        if (intIt.GetInterface()->GetNumVirtuals() != 0)
+        if (intIt.GetInterfaceApprox()->GetNumVirtuals() != 0)
         {
             MethodDesc *pClsMD = NULL;
+            _ASSERTE(!intIt.GetInterfaceApprox()->HasInstantiation());
 
             // Find the implementation for the first slot of the interface
-            DispatchSlot impl(pMT->FindDispatchSlot(intIt.GetInterface()->GetTypeID(), 0, FALSE /* throwOnConflict */));
+            DispatchSlot impl(pMT->FindDispatchSlot(intIt.GetInterfaceApprox()->GetTypeID(), 0, FALSE /* throwOnConflict */));
             CONSISTENCY_CHECK(!impl.IsNull());
 
             // Get the MethodDesc for this slot in the class
@@ -3991,7 +3992,7 @@ ComCallWrapperTemplate::CCWInterfaceMapIterator::CCWInterfaceMapIterator(TypeHan
     MethodTable::InterfaceMapIterator it = pMT->IterateInterfaceMap();
     while (it.Next())
     {
-        MethodTable *pItfMT = it.GetInterface();
+        MethodTable *pItfMT = it.GetInterface(pMT);
         AppendInterface(pItfMT);
     }
 

--- a/src/coreclr/vm/comcallablewrapper.cpp
+++ b/src/coreclr/vm/comcallablewrapper.cpp
@@ -2520,13 +2520,14 @@ static IUnknown * GetComIPFromCCW_HandleExtendsCOMObject(
         MethodTable::InterfaceMapIterator intIt = pMT->IterateInterfaceMapFrom(intfIndex);
 
         // If the number of slots is 0, then no need to proceed
-        if (intIt.GetInterfaceApprox()->GetNumVirtuals() != 0)
+        MethodTable* pItf = intIt.GetInterfaceApprox();
+        if (pItf->GetNumVirtuals() != 0)
         {
             MethodDesc *pClsMD = NULL;
-            _ASSERTE(!intIt.GetInterfaceApprox()->HasInstantiation());
+            _ASSERTE(!pItf->HasInstantiation());
 
             // Find the implementation for the first slot of the interface
-            DispatchSlot impl(pMT->FindDispatchSlot(intIt.GetInterfaceApprox()->GetTypeID(), 0, FALSE /* throwOnConflict */));
+            DispatchSlot impl(pMT->FindDispatchSlot(pItf->GetTypeID(), 0, FALSE /* throwOnConflict */));
             CONSISTENCY_CHECK(!impl.IsNull());
 
             // Get the MethodDesc for this slot in the class

--- a/src/coreclr/vm/cominterfacemarshaler.cpp
+++ b/src/coreclr/vm/cominterfacemarshaler.cpp
@@ -425,7 +425,7 @@ VOID COMInterfaceMarshaler::EnsureCOMInterfacesSupported(OBJECTREF oref, MethodT
 
     while (it.Next())
     {
-        MethodTable *pItfMT = it.GetInterface();
+        MethodTable *pItfMT = it.GetInterfaceApprox();
         if (!pItfMT)
             COMPlusThrow(kInvalidCastException, IDS_EE_CANNOT_COERCE_COMOBJECT);
 

--- a/src/coreclr/vm/compile.cpp
+++ b/src/coreclr/vm/compile.cpp
@@ -5235,7 +5235,7 @@ void CEEPreloader::ExpandTypeDependencies(TypeHandle th)
     MethodTable::InterfaceMapIterator intIterator = pMT->IterateInterfaceMap();
     while (intIterator.Next())
     {
-        TriageTypeForZap(intIterator.GetInterface(), TRUE);
+        TriageTypeForZap(intIterator.GetInterfaceApprox(), TRUE);
     }
 
     // Make sure approx types for all fields are saved
@@ -5423,7 +5423,7 @@ void CEEPreloader::TriageTypeFromSoftBoundModule(TypeHandle th, Module * pSoftBo
         MethodTable::InterfaceMapIterator intIterator = pMT->IterateInterfaceMap();
         while (intIterator.Next())
         {
-            TriageTypeFromSoftBoundModule(intIterator.GetInterface(), pSoftBoundModule);
+            TriageTypeFromSoftBoundModule(intIterator.GetInterfaceApprox(), pSoftBoundModule);
         }
 
         // It does not seem worth it to reject the remaining items

--- a/src/coreclr/vm/generics.cpp
+++ b/src/coreclr/vm/generics.cpp
@@ -705,7 +705,11 @@ BOOL RecursionGraph::CheckForIllegalRecursion()
     MethodTable::InterfaceMapIterator it = pMT->IterateInterfaceMap();
     while (it.Next())
     {
-        AddDependency(it.GetInterface());
+        MethodTable *pItfApprox = it.GetInterfaceApprox();
+        if (!pItfApprox->IsTypicalTypeDefinition())
+        {
+            AddDependency(pItfApprox);
+        }
     }
 
     // Check all owned nodes for expanding cycles. The edges recorded above must all

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -14301,9 +14301,10 @@ BOOL LoadDynamicInfoEntry(Module *currentModule,
                     MethodTable::InterfaceMapIterator it = thImpl.GetMethodTable()->IterateInterfaceMap();
                     while (it.Next())
                     {
-                        if (pInterfaceTypeCanonical == it.GetInterface()->GetCanonicalMethodTable())
+                        MethodTable *pItfInMap = it.GetInterface(thImpl.GetMethodTable());
+                        if (pInterfaceTypeCanonical == pItfInMap->GetCanonicalMethodTable())
                         {
-                            pDeclMethod = MethodDesc::FindOrCreateAssociatedMethodDesc(pDeclMethod, it.GetInterface(), FALSE, pDeclMethod->GetMethodInstantiation(), FALSE, TRUE);
+                            pDeclMethod = MethodDesc::FindOrCreateAssociatedMethodDesc(pDeclMethod, pItfInMap, FALSE, pDeclMethod->GetMethodInstantiation(), FALSE, TRUE);
                             break;
                         }
                     }

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -8973,7 +8973,7 @@ bool CEEInfo::resolveVirtualMethodHelper(CORINFO_DEVIRTUALIZATION_INFO * info)
                 int canonicallyMatchingInterfacesFound = 0;
                 while (it.Next())
                 {
-                    if (it.GetInterface()->GetCanonicalMethodTable() == pOwnerMT)
+                    if (it.GetInterface(pObjMT)->GetCanonicalMethodTable() == pOwnerMT)
                     {
                         canonicallyMatchingInterfacesFound++;
                         if (canonicallyMatchingInterfacesFound > 1)

--- a/src/coreclr/vm/marshalnative.cpp
+++ b/src/coreclr/vm/marshalnative.cpp
@@ -1064,7 +1064,7 @@ FCIMPL2(Object*, MarshalNative::InternalCreateWrapperOfType, Object* objUNSAFE, 
         MethodTable::InterfaceMapIterator it = pNewWrapMT->IterateInterfaceMap();
         while (it.Next())
         {
-            MethodTable *pItfMT = it.GetInterface();
+            MethodTable *pItfMT = it.GetInterfaceApprox(); // ComImport interfaces cannot be generic
             if (pItfMT->IsComImport())
             {
                 if (!Object::SupportsInterface(gc.obj, pItfMT))

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -1240,6 +1240,20 @@ public:
 
     BOOL ContainsGenericMethodVariables();
 
+    // When creating an interface map, under some circumstances the
+    // runtime will place the special marker type in the interface map instead
+    // of the fully loaded type. This is to reduce the amount of type loading
+    // performed at process startup.
+    //
+    // The current rule is that these interfaces can only appear
+    // on valuetypes that are not shared generic, and that the special
+    // marker type is the open generic type.
+    // 
+    inline bool IsSpecialMarkerTypeForGenericCasting()
+    {
+        return IsGenericTypeDefinition();
+    }
+
     static BOOL ComputeContainsGenericVariables(Instantiation inst);
 
     inline void SetContainsGenericVariables()
@@ -1913,7 +1927,7 @@ public:
     BOOL ArraySupportsBizarreInterface(MethodTable* pInterfaceMT, TypeHandlePairList* pVisited);
     BOOL ArrayIsInstanceOf(MethodTable* pTargetMT, TypeHandlePairList* pVisited);
 
-    BOOL CanCastByVarianceToInterfaceOrDelegate(MethodTable* pTargetMT, TypeHandlePairList* pVisited);
+    BOOL CanCastByVarianceToInterfaceOrDelegate(MethodTable* pTargetMT, TypeHandlePairList* pVisited, MethodTable* pMTInterfaceMapOwner = NULL);
 
     // The inline part of equivalence check.
 #ifndef DACCESS_COMPILE
@@ -2211,7 +2225,7 @@ public:
             {
                 if (m_pMap->GetMethodTable()->HasSameTypeDefAs(pMT) && 
                     pMT->HasInstantiation() && 
-                    m_pMap->GetMethodTable()->IsGenericTypeDefinition() && 
+                    m_pMap->GetMethodTable()->IsSpecialMarkerTypeForGenericCasting() && 
                     pMT->GetInstantiation().ContainsAllOneType(pMTOwner))
                 {
                     exactMatch = true;
@@ -3695,6 +3709,7 @@ private:
                                              | enum_flag_ComObject
                                              | enum_flag_ICastable
                                              | enum_flag_IDynamicInterfaceCastable
+                                             | enum_flag_Category_ValueType
 
     };  // enum WFLAGS_HIGH_ENUM
 

--- a/src/coreclr/vm/methodtable.inl
+++ b/src/coreclr/vm/methodtable.inl
@@ -1570,6 +1570,33 @@ FORCEINLINE BOOL MethodTable::ImplementsInterfaceInline(MethodTable *pInterface)
     }
     while (--numInterfaces);
 
+    // TODO! Consider breaking out into seperate function!
+    // Second scan, looking for the curiously recurring generic scenario
+    if (pInterface->HasInstantiation() && pInterface->GetInstantiation().ContainsAllOneType(this))
+    {
+        numInterfaces = GetNumInterfaces();
+        pInfo = GetInterfaceMap();
+
+        do
+        {
+            if (pInfo->GetMethodTable()->HasSameTypeDefAs(pInterface) && pInfo->GetMethodTable()->IsGenericTypeDefinition())
+            {
+                // Extensible RCW's need to be handled specially because they can have interfaces
+                // in their map that are added at runtime. These interfaces will have a start offset
+                // of -1 to indicate this. We cannot take for granted that every instance of this
+                // COM object has this interface so FindInterface on these interfaces is made to fail.
+                //
+                // However, we are only considering the statically available slots here
+                // (m_wNumInterface doesn't contain the dynamic slots), so we can safely
+                // ignore this detail.
+                pInfo->SetMethodTable(pInterface);
+                return TRUE;
+            }
+            pInfo++;
+        }
+        while (--numInterfaces);
+    }
+
     return FALSE;
 }
 

--- a/src/coreclr/vm/methodtable.inl
+++ b/src/coreclr/vm/methodtable.inl
@@ -1570,7 +1570,6 @@ FORCEINLINE BOOL MethodTable::ImplementsInterfaceInline(MethodTable *pInterface)
     }
     while (--numInterfaces);
 
-    // TODO! Consider breaking out into seperate function!
     // Second scan, looking for the curiously recurring generic scenario
     if (pInterface->HasInstantiation() && pInterface->GetInstantiation().ContainsAllOneType(this))
     {
@@ -1579,7 +1578,7 @@ FORCEINLINE BOOL MethodTable::ImplementsInterfaceInline(MethodTable *pInterface)
 
         do
         {
-            if (pInfo->GetMethodTable()->HasSameTypeDefAs(pInterface) && pInfo->GetMethodTable()->IsGenericTypeDefinition())
+            if (pInfo->GetMethodTable()->HasSameTypeDefAs(pInterface) && pInfo->GetMethodTable()->IsSpecialMarkerTypeForGenericCasting())
             {
                 // Extensible RCW's need to be handled specially because they can have interfaces
                 // in their map that are added at runtime. These interfaces will have a start offset
@@ -1590,7 +1589,8 @@ FORCEINLINE BOOL MethodTable::ImplementsInterfaceInline(MethodTable *pInterface)
                 // (m_wNumInterface doesn't contain the dynamic slots), so we can safely
                 // ignore this detail.
 #ifndef DACCESS_COMPILE
-                pInfo->SetMethodTable(pInterface);
+                if (pInterface->IsFullyLoaded())
+                    pInfo->SetMethodTable(pInterface);
 #endif
                 return TRUE;
             }

--- a/src/coreclr/vm/methodtable.inl
+++ b/src/coreclr/vm/methodtable.inl
@@ -1589,7 +1589,9 @@ FORCEINLINE BOOL MethodTable::ImplementsInterfaceInline(MethodTable *pInterface)
                 // However, we are only considering the statically available slots here
                 // (m_wNumInterface doesn't contain the dynamic slots), so we can safely
                 // ignore this detail.
+#ifndef DACCESS_COMPILE
                 pInfo->SetMethodTable(pInterface);
+#endif
                 return TRUE;
             }
             pInfo++;

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -412,15 +412,22 @@ MethodTableBuilder::ExpandApproxInterface(
 
     bmtInterface->dwInterfaceMapSize++;
 
-    // Make sure to pass in the substitution from the new itf type created above as
-    // these methods assume that substitutions are allocated in the stacking heap,
-    // not the stack.
-    InterfaceDeclarationScope declaredItfScope(declScope.fIsInterfaceDeclaredOnParent, false);
-    ExpandApproxDeclaredInterfaces(
-        bmtInterface,
-        bmtTypeHandle(pNewItfType),
-        declaredItfScope
-        COMMA_INDEBUG(dbg_pClassMT));
+    // Checking for further expanded interfaces isn't necessary for the system module, as we can rely on the C# compiler
+    // to have found all of the interfaces that the type implements, and to place them in the interface list itself. Also
+    // we can assume no ambiguous interfaces
+    // Code related to this is marked with #SpecialCorelibInterfaceExpansionAlgorithm
+   if (!GetModule()->IsSystem())
+    {
+        // Make sure to pass in the substitution from the new itf type created above as
+        // these methods assume that substitutions are allocated in the stacking heap,
+        // not the stack.
+        InterfaceDeclarationScope declaredItfScope(declScope.fIsInterfaceDeclaredOnParent, false);
+        ExpandApproxDeclaredInterfaces(
+            bmtInterface,
+            bmtTypeHandle(pNewItfType),
+            declaredItfScope
+            COMMA_INDEBUG(dbg_pClassMT));
+    }
 } // MethodTableBuilder::ExpandApproxInterface
 
 //*******************************************************************************
@@ -9022,6 +9029,18 @@ void MethodTableBuilder::CopyExactParentSlots(MethodTable *pMT, MethodTable *pAp
     }
 } // MethodTableBuilder::CopyExactParentSlots
 
+bool InstantiationIsAllTypeVariables(const Instantiation &inst)
+{
+    for (auto i = inst.GetNumArgs(); i > 0;)
+    {
+        TypeHandle th = inst[--i];
+        if (!th.IsGenericVariable())
+            return false;
+    }
+
+    return true;
+}
+
 //*******************************************************************************
 /* static */
 void
@@ -9038,7 +9057,7 @@ MethodTableBuilder::LoadExactInterfaceMap(MethodTable *pMT)
     MethodTable::InterfaceMapIterator it = pMT->IterateInterfaceMap();
     while (it.Next())
     {
-        if (it.GetInterface()->HasInstantiation())
+        if (it.GetInterfaceApprox()->HasInstantiation())
         {
             hasInstantiatedInterfaces = TRUE;
             break;
@@ -9080,41 +9099,91 @@ MethodTableBuilder::LoadExactInterfaceMap(MethodTable *pMT)
     // (e) If duplicates found then use the slow metadata-based technique code:#LoadExactInterfaceMap_Algorithm2
     DWORD nInterfacesCount = pMT->GetNumInterfaces();
     MethodTable **pExactMTs = (MethodTable**) _alloca(sizeof(MethodTable *) * nInterfacesCount);
+    BOOL duplicates;
+    bool retry = false;
+    bool retryWithExactInterfaces = !pMT->IsValueType() || pMT->IsSharedByGenericInstantiations(); // Always use exact loading behavior with classes or shared generics, as they have to deal with inheritance, and the
+                                                                                          // inexact matching logic for classes would be more complex to write.
+    
     DWORD nAssigned = 0;
-    BOOL duplicates = false;
-    if (pParentMT != NULL)
+    do
     {
-        MethodTable::InterfaceMapIterator parentIt = pParentMT->IterateInterfaceMap();
-        while (parentIt.Next())
+        nAssigned = 0;
+        retry = false;
+        duplicates = false;
+        if (pParentMT != NULL)
         {
-            duplicates |= InsertMethodTable(parentIt.GetInterface(), pExactMTs, nInterfacesCount, &nAssigned);
+            MethodTable::InterfaceMapIterator parentIt = pParentMT->IterateInterfaceMap();
+            while (parentIt.Next())
+            {
+                duplicates |= InsertMethodTable(parentIt.GetInterface(pParentMT, CLASS_LOAD_EXACTPARENTS), pExactMTs, nInterfacesCount, &nAssigned);
+            }
         }
-    }
-    InterfaceImplEnum ie(pMT->GetModule(), pMT->GetCl(), NULL);
-    while ((hr = ie.Next()) == S_OK)
-    {
-        MethodTable *pNewIntfMT = ClassLoader::LoadTypeDefOrRefOrSpecThrowing(pMT->GetModule(),
-                                                                              ie.CurrentToken(),
-                                                                              &typeContext,
-                                                                              ClassLoader::ThrowIfNotFound,
-                                                                              ClassLoader::FailIfUninstDefOrRef,
-                                                                              ClassLoader::LoadTypes,
-                                                                              CLASS_LOAD_EXACTPARENTS,
-                                                                              TRUE).GetMethodTable();
+        InterfaceImplEnum ie(pMT->GetModule(), pMT->GetCl(), NULL);
+        while ((hr = ie.Next()) == S_OK)
+        {
+            // TODO This feels like code that will need intesreting special casing
+            MethodTable *pNewIntfMT = ClassLoader::LoadTypeDefOrRefOrSpecThrowing(pMT->GetModule(),
+                                                                                ie.CurrentToken(),
+                                                                                &typeContext,
+                                                                                ClassLoader::ThrowIfNotFound,
+                                                                                ClassLoader::FailIfUninstDefOrRef,
+                                                                                ClassLoader::LoadTypes,
+                                                                                CLASS_LOAD_EXACTPARENTS,
+                                                                                TRUE,
+                                                                                (const Substitution*)0,
+                                                                                retryWithExactInterfaces ? NULL : pMT).GetMethodTable();
 
-        duplicates |= InsertMethodTable(pNewIntfMT, pExactMTs, nInterfacesCount, &nAssigned);
-        MethodTable::InterfaceMapIterator intIt = pNewIntfMT->IterateInterfaceMap();
-        while (intIt.Next())
-        {
-            duplicates |= InsertMethodTable(intIt.GetInterface(), pExactMTs, nInterfacesCount, &nAssigned);
+            bool uninstGenericCase = pNewIntfMT->IsGenericTypeDefinition();
+
+            duplicates |= InsertMethodTable(pNewIntfMT, pExactMTs, nInterfacesCount, &nAssigned);
+
+            // We have a special algorithm for interface maps in CoreLib, which doesn't expand interfaces, and assumes no ambiguous
+            // duplicates. Code related to this is marked with #SpecialCorelibInterfaceExpansionAlgorithm
+            if (!pMT->GetModule()->IsSystem())
+            {
+                MethodTable::InterfaceMapIterator intIt = pNewIntfMT->IterateInterfaceMap();
+                while (intIt.Next())
+                {
+                    MethodTable *pItfPossiblyApprox = intIt.GetInterfaceApprox();
+                    if (uninstGenericCase && pItfPossiblyApprox->HasInstantiation() && pItfPossiblyApprox->ContainsGenericVariables())
+                    {
+                        // We allow a limited set of interface generic shapes with type variables. In particular, we require the instantiations to be exactly type variables
+                        // the current type
+
+                        if (InstantiationIsAllTypeVariables(pItfPossiblyApprox->GetInstantiation()))
+                        {
+                            pItfPossiblyApprox = ClassLoader::LoadTypeDefThrowing(pItfPossiblyApprox->GetModule(), pItfPossiblyApprox->GetCl(), ClassLoader::ThrowIfNotFound, ClassLoader::PermitUninstDefOrRef, 0, CLASS_LOAD_EXACTPARENTS).AsMethodTable();
+                        }
+                        else
+                        {
+                            retry = true;
+                            break;
+                        }
+                    }
+                    duplicates |= InsertMethodTable(intIt.GetInterface(pNewIntfMT, CLASS_LOAD_EXACTPARENTS), pExactMTs, nInterfacesCount, &nAssigned);
+                }
+            }
+
+            if (retry)
+                break;
         }
-    }
+
+        if (retry)
+        {
+            retryWithExactInterfaces = true;
+        }
+    } while (retry);
+
     if (FAILED(hr))
     {
         pMT->GetAssembly()->ThrowTypeLoadException(pMT->GetMDImport(), pMT->GetCl(), IDS_CLASSLOAD_BADFORMAT);
     }
 #ifdef _DEBUG
-    duplicates |= CLRConfig::GetConfigValue(CLRConfig::INTERNAL_AlwaysUseMetadataInterfaceMapLayout);
+    if (!pMT->GetModule()->IsSystem())
+    {
+
+        duplicates |= CLRConfig::GetConfigValue(CLRConfig::INTERNAL_AlwaysUseMetadataInterfaceMapLayout);
+    }
 
     //#InjectInterfaceDuplicates_LoadExactInterfaceMap
     // If we are injecting duplicates also for non-generic interfaces in check builds, we have to use
@@ -9122,6 +9191,10 @@ MethodTableBuilder::LoadExactInterfaceMap(MethodTable *pMT)
     // Has to be in sync with code:#InjectInterfaceDuplicates_Main.
     duplicates |= pMT->Debug_HasInjectedInterfaceDuplicates();
 #endif
+    // We have a special algorithm for interface maps in CoreLib, which doesn't expand interfaces, and assumes no ambiguous
+    // duplicates. Code related to this is marked with #SpecialCorelibInterfaceExpansionAlgorithm
+    _ASSERTE(!duplicates || !pMT->GetModule()->IsSystem()); 
+
     CONSISTENCY_CHECK(duplicates || (nAssigned == pMT->GetNumInterfaces()));
     if (duplicates)
     {
@@ -9181,7 +9254,8 @@ MethodTableBuilder::LoadExactInterfaceMap(MethodTable *pMT)
                 pParentMT,
                 pParentSubstForTypeLoad,
                 pParentSubstForComparing,
-                pStackingAllocator);
+                pStackingAllocator,
+                retryWithExactInterfaces ? NULL : pMT);
         }
 #ifdef _DEBUG
         //#ExactInterfaceMap_SupersetOfParent
@@ -9204,7 +9278,7 @@ MethodTableBuilder::LoadExactInterfaceMap(MethodTable *pMT)
                 }
                 else
                 {   // It is not canonical instantiation, we can compare MethodTables
-                    _ASSERTE(parentInterfacesIterator.GetInterface() == bmtExactInterface.pExactMTs[nInterfaceIndex]);
+                    _ASSERTE(parentInterfacesIterator.GetInterfaceApprox() == bmtExactInterface.pExactMTs[nInterfaceIndex]);
                 }
                 nInterfaceIndex++;
             }
@@ -9237,7 +9311,8 @@ MethodTableBuilder::LoadExactInterfaceMap(MethodTable *pMT)
             pMT->GetCl(),
             NULL,
             NULL,
-            pStackingAllocator
+            pStackingAllocator,
+            retryWithExactInterfaces ? NULL : pMT
             COMMA_INDEBUG(pMT));
         CONSISTENCY_CHECK(bmtExactInterface.nAssigned == pMT->GetNumInterfaces());
 
@@ -9405,9 +9480,8 @@ MethodTableBuilder::LoadExactInterfaceMap(MethodTable *pMT)
     while (thisIt.Next())
     {
 #ifdef _DEBUG
-        MethodTable*pOldMT = thisIt.GetInterface();
         MethodTable *pNewMT = pExactMTs[i];
-        CONSISTENCY_CHECK(pOldMT->HasSameTypeDefAs(pNewMT));
+        CONSISTENCY_CHECK(thisIt.HasSameTypeDefAs(pNewMT));
 #endif // _DEBUG
         thisIt.SetInterface(pExactMTs[i]);
         i++;
@@ -9422,7 +9496,8 @@ MethodTableBuilder::ExpandExactInheritedInterfaces(
     MethodTable *           pMT,
     const Substitution *    pSubstForTypeLoad,
     Substitution *          pSubstForComparing,
-    StackingAllocator *     pStackingAllocator)
+    StackingAllocator *     pStackingAllocator,
+    MethodTable *           pMTInterfaceMapOwner)
 {
     STANDARD_VM_CONTRACT;
 
@@ -9449,7 +9524,8 @@ MethodTableBuilder::ExpandExactInheritedInterfaces(
             pParentMT,
             pParentSubstForTypeLoad,
             pParentSubstForComparing,
-            pStackingAllocator);
+            pStackingAllocator,
+            pMTInterfaceMapOwner);
     }
     ExpandExactDeclaredInterfaces(
         bmtInfo,
@@ -9457,7 +9533,8 @@ MethodTableBuilder::ExpandExactInheritedInterfaces(
         pMT->GetCl(),
         pSubstForTypeLoad,
         pSubstForComparing,
-        pStackingAllocator
+        pStackingAllocator,
+        pMTInterfaceMapOwner
         COMMA_INDEBUG(pMT));
 
     // Restore type's subsitution chain for comparing interfaces
@@ -9473,7 +9550,8 @@ MethodTableBuilder::ExpandExactDeclaredInterfaces(
     mdToken                     typeDef,
     const Substitution *        pSubstForTypeLoad,
     Substitution *              pSubstForComparing,
-    StackingAllocator *         pStackingAllocator
+    StackingAllocator *         pStackingAllocator,
+    MethodTable *               pMTInterfaceMapOwner
     COMMA_INDEBUG(MethodTable * dbg_pClassMT))
 {
     STANDARD_VM_CONTRACT;
@@ -9491,7 +9569,8 @@ MethodTableBuilder::ExpandExactDeclaredInterfaces(
             ClassLoader::LoadTypes,
             CLASS_LOAD_EXACTPARENTS,
             TRUE,
-            pSubstForTypeLoad).GetMethodTable();
+            pSubstForTypeLoad,
+            pMTInterfaceMapOwner).GetMethodTable();
 
         Substitution ifaceSubstForTypeLoad(ie.CurrentToken(), pModule, pSubstForTypeLoad);
         Substitution ifaceSubstForComparing(ie.CurrentToken(), pModule, pSubstForComparing);
@@ -9500,7 +9579,8 @@ MethodTableBuilder::ExpandExactDeclaredInterfaces(
             pInterface,
             &ifaceSubstForTypeLoad,
             &ifaceSubstForComparing,
-            pStackingAllocator
+            pStackingAllocator,
+            pMTInterfaceMapOwner
             COMMA_INDEBUG(dbg_pClassMT));
     }
     if (FAILED(hr))
@@ -9516,7 +9596,8 @@ MethodTableBuilder::ExpandExactInterface(
     MethodTable *               pIntf,
     const Substitution *        pSubstForTypeLoad_OnStack,   // Allocated on stack!
     const Substitution *        pSubstForComparing_OnStack,  // Allocated on stack!
-    StackingAllocator *         pStackingAllocator
+    StackingAllocator *         pStackingAllocator,
+    MethodTable *               pMTInterfaceMapOwner
     COMMA_INDEBUG(MethodTable * dbg_pClassMT))
 {
     STANDARD_VM_CONTRACT;
@@ -9563,7 +9644,8 @@ MethodTableBuilder::ExpandExactInterface(
         pIntf->GetCl(),
         pSubstForTypeLoad,
         &bmtInfo->pInterfaceSubstitution[n],
-        pStackingAllocator
+        pStackingAllocator,
+        pMTInterfaceMapOwner
         COMMA_INDEBUG(dbg_pClassMT));
 } // MethodTableBuilder::ExpandExactInterface
 
@@ -10716,7 +10798,7 @@ MethodTableBuilder::SetupMethodTable2(
         MethodTable::InterfaceMapIterator intIt = pMT->IterateInterfaceMap();
         while (intIt.Next())
         {
-            MethodTable* pIntfMT = intIt.GetInterface();
+            MethodTable* pIntfMT = intIt.GetInterface(pMT, pMT->GetLoadLevel());
             if (pIntfMT->GetNumVirtuals() != 0)
             {
                 BOOL hasComImportMethod = FALSE;

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -416,7 +416,7 @@ MethodTableBuilder::ExpandApproxInterface(
     // to have found all of the interfaces that the type implements, and to place them in the interface list itself. Also
     // we can assume no ambiguous interfaces
     // Code related to this is marked with #SpecialCorelibInterfaceExpansionAlgorithm
-   if (!(GetModule()->IsSystem() && IsValueClass()))
+    if (!(GetModule()->IsSystem() && IsValueClass()))
     {
         // Make sure to pass in the substitution from the new itf type created above as
         // these methods assume that substitutions are allocated in the stacking heap,
@@ -9146,9 +9146,8 @@ MethodTableBuilder::LoadExactInterfaceMap(MethodTable *pMT)
                     MethodTable *pItfPossiblyApprox = intIt.GetInterfaceApprox();
                     if (uninstGenericCase && pItfPossiblyApprox->HasInstantiation() && pItfPossiblyApprox->ContainsGenericVariables())
                     {
-                        // We allow a limited set of interface generic shapes with type variables. In particular, we require the instantiations to be exactly type variables
-                        // the current type
-
+                        // We allow a limited set of interface generic shapes with type variables. In particular, we require the 
+                        // instantiations to be exactly simple type variables
                         if (InstantiationIsAllTypeVariables(pItfPossiblyApprox->GetInstantiation()))
                         {
                             pItfPossiblyApprox = ClassLoader::LoadTypeDefThrowing(pItfPossiblyApprox->GetModule(), pItfPossiblyApprox->GetCl(), ClassLoader::ThrowIfNotFound, ClassLoader::PermitUninstDefOrRef, 0, CLASS_LOAD_EXACTPARENTS).AsMethodTable();

--- a/src/coreclr/vm/methodtablebuilder.h
+++ b/src/coreclr/vm/methodtablebuilder.h
@@ -2454,7 +2454,8 @@ private:
         MethodTable *               pIntf,
         const Substitution *        pSubstForTypeLoad_OnStack,  // Allocated on stack!
         const Substitution *        pSubstForComparing_OnStack, // Allocated on stack!
-        StackingAllocator *         pStackingAllocator
+        StackingAllocator *         pStackingAllocator,
+        MethodTable *               pMTInterfaceMapOwner
         COMMA_INDEBUG(MethodTable * dbg_pClassMT));
 
 public:
@@ -2465,7 +2466,8 @@ public:
         mdToken                     typeDef,
         const Substitution *        pSubstForTypeLoad,
         Substitution *              pSubstForComparing,
-        StackingAllocator *     pStackingAllocator
+        StackingAllocator *         pStackingAllocator,
+        MethodTable *               pMTInterfaceMapOwner
         COMMA_INDEBUG(MethodTable * dbg_pClassMT));
 
     static void
@@ -2474,7 +2476,8 @@ public:
         MethodTable *           pParentMT,
         const Substitution *    pSubstForTypeLoad,
         Substitution *          pSubstForComparing,
-        StackingAllocator *     pStackingAllocator);
+        StackingAllocator *     pStackingAllocator,
+        MethodTable *           pMTInterfaceMapOwner);
 
 public:
     // --------------------------------------------------------------------------------------------

--- a/src/coreclr/vm/runtimecallablewrapper.cpp
+++ b/src/coreclr/vm/runtimecallablewrapper.cpp
@@ -2548,7 +2548,11 @@ BOOL ComObject::SupportsInterface(OBJECTREF oref, MethodTable* pIntfTable)
                     MethodTable::InterfaceMapIterator it = pIntfTable->IterateInterfaceMap();
                     while (it.Next())
                     {
-                        bSupportsItf = Object::SupportsInterface(oref, it.GetInterface());
+                        MethodTable *pItf = it.GetInterfaceApprox();
+                        if (pItf->HasInstantiation() || pItf->IsGenericTypeDefinition())
+                            continue;
+
+                        bSupportsItf = Object::SupportsInterface(oref, pItf);
                         if (!bSupportsItf)
                             break;
                     }

--- a/src/coreclr/vm/runtimehandles.cpp
+++ b/src/coreclr/vm/runtimehandles.cpp
@@ -906,7 +906,7 @@ FCIMPL1(PtrArray*, RuntimeTypeHandle::GetInterfaces, ReflectClassBaseObject *pTy
             MethodTable::InterfaceMapIterator it = typeHandle.GetMethodTable()->IterateInterfaceMap();
             while (it.Next())
             {
-                OBJECTREF refInterface = it.GetInterface()->GetManagedClassObject();
+                OBJECTREF refInterface = it.GetInterface(typeHandle.GetMethodTable())->GetManagedClassObject();
                 refRetVal->SetAt(i, refInterface);
                 _ASSERTE(refRetVal->GetAt(i) != NULL);
                 i++;

--- a/src/coreclr/vm/siginfo.cpp
+++ b/src/coreclr/vm/siginfo.cpp
@@ -990,7 +990,7 @@ TypeHandle SigPointer::GetTypeHandleThrowing(
                  const Substitution *        pSubst/*=NULL*/,
                  // ZapSigContext is only set when decoding zapsigs
                  const ZapSig::Context *     pZapSigContext,
-                 MethodTable *pMTInterfaceMapOwner) const
+                 MethodTable *               pMTInterfaceMapOwner) const
 {
     CONTRACT(TypeHandle)
     {

--- a/src/coreclr/vm/siginfo.cpp
+++ b/src/coreclr/vm/siginfo.cpp
@@ -989,7 +989,8 @@ TypeHandle SigPointer::GetTypeHandleThrowing(
                  BOOL                        dropGenericArgumentLevel/*=FALSE*/,
                  const Substitution *        pSubst/*=NULL*/,
                  // ZapSigContext is only set when decoding zapsigs
-                 const ZapSig::Context *     pZapSigContext) const
+                 const ZapSig::Context *     pZapSigContext,
+                 MethodTable *pMTInterfaceMapOwner) const
 {
     CONTRACT(TypeHandle)
     {
@@ -1414,20 +1415,29 @@ TypeHandle SigPointer::GetTypeHandleThrowing(
                 break;
             }
 
-            // Group together the current signature type context and substitution chain, which
-            // we may later use to instantiate constraints of type arguments that turn out to be
-            // typespecs, i.e. generic types.
-            InstantiationContext instContext(pTypeContext, pSubst);
+            Instantiation genericLoadInst(thisinst, ntypars);
 
-            // Now make the instantiated type
-            // The class loader will check the arity
-            // When we know it was correctly computed at NGen time, we ask the class loader to skip that check.
-            thRet = (ClassLoader::LoadGenericInstantiationThrowing(pGenericTypeModule,
-                                                                   tkGenericType,
-                                                                   Instantiation(thisinst, ntypars),
-                                                                   fLoadTypes, level,
-                                                                   &instContext,
-                                                                   pZapSigContext && pZapSigContext->externalTokens == ZapSig::NormalTokens));
+            if (pMTInterfaceMapOwner != NULL && genericLoadInst.ContainsAllOneType(pMTInterfaceMapOwner))
+            {
+                thRet = ClassLoader::LoadTypeDefThrowing(pGenericTypeModule, tkGenericType, ClassLoader::ThrowIfNotFound, ClassLoader::PermitUninstDefOrRef, 0, level);
+            }
+            else
+            {
+                // Group together the current signature type context and substitution chain, which
+                // we may later use to instantiate constraints of type arguments that turn out to be
+                // typespecs, i.e. generic types.
+                InstantiationContext instContext(pTypeContext, pSubst);
+
+                // Now make the instantiated type
+                // The class loader will check the arity
+                // When we know it was correctly computed at NGen time, we ask the class loader to skip that check.
+                thRet = (ClassLoader::LoadGenericInstantiationThrowing(pGenericTypeModule,
+                                                                    tkGenericType,
+                                                                    genericLoadInst,
+                                                                    fLoadTypes, level,
+                                                                    &instContext,
+                                                                    pZapSigContext && pZapSigContext->externalTokens == ZapSig::NormalTokens));
+            }
             break;
         }
 

--- a/src/coreclr/vm/siginfo.hpp
+++ b/src/coreclr/vm/siginfo.hpp
@@ -253,7 +253,8 @@ public:
                                          ClassLoadLevel level = CLASS_LOADED,
                                          BOOL dropGenericArgumentLevel = FALSE,
                                          const Substitution *pSubst = NULL,
-                                         const ZapSig::Context *pZapSigContext = NULL) const;
+                                         const ZapSig::Context *pZapSigContext = NULL,
+                                         MethodTable *pMTInterfaceMapOwner = NULL) const;
 
 public:
         //------------------------------------------------------------------------

--- a/src/coreclr/vm/typehandle.cpp
+++ b/src/coreclr/vm/typehandle.cpp
@@ -740,7 +740,7 @@ TypeHandle TypeHandle::MergeClassWithInterface(TypeHandle tClass, TypeHandle tIn
     MethodTable::InterfaceMapIterator intIt = pMTInterface->IterateInterfaceMap();
     while (intIt.Next())
     {
-        MethodTable *pMT = intIt.GetInterface();
+        MethodTable *pMT = intIt.GetInterface(pMTInterface);
         if (pMTClass->ImplementsEquivalentInterface(pMT))
         {
             // Found a common interface.  If there are multiple common interfaces, then

--- a/src/coreclr/vm/typehandle.h
+++ b/src/coreclr/vm/typehandle.h
@@ -756,6 +756,16 @@ public:
         return m_pArgs;
     }
 
+    bool ContainsAllOneType(TypeHandle th)
+    {
+        for (auto i = GetNumArgs(); i > 0;)
+        {
+            if ((*this)[--i] != th)
+                return false;
+        }
+        return true;
+    }
+
 private:
     // Note that for DAC builds, m_pArgs may be host allocated buffer, not a copy of an object marshalled by DAC.
     FixupPointer<TypeHandle> * m_pArgs;


### PR DESCRIPTION
Change interface map layout in two interesting ways
1. For interface maps defined in System.Private.CoreLib, rely on the C# compiler to prevent any ambiguous duplicates, and to find the full interface expansion, instead of expanding it within the type loader See code marked with #SpecialCorelibInterfaceExpansionAlgorithm
- Note that this optimization is only applied for ValueTypes as the presence of inheritance makes the optimization much more complex in many cases, and isn't needed.
- This optimization reduces the amount of parsing of the interface implementation table must be done for valuetypes in CoreLib. In particular, with the new interfaces that are added as part of #54650 there is a very deep interface hierarchy that requires a great deal of scanning. As those interfaces are added to all the primitive types, the impact on startup performance is significant and measurable.
2. For interface map expansion that follows the curiously recurring generic pattern, place the open instantiation of the type in the interface map instead of the the exact instantiation, and update all places in the runtime which consider the interface map to deal with that change (Mostly by adding special purpose logic to work with the special marker type in the interface map, but there is also logic to simply force the exact interface type to be loaded, when working with the partially loaded type is not quite good enough, or excessively complex)
- This optimization reduces the set of interface types that need to be loaded if they are unused. Of particular benefit are the numerous interfaces associated with the primitive types that are added as part of #54650.

Performance of launching an extremely simple .NET process (process with empty main method). Results acquired using local testing on my developer machine, using a simple script that launches the process 500 times in a row.

| Before #54650 | After #54650 | After #54650 and #54588 (this pr) |
| :-: | :-: | :-: |
| 14.1ms | 16.5ms |14.3ms |
