### PR TITLE
Update ELT profiler tests to include tests when a function returns HFA/HVA struct on Arm64

### DIFF
--- a/src/coreclr/vm/amd64/asmhelpers.S
+++ b/src/coreclr/vm/amd64/asmhelpers.S
@@ -199,7 +199,7 @@ NESTED_ENTRY ProfileLeaveNaked, _TEXT, NoHandler
   movsd                   real8 ptr [rsp + 0x70], xmm7    #      -- struct flt7 field
   mov                     [rsp + 0x78], r11     #                -- struct rdi field
   mov                     [rsp + 0x80], r11     #                -- struct rsi field
-  mov                     [rsp + 0x88], r11     #                -- struct rdx field
+  mov                     [rsp + 0x88], rdx     #                -- struct rdx field
   mov                     [rsp + 0x90], r11     #                -- struct rcx field
   mov                     [rsp + 0x98], r11     #                -- struct r8 field
   mov                     [rsp + 0xa0], r11    #                -- struct r9 field
@@ -273,7 +273,7 @@ NESTED_ENTRY ProfileTailcallNaked, _TEXT, NoHandler
   movsd                   real8 ptr [rsp + 0x70], xmm7    #      -- struct flt7 field
   mov                     [rsp + 0x78], r11     #                -- struct rdi field
   mov                     [rsp + 0x80], r11     #                -- struct rsi field
-  mov                     [rsp + 0x88], r11     #                -- struct rdx field
+  mov                     [rsp + 0x88], rdx     #                -- struct rdx field
   mov                     [rsp + 0x90], r11     #                -- struct rcx field
   mov                     [rsp + 0x98], r11     #                -- struct r8 field
   mov                     [rsp + 0xa0], r11     #                -- struct r9 field

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -1141,7 +1141,7 @@ LEAF_END JIT_ProfilerEnterLeaveTailcallStub, _TEXT
 #define PROFILE_ENTER    1
 #define PROFILE_LEAVE    2
 #define PROFILE_TAILCALL 4
-#define SIZEOF__PROFILE_PLATFORM_SPECIFIC_DATA 272
+#define SIZEOF__PROFILE_PLATFORM_SPECIFIC_DATA 320
 
 // ------------------------------------------------------------------
 .macro GenerateProfileHelper helper, flags

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -1366,7 +1366,7 @@ CallHelper2
  #define PROFILE_ENTER    1
  #define PROFILE_LEAVE    2
  #define PROFILE_TAILCALL 4
- #define SIZEOF__PROFILE_PLATFORM_SPECIFIC_DATA 272
+ #define SIZEOF__PROFILE_PLATFORM_SPECIFIC_DATA 320
 
 ; ------------------------------------------------------------------
     MACRO

--- a/src/coreclr/vm/proftoeeinterfaceimpl.h
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.h
@@ -58,7 +58,21 @@ private:
     ArgIterator  m_argIterator;
 #if defined(UNIX_AMD64_ABI) || defined(TARGET_ARM64)
     UINT64       m_bufferPos;
-#endif // defined(UNIX_AMD64_ABI) || defined(TARGET_ARM64)
+
+#if defined(UNIX_AMD64_ABI)
+    // On certain architectures we can pass args in non-sequential registers,
+    // this function will copy the struct so it is laid out as it would be in memory
+    // so it can be passed to the profiler
+    LPVOID CopyStructFromRegisters();
+#endif
+
+#if defined(TARGET_ARM64)
+    // On Arm64 the fields an HFA or an HVA argument will need to be copied
+    // to a temporary buffer in memory, so they are laid out contiguously in memory.
+    LPVOID CopyStructFromFPRegs(int idxFPReg, int cntFPRegs, int hfaFieldSize);
+#endif
+
+#endif // UNIX_AMD64_ABI || TARGET_ARM64
 
 public:
     ProfileArgIterator(MetaSig * pMetaSig, void* platformSpecificHandle);
@@ -73,13 +87,6 @@ public:
         LIMITED_METHOD_CONTRACT;
         return m_argIterator.NumFixedArgs();
     }
-
-#if defined(UNIX_AMD64_ABI)
-    // On certain architectures we can pass args in non-sequential registers,
-    // this function will copy the struct so it is laid out as it would be in memory
-    // so it can be passed to the profiler
-    LPVOID CopyStructFromRegisters();
-#endif // defined(UNIX_AMD64_ABI)
 
     //
     // After initialization, this method is called repeatedly until it

--- a/src/tests/profiler/elt/slowpathcommon.cs
+++ b/src/tests/profiler/elt/slowpathcommon.cs
@@ -207,6 +207,118 @@ namespace SlowPathELTTests
         }
     }
 
