### PR TITLE
Allow implicit widenings when tailcalling

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -7884,13 +7884,10 @@ bool Compiler::impTailCallRetTypeCompatible(var_types                callerRetTy
     // will widen the return value to 4 bytes, so we can allow implicit widening
     // in managed to managed tailcalls when dealing with <= 4 bytes.
     bool isManaged =
-        (callerCallConv == CorInfoCallConvExtension::Managed) &&
-        (calleeCallConv == CorInfoCallConvExtension::Managed);
+        (callerCallConv == CorInfoCallConvExtension::Managed) && (calleeCallConv == CorInfoCallConvExtension::Managed);
 
-    if (isManaged &&
-        varTypeIsIntegral(callerRetType) && varTypeIsIntegral(calleeRetType) &&
-        (genTypeSize(callerRetType) <= 4) &&
-        (genTypeSize(calleeRetType) <= genTypeSize(callerRetType)))
+    if (isManaged && varTypeIsIntegral(callerRetType) && varTypeIsIntegral(calleeRetType) &&
+        (genTypeSize(callerRetType) <= 4) && (genTypeSize(calleeRetType) <= genTypeSize(callerRetType)))
     {
         return true;
     }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -6803,18 +6803,7 @@ void Compiler::fgMorphCallInlineHelper(GenTreeCall* call, InlineResult* result)
 //    structs being passed to either the caller or callee.
 //
 // Exceptions:
-//    1) If the callee has structs which cannot be enregistered it will be
-//    reported as cannot fast tail call. This is an implementation limitation
-//    where the callee only is checked for non enregisterable structs. This is
-//    tracked with https://github.com/dotnet/runtime/issues/8492.
-//
-//    2) If the caller or callee has stack arguments and the callee has more
-//    arguments then the caller it will be reported as cannot fast tail call.
-//    This is due to a bug in LowerFastTailCall which assumes that
-//    nCalleeArgs <= nCallerArgs, which is always true on Windows Amd64. This
-//    is tracked with https://github.com/dotnet/runtime/issues/8413.
-//
-//    3) If the callee has a 9 to 16 byte struct argument and the callee has
+//    If the callee has a 9 to 16 byte struct argument and the callee has
 //    stack arguments, the decision will be to not fast tail call. This is
 //    because before fgMorphArgs is done, the struct is unknown whether it
 //    will be placed on the stack or enregistered. Therefore, the conservative

--- a/src/tests/JIT/Methodical/tailcall/widen.cs
+++ b/src/tests/JIT/Methodical/tailcall/widen.cs
@@ -1,0 +1,1086 @@
+using System;
+using System.Runtime.CompilerServices;
+
+public class Program
+{
+    // Random field we assign some bogus values to to trick the inliner below.
+    // We cannot use NoInlining as the runtime disables tailcalls from such functions.
+    private static int s_val;
+
+    public static int Main()
+    {
+        bool result = true;
+        Console.Write("Test1U1S: ");
+        if (Test1U1S(123) == (byte)Return1S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test1U2U: ");
+        if (Test1U2U(123) == (byte)Return2U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test1U2S: ");
+        if (Test1U2S(123) == (byte)Return2S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test1U4U: ");
+        if (Test1U4U(123) == (byte)Return4U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test1U4S: ");
+        if (Test1U4S(123) == (byte)Return4S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test1U8U: ");
+        if (Test1U8U(123) == (byte)Return8U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test1U8S: ");
+        if (Test1U8S(123) == (byte)Return8S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test1S1U: ");
+        if (Test1S1U(123) == (sbyte)Return1U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test1S2U: ");
+        if (Test1S2U(123) == (sbyte)Return2U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test1S2S: ");
+        if (Test1S2S(123) == (sbyte)Return2S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test1S4U: ");
+        if (Test1S4U(123) == (sbyte)Return4U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test1S4S: ");
+        if (Test1S4S(123) == (sbyte)Return4S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test1S8U: ");
+        if (Test1S8U(123) == (sbyte)Return8U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test1S8S: ");
+        if (Test1S8S(123) == (sbyte)Return8S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test2U1U: ");
+        if (Test2U1U(123) == Return1U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test2U1S: ");
+        if (Test2U1S(123) == (ushort)Return1S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test2U2S: ");
+        if (Test2U2S(123) == (ushort)Return2S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test2U4U: ");
+        if (Test2U4U(123) == (ushort)Return4U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test2U4S: ");
+        if (Test2U4S(123) == (ushort)Return4S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test2U8U: ");
+        if (Test2U8U(123) == (ushort)Return8U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test2U8S: ");
+        if (Test2U8S(123) == (ushort)Return8S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test2S1U: ");
+        if (Test2S1U(123) == Return1U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test2S1S: ");
+        if (Test2S1S(123) == Return1S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test2S2U: ");
+        if (Test2S2U(123) == (short)Return2U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test2S4U: ");
+        if (Test2S4U(123) == (short)Return4U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test2S4S: ");
+        if (Test2S4S(123) == (short)Return4S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test2S8U: ");
+        if (Test2S8U(123) == (short)Return8U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test2S8S: ");
+        if (Test2S8S(123) == (short)Return8S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test4U1U: ");
+        if (Test4U1U(123) == Return1U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test4U1S: ");
+        if (Test4U1S(123) == (uint)Return1S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test4U2U: ");
+        if (Test4U2U(123) == Return2U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test4U2S: ");
+        if (Test4U2S(123) == (uint)Return2S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test4U4S: ");
+        if (Test4U4S(123) == (uint)Return4S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test4U8U: ");
+        if (Test4U8U(123) == (uint)Return8U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test4U8S: ");
+        if (Test4U8S(123) == (uint)Return8S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test4S1U: ");
+        if (Test4S1U(123) == Return1U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test4S1S: ");
+        if (Test4S1S(123) == Return1S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test4S2U: ");
+        if (Test4S2U(123) == Return2U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test4S2S: ");
+        if (Test4S2S(123) == Return2S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test4S4U: ");
+        if (Test4S4U(123) == (int)Return4U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test4S8U: ");
+        if (Test4S8U(123) == (int)Return8U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test4S8S: ");
+        if (Test4S8S(123) == (int)Return8S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test8U1U: ");
+        if (Test8U1U(123) == (ulong)Return1U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test8U1S: ");
+        if (Test8U1S(123) == (ulong)Return1S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test8U2U: ");
+        if (Test8U2U(123) == Return2U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test8U2S: ");
+        if (Test8U2S(123) == (ulong)Return2S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test8U4U: ");
+        if (Test8U4U(123) == Return4U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test8U4S: ");
+        if (Test8U4S(123) == (ulong)Return4S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test8U8S: ");
+        if (Test8U8S(123) == (ulong)Return8S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test8S1U: ");
+        if (Test8S1U(123) == Return1U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test8S1S: ");
+        if (Test8S1S(123) == Return1S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test8S2U: ");
+        if (Test8S2U(123) == Return2U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test8S2S: ");
+        if (Test8S2S(123) == Return2S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test8S4U: ");
+        if (Test8S4U(123) == Return4U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test8S4S: ");
+        if (Test8S4S(123) == Return4S(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+        Console.Write("Test8S8U: ");
+        if (Test8S8U(123) == (long)Return8U(123))
+        {
+            Console.WriteLine("Pass");
+        }
+        else
+        {
+            Console.WriteLine("Fail");
+            result = false;
+        }
+
+        return result ? 100 : 101;
+    }
+
+    private static byte Return1U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        return 112;
+    }
+
+    private static sbyte Return1S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        return -11;
+    }
+
+    private static ushort Return2U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        return 11223;
+    }
+
+    private static short Return2S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        return -22334;
+    }
+
+    private static uint Return4U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        return 1122334455;
+    }
+
+    private static int Return4S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        return -554433221;
+    }
+
+    private static ulong Return8U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        return 11223344556677889911;
+    }
+
+    private static long Return8S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        return -998877665544332211;
+    }
+
+    private static byte Test1U1S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (byte)Return1S(arg);
+    }
+
+    private static byte Test1U2U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (byte)Return2U(arg);
+    }
+
+    private static byte Test1U2S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (byte)Return2S(arg);
+    }
+
+    private static byte Test1U4U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (byte)Return4U(arg);
+    }
+
+    private static byte Test1U4S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (byte)Return4S(arg);
+    }
+
+    private static byte Test1U8U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (byte)Return8U(arg);
+    }
+
+    private static byte Test1U8S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (byte)Return8S(arg);
+    }
+
+    private static sbyte Test1S1U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (sbyte)Return1U(arg);
+    }
+
+    private static sbyte Test1S2U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (sbyte)Return2U(arg);
+    }
+
+    private static sbyte Test1S2S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (sbyte)Return2S(arg);
+    }
+
+    private static sbyte Test1S4U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (sbyte)Return4U(arg);
+    }
+
+    private static sbyte Test1S4S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (sbyte)Return4S(arg);
+    }
+
+    private static sbyte Test1S8U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (sbyte)Return8U(arg);
+    }
+
+    private static sbyte Test1S8S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (sbyte)Return8S(arg);
+    }
+
+    private static ushort Test2U1U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return Return1U(arg);
+    }
+
+    private static ushort Test2U1S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (ushort)Return1S(arg);
+    }
+
+    private static ushort Test2U2S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (ushort)Return2S(arg);
+    }
+
+    private static ushort Test2U4U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (ushort)Return4U(arg);
+    }
+
+    private static ushort Test2U4S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (ushort)Return4S(arg);
+    }
+
+    private static ushort Test2U8U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (ushort)Return8U(arg);
+    }
+
+    private static ushort Test2U8S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (ushort)Return8S(arg);
+    }
+
+    private static short Test2S1U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return Return1U(arg);
+    }
+
+    private static short Test2S1S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return Return1S(arg);
+    }
+
+    private static short Test2S2U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (short)Return2U(arg);
+    }
+
+    private static short Test2S4U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (short)Return4U(arg);
+    }
+
+    private static short Test2S4S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (short)Return4S(arg);
+    }
+
+    private static short Test2S8U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (short)Return8U(arg);
+    }
+
+    private static short Test2S8S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (short)Return8S(arg);
+    }
+
+    private static uint Test4U1U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return Return1U(arg);
+    }
+
+    private static uint Test4U1S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (uint)Return1S(arg);
+    }
+
+    private static uint Test4U2U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return Return2U(arg);
+    }
+
+    private static uint Test4U2S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (uint)Return2S(arg);
+    }
+
+    private static uint Test4U4S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (uint)Return4S(arg);
+    }
+
+    private static uint Test4U8U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (uint)Return8U(arg);
+    }
+
+    private static uint Test4U8S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (uint)Return8S(arg);
+    }
+
+    private static int Test4S1U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return Return1U(arg);
+    }
+
+    private static int Test4S1S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return Return1S(arg);
+    }
+
+    private static int Test4S2U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return Return2U(arg);
+    }
+
+    private static int Test4S2S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return Return2S(arg);
+    }
+
+    private static int Test4S4U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (int)Return4U(arg);
+    }
+
+    private static int Test4S8U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (int)Return8U(arg);
+    }
+
+    private static int Test4S8S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (int)Return8S(arg);
+    }
+
+    private static ulong Test8U1U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return Return1U(arg);
+    }
+
+    private static ulong Test8U1S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (ulong)Return1S(arg);
+    }
+
+    private static ulong Test8U2U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return Return2U(arg);
+    }
+
+    private static ulong Test8U2S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (ulong)Return2S(arg);
+    }
+
+    private static ulong Test8U4U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return Return4U(arg);
+    }
+
+    private static ulong Test8U4S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (ulong)Return4S(arg);
+    }
+
+    private static ulong Test8U8S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (ulong)Return8S(arg);
+    }
+
+    private static long Test8S1U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return Return1U(arg);
+    }
+
+    private static long Test8S1S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return Return1S(arg);
+    }
+
+    private static long Test8S2U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return Return2U(arg);
+    }
+
+    private static long Test8S2S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return Return2S(arg);
+    }
+
+    private static long Test8S4U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return Return4U(arg);
+    }
+
+    private static long Test8S4S(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return Return4S(arg);
+    }
+
+    private static long Test8S8U(int arg)
+    {
+        if (arg == int.MaxValue) s_val = Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount + Environment.TickCount;
+
+        ClobberReturnReg();
+        return (long)Return8U(arg);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static ulong ClobberReturnReg()
+    {
+        return 0xdeadbeefdeadbeef;
+    }
+}

