### PR TITLE
Address System.Net.Http.WinHttpHandler's nullable warnings targeting .NETCoreApp

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/WinHttp/Interop.winhttp.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinHttp/Interop.winhttp.cs
@@ -13,8 +13,8 @@ internal static partial class Interop
         public static extern SafeWinHttpHandle WinHttpOpen(
             IntPtr userAgent,
             uint accessType,
-            string proxyName,
-            string proxyBypass, int flags);
+            string? proxyName,
+            string? proxyBypass, int flags);
 
         [DllImport(Interop.Libraries.WinHttp, CharSet = CharSet.Unicode, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
@@ -33,7 +33,7 @@ internal static partial class Interop
             SafeWinHttpHandle connectHandle,
             string verb,
             string objectName,
-            string version,
+            string? version,
             string referrer,
             string acceptTypes,
             uint flags);
@@ -161,8 +161,8 @@ internal static partial class Interop
             SafeWinHttpHandle requestHandle,
             uint authTargets,
             uint authScheme,
-            string userName,
-            string password,
+            string? userName,
+            string? password,
             IntPtr reserved);
 
         [DllImport(Interop.Libraries.WinHttp, CharSet = CharSet.Unicode, SetLastError = true)]

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
@@ -10,8 +10,6 @@
   <PropertyGroup>
     <GeneratePlatformNotSupportedAssemblyMessage Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) != '.NETFramework' and
                                                             '$(TargetsWindows)' != 'true'">SR.PlatformNotSupported_WinHttpHandler</GeneratePlatformNotSupportedAssemblyMessage>
-    <!-- S.N.Http.WinHttpHandler has a lot nullable warnings that need to be addressed: https://github.com/dotnet/runtime/issues/54598. -->
-    <Nullable Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">annotations</Nullable>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'" >

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpAuthHelper.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpAuthHelper.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-
+using System.Diagnostics.CodeAnalysis;
 using SafeWinHttpHandle = Interop.WinHttp.SafeWinHttpHandle;
 
 namespace System.Net.Http
@@ -14,7 +14,7 @@ namespace System.Net.Http
         // WINHTTP_AUTH_SCHEME_NTLM = 0x00000002;
         // WINHTTP_AUTH_SCHEME_DIGEST = 0x00000008;
         // WINHTTP_AUTH_SCHEME_NEGOTIATE = 0x00000010;
