### PR TITLE
Fix BackoutJitData

### DIFF
--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -2685,7 +2685,6 @@ void EEJitManager::allocCode(MethodDesc* pMD, size_t blockSize, size_t reserveFo
         pCodeHdr = ((CodeHeader *)pCode) - 1;
 
         *pAllocatedSize = sizeof(CodeHeader) + totalSize;
-#define FEATURE_WXORX        
 #ifdef FEATURE_WXORX
         pCodeHdrRW = (CodeHeader *)new BYTE[*pAllocatedSize];
 #else

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -2685,6 +2685,11 @@ void EEJitManager::allocCode(MethodDesc* pMD, size_t blockSize, size_t reserveFo
         pCodeHdr = ((CodeHeader *)pCode) - 1;
 
         *pAllocatedSize = sizeof(CodeHeader) + totalSize;
+
+#if defined(HOST_OSX) && defined(HOST_ARM64)
+#define FEATURE_WXORX
+#endif
+
 #ifdef FEATURE_WXORX
         pCodeHdrRW = (CodeHeader *)new BYTE[*pAllocatedSize];
 #else

--- a/src/coreclr/vm/jitinterface.h
+++ b/src/coreclr/vm/jitinterface.h
@@ -941,6 +941,8 @@ public:
 
 protected :
 
+    void WriteCodeBytes();
+
 #ifdef FEATURE_PGO
     // PGO data
     struct ComputedPgoData


### PR DESCRIPTION
The RemoveJitData that the BackoutJitData calls requires the code
header to be copied to the final location. This change fixes it.

I've also found that in one of my previous changes, I've accidentally
enabled jitting into a scratch buffer by default by adding the
FEATURE_WXORX define. So I am removing it in this change, it will
be replaced by a dynamic check whether W^X is enabled in the final
W^X change.

Close #54706