+    // The following structs are to test correctness of how ProfileArgIterator works with
+    // multi-reg return values when running on a System V ABI OS (e.g. Linux and macOS x64).
+    // A struct up to 16 bytes (inclusive) can be returned in (rax, rdx), (rax, xmm0), (xmm0, rax), (xmm0, xmm1).
+    // We already have a comprehensive set of Fp{n}x{m}Struct above that covers the last variant,
+    // so there is no need to duplicate them here.
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct IntegerSseStruct
+    {
+        public int x;
+        public int y;
+        public double z;
+
+        public IntegerSseStruct(int x, int y, double z)
+        {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+        }
+
+        public override String ToString()
+        {
+            return $"x={x} y={y} z={z}";
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct SseIntegerStruct
+    {
+        public float x;
+        public float y;
+        public int z;
+
+        public SseIntegerStruct(float x, float y, int z)
+        {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+        }
+
+        public override String ToString()
+        {
+            return $"x={x} y={y} z={z}";
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct MixedSseStruct
+    {
+        public float x;
+        public int y;
+        public float z;
+        public float w;
+
+        public MixedSseStruct(float x, int y, float z, float w)
+        {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.w = w;
+        }
+
+        public override String ToString()
+        {
+            return $"x={x} y={y} z={z} w={w}";
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct SseMixedStruct
+    {
+        public float x;
+        public float y;
+        public int z;
+        public float w;
+
+        public SseMixedStruct(float x, float y, int z, float w)
+        {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.w = w;
+        }
+
+        public override String ToString()
+        {
+            return $"x={x} y={y} z={z} w={w}";
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct MixedMixedStruct
+    {
+        public float x;
+        public int y;
+        public int z;
+        public float w;
+
+        public MixedMixedStruct(float x, int y, int z, float w)
+        {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.w = w;
+        }
+
+        public override String ToString()
+        {
+            return $"x={x} y={y} z={z} w={w}";
+        }
+    }
+
     public class SlowPathELTHelpers
     {
         public static int RunTest()
@@ -256,6 +368,16 @@ namespace SlowPathELTTests
             Console.WriteLine($"Fp64x4StructFp64x4StructFunc returned {Fp64x4StructFp64x4StructFunc(fp64x4, fp64x4)}");
 
             Console.WriteLine($"DoubleRetFunc returned {DoubleRetFunc()}");
+
+            Console.WriteLine($"IntegerSseStructFunc returned {IntegerSseStructFunc()}");
+
+            Console.WriteLine($"SseIntegerStructFunc returned {SseIntegerStructFunc()}");
+
+            Console.WriteLine($"MixedSseStructFunc returned {MixedSseStructFunc()}");
+
+            Console.WriteLine($"SseMixedStructFunc returned {SseMixedStructFunc()}");
+
+            Console.WriteLine($"MixedMixedStructFunc returned {MixedMixedStructFunc()}");
 
             return 100;
         }
@@ -395,6 +517,36 @@ namespace SlowPathELTTests
         public static double DoubleRetFunc()
         {
             return 13.0;
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static IntegerSseStruct IntegerSseStructFunc()
+        {
+            return new IntegerSseStruct(1, 2, 3.5);
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static SseIntegerStruct SseIntegerStructFunc()
+        {
+            return new SseIntegerStruct(1.2f, 3.5f, 6);
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static MixedSseStruct MixedSseStructFunc()
+        {
+            return new MixedSseStruct(1.2f, 3, 5.6f, 7.10f);
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static SseMixedStruct SseMixedStructFunc()
+        {
+            return new SseMixedStruct(1.2f, 3.5f, 6, 7.10f);
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static MixedMixedStruct MixedMixedStructFunc()
+        {
+            return new MixedMixedStruct(1.2f, 3, 5, 6.7f);
         }
     }
 }

--- a/src/tests/profiler/elt/slowpathcommon.cs
+++ b/src/tests/profiler/elt/slowpathcommon.cs
@@ -33,20 +33,122 @@ namespace SlowPathELTTests
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    public struct FloatingPointStruct
+    public struct Fp32x2Struct
     {
-        public double d1;
-        public double d2;
+        public float x;
+        public float y;
 
-        public FloatingPointStruct(double d1, double d2)
+        public Fp32x2Struct(float x, float y)
         {
-            this.d1 = d1;
-            this.d2 = d2;
+            this.x = x;
+            this.y = y;
         }
 
         public override String ToString()
         {
-            return $"d1={d1} d2={d2}";
+            return $"x={x} y={y}";
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Fp32x3Struct
+    {
+        public float x;
+        public float y;
+        public float z;
+
+        public Fp32x3Struct(float x, float y, float z)
+        {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+        }
+
+        public override String ToString()
+        {
+            return $"x={x} y={y} z={z}";
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Fp32x4Struct
+    {
+        public float x;
+        public float y;
+        public float z;
+        public float w;
+
+        public Fp32x4Struct(float x, float y, float z, float w)
+        {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.w = w;
+        }
+
+        public override String ToString()
+        {
+            return $"x={x} y={y} z={z} w={w}";
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Fp64x2Struct
+    {
+        public double x;
+        public double y;
+
+        public Fp64x2Struct(double x, double y)
+        {
+            this.x = x;
+            this.y = y;
+        }
+
+        public override String ToString()
+        {
+            return $"x={x} y={y}";
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Fp64x3Struct
+    {
+        public double x;
+        public double y;
+        public double z;
+
+        public Fp64x3Struct(double x, double y, double z)
+        {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+        }
+
+        public override String ToString()
+        {
+            return $"x={x} y={y} z={z}";
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Fp64x4Struct
+    {
+        public double x;
+        public double y;
+        public double z;
+        public double w;
+
+        public Fp64x4Struct(double x, double y, double z, double w)
+        {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.w = w;
+        }
+
+        public override String ToString()
+        {
+            return $"x={x} y={y} z={z} w={w}";
         }
     }
 
@@ -80,7 +182,7 @@ namespace SlowPathELTTests
         public int x3;
         public double d3;
 
-        public LargeStruct(int x0, 
+        public LargeStruct(int x0,
                            double d0,
                            int x1,
                            double d1,
@@ -117,7 +219,41 @@ namespace SlowPathELTTests
 
             Console.WriteLine($"IntegerStructFunc returned {IntegerStructFunc(new IntegerStruct(14, 256))}");
 
-            Console.WriteLine($"FloatingPointStructFunc returned {FloatingPointStructFunc(new FloatingPointStruct(13.0, 145.2))}");
+            var fp32x2 = new Fp32x2Struct(1.2f, 3.5f);
+            var fp32x3 = new Fp32x3Struct(6.7f, 10.11f, 13.14f);
+            var fp32x4 = new Fp32x4Struct(15.17f, 19.21f, 22.23f, 26.29f);
+
+            Console.WriteLine($"Fp32x2StructFunc returned {Fp32x2StructFunc(fp32x2)}");
+
+            Console.WriteLine($"Fp32x2StructFp32x3StructFunc returned {Fp32x2StructFp32x3StructFunc(fp32x2, fp32x3)}");
+
+            Console.WriteLine($"Fp32x3StructFunc returned {Fp32x3StructFunc(fp32x3)}");
+
+            Console.WriteLine($"Fp32x3StructFp32x2StructFunc returned {Fp32x3StructFp32x2StructFunc(fp32x3, fp32x2)}");
+
+            Console.WriteLine($"Fp32x3StructSingleFp32x3StructSingleFunc returned {Fp32x3StructSingleFp32x3StructSingleFunc(fp32x3, 1.2f, fp32x3, 3.5f)}");
+
+            Console.WriteLine($"Fp32x4StructFunc returned {Fp32x4StructFunc(fp32x4)}");
+
+            Console.WriteLine($"Fp32x4StructFp32x4StructFunc returned {Fp32x4StructFp32x4StructFunc(fp32x4, fp32x4)}");
+
+            var fp64x2 = new Fp64x2Struct(1.2, 3.5);
+            var fp64x3 = new Fp64x3Struct(6.7, 10.11, 13.14);
+            var fp64x4 = new Fp64x4Struct(15.17, 19.21, 22.23, 26.29);
+
+            Console.WriteLine($"Fp64x2StructFunc returned {Fp64x2StructFunc(fp64x2)}");
+
+            Console.WriteLine($"Fp64x2StructFp64x3StructFunc returned {Fp64x2StructFp64x3StructFunc(fp64x2, fp64x3)}");
+
+            Console.WriteLine($"Fp64x3StructFunc returned {Fp64x3StructFunc(fp64x3)}");
+
+            Console.WriteLine($"Fp64x3StructFp64x2StructFunc returned {Fp64x3StructFp64x2StructFunc(fp64x3, fp64x2)}");
+
+            Console.WriteLine($"Fp64x3StructDoubleFp64x3StructDoubleFunc returned {Fp64x3StructDoubleFp64x3StructDoubleFunc(fp64x3, 1.2, fp64x3, 3.5)}");
+
+            Console.WriteLine($"Fp64x4StructFunc returned {Fp64x4StructFunc(fp64x4)}");
+
+            Console.WriteLine($"Fp64x4StructFp64x4StructFunc returned {Fp64x4StructFp64x4StructFunc(fp64x4, fp64x4)}");
 
             Console.WriteLine($"DoubleRetFunc returned {DoubleRetFunc()}");
 
@@ -154,10 +290,105 @@ namespace SlowPathELTTests
         }
 
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
-        public static FloatingPointStruct FloatingPointStructFunc(FloatingPointStruct fps)
+        public static Fp32x2Struct Fp32x2StructFunc(Fp32x2Struct fps)
         {
-            fps.d2 = 256.8;
+            fps.y = 2;
             return fps;
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static Fp32x3Struct Fp32x2StructFp32x3StructFunc(Fp32x2Struct fps1, Fp32x3Struct fps2)
+        {
+            return fps2;
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static Fp32x3Struct Fp32x3StructFunc(Fp32x3Struct fps)
+        {
+            fps.z = 3;
+            return fps;
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static Fp32x2Struct Fp32x3StructFp32x2StructFunc(Fp32x3Struct fps1, Fp32x2Struct fps2)
+        {
+            return fps2;
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static Fp32x3Struct Fp32x3StructSingleFp32x3StructSingleFunc(Fp32x3Struct fps1, float flt1, Fp32x3Struct fps2, float flt2)
+        {
+            return fps2;
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static Fp32x4Struct Fp32x4StructFunc(Fp32x4Struct fps)
+        {
+            fps.w = 4;
+            return fps;
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static Fp32x4Struct Fp32x4StructFp32x4StructFunc(Fp32x4Struct fps1, Fp32x4Struct fps2)
+        {
+            return fps2;
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static Fp32x2Struct Fp32x4StructFp32x4StructFunc(Fp32x3Struct fps1, Fp32x3Struct fps2, Fp32x2Struct fps3)
+        {
+            return fps3;
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static Fp64x2Struct Fp64x2StructFunc(Fp64x2Struct fps)
+        {
+            fps.y = 2;
+            return fps;
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static Fp64x3Struct Fp64x2StructFp64x3StructFunc(Fp64x2Struct fps1, Fp64x3Struct fps2)
+        {
+            return fps2;
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static Fp64x3Struct Fp64x3StructFunc(Fp64x3Struct fps)
+        {
+            fps.z = 3;
+            return fps;
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static Fp64x2Struct Fp64x3StructFp64x2StructFunc(Fp64x3Struct fps1, Fp64x2Struct fps2)
+        {
+            return fps2;
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static Fp64x3Struct Fp64x3StructDoubleFp64x3StructDoubleFunc(Fp64x3Struct fps1, double dbl1, Fp64x3Struct fps2, double dbl2)
+        {
+            return fps2;
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static Fp64x4Struct Fp64x4StructFunc(Fp64x4Struct fps)
+        {
+            fps.w = 4;
+            return fps;
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static Fp64x4Struct Fp64x4StructFp64x4StructFunc(Fp64x4Struct fps1, Fp64x4Struct fps2)
+        {
+            return fps2;
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static Fp64x2Struct Fp64x4StructFp64x4StructFunc(Fp64x3Struct fps1, Fp64x3Struct fps2, Fp64x2Struct fps3)
+        {
+            return fps3;
         }
 
         [MethodImplAttribute(MethodImplOptions.NoInlining)]

--- a/src/tests/profiler/native/eltprofiler/slowpatheltprofiler.cpp
+++ b/src/tests/profiler/native/eltprofiler/slowpatheltprofiler.cpp
@@ -433,63 +433,123 @@ HRESULT STDMETHODCALLTYPE SlowPathELTProfiler::LeaveCallback(FunctionIDOrClientI
 
         ExpectedArgValue simpleRetValue = { sizeof(UINT_PTR), (void *)str, [&](UINT_PTR ptr){ return ValidateString(ptr, str); } };
         hr = ValidateOneArgument(pRetvalRange, functionName, 0, simpleRetValue);
+
+        _sawFuncLeave[functionName.ToWString()] = true;
     }
     else if (functionName == WCHAR("MixedStructFunc"))
     {
         MixedStruct ss = { 4, 1.0 };
         ExpectedArgValue MixedStructRetValue = { sizeof(MixedStruct), (void *)&ss, [&](UINT_PTR ptr){ return ValidateMixedStruct(ptr, ss); } };
         hr = ValidateOneArgument(pRetvalRange, functionName, 0, MixedStructRetValue);
+
+        _sawFuncLeave[functionName.ToWString()] = true;
     }
     else if (functionName == WCHAR("LargeStructFunc"))
     {
         int32_t val = 3;
         ExpectedArgValue largeStructRetValue = { sizeof(int32_t), (void *)&val, [&](UINT_PTR ptr){ return ValidateInt(ptr, val); } };
         hr = ValidateOneArgument(pRetvalRange, functionName, 0, largeStructRetValue);
+
+        _sawFuncLeave[functionName.ToWString()] = true;
     }
     else if (functionName == WCHAR("IntegerStructFunc"))
     {
         IntegerStruct is = { 21, 256 };
         ExpectedArgValue integerStructRetValue = { sizeof(IntegerStruct), (void *)&is, [&](UINT_PTR ptr){ return ValidateIntegerStruct(ptr, is); } };
         hr = ValidateOneArgument(pRetvalRange, functionName, 0, integerStructRetValue);
+
+        _sawFuncLeave[functionName.ToWString()] = true;
     }
     else if (functionName == WCHAR("Fp32x2StructFunc"))
     {
         ExpectedArgValue floatingPointStructRetValue = { sizeof(Fp32x2Struct), (void *)&fp32x2, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp32x2); } };
         hr = ValidateOneArgument(pRetvalRange, functionName, 0, floatingPointStructRetValue);
+
+        _sawFuncLeave[functionName.ToWString()] = true;
     }
     else if (functionName == WCHAR("Fp32x3StructFunc"))
     {
         ExpectedArgValue floatingPointStructRetValue = { sizeof(Fp32x3Struct), (void *)&fp32x3, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp32x3); } };
         hr = ValidateOneArgument(pRetvalRange, functionName, 0, floatingPointStructRetValue);
+
+        _sawFuncLeave[functionName.ToWString()] = true;
     }
     else if (functionName == WCHAR("Fp32x4StructFunc"))
     {
         ExpectedArgValue floatingPointStructRetValue = { sizeof(Fp32x4Struct), (void *)&fp32x4, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp32x4); } };
         hr = ValidateOneArgument(pRetvalRange, functionName, 0, floatingPointStructRetValue);
+
+        _sawFuncLeave[functionName.ToWString()] = true;
     }
     else if (functionName == WCHAR("Fp64x2StructFunc"))
     {
         ExpectedArgValue floatingPointStructRetValue = { sizeof(Fp64x2Struct), (void *)&fp64x2, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp64x2); } };
         hr = ValidateOneArgument(pRetvalRange, functionName, 0, floatingPointStructRetValue);
+
+        _sawFuncLeave[functionName.ToWString()] = true;
     }
     else if (functionName == WCHAR("Fp64x3StructFunc"))
     {
         ExpectedArgValue floatingPointStructRetValue = { sizeof(Fp64x3Struct), (void *)&fp64x3, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp64x3); } };
         hr = ValidateOneArgument(pRetvalRange, functionName, 0, floatingPointStructRetValue);
+
+        _sawFuncLeave[functionName.ToWString()] = true;
     }
     else if (functionName == WCHAR("Fp64x4StructFunc"))
     {
         ExpectedArgValue floatingPointStructRetValue = { sizeof(Fp64x4Struct), (void *)&fp64x4, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp64x4); } };
         hr = ValidateOneArgument(pRetvalRange, functionName, 0, floatingPointStructRetValue);
+
+        _sawFuncLeave[functionName.ToWString()] = true;
     }
     else if (functionName == WCHAR("DoubleRetFunc"))
     {
         double d = 13.0;
         ExpectedArgValue doubleRetValue = { sizeof(double), (void *)&d, [&](UINT_PTR ptr){ return ValidateDouble(ptr, d); } };
         hr = ValidateOneArgument(pRetvalRange, functionName, 0, doubleRetValue);
-    }
 
-    _sawFuncLeave[functionName.ToWString()] = true;
+        _sawFuncLeave[functionName.ToWString()] = true;
+    }
+    else if (functionName == WCHAR("IntegerSseStructFunc"))
+    {
+        IntegerSseStruct val = { 1, 2, 3.5 };
+        ExpectedArgValue expectedRetValue = { sizeof(IntegerSseStruct), (void*)&val, [&](UINT_PTR ptr) { return ValidateIntegerSseStruct(ptr, val); } };
+        hr = ValidateOneArgument(pRetvalRange, functionName, 0, expectedRetValue);
+
+        _sawFuncLeave[functionName.ToWString()] = true;
+    }
+    else if (functionName == WCHAR("SseIntegerStructFunc"))
+    {
+        SseIntegerStruct val = { 1.2f, 3.5f, 6 };
+        ExpectedArgValue expectedRetValue = { sizeof(SseIntegerStruct), (void*)&val, [&](UINT_PTR ptr) { return ValidateSseIntegerStruct(ptr, val); } };
+        hr = ValidateOneArgument(pRetvalRange, functionName, 0, expectedRetValue);
+
+        _sawFuncLeave[functionName.ToWString()] = true;
+    }
+    else if (functionName == WCHAR("MixedSseStructFunc"))
+    {
+        MixedSseStruct val = { 1.2f, 3, 5.6f, 7.10f };
+        ExpectedArgValue expectedRetValue = { sizeof(MixedSseStruct), (void*)&val, [&](UINT_PTR ptr) { return ValidateMixedSseStruct(ptr, val); } };
+        hr = ValidateOneArgument(pRetvalRange, functionName, 0, expectedRetValue);
+
+        _sawFuncLeave[functionName.ToWString()] = true;
+    }
+    else if (functionName == WCHAR("SseMixedStructFunc"))
+    {
+        SseMixedStruct val = { 1.2f, 3.5f, 6, 7.10f };
+        ExpectedArgValue expectedRetValue = { sizeof(SseMixedStruct), (void*)&val, [&](UINT_PTR ptr) { return ValidateSseMixedStruct(ptr, val); } };
+        hr = ValidateOneArgument(pRetvalRange, functionName, 0, expectedRetValue);
+
+        _sawFuncLeave[functionName.ToWString()] = true;
+    }
+    else if (functionName == WCHAR("MixedMixedStructFunc"))
+    {
+        MixedMixedStruct val = { 1.2f, 3, 5, 6.7f };
+        ExpectedArgValue expectedRetValue = { sizeof(MixedMixedStruct), (void*)&val, [&](UINT_PTR ptr) { return ValidateMixedMixedStruct(ptr, val); } };
+        hr = ValidateOneArgument(pRetvalRange, functionName, 0, expectedRetValue);
+
+        _sawFuncLeave[functionName.ToWString()] = true;
+    }
 
     return hr;
 }
@@ -695,6 +755,73 @@ bool SlowPathELTProfiler::ValidateIntegerStruct(UINT_PTR ptr, IntegerStruct expe
     return lhs.x == expected.x && lhs.y == expected.y;
 }
 
+bool SlowPathELTProfiler::ValidateIntegerSseStruct(UINT_PTR ptr, IntegerSseStruct expected)
+{
+    if (ptr == NULL)
+    {
+        return false;
+    }
+
+    IntegerSseStruct lhs = *(IntegerSseStruct*)ptr;
+    return lhs.x == expected.x
+        && lhs.y == expected.y
+        && lhs.z == expected.z;
+}
+
+bool SlowPathELTProfiler::ValidateSseIntegerStruct(UINT_PTR ptr, SseIntegerStruct expected)
+{
+    if (ptr == NULL)
+    {
+        return false;
+    }
+
+    SseIntegerStruct lhs = *(SseIntegerStruct*)ptr;
+    return lhs.x == expected.x
+        && lhs.y == expected.y
+        && lhs.z == expected.z;
+}
+
+bool SlowPathELTProfiler::ValidateMixedSseStruct(UINT_PTR ptr, MixedSseStruct expected)
+{
+    if (ptr == NULL)
+    {
+        return false;
+    }
+
+    MixedSseStruct lhs = *(MixedSseStruct*)ptr;
+    return lhs.x == expected.x
+        && lhs.y == expected.y
+        && lhs.z == expected.z
+        && lhs.w == expected.w;
+}
+
+bool SlowPathELTProfiler::ValidateSseMixedStruct(UINT_PTR ptr, SseMixedStruct expected)
+{
+    if (ptr == NULL)
+    {
+        return false;
+    }
+
+    SseMixedStruct lhs = *(SseMixedStruct*)ptr;
+    return lhs.x == expected.x
+        && lhs.y == expected.y
+        && lhs.z == expected.z
+        && lhs.w == expected.w;
+}
+
+bool SlowPathELTProfiler::ValidateMixedMixedStruct(UINT_PTR ptr, MixedMixedStruct expected)
+{
+    if (ptr == NULL)
+    {
+        return false;
+    }
+
+    MixedMixedStruct lhs = *(MixedMixedStruct*)ptr;
+    return lhs.x == expected.x
+        && lhs.y == expected.y
+        && lhs.z == expected.z
+        && lhs.w == expected.w;
+}
 
 HRESULT SlowPathELTProfiler::ValidateOneArgument(COR_PRF_FUNCTION_ARGUMENT_RANGE *pArgRange,
                                         String functionName,

--- a/src/tests/profiler/native/eltprofiler/slowpatheltprofiler.cpp
+++ b/src/tests/profiler/native/eltprofiler/slowpatheltprofiler.cpp
@@ -94,10 +94,10 @@ HRESULT SlowPathELTProfiler::Initialize(IUnknown* pICorProfilerInfoUnk)
 
     SlowPathELTProfiler::s_profiler = shared_ptr<SlowPathELTProfiler>(this);
 
-    if (FAILED(hr = pCorProfilerInfo->SetEventMask2(COR_PRF_MONITOR_ENTERLEAVE 
+    if (FAILED(hr = pCorProfilerInfo->SetEventMask2(COR_PRF_MONITOR_ENTERLEAVE
                                                     | COR_PRF_ENABLE_FUNCTION_ARGS
                                                     | COR_PRF_ENABLE_FUNCTION_RETVAL
-                                                    | COR_PRF_ENABLE_FRAME_INFO, 
+                                                    | COR_PRF_ENABLE_FRAME_INFO,
                                                     0)))
     {
         wcout << L"FAIL: IpCorProfilerInfo::SetEventMask2() failed hr=0x" << std::hex << hr << endl;
@@ -122,41 +122,56 @@ HRESULT SlowPathELTProfiler::Shutdown()
 
     if (_testType == TestType::EnterHooks)
     {
-        if (_failures == 0 
-             && _testType == TestType::EnterHooks
-             && _sawSimpleFuncEnter
-             && _sawMixedStructFuncEnter
-             && _sawLargeStructFuncEnter)
+        bool _sawFuncsEnter = true;
+
+        for (auto p: _sawFuncEnter)
+        {
+            _sawFuncsEnter = _sawFuncsEnter && p.second;
+        }
+
+        if ((_failures == 0) && _sawFuncsEnter)
         {
             wcout << L"PROFILER TEST PASSES" << endl;
         }
         else
         {
-            wcout << L"TEST FAILED _failures=" << _failures.load() << L", _sawSimpleFuncEnter=" << _sawSimpleFuncEnter 
-                    << L", _sawMixedStructFuncEnter=" << _sawMixedStructFuncEnter << L", _sawLargeStructFuncEnter=" 
-                    << _sawLargeStructFuncEnter << endl;
-        }    
+            wcout << L"TEST FAILED _failures=" << _failures.load() << endl;
+
+            if (!_sawFuncsEnter)
+            {
+                for (auto p: _sawFuncEnter)
+                {
+                    if (!p.second)
+                        wcout << L"_sawFuncEnter[" << p.first << L"]=" << p.second << endl;
+                }
+            }
+        }
     }
     else if (_testType == TestType::LeaveHooks)
     {
-        if (_failures == 0
-              && _testType == TestType::LeaveHooks
-              && _sawSimpleFuncLeave
-              && _sawMixedStructFuncLeave
-              && _sawLargeStructFuncLeave
-              && _sawIntegerStructFuncLeave
-              && _sawFloatingPointStructFuncLeave
-              && _sawDoubleRetFuncLeave)
+        bool _sawFuncsLeave = true;
+
+        for (auto p: _sawFuncLeave)
+        {
+            _sawFuncsLeave = _sawFuncsLeave && p.second;
+        }
+
+        if ((_failures == 0) && _sawFuncsLeave)
         {
             wcout << L"PROFILER TEST PASSES" << endl;
         }
         else
         {
-            wcout << L"TEST FAILED _failures=" << _failures.load() << L", _sawSimpleFuncLeave=" << _sawSimpleFuncLeave 
-                    << L", _sawMixedStructFuncLeave=" << _sawMixedStructFuncLeave << L", _sawLargeStructFuncLeave=" 
-                    << _sawLargeStructFuncLeave << L"_sawIntegerStructFuncLeave=" << _sawIntegerStructFuncLeave 
-                    << L"_sawFloatingPointStructFuncLeave=" << _sawFloatingPointStructFuncLeave 
-                    << L"_sawDoubleRetFuncLeave=" << _sawDoubleRetFuncLeave << endl;
+            wcout << L"TEST FAILED _failures=" << _failures.load() << endl;
+
+            if (!_sawFuncsLeave)
+            {
+                for (auto p: _sawFuncLeave)
+                {
+                    if (!p.second)
+                        wcout << L"_sawFuncLeave[" << p.first << L"]=" << p.second << endl;
+                }
+            }
         }
     }
 
@@ -195,11 +210,16 @@ HRESULT STDMETHODCALLTYPE SlowPathELTProfiler::EnterCallback(FunctionIDOrClientI
         }
     }
 
+    Fp32x2Struct fp32x2 = {1.2f, 3.5f};
+    Fp32x3Struct fp32x3 = {6.7f, 10.11f, 13.14f};
+    Fp32x4Struct fp32x4 = {15.17f, 19.21f, 22.23f, 26.29f};
+    Fp64x2Struct fp64x2 = {1.2, 3.5};
+    Fp64x3Struct fp64x3 = {6.7, 10.11, 13.14};
+    Fp64x4Struct fp64x4 = {15.17, 19.21, 22.23, 26.29};
+
     String functionName = GetFunctionIDName(functionIdOrClientID.functionID);
     if (functionName == WCHAR("SimpleArgsFunc"))
     {
-        _sawSimpleFuncEnter = true;
-
         int x = -123;
         float f = -4.3f;
         const WCHAR *str = WCHAR("Hello, test!");
@@ -209,26 +229,174 @@ HRESULT STDMETHODCALLTYPE SlowPathELTProfiler::EnterCallback(FunctionIDOrClientI
                                                     { sizeof(UINT_PTR), (void *)str, [&](UINT_PTR ptr){ return ValidateString(ptr, str); } } };
 
         hr = ValidateFunctionArgs(pArgumentInfo, functionName, expectedValues);
+
+        _sawFuncEnter[functionName.ToWString()] = true;
     }
     else if (functionName == WCHAR("MixedStructFunc"))
     {
-        _sawMixedStructFuncEnter = true;
-
         // On linux structs can be split with some in int registers and some in float registers
         // so a struct with interleaved ints/doubles is interesting.
         MixedStruct ss = { 1, 1.0 };
         vector<ExpectedArgValue> expectedValues = { { sizeof(MixedStruct), (void *)&ss, [&](UINT_PTR ptr){ return ValidateMixedStruct(ptr, ss); } } };
-        
+
         hr = ValidateFunctionArgs(pArgumentInfo, functionName, expectedValues);
+
+        _sawFuncEnter[functionName.ToWString()] = true;
     }
     else if (functionName == WCHAR("LargeStructFunc"))
     {
-        _sawLargeStructFuncEnter = true;
-
         LargeStruct ls = { 0, 0.0, 1, 1.0, 2, 2.0, 3, 3.0 };
         vector<ExpectedArgValue> expectedValues = { { sizeof(LargeStruct), (void *)&ls, [&](UINT_PTR ptr){ return ValidateLargeStruct(ptr, ls); } } };;
 
         hr = ValidateFunctionArgs(pArgumentInfo, functionName, expectedValues);
+
+        _sawFuncEnter[functionName.ToWString()] = true;
+    }
+    else if (functionName == WCHAR("Fp32x2StructFunc"))
+    {
+        vector<ExpectedArgValue> expectedValues = { { sizeof(Fp32x2Struct), (void *)&fp32x2, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp32x2); } } };
+
+        hr = ValidateFunctionArgs(pArgumentInfo, functionName, expectedValues);
+
+        _sawFuncEnter[functionName.ToWString()] = true;
+    }
+    else if (functionName == WCHAR("Fp32x2StructFp32x3StructFunc"))
+    {
+        vector<ExpectedArgValue> expectedValues = {
+            { sizeof(Fp32x2Struct), (void *)&fp32x2, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp32x2); } },
+            { sizeof(Fp32x3Struct), (void *)&fp32x3, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp32x3); } }
+        };
+
+        hr = ValidateFunctionArgs(pArgumentInfo, functionName, expectedValues);
+
+        _sawFuncEnter[functionName.ToWString()] = true;
+    }
+     else if (functionName == WCHAR("Fp32x3StructFunc"))
+    {
+        vector<ExpectedArgValue> expectedValues = { { sizeof(Fp32x3Struct), (void *)&fp32x3, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp32x3); } } };
+
+        hr = ValidateFunctionArgs(pArgumentInfo, functionName, expectedValues);
+
+        _sawFuncEnter[functionName.ToWString()] = true;
+    }
+    else if (functionName == WCHAR("Fp32x3StructFp32x2StructFunc"))
+    {
+        vector<ExpectedArgValue> expectedValues = {
+            { sizeof(Fp32x3Struct), (void *)&fp32x3, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp32x3); } },
+            { sizeof(Fp32x2Struct), (void *)&fp32x2, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp32x2); } }
+        };
+
+        hr = ValidateFunctionArgs(pArgumentInfo, functionName, expectedValues);
+
+        _sawFuncEnter[functionName.ToWString()] = true;
+    }
+    else if (functionName == WCHAR("Fp32x3StructSingleFp32x3StructSingleFunc"))
+    {
+        float flt1 = 1.2f;
+        float flt2 = 3.5f;
+
+        vector<ExpectedArgValue> expectedValues = {
+            { sizeof(Fp32x3Struct), (void *)&fp32x3, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp32x3); } },
+            { sizeof(float), (void *)&flt1, [&](UINT_PTR ptr){ return ValidateFloat(ptr, flt1); } },
+            { sizeof(Fp32x3Struct), (void *)&fp32x3, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp32x3); } },
+            { sizeof(float), (void *)&flt2, [&](UINT_PTR ptr){ return ValidateFloat(ptr, flt2); } }
+        };
+
+        hr = ValidateFunctionArgs(pArgumentInfo, functionName, expectedValues);
+
+        _sawFuncEnter[functionName.ToWString()] = true;
+    }
+    else if (functionName == WCHAR("Fp32x4StructFunc"))
+    {
+        vector<ExpectedArgValue> expectedValues ={ { sizeof(Fp32x4Struct), (void *)&fp32x4, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp32x4); } } };
+
+        hr = ValidateFunctionArgs(pArgumentInfo, functionName, expectedValues);
+
+        _sawFuncEnter[functionName.ToWString()] = true;
+    }
+    else if (functionName == WCHAR("Fp32x4StructFp32x4StructFunc"))
+    {
+        vector<ExpectedArgValue> expectedValues = {
+            { sizeof(Fp32x4Struct), (void *)&fp32x4, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp32x4); } },
+            { sizeof(Fp32x4Struct), (void *)&fp32x4, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp32x4); } }
+        };
+
+        hr = ValidateFunctionArgs(pArgumentInfo, functionName, expectedValues);
+
+        _sawFuncEnter[functionName.ToWString()] = true;
+    }
+    else if (functionName == WCHAR("Fp64x2StructFunc"))
+    {
+        vector<ExpectedArgValue> expectedValues = { { sizeof(Fp64x2Struct), (void *)&fp64x2, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp64x2); } } };
+
+        hr = ValidateFunctionArgs(pArgumentInfo, functionName, expectedValues);
+
+        _sawFuncEnter[functionName.ToWString()] = true;
+    }
+    else if (functionName == WCHAR("Fp64x2StructFp64x3StructFunc"))
+    {
+        vector<ExpectedArgValue> expectedValues = {
+            { sizeof(Fp64x2Struct), (void *)&fp64x2, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp64x2); } },
+            { sizeof(Fp64x3Struct), (void *)&fp64x3, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp64x3); } }
+        };
+
+        hr = ValidateFunctionArgs(pArgumentInfo, functionName, expectedValues);
+
+        _sawFuncEnter[functionName.ToWString()] = true;
+    }
+     else if (functionName == WCHAR("Fp64x3StructFunc"))
+    {
+        vector<ExpectedArgValue> expectedValues = { { sizeof(Fp64x3Struct), (void *)&fp64x3, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp64x3); } } };
+
+        hr = ValidateFunctionArgs(pArgumentInfo, functionName, expectedValues);
+
+        _sawFuncEnter[functionName.ToWString()] = true;
+    }
+    else if (functionName == WCHAR("Fp64x3StructFp64x2StructFunc"))
+    {
+        vector<ExpectedArgValue> expectedValues = {
+            { sizeof(Fp64x3Struct), (void *)&fp64x3, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp64x3); } },
+            { sizeof(Fp64x2Struct), (void *)&fp64x2, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp64x2); } }
+        };
+
+        hr = ValidateFunctionArgs(pArgumentInfo, functionName, expectedValues);
+
+        _sawFuncEnter[functionName.ToWString()] = true;
+    }
+    else if (functionName == WCHAR("Fp64x3StructDoubleFp64x3StructDoubleFunc"))
+    {
+        double dbl1 = 1.2;
+        double dbl2 = 3.5;
+
+        vector<ExpectedArgValue> expectedValues = {
+            { sizeof(Fp64x3Struct), (void *)&fp64x3, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp64x3); } },
+            { sizeof(double), (void *)&dbl1, [&](UINT_PTR ptr){ return ValidateDouble(ptr, dbl1); } },
+            { sizeof(Fp64x3Struct), (void *)&fp64x3, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp64x3); } },
+            { sizeof(double), (void *)&dbl2, [&](UINT_PTR ptr){ return ValidateDouble(ptr, dbl2); } }
+        };
+
+        hr = ValidateFunctionArgs(pArgumentInfo, functionName, expectedValues);
+
+        _sawFuncEnter[functionName.ToWString()] = true;
+    }
+    else if (functionName == WCHAR("Fp64x4StructFunc"))
+    {
+        vector<ExpectedArgValue> expectedValues ={ { sizeof(Fp64x4Struct), (void *)&fp64x4, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp64x4); } } };
+
+        hr = ValidateFunctionArgs(pArgumentInfo, functionName, expectedValues);
+
+        _sawFuncEnter[functionName.ToWString()] = true;
+    }
+    else if (functionName == WCHAR("Fp64x4StructFp64x4StructFunc"))
+    {
+        vector<ExpectedArgValue> expectedValues = {
+            { sizeof(Fp64x4Struct), (void *)&fp64x4, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp64x4); } },
+            { sizeof(Fp64x4Struct), (void *)&fp64x4, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp64x4); } }
+        };
+
+        hr = ValidateFunctionArgs(pArgumentInfo, functionName, expectedValues);
+
+        _sawFuncEnter[functionName.ToWString()] = true;
     }
 
     return hr;
