### PR TITLE
Revive #48505

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,13 +10,15 @@
   </PropertyGroup>
 
   <PropertyGroup Label="CalculateTargetOS">
-    <TargetOS Condition="'$(TargetOS)' == '' and $([MSBuild]::IsOSPlatform('OSX'))">OSX</TargetOS>
-    <TargetOS Condition="'$(TargetOS)' == '' and $([MSBuild]::IsOSPlatform('FREEBSD'))">FreeBSD</TargetOS>
-    <TargetOS Condition="'$(TargetOS)' == '' and $([MSBuild]::IsOSPlatform('NETBSD'))">NetBSD</TargetOS>
-    <TargetOS Condition="'$(TargetOS)' == '' and $([MSBuild]::IsOSPlatform('ILLUMOS'))">illumos</TargetOS>
-    <TargetOS Condition="'$(TargetOS)' == '' and $([MSBuild]::IsOSPlatform('SOLARIS'))">Solaris</TargetOS>
-    <TargetOS Condition="'$(TargetOS)' == '' and $([MSBuild]::IsOSUnixLike())">Linux</TargetOS>
-    <TargetOS Condition="'$(TargetOS)' == '' and $([MSBuild]::IsOSPlatform('WINDOWS'))">windows</TargetOS>
+    <_hostOS>Linux</_hostOS>
+    <_hostOS Condition="$([MSBuild]::IsOSPlatform('OSX'))">OSX</_hostOS>
+    <_hostOS Condition="$([MSBuild]::IsOSPlatform('FREEBSD'))">FreeBSD</_hostOS>
+    <_hostOS Condition="$([MSBuild]::IsOSPlatform('NETBSD'))">NetBSD</_hostOS>
+    <_hostOS Condition="$([MSBuild]::IsOSPlatform('ILLUMOS'))">illumos</_hostOS>
+    <_hostOS Condition="$([MSBuild]::IsOSPlatform('SOLARIS'))">Solaris</_hostOS>
+    <_hostOS Condition="$([MSBuild]::IsOSPlatform('WINDOWS'))">windows</_hostOS>
+    <_hostOS Condition="'$(TargetOS)' == 'Browser'">Browser</_hostOS>
+    <TargetOS Condition="'$(TargetOS)' == ''">$(_hostOS)</TargetOS>
     <TargetsMobile Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'iOSSimulator' or '$(TargetOS)' == 'MacCatalyst' or '$(TargetOS)' == 'tvOS' or '$(TargetOS)' == 'tvOSSimulator' or '$(TargetOS)' == 'Android' or '$(TargetOS)' == 'Browser'">true</TargetsMobile>
   </PropertyGroup>
 
@@ -114,16 +116,13 @@
          the build system to use browser/ios/android as the _runtimeOS for produced package RIDs. -->
     <_runtimeOS Condition="'$(TargetsMobile)' == 'true'">$(TargetOS.ToLowerInvariant())</_runtimeOS>
 
-    <_runtimeOSVersionIndex>$(_runtimeOS.IndexOfAny(".-0123456789"))</_runtimeOSVersionIndex>
-    <_runtimeOSFamily Condition="'$(_runtimeOSVersionIndex)' != '-1'">$(_runtimeOS.SubString(0, $(_runtimeOSVersionIndex)))</_runtimeOSFamily>
-
     <_portableOS>linux</_portableOS>
     <_portableOS Condition="'$(_runtimeOS)' == 'linux-musl'">linux-musl</_portableOS>
-    <_portableOS Condition="$([MSBuild]::IsOSPlatform('OSX'))">osx</_portableOS>
-    <_portableOS Condition="'$(_runtimeOSFamily)' == 'win' or '$(_runtimeOS)' == 'win' or '$(TargetOS)' == 'windows'">win</_portableOS>
-    <_portableOS Condition="'$(_runtimeOSFamily)' == 'FreeBSD'">freebsd</_portableOS>
-    <_portableOS Condition="'$(_runtimeOSFamily)' == 'illumos'">illumos</_portableOS>
-    <_portableOS Condition="'$(_runtimeOSFamily)' == 'Solaris'">solaris</_portableOS>
+    <_portableOS Condition="'$(_hostOS)' == 'OSX'">osx</_portableOS>
+    <_portableOS Condition="'$(_runtimeOS)' == 'win' or '$(TargetOS)' == 'windows'">win</_portableOS>
+    <_portableOS Condition="'$(_runtimeOS)' == 'FreeBSD' or '$(TargetOS)' == 'FreeBSD'">freebsd</_portableOS>
+    <_portableOS Condition="'$(_runtimeOS)' == 'illumos' or '$(TargetOS)' == 'illumos'">illumos</_portableOS>
+    <_portableOS Condition="'$(_runtimeOS)' == 'Solaris' or '$(TargetOS)' == 'Solaris'">solaris</_portableOS>
     <_portableOS Condition="'$(_runtimeOS)' == 'Browser'">browser</_portableOS>
     <_portableOS Condition="'$(_runtimeOS)' == 'maccatalyst'">maccatalyst</_portableOS>
     <_portableOS Condition="'$(_runtimeOS)' == 'ios'">ios</_portableOS>
