### PR TITLE
package native quic library

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Interop.Libraries.cs
+++ b/src/libraries/Common/src/Interop/Windows/Interop.Libraries.cs
@@ -42,7 +42,7 @@ internal static partial class Interop
         internal const string Wtsapi32 = "wtsapi32.dll";
         internal const string CompressionNative = "System.IO.Compression.Native";
         internal const string GlobalizationNative = "System.Globalization.Native";
-        internal const string MsQuic = "MsQuic.Native.dll";
+        internal const string MsQuic = "msquic.dll";
         internal const string HostPolicy = "hostpolicy.dll";
         internal const string Ucrtbase = "ucrtbase.dll";
     }

--- a/src/libraries/Common/src/Interop/Windows/Interop.Libraries.cs
+++ b/src/libraries/Common/src/Interop/Windows/Interop.Libraries.cs
@@ -42,7 +42,7 @@ internal static partial class Interop
         internal const string Wtsapi32 = "wtsapi32.dll";
         internal const string CompressionNative = "System.IO.Compression.Native";
         internal const string GlobalizationNative = "System.Globalization.Native";
-        internal const string MsQuic = "msquic.dll";
+        internal const string MsQuic = "MsQuic.Native.dll";
         internal const string HostPolicy = "hostpolicy.dll";
         internal const string Ucrtbase = "ucrtbase.dll";
     }

--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -58,8 +58,10 @@
   <!-- Project references -->
 
   <ItemGroup>
-    <PackageReference Include="System.Net.MsQuic.Transport" PrivateAssets="all" GeneratePathProperty="true" Version="$(SystemNetMsQuicTransportVersion)" />
-    <BinPlaceDir Include="$(MicrosoftNetCoreAppRuntimePackNativeDir)" BinPlaceItem="NativeBinPlaceItem" />
+    <PackageReference Include="System.Net.MsQuic.Transport"
+                      Version="$(SystemNetMsQuicTransportVersion)"
+                      PrivateAssets="all"
+                      GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup>
@@ -81,7 +83,11 @@
   </ItemGroup>
 
   <!-- Support for deploying msquic -->
-  <ItemGroup Condition="'$(TargetsWindows)' == 'true' and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'x86')">
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' and
+                        ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'x86')">
+    <BinPlaceDir Include="$(MicrosoftNetCoreAppRuntimePackNativeDir)" ItemName="NativeBinPlaceItem" />
+    <BinPlaceDir Include="$(NetCoreAppCurrentTestHostSharedFrameworkPath)" ItemName="NativeBinPlaceItem" />
+    <BinPlaceDir Include="$(NetCoreAppCurrentRuntimePath)" ItemName="NativeBinPlaceItem" />
     <NativeBinPlaceItem Include="$(PkgSystem_Net_MsQuic_Transport)\runtimes\win10-$(TargetArchitecture)\native\msquic.dll" TargetPath="MsQuic.Native.dll" />
     <NativeBinPlaceItem Include="$(PkgSystem_Net_MsQuic_Transport)\runtimes\win10-$(TargetArchitecture)\native\msquic.pdb" TargetPath="MsQuic.Native.pdb" />
   </ItemGroup>

--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -57,8 +57,9 @@
   </ItemGroup>
   <!-- Project references -->
 
-  <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
+  <ItemGroup>
     <PackageReference Include="System.Net.MsQuic.Transport" PrivateAssets="all" GeneratePathProperty="true" Version="$(SystemNetMsQuicTransportVersion)" />
+    <BinPlaceDir Include="$(MicrosoftNetCoreAppRuntimePackNativeDir)" BinPlaceItem="NativeBinPlaceItem" />
   </ItemGroup>
 
   <ItemGroup>
@@ -79,23 +80,10 @@
     <Reference Include="System.Threading.Channels" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <BinPlaceNative>true</BinPlaceNative>
-    <BinPlaceRuntime>false</BinPlaceRuntime>
-  </PropertyGroup>
-
   <!-- Support for deploying msquic -->
   <ItemGroup Condition="'$(TargetsWindows)' == 'true' and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'x86')">
