### PR TITLE
Annotate System.Reflection.Context for nullability

### DIFF
--- a/src/libraries/System.Reflection.Context/ref/System.Reflection.Context.cs
+++ b/src/libraries/System.Reflection.Context/ref/System.Reflection.Context.cs
@@ -11,8 +11,8 @@ namespace System.Reflection.Context
         protected CustomReflectionContext() { }
         protected CustomReflectionContext(System.Reflection.ReflectionContext source) { }
         protected virtual System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> AddProperties(System.Type type) { throw null; }
-        protected System.Reflection.PropertyInfo CreateProperty(System.Type propertyType, string name, System.Func<object, object>? getter, System.Action<object, object>? setter) { throw null; }
-        protected System.Reflection.PropertyInfo CreateProperty(System.Type propertyType, string name, System.Func<object, object>? getter, System.Action<object, object>? setter, System.Collections.Generic.IEnumerable<System.Attribute>? propertyCustomAttributes, System.Collections.Generic.IEnumerable<System.Attribute>? getterCustomAttributes, System.Collections.Generic.IEnumerable<System.Attribute>? setterCustomAttributes) { throw null; }
+        protected System.Reflection.PropertyInfo CreateProperty(System.Type propertyType, string name, System.Func<object, object?>? getter, System.Action<object, object?>? setter) { throw null; }
+        protected System.Reflection.PropertyInfo CreateProperty(System.Type propertyType, string name, System.Func<object, object?>? getter, System.Action<object, object?>? setter, System.Collections.Generic.IEnumerable<System.Attribute>? propertyCustomAttributes, System.Collections.Generic.IEnumerable<System.Attribute>? getterCustomAttributes, System.Collections.Generic.IEnumerable<System.Attribute>? setterCustomAttributes) { throw null; }
         protected virtual System.Collections.Generic.IEnumerable<object> GetCustomAttributes(System.Reflection.MemberInfo member, System.Collections.Generic.IEnumerable<object> declaredAttributes) { throw null; }
         protected virtual System.Collections.Generic.IEnumerable<object> GetCustomAttributes(System.Reflection.ParameterInfo parameter, System.Collections.Generic.IEnumerable<object> declaredAttributes) { throw null; }
         public override System.Reflection.Assembly MapAssembly(System.Reflection.Assembly assembly) { throw null; }

--- a/src/libraries/System.Reflection.Context/src/System.Reflection.Context.csproj
+++ b/src/libraries/System.Reflection.Context/src/System.Reflection.Context.csproj
@@ -6,8 +6,6 @@
 
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>
-    <!-- S.R.Context has a lot nullable warnings that need to be addressed: https://github.com/dotnet/runtime/issues/54596. -->
-    <Nullable Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">annotations</Nullable>
     <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetFramework)' == 'netstandard2.0'">SR.PlatformNotSupported_ReflectionContext</GeneratePlatformNotSupportedAssemblyMessage>
   </PropertyGroup>
 

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/CollectionServices.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/CollectionServices.cs
@@ -12,7 +12,7 @@ namespace System.Reflection.Context
             return Array.Empty<T>();
         }
 
-        public static bool CompareArrays<T>(T[] left, T[] right)
+        public static bool CompareArrays<T>(T[] left, T[] right) where T : notnull
         {
             if (left.Length != right.Length)
                 return false;
@@ -26,7 +26,7 @@ namespace System.Reflection.Context
             return true;
         }
 