--- a/src/tests/JIT/Methodical/tailcall/widen.csproj
+++ b/src/tests/JIT/Methodical/tailcall/widen.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="widen.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The managed calling convention dictates that the callee is responsible
for widening up to 4 bytes. We can use this to allow some more
tailcalls.

Fix #51957

I couldn't use SPMI as the new tailcalls change the jitinterface calls (thanks for explaining @sandreenko), so I used PMI. A few diffs in frameworks:
```text
Analyzing CodeSize diffs...
Found 10 files with textual diffs.

PMI CodeSize Diffs for System.Private.CoreLib.dll, framework assemblies for  default jit

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 55385375
Total bytes of diff: 55385274
Total bytes of delta: -101 (-0,00% of base)
    diff is an improvement.


Top file improvements (bytes):
         -24 : Microsoft.CodeAnalysis.dasm (-0,00% of base)
         -20 : System.Private.DataContractSerialization.dasm (-0,00% of base)
         -15 : System.Reflection.Metadata.dasm (-0,00% of base)
         -14 : System.Drawing.Common.dasm (-0,00% of base)
         -10 : System.Diagnostics.EventLog.dasm (-0,01% of base)
          -6 : Microsoft.CodeAnalysis.CSharp.dasm (-0,00% of base)
          -6 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0,00% of base)
          -4 : System.Net.Quic.dasm (-0,00% of base)
          -2 : System.Reflection.MetadataLoadContext.dasm (-0,00% of base)

9 total files with Code Size differences (9 improved, 0 regressed), 263 unchanged.

Top method improvements (bytes):
         -14 (-33,33% of base) : System.Drawing.Common.dasm - System.Drawing.Printing.PrinterSettings:get_Duplex():int:this
         -10 (-47,62% of base) : System.Private.DataContractSerialization.dasm - System.Xml.XmlBinaryReader:GetNodeType():int:this
         -10 (-66,67% of base) : System.Private.DataContractSerialization.dasm - System.Xml.XmlBufferReader:GetNodeType():int:this
         -10 (-37,04% of base) : System.Diagnostics.EventLog.dasm - System.Diagnostics.EventLogEntry:get_EntryType():int:this
          -6 (-30,00% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxToken:get_RawContextualKind():int:this
          -6 (-31,58% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.ConstantValue:get_Int16Value():short:this
          -6 (-30,00% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.ConstantValue:get_UInt16Value():ushort:this
          -6 (-30,00% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.ConstantValue:get_Int32Value():int:this
          -6 (-30,00% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.ConstantValue:get_UInt32Value():int:this
          -6 (-30,00% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.IdentifierTokenSyntax:get_RawContextualKind():int:this
          -5 (-12,20% of base) : System.Reflection.Metadata.dasm - System.Reflection.Metadata.GenericParameter:get_Index():int:this
          -5 (-12,20% of base) : System.Reflection.Metadata.dasm - System.Reflection.Metadata.Parameter:get_SequenceNumber():int:this
          -5 (-12,20% of base) : System.Reflection.Metadata.dasm - System.Reflection.Metadata.LocalVariable:get_Index():int:this
          -2 (-2,74% of base) : System.Net.Quic.dasm - System.Net.Quic.Implementations.MsQuic.MsQuicConnection:GetRemoteAvailableUnidirectionalStreamCount():int:this
          -2 (-2,74% of base) : System.Net.Quic.dasm - System.Net.Quic.Implementations.MsQuic.MsQuicConnection:GetRemoteAvailableBidirectionalStreamCount():int:this
          -2 (-3,45% of base) : System.Reflection.MetadataLoadContext.dasm - System.Reflection.TypeLoading.Ecma.EcmaGenericParameterType:ComputePosition():int:this

16 total methods with Code Size differences (16 improved, 0 regressed), 369818 unchanged.
```

