### PR TITLE
[mono] Don't call Assembly.CodeBase directly in RuntimeAssembly.GetName

### DIFF
--- a/src/libraries/System.Reflection/tests/AssemblyTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyTests.cs
@@ -510,7 +510,7 @@ namespace System.Reflection.Tests
         }
 
 #pragma warning disable SYSLIB0012
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))] // single file
         public void CodeBase()
         {
             Assert.NotEmpty(Helpers.ExecutingAssembly.CodeBase);

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -253,7 +253,7 @@ namespace System.Reflection
 
         public override AssemblyName GetName(bool copiedName)
         {
-            return AssemblyName.Create(_mono_assembly, get_code_base (this, false));
+            return AssemblyName.Create(_mono_assembly, get_code_base (this));
         }
 
         [RequiresUnreferencedCode("Types might be removed")]

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -253,9 +253,7 @@ namespace System.Reflection
 
         public override AssemblyName GetName(bool copiedName)
         {
-#pragma warning disable IL3002 // Suppressing for now. See https://github.com/dotnet/runtime/issues/54835
-            return AssemblyName.Create(_mono_assembly, CodeBase);
-#pragma warning restore IL3002
+            return AssemblyName.Create(_mono_assembly, get_code_base (this, false));
         }
 
         [RequiresUnreferencedCode("Types might be removed")]

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -4462,12 +4462,18 @@ MonoStringHandle
 ves_icall_System_Reflection_RuntimeAssembly_get_code_base (MonoReflectionAssemblyHandle assembly, MonoError *error)
 {
 	MonoAssembly *mass = MONO_HANDLE_GETVAL (assembly, assembly);
-	gchar *absolute;
 	
-	if (g_path_is_absolute (mass->image->name)) {
-		absolute = g_strdup (mass->image->name);
+	/* return NULL for bundled assemblies in single-file scenarios */
+	const char* filename = m_image_get_filename (mass->image);
+
+	if (!filename)
+		return NULL_HANDLE_STRING;
+
+	gchar *absolute;
+	if (g_path_is_absolute (filename)) {
+		absolute = g_strdup (filename);
 	} else {
-		absolute = g_build_filename (mass->basedir, mass->image->name, (const char*)NULL);
+		absolute = g_build_filename (mass->basedir, filename, (const char*)NULL);
 	}
 
 	mono_icall_make_platform_path (absolute);


### PR DESCRIPTION
It's marked as not available in single file apps.
Call the underlying get_code_base icall.

Fixes https://github.com/dotnet/runtime/issues/54835