@@ -134,16 +133,12 @@
 
     <_runtimeOS Condition="$(_runtimeOS.StartsWith('tizen'))">linux</_runtimeOS>
     <_runtimeOS Condition="'$(PortableBuild)' == 'true'">$(_portableOS)</_runtimeOS>
-
-    <!-- support cross-targeting by choosing a RID to restore when running on a different machine that what we're build for -->
-    <_portableOS Condition="'$(TargetOS)' == 'Unix' and '$(_runtimeOSFamily)' != 'osx' and '$(_runtimeOSFamily)' != 'FreeBSD' and '$(_runtimeOS)' != 'linux-musl' and '$(_runtimeOSFamily)' != 'illumos' and '$(_runtimeOSFamily)' != 'Solaris'">linux</_portableOS>
   </PropertyGroup>
 
   <PropertyGroup Label="CalculateRID">
+    <_toolRuntimeRID Condition="'$(CrossBuild)' == 'true'">$(_hostOS.ToLowerInvariant)-$(_hostArch)</_toolRuntimeRID>
     <_toolRuntimeRID Condition="'$(BuildingInsideVisualStudio)' == 'true'">$(_runtimeOS)-x64</_toolRuntimeRID>
     <_toolRuntimeRID Condition="'$(_toolRuntimeRID)' == ''">$(_runtimeOS)-$(_hostArch)</_toolRuntimeRID>
-    <!-- We build linux-musl-arm on a ubuntu container, so we can't use the toolset build for alpine runtime. We need to use portable linux RID for our toolset in order to be able to use it. -->
-    <_toolRuntimeRID Condition="'$(_runtimeOS)' == 'linux-musl' and $(TargetArchitecture.StartsWith('arm')) and !$(_hostArch.StartsWith('arm'))">linux-x64</_toolRuntimeRID>
 
     <!-- There are no WebAssembly tools, so use the default ones -->
     <_toolRuntimeRID Condition="'$(_runtimeOS)' == 'browser'">linux-x64</_toolRuntimeRID>
@@ -163,26 +158,12 @@
     <MicrosoftNetCoreIlasmPackageRuntimeId Condition="'$(MicrosoftNetCoreIlasmPackageRuntimeId)' == ''">$(_toolRuntimeRID)</MicrosoftNetCoreIlasmPackageRuntimeId>
 
     <_packageRID Condition="'$(PortableBuild)' == 'true'">$(_portableOS)-$(TargetArchitecture)</_packageRID>
+    <_packageRID Condition="'$(CrossBuild)' == 'true'">$(_hostOS.ToLowerInvariant)-$(TargetArchitecture)</_packageRID>
     <PackageRID Condition="'$(PackageRID)' == ''">$(_packageRID)</PackageRID>
     <PackageRID Condition="'$(PackageRID)' == ''">$(_runtimeOS)-$(TargetArchitecture)</PackageRID>
 
-    <_outputRID Condition="'$(TargetOS)' == 'windows'">win-$(TargetArchitecture)</_outputRID>
-    <_outputRID Condition="'$(TargetOS)' == 'OSX'">osx-$(TargetArchitecture)</_outputRID>
-    <_outputRID Condition="'$(TargetOS)' == 'Linux'">linux-$(TargetArchitecture)</_outputRID>
-    <_outputRID Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-$(TargetArchitecture)</_outputRID>
-    <_outputRID Condition="'$(TargetOS)' == 'NetBSD'">netbsd-$(TargetArchitecture)</_outputRID>
-    <_outputRID Condition="'$(TargetOS)' == 'illumos'">illumos-$(TargetArchitecture)</_outputRID>
-    <_outputRID Condition="'$(TargetOS)' == 'Solaris'">solaris-$(TargetArchitecture)</_outputRID>
-    <_outputRID Condition="'$(TargetOS)' == 'MacCatalyst'">maccatalyst-$(TargetArchitecture)</_outputRID>
-    <_outputRID Condition="'$(TargetOS)' == 'iOS'">ios-$(TargetArchitecture)</_outputRID>
-    <_outputRID Condition="'$(TargetOS)' == 'iOSSimulator'">iossimulator-$(TargetArchitecture)</_outputRID>
-    <_outputRID Condition="'$(TargetOS)' == 'tvOS'">tvos-$(TargetArchitecture)</_outputRID>
-    <_outputRID Condition="'$(TargetOS)' == 'tvOSSimulator'">tvossimulator-$(TargetArchitecture)</_outputRID>
-    <_outputRID Condition="'$(TargetOS)' == 'Android'">android-$(TargetArchitecture)</_outputRID>
-    <_outputRID Condition="'$(TargetOS)' == 'Browser'">browser-$(TargetArchitecture)</_outputRID>
-
     <OutputRid Condition="'$(OutputRid)' == ''">$(PackageRID)</OutputRid>
