### PR TITLE
Use inline Vector{128|256}.Create for constants

### DIFF
--- a/src/libraries/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/libraries/System.Collections/src/System/Collections/BitArray.cs
@@ -120,12 +120,6 @@ namespace System.Collections
             _version = 0;
         }
 
-#if !NET6_0_OR_GREATER
-        private static readonly Vector128<byte> s_bitMask128 = BitConverter.IsLittleEndian ?
-                                                Vector128.Create(0x80402010_08040201).AsByte() :
-                                                Vector128.Create(0x01020408_10204080).AsByte();
-#endif
-
         private const uint Vector128ByteCount = 16;
         private const uint Vector128IntCount = 4;
         private const uint Vector256ByteCount = 32;
@@ -192,14 +186,9 @@ namespace System.Collections
                 // However comparison against zero can be replaced to cmeq against zero (vceqzq_s8)
                 // See dotnet/runtime#33972 for details
                 Vector128<byte> zero = Vector128<byte>.Zero;
-
-#if NET6_0_OR_GREATER
                 Vector128<byte> bitMask128 = BitConverter.IsLittleEndian ?
                                              Vector128.Create(0x80402010_08040201).AsByte() :
                                              Vector128.Create(0x01020408_10204080).AsByte();
-#else
-                Vector128<byte> bitMask128 = s_bitMask128;
-#endif
 
                 fixed (bool* ptr = values)
                 {
@@ -868,14 +857,6 @@ namespace System.Collections
             }
         }
 
