### PR TITLE
Fix build errors in EventPipe native test located under Mono.

### DIFF
--- a/src/mono/mono/eventpipe/test/ep-buffer-manager-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-buffer-manager-tests.c
@@ -102,7 +102,8 @@ buffer_manager_init (
 			1,
 			current_provider_config,
 			1,
-			false);
+			NULL,
+			NULL);
 	EP_LOCK_EXIT (section1)
 
 	ep_raise_error_if_nok (*session != NULL);

--- a/src/mono/mono/eventpipe/test/ep-buffer-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-buffer-tests.c
@@ -90,7 +90,8 @@ load_buffer_with_events_init (
 			1,
 			current_provider_config,
 			1,
-			false);
+			NULL,
+			NULL);
 	EP_LOCK_EXIT (section1)
 
 	ep_raise_error_if_nok (*session != NULL);

--- a/src/mono/mono/eventpipe/test/ep-session-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-session-tests.c
@@ -50,7 +50,8 @@ test_create_delete_session (void)
 			1,
 			current_provider_config,
 			1,
-			false);
+			NULL,
+			NULL);
 	EP_LOCK_EXIT (section1)
 
 	ep_raise_error_if_nok (test_session != NULL);
@@ -91,7 +92,8 @@ test_add_session_providers (void)
 			1,
 			current_provider_config,
 			1,
-			false);
+			NULL,
+			NULL);
 
 		ep_raise_error_if_nok_holding_lock (test_session != NULL, section1);
 
@@ -173,7 +175,8 @@ test_session_special_get_set (void)
 			1,
 			current_provider_config,
 			1,
-			false);
+			NULL,
+			NULL);
 	EP_LOCK_EXIT (section1)
 
 	ep_raise_error_if_nok (test_session != NULL);

--- a/src/mono/mono/eventpipe/test/ep-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-tests.c
@@ -227,6 +227,7 @@ test_enable_disable (void)
 		EP_SERIALIZATION_FORMAT_NETTRACE_V4,
 		false,
 		NULL,
+		NULL,
 		NULL);
 
 	if (!session_id) {
@@ -349,6 +350,7 @@ test_enable_disable_default_provider_config (void)
 		EP_SERIALIZATION_FORMAT_NETTRACE_V4,
 		false,
 		NULL,
+		NULL,
 		NULL);
 
 	if (!session_id) {
@@ -397,6 +399,7 @@ test_enable_disable_multiple_default_provider_config (void)
 		EP_SERIALIZATION_FORMAT_NETTRACE_V4,
 		false,
 		NULL,
+		NULL,
 		NULL);
 
 	if (!session_id_1) {
@@ -427,6 +430,7 @@ test_enable_disable_multiple_default_provider_config (void)
 		EP_SESSION_TYPE_FILE,
 		EP_SERIALIZATION_FORMAT_NETTRACE_V4,
 		false,
+		NULL,
 		NULL,
 		NULL);
 
@@ -476,6 +480,7 @@ test_enable_disable_provider_config (void)
 		EP_SESSION_TYPE_FILE,
 		EP_SERIALIZATION_FORMAT_NETTRACE_V4,
 		false,
+		NULL,
 		NULL,
 		NULL);
 
@@ -557,6 +562,7 @@ test_enable_disable_provider_parse_default_config (void)
 		EP_SERIALIZATION_FORMAT_NETTRACE_V4,
 		false,
 		NULL,
+		NULL,
 		NULL);
 
 	if (!session_id) {
@@ -627,6 +633,7 @@ test_create_delete_provider_with_callback (void)
 		EP_SESSION_TYPE_FILE,
 		EP_SERIALIZATION_FORMAT_NETTRACE_V4,
 		false,
+		NULL,
 		NULL,
 		NULL);
 
@@ -729,6 +736,7 @@ test_session_start_streaming (void)
 		EP_SERIALIZATION_FORMAT_NETTRACE_V4,
 		false,
 		NULL,
