### PR TITLE
Noticed we ran out of memory with regions on the GC stress test.

### DIFF
--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -5526,6 +5526,7 @@ public:
     bool allocate_basic_region (uint8_t** start, uint8_t** end);
     bool allocate_large_region (uint8_t** start, uint8_t** end, allocate_direction direction, size_t size = 0);
     void delete_region (uint8_t* start);
+    bool should_delete_region (uint8_t* start, int num_free_regions, int num_free_large_regions);
     uint32_t get_va_memory_load()
     {
         return (uint32_t)(((global_region_left_used - global_region_start) + ((global_region_end - global_region_right_used)))* 100.0


### PR DESCRIPTION
The fix is to limit the number of regions that go on the per-heap free lists.

Whether a region should be returned to the region allocator is decided by a new API region_allocator::should_delete_region.

The current implementation takes a couple things into consideration, subject to future tuning:
- the address space that is tied up in free regions per heap should not get too large
- when the va memory load exceeds 50%, we want to get more stingy with virtual address space.
- we want to try to keep the upper half of the address space less fragmented

The changes also include some improvements to dprintf calls.