-#if !NET6_0_OR_GREATER
-        // The mask used when shuffling a single int into Vector128/256.
-        // On little endian machines, the lower 8 bits of int belong in the first byte, next lower 8 in the second and so on.
-        // We place the bytes that contain the bits to its respective byte so that we can mask out only the relevant bits later.
-        private static readonly Vector128<byte> s_lowerShuffleMask_CopyToBoolArray = Vector128.Create(0, 0x01010101_01010101).AsByte();
-        private static readonly Vector128<byte> s_upperShuffleMask_CopyToBoolArray = Vector128.Create(0x02020202_02020202, 0x03030303_03030303).AsByte();
-#endif
-
         public unsafe void CopyTo(Array array, int index)
         {
             if (array == null)
@@ -966,16 +947,11 @@ namespace System.Collections
                 if (m_length < BitsPerInt32)
                     goto LessThan32;
 
-#if NET6_0_OR_GREATER
                 // The mask used when shuffling a single int into Vector128/256.
                 // On little endian machines, the lower 8 bits of int belong in the first byte, next lower 8 in the second and so on.
                 // We place the bytes that contain the bits to its respective byte so that we can mask out only the relevant bits later.
                 Vector128<byte> lowerShuffleMask_CopyToBoolArray = Vector128.Create(0, 0x01010101_01010101).AsByte();
                 Vector128<byte> upperShuffleMask_CopyToBoolArray = Vector128.Create(0x02020202_02020202, 0x03030303_03030303).AsByte();
-#else
-                Vector128<byte> lowerShuffleMask_CopyToBoolArray = s_lowerShuffleMask_CopyToBoolArray;
-                Vector128<byte> upperShuffleMask_CopyToBoolArray = s_upperShuffleMask_CopyToBoolArray;                
-#endif
 
                 if (Avx2.IsSupported)
                 {
@@ -1004,13 +980,9 @@ namespace System.Collections
                     Vector128<byte> lowerShuffleMask = lowerShuffleMask_CopyToBoolArray;
                     Vector128<byte> upperShuffleMask = upperShuffleMask_CopyToBoolArray;
                     Vector128<byte> ones = Vector128.Create((byte)1);
-#if NET6_0_OR_GREATER
                     Vector128<byte> bitMask128 = BitConverter.IsLittleEndian ?
                                                  Vector128.Create(0x80402010_08040201).AsByte() :
                                                  Vector128.Create(0x01020408_10204080).AsByte();
-#else
-                    Vector128<byte> bitMask128 = s_bitMask128;
-#endif
 
                     fixed (bool* destination = &boolArray[index])
                     {
@@ -1034,14 +1006,9 @@ namespace System.Collections
                 else if (AdvSimd.IsSupported)
                 {
                     Vector128<byte> ones = Vector128.Create((byte)1);
-
-#if NET6_0_OR_GREATER
                     Vector128<byte> bitMask128 = BitConverter.IsLittleEndian ?
                                                  Vector128.Create(0x80402010_08040201).AsByte() :
                                                  Vector128.Create(0x01020408_10204080).AsByte();
-#else
-                    Vector128<byte> bitMask128 = s_bitMask128;
-#endif
 
                     fixed (bool* destination = &boolArray[index])
                     {

--- a/src/libraries/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/libraries/System.Collections/src/System/Collections/BitArray.cs
@@ -120,9 +120,11 @@ namespace System.Collections
             _version = 0;
         }
 
+#if !NET6_0_OR_GREATER
         private static readonly Vector128<byte> s_bitMask128 = BitConverter.IsLittleEndian ?
                                                 Vector128.Create(0x80402010_08040201).AsByte() :
                                                 Vector128.Create(0x01020408_10204080).AsByte();
+#endif
 
         private const uint Vector128ByteCount = 16;
         private const uint Vector128IntCount = 4;
@@ -190,6 +192,15 @@ namespace System.Collections
                 // However comparison against zero can be replaced to cmeq against zero (vceqzq_s8)
                 // See dotnet/runtime#33972 for details
                 Vector128<byte> zero = Vector128<byte>.Zero;
+
+#if NET6_0_OR_GREATER
+                Vector128<byte> bitMask128 = BitConverter.IsLittleEndian ?
+                                             Vector128.Create(0x80402010_08040201).AsByte() :
+                                             Vector128.Create(0x01020408_10204080).AsByte();
+#else
+                Vector128<byte> bitMask128 = s_bitMask128;
+#endif
+
                 fixed (bool* ptr = values)
                 {
                     for (; (i + Vector128ByteCount * 2u) <= (uint)values.Length; i += Vector128ByteCount * 2u)
@@ -199,7 +210,7 @@ namespace System.Collections
                         // and combine by ORing all of them together (In this case, adding all of them does the same thing)
                         Vector128<byte> lowerVector = AdvSimd.LoadVector128((byte*)ptr + i);
                         Vector128<byte> lowerIsFalse = AdvSimd.CompareEqual(lowerVector, zero);
-                        Vector128<byte> bitsExtracted1 = AdvSimd.And(lowerIsFalse, s_bitMask128);
+                        Vector128<byte> bitsExtracted1 = AdvSimd.And(lowerIsFalse, bitMask128);
                         bitsExtracted1 = AdvSimd.Arm64.AddPairwise(bitsExtracted1, bitsExtracted1);
                         bitsExtracted1 = AdvSimd.Arm64.AddPairwise(bitsExtracted1, bitsExtracted1);
                         bitsExtracted1 = AdvSimd.Arm64.AddPairwise(bitsExtracted1, bitsExtracted1);
@@ -207,7 +218,7 @@ namespace System.Collections
 
                         Vector128<byte> upperVector = AdvSimd.LoadVector128((byte*)ptr + i + Vector128<byte>.Count);
                         Vector128<byte> upperIsFalse = AdvSimd.CompareEqual(upperVector, zero);
-                        Vector128<byte> bitsExtracted2 = AdvSimd.And(upperIsFalse, s_bitMask128);
+                        Vector128<byte> bitsExtracted2 = AdvSimd.And(upperIsFalse, bitMask128);
                         bitsExtracted2 = AdvSimd.Arm64.AddPairwise(bitsExtracted2, bitsExtracted2);
                         bitsExtracted2 = AdvSimd.Arm64.AddPairwise(bitsExtracted2, bitsExtracted2);
                         bitsExtracted2 = AdvSimd.Arm64.AddPairwise(bitsExtracted2, bitsExtracted2);
@@ -857,11 +868,13 @@ namespace System.Collections
             }
         }
 
+#if !NET6_0_OR_GREATER
         // The mask used when shuffling a single int into Vector128/256.
         // On little endian machines, the lower 8 bits of int belong in the first byte, next lower 8 in the second and so on.
         // We place the bytes that contain the bits to its respective byte so that we can mask out only the relevant bits later.
         private static readonly Vector128<byte> s_lowerShuffleMask_CopyToBoolArray = Vector128.Create(0, 0x01010101_01010101).AsByte();
         private static readonly Vector128<byte> s_upperShuffleMask_CopyToBoolArray = Vector128.Create(0x02020202_02020202, 0x03030303_03030303).AsByte();
+#endif
 
         public unsafe void CopyTo(Array array, int index)
         {
@@ -953,9 +966,20 @@ namespace System.Collections
                 if (m_length < BitsPerInt32)
                     goto LessThan32;
 
+#if NET6_0_OR_GREATER
+                // The mask used when shuffling a single int into Vector128/256.
+                // On little endian machines, the lower 8 bits of int belong in the first byte, next lower 8 in the second and so on.
+                // We place the bytes that contain the bits to its respective byte so that we can mask out only the relevant bits later.
+                Vector128<byte> lowerShuffleMask_CopyToBoolArray = Vector128.Create(0, 0x01010101_01010101).AsByte();
+                Vector128<byte> upperShuffleMask_CopyToBoolArray = Vector128.Create(0x02020202_02020202, 0x03030303_03030303).AsByte();
+#else
+                Vector128<byte> lowerShuffleMask_CopyToBoolArray = s_lowerShuffleMask_CopyToBoolArray;
+                Vector128<byte> upperShuffleMask_CopyToBoolArray = s_upperShuffleMask_CopyToBoolArray;                
+#endif
+
                 if (Avx2.IsSupported)
                 {
-                    Vector256<byte> shuffleMask = Vector256.Create(s_lowerShuffleMask_CopyToBoolArray, s_upperShuffleMask_CopyToBoolArray);
+                    Vector256<byte> shuffleMask = Vector256.Create(lowerShuffleMask_CopyToBoolArray, upperShuffleMask_CopyToBoolArray);
                     Vector256<byte> bitMask = Vector256.Create(0x80402010_08040201).AsByte();
                     Vector256<byte> ones = Vector256.Create((byte)1);
 
@@ -977,9 +1001,16 @@ namespace System.Collections
                 }
                 else if (Ssse3.IsSupported)
                 {
-                    Vector128<byte> lowerShuffleMask = s_lowerShuffleMask_CopyToBoolArray;
-                    Vector128<byte> upperShuffleMask = s_upperShuffleMask_CopyToBoolArray;
+                    Vector128<byte> lowerShuffleMask = lowerShuffleMask_CopyToBoolArray;
+                    Vector128<byte> upperShuffleMask = upperShuffleMask_CopyToBoolArray;
                     Vector128<byte> ones = Vector128.Create((byte)1);
+#if NET6_0_OR_GREATER
+                    Vector128<byte> bitMask128 = BitConverter.IsLittleEndian ?
+                                                 Vector128.Create(0x80402010_08040201).AsByte() :
+                                                 Vector128.Create(0x01020408_10204080).AsByte();
+#else
+                    Vector128<byte> bitMask128 = s_bitMask128;
+#endif
 
                     fixed (bool* destination = &boolArray[index])
                     {
@@ -989,12 +1020,12 @@ namespace System.Collections
                             Vector128<int> scalar = Vector128.CreateScalarUnsafe(bits);
 
                             Vector128<byte> shuffledLower = Ssse3.Shuffle(scalar.AsByte(), lowerShuffleMask);
-                            Vector128<byte> extractedLower = Sse2.And(shuffledLower, s_bitMask128);
+                            Vector128<byte> extractedLower = Sse2.And(shuffledLower, bitMask128);
                             Vector128<byte> normalizedLower = Sse2.Min(extractedLower, ones);
                             Sse2.Store((byte*)destination + i, normalizedLower);
 
                             Vector128<byte> shuffledHigher = Ssse3.Shuffle(scalar.AsByte(), upperShuffleMask);
-                            Vector128<byte> extractedHigher = Sse2.And(shuffledHigher, s_bitMask128);
+                            Vector128<byte> extractedHigher = Sse2.And(shuffledHigher, bitMask128);
                             Vector128<byte> normalizedHigher = Sse2.Min(extractedHigher, ones);
                             Sse2.Store((byte*)destination + i + Vector128<byte>.Count, normalizedHigher);
                         }
@@ -1003,6 +1034,15 @@ namespace System.Collections
                 else if (AdvSimd.IsSupported)
                 {
                     Vector128<byte> ones = Vector128.Create((byte)1);
+
+#if NET6_0_OR_GREATER
+                    Vector128<byte> bitMask128 = BitConverter.IsLittleEndian ?
+                                                 Vector128.Create(0x80402010_08040201).AsByte() :
+                                                 Vector128.Create(0x01020408_10204080).AsByte();
+#else
+                    Vector128<byte> bitMask128 = s_bitMask128;
+#endif
+
                     fixed (bool* destination = &boolArray[index])
                     {
                         for (; (i + Vector128ByteCount * 2u) <= (uint)m_length; i += Vector128ByteCount * 2u)
@@ -1028,12 +1068,12 @@ namespace System.Collections
                             vector = AdvSimd.Arm64.ZipLow(vector, vector);
 
                             Vector128<byte> shuffledLower = AdvSimd.Arm64.ZipLow(vector, vector);
-                            Vector128<byte> extractedLower = AdvSimd.And(shuffledLower, s_bitMask128);
+                            Vector128<byte> extractedLower = AdvSimd.And(shuffledLower, bitMask128);
                             Vector128<byte> normalizedLower = AdvSimd.Min(extractedLower, ones);
                             AdvSimd.Store((byte*)destination + i, normalizedLower);
 
                             Vector128<byte> shuffledHigher = AdvSimd.Arm64.ZipHigh(vector, vector);
-                            Vector128<byte> extractedHigher = AdvSimd.And(shuffledHigher, s_bitMask128);
+                            Vector128<byte> extractedHigher = AdvSimd.And(shuffledHigher, bitMask128);
                             Vector128<byte> normalizedHigher = AdvSimd.Min(extractedHigher, ones);
                             AdvSimd.Store((byte*)destination + i + Vector128<byte>.Count, normalizedHigher);
                         }

--- a/src/libraries/System.Memory/src/System/Buffers/Text/Base64.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/Text/Base64.cs
@@ -2,20 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using Internal.Runtime.CompilerServices;
 
 namespace System.Buffers.Text
 {
     public static partial class Base64
     {
-        private static TVector ReadVector<TVector>(ReadOnlySpan<sbyte> data)
-        {
-            ref sbyte tmp = ref MemoryMarshal.GetReference(data);
-            return Unsafe.As<sbyte, TVector>(ref tmp);
-        }
-
         [Conditional("DEBUG")]
         private static unsafe void AssertRead<TVector>(byte* src, byte* srcStart, int srcLength)
         {

--- a/src/libraries/System.Memory/src/System/Buffers/Text/Base64Decoder.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/Text/Base64Decoder.cs
@@ -362,7 +362,6 @@ namespace System.Buffers.Text
             // See SSSE3-version below for an explanation of how the code works.
 
             // The JIT won't hoist these "constants", so help it
-#if NET6_0_OR_GREATER
             Vector256<sbyte> lutHi = Vector256.Create(
                 0x10, 0x10, 0x01, 0x02,
                 0x04, 0x08, 0x04, 0x08,
@@ -392,6 +391,7 @@ namespace System.Buffers.Text
                 -65, -65, -71, -71,
                 0, 0, 0, 0,
                 0, 0, 0, 0);
+
             Vector256<sbyte> packBytesInLaneMask = Vector256.Create(
                 2, 1, 0, 6,
                 5, 4, 10, 9,
@@ -401,6 +401,7 @@ namespace System.Buffers.Text
                 5, 4, 10, 9,
                 8, 14, 13, 12,
                 -1, -1, -1, -1);
+
             Vector256<int> packLanesControl = Vector256.Create(
                  0, 0, 0, 0,
                 1, 0, 0, 0,
@@ -410,13 +411,7 @@ namespace System.Buffers.Text
                 6, 0, 0, 0,
                 -1, -1, -1, -1,
                 -1, -1, -1, -1).AsInt32();
-#else
-            Vector256<sbyte> lutHi = ReadVector<Vector256<sbyte>>(s_avxDecodeLutHi);
-            Vector256<sbyte> lutLo = ReadVector<Vector256<sbyte>>(s_avxDecodeLutLo);
-            Vector256<sbyte> lutShift = ReadVector<Vector256<sbyte>>(s_avxDecodeLutShift);
-            Vector256<sbyte> packBytesInLaneMask = ReadVector<Vector256<sbyte>>(s_avxDecodePackBytesInLaneMask);
-            Vector256<int> packLanesControl = ReadVector<Vector256<sbyte>>(s_avxDecodePackLanesControl).AsInt32();
-#endif
+
             Vector256<sbyte> mask2F = Vector256.Create((sbyte)'/');
             Vector256<sbyte> mergeConstant0 = Vector256.Create(0x01400140).AsSByte();
             Vector256<short> mergeConstant1 = Vector256.Create(0x00011000).AsInt16();
@@ -558,7 +553,6 @@ namespace System.Buffers.Text
             // 1111 0x10 andlut     0x10 0x10 0x10 0x10 0x10 0x10 0x10 0x10 0x10 0x10 0x10 0x10 0x10 0x10 0x10 0x10
 
             // The JIT won't hoist these "constants", so help it
-#if NET6_0_OR_GREATER
             Vector128<sbyte> lutHi = Vector128.Create(
                 0x10, 0x10, 0x01, 0x02,
                 0x04, 0x08, 0x04, 0x08,
@@ -582,12 +576,7 @@ namespace System.Buffers.Text
                 5, 4, 10, 9,
                 8, 14, 13, 12,
                 -1, -1, -1, -1);
-#else
-            Vector128<sbyte> lutHi = ReadVector<Vector128<sbyte>>(s_sseDecodeLutHi);
-            Vector128<sbyte> lutLo = ReadVector<Vector128<sbyte>>(s_sseDecodeLutLo);
-            Vector128<sbyte> lutShift = ReadVector<Vector128<sbyte>>(s_sseDecodeLutShift);
-            Vector128<sbyte> packBytesMask = ReadVector<Vector128<sbyte>>(s_sseDecodePackBytesMask);
-#endif
+
             Vector128<sbyte> mask2F = Vector128.Create((sbyte)'/');
             Vector128<sbyte> mergeConstant0 = Vector128.Create(0x01400140).AsSByte();
             Vector128<short> mergeConstant1 = Vector128.Create(0x00011000).AsInt16();
@@ -707,90 +696,5 @@ namespace System.Buffers.Text
             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
         };
-
-#if !NET6_0_OR_GREATER
-        private static ReadOnlySpan<sbyte> s_sseDecodePackBytesMask => new sbyte[] {
-            2, 1, 0, 6,
-            5, 4, 10, 9,
-            8, 14, 13, 12,
-            -1, -1, -1, -1
-        };
-
-        private static ReadOnlySpan<sbyte> s_sseDecodeLutLo => new sbyte[] {
-            0x15, 0x11, 0x11, 0x11,
-            0x11, 0x11, 0x11, 0x11,
-            0x11, 0x11, 0x13, 0x1A,
-            0x1B, 0x1B, 0x1B, 0x1A
-        };
-
-        private static ReadOnlySpan<sbyte> s_sseDecodeLutHi => new sbyte[] {
-            0x10, 0x10, 0x01, 0x02,
-            0x04, 0x08, 0x04, 0x08,
-            0x10, 0x10, 0x10, 0x10,
-            0x10, 0x10, 0x10, 0x10
-        };
-
-        private static ReadOnlySpan<sbyte> s_sseDecodeLutShift => new sbyte[] {
-            0, 16, 19, 4,
-            -65, -65, -71, -71,
-            0, 0, 0, 0,
-            0, 0, 0, 0
-        };
-
-        private static ReadOnlySpan<sbyte> s_avxDecodePackBytesInLaneMask => new sbyte[] {
-            2, 1, 0, 6,
-            5, 4, 10, 9,
-            8, 14, 13, 12,
-            -1, -1, -1, -1,
-            2, 1, 0, 6,
-            5, 4, 10, 9,
-            8, 14, 13, 12,
-            -1, -1, -1, -1
-        };
-
-        private static ReadOnlySpan<sbyte> s_avxDecodePackLanesControl => new sbyte[] {
-            0, 0, 0, 0,
-            1, 0, 0, 0,
-            2, 0, 0, 0,
-            4, 0, 0, 0,
-            5, 0, 0, 0,
-            6, 0, 0, 0,
-            -1, -1, -1, -1,
-            -1, -1, -1, -1
-        };
-
-        private static ReadOnlySpan<sbyte> s_avxDecodeLutLo => new sbyte[] {
-            0x15, 0x11, 0x11, 0x11,
-            0x11, 0x11, 0x11, 0x11,
-            0x11, 0x11, 0x13, 0x1A,
-            0x1B, 0x1B, 0x1B, 0x1A,
-            0x15, 0x11, 0x11, 0x11,
-            0x11, 0x11, 0x11, 0x11,
-            0x11, 0x11, 0x13, 0x1A,
-            0x1B, 0x1B, 0x1B, 0x1A
-        };
-
-        private static ReadOnlySpan<sbyte> s_avxDecodeLutHi => new sbyte[] {
-            0x10, 0x10, 0x01, 0x02,
-            0x04, 0x08, 0x04, 0x08,
-            0x10, 0x10, 0x10, 0x10,
-            0x10, 0x10, 0x10, 0x10,
-            0x10, 0x10, 0x01, 0x02,
-            0x04, 0x08, 0x04, 0x08,
-            0x10, 0x10, 0x10, 0x10,
-            0x10, 0x10, 0x10, 0x10
-        };
-
-        private static ReadOnlySpan<sbyte> s_avxDecodeLutShift => new sbyte[] {
-            0, 16, 19, 4,
-            -65, -65, -71, -71,
-            0, 0, 0, 0,
-            0, 0, 0, 0,
-            0, 16, 19, 4,
-            -65, -65, -71, -71,
-            0, 0, 0, 0,
-            0, 0, 0, 0
-        };
-#endif
     }
 }

--- a/src/libraries/System.Memory/src/System/Buffers/Text/Base64Decoder.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/Text/Base64Decoder.cs
@@ -100,7 +100,7 @@ namespace System.Buffers.Text
                     maxSrcLength = (destLength / 3) * 4;
                 }
 
-                ref sbyte decodingMap = ref MemoryMarshal.GetReference(s_decodingMap);
+                ref sbyte decodingMap = ref MemoryMarshal.GetReference(DecodingMap);
                 srcMax = srcBytes + (uint)maxSrcLength;
 
                 while (src < srcMax)
@@ -275,7 +275,7 @@ namespace System.Buffers.Text
                 if (bufferLength == 0)
                     goto DoneExit;
 
-                ref sbyte decodingMap = ref MemoryMarshal.GetReference(s_decodingMap);
+                ref sbyte decodingMap = ref MemoryMarshal.GetReference(DecodingMap);
 
                 while (sourceIndex < bufferLength - 4)
                 {
@@ -362,14 +362,64 @@ namespace System.Buffers.Text
             // See SSSE3-version below for an explanation of how the code works.
 
             // The JIT won't hoist these "constants", so help it
+#if NET6_0_OR_GREATER
+            Vector256<sbyte> lutHi = Vector256.Create(
+                0x10, 0x10, 0x01, 0x02,
+                0x04, 0x08, 0x04, 0x08,
+                0x10, 0x10, 0x10, 0x10,
+                0x10, 0x10, 0x10, 0x10,
+                0x10, 0x10, 0x01, 0x02,
+                0x04, 0x08, 0x04, 0x08,
+                0x10, 0x10, 0x10, 0x10,
+                0x10, 0x10, 0x10, 0x10);
+
+            Vector256<sbyte> lutLo = Vector256.Create(
+                0x15, 0x11, 0x11, 0x11,
+                0x11, 0x11, 0x11, 0x11,
+                0x11, 0x11, 0x13, 0x1A,
+                0x1B, 0x1B, 0x1B, 0x1A,
+                0x15, 0x11, 0x11, 0x11,
+                0x11, 0x11, 0x11, 0x11,
+                0x11, 0x11, 0x13, 0x1A,
+                0x1B, 0x1B, 0x1B, 0x1A);
+
+            Vector256<sbyte> lutShift = Vector256.Create(
+                 0, 16, 19, 4,
+                -65, -65, -71, -71,
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+                0, 16, 19, 4,
+                -65, -65, -71, -71,
+                0, 0, 0, 0,
+                0, 0, 0, 0);
+            Vector256<sbyte> packBytesInLaneMask = Vector256.Create(
+                2, 1, 0, 6,
+                5, 4, 10, 9,
+                8, 14, 13, 12,
+                -1, -1, -1, -1,
+                2, 1, 0, 6,
+                5, 4, 10, 9,
+                8, 14, 13, 12,
+                -1, -1, -1, -1);
+            Vector256<int> packLanesControl = Vector256.Create(
+                 0, 0, 0, 0,
+                1, 0, 0, 0,
+                2, 0, 0, 0,
+                4, 0, 0, 0,
+                5, 0, 0, 0,
+                6, 0, 0, 0,
+                -1, -1, -1, -1,
+                -1, -1, -1, -1).AsInt32();
+#else
             Vector256<sbyte> lutHi = ReadVector<Vector256<sbyte>>(s_avxDecodeLutHi);
             Vector256<sbyte> lutLo = ReadVector<Vector256<sbyte>>(s_avxDecodeLutLo);
             Vector256<sbyte> lutShift = ReadVector<Vector256<sbyte>>(s_avxDecodeLutShift);
+            Vector256<sbyte> packBytesInLaneMask = ReadVector<Vector256<sbyte>>(s_avxDecodePackBytesInLaneMask);
+            Vector256<int> packLanesControl = ReadVector<Vector256<sbyte>>(s_avxDecodePackLanesControl).AsInt32();
+#endif
             Vector256<sbyte> mask2F = Vector256.Create((sbyte)'/');
             Vector256<sbyte> mergeConstant0 = Vector256.Create(0x01400140).AsSByte();
             Vector256<short> mergeConstant1 = Vector256.Create(0x00011000).AsInt16();
-            Vector256<sbyte> packBytesInLaneMask = ReadVector<Vector256<sbyte>>(s_avxDecodePackBytesInLaneMask);
-            Vector256<int> packLanesControl = ReadVector<Vector256<sbyte>>(s_avxDecodePackLanesControl).AsInt32();
 
             byte* src = srcBytes;
             byte* dest = destBytes;
@@ -508,13 +558,39 @@ namespace System.Buffers.Text
             // 1111 0x10 andlut     0x10 0x10 0x10 0x10 0x10 0x10 0x10 0x10 0x10 0x10 0x10 0x10 0x10 0x10 0x10 0x10
 
             // The JIT won't hoist these "constants", so help it
+#if NET6_0_OR_GREATER
+            Vector128<sbyte> lutHi = Vector128.Create(
+                0x10, 0x10, 0x01, 0x02,
+                0x04, 0x08, 0x04, 0x08,
+                0x10, 0x10, 0x10, 0x10,
+                0x10, 0x10, 0x10, 0x10);
+
+            Vector128<sbyte> lutLo = Vector128.Create(
+                0x15, 0x11, 0x11, 0x11,
+                0x11, 0x11, 0x11, 0x11,
+                0x11, 0x11, 0x13, 0x1A,
+                0x1B, 0x1B, 0x1B, 0x1A);
+
+            Vector128<sbyte> lutShift = Vector128.Create(
+                0, 16, 19, 4,
+                -65, -65, -71, -71,
+                0, 0, 0, 0,
+                0, 0, 0, 0);
+
+            Vector128<sbyte> packBytesMask = Vector128.Create(
+                2, 1, 0, 6,
+                5, 4, 10, 9,
+                8, 14, 13, 12,
+                -1, -1, -1, -1);
+#else
             Vector128<sbyte> lutHi = ReadVector<Vector128<sbyte>>(s_sseDecodeLutHi);
             Vector128<sbyte> lutLo = ReadVector<Vector128<sbyte>>(s_sseDecodeLutLo);
             Vector128<sbyte> lutShift = ReadVector<Vector128<sbyte>>(s_sseDecodeLutShift);
+            Vector128<sbyte> packBytesMask = ReadVector<Vector128<sbyte>>(s_sseDecodePackBytesMask);
+#endif
             Vector128<sbyte> mask2F = Vector128.Create((sbyte)'/');
             Vector128<sbyte> mergeConstant0 = Vector128.Create(0x01400140).AsSByte();
             Vector128<short> mergeConstant1 = Vector128.Create(0x00011000).AsInt16();
-            Vector128<sbyte> packBytesMask = ReadVector<Vector128<sbyte>>(s_sseDecodePackBytesMask);
             Vector128<sbyte> zero = Vector128<sbyte>.Zero;
 
             byte* src = srcBytes;
@@ -613,7 +689,7 @@ namespace System.Buffers.Text
         }
 
         // Pre-computing this table using a custom string(s_characters) and GenerateDecodingMapAndVerify (found in tests)
-        private static ReadOnlySpan<sbyte> s_decodingMap => new sbyte[] {
+        private static ReadOnlySpan<sbyte> DecodingMap => new sbyte[] {
             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, -1, -1, 63,         //62 is placed at index 43 (for +), 63 at index 47 (for /)
@@ -632,6 +708,7 @@ namespace System.Buffers.Text
             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
         };
 
+#if !NET6_0_OR_GREATER
         private static ReadOnlySpan<sbyte> s_sseDecodePackBytesMask => new sbyte[] {
             2, 1, 0, 6,
             5, 4, 10, 9,
@@ -714,5 +791,6 @@ namespace System.Buffers.Text
             0, 0, 0, 0,
             0, 0, 0, 0
         };
+#endif
     }
 }

--- a/src/libraries/System.Memory/src/System/Buffers/Text/Base64Encoder.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/Text/Base64Encoder.cs
@@ -241,7 +241,6 @@ namespace System.Buffers.Text
             // l k j i h g f e d c b a 0 0 0 0
 
             // The JIT won't hoist these "constants", so help it
-#if NET6_0_OR_GREATER
             Vector256<sbyte> shuffleVec = Vector256.Create(
                 5, 4, 6, 5,
                 8, 7, 9, 8,
@@ -261,10 +260,7 @@ namespace System.Buffers.Text
                 -4, -4, -4, -4,
                 -4, -4, -4, -4,
                 -19, -16, 0, 0);
-#else
-            Vector256<sbyte> shuffleVec = ReadVector<Vector256<sbyte>>(s_avxEncodeShuffleVec);
-            Vector256<sbyte> lut = ReadVector<Vector256<sbyte>>(s_avxEncodeLut);
-#endif
+
             Vector256<sbyte> maskAC = Vector256.Create(0x0fc0fc00).AsSByte();
             Vector256<sbyte> maskBB = Vector256.Create(0x003f03f0).AsSByte();
             Vector256<ushort> shiftAC = Vector256.Create(0x04000040).AsUInt16();
@@ -280,7 +276,6 @@ namespace System.Buffers.Text
             Vector256<sbyte> str = Avx.LoadVector256(src).AsSByte();
 
             // shift by 4 bytes, as required by Reshuffle
-#if NET6_0_OR_GREATER
             str = Avx2.PermuteVar8x32(str.AsInt32(), Vector256.Create(
                 0, 0, 0, 0,
                 0, 0, 0, 0,
@@ -290,9 +285,6 @@ namespace System.Buffers.Text
                 4, 0, 0, 0,
                 5, 0, 0, 0,
                 6, 0, 0, 0).AsInt32()).AsSByte();
-#else
-            str = Avx2.PermuteVar8x32(str.AsInt32(), ReadVector<Vector256<sbyte>>(s_avxEncodePermuteVec).AsInt32()).AsSByte();
-#endif
 
             // Next loads are done at src-4, as required by Reshuffle, so shift it once
             src -= 4;
@@ -414,7 +406,6 @@ namespace System.Buffers.Text
             // 0 0 0 0 l k j i h g f e d c b a
 
             // The JIT won't hoist these "constants", so help it
-#if NET6_0_OR_GREATER
             Vector128<sbyte> shuffleVec = Vector128.Create(
                 1, 0, 2, 1,
                 4, 3, 5, 4,
@@ -426,10 +417,7 @@ namespace System.Buffers.Text
                 -4, -4, -4, -4,
                 -4, -4, -4, -4,
                 -19, -16, 0, 0);
-#else
-            Vector128<sbyte> shuffleVec = ReadVector<Vector128<sbyte>>(s_sseEncodeShuffleVec);
-            Vector128<sbyte> lut = ReadVector<Vector128<sbyte>>(s_sseEncodeLut);
-#endif
+
             Vector128<sbyte> maskAC = Vector128.Create(0x0fc0fc00).AsSByte();
             Vector128<sbyte> maskBB = Vector128.Create(0x003f03f0).AsSByte();
             Vector128<ushort> shiftAC = Vector128.Create(0x04000040).AsUInt16();
@@ -601,54 +589,5 @@ namespace System.Buffers.Text
             119, 120, 121, 122, 48, 49, 50, 51,     //w..z, 0..3
             52, 53, 54, 55, 56, 57, 43, 47          //4..9, +, /
         };
-
-#if !NET6_0_OR_GREATER
-        private static ReadOnlySpan<sbyte> s_sseEncodeShuffleVec => new sbyte[] {
-            1, 0, 2, 1,
-            4, 3, 5, 4,
-            7, 6, 8, 7,
-            10, 9, 11, 10
-        };
-
-        private static ReadOnlySpan<sbyte> s_sseEncodeLut => new sbyte[] {
-            65, 71, -4, -4,
-            -4, -4, -4, -4,
-            -4, -4, -4, -4,
-            -19, -16, 0, 0
-        };
-
-        private static ReadOnlySpan<sbyte> s_avxEncodePermuteVec => new sbyte[] {
-            0, 0, 0, 0,
-            0, 0, 0, 0,
-            1, 0, 0, 0,
-            2, 0, 0, 0,
-            3, 0, 0, 0,
-            4, 0, 0, 0,
-            5, 0, 0, 0,
-            6, 0, 0, 0
-        };
-
-        private static ReadOnlySpan<sbyte> s_avxEncodeShuffleVec => new sbyte[] {
-            5, 4, 6, 5,
-            8, 7, 9, 8,
-            11, 10, 12, 11,
-            14, 13, 15, 14,
-            1, 0, 2, 1,
-            4, 3, 5, 4,
-            7, 6, 8, 7,
-            10, 9, 11, 10
-        };
-
-        private static ReadOnlySpan<sbyte> s_avxEncodeLut => new sbyte[] {
-            65, 71, -4, -4,
-            -4, -4, -4, -4,
-            -4, -4, -4, -4,
-            -19, -16, 0, 0,
-            65, 71, -4, -4,
-            -4, -4, -4, -4,
-            -4, -4, -4, -4,
-            -19, -16, 0, 0
-        };
-#endif
     }
 }

--- a/src/libraries/System.Memory/src/System/Buffers/Text/Base64Encoder.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/Text/Base64Encoder.cs
@@ -85,7 +85,7 @@ namespace System.Buffers.Text
                     }
                 }
 
