### PR TITLE
Add `-metrics` argument to superpmi.py asmdiffs

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -311,6 +311,7 @@ asm_diff_parser.add_argument("--gcinfo", action="store_true", help="Include GC i
 asm_diff_parser.add_argument("-base_jit_option", action="append", help="Option to pass to the baseline JIT. Format is key=value, where key is the option name without leading COMPlus_...")
 asm_diff_parser.add_argument("-diff_jit_option", action="append", help="Option to pass to the diff JIT. Format is key=value, where key is the option name without leading COMPlus_...")
 asm_diff_parser.add_argument("-tag", help="Specify a word to add to the directory name where the asm diffs will be placed")
+asm_diff_parser.add_argument("-metrics", action="append", help="Metrics option to pass to jit-analyze. Can be specified multiple times, or pass comma-separated values.")
 
 # subparser for upload
 upload_parser = subparsers.add_parser("upload", description=upload_description, parents=[core_root_parser, target_parser])
@@ -1970,6 +1971,8 @@ class SuperPMIReplayAsmDiffs:
                                 summary_file_info = ( mch_file, md_summary_file )
                                 all_md_summary_files.append(summary_file_info)
                                 command = [ jit_analyze_path, "--md", md_summary_file, "-r", "--base", base_asm_location, "--diff", diff_asm_location ]
+                                if self.coreclr_args.metrics:
+                                    command += [ "--metrics", ",".join(self.coreclr_args.metrics) ]
                                 run_and_log(command, logging.INFO)
                                 ran_jit_analyze = True
 
@@ -3652,6 +3655,11 @@ def setup_args(args):
                             lambda unused: True,
                             "Unable to set tag.",
                             modify_arg=lambda arg: make_safe_filename(arg) if arg is not None else arg)
+
+        coreclr_args.verify(args,
+                            "metrics",
+                            lambda unused: True,
+                            "Unable to set metrics.")
 
         process_base_jit_path_arg(coreclr_args)
 


### PR DESCRIPTION
All the passed metrics are passed through to the `--metrics` argument to jit-analyze.

E.g.,
```
superpmi.py asmdiffs -metrics PerfScore
superpmi.py asmdiffs -metrics CodeSize,PerfScore
superpmi.py asmdiffs -metrics CodeSize -metrics PerfScore
superpmi.py asmdiffs -metrics CodeSize,PrologSize -metrics PerfScore
```