### PR TITLE
Enregister structs on win x64.

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -4355,16 +4355,10 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
 #endif // defined(UNIX_AMD64_ABI)
 
             noway_assert(varDsc->lvIsParam && varDsc->lvIsRegArg);
-#ifndef TARGET_64BIT
-#ifndef TARGET_ARM
-            // Right now we think that incoming arguments are not pointer sized.  When we eventually
-            // understand the calling convention, this still won't be true. But maybe we'll have a better
-            // idea of how to ignore it.
-
-            // On Arm, a long can be passed in register
-            noway_assert(genTypeSize(genActualType(varDsc->TypeGet())) == TARGET_POINTER_SIZE);
-#endif
-#endif // TARGET_64BIT
+#ifdef TARGET_X86
+            // On x86 we don't enregister args that are not pointer sized.
+            noway_assert(genTypeSize(varDsc->GetActualRegisterType()) == TARGET_POINTER_SIZE);
+#endif // TARGET_X86
 
             noway_assert(varDsc->lvIsInReg() && !regArgTab[argNum].circular);
 

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -1195,8 +1195,8 @@ void CodeGen::genUnspillRegIfNeeded(GenTree* tree)
             // Load local variable from its home location.
             // In most cases the tree type will indicate the correct type to use for the load.
             // However, if it is NOT a normalizeOnLoad lclVar (i.e. NOT a small int that always gets
-            // widened when loaded into a register), and its size is not the same as genActualType of
-            // the type of the lclVar, then we need to change the type of the tree node when loading.
+            // widened when loaded into a register), and its size is not the same as the actual register type
+            // of the lclVar, then we need to change the type of the tree node when loading.
             // This situation happens due to "optimizations" that avoid a cast and
             // simply retype the node when using long type lclVar as an int.
             // While loading the int in that case would work for this use of the lclVar, if it is

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -1191,7 +1191,7 @@ void CodeGen::genUnspillRegIfNeeded(GenTree* tree)
             assert(spillType != TYP_UNDEF);
 
 // TODO-Cleanup: The following code could probably be further merged and cleaned up.
-#ifdef TARGET_XARCH
+#if defined(TARGET_XARCH) || defined(TARGET_ARM64)
             // Load local variable from its home location.
             // In most cases the tree type will indicate the correct type to use for the load.
             // However, if it is NOT a normalizeOnLoad lclVar (i.e. NOT a small int that always gets
@@ -1209,13 +1209,6 @@ void CodeGen::genUnspillRegIfNeeded(GenTree* tree)
             {
                 assert(!varTypeIsGC(varDsc));
                 spillType = lclActualType;
-            }
-#elif defined(TARGET_ARM64)
-            var_types targetType = unspillTree->gtType;
-            if (spillType != genActualType(varDsc->lvType) && !varTypeIsGC(spillType) && !varDsc->lvNormalizeOnLoad())
-            {
-                assert(!varTypeIsGC(varDsc));
-                spillType = genActualType(varDsc->lvType);
             }
 #elif defined(TARGET_ARM)
 // No normalizing for ARM
@@ -1465,7 +1458,8 @@ regNumber CodeGen::genConsumeReg(GenTree* tree)
         LclVarDsc*           varDsc = &compiler->lvaTable[lcl->GetLclNum()];
         if (varDsc->GetRegNum() != REG_STK)
         {
-            inst_Mov(tree->TypeGet(), tree->GetRegNum(), varDsc->GetRegNum(), /* canSkip */ true);
+            var_types regType = varDsc->GetRegisterType(lcl);
+            inst_Mov(regType, tree->GetRegNum(), varDsc->GetRegNum(), /* canSkip */ true);
         }
     }
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -1016,9 +1016,18 @@ public:
 
     var_types GetActualRegisterType() const;
 
