### PR TITLE
Enable NonValidated_ValidInvalidAndRaw_AllReturned test on Browser

### DIFF
--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
@@ -1538,7 +1538,6 @@ namespace System.Net.Http.Tests
             Assert.Equal(new HashSet<string> { "Location", "Date" }, nonValidated.Keys.ToHashSet());
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/53647", TestPlatforms.Browser)]
         [Fact]
         public void NonValidated_ValidInvalidAndRaw_AllReturned()
         {


### PR DESCRIPTION
This is reported to have been fixed by https://github.com/dotnet/runtime/pull/54932.
cc: @fanyang-mono 