@@ -240,7 +408,7 @@ HRESULT STDMETHODCALLTYPE SlowPathELTProfiler::LeaveCallback(FunctionIDOrClientI
     {
         return S_OK;
     }
-    
+
     COR_PRF_FRAME_INFO frameInfo;
     COR_PRF_FUNCTION_ARGUMENT_RANGE * pRetvalRange = new COR_PRF_FUNCTION_ARGUMENT_RANGE;
     HRESULT hr = pCorProfilerInfo->GetFunctionLeave3Info(functionIdOrClientID.functionID, eltInfo, &frameInfo, pRetvalRange);
@@ -251,11 +419,16 @@ HRESULT STDMETHODCALLTYPE SlowPathELTProfiler::LeaveCallback(FunctionIDOrClientI
         return hr;
     }
 
+    Fp32x2Struct fp32x2 = { 1.2f, 2 };
+    Fp32x3Struct fp32x3 = { 6.7f, 10.11f, 3 };
+    Fp32x4Struct fp32x4 = { 15.17f, 19.21f, 22.23f, 4 };
+    Fp64x2Struct fp64x2 = { 1.2, 2 };
+    Fp64x3Struct fp64x3 = { 6.7, 10.11, 3 };
+    Fp64x4Struct fp64x4 = { 15.17, 19.21, 22.23, 4 };
+
     String functionName = GetFunctionIDName(functionIdOrClientID.functionID);
     if (functionName == WCHAR("SimpleArgsFunc"))
     {
-        _sawSimpleFuncLeave = true;
-
         const WCHAR *str = WCHAR("Hello from SimpleArgsFunc!");
 
         ExpectedArgValue simpleRetValue = { sizeof(UINT_PTR), (void *)str, [&](UINT_PTR ptr){ return ValidateString(ptr, str); } };
@@ -263,46 +436,62 @@ HRESULT STDMETHODCALLTYPE SlowPathELTProfiler::LeaveCallback(FunctionIDOrClientI
     }
     else if (functionName == WCHAR("MixedStructFunc"))
     {
-        _sawMixedStructFuncLeave = true;
-
         MixedStruct ss = { 4, 1.0 };
         ExpectedArgValue MixedStructRetValue = { sizeof(MixedStruct), (void *)&ss, [&](UINT_PTR ptr){ return ValidateMixedStruct(ptr, ss); } };
         hr = ValidateOneArgument(pRetvalRange, functionName, 0, MixedStructRetValue);
     }
     else if (functionName == WCHAR("LargeStructFunc"))
     {
-        _sawLargeStructFuncLeave = true;
-
         int32_t val = 3;
         ExpectedArgValue largeStructRetValue = { sizeof(int32_t), (void *)&val, [&](UINT_PTR ptr){ return ValidateInt(ptr, val); } };
         hr = ValidateOneArgument(pRetvalRange, functionName, 0, largeStructRetValue);
     }
     else if (functionName == WCHAR("IntegerStructFunc"))
     {
-        _sawIntegerStructFuncLeave = true;
-
         IntegerStruct is = { 21, 256 };
         ExpectedArgValue integerStructRetValue = { sizeof(IntegerStruct), (void *)&is, [&](UINT_PTR ptr){ return ValidateIntegerStruct(ptr, is); } };
         hr = ValidateOneArgument(pRetvalRange, functionName, 0, integerStructRetValue);
     }
-    else if (functionName == WCHAR("FloatingPointStructFunc"))
+    else if (functionName == WCHAR("Fp32x2StructFunc"))
     {
-        _sawFloatingPointStructFuncLeave = true;
-
-        FloatingPointStruct fps = { 13.0, 256.8 };
-        ExpectedArgValue floatingPointStructRetValue = { sizeof(FloatingPointStruct), (void *)&fps, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fps); } };
+        ExpectedArgValue floatingPointStructRetValue = { sizeof(Fp32x2Struct), (void *)&fp32x2, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp32x2); } };
+        hr = ValidateOneArgument(pRetvalRange, functionName, 0, floatingPointStructRetValue);
+    }
+    else if (functionName == WCHAR("Fp32x3StructFunc"))
+    {
+        ExpectedArgValue floatingPointStructRetValue = { sizeof(Fp32x3Struct), (void *)&fp32x3, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp32x3); } };
+        hr = ValidateOneArgument(pRetvalRange, functionName, 0, floatingPointStructRetValue);
+    }
+    else if (functionName == WCHAR("Fp32x4StructFunc"))
+    {
+        ExpectedArgValue floatingPointStructRetValue = { sizeof(Fp32x4Struct), (void *)&fp32x4, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp32x4); } };
+        hr = ValidateOneArgument(pRetvalRange, functionName, 0, floatingPointStructRetValue);
+    }
+    else if (functionName == WCHAR("Fp64x2StructFunc"))
+    {
+        ExpectedArgValue floatingPointStructRetValue = { sizeof(Fp64x2Struct), (void *)&fp64x2, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp64x2); } };
+        hr = ValidateOneArgument(pRetvalRange, functionName, 0, floatingPointStructRetValue);
+    }
+    else if (functionName == WCHAR("Fp64x3StructFunc"))
+    {
+        ExpectedArgValue floatingPointStructRetValue = { sizeof(Fp64x3Struct), (void *)&fp64x3, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp64x3); } };
+        hr = ValidateOneArgument(pRetvalRange, functionName, 0, floatingPointStructRetValue);
+    }
+    else if (functionName == WCHAR("Fp64x4StructFunc"))
+    {
+        ExpectedArgValue floatingPointStructRetValue = { sizeof(Fp64x4Struct), (void *)&fp64x4, [&](UINT_PTR ptr){ return ValidateFloatingPointStruct(ptr, fp64x4); } };
         hr = ValidateOneArgument(pRetvalRange, functionName, 0, floatingPointStructRetValue);
     }
     else if (functionName == WCHAR("DoubleRetFunc"))
     {
-        _sawDoubleRetFuncLeave = true;
-
         double d = 13.0;
         ExpectedArgValue doubleRetValue = { sizeof(double), (void *)&d, [&](UINT_PTR ptr){ return ValidateDouble(ptr, d); } };
         hr = ValidateOneArgument(pRetvalRange, functionName, 0, doubleRetValue);
     }
 
