### PR TITLE
Http2Stream throws a wrapped Http2ConnectionException on GO_AWAY

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -1275,6 +1275,15 @@ namespace System.Net.Http
                         await _connection.SendStreamDataAsync(StreamId, current, flush, _requestBodyCancellationSource.Token).ConfigureAwait(false);
                     }
                 }
+                catch (Exception)
+                {
+                    if (_resetException is Exception resetException)
+                    {
+                        ThrowRequestAborted(resetException);
+                    }
+
+                    throw;
+                }
                 finally
                 {
                     linkedRegistration.Dispose();

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -1275,7 +1275,7 @@ namespace System.Net.Http
                         await _connection.SendStreamDataAsync(StreamId, current, flush, _requestBodyCancellationSource.Token).ConfigureAwait(false);
                     }
                 }
-                catch (Exception)
+                catch (OperationCanceledException e) when (e.CancellationToken == _requestBodyCancellationSource.Token)
                 {
                     if (_resetException is Exception resetException)
                     {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -1279,6 +1279,11 @@ namespace System.Net.Http
                 {
                     if (_resetException is Exception resetException)
                     {
+                        if (_canRetry)
+                        {
+                            ThrowRetry(SR.net_http_request_aborted, resetException);
+                        }
+
                         ThrowRequestAborted(resetException);
                     }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -1277,14 +1277,17 @@ namespace System.Net.Http
                 }
                 catch (OperationCanceledException e) when (e.CancellationToken == _requestBodyCancellationSource.Token)
                 {
-                    if (_resetException is Exception resetException)
+                    lock (SyncObject)
                     {
-                        if (_canRetry)
+                        if (_resetException is Exception resetException)
                         {
-                            ThrowRetry(SR.net_http_request_aborted, resetException);
-                        }
+                            if (_canRetry)
+                            {
+                                ThrowRetry(SR.net_http_request_aborted, resetException);
+                            }
 
-                        ThrowRequestAborted(resetException);
+                            ThrowRequestAborted(resetException);
+                        }
                     }
 
                     throw;

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -921,6 +921,7 @@ namespace System.Net.Http.Functional.Tests
                 (int streamId, _) = await connection.ReadAndParseRequestHeaderAsync(readBody: false);
                 await connection.SendDefaultResponseHeadersAsync(streamId);
 
+                Debugger.Launch();
                 await connection.SendGoAway(0, errorCode: ProtocolErrors.PROTOCOL_ERROR);
 
                 // Expect client to detect that server has disconnected and throw an exception
@@ -932,7 +933,7 @@ namespace System.Net.Http.Functional.Tests
 
                 Assert.IsType<IOException>(exception.InnerException);
                 Assert.NotNull(exception.InnerException.InnerException);
-                Assert.Contains("HTTP/2 error code 'PROTOCOL_ERROR'", exception.InnerException.InnerException.Message);
+                Assert.Contains("PROTOCOL_ERROR", exception.InnerException.InnerException.Message);
             }
         }
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -904,6 +904,39 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ConditionalFact(nameof(SupportsAlpn))]
+        public async Task GoAwayFrame_RequestWithBody_ServerDisconnect_AbortStreamsAndThrowIOException()
+        {
+            using (Http2LoopbackServer server = Http2LoopbackServer.CreateServer())
+            using (HttpClient client = CreateHttpClient())
+            {
+                var request = new HttpRequestMessage(HttpMethod.Post, server.Address);
+                request.Version = new Version(2, 0);
+                var content = new string('*', 300);
+                var stream = new CustomContent.SlowTestStream(Encoding.UTF8.GetBytes(content), null, count: 60);
+                request.Content = new CustomContent(stream);
+
+                Task<HttpResponseMessage> sendTask = client.SendAsync(request);
+
+                Http2LoopbackConnection connection = await server.EstablishConnectionAsync();
+                (int streamId, _) = await connection.ReadAndParseRequestHeaderAsync(readBody: false);
+                await connection.SendDefaultResponseHeadersAsync(streamId);
+
+                await connection.SendGoAway(0, errorCode: ProtocolErrors.PROTOCOL_ERROR);
+
+                // Expect client to detect that server has disconnected and throw an exception
+                var exception = await Assert.ThrowsAnyAsync<HttpRequestException>(() =>
+                    new Task[]
+                    {
+                        sendTask
+                    }.WhenAllOrAnyFailed(TestHelper.PassingTestTimeoutMilliseconds));
+
+                Assert.IsType<IOException>(exception.InnerException);
+                Assert.NotNull(exception.InnerException.InnerException);
+                Assert.Contains("HTTP/2 error code 'PROTOCOL_ERROR'", exception.InnerException.InnerException.Message);
+            }
+        }
+
+        [ConditionalFact(nameof(SupportsAlpn))]
         public async Task GoAwayFrame_UnprocessedStreamFirstRequestFinishedFirst_RequestRestarted()
         {
             // This test case is similar to GoAwayFrame_UnprocessedStreamFirstRequestWaitsUntilSecondFinishes_RequestRestarted
@@ -2790,8 +2823,8 @@ namespace System.Net.Http.Functional.Tests
                     // Trying to read on the response stream should fail now, and client should ignore any data received
                     await AssertProtocolErrorForIOExceptionAsync(SendAndReceiveResponseDataAsync(contentBytes, responseStream, connection, streamId), ProtocolErrors.ENHANCE_YOUR_CALM);
 
-                    // Attempting to write on the request body should now fail with OperationCanceledException.
-                    Exception e = await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => { await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId); });
+                    // Attempting to write on the request body should now fail with IOException.
+                    Exception e = await Assert.ThrowsAnyAsync<IOException>(async () => { await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId); });
 
                     // Propagate the exception to the request stream serialization task.
                     // This allows the request processing to complete.

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -921,7 +921,6 @@ namespace System.Net.Http.Functional.Tests
                 (int streamId, _) = await connection.ReadAndParseRequestHeaderAsync(readBody: false);
                 await connection.SendDefaultResponseHeadersAsync(streamId);
 
-                Debugger.Launch();
                 await connection.SendGoAway(0, errorCode: ProtocolErrors.PROTOCOL_ERROR);
 
                 // Expect client to detect that server has disconnected and throw an exception


### PR DESCRIPTION
If server sends `GO_AWAY` to client, `Http2Connection` handles it and sets a correct `Http2ConnectionException` to `_resetException` field followed by resetting all active Http2Streams. Each of these streams is expected to rethrow that `_resetException` to communicate the original protocol error to the application code. However, the method `Http2Stream.SendDataAsync` currently doesn't take into account that field, thus when it gets cancelled as part of a stream reset it just throws `OperationCanceledException` which doesn't contain any details. This PR fixes that and makes `Http2Stream.SendDataAsync` throw the original `Http2ConnectionException` wrapped by `IOException`.

Fixes #42472