### PR TITLE
Fix EnumMemberRefs always returning NULL

### DIFF
--- a/src/coreclr/md/compiler/import.cpp
+++ b/src/coreclr/md/compiler/import.cpp
@@ -762,7 +762,7 @@ STDMETHODIMP RegMeta::EnumMemberRefs(         // S_OK, S_FALSE, or error.
 
         // set the output parameter
         *ppmdEnum = pEnum;
-        *ppmdEnum = 0;
+        pEnum = NULL;
     }
 
     // fill the output token buffer


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/54795.

Regressed in https://github.com/dotnet/runtime/pull/50471.

@jkotas @janvorli ptal

cc @kalikin