### PR TITLE
Disallow promotion of HVA structs when their fields of TYP_SIMD8 were promoted as plain structs

### DIFF
--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -1946,9 +1946,11 @@ bool Compiler::StructPromotionHelper::CanPromoteStructVar(unsigned lclNum)
                 var_types fieldType = structPromotionInfo.fields[i].fldType;
                 // Non-HFA structs are always passed in general purpose registers.
                 // If there are any floating point fields, don't promote for now.
+                // Likewise, since HVA structs are passed in SIMD registers
+                // promotion of non FP or SIMD type fields is disallowed.
                 // TODO-1stClassStructs: add support in Lowering and prolog generation
                 // to enable promoting these types.
-                if (varDsc->lvIsParam && !varDsc->lvIsHfa() && varTypeUsesFloatReg(fieldType))
+                if (varDsc->lvIsParam && (varDsc->lvIsHfa() != varTypeUsesFloatReg(fieldType)))
                 {
                     canPromote = false;
                 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_54647/Runtime_54647.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_54647/Runtime_54647.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+
+namespace Runtime_54647
+{
+    struct Vector64x2
+    {
+        Vector64<int> _fld1;
+        Vector64<int> _fld2;
+    }
+
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            var val1 = new Vector64x2();
+            var val2 = new Vector64x2();
+
+            Copy(ref val1, val2);
+
+            return 100;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void Copy(ref Vector64x2 dst, Vector64x2 src)
+        {
+            dst = src;
+        }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_54647/Runtime_54647.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_54647/Runtime_54647.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes #54647