### PR TITLE
Correct SerialPort.BytesToRead for Linux (#53430)

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.IO.Ports.Native/Interop.Termios.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.IO.Ports.Native/Interop.Termios.cs
@@ -48,7 +48,7 @@ internal static partial class Interop
         internal static extern int TermiosGetSpeed(SafeSerialDeviceHandle handle);
 
         [DllImport(Libraries.IOPortsNative, EntryPoint = "SystemIoPortsNative_TermiosAvailableBytes", SetLastError = true)]
-        internal static extern int TermiosGetAvailableBytes(SafeSerialDeviceHandle handle, bool fromReadBuffer);
+        internal static extern int TermiosGetAvailableBytes(SafeSerialDeviceHandle handle, [MarshalAs(UnmanagedType.I4)]bool fromReadBuffer);
 
         [DllImport(Libraries.IOPortsNative, EntryPoint = "SystemIoPortsNative_TermiosDiscard", SetLastError = true)]
         internal static extern int TermiosDiscard(SafeSerialDeviceHandle handle, Queue input);

--- a/src/libraries/Common/src/Interop/Unix/System.IO.Ports.Native/Interop.Termios.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.IO.Ports.Native/Interop.Termios.cs
@@ -48,7 +48,7 @@ internal static partial class Interop
         internal static extern int TermiosGetSpeed(SafeSerialDeviceHandle handle);
 
         [DllImport(Libraries.IOPortsNative, EntryPoint = "SystemIoPortsNative_TermiosAvailableBytes", SetLastError = true)]
-        internal static extern int TermiosGetAvailableBytes(SafeSerialDeviceHandle handle, Queue input);
+        internal static extern int TermiosGetAvailableBytes(SafeSerialDeviceHandle handle, bool fromReadBuffer);
 
         [DllImport(Libraries.IOPortsNative, EntryPoint = "SystemIoPortsNative_TermiosDiscard", SetLastError = true)]
         internal static extern int TermiosDiscard(SafeSerialDeviceHandle handle, Queue input);

--- a/src/libraries/Common/src/Interop/Unix/System.IO.Ports.Native/Interop.Termios.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.IO.Ports.Native/Interop.Termios.cs
@@ -48,7 +48,7 @@ internal static partial class Interop
         internal static extern int TermiosGetSpeed(SafeSerialDeviceHandle handle);
 
         [DllImport(Libraries.IOPortsNative, EntryPoint = "SystemIoPortsNative_TermiosAvailableBytes", SetLastError = true)]
-        internal static extern int TermiosGetAvailableBytes(SafeSerialDeviceHandle handle, [MarshalAs(UnmanagedType.I4)]bool fromReadBuffer);
+        internal static extern int TermiosGetAvailableBytes(SafeSerialDeviceHandle handle, [MarshalAs(UnmanagedType.Bool)]bool fromReadBuffer);
 
         [DllImport(Libraries.IOPortsNative, EntryPoint = "SystemIoPortsNative_TermiosDiscard", SetLastError = true)]
         internal static extern int TermiosDiscard(SafeSerialDeviceHandle handle, Queue input);

--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
@@ -159,12 +159,12 @@ namespace System.IO.Ports
 
         internal int BytesToWrite
         {
-            get { return Interop.Termios.TermiosGetAvailableBytes(_handle, Interop.Termios.Queue.SendQueue); }
+            get { return Interop.Termios.TermiosGetAvailableBytes(_handle, false); }
         }
 
         internal int BytesToRead
         {
-            get { return Interop.Termios.TermiosGetAvailableBytes(_handle, Interop.Termios.Queue.ReceiveQueue); }
+            get { return Interop.Termios.TermiosGetAvailableBytes(_handle, true); }
         }
 
         internal bool CDHolding


### PR DESCRIPTION
Correct PInvoke signature Interop.Termios.TermiosGetAvailableBytes()
because SystemIoPortsNative_TermiosAvailableBytes() want a boolean and
not an enum to determine which queue should return the available bytes

Fix #53430