-        public static int GetArrayHashCode<T>(T[] array)
+        public static int GetArrayHashCode<T>(T[] array) where T : notnull
         {
             int hashcode = 0;
             foreach (T t in array)

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Custom/AttributeUtils.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Custom/AttributeUtils.cs
@@ -15,7 +15,7 @@ namespace System.Reflection.Context.Custom
             if (!inherit)
                 return CollectionServices.IEnumerableToArray(attributes, attributeFilterType);
 
-            CustomType baseMember = type.BaseType as CustomType;
+            CustomType? baseMember = type.BaseType as CustomType;
 
             if (baseMember == null)
                 return CollectionServices.IEnumerableToArray(attributes, attributeFilterType);
@@ -55,7 +55,7 @@ namespace System.Reflection.Context.Custom
             if (!inherit)
                 return CollectionServices.IEnumerableToArray(attributes, attributeFilterType);
 
-            CustomMethodInfo baseMember = method.GetBaseDefinition() as CustomMethodInfo;
+            CustomMethodInfo? baseMember = method.GetBaseDefinition() as CustomMethodInfo;
 
             if (baseMember == null || baseMember.Equals(method))
                 return CollectionServices.IEnumerableToArray(attributes, attributeFilterType);

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Custom/CustomType.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Custom/CustomType.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Context.Projection;
 using System.Reflection.Context.Virtual;
 
@@ -10,7 +11,7 @@ namespace System.Reflection.Context.Custom
 {
     internal sealed class CustomType : ProjectingType
     {
-        private IEnumerable<PropertyInfo> _newProperties;
+        private IEnumerable<PropertyInfo>? _newProperties;
 
         public CustomType(Type template, CustomReflectionContext context)
             : base(template, context.Projector)
@@ -37,9 +38,9 @@ namespace System.Reflection.Context.Custom
             return AttributeUtils.IsDefined(this, attributeType, inherit);
         }
 
-        public override bool IsInstanceOfType(object o)
+        public override bool IsInstanceOfType([NotNullWhen(true)] object? o)
         {
-            Type objectType = ReflectionContext.GetTypeForObject(o);
+            Type objectType = ReflectionContext.GetTypeForObject(o!);
             return IsAssignableFrom(objectType);
         }
 
@@ -64,7 +65,7 @@ namespace System.Reflection.Context.Custom
             // adding new properties declared on base types
             if (!getDeclaredOnly)
             {
-                CustomType baseType = BaseType as CustomType;
+                CustomType? baseType = BaseType as CustomType;
                 while (baseType != null)
                 {
                     IEnumerable<PropertyInfo> newProperties = baseType.NewProperties;
@@ -81,9 +82,9 @@ namespace System.Reflection.Context.Custom
             return results.ToArray();
         }
 
-        protected override PropertyInfo GetPropertyImpl(string name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types, ParameterModifier[] modifiers)
+        protected override PropertyInfo? GetPropertyImpl(string name, BindingFlags bindingAttr, Binder? binder, Type? returnType, Type[]? types, ParameterModifier[]? modifiers)
         {
-            PropertyInfo property = base.GetPropertyImpl(name, bindingAttr, binder, returnType, types, modifiers);
+            PropertyInfo? property = base.GetPropertyImpl(name, bindingAttr, binder, returnType, types, modifiers);
 
             bool getIgnoreCase = (bindingAttr & BindingFlags.IgnoreCase) == BindingFlags.IgnoreCase;
             bool getDeclaredOnly = (bindingAttr & BindingFlags.DeclaredOnly) == BindingFlags.DeclaredOnly;
@@ -111,7 +112,7 @@ namespace System.Reflection.Context.Custom
 
             StringComparison comparison = getIgnoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 
-            CustomType type = this;
+            CustomType? type = this;
             foreach (PropertyInfo newDeclaredProperty in type.NewProperties)
             {
                 if (string.Equals(newDeclaredProperty.Name, name, comparison))
@@ -163,7 +164,7 @@ namespace System.Reflection.Context.Custom
             // adding new methods declared on base types
             if (!getDeclaredOnly)
             {
-                CustomType baseType = BaseType as CustomType;
+                CustomType? baseType = BaseType as CustomType;
                 while (baseType != null)
                 {
                     // We shouldn't add a base type method directly on a subtype.
@@ -181,9 +182,9 @@ namespace System.Reflection.Context.Custom
             return results.ToArray();
         }
 
-        protected override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
+        protected override MethodInfo? GetMethodImpl(string name, BindingFlags bindingAttr, Binder? binder, CallingConventions callConvention, Type[]? types, ParameterModifier[]? modifiers)
         {
-            MethodInfo method = base.GetMethodImpl(name, bindingAttr, binder, callConvention, types, modifiers);
+            MethodInfo? method = base.GetMethodImpl(name, bindingAttr, binder, callConvention, types, modifiers);
 
             bool getIgnoreCase = (bindingAttr & BindingFlags.IgnoreCase) == BindingFlags.IgnoreCase;
             bool getDeclaredOnly = (bindingAttr & BindingFlags.DeclaredOnly) == BindingFlags.DeclaredOnly;
@@ -226,7 +227,7 @@ namespace System.Reflection.Context.Custom
             {
                 if (string.Equals(newDeclaredProperty.Name, targetPropertyName, comparison))
                 {
-                    MethodInfo accessor = getPropertyGetter ? newDeclaredProperty.GetGetMethod() : newDeclaredProperty.GetSetMethod();
+                    MethodInfo? accessor = getPropertyGetter ? newDeclaredProperty.GetGetMethod() : newDeclaredProperty.GetSetMethod();
                     if (accessor != null)
                         matchingMethods.Add(accessor);
                 }
@@ -235,7 +236,7 @@ namespace System.Reflection.Context.Custom
             // adding new methods declared on base types
             if (!getDeclaredOnly)
             {
-                CustomType baseType = BaseType as CustomType;
+                CustomType? baseType = BaseType as CustomType;
 
                 while (baseType != null)
                 {
@@ -247,7 +248,7 @@ namespace System.Reflection.Context.Custom
                         {
                             PropertyInfo inheritedProperty = new InheritedPropertyInfo(newBaseProperty, this);
 
-                            MethodInfo accessor = getPropertyGetter ? inheritedProperty.GetGetMethod() : inheritedProperty.GetSetMethod();
+                            MethodInfo? accessor = getPropertyGetter ? inheritedProperty.GetGetMethod() : inheritedProperty.GetSetMethod();
                             if (accessor != null)
                                 matchingMethods.Add(accessor);
                         }
@@ -278,7 +279,7 @@ namespace System.Reflection.Context.Custom
                 if (binder == null)
                     binder = Type.DefaultBinder;
 
-                return (MethodInfo)binder.SelectMethod(bindingAttr, matchingMethods.ToArray(), types, modifiers);
+                return (MethodInfo?)binder.SelectMethod(bindingAttr, matchingMethods.ToArray(), types, modifiers);
             }
         }
 

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/CustomReflectionContext.Projector.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/CustomReflectionContext.Projector.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Context.Custom;
 using System.Reflection.Context.Projection;
 
@@ -45,7 +46,8 @@ namespace System.Reflection.Context
                     return value;
             }
 
-            public override TypeInfo ProjectType(Type value)
+            [return: NotNullIfNotNull("value")]
+            public override TypeInfo? ProjectType(Type? value)
             {
                 if (value == null)
                     return null;
@@ -55,7 +57,8 @@ namespace System.Reflection.Context
                 return new CustomType(value, ReflectionContext);
             }
 
-            public override Assembly ProjectAssembly(Assembly value)
+            [return: NotNullIfNotNull("value")]
+            public override Assembly? ProjectAssembly(Assembly? value)
             {
                 if (value == null)
                     return null;
@@ -65,7 +68,8 @@ namespace System.Reflection.Context
                 return new CustomAssembly(value, ReflectionContext);
             }
 
-            public override Module ProjectModule(Module value)
+            [return: NotNullIfNotNull("value")]
+            public override Module? ProjectModule(Module? value)
             {
                 if (value == null)
                     return null;
@@ -75,7 +79,8 @@ namespace System.Reflection.Context
                 return new CustomModule(value, ReflectionContext);
             }
 
-            public override FieldInfo ProjectField(FieldInfo value)
+            [return: NotNullIfNotNull("value")]
+            public override FieldInfo? ProjectField(FieldInfo? value)
             {
                 if (value == null)
                     return null;
@@ -85,7 +90,8 @@ namespace System.Reflection.Context
                 return new CustomFieldInfo(value, ReflectionContext);
             }
 
-            public override EventInfo ProjectEvent(EventInfo value)
+            [return: NotNullIfNotNull("value")]
+            public override EventInfo? ProjectEvent(EventInfo? value)
             {
                 if (value == null)
                     return null;
@@ -95,7 +101,8 @@ namespace System.Reflection.Context
                 return new CustomEventInfo(value, ReflectionContext);
             }
 
-            public override ConstructorInfo ProjectConstructor(ConstructorInfo value)
+            [return: NotNullIfNotNull("value")]
+            public override ConstructorInfo? ProjectConstructor(ConstructorInfo? value)
             {
                 if (value == null)
                     return null;
@@ -105,7 +112,8 @@ namespace System.Reflection.Context
                 return new CustomConstructorInfo(value, ReflectionContext);
             }
 
-            public override MethodInfo ProjectMethod(MethodInfo value)
+            [return: NotNullIfNotNull("value")]
+            public override MethodInfo? ProjectMethod(MethodInfo? value)
             {
                 if (value == null)
                     return null;
@@ -115,23 +123,25 @@ namespace System.Reflection.Context
                 return new CustomMethodInfo(value, ReflectionContext);
             }
 
-            public override MethodBase ProjectMethodBase(MethodBase value)
+            [return: NotNullIfNotNull("value")]
+            public override MethodBase? ProjectMethodBase(MethodBase? value)
             {
                 if (value == null)
                     return null;
 
-                MethodInfo method = value as MethodInfo;
+                MethodInfo? method = value as MethodInfo;
                 if (method != null)
                     return ProjectMethod(method);
 
-                ConstructorInfo constructor = value as ConstructorInfo;
+                ConstructorInfo? constructor = value as ConstructorInfo;
                 if (constructor != null)
                     return ProjectConstructor(constructor);
 
                 throw new InvalidOperationException(SR.Format(SR.InvalidOperation_InvalidMethodType, value.GetType()));
             }
 
-            public override PropertyInfo ProjectProperty(PropertyInfo value)
+            [return: NotNullIfNotNull("value")]
+            public override PropertyInfo? ProjectProperty(PropertyInfo? value)
             {
                 if (value == null)
                     return null;
@@ -141,7 +151,8 @@ namespace System.Reflection.Context
                 return new CustomPropertyInfo(value, ReflectionContext);
             }
 
-            public override ParameterInfo ProjectParameter(ParameterInfo value)
+            [return: NotNullIfNotNull("value")]
+            public override ParameterInfo? ProjectParameter(ParameterInfo? value)
             {
                 if (value == null)
                     return null;
@@ -151,7 +162,8 @@ namespace System.Reflection.Context
                 return new CustomParameterInfo(value, ReflectionContext);
             }
 
-            public override MethodBody ProjectMethodBody(MethodBody value)
+            [return: NotNullIfNotNull("value")]
+            public override MethodBody? ProjectMethodBody(MethodBody? value)
             {
                 if (value == null)
                     return null;
@@ -161,7 +173,8 @@ namespace System.Reflection.Context
                 return new ProjectingMethodBody(value, this);
             }
 
-            public override LocalVariableInfo ProjectLocalVariable(LocalVariableInfo value)
+            [return: NotNullIfNotNull("value")]
+            public override LocalVariableInfo? ProjectLocalVariable(LocalVariableInfo? value)
             {
                 if (value == null)
                     return null;
@@ -171,7 +184,8 @@ namespace System.Reflection.Context
                 return new ProjectingLocalVariableInfo(value, this);
             }
 
-            public override ExceptionHandlingClause ProjectExceptionHandlingClause(ExceptionHandlingClause value)
+            [return: NotNullIfNotNull("value")]
+            public override ExceptionHandlingClause? ProjectExceptionHandlingClause(ExceptionHandlingClause? value)
             {
                 if (value == null)
                     return null;
@@ -181,7 +195,8 @@ namespace System.Reflection.Context
                 return new ProjectingExceptionHandlingClause(value, this);
             }
 
-            public override CustomAttributeData ProjectCustomAttributeData(CustomAttributeData value)
+            [return: NotNullIfNotNull("value")]
+            public override CustomAttributeData? ProjectCustomAttributeData(CustomAttributeData? value)
             {
                 if (value == null)
                     return null;
@@ -191,7 +206,8 @@ namespace System.Reflection.Context
                 return new ProjectingCustomAttributeData(value, this);
             }
 
-            public override ManifestResourceInfo ProjectManifestResource(ManifestResourceInfo value)
+            [return: NotNullIfNotNull("value")]
+            public override ManifestResourceInfo? ProjectManifestResource(ManifestResourceInfo? value)
             {
                 if (value == null)
                     return null;
@@ -201,12 +217,13 @@ namespace System.Reflection.Context
                 return new ProjectingManifestResourceInfo(value, this);
             }
 
-            public override MemberInfo ProjectMember(MemberInfo value)
+            [return: NotNullIfNotNull("value")]
+            public override MemberInfo? ProjectMember(MemberInfo? value)
             {
                 if (value == null)
                     return null;
 
-                MemberInfo output = null;
+                MemberInfo? output;
                 switch (value.MemberType)
                 {
                     case MemberTypes.TypeInfo:
@@ -243,7 +260,7 @@ namespace System.Reflection.Context
 
             public override CustomAttributeTypedArgument ProjectTypedArgument(CustomAttributeTypedArgument value)
             {
-                Type argumentType = ProjectType(value.ArgumentType);
+                Type? argumentType = ProjectType(value.ArgumentType);
 
                 return new CustomAttributeTypedArgument(argumentType, value.Value);
             }

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/CustomReflectionContext.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/CustomReflectionContext.cs
@@ -66,8 +66,8 @@ namespace System.Reflection.Context
         protected PropertyInfo CreateProperty(
             Type propertyType,
             string name,
-            Func<object, object>? getter,
-            Action<object, object>? setter)
+            Func<object, object?>? getter,
+            Action<object, object?>? setter)
         {
             return new VirtualPropertyInfo(
                 name,
@@ -83,8 +83,8 @@ namespace System.Reflection.Context
         protected PropertyInfo CreateProperty(
             Type propertyType,
             string name,
-            Func<object, object>? getter,
-            Action<object, object>? setter,
+            Func<object, object?>? getter,
+            Action<object, object?>? setter,
             IEnumerable<Attribute>? propertyCustomAttributes,
             IEnumerable<Attribute>? getterCustomAttributes,
             IEnumerable<Attribute>? setterCustomAttributes)
@@ -115,7 +115,7 @@ namespace System.Reflection.Context
                 if (prop == null)
                     throw new InvalidOperationException(SR.InvalidOperation_AddNullProperty);
 
-                VirtualPropertyBase vp = prop as VirtualPropertyBase;
+                VirtualPropertyBase? vp = prop as VirtualPropertyBase;
                 if (vp == null || vp.ReflectionContext != this)
                     throw new InvalidOperationException(SR.InvalidOperation_AddPropertyDifferentContext);
 

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Delegation/DelegatingAssembly.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Delegation/DelegatingAssembly.cs
@@ -76,17 +76,17 @@ namespace System.Reflection.Context.Delegation
         [Obsolete]
         [RequiresAssemblyFiles]
 #endif
-        public override string CodeBase
+        public override string? CodeBase
         {
             get { return UnderlyingAssembly.CodeBase; }
         }
 
-        public override object CreateInstance(string typeName, bool ignoreCase, BindingFlags bindingAttr, Binder binder, object[] args, CultureInfo culture, object[] activationAttributes)
+        public override object? CreateInstance(string typeName, bool ignoreCase, BindingFlags bindingAttr, Binder? binder, object[]? args, CultureInfo? culture, object[]? activationAttributes)
         {
             return UnderlyingAssembly.CreateInstance(typeName, ignoreCase, bindingAttr, binder, args, culture, activationAttributes);
         }
 
-        public override MethodInfo EntryPoint
+        public override MethodInfo? EntryPoint
         {
             get { return UnderlyingAssembly.EntryPoint; }
         }
@@ -100,7 +100,7 @@ namespace System.Reflection.Context.Delegation
             get { return UnderlyingAssembly.EscapedCodeBase; }
         }
 
-        public override string FullName
+        public override string? FullName
         {
             get { return UnderlyingAssembly.FullName; }
         }
@@ -112,7 +112,7 @@ namespace System.Reflection.Context.Delegation
 
 #pragma warning disable IL3003 // netstandard2.1 didn't have RequiresAssemblyFiles attributes applied on Assembly
         [RequiresAssemblyFiles(Message = "Calling 'System.Reflection.Assembly.GetFile(string)' will throw for assemblies embedded in a single-file app", Url = "https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/il3001")]
-        public override FileStream GetFile(string name)
+        public override FileStream? GetFile(string name)
         {
             return UnderlyingAssembly.GetFile(name);
         }
@@ -135,7 +135,7 @@ namespace System.Reflection.Context.Delegation
             return UnderlyingAssembly.GetLoadedModules(getResourceModules);
         }
 
-        public override ManifestResourceInfo GetManifestResourceInfo(string resourceName)
+        public override ManifestResourceInfo? GetManifestResourceInfo(string resourceName)
         {
             return UnderlyingAssembly.GetManifestResourceInfo(resourceName);
         }
@@ -145,17 +145,17 @@ namespace System.Reflection.Context.Delegation
             return UnderlyingAssembly.GetManifestResourceNames();
         }
 
-        public override Stream GetManifestResourceStream(string name)
+        public override Stream? GetManifestResourceStream(string name)
         {
             return UnderlyingAssembly.GetManifestResourceStream(name);
         }
 
-        public override Stream GetManifestResourceStream(Type type, string name)
+        public override Stream? GetManifestResourceStream(Type type, string name)
         {
             return UnderlyingAssembly.GetManifestResourceStream(type, name);
         }
 
-        public override Module GetModule(string name)
+        public override Module? GetModule(string name)
         {
             return UnderlyingAssembly.GetModule(name);
         }
@@ -185,12 +185,12 @@ namespace System.Reflection.Context.Delegation
             return UnderlyingAssembly.GetSatelliteAssembly(culture);
         }
 
-        public override Assembly GetSatelliteAssembly(CultureInfo culture, Version version)
+        public override Assembly GetSatelliteAssembly(CultureInfo culture, Version? version)
         {
             return UnderlyingAssembly.GetSatelliteAssembly(culture, version);
         }
 
-        public override Type GetType(string name, bool throwOnError, bool ignoreCase)
+        public override Type? GetType(string name, bool throwOnError, bool ignoreCase)
         {
             return UnderlyingAssembly.GetType(name, throwOnError, ignoreCase);
         }
@@ -223,7 +223,7 @@ namespace System.Reflection.Context.Delegation
             get { return UnderlyingAssembly.IsDynamic; }
         }
 
-        public override Module LoadModule(string moduleName, byte[] rawModule, byte[] rawSymbolStore)
+        public override Module LoadModule(string moduleName, byte[]? rawModule, byte[]? rawSymbolStore)
         {
             return UnderlyingAssembly.LoadModule(moduleName, rawModule, rawSymbolStore);
         }

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Delegation/DelegatingConstructorInfo.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Delegation/DelegatingConstructorInfo.cs
@@ -31,7 +31,7 @@ namespace System.Reflection.Context.Delegation
             get { return UnderlyingConstructor.ContainsGenericParameters; }
         }
 
-        public override Type DeclaringType
+        public override Type? DeclaringType
         {
             get { return UnderlyingConstructor.DeclaringType; }
         }
@@ -81,7 +81,7 @@ namespace System.Reflection.Context.Delegation
             get { return UnderlyingConstructor.Name; }
         }
 
-        public override Type ReflectedType
+        public override Type? ReflectedType
         {
             get { return UnderlyingConstructor.ReflectedType; }
         }
@@ -108,7 +108,7 @@ namespace System.Reflection.Context.Delegation
             return UnderlyingConstructor.GetGenericArguments();
         }
 
-        public override MethodBody GetMethodBody()
+        public override MethodBody? GetMethodBody()
         {
             return UnderlyingConstructor.GetMethodBody();
         }
@@ -123,12 +123,12 @@ namespace System.Reflection.Context.Delegation
             return UnderlyingConstructor.GetParameters();
         }
 
-        public override object Invoke(BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture)
+        public override object Invoke(BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture)
         {
             return UnderlyingConstructor.Invoke(invokeAttr, binder, parameters, culture);
         }
 
-        public override object Invoke(object obj, BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture)
+        public override object? Invoke(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture)
         {
             return UnderlyingConstructor.Invoke(obj, invokeAttr, binder, parameters, culture);
         }
@@ -138,7 +138,7 @@ namespace System.Reflection.Context.Delegation
             return UnderlyingConstructor.IsDefined(attributeType, inherit);
         }
 