-    <OutputRid Condition="'$(PortableBuild)' == 'true'">$(_outputRID)</OutputRid>
+    <OutputRid Condition="'$(PortableBuild)' == 'true'">$(_portableOS)-$(TargetArchitecture)</OutputRid>
   </PropertyGroup>
 
   <PropertyGroup Label="CalculateTargetOSName" Condition="'$(SkipInferTargetOSName)' != 'true'">

--- a/src/coreclr/.nuget/Directory.Build.props
+++ b/src/coreclr/.nuget/Directory.Build.props
@@ -119,8 +119,8 @@
   <ItemGroup>
     <!-- Ensure we have a RID-specific package for the current build, even if it isn't in our official set, but
          don't build the RID-specific package if we're in an unsupported os family -->
-    <BuildRID Include="@(OfficialBuildRID)" Exclude="$(PackageRID)"/>
-    <BuildRID Include="$(PackageRID)"
+    <BuildRID Include="@(OfficialBuildRID)" Exclude="$(OutputRid)"/>
+    <BuildRID Include="$(OutputRid)"
               Condition="'$(_isSupportedOSGroup)' == 'true'">
       <Platform Condition="'$(TargetArchitecture)' == 'x64'">amd64</Platform>
       <Platform Condition="'$(TargetArchitecture)' != 'x64'">$(TargetArchitecture)</Platform>

--- a/src/coreclr/.nuget/builds.targets
+++ b/src/coreclr/.nuget/builds.targets
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <Target Name="FilterProjects" BeforeTargets="Build;Pack">
-    <Error Condition="'$(PackageRID)' == ''" Text="'PackageRID' property must be specified."/>
+    <Error Condition="'$(OutputRid)' == ''" Text="'OutputRid' property must be specified."/>
 
     <!-- Only build packages for current RID or non-RID-specific -->
     <ItemGroup>
-      <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)' == '$(PackageRID)'" />
+      <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)' == '$(OutputRid)'" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(BuildIdentityPackage)' == 'true'">

--- a/src/coreclr/tools/aot/crossgen2/crossgen2.csproj
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2.csproj
@@ -7,7 +7,7 @@
     <TargetArchitectureAppHost>$(TargetArchitecture)</TargetArchitectureAppHost>
     <TargetArchitectureAppHost Condition="'$(TargetArchitectureAppHost)'=='armel'">arm</TargetArchitectureAppHost>
 
-    <AppHostRuntimeIdentifier>$(PackageRID)-$(TargetArchitectureAppHost)</AppHostRuntimeIdentifier>
+    <AppHostRuntimeIdentifier>$(PackageRID)</AppHostRuntimeIdentifier>
   </PropertyGroup>
   <Import Project="crossgen2.props" />
 </Project>

--- a/src/coreclr/tools/aot/crossgen2/crossgen2.csproj
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2.csproj
@@ -7,7 +7,7 @@
     <TargetArchitectureAppHost>$(TargetArchitecture)</TargetArchitectureAppHost>
     <TargetArchitectureAppHost Condition="'$(TargetArchitectureAppHost)'=='armel'">arm</TargetArchitectureAppHost>
 
-    <AppHostRuntimeIdentifier>$(_runtimeOS)-$(TargetArchitectureAppHost)</AppHostRuntimeIdentifier>
+    <AppHostRuntimeIdentifier>$(PackageRID)-$(TargetArchitectureAppHost)</AppHostRuntimeIdentifier>
   </PropertyGroup>
   <Import Project="crossgen2.props" />
 </Project>

--- a/src/libraries/pkg/Directory.Build.props
+++ b/src/libraries/pkg/Directory.Build.props
@@ -16,8 +16,8 @@
   <!-- create the "BuildRID" item which is the set of all supported RIDs, with metadata.
        We'll add a RID for the current platform even if it isn't in the officially supported set -->
   <ItemGroup Condition="'@(OfficialBuildRID)' != ''">
-    <BuildRID Include="@(OfficialBuildRID)" Exclude="$(PackageRID)"/>
-    <BuildRID Include="$(PackageRID)">
+    <BuildRID Include="@(OfficialBuildRID)" Exclude="$(OutputRid)"/>
+    <BuildRID Include="$(OutputRid)">
       <Platform Condition="'$(TargetArchitecture)' == 'x64'">amd64</Platform>
       <Platform Condition="'$(TargetArchitecture)' != 'x64'">$(TargetArchitecture)</Platform>
     </BuildRID>

