### PR TITLE
disable a failing poison test.

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -11,6 +11,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/GitHub_45929/test45929/*">
             <Issue>https://github.com/dotnet/runtime/issues/49881</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/debugging/poison/*">
+            <Issue>https://github.com/dotnet/runtime/issues/55062</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- All OS/Arch CoreCLR excludes -->


### PR DESCRIPTION
PTAL @dotnet/jit-contrib , revert when #55062 is fixed.