-    return hr;   
+    _sawFuncLeave[functionName.ToWString()] = true;
+
+    return hr;
 }
 
 HRESULT STDMETHODCALLTYPE SlowPathELTProfiler::TailcallCallback(FunctionIDOrClientID functionIdOrClientID, COR_PRF_ELT_INFO eltInfo)
@@ -318,7 +507,7 @@ HRESULT STDMETHODCALLTYPE SlowPathELTProfiler::TailcallCallback(FunctionIDOrClie
 
     // Tailcalls don't happen on debug builds, and there's no arguments to verify from GetFunctionTailcallinfo3
 
-    return hr;    
+    return hr;
 }
 
 void SlowPathELTProfiler::PrintBytes(const BYTE *bytes, size_t length)
@@ -415,23 +604,84 @@ bool SlowPathELTProfiler::ValidateLargeStruct(UINT_PTR ptr, LargeStruct expected
     LargeStruct lhs = *(LargeStruct *)ptr;
     return lhs.x0 == expected.x0
             && lhs.x1 == expected.x1
-            && lhs.x2 == expected.x2 
+            && lhs.x2 == expected.x2
             && lhs.x3 == expected.x3
             && lhs.d0 == expected.d0
             && lhs.d1 == expected.d1
-            && lhs.d2 == expected.d2 
+            && lhs.d2 == expected.d2
             && lhs.d3 == expected.d3;
 }
 
