### PR TITLE
Avoid object[1] allocation in PropertyInfo.SetValue

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
@@ -460,7 +460,12 @@ namespace System.Reflection.Emit
             bool wrapExceptions = (invokeAttr & BindingFlags.DoNotWrapExceptions) == 0;
 
             StackAllocedArguments stackArgs = default;
-            Span<object?> arguments = CheckArguments(ref stackArgs, parameters, binder, invokeAttr, culture, sig);
+            Span<object?> arguments = default;
+            if (actualCount != 0)
+            {
+                arguments = CheckArguments(ref stackArgs, parameters, binder, invokeAttr, culture, sig);
+            }
+
             object? retValue = RuntimeMethodHandle.InvokeMethod(null, arguments, sig, false, wrapExceptions);
 
             // copy out. This should be made only if ByRef are present.

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
@@ -340,7 +340,12 @@ namespace System.Reflection
             bool wrapExceptions = (invokeAttr & BindingFlags.DoNotWrapExceptions) == 0;
 
             StackAllocedArguments stackArgs = default;
-            Span<object?> arguments = CheckArguments(ref stackArgs, parameters, binder, invokeAttr, culture, sig);
+            Span<object?> arguments = default;
+            if (actualCount != 0)
+            {
+                arguments = CheckArguments(ref stackArgs, parameters, binder, invokeAttr, culture, sig);
+            }
+
             object? retValue = RuntimeMethodHandle.InvokeMethod(obj, arguments, sig, false, wrapExceptions);
 
             // copy out. This should be made only if ByRef are present.
@@ -394,7 +399,12 @@ namespace System.Reflection
             bool wrapExceptions = (invokeAttr & BindingFlags.DoNotWrapExceptions) == 0;
 
             StackAllocedArguments stackArgs = default;
