### PR TITLE
Add CollectionsMarshal.GetValueRefOrAddDefault

### DIFF
--- a/src/libraries/System.Collections/tests/Generic/Dictionary/HashCollisionScenarios/OutOfBoundsRegression.cs
+++ b/src/libraries/System.Collections/tests/Generic/Dictionary/HashCollisionScenarios/OutOfBoundsRegression.cs
@@ -90,6 +90,17 @@ namespace System.Collections.Tests
                 expectedPublicComparerBeforeCollisionThreshold: StringComparer.InvariantCulture,
                 expectedInternalComparerTypeAfterCollisionThreshold: StringComparer.InvariantCulture.GetType());
 
+            // CollectionsMarshal.GetValueRefOrAddDefault
+
+            RunCollectionTestCommon(
+                () => new Dictionary<string, object>(StringComparer.Ordinal),
+                (dictionary, key) => CollectionsMarshal.GetValueRefOrAddDefault(dictionary, key, out _) = null,
+                (dictionary, key) => dictionary.ContainsKey(key),
+                dictionary => dictionary.Comparer,
+                expectedInternalComparerTypeBeforeCollisionThreshold: nonRandomizedOrdinalComparerType,
+                expectedPublicComparerBeforeCollisionThreshold: StringComparer.Ordinal,
+                expectedInternalComparerTypeAfterCollisionThreshold: randomizedOrdinalComparerType);
+
             static void RunDictionaryTest(
                 IEqualityComparer<string> equalityComparer,
                 Type expectedInternalComparerTypeBeforeCollisionThreshold,

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
@@ -681,67 +681,105 @@ namespace System.Collections.Generic
             return true;
         }
 