-        public override string ToString()
+        public override string? ToString()
         {
             return UnderlyingConstructor.ToString();
         }

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Delegation/DelegatingEventInfo.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Delegation/DelegatingEventInfo.cs
@@ -20,12 +20,12 @@ namespace System.Reflection.Context.Delegation
             get { return UnderlyingEvent.Attributes; }
         }
 
-        public override Type DeclaringType
+        public override Type? DeclaringType
         {
             get { return UnderlyingEvent.DeclaringType; }
         }
 
-        public override Type EventHandlerType
+        public override Type? EventHandlerType
         {
             get { return UnderlyingEvent.EventHandlerType; }
         }
@@ -50,19 +50,19 @@ namespace System.Reflection.Context.Delegation
             get { return UnderlyingEvent.Name; }
         }
 
-        public override Type ReflectedType
+        public override Type? ReflectedType
         {
             get { return UnderlyingEvent.ReflectedType; }
         }
 
         public EventInfo UnderlyingEvent { get; }
 
-        public override void AddEventHandler(object target, Delegate handler)
+        public override void AddEventHandler(object? target, Delegate? handler)
         {
             UnderlyingEvent.AddEventHandler(target, handler);
         }
 
-        public override MethodInfo GetAddMethod(bool nonPublic)
+        public override MethodInfo? GetAddMethod(bool nonPublic)
         {
             return UnderlyingEvent.GetAddMethod(nonPublic);
         }
@@ -72,12 +72,12 @@ namespace System.Reflection.Context.Delegation
             return UnderlyingEvent.GetOtherMethods(nonPublic);
         }
 
-        public override MethodInfo GetRaiseMethod(bool nonPublic)
+        public override MethodInfo? GetRaiseMethod(bool nonPublic)
         {
             return UnderlyingEvent.GetRaiseMethod(nonPublic);
         }
 
-        public override MethodInfo GetRemoveMethod(bool nonPublic)
+        public override MethodInfo? GetRemoveMethod(bool nonPublic)
         {
             return UnderlyingEvent.GetRemoveMethod(nonPublic);
         }
@@ -102,12 +102,12 @@ namespace System.Reflection.Context.Delegation
             return UnderlyingEvent.IsDefined(attributeType, inherit);
         }
 
-        public override void RemoveEventHandler(object target, Delegate handler)
+        public override void RemoveEventHandler(object? target, Delegate? handler)
         {
             UnderlyingEvent.RemoveEventHandler(target, handler);
         }
 
-        public override string ToString()
+        public override string? ToString()
         {
             return UnderlyingEvent.ToString();
         }

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Delegation/DelegatingExceptionHandlingClause.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Delegation/DelegatingExceptionHandlingClause.cs
@@ -16,7 +16,7 @@ namespace System.Reflection.Context.Delegation
             _clause = clause;
         }
 
-        public override Type CatchType
+        public override Type? CatchType
         {
             get { return _clause.CatchType; }
         }

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Delegation/DelegatingFieldInfo.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Delegation/DelegatingFieldInfo.cs
@@ -21,7 +21,7 @@ namespace System.Reflection.Context.Delegation
             get { return UnderlyingField.Attributes; }
         }
 
-        public override Type DeclaringType
+        public override Type? DeclaringType
         {
             get { return UnderlyingField.DeclaringType; }
         }
@@ -66,7 +66,7 @@ namespace System.Reflection.Context.Delegation
             get { return UnderlyingField.Name; }
         }
 
-        public override Type ReflectedType
+        public override Type? ReflectedType
         {
             get { return UnderlyingField.ReflectedType; }
         }
@@ -93,7 +93,7 @@ namespace System.Reflection.Context.Delegation
             return UnderlyingField.GetOptionalCustomModifiers();
         }
 
-        public override object GetRawConstantValue()
+        public override object? GetRawConstantValue()
         {
             return UnderlyingField.GetRawConstantValue();
         }
@@ -103,12 +103,12 @@ namespace System.Reflection.Context.Delegation
             return UnderlyingField.GetRequiredCustomModifiers();
         }
 
-        public override object GetValue(object obj)
+        public override object? GetValue(object? obj)
         {
             return UnderlyingField.GetValue(obj);
         }
 
-        public override object GetValueDirect(TypedReference obj)
+        public override object? GetValueDirect(TypedReference obj)
         {
             return UnderlyingField.GetValueDirect(obj);
         }
@@ -118,7 +118,7 @@ namespace System.Reflection.Context.Delegation
             return UnderlyingField.IsDefined(attributeType, inherit);
         }
 
-        public override void SetValue(object obj, object value, BindingFlags invokeAttr, Binder binder, CultureInfo culture)
+        public override void SetValue(object? obj, object? value, BindingFlags invokeAttr, Binder? binder, CultureInfo? culture)
         {
             UnderlyingField.SetValue(obj, value, invokeAttr, binder, culture);
         }
@@ -128,7 +128,7 @@ namespace System.Reflection.Context.Delegation
             UnderlyingField.SetValueDirect(obj, value);
         }
 
-        public override string ToString()
+        public override string? ToString()
         {
             return UnderlyingField.ToString();
         }

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Delegation/DelegatingMethodBody.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Delegation/DelegatingMethodBody.cs
@@ -42,12 +42,12 @@ namespace System.Reflection.Context.Delegation
             get { return _body.MaxStackSize; }
         }
 
-        public override byte[] GetILAsByteArray()
+        public override byte[]? GetILAsByteArray()
         {
             return _body.GetILAsByteArray();
         }
 
-        public override string ToString()
+        public override string? ToString()
         {
             return _body.ToString();
         }

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Delegation/DelegatingMethodInfo.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Delegation/DelegatingMethodInfo.cs
@@ -32,7 +32,7 @@ namespace System.Reflection.Context.Delegation
             get { return UnderlyingMethod.ContainsGenericParameters; }
         }
 
-        public override Type DeclaringType
+        public override Type? DeclaringType
         {
             get { return UnderlyingMethod.DeclaringType; }
         }
@@ -82,7 +82,7 @@ namespace System.Reflection.Context.Delegation
             get { return UnderlyingMethod.Name; }
         }
 
-        public override Type ReflectedType
+        public override Type? ReflectedType
         {
             get { return UnderlyingMethod.ReflectedType; }
         }
@@ -134,7 +134,7 @@ namespace System.Reflection.Context.Delegation
             return UnderlyingMethod.GetGenericMethodDefinition();
         }
 
-        public override MethodBody GetMethodBody()
+        public override MethodBody? GetMethodBody()
         {
             return UnderlyingMethod.GetMethodBody();
         }
@@ -149,7 +149,7 @@ namespace System.Reflection.Context.Delegation
             return UnderlyingMethod.GetParameters();
         }
 
-        public override object Invoke(object obj, BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture)
+        public override object? Invoke(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture)
         {
             return UnderlyingMethod.Invoke(obj, invokeAttr, binder, parameters, culture);
         }
@@ -169,12 +169,12 @@ namespace System.Reflection.Context.Delegation
             return UnderlyingMethod.CreateDelegate(delegateType);
         }
 
-        public override Delegate CreateDelegate(Type delegateType, object target)
+        public override Delegate CreateDelegate(Type delegateType, object? target)
         {
             return UnderlyingMethod.CreateDelegate(delegateType, target);
         }
 
-        public override string ToString()
+        public override string? ToString()
         {
             return UnderlyingMethod.ToString();
         }

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Delegation/DelegatingModule.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Delegation/DelegatingModule.cs
@@ -52,7 +52,7 @@ namespace System.Reflection.Context.Delegation
             get { return UnderlyingModule.ScopeName; }
         }
 
-        public override Type[] FindTypes(TypeFilter filter, object filterCriteria)
+        public override Type[] FindTypes(TypeFilter? filter, object? filterCriteria)
         {
             return UnderlyingModule.FindTypes(filter, filterCriteria);
         }
@@ -72,7 +72,7 @@ namespace System.Reflection.Context.Delegation
             return UnderlyingModule.GetCustomAttributesData();
         }
 
-        public override FieldInfo GetField(string name, BindingFlags bindingAttr)
+        public override FieldInfo? GetField(string name, BindingFlags bindingAttr)
         {
             return UnderlyingModule.GetField(name, bindingAttr);
         }
@@ -82,7 +82,7 @@ namespace System.Reflection.Context.Delegation
             return UnderlyingModule.GetFields(bindingFlags);
         }
 
-        protected override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
+        protected override MethodInfo? GetMethodImpl(string name, BindingFlags bindingAttr, Binder? binder, CallingConventions callConvention, Type[]? types, ParameterModifier[]? modifiers)
         {
             if (types == null)
             {
@@ -107,7 +107,7 @@ namespace System.Reflection.Context.Delegation
         //    return UnderlyingModule.GetSignerCertificate();
         //}
 
-        public override Type GetType(string className, bool throwOnError, bool ignoreCase)
+        public override Type? GetType(string className, bool throwOnError, bool ignoreCase)
         {
             return UnderlyingModule.GetType(className, throwOnError, ignoreCase);
         }
@@ -127,17 +127,17 @@ namespace System.Reflection.Context.Delegation
             return UnderlyingModule.IsResource();
         }
 
-        public override FieldInfo ResolveField(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments)
+        public override FieldInfo? ResolveField(int metadataToken, Type[]? genericTypeArguments, Type[]? genericMethodArguments)
         {
             return UnderlyingModule.ResolveField(metadataToken, genericTypeArguments, genericMethodArguments);
         }
 
-        public override MemberInfo ResolveMember(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments)
+        public override MemberInfo? ResolveMember(int metadataToken, Type[]? genericTypeArguments, Type[]? genericMethodArguments)
         {
             return UnderlyingModule.ResolveMember(metadataToken, genericTypeArguments, genericMethodArguments);
         }
 
-        public override MethodBase ResolveMethod(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments)
+        public override MethodBase? ResolveMethod(int metadataToken, Type[]? genericTypeArguments, Type[]? genericMethodArguments)
         {
             return UnderlyingModule.ResolveMethod(metadataToken, genericTypeArguments, genericMethodArguments);
         }
@@ -152,7 +152,7 @@ namespace System.Reflection.Context.Delegation
             return UnderlyingModule.ResolveString(metadataToken);
         }
 
