### PR TITLE
Preserve necessary type and method

### DIFF
--- a/eng/testing/ILLink.Descriptor.xunit.xml
+++ b/eng/testing/ILLink.Descriptor.xunit.xml
@@ -15,5 +15,13 @@
     <namespace fullname="Xunit" />
     <namespace fullname="Xunit.Sdk" />
   </assembly>
+  <assembly fullname="xunit.assert">
+    <type fullname="Xunit.Sdk.AssertEqualityComparer`1">
+      <method signature="System.Boolean CompareTypedSets(System.Collections.IEnumerable,System.Collections.IEnumerable)" />
+    </type>
+  </assembly>
+  <assembly fullname="System.Runtime.InteropServices">
+    <type fullname="System.Runtime.InteropServices.IDispatchImplAttribute" />
+  </assembly>
   <assembly fullname="xunit.runner.utility.netcoreapp10" />
 </linker>

--- a/eng/testing/ILLink.Descriptor.xunit.xml
+++ b/eng/testing/ILLink.Descriptor.xunit.xml
@@ -20,8 +20,5 @@
       <method signature="System.Boolean CompareTypedSets(System.Collections.IEnumerable,System.Collections.IEnumerable)" />
     </type>
   </assembly>
-  <assembly fullname="System.Runtime.InteropServices">
-    <type fullname="System.Runtime.InteropServices.IDispatchImplAttribute" />
-  </assembly>
   <assembly fullname="xunit.runner.utility.netcoreapp10" />
 </linker>

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
@@ -1501,7 +1501,6 @@ namespace System.Net.Http.Tests
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/53647", TestPlatforms.Browser)]
         [Fact]
         public void NonValidated_ValidAndInvalidValues_DictionaryMembersWork()
         {

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslCompiledTransform.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslCompiledTransform.cs
@@ -3002,7 +3002,6 @@ namespace System.Xml.Tests
         }
 
         //[Variation("Pass XmlUrlResolver, load style sheet with document function, should resolve during transform", Param = "xmlResolver_document_function.txt")]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/51911", typeof(PlatformDetection), nameof(PlatformDetection.IsBuiltWithAggressiveTrimming), nameof(PlatformDetection.IsBrowser))]
         [InlineData("xmlResolver_document_function.txt", XslInputType.Reader, ReaderType.XmlValidatingReader)]
         [InlineData("xmlResolver_document_function.txt", XslInputType.URI, ReaderType.XmlValidatingReader)]
         [InlineData("xmlResolver_document_function.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader)]

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/IDispatchImplAttributeTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/IDispatchImplAttributeTests.cs
@@ -8,9 +8,6 @@ namespace System.Runtime.InteropServices.Tests
 {
     public class IDispatchImplAttributeTests
     {
-        private const string TypeName = "System.Runtime.InteropServices.IDispatchImplAttribute";
-        private const string ValueName = "Value";
-
         [Theory]
         [InlineData(-1)]
         [InlineData(0)]
@@ -18,7 +15,7 @@ namespace System.Runtime.InteropServices.Tests
         public void Ctor_ImplTypeShort(short implType)
         {
             Type type = Type.GetType("System.Runtime.InteropServices.IDispatchImplAttribute, System.Runtime.InteropServices");
-            PropertyInfo valueProperty = type.GetProperty(ValueName);
+            PropertyInfo valueProperty = type.GetProperty("Value");
             Assert.NotNull(type);
             Assert.NotNull(valueProperty);
 

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/IDispatchImplAttributeTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/IDispatchImplAttributeTests.cs
@@ -17,7 +17,7 @@ namespace System.Runtime.InteropServices.Tests
         [InlineData(2)]
         public void Ctor_ImplTypeShort(short implType)
         {
-            Type type = typeof(HandleCollector).Assembly.GetType(TypeName);
+            Type type = Type.GetType("System.Runtime.InteropServices.IDispatchImplAttribute, System.Runtime.InteropServices");
             PropertyInfo valueProperty = type.GetProperty(ValueName);
             Assert.NotNull(type);
             Assert.NotNull(valueProperty);

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/IDispatchImplAttributeTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/IDispatchImplAttributeTests.cs
@@ -12,7 +12,6 @@ namespace System.Runtime.InteropServices.Tests
         private const string ValueName = "Value";
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50717", typeof(PlatformDetection), nameof(PlatformDetection.IsBuiltWithAggressiveTrimming), nameof(PlatformDetection.IsBrowser))]
         [InlineData(-1)]
         [InlineData(0)]
         [InlineData(2)]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CollectionTests/CollectionTests.Generic.Write.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CollectionTests/CollectionTests.Generic.Write.cs
@@ -633,7 +633,6 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50721", typeof(PlatformDetection), nameof(PlatformDetection.IsBuiltWithAggressiveTrimming), nameof(PlatformDetection.IsBrowser))]
         public static void WriteHashSetTOfHashSetT()
         {
             HashSet<HashSet<int>> input = new HashSet<HashSet<int>>(new List<HashSet<int>>


### PR DESCRIPTION
Fixes #50721 
For test `System.Text.Json.Serialization.Tests.CollectionTests.WriteHashSetTOfHashSetT`,
the line of code which triggered System.NullReferenceException was https://github.com/xunit/assert.xunit/blob/3e9f13f2fae7ff8f379da0f19f72d56aea2dae46/Sdk/AssertEqualityComparer.cs#L249
Thus, `CompareTypedSets` was the missing method. It is a method of type `Xunit.Sdk.AssertEqualityComparer`, which belongs to assembly `xunit.assert.dll`

Fixes #50717
Rewrite the way of getting the type `System.Runtime.InteropServices.IDispatchImplAttribute`.

Fixes #53647 
Fix for #50721 also fixed this.

Fixes  #51911
Simply enable the tests. Not reproducible anymore.