### PR TITLE
Fix gc hole in IO thread pool

### DIFF
--- a/src/coreclr/vm/win32threadpool.cpp
+++ b/src/coreclr/vm/win32threadpool.cpp
@@ -1278,8 +1278,9 @@ void ThreadpoolMgr::ManagedWaitIOCompletionCallback_Worker(LPVOID state)
     DestroyHandle(completeWaitWorkItemObjectHandle);
     completeWaitWorkItemObjectHandle = NULL;
 
+    MethodDescCallSite completeAwait(METHOD__COMPLETE_WAIT_THREAD_POOL_WORK_ITEM__COMPLETE_WAIT, &completeWaitWorkItemObject);
     ARG_SLOT args[] = { ObjToArgSlot(completeWaitWorkItemObject) };
-    MethodDescCallSite(METHOD__COMPLETE_WAIT_THREAD_POOL_WORK_ITEM__COMPLETE_WAIT, &completeWaitWorkItemObject).Call(args);
+    completeAwait.Call(args);
 
     GCPROTECT_END();
 }

--- a/src/tests/tracing/eventpipe/processenvironment/processenvironment.csproj
+++ b/src/tests/tracing/eventpipe/processenvironment/processenvironment.csproj
@@ -8,8 +8,6 @@
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
-    <!-- Disable under GCStress. Tracking: https://github.com/dotnet/runtime/issues/51477 -->
-    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
Its not safe to place a managed object reference in an ARG_SLOT without gc protecting the ARG_SLOT across a call to the MethodDescCallSite constructor.

Fix #51477 