### PR TITLE
[release/5.0] Make sure we consider buffer length when marshalling back Unicode ByValTStr fields

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/StubHelpers.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/StubHelpers.cs
@@ -537,6 +537,17 @@ namespace System.StubHelpers
             managed.Slice(0, numChars).CopyTo(native);
             native[numChars] = '\0';
         }
+
+        internal static unsafe string ConvertToManaged(IntPtr nativeHome, int length)
+        {
+            int end = SpanHelpers.IndexOf(ref *(char*)nativeHome, '\0', length);
+            if (end != -1)
+            {
+                length = end;
+            }
+
+            return new string((char*)nativeHome, 0, length);
+        }
     }  // class WSTRBufferMarshaler
 #if FEATURE_COMINTEROP
 

--- a/src/coreclr/src/vm/corelib.h
+++ b/src/coreclr/src/vm/corelib.h
@@ -1050,6 +1050,7 @@ DEFINE_METHOD(CSTRMARSHALER,        CLEAR_NATIVE,           ClearNative,        
 
 DEFINE_CLASS(FIXEDWSTRMARSHALER,   StubHelpers,            FixedWSTRMarshaler)
 DEFINE_METHOD(FIXEDWSTRMARSHALER,  CONVERT_TO_NATIVE,      ConvertToNative,            SM_Str_IntPtr_Int_RetVoid)
+DEFINE_METHOD(FIXEDWSTRMARSHALER,  CONVERT_TO_MANAGED,     ConvertToManaged,           SM_IntPtr_Int_RetStr)
 
 DEFINE_CLASS(BSTRMARSHALER,         StubHelpers,            BSTRMarshaler)
 DEFINE_METHOD(BSTRMARSHALER,        CONVERT_TO_NATIVE,      ConvertToNative,            SM_Str_IntPtr_RetIntPtr)

--- a/src/coreclr/src/vm/ilmarshalers.cpp
+++ b/src/coreclr/src/vm/ilmarshalers.cpp
@@ -1909,11 +1909,8 @@ void ILFixedWSTRMarshaler::EmitConvertContentsNativeToCLR(ILCodeStream* pslILEmi
     STANDARD_VM_CONTRACT;
 
     EmitLoadNativeHomeAddr(pslILEmit);
-    pslILEmit->EmitDUP();
-    pslILEmit->EmitCALL(METHOD__STRING__WCSLEN, 1, 1);
-    pslILEmit->EmitCALL(METHOD__STUBHELPERS__CHECK_STRING_LENGTH, 1, 0);
-
-    pslILEmit->EmitNEWOBJ(METHOD__STRING__CTOR_CHARPTR, 1);
+    pslILEmit->EmitLDC(m_pargs->fs.fixedStringLength);
+    pslILEmit->EmitCALL(METHOD__FIXEDWSTRMARSHALER__CONVERT_TO_MANAGED, 2, 1);
     EmitStoreManagedValue(pslILEmit);
 }
 

--- a/src/tests/Interop/StringMarshalling/LPTSTR/LPTSTRTest.cs
+++ b/src/tests/Interop/StringMarshalling/LPTSTR/LPTSTRTest.cs
@@ -60,5 +60,20 @@ class LPTStrTest
         ReverseByValStringUni(ref uniStr);
 
         Assert.AreEqual(Helpers.Reverse(InitialString), uniStr.str);
+
+        ReverseCopyByValStringAnsi(new ByValStringInStructAnsi { str = LongString }, out ByValStringInStructSplitAnsi ansiStrSplit);
+
+        Assert.AreEqual(Helpers.Reverse(LongString[^10..]), ansiStrSplit.str1);
+        Assert.AreEqual(Helpers.Reverse(LongString[..^10]), ansiStrSplit.str2);
+
+        ReverseCopyByValStringUni(new ByValStringInStructUnicode { str = LongString }, out ByValStringInStructSplitUnicode uniStrSplit);
+
+        Assert.AreEqual(Helpers.Reverse(LongString[^10..]), uniStrSplit.str1);
+        Assert.AreEqual(Helpers.Reverse(LongString[..^10]), uniStrSplit.str2);
+
+        ReverseCopyByValStringUni(new ByValStringInStructUnicode { str = LongUnicodeString }, out ByValStringInStructSplitUnicode uniStrSplit2);
+
+        Assert.AreEqual(Helpers.Reverse(LongUnicodeString[^10..]), uniStrSplit2.str1);
+        Assert.AreEqual(Helpers.Reverse(LongUnicodeString[..^10]), uniStrSplit2.str2);
     }
 }

