### PR TITLE
[wasm][http] Improve compatibility of abort and cancelation of BrowserHttpHandler

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.RemoteServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.RemoteServer.cs
@@ -928,6 +928,7 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers")]
         [Theory, MemberData(nameof(RemoteServersAndRedirectStatusCodes))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55083", TestPlatforms.Browser)]
         public async Task GetAsync_AllowAutoRedirectFalse_RedirectFromHttpToHttp_StatusCodeRedirect(Configuration.Http.RemoteServer remoteServer, int statusCode)
         {
             if (statusCode == 308 && (IsWinHttpHandler && PlatformDetection.WindowsVersion < 10))
@@ -955,6 +956,7 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers")]
         [Theory, MemberData(nameof(RemoteServersAndRedirectStatusCodes))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55083", TestPlatforms.Browser)]
         public async Task GetAsync_AllowAutoRedirectTrue_RedirectFromHttpToHttp_StatusCodeOK(Configuration.Http.RemoteServer remoteServer, int statusCode)
         {
             if (statusCode == 308 && (IsWinHttpHandler && PlatformDetection.WindowsVersion < 10))
@@ -982,6 +984,7 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55083", TestPlatforms.Browser)]
         public async Task GetAsync_AllowAutoRedirectTrue_RedirectFromHttpToHttps_StatusCodeOK()
         {
             HttpClientHandler handler = CreateHttpClientHandler();
@@ -1003,6 +1006,7 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55083", TestPlatforms.Browser)]
         public async Task GetAsync_AllowAutoRedirectTrue_RedirectFromHttpsToHttp_StatusCodeRedirect()
         {
             HttpClientHandler handler = CreateHttpClientHandler();
@@ -1025,6 +1029,7 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers")]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55083", TestPlatforms.Browser)]
         public async Task GetAsync_AllowAutoRedirectTrue_RedirectToUriWithParams_RequestMsgUriSet(Configuration.Http.RemoteServer remoteServer)
         {
             HttpClientHandler handler = CreateHttpClientHandler();
@@ -1050,6 +1055,7 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(3, 2)]
         [InlineData(3, 3)]
         [InlineData(3, 4)]
+        [SkipOnPlatform(TestPlatforms.Browser, "MaxConnectionsPerServer not supported on Browser")]
         public async Task GetAsync_MaxAutomaticRedirectionsNServerHops_ThrowsIfTooMany(int maxHops, int hops)
         {
             if (IsWinHttpHandler && !PlatformDetection.IsWindows10Version1703OrGreater)
@@ -1095,6 +1101,7 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers")]
         [Theory, MemberData(nameof(RemoteServersMemberData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55083", TestPlatforms.Browser)]
         public async Task GetAsync_AllowAutoRedirectTrue_RedirectWithRelativeLocation(Configuration.Http.RemoteServer remoteServer)
         {
             HttpClientHandler handler = CreateHttpClientHandler();
@@ -1118,6 +1125,7 @@ namespace System.Net.Http.Functional.Tests
 
         [Theory, MemberData(nameof(RemoteServersMemberData))]
         [OuterLoop("Uses external servers")]
+        [SkipOnPlatform(TestPlatforms.Browser, "Credentials is not supported on Browser")]
         public async Task GetAsync_CredentialIsNetworkCredentialUriRedirect_StatusCodeUnauthorized(Configuration.Http.RemoteServer remoteServer)
         {
             HttpClientHandler handler = CreateHttpClientHandler();
@@ -1137,6 +1145,7 @@ namespace System.Net.Http.Functional.Tests
 
         [Theory, MemberData(nameof(RemoteServersMemberData))]
         [OuterLoop("Uses external servers")]
+        [SkipOnPlatform(TestPlatforms.Browser, "Credentials is not supported on Browser")]
         public async Task HttpClientHandler_CredentialIsNotCredentialCacheAfterRedirect_StatusCodeOK(Configuration.Http.RemoteServer remoteServer)
         {
             HttpClientHandler handler = CreateHttpClientHandler();
@@ -1163,6 +1172,7 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers")]
         [Theory, MemberData(nameof(RemoteServersAndRedirectStatusCodes))]
+        [SkipOnPlatform(TestPlatforms.Browser, "Credentials is not supported on Browser")]
         public async Task GetAsync_CredentialIsCredentialCacheUriRedirect_StatusCodeOK(Configuration.Http.RemoteServer remoteServer, int statusCode)
         {
             if (statusCode == 308 && (IsWinHttpHandler && PlatformDetection.WindowsVersion < 10))

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
@@ -329,6 +329,10 @@ namespace System.Net.Http
             }
             catch (JSException jse)
             {
+                if (jse.Message.StartsWith("AbortError"))
+                {
+                    throw CancellationHelper.CreateOperationCanceledException(jse, CancellationToken.None);
+                }
                 if (cancellationToken.IsCancellationRequested)
                 {
                     throw CancellationHelper.CreateOperationCanceledException(jse, cancellationToken);
@@ -392,7 +396,7 @@ namespace System.Net.Http
                 _status = status ?? throw new ArgumentNullException(nameof(status));
             }
 
-            private async Task<byte[]> GetResponseData()
+            private async Task<byte[]> GetResponseData(CancellationToken cancellationToken)
             {
                 if (_data != null)
                 {
@@ -413,7 +417,7 @@ namespace System.Net.Http
                 {
                     if (jse.Message.StartsWith("AbortError"))
                     {
-                        throw CancellationHelper.CreateOperationCanceledException(jse, CancellationToken.None);
+                        throw CancellationHelper.CreateOperationCanceledException(jse, cancellationToken);
                     }
                     throw new HttpRequestException(jse.Message, jse);
                 }
@@ -423,7 +427,7 @@ namespace System.Net.Http
 
             protected override async Task<Stream> CreateContentReadStreamAsync()
             {
-                byte[] data = await GetResponseData().ConfigureAwait(continueOnCapturedContext: true);
+                byte[] data = await GetResponseData(CancellationToken.None).ConfigureAwait(continueOnCapturedContext: true);
                 return new MemoryStream(data, writable: false);
             }
 
@@ -431,7 +435,7 @@ namespace System.Net.Http
                 SerializeToStreamAsync(stream, context, CancellationToken.None);
             protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken)
             {
-                byte[] data = await GetResponseData().ConfigureAwait(continueOnCapturedContext: true);
+                byte[] data = await GetResponseData(cancellationToken).ConfigureAwait(continueOnCapturedContext: true);
                 await stream.WriteAsync(data, cancellationToken).ConfigureAwait(continueOnCapturedContext: true);
             }
             protected internal override bool TryComputeLength(out long length)
@@ -505,6 +509,10 @@ namespace System.Net.Http
                     }
                     catch (JSException jse)
                     {
+                        if (jse.Message.StartsWith("AbortError"))
+                        {
+                            throw CancellationHelper.CreateOperationCanceledException(jse, CancellationToken.None);
+                        }
                         if (cancellationToken.IsCancellationRequested)
                         {
                             throw CancellationHelper.CreateOperationCanceledException(jse, cancellationToken);
@@ -545,6 +553,10 @@ namespace System.Net.Http
                 }
                 catch (JSException jse)
                 {
+                    if (jse.Message.StartsWith("AbortError"))
+                    {
+                        throw CancellationHelper.CreateOperationCanceledException(jse, CancellationToken.None);
+                    }
                     if (cancellationToken.IsCancellationRequested)
                     {
                         throw CancellationHelper.CreateOperationCanceledException(jse, cancellationToken);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpHandler.cs
@@ -139,7 +139,7 @@ namespace System.Net.Http
 
         protected internal override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            throw new PlatformNotSupportedException ();
+            throw new PlatformNotSupportedException();
         }
 
         protected internal override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -323,22 +323,27 @@ namespace System.Net.Http
                 return httpResponse;
 
             }
-            catch (OperationCanceledException oce ) when (cancellationToken.IsCancellationRequested)
+            catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested)
             {
                 throw CancellationHelper.CreateOperationCanceledException(oce, cancellationToken);
             }
             catch (JSException jse)
             {
-                if (jse.Message.StartsWith("AbortError"))
-                {
-                    throw CancellationHelper.CreateOperationCanceledException(jse, CancellationToken.None);
-                }
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    throw CancellationHelper.CreateOperationCanceledException(jse, cancellationToken);
-                }
-                throw new HttpRequestException(jse.Message, jse);
+                throw TranslateJSException(jse, cancellationToken);
             }
+        }
+
+        private static Exception TranslateJSException(JSException jse, CancellationToken cancellationToken)
+        {
+            if (jse.Message.StartsWith("AbortError", StringComparison.Ordinal))
+            {
+                return CancellationHelper.CreateOperationCanceledException(jse, CancellationToken.None);
+            }
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return CancellationHelper.CreateOperationCanceledException(jse, cancellationToken);
+            }
+            return new HttpRequestException(jse.Message, jse);
         }
 
         private sealed class WasmFetchResponse : IDisposable
@@ -415,11 +420,7 @@ namespace System.Net.Http
                 }
                 catch (JSException jse)
                 {
-                    if (jse.Message.StartsWith("AbortError"))
-                    {
-                        throw CancellationHelper.CreateOperationCanceledException(jse, cancellationToken);
-                    }
-                    throw new HttpRequestException(jse.Message, jse);
+                    throw TranslateJSException(jse, cancellationToken);
                 }
 
                 return _data;
@@ -503,21 +504,13 @@ namespace System.Net.Http
                             _reader = (JSObject)body.Invoke("getReader");
                         }
                     }
-                    catch (OperationCanceledException oce ) when (cancellationToken.IsCancellationRequested)
+                    catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested)
                     {
                         throw CancellationHelper.CreateOperationCanceledException(oce, cancellationToken);
                     }
                     catch (JSException jse)
                     {
-                        if (jse.Message.StartsWith("AbortError"))
-                        {
-                            throw CancellationHelper.CreateOperationCanceledException(jse, CancellationToken.None);
-                        }
-                        if (cancellationToken.IsCancellationRequested)
-                        {
-                            throw CancellationHelper.CreateOperationCanceledException(jse, cancellationToken);
-                        }
-                        throw new HttpRequestException(jse.Message, jse);
+                        throw TranslateJSException(jse, cancellationToken);
                     }
                 }
 
@@ -547,21 +540,13 @@ namespace System.Net.Http
                             _bufferedBytes = binValue.ToArray();
                     }
                 }
-                catch (OperationCanceledException oce ) when (cancellationToken.IsCancellationRequested)
+                catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested)
                 {
                     throw CancellationHelper.CreateOperationCanceledException(oce, cancellationToken);
                 }
                 catch (JSException jse)
                 {
-                    if (jse.Message.StartsWith("AbortError"))
-                    {
-                        throw CancellationHelper.CreateOperationCanceledException(jse, CancellationToken.None);
-                    }
-                    if (cancellationToken.IsCancellationRequested)
-                    {
-                        throw CancellationHelper.CreateOperationCanceledException(jse, cancellationToken);
-                    }
-                    throw new HttpRequestException(jse.Message, jse);
+                    throw TranslateJSException(jse, cancellationToken);
                 }
 
                 return ReadBuffered();

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -385,7 +385,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/54270", TestPlatforms.Browser)]
         public async Task GetStringAsync_CanBeCanceled_AlreadyCanceledCts()
         {
             var onClientFinished = new SemaphoreSlim(0, 1);
@@ -410,7 +409,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/54270", TestPlatforms.Browser)]
         public async Task GetStringAsync_CanBeCanceled()
         {
             var cts = new CancellationTokenSource();
@@ -445,7 +443,6 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(1, 0)]
         [InlineData(1, 1)]
         [InlineData(1, 2)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/54270", TestPlatforms.Browser)]
         public async Task GetAsync_ContentCanBeCanceled(int getMode, int cancelMode)
         {
             // cancelMode:
@@ -555,7 +552,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/54270", TestPlatforms.Browser)]
         public async Task GetByteArrayAsync_CanBeCanceled_AlreadyCanceledCts()
         {
             var onClientFinished = new SemaphoreSlim(0, 1);
@@ -580,7 +576,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/54270", TestPlatforms.Browser)]
         public async Task GetByteArrayAsync_CanBeCanceled()
         {
             var cts = new CancellationTokenSource();
@@ -631,7 +626,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/54270", TestPlatforms.Browser)]
         public async Task GetStreamAsync_CanBeCanceled_AlreadyCanceledCts()
         {
             var onClientFinished = new SemaphoreSlim(0, 1);
@@ -656,7 +650,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/54270", TestPlatforms.Browser)]
         public async Task GetStreamAsync_CanBeCanceled()
         {
             var cts = new CancellationTokenSource();


### PR DESCRIPTION
- fixed handling of cancelation and abort exceptions to match unit test expectations
- for redirect outerloop tests added https://github.com/dotnet/runtime/issues/55083 

Fixes https://github.com/dotnet/runtime/issues/54270