### PR TITLE
[samples] Include parent Directory.Build.targets in wasm/samples

### DIFF
--- a/src/mono/sample/wasm/Directory.Build.targets
+++ b/src/mono/sample/wasm/Directory.Build.targets
@@ -1,4 +1,5 @@
 <Project>
+  <Import Project="../Directory.Build.targets" />
   <Target Name="PrepareForWasmBuild" BeforeTargets="WasmBuildApp">
     <ItemGroup>
       <WasmAssembliesToBundle Include="$(TargetDir)publish\*.dll" />


### PR DESCRIPTION
Fixes building the samples against the intree ref assemblies