-        internal ref TValue? GetValueRefOrAddDefault(TKey key, out bool exists)
+        /// <summary>
+        /// A helper class containing APIs exposed through <see cref="Runtime.InteropServices.CollectionsMarshal"/>.
+        /// These methods are relatively niche and only used in specific scenarios, so adding them in a separate type avoids
+        /// the additional overhead on each <see cref="Dictionary{TKey, TValue}"/> instantiation, especially in AOT scenarios.
+        /// </summary>
+        internal static class CollectionsMarshalHelper
         {
-            if (key == null)
+            /// <inheritdoc cref="Runtime.InteropServices.CollectionsMarshal.GetValueRefOrAddDefault{TKey, TValue}(Dictionary{TKey, TValue}, TKey, out bool)"/>
+            public static ref TValue? GetValueRefOrAddDefault(Dictionary<TKey, TValue> dictionary, TKey key, out bool exists)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
-            }
-
-            if (_buckets == null)
-            {
-                Initialize(0);
-            }
-            Debug.Assert(_buckets != null);
-
-            Entry[]? entries = _entries;
-            Debug.Assert(entries != null, "expected entries to be non-null");
-
-            IEqualityComparer<TKey>? comparer = _comparer;
-            uint hashCode = (uint)((comparer == null) ? key.GetHashCode() : comparer.GetHashCode(key));
-
-            uint collisionCount = 0;
-            ref int bucket = ref GetBucket(hashCode);
-            int i = bucket - 1; // Value in _buckets is 1-based
-
-            if (comparer == null)
-            {
-                if (typeof(TKey).IsValueType)
+                if (key == null)
                 {
-                    // ValueType: Devirtualize with EqualityComparer<TValue>.Default intrinsic
-                    while (true)
+                    ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
+                }
+
+                if (dictionary._buckets == null)
+                {
+                    dictionary.Initialize(0);
+                }
+                Debug.Assert(dictionary._buckets != null);
+
+                Entry[]? entries = dictionary._entries;
+                Debug.Assert(entries != null, "expected entries to be non-null");
+
+                IEqualityComparer<TKey>? comparer = dictionary._comparer;
+                uint hashCode = (uint)((comparer == null) ? key.GetHashCode() : comparer.GetHashCode(key));
+
+                uint collisionCount = 0;
+                ref int bucket = ref dictionary.GetBucket(hashCode);
+                int i = bucket - 1; // Value in _buckets is 1-based
+
+                if (comparer == null)
+                {
+                    if (typeof(TKey).IsValueType)
                     {
-                        // Should be a while loop https://github.com/dotnet/runtime/issues/9422
-                        // Test uint in if rather than loop condition to drop range check for following array access
-                        if ((uint)i >= (uint)entries.Length)
+                        // ValueType: Devirtualize with EqualityComparer<TValue>.Default intrinsic
+                        while (true)
                         {
-                            break;
+                            // Should be a while loop https://github.com/dotnet/runtime/issues/9422
+                            // Test uint in if rather than loop condition to drop range check for following array access
+                            if ((uint)i >= (uint)entries.Length)
+                            {
+                                break;
+                            }
+
+                            if (entries[i].hashCode == hashCode && EqualityComparer<TKey>.Default.Equals(entries[i].key, key))
+                            {
+                                exists = true;
+
+                                return ref entries[i].value!;
+                            }
+
+                            i = entries[i].next;
+
+                            collisionCount++;
+                            if (collisionCount > (uint)entries.Length)
+                            {
+                                // The chain of entries forms a loop; which means a concurrent update has happened.
+                                // Break out of the loop and throw, rather than looping forever.
+                                ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                            }
                         }
-
-                        if (entries[i].hashCode == hashCode && EqualityComparer<TKey>.Default.Equals(entries[i].key, key))
+                    }
+                    else
+                    {
+                        // Object type: Shared Generic, EqualityComparer<TValue>.Default won't devirtualize
+                        // https://github.com/dotnet/runtime/issues/10050
+                        // So cache in a local rather than get EqualityComparer per loop iteration
+                        EqualityComparer<TKey> defaultComparer = EqualityComparer<TKey>.Default;
+                        while (true)
                         {
-                            exists = true;
+                            // Should be a while loop https://github.com/dotnet/runtime/issues/9422
+                            // Test uint in if rather than loop condition to drop range check for following array access
+                            if ((uint)i >= (uint)entries.Length)
+                            {
+                                break;
+                            }
 
-                            return ref entries[i].value!;
-                        }
+                            if (entries[i].hashCode == hashCode && defaultComparer.Equals(entries[i].key, key))
+                            {
+                                exists = true;
 
-                        i = entries[i].next;
+                                return ref entries[i].value!;
+                            }
 
-                        collisionCount++;
-                        if (collisionCount > (uint)entries.Length)
-                        {
-                            // The chain of entries forms a loop; which means a concurrent update has happened.
-                            // Break out of the loop and throw, rather than looping forever.
-                            ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                            i = entries[i].next;
+
+                            collisionCount++;
+                            if (collisionCount > (uint)entries.Length)
+                            {
+                                // The chain of entries forms a loop; which means a concurrent update has happened.
+                                // Break out of the loop and throw, rather than looping forever.
+                                ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                            }
                         }
                     }
                 }
                 else
                 {
-                    // Object type: Shared Generic, EqualityComparer<TValue>.Default won't devirtualize
-                    // https://github.com/dotnet/runtime/issues/10050
-                    // So cache in a local rather than get EqualityComparer per loop iteration
-                    EqualityComparer<TKey> defaultComparer = EqualityComparer<TKey>.Default;
                     while (true)
                     {
                         // Should be a while loop https://github.com/dotnet/runtime/issues/9422
@@ -751,7 +789,7 @@ namespace System.Collections.Generic
                             break;
                         }
 
-                        if (entries[i].hashCode == hashCode && defaultComparer.Equals(entries[i].key, key))
+                        if (entries[i].hashCode == hashCode && comparer.Equals(entries[i].key, key))
                         {
                             exists = true;
 
@@ -769,88 +807,59 @@ namespace System.Collections.Generic
                         }
                     }
                 }
