### PR TITLE
Add metadatatoken override to SymbolMethod

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/SymbolMethod.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/SymbolMethod.cs
@@ -67,6 +67,8 @@ namespace System.Reflection.Emit
         #endregion
 
         #region MemberInfo Overrides
+        public override int MetadataToken => m_token;
+
         public override Module Module => m_module;
 
         public override Type? ReflectedType => m_containingType;

--- a/src/libraries/System.Reflection.Emit/tests/ModuleBuilder/ModuleBuilderGetArrayMethod.cs
+++ b/src/libraries/System.Reflection.Emit/tests/ModuleBuilder/ModuleBuilderGetArrayMethod.cs
@@ -137,6 +137,7 @@ namespace System.Reflection.Emit.Tests
             Assert.Equal(methodName, method.Name);
             Assert.Equal(callingConvention, method.CallingConvention);
             Assert.Equal(returnType, method.ReturnType);
+            Assert.NotEqual(0, method.MetadataToken);
         }
     }
 }


### PR DESCRIPTION
Fixes #53300 - RefEmit SymbolMethod should probably have a Metadata token override

The MetadataToken base implementation of MetadataToken throws an exception.  This provides an implementation that merely returns m_token to get a token for the symbol.

Originally the token was retrieved using the GetToken() method removed here:   https://github.com/dotnet/runtime/commit/b72b13e#diff-0db30e8f862ac0489421d919d343654824ac89bd001e8fb50e3c54cb53862b85L138

m_token is passed in to the SymbolMethod constructor

**Without Fix**
````
C:\kevinransom\runtime\artifacts\bin\testhost\net6.0-windows-Release-x64>dotnet C:\kevinransom\fsharp\artifacts\bin\fsi\Release\net5.0\fsi.dll

Microsoft (R) F# Interactive version 11.4.2.0 for F# 5.0
Copyright (c) Microsoft Corporation. All Rights Reserved.

For help type #help;;

> let arr = Array2D.create 3 4 0
- let _ = Array2D.get arr 0 0;;


error FS0193: internal error: Operation is not valid due to the current state of the object.

>
````

**With Fix**
````
C:\kevinransom\runtime\artifacts\bin\testhost\net6.0-windows-Release-x64>dotnet C:\kevinransom\fsharp\artifacts\bin\fsi\Release\net5.0\fsi.dll

Microsoft (R) F# Interactive version 11.4.2.0 for F# 5.0
Copyright (c) Microsoft Corporation. All Rights Reserved.

For help type #help;;

> let arr = Array2D.create 3 4 0
- let _ = Array2D.get arr 0 0;;
val arr : int [,] = [[0; 0; 0; 0]
                     [0; 0; 0; 0]
                     [0; 0; 0; 0]]
````


