### PR TITLE
add System.Net.MsQuic.Transport as dependency for Windows build

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,6 +4,10 @@
       <Uri>https://github.com/dotnet/icu</Uri>
       <Sha>59588c1257a842089d0b7df3bad1cdd69ac720e1</Sha>
     </Dependency>
+    <Dependency Name="System.Net.MsQuic.Transport" Version="6.0.0-preview.7.21328.2">
+      <Uri>https://github.com/dotnet/msquic</Uri>
+      <Sha>d7db669b70f4dd67ec001c192f9809c218cab88b</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.21321.1">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -166,6 +166,8 @@
     <MicrosoftNETILLinkAnalyzerPackageVersion>$(MicrosoftNETILLinkTasksVersion)</MicrosoftNETILLinkAnalyzerPackageVersion>
     <!-- ICU -->
     <MicrosoftNETCoreRuntimeICUTransportVersion>6.0.0-preview.7.21315.3</MicrosoftNETCoreRuntimeICUTransportVersion>
+    <!-- MsQuic -->
+    <SystemNetMsQuicTransportVersion>6.0.0-preview.7.21328.2</SystemNetMsQuicTransportVersion>
     <!-- Mono LLVM -->
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>11.1.0-alpha.1.21314.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>11.1.0-alpha.1.21314.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>

--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -56,6 +56,9 @@
     <Compile Include="System\Net\Quic\Implementations\MsQuic\Interop\MsQuicStatusCodes.OSX.cs" />
   </ItemGroup>
   <!-- Project references -->
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
+    <PackageReference Include="System.Net.MsQuic.Transport" PrivateAssets="all" Version="$(SystemNetMsQuicTransportVersion)" />
+  </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Collections" />
     <Reference Include="System.Collections.Concurrent" />


### PR DESCRIPTION
Consume package produced by dotnet/msquic repro. 
This is not the final step yet. Runtime build will now restore the package and provide access to msquic.dll and msquic.pdb.