### PR TITLE
HTTP/3 stress tests (requires libmsquic.so)

### DIFF
--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
@@ -42,7 +42,8 @@ namespace HttpStress
         public int TaskNum { get; }
         public bool IsCancellationRequested { get; private set; }
 
-        public Version HttpVersion => _config.HttpVersion;
+        public Version HttpVersion => _client.DefaultRequestVersion;
+        public HttpVersionPolicy HttpVersionPolicy => _client.DefaultVersionPolicy;
         public int MaxRequestParameters => _config.MaxParameters;
         public int MaxRequestUriSize => _config.MaxRequestUriSize;
         public int MaxRequestHeaderCount => _config.MaxRequestHeaderCount;
@@ -54,6 +55,7 @@ namespace HttpStress
         public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, HttpCompletionOption httpCompletion = HttpCompletionOption.ResponseContentRead, CancellationToken? token = null)
         {
             request.Version = HttpVersion;
+            request.VersionPolicy = HttpVersionPolicy;
 
             if (token != null)
             {

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
@@ -1,11 +1,29 @@
-ARG SDK_BASE_IMAGE=mcr.microsoft.com/dotnet/nightly/sdk:5.0-buster-slim
+# use nightly build of 6.0 from main (Debian)
+ARG SDK_BASE_IMAGE=mcr.microsoft.com/dotnet/nightly/sdk:latest
 FROM $SDK_BASE_IMAGE
 
 RUN echo "DOTNET_SDK_VERSION="$DOTNET_SDK_VERSION
 RUN echo "DOTNET_VERSION="$DOTNET_VERSION
 
+# install dependencies of libmsquic.so
+RUN apt-get update -y \
+    && apt-get install -y \
+        liblttng-ust0 \
+        libatomic1 \
+        libc6 \
+    && apt-get clean
+
 WORKDIR /app
 COPY . .
+
+# pre-built msquic should be inside stress tests directory so we can copy it to container here
+COPY libmsquic.so /usr/share/dotnet/shared/Microsoft.NETCore.App/$DOTNET_VERSION/
+COPY libmsquic.lttng.so /usr/share/dotnet/shared/Microsoft.NETCore.App/$DOTNET_VERSION/
+
+# no need to rebuild whole clr+libs with "-b" argument, we can substitute specific dlls only
+# for that, pre-build locally for net6.0-Linux-Release, put inside stress tests directory and uncomment copy below
+# COPY System.Net.Quic.dll /usr/share/dotnet/shared/Microsoft.NETCore.App/$DOTNET_VERSION/
+# COPY System.Net.Http.dll /usr/share/dotnet/shared/Microsoft.NETCore.App/$DOTNET_VERSION/
 
 ARG CONFIGURATION=Release
 RUN dotnet build -c $CONFIGURATION

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/HttpStress.csproj
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/HttpStress.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -13,6 +13,8 @@
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19577.1" />
     <PackageReference Include="System.Net.Http.WinHttpHandler" Version="4.5.4" />
+
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Quic" Version="6.0.0-preview.5.21301.17"/>
   </ItemGroup>
 
 </Project>

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
@@ -65,8 +65,8 @@ namespace HttpStress
                 }
             }
 
-            return new HttpClient(CreateHttpHandler()) 
-            { 
+            return new HttpClient(CreateHttpHandler())
+            {
                 BaseAddress = _baseAddress,
                 Timeout = _config.DefaultTimeout,
                 DefaultRequestVersion = _config.HttpVersion,
@@ -283,7 +283,7 @@ namespace HttpStress
             public void RecordFailure(Exception exn, int operationIndex, TimeSpan elapsed, bool isCancelled, int taskNum, long iteration)
             {
                 DateTime timestamp = DateTime.Now;
-                
+
                 Interlocked.Increment(ref _totalRequests);
                 Interlocked.Increment(ref _failures[operationIndex]);
 

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
@@ -108,6 +108,10 @@ namespace HttpStress
                                 }
                                 listenOptions.UseHttps(cert);
                             }
+                            if (configuration.HttpVersion == new Version(3,0))
+                            {
+                                listenOptions.Protocols = HttpProtocols.Http3;
+                            }
                         }
                         else
                         {
@@ -118,6 +122,15 @@ namespace HttpStress
                         }
                     }
                 });
+
+                if (configuration.HttpVersion == new Version(3,0))
+                {
+                    host = host.UseQuic(options =>
+                    {
+                        options.Alpn = "h3-29";
+                        options.IdleTimeout = TimeSpan.FromHours(1);
+                    });
+                }
             };
 
             LoggerConfiguration loggerConfiguration = new LoggerConfiguration();


### PR DESCRIPTION
This is a temporary workaround to run stress tests for HTTP/3 with a pre-built libmsquic.so (until we have proper packaging for Linux).

### How to run the tests

Before running, you will need to acquire libmsquic.so and libmsquic.lttng.so and put them to stress dir.
To run the stress for HTTP/3, you need to specify 3.0 on both client and server.
```pwsh
cd ${RUNTIME_DIR}/src/libraries/System.Net.Http/tests/StressTests/HttpStress/
cp ${MSQUIC_LIBS_DIR}/libmsquic.so .
cp ${MSQUIC_LIBS_DIR}/libmsquic.lttng.so .
./run-docker-compose.ps1 -clientstressargs "-maxExecutionTime 10 -http 3.0" -serverstressargs "-http 3.0"
```

### How to get libmsquic.so