-        public override Type ResolveType(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments)
+        public override Type ResolveType(int metadataToken, Type[]? genericTypeArguments, Type[]? genericMethodArguments)
         {
             return UnderlyingModule.ResolveType(metadataToken, genericTypeArguments, genericMethodArguments);
         }

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Delegation/DelegatingParameterInfo.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Delegation/DelegatingParameterInfo.cs
@@ -20,7 +20,7 @@ namespace System.Reflection.Context.Delegation
             get { return UnderlyingParameter.Attributes; }
         }
 
-        public override object DefaultValue
+        public override object? DefaultValue
         {
             get { return UnderlyingParameter.DefaultValue; }
         }
@@ -35,7 +35,7 @@ namespace System.Reflection.Context.Delegation
             get { return UnderlyingParameter.MetadataToken; }
         }
 
-        public override string Name
+        public override string? Name
         {
             get { return UnderlyingParameter.Name; }
         }
@@ -50,7 +50,7 @@ namespace System.Reflection.Context.Delegation
             get { return UnderlyingParameter.Position; }
         }
 
-        public override object RawDefaultValue
+        public override object? RawDefaultValue
         {
             get { return UnderlyingParameter.RawDefaultValue; }
         }

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Delegation/DelegatingPropertyInfo.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Delegation/DelegatingPropertyInfo.cs
@@ -31,7 +31,7 @@ namespace System.Reflection.Context.Delegation
             get { return UnderlyingProperty.CanWrite; }
         }
 
-        public override Type DeclaringType
+        public override Type? DeclaringType
         {
             get { return UnderlyingProperty.DeclaringType; }
         }
@@ -56,7 +56,7 @@ namespace System.Reflection.Context.Delegation
             get { return UnderlyingProperty.PropertyType; }
         }
 
-        public override Type ReflectedType
+        public override Type? ReflectedType
         {
             get { return UnderlyingProperty.ReflectedType; }
         }
@@ -68,7 +68,7 @@ namespace System.Reflection.Context.Delegation
             return UnderlyingProperty.GetAccessors(nonPublic);
         }
 
-        public override MethodInfo GetGetMethod(bool nonPublic)
+        public override MethodInfo? GetGetMethod(bool nonPublic)
         {
             return UnderlyingProperty.GetGetMethod(nonPublic);
         }
@@ -78,27 +78,27 @@ namespace System.Reflection.Context.Delegation
             return UnderlyingProperty.GetIndexParameters();
         }
 
-        public override MethodInfo GetSetMethod(bool nonPublic)
+        public override MethodInfo? GetSetMethod(bool nonPublic)
         {
             return UnderlyingProperty.GetSetMethod(nonPublic);
         }
 
-        public override object GetValue(object obj, object[] index)
+        public override object? GetValue(object? obj, object?[]? index)
         {
             return UnderlyingProperty.GetValue(obj, index);
         }
 
-        public override object GetValue(object obj, BindingFlags invokeAttr, Binder binder, object[] index, CultureInfo culture)
+        public override object? GetValue(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? index, CultureInfo? culture)
         {
             return UnderlyingProperty.GetValue(obj, invokeAttr, binder, index, culture);
         }
 
-        public override void SetValue(object obj, object value, object[] index)
+        public override void SetValue(object? obj, object? value, object?[]? index)
         {
             UnderlyingProperty.SetValue(obj, value, index);
         }
 
-        public override void SetValue(object obj, object value, BindingFlags invokeAttr, Binder binder, object[] index, CultureInfo culture)
+        public override void SetValue(object? obj, object? value, BindingFlags invokeAttr, Binder? binder, object?[]? index, CultureInfo? culture)
         {
             UnderlyingProperty.SetValue(obj, value, invokeAttr, binder, index, culture);
         }
@@ -118,12 +118,12 @@ namespace System.Reflection.Context.Delegation
             return UnderlyingProperty.GetCustomAttributesData();
         }
 
-        public override object GetConstantValue()
+        public override object? GetConstantValue()
         {
             return UnderlyingProperty.GetConstantValue();
         }
 
-        public override object GetRawConstantValue()
+        public override object? GetRawConstantValue()
         {
             return UnderlyingProperty.GetRawConstantValue();
         }
@@ -143,7 +143,7 @@ namespace System.Reflection.Context.Delegation
             return UnderlyingProperty.IsDefined(attributeType, inherit);
         }
 
-        public override string ToString()
+        public override string? ToString()
         {
             return UnderlyingProperty.ToString();
         }

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Delegation/DelegatingType.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Delegation/DelegatingType.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
 
@@ -28,12 +29,12 @@ namespace System.Reflection.Context.Delegation
             get { return _typeInfo.Assembly; }
         }
 
-        public override string AssemblyQualifiedName
+        public override string? AssemblyQualifiedName
         {
             get { return _typeInfo.AssemblyQualifiedName; }
         }
 
-        public override Type BaseType
+        public override Type? BaseType
         {
             get { return _typeInfo.BaseType; }
         }
@@ -48,17 +49,17 @@ namespace System.Reflection.Context.Delegation
             get { return _typeInfo.GenericParameterPosition; }
         }
 
-        public override MethodBase DeclaringMethod
+        public override MethodBase? DeclaringMethod
         {
             get { return _typeInfo.DeclaringMethod; }
         }
 
-        public override Type DeclaringType
+        public override Type? DeclaringType
         {
             get { return _typeInfo.DeclaringType; }
         }
 
-        public override string FullName
+        public override string? FullName
         {
             get { return _typeInfo.FullName; }
         }
@@ -128,17 +129,17 @@ namespace System.Reflection.Context.Delegation
             get { return _typeInfo.Name; }
         }
 
-        public override string Namespace
+        public override string? Namespace
         {
             get { return _typeInfo.Namespace; }
         }
 
-        public override Type ReflectedType
+        public override Type? ReflectedType
         {
             get { return _typeInfo.ReflectedType; }
         }
 
-        public override StructLayoutAttribute StructLayoutAttribute
+        public override StructLayoutAttribute? StructLayoutAttribute
         {
             get { return _typeInfo.StructLayoutAttribute; }
         }
@@ -173,7 +174,7 @@ namespace System.Reflection.Context.Delegation
             return _typeInfo.GetDefaultMembers();
         }
 
-        public override string GetEnumName(object value)
+        public override string? GetEnumName(object value)
         {
             return _typeInfo.GetEnumName(value);
         }
@@ -243,7 +244,7 @@ namespace System.Reflection.Context.Delegation
             return Type.GetTypeCode(_typeInfo);
         }
 
-        public override bool IsAssignableFrom(Type c)
+        public override bool IsAssignableFrom([NotNullWhen(true)] Type? c)
         {
             return _typeInfo.IsAssignableFrom(c);
         }
@@ -263,12 +264,12 @@ namespace System.Reflection.Context.Delegation
             return _typeInfo.IsEnumDefined(value);
         }
 
-        public override bool IsEquivalentTo(Type other)
+        public override bool IsEquivalentTo([NotNullWhen(true)] Type? other)
         {
             return _typeInfo.IsEquivalentTo(other);
         }
 
-        public override bool IsInstanceOfType(object o)
+        public override bool IsInstanceOfType([NotNullWhen(true)] object? o)
         {
             return _typeInfo.IsInstanceOfType(o);
         }
@@ -296,7 +297,7 @@ namespace System.Reflection.Context.Delegation
             return _typeInfo.Attributes;
         }
 
-        protected override ConstructorInfo GetConstructorImpl(BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
+        protected override ConstructorInfo? GetConstructorImpl(BindingFlags bindingAttr, Binder? binder, CallingConventions callConvention, Type[] types, ParameterModifier[]? modifiers)
         {
             return _typeInfo.GetConstructor(bindingAttr, binder, callConvention, types, modifiers);
         }
@@ -306,12 +307,12 @@ namespace System.Reflection.Context.Delegation
             return _typeInfo.GetConstructors(bindingAttr);
         }
 
-        public override Type GetElementType()
+        public override Type? GetElementType()
         {
             return _typeInfo.GetElementType();
         }
 
-        public override EventInfo GetEvent(string name, BindingFlags bindingAttr)
+        public override EventInfo? GetEvent(string name, BindingFlags bindingAttr)
         {
             return _typeInfo.GetEvent(name, bindingAttr);
         }
@@ -321,7 +322,7 @@ namespace System.Reflection.Context.Delegation
             return _typeInfo.GetEvents(bindingAttr);
         }
 
-        public override FieldInfo GetField(string name, BindingFlags bindingAttr)
+        public override FieldInfo? GetField(string name, BindingFlags bindingAttr)
         {
             return _typeInfo.GetField(name, bindingAttr);
         }
@@ -331,7 +332,7 @@ namespace System.Reflection.Context.Delegation
             return _typeInfo.GetFields(bindingAttr);
         }
 
-        public override Type GetInterface(string name, bool ignoreCase)
+        public override Type? GetInterface(string name, bool ignoreCase)
         {
             return _typeInfo.GetInterface(name, ignoreCase);
         }
@@ -346,7 +347,7 @@ namespace System.Reflection.Context.Delegation
             return _typeInfo.GetMembers(bindingAttr);
         }
 
-        protected override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
+        protected override MethodInfo? GetMethodImpl(string name, BindingFlags bindingAttr, Binder? binder, CallingConventions callConvention, Type[]? types, ParameterModifier[]? modifiers)
         {
             // Unfortunately we cannot directly call the protected GetMethodImpl on _typeInfo.
             return (types == null) ?
@@ -359,7 +360,7 @@ namespace System.Reflection.Context.Delegation
             return _typeInfo.GetMethods(bindingAttr);
         }
 
-        public override Type GetNestedType(string name, BindingFlags bindingAttr)
+        public override Type? GetNestedType(string name, BindingFlags bindingAttr)
         {
             return _typeInfo.GetNestedType(name, bindingAttr);
         }
@@ -374,10 +375,10 @@ namespace System.Reflection.Context.Delegation
             return _typeInfo.GetProperties(bindingAttr);
         }
 
-        protected override PropertyInfo GetPropertyImpl(string name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types, ParameterModifier[] modifiers)
+        protected override PropertyInfo? GetPropertyImpl(string name, BindingFlags bindingAttr, Binder? binder, Type? returnType, Type[]? types, ParameterModifier[]? modifiers)
         {
             // Unfortunately we cannot directly call the protected GetPropertyImpl on _typeInfo.
-            PropertyInfo property;
+            PropertyInfo? property;
 
             if (types == null)
             {
@@ -409,7 +410,7 @@ namespace System.Reflection.Context.Delegation
             return _typeInfo.HasElementType;
         }
 
-        public override object InvokeMember(string name, BindingFlags invokeAttr, Binder binder, object target, object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] namedParameters)
+        public override object? InvokeMember(string name, BindingFlags invokeAttr, Binder? binder, object? target, object?[]? args, ParameterModifier[]? modifiers, CultureInfo? culture, string[]? namedParameters)
         {
             return _typeInfo.InvokeMember(name, invokeAttr, binder, target, args, modifiers, culture, namedParameters);
         }

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Projection/ProjectingAssembly.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Projection/ProjectingAssembly.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection.Context.Delegation;
 
