### PR TITLE
Add binplaced analyzers to ASP.NET transport package

### DIFF
--- a/src/libraries/Microsoft.AspNetCore.Internal.Transport/pkg/Microsoft.AspNetCore.Internal.Transport.pkgproj
+++ b/src/libraries/Microsoft.AspNetCore.Internal.Transport/pkg/Microsoft.AspNetCore.Internal.Transport.pkgproj
@@ -8,6 +8,8 @@
     <PackageDescription>Internal transport package to provide aspnetcore with the assemblies that make up the Microsoft.ASPNetCore.App shared framework.</PackageDescription>
   </PropertyGroup>
   <ItemGroup>
+    <_analyzers Include="$(ASPNETCoreAppPackageRootPath)\analyzers\**\*.*" />
+    <File Include="@(_analyzers)" TargetPath="analyzers\%(RecursiveDir)" />
     <_libDocs Include="$(ASPNETCoreAppPackageRuntimePath)\*.xml" />
     <File Include="$(ASPNETCoreAppPackageRefPath)\*.*;@(_libDocs)" TargetPath="ref\$(NetCoreAppCurrent)" />
     <File Include="$(ASPNETCoreAppPackageRuntimePath)\*.*"  Exclude="@(_libDocs)" TargetPath="lib\$(NetCoreAppCurrent)" />


### PR DESCRIPTION
@dougbu caught this with my previous PR.  I missed actually adding the files to the package.

I had assumed we recursively included the aspnetcore directory, but we don't today.  I considered changing that but it wouldn't work correctly due to the way doc files are gathered.