### PR TITLE
Do not consider constant indirections to be invariant

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -6092,13 +6092,18 @@ void Compiler::optHoistLoopBlocks(unsigned loopNum, ArrayStack<BasicBlock*>* blo
         bool IsTreeVNInvariant(GenTree* tree)
         {
             ValueNum vn = tree->gtVNPair.GetLiberal();
+            if (vn == ValueNumStore::NoVN)
+                return false;
+
+            ValueNum vnx;
+            m_compiler->vnStore->VNUnpackExc(vn, &vn, &vnx);
             if (m_compiler->vnStore->IsVNConstant(vn))
             {
-                // It is unsafe to allow a GT_CLS_VAR that has been assigned a constant.
+                // It is unsafe to allow a GT_CLS_VAR or GT_IND that has been assigned a constant.
                 // The logic in optVNIsLoopInvariant would consider it to be loop-invariant, even
-                // if the assignment of the constant to the GT_CLS_VAR was inside the loop.
+                // if the assignment of the constant to the GT_CLS_VAR/GT_IND was inside the loop.
                 //
-                if (tree->OperIs(GT_CLS_VAR))
+                if (tree->OperIs(GT_CLS_VAR, GT_IND))
                 {
                     return false;
                 }

--- a/src/tests/JIT/Regression/JitBlue/GitHub_54118/GitHub_54118.cs
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_54118/GitHub_54118.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+class Program
+{
+    public static int Main()
+    {
+        int[] arr = new int[1];
+        ref int r = ref arr[0];
+        for (int i = 0; i < 2; i++)
+        {
+            r = 1;
+            if (r != 1)
+                return 101;
+        }
+
+        return 100;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/GitHub_54118/GitHub_54118.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_54118/GitHub_54118.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
It is possible they are constant because they were assigned inside the
loop, so we cannot hoist them out in this situation.

Fix #54118

There are SPMI diffs over in https://github.com/dotnet/runtime/issues/54118#issuecomment-872234387. Note that the regressions where we no longer hoist a method chunk out of a loop can hopefully be better solved by fixing #55079.