I will paste a link to pre-built libs, but if you wish to build it yourself, you can use [Dockerfile](https://github.com/microsoft/msquic/blob/main/Dockerfile) from msquic repo, run it and then copy the libs from the container to local machine.
It might be helpful to substitute container entrypoint from "/run_endpoint.sh" to "/bin/bash" so the container would not terminate prematurely at the end of the script.
If building docker image on Windows, shell scripts need to be updated from CRLF to LF EOL or they won't work (with a very confusing error "command not found"). From the top of my head it's "scripts/install-powershell-docker.sh", "submodules/openssl/config" and "scripts/run_endpoint.sh".

### Leveraging local changes to System.Net.Quic.dll or System.Net.Http.dll

I would strongly advise against building whole clr+libs by passing `-b` flag to `run-docker-compose.ps1` as it takes tons of time. With my updates to Dockerfile, container will already have nightly dotnet build from main. It should be enough to just substitute specific dll -- build it locally for Linux, copy to stress dir and uncomment COPY command. (see Dockerfile)

### Results

I haven't run for too long (maxExecutionTime=10 minutes) but it was enough for requests to stop going through and just time out - I'd suspect improper stream closure might be the reason.

```
HttpStress Run Final Report

[06/25/2021 17:57:10] Total: 110,577 Runtime: 00:11:00
	 0: GET                       Success: 6,861	Canceled: 504	Fail: 8
	 1: GET Partial               Success: 6,867	Canceled: 498	Fail: 7
	 2: GET Headers               Success: 6,788	Canceled: 578	Fail: 7
	 3: GET Parameters            Success: 6,871	Canceled: 500	Fail: 2
	 4: GET Aborted               Success: 0	Canceled: 505	Fail: 6,864
	 5: POST                      Success: 6,836	Canceled: 532	Fail: 2
	 6: POST Multipart Data       Success: 6,841	Canceled: 529	Fail: 1
	 7: POST Duplex               Success: 6,838	Canceled: 532	Fail: 1
	 8: POST Duplex Slow          Success: 6,836	Canceled: 534	Fail: 0
	 9: POST Duplex Dispose       Success: 6,890	Canceled: 479	Fail: 2
	10: POST ExpectContinue       Success: 0	Canceled: 530	Fail: 6,842
	11: HEAD                      Success: 6,887	Canceled: 482	Fail: 4
	12: PUT                       Success: 6,851	Canceled: 519	Fail: 3
	13: PUT Slow                  Success: 6,627	Canceled: 738	Fail: 8
	14: GET Slow                  Success: 6,816	Canceled: 549	Fail: 8
	    TOTAL                     Success: 88,809	Canceled: 8,009	Fail: 13,759

Latency(ms) : n=110577, p50=10.89, p75=17.29, p99=386.3, p999=1002.77, max=60018.42
```

Of all the scenarios, GET Aborted and POST ExpectContinue are the only ones that are not working at all. Other scenarios failures are timeouts that I mentioned before

### Observed failures

1. `System.Exception: Expected status code OK, got InternalServerError` 
Scenario: POST ExpectContinue
2. `System.Net.Http.HttpRequestException: An error occurred while sending the request.`
`  ---> System.Net.Quic.QuicStreamAbortedException: Stream aborted by peer (258).`
Scenario: GET Aborted
3. `System.Net.Http.HttpRequestException: Error while copying content to a stream.`
`  ---> System.IO.IOException: An error occurred while sending the request.`
`  ---> System.Net.Http.HttpRequestException: An error occurred while sending the request.`
`  ---> System.Net.Quic.QuicStreamAbortedException: Stream aborted by peer (258).`
Scenario: GET Aborted
4. `System.Threading.Tasks.TaskCanceledException: The request was canceled due to the configured HttpClient.Timeout of 60 seconds elapsing.`
`  ---> System.TimeoutException: Read was canceled`
Scenarios: GET, GET Partial, GET Headers, GET Parameters
POST, POST Multipart Data, POST Duplex Dispose, POST ExpectContinue
HEAD
PUT, PUT Slow
GET Slow
5. `System.Exception: Completed unexpectedly`
Scenario: GET Aborted
6. `System.Net.Http.HttpRequestException: Error while copying content to a stream.`
`  ---> System.IO.IOException: An error occurred while sending the request.`
`  ---> System.Net.Http.HttpRequestException: An error occurred while sending the request.`
`  ---> System.Net.Http.HttpRequestException: The response ended prematurely, with at least X additional bytes expected.`
Scenario: GET Aborted
7. `System.Net.Http.HttpRequestException: Error while copying content to a stream.`
`  ---> System.IO.IOException: An error occurred while sending the request.`
`  ---> System.Net.Http.HttpRequestException: An error occurred while sending the request.`
`  ---> System.Net.Quic.QuicOperationAbortedException: Operation aborted.`
Scenario: POST Duplex

### Additional problems

- Kestrel does not seem to respect MsQuicApi.IsQuicSupported=false (continues with creating QuicListener which fails with NRE)
- Our System.Net.Quic tracing does not work ("Exception in Command Processing for EventSource "Microsoft-System-Net-Quic": Event VerboseMessage has ID 5 which is already in use.")
- Event source for System.Net.Quic has unconsistent naming "Microsoft-System-Net-Quic" (changing it to "Private.InternalDiagnostics.System.Net.Quic" doesn't fix the problem above)


cc @ManickaP @wfurt @geoffkizer 