### PR TITLE
[mono] Intrinsify inequality comparison between runtime types

### DIFF
--- a/src/mono/System.Private.CoreLib/src/System/Type.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Type.Mono.cs
@@ -152,6 +152,7 @@ namespace System
             return left.Equals(right);
         }
 
+        [Intrinsic]
         public static bool operator !=(Type? left, Type? right)
         {
             return !(left == right);

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -2429,6 +2429,9 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 		// We do a reference comparison only if we know both operands are runtime type
 		// (they originate from object.GetType or ldftn + GetTypeFromHandle)
 		*op = MINT_CEQ_P;
+	} else if (in_corlib && target_method->klass == mono_defaults.systemtype_class && !strcmp (target_method->name, "op_Inequality") &&
+			td->sp [-1].klass == mono_defaults.runtimetype_class && td->sp [-2].klass == mono_defaults.runtimetype_class) {
+		*op = MINT_CNE_P;
 	} else if (in_corlib && target_method->klass == mono_defaults.object_class) {
 		if (!strcmp (tm, "InternalGetHashCode")) {
 			*op = MINT_INTRINS_GET_HASHCODE;

--- a/src/mono/mono/mini/intrinsics.c
+++ b/src/mono/mono/mini/intrinsics.c
@@ -1813,6 +1813,14 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 		ins->type = STACK_I4;
 		MONO_ADD_INS (cfg->cbb, ins);
 		return ins;
+	} else if (cmethod->klass == mono_defaults.systemtype_class && !strcmp (cmethod->name, "op_Inequality") &&
+			args [0]->klass == mono_defaults.runtimetype_class && args [1]->klass == mono_defaults.runtimetype_class) {
+		EMIT_NEW_BIALU (cfg, ins, OP_COMPARE, -1, args [0]->dreg, args [1]->dreg);
+		MONO_INST_NEW (cfg, ins, OP_ICNEQ);
+		ins->dreg = alloc_preg (cfg);
+		ins->type = STACK_I4;
+		MONO_ADD_INS (cfg->cbb, ins);
+		return ins;
 	} else if (((!strcmp (cmethod_klass_image->assembly->aname.name, "MonoMac") ||
 	            !strcmp (cmethod_klass_image->assembly->aname.name, "monotouch")) &&
 				!strcmp (cmethod_klass_name_space, "XamCore.ObjCRuntime") &&


### PR DESCRIPTION
This is needed because, when inlining op_Inequality, the information on whether the arguments are runtime types gets lost. We should track that information instead when inlining, but it is a more invasive change.

https://github.com/dotnet/runtime/issues/54567