### PR TITLE
minor optimization: move creation of X509 Subject Summary into catch block on MacOS.

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.cs
@@ -399,7 +399,6 @@ namespace Internal.Cryptography.Pal
                 return;
 
             Debug.Assert(!_certHandle.IsInvalid);
-            string? subjectSummary = Interop.AppleCrypto.X509GetSubjectSummary(_certHandle);
 
             try
             {
@@ -407,6 +406,7 @@ namespace Internal.Cryptography.Pal
             }
             catch (CryptographicException e)
             {
+                string? subjectSummary = Interop.AppleCrypto.X509GetSubjectSummary(_certHandle);
                 if (subjectSummary is null)
                 {
                     throw;


### PR DESCRIPTION
Currently we are making a call to Interop.AppleCrypto.X509GetSubjectSummary on each call to EnsureCertData. 
However, this is needed only when something goes wrong, for a better error message. Thus, moving the call into the catch block.