-            }
-            else
-            {
-                while (true)
+
+                int index;
+                if (dictionary._freeCount > 0)
                 {
-                    // Should be a while loop https://github.com/dotnet/runtime/issues/9422
-                    // Test uint in if rather than loop condition to drop range check for following array access
-                    if ((uint)i >= (uint)entries.Length)
-                    {
-                        break;
-                    }
-
-                    if (entries[i].hashCode == hashCode && comparer.Equals(entries[i].key, key))
-                    {
-                        exists = true;
-
-                        return ref entries[i].value!;
-                    }
-
-                    i = entries[i].next;
-
-                    collisionCount++;
-                    if (collisionCount > (uint)entries.Length)
-                    {
-                        // The chain of entries forms a loop; which means a concurrent update has happened.
-                        // Break out of the loop and throw, rather than looping forever.
-                        ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
-                    }
+                    index = dictionary._freeList;
+                    Debug.Assert((StartOfFreeList - entries[dictionary._freeList].next) >= -1, "shouldn't overflow because `next` cannot underflow");
+                    dictionary._freeList = StartOfFreeList - entries[dictionary._freeList].next;
+                    dictionary._freeCount--;
                 }
-            }
-
-            int index;
-            if (_freeCount > 0)
-            {
-                index = _freeList;
-                Debug.Assert((StartOfFreeList - entries[_freeList].next) >= -1, "shouldn't overflow because `next` cannot underflow");
-                _freeList = StartOfFreeList - entries[_freeList].next;
-                _freeCount--;
-            }
-            else
-            {
-                int count = _count;
-                if (count == entries.Length)
+                else
                 {
-                    Resize();
-                    bucket = ref GetBucket(hashCode);
+                    int count = dictionary._count;
+                    if (count == entries.Length)
+                    {
+                        dictionary.Resize();
+                        bucket = ref dictionary.GetBucket(hashCode);
+                    }
+                    index = count;
+                    dictionary._count = count + 1;
+                    entries = dictionary._entries;
                 }
-                index = count;
-                _count = count + 1;
-                entries = _entries;
-            }
 
-            ref Entry entry = ref entries![index];
-            entry.hashCode = hashCode;
-            entry.next = bucket - 1; // Value in _buckets is 1-based
-            entry.key = key;
-            entry.value = default!;
-            bucket = index + 1; // Value in _buckets is 1-based
-            _version++;
+                ref Entry entry = ref entries![index];
+                entry.hashCode = hashCode;
+                entry.next = bucket - 1; // Value in _buckets is 1-based
+                entry.key = key;
+                entry.value = default!;
+                bucket = index + 1; // Value in _buckets is 1-based
+                dictionary._version++;
 
-            // Value types never rehash
-            if (!typeof(TKey).IsValueType && collisionCount > HashHelpers.HashCollisionThreshold && comparer is NonRandomizedStringEqualityComparer)
-            {
-                // If we hit the collision threshold we'll need to switch to the comparer which is using randomized string hashing
-                // i.e. EqualityComparer<string>.Default.
-                Resize(entries.Length, true);
+                // Value types never rehash
+                if (!typeof(TKey).IsValueType && collisionCount > HashHelpers.HashCollisionThreshold && comparer is NonRandomizedStringEqualityComparer)
+                {
+                    // If we hit the collision threshold we'll need to switch to the comparer which is using randomized string hashing
+                    // i.e. EqualityComparer<string>.Default.
+                    dictionary.Resize(entries.Length, true);
+
+                    exists = false;
+
+                    // At this point the entries array has been resized, so the current reference we have is no longer valid.
+                    // We're forced to do a new lookup and return an updated reference to the new entry instance. This new
+                    // lookup is guaranteed to always find a value though and it will never return a null reference here.
+                    ref TValue? value = ref dictionary.FindValue(key)!;
+
+                    Debug.Assert(!Unsafe.IsNullRef(ref value), "the lookup result cannot be a null ref here");
+
+                    return ref value;
+                }
 
                 exists = false;
 
-                // At this point the entries array has been resized, so the current reference we have is no longer valid.
-                // We're forced to do a new lookup and return an updated reference to the new entry instance. This new
-                // lookup is guaranteed to always find a value though and it will never return a null reference here.
-                ref TValue? value = ref FindValue(key)!;
-
-                Debug.Assert(!Unsafe.IsNullRef(ref value), "the lookup result cannot be a null ref here");
-
-                return ref value;
+                return ref entry.value!;
             }
-
-            exists = false;
-
-            return ref entry.value!;
         }
 
         public virtual void OnDeserialization(object? sender)

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
@@ -835,6 +835,17 @@ namespace System.Collections.Generic
                 // If we hit the collision threshold we'll need to switch to the comparer which is using randomized string hashing
                 // i.e. EqualityComparer<string>.Default.
                 Resize(entries.Length, true);
