### PR TITLE
Fixed misleading exception when configuration file is excluded

### DIFF
--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/ref/Microsoft.Extensions.FileProviders.Physical.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/ref/Microsoft.Extensions.FileProviders.Physical.cs
@@ -34,6 +34,18 @@ namespace Microsoft.Extensions.FileProviders.Internal
 }
 namespace Microsoft.Extensions.FileProviders.Physical
 {
+    public partial class ExcludedFileInfo : Microsoft.Extensions.FileProviders.IFileInfo
+    {
+        public ExcludedFileInfo(System.IO.FileInfo info, ExclusionFilters matchingFilter) { }
+        public Microsoft.Extensions.FileProviders.Physical.ExclusionFilters MatchingFilter { get { throw null; } }
+        public bool Exists { get { throw null; } }
+        public bool IsDirectory { get { throw null; } }
+        public System.DateTimeOffset LastModified { get { throw null; } }
+        public long Length { get { throw null; } }
+        public string Name { get { throw null; } }
+        public string PhysicalPath { get { throw null; } }
+        public System.IO.Stream CreateReadStream() { throw null; }
+    }
     [System.FlagsAttribute]
     public enum ExclusionFilters
     {
@@ -42,6 +54,11 @@ namespace Microsoft.Extensions.FileProviders.Physical
         Hidden = 2,
         System = 4,
         Sensitive = 7,
+    }
+    public partial class FileExcludedException : System.Exception
+    {
+        public FileExcludedException(string message, ExclusionFilters matchingFilter) { }
+        public Microsoft.Extensions.FileProviders.Physical.ExclusionFilters MatchingFilter { get { throw null; } }
     }
     public partial class PhysicalDirectoryInfo : Microsoft.Extensions.FileProviders.IFileInfo
     {

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/ExcludedFileInfo.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/ExcludedFileInfo.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+
+namespace Microsoft.Extensions.FileProviders.Physical
+{
+    public class ExcludedFileInfo : IFileInfo
+    {
+        private readonly FileInfo _info;
+
+        /// <summary>
+        /// Initializes an instance of <see cref="ExcludedFileInfo"/>.
+        /// </summary>
+        /// <param name="info">The <see cref="System.IO.FileInfo"/> of the file that could was excluded.</param>
+        /// <param name="matchingFilter">The <see cref="ExclusionFilters"/> the file matched with.</param>
+        public ExcludedFileInfo(FileInfo info, ExclusionFilters matchingFilter)
+        {
+            _info = info;
+            MatchingFilter = matchingFilter;
+        }
+
+        /// <summary>
+        /// The <see cref="ExclusionFilters"/> the file matched with.
+        /// </summary>
+        public ExclusionFilters MatchingFilter { get; }
+
+        /// <inheritdoc />
+        public bool Exists => _info.Exists;
+
+        /// <inheritdoc />
+        public long Length => _info.Length;
+
+        /// <inheritdoc />
+        public string PhysicalPath => _info.FullName;
+
+        /// <inheritdoc />
+        public string Name => _info.Name;
+
+        /// <inheritdoc />
+        public DateTimeOffset LastModified => _info.LastWriteTimeUtc;
+
+        /// <summary>
+        /// Always false.
+        /// </summary>
+        public bool IsDirectory => false;
+
+        /// <summary>
+        /// Always throws. A stream cannot be created for non-existing file.
+        /// </summary>
+        /// <exception cref="FileNotFoundException">Always thrown.</exception>
+        /// <returns>Does not return</returns>
+        public Stream CreateReadStream()
+        {
+            throw new FileExcludedException(SR.Format(SR.FileExcluded, Name), MatchingFilter);
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/FileExcludedException.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/FileExcludedException.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Extensions.FileProviders.Physical
+{
+    public class FileExcludedException : Exception
+    {
+        public ExclusionFilters MatchingFilter { get; }
+
+        public FileExcludedException(string message, ExclusionFilters matchingFilter)
+            : base(message)
+        {
+            MatchingFilter = matchingFilter;
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Internal/FileSystemInfoHelper.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Internal/FileSystemInfoHelper.cs
@@ -8,24 +8,37 @@ namespace Microsoft.Extensions.FileProviders.Physical
 {
     internal static class FileSystemInfoHelper
     {
-        public static bool IsExcluded(FileSystemInfo fileSystemInfo, ExclusionFilters filters)
+        public static bool IsExcluded(FileSystemInfo fileSystemInfo, ExclusionFilters filters) =>
+            FindMatchingExclusionFilter(fileSystemInfo, filters) != ExclusionFilters.None;
+
+        public static ExclusionFilters FindMatchingExclusionFilter(FileSystemInfo fileSystemInfo, ExclusionFilters filters)
         {
             if (filters == ExclusionFilters.None)
             {
-                return false;
-            }
-            else if (fileSystemInfo.Name.StartsWith(".", StringComparison.Ordinal) && (filters & ExclusionFilters.DotPrefixed) != 0)
-            {
-                return true;
-            }
-            else if (fileSystemInfo.Exists &&
-                (((fileSystemInfo.Attributes & FileAttributes.Hidden) != 0 && (filters & ExclusionFilters.Hidden) != 0) ||
-                 ((fileSystemInfo.Attributes & FileAttributes.System) != 0 && (filters & ExclusionFilters.System) != 0)))
-            {
-                return true;
+                return ExclusionFilters.None;
             }
 
-            return false;
+            if (fileSystemInfo.Name.StartsWith(".", StringComparison.Ordinal) && (filters & ExclusionFilters.DotPrefixed) != 0)
+            {
+                return ExclusionFilters.DotPrefixed;
+            }
+
+            if (fileSystemInfo.Exists)
+            {
+                if ((fileSystemInfo.Attributes & FileAttributes.Hidden) != 0 &&
+                    (filters & ExclusionFilters.Hidden) != 0)
+                {
+                    return ExclusionFilters.Hidden;
+                }
+
+                if ((fileSystemInfo.Attributes & FileAttributes.System) != 0 &&
+                    (filters & ExclusionFilters.System) != 0)
+                {
+                    return ExclusionFilters.System;
+                }
+            }
+
+            return ExclusionFilters.None;
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFileProvider.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFileProvider.cs
@@ -266,9 +266,10 @@ namespace Microsoft.Extensions.FileProviders
             }
 
             var fileInfo = new FileInfo(fullPath);
-            if (FileSystemInfoHelper.IsExcluded(fileInfo, _filters))
+            var matchingExclusion = FileSystemInfoHelper.FindMatchingExclusionFilter(fileInfo, _filters);
+            if (matchingExclusion != ExclusionFilters.None)
             {
-                return new NotFoundFileInfo(subpath);
+                return new ExcludedFileInfo(fileInfo, matchingExclusion);
             }
 
             return new PhysicalFileInfo(fileInfo);

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Resources/Strings.resx
@@ -129,4 +129,7 @@
   <data name="UnexpectedFileSystemInfo" xml:space="preserve">
     <value>Unexpected type of FileSystemInfo</value>
   </data>
+  <data name="FileExcluded" xml:space="preserve">
+    <value>The file {0} has been excluded.</value>
+  </data>
 </root>


### PR DESCRIPTION
The `PhysicalFileProvider.GetFileInfo(string)` method currently returns a `NotFoundFileInfo` if it the file matches any of the provided `ExclusionFilter` flags. This results in a `FileNotFoundException` being thrown when trying to load a file using the `FileConfigurationProvider`. 

Example:
```
System.IO.FileNotFoundException
The configuration file '.env' was not found and is not optional.
   at Microsoft.Extensions.Configuration.FileConfigurationProvider.HandleException(ExceptionDispatchInfo info)
   at Microsoft.Extensions.Configuration.FileConfigurationProvider.Load(Boolean reload)
   at Microsoft.Extensions.Configuration.FileConfigurationProvider.Load()
   at Microsoft.Extensions.Configuration.ConfigurationRoot..ctor(IList`1 providers)
   at Microsoft.Extensions.Configuration.ConfigurationBuilder.Build()
```

This is misleading as the file may in fact be reachable, but excluded using the `ExclusionFilter` flags.
I spent some time trying to figure out why my own app couldn't find the `.env` file I had specified, only to realise **after reading the source code for the PhysicalFileProvider** that it _could_ have been found if it was not being excluded. 

This PR introduces an `ExcludedFileInfo` and a `FileExcludedException` to provide better feedback when a file has been intentionally excluded.