### PR TITLE
Fix unreached during dump on amd64 Unix.

### DIFF
--- a/src/coreclr/jit/ee_il_dll.cpp
+++ b/src/coreclr/jit/ee_il_dll.cpp
@@ -810,11 +810,11 @@ void Compiler::eeDispVar(ICorDebugInfo::NativeVarInfo* var)
             }
             break;
 
-#ifndef TARGET_AMD64
         case CodeGenInterface::VLT_REG_REG:
             printf("%s-%s", getRegName(var->loc.vlRegReg.vlrrReg1), getRegName(var->loc.vlRegReg.vlrrReg2));
             break;
 
+#ifndef TARGET_AMD64
         case CodeGenInterface::VLT_REG_STK:
             if ((int)var->loc.vlRegStk.vlrsStk.vlrssBaseReg != (int)ICorDebugInfo::REGNUM_AMBIENT_SP)
             {


### PR DESCRIPTION
To repro the issue run the following with JitDump enabled:
```
        struct SMultiRegPromotedMatching
        {
            long l1;
            long l2;
        }


        [MethodImpl(MethodImplOptions.NoInlining)]
        static SMultiRegPromotedMatching Return1(SMultiRegPromotedMatching s)
        {
            return s;
        }
```
`s` is passed using 2 regs, so its type is `VLT_REG_REG`.