### PR TITLE
Mark vars as do not enreg earlier in minopts.

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2855,8 +2855,8 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
     setUsesSIMDTypes(false);
 #endif // FEATURE_SIMD
 
-    lvaEnregEHVars       = (((opts.compFlags & CLFLG_REGVAR) != 0) && JitConfig.EnableEHWriteThru());
-    lvaEnregMultiRegVars = (((opts.compFlags & CLFLG_REGVAR) != 0) && JitConfig.EnableMultiRegLocals());
+    lvaEnregEHVars       = (compEnregLocals() && JitConfig.EnableEHWriteThru());
+    lvaEnregMultiRegVars = (compEnregLocals() && JitConfig.EnableMultiRegLocals());
 
     if (compIsForImportOnly())
     {

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9778,6 +9778,11 @@ public:
 #endif // FEATURE_MULTIREG_RET
     }
 
+    bool compEnregLocals()
+    {
+        return ((opts.compFlags & CLFLG_REGVAR) != 0);
+    }
+
     bool compEnregStructLocals()
     {
         return (JitConfig.JitEnregStructLocals() != 0);

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1585,6 +1585,11 @@ inline unsigned Compiler::lvaGrabTemp(bool shortLifetime DEBUGARG(const char* re
     lvaTable[tempNum].lvIsTemp  = shortLifetime;
     lvaTable[tempNum].lvOnFrame = true;
 
+    if (!compEnregLocals())
+    {
+        lvaSetVarDoNotEnregister(tempNum DEBUGARG(Compiler::DNER_NoRegVars));
+    }
+
     // If we've started normal ref counting, bump the ref count of this
     // local, as we no longer do any incremental counting, and we presume
     // this new local will be referenced.

--- a/src/coreclr/jit/decomposelongs.cpp
+++ b/src/coreclr/jit/decomposelongs.cpp
@@ -2076,7 +2076,7 @@ genTreeOps DecomposeLongs::GetLoOper(genTreeOps oper)
 //
 void DecomposeLongs::PromoteLongVars()
 {
-    if ((m_compiler->opts.compFlags & CLFLG_REGVAR) == 0)
+    if (!m_compiler->compEnregLocals())
     {
         return;
     }

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -3467,7 +3467,7 @@ void Compiler::lvaSortByRefCount()
             assert(varDsc->lvType != TYP_STRUCT ||
                    varDsc->lvDoNotEnregister); // For structs, should have set this when we set lvAddrExposed.
         }
-        else if (varTypeIsStruct(varDsc))
+        if (varTypeIsStruct(varDsc))
         {
             // Promoted structs will never be considered for enregistration anyway,
             // and the DoNotEnregister flag was used to indicate whether promotion was
@@ -3481,28 +3481,28 @@ void Compiler::lvaSortByRefCount()
                 lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_IsStruct));
             }
         }
-        else if (varDsc->lvIsStructField && (lvaGetParentPromotionType(lclNum) != PROMOTION_TYPE_INDEPENDENT))
+        if (varDsc->lvIsStructField && (lvaGetParentPromotionType(lclNum) != PROMOTION_TYPE_INDEPENDENT))
         {
             lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_DepField));
         }
-        else if (varDsc->lvPinned)
+        if (varDsc->lvPinned)
         {
             varDsc->lvTracked = 0;
 #ifdef JIT32_GCENCODER
             lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_PinningRef));
 #endif
         }
-        else if (opts.MinOpts() && !JitConfig.JitMinOptsTrackGCrefs() && varTypeIsGC(varDsc->TypeGet()))
+        if (opts.MinOpts() && !JitConfig.JitMinOptsTrackGCrefs() && varTypeIsGC(varDsc->TypeGet()))
         {
             varDsc->lvTracked = 0;
             lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_MinOptsGC));
         }
-        else if ((opts.compFlags & CLFLG_REGVAR) == 0)
+        if ((opts.compFlags & CLFLG_REGVAR) == 0)
         {
             lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_NoRegVars));
         }
 #if defined(JIT32_GCENCODER) && defined(FEATURE_EH_FUNCLETS)
