### PR TITLE
Partially allow marshalling ILSTUB compilation for ndirect methods using crossgen2 if SPC.dll is in the same bubble

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
@@ -346,10 +346,8 @@ namespace ILCompiler
         {
             // PInvokes depend on details of the core library, so for now only compile them if:
             //    1) We're compiling the core library module, or
-            //    2) We're compiling any module, and no marshalling is needed
-            //
-            // TODO Future: consider compiling PInvokes with complex marshalling in version bubble
-            // mode when the core library is included in the bubble.
+            //    2) We're compiling any module, and no marshalling is needed, or
+            //    3) We're compiling any module, and core library module is in the same bubble, and marhaller supports compilation
 
             Debug.Assert(method is EcmaMethod);
 
@@ -360,6 +358,9 @@ namespace ILCompiler
 
             if (((EcmaMethod)method).Module.Equals(method.Context.SystemModule))
                 return true;
+
+            if (_versionBubbleModuleSet.Contains(method.Context.SystemModule))
+                return !Marshaller.IsMarshallingNotSupported(method);
 
             return !Marshaller.IsMarshallingRequired(method);
         }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Interop/IL/Marshaller.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Interop/IL/Marshaller.ReadyToRun.cs
@@ -141,5 +141,22 @@ namespace Internal.TypeSystem.Interop
 
             return false;
         }
+
+        public static bool IsMarshallingNotSupported(MethodDesc targetMethod)
+        {
+            Debug.Assert(targetMethod.IsPInvoke);
+
+            var marshallers = GetMarshallersForMethod(targetMethod);
+            for (int i = 0; i < marshallers.Length; i++)
+            {
+                if (marshallers[i].GetType() == typeof(NotSupportedMarshaller)
+                    // TODO: AnsiStringMarshaller can be allowed when it's logic is fixed,
+                    // currently it leads to free(): invalid pointer
+                    || marshallers[i].GetType() == typeof(AnsiStringMarshaller))
+                    return true;
+            }
+
+            return false;
+        }
     }
 }


### PR DESCRIPTION
AnsiStringMarshaller is disallowed because it incorrectly handles pointers returned from native code (related issue: https://github.com/dotnet/runtime/issues/54820).

This change reduces number of ilstubs compiled during startup on ~40-50 on tizen xamarin apps. Startup time is improved on ~1.5%.

cc @alpencolt @jkotas 