### PR TITLE
[release/6.0-preview6][mono][debugger] Fix debugging with XAML hot reload enabled.

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -9719,7 +9719,7 @@ mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, Mon
 		mono_runtime_print_stats ();
 	}
 
-	MonoJitMemoryManager *jit_mm = jit_mm_for_method (imethod->method);
+	MonoJitMemoryManager *jit_mm = get_default_jit_mm ();
 	jit_mm_lock (jit_mm);
 	if (!g_hash_table_lookup (jit_mm->seq_points, imethod->method))
 		g_hash_table_insert (jit_mm->seq_points, imethod->method, imethod->jinfo->seq_points);

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -2723,6 +2723,12 @@ mono_jit_free_method (MonoMethod *method)
 	mono_debug_remove_method (method, NULL);
 	mono_lldb_remove_method (method, ji);
 
+	//seq_points are always on get_default_jit_mm
+	jit_mm = get_default_jit_mm ();
+	jit_mm_lock (jit_mm);
+	g_hash_table_remove (jit_mm->seq_points, method);
+	jit_mm_unlock (jit_mm);
+
 	jit_mm = jit_mm_for_method (method);
 
 	jit_code_hash_lock (jit_mm);


### PR DESCRIPTION
## Backport of #54757 to release/6.0-preview6

/cc @thaystg

## Customer Impact

Fix a problem where android apps assert in startup when hot reload and the interpreter are enabled. This fixes breakpoint locating when using ALCs. Without this fix Android hot-reload apps may not start but the issue extends more generally to debugging assemblies loaded later with ALC across the mobile runtimes.

## Testing

Manual testing.  Additional tests are being added.

## Risk

Low, it resolves the method lookup using existing code.