@@ -45,7 +46,7 @@ namespace System.Reflection.Context.Projection
             return base.IsDefined(attributeType, inherit);
         }
 
-        public override MethodInfo EntryPoint
+        public override MethodInfo? EntryPoint
         {
             get { return Projector.ProjectMethod(base.EntryPoint); }
         }
@@ -60,12 +61,12 @@ namespace System.Reflection.Context.Projection
             return Projector.Project(base.GetLoadedModules(getResourceModules), Projector.ProjectModule);
         }
 
-        public override ManifestResourceInfo GetManifestResourceInfo(string resourceName)
+        public override ManifestResourceInfo? GetManifestResourceInfo(string resourceName)
         {
             return Projector.ProjectManifestResource(base.GetManifestResourceInfo(resourceName));
         }
 
-        public override Module GetModule(string name)
+        public override Module? GetModule(string name)
         {
             return Projector.ProjectModule(base.GetModule(name));
         }
@@ -80,12 +81,12 @@ namespace System.Reflection.Context.Projection
             return Projector.ProjectAssembly(base.GetSatelliteAssembly(culture));
         }
 
-        public override Assembly GetSatelliteAssembly(CultureInfo culture, Version version)
+        public override Assembly GetSatelliteAssembly(CultureInfo culture, Version? version)
         {
             return Projector.ProjectAssembly(base.GetSatelliteAssembly(culture, version));
         }
 
-        public override Type GetType(string name, bool throwOnError, bool ignoreCase)
+        public override Type? GetType(string name, bool throwOnError, bool ignoreCase)
         {
             return Projector.ProjectType(base.GetType(name, throwOnError, ignoreCase));
         }
@@ -95,16 +96,14 @@ namespace System.Reflection.Context.Projection
             return Projector.Project(base.GetTypes(), Projector.ProjectType);
         }
 
-        public override Module LoadModule(string moduleName, byte[] rawModule, byte[] rawSymbolStore)
+        public override Module LoadModule(string moduleName, byte[]? rawModule, byte[]? rawSymbolStore)
         {
             return Projector.ProjectModule(base.LoadModule(moduleName, rawModule, rawSymbolStore));
         }
 
-        public override bool Equals(object o)
+        public override bool Equals([NotNullWhen(true)] object? o)
         {
-            var other = o as ProjectingAssembly;
-
-            return other != null &&
+            return o is ProjectingAssembly other &&
                    Projector == other.Projector &&
                    UnderlyingAssembly == other.UnderlyingAssembly;
         }

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Projection/ProjectingConstructorInfo.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Projection/ProjectingConstructorInfo.cs
@@ -20,7 +20,7 @@ namespace System.Reflection.Context.Projection
 
         public Projector Projector { get; }
 
-        public override Type DeclaringType
+        public override Type? DeclaringType
         {
             get { return Projector.ProjectType(base.DeclaringType); }
         }
@@ -30,7 +30,7 @@ namespace System.Reflection.Context.Projection
             get { return Projector.ProjectModule(base.Module); }
         }
 
-        public override Type ReflectedType
+        public override Type? ReflectedType
         {
             get { return Projector.ProjectType(base.ReflectedType); }
         }
@@ -59,7 +59,7 @@ namespace System.Reflection.Context.Projection
             return Projector.Project(base.GetGenericArguments(), Projector.ProjectType);
         }
 
-        public override MethodBody GetMethodBody()
+        public override MethodBody? GetMethodBody()
         {
             return Projector.ProjectMethodBody(base.GetMethodBody());
         }
@@ -69,11 +69,9 @@ namespace System.Reflection.Context.Projection
             return Projector.Project(base.GetParameters(), Projector.ProjectParameter);
         }
 
-        public override bool Equals(object o)
+        public override bool Equals(object? o)
         {
-            ProjectingConstructorInfo other = o as ProjectingConstructorInfo;
-
-            return other != null &&
+            return o is ProjectingConstructorInfo other &&
                    Projector == other.Projector &&
                    UnderlyingConstructor.Equals(other.UnderlyingConstructor);
         }

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Projection/ProjectingEventInfo.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Projection/ProjectingEventInfo.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Context.Delegation;
 
 namespace System.Reflection.Context.Projection
@@ -20,12 +21,12 @@ namespace System.Reflection.Context.Projection
 
         public Projector Projector { get; }
 
-        public override Type DeclaringType
+        public override Type? DeclaringType
         {
             get { return Projector.ProjectType(base.DeclaringType); }
         }
 
-        public override Type EventHandlerType
+        public override Type? EventHandlerType
         {
             get { return Projector.ProjectType(base.EventHandlerType); }
         }
@@ -34,12 +35,12 @@ namespace System.Reflection.Context.Projection
         {
             get { return Projector.ProjectModule(base.Module); }
         }
-        public override Type ReflectedType
+        public override Type? ReflectedType
         {
             get { return Projector.ProjectType(base.ReflectedType); }
         }
 
-        public override MethodInfo GetAddMethod(bool nonPublic)
+        public override MethodInfo? GetAddMethod(bool nonPublic)
         {
             return Projector.ProjectMethod(base.GetAddMethod(nonPublic));
         }
@@ -49,12 +50,12 @@ namespace System.Reflection.Context.Projection
             return Projector.Project(base.GetOtherMethods(nonPublic), Projector.ProjectMethod);
         }
 
-        public override MethodInfo GetRaiseMethod(bool nonPublic)
+        public override MethodInfo? GetRaiseMethod(bool nonPublic)
         {
             return Projector.ProjectMethod(base.GetRaiseMethod(nonPublic));
         }
 
-        public override MethodInfo GetRemoveMethod(bool nonPublic)
+        public override MethodInfo? GetRemoveMethod(bool nonPublic)
         {
             return Projector.ProjectMethod(base.GetRemoveMethod(nonPublic));
         }
@@ -78,11 +79,9 @@ namespace System.Reflection.Context.Projection
             return base.IsDefined(attributeType, inherit);
         }
 
-        public override bool Equals(object o)
+        public override bool Equals([NotNullWhen(true)] object? o)
         {
-            var other = o as ProjectingEventInfo;
-
-            return other != null &&
+            return o is ProjectingEventInfo other &&
                    Projector == other.Projector &&
                    UnderlyingEvent.Equals(other.UnderlyingEvent);
         }

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Projection/ProjectingExceptionHandlingClause.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Projection/ProjectingExceptionHandlingClause.cs
@@ -19,7 +19,7 @@ namespace System.Reflection.Context.Projection
             _projector = projector;
         }
 
-        public override Type CatchType
+        public override Type? CatchType
         {
             get { return _projector.ProjectType(base.CatchType); }
         }

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Projection/ProjectingFieldInfo.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Projection/ProjectingFieldInfo.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Context.Delegation;
 
 namespace System.Reflection.Context.Projection
@@ -20,7 +21,7 @@ namespace System.Reflection.Context.Projection
 
         public Projector Projector { get; }
 
-        public override Type DeclaringType
+        public override Type? DeclaringType
         {
             get { return Projector.ProjectType(base.DeclaringType); }
         }
@@ -35,7 +36,7 @@ namespace System.Reflection.Context.Projection
             get { return Projector.ProjectModule(base.Module); }
         }
 
-        public override Type ReflectedType
+        public override Type? ReflectedType
         {
             get { return Projector.ProjectType(base.ReflectedType); }
         }
@@ -69,11 +70,9 @@ namespace System.Reflection.Context.Projection
             return Projector.Project(base.GetRequiredCustomModifiers(), Projector.ProjectType);
         }
 
-        public override bool Equals(object o)
+        public override bool Equals([NotNullWhen(true)] object? o)
         {
-            var other = o as ProjectingFieldInfo;
-
-            return other != null &&
+            return o is ProjectingFieldInfo other &&
                    Projector == other.Projector &&
                    UnderlyingField.Equals(other.UnderlyingField);
         }

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Projection/ProjectingManifestResourceInfo.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Projection/ProjectingManifestResourceInfo.cs
@@ -19,7 +19,7 @@ namespace System.Reflection.Context.Projection
             _projector = projector;
         }
 
-        public override Assembly ReferencedAssembly
+        public override Assembly? ReferencedAssembly
         {
             get { return _projector.ProjectAssembly(base.ReferencedAssembly); }
         }

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Projection/ProjectingMethodInfo.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Projection/ProjectingMethodInfo.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Context.Delegation;
 
 namespace System.Reflection.Context.Projection
@@ -20,7 +21,7 @@ namespace System.Reflection.Context.Projection
 
         public Projector Projector { get; }
 
-        public override Type DeclaringType
+        public override Type? DeclaringType
         {
             get { return Projector.ProjectType(base.DeclaringType); }
         }
@@ -30,7 +31,7 @@ namespace System.Reflection.Context.Projection
             get { return Projector.ProjectModule(base.Module); }
         }
 
-        public override Type ReflectedType
+        public override Type? ReflectedType
         {
             get { return Projector.ProjectType(base.ReflectedType); }
         }
@@ -93,7 +94,7 @@ namespace System.Reflection.Context.Projection
             return Projector.ProjectMethod(base.GetGenericMethodDefinition());
         }
 
-        public override MethodBody GetMethodBody()
+        public override MethodBody? GetMethodBody()
         {
             return Projector.ProjectMethodBody(base.GetMethodBody());
         }
@@ -113,16 +114,14 @@ namespace System.Reflection.Context.Projection
             return base.CreateDelegate(Projector.Unproject(delegateType));
         }
 
-        public override Delegate CreateDelegate(Type delegateType, object target)
+        public override Delegate CreateDelegate(Type delegateType, object? target)
         {
             return base.CreateDelegate(Projector.Unproject(delegateType), target);
         }
 
-        public override bool Equals(object o)
+        public override bool Equals([NotNullWhen(true)] object? o)
         {
-            var other = o as ProjectingMethodInfo;
-
-            return other != null &&
+            return o is ProjectingMethodInfo other &&
                    Projector == other.Projector &&
                    UnderlyingMethod.Equals(other.UnderlyingMethod);
         }

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Projection/ProjectingModule.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Projection/ProjectingModule.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Context.Delegation;
 
 namespace System.Reflection.Context.Projection
@@ -44,7 +45,7 @@ namespace System.Reflection.Context.Projection
             return base.IsDefined(attributeType, inherit);
         }
 
-        public override FieldInfo GetField(string name, BindingFlags bindingAttr)
+        public override FieldInfo? GetField(string name, BindingFlags bindingAttr)
         {
             return Projector.ProjectField(base.GetField(name, bindingAttr));
         }
@@ -54,7 +55,7 @@ namespace System.Reflection.Context.Projection
             return Projector.Project(base.GetFields(bindingFlags), Projector.ProjectField);
         }
 
-        protected override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
+        protected override MethodInfo? GetMethodImpl(string name, BindingFlags bindingAttr, Binder? binder, CallingConventions callConvention, Type[]? types, ParameterModifier[]? modifiers)
         {
             types = Projector.Unproject(types);
             return Projector.ProjectMethod(base.GetMethodImpl(name, bindingAttr, binder, callConvention, types, modifiers));
@@ -65,7 +66,7 @@ namespace System.Reflection.Context.Projection
             return Projector.Project(base.GetMethods(bindingFlags), Projector.ProjectMethod);
         }
 
