### PR TITLE
Fix spinwaiting in LockFreeReaderHashtable

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/Utilities/LockFreeReaderHashtable.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/Utilities/LockFreeReaderHashtable.cs
@@ -245,20 +245,14 @@ namespace Internal.TypeSystem
             if (sentinel == null)
                 return null;
 
-            TValue value = Volatile.Read(ref hashtable[tableIndex]);
+            var sw = new SpinWait();
             while (true)
             {
-                for (int i = 0; (i < 10000) && value == sentinel; i++)
-                {
-                    value = Volatile.Read(ref hashtable[tableIndex]);
-                }
+                TValue value = Volatile.Read(ref hashtable[tableIndex]);
                 if (value != sentinel)
-                    break;
-
-                Task.Delay(1).Wait();
+                    return value;
+                sw.SpinOnce();
             }
-
-            return value;
         }
 
         /// <summary>


### PR DESCRIPTION
Task.Delay(1).Wait() is variant of sync-over-async anti-patern. It does not work well with threadpool used to run parallel AOT compilation. It can lead to too many threadpool threads getting created and progress slowing down to crawl, at least temporarily.