-    bool IsEnregisterable() const
+    bool IsEnregisterableType() const
     {
         return GetRegisterType() != TYP_UNDEF;
+    }
+
+    bool IsEnregisterableLcl() const
+    {
+        if (lvDoNotEnregister)
+        {
+            return false;
+        }
+        return IsEnregisterableType();
     }
 
     bool CanBeReplacedWithItsField(Compiler* comp) const;

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -543,8 +543,12 @@ CONFIG_INTEGER(JitSaveFpLrWithCalleeSavedRegisters, W("JitSaveFpLrWithCalleeSave
 #endif // defined(TARGET_ARM64)
 #endif // DEBUG
 
-// Allow to enregister locals with struct type.
-CONFIG_INTEGER(JitEnregStructLocals, W("JitEnregStructLocals"), 0)
+#if defined(TARGET_AMD64) && defined(TARGET_WINDOWS)
+CONFIG_INTEGER(JitEnregStructLocals, W("JitEnregStructLocals"), 1) // Allow to enregister locals with struct type.
+#else
+CONFIG_INTEGER(JitEnregStructLocals, W("JitEnregStructLocals"), 0) // Don't allow to enregister locals with struct type
+                                                                   // yet.
+#endif
 
 #undef CONFIG_INTEGER
 #undef CONFIG_STRING

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -3482,10 +3482,6 @@ void Compiler::lvaSortByRefCount()
             {
                 varDsc->lvTracked = 0;
             }
-            else if ((varDsc->lvType == TYP_STRUCT) && !varDsc->lvRegStruct)
-            {
-                lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_IsStruct));
-            }
         }
         if (varDsc->lvIsStructField && (lvaGetParentPromotionType(lclNum) != PROMOTION_TYPE_INDEPENDENT))
         {

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -3482,6 +3482,10 @@ void Compiler::lvaSortByRefCount()
             {
                 varDsc->lvTracked = 0;
             }
+            else if ((varDsc->lvType == TYP_STRUCT) && !varDsc->lvRegStruct && !compEnregStructLocals())
+            {
+                lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_IsStruct));
+            }
         }
         if (varDsc->lvIsStructField && (lvaGetParentPromotionType(lclNum) != PROMOTION_TYPE_INDEPENDENT))
         {

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3160,7 +3160,7 @@ void Lowering::LowerStoreLocCommon(GenTreeLclVarCommon* lclStore)
 #endif // !WINDOWS_AMD64_ABI
             convertToStoreObj = false;
         }
-        else if (!varDsc->IsEnregisterable())
+        else if (!varDsc->IsEnregisterableType())
         {
             convertToStoreObj = true;
         }
@@ -3418,11 +3418,10 @@ void Lowering::LowerRetSingleRegStructLclVar(GenTreeUnOp* ret)
         lclNum = fieldLclNum;
         varDsc = comp->lvaGetDesc(lclNum);
     }
-    else if (!varDsc->lvRegStruct && !varTypeIsEnregisterable(varDsc))
-
+    else if (varDsc->lvPromoted)
     {
-        // TODO-1stClassStructs: We can no longer promote or enregister this struct,
-        // since it is referenced as a whole.
+        // TODO-1stClassStructs: We can no longer independently promote
+        // or enregister this struct, since it is referenced as a whole.
         comp->lvaSetVarDoNotEnregister(lclNum DEBUGARG(Compiler::DNER_BlockOp));
     }
 
