### PR TITLE
[release/6.0-preview6] Set DLL flag on R2R binaries

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/R2RPEBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/R2RPEBuilder.cs
@@ -697,6 +697,7 @@ namespace ILCompiler.PEWriter
 
             imageCharacteristics &= ~(Characteristics.Bit32Machine | Characteristics.LargeAddressAware);
             imageCharacteristics |= (is64BitTarget ? Characteristics.LargeAddressAware : Characteristics.Bit32Machine);
+            imageCharacteristics |= Characteristics.Dll;
 
             ulong imageBase = PE32HeaderConstants.ImageBase;
             if (target.IsWindows && is64BitTarget && (imageBase <= uint.MaxValue))


### PR DESCRIPTION
Always set the `IMAGE_FILE_DLL` flag on output assemblies containing ReadyToRun code even if the corresponding input IL assembly misses it. This is required for R2R relocations to be processed by the OS loader on Windows 7 and Windows 8.1.  Fixes #54440.

## Customer Impact

Any `dotnet` command that uses `MSBuild.dll` (e.g., `dotnet restore`) crashes after jumping to an invalid memory address on Windows 7 and Windows 8.1. This is a regression caused by switching to Crossgen2 compiler. The only workaround is to disable ReadyToRun code using an environment variable, which would regress start-up performance.

## Testing

This one-line fix brings Crossgen2 on par with the old Crossgen that always set the flag in question.  The fix has been tested in the main branch.

## Risk

Low.