### PR TITLE
Pass the default ALC gchandle to the v3 preload hook

### DIFF
--- a/src/mono/mono/metadata/assembly-load-context.c
+++ b/src/mono/mono/metadata/assembly-load-context.c
@@ -424,6 +424,7 @@ mono_alc_from_gchandle (MonoGCHandle alc_gchandle)
 
 	HANDLE_FUNCTION_ENTER ();
 	MonoManagedAssemblyLoadContextHandle managed_alc = MONO_HANDLE_CAST (MonoManagedAssemblyLoadContext, mono_gchandle_get_target_handle (alc_gchandle));
+	g_assert (!MONO_HANDLE_IS_NULL (managed_alc));
 	MonoAssemblyLoadContext *alc = MONO_HANDLE_GETVAL (managed_alc, native_assembly_load_context);
 	HANDLE_FUNCTION_RETURN_VAL (alc);
 }


### PR DESCRIPTION
Fixes crashes when the gchandle is then used by the hooks to call mono API functions.

Example crash
https://gist.github.com/grendello/b4ab24587a055725cc5e1416b86ad7ca