-        public override Type GetType(string className, bool throwOnError, bool ignoreCase)
+        public override Type? GetType(string className, bool throwOnError, bool ignoreCase)
         {
             return Projector.ProjectType(base.GetType(className, throwOnError, ignoreCase));
         }
@@ -75,7 +76,7 @@ namespace System.Reflection.Context.Projection
             return Projector.Project(base.GetTypes(), Projector.ProjectType);
         }
 
-        public override FieldInfo ResolveField(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments)
+        public override FieldInfo? ResolveField(int metadataToken, Type[]? genericTypeArguments, Type[]? genericMethodArguments)
         {
             genericTypeArguments = Projector.Unproject(genericTypeArguments);
             genericMethodArguments = Projector.Unproject(genericMethodArguments);
@@ -83,7 +84,7 @@ namespace System.Reflection.Context.Projection
             return Projector.ProjectField(base.ResolveField(metadataToken, genericTypeArguments, genericMethodArguments));
         }
 
-        public override MemberInfo ResolveMember(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments)
+        public override MemberInfo? ResolveMember(int metadataToken, Type[]? genericTypeArguments, Type[]? genericMethodArguments)
         {
             genericTypeArguments = Projector.Unproject(genericTypeArguments);
             genericMethodArguments = Projector.Unproject(genericMethodArguments);
@@ -91,7 +92,7 @@ namespace System.Reflection.Context.Projection
             return Projector.ProjectMember(base.ResolveMember(metadataToken, genericTypeArguments, genericMethodArguments));
         }
 
-        public override MethodBase ResolveMethod(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments)
+        public override MethodBase? ResolveMethod(int metadataToken, Type[]? genericTypeArguments, Type[]? genericMethodArguments)
         {
             genericTypeArguments = Projector.Unproject(genericTypeArguments);
             genericMethodArguments = Projector.Unproject(genericMethodArguments);
@@ -99,7 +100,7 @@ namespace System.Reflection.Context.Projection
             return Projector.ProjectMethodBase(base.ResolveMethod(metadataToken, genericTypeArguments, genericMethodArguments));
         }
 
-        public override Type ResolveType(int metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments)
+        public override Type ResolveType(int metadataToken, Type[]? genericTypeArguments, Type[]? genericMethodArguments)
         {
             genericTypeArguments = Projector.Unproject(genericTypeArguments);
             genericMethodArguments = Projector.Unproject(genericMethodArguments);
@@ -107,11 +108,9 @@ namespace System.Reflection.Context.Projection
             return Projector.ProjectType(base.ResolveType(metadataToken, genericTypeArguments, genericMethodArguments));
         }
 
-        public override bool Equals(object o)
+        public override bool Equals([NotNullWhen(true)] object? o)
         {
-            var other = o as ProjectingModule;
-
-            return other != null &&
+            return o is ProjectingModule other &&
                    Projector == other.Projector &&
                    UnderlyingModule.Equals(other.UnderlyingModule);
         }

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Projection/ProjectingParameterInfo.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Projection/ProjectingParameterInfo.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Context.Delegation;
 
 namespace System.Reflection.Context.Projection
@@ -59,7 +60,7 @@ namespace System.Reflection.Context.Projection
             return Projector.Project(base.GetRequiredCustomModifiers(), Projector.ProjectType);
         }
 
-        public override bool Equals(object o)
+        public override bool Equals([NotNullWhen(true)] object? o)
         {
             return o is ProjectingParameterInfo other &&
                 Projector == other.Projector &&

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Projection/ProjectingPropertyInfo.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Projection/ProjectingPropertyInfo.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Context.Delegation;
 
 namespace System.Reflection.Context.Projection
@@ -20,7 +21,7 @@ namespace System.Reflection.Context.Projection
 
         public Projector Projector { get; }
 
-        public override Type DeclaringType
+        public override Type? DeclaringType
         {
             get { return Projector.ProjectType(base.DeclaringType); }
         }
@@ -35,7 +36,7 @@ namespace System.Reflection.Context.Projection
             get { return Projector.ProjectType(base.PropertyType); }
         }
 
-        public override Type ReflectedType
+        public override Type? ReflectedType
         {
             get { return Projector.ProjectType(base.ReflectedType); }
         }
@@ -45,7 +46,7 @@ namespace System.Reflection.Context.Projection
             return Projector.Project(base.GetAccessors(nonPublic), Projector.ProjectMethod);
         }
 
-        public override MethodInfo GetGetMethod(bool nonPublic)
+        public override MethodInfo? GetGetMethod(bool nonPublic)
         {
             return Projector.ProjectMethod(base.GetGetMethod(nonPublic));
         }
@@ -55,7 +56,7 @@ namespace System.Reflection.Context.Projection
             return Projector.Project(base.GetIndexParameters(), Projector.ProjectParameter);
         }
 
-        public override MethodInfo GetSetMethod(bool nonPublic)
+        public override MethodInfo? GetSetMethod(bool nonPublic)
         {
             return Projector.ProjectMethod(base.GetSetMethod(nonPublic));
         }
@@ -89,7 +90,7 @@ namespace System.Reflection.Context.Projection
             return Projector.Project(base.GetRequiredCustomModifiers(), Projector.ProjectType);
         }
 
-        public override bool Equals(object o)
+        public override bool Equals([NotNullWhen(true)] object? o)
         {
             return o is ProjectingPropertyInfo other &&
                 Projector == other.Projector &&

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Projection/ProjectingType.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Projection/ProjectingType.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Context.Delegation;
 
 namespace System.Reflection.Context.Projection
@@ -30,17 +31,17 @@ namespace System.Reflection.Context.Projection
             get { return _projector.ProjectAssembly(base.Assembly); }
         }
 
-        public override Type BaseType
+        public override Type? BaseType
         {
             get { return _projector.ProjectType(base.BaseType); }
         }
 
-        public override MethodBase DeclaringMethod
+        public override MethodBase? DeclaringMethod
         {
             get { return _projector.ProjectMethodBase(base.DeclaringMethod); }
         }
 
-        public override Type DeclaringType
+        public override Type? DeclaringType
         {
             get { return _projector.ProjectType(base.DeclaringType); }
         }
@@ -50,7 +51,7 @@ namespace System.Reflection.Context.Projection
             get { return _projector.ProjectModule(base.Module); }
         }
 
-        public override Type ReflectedType
+        public override Type? ReflectedType
         {
             get { return _projector.ProjectType(base.ReflectedType); }
         }
@@ -134,9 +135,9 @@ namespace System.Reflection.Context.Projection
             return matchingMembers.ToArray();
         }
 
-        public override bool IsAssignableFrom(Type c)
+        public override bool IsAssignableFrom([NotNullWhen(true)] Type? c)
         {
-            ProjectingType otherType = c as ProjectingType;
+            ProjectingType? otherType = c as ProjectingType;
             if (otherType == null || Projector != otherType.Projector)
                 return false;
 
@@ -150,18 +151,18 @@ namespace System.Reflection.Context.Projection
             return base.IsDefined(attributeType, inherit);
         }
 
-        public override bool IsEquivalentTo(Type other)
+        public override bool IsEquivalentTo([NotNullWhen(true)] Type? other)
         {
-            ProjectingType otherType = other as ProjectingType;
+            ProjectingType? otherType = other as ProjectingType;
             if (otherType == null || Projector != otherType.Projector)
                 return false;
 
             return UnderlyingType.IsEquivalentTo(otherType.UnderlyingType);
         }
 
-        public override bool IsInstanceOfType(object o)
+        public override bool IsInstanceOfType([NotNullWhen(true)] object? o)
         {
-            Type objectType = _projector.ProjectType(o.GetType());
+            Type? objectType = _projector.ProjectType(o?.GetType());
 
             return IsAssignableFrom(objectType);
         }
@@ -171,14 +172,14 @@ namespace System.Reflection.Context.Projection
         // and interfaces->objec.
         public override bool IsSubclassOf(Type c)
         {
-            ProjectingType otherType = c as ProjectingType;
+            ProjectingType? otherType = c as ProjectingType;
             if (otherType == null || Projector != otherType.Projector)
                 return false;
 
             return UnderlyingType.IsSubclassOf(otherType.UnderlyingType);
         }
 
-        protected override ConstructorInfo GetConstructorImpl(BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
+        protected override ConstructorInfo? GetConstructorImpl(BindingFlags bindingAttr, Binder? binder, CallingConventions callConvention, Type[] types, ParameterModifier[]? modifiers)
         {
             types = _projector.Unproject(types);
 
@@ -190,12 +191,12 @@ namespace System.Reflection.Context.Projection
             return _projector.Project(base.GetConstructors(bindingAttr), _projector.ProjectConstructor);
         }
 
-        public override Type GetElementType()
+        public override Type? GetElementType()
         {
             return _projector.ProjectType(base.GetElementType());
         }
 
-        public override EventInfo GetEvent(string name, BindingFlags bindingAttr)
+        public override EventInfo? GetEvent(string name, BindingFlags bindingAttr)
         {
             return _projector.ProjectEvent(base.GetEvent(name, bindingAttr));
         }
@@ -205,7 +206,7 @@ namespace System.Reflection.Context.Projection
             return _projector.Project(base.GetEvents(bindingAttr), _projector.ProjectEvent);
         }
 
-        public override FieldInfo GetField(string name, BindingFlags bindingAttr)
+        public override FieldInfo? GetField(string name, BindingFlags bindingAttr)
         {
             return _projector.ProjectField(base.GetField(name, bindingAttr));
         }
@@ -215,7 +216,7 @@ namespace System.Reflection.Context.Projection
             return _projector.Project(base.GetFields(bindingAttr), _projector.ProjectField);
         }
 
-        public override Type GetInterface(string name, bool ignoreCase)
+        public override Type? GetInterface(string name, bool ignoreCase)
         {
             return _projector.ProjectType(base.GetInterface(name, ignoreCase));
         }
@@ -256,7 +257,7 @@ namespace System.Reflection.Context.Projection
             return members;
         }
 
-        protected override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
+        protected override MethodInfo? GetMethodImpl(string name, BindingFlags bindingAttr, Binder? binder, CallingConventions callConvention, Type[]? types, ParameterModifier[]? modifiers)
         {
             types = _projector.Unproject(types);
 
@@ -268,7 +269,7 @@ namespace System.Reflection.Context.Projection
             return _projector.Project(base.GetMethods(bindingAttr), _projector.ProjectMethod);
         }
 
-        public override Type GetNestedType(string name, BindingFlags bindingAttr)
+        public override Type? GetNestedType(string name, BindingFlags bindingAttr)
         {
             return _projector.ProjectType(base.GetNestedType(name, bindingAttr));
         }
@@ -283,7 +284,7 @@ namespace System.Reflection.Context.Projection
             return _projector.Project(base.GetProperties(bindingAttr), _projector.ProjectProperty);
         }
 
-        protected override PropertyInfo GetPropertyImpl(string name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types, ParameterModifier[] modifiers)
+        protected override PropertyInfo? GetPropertyImpl(string name, BindingFlags bindingAttr, Binder? binder, Type? returnType, Type[]? types, ParameterModifier[]? modifiers)
         {
             returnType = _projector.Unproject(returnType);
             types = _projector.Unproject(types);
@@ -318,7 +319,7 @@ namespace System.Reflection.Context.Projection
             return _projector.ProjectType(base.MakeByRefType());
         }
 