@@ -3434,9 +3433,10 @@ void Lowering::LowerRetSingleRegStructLclVar(GenTreeUnOp* ret)
     }
     else
     {
-        var_types lclVarType = varDsc->GetRegisterType(lclVar);
+        const var_types lclVarType = varDsc->GetRegisterType(lclVar);
         assert(lclVarType != TYP_UNDEF);
-        lclVar->ChangeType(lclVarType);
+        const var_types actualType = genActualType(lclVarType);
+        lclVar->ChangeType(actualType);
 
         if (varTypeUsesFloatReg(ret) != varTypeUsesFloatReg(lclVarType))
         {
@@ -4039,12 +4039,12 @@ void Lowering::InsertPInvokeMethodProlog()
     GenTree* call = comp->gtNewHelperCallNode(CORINFO_HELP_INIT_PINVOKE_FRAME, TYP_I_IMPL, argList);
 
     // some sanity checks on the frame list root vardsc
-    LclVarDsc* varDsc = &comp->lvaTable[comp->info.compLvFrameListRoot];
+    const unsigned   lclNum = comp->info.compLvFrameListRoot;
+    const LclVarDsc* varDsc = comp->lvaGetDesc(lclNum);
     noway_assert(!varDsc->lvIsParam);
     noway_assert(varDsc->lvType == TYP_I_IMPL);
 
-    GenTree* store =
-        new (comp, GT_STORE_LCL_VAR) GenTreeLclVar(GT_STORE_LCL_VAR, TYP_I_IMPL, comp->info.compLvFrameListRoot);
+    GenTree* store       = new (comp, GT_STORE_LCL_VAR) GenTreeLclVar(GT_STORE_LCL_VAR, TYP_I_IMPL, lclNum);
     store->AsOp()->gtOp1 = call;
     store->gtFlags |= GTF_VAR_DEF;
 
@@ -4065,6 +4065,7 @@ void Lowering::InsertPInvokeMethodProlog()
         GenTreeLclFld(GT_STORE_LCL_FLD, TYP_I_IMPL, comp->lvaInlinedPInvokeFrameVar, callFrameInfo.offsetOfCallSiteSP);
     storeSP->gtOp1 = PhysReg(REG_SPBASE);
     storeSP->gtFlags |= GTF_VAR_DEF;
+    comp->lvaSetVarDoNotEnregister(comp->lvaInlinedPInvokeFrameVar DEBUGARG(Compiler::DNER_LocalField));
 
     firstBlockRange.InsertBefore(insertionPoint, LIR::SeqTree(comp, storeSP));
     DISPTREERANGE(firstBlockRange, storeSP);
@@ -6524,7 +6525,7 @@ void Lowering::ContainCheckRet(GenTreeUnOp* ret)
             assert(varDsc->lvIsMultiRegRet || (varDsc->lvIsHfa() && varTypeIsValidHfaType(varDsc->lvType)));
 
             // Mark var as contained if not enregisterable.
-            if (!varTypeIsEnregisterable(op1))
+            if (!varDsc->IsEnregisterableLcl())
             {
                 if (!op1->IsMultiRegLclVar())
                 {

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -269,6 +269,12 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
             // address, not knowing that GT_IND is part of a block op that has containment restrictions.
             src->AsIndir()->Addr()->ClearContained();
         }
+        else if (src->OperIs(GT_LCL_VAR))
+        {
+            // TODO-1stClassStructs: for now we can't work with STORE_BLOCK source in register.
+            const unsigned srcLclNum = src->AsLclVar()->GetLclNum();
+            comp->lvaSetVarDoNotEnregister(srcLclNum DEBUGARG(Compiler::DNER_BlockOp));
+        }
 
         if (blkNode->OperIs(GT_STORE_OBJ))
         {

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -1490,7 +1490,7 @@ bool LinearScan::isRegCandidate(LclVarDsc* varDsc)
     // or enregistered, on x86 -- it is believed that we can enregister pinned (more properly, "pinning")
     // references when using the general GC encoding.
     unsigned lclNum = (unsigned)(varDsc - compiler->lvaTable);
-    if (varDsc->lvAddrExposed || !varDsc->IsEnregisterable() ||
+    if (varDsc->lvAddrExposed || !varDsc->IsEnregisterableType() ||
         (!compiler->compEnregStructLocals() && (varDsc->lvType == TYP_STRUCT)))
     {
 #ifdef DEBUG


### PR DESCRIPTION
This PR enables struct enregistration for x64 windows (the only platform without multiregs).

Contributes to https://github.com/dotnet/runtime/issues/43867.

```
diffs:
libraries_tests.pmi.windows.x64.checked.mch
Total bytes of delta: -10799
532 total files with Code Size differences (405 improved, 127 regressed)

libraries.pmi.windows.x64.checked.mch
Total bytes of delta: -9534
253 total files with Code Size differences (217 improved, 36 regressed)

libraries.crossgen2.windows.x64.checked.mch
Total bytes of delta: -9243
701 total files with Code Size differences (593 improved, 108 regressed)

coreclr_tests.pmi.windows.x64.checked.mch
Total bytes of delta: -18353
201 total files with Code Size differences (200 improved, 1 regressed)

benchmarks.run.windows.x64.checked.mch
Total bytes of delta: -1166
25 total files with Code Size differences (23 improved, 2 regressed)
```

The regressions are expected, they are caused by:
1. change in lcl frame size from (N1 %16 == 0) to (N2 < N1 but N1 % 16 != 0) causes more instructions in the prolog to do zero-init.
2. push/pop of callee-saved registers that we did not use before costs us 2 instructions.

There are tiny changes on other platforms because of improved lowering (`IsEnregisterableLcl` return false oftener and allows more contained cases) not worth mentioning here (all improvements, no regressions).

Note that it is not the final state, the biggest beast is `call(obj(addr(lcl_var)))` and  I will be dealing with it separately.

<details>
  <summary>Benchmarks improvement (for improvements analysis)</summary>

```
Top method regressions (percentages):
           8 ( 1.55% of base) : 20377.dasm - Microsoft.CodeAnalysis.CSharp.Binder:BindDeclaratorArguments(Microsoft.CodeAnalysis.CSharp.Syntax.VariableDeclaratorSyntax,Microsoft.CodeAnalysis.DiagnosticBag):System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.CSharp.BoundExpression, Microsoft.CodeAnalysis.CSharp, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]:this
           3 ( 0.22% of base) : 10240.dasm - <WriteAsync>d__21:MoveNext():this

Top method improvements (percentages):
         -12 (-21.82% of base) : 15891.dasm - System.Numerics.Tests.Perf_Matrix4x4:CreateReflectionBenchmark():System.Numerics.Matrix4x4:this
         -30 (-18.29% of base) : 23340.dasm - System.Numerics.Tests.Perf_Quaternion:MultiplyByQuaternionBenchmark():System.Numerics.Quaternion:this
        -156 (-13.74% of base) : 18406.dasm - BinopEasyOut:TypeToIndex(Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol):System.Nullable`1[Int32]
         -43 (-13.23% of base) : 20176.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.LanguageParser:IsPossibleTypedIdentifierStart(Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxToken,Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxToken,bool):System.Nullable`1[Boolean]:this
         -12 (-10.34% of base) : 22931.dasm - System.Numerics.Tests.Perf_Quaternion:LerpBenchmark():System.Numerics.Quaternion:this
         -96 (-8.99% of base) : 8287.dasm - System.TimeZoneInfo:CreateAdjustmentRuleFromTimeZoneInformation(byref,System.DateTime,System.DateTime,int):AdjustmentRule
         -80 (-8.06% of base) : 9184.dasm - Jil.Common.Utils:_ReadFieldOperands(System.Reflection.Emit.OpCode,System.Byte[],int,int,byref,byref,byref,byref):System.Nullable`1[Int32]
         -44 (-3.26% of base) : 10850.dasm - Newtonsoft.Json.JsonTextReader:ReadAsBoolean():System.Nullable`1[Boolean]:this
         -12 (-2.09% of base) : 17034.dasm - Microsoft.CodeAnalysis.CSharp.CSharpCompilation:CreateModuleBuilder(Microsoft.CodeAnalysis.Emit.EmitOptions,Microsoft.CodeAnalysis.IMethodSymbol,System.IO.Stream,System.Collections.Generic.IEnumerable`1[[Microsoft.CodeAnalysis.EmbeddedText, Microsoft.CodeAnalysis, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],System.Collections.Generic.IEnumerable`1[[Microsoft.CodeAnalysis.ResourceDescription, Microsoft.CodeAnalysis, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],Microsoft.CodeAnalysis.CodeGen.CompilationTestData,Microsoft.CodeAnalysis.DiagnosticBag,System.Threading.CancellationToken):Microsoft.CodeAnalysis.Emit.CommonPEModuleBuilder:this
          -4 (-1.58% of base) : 19450.dasm - System.Reflection.Metadata.Ecma335.MetadataBuilder:AddMethodDefinition(int,int,System.Reflection.Metadata.StringHandle,System.Reflection.Metadata.BlobHandle,int,System.Reflection.Metadata.ParameterHandle):System.Reflection.Metadata.MethodDefinitionHandle:this
        -156 (-1.06% of base) : 15598.dasm - DynamicClass:_DynamicMethod3(byref,int):MicroBenchmarks.Serializers.MyEventsListerItem
          -4 (-1.01% of base) : 19377.dasm - System.Reflection.Metadata.Ecma335.MetadataBuilder:AddAssemblyReference(System.Reflection.Metadata.StringHandle,System.Version,System.Reflection.Metadata.StringHandle,System.Reflection.Metadata.BlobHandle,int,System.Reflection.Metadata.BlobHandle):System.Reflection.Metadata.AssemblyReferenceHandle:this
        -130 (-0.89% of base) : 16200.dasm - DynamicClass:_DynamicMethod3(System.IO.TextReader,int):MicroBenchmarks.Serializers.MyEventsListerItem
         -46 (-0.67% of base) : 21098.dasm - DynamicClass:_DynamicMethod1(byref,int):MicroBenchmarks.Serializers.CollectionsOfPrimitives
         -21 (-0.66% of base) : 4229.dasm - HillClimbing:Update(int,double,int):System.ValueTuple`2[Int32,Int32]:this
          -8 (-0.64% of base) : 11030.dasm - Benchmarks.SIMD.RayTracer.RayTracer:CreateDefaultScene():Benchmarks.SIMD.RayTracer.Scene
         -44 (-0.60% of base) : 26146.dasm - DynamicClass:_DynamicMethod1(System.IO.TextReader,int):MicroBenchmarks.Serializers.CollectionsOfPrimitives
        -130 (-0.55% of base) : 24235.dasm - DynamicClass:_DynamicMethod1(System.IO.TextReader,int):MicroBenchmarks.Serializers.IndexViewModel
        -130 (-0.54% of base) : 13985.dasm - DynamicClass:_DynamicMethod1(byref,int):MicroBenchmarks.Serializers.IndexViewModel
          -2 (-0.19% of base) : 15808.dasm - <SyncReadAsync>d__5:MoveNext():this
```

</details>

<details>
  <summary>Improvement example</summary>

```C#
        struct S
        {
            public byte b0;
            public byte b1;
            public byte b2;
            public byte b3;
            public byte b4;
            public byte b5;
            public byte b6;
            public byte b7;
        }

        [MethodImpl(MethodImplOptions.NoInlining)]
        static S TestInit(int a)
        {
            S s = new S();
          
            if (a == 0)
            {
                s = GetS1();
            }
            else if (a == 1)
            {
                s = GetS2();
            }
            else
            {
                S s2 = GetS1();
                s = s2;               
            }
            return s;
        }
```

for such test where we init/copy a struct that fits into a register and doesn't access its fields (7.0 maybe) and do not pass it as a call argument (next step, hopefully, 6.0)
we have such diffs:

```diff
; Final local variable assignments
;
;  V00 arg0         [V00,T00] (  4,  3.50)     int  ->  rcx
-;  V01 loc0         [V01,T01] (  4,  2.50)  struct ( 8) [rsp+20H]   do-not-enreg[SB] ld-addr-op
+;  V01 loc0         [V01,T01] (  4,  2.50)  struct ( 8) rax         ld-addr-op
;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+00H]   "OutgoingArgSpace"

-; Total bytes of code 57
+; Total bytes of code 38

G_M65053_IG01:        ; func=00, offs=000000H, size=0004H, bbWeight=1    PerfScore 0.25, gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref, nogc <-- Prolog IG

IN000e: 000000 sub      rsp, 40

G_M65053_IG02:        ; offs=000004H, size=0004H, bbWeight=1    PerfScore 1.25, gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref, isz

IN0001: 000004 test     ecx, ecx
IN0002: 000006 jne      SHORT G_M65053_IG04

G_M65053_IG03:        ; offs=000008H, size=000CH, bbWeight=0.50 PerfScore 2.00, gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref, isz

IN0003: 000008 call     TestStructFields.Program:GetS1():S
-IN0004: 00000D mov      qword ptr [V01 rsp+20H], rax
IN0005: 000012 jmp      SHORT G_M65053_IG06

G_M65053_IG04:        ; offs=000014H, size=0011H, bbWeight=0.50 PerfScore 2.63, gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref, isz

IN0006: 000014 cmp      ecx, 1
IN0007: 000017 jne      SHORT G_M65053_IG05
IN0008: 000019 call     TestStructFields.Program:GetS2():S
-IN0009: 00001E mov      qword ptr [V01 rsp+20H], rax
IN000a: 000023 jmp      SHORT G_M65053_IG06

G_M65053_IG05:        ; offs=000025H, size=000AH, bbWeight=0.50 PerfScore 1.00, gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref

IN000b: 000025 call     TestStructFields.Program:GetS1():S
-IN000c: 00002A mov      qword ptr [V01 rsp+20H], rax

G_M65053_IG06:        ; offs=00002FH, size=0005H, bbWeight=1    PerfScore 1.00, gcrefRegs=00000000 {}, byrefRegs=00000000 {}, byref

-IN000d: 00002F mov      rax, qword ptr [V01 rsp+20H]
+IN000a: 000020 nop

G_M65053_IG07:        ; offs=000034H, size=0005H, bbWeight=1    PerfScore 1.25, epilog, nogc, extend

IN000f: 000034 add      rsp, 40
IN0010: 000038 ret
```


</details>