### PR TITLE
[wasm][debugger] Fixing debugger tests errors

### DIFF
--- a/src/mono/mono/mini/mini-wasm-debugger.c
+++ b/src/mono/mono/mini/mini-wasm-debugger.c
@@ -250,6 +250,7 @@ static gboolean
 write_value_to_buffer (MdbgProtBuffer *buf, MonoTypeEnum type, const char* variableValue)
 {
 	char* endptr = NULL;
+	const char *variableValueEnd = variableValue + strlen(variableValue);
 	errno = 0;
 	buffer_add_byte (buf, type);
 	switch (type) {
@@ -268,7 +269,7 @@ write_value_to_buffer (MdbgProtBuffer *buf, MonoTypeEnum type, const char* varia
 			break;
 		case MONO_TYPE_I1: {
 			intmax_t val = strtoimax (variableValue, &endptr, 10);
-			if (errno != 0 || variableValue == endptr)
+			if (errno != 0 || variableValue == endptr || endptr != variableValueEnd)
 				return FALSE;
 			if (val >= -128 && val <= 127)
 				buffer_add_int (buf, val);
@@ -278,7 +279,7 @@ write_value_to_buffer (MdbgProtBuffer *buf, MonoTypeEnum type, const char* varia
 		}
 		case MONO_TYPE_U1: {
 			intmax_t val = strtoimax (variableValue, &endptr, 10);
-			if (errno != 0 || variableValue == endptr)
+			if (errno != 0 || variableValue == endptr || endptr != variableValueEnd)
 				return FALSE;
 			if (val >= 0 && val <= 255)
 				buffer_add_int (buf, val);
@@ -288,7 +289,7 @@ write_value_to_buffer (MdbgProtBuffer *buf, MonoTypeEnum type, const char* varia
 		}
 		case MONO_TYPE_I2: {
 			intmax_t val = strtoimax (variableValue, &endptr, 10);
-			if (errno != 0 || variableValue == endptr)
+			if (errno != 0 || variableValue == endptr || endptr != variableValueEnd)
 				return FALSE;
 			if (val >= -32768 && val <= 32767)
 				buffer_add_int (buf, val);
@@ -298,7 +299,7 @@ write_value_to_buffer (MdbgProtBuffer *buf, MonoTypeEnum type, const char* varia
 		}
 		case MONO_TYPE_U2: {
 			intmax_t val = strtoimax (variableValue, &endptr, 10);
-			if (errno != 0 || variableValue == endptr)
+			if (errno != 0 || variableValue == endptr || endptr != variableValueEnd)
 				return FALSE;
 			if (val >= 0 && val <= 65535)
 				buffer_add_int (buf, val);
@@ -308,7 +309,7 @@ write_value_to_buffer (MdbgProtBuffer *buf, MonoTypeEnum type, const char* varia
 		}
 		case MONO_TYPE_I4: {
 			intmax_t val = strtoimax (variableValue, &endptr, 10);
-			if (errno != 0 || variableValue == endptr)
+			if (errno != 0 || variableValue == endptr || endptr != variableValueEnd)
 				return FALSE;
 			if (val >= -2147483648 && val <= 2147483647)
 				buffer_add_int (buf, val);
@@ -318,7 +319,7 @@ write_value_to_buffer (MdbgProtBuffer *buf, MonoTypeEnum type, const char* varia
 		}
 		case MONO_TYPE_U4: {
 			intmax_t val = strtoimax (variableValue, &endptr, 10);
-			if (errno != 0 || variableValue == endptr)
+			if (errno != 0 || variableValue == endptr || endptr != variableValueEnd)
 				return FALSE;
 			if (val >= 0 && val <= 4294967295)
 				buffer_add_int (buf, val);
@@ -328,28 +329,28 @@ write_value_to_buffer (MdbgProtBuffer *buf, MonoTypeEnum type, const char* varia
 		}
 		case MONO_TYPE_I8: {
 			long long val = strtoll (variableValue, &endptr, 10);
-			if (errno != 0 || variableValue == endptr)
+			if (errno != 0 || variableValue == endptr || endptr != variableValueEnd)
 				return FALSE;
 			buffer_add_long (buf, val);
 			break;
 		}
 		case MONO_TYPE_U8: {
 			long long val = strtoll (variableValue, &endptr, 10);
-			if (errno != 0)
+			if (errno != 0 || variableValue == endptr || endptr != variableValueEnd)
 				return FALSE;
 			buffer_add_long (buf, val);
 			break;
 		}
 		case MONO_TYPE_R4: {
 			gfloat val = strtof (variableValue, &endptr);
-			if (errno != 0 || variableValue == endptr)
+			if (errno != 0 || variableValue == endptr || endptr != variableValueEnd)
 				return FALSE;
 			buffer_add_int (buf, *((gint32*)(&val)));
 			break;
 		}
 		case MONO_TYPE_R8: {
 			gdouble val = strtof (variableValue, &endptr);
-			if (errno != 0 || variableValue == endptr)
+			if (errno != 0 || variableValue == endptr || endptr != variableValueEnd)
 				return FALSE;
 			buffer_add_long (buf, *((guint64*)(&val)));
 			break;

--- a/src/mono/mono/mini/mini-wasm-debugger.c
+++ b/src/mono/mono/mini/mini-wasm-debugger.c
@@ -249,7 +249,7 @@ mono_wasm_breakpoint_hit (void)
 static gboolean
 write_value_to_buffer (MdbgProtBuffer *buf, MonoTypeEnum type, const char* variableValue)
 {
-	char* endptr;
+	char* endptr = NULL;
 	errno = 0;
 	buffer_add_byte (buf, type);
 	switch (type) {
@@ -268,7 +268,7 @@ write_value_to_buffer (MdbgProtBuffer *buf, MonoTypeEnum type, const char* varia
 			break;
 		case MONO_TYPE_I1: {
 			intmax_t val = strtoimax (variableValue, &endptr, 10);
-			if (errno != 0)
+			if (errno != 0 || variableValue == endptr)
 				return FALSE;
 			if (val >= -128 && val <= 127)
 				buffer_add_int (buf, val);
@@ -278,7 +278,7 @@ write_value_to_buffer (MdbgProtBuffer *buf, MonoTypeEnum type, const char* varia
 		}
 		case MONO_TYPE_U1: {
 			intmax_t val = strtoimax (variableValue, &endptr, 10);
-			if (errno != 0)
+			if (errno != 0 || variableValue == endptr)
 				return FALSE;
 			if (val >= 0 && val <= 255)
 				buffer_add_int (buf, val);
@@ -288,7 +288,7 @@ write_value_to_buffer (MdbgProtBuffer *buf, MonoTypeEnum type, const char* varia
 		}
 		case MONO_TYPE_I2: {
 			intmax_t val = strtoimax (variableValue, &endptr, 10);
-			if (errno != 0)
+			if (errno != 0 || variableValue == endptr)
 				return FALSE;
 			if (val >= -32768 && val <= 32767)
 				buffer_add_int (buf, val);
@@ -298,7 +298,7 @@ write_value_to_buffer (MdbgProtBuffer *buf, MonoTypeEnum type, const char* varia
 		}
 		case MONO_TYPE_U2: {
 			intmax_t val = strtoimax (variableValue, &endptr, 10);
-			if (errno != 0)
+			if (errno != 0 || variableValue == endptr)
 				return FALSE;
 			if (val >= 0 && val <= 65535)
 				buffer_add_int (buf, val);
@@ -308,7 +308,7 @@ write_value_to_buffer (MdbgProtBuffer *buf, MonoTypeEnum type, const char* varia
 		}
 		case MONO_TYPE_I4: {
 			intmax_t val = strtoimax (variableValue, &endptr, 10);
-			if (errno != 0)
+			if (errno != 0 || variableValue == endptr)
 				return FALSE;
 			if (val >= -2147483648 && val <= 2147483647)
 				buffer_add_int (buf, val);
@@ -318,7 +318,7 @@ write_value_to_buffer (MdbgProtBuffer *buf, MonoTypeEnum type, const char* varia
 		}
 		case MONO_TYPE_U4: {
 			intmax_t val = strtoimax (variableValue, &endptr, 10);
-			if (errno != 0)
+			if (errno != 0 || variableValue == endptr)
 				return FALSE;
 			if (val >= 0 && val <= 4294967295)
 				buffer_add_int (buf, val);
@@ -328,7 +328,7 @@ write_value_to_buffer (MdbgProtBuffer *buf, MonoTypeEnum type, const char* varia
 		}
 		case MONO_TYPE_I8: {
 			long long val = strtoll (variableValue, &endptr, 10);
-			if (errno != 0)
+			if (errno != 0 || variableValue == endptr)
 				return FALSE;
 			buffer_add_long (buf, val);
 			break;
@@ -342,14 +342,14 @@ write_value_to_buffer (MdbgProtBuffer *buf, MonoTypeEnum type, const char* varia
 		}
 		case MONO_TYPE_R4: {
 			gfloat val = strtof (variableValue, &endptr);
-			if (errno != 0)
+			if (errno != 0 || variableValue == endptr)
 				return FALSE;
 			buffer_add_int (buf, *((gint32*)(&val)));
 			break;
 		}
 		case MONO_TYPE_R8: {
 			gdouble val = strtof (variableValue, &endptr);
-			if (errno != 0)
+			if (errno != 0 || variableValue == endptr)
 				return FALSE;
 			buffer_add_long (buf, *((guint64*)(&val)));
 			break;

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -547,6 +547,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             var command_params_writer = new MonoBinaryWriter(command_params);
             command_params_writer.Write(MAJOR_VERSION);
             command_params_writer.Write(MINOR_VERSION);
+            command_params_writer.Write((byte)0);
 
             var ret_debugger_cmd_reader = await SendDebuggerAgentCommand<CmdVM>(sessionId, CmdVM.SetProtocolVersion, command_params, token);
             return true;

--- a/src/mono/wasm/debugger/DebuggerTestSuite/SetVariableValueTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/SetVariableValueTests.cs
@@ -212,6 +212,7 @@ namespace DebuggerTests
         [InlineData(1, "b", 20, "wrongValue")]
         [InlineData(2, "c", 30, "wrongValue")]
         [InlineData(3, "d", 50, "wrongValue")]
+        [InlineData(3, "d", 50, "123wrongValue")]
         public async Task SetVariableValuesAtBreakpointSiteFail(int offset, string variableName, int originalValue, string invalidValue){
             await SetBreakpointInMethod("debugger-test.dll", "Math", "IntAdd", offset);
             var pause_location = await EvaluateAndCheck(
@@ -263,6 +264,7 @@ namespace DebuggerTests
         [InlineData("A", 10, "error", false)]
         [InlineData("d", 15, "20", true)]
         [InlineData("d", 15, "error", false)]
+        [InlineData("d", 15, "123error", false)]
         public async Task TestSetValueOnObject(string prop_name, int prop_value, string prop_new_value, bool expect_ok)
         {
             var bp = await SetBreakpointInMethod("debugger-test.dll", "Math", "UseComplex", 5);


### PR DESCRIPTION
1. Errno is not being assigned anymore in a case like this:
intmax_t val = strtoimax ("error", &endptr, 10);
This was causing failures in these tests: DebuggerTests.SetVariableValueTests

2. Passing icordbg flag as false.