-        private static readonly string[] s_authSchemeStringMapping =
+        private static readonly string?[] s_authSchemeStringMapping =
         {
             null,
             "Basic",
@@ -54,6 +54,10 @@ namespace System.Net.Http
             uint supportedSchemes = 0;
             uint firstSchemeIgnored = 0;
             uint authTarget = 0;
+
+            Debug.Assert(state.RequestMessage != null);
+            Debug.Assert(state.RequestMessage.RequestUri != null);
+            Debug.Assert(state.RequestHandle != null);
             Uri uri = state.RequestMessage.RequestUri;
 
             state.RetryRequest = false;
@@ -121,7 +125,7 @@ namespace System.Net.Http
                     state.LastStatusCode = statusCode;
 
                     // If we don't have any proxy credentials to try, then we end up with 407.
-                    ICredentials proxyCreds = state.Proxy == null ?
+                    ICredentials? proxyCreds = state.Proxy == null ?
                         state.DefaultProxyCredentials :
                         state.Proxy.Credentials;
                     if (proxyCreds == null)
@@ -161,6 +165,7 @@ namespace System.Net.Http
                 default:
                     if (state.PreAuthenticate && serverAuthScheme != 0)
                     {
+                        Debug.Assert(state.ServerCredentials != null);
                         SaveServerCredentialsToCache(uri, serverAuthScheme, state.ServerCredentials);
                     }
                     break;
@@ -169,6 +174,10 @@ namespace System.Net.Http
 
         public void PreAuthenticateRequest(WinHttpRequestState state, uint proxyAuthScheme)
         {
+            Debug.Assert(state.RequestHandle != null);
+            Debug.Assert(state.RequestMessage != null);
+            Debug.Assert(state.RequestMessage.RequestUri != null);
+
             // Set proxy credentials if we have them.
             // If a proxy authentication challenge was responded to, reset
             // those credentials before each SendRequest, because the proxy
@@ -177,8 +186,9 @@ namespace System.Net.Http
             // 407-401-407-401- loop.
             if (proxyAuthScheme != 0)
             {
-                ICredentials proxyCredentials;
-                Uri proxyUri;
+                ICredentials? proxyCredentials;
+                Uri? proxyUri;
+
                 if (state.Proxy != null)
                 {
                     proxyCredentials = state.Proxy.Credentials;
@@ -189,6 +199,9 @@ namespace System.Net.Http
                     proxyCredentials = state.DefaultProxyCredentials;
                     proxyUri = state.RequestMessage.RequestUri;
                 }
+
+                Debug.Assert(proxyCredentials != null);
+                Debug.Assert(proxyUri != null);
 
                 SetWinHttpCredential(
                     state.RequestHandle,
@@ -202,7 +215,7 @@ namespace System.Net.Http
             if (state.PreAuthenticate)
             {
                 uint authScheme;
-                NetworkCredential serverCredentials;
+                NetworkCredential? serverCredentials;
                 if (GetServerCredentialsFromCache(
                         state.RequestMessage.RequestUri,
                         out authScheme,
@@ -226,18 +239,18 @@ namespace System.Net.Http
         public bool GetServerCredentialsFromCache(
             Uri uri,
             out uint serverAuthScheme,
-            out NetworkCredential serverCredentials)
+            [NotNullWhen(true)] out NetworkCredential? serverCredentials)
         {
             serverAuthScheme = 0;
             serverCredentials = null;
 
-            NetworkCredential cred = null;
+            NetworkCredential? cred = null;
 
             lock (_credentialCacheLock)
             {
                 foreach (uint authScheme in s_authSchemePriorityOrder)
                 {
-                    cred = _credentialCache.GetCredential(uri, s_authSchemeStringMapping[authScheme]);
+                    cred = _credentialCache.GetCredential(uri, s_authSchemeStringMapping[authScheme]!);
                     if (cred != null)
                     {
                         serverAuthScheme = authScheme;
@@ -253,10 +266,10 @@ namespace System.Net.Http
 
         public void SaveServerCredentialsToCache(Uri uri, uint authScheme, ICredentials serverCredentials)
         {
-            string authType = s_authSchemeStringMapping[authScheme];
+            string? authType = s_authSchemeStringMapping[authScheme];
             Debug.Assert(!string.IsNullOrEmpty(authType));
 
-            NetworkCredential cred = serverCredentials.GetCredential(uri, authType);
+            NetworkCredential? cred = serverCredentials.GetCredential(uri, authType);
             if (cred != null)
             {
                 lock (_credentialCacheLock)
@@ -303,15 +316,17 @@ namespace System.Net.Http
             uint authScheme,
             uint authTarget)
         {
-            string userName;
-            string password;
+            string? userName;
+            string? password;
 
             Debug.Assert(credentials != null);
             Debug.Assert(authScheme != 0);
             Debug.Assert(authTarget == Interop.WinHttp.WINHTTP_AUTH_TARGET_PROXY ||
                          authTarget == Interop.WinHttp.WINHTTP_AUTH_TARGET_SERVER);
 
-            NetworkCredential networkCredential = credentials.GetCredential(uri, s_authSchemeStringMapping[authScheme]);
+            string? authType = s_authSchemeStringMapping[authScheme];
+            Debug.Assert(!string.IsNullOrEmpty(authType));
+            NetworkCredential? networkCredential = credentials.GetCredential(uri, authType);
 
             if (networkCredential == null)
             {
@@ -367,7 +382,7 @@ namespace System.Net.Http
             return true;
         }
 
-        private static uint ChooseAuthScheme(uint supportedSchemes, Uri uri, ICredentials credentials)
+        private static uint ChooseAuthScheme(uint supportedSchemes, Uri? uri, ICredentials? credentials)
         {
             if (credentials == null)
             {
@@ -383,9 +398,11 @@ namespace System.Net.Http
                 return 0;
             }
 
+            Debug.Assert(uri != null);
+
             foreach (uint authScheme in s_authSchemePriorityOrder)
             {
-                if ((supportedSchemes & authScheme) != 0 && credentials.GetCredential(uri, s_authSchemeStringMapping[authScheme]) != null)
+                if ((supportedSchemes & authScheme) != 0 && credentials.GetCredential(uri, s_authSchemeStringMapping[authScheme]!) != null)
                 {
                     return authScheme;
                 }

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCertificateHelper.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCertificateHelper.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Net.Security;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
@@ -20,7 +21,6 @@ namespace System.Net.Http
             out X509Chain chain,
             out SslPolicyErrors sslPolicyErrors)
         {
-            chain = null;
             sslPolicyErrors = SslPolicyErrors.None;
 
             // Build the chain.
@@ -68,6 +68,8 @@ namespace System.Net.Http
                     cppStruct.dwFlags =
                         Interop.Crypt32.CertChainPolicyIgnoreFlags.CERT_CHAIN_POLICY_IGNORE_ALL &
                         ~Interop.Crypt32.CertChainPolicyIgnoreFlags.CERT_CHAIN_POLICY_IGNORE_INVALID_NAME_FLAG;
+
+                    Debug.Assert(chain.SafeHandle != null);
 
                     Interop.Crypt32.CERT_CHAIN_POLICY_STATUS status = default;
                     status.cbSize = (uint)sizeof(Interop.Crypt32.CERT_CHAIN_POLICY_STATUS);

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpChannelBinding.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpChannelBinding.cs
@@ -13,7 +13,7 @@ namespace System.Net.Http
     internal sealed class WinHttpChannelBinding : ChannelBinding
     {
         private int _size;
-        private string _cachedToString;
+        private string? _cachedToString;
 
         internal WinHttpChannelBinding(SafeWinHttpHandle requestHandle)
         {
@@ -55,7 +55,7 @@ namespace System.Net.Http
             }
         }
 
-        public override string ToString()
+        public override string? ToString()
         {
             if (_cachedToString == null && !IsInvalid)
             {

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCookieContainerAdapter.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCookieContainerAdapter.cs
@@ -15,17 +15,21 @@ namespace System.Net.Http
 
         public static void AddResponseCookiesToContainer(WinHttpRequestState state)
         {
-            HttpRequestMessage request = state.RequestMessage;
-            SafeWinHttpHandle requestHandle = state.RequestHandle;
-            CookieContainer cookieContainer = state.Handler.CookieContainer;
+            HttpRequestMessage? request = state.RequestMessage;
+            SafeWinHttpHandle? requestHandle = state.RequestHandle;
+            Debug.Assert(state.Handler != null);
+            CookieContainer? cookieContainer = state.Handler.CookieContainer;
 
             Debug.Assert(state.Handler.CookieUsePolicy == CookieUsePolicy.UseSpecifiedCookieContainer);
+            Debug.Assert(request != null);
+            Debug.Assert(requestHandle != null);
             Debug.Assert(cookieContainer != null);
+            Debug.Assert(request.RequestUri != null);
 
             // Get 'Set-Cookie' headers from response.
-            char[] buffer = null;
+            char[]? buffer = null;
             uint index = 0;
-            string cookieHeader;
+            string? cookieHeader;
             while (WinHttpResponseParser.GetResponseHeader(
                 requestHandle, Interop.WinHttp.WINHTTP_QUERY_SET_COOKIE, ref buffer, ref index, out cookieHeader))
             {
@@ -44,9 +48,12 @@ namespace System.Net.Http
 
         public static void ResetCookieRequestHeaders(WinHttpRequestState state, Uri redirectUri)
         {
-            SafeWinHttpHandle requestHandle = state.RequestHandle;
+            SafeWinHttpHandle? requestHandle = state.RequestHandle;
 
+            Debug.Assert(state.Handler != null);
             Debug.Assert(state.Handler.CookieUsePolicy == CookieUsePolicy.UseSpecifiedCookieContainer);
+            Debug.Assert(state.Handler.CookieContainer != null);
+            Debug.Assert(requestHandle != null);
 
             // Clear cookies.
             if (!Interop.WinHttp.WinHttpAddRequestHeaders(
@@ -64,7 +71,7 @@ namespace System.Net.Http
 
             // Re-add cookies. The GetCookieHeader() method will return the correct set of
             // cookies based on the redirectUri.
-            string cookieHeader = GetCookieHeader(redirectUri, state.Handler.CookieContainer);
+            string? cookieHeader = GetCookieHeader(redirectUri, state.Handler.CookieContainer);
             if (!string.IsNullOrEmpty(cookieHeader))
             {
                 if (!Interop.WinHttp.WinHttpAddRequestHeaders(
@@ -78,9 +85,9 @@ namespace System.Net.Http
             }
         }
 
-        public static string GetCookieHeader(Uri uri, CookieContainer cookies)
+        public static string? GetCookieHeader(Uri uri, CookieContainer cookies)
         {
-            string cookieHeader = null;
+            string? cookieHeader = null;
 
             Debug.Assert(cookies != null);
 

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -46,16 +46,16 @@ namespace System.Net.Http
         private static readonly StringWithQualityHeaderValue s_deflateHeaderValue = new StringWithQualityHeaderValue("deflate");
 
         [ThreadStatic]
-        private static StringBuilder t_requestHeadersBuilder;
+        private static StringBuilder? t_requestHeadersBuilder;
 
         private readonly object _lockObject = new object();
         private bool _doManualDecompressionCheck;
-        private WinInetProxyHelper _proxyHelper;
+        private WinInetProxyHelper? _proxyHelper;
         private bool _automaticRedirection = HttpHandlerDefaults.DefaultAutomaticRedirection;
         private int _maxAutomaticRedirections = HttpHandlerDefaults.DefaultMaxAutomaticRedirections;
         private DecompressionMethods _automaticDecompression = HttpHandlerDefaults.DefaultAutomaticDecompression;
         private CookieUsePolicy _cookieUsePolicy = CookieUsePolicy.UseInternalCookieStoreOnly;
-        private CookieContainer _cookieContainer;
+        private CookieContainer? _cookieContainer;
         private bool _enableMultipleHttp2Connections;
 
         private SslProtocols _sslProtocols = SslProtocols.None; // Use most secure protocols available.
@@ -64,15 +64,15 @@ namespace System.Net.Http
             X509Certificate2,
             X509Chain,
             SslPolicyErrors,
-            bool> _serverCertificateValidationCallback;
+            bool>? _serverCertificateValidationCallback;
         private bool _checkCertificateRevocationList;
         private ClientCertificateOption _clientCertificateOption = ClientCertificateOption.Manual;
-        private X509Certificate2Collection _clientCertificates; // Only create collection when required.
-        private ICredentials _serverCredentials;
+        private X509Certificate2Collection? _clientCertificates; // Only create collection when required.
+        private ICredentials? _serverCredentials;
         private bool _preAuthenticate;
         private WindowsProxyUsePolicy _windowsProxyUsePolicy = WindowsProxyUsePolicy.UseWinHttpProxy;
-        private ICredentials _defaultProxyCredentials;
-        private IWebProxy _proxy;
+        private ICredentials? _defaultProxyCredentials;
+        private IWebProxy? _proxy;
         private int _maxConnectionsPerServer = int.MaxValue;
         private TimeSpan _sendTimeout = TimeSpan.FromSeconds(30);
         private TimeSpan _receiveHeadersTimeout = TimeSpan.FromSeconds(30);
@@ -86,10 +86,10 @@ namespace System.Net.Http
 
         private int _maxResponseHeadersLength = HttpHandlerDefaults.DefaultMaxResponseHeadersLength;
         private int _maxResponseDrainSize = 64 * 1024;
-        private IDictionary<string, object> _properties; // Only create dictionary when required.
+        private IDictionary<string, object>? _properties; // Only create dictionary when required.
         private volatile bool _operationStarted;
         private volatile bool _disposed;
-        private SafeWinHttpHandle _sessionHandle;
+        private SafeWinHttpHandle? _sessionHandle;
         private readonly WinHttpAuthHelper _authHelper = new WinHttpAuthHelper();
 
         public WinHttpHandler()
@@ -617,8 +617,8 @@ namespace System.Net.Http
 
             Task.Factory.StartNew(s =>
                 {
-                    var whrs = (WinHttpRequestState)s;
-                    _ = whrs.Handler.StartRequestAsync(whrs);
+                    var whrs = (WinHttpRequestState)s!;
+                    _ = whrs.Handler!.StartRequestAsync(whrs);
                 },
                 state,
                 CancellationToken.None,
@@ -638,7 +638,7 @@ namespace System.Net.Http
                 chunkedMode = WinHttpChunkMode.Manual;
             }
 
-            HttpContent requestContent = requestMessage.Content;
+            HttpContent? requestContent = requestMessage.Content;
             if (requestContent != null)
             {
                 if (requestContent.Headers.ContentLength.HasValue)
@@ -686,12 +686,14 @@ namespace System.Net.Http
         private static void AddRequestHeaders(
             SafeWinHttpHandle requestHandle,
             HttpRequestMessage requestMessage,
-            CookieContainer cookies,
+            CookieContainer? cookies,
             DecompressionMethods manuallyProcessedDecompressionMethods)
         {
+            Debug.Assert(requestMessage.RequestUri != null);
+
             // Get a StringBuilder to use for creating the request headers.
             // We cache one in TLS to avoid creating a new one for each request.
-            StringBuilder requestHeadersBuffer = t_requestHeadersBuilder;
+            StringBuilder? requestHeadersBuffer = t_requestHeadersBuilder;
             if (requestHeadersBuffer != null)
             {
                 requestHeadersBuffer.Clear();
@@ -724,7 +726,7 @@ namespace System.Net.Http
             // Manually add cookies.
             if (cookies != null && cookies.Count > 0)
             {
-                string cookieHeader = WinHttpCookieContainerAdapter.GetCookieHeader(requestMessage.RequestUri, cookies);
+                string? cookieHeader = WinHttpCookieContainerAdapter.GetCookieHeader(requestMessage.RequestUri, cookies);
                 if (!string.IsNullOrEmpty(cookieHeader))
                 {
                     requestHeadersBuffer.AppendLine(cookieHeader);
@@ -778,6 +780,8 @@ namespace System.Net.Http
                         if (state.WindowsProxyUsePolicy == WindowsProxyUsePolicy.UseCustomProxy)
                         {
                             Debug.Assert(state.Proxy != null);
+                            Debug.Assert(state.RequestMessage != null);
+                            Debug.Assert(state.RequestMessage.RequestUri != null);
                             try
                             {
                                 state.Proxy.GetProxy(state.RequestMessage.RequestUri);
@@ -867,6 +871,13 @@ namespace System.Net.Http
 
         private async Task StartRequestAsync(WinHttpRequestState state)
         {
+            Debug.Assert(state.RequestMessage != null);
+            Debug.Assert(state.RequestMessage.RequestUri != null);
+            Debug.Assert(state.RequestHandle != null);
+            Debug.Assert(state.Handler != null);
+            Debug.Assert(state.Tcs != null);
+            Debug.Assert(_sessionHandle != null);
+
             if (state.CancellationToken.IsCancellationRequested)
             {
                 state.Tcs.TrySetCanceled(state.CancellationToken);
@@ -874,8 +885,8 @@ namespace System.Net.Http
                 return;
             }
 
-            Task sendRequestBodyTask = null;
-            SafeWinHttpHandle connectHandle = null;
+            Task? sendRequestBodyTask = null;
+            SafeWinHttpHandle? connectHandle = null;
             try
             {
                 EnsureSessionHandleExists(state);
@@ -893,7 +904,7 @@ namespace System.Net.Http
 
                 // Try to use the requested version if a known/supported version was explicitly requested.
                 // Otherwise, we simply use winhttp's default.
-                string httpVersion = null;
+                string? httpVersion = null;
                 if (state.RequestMessage.Version == HttpVersion.Version10)
                 {
                     httpVersion = "HTTP/1.0";
@@ -929,7 +940,7 @@ namespace System.Net.Http
                 // will have the side-effect of WinHTTP cancelling any pending I/O and accelerating its callbacks
                 // on the handle and thus releasing the awaiting tasks in the loop below. This helps to provide
                 // a more timely, cooperative, cancellation pattern.
-                using (state.CancellationToken.Register(s => ((WinHttpRequestState)s).RequestHandle.Dispose(), state))
+                using (state.CancellationToken.Register(s => ((WinHttpRequestState)s!).RequestHandle!.Dispose(), state))
                 {
                     do
                     {
@@ -1031,8 +1042,10 @@ namespace System.Net.Http
             }
         }
 
-        private void OpenRequestHandle(WinHttpRequestState state, SafeWinHttpHandle connectHandle, string httpVersion, out WinHttpChunkMode chunkedModeForSend, out SafeWinHttpHandle requestHandle)
+        private void OpenRequestHandle(WinHttpRequestState state, SafeWinHttpHandle connectHandle, string? httpVersion, out WinHttpChunkMode chunkedModeForSend, out SafeWinHttpHandle requestHandle)
         {
+            Debug.Assert(state.RequestMessage != null);
+            Debug.Assert(state.RequestMessage.RequestUri != null);
             chunkedModeForSend = GetChunkedModeForSend(state.RequestMessage);
 
             // Create an HTTP request handle.
@@ -1079,7 +1092,7 @@ namespace System.Net.Http
                 // .NET Framework behavior. System.Uri establishes the baseline rules for percent-encoding
                 // of reserved characters.
                 uint flags = Interop.WinHttp.WINHTTP_FLAG_ESCAPE_DISABLE;
-                if (state.RequestMessage.RequestUri.Scheme == UriScheme.Https)
+                if (state.RequestMessage!.RequestUri!.Scheme == UriScheme.Https)
                 {
                     flags |= Interop.WinHttp.WINHTTP_FLAG_SECURE;
                 }
@@ -1193,6 +1206,10 @@ namespace System.Net.Http
 
         private void SetRequestHandleOptions(WinHttpRequestState state)
         {
+            Debug.Assert(state.RequestHandle != null);
+            Debug.Assert(state.RequestMessage != null);
+            Debug.Assert(state.RequestMessage.RequestUri != null);
+
             SetRequestHandleProxyOptions(state);
             SetRequestHandleDecompressionOptions(state.RequestHandle);
             SetRequestHandleRedirectionOptions(state.RequestHandle);
@@ -1206,6 +1223,10 @@ namespace System.Net.Http
 
         private void SetRequestHandleProxyOptions(WinHttpRequestState state)
         {
+            Debug.Assert(state.RequestMessage != null);
+            Debug.Assert(state.RequestMessage.RequestUri != null);
+            Debug.Assert(state.RequestHandle != null);
+
             // We've already set the proxy on the session handle if we're using no proxy or default proxy settings.
             // We only need to change it on the request handle if we have a specific IWebProxy or need to manually
             // implement Wininet-style auto proxy detection.
@@ -1222,14 +1243,15 @@ namespace System.Net.Http
                     {
                         Debug.Assert(state.WindowsProxyUsePolicy == WindowsProxyUsePolicy.UseCustomProxy);
                         updateProxySettings = true;
-                        if (state.Proxy.IsBypassed(uri))
+
+                        Uri? proxyUri = state.Proxy.IsBypassed(uri) ? null : state.Proxy.GetProxy(uri);
+                        if (proxyUri == null)
                         {
                             proxyInfo.AccessType = Interop.WinHttp.WINHTTP_ACCESS_TYPE_NO_PROXY;
                         }
                         else
                         {
                             proxyInfo.AccessType = Interop.WinHttp.WINHTTP_ACCESS_TYPE_NAMED_PROXY;
-                            Uri proxyUri = state.Proxy.GetProxy(uri);
                             string proxyString = proxyUri.Scheme + "://" + proxyUri.Authority;
                             proxyInfo.Proxy = Marshal.StringToHGlobalUni(proxyString);
                         }
@@ -1362,7 +1384,7 @@ namespace System.Net.Http
                 return;
             }
 
-            X509Certificate2 clientCertificate = null;
+            X509Certificate2? clientCertificate = null;
             if (_clientCertificateOption == ClientCertificateOption.Manual)
             {
                 clientCertificate = CertificateHelper.GetEligibleClientCertificate(ClientCertificates);
@@ -1388,6 +1410,8 @@ namespace System.Net.Http
 
         private void SetEnableHttp2PlusClientCertificate(Uri requestUri, Version requestVersion)
         {
+            Debug.Assert(_sessionHandle != null);
+
             if (requestUri.Scheme != UriScheme.Https || requestVersion != HttpVersion20)
             {
                 return;
@@ -1436,6 +1460,7 @@ namespace System.Net.Http
 
         private void SetRequestHandleCredentialsOptions(WinHttpRequestState state)
         {
+            Debug.Assert(state.RequestHandle != null);
             // By default, WinHTTP sets the default credentials policy such that it automatically sends default credentials
             // (current user's logged on Windows credentials) to a proxy when needed (407 response). It only sends
             // default credentials to a server (401 response) if the server is considered to be on the Intranet.
@@ -1506,6 +1531,7 @@ namespace System.Net.Http
 
         private void HandleAsyncException(WinHttpRequestState state, Exception ex)
         {
+            Debug.Assert(state.Tcs != null);
             if (state.CancellationToken.IsCancellationRequested)
             {
                 // If the exception was due to the cancellation token being canceled, throw cancellation exception.
@@ -1597,6 +1623,8 @@ namespace System.Net.Http
         {
             lock (state.Lock)
             {
+                Debug.Assert(state.RequestHandle != null);
+
                 state.Pin();
                 if (!Interop.WinHttp.WinHttpSendRequest(
                     state.RequestHandle,
@@ -1622,6 +1650,9 @@ namespace System.Net.Http
 
         private async Task InternalSendRequestBodyAsync(WinHttpRequestState state, WinHttpChunkMode chunkedModeForSend)
         {
+            Debug.Assert(state.RequestMessage != null);
+            Debug.Assert(state.RequestMessage.Content != null);
+
             using (var requestStream = new WinHttpRequestStream(state, chunkedModeForSend))
             {
                 await state.RequestMessage.Content.CopyToAsync(requestStream, state.TransportContext).ConfigureAwait(false);
@@ -1633,6 +1664,8 @@ namespace System.Net.Http
         {
             lock (state.Lock)
             {
+                Debug.Assert(state.RequestHandle != null);
+
                 if (!Interop.WinHttp.WinHttpReceiveResponse(state.RequestHandle, IntPtr.Zero))
                 {
                     throw WinHttpException.CreateExceptionUsingLastError(nameof(Interop.WinHttp.WinHttpReceiveResponse));

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -873,7 +873,6 @@ namespace System.Net.Http
         {
             Debug.Assert(state.RequestMessage != null);
             Debug.Assert(state.RequestMessage.RequestUri != null);
-            Debug.Assert(state.RequestHandle != null);
             Debug.Assert(state.Handler != null);
             Debug.Assert(state.Tcs != null);
 

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -876,7 +876,6 @@ namespace System.Net.Http
             Debug.Assert(state.RequestHandle != null);
             Debug.Assert(state.Handler != null);
             Debug.Assert(state.Tcs != null);
-            Debug.Assert(_sessionHandle != null);
 
             if (state.CancellationToken.IsCancellationRequested)
             {
@@ -890,6 +889,7 @@ namespace System.Net.Http
             try
             {
                 EnsureSessionHandleExists(state);
+                Debug.Assert(_sessionHandle != null);
 
                 SetEnableHttp2PlusClientCertificate(state.RequestMessage.RequestUri, state.RequestMessage.Version);
 

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
@@ -40,7 +40,7 @@ namespace System.Net.Http
                 return;
             }
 
-            WinHttpRequestState state = WinHttpRequestState.FromIntPtr(context);
+            WinHttpRequestState? state = WinHttpRequestState.FromIntPtr(context);
             Debug.Assert(state != null, "WinHttpCallback must have a non-null state object");
 
             RequestCallback(handle, state, internetStatus, statusInformation, statusInformationLength);
@@ -84,7 +84,8 @@ namespace System.Net.Http
                         return;
 
                     case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_REDIRECT:
-                        string redirectUriString = Marshal.PtrToStringUni(statusInformation);
+                        string? redirectUriString = Marshal.PtrToStringUni(statusInformation);
+                        Debug.Assert(redirectUriString != null);
                         var redirectUri = new Uri(redirectUriString);
                         OnRequestRedirect(state, redirectUri);
                         return;
@@ -192,6 +193,8 @@ namespace System.Net.Http
         private static void OnRequestRedirect(WinHttpRequestState state, Uri redirectUri)
         {
             Debug.Assert(state != null, "OnRequestRedirect: state is null");
+            Debug.Assert(state.Handler != null, "OnRequestRedirect: state.Handler is null");
+            Debug.Assert(state.RequestMessage != null, "OnRequestRedirect: state.RequestMessage is null");
             Debug.Assert(redirectUri != null, "OnRequestRedirect: redirectUri is null");
 
             // If we're manually handling cookies, we need to reset them based on the new URI.
@@ -234,6 +237,8 @@ namespace System.Net.Http
         {
             Debug.Assert(state != null, "OnRequestSendingRequest: state is null");
             Debug.Assert(state.RequestHandle != null, "OnRequestSendingRequest: state.RequestHandle is null");
+            Debug.Assert(state.RequestMessage != null, "OnRequestSendingRequest: state.RequestMessage is null");
+            Debug.Assert(state.RequestMessage.RequestUri != null, "OnRequestSendingRequest: state.RequestMessage.RequestUri is null");
 
             if (state.RequestMessage.RequestUri.Scheme != UriScheme.Https)
             {
@@ -280,7 +285,7 @@ namespace System.Net.Http
                 var serverCertificate = new X509Certificate2(certHandle);
                 Interop.Crypt32.CertFreeCertificateContext(certHandle);
 
-                X509Chain chain = null;
+                X509Chain? chain = null;
                 SslPolicyErrors sslPolicyErrors;
                 bool result = false;
 
@@ -391,6 +396,7 @@ namespace System.Net.Http
                     break;
 
                 case Interop.WinHttp.API_WRITE_DATA:
+                    Debug.Assert(state.TcsInternalWriteDataToRequestStream != null);
                     if (asyncResult.dwError == Interop.WinHttp.ERROR_WINHTTP_OPERATION_CANCELLED)
                     {
                         if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(state, "API_WRITE_DATA - ERROR_WINHTTP_OPERATION_CANCELLED");
@@ -414,7 +420,8 @@ namespace System.Net.Http
         private static void ResetAuthRequestHeaders(WinHttpRequestState state)
         {
             const string AuthHeaderNameWithColon = "Authorization:";
-            SafeWinHttpHandle requestHandle = state.RequestHandle;
+            SafeWinHttpHandle? requestHandle = state.RequestHandle;
+            Debug.Assert(requestHandle != null);
 
             // Clear auth headers.
             if (!Interop.WinHttp.WinHttpAddRequestHeaders(

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
@@ -84,9 +84,7 @@ namespace System.Net.Http
                         return;
 
                     case Interop.WinHttp.WINHTTP_CALLBACK_STATUS_REDIRECT:
-                        string? redirectUriString = Marshal.PtrToStringUni(statusInformation);
-                        Debug.Assert(redirectUriString != null);
-                        var redirectUri = new Uri(redirectUriString);
+                        var redirectUri = new Uri(Marshal.PtrToStringUni(statusInformation)!);
                         OnRequestRedirect(state, redirectUri);
                         return;
 

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Security;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
@@ -28,7 +29,7 @@ namespace System.Net.Http
         // A GCHandle for this operation object.
         // This is owned by the callback and will be deallocated when the sessionHandle has been closed.
         private GCHandle _operationHandle;
-        private WinHttpTransportContext _transportContext;
+        private WinHttpTransportContext? _transportContext;
         private volatile bool _disposed; // To detect redundant calls.
 
         public WinHttpRequestState()
@@ -49,10 +50,10 @@ namespace System.Net.Http
             }
         }
 
-        public static WinHttpRequestState FromIntPtr(IntPtr gcHandle)
+        public static WinHttpRequestState? FromIntPtr(IntPtr gcHandle)
         {
             GCHandle stateHandle = GCHandle.FromIntPtr(gcHandle);
-            return (WinHttpRequestState)stateHandle.Target;
+            return (WinHttpRequestState?)stateHandle.Target;
         }
 
         public IntPtr ToIntPtr()
@@ -92,16 +93,16 @@ namespace System.Net.Http
             }
         }
 
-        public TaskCompletionSource<HttpResponseMessage> Tcs { get; set; }
+        public TaskCompletionSource<HttpResponseMessage>? Tcs { get; set; }
 
         public CancellationToken CancellationToken { get; set; }
 
-        public HttpRequestMessage RequestMessage { get; set; }
+        public HttpRequestMessage? RequestMessage { get; set; }
 
-        public WinHttpHandler Handler { get; set; }
+        public WinHttpHandler? Handler { get; set; }
 
-        private SafeWinHttpHandle _requestHandle;
-        public SafeWinHttpHandle RequestHandle
+        private SafeWinHttpHandle? _requestHandle;
+        public SafeWinHttpHandle? RequestHandle
         {
             get
             {
@@ -120,12 +121,13 @@ namespace System.Net.Http
             }
         }
 
-        public Exception SavedException { get; set; }
+        public Exception? SavedException { get; set; }
 
         public bool CheckCertificateRevocationList { get; set; }
 
-        public Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> ServerCertificateValidationCallback { get; set; }
+        public Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool>? ServerCertificateValidationCallback { get; set; }
 
+        [AllowNull]
         public WinHttpTransportContext TransportContext
         {
             get { return _transportContext ?? (_transportContext = new WinHttpTransportContext()); }
@@ -134,11 +136,11 @@ namespace System.Net.Http
 
         public WindowsProxyUsePolicy WindowsProxyUsePolicy { get; set; }
 
-        public IWebProxy Proxy { get; set; }
+        public IWebProxy? Proxy { get; set; }
 
-        public ICredentials ServerCredentials { get; set; }
+        public ICredentials? ServerCredentials { get; set; }
 
-        public ICredentials DefaultProxyCredentials { get; set; }
+        public ICredentials? DefaultProxyCredentials { get; set; }
 
         public bool PreAuthenticate { get; set; }
 
@@ -147,7 +149,7 @@ namespace System.Net.Http
         public bool RetryRequest { get; set; }
 
         public RendezvousAwaitable<int> LifecycleAwaitable { get; set; } = new RendezvousAwaitable<int>();
-        public TaskCompletionSource<bool> TcsInternalWriteDataToRequestStream { get; set; }
+        public TaskCompletionSource<bool>? TcsInternalWriteDataToRequestStream { get; set; }
         public bool AsyncReadInProgress { get; set; }
 
         // WinHttpResponseStream state.

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
@@ -33,6 +33,7 @@ namespace System.Net.Http
 
             // Take copy of handle from state.
             // The state's request handle will be set to null once the response stream starts.
+            Debug.Assert(_state.RequestHandle != null);
             _requestHandle = _state.RequestHandle;
         }
 

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseHeaderReader.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseHeaderReader.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Net.Http
 {
@@ -28,7 +29,7 @@ namespace System.Net.Http
         /// Empty header lines are skipped, as are malformed header lines that are missing a colon character.
         /// </summary>
         /// <returns>true if the next header was read successfully, or false if all characters have been read.</returns>
-        public bool ReadHeader(out string name, out string value)
+        public bool ReadHeader([NotNullWhen(true)] out string? name, [NotNullWhen(true)] out string? value)
         {
             int startIndex;
             int length;

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Compression;
 using System.Net.Http.Headers;
@@ -21,8 +22,11 @@ namespace System.Net.Http
             WinHttpRequestState state,
             DecompressionMethods manuallyProcessedDecompressionMethods)
         {
-            HttpRequestMessage request = state.RequestMessage;
-            SafeWinHttpHandle requestHandle = state.RequestHandle;
+            HttpRequestMessage? request = state.RequestMessage;
+            SafeWinHttpHandle? requestHandle = state.RequestHandle;
+            Debug.Assert(request != null);
+            Debug.Assert(requestHandle != null);
+
             var response = new HttpResponseMessage();
             bool stripEncodingHeaders = false;
 
@@ -133,9 +137,9 @@ namespace System.Net.Http
         public static unsafe bool GetResponseHeader(
             SafeWinHttpHandle requestHandle,
             uint infoLevel,
-            ref char[] buffer,
+            ref char[]? buffer,
             ref uint index,
-            out string headerValue)
+            [NotNullWhen(true)] out string? headerValue)
         {
             const int StackLimit = 128;
 
@@ -286,7 +290,7 @@ namespace System.Net.Http
 
             // If it's a known reason phrase, use the known reason phrase instead of allocating a new string.
 
-            string knownReasonPhrase = HttpStatusDescription.Get(statusCode);
+            string? knownReasonPhrase = HttpStatusDescription.Get(statusCode);
 
             return (knownReasonPhrase != null && knownReasonPhrase.AsSpan().SequenceEqual(buffer.AsSpan(0, bufferLength))) ?
                 knownReasonPhrase :
@@ -313,7 +317,7 @@ namespace System.Net.Http
             reader.ReadLine();
 
             // Parse the array of headers and split them between Content headers and Response headers.
-            while (reader.ReadHeader(out string headerName, out string headerValue))
+            while (reader.ReadHeader(out string? headerName, out string? headerValue))
             {
                 if (!responseHeaders.TryAddWithoutValidation(headerName, headerValue))
                 {
@@ -350,7 +354,7 @@ namespace System.Net.Http
             var reader = new WinHttpResponseHeaderReader(buffer, 0, bufferLength);
 
             // Parse the array of headers and split them between Content headers and Response headers.
-            while (reader.ReadHeader(out string headerName, out string headerValue))
+            while (reader.ReadHeader(out string? headerName, out string? headerValue))
             {
                 responseTrailers.TryAddWithoutValidation(headerName, headerValue);
             }

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
@@ -113,7 +113,7 @@ namespace System.Net.Http
         private async Task CopyToAsyncCore(Stream destination, byte[] buffer, CancellationToken cancellationToken)
         {
             _state.PinReceiveBuffer(buffer);
-            CancellationTokenRegistration ctr = cancellationToken.Register(s => ((WinHttpResponseStream)s).CancelPendingResponseStreamReadOperation(), this);
+            CancellationTokenRegistration ctr = cancellationToken.Register(s => ((WinHttpResponseStream)s!).CancelPendingResponseStreamReadOperation(), this);
             _state.AsyncReadInProgress = true;
             try
             {
@@ -223,7 +223,7 @@ namespace System.Net.Http
             }
 
             _state.PinReceiveBuffer(buffer);
-            var ctr = token.Register(s => ((WinHttpResponseStream)s).CancelPendingResponseStreamReadOperation(), this);
+            var ctr = token.Register(s => ((WinHttpResponseStream)s!).CancelPendingResponseStreamReadOperation(), this);
             _state.AsyncReadInProgress = true;
             try
             {
@@ -330,7 +330,7 @@ namespace System.Net.Http
                     if (_requestHandle != null)
                     {
                         _requestHandle.Dispose();
-                        _requestHandle = null;
+                        _requestHandle = null!;
                     }
                 }
             }

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpTraceHelper.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpTraceHelper.cs
@@ -9,7 +9,7 @@ namespace System.Net.Http
 {
     internal static class WinHttpTraceHelper
     {
-        public static void TraceCallbackStatus(object thisOrContextObject, IntPtr handle, IntPtr context, uint status, [CallerMemberName] string memberName = null)
+        public static void TraceCallbackStatus(object? thisOrContextObject, IntPtr handle, IntPtr context, uint status, [CallerMemberName] string? memberName = null)
         {
             Debug.Assert(NetEventSource.Log.IsEnabled());
 
@@ -19,7 +19,7 @@ namespace System.Net.Http
                 memberName);
         }
 
-        public static void TraceAsyncError(object thisOrContextObject, Interop.WinHttp.WINHTTP_ASYNC_RESULT asyncResult, [CallerMemberName] string memberName = null)
+        public static void TraceAsyncError(object thisOrContextObject, Interop.WinHttp.WINHTTP_ASYNC_RESULT asyncResult, [CallerMemberName] string? memberName = null)
         {
             Debug.Assert(NetEventSource.Log.IsEnabled());
 

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpTransportContext.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpTransportContext.cs
@@ -10,13 +10,13 @@ namespace System.Net.Http
 {
     internal sealed class WinHttpTransportContext : TransportContext
     {
-        private WinHttpChannelBinding _channelBinding;
+        private WinHttpChannelBinding? _channelBinding;
 
         internal WinHttpTransportContext()
         {
         }
 
-        public override ChannelBinding GetChannelBinding(ChannelBindingKind kind)
+        public override ChannelBinding? GetChannelBinding(ChannelBindingKind kind)
         {
             // WinHTTP only supports retrieval of ChannelBindingKind.Endpoint for CBT.
             if (kind == ChannelBindingKind.Endpoint)


### PR DESCRIPTION
Closes #54598

Mainly using asserts. `!` is only used in lambda and local function.