### PR TITLE
Make mono_polling_required a public symbol

### DIFF
--- a/src/mono/mono/utils/mono-threads-coop.h
+++ b/src/mono/mono/utils/mono-threads-coop.h
@@ -20,7 +20,7 @@
 #include "mono/metadata/icalls.h"
 
 /* JIT specific interface */
-extern volatile size_t mono_polling_required;
+MONO_API_DATA volatile size_t mono_polling_required;
 
 /* Internal API */
 


### PR DESCRIPTION
Resolves build failure with the Android aot+llvm functional test