### PR TITLE
Move defMAC construction up a scope to make it live long enough.

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -6040,6 +6040,10 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
     }
 #endif
 
+    // Create a default MorphAddrContext early so it doesn't go out of scope
+    // before it is used.
+    MorphAddrContext defMAC(MACK_Ind);
+
     /* Is this an instance data member? */
 
     if (objRef)
@@ -6130,7 +6134,6 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
 
         // NULL mac means we encounter the GT_FIELD first.  This denotes a dereference of the field,
         // and thus is equivalent to a MACK_Ind with zero offset.
-        MorphAddrContext defMAC(MACK_Ind);
         if (mac == nullptr)
         {
             mac = &defMAC;


### PR DESCRIPTION
Fixes #54649

cc: @dotnet/jit-contrib 