### PR TITLE
Fix compiling  System.Net.Security.Native with HAVE_HEIMDAL_HEADERS

### DIFF
--- a/src/libraries/Native/Unix/System.Net.Security.Native/pal_gssapi.c
+++ b/src/libraries/Native/Unix/System.Net.Security.Native/pal_gssapi.c
@@ -19,6 +19,7 @@
 
 #include <assert.h>
 #include <string.h>
+#include <stdlib.h>
 
 c_static_assert(PAL_GSS_C_DELEG_FLAG == GSS_C_DELEG_FLAG);
 c_static_assert(PAL_GSS_C_MUTUAL_FLAG == GSS_C_MUTUAL_FLAG);


### PR DESCRIPTION
We are using malloc/free but don't declare a header. It likely happens to be included from GSS/GSS.h which is why it builds now, but it's not included from the Heimdal headers.