### PR TITLE
Fix sporadic double fd close

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/RandomAccess/Base.cs
+++ b/src/libraries/System.IO.FileSystem/tests/RandomAccess/Base.cs
@@ -46,7 +46,7 @@ namespace System.IO.Tests
         public void ThrowsNotSupportedExceptionForUnseekableFile()
         {
             using (var server = new AnonymousPipeServerStream(PipeDirection.Out))
-            using (SafeFileHandle handle = new SafeFileHandle(server.SafePipeHandle.DangerousGetHandle(), true))
+            using (SafeFileHandle handle = new SafeFileHandle(server.SafePipeHandle.DangerousGetHandle(), ownsHandle: false))
             {
                 Assert.Throws<NotSupportedException>(() => MethodUnderTest(handle, Array.Empty<byte>(), 0));
             }


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/54589

Untested.

I looked at other grep hits in the tests for `new SafeFileHandle.*DangerousGetHandle.*true` and they seem to avoid this problem by calling `SetHandleAsInvalid()`.