### PR TITLE
Override Read(Span)/ReadByte on PipeReaderStream

### DIFF
--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeReaderStream.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeReaderStream.cs
@@ -45,8 +45,28 @@ namespace System.IO.Pipelines
         {
         }
 
-        public override int Read(byte[] buffer, int offset, int count) =>
-            ReadAsync(buffer, offset, count).GetAwaiter().GetResult();
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (buffer is null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+
+            return ReadInternal(new Span<byte>(buffer, offset, count));
+        }
+
+        public override int ReadByte()
+        {
+            Span<byte> oneByte = stackalloc byte[1];
+            return ReadInternal(oneByte) == 0 ? -1 : oneByte[0];
+        }
+
+        private int ReadInternal(Span<byte> buffer)
+        {
+            ValueTask<ReadResult> vt = _pipeReader.ReadAsync();
+            ReadResult result = vt.IsCompletedSuccessfully ? vt.Result : vt.AsTask().Result;
+            return HandleReadResult(result, buffer);
+        }
 
         public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
 
@@ -71,6 +91,11 @@ namespace System.IO.Pipelines
         }
 
 #if (!NETSTANDARD2_0 && !NETFRAMEWORK)
+        public override int Read(Span<byte> buffer)
+        {
+            return ReadInternal(buffer);
+        }
+
         public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
             return ReadAsyncInternal(buffer, cancellationToken);
@@ -80,7 +105,11 @@ namespace System.IO.Pipelines
         private async ValueTask<int> ReadAsyncInternal(Memory<byte> buffer, CancellationToken cancellationToken)
         {
             ReadResult result = await _pipeReader.ReadAsync(cancellationToken).ConfigureAwait(false);
+            return HandleReadResult(result, buffer.Span);
+        }
 
+        private int HandleReadResult(ReadResult result, Span<byte> buffer)
+        {
             if (result.IsCanceled)
             {
                 ThrowHelper.ThrowOperationCanceledException_ReadCanceled();
@@ -98,7 +127,7 @@ namespace System.IO.Pipelines
 
                     ReadOnlySequence<byte> slice = actual == bufferLength ? sequence : sequence.Slice(0, actual);
                     consumed = slice.End;
-                    slice.CopyTo(buffer.Span);
+                    slice.CopyTo(buffer);
 
                     return actual;
                 }


### PR DESCRIPTION
We can do better than the base implementations for reading.  For writing, there's not a lot we can do better than the base.

Fixes https://github.com/dotnet/runtime/issues/53692
cc: @halter73 

|   Method |         Toolchain |         Mean | Ratio | Allocated |
|--------- |------------------ |-------------:|------:|----------:|
| ReadByte | \main\corerun.exe | 542,053.1 ns |  1.00 | 131,072 B |
| ReadByte |   \pr\corerun.exe | 423,396.2 ns |  0.78 |       0 B |
|          |                   |              |       |           |
| ReadSpan | \main\corerun.exe |     459.7 ns |  1.00 |      72 B |
| ReadSpan |   \pr\corerun.exe |     309.6 ns |  0.67 |       0 B |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Columns;
using BenchmarkDotNet.Configs;
using BenchmarkDotNet.Diagnosers;
using BenchmarkDotNet.Reports;
using BenchmarkDotNet.Running;
using Perfolizer.Horology;
using System;
using System.Globalization;
using System.IO;
using System.IO.Pipelines;

[MemoryDiagnoser]
public class Program
{
    public static void Main(string[] args) =>
        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args,
            DefaultConfig.Instance.WithSummaryStyle(new SummaryStyle(CultureInfo.InvariantCulture,
                printUnitsInHeader: false, sizeUnit: SizeUnit.B, timeUnit: TimeUnit.Nanosecond, printZeroValuesInContent: true)));

    const int Length = 4096;

    private Stream _writer, _reader;
    private byte[] _buffer = new byte[Length];

    public Program()
    {
        var pipe = new Pipe();
        _writer = pipe.Writer.AsStream();
        _reader = pipe.Reader.AsStream();
    }

    [Benchmark]
    public void ReadByte()
    {
        _writer.WriteAsync(_buffer).GetAwaiter().GetResult();
        for (int i = 0; i < Length; i++)
        {
            _reader.ReadByte();
        }
    }

    [Benchmark]
    public void ReadSpan()
    {
        _writer.WriteAsync(_buffer).GetAwaiter().GetResult();
        Span<byte> buffer = _buffer;
        while (!buffer.IsEmpty)
        {
            buffer = buffer.Slice(_reader.Read(buffer));
        }
    }
}
```