--- a/src/tests/Interop/StringMarshalling/LPTSTR/LPTStrTestNative.cpp
+++ b/src/tests/Interop/StringMarshalling/LPTSTR/LPTStrTestNative.cpp
@@ -47,3 +47,15 @@ extern "C" DLL_EXPORT void STDMETHODCALLTYPE ReverseByValStringUni(ByValStringIn
 {
     StringMarshalingTests<LPWSTR, TP_slen>::ReverseInplace(str->str);
 }
+
+extern "C" DLL_EXPORT void STDMETHODCALLTYPE ReverseCopyByValStringAnsi(ByValStringInStructAnsi str, ByValStringInStructAnsi* out)
+{
+    *out = str;
+    StringMarshalingTests<char*, default_callconv_strlen>::ReverseInplace(out->str);
+}
+
+extern "C" DLL_EXPORT void STDMETHODCALLTYPE ReverseCopyByValStringUni(ByValStringInStructUnicode str, ByValStringInStructUnicode* out)
+{
+    *out = str;
+    StringMarshalingTests<LPWSTR, TP_slen>::ReverseInplace(out->str);
+}

--- a/src/tests/Interop/StringMarshalling/LPTSTR/LPTStrTestNative.cs
+++ b/src/tests/Interop/StringMarshalling/LPTSTR/LPTStrTestNative.cs
@@ -14,11 +14,29 @@ class LPTStrTestNative
         public string str;
     }
 
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+    public struct ByValStringInStructSplitAnsi
+    {
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 10)]
+        public string str1;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 10)]
+        public string str2;
+    }
+
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     public struct ByValStringInStructUnicode
     {
         [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 20)]
         public string str;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct ByValStringInStructSplitUnicode
+    {
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 10)]
+        public string str1;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 10)]
+        public string str2;
     }
 
     [DllImport(nameof(LPTStrTestNative), CharSet = CharSet.Unicode)]


### PR DESCRIPTION
Port #54695 to release/5.0

## Customer Impact

The customer is trying to read a BSTR representing "012", into two strings "01" a "2" based on the buffer size. The strings point to the correct position but the parsing doesn't stop at buffer size, so the result is "012" and "2". The customer's scenario is a 64 character long string with 13 fields, this is the repro they reported the issue with.

    using System;
    using System.Runtime.InteropServices;
    using System.Text;

    public class Program
    {
        public static void Main()
        {
           string str = "012";
           IntPtr pBuf = Marshal.StringToBSTR(str);
           CEStruct ces = (CEStruct)Marshal.PtrToStructure(pBuf, typeof(CEStruct));
           Console.WriteLine(ces.tipoDocumento);
           Console.WriteLine(ces.tipoContribuyente);
        }
    }
    
    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
    public struct CEStruct
    {
        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 2)]
        public string tipoDocumento;
        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 1)]
        public string tipoContribuyente;
    }

Instead of reading only up to the constant buffer length based on the string marshalling data, the runtime would read until it found a null terminator. In the case described by the user, it would read the whole string instead of just the two characters. If the buffer itself is not null-terminated (since is supposed to be constant length), then it would read significantly more data than it was supposed to and create a string from that.

## Testing
Testing added in PR.

## Risk
Low. We have unit tests validating multiple edge cases with the scenario

## Regression
This is a regression from 3.1