+		NULL,
 		NULL);
 
 	if (!session_id) {
@@ -778,7 +786,7 @@ test_session_write_event (void)
 
 	test_location = 3;
 
-	session_id = ep_enable (TEST_FILE, 1, current_provider_config, 1, EP_SESSION_TYPE_FILE, EP_SERIALIZATION_FORMAT_NETTRACE_V4,false, NULL, NULL);
+	session_id = ep_enable (TEST_FILE, 1, current_provider_config, 1, EP_SESSION_TYPE_FILE, EP_SERIALIZATION_FORMAT_NETTRACE_V4,false, NULL, NULL, NULL);
 	ep_raise_error_if_nok (session_id != 0);
 
 	test_location = 4;
@@ -831,7 +839,7 @@ test_session_write_event_seq_point (void)
 
 	test_location = 3;
 
-	session_id = ep_enable (TEST_FILE, 1, current_provider_config, 1, EP_SESSION_TYPE_FILE, EP_SERIALIZATION_FORMAT_NETTRACE_V4,false, NULL, NULL);
+	session_id = ep_enable (TEST_FILE, 1, current_provider_config, 1, EP_SESSION_TYPE_FILE, EP_SERIALIZATION_FORMAT_NETTRACE_V4, false, NULL, NULL, NULL);
 	ep_raise_error_if_nok (session_id != 0);
 
 	test_location = 4;
@@ -888,7 +896,7 @@ test_session_write_wait_get_next_event (void)
 
 	test_location = 3;
 
-	session_id = ep_enable (TEST_FILE, 1, current_provider_config, 1, EP_SESSION_TYPE_FILE, EP_SERIALIZATION_FORMAT_NETTRACE_V4,false, NULL, NULL);
+	session_id = ep_enable (TEST_FILE, 1, current_provider_config, 1, EP_SESSION_TYPE_FILE, EP_SERIALIZATION_FORMAT_NETTRACE_V4, false, NULL, NULL, NULL);
 	ep_raise_error_if_nok (session_id != 0);
 
 	test_location = 4;
@@ -953,7 +961,7 @@ test_session_write_get_next_event (void)
 
 	test_location = 3;
 
-	session_id = ep_enable (TEST_FILE, 1, current_provider_config, 1, EP_SESSION_TYPE_FILE, EP_SERIALIZATION_FORMAT_NETTRACE_V4,false, NULL, false);
+	session_id = ep_enable (TEST_FILE, 1, current_provider_config, 1, EP_SESSION_TYPE_FILE, EP_SERIALIZATION_FORMAT_NETTRACE_V4, false, NULL, NULL, NULL);
 	ep_raise_error_if_nok (session_id != 0);
 
 	test_location = 4;
@@ -1030,7 +1038,7 @@ test_session_write_suspend_event (void)
 
 	test_location = 3;
 
-	session_id = ep_enable (TEST_FILE, 1, current_provider_config, 1, EP_SESSION_TYPE_FILE, EP_SERIALIZATION_FORMAT_NETTRACE_V4,false, NULL, false);
+	session_id = ep_enable (TEST_FILE, 1, current_provider_config, 1, EP_SESSION_TYPE_FILE, EP_SERIALIZATION_FORMAT_NETTRACE_V4, false, NULL, NULL, NULL);
 	ep_raise_error_if_nok (session_id != 0);
 
 	test_location = 4;
@@ -1090,7 +1098,7 @@ test_write_event (void)
 
 	test_location = 3;
 
-	session_id = ep_enable (TEST_FILE, 1, current_provider_config, 1, EP_SESSION_TYPE_FILE, EP_SERIALIZATION_FORMAT_NETTRACE_V4,false, NULL, false);
+	session_id = ep_enable (TEST_FILE, 1, current_provider_config, 1, EP_SESSION_TYPE_FILE, EP_SERIALIZATION_FORMAT_NETTRACE_V4, false, NULL, NULL, NULL);
 	ep_raise_error_if_nok (session_id != 0);
 
 	test_location = 4;
@@ -1141,7 +1149,7 @@ test_write_get_next_event (void)
 
 	test_location = 3;
 
-	session_id = ep_enable (TEST_FILE, 1, current_provider_config, 1, EP_SESSION_TYPE_FILE, EP_SERIALIZATION_FORMAT_NETTRACE_V4,false, NULL, false);
+	session_id = ep_enable (TEST_FILE, 1, current_provider_config, 1, EP_SESSION_TYPE_FILE, EP_SERIALIZATION_FORMAT_NETTRACE_V4, false, NULL, NULL, NULL);
 	ep_raise_error_if_nok (session_id != 0);
 
 	test_location = 4;
@@ -1201,7 +1209,7 @@ test_write_wait_get_next_event (void)
 
 	test_location = 3;
 
-	session_id = ep_enable (TEST_FILE, 1, current_provider_config, 1, EP_SESSION_TYPE_FILE, EP_SERIALIZATION_FORMAT_NETTRACE_V4,false, NULL, false);
+	session_id = ep_enable (TEST_FILE, 1, current_provider_config, 1, EP_SESSION_TYPE_FILE, EP_SERIALIZATION_FORMAT_NETTRACE_V4, false, NULL, NULL, NULL);
 	ep_raise_error_if_nok (session_id != 0);
 
 	session = ep_get_session (session_id);
@@ -1281,7 +1289,7 @@ test_write_event_perf (void)
 
 	test_location = 3;
 
-	session_id = ep_enable (TEST_FILE, 1, current_provider_config, 1, EP_SESSION_TYPE_FILE, EP_SERIALIZATION_FORMAT_NETTRACE_V4,false, NULL, false);
+	session_id = ep_enable (TEST_FILE, 1, current_provider_config, 1, EP_SESSION_TYPE_FILE, EP_SERIALIZATION_FORMAT_NETTRACE_V4, false, NULL, NULL, NULL);
 	ep_raise_error_if_nok (session_id != 0);
 
 	test_location = 4;

--- a/src/mono/mono/eventpipe/test/ep-thread-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-thread-tests.c
@@ -398,7 +398,8 @@ test_thread_session_state (void)
 			1,
 			provider_config,
 			1,
-			false);
+			NULL,
+			NULL);
 	EP_LOCK_EXIT (section1)
 
 	if (!session) {


### PR DESCRIPTION
Changes in EventPipe ep_session_alloc added new arguments breaking the build of native EventPipe tests located under Mono.