### PR TITLE
Print indices of assertions instead of raw bitsets

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -558,7 +558,7 @@ void Compiler::optAssertionInit(bool isLocalProp)
 }
 
 #ifdef DEBUG
-void Compiler::optPrintAssertion(AssertionDsc* curAssertion, AssertionIndex assertionIndex /* =0 */)
+void Compiler::optPrintAssertion(AssertionDsc* curAssertion, AssertionIndex assertionIndex /* = 0 */)
 {
     if (curAssertion->op1.kind == O1K_EXACT_TYPE)
     {
@@ -778,12 +778,67 @@ void Compiler::optPrintAssertion(AssertionDsc* curAssertion, AssertionIndex asse
 
     if (assertionIndex > 0)
     {
-        printf(" index=#%02u, mask=", assertionIndex);
-        printf("%s", BitVecOps::ToString(apTraits, BitVecOps::MakeSingleton(apTraits, assertionIndex - 1)));
+        printf(", index = ");
+        optPrintAssertionIndex(assertionIndex);
     }
     printf("\n");
 }
+
+void Compiler::optPrintAssertionIndex(AssertionIndex index)
+{
+    if (index == NO_ASSERTION_INDEX)
+    {
+        printf("#NA");
+        return;
+    }
+
+    printf("#%02u", index);
+}
+
+void Compiler::optPrintAssertionIndices(ASSERT_TP assertions)
+{
+    if (BitVecOps::IsEmpty(apTraits, assertions))
+    {
+        optPrintAssertionIndex(NO_ASSERTION_INDEX);
+        return;
+    }
+
+    BitVecOps::Iter iter(apTraits, assertions);
+    unsigned        bitIndex = 0;
+    if (iter.NextElem(&bitIndex))
+    {
+        optPrintAssertionIndex(static_cast<AssertionIndex>(bitIndex + 1));
+        while (iter.NextElem(&bitIndex))
+        {
+            printf(" ");
+            optPrintAssertionIndex(static_cast<AssertionIndex>(bitIndex + 1));
+        }
+    }
+}
 #endif // DEBUG
+
+/* static */
+void Compiler::optDumpAssertionIndices(const char* header, ASSERT_TP assertions, const char* footer /* = nullptr */ )
+{
+#ifdef DEBUG
+    Compiler* compiler = JitTls::GetCompiler();
+    if (compiler->verbose)
+    {
+        printf(header);
+        compiler->optPrintAssertionIndices(assertions);
+        if (footer != nullptr)
+        {
+            printf(footer);
+        }
+    }
+#endif // DEBUG
+}
+
+/* static */
+void Compiler::optDumpAssertionIndices(ASSERT_TP assertions, const char* footer /* = nullptr */ )
+{
+    optDumpAssertionIndices("", assertions, footer);
+}
 
 /******************************************************************************
  *

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -590,10 +590,6 @@ void Compiler::optPrintAssertion(AssertionDsc* curAssertion, AssertionIndex asse
         printf("?assertion classification? ");
     }
     printf("Assertion: ");
-    if (!optLocalAssertionProp)
-    {
-        printf("(%d, %d) ", curAssertion->op1.vn, curAssertion->op2.vn);
-    }
 
     if (!optLocalAssertionProp)
     {

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5487,15 +5487,14 @@ void Compiler::optAssertionPropMain()
     {
         for (BasicBlock* const block : Blocks())
         {
-            printf(FMT_BB " ", block->bbNum);
-            optDumpAssertionIndices("in = ", block->bbAssertionIn, "; ");
-            optDumpAssertionIndices("out = ", block->bbAssertionOut);
+            printf(FMT_BB ":\n", block->bbNum);
+            optDumpAssertionIndices(" in   = ", block->bbAssertionIn, "\n");
+            optDumpAssertionIndices(" out  = ", block->bbAssertionOut, "\n");
             if (block->bbJumpKind == BBJ_COND)
             {
-                printf(" => " FMT_BB " ", block->bbJumpDest->bbNum);
-                optDumpAssertionIndices("out = ", bbJtrueAssertionOut[block->bbNum]);
+                printf(" " FMT_BB " = ", block->bbJumpDest->bbNum);
+                optDumpAssertionIndices(bbJtrueAssertionOut[block->bbNum], "\n");
             }
-            printf("\n");
         }
         printf("\n");
     }

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7491,9 +7491,14 @@ public:
 
 #ifdef DEBUG
     void optPrintAssertion(AssertionDsc* newAssertion, AssertionIndex assertionIndex = 0);
+    void optPrintAssertionIndex(AssertionIndex index);
+    void optPrintAssertionIndices(ASSERT_TP assertions);
     void optDebugCheckAssertion(AssertionDsc* assertion);
     void optDebugCheckAssertions(AssertionIndex AssertionIndex);
 #endif
+    static void optDumpAssertionIndices(const char* header, ASSERT_TP assertions, const char* footer = nullptr);
+    static void optDumpAssertionIndices(ASSERT_TP assertions, const char* footer = nullptr);
+
     void optAddCopies();
 #endif // ASSERTION_PROP
 

--- a/src/coreclr/jit/copyprop.cpp
+++ b/src/coreclr/jit/copyprop.cpp
@@ -270,9 +270,9 @@ void Compiler::optCopyProp(BasicBlock* block, Statement* stmt, GenTree* tree, Lc
         {
             JITDUMP("VN based copy assertion for ");
             printTreeID(tree);
-            printf(" V%02d @%08X by ", lclNum, tree->GetVN(VNK_Conservative));
+            printf(" V%02d " FMT_VN " by ", lclNum, tree->GetVN(VNK_Conservative));
             printTreeID(op);
-            printf(" V%02d @%08X.\n", newLclNum, op->GetVN(VNK_Conservative));
+            printf(" V%02d " FMT_VN ".\n", newLclNum, op->GetVN(VNK_Conservative));
             gtDispTree(tree, nullptr, nullptr, true);
         }
 #endif

--- a/src/coreclr/jit/jit.h
+++ b/src/coreclr/jit/jit.h
@@ -487,6 +487,11 @@ const bool dspGCtbls = true;
         if (JitTls::GetCompiler()->verbose)                                                                            \
             logf(__VA_ARGS__);                                                                                         \
     }
+#define JITDUMPEXEC(x)                                                                                                 \
+    {                                                                                                                  \
+        if (JitTls::GetCompiler()->verbose)                                                                            \
+            x;                                                                                                         \
+    }
 #define JITLOG(x)                                                                                                      \
     {                                                                                                                  \
         JitLogEE x;                                                                                                    \
@@ -521,6 +526,7 @@ const bool dspGCtbls = true;
 #define VERBOSE JitTls::GetCompiler()->verbose
 #else // !DEBUG
 #define JITDUMP(...)
+#define JITDUMPEXEC(x)
 #define JITLOG(x)
 #define JITLOG_THIS(t, x)
 #define DBEXEC(flg, expr)

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -865,16 +865,16 @@ void RangeCheck::MergeAssertion(BasicBlock* block, GenTree* op, Range* pRange DE
         if (pred->bbFallsThrough() && pred->bbNext == block)
         {
             assertions = pred->bbAssertionOut;
-            JITDUMP("Merge assertions from pred " FMT_BB " edge: %s\n", pred->bbNum,
-                    BitVecOps::ToString(m_pCompiler->apTraits, assertions));
+            JITDUMP("Merge assertions from pred " FMT_BB " edge: ", pred->bbNum);
+            Compiler::optDumpAssertionIndices(assertions, "\n");
         }
         else if ((pred->bbJumpKind == BBJ_COND || pred->bbJumpKind == BBJ_ALWAYS) && pred->bbJumpDest == block)
         {
             if (m_pCompiler->bbJtrueAssertionOut != nullptr)
             {
                 assertions = m_pCompiler->bbJtrueAssertionOut[pred->bbNum];
-                JITDUMP("Merge assertions from pred " FMT_BB " JTrue edge: %s\n", pred->bbNum,
-                        BitVecOps::ToString(m_pCompiler->apTraits, assertions));
+                JITDUMP("Merge assertions from pred " FMT_BB " JTrue edge: ", pred->bbNum);
+                Compiler::optDumpAssertionIndices(assertions, "\n");
             }
         }
     }
@@ -1012,9 +1012,10 @@ Range RangeCheck::ComputeRangeForLocalDef(BasicBlock*          block,
     Range range = GetRange(ssaDef->GetBlock(), ssaDef->GetAssignment()->gtGetOp2(), monIncreasing DEBUGARG(indent));
     if (!BitVecOps::MayBeUninit(block->bbAssertionIn) && (m_pCompiler->GetAssertionCount() > 0))
     {
-        JITDUMP("Merge assertions from " FMT_BB ":%s for assignment about [%06d]\n", block->bbNum,
-                BitVecOps::ToString(m_pCompiler->apTraits, block->bbAssertionIn),
-                Compiler::dspTreeID(ssaDef->GetAssignment()->gtGetOp1()));
+        JITDUMP("Merge assertions from " FMT_BB ": ", block->bbNum);
+        Compiler::optDumpAssertionIndices(block->bbAssertionIn, " ");
+        JITDUMP("for assignment about [%06d]\n", Compiler::dspTreeID(ssaDef->GetAssignment()->gtGetOp1()))
+
         MergeEdgeAssertions(ssaDef->GetAssignment()->gtGetOp1()->AsLclVarCommon(), block->bbAssertionIn, &range);
         JITDUMP("done merging\n");
     }


### PR DESCRIPTION
This is to improve the experience of reading assertion propagation dumps.

Before:
```scala
GenTreeNode creates assertion:
N004 (  5,  5) [000017] ------------              *  JTRUE     void  
In BB04 New Global Constant Assertion: (337, 64) ($151,$40) Oper_Bnd { {ADD($46, $1c1)} LT  {ARR_LENGTH($80)}ADD {IntCns -1}} is  {IntCns 0} index=#08, mask=0000000000000080
BB01 valueGen = 0000000000000005 => BB03 valueGen = 0000000000000003,
BB02 valueGen = 0000000000000000
BB03 valueGen = 0000000000000010 => BB05 valueGen = 0000000000000008,
BB06 valueGen = 0000000000000000
BB04 valueGen = 00000000000000A0 => BB04 valueGen = 0000000000000060,
BB05 valueGen = 0000000000000000
AssertionPropCallback::StartMerge: BB01 in -> 0000000000000000
AssertionPropCallback::EndMerge  : BB01 in -> 0000000000000000
```
After:
```scala
GenTreeNode creates assertion:
N004 (  5,  5) [000017] ------------              *  JTRUE     void  
In BB04 New Global Constant Assertion: ($151,$40) Oper_Bnd { {ADD($46, $1c1)} LT  {ARR_LENGTH($80)}ADD {IntCns -1}} is  {IntCns 0}, index = #08

BB01 valueGen = #01 #03 => BB03 valueGen = #01 #02
BB02 valueGen = #NA
BB03 valueGen = #05 => BB05 valueGen = #04
BB06 valueGen = #NA
BB04 valueGen = #06 #08 => BB04 valueGen = #06 #07
BB05 valueGen = #NA

AssertionPropFlowCallback:

StartMerge: BB01 in -> #NA
EndMerge  : BB01 in -> #NA
```

Before:
```scala
AssertionPropCallback::StartMerge: BB02 in -> 00000000000000FF
AssertionPropCallback::Merge     : BB02 in -> 00000000000000FF, predBlock BB01 out -> 0000000000000005
AssertionPropCallback::EndMerge  : BB02 in -> 0000000000000005

AssertionPropCallback::Changed   : BB02 before out -> 00000000000000FF; after out -> 0000000000000005;
		jumpDest before out -> 00000000000000FF; jumpDest after out -> 0000000000000005;
```
After
```scala
StartMerge: BB02 in -> #01 #02 #03 #04 #05 #06 #07 #08
Merge     : BB02 in -> #01 #02 #03 #04 #05 #06 #07 #08; pred BB01 out -> #01 #03
EndMerge  : BB02 in -> #01 #03

Changed   : BB02 before out -> #01 #02 #03 #04 #05 #06 #07 #08; after out -> #01 #03;
        jumpDest before out -> #01 #02 #03 #04 #05 #06 #07 #08; jumpDest after out -> #01 #03;
```

Before:
```scala
BB01 valueIn  = 0000000000000000 valueOut = 0000000000000005 => BB03 valueOut= 0000000000000003
BB02 valueIn  = 0000000000000005 valueOut = 0000000000000005
BB03 valueIn  = 0000000000000003 valueOut = 0000000000000013 => BB05 valueOut= 000000000000000B
BB06 valueIn  = 0000000000000013 valueOut = 0000000000000013
BB04 valueIn  = 0000000000000013 valueOut = 00000000000000B3 => BB04 valueOut= 0000000000000073
BB05 valueIn  = 0000000000000003 valueOut = 0000000000000003
```
After:
```scala
BB01 in = #NA; out = #01 #03 => BB03 out = #01 #02
BB02 in = #01 #03; out = #01 #03
BB03 in = #01 #02; out = #01 #02 #05 => BB05 out = #01 #02 #04
BB06 in = #01 #02 #05; out = #01 #02 #05
BB04 in = #01 #02 #05; out = #01 #02 #05 #06 #08 => BB04 out = #01 #02 #05 #06 #07
BB05 in = #01 #02; out = #01 #02
```
(This part I am unsure about - would it be worth it to increase the vertical size of the dump to align `in`s with `out`s?)

Before:
```scala
Propagating 0000000000000013 assertions for BB04, stmt STMT00004, tree [000020], tree -> 0
Propagating 0000000000000013 assertions for BB04, stmt STMT00004, tree [000082], tree -> 0
Propagating 0000000000000013 assertions for BB04, stmt STMT00004, tree [000037], tree -> 6
Propagating 0000000000000033 assertions for BB04, stmt STMT00004, tree [000034], tree -> 0
Propagating 0000000000000033 assertions for BB04, stmt STMT00004, tree [000035], tree -> 0
```
After:
```scala
Propagating #01 #02 #05 for BB04, stmt STMT00004, tree [000020], tree -> #NA
Propagating #01 #02 #05 for BB04, stmt STMT00004, tree [000082], tree -> #NA
Propagating #01 #02 #05 for BB04, stmt STMT00004, tree [000037], tree -> #06
Propagating #01 #02 #05 #06 for BB04, stmt STMT00004, tree [000034], tree -> #NA
Propagating #01 #02 #05 #06 for BB04, stmt STMT00004, tree [000035], tree -> #NA
```

Before:
```scala
Merging assertions from pred edges of BB04 for op [000066] $ffffffff
Merge assertions from pred BB04 JTrue edge: 0000000000000073
Constant Assertion: (337, 64) ($151,$40) Oper_Bnd { {ADD($46, $1c1)} LT  {ARR_LENGTH($80)}ADD {IntCns -1}} is not  {IntCns 0} index=#07, mask=0000000000000040
The range after edge merging:<Dependent, $c0 + -2>
```
After:
```scala
Merging assertions from pred edges of BB04 for op [000066] $ffffffff
Merge assertions from pred BB04 JTrue edge: #01 #02 #05 #06 #07
Constant Assertion: ($151,$40) Oper_Bnd { {ADD($46, $1c1)} LT  {ARR_LENGTH($80)}ADD {IntCns -1}} is not  {IntCns 0}, index = #07
The range after edge merging:<Dependent, $c0 + -2>
```

The downside to this style of printing is the horizontal size of the dump increases when working with methods that have a large number of assertions. I think it is worth it.

Naturally, no diffs for this change.