+
+                exists = false;
+
+                // At this point the entries array has been resized, so the current reference we have is no longer valid.
+                // We're forced to do a new lookup and return an updated reference to the new entry instance. This new
+                // lookup is guaranteed to always find a value though and it will never return a null reference here.
+                ref TValue? value = ref FindValue(key)!;
+
+                Debug.Assert(!Unsafe.IsNullRef(ref value), "the lookup result cannot be a null ref here");
+
+                return ref value;
             }
 
             exists = false;

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
@@ -497,6 +497,9 @@ namespace System.Collections.Generic
 
         private bool TryInsert(TKey key, TValue value, InsertionBehavior behavior)
         {
+            // NOTE: this method is mirrored in CollectionsMarshal.GetValueRefOrAddDefault below.
+            // If you make any changes here, make sure to keep that version in sync as well.
+
             if (key == null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
@@ -691,6 +694,9 @@ namespace System.Collections.Generic
             /// <inheritdoc cref="Runtime.InteropServices.CollectionsMarshal.GetValueRefOrAddDefault{TKey, TValue}(Dictionary{TKey, TValue}, TKey, out bool)"/>
             public static ref TValue? GetValueRefOrAddDefault(Dictionary<TKey, TValue> dictionary, TKey key, out bool exists)
             {
+                // NOTE: this method is mirrored by Dictionary<TKey, TValue>.TryInsert above.
+                // If you make any changes here, make sure to keep that version in sync as well.
+
                 if (key == null)
                 {
                     ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CollectionsMarshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CollectionsMarshal.cs
@@ -38,6 +38,6 @@ namespace System.Runtime.InteropServices
         /// <param name="exists">Whether or not a new entry for the given key was added to the dictionary.</param>
         /// <remarks>Items should not be added to or removed from the <see cref="Dictionary{TKey, TValue}"/> while the ref <typeparamref name="TValue"/> is in use.</remarks>
         public static ref TValue? GetValueRefOrAddDefault<TKey, TValue>(Dictionary<TKey, TValue> dictionary, TKey key, out bool exists) where TKey : notnull
-            => ref dictionary.GetValueRefOrAddDefault(key, out exists);
+            => ref Dictionary<TKey, TValue>.CollectionsMarshalHelper.GetValueRefOrAddDefault(dictionary, key, out exists);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CollectionsMarshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CollectionsMarshal.cs
@@ -29,5 +29,15 @@ namespace System.Runtime.InteropServices
         /// </remarks>
         public static ref TValue GetValueRefOrNullRef<TKey, TValue>(Dictionary<TKey, TValue> dictionary, TKey key) where TKey : notnull
             => ref dictionary.FindValue(key);
+
+        /// <summary>
+        /// Gets a ref to a <typeparamref name="TValue"/> in the <see cref="Dictionary{TKey, TValue}"/>, adding a new entry with a default value if it does not exist in the <paramref name="dictionary"/>.
+        /// </summary>
+        /// <param name="dictionary">The dictionary to get the ref to <typeparamref name="TValue"/> from.</param>
+        /// <param name="key">The key used for lookup.</param>
+        /// <param name="exists">Whether or not a new entry for the given key was added to the dictionary.</param>
+        /// <remarks>Items should not be added to or removed from the <see cref="Dictionary{TKey, TValue}"/> while the ref <typeparamref name="TValue"/> is in use.</remarks>
+        public static ref TValue? GetValueRefOrAddDefault<TKey, TValue>(Dictionary<TKey, TValue> dictionary, TKey key, out bool exists) where TKey : notnull
+            => ref dictionary.GetValueRefOrAddDefault(key, out exists);
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -177,6 +177,7 @@ namespace System.Runtime.InteropServices
     {
         public static System.Span<T> AsSpan<T>(System.Collections.Generic.List<T>? list) { throw null; }
         public static ref TValue GetValueRefOrNullRef<TKey, TValue>(System.Collections.Generic.Dictionary<TKey, TValue> dictionary, TKey key) where TKey : notnull { throw null; }
+        public static ref TValue? GetValueRefOrAddDefault<TKey, TValue>(System.Collections.Generic.Dictionary<TKey, TValue> dictionary, TKey key, out bool exists) where TKey : notnull { throw null; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Parameter | System.AttributeTargets.Property | System.AttributeTargets.ReturnValue, Inherited=false)]
     public sealed partial class ComAliasNameAttribute : System.Attribute

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/CollectionsMarshalTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/CollectionsMarshalTests.cs
@@ -299,6 +299,200 @@ namespace System.Runtime.InteropServices.Tests
             Assert.Equal(50, dict.Count);
         }
 
+        [Fact]
+        public void GetValueRefOrAddDefaultValueType()
+        {
+            // This test is the same as the one for GetValueRefOrNullRef, but it uses
+            // GetValueRefOrAddDefault instead, and also checks for incorrect additions.
+            // The two APIs should behave the same when values are already existing.
+            var dict = new Dictionary<int, Struct>
+            {
+                {  1, default },
+                {  2, default }
+            };
+
+            Assert.Equal(2, dict.Count);
+
+            Assert.Equal(0, dict[1].Value);
+            Assert.Equal(0, dict[1].Property);
+
+            var itemVal = dict[1];
+            itemVal.Value = 1;
+            itemVal.Property = 2;
+
+            // Does not change values in dictionary
+            Assert.Equal(0, dict[1].Value);
+            Assert.Equal(0, dict[1].Property);
+
+            CollectionsMarshal.GetValueRefOrAddDefault(dict, 1, out bool exists).Value = 3;
+
+            Assert.True(exists);
+            Assert.Equal(2, dict.Count);
+
+            CollectionsMarshal.GetValueRefOrAddDefault(dict, 1, out exists).Property = 4;
+
+            Assert.True(exists);
+            Assert.Equal(2, dict.Count);
+            Assert.Equal(3, dict[1].Value);
+            Assert.Equal(4, dict[1].Property);
+
+            ref var itemRef = ref CollectionsMarshal.GetValueRefOrAddDefault(dict, 2, out exists);
+
+            Assert.True(exists);
+            Assert.Equal(2, dict.Count);
+            Assert.Equal(0, itemRef.Value);
+            Assert.Equal(0, itemRef.Property);
+
+            itemRef.Value = 5;
+            itemRef.Property = 6;
+
+            Assert.Equal(5, itemRef.Value);
+            Assert.Equal(6, itemRef.Property);
+            Assert.Equal(dict[2].Value, itemRef.Value);
+            Assert.Equal(dict[2].Property, itemRef.Property);
+
+            itemRef = new() { Value = 7, Property = 8 };
+
+            Assert.Equal(7, itemRef.Value);
+            Assert.Equal(8, itemRef.Property);
+            Assert.Equal(dict[2].Value, itemRef.Value);
+            Assert.Equal(dict[2].Property, itemRef.Property);
+
+            // Check for correct additions
+
+            ref var entry3Ref = ref CollectionsMarshal.GetValueRefOrAddDefault(dict, 3, out exists);
+
+            Assert.False(exists);
+            Assert.Equal(3, dict.Count);
+            Assert.False(Unsafe.IsNullRef(ref entry3Ref));
+
+            entry3Ref.Property = 42;
+            entry3Ref.Value = 12345;
+
+            var value3 = dict[3];
+
+            Assert.Equal(42, value3.Property);
+            Assert.Equal(12345, value3.Value);
+        }
+
+        [Fact]
+        public void GetValueRefOrAddDefaultClass()
+        {
+            var dict = new Dictionary<int, IntAsObject>
+            {
+                {  1, new() },
+                {  2, new() }
+            };
+
+            Assert.Equal(2, dict.Count);
+
+            Assert.Equal(0, dict[1].Value);
+            Assert.Equal(0, dict[1].Property);
+
+            var itemVal = dict[1];
+            itemVal.Value = 1;
+            itemVal.Property = 2;
+
+            // Does change values in dictionary
+            Assert.Equal(1, dict[1].Value);
+            Assert.Equal(2, dict[1].Property);
+
+            CollectionsMarshal.GetValueRefOrAddDefault(dict, 1, out bool exists).Value = 3;
+
+            Assert.True(exists);
+            Assert.Equal(2, dict.Count);
+
+            CollectionsMarshal.GetValueRefOrAddDefault(dict, 1, out exists).Property = 4;
+
+            Assert.True(exists);
+            Assert.Equal(2, dict.Count);
+            Assert.Equal(3, dict[1].Value);
+            Assert.Equal(4, dict[1].Property);
+
+            ref var itemRef = ref CollectionsMarshal.GetValueRefOrAddDefault(dict, 2, out exists);
+
+            Assert.True(exists);
+            Assert.Equal(2, dict.Count);
+            Assert.Equal(0, itemRef.Value);
+            Assert.Equal(0, itemRef.Property);
+
+            itemRef.Value = 5;
+            itemRef.Property = 6;
+
+            Assert.Equal(5, itemRef.Value);
+            Assert.Equal(6, itemRef.Property);
+            Assert.Equal(dict[2].Value, itemRef.Value);
+            Assert.Equal(dict[2].Property, itemRef.Property);
+
+            itemRef = new() { Value = 7, Property = 8 };
+
+            Assert.Equal(7, itemRef.Value);
+            Assert.Equal(8, itemRef.Property);
+            Assert.Equal(dict[2].Value, itemRef.Value);
+            Assert.Equal(dict[2].Property, itemRef.Property);
+
+            // Check for correct additions
+
+            ref var entry3Ref = ref CollectionsMarshal.GetValueRefOrAddDefault(dict, 3, out exists);
+
+            Assert.False(exists);
+            Assert.Equal(3, dict.Count);
+            Assert.False(Unsafe.IsNullRef(ref entry3Ref));
+            Assert.Null(entry3Ref);
+
+            entry3Ref = new() { Value = 12345, Property = 42 };
+
+            var value3 = dict[3];
+
+            Assert.Equal(42, value3.Property);
+            Assert.Equal(12345, value3.Value);
+        }
+
+        [Fact]
+        public void GetValueRefOrAddDefaultLinkBreaksOnResize()
+        {
+            var dict = new Dictionary<int, Struct>
+            {
+                {  1, new() }
+            };
+
+            Assert.Equal(1, dict.Count);
+
+            ref var itemRef = ref CollectionsMarshal.GetValueRefOrAddDefault(dict, 1, out bool exists);
+
+            Assert.True(exists);
+            Assert.Equal(1, dict.Count);
+            Assert.Equal(0, itemRef.Value);
+            Assert.Equal(0, itemRef.Property);
+
+            itemRef.Value = 1;
+            itemRef.Property = 2;
+
+            Assert.Equal(1, itemRef.Value);
+            Assert.Equal(2, itemRef.Property);
+            Assert.Equal(dict[1].Value, itemRef.Value);
+            Assert.Equal(dict[1].Property, itemRef.Property);
+
+            // Resize
+            dict.EnsureCapacity(100);
+            for (int i = 2; i <= 50; i++)
+            {
+                dict.Add(i, new());
+            }
+
+            itemRef.Value = 3;
+            itemRef.Property = 4;
+
+            Assert.Equal(3, itemRef.Value);
+            Assert.Equal(4, itemRef.Property);
+
+            // Check connection broken
+            Assert.NotEqual(dict[1].Value, itemRef.Value);
+            Assert.NotEqual(dict[1].Property, itemRef.Property);
+
+            Assert.Equal(50, dict.Count);
+        }
+
         private struct Struct
         {
             public int Value;

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/CollectionsMarshalTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/CollectionsMarshalTests.cs
@@ -365,6 +365,7 @@ namespace System.Runtime.InteropServices.Tests
             Assert.False(exists);
             Assert.Equal(3, dict.Count);
             Assert.False(Unsafe.IsNullRef(ref entry3Ref));
+            Assert.True(EqualityComparer<Struct>.Default.Equals(entry3Ref, default));
 
             entry3Ref.Property = 42;
             entry3Ref.Value = 12345;

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/CollectionsMarshalTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/CollectionsMarshalTests.cs
@@ -304,7 +304,7 @@ namespace System.Runtime.InteropServices.Tests
         {
             // This test is the same as the one for GetValueRefOrNullRef, but it uses
             // GetValueRefOrAddDefault instead, and also checks for incorrect additions.
-            // The two APIs should behave the same when values are already existing.
+            // The two APIs should behave the same when values already exist.
             var dict = new Dictionary<int, Struct>
             {
                 {  1, default },


### PR DESCRIPTION
### Contributes to https://github.com/dotnet/runtime/issues/27062

```csharp
namespace System.Runtime.InteropServices
{
    public static class CollectionsMarshal
    {
        public static ref TValue? GetValueRefOrAddDefault<TKey, TValue>(Dictionary<TKey, TValue> dictionary, TKey key, out bool exists)
            where TKey : notnull;
    }
}
```

> **NOTE:** I've marked the returned `TValue` as an uncostrained nullable value, because if `TValue` is a reference type the returned reference will point to `null`. Value types are not affected by this, ie. there is no `Nullable<T>` involved here at all.