-    <Content Include="$(PkgSystem_Net_MsQuic_Transport)\runtimes\win10-$(TargetArchitecture)\native\msquic.dll" Condition="'$(TargetsWindows)' == 'true'">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-      <TargetPath>MsQuic.Native.dll</TargetPath>
-    </Content>
-    <Content Include="$(PkgSystem_Net_MsQuic_Transport)\runtimes\win10-$(TargetArchitecture)\native\msquic.pdb" Condition="'$(TargetsWindows)' == 'true'">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-      <TargetPath>MsQuic.Native.pdb</TargetPath>
-    </Content>
+    <NativeBinPlaceItem Include="$(PkgSystem_Net_MsQuic_Transport)\runtimes\win10-$(TargetArchitecture)\native\msquic.dll" TargetPath="MsQuic.Native.dll" />
+    <NativeBinPlaceItem Include="$(PkgSystem_Net_MsQuic_Transport)\runtimes\win10-$(TargetArchitecture)\native\msquic.pdb" TargetPath="MsQuic.Native.pdb" />
   </ItemGroup>
 
   <ItemGroup>
@@ -107,6 +95,7 @@
     <Content Include="msquic.pdb" Condition="Exists('msquic.pdb')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      <TargetPath>MsQuic.Native.pdb</TargetPath>
     </Content>
     <Content Include="libmsquic.dylib" Condition="Exists('libmsquic.dylib')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -56,9 +56,11 @@
     <Compile Include="System\Net\Quic\Implementations\MsQuic\Interop\MsQuicStatusCodes.OSX.cs" />
   </ItemGroup>
   <!-- Project references -->
+
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
-    <PackageReference Include="System.Net.MsQuic.Transport" PrivateAssets="all" Version="$(SystemNetMsQuicTransportVersion)" />
+    <PackageReference Include="System.Net.MsQuic.Transport" PrivateAssets="all" GeneratePathProperty="true" Version="$(SystemNetMsQuicTransportVersion)" />
   </ItemGroup>
+
   <ItemGroup>
     <Reference Include="System.Collections" />
     <Reference Include="System.Collections.Concurrent" />
@@ -76,11 +78,31 @@
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Channels" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <BinPlaceNative>true</BinPlaceNative>
+    <BinPlaceRuntime>false</BinPlaceRuntime>
+  </PropertyGroup>
+
   <!-- Support for deploying msquic -->
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'x86')">
+    <Content Include="$(PkgSystem_Net_MsQuic_Transport)\runtimes\win10-$(TargetArchitecture)\native\msquic.dll" Condition="'$(TargetsWindows)' == 'true'">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      <TargetPath>MsQuic.Native.dll</TargetPath>
+    </Content>
+    <Content Include="$(PkgSystem_Net_MsQuic_Transport)\runtimes\win10-$(TargetArchitecture)\native\msquic.pdb" Condition="'$(TargetsWindows)' == 'true'">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      <TargetPath>MsQuic.Native.pdb</TargetPath>
+    </Content>
+  </ItemGroup>
+
   <ItemGroup>
     <Content Include="msquic.dll" Condition="Exists('msquic.dll')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      <TargetPath>MsQuic.Native.dll</TargetPath>
     </Content>
     <Content Include="msquic.pdb" Condition="Exists('msquic.pdb')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -88,20 +88,18 @@
     <BinPlaceDir Include="$(MicrosoftNetCoreAppRuntimePackNativeDir)" ItemName="NativeBinPlaceItem" />
     <BinPlaceDir Include="$(NetCoreAppCurrentTestHostSharedFrameworkPath)" ItemName="NativeBinPlaceItem" />
     <BinPlaceDir Include="$(NetCoreAppCurrentRuntimePath)" ItemName="NativeBinPlaceItem" />
