### PR TITLE
[wasm] Fix blazor/aot builds

### DIFF
--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -336,6 +336,10 @@ EMSCRIPTEN_KEEPALIVE void mono_wasm_load_profiler_aot (const char *desc) { mono_
   -->
 
   <Target Name="_WasmAotCompileApp" Condition="'$(RunAOTCompilation)' == 'true'">
+    <PropertyGroup>
+      <_MonoAotCrossCompilerPath>@(MonoAotCrossCompiler->WithMetadataValue('RuntimeIdentifier','browser-wasm'))</_MonoAotCrossCompilerPath>
+    </PropertyGroup>
+
     <Error Condition="'@(_WasmAssembliesInternal)' == ''" Text="Item _WasmAssembliesInternal is empty" />
     <Error Condition="'$(_IsEMSDKMissing)' == 'true'"
            Text="$(_EMSDKMissingErrorMessage) Emscripten SDK is required for AOT'ing assemblies." />


### PR DESCRIPTION
`dotnet\packs\Microsoft.NET.Runtime.WebAssembly.Sdk\6.0.0-preview.7.21321.15\Sdk\WasmApp.Native.targets(342,5): error : Could not find AOT cross compiler at $(_MonoAotCrossCompilerPath)=`

Make sure this is set for the aot code path.

## Background:

- This wasn't getting caught by the `Wasm.Build.Tests` because they rely on the `runtime` repo's infrastructure to get all the bits required for building, which includes the cross compiler. So, the correct properties are already set up.

- In case of workloads though, all this information comes from the *packs*, including the cross compiler path. There was a recent change to use an item for cross compiler paths(because on other platforms, there could be more than one available cross compiler, eg. android), instead of a property.
- So, the targets were updated to extract the path in case of wasm
  - *but* the update was incomplete
  - since this property->item change is only in the `Sdk.props` for the cross compiler, it comes into play only with workloads!

I have an upcoming PR, which enables running `Wasm.Build.Tests` with workloads, and that would be able to catch this bug.