### PR TITLE
Fix MonoCrossAOT.UnixFilePermissions for wasm

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.UnixFilePermissions.xml
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.UnixFilePermissions.xml
@@ -1,5 +1,0 @@
-<FileList>
-    <File Path="tools/mono-aot-cross" Permission="755" />
-    <File Path="tools/opt" Permission="755" />
-    <File Path="tools/llc" Permission="755" />
-</FileList>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.UnixFilePermissions.xml.in
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.UnixFilePermissions.xml.in
@@ -1,3 +1,3 @@
 <FileList>
-    ${PermissionsFiles}
+    ${PermissionsProperties}
 </FileList>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.UnixFilePermissions.xml.in
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.UnixFilePermissions.xml.in
@@ -1,0 +1,3 @@
+<FileList>
+    ${PermissionsFiles}
+</FileList>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.sfxproj
@@ -18,7 +18,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <NativeRuntimeAsset Include="$(MonoAotCrossDir)$(TargetCrossRid)\**" TargetPath="tools/" />
+    <_ToolFile Include="$(MonoAotCrossDir)$(TargetCrossRid)\**" />
+    <NativeRuntimeAsset Include="@(_ToolFile)" TargetPath="tools/" />
     <NativeRuntimeAsset Include="$(MonoAotCrossDir)$(TargetCrossRid).Sdk.props" TargetPath="Sdk/Sdk.props" />
     <NativeRuntimeAsset Condition="!$([MSBuild]::IsOsPlatform('Windows'))" Include="$(MonoAotCrossDir)Microsoft.NETCore.App.MonoCrossAOT.UnixFilePermissions.xml" TargetPath="data/UnixFilePermissions.xml" />
   </ItemGroup>
@@ -30,13 +31,7 @@
       <_SdkPropsProperties Include="TargetRid" Value="$(TargetCrossRid)" />
     </ItemGroup>
     <PropertyGroup>
-      <_PermissionsFiles>&lt;File Path=&quot;tools/mono-aot-cross&quot; Permission=&quot;755&quot; /&gt;</_PermissionsFiles>
-    </PropertyGroup>
-    <PropertyGroup Condition="(!$([MSBuild]::IsOsPlatform('Windows')) and '$(TargetCrossRid)' != 'browser-wasm')">
-      <_PermissionsFiles>$(_PermissionsFiles)
-    &lt;File Path=&quot;tools/opt&quot; Permission=&quot;755&quot; /&gt;</_PermissionsFiles>
-      <_PermissionsFiles>$(_PermissionsFiles)
-    &lt;File Path=&quot;tools/llc&quot; Permission=&quot;755&quot; /&gt;</_PermissionsFiles>
+      <_PermissionsFiles>@(_ToolFile -> '&lt;File Path=&quot;tools/%(RecursiveDir)%(FileName)%(Extension)&quot; Permission=&quot;755&quot; /&gt;', ' ')</_PermissionsFiles>
     </PropertyGroup>
     <ItemGroup>
       <_PermissionsProperties Include="PermissionsProperties" Value="$(_PermissionsFiles)" />

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.sfxproj
@@ -20,15 +20,27 @@
   <ItemGroup>
     <NativeRuntimeAsset Include="$(MonoAotCrossDir)$(TargetCrossRid)\**" TargetPath="tools/" />
     <NativeRuntimeAsset Include="$(MonoAotCrossDir)$(TargetCrossRid).Sdk.props" TargetPath="Sdk/Sdk.props" />
-    <NativeRuntimeAsset Condition="!$([MSBuild]::IsOsPlatform('Windows'))" Include="Microsoft.NETCore.App.MonoCrossAOT.UnixFilePermissions.xml" TargetPath="data/UnixFilePermissions.xml" />
+    <NativeRuntimeAsset Condition="!$([MSBuild]::IsOsPlatform('Windows'))" Include="$(MonoAotCrossDir)Microsoft.NETCore.App.MonoCrossAOT.UnixFilePermissions.xml" TargetPath="data/UnixFilePermissions.xml" />
   </ItemGroup>
 
-  <Target Name="WriteAotSdkProps" BeforeTargets="ValidateProperties">
+  <Target Name="WriteTemplateFiles" BeforeTargets="ValidateProperties">
     <ItemGroup>
       <_SdkPropsProperties Condition="!$([MSBuild]::IsOsPlatform('Windows'))" Include="ExeSuffix" Value="" />
       <_SdkPropsProperties Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="ExeSuffix" Value=".exe" />
       <_SdkPropsProperties Include="TargetRid" Value="$(TargetCrossRid)" />
     </ItemGroup>
