### PR TITLE
Fix Connect_DualMode_DnsConnect_RetrievedEndPoints_Success on Linux

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -109,7 +109,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/54677", TestPlatforms.Linux)]
         public async Task Connect_DualMode_DnsConnect_RetrievedEndPoints_Success()
         {
             var localhostAddresses = Dns.GetHostAddresses("localhost");
@@ -130,7 +129,7 @@ namespace System.Net.Sockets.Tests
 
                 var localEndPoint = client.LocalEndPoint as IPEndPoint;
                 Assert.NotNull(localEndPoint);
-                Assert.Equal(IPAddress.Loopback.MapToIPv6(), localEndPoint.Address);
+                Assert.True(localEndPoint.Address == IPAddress.Loopback || localEndPoint.Address == IPAddress.Loopback.MapToIPv6());
 
                 var remoteEndPoint = client.RemoteEndPoint as IPEndPoint;
                 Assert.NotNull(remoteEndPoint);

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -109,6 +109,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/54677", TestPlatforms.Linux)]
         public async Task Connect_DualMode_DnsConnect_RetrievedEndPoints_Success()
         {
             var localhostAddresses = Dns.GetHostAddresses("localhost");

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -129,7 +129,7 @@ namespace System.Net.Sockets.Tests
 
                 var localEndPoint = client.LocalEndPoint as IPEndPoint;
                 Assert.NotNull(localEndPoint);
-                Assert.True(localEndPoint.Address == IPAddress.Loopback || localEndPoint.Address == IPAddress.Loopback.MapToIPv6());
+                Assert.True(localEndPoint.Address.Equals(IPAddress.Loopback) || localEndPoint.Address.Equals(IPAddress.Loopback.MapToIPv6()));
 
                 var remoteEndPoint = client.RemoteEndPoint as IPEndPoint;
                 Assert.NotNull(remoteEndPoint);

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -129,7 +129,7 @@ namespace System.Net.Sockets.Tests
 
                 var localEndPoint = client.LocalEndPoint as IPEndPoint;
                 Assert.NotNull(localEndPoint);
-                Assert.True(localEndPoint.Address.Equals(IPAddress.Loopback) || localEndPoint.Address.Equals(IPAddress.Loopback.MapToIPv6()));
+                Assert.True(localEndPoint.Address.Equals(IPAddress.IPv6Loopback) || localEndPoint.Address.Equals(IPAddress.Loopback.MapToIPv6()));
 
                 var remoteEndPoint = client.RemoteEndPoint as IPEndPoint;
                 Assert.NotNull(remoteEndPoint);


### PR DESCRIPTION
50 failures in ~20 days. See https://github.com/dotnet/runtime/issues/54677#issuecomment-867591590.

/cc @tmds

Fixes #54677