### PR TITLE
Use XmlWriter.Create instead of XmlTextWriter

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -423,10 +423,11 @@ namespace System.Xml.Serialization
         [RequiresUnreferencedCode(TrimDeserializationWarning)]
         public object? Deserialize(Stream stream)
         {
-            XmlTextReader xmlReader = new XmlTextReader(stream);
-            xmlReader.WhitespaceHandling = WhitespaceHandling.Significant;
-            xmlReader.Normalization = true;
-            xmlReader.XmlResolver = null;
+            //XmlTextReader xmlReader = new XmlTextReader(stream);
+            //xmlReader.WhitespaceHandling = WhitespaceHandling.Significant;
+            //xmlReader.Normalization = true;
+            //xmlReader.XmlResolver = null;
+            XmlReader xmlReader = XmlReader.Create(stream, new XmlReaderSettings() { IgnoreWhitespace = true });
             return Deserialize(xmlReader, null);
         }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -317,9 +317,10 @@ namespace System.Xml.Serialization
         [RequiresUnreferencedCode(TrimSerializationWarning)]
         public void Serialize(TextWriter textWriter, object? o, XmlSerializerNamespaces? namespaces)
         {
-            XmlTextWriter xmlWriter = new XmlTextWriter(textWriter);
-            xmlWriter.Formatting = Formatting.Indented;
-            xmlWriter.Indentation = 2;
+            //XmlTextWriter xmlWriter = new XmlTextWriter(textWriter);
+            //xmlWriter.Formatting = Formatting.Indented;
+            //xmlWriter.Indentation = 2;
+            XmlWriter xmlWriter = XmlWriter.Create(textWriter, new XmlWriterSettings() { CheckCharacters = true, IndentChars = "  ", Indent = true });
             Serialize(xmlWriter, o, namespaces);
         }
 
@@ -332,9 +333,10 @@ namespace System.Xml.Serialization
         [RequiresUnreferencedCode(TrimSerializationWarning)]
         public void Serialize(Stream stream, object? o, XmlSerializerNamespaces? namespaces)
         {
-            XmlTextWriter xmlWriter = new XmlTextWriter(stream, null);
-            xmlWriter.Formatting = Formatting.Indented;
-            xmlWriter.Indentation = 2;
+            //XmlTextWriter xmlWriter = new XmlTextWriter(stream, null);
+            //xmlWriter.Formatting = Formatting.Indented;
+            //xmlWriter.Indentation = 2;
+            XmlWriter xmlWriter = XmlWriter.Create(stream, new XmlWriterSettings() { CheckCharacters = true, IndentChars = "  ", Indent = true });
             Serialize(xmlWriter, o, namespaces);
         }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -317,9 +317,6 @@ namespace System.Xml.Serialization
         [RequiresUnreferencedCode(TrimSerializationWarning)]
         public void Serialize(TextWriter textWriter, object? o, XmlSerializerNamespaces? namespaces)
         {
-            //XmlTextWriter xmlWriter = new XmlTextWriter(textWriter);
-            //xmlWriter.Formatting = Formatting.Indented;
-            //xmlWriter.Indentation = 2;
             XmlWriter xmlWriter = XmlWriter.Create(textWriter, new XmlWriterSettings() { CheckCharacters = true, IndentChars = "  ", Indent = true });
             Serialize(xmlWriter, o, namespaces);
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -330,9 +330,6 @@ namespace System.Xml.Serialization
         [RequiresUnreferencedCode(TrimSerializationWarning)]
         public void Serialize(Stream stream, object? o, XmlSerializerNamespaces? namespaces)
         {
-            //XmlTextWriter xmlWriter = new XmlTextWriter(stream, null);
-            //xmlWriter.Formatting = Formatting.Indented;
-            //xmlWriter.Indentation = 2;
             XmlWriter xmlWriter = XmlWriter.Create(stream, new XmlWriterSettings() { CheckCharacters = true, IndentChars = "  ", Indent = true });
             Serialize(xmlWriter, o, namespaces);
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -417,10 +417,6 @@ namespace System.Xml.Serialization
         [RequiresUnreferencedCode(TrimDeserializationWarning)]
         public object? Deserialize(Stream stream)
         {
-            //XmlTextReader xmlReader = new XmlTextReader(stream);
-            //xmlReader.WhitespaceHandling = WhitespaceHandling.Significant;
-            //xmlReader.Normalization = true;
-            //xmlReader.XmlResolver = null;
             XmlReader xmlReader = XmlReader.Create(stream, new XmlReaderSettings() { IgnoreWhitespace = true });
             return Deserialize(xmlReader, null);
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -317,7 +317,7 @@ namespace System.Xml.Serialization
         [RequiresUnreferencedCode(TrimSerializationWarning)]
         public void Serialize(TextWriter textWriter, object? o, XmlSerializerNamespaces? namespaces)
         {
-            XmlWriter xmlWriter = XmlWriter.Create(textWriter, new XmlWriterSettings() { CheckCharacters = true, IndentChars = "  ", Indent = true });
+            XmlWriter xmlWriter = XmlWriter.Create(textWriter, new XmlWriterSettings() { Indent = true });
             Serialize(xmlWriter, o, namespaces);
         }
 
@@ -330,7 +330,7 @@ namespace System.Xml.Serialization
         [RequiresUnreferencedCode(TrimSerializationWarning)]
         public void Serialize(Stream stream, object? o, XmlSerializerNamespaces? namespaces)
         {
-            XmlWriter xmlWriter = XmlWriter.Create(stream, new XmlWriterSettings() { CheckCharacters = true, IndentChars = "  ", Indent = true });
+            XmlWriter xmlWriter = XmlWriter.Create(stream, new XmlWriterSettings() { Indent = true });
             Serialize(xmlWriter, o, namespaces);
         }
 

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
@@ -263,6 +263,13 @@ public static partial class XmlSerializerTests
     }
 
     [Fact]
+    public static void Xml_StringWithNullChar()
+    {
+        Assert.Throws<InvalidOperationException>(() => SerializeWithDefaultValue<string>("Sample\0String", null));
+        Assert.Throws<InvalidOperationException>(() => DeserializeFromXmlString<string>("<?xml version=\"1.0\"?><string>Sample&#x0;String</string>"));
+    }
+
+    [Fact]
     public static void Xml_UintAsRoot()
     {
         foreach (uint value in new uint[] { (uint)3, (uint)0, uint.MinValue, uint.MaxValue })

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -1726,6 +1726,17 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
         }
     }
 
+    private static T DeserializeFromXmlString<T>(string xmlString)
+    {
+        XmlSerializer serializer = new XmlSerializer(typeof(T));
+        using (Stream ms = GenerateStreamFromString(xmlString))
+        {
+            T value = (T)serializer.Deserialize(ms);
+            return value;
+        }
+
+    }
+
     [Fact]
     public static void Xml_TypeWithMismatchBetweenAttributeAndPropertyType()
     {


### PR DESCRIPTION
Use XmlReader/Writer.Create instead of XmlTextReader/Writer.

XmlTextWriter is not strict about some of the things it writes. Like
the null character, which is technically illegal in XML 1.0 and 1.1.
(The way we used the XmlTextReader counterpart, we would end
up successfully serializing a null character, and then hit an exception
when trying to deserialize what we just serialized. This inability to
round trip breaks a core tenet of serialization.)

Since the long ago days of .Net 2.0, Microsoft has been
recommending people to use XmlReader/Writer.Create()
instead of directly instantiating XmlTextReader/Writer. This PR
will bring us in line with those recommendations from long ago.

Fixes #1411
