### PR TITLE
Reduce overhead of Enumerable.Chunk

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Chunk.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Chunk.cs
@@ -55,19 +55,22 @@ namespace System.Linq
                 TSource[] chunk = new TSource[size];
                 chunk[0] = e.Current;
 
-                for (int i = 1; i < size; i++)
+                int i = 1;
+                for (; i < chunk.Length && e.MoveNext(); i++)
                 {
-                    if (!e.MoveNext())
-                    {
-                        Array.Resize(ref chunk, i);
-                        yield return chunk;
-                        yield break;
-                    }
-
                     chunk[i] = e.Current;
                 }
 
-                yield return chunk;
+                if (i == chunk.Length)
+                {
+                    yield return chunk;
+                }
+                else
+                {
+                    Array.Resize(ref chunk, i);
+                    yield return chunk;
+                    yield break;
+                }
             }
         }
     }


### PR DESCRIPTION
Avoid passing the array by ref and yielding inside the loop, which defeat various optimizations (e.g. bounds checking elimination).