--- a/src/libraries/pkg/dir.traversal.targets
+++ b/src/libraries/pkg/dir.traversal.targets
@@ -47,18 +47,18 @@
 
   <PropertyGroup>
     <TraversalBuildDependsOn>
-      FilterProjectsPackageRID;
+      FilterProjectsOutputRid;
       $(TraversalBuildDependsOn);
     </TraversalBuildDependsOn>
   </PropertyGroup>
 
-  <!-- When @(BuildRID) is set, filter the set of projects down to only those applicable to $(PackageRID) -->
-  <Target Name="FilterProjectsPackageRID" Condition="'@(BuildRID)' != ''">
+  <!-- When @(BuildRID) is set, filter the set of projects down to only those applicable to $(OutputRid) -->
+  <Target Name="FilterProjectsOutputRid" Condition="'@(BuildRID)' != ''">
     <ItemGroup>
       <!-- Build identity package, when SkipBuildIdentityPackage is not set -->
       <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)' == '' and '$(SkipBuildIdentityPackage)' != 'true'" />
       <!-- Build packages for current RID, when SkipBuildRuntimePackage is not set -->
-      <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)' == '$(PackageRID)' and '$(SkipBuildRuntimePackage)' != 'true'" />
+      <_projectsToBuild Include="@(Project)" Condition="'%(Project.PackageTargetRuntime)' == '$(OutputRid)' and '$(SkipBuildRuntimePackage)' != 'true'" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/libraries/pkg/runtime.native.System.IO.Ports/runtime.native.System.IO.Ports.pkgproj
+++ b/src/libraries/pkg/runtime.native.System.IO.Ports/runtime.native.System.IO.Ports.pkgproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(PackageTargetRuntime)' == 'linux-arm' or '$(PackageTargetRuntime)' == 'linux-arm64' or '$(PackageTargetRuntime)' == 'linux-x64' or '$(PackageTargetRuntime)' == 'osx-x64' or '$(PackageTargetRuntime)' == 'freebsd-x64'">
     <File Include="$(NativeBinDir)$(LibPrefix)System.IO.Ports.Native$(LibSuffix)" >
-      <TargetPath>runtimes/$(PackageRID)/native</TargetPath>
+      <TargetPath>runtimes/$(OutputRid)/native</TargetPath>
     </File>
   </ItemGroup>
   <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -43,7 +43,7 @@
 
   <Target Name="RestorePackage">
     <PropertyGroup>
-      <_ConfigurationProperties>/p:TargetOS=$(TargetOS) /p:TargetArchitecture=$(TargetArchitecture) /p:Configuration=$(Configuration)</_ConfigurationProperties>
+      <_ConfigurationProperties>/p:TargetOS=$(TargetOS) /p:TargetArchitecture=$(TargetArchitecture) /p:Configuration=$(Configuration) /p:CrossBuild=$(CrossBuild)</_ConfigurationProperties>
       <DotnetRestoreCommand Condition="'$(__DistroRid)' == ''">"$(DotNetTool)" restore $(RestoreProj) $(PackageVersionArg) /p:SetTFMForRestore=true $(_ConfigurationProperties)</DotnetRestoreCommand>
       <DotnetRestoreCommand Condition="'$(__DistroRid)' != ''">"$(DotNetTool)" restore -r $(__DistroRid) $(RestoreProj) $(PackageVersionArg) /p:SetTFMForRestore=true $(_ConfigurationProperties)</DotnetRestoreCommand>
     </PropertyGroup>

--- a/src/tests/build.sh
+++ b/src/tests/build.sh
@@ -573,6 +573,10 @@ if [[ "${__BuildArch}" != "${__HostArch}" ]]; then
     __CrossBuild=1
 fi
 
+if [[ "$__CrossBuild" == 1 ]]; then
+    __UnprocessedBuildArgs+=("/p:CrossBuild=true")
++fi
+
 # Set dependent variables
 __LogsDir="$__RootBinDir/log"
 __MsbuildDebugLogsDir="$__LogsDir/MsbuildDebugLogs"

--- a/src/tests/build.sh
+++ b/src/tests/build.sh
@@ -575,7 +575,7 @@ fi
 
 if [[ "$__CrossBuild" == 1 ]]; then
     __UnprocessedBuildArgs+=("/p:CrossBuild=true")
-+fi
+fi
 
 # Set dependent variables
 __LogsDir="$__RootBinDir/log"


### PR DESCRIPTION
Revive https://github.com/dotnet/runtime/pull/48505 and try to find out why the change caused official builds to break.

I couldn't apply the patch in src/tests/build.sh as sources changed: https://github.com/dotnet/runtime/pull/48505/files#diff-056300437704f257a4c8567b61dfdb647da75c5ef93baefec47709796792f182.

cc @am11 @ericstj 