### PR TITLE
Fix handling of static virtual method implementation checking

### DIFF
--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -2285,7 +2285,11 @@ public:
 
 
     // Resolve virtual static interface method pInterfaceMD on this type.
-    MethodDesc *ResolveVirtualStaticMethod(MethodTable* pInterfaceType, MethodDesc* pInterfaceMD, BOOL allowNullResult, BOOL checkDuplicates = FALSE, BOOL allowVariantMatches = TRUE);
+    //
+    // Specify allowNullResult to return NULL instead of throwing if the there is no implementation
+    // Specify verifyImplemented to verify that there is a match, but do not actually return a final useable MethodDesc
+    // Specify allowVariantMatches to permit generic interface variance
+    MethodDesc *ResolveVirtualStaticMethod(MethodTable* pInterfaceType, MethodDesc* pInterfaceMD, BOOL allowNullResult, BOOL verifyImplemented = FALSE, BOOL allowVariantMatches = TRUE);
 
     // Try a partial resolve of the constraint call, up to generic code sharing.
     //
@@ -2402,7 +2406,7 @@ public:
 
     // Try to resolve a given static virtual method override on this type. Return nullptr
     // when not found.
-    MethodDesc *TryResolveVirtualStaticMethodOnThisType(MethodTable* pInterfaceType, MethodDesc* pInterfaceMD, BOOL checkDuplicates);
+    MethodDesc *TryResolveVirtualStaticMethodOnThisType(MethodTable* pInterfaceType, MethodDesc* pInterfaceMD, BOOL verifyImplemented);
 
 public:
     static MethodDesc *MapMethodDeclToMethodImpl(MethodDesc *pMDDecl);

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -1186,12 +1186,29 @@ MethodTableBuilder::bmtInterfaceEntry::CreateSlotTable(
     CONSISTENCY_CHECK(m_pImplTable == NULL);
 
     SLOT_INDEX cSlots = (SLOT_INDEX)GetInterfaceType()->GetMethodTable()->GetNumVirtuals();
-    bmtInterfaceSlotImpl * pST = new (pStackingAllocator) bmtInterfaceSlotImpl[cSlots];
+    SLOT_INDEX cSlotsTotal = cSlots;
+
+    if (GetInterfaceType()->GetMethodTable()->HasVirtualStaticMethods())
+    {
+        MethodTable::MethodIterator it(GetInterfaceType()->GetMethodTable());
+        for (; it.IsValid(); it.Next())
+        {
+            MethodDesc *pDeclMD = it.GetDeclMethodDesc();
+            if (pDeclMD->IsStatic() && pDeclMD->IsVirtual())
+            {
+                cSlotsTotal++;
+            }
+        }
+    }
+
+    bmtInterfaceSlotImpl * pST = new (pStackingAllocator) bmtInterfaceSlotImpl[cSlotsTotal];
+
 
     MethodTable::MethodIterator it(GetInterfaceType()->GetMethodTable());
     for (; it.IsValid(); it.Next())
     {
-        if (!it.IsVirtual())
+        MethodDesc *pDeclMD = it.GetDeclMethodDesc();
+        if (!pDeclMD->IsVirtual())
         {
             break;
         }
@@ -1199,8 +1216,15 @@ MethodTableBuilder::bmtInterfaceEntry::CreateSlotTable(
         bmtRTMethod * pCurMethod = new (pStackingAllocator)
             bmtRTMethod(GetInterfaceType(), it.GetDeclMethodDesc());
 
-        CONSISTENCY_CHECK(m_cImplTable == it.GetSlotNumber());
-        pST[m_cImplTable++] = bmtInterfaceSlotImpl(pCurMethod, INVALID_SLOT_INDEX);
+        if (pDeclMD->IsStatic())
+        {
+            pST[cSlots + m_cImplTableStatics++] = bmtInterfaceSlotImpl(pCurMethod, INVALID_SLOT_INDEX);
+        }
+        else
+        {
+            CONSISTENCY_CHECK(m_cImplTable == it.GetSlotNumber());
+            pST[m_cImplTable++] = bmtInterfaceSlotImpl(pCurMethod, INVALID_SLOT_INDEX);
+        }
     }
 
     m_pImplTable = pST;
@@ -4808,16 +4832,16 @@ VOID MethodTableBuilder::TestMethodImpl(
     {
         BuildMethodTableThrowException(IDS_CLASSLOAD_MI_NONVIRTUAL_DECL);
     }
-    if (!IsMdVirtual(dwImplAttrs))
+    if ((IsMdVirtual(dwImplAttrs) && IsMdStatic(dwImplAttrs)) || (!IsMdVirtual(dwImplAttrs) && !IsMdStatic(dwImplAttrs)))
     {
         BuildMethodTableThrowException(IDS_CLASSLOAD_MI_MUSTBEVIRTUAL);
     }
-    // Virtual methods cannot be static
-    if (IsMdStatic(dwDeclAttrs))
+    // Virtual methods on classes/valuetypes cannot be static
+    if (IsMdStatic(dwDeclAttrs) && !hDeclMethod.GetOwningType().IsInterface())
     {
         BuildMethodTableThrowException(IDS_CLASSLOAD_STATICVIRTUAL);
     }
-    if (IsMdStatic(dwImplAttrs))
+    if ((!!IsMdStatic(dwImplAttrs)) != (!!IsMdStatic(dwDeclAttrs)))
     {
         BuildMethodTableThrowException(IDS_CLASSLOAD_STATICVIRTUAL);
     }
@@ -5421,14 +5445,14 @@ MethodTableBuilder::PlaceVirtualMethods()
 // that the name+signature corresponds to. Used by ProcessMethodImpls and ProcessInexactMethodImpls
 // Always returns the first match that it finds. Affects the ambiguities in code:#ProcessInexactMethodImpls_Ambiguities
 MethodTableBuilder::bmtMethodHandle
-MethodTableBuilder::FindDeclMethodOnInterfaceEntry(bmtInterfaceEntry *pItfEntry, MethodSignature &declSig)
+MethodTableBuilder::FindDeclMethodOnInterfaceEntry(bmtInterfaceEntry *pItfEntry, MethodSignature &declSig, bool searchForStaticMethods)
 {
     STANDARD_VM_CONTRACT;
 
     bmtMethodHandle declMethod;
 
     bmtInterfaceEntry::InterfaceSlotIterator slotIt =
-        pItfEntry->IterateInterfaceSlots(GetStackingAllocator());
+        pItfEntry->IterateInterfaceSlots(GetStackingAllocator(), searchForStaticMethods);
     // Check for exact match
     for (; !slotIt.AtEnd(); slotIt.Next())
     {
@@ -5656,7 +5680,7 @@ MethodTableBuilder::ProcessMethodImpls()
     DeclaredMethodIterator it(*this);
     while (it.Next())
     {
-        if (!IsMdVirtual(it.Attrs()) && it.IsMethodImpl())
+        if (!IsMdVirtual(it.Attrs()) && it.IsMethodImpl() && bmtProp->fNoSanityChecks)
         {
             // Non-virtual methods can only be classified as methodImpl when implementing
             // static virtual methods.
@@ -5839,7 +5863,7 @@ MethodTableBuilder::ProcessMethodImpls()
                                 }
 
                                 // 3. Find the matching method.
-                                declMethod = FindDeclMethodOnInterfaceEntry(pItfEntry, declSig);
+                                declMethod = FindDeclMethodOnInterfaceEntry(pItfEntry, declSig, !IsMdVirtual(it.Attrs())); // Search for statics when the impl is non-virtual
                             }
                             else
                             {
@@ -5872,6 +5896,14 @@ MethodTableBuilder::ProcessMethodImpls()
                     if (!IsMdVirtual(declMethod.GetDeclAttrs()))
                     {   // Make sure the decl is virtual
                         BuildMethodTableThrowException(IDS_CLASSLOAD_MI_MUSTBEVIRTUAL, it.Token());
+                    }
+
+                    if (!IsMdVirtual(it.Attrs()) && it.IsMethodImpl() && IsMdStatic(it.Attrs()))
+                    {
+                        // Non-virtual methods can only be classified as methodImpl when implementing
+                        // static virtual methods.
+                        ValidateStaticMethodImpl(declMethod, *it);//bmtMethodHandle(pCurImplMethod));
+                        continue;
                     }
 
                     if (bmtMetaData->rgMethodImplTokens[m].fRequiresCovariantReturnTypeChecking)
@@ -6743,6 +6775,30 @@ MethodTableBuilder::PlaceParentDeclarationOnClass(
     // increment the counter
     (*pSlotIndex)++;
 } // MethodTableBuilder::PlaceParentDeclarationOnClass
+
+VOID MethodTableBuilder::ValidateStaticMethodImpl(
+    bmtMethodHandle     hDecl,
+    bmtMethodHandle     hImpl)
+{
+    // While we don't want to place the static method impl declarations on the class/interface, we do 
+    // need to validate the method constraints and signature are compatible
+    if (!bmtProp->fNoSanityChecks)
+    {
+        ///////////////////////////////
+        // Verify the signatures match
+
+        MethodImplCompareSignatures(
+            hDecl,
+            hImpl,
+            FALSE /* allowCovariantReturn */,
+            IDS_CLASSLOAD_CONSTRAINT_MISMATCH_ON_INTERFACE_METHOD_IMPL);
+
+        ///////////////////////////////
+        // Validate the method impl.
+
+        TestMethodImpl(hDecl, hImpl);
+    }
+}
 
 //*******************************************************************************
 // This will validate that all interface methods that were matched during

--- a/src/coreclr/vm/runtimehandles.cpp
+++ b/src/coreclr/vm/runtimehandles.cpp
@@ -1190,7 +1190,7 @@ MethodDesc* QCALLTYPE RuntimeTypeHandle::GetInterfaceMethodImplementation(QCall:
 
     if (pMD->IsStatic())
     {
-        pResult = typeHandle.GetMethodTable()->ResolveVirtualStaticMethod(thOwnerOfMD.GetMethodTable(), pMD, /* allowNullResult */ TRUE, /* checkDuplicates*/ FALSE, /*allowVariantMatches */ TRUE);
+        pResult = typeHandle.GetMethodTable()->ResolveVirtualStaticMethod(thOwnerOfMD.GetMethodTable(), pMD, /* allowNullResult */ TRUE, /* verifyImplemented*/ FALSE, /*allowVariantMatches */ TRUE);
     }
     else
     {

--- a/src/coreclr/vm/typedesc.cpp
+++ b/src/coreclr/vm/typedesc.cpp
@@ -1922,7 +1922,7 @@ BOOL TypeVarTypeDesc::SatisfiesConstraints(SigTypeContext *pTypeContextOfConstra
                                 MethodDesc *pMD = it.GetMethodDesc();
                                 if (pMD->IsVirtual() &&
                                     pMD->IsStatic() &&
-                                    !thElem.AsMethodTable()->ResolveVirtualStaticMethod(pInterfaceMT, pMD, /* allowNullResult */ TRUE, /* checkDuplicates */ TRUE))
+                                    !thElem.AsMethodTable()->ResolveVirtualStaticMethod(pInterfaceMT, pMD, /* allowNullResult */ TRUE, /* verifyImplemented */ TRUE))
                                 {
                                     virtualStaticResolutionCheckFailed = true;
                                     break;

--- a/src/tests/Loader/classloader/StaticVirtualMethods/NegativeTestCases/CuriouslyRecurringGenericWithUnimplementedMethod.il
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/NegativeTestCases/CuriouslyRecurringGenericWithUnimplementedMethod.il
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly extern System.Console {}
+.assembly extern mscorlib {}
+.assembly extern System.Runtime {}
+.assembly extern TypeHierarchyCommonCs {}
+.assembly TypeHierarchyTest {}
+.class interface public abstract auto ansi InterfaceScenario1`1<T>
+{
+  .method public newslot virtual abstract static int32 Method() cil managed noinlining
+  {
+  } // end of method Method
+} // end of class InterfaceScenario1
+
+.class public auto ansi BaseScenario1`1<V>
+       extends [System.Runtime]System.Object
+       implements class InterfaceScenario1`1<class BaseScenario1`1<!0>>
+{
+} // end of class BaseScenario1
+
+.class public auto ansi TestEntrypoint
+       extends [System.Runtime]System.Object
+{
+  .method public static class [System.Runtime]System.Type Test_Scenario1() cil managed noinlining
+  {
+    ldtoken class BaseScenario1`1<object>
+    call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    ret
+  } // end of method Test_Scenario1
+  .method public static int32 Main() cil managed noinlining
+  {
+    .entrypoint
+    .locals init (class [System.Runtime]System.Exception V_0)
+    .try {
+        call class [System.Runtime]System.Type TestEntrypoint::Test_Scenario1()
+        pop
+        ldstr "CuriouslyRecurringGenericWithUnimplementedMethod"
+        ldstr "TypeLoadException"
+        ldstr "Did not throw exception"
+        call void [TypeHierarchyCommonCs]Statics::CheckForFailure(string,string,string)
+        leave.s CuriouslyRecurringGenericWithUnimplementedMethodDone
+    } catch [System.Runtime]System.Exception {
+        stloc.0
+        ldstr "CuriouslyRecurringGenericWithUnimplementedMethod"
+        ldstr "TypeLoadException"
+        ldloc.0
+        callvirt   instance class [System.Runtime]System.Type [System.Runtime]System.Exception::GetType()
+        callvirt   instance string [System.Runtime]System.Reflection.MemberInfo::get_Name()
+        call void [TypeHierarchyCommonCs]Statics::CheckForFailure(string,string,string)
+        leave.s CuriouslyRecurringGenericWithUnimplementedMethodDone
+    }
+CuriouslyRecurringGenericWithUnimplementedMethodDone: nop
+    
+    call int32 [TypeHierarchyCommonCs]Statics::ReportResults()
+    ret  } // end of method Main
+} // end of class TestEntrypoint

--- a/src/tests/Loader/classloader/StaticVirtualMethods/NegativeTestCases/CuriouslyRecurringGenericWithUnimplementedMethod.ilproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/NegativeTestCases/CuriouslyRecurringGenericWithUnimplementedMethod.ilproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../TypeHierarchy/TypeHierarchyCommonCs.csproj" />
+    <Compile Include="$(MSBuildThisFileName).il" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/classloader/StaticVirtualMethods/NegativeTestCases/MethodConstraintMismatch.il
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/NegativeTestCases/MethodConstraintMismatch.il
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly extern System.Console {}
+.assembly extern mscorlib {}
+.assembly extern System.Runtime {}
+.assembly extern TypeHierarchyCommonCs {}
+.assembly TypeHierarchyTest {}
+.class interface public abstract auto ansi InterfaceScenario1
+{
+  .method public newslot virtual abstract static int32 GenericMethod<U>() cil managed noinlining
+  {
+  } // end of method Method
+} // end of class InterfaceScenario1
+
+.class public auto ansi BaseScenario1
+       extends [System.Runtime]System.Object
+       implements InterfaceScenario1
+{
+  .method public static int32 GenericMethod<(class InterfaceScenario1) U>() cil managed noinlining
+  {
+    .override method int32 InterfaceScenario1::GenericMethod<[1]>()
+    .locals init (int32 V_O)
+    ldloca.s 0
+    initobj int32
+    ldloc.0
+    ret
+  } // end of method Method
+} // end of class BaseScenario1
+
+.class public auto ansi TestEntrypoint
+       extends [System.Runtime]System.Object
+{
+  .method public static class [System.Runtime]System.Type Test_Scenario1() cil managed noinlining
+  {
+    ldtoken BaseScenario1
+    call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    ret
+  } // end of method Test_Scenario1
+  .method public static int32 Main() cil managed noinlining
+  {
+    .entrypoint
+    .locals init (class [System.Runtime]System.Exception V_0)
+    .try {
+        call class [System.Runtime]System.Type TestEntrypoint::Test_Scenario1()
+        pop
+        ldstr "MethodConstraintMismatch"
+        ldstr "TypeLoadException"
+        ldstr "Did not throw exception"
+        call void [TypeHierarchyCommonCs]Statics::CheckForFailure(string,string,string)
+        leave.s MethodConstraintMismatchDone
+    } catch [System.Runtime]System.Exception {
+        stloc.0
+        ldstr "MethodConstraintMismatch"
+        ldstr "TypeLoadException"
+        ldloc.0
+        callvirt   instance class [System.Runtime]System.Type [System.Runtime]System.Exception::GetType()
+        callvirt   instance string [System.Runtime]System.Reflection.MemberInfo::get_Name()
+        call void [TypeHierarchyCommonCs]Statics::CheckForFailure(string,string,string)
+        leave.s MethodConstraintMismatchDone
+    }
+MethodConstraintMismatchDone: nop
+    
+    call int32 [TypeHierarchyCommonCs]Statics::ReportResults()
+    ret  } // end of method Main
+} // end of class TestEntrypoint

--- a/src/tests/Loader/classloader/StaticVirtualMethods/NegativeTestCases/MethodConstraintMismatch.ilproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/NegativeTestCases/MethodConstraintMismatch.ilproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../TypeHierarchy/TypeHierarchyCommonCs.csproj" />
+    <Compile Include="$(MSBuildThisFileName).il" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
- It turns out that GetMethodDescFromMemberDefOrRefOrSpec and FindOrCreateAssociatedMethodDesc are not safe to use on a MemberRef whent  the associated MethodTable is not fully loaded.
- Instead only use that feature when working with a MethodDef or a fully loaded type, and when working with a not fully loaded type, use MemberLoader::FindMethod instead.
- When running the resolution algorithm for doing constraint validation, it also is not necessary to fully resolve to the exact correct MethodDesc, which as that process uses FindOrCreateAssociatedMethodDesc needs to be avoided.
- The above was not evident as in many cases, the validation algorithm did not run as it was misplaced and located directly before the call to SetIsFullyLoaded. That code path is only followed if the type is able to fully load without circular dependencies. (Test case CuriouslyRecurringGenericWithUnimplementedMethod added to cover that scenario)
- In addition, while investigating these issues, I realized we were lacking checks that the constraints on the impl and decl method were not checked at during type load, but that work was instead deferred to dispatch time. Along with the constraint check there was also a set of accessibility checks that had been missed that are common to all MethodImpl handling. Fix by adding tweaking the logic to share most of that code.