### PR TITLE
Remove GenerateCompiledExpressionsTempFilePathForEditing hack

### DIFF
--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -202,14 +202,6 @@
     </ItemGroup>
   </Target>
 
-  <PropertyGroup>
-    <!--
-    Hack workaround to skip the GenerateCompiledExpressionsTempFile target in
-    Microsoft.WorkflowBuildExtensions.targets target that always runs in VS
-    -->
-    <GenerateCompiledExpressionsTempFilePathForEditing />
-  </PropertyGroup>
-
   <!-- Returns the assembly version of the project for consumption
        by the NuGet package generation -->
   <Target Name="GetAssemblyVersion"


### PR DESCRIPTION
This was fix in Feb 2019: https://github.com/dotnet/msbuild/pull/4100.