-                ref byte encodingMap = ref MemoryMarshal.GetReference(s_encodingMap);
+                ref byte encodingMap = ref MemoryMarshal.GetReference(EncodingMap);
                 uint result = 0;
 
                 srcMax -= 2;
@@ -189,7 +189,7 @@ namespace System.Buffers.Text
                 uint destinationIndex = (uint)(encodedLength - 4);
                 uint sourceIndex = (uint)(dataLength - leftover);
                 uint result = 0;
-                ref byte encodingMap = ref MemoryMarshal.GetReference(s_encodingMap);
+                ref byte encodingMap = ref MemoryMarshal.GetReference(EncodingMap);
 
                 // encode last pack to avoid conditional in the main loop
                 if (leftover != 0)
@@ -241,14 +241,36 @@ namespace System.Buffers.Text
             // l k j i h g f e d c b a 0 0 0 0
 
             // The JIT won't hoist these "constants", so help it
+#if NET6_0_OR_GREATER
+            Vector256<sbyte> shuffleVec = Vector256.Create(
+                5, 4, 6, 5,
+                8, 7, 9, 8,
+                11, 10, 12, 11,
+                14, 13, 15, 14,
+                1, 0, 2, 1,
+                4, 3, 5, 4,
+                7, 6, 8, 7,
+                10, 9, 11, 10);
+
+            Vector256<sbyte> lut = Vector256.Create(
+                65, 71, -4, -4,
+                -4, -4, -4, -4,
+                -4, -4, -4, -4,
+                -19, -16, 0, 0,
+                65, 71, -4, -4,
+                -4, -4, -4, -4,
+                -4, -4, -4, -4,
+                -19, -16, 0, 0);
+#else
             Vector256<sbyte> shuffleVec = ReadVector<Vector256<sbyte>>(s_avxEncodeShuffleVec);
