### PR TITLE
Fix load exception on generic covariant return type

### DIFF
--- a/src/coreclr/vm/class.cpp
+++ b/src/coreclr/vm/class.cpp
@@ -1170,12 +1170,13 @@ void ClassLoader::ValidateMethodsWithCovariantReturnTypes(MethodTable* pMT)
                 continue;
 
             // Locate the MethodTable defining the pParentMD.
-            while (pParentMT->GetCanonicalMethodTable() != pParentMD->GetMethodTable())
+            MethodTable* pDefinitionParentMT = pParentMT;
+            while (pDefinitionParentMT->GetCanonicalMethodTable() != pParentMD->GetMethodTable())
             {
-                pParentMT = pParentMT->GetParentMethodTable();
+                pDefinitionParentMT = pDefinitionParentMT->GetParentMethodTable();
             }
 
-            SigTypeContext context1(pParentMT->GetInstantiation(), pMD->GetMethodInstantiation());
+            SigTypeContext context1(pDefinitionParentMT->GetInstantiation(), pMD->GetMethodInstantiation());
             MetaSig methodSig1(pParentMD);
             TypeHandle hType1 = methodSig1.GetReturnProps().GetTypeHandleThrowing(pParentMD->GetModule(), &context1, ClassLoader::LoadTypesFlag::LoadTypes, CLASS_LOAD_EXACTPARENTS);
 

--- a/src/tests/Regressions/coreclr/GitHub_54719/test54719.cs
+++ b/src/tests/Regressions/coreclr/GitHub_54719/test54719.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+public class IA { }
+public class IB { }
+
+public abstract class Base
+{
+    public abstract IA Key { get; }
+    public abstract IB Value { get; }
+}
+public sealed class Derived : Base<IB>
+{
+    public class A : IA { }
+    public sealed override A Key => default;
+}
+public abstract class Base<B> : Base where B : IB
+{
+    public sealed override B Value => null;
+}
+
+class Program
+{
+    static int Main()
+    {
+        new Derived();
+
+        return 100;
+    }
+}

--- a/src/tests/Regressions/coreclr/GitHub_54719/test54719.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_54719/test54719.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test54719.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/54719

The issue was `pParentMT` being modified, which caused the next iteration to use a different parent method table