### PR TITLE
[interp] Re-enable tests for mono interpreter

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2209,12 +2209,6 @@
         <ExcludeList Include = "$(XunitTestBinBase)JIT/IL_Conformance/Old/Base/ckfinite/**">
             <Issue>https://github.com/dotnet/runtime/issues/54376</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/HardwareIntrinsics/General/Vector128_1/Vector128_1_r/**">
-            <Issue>https://github.com/dotnet/runtime/issues/54374e</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/HardwareIntrinsics/General/Vector128_1/Vector128_1_ro/**">
-            <Issue>https://github.com/dotnet/runtime/issues/54374</Issue>
-        </ExcludeList>
         <!-- End interpreter issues -->
     </ItemGroup>
 


### PR DESCRIPTION
Fixed by https://github.com/dotnet/runtime/pull/54734