+            Vector256<sbyte> lut = ReadVector<Vector256<sbyte>>(s_avxEncodeLut);
+#endif
             Vector256<sbyte> maskAC = Vector256.Create(0x0fc0fc00).AsSByte();
             Vector256<sbyte> maskBB = Vector256.Create(0x003f03f0).AsSByte();
             Vector256<ushort> shiftAC = Vector256.Create(0x04000040).AsUInt16();
             Vector256<short> shiftBB = Vector256.Create(0x01000010).AsInt16();
             Vector256<byte> const51 = Vector256.Create((byte)51);
             Vector256<sbyte> const25 = Vector256.Create((sbyte)25);
-            Vector256<sbyte> lut = ReadVector<Vector256<sbyte>>(s_avxEncodeLut);
 
             byte* src = srcBytes;
             byte* dest = destBytes;
@@ -258,7 +280,19 @@ namespace System.Buffers.Text
             Vector256<sbyte> str = Avx.LoadVector256(src).AsSByte();
 
             // shift by 4 bytes, as required by Reshuffle
+#if NET6_0_OR_GREATER
+            str = Avx2.PermuteVar8x32(str.AsInt32(), Vector256.Create(
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+                1, 0, 0, 0,
+                2, 0, 0, 0,
+                3, 0, 0, 0,
+                4, 0, 0, 0,
+                5, 0, 0, 0,
+                6, 0, 0, 0).AsInt32()).AsSByte();
+#else
             str = Avx2.PermuteVar8x32(str.AsInt32(), ReadVector<Vector256<sbyte>>(s_avxEncodePermuteVec).AsInt32()).AsSByte();