Diffs look as expected, we get some cases where we were relying on the widening anyway.
```diff
 ; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
 ; optimized code
 ; rsp based frame
-; partially interruptible
+; fully interruptible
 ; No PGO data
 ; Final local variable assignments
 ;
 ;  V00 this         [V00,T00] (  4,  4   )     ref  ->  rcx         this class-hnd
-;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+00H]   "OutgoingArgSpace"
+;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+00H]   "OutgoingArgSpace"
 ;
-; Lcl frame size = 40
+; Lcl frame size = 0
 
 G_M58155_IG01:
-       sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
+						;; bbWeight=1    PerfScore 0.00
 G_M58155_IG02:
        mov      rax, qword ptr [rcx]
        mov      rax, qword ptr [rax+120]
-       call     qword ptr [rax+8]Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.IdentifierTokenSyntax:get_PossibleKeywordKind():ushort:this
-       nop      
-						;; bbWeight=1    PerfScore 7.25
+       mov      rax, qword ptr [rax+8]
+						;; bbWeight=1    PerfScore 6.00
 G_M58155_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
+       rex.jmp  rax
+						;; bbWeight=1    PerfScore 2.00
 
-; Total bytes of code 20, prolog size 4, PerfScore 10.75, instruction count 7, allocated bytes for code 20 (MethodHash=91bc1cd4) for method Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.IdentifierTokenSyntax:get_RawContextualKind():int:this
+; Total bytes of code 14, prolog size 0, PerfScore 9.40, instruction count 4, allocated bytes for code 14 (MethodHash=91bc1cd4) for method Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.IdentifierTokenSyntax:get_RawContextualKind():int:this
```