-        public override bool Equals(object o)
+        public override bool Equals([NotNullWhen(true)] object? o)
         {
             return o is ProjectingType other &&
                 Projector == other.Projector &&

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Projection/Projector.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Projection/Projector.cs
@@ -3,12 +3,14 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Reflection.Context.Projection
 {
     internal abstract class Projector
     {
-        public IList<T> Project<T>(IList<T> values, Func<T, T> project)
+        [return: NotNullIfNotNull("values")]
+        public IList<T>? Project<T>(IList<T>? values, Func<T, T> project)
         {
             if (values == null || values.Count == 0)
                 return values;
@@ -18,7 +20,8 @@ namespace System.Reflection.Context.Projection
             return Array.AsReadOnly(projected);
         }
 
-        public T[] Project<T>(T[] values, Func<T, T> project)
+        [return: NotNullIfNotNull("values")]
+        public T[]? Project<T>(T[]? values, Func<T, T> project)
         {
             if (values == null || values.Length == 0)
                 return values;
@@ -39,27 +42,44 @@ namespace System.Reflection.Context.Projection
             return value;
         }
 
-        public abstract TypeInfo ProjectType(Type value);
-        public abstract Assembly ProjectAssembly(Assembly value);
-        public abstract Module ProjectModule(Module value);
-        public abstract FieldInfo ProjectField(FieldInfo value);
-        public abstract EventInfo ProjectEvent(EventInfo value);
-        public abstract ConstructorInfo ProjectConstructor(ConstructorInfo value);
-        public abstract MethodInfo ProjectMethod(MethodInfo value);
-        public abstract MethodBase ProjectMethodBase(MethodBase value);
-        public abstract PropertyInfo ProjectProperty(PropertyInfo value);
-        public abstract ParameterInfo ProjectParameter(ParameterInfo value);
-        public abstract MethodBody ProjectMethodBody(MethodBody value);
-        public abstract LocalVariableInfo ProjectLocalVariable(LocalVariableInfo value);
-        public abstract ExceptionHandlingClause ProjectExceptionHandlingClause(ExceptionHandlingClause value);
-        public abstract CustomAttributeData ProjectCustomAttributeData(CustomAttributeData value);
-        public abstract ManifestResourceInfo ProjectManifestResource(ManifestResourceInfo value);
+        [return: NotNullIfNotNull("value")]
+        public abstract TypeInfo? ProjectType(Type? value);
+        [return: NotNullIfNotNull("value")]
+        public abstract Assembly? ProjectAssembly(Assembly? value);
+        [return: NotNullIfNotNull("value")]
+        public abstract Module? ProjectModule(Module? value);
+        [return: NotNullIfNotNull("value")]
+        public abstract FieldInfo? ProjectField(FieldInfo? value);
+        [return: NotNullIfNotNull("value")]
+        public abstract EventInfo? ProjectEvent(EventInfo? value);
+        [return: NotNullIfNotNull("value")]
+        public abstract ConstructorInfo? ProjectConstructor(ConstructorInfo? value);
+        [return: NotNullIfNotNull("value")]
+        public abstract MethodInfo? ProjectMethod(MethodInfo? value);
+        [return: NotNullIfNotNull("value")]
+        public abstract MethodBase? ProjectMethodBase(MethodBase? value);
+        [return: NotNullIfNotNull("value")]
+        public abstract PropertyInfo? ProjectProperty(PropertyInfo? value);
+        [return: NotNullIfNotNull("value")]
+        public abstract ParameterInfo? ProjectParameter(ParameterInfo? value);
+        [return: NotNullIfNotNull("value")]
+        public abstract MethodBody? ProjectMethodBody(MethodBody? value);
+        [return: NotNullIfNotNull("value")]
+        public abstract LocalVariableInfo? ProjectLocalVariable(LocalVariableInfo? value);
+        [return: NotNullIfNotNull("value")]
+        public abstract ExceptionHandlingClause? ProjectExceptionHandlingClause(ExceptionHandlingClause? value);
+        [return: NotNullIfNotNull("value")]
+        public abstract CustomAttributeData? ProjectCustomAttributeData(CustomAttributeData? value);
+        [return: NotNullIfNotNull("value")]
+        public abstract ManifestResourceInfo? ProjectManifestResource(ManifestResourceInfo? value);
         public abstract CustomAttributeTypedArgument ProjectTypedArgument(CustomAttributeTypedArgument value);
         public abstract CustomAttributeNamedArgument ProjectNamedArgument(CustomAttributeNamedArgument value);
         public abstract InterfaceMapping ProjectInterfaceMapping(InterfaceMapping value);
-        public abstract MemberInfo ProjectMember(MemberInfo value);
+        [return: NotNullIfNotNull("value")]
+        public abstract MemberInfo? ProjectMember(MemberInfo? value);
 
-        public Type[] Unproject(Type[] values)
+        [return: NotNullIfNotNull("values")]
+        public Type[]? Unproject(Type[]? values)
         {
             if (values == null)
                 return null;
@@ -73,7 +93,8 @@ namespace System.Reflection.Context.Projection
             return newTypes;
         }
 
-        public Type Unproject(Type value)
+        [return: NotNullIfNotNull("value")]
+        public Type? Unproject(Type? value)
         {
             if (value is ProjectingType projectingType)
                 return projectingType.UnderlyingType;
@@ -81,7 +102,7 @@ namespace System.Reflection.Context.Projection
                 return value;
         }
 
-        public bool NeedsProjection(object value)
+        public bool NeedsProjection([NotNullWhen(true)] object? value)
         {
             Debug.Assert(value != null);
 

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Virtual/InheritedMethodInfo.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Virtual/InheritedMethodInfo.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Context.Delegation;
 
 namespace System.Reflection.Context.Virtual
@@ -15,11 +16,11 @@ namespace System.Reflection.Context.Virtual
             : base(baseMethod)
         {
             Debug.Assert(reflectedType != null);
-            Debug.Assert(reflectedType.IsSubclassOf(baseMethod.DeclaringType));
+            Debug.Assert(reflectedType.IsSubclassOf(baseMethod.DeclaringType!));
             Debug.Assert(baseMethod is VirtualMethodBase);
 
             // Should we require that baseMethod is a declared method?
-            Debug.Assert(baseMethod.ReflectedType.Equals(baseMethod.DeclaringType));
+            Debug.Assert(baseMethod.ReflectedType!.Equals(baseMethod.DeclaringType));
 
             _reflectedType = reflectedType;
         }
@@ -32,11 +33,9 @@ namespace System.Reflection.Context.Virtual
             }
         }
 
-        public override bool Equals(object o)
+        public override bool Equals([NotNullWhen(true)] object? o)
         {
-            var other = o as InheritedMethodInfo;
-
-            return other != null &&
+            return o is InheritedMethodInfo other &&
                    UnderlyingMethod.Equals(other.UnderlyingMethod) &&
                    ReflectedType.Equals(other.ReflectedType);
         }

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Virtual/InheritedPropertyInfo.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Virtual/InheritedPropertyInfo.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Context.Delegation;
 
 namespace System.Reflection.Context.Virtual
@@ -15,11 +16,11 @@ namespace System.Reflection.Context.Virtual
             : base(baseProperty)
         {
             Debug.Assert(reflectedType != null);
-            Debug.Assert(reflectedType.IsSubclassOf(baseProperty.DeclaringType));
+            Debug.Assert(reflectedType.IsSubclassOf(baseProperty.DeclaringType!));
             Debug.Assert(baseProperty is VirtualPropertyBase);
 
             // Should we require that baseProperty is a declared property?
-            Debug.Assert(baseProperty.ReflectedType.Equals(baseProperty.DeclaringType));
+            Debug.Assert(baseProperty.ReflectedType!.Equals(baseProperty.DeclaringType));
 
             _reflectedType = reflectedType;
         }
@@ -32,25 +33,25 @@ namespace System.Reflection.Context.Virtual
             }
         }
 
-        public override MethodInfo GetGetMethod(bool nonPublic)
+        public override MethodInfo? GetGetMethod(bool nonPublic)
         {
-            MethodInfo underlyingGetter = UnderlyingProperty.GetGetMethod(nonPublic);
+            MethodInfo? underlyingGetter = UnderlyingProperty.GetGetMethod(nonPublic);
             if (underlyingGetter == null)
                 return null;
             else
                 return new InheritedMethodInfo(underlyingGetter, _reflectedType);
         }
 
-        public override MethodInfo GetSetMethod(bool nonPublic)
+        public override MethodInfo? GetSetMethod(bool nonPublic)
         {
-            MethodInfo underlyingSetter = UnderlyingProperty.GetSetMethod(nonPublic);
+            MethodInfo? underlyingSetter = UnderlyingProperty.GetSetMethod(nonPublic);
             if (underlyingSetter == null)
                 return null;
             else
                 return new InheritedMethodInfo(underlyingSetter, _reflectedType);
         }
 