-        else if (lvaIsOriginalThisArg(lclNum) && (info.compMethodInfo->options & CORINFO_GENERICS_CTXT_FROM_THIS) != 0)
+        if (lvaIsOriginalThisArg(lclNum) && (info.compMethodInfo->options & CORINFO_GENERICS_CTXT_FROM_THIS) != 0)
         {
             // For x86/Linux, we need to track "this".
             // However we cannot have it in tracked variables, so we set "this" pointer always untracked

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -1431,6 +1431,11 @@ void Compiler::lvaInitVarDsc(LclVarDsc*              varDsc,
     }
 #endif
 
+    if (!compEnregLocals())
+    {
+        lvaSetVarDoNotEnregister(varNum DEBUGARG(Compiler::DNER_NoRegVars));
+    }
+
 #ifdef DEBUG
     varDsc->SetStackOffset(BAD_STK_OFFS);
 #endif

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -2622,6 +2622,7 @@ void Compiler::lvaSetVarDoNotEnregister(unsigned varNum DEBUGARG(DoNotEnregister
         case DNER_NoRegVars:
             JITDUMP("opts.compFlags & CLFLG_REGVAR is not set\n");
             assert((opts.compFlags & CLFLG_REGVAR) == 0);
+            assert(!compEnregLocals());
             break;
         case DNER_MinOptsGC:
             JITDUMP("It is a GC Ref and we are compiling MinOpts\n");
@@ -3496,10 +3497,6 @@ void Compiler::lvaSortByRefCount()
         {
             varDsc->lvTracked = 0;
             lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_MinOptsGC));
-        }
-        if ((opts.compFlags & CLFLG_REGVAR) == 0)
-        {
-            lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_NoRegVars));
         }
 #if defined(JIT32_GCENCODER) && defined(FEATURE_EH_FUNCLETS)
         if (lvaIsOriginalThisArg(lclNum) && (info.compMethodInfo->options & CORINFO_GENERICS_CTXT_FROM_THIS) != 0)

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -700,7 +700,7 @@ LinearScan::LinearScan(Compiler* theCompiler)
     // after the first liveness analysis - either by optimizations or by Lowering, and the tracked
     // set won't be recomputed until after Lowering (and this constructor is called prior to Lowering),
     // so we don't want to check that yet.
-    enregisterLocalVars = ((compiler->opts.compFlags & CLFLG_REGVAR) != 0);
+    enregisterLocalVars = compiler->compEnregLocals();
 #ifdef TARGET_ARM64
     availableIntRegs = (RBM_ALLINT & ~(RBM_PR | RBM_FP | RBM_LR) & ~compiler->codeGen->regSet.rsMaskResvd);
 #else
@@ -1448,7 +1448,7 @@ bool LinearScan::isRegCandidate(LclVarDsc* varDsc)
     {
         return false;
     }
-    assert((compiler->opts.compFlags & CLFLG_REGVAR) != 0);
+    assert(compiler->compEnregLocals());
 
     if (!varDsc->lvTracked)
     {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -2064,6 +2064,7 @@ GenTree* Compiler::fgMakeTmpArgNode(fgArgTabEntry* curArgTabEntry)
         {
             arg->ChangeOper(GT_LCL_FLD);
             arg->gtType = type;
+            lvaSetVarDoNotEnregister(tmpVarNum DEBUGARG(Compiler::DNER_LocalField));
         }
         else
         {


### PR DESCRIPTION
and improve morph block init/copy a little bit.

There is a known problem that we start asking `is it already known to be not on register?` before the value is finalized during morph (block copy, should we do field by field) and lowering (do we need bitcast? can we mark the source as contained?) .
I have an markdown description of it in 6.0 planning.

For now, just mark them as `doNotEnreg` earlier when enregistration is disabled. Give us small improvements on minopts methods and prevent some regressions with future changes.

```
coreclr_tests.pmi.windows.x64.checked.mch
Total bytes of delta: -4
1 total methods with Code Size differences (1 improved, 0 regressed)

coreclr_tests.pmi.Linux.arm64.checked.mch
Total bytes of delta: -8
2 total methods with Code Size differences (2 improved, 0 regressed)

libraries_tests.pmi.Linux.arm64.checked.mch
Total bytes of delta: -28
5 total methods with Code Size differences (5 improved, 0 regressed)

benchmarks.run.Linux.x64.checked.mch
Total bytes of delta: -3
1 total methods with Code Size differences (1 improved, 0 regressed)

coreclr_tests.pmi.Linux.x64.checked.mch
Total bytes of delta: -4 
1 total methods with Code Size differences (1 improved, 0 regressed)

benchmarks.run.windows.arm64.checked.mch
Total bytes of delta: -8
1 total methods with Code Size differences (1 improved, 0 regressed)

coreclr_tests.pmi.windows.arm64.checked.mch
Total bytes of delta: -8
2 total methods with Code Size differences (2 improved, 0 regressed)

libraries_tests.pmi.windows.arm64.checked.mch
Total bytes of delta: -28
5 total methods with Code Size differences (5 improved, 0 regressed)

coreclr_tests.pmi.windows.x86.checked.mch
Total bytes of delta: -4
1 total methods with Code Size differences (1 improved, 0 regressed)
```

+no diffs improvements of morph block init/copy.