### PR TITLE
Auto-enable SO_REUSE_UNICASTPORT for ConnectEx

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
@@ -14,7 +14,6 @@ namespace System.Net.Sockets
 {
     public partial class Socket
     {
-        //private static readonly bool s_osSupportsReuseUnicastPort = IsReuseUnicastPortSupported();
         private static CachedSerializedEndPoint? s_cachedAnyEndPoint;
         private static CachedSerializedEndPoint? s_cachedAnyV6EndPoint;
         private static CachedSerializedEndPoint? s_cachedMappedAnyV6EndPoint;

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -12,13 +12,9 @@ using Xunit;
 
 namespace System.Net.Sockets.Tests
 {
-    public class SocketOptionNameTest : MemberDatas
+    public partial class SocketOptionNameTest
     {
         private static bool SocketsReuseUnicastPortSupport => Capability.SocketsReuseUnicastPortSupport().HasValue;
-
-        // Capability.SocketsReuseUnicastPortSupport() returns null if capability support is unclear,
-        // true is returned on Windows 10+.
-        private static bool SocketsReuseUnicastPortOptionExists => Capability.SocketsReuseUnicastPortSupport() == true;
 
         [ConditionalFact(nameof(SocketsReuseUnicastPortSupport))]
         public void ReuseUnicastPort_CreateSocketGetOption()
@@ -52,27 +48,6 @@ namespace System.Net.Sockets.Tests
                     Assert.Throws<SocketException>(() => socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseUnicastPort, 1));
                 }
             }
-        }
-
-        [ConditionalTheory(nameof(SocketsReuseUnicastPortOptionExists))]
-        [MemberData(nameof(Loopbacks))]
-        public async Task ConnectAsync_Enables_ReuseUnicastPort(IPAddress listenAddress)
-        {
-            using var listener = new Socket(listenAddress.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-            int port = listener.BindToAnonymousPort(listenAddress);
-            listener.Listen();
-            
-            Task<Socket> acceptTask = listener.AcceptAsync();
-            IPEndPoint ep = new IPEndPoint(listenAddress, port);
-            using var socket = new Socket(listenAddress.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-
-            // The option should be enabled after an asynchronous connect call:
-            await socket.ConnectAsync(ep);
-            int optionValue = (int)socket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseUnicastPort);
-            Assert.Equal(1, optionValue);
-
-            // Close the accept socket:
-            (await acceptTask).Dispose();
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #48219.

## Validation

https://gist.github.com/antonfirsov/ef27d1048dfb362cc19b2c0165dc0d7d

The test in the gist succeeds if and only if:
- Being executed against code in the PR
- The auto reuse port range is configured (`Set-NetTCPSetting -SettingName InternetCustom -AutoReusePortRangeStartPort 40000 -AutoReusePortRangeNumberOfPorts 2000`) and the PC is rebooted

Unfortunately, there is no way to implement an automatic test for this, because of the admin hackery required.

/cc @geoffkizer 