-bool SlowPathELTProfiler::ValidateFloatingPointStruct(UINT_PTR ptr, FloatingPointStruct expected)
+bool SlowPathELTProfiler::ValidateFloatingPointStruct(UINT_PTR ptr, Fp32x2Struct expected)
 {
     if (ptr == NULL)
     {
         return false;
     }
 
-    FloatingPointStruct lhs = *(FloatingPointStruct *)ptr;
-    return lhs.d1 == expected.d1 && lhs.d2 == expected.d2;
+    Fp32x2Struct lhs = *(Fp32x2Struct *)ptr;
+    return lhs.x == expected.x && lhs.y == expected.y;
+}
+
+bool SlowPathELTProfiler::ValidateFloatingPointStruct(UINT_PTR ptr, Fp32x3Struct expected)
+{
+    if (ptr == NULL)
+    {
+        return false;
+    }
+
+    Fp32x3Struct lhs = *(Fp32x3Struct *)ptr;
+    return lhs.x == expected.x && lhs.y == expected.y && lhs.z == expected.z;
+}
+
+bool SlowPathELTProfiler::ValidateFloatingPointStruct(UINT_PTR ptr, Fp32x4Struct expected)
+{
+    if (ptr == NULL)
+    {
+        return false;
+    }
+
+    Fp32x4Struct lhs = *(Fp32x4Struct *)ptr;
+    return lhs.x == expected.x
+        && lhs.y == expected.y
+        && lhs.z == expected.z
+        && lhs.w == expected.w;
+}
+
+bool SlowPathELTProfiler::ValidateFloatingPointStruct(UINT_PTR ptr, Fp64x2Struct expected)
+{
+    if (ptr == NULL)
+    {
+        return false;
+    }
+
+    Fp64x2Struct lhs = *(Fp64x2Struct *)ptr;
+    return lhs.x == expected.x && lhs.y == expected.y;
+}
+
+bool SlowPathELTProfiler::ValidateFloatingPointStruct(UINT_PTR ptr, Fp64x3Struct expected)
+{
+    if (ptr == NULL)
+    {
+        return false;
+    }
+
+    Fp64x3Struct lhs = *(Fp64x3Struct *)ptr;
+    return lhs.x == expected.x && lhs.y == expected.y && lhs.z == expected.z;
+}
+
+bool SlowPathELTProfiler::ValidateFloatingPointStruct(UINT_PTR ptr, Fp64x4Struct expected)
+{
+    if (ptr == NULL)
+    {
+        return false;
+    }
+
+    Fp64x4Struct lhs = *(Fp64x4Struct *)ptr;
+    return lhs.x == expected.x
+        && lhs.y == expected.y
+        && lhs.z == expected.z
+        && lhs.w == expected.w;
 }
 
 bool SlowPathELTProfiler::ValidateIntegerStruct(UINT_PTR ptr, IntegerStruct expected)
