### PR TITLE
Add documentation for SafeBuffer.ReadSpan/WriteSpan

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeBuffer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeBuffer.cs
@@ -4,7 +4,7 @@
 /*============================================================
 **
 ** Purpose: Unsafe code that uses pointers should use
-** SafePointer to fix subtle lifetime problems with the
+** SafeBuffer to fix subtle lifetime problems with the
 ** underlying resource.
 **
 ===========================================================*/

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeBuffer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeBuffer.cs
@@ -227,7 +227,7 @@ namespace System.Runtime.InteropServices
         }
 
         /// <summary>
-        /// Reads value types from memory starting at the offset, and writes them into a span.</summary>
+        /// Reads value types from memory starting at the offset, and writes them into a span. The number of value types that will be read is determined by the length of the span.</summary>
         /// <typeparam name="T">The value type to read.</typeparam>
         /// <param name="byteOffset">The location from which to start reading.</param>
         /// <param name="buffer">The output span to write to.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeBuffer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/SafeBuffer.cs
@@ -203,6 +203,13 @@ namespace System.Runtime.InteropServices
             return value;
         }
 
+        /// <summary>
+        /// Reads the specified number of value types from memory starting at the offset, and writes them into an array starting at the index.</summary>
+        /// <typeparam name="T">The value type to read.</typeparam>
+        /// <param name="byteOffset">The location from which to start reading.</param>
+        /// <param name="array">The output array to write to.</param>
+        /// <param name="index">The location in the output array to begin writing to.</param>
+        /// <param name="count">The number of value types to read from the input array and to write to the output array.</param>
         [CLSCompliant(false)]
         public void ReadArray<T>(ulong byteOffset, T[] array, int index, int count)
             where T : struct
@@ -219,6 +226,11 @@ namespace System.Runtime.InteropServices
             ReadSpan(byteOffset, new Span<T>(array, index, count));
         }
 
+        /// <summary>
+        /// Reads value types from memory starting at the offset, and writes them into a span.</summary>
+        /// <typeparam name="T">The value type to read.</typeparam>
+        /// <param name="byteOffset">The location from which to start reading.</param>
+        /// <param name="buffer">The output span to write to.</param>
         [CLSCompliant(false)]
         public void ReadSpan<T>(ulong byteOffset, Span<T> buffer)
             where T : struct
@@ -279,6 +291,14 @@ namespace System.Runtime.InteropServices
             }
         }
 
+        /// <summary>
+        /// Writes the specified number of value types to a memory location by reading bytes starting from the specified location in the input array.
+        /// </summary>
+        /// <typeparam name="T">The value type to write.</typeparam>
+        /// <param name="byteOffset">The location in memory to write to.</param>
+        /// <param name="array">The input array.</param>
+        /// <param name="index">The offset in the array to start reading from.</param>
+        /// <param name="count">The number of value types to write.</param>
         [CLSCompliant(false)]
         public void WriteArray<T>(ulong byteOffset, T[] array, int index, int count)
             where T : struct
@@ -295,6 +315,12 @@ namespace System.Runtime.InteropServices
             WriteSpan(byteOffset, new ReadOnlySpan<T>(array, index, count));
         }
 
+        /// <summary>
+        /// Writes the value types from a read-only span to a memory location.
+        /// </summary>
+        /// <typeparam name="T">The value type to write.</typeparam>
+        /// <param name="byteOffset">The location in memory to write to.</param>
+        /// <param name="data">The input span.</param>
         [CLSCompliant(false)]
         public void WriteSpan<T>(ulong byteOffset, ReadOnlySpan<T> data)
             where T : struct


### PR DESCRIPTION
Add missing doc for new `SafeBuffer.ReadSpan` and `SafeBuffer.WriteSpan` 6.0 APIs.
Also copied over the docs for `SafeBuffer.ReadArray/WriteArray` into code.

Contributes to https://github.com/dotnet/runtime/issues/54880

cc @AaronRobinsonMSFT @jkoritzinsky 