+#endif
 
             // Next loads are done at src-4, as required by Reshuffle, so shift it once
             src -= 4;
@@ -380,14 +414,28 @@ namespace System.Buffers.Text
             // 0 0 0 0 l k j i h g f e d c b a
 
             // The JIT won't hoist these "constants", so help it
+#if NET6_0_OR_GREATER
+            Vector128<sbyte> shuffleVec = Vector128.Create(
+                1, 0, 2, 1,
+                4, 3, 5, 4,
+                7, 6, 8, 7,
+                10, 9, 11, 10);
+
+            Vector128<sbyte> lut = Vector128.Create(
+                65, 71, -4, -4,
+                -4, -4, -4, -4,
+                -4, -4, -4, -4,
+                -19, -16, 0, 0);
+#else
             Vector128<sbyte> shuffleVec = ReadVector<Vector128<sbyte>>(s_sseEncodeShuffleVec);
+            Vector128<sbyte> lut = ReadVector<Vector128<sbyte>>(s_sseEncodeLut);
+#endif
             Vector128<sbyte> maskAC = Vector128.Create(0x0fc0fc00).AsSByte();
             Vector128<sbyte> maskBB = Vector128.Create(0x003f03f0).AsSByte();
             Vector128<ushort> shiftAC = Vector128.Create(0x04000040).AsUInt16();
             Vector128<short> shiftBB = Vector128.Create(0x01000010).AsInt16();
             Vector128<byte> const51 = Vector128.Create((byte)51);
             Vector128<sbyte> const25 = Vector128.Create((sbyte)25);
