### PR TITLE
Ensure relocation blocks are 4-byte aligned

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/SectionBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/SectionBuilder.cs
@@ -703,6 +703,13 @@ namespace ILCompiler.PEWriter
         /// <param name="offsetsAndTypes">16-bit entries encoding offset relative to the base RVA (low 12 bits) and relocation type (top 4 bite)</param>
         private static void FlushRelocationBlock(BlobBuilder builder, int baseRVA, List<ushort> offsetsAndTypes)
         {
+            // Ensure blocks are 4-byte aligned. This is required by kernel memory manager
+            // on Windows 8.1 and earlier.
+            if ((offsetsAndTypes.Count & 1) == 1)
+            {
+                offsetsAndTypes.Add(0);
+            }
+
             // First, emit the block header: 4 bytes starting RVA,
             builder.WriteInt32(baseRVA);
             // followed by the total block size comprising this header


### PR DESCRIPTION
The kernel memory manager on Windows 8.1 and earlier requires relocation blocks to be 4-byte aligned.  If they are not, `MiRelocateImage` fails to relocate the image and the relocations are processed later by the user mode loader — but only if the `IMAGE_FILE_DLL` flag is set in the PE file header, which was not the case for some assemblies (#54440). @dotnet/crossgen-contrib

Note the [official documentation](https://docs.microsoft.com/en-us/windows/win32/debug/pe-format):
> The base relocation table is divided into blocks. Each block represents the base relocations for a 4K page. Each block must start on a 32-bit boundary.

and the corresponding code in the old Crossgen: https://github.com/dotnet/runtime/blob/dae9156dd0d5b82c9f3fc98baeb5a75cc3f66211/src/coreclr/zap/zaprelocs.cpp#L180-L186