-    <NativeBinPlaceItem Include="$(PkgSystem_Net_MsQuic_Transport)\runtimes\win10-$(TargetArchitecture)\native\msquic.dll" TargetPath="MsQuic.Native.dll" />
-    <NativeBinPlaceItem Include="$(PkgSystem_Net_MsQuic_Transport)\runtimes\win10-$(TargetArchitecture)\native\msquic.pdb" TargetPath="MsQuic.Native.pdb" />
+    <NativeBinPlaceItem Include="$(PkgSystem_Net_MsQuic_Transport)\runtimes\win10-$(TargetArchitecture)\native\msquic.dll" />
+    <NativeBinPlaceItem Include="$(PkgSystem_Net_MsQuic_Transport)\runtimes\win10-$(TargetArchitecture)\native\msquic.pdb" />
   </ItemGroup>
 
   <ItemGroup>
     <Content Include="msquic.dll" Condition="Exists('msquic.dll')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-      <TargetPath>MsQuic.Native.dll</TargetPath>
     </Content>
     <Content Include="msquic.pdb" Condition="Exists('msquic.pdb')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-      <TargetPath>MsQuic.Native.pdb</TargetPath>
     </Content>
     <Content Include="libmsquic.dylib" Condition="Exists('libmsquic.dylib')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -93,14 +93,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="msquic.dll" Condition="Exists('msquic.dll')">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
-    <Content Include="msquic.pdb" Condition="Exists('msquic.pdb')">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
     <Content Include="libmsquic.dylib" Condition="Exists('libmsquic.dylib')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>

--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -88,8 +88,7 @@
     <BinPlaceDir Include="$(MicrosoftNetCoreAppRuntimePackNativeDir)" ItemName="NativeBinPlaceItem" />
     <BinPlaceDir Include="$(NetCoreAppCurrentTestHostSharedFrameworkPath)" ItemName="NativeBinPlaceItem" />
     <BinPlaceDir Include="$(NetCoreAppCurrentRuntimePath)" ItemName="NativeBinPlaceItem" />
-    <NativeBinPlaceItem Include="$(PkgSystem_Net_MsQuic_Transport)\runtimes\win10-$(TargetArchitecture)\native\msquic.dll" />
-    <NativeBinPlaceItem Include="$(PkgSystem_Net_MsQuic_Transport)\runtimes\win10-$(TargetArchitecture)\native\msquic.pdb" />
+    <NativeBinPlaceItem Include="$(PkgSystem_Net_MsQuic_Transport)\runtimes\win10-$(TargetArchitecture)\native\*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/illink-oob.targets
+++ b/src/libraries/illink-oob.targets
@@ -24,7 +24,7 @@
       <_OOBsToIgnore Include="System.Configuration.ConfigurationManager" />
       <_OOBsToIgnore Include="System.Speech" />
 
-      <_NetCoreAppRuntimeAssemblies Include="$(NetCoreAppCurrentRuntimePath)*.dll" Exclude="$(NetCoreAppCurrentRuntimePath)*.Generator.dll;$(NetCoreAppCurrentRuntimePath)*.Native.dll" />
+      <_NetCoreAppRuntimeAssemblies Include="$(NetCoreAppCurrentRuntimePath)*.dll" Exclude="$(NetCoreAppCurrentRuntimePath)*.Generator.dll;$(NetCoreAppCurrentRuntimePath)*.Native.dll;$(NetCoreAppCurrentRuntimePath)*msquic.dll" />
       <_RuntimePackTrimmedAssemblies Include="$(MicrosoftNetCoreAppRuntimePackRidLibTfmDir)*.dll" />
 
       <!-- Move previous items to FileName so that we can subtract them -->


### PR DESCRIPTION
This mostly does what we need to and it includes native msquic part in runtime. 
I did not find good way how to split native/managed output in single project file or how to create csproj without creating empty assembly. The `BinPlace` approach suggested by @ViktorHofer did not quite work because of include sequence so I give up even with help from @safern. I also look into including the logic in externals.csproj but the copy magic did not work - perhaps because it is based on different SDK. 
I also renamed the native library to avoid being incorectly picked up by ILLinker. 
I'm wondering if we could/should fall-back to simple copy.