-            Vector128<sbyte> lut = ReadVector<Vector128<sbyte>>(s_sseEncodeLut);
 
             byte* src = srcBytes;
             byte* dest = destBytes;
@@ -543,7 +591,7 @@ namespace System.Buffers.Text
         private const int MaximumEncodeLength = (int.MaxValue / 4) * 3; // 1610612733
 
         // Pre-computing this table using a custom string(s_characters) and GenerateEncodingMapAndVerify (found in tests)
-        private static ReadOnlySpan<byte> s_encodingMap => new byte[] {
+        private static ReadOnlySpan<byte> EncodingMap => new byte[] {
             65, 66, 67, 68, 69, 70, 71, 72,         //A..H
             73, 74, 75, 76, 77, 78, 79, 80,         //I..P
             81, 82, 83, 84, 85, 86, 87, 88,         //Q..X
@@ -554,6 +602,7 @@ namespace System.Buffers.Text
             52, 53, 54, 55, 56, 57, 43, 47          //4..9, +, /
         };
 
+#if !NET6_0_OR_GREATER
         private static ReadOnlySpan<sbyte> s_sseEncodeShuffleVec => new sbyte[] {
             1, 0, 2, 1,
             4, 3, 5, 4,
@@ -600,5 +649,6 @@ namespace System.Buffers.Text
             -4, -4, -4, -4,
             -19, -16, 0, 0
         };
+#endif
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/44115

Used `Vector(128|256)<\w+> \w+ =` as regex-search, seems that these three places are the onley one left.
The SSE-helper, that are mentioned in the issue, got re-written by @GrabYourPitchforks some time ago, and there patterns for the new codegen is already used.

Codegen was validated (manually) to see that it's an improvement.

It's not clear to me whether the touched codes are built for .NET Core 3.1 or not. So I added conditional compilation, as for .NET Core 3.1 the codegen is quite worse when Vector{128|256}.Create is used (that's why we initially had the different patterns before the JIT started to emit constants and read them from the data-segment).

/cc: @tannergooding 