### PR TITLE
Add test global install path is used when DOTNET_ROOT does not exist

### DIFF
--- a/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
+++ b/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
@@ -103,18 +103,19 @@ namespace HostActivation.Tests
                 .Copy();
 
             var appExe = fixture.TestProject.AppExe;
+            var projDir = fixture.TestProject.ProjectDirectory;
             using (TestOnlyProductBehavior.Enable(appExe))
             {
                 Command.Create(appExe)
                 .EnableTracingAndCaptureOutputs()
-                .DotNetRoot(fixture.TestProject.ProjectDirectory)
+                .DotNetRoot(projDir)
                 .MultilevelLookup(false)
                 .EnvironmentVariable(
                     Constants.TestOnlyEnvironmentVariables.GloballyRegisteredPath,
                     sharedTestState.InstallLocation)
                 .Execute()
                 .Should().Fail()
-                .And.HaveUsedDotNetRootInstallLocation(sharedTestState.InstallLocation, fixture.CurrentRid)
+                .And.HaveStdErrContaining($"Using environment variable DOTNET_ROOT=[{projDir}]")
                 // If DOTNET_ROOT points to a folder that exists we assume that there's a dotnet installation in it
                 .And.HaveStdErrContaining("A fatal error occurred. The required library hostfxr.dll could not be found.");
             }

--- a/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
+++ b/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
@@ -103,18 +103,21 @@ namespace HostActivation.Tests
                 .Copy();
 
             var appExe = fixture.TestProject.AppExe;
-            Command.Create(appExe)
+            using (TestOnlyProductBehavior.Enable(appExe))
+            {
+                Command.Create(appExe)
                 .EnableTracingAndCaptureOutputs()
                 .DotNetRoot(fixture.TestProject.ProjectDirectory)
                 .MultilevelLookup(false)
                 .EnvironmentVariable(
-                    Constants.TestOnlyEnvironmentVariables.DefaultInstallPath,
+                    Constants.TestOnlyEnvironmentVariables.GloballyRegisteredPath,
                     sharedTestState.InstallLocation)
                 .Execute()
                 .Should().Fail()
-                .And.HaveStdErrContaining($"Using environment variable DOTNET_ROOT=[{fixture.TestProject.ProjectDirectory}] as runtime location.")
+                .And.HaveUsedDotNetRootInstallLocation(sharedTestState.InstallLocation, fixture.CurrentRid)
                 // If DOTNET_ROOT points to a folder that exists we assume that there's a dotnet installation in it
                 .And.HaveStdErrContaining("A fatal error occurred. The required library hostfxr.dll could not be found.");
+            }
         }
 
         [Fact]

--- a/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
+++ b/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
@@ -72,6 +72,24 @@ namespace HostActivation.Tests
         }
 
         [Fact]
+        public void EnvironmentVariable_DotnetRootPathDoesNotExist()
+        {
+            var fixture = sharedTestState.PortableAppFixture
+                .Copy();
+
+            var appExe = fixture.TestProject.AppExe;
+            Command.Create(appExe)
+                .EnableTracingAndCaptureOutputs()
+                .DotNetRoot("non_existent_path")
+                .EnvironmentVariable("DOTNET_MULTILEVEL_LOOKUP", "0")
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdErrContaining("Did not find [DOTNET_ROOT] directory [non_existent_path]")
+                .And.HaveStdErrContaining("Using global installation location")
+                .And.HaveStdOutContaining("Hello World");
+        }
+
+        [Fact]
         [SkipOnPlatform(TestPlatforms.Windows, "This test targets the install_location config file which is only used on Linux and macOS.")]
         public void InstallLocationFile_ArchSpecificLocationIsPickedFirst()
         {

--- a/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
+++ b/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
@@ -115,9 +115,9 @@ namespace HostActivation.Tests
                     sharedTestState.InstallLocation)
                 .Execute()
                 .Should().Fail()
-                .And.HaveStdErrContaining($"Using environment variable DOTNET_ROOT=[{projDir}]")
+                .And.HaveUsedDotNetRootInstallLocation(projDir, fixture.CurrentRid)
                 // If DOTNET_ROOT points to a folder that exists we assume that there's a dotnet installation in it
-                .And.HaveStdErrContaining("A fatal error occurred. The required library hostfxr.dll could not be found.");
+                .And.HaveStdErrContaining($"A fatal error occurred. The required library {RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform ("hostfxr")} could not be found.");
             }
         }
 


### PR DESCRIPTION
The global installation path should be used when `DOTNET_ROOT` is specified but the path it points to does not exist.