@@ -453,7 +703,7 @@ HRESULT SlowPathELTProfiler::ValidateOneArgument(COR_PRF_FUNCTION_ARGUMENT_RANGE
 {
     if (pArgRange->length != expectedValue.length)
     {
-        wcout << L"Argument " << argPos << L" for function " << functionName << " expected length " << expectedValue.length 
+        wcout << L"Argument " << argPos << L" for function " << functionName << " expected length " << expectedValue.length
                 << L" but got length " << pArgRange->length << endl;
         _failures++;
         return E_FAIL;
@@ -466,11 +716,11 @@ HRESULT SlowPathELTProfiler::ValidateOneArgument(COR_PRF_FUNCTION_ARGUMENT_RANGE
 
         // Print out the bytes so you don't have to debug if something mismatches
         BYTE *expectedBytes = (BYTE *)expectedValue.value;
-        wcout << L"Expected bytes: "; 
+        wcout << L"Expected bytes: ";
         PrintBytes(expectedBytes, expectedValue.length);
 
         BYTE *actualBytes = (BYTE *)pArgRange->startAddress;
-        wcout << L"Actual bytes  : "; 
+        wcout << L"Actual bytes  : ";
         PrintBytes(actualBytes, pArgRange->length);
 
         return E_FAIL;

--- a/src/tests/profiler/native/eltprofiler/slowpatheltprofiler.h
+++ b/src/tests/profiler/native/eltprofiler/slowpatheltprofiler.h
@@ -3,9 +3,10 @@
 
 #pragma once
 
-#include <memory>
-#include <vector>
 #include <functional>
+#include <memory>
+#include <unordered_map>
+#include <vector>
 #include "../profiler.h"
 
 typedef bool (*validateFunc)(void *pMem);
@@ -43,30 +44,87 @@ typedef struct
 
 typedef struct
 {
-    double d1;
-    double d2;
-} FloatingPointStruct;
+    float x;
+    float y;
+} Fp32x2Struct;
+
+typedef struct
+{
+    float x;
+    float y;
+    float z;
+} Fp32x3Struct;
+
+typedef struct
+{
+    float x;
+    float y;
+    float z;
+    float w;
+} Fp32x4Struct;
+
+typedef struct
+{
+    double x;
+    double y;
+} Fp64x2Struct;
+
+typedef struct
+{
+    double x;
+    double y;
+    double z;
+} Fp64x3Struct;
+
+typedef struct
+{
+    double x;
+    double y;
+    double z;
+    double w;
+} Fp64x4Struct;
 
 class SlowPathELTProfiler : public Profiler
 {
 public:
     static std::shared_ptr<SlowPathELTProfiler> s_profiler;
 
-    SlowPathELTProfiler() : Profiler(),
-        _failures(0),
-        _sawSimpleFuncEnter(false),
-        _sawMixedStructFuncEnter(false),
-        _sawLargeStructFuncEnter(false),
-        _sawSimpleFuncLeave(false),
-        _sawMixedStructFuncLeave(false),
-        _sawLargeStructFuncLeave(false),
-        _testType(TestType::Unknown)
-    {}
+    SlowPathELTProfiler() : Profiler(), _failures(0), _testType(TestType::Unknown)
+    {
+        _sawFuncEnter[L"SimpleArgsFunc"] = false;
+        _sawFuncEnter[L"MixedStructFunc"] = false;
+        _sawFuncEnter[L"LargeStructFunc"] = false;
+        _sawFuncEnter[L"Fp32x2StructFunc"] = false;
+        _sawFuncEnter[L"Fp32x2StructFp32x3StructFunc"] = false;
+        _sawFuncEnter[L"Fp32x3StructFunc"] = false;
+        _sawFuncEnter[L"Fp32x3StructFp32x2StructFunc"] = false;
+        _sawFuncEnter[L"Fp32x3StructSingleFp32x3StructSingleFunc"] = false;
+        _sawFuncEnter[L"Fp32x4StructFunc"] = false;
+        _sawFuncEnter[L"Fp32x4StructFp32x4StructFunc"] = false;
+        _sawFuncEnter[L"Fp64x2StructFunc"] = false;
+        _sawFuncEnter[L"Fp64x2StructFp64x3StructFunc"] = false;
+        _sawFuncEnter[L"Fp64x3StructFunc"] = false;
+        _sawFuncEnter[L"Fp64x3StructFp64x2StructFunc"] = false;
+        _sawFuncEnter[L"Fp64x3StructDoubleFp64x3StructDoubleFunc"] = false;
+        _sawFuncEnter[L"Fp64x4StructFunc"] = false;
+        _sawFuncEnter[L"Fp64x4StructFp64x4StructFunc"] = false;
+
+        _sawFuncLeave[L"SimpleArgsFunc"] = false;
+        _sawFuncLeave[L"MixedStructFunc"] = false;
+        _sawFuncLeave[L"LargeStructFunc"] = false;
+        _sawFuncLeave[L"IntegerStructFunc"] = false;
+        _sawFuncLeave[L"Fp32x2StructFunc"] = false;
+        _sawFuncLeave[L"Fp32x3StructFunc"] = false;
+        _sawFuncLeave[L"Fp32x4StructFunc"] = false;
+        _sawFuncLeave[L"Fp64x2StructFunc"] = false;
+        _sawFuncLeave[L"Fp64x3StructFunc"] = false;
+        _sawFuncLeave[L"Fp64x4StructFunc"] = false;
+        _sawFuncLeave[L"DoubleRetFunc"] = false;
+    }
 
     static GUID GetClsid();
     virtual HRESULT STDMETHODCALLTYPE Initialize(IUnknown* pICorProfilerInfoUnk);
     virtual HRESULT STDMETHODCALLTYPE Shutdown();
-
 
     HRESULT STDMETHODCALLTYPE EnterCallback(FunctionIDOrClientID functionId, COR_PRF_ELT_INFO eltInfo);
     HRESULT STDMETHODCALLTYPE LeaveCallback(FunctionIDOrClientID functionId, COR_PRF_ELT_INFO eltInfo);
@@ -81,27 +139,25 @@ private:
     };
 
     std::atomic<int> _failures;
-    bool _sawSimpleFuncEnter;
-    bool _sawMixedStructFuncEnter;
-    bool _sawLargeStructFuncEnter;
-    bool _sawSimpleFuncLeave;
-    bool _sawMixedStructFuncLeave;
-    bool _sawLargeStructFuncLeave;
-    bool _sawIntegerStructFuncLeave;
-    bool _sawFloatingPointStructFuncLeave;
-    bool _sawDoubleRetFuncLeave;
+    std::unordered_map<std::wstring, bool> _sawFuncEnter;
+    std::unordered_map<std::wstring, bool> _sawFuncLeave;
 
     TestType _testType;
-    
+
     void PrintBytes(const BYTE *bytes, size_t length);
-    
+
     bool ValidateInt(UINT_PTR ptr, int expected);
     bool ValidateFloat(UINT_PTR ptr, float expected);
     bool ValidateDouble(UINT_PTR ptr, double expected);
     bool ValidateString(UINT_PTR ptr, const WCHAR *expected);
     bool ValidateMixedStruct(UINT_PTR ptr, MixedStruct expected);
     bool ValidateLargeStruct(UINT_PTR ptr, LargeStruct expected);
-    bool ValidateFloatingPointStruct(UINT_PTR ptr, FloatingPointStruct expected);
+    bool ValidateFloatingPointStruct(UINT_PTR ptr, Fp32x2Struct expected);
+    bool ValidateFloatingPointStruct(UINT_PTR ptr, Fp32x3Struct expected);
+    bool ValidateFloatingPointStruct(UINT_PTR ptr, Fp32x4Struct expected);
+    bool ValidateFloatingPointStruct(UINT_PTR ptr, Fp64x2Struct expected);
+    bool ValidateFloatingPointStruct(UINT_PTR ptr, Fp64x3Struct expected);
+    bool ValidateFloatingPointStruct(UINT_PTR ptr, Fp64x4Struct expected);
     bool ValidateIntegerStruct(UINT_PTR ptr, IntegerStruct expected);
 
     HRESULT ValidateOneArgument(COR_PRF_FUNCTION_ARGUMENT_RANGE *pArgRange,

--- a/src/tests/profiler/native/eltprofiler/slowpatheltprofiler.h
+++ b/src/tests/profiler/native/eltprofiler/slowpatheltprofiler.h
@@ -84,6 +84,44 @@ typedef struct
     double w;
 } Fp64x4Struct;
 
+typedef struct
+{
+    int x;
+    int y;
+    double z;
+} IntegerSseStruct;
+
+typedef struct
+{
+    float x;
+    float y;
+    int z;
+} SseIntegerStruct;
+
+typedef struct
+{
+    float x;
+    int y;
+    float z;
+    float w;
+} MixedSseStruct;
+
+typedef struct
+{
+    float x;
+    float y;
+    int z;
+    float w;
+} SseMixedStruct;
+
+typedef struct
+{
+    float x;
+    int y;
+    int z;
+    float w;
+} MixedMixedStruct;
+
 class SlowPathELTProfiler : public Profiler
 {
 public:
@@ -120,6 +158,11 @@ public:
         _sawFuncLeave[L"Fp64x3StructFunc"] = false;
         _sawFuncLeave[L"Fp64x4StructFunc"] = false;
         _sawFuncLeave[L"DoubleRetFunc"] = false;
+        _sawFuncLeave[L"IntegerSseStructFunc"] = false;
+        _sawFuncLeave[L"SseIntegerStructFunc"] = false;
+        _sawFuncLeave[L"MixedSseStructFunc"] = false;
+        _sawFuncLeave[L"SseMixedStructFunc"] = false;
+        _sawFuncLeave[L"MixedMixedStructFunc"] = false;
     }
 
     static GUID GetClsid();
@@ -159,6 +202,11 @@ private:
     bool ValidateFloatingPointStruct(UINT_PTR ptr, Fp64x3Struct expected);
     bool ValidateFloatingPointStruct(UINT_PTR ptr, Fp64x4Struct expected);
     bool ValidateIntegerStruct(UINT_PTR ptr, IntegerStruct expected);
+    bool ValidateIntegerSseStruct(UINT_PTR ptr, IntegerSseStruct expected);
+    bool ValidateSseIntegerStruct(UINT_PTR ptr, SseIntegerStruct expected);
+    bool ValidateMixedSseStruct(UINT_PTR ptr, MixedSseStruct expected);
+    bool ValidateSseMixedStruct(UINT_PTR ptr, SseMixedStruct expected);
+    bool ValidateMixedMixedStruct(UINT_PTR ptr, MixedMixedStruct expected);
 
     HRESULT ValidateOneArgument(COR_PRF_FUNCTION_ARGUMENT_RANGE *pArgRange,
                                 String functionName,


### PR DESCRIPTION
* Add various ELT profiler tests for HFA/HVA arguments/return values.
* Fix an issue with `ProfileArgIterator::GetNextArgAddr` and `ProfileArgIterator::GetReturnBufferAddr` not properly handling HFA/HVAs on Arm64.
* Fix an issue with `ProfileArgIterator::GetReturnBufferAddr` not properly handling struct returned in registers on Linux x64 and macOS x64.
* Add tests to cover different ways of returning a struct on System V .
* Fix an issue with not passing an actual value of `rdx` down to a callback in `ProfileLeaveNaked` and `ProfileTailcallNaked` helpers.