### PR TITLE
[wasm] browser http response stream could be seekable

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -972,7 +972,7 @@ namespace System.Net.Http.Functional.Tests
 
                         // Not supported operations
                         Assert.Throws<NotSupportedException>(() => responseStream.BeginWrite(new byte[1], 0, 1, null, null));
-                        if (PlatformDetection.IsNotBrowser)
+                        if (!responseStream.CanSeek)
                         {
                             Assert.Throws<NotSupportedException>(() => responseStream.Length);
                             Assert.Throws<NotSupportedException>(() => responseStream.Position);
@@ -1127,7 +1127,7 @@ namespace System.Net.Http.Functional.Tests
 
                         // Not supported operations
                         Assert.Throws<NotSupportedException>(() => responseStream.BeginWrite(new byte[1], 0, 1, null, null));
-                        if (PlatformDetection.IsNotBrowser)
+                        if (!responseStream.CanSeek)
                         {
                             Assert.Throws<NotSupportedException>(() => responseStream.Length);
                             Assert.Throws<NotSupportedException>(() => responseStream.Position);

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -958,6 +958,11 @@ namespace System.Net.Http.Functional.Tests
             await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
             {
                 var request = new HttpRequestMessage(HttpMethod.Get, uri) { Version = UseVersion };
+                if (PlatformDetection.IsBrowser)
+                {
+                    request.Options.Set(new HttpRequestOptionsKey<bool>("WebAssemblyEnableStreamingResponse"), true);
+                }
+
                 using (var client = new HttpMessageInvoker(CreateHttpClientHandler()))
                 using (HttpResponseMessage response = await client.SendAsync(TestAsync, request, CancellationToken.None))
                 {
@@ -968,7 +973,7 @@ namespace System.Net.Http.Functional.Tests
                         // Boolean properties returning correct values
                         Assert.True(responseStream.CanRead);
                         Assert.False(responseStream.CanWrite);
-                        Assert.Equal(PlatformDetection.IsBrowser, responseStream.CanSeek);
+                        Assert.False(responseStream.CanSeek);
 
                         // Not supported operations
                         Assert.Throws<NotSupportedException>(() => responseStream.BeginWrite(new byte[1], 0, 1, null, null));
@@ -999,11 +1004,14 @@ namespace System.Net.Http.Functional.Tests
                         Assert.Throws<ArgumentOutOfRangeException>(() => { responseStream.CopyToAsync(Stream.Null, -1, default); });
                         Assert.Throws<NotSupportedException>(() => { responseStream.CopyToAsync(nonWritableStream, 100, default); });
                         Assert.Throws<ObjectDisposedException>(() => { responseStream.CopyToAsync(disposedStream, 100, default); });
-                        Assert.Throws<ArgumentNullException>(() => responseStream.Read(null, 0, 100));
-                        Assert.Throws<ArgumentOutOfRangeException>(() => responseStream.Read(new byte[1], -1, 1));
-                        Assert.ThrowsAny<ArgumentException>(() => responseStream.Read(new byte[1], 2, 1));
-                        Assert.Throws<ArgumentOutOfRangeException>(() => responseStream.Read(new byte[1], 0, -1));
-                        Assert.ThrowsAny<ArgumentException>(() => responseStream.Read(new byte[1], 0, 2));
+                        if (PlatformDetection.IsNotBrowser)
+                        {
+                            Assert.Throws<ArgumentNullException>(() => responseStream.Read(null, 0, 100));
+                            Assert.Throws<ArgumentOutOfRangeException>(() => responseStream.Read(new byte[1], -1, 1));
+                            Assert.ThrowsAny<ArgumentException>(() => responseStream.Read(new byte[1], 2, 1));
+                            Assert.Throws<ArgumentOutOfRangeException>(() => responseStream.Read(new byte[1], 0, -1));
+                            Assert.ThrowsAny<ArgumentException>(() => responseStream.Read(new byte[1], 0, 2));
+                        }
                         Assert.Throws<ArgumentNullException>(() => responseStream.BeginRead(null, 0, 100, null, null));
                         Assert.Throws<ArgumentOutOfRangeException>(() => responseStream.BeginRead(new byte[1], -1, 1, null, null));
                         Assert.ThrowsAny<ArgumentException>(() => responseStream.BeginRead(new byte[1], 2, 1, null, null));
@@ -1019,62 +1027,97 @@ namespace System.Net.Http.Functional.Tests
                         // Various forms of reading
                         var buffer = new byte[1];
 
-                        Assert.Equal('h', responseStream.ReadByte());
+                        if (PlatformDetection.IsBrowser)
+                        {
+                            Assert.Equal('h', await responseStream.ReadByteAsync());
+                            Assert.Equal('e', await responseStream.ReadByteAsync());
+                            Assert.Equal(1, await responseStream.ReadAsync(new Memory<byte>(buffer)));
+                            Assert.Equal((byte)'l', buffer[0]);
 
-                        Assert.Equal(1, await Task.Factory.FromAsync(responseStream.BeginRead, responseStream.EndRead, buffer, 0, 1, null));
-                        Assert.Equal((byte)'e', buffer[0]);
+                            Assert.Equal(1, await responseStream.ReadAsync(buffer, 0, 1));
+                            Assert.Equal((byte)'l', buffer[0]);
+
+                            Assert.Equal(1, await responseStream.ReadAsync(buffer));
+                            Assert.Equal((byte)'o', buffer[0]);
+
+                            Assert.Equal(1, await responseStream.ReadAsync(buffer, 0, 1));
+                            Assert.Equal((byte)' ', buffer[0]);
+
+                            // Doing any of these 0-byte reads causes the connection to fail.
+                            Assert.Equal(0, await responseStream.ReadAsync(Memory<byte>.Empty));
+                            Assert.Equal(0, await responseStream.ReadAsync(Array.Empty<byte>(), 0, 0));
+
+                            // And copying
+                            var ms = new MemoryStream();
+                            await responseStream.CopyToAsync(ms);
+                            Assert.Equal("world", Encoding.ASCII.GetString(ms.ToArray()));
+
+                            // Read and copy again once we've exhausted all data
+                            ms = new MemoryStream();
+                            await responseStream.CopyToAsync(ms);
+                            Assert.Equal(0, ms.Length);
+                            Assert.Equal(0, await responseStream.ReadAsync(buffer, 0, 1));
+                            Assert.Equal(0, await responseStream.ReadAsync(new Memory<byte>(buffer)));
+                        }
+                        else
+                        {
+                            Assert.Equal('h', responseStream.ReadByte());
+                            Assert.Equal(1, await Task.Factory.FromAsync(responseStream.BeginRead, responseStream.EndRead, buffer, 0, 1, null));
+                            Assert.Equal((byte)'e', buffer[0]);
+
 
 #if !NETFRAMEWORK
-                        Assert.Equal(1, await responseStream.ReadAsync(new Memory<byte>(buffer)));
+                            Assert.Equal(1, await responseStream.ReadAsync(new Memory<byte>(buffer)));
 #else
-                        Assert.Equal(1, await responseStream.ReadAsync(buffer, 0, 1));
+                            Assert.Equal(1, await responseStream.ReadAsync(buffer, 0, 1));
 #endif
-                        Assert.Equal((byte)'l', buffer[0]);
+                            Assert.Equal((byte)'l', buffer[0]);
 
-                        Assert.Equal(1, await responseStream.ReadAsync(buffer, 0, 1));
-                        Assert.Equal((byte)'l', buffer[0]);
+                            Assert.Equal(1, await responseStream.ReadAsync(buffer, 0, 1));
+                            Assert.Equal((byte)'l', buffer[0]);
 
 #if !NETFRAMEWORK
-                        Assert.Equal(1, responseStream.Read(new Span<byte>(buffer)));
+                            Assert.Equal(1, responseStream.Read(new Span<byte>(buffer)));
 #else
-                        Assert.Equal(1, await responseStream.ReadAsync(buffer, 0, 1));
+                            Assert.Equal(1, await responseStream.ReadAsync(buffer, 0, 1));
 #endif
-                        Assert.Equal((byte)'o', buffer[0]);
+                            Assert.Equal((byte)'o', buffer[0]);
 
-                        Assert.Equal(1, responseStream.Read(buffer, 0, 1));
-                        Assert.Equal((byte)' ', buffer[0]);
+                            Assert.Equal(1, responseStream.Read(buffer, 0, 1));
+                            Assert.Equal((byte)' ', buffer[0]);
 
-                        // Doing any of these 0-byte reads causes the connection to fail.
-                        Assert.Equal(0, await Task.Factory.FromAsync(responseStream.BeginRead, responseStream.EndRead, Array.Empty<byte>(), 0, 0, null));
+                            // Doing any of these 0-byte reads causes the connection to fail.
+                            Assert.Equal(0, await Task.Factory.FromAsync(responseStream.BeginRead, responseStream.EndRead, Array.Empty<byte>(), 0, 0, null));
 #if !NETFRAMEWORK
-                        Assert.Equal(0, await responseStream.ReadAsync(Memory<byte>.Empty));
+                            Assert.Equal(0, await responseStream.ReadAsync(Memory<byte>.Empty));
 #endif
-                        Assert.Equal(0, await responseStream.ReadAsync(Array.Empty<byte>(), 0, 0));
+                            Assert.Equal(0, await responseStream.ReadAsync(Array.Empty<byte>(), 0, 0));
 #if !NETFRAMEWORK
-                        Assert.Equal(0, responseStream.Read(Span<byte>.Empty));
+                            Assert.Equal(0, responseStream.Read(Span<byte>.Empty));
 #endif
-                        Assert.Equal(0, responseStream.Read(Array.Empty<byte>(), 0, 0));
+                            Assert.Equal(0, responseStream.Read(Array.Empty<byte>(), 0, 0));
 
-                        // And copying
-                        var ms = new MemoryStream();
-                        await responseStream.CopyToAsync(ms);
-                        Assert.Equal("world", Encoding.ASCII.GetString(ms.ToArray()));
+                            // And copying
+                            var ms = new MemoryStream();
+                            await responseStream.CopyToAsync(ms);
+                            Assert.Equal("world", Encoding.ASCII.GetString(ms.ToArray()));
 
-                        // Read and copy again once we've exhausted all data
-                        ms = new MemoryStream();
-                        await responseStream.CopyToAsync(ms);
-                        responseStream.CopyTo(ms);
-                        Assert.Equal(0, ms.Length);
-                        Assert.Equal(-1, responseStream.ReadByte());
-                        Assert.Equal(0, responseStream.Read(buffer, 0, 1));
+                            // Read and copy again once we've exhausted all data
+                            ms = new MemoryStream();
+                            await responseStream.CopyToAsync(ms);
+                            responseStream.CopyTo(ms);
+                            Assert.Equal(0, ms.Length);
+                            Assert.Equal(-1, responseStream.ReadByte());
+                            Assert.Equal(0, responseStream.Read(buffer, 0, 1));
 #if !NETFRAMEWORK
-                        Assert.Equal(0, responseStream.Read(new Span<byte>(buffer)));
+                            Assert.Equal(0, responseStream.Read(new Span<byte>(buffer)));
 #endif
-                        Assert.Equal(0, await responseStream.ReadAsync(buffer, 0, 1));
+                            Assert.Equal(0, await responseStream.ReadAsync(buffer, 0, 1));
 #if !NETFRAMEWORK
-                        Assert.Equal(0, await responseStream.ReadAsync(new Memory<byte>(buffer)));
+                            Assert.Equal(0, await responseStream.ReadAsync(new Memory<byte>(buffer)));
 #endif
-                        Assert.Equal(0, await Task.Factory.FromAsync(responseStream.BeginRead, responseStream.EndRead, buffer, 0, 1, null));
+                            Assert.Equal(0, await Task.Factory.FromAsync(responseStream.BeginRead, responseStream.EndRead, buffer, 0, 1, null));
+                        }
                     }
                 }
             }, async server =>

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -936,7 +936,6 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(true)]
         [InlineData(false)]
         [InlineData(null)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/54159", TestPlatforms.Browser)]
         public async Task ReadAsStreamAsync_HandlerProducesWellBehavedResponseStream(bool? chunked)
         {
             if (IsWinHttpHandler && UseVersion >= HttpVersion20.Value)
@@ -969,21 +968,24 @@ namespace System.Net.Http.Functional.Tests
                         // Boolean properties returning correct values
                         Assert.True(responseStream.CanRead);
                         Assert.False(responseStream.CanWrite);
-                        Assert.False(responseStream.CanSeek);
+                        Assert.Equal(PlatformDetection.IsBrowser, responseStream.CanSeek);
 
                         // Not supported operations
                         Assert.Throws<NotSupportedException>(() => responseStream.BeginWrite(new byte[1], 0, 1, null, null));
-                        Assert.Throws<NotSupportedException>(() => responseStream.Length);
-                        Assert.Throws<NotSupportedException>(() => responseStream.Position);
-                        Assert.Throws<NotSupportedException>(() => responseStream.Position = 0);
-                        Assert.Throws<NotSupportedException>(() => responseStream.Seek(0, SeekOrigin.Begin));
+                        if (PlatformDetection.IsNotBrowser)
+                        {
+                            Assert.Throws<NotSupportedException>(() => responseStream.Length);
+                            Assert.Throws<NotSupportedException>(() => responseStream.Position);
+                            Assert.Throws<NotSupportedException>(() => responseStream.Position = 0);
+                            Assert.Throws<NotSupportedException>(() => responseStream.Seek(0, SeekOrigin.Begin));
+                        }
                         Assert.Throws<NotSupportedException>(() => responseStream.SetLength(0));
                         Assert.Throws<NotSupportedException>(() => responseStream.Write(new byte[1], 0, 1));
 #if !NETFRAMEWORK
                         Assert.Throws<NotSupportedException>(() => responseStream.Write(new Span<byte>(new byte[1])));
-                        Assert.Throws<NotSupportedException>(() => { responseStream.WriteAsync(new Memory<byte>(new byte[1])); });
+                        await Assert.ThrowsAsync<NotSupportedException>(async () => await responseStream.WriteAsync(new Memory<byte>(new byte[1])));
 #endif
-                        Assert.Throws<NotSupportedException>(() => { responseStream.WriteAsync(new byte[1], 0, 1); });
+                        await Assert.ThrowsAsync<NotSupportedException>(async () => await responseStream.WriteAsync(new byte[1], 0, 1));
                         Assert.Throws<NotSupportedException>(() => responseStream.WriteByte(1));
 
                         // Invalid arguments
@@ -1102,7 +1104,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/54159", TestPlatforms.Browser)]
         public async Task ReadAsStreamAsync_EmptyResponseBody_HandlerProducesWellBehavedResponseStream()
         {
             if (IsWinHttpHandler && UseVersion >= HttpVersion20.Value)
@@ -1122,14 +1123,17 @@ namespace System.Net.Http.Functional.Tests
                         // Boolean properties returning correct values
                         Assert.True(responseStream.CanRead);
                         Assert.False(responseStream.CanWrite);
-                        Assert.False(responseStream.CanSeek);
+                        Assert.Equal(PlatformDetection.IsBrowser, responseStream.CanSeek);
 
                         // Not supported operations
                         Assert.Throws<NotSupportedException>(() => responseStream.BeginWrite(new byte[1], 0, 1, null, null));
-                        Assert.Throws<NotSupportedException>(() => responseStream.Length);
-                        Assert.Throws<NotSupportedException>(() => responseStream.Position);
-                        Assert.Throws<NotSupportedException>(() => responseStream.Position = 0);
-                        Assert.Throws<NotSupportedException>(() => responseStream.Seek(0, SeekOrigin.Begin));
+                        if (PlatformDetection.IsNotBrowser)
+                        {
+                            Assert.Throws<NotSupportedException>(() => responseStream.Length);
+                            Assert.Throws<NotSupportedException>(() => responseStream.Position);
+                            Assert.Throws<NotSupportedException>(() => responseStream.Position = 0);
+                            Assert.Throws<NotSupportedException>(() => responseStream.Seek(0, SeekOrigin.Begin));
+                        }
                         Assert.Throws<NotSupportedException>(() => responseStream.SetLength(0));
                         Assert.Throws<NotSupportedException>(() => responseStream.Write(new byte[1], 0, 1));
 #if !NETFRAMEWORK


### PR DESCRIPTION
As discussed [here](https://github.com/dotnet/runtime/pull/54303#issuecomment-863217223), the unit test is too restrictive.
Fixes https://github.com/dotnet/runtime/issues/54159