-        public override bool Equals(object o)
+        public override bool Equals([NotNullWhen(true)] object? o)
         {
             return o is InheritedPropertyInfo other &&
                 UnderlyingProperty.Equals(other.UnderlyingProperty) &&

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Virtual/VirtualMethodBase.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Virtual/VirtualMethodBase.cs
@@ -8,7 +8,7 @@ namespace System.Reflection.Context.Virtual
 {
     internal abstract class VirtualMethodBase : MethodInfo
     {
-        private ParameterInfo _returnParameter;
+        private ParameterInfo? _returnParameter;
 
         protected abstract Type[] GetParameterTypes();
 
@@ -44,10 +44,10 @@ namespace System.Reflection.Context.Virtual
 
         public override sealed Module Module
         {
-            get { return DeclaringType.Module; }
+            get { return DeclaringType!.Module; }
         }
 
-        public override sealed Type ReflectedType
+        public override sealed Type? ReflectedType
         {
             get { return DeclaringType; }
         }
@@ -112,20 +112,20 @@ namespace System.Reflection.Context.Virtual
             return false;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             // We don't need to compare the invokees
             // But do we need to compare the contexts and return types?
             return obj is VirtualMethodBase other &&
                 Name == other.Name &&
-                DeclaringType.Equals(other.DeclaringType) &&
+                DeclaringType!.Equals(other.DeclaringType) &&
                 CollectionServices.CompareArrays(GetParameterTypes(), other.GetParameterTypes());
         }
 
         public override int GetHashCode()
         {
             return Name.GetHashCode() ^
-                DeclaringType.GetHashCode() ^
+                DeclaringType!.GetHashCode() ^
                 CollectionServices.GetArrayHashCode(GetParameterTypes());
         }
 

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Virtual/VirtualParameter.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Virtual/VirtualParameter.cs
@@ -2,12 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Reflection.Context.Virtual
 {
     internal class VirtualParameter : ParameterInfo
     {
-        public VirtualParameter(MemberInfo member, Type parameterType, string name, int position)
+        public VirtualParameter(MemberInfo member, Type parameterType, string? name, int position)
         {
             Debug.Assert(position >= -1);
 
@@ -36,7 +37,7 @@ namespace System.Reflection.Context.Virtual
             return clonedParameters;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals([NotNullWhen(true)] object? obj)
         {
             // Do we need to compare Name and ParameterType?
             return obj is VirtualParameter other &&

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Virtual/VirtualPropertyBase.FuncPropertyAccessorBase.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Virtual/VirtualPropertyBase.FuncPropertyAccessorBase.cs
@@ -26,7 +26,7 @@ namespace System.Reflection.Context.Virtual
                 get { return base.Attributes | MethodAttributes.SpecialName; }
             }
 
-            public override sealed Type DeclaringType
+            public override sealed Type? DeclaringType
             {
                 get { return DeclaringProperty.DeclaringType; }
             }

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Virtual/VirtualPropertyBase.PropertySetterBase.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Virtual/VirtualPropertyBase.PropertySetterBase.cs
@@ -7,7 +7,7 @@ namespace System.Reflection.Context.Virtual
     {
         protected abstract class PropertySetterBase : FuncPropertyAccessorBase
         {
-            private Type[] _parameterTypes;
+            private Type[]? _parameterTypes;
 
             protected PropertySetterBase(VirtualPropertyBase property)
                 : base(property)

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Virtual/VirtualPropertyBase.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Virtual/VirtualPropertyBase.cs
@@ -12,8 +12,8 @@ namespace System.Reflection.Context.Virtual
     {
         private readonly string _name;
         private readonly Type _propertyType;
-        private Type _declaringType;
-        private ParameterInfo[] _indexedParameters;
+        private Type? _declaringType;
+        private ParameterInfo[]? _indexedParameters;
 
         protected VirtualPropertyBase(Type propertyType, string name, CustomReflectionContext context)
         {
@@ -40,7 +40,7 @@ namespace System.Reflection.Context.Virtual
             get { return PropertyAttributes.None; }
         }
 
-        public override sealed Type DeclaringType
+        public override sealed Type? DeclaringType
         {
             get { return _declaringType; }
         }
@@ -72,24 +72,24 @@ namespace System.Reflection.Context.Virtual
 
         public override sealed Module Module
         {
-            get { return DeclaringType.Module; }
+            get { return DeclaringType!.Module; }
         }
 
-        public override sealed Type ReflectedType
+        public override sealed Type? ReflectedType
         {
             get { return DeclaringType; }
         }
 
         public override sealed MethodInfo[] GetAccessors(bool nonPublic)
         {
-            MethodInfo getMethod = GetGetMethod(nonPublic);
-            MethodInfo setMethod = GetSetMethod(nonPublic);
+            MethodInfo? getMethod = GetGetMethod(nonPublic);
+            MethodInfo? setMethod = GetSetMethod(nonPublic);
 
             Debug.Assert(getMethod != null || setMethod != null);
 
             if (getMethod == null || setMethod == null)
             {
-                return new MethodInfo[] { getMethod ?? setMethod };
+                return new MethodInfo[] { getMethod ?? setMethod! };
             }
 
             return new MethodInfo[] { getMethod, setMethod };
@@ -100,22 +100,22 @@ namespace System.Reflection.Context.Virtual
             return (ParameterInfo[])GetIndexParametersNoCopy().Clone();
         }
 
-        public override sealed object GetValue(object obj, BindingFlags invokeAttr, Binder binder, object[] index, CultureInfo culture)
+        public override sealed object? GetValue(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? index, CultureInfo? culture)
         {
-            MethodInfo getMethod = GetGetMethod(true);
+            MethodInfo? getMethod = GetGetMethod(true);
             if (getMethod == null)
                 throw new ArgumentException(SR.Argument_GetMethNotFnd);
 
             return getMethod.Invoke(obj, invokeAttr, binder, index, culture);
         }
 
-        public override sealed void SetValue(object obj, object value, BindingFlags invokeAttr, Binder binder, object[] index, CultureInfo culture)
+        public override sealed void SetValue(object? obj, object? value, BindingFlags invokeAttr, Binder? binder, object?[]? index, CultureInfo? culture)
         {
-            MethodInfo setMethod = GetSetMethod(true);
+            MethodInfo? setMethod = GetSetMethod(true);
             if (setMethod == null)
                 throw new ArgumentException(SR.Argument_GetMethNotFnd);
 
-            object[] args = null;
+            object?[] args;
 
             if (index != null)
             {
@@ -174,13 +174,13 @@ namespace System.Reflection.Context.Virtual
             return false;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             // We don't need to compare the getters and setters.
             // But do we need to compare the contexts and return types?
             return obj is VirtualPropertyBase other &&
                 _name == other._name &&
-                _declaringType.Equals(other._declaringType) &&
+                _declaringType!.Equals(other._declaringType) &&
                 _propertyType == other._propertyType &&
                 CollectionServices.CompareArrays(GetIndexParametersNoCopy(), other.GetIndexParametersNoCopy());
         }
@@ -188,14 +188,14 @@ namespace System.Reflection.Context.Virtual
         public override int GetHashCode()
         {
             return _name.GetHashCode() ^
-                _declaringType.GetHashCode() ^
+                _declaringType!.GetHashCode() ^
                 _propertyType.GetHashCode() ^
                 CollectionServices.GetArrayHashCode(GetIndexParametersNoCopy());
         }
 
         public override string ToString()
         {
-            return base.ToString();
+            return base.ToString()!;
         }
 
         internal void SetDeclaringType(Type declaringType)
@@ -207,7 +207,7 @@ namespace System.Reflection.Context.Virtual
         {
             if (_indexedParameters == null)
             {
-                MethodInfo method = GetGetMethod(true);
+                MethodInfo? method = GetGetMethod(true);
                 if (method != null)
                 {
                     _indexedParameters = VirtualParameter.CloneParameters(this, method.GetParameters(), skipLastParameter: false);

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Virtual/VirtualPropertyInfo.PropertyGetter.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Virtual/VirtualPropertyInfo.PropertyGetter.cs
@@ -12,10 +12,10 @@ namespace System.Reflection.Context.Virtual
     {
         private sealed class PropertyGetter : PropertyGetterBase
         {
-            private readonly Func<object, object> _getter;
+            private readonly Func<object, object?> _getter;
             private readonly IEnumerable<Attribute> _attributes;
 
-            public PropertyGetter(VirtualPropertyBase property, Func<object, object> getter, IEnumerable<Attribute> getterAttributes)
+            public PropertyGetter(VirtualPropertyBase property, Func<object, object?> getter, IEnumerable<Attribute>? getterAttributes)
                 : base(property)
             {
                 Debug.Assert(null != getter);
@@ -24,14 +24,14 @@ namespace System.Reflection.Context.Virtual
                 _attributes = getterAttributes ?? CollectionServices.Empty<Attribute>();
             }
 
-            public override object Invoke(object obj, BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture)
+            public override object? Invoke(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture)
             {
                 // invokeAttr, binder, and culture are ignored, similar to what runtime reflection does with the default binder.
 
                 if (parameters != null && parameters.Length > 0)
                     throw new TargetParameterCountException();
 
-                if (!ReflectedType.IsInstanceOfType(obj))
+                if (!ReflectedType!.IsInstanceOfType(obj))
                     throw new ArgumentException();
 
                 return _getter(obj);

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Virtual/VirtualPropertyInfo.PropertySetter.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Virtual/VirtualPropertyInfo.PropertySetter.cs
@@ -12,11 +12,11 @@ namespace System.Reflection.Context.Virtual
     {
         private sealed class PropertySetter : PropertySetterBase
         {
-            private readonly Action<object, object> _setter;
+            private readonly Action<object, object?> _setter;
             private readonly ParameterInfo _valueParameter;
             private readonly IEnumerable<Attribute> _attributes;
 
-            public PropertySetter(VirtualPropertyBase property, Action<object, object> setter, IEnumerable<Attribute> setterAttributes)
+            public PropertySetter(VirtualPropertyBase property, Action<object, object?> setter, IEnumerable<Attribute>? setterAttributes)
                 : base(property)
             {
                 Debug.Assert(null != setter);
@@ -31,19 +31,19 @@ namespace System.Reflection.Context.Virtual
                 return new ParameterInfo[] { _valueParameter };
             }
 
-            public override object Invoke(object obj, BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture)
+            public override object? Invoke(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture)
             {
                 // invokeAttr, binder, and culture are ignored, similar to what runtime reflection does with the default binder.
 
                 if (parameters == null || parameters.Length != 1)
                     throw new TargetParameterCountException();
 
-                object value = parameters[0];
+                object? value = parameters[0];
 
                 if (obj == null)
                     throw new TargetException(SR.Target_InstanceMethodRequiresTarget);
 
-                if (!ReflectedType.IsInstanceOfType(obj))
+                if (!ReflectedType!.IsInstanceOfType(obj))
                     throw new TargetException(SR.Target_ObjectTargetMismatch);
 
                 if (ReturnType.IsInstanceOfType(value))

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Virtual/VirtualPropertyInfo.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Virtual/VirtualPropertyInfo.cs
@@ -10,25 +10,25 @@ namespace System.Reflection.Context.Virtual
     // Represents a func-based 'PropertyInfo'
     internal sealed partial class VirtualPropertyInfo : VirtualPropertyBase
     {
-        private readonly PropertyGetter _getter;
-        private readonly PropertySetter _setter;
+        private readonly PropertyGetter? _getter;
+        private readonly PropertySetter? _setter;
         private readonly IEnumerable<Attribute> _attributes;
 
         public VirtualPropertyInfo(
             string name,
             Type propertyType,
-            Func<object, object> getter,
-            Action<object, object> setter,
-            IEnumerable<Attribute> propertyAttributes,
-            IEnumerable<Attribute> getterAttributes,
-            IEnumerable<Attribute> setterAttributes,
+            Func<object, object?>? getter,
+            Action<object, object?>? setter,
+            IEnumerable<Attribute>? propertyAttributes,
+            IEnumerable<Attribute>? getterAttributes,
+            IEnumerable<Attribute>? setterAttributes,
             CustomReflectionContext context)
             : base(propertyType, name, context)
         {
             if (getter == null && setter == null)
                 throw new ArgumentException(SR.ArgumentNull_GetterOrSetterMustBeSpecified);
 
-            CustomType rcType = propertyType as CustomType;
+            CustomType? rcType = propertyType as CustomType;
             if (rcType == null || rcType.ReflectionContext != context)
                 throw new ArgumentException(SR.Argument_PropertyTypeFromDifferentContext);
 
@@ -41,14 +41,14 @@ namespace System.Reflection.Context.Virtual
             _attributes = propertyAttributes ?? CollectionServices.Empty<Attribute>();
         }
 
-        public override MethodInfo GetGetMethod(bool nonPublic)
+        public override MethodInfo? GetGetMethod(bool nonPublic)
         {
             // Current we don't support adding nonpulbic getters
             Debug.Assert(_getter == null || _getter.IsPublic);
             return _getter;
         }
 
-        public override MethodInfo GetSetMethod(bool nonPublic)
+        public override MethodInfo? GetSetMethod(bool nonPublic)
         {
             // Current we don't support adding nonpulbic setters
             Debug.Assert(_setter == null || _setter.IsPublic);

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Virtual/VirtualReturnParameter.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/Virtual/VirtualReturnParameter.cs
@@ -7,7 +7,7 @@ namespace System.Reflection.Context.Virtual
     internal sealed class VirtualReturnParameter : VirtualParameter
     {
         public VirtualReturnParameter(MethodInfo method)
-            : base(method, method.ReturnType, name:null,  position: -1)
+            : base(method, method.ReturnType, name: null,  position: -1)
         {
         }
     }


### PR DESCRIPTION
The impact here is almost entirely internal; the ref only gains two question marks.

Fixes https://github.com/dotnet/runtime/issues/54596
cc: @ViktorHofer, @dotnet/area-system-reflection 