### PR TITLE
Fix lowering usage of an unset LSRA field.

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -863,8 +863,10 @@ protected:
     // Generate code for a GT_BITCAST that is not contained.
     void genCodeForBitCast(GenTreeOp* treeNode);
 
+#if defined(TARGET_XARCH)
     // Generate the instruction to move a value between register files
     void genBitCast(var_types targetType, regNumber targetReg, var_types srcType, regNumber srcReg);
+#endif // TARGET_XARCH
 
     struct GenIntCastDesc
     {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -7396,6 +7396,7 @@ GenTree* Compiler::gtNewPutArgReg(var_types type, GenTree* arg, regNumber argReg
 GenTree* Compiler::gtNewBitCastNode(var_types type, GenTree* arg)
 {
     assert(arg != nullptr);
+    assert(type != TYP_STRUCT);
 
     GenTree* node = nullptr;
 #if defined(TARGET_ARM)

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -3779,6 +3779,7 @@ var_types LclVarDsc::GetRegisterType(const GenTreeLclVarCommon* tree) const
     {
         if (lclVarType == TYP_STRUCT)
         {
+            assert(!tree->OperIsLocalField() && "do not expect struct local fields.");
             lclVarType = GetLayout()->GetRegisterType();
         }
         targetType = lclVarType;

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3097,9 +3097,7 @@ void Lowering::LowerStoreLocCommon(GenTreeLclVarCommon* lclStore)
             varDsc = fldDsc;
         }
     }
-
-    if ((varTypeUsesFloatReg(lclStore) != varTypeUsesFloatReg(src)) && !lclStore->IsPhiDefn() &&
-        (src->TypeGet() != TYP_STRUCT))
+    if ((varTypeUsesFloatReg(lclStore) != varTypeUsesFloatReg(src)) && !src->TypeIs(TYP_STRUCT))
     {
         GenTree* bitcast = comp->gtNewBitCastNode(lclStore->TypeGet(), src);
         lclStore->gtOp1  = bitcast;

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3097,6 +3097,11 @@ void Lowering::LowerStoreLocCommon(GenTreeLclVarCommon* lclStore)
             varDsc = fldDsc;
         }
     }
+
+    // TODO-CQ: the condition could be improved for the struct types, for example,
+    // /--*  CALL      simd8  hackishModuleName.hackishMethodName
+    // *  STORE_LCL_VAR struct<HVA64_01[Byte], 8> V03 tmp1
+    // does not need a bitcast because the struct enreg type is SIMD8.
     if ((varTypeUsesFloatReg(lclStore) != varTypeUsesFloatReg(src)) && !src->TypeIs(TYP_STRUCT))
     {
         GenTree* bitcast = comp->gtNewBitCastNode(lclStore->TypeGet(), src);

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -1549,6 +1549,9 @@ void Lowering::ContainCheckStoreLoc(GenTreeLclVarCommon* storeLoc) const
     assert(storeLoc->OperIsLocalStore());
     GenTree* op1 = storeLoc->gtGetOp1();
 
+#if 0
+    // TODO-ARMARCH-CQ: support contained bitcast under STORE_LCL_VAR/FLD,
+    // currently codegen does not expect it.
     if (op1->OperIs(GT_BITCAST))
     {
         // If we know that the source of the bitcast will be in a register, then we can make
@@ -1561,6 +1564,7 @@ void Lowering::ContainCheckStoreLoc(GenTreeLclVarCommon* storeLoc) const
             return;
         }
     }
+#endif
 
     const LclVarDsc* varDsc = comp->lvaGetDesc(storeLoc);
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_54466/Runtime_54466.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_54466/Runtime_54466.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace Runtime_54466
+{
+    public class Test
+    {
+        static int Main()
+        {
+            return t(1, 1, 1, 1, Vector2.One, Vector2.One, Vector2.One, Vector2.One);
+        }
+        
+        
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        static int t(int a1, int a2, int a3, int a4, Vector2 x1, Vector2 x2, Vector2 x3, Vector2 x4)
+        {
+           if (x1 != Vector2.One) 
+           {
+               Console.WriteLine("FAIL");
+               return 101;
+           }
+           return 100;
+        }
+    }
+        
+}
+
+

--- a/src/tests/JIT/Regression/JitBlue/Runtime_54466/Runtime_54466.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_54466/Runtime_54466.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The old code was using `m_lsra->isRegCandidate(varDsc)` that reads `lvIsTracked` field that is not set during lowering and until liveness. So we were reading default `lvIsTracked=false` and always saying that it is not a reg candidate.

The issue started to happen after we added HW support in VN/CSE, it started to produce wrong results, then we added more checks in codegen and it started to fail with assert.

No diffs, the codegen is now clever enough to skip bitcast node when the source is in memory. In theory, we still don't want to create it for TP purposes so we need something like "varIsAlreadyKnownToBeInMemory" but I will try to add it in another change.

Fixes https://github.com/dotnet/runtime/issues/54466