### PR TITLE
Use Empty instead of null for DCS deserializing namespace.

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializer.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializer.cs
@@ -355,7 +355,7 @@ namespace System.Runtime.Serialization
             reader.MoveToElement();
             if (name != null) // root name set explicitly
             {
-                return reader.IsStartElement(name, ns!); // https://github.com/dotnet/runtime/issues/41395
+                return reader.IsStartElement(name, ns ?? XmlDictionaryString.Empty);
             }
             else
             {

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -1394,6 +1394,30 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
+    public static void DCS_RootNameAndNamespaceThroughSettings()
+    {
+        var xmlDictionary = new XmlDictionary();
+        var obj = new MyOtherType() { Str = "Hello" };
+        var settings = new DataContractSerializerSettings() { RootName = xmlDictionary.Add("ChangedRoot"), RootNamespace = xmlDictionary.Add("http://changedNamespace") };
+        Func<DataContractSerializer> serializerFactory = () => new DataContractSerializer(typeof(MyOtherType), settings);
+        string baselineXml = @"<ChangedRoot xmlns=""http://changedNamespace"" xmlns:a=""http://schemas.datacontract.org/2004/07/SerializationTypes"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><a:Str>Hello</a:Str></ChangedRoot>";
+        var result = DataContractSerializerHelper.SerializeAndDeserialize(obj, baselineXml, serializerFactory: serializerFactory);
+        Assert.Equal("Hello", result.Str);
+    }
+
+    [Fact]
+    public static void DCS_RootNameWithoutNamespaceThroughSettings()
+    {
+        var xmlDictionary = new XmlDictionary();
+        var obj = new MyOtherType() { Str = "Hello" };
+        var settings = new DataContractSerializerSettings() { RootName = xmlDictionary.Add("ChangedRoot") };
+        Func<DataContractSerializer> serializerFactory = () => new DataContractSerializer(typeof(MyOtherType), settings);
+        string baselineXml = @"<ChangedRoot xmlns:a=""http://schemas.datacontract.org/2004/07/SerializationTypes"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><a:Str>Hello</a:Str></ChangedRoot>";
+        var result = DataContractSerializerHelper.SerializeAndDeserialize(obj, baselineXml, serializerFactory: serializerFactory);
+        Assert.Equal("Hello", result.Str);
+    }
+
+    [Fact]
     public static void DCS_KnownTypesThroughConstructor()
     {
         //Constructor# 5


### PR DESCRIPTION
DCS: Allow RootName without RootNamespace when deserializing

DCS will allow users to specify a custom RootName for serializing without also
specifying a custom RootNamespace if the DCS is created from
DataContractSerializerSettings. In this case, the root namespace is simply
left out and the xml gets generated without a root namespace. Going
the other way through deserialization fails though because DCS passes
'null' as the expected namespace and the XmlReader classes are calling
the absence of an explicitly given namespace '' - aka, the empty string.

Fixes #41395