### PR TITLE
Fix ordinal imports on Windows.

### DIFF
--- a/src/mono/mono/metadata/native-library.c
+++ b/src/mono/mono/metadata/native-library.c
@@ -1102,16 +1102,6 @@ pinvoke_probe_for_symbol (MonoDl *module, MonoMethodPInvoke *piinfo, const char 
 
 	g_assert (error_msg_out);
 
-#ifdef HOST_WIN32
-	if (import && import [0] == '#' && isdigit (import [1])) {
-		char *end;
-		long id;
-
-		id = strtol (import + 1, &end, 10);
-		if (id > 0 && *end == '\0')
-			import++;
-	}
-#endif
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_DLLIMPORT,
 				"Searching for '%s'.", import);
 

--- a/src/mono/mono/utils/mono-dl-windows.c
+++ b/src/mono/mono/utils/mono-dl-windows.c
@@ -157,7 +157,21 @@ mono_dl_lookup_symbol (MonoDl *module, const char *symbol_name)
 
 	/* get the symbol directly from the specified module */
 	if (!module->main_module)
+	{
+		if (symbol_name[0] == '#')
+		{
+			/* lookup by ordinal */
+			unsigned long ord;
+			char *end;
+
+			ord = strtoul(symbol_name + 1, &end, 10);
+
+			if (*end == '\0' && ord > 0 && ord < 65536)
+				symbol_name = (const char*)(uintptr_t)ord;
+		}
+
 		return (void*)GetProcAddress ((HMODULE)module->handle, symbol_name);
+	}
 
 	/* get the symbol from the main module */
 	proc = (gpointer)GetProcAddress ((HMODULE)module->handle, symbol_name);


### PR DESCRIPTION
!! This PR is a copy of mono/mono#21123,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Fixes mono/mono#21122 

We have existing code for this, but as the test case shows, it doesn't work. It's not really clear how it's supposed to work, since all it does is skip the "#" in the entry point name. GetProcAddress does not interpret numeric strings as ordinals, but it will interpret a pointer address from 1 to 65535 as an ordinal.