### PR TITLE
[wasm][aot] Enable System.Text.Json tests for Wasm AOT

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -283,9 +283,6 @@
 
     <!-- Issue: https://github.com/dotnet/runtime/issues/52393 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime/tests/System.Runtime.Tests.csproj" />
-
-    <!-- Issue: https://github.com/dotnet/runtime/issues/51961 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(BuildAOTTestsOnHelix)' == 'true' and '$(RunDisabledWasmTests)' != 'true'">


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/51961 was the container running out of memory and is fixed in https://github.com/dotnet/runtime/pull/53603