```diff
 ; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
 ; optimized code
 ; rsp based frame
-; partially interruptible
+; fully interruptible
 ; No PGO data
 ; 0 inlinees with PGO data; 1 single block inlinees; 0 inlinees without PGO data
 ; Final local variable assignments
 ;
 ;  V00 this         [V00,T00] (  4,  3.50)     ref  ->  rcx         this class-hnd
-;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+00H]   "OutgoingArgSpace"
+;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+00H]   "OutgoingArgSpace"
 ;  V02 cse0         [V02,T01] (  3,  2.50)     int  ->  rax         "CSE - aggressive"
 ;
-; Lcl frame size = 40
+; Lcl frame size = 0
 
 G_M35284_IG01:
-       sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
+						;; bbWeight=1    PerfScore 0.00
 G_M35284_IG02:
        mov      eax, dword ptr [rcx+56]
        cmp      eax, -1
        je       SHORT G_M35284_IG04
 						;; bbWeight=1    PerfScore 3.25
 G_M35284_IG03:
-       add      rsp, 40
        ret      
-						;; bbWeight=0.50 PerfScore 0.63
+						;; bbWeight=0.50 PerfScore 0.50
 G_M35284_IG04:
        mov      edx, 8
        mov      r8d, 1
        xor      r9d, r9d
-       call     System.Drawing.Printing.PrinterSettings:GetModeField(int,short,long):short:this
-       nop      
-						;; bbWeight=0.50 PerfScore 1.00
+						;; bbWeight=0.50 PerfScore 0.38
 G_M35284_IG05:
-       add      rsp, 40
-       ret      
-						;; bbWeight=0.50 PerfScore 0.63
+       jmp      System.Drawing.Printing.PrinterSettings:GetModeField(int,short,long):short:this
+						;; bbWeight=0.50 PerfScore 1.00
 
-; Total bytes of code 42, prolog size 4, PerfScore 9.95, instruction count 13, allocated bytes for code 42 (MethodHash=b14c762b) for method System.Drawing.Printing.PrinterSettings:get_Duplex():int:this
+; Total bytes of code 28, prolog size 0, PerfScore 7.93, instruction count 8, allocated bytes for code 28 (MethodHash=b14c762b) for method System.Drawing.Printing.PrinterSettings:get_Duplex():int:this
```

cc @dotnet/jit-contrib 