### PR TITLE
Fix alloc-dealloc mismatches

### DIFF
--- a/src/coreclr/vm/ilstubresolver.cpp
+++ b/src/coreclr/vm/ilstubresolver.cpp
@@ -344,7 +344,7 @@ ILStubResolver::AllocGeneratedIL(
     if (!UseLoaderHeap())
     {
         NewArrayHolder<BYTE>             pNewILCodeBuffer = new BYTE[cbCode];
-        NewArrayHolder<CompileTimeState> pNewCompileTimeState = (CompileTimeState*)new BYTE[sizeof(CompileTimeState)];
+        NewHolder<CompileTimeState>      pNewCompileTimeState = new CompileTimeState{};
         memset(pNewCompileTimeState, 0, sizeof(CompileTimeState));
         NewArrayHolder<BYTE>             pNewLocalSig = NULL;
 

--- a/src/coreclr/vm/ilstubresolver.cpp
+++ b/src/coreclr/vm/ilstubresolver.cpp
@@ -345,7 +345,6 @@ ILStubResolver::AllocGeneratedIL(
     {
         NewArrayHolder<BYTE>             pNewILCodeBuffer = new BYTE[cbCode];
         NewHolder<CompileTimeState>      pNewCompileTimeState = new CompileTimeState{};
-        memset(pNewCompileTimeState, 0, sizeof(CompileTimeState));
         NewArrayHolder<BYTE>             pNewLocalSig = NULL;
 
         if (0 != cbLocalSig)

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -8504,10 +8504,7 @@ MethodTable::GetMethodDataHelper(
     MethodDataWrapper hDecl(GetMethodData(pMTDecl, FALSE));
     MethodDataWrapper hImpl(GetMethodData(pMTImpl, FALSE));
 
-    UINT32 cb = MethodDataInterfaceImpl::GetObjectSize(pMTDecl);
-    NewArrayHolder<BYTE> pb(new BYTE[cb]);
-    MethodDataInterfaceImpl * pData = new (pb.GetValue()) MethodDataInterfaceImpl(rgDeclTypeIDs, cDeclTypeIDs, hDecl, hImpl);
-    pb.SuppressRelease();
+    MethodDataInterfaceImpl * pData = new ({ pMTDecl }) MethodDataInterfaceImpl(rgDeclTypeIDs, cDeclTypeIDs, hDecl, hImpl);
 
     return pData;
 } // MethodTable::GetMethodDataHelper
@@ -8548,10 +8545,8 @@ MethodTable::MethodData *MethodTable::GetMethodDataHelper(MethodTable *pMTDecl,
         }
         else {
             UINT32 cb = MethodDataObject::GetObjectSize(pMTDecl);
-            NewArrayHolder<BYTE> pb(new BYTE[cb]);
             MethodDataHolder h(FindParentMethodDataHelper(pMTDecl));
-            pData = new (pb.GetValue()) MethodDataObject(pMTDecl, h.GetValue());
-            pb.SuppressRelease();
+            pData = new ({ pMTDecl }) MethodDataObject(pMTDecl, h.GetValue());
         }
     }
     else {

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -3153,7 +3153,7 @@ public:
 
 protected:
     //--------------------------------------------------------------------------------------
-    class MethodDataObject : public MethodData
+    class MethodDataObject final : public MethodData
     {
       public:
         // Static method that returns the amount of memory to allocate for a particular type.
@@ -3233,19 +3233,32 @@ protected:
                 { LIMITED_METHOD_CONTRACT; return m_pMDImpl; }
         };
 
-        //
-        // At the end of this object is an array, so you cannot derive from this class.
-        //
 
         inline MethodDataObjectEntry *GetEntryData()
-            { LIMITED_METHOD_CONTRACT; return (MethodDataObjectEntry *)(this + 1); }
+            { LIMITED_METHOD_CONTRACT; return &m_rgEntries[0]; }
 
         inline MethodDataObjectEntry *GetEntry(UINT32 i)
             { LIMITED_METHOD_CONTRACT; CONSISTENCY_CHECK(i < GetNumMethods()); return GetEntryData() + i; }
 
         void FillEntryDataForAncestor(MethodTable *pMT);
 
-        // MethodDataObjectEntry m_rgEntries[...];
+        //
+        // At the end of this object is an array
+        //
+        MethodDataObjectEntry m_rgEntries[0];
+
+      public:
+        struct TargetMethodTable
+        {
+            MethodTable* pMT;
+        };
+
+        static void* operator new(size_t size, TargetMethodTable targetMT)
+        {
+            _ASSERTE(size <= GetObjectSize(targetMT.pMT));
+            return ::operator new(GetObjectSize(targetMT.pMT));
+        }
+        static void* operator new(size_t size) = delete;
     };  // class MethodDataObject
 
     //--------------------------------------------------------------------------------------
@@ -3299,7 +3312,7 @@ protected:
     };  // class MethodDataInterface
 
     //--------------------------------------------------------------------------------------
-    class MethodDataInterfaceImpl : public MethodData
+    class MethodDataInterfaceImpl final : public MethodData
     {
       public:
         // Object construction-related methods
@@ -3373,12 +3386,25 @@ protected:
         //
 
         inline MethodDataEntry *GetEntryData()
-            { LIMITED_METHOD_CONTRACT; return (MethodDataEntry *)(this + 1); }
+            { LIMITED_METHOD_CONTRACT; return &m_rgEntries[0]; }
 
         inline MethodDataEntry *GetEntry(UINT32 i)
             { LIMITED_METHOD_CONTRACT; CONSISTENCY_CHECK(i < GetNumMethods()); return GetEntryData() + i; }
 
-        // MethodDataEntry m_rgEntries[...];
+        MethodDataEntry m_rgEntries[0];
+
+      public:
+        struct TargetMethodTable
+        {
+            MethodTable* pMT;
+        };
+
+        static void* operator new(size_t size, TargetMethodTable targetMT)
+        {
+            _ASSERTE(size <= GetObjectSize(targetMT.pMT));
+            return ::operator new(GetObjectSize(targetMT.pMT));
+        }
+        static void* operator new(size_t size) = delete;
     };  // class MethodDataInterfaceImpl
 
     //--------------------------------------------------------------------------------------


### PR DESCRIPTION
Use specialized new operators to correctly allocate space with the non-array new allocator for MethodDataObject and MethodDataInterfaceImpl.

Fix alloc/dealloc mismatch in ILStubResolver by just using `new` instead of new-ing up a buffer and placement new-ing into it.

Fixes #54637