-            Span<object?> arguments = CheckArguments(ref stackArgs, parameters, binder, invokeAttr, culture, sig);
+            Span<object?> arguments = default;
+            if (actualCount != 0)
+            {
+                arguments = CheckArguments(ref stackArgs, parameters, binder, invokeAttr, culture, sig);
+            }
+
             object retValue = RuntimeMethodHandle.InvokeMethod(null, arguments, sig, true, wrapExceptions)!; // ctor must return non-null
 
             // copy out. This should be made only if ByRef are present.

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
@@ -410,8 +410,26 @@ namespace System.Reflection
         [Diagnostics.DebuggerHidden]
         public override object? Invoke(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture)
         {
+            // INVOCATION_FLAGS_CONTAINS_STACK_POINTERS means that the struct (either the declaring type or the return type)
+            // contains pointers that point to the stack. This is either a ByRef or a TypedReference. These structs cannot
+            // be boxed and thus cannot be invoked through reflection which only deals with boxed value type objects.
+            if ((InvocationFlags & (INVOCATION_FLAGS.INVOCATION_FLAGS_NO_INVOKE | INVOCATION_FLAGS.INVOCATION_FLAGS_CONTAINS_STACK_POINTERS)) != 0)
+                ThrowNoInvokeException();
+
+            // check basic method consistency. This call will throw if there are problems in the target/method relationship
+            CheckConsistency(obj);
+
+            Signature sig = Signature;
+            int actualCount = (parameters != null) ? parameters.Length : 0;
+            if (sig.Arguments.Length != actualCount)
+                throw new TargetParameterCountException(SR.Arg_ParmCnt);
+
             StackAllocedArguments stackArgs = default; // try to avoid intermediate array allocation if possible
-            Span<object?> arguments = InvokeArgumentsCheck(ref stackArgs, obj, invokeAttr, binder, parameters, culture);
+            Span<object?> arguments = default;
+            if (actualCount != 0)
+            {
+                arguments = CheckArguments(ref stackArgs, parameters!, binder, invokeAttr, culture, sig);
+            }
 
             bool wrapExceptions = (invokeAttr & BindingFlags.DoNotWrapExceptions) == 0;
             object? retValue = RuntimeMethodHandle.InvokeMethod(obj, arguments, Signature, false, wrapExceptions);
@@ -426,34 +444,30 @@ namespace System.Reflection
 
         [DebuggerStepThroughAttribute]
         [Diagnostics.DebuggerHidden]
-        private Span<object?> InvokeArgumentsCheck(ref StackAllocedArguments stackArgs, object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture)
+        internal object? InvokeOneParameter(object? obj, BindingFlags invokeAttr, Binder? binder, object? parameter, CultureInfo? culture)
         {
-            Signature sig = Signature;
-
-            // get the signature
-            int formalCount = sig.Arguments.Length;
-            int actualCount = (parameters != null) ? parameters.Length : 0;
-
-            INVOCATION_FLAGS invocationFlags = InvocationFlags;
-
             // INVOCATION_FLAGS_CONTAINS_STACK_POINTERS means that the struct (either the declaring type or the return type)
             // contains pointers that point to the stack. This is either a ByRef or a TypedReference. These structs cannot
             // be boxed and thus cannot be invoked through reflection which only deals with boxed value type objects.
-            if ((invocationFlags & (INVOCATION_FLAGS.INVOCATION_FLAGS_NO_INVOKE | INVOCATION_FLAGS.INVOCATION_FLAGS_CONTAINS_STACK_POINTERS)) != 0)
+            if ((InvocationFlags & (INVOCATION_FLAGS.INVOCATION_FLAGS_NO_INVOKE | INVOCATION_FLAGS.INVOCATION_FLAGS_CONTAINS_STACK_POINTERS)) != 0)
+            {
                 ThrowNoInvokeException();
+            }
 
             // check basic method consistency. This call will throw if there are problems in the target/method relationship
             CheckConsistency(obj);
 
-            if (formalCount != actualCount)
-                throw new TargetParameterCountException(SR.Arg_ParmCnt);
-
-            Span<object?> retVal = default;
-            if (actualCount != 0)
+            Signature sig = Signature;
+            if (sig.Arguments.Length != 1)
             {
-                retVal = CheckArguments(ref stackArgs, parameters!, binder, invokeAttr, culture, sig);
+                throw new TargetParameterCountException(SR.Arg_ParmCnt);
             }
-            return retVal;
+
+            StackAllocedArguments stackArgs = default;
+            Span<object?> arguments = CheckArguments(ref stackArgs, new ReadOnlySpan<object?>(ref parameter, 1), binder, invokeAttr, culture, sig);
+
+            bool wrapExceptions = (invokeAttr & BindingFlags.DoNotWrapExceptions) == 0;
+            return RuntimeMethodHandle.InvokeMethod(obj, arguments, Signature, constructor: false, wrapExceptions);
         }
 
         #endregion

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
@@ -239,7 +239,7 @@ namespace System.Reflection
 
         public override Type PropertyType => Signature.ReturnType;
 
-        public override MethodInfo? GetGetMethod(bool nonPublic)
+        public override RuntimeMethodInfo? GetGetMethod(bool nonPublic)
         {
             if (!Associates.IncludeAccessor(m_getterMethod, nonPublic))
                 return null;
@@ -247,7 +247,7 @@ namespace System.Reflection
             return m_getterMethod;
         }
 
-        public override MethodInfo? GetSetMethod(bool nonPublic)
+        public override RuntimeMethodInfo? GetSetMethod(bool nonPublic)
         {
             if (!Associates.IncludeAccessor(m_setterMethod, nonPublic))
                 return null;
@@ -282,7 +282,7 @@ namespace System.Reflection
                 ParameterInfo[]? methParams = null;
 
                 // First try to get the Get method.
-                MethodInfo? m = GetGetMethod(true);
+                RuntimeMethodInfo? m = GetGetMethod(true);
                 if (m != null)
                 {
                     // There is a Get method so use it.
@@ -337,7 +337,7 @@ namespace System.Reflection
         [Diagnostics.DebuggerHidden]
         public override object? GetValue(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? index, CultureInfo? culture)
         {
-            MethodInfo? m = GetGetMethod(true);
+            RuntimeMethodInfo? m = GetGetMethod(true);
             if (m == null)
                 throw new ArgumentException(System.SR.Arg_GetMethNotFnd);
             return m.Invoke(obj, invokeAttr, binder, index, null);
@@ -359,28 +359,26 @@ namespace System.Reflection
         [Diagnostics.DebuggerHidden]
         public override void SetValue(object? obj, object? value, BindingFlags invokeAttr, Binder? binder, object?[]? index, CultureInfo? culture)
         {
-            MethodInfo? m = GetSetMethod(true);
+            RuntimeMethodInfo? m = GetSetMethod(true);
 
             if (m == null)
                 throw new ArgumentException(System.SR.Arg_SetMethNotFnd);
 
-            object?[] args;
-            if (index != null)
+            if (index is null)
             {
-                args = new object[index.Length + 1];
+                m.InvokeOneParameter(obj, invokeAttr, binder, value, culture);
+            }
+            else
+            {
+                var args = new object?[index.Length + 1];
 
                 for (int i = 0; i < index.Length; i++)
                     args[i] = index[i];
 
                 args[index.Length] = value;
-            }
-            else
-            {
-                args = new object[1];
-                args[0] = value;
-            }
 
-            m.Invoke(obj, invokeAttr, binder, args, culture);
+                m.Invoke(obj, invokeAttr, binder, args, culture);
+            }
         }
         #endregion
 


### PR DESCRIPTION
P0Set (setting the value of a non-indexer property) below is the benchmark being targeted here.

| Method |         Toolchain |      Mean |    Error |   StdDev | Ratio | RatioSD | Allocated |
|------- |------------------ |----------:|---------:|---------:|------:|--------:|----------:|
|     M0 | \main\corerun.exe |  55.14 ns | 0.473 ns | 0.395 ns |  1.00 |    0.00 |         - |
|     M0 |   \pr\corerun.exe |  51.56 ns | 0.207 ns | 0.173 ns |  0.94 |    0.01 |         - |
|        |                   |           |          |          |       |         |           |
|     M1 | \main\corerun.exe |  90.90 ns | 0.871 ns | 0.814 ns |  1.00 |    0.00 |      32 B |
|     M1 |   \pr\corerun.exe |  89.37 ns | 0.774 ns | 0.646 ns |  0.98 |    0.01 |      32 B |
|        |                   |           |          |          |       |         |           |
|     R1 | \main\corerun.exe |  84.12 ns | 1.535 ns | 1.508 ns |  1.00 |    0.00 |      24 B |
|     R1 |   \pr\corerun.exe |  79.19 ns | 1.293 ns | 1.209 ns |  0.94 |    0.02 |      24 B |
|        |                   |           |          |          |       |         |           |
|  P0Get | \main\corerun.exe |  85.63 ns | 0.598 ns | 0.467 ns |  1.00 |    0.00 |      24 B |
|  P0Get |   \pr\corerun.exe |  80.86 ns | 0.583 ns | 0.455 ns |  0.94 |    0.01 |      24 B |
|        |                   |           |          |          |       |         |           |
|  P0Set | \main\corerun.exe | 106.69 ns | 0.938 ns | 0.877 ns |  1.00 |    0.00 |      56 B |
|  P0Set |   \pr\corerun.exe |  94.36 ns | 0.765 ns | 0.716 ns |  0.88 |    0.01 |      24 B |
|        |                   |           |          |          |       |         |           |
|  P1Get | \main\corerun.exe | 125.07 ns | 2.057 ns | 1.924 ns |  1.00 |    0.00 |      24 B |
|  P1Get |   \pr\corerun.exe | 120.76 ns | 0.603 ns | 0.471 ns |  0.97 |    0.02 |      24 B |
|        |                   |           |          |          |       |         |           |
|  P1Set | \main\corerun.exe | 143.11 ns | 1.282 ns | 1.136 ns |  1.00 |    0.00 |      64 B |
|  P1Set |   \pr\corerun.exe | 138.71 ns | 1.036 ns | 0.969 ns |  0.97 |    0.01 |      64 B |

```
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System;
using System.Reflection;

[MemoryDiagnoser]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssemblies(new[] { typeof(Program).Assembly }).Run(args);

    private MethodInfo _m0 = typeof(Program).GetMethod("Method0");
    private MethodInfo _m1 = typeof(Program).GetMethod("Method1");
    private MethodInfo _r1 = typeof(Program).GetMethod("Return1");
    private PropertyInfo _p0 = typeof(Program).GetProperty("Prop0");
    private PropertyInfo _p1 = typeof(Program).GetProperty("Item");
    private object[] _index = new object[] { 0 };

    [Benchmark] public void M0() => _m0.Invoke(this, Array.Empty<object>());
    [Benchmark] public void M1() => _m1.Invoke(this, new string[1] { "" });
    [Benchmark] public int R1() => (int)_r1.Invoke(this, Array.Empty<object>());
    [Benchmark] public int P0Get() => (int)_p0.GetValue(this);
    [Benchmark] public void P0Set() => _p0.SetValue(this, 42);
    [Benchmark] public int P1Get() => (int)_p1.GetValue(this, _index);
    [Benchmark] public void P1Set() => _p1.SetValue(this, 42, _index);

    public void Method0() { }
    public int Return1() => 42;
    public void Method1(string s) { }

    public int Prop0
    {
        get => 42;
        set { }
    }

    public int this[int index]
    {
        get => 42;
        set { }
    }
}
```