+    <ItemGroup>
+      <_PermissionsFiles Include="PermissionsFiles" Value="&lt;File Path=&quot;tools/mono-aot-cross&quot; Permission=&quot;755&quot; /&gt;" />
+    </ItemGroup>
+    <ItemGroup Condition="(!$([MSBuild]::IsOsPlatform('Windows')) and '$(TargetCrossRid)' != 'browser-wasm')">
+      <_PermissionsFiles Include="PermissionsFiles" Value="&lt;File Path=&quot;tools/opt&quot; Permission=&quot;755&quot; /&gt;" />
+      <_PermissionsFiles Include="PermissionsFiles" Value="&lt;File Path=&quot;tools/llc&quot; Permission=&quot;755&quot; /&gt;" />
+    </ItemGroup>
+    <GenerateFileFromTemplate
+      Condition="!$([MSBuild]::IsOsPlatform('Windows'))"
+      TemplateFile="Microsoft.NETCore.App.MonoCrossAOT.UnixFilePermissions.xml.in"
+      Properties="@(_PermissionsFiles)"
+      OutputPath="$(MonoAotCrossDir)Microsoft.NETCore.App.MonoCrossAOT.UnixFilePermissions.xml" />
     <GenerateFileFromTemplate
       TemplateFile="Microsoft.NETCore.App.MonoCrossAOT.Sdk.props.in"
       Properties="@(_SdkPropsProperties)"

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.MonoCrossAOT.sfxproj
@@ -29,17 +29,22 @@
       <_SdkPropsProperties Condition="$([MSBuild]::IsOsPlatform('Windows'))" Include="ExeSuffix" Value=".exe" />
       <_SdkPropsProperties Include="TargetRid" Value="$(TargetCrossRid)" />
     </ItemGroup>
+    <PropertyGroup>
+      <_PermissionsFiles>&lt;File Path=&quot;tools/mono-aot-cross&quot; Permission=&quot;755&quot; /&gt;</_PermissionsFiles>
+    </PropertyGroup>
+    <PropertyGroup Condition="(!$([MSBuild]::IsOsPlatform('Windows')) and '$(TargetCrossRid)' != 'browser-wasm')">
+      <_PermissionsFiles>$(_PermissionsFiles)
+    &lt;File Path=&quot;tools/opt&quot; Permission=&quot;755&quot; /&gt;</_PermissionsFiles>
+      <_PermissionsFiles>$(_PermissionsFiles)
+    &lt;File Path=&quot;tools/llc&quot; Permission=&quot;755&quot; /&gt;</_PermissionsFiles>
+    </PropertyGroup>
     <ItemGroup>
-      <_PermissionsFiles Include="PermissionsFiles" Value="&lt;File Path=&quot;tools/mono-aot-cross&quot; Permission=&quot;755&quot; /&gt;" />
-    </ItemGroup>
-    <ItemGroup Condition="(!$([MSBuild]::IsOsPlatform('Windows')) and '$(TargetCrossRid)' != 'browser-wasm')">
-      <_PermissionsFiles Include="PermissionsFiles" Value="&lt;File Path=&quot;tools/opt&quot; Permission=&quot;755&quot; /&gt;" />
-      <_PermissionsFiles Include="PermissionsFiles" Value="&lt;File Path=&quot;tools/llc&quot; Permission=&quot;755&quot; /&gt;" />
+      <_PermissionsProperties Include="PermissionsProperties" Value="$(_PermissionsFiles)" />
     </ItemGroup>
     <GenerateFileFromTemplate
       Condition="!$([MSBuild]::IsOsPlatform('Windows'))"
       TemplateFile="Microsoft.NETCore.App.MonoCrossAOT.UnixFilePermissions.xml.in"
-      Properties="@(_PermissionsFiles)"
+      Properties="@(_PermissionsProperties)"
       OutputPath="$(MonoAotCrossDir)Microsoft.NETCore.App.MonoCrossAOT.UnixFilePermissions.xml" />
     <GenerateFileFromTemplate
       TemplateFile="Microsoft.NETCore.App.MonoCrossAOT.Sdk.props.in"


### PR DESCRIPTION
We introduced Microsoft.NETCore.App.MonoCrossAOT.UnixFilePermissions.xml in https://github.com/dotnet/runtime/pull/54501 to make sure the right permissions are set when installing AOT compiler workload packs.  We hardcoded the list to include mono-aot-cross, llc, and opt.  However, in wasm's case they only have mono-aot-cross.

This change makes the xml file a template and only includes mono-aot-cross for browser and all three for the other configurations.

Fixes https://github.com/dotnet/runtime/issues/54612