### PR TITLE
Refactor symmetric one-shots

### DIFF
--- a/src/libraries/Common/src/Internal/Cryptography/ILiteSymmetricCipher.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/ILiteSymmetricCipher.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Security.Cryptography;
+
+namespace Internal.Cryptography
+{
+    internal interface ILiteSymmetricCipher : IDisposable
+    {
+        int TransformFinal(ReadOnlySpan<byte> input, Span<byte> output);
+        int Transform(ReadOnlySpan<byte> input, Span<byte> output);
+        void Reset(ReadOnlySpan<byte> iv);
+
+        int BlockSizeInBytes { get; }
+        int PaddingSizeInBytes { get; }
+    }
+}

--- a/src/libraries/Common/src/Internal/Cryptography/SymmetricPadding.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/SymmetricPadding.cs
@@ -1,0 +1,220 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Security.Cryptography;
+
+namespace Internal.Cryptography
+{
+    internal static class SymmetricPadding
+    {
+        public static int GetCiphertextLength(int plaintextLength, int paddingSizeInBytes, PaddingMode paddingMode)
+        {
+            Debug.Assert(plaintextLength >= 0);
+
+             //divisor and factor are same and won't overflow.
+            int wholeBlocks = Math.DivRem(plaintextLength, paddingSizeInBytes, out int remainder) * paddingSizeInBytes;
+
+            switch (paddingMode)
+            {
+                case PaddingMode.None when (remainder != 0):
+                    throw new CryptographicException(SR.Cryptography_PartialBlock);
+                case PaddingMode.None:
+                case PaddingMode.Zeros when (remainder == 0):
+                    return plaintextLength;
+                case PaddingMode.Zeros:
+                case PaddingMode.PKCS7:
+                case PaddingMode.ANSIX923:
+                case PaddingMode.ISO10126:
+                    return checked(wholeBlocks + paddingSizeInBytes);
+                default:
+                    Debug.Fail($"Unknown padding mode {paddingMode}.");
+                    throw new CryptographicException(SR.Cryptography_UnknownPaddingMode);
+            }
+        }
+
+        public static int PadBlock(ReadOnlySpan<byte> block, Span<byte> destination, int paddingSizeInBytes, PaddingMode paddingMode)
+        {
+            int count = block.Length;
+            int paddingRemainder = count % paddingSizeInBytes;
+            int padBytes = paddingSizeInBytes - paddingRemainder;
+
+            switch (paddingMode)
+            {
+                case PaddingMode.None when (paddingRemainder != 0):
+                    throw new CryptographicException(SR.Cryptography_PartialBlock);
+
+                case PaddingMode.None:
+                    if (destination.Length < count)
+                    {
+                        throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
+                    }
+
+                    block.CopyTo(destination);
+                    return count;
+
+                // ANSI padding fills the blocks with zeros and adds the total number of padding bytes as
+                // the last pad byte, adding an extra block if the last block is complete.
+                //
+                // xx 00 00 00 00 00 00 07
+                case PaddingMode.ANSIX923:
+                    int ansiSize = count + padBytes;
+
+                    if (destination.Length < ansiSize)
+                    {
+                        throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
+                    }
+
+                    block.CopyTo(destination);
+                    destination.Slice(count, padBytes - 1).Clear();
+                    destination[count + padBytes - 1] = (byte)padBytes;
+                    return ansiSize;
+
+                // ISO padding fills the blocks up with random bytes and adds the total number of padding
+                // bytes as the last pad byte, adding an extra block if the last block is complete.
+                //
+                // xx rr rr rr rr rr rr 07
+                case PaddingMode.ISO10126:
+                    int isoSize = count + padBytes;
+
+                    if (destination.Length < isoSize)
+                    {
+                        throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
+                    }
+
+                    block.CopyTo(destination);
+                    RandomNumberGenerator.Fill(destination.Slice(count, padBytes - 1));
+                    destination[count + padBytes - 1] = (byte)padBytes;
+                    return isoSize;
+
+                // PKCS padding fills the blocks up with bytes containing the total number of padding bytes
+                // used, adding an extra block if the last block is complete.
+                //
+                // xx xx 06 06 06 06 06 06
+                case PaddingMode.PKCS7:
+                    int pkcsSize = count + padBytes;
+
+                    if (destination.Length < pkcsSize)
+                    {
+                        throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
+                    }
+
+                    block.CopyTo(destination);
+                    destination.Slice(count, padBytes).Fill((byte)padBytes);
+                    return pkcsSize;
+
+                // Zeros padding fills the last partial block with zeros, and does not add a new block to
+                // the end if the last block is already complete.
+                //
+                //  xx 00 00 00 00 00 00 00
+                case PaddingMode.Zeros:
+                    if (padBytes == paddingSizeInBytes)
+                    {
+                        padBytes = 0;
+                    }
+
+                    int zeroSize = count + padBytes;
+
+                    if (destination.Length < zeroSize)
+                    {
+                        throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
+                    }
+
+                    block.CopyTo(destination);
+                    destination.Slice(count, padBytes).Clear();
+                    return zeroSize;
+
+                default:
+                    throw new CryptographicException(SR.Cryptography_UnknownPaddingMode);
+            }
+        }
+
+        public static bool DepaddingRequired(PaddingMode padding)
+        {
+            // Some padding modes encode sufficient information to allow for automatic depadding to happen.
+            switch (padding)
+            {
+                case PaddingMode.PKCS7:
+                case PaddingMode.ANSIX923:
+                case PaddingMode.ISO10126:
+                    return true;
+                case PaddingMode.Zeros:
+                case PaddingMode.None:
+                    return false;
+                default:
+                    Debug.Fail($"Unknown padding mode {padding}.");
+                    throw new CryptographicException(SR.Cryptography_UnknownPaddingMode);
+            }
+        }
+
+        public static int GetPaddingLength(ReadOnlySpan<byte> block, PaddingMode paddingMode, int blockSize)
+        {
+            int padBytes = 0;
+
+            // See PadBlock for a description of the padding modes.
+            switch (paddingMode)
+            {
+                case PaddingMode.ANSIX923:
+                    padBytes = block[^1];
+
+                    // Verify the amount of padding is reasonable
+                    if (padBytes <= 0 || padBytes > blockSize)
+                    {
+                        throw new CryptographicException(SR.Cryptography_InvalidPadding);
+                    }
+
+                    // Verify that all the padding bytes are 0s
+                    for (int i = block.Length - padBytes; i < block.Length - 1; i++)
+                    {
+                        if (block[i] != 0)
+                        {
+                            throw new CryptographicException(SR.Cryptography_InvalidPadding);
+                        }
+                    }
+
+                    break;
+
+                case PaddingMode.ISO10126:
+                    padBytes = block[^1];
+
+                    // Verify the amount of padding is reasonable
+                    if (padBytes <= 0 || padBytes > blockSize)
+                    {
+                        throw new CryptographicException(SR.Cryptography_InvalidPadding);
+                    }
+
+                    // Since the padding consists of random bytes, we cannot verify the actual pad bytes themselves
+                    break;
+
+                case PaddingMode.PKCS7:
+                    padBytes = block[^1];
+
+                    // Verify the amount of padding is reasonable
+                    if (padBytes <= 0 || padBytes > blockSize)
+                        throw new CryptographicException(SR.Cryptography_InvalidPadding);
+
+                    // Verify all the padding bytes match the amount of padding
+                    for (int i = block.Length - padBytes; i < block.Length - 1; i++)
+                    {
+                        if (block[i] != padBytes)
+                            throw new CryptographicException(SR.Cryptography_InvalidPadding);
+                    }
+
+                    break;
+
+                // We cannot remove Zeros padding because we don't know if the zeros at the end of the block
+                // belong to the padding or the plaintext itself.
+                case PaddingMode.Zeros:
+                case PaddingMode.None:
+                    padBytes = 0;
+                    break;
+
+                default:
+                    throw new CryptographicException(SR.Cryptography_UnknownPaddingMode);
+            }
+
+            return block.Length - padBytes;
+        }
+    }
+}

--- a/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoDecryptor.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoDecryptor.cs
@@ -35,7 +35,7 @@ namespace Internal.Cryptography
             // zeros at the end of a block are part of the plaintext or the padding.
             //
             int decryptedBytes = 0;
-            if (DepaddingRequired)
+            if (SymmetricPadding.DepaddingRequired(PaddingMode))
             {
                 // If we have data saved from a previous call, decrypt that into the output first
                 if (_heldoverCipher != null)
@@ -131,7 +131,7 @@ namespace Internal.Cryptography
 
         protected override unsafe byte[] UncheckedTransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
         {
-            if (DepaddingRequired)
+            if (SymmetricPadding.DepaddingRequired(PaddingMode))
             {
                 byte[] rented = CryptoPool.Rent(inputCount + InputBlockSize);
                 int written = 0;
@@ -190,7 +190,7 @@ namespace Internal.Cryptography
             // until it's been decrypted. We don't want to decrypt in to a user-supplied buffer and then throw
             // a padding exception after we've already filled the user buffer with plaintext. We should only
             // release the plaintext to the caller once we know the padding is valid.
-            if (!DepaddingRequired)
+            if (!SymmetricPadding.DepaddingRequired(PaddingMode))
             {
                 if (output.Length >= input.Length)
                 {
@@ -239,27 +239,6 @@ namespace Internal.Cryptography
             {
                 Array.Clear(_heldoverCipher);
                 _heldoverCipher = null;
-            }
-        }
-
-        private bool DepaddingRequired
-        {
-            get
-            {
-                // Some padding modes encode sufficient information to allow for automatic depadding to happen.
-                switch (PaddingMode)
-                {
-                    case PaddingMode.PKCS7:
-                    case PaddingMode.ANSIX923:
-                    case PaddingMode.ISO10126:
-                        return true;
-                    case PaddingMode.Zeros:
-                    case PaddingMode.None:
-                        return false;
-                    default:
-                        Debug.Fail($"Unknown padding mode {PaddingMode}.");
-                        throw new CryptographicException(SR.Cryptography_UnknownPaddingMode);
-                }
             }
         }
 

--- a/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoEncryptor.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoEncryptor.cs
@@ -33,7 +33,7 @@ namespace Internal.Cryptography
             // always new memory, not a user-provided buffer.
             Debug.Assert(!inputBuffer.Overlaps(outputBuffer));
 
-            int padWritten = PadBlock(inputBuffer, outputBuffer);
+            int padWritten = SymmetricPadding.PadBlock(inputBuffer, outputBuffer, PaddingSizeBytes, PaddingMode);
             int transformWritten = BasicSymmetricCipher.TransformFinal(outputBuffer.Slice(0, padWritten), outputBuffer);
 
             // After padding, we should have an even number of blocks, and the same applies
@@ -45,11 +45,12 @@ namespace Internal.Cryptography
 
         protected override byte[] UncheckedTransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
         {
+            int ciphertextLength = SymmetricPadding.GetCiphertextLength(inputCount, PaddingSizeBytes, PaddingMode);
             byte[] buffer;
 #if NET5_0_OR_GREATER
-            buffer = GC.AllocateUninitializedArray<byte>(GetCiphertextLength(inputCount));
+            buffer = GC.AllocateUninitializedArray<byte>(ciphertextLength);
 #else
-            buffer = new byte[GetCiphertextLength(inputCount)];
+            buffer = new byte[ciphertextLength];
 #endif
             int written = UncheckedTransformFinalBlock(inputBuffer.AsSpan(inputOffset, inputCount), buffer);
             Debug.Assert(written == buffer.Length);
@@ -58,7 +59,7 @@ namespace Internal.Cryptography
 
         public override bool TransformOneShot(ReadOnlySpan<byte> input, Span<byte> output, out int bytesWritten)
         {
-            int ciphertextLength = GetCiphertextLength(input.Length);
+            int ciphertextLength = SymmetricPadding.GetCiphertextLength(input.Length, PaddingSizeBytes, PaddingMode);
 
             if (output.Length < ciphertextLength)
             {
@@ -69,7 +70,7 @@ namespace Internal.Cryptography
             // Copy the input to the output, and apply padding if required. This will not throw since the
             // output length has already been checked, and PadBlock will not copy from input to output
             // until it has checked that it will be able to apply padding correctly.
-            int padWritten = PadBlock(input, output);
+            int padWritten = SymmetricPadding.PadBlock(input, output, PaddingSizeBytes, PaddingMode);
 
             // Do an in-place encrypt. All of our implementations support this, either natively
             // or making a temporary buffer themselves if in-place is not supported by the native
@@ -81,127 +82,6 @@ namespace Internal.Cryptography
             // to the transform.
             Debug.Assert(padWritten == bytesWritten);
             return true;
-        }
-
-        private int GetCiphertextLength(int plaintextLength)
-        {
-            Debug.Assert(plaintextLength >= 0);
-
-             //divisor and factor are same and won't overflow.
-            int wholeBlocks = Math.DivRem(plaintextLength, PaddingSizeBytes, out int remainder) * PaddingSizeBytes;
-
-            switch (PaddingMode)
-            {
-                case PaddingMode.None when (remainder != 0):
-                    throw new CryptographicException(SR.Cryptography_PartialBlock);
-                case PaddingMode.None:
-                case PaddingMode.Zeros when (remainder == 0):
-                    return plaintextLength;
-                case PaddingMode.Zeros:
-                case PaddingMode.PKCS7:
-                case PaddingMode.ANSIX923:
-                case PaddingMode.ISO10126:
-                    return checked(wholeBlocks + PaddingSizeBytes);
-                default:
-                    Debug.Fail($"Unknown padding mode {PaddingMode}.");
-                    throw new CryptographicException(SR.Cryptography_UnknownPaddingMode);
-            }
-        }
-
-        private int PadBlock(ReadOnlySpan<byte> block, Span<byte> destination)
-        {
-            int count = block.Length;
-            int paddingRemainder = count % PaddingSizeBytes;
-            int padBytes = PaddingSizeBytes - paddingRemainder;
-
-            switch (PaddingMode)
-            {
-                case PaddingMode.None when (paddingRemainder != 0):
-                    throw new CryptographicException(SR.Cryptography_PartialBlock);
-
-                case PaddingMode.None:
-                    if (destination.Length < count)
-                    {
-                        throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-                    }
-
-                    block.CopyTo(destination);
-                    return count;
-
-                // ANSI padding fills the blocks with zeros and adds the total number of padding bytes as
-                // the last pad byte, adding an extra block if the last block is complete.
-                //
-                // xx 00 00 00 00 00 00 07
-                case PaddingMode.ANSIX923:
-                    int ansiSize = count + padBytes;
-
-                    if (destination.Length < ansiSize)
-                    {
-                        throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-                    }
-
-                    block.CopyTo(destination);
-                    destination.Slice(count, padBytes - 1).Clear();
-                    destination[count + padBytes - 1] = (byte)padBytes;
-                    return ansiSize;
-
-                // ISO padding fills the blocks up with random bytes and adds the total number of padding
-                // bytes as the last pad byte, adding an extra block if the last block is complete.
-                //
-                // xx rr rr rr rr rr rr 07
-                case PaddingMode.ISO10126:
-                    int isoSize = count + padBytes;
-
-                    if (destination.Length < isoSize)
-                    {
-                        throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-                    }
-
-                    block.CopyTo(destination);
-                    RandomNumberGenerator.Fill(destination.Slice(count, padBytes - 1));
-                    destination[count + padBytes - 1] = (byte)padBytes;
-                    return isoSize;
-
-                // PKCS padding fills the blocks up with bytes containing the total number of padding bytes
-                // used, adding an extra block if the last block is complete.
-                //
-                // xx xx 06 06 06 06 06 06
-                case PaddingMode.PKCS7:
-                    int pkcsSize = count + padBytes;
-
-                    if (destination.Length < pkcsSize)
-                    {
-                        throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-                    }
-
-                    block.CopyTo(destination);
-                    destination.Slice(count, padBytes).Fill((byte)padBytes);
-                    return pkcsSize;
-
-                // Zeros padding fills the last partial block with zeros, and does not add a new block to
-                // the end if the last block is already complete.
-                //
-                //  xx 00 00 00 00 00 00 00
-                case PaddingMode.Zeros:
-                    if (padBytes == PaddingSizeBytes)
-                    {
-                        padBytes = 0;
-                    }
-
-                    int zeroSize = count + padBytes;
-
-                    if (destination.Length < zeroSize)
-                    {
-                        throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
-                    }
-
-                    block.CopyTo(destination);
-                    destination.Slice(count, padBytes).Clear();
-                    return zeroSize;
-
-                default:
-                    throw new CryptographicException(SR.Cryptography_UnknownPaddingMode);
-            }
         }
     }
 }

--- a/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoOneShot.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoOneShot.cs
@@ -1,0 +1,105 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Security.Cryptography;
+
+namespace Internal.Cryptography
+{
+    internal static class UniversalCryptoOneShot
+    {
+        public static unsafe bool OneShotDecrypt(
+            ILiteSymmetricCipher cipher,
+            PaddingMode paddingMode,
+            ReadOnlySpan<byte> input,
+            Span<byte> output,
+            out int bytesWritten)
+        {
+            if (input.Length % cipher.PaddingSizeInBytes != 0)
+                throw new CryptographicException(SR.Cryptography_PartialBlock);
+
+            // If there is no padding that needs to be removed, and the output buffer is large enough to hold
+            // the resulting plaintext, we can decrypt directly in to the output buffer.
+            // We do not do this for modes that require padding removal.
+            //
+            // This is not done for padded ciphertexts because we don't know if the padding is valid
+            // until it's been decrypted. We don't want to decrypt in to a user-supplied buffer and then throw
+            // a padding exception after we've already filled the user buffer with plaintext. We should only
+            // release the plaintext to the caller once we know the padding is valid.
+            if (!SymmetricPadding.DepaddingRequired(paddingMode))
+            {
+                if (output.Length >= input.Length)
+                {
+                    bytesWritten = cipher.TransformFinal(input, output);
+                    return true;
+                }
+
+                // If no padding is going to be removed, we know the buffer is too small and we can bail out.
+                bytesWritten = 0;
+                return false;
+            }
+
+            byte[] rentedBuffer = CryptoPool.Rent(input.Length);
+            Span<byte> buffer = rentedBuffer.AsSpan(0, input.Length);
+            Span<byte> decryptedBuffer = default;
+
+            fixed (byte* pBuffer = buffer)
+            {
+                try
+                {
+                    int transformWritten = cipher.TransformFinal(input, buffer);
+                    decryptedBuffer = buffer.Slice(0, transformWritten);
+                    int unpaddedLength = SymmetricPadding.GetPaddingLength(decryptedBuffer, paddingMode, cipher.BlockSizeInBytes); // validates padding
+
+                    if (unpaddedLength > output.Length)
+                    {
+                        bytesWritten = 0;
+                        return false;
+                    }
+
+                    decryptedBuffer.Slice(0, unpaddedLength).CopyTo(output);
+                    bytesWritten = unpaddedLength;
+                    return true;
+                }
+                finally
+                {
+                    CryptographicOperations.ZeroMemory(decryptedBuffer);
+                    CryptoPool.Return(rentedBuffer, clearSize: 0); // ZeroMemory clears the part of the buffer that was written to.
+                }
+            }
+        }
+
+        public static bool OneShotEncrypt(
+            ILiteSymmetricCipher cipher,
+            PaddingMode paddingMode,
+            ReadOnlySpan<byte> input,
+            Span<byte> output,
+            out int bytesWritten)
+        {
+            int ciphertextLength = SymmetricPadding.GetCiphertextLength(input.Length, cipher.PaddingSizeInBytes, paddingMode);
+
+            if (output.Length < ciphertextLength)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            // Copy the input to the output, and apply padding if required. This will not throw since the
+            // output length has already been checked, and PadBlock will not copy from input to output
+            // until it has checked that it will be able to apply padding correctly.
+            int padWritten = SymmetricPadding.PadBlock(input, output, cipher.PaddingSizeInBytes, paddingMode);
+
+            // Do an in-place encrypt. All of our implementations support this, either natively
+            // or making a temporary buffer themselves if in-place is not supported by the native
+            // implementation.
+            Span<byte> paddedOutput = output.Slice(0, padWritten);
+            bytesWritten = cipher.TransformFinal(paddedOutput, paddedOutput);
+
+            // After padding, we should have an even number of blocks, and the same applies
+            // to the transform.
+            Debug.Assert(padWritten == bytesWritten);
+            return true;
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesImplementation.OSX.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesImplementation.OSX.cs
@@ -37,10 +37,18 @@ namespace Internal.Cryptography
             ReadOnlySpan<byte> iv,
             int blockSize,
             int paddingSize,
-            int feedback,
+            int feedbackSizeInBytes,
             bool encrypting)
         {
-            throw new NotImplementedException();
+            return new AppleCCCryptorLite(
+                Interop.AppleCrypto.PAL_SymmetricAlgorithm.AES,
+                cipherMode,
+                blockSize,
+                key,
+                iv,
+                encrypting,
+                feedbackSizeInBytes,
+                paddingSize);
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesImplementation.OSX.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesImplementation.OSX.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Security.Cryptography;
 
 namespace Internal.Cryptography
@@ -28,6 +29,18 @@ namespace Internal.Cryptography
                 paddingSize);
 
             return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
+        }
+
+        private static ILiteSymmetricCipher CreateLiteCipher(
+            CipherMode cipherMode,
+            ReadOnlySpan<byte> key,
+            ReadOnlySpan<byte> iv,
+            int blockSize,
+            int paddingSize,
+            int feedback,
+            bool encrypting)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesImplementation.Unix.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesImplementation.Unix.cs
@@ -25,6 +25,19 @@ namespace Internal.Cryptography
             return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
         }
 
+        private static ILiteSymmetricCipher CreateLiteCipher(
+            CipherMode cipherMode,
+            ReadOnlySpan<byte> key,
+            ReadOnlySpan<byte> iv,
+            int blockSize,
+            int paddingSize,
+            int feedback,
+            bool encrypting)
+        {
+            IntPtr algorithm = GetAlgorithm(key.Length * 8, feedback * 8, cipherMode);
+            return new OpenSslCipherLite(algorithm, cipherMode, blockSize, paddingSize, key, 0, iv, encrypting);
+        }
+
         private static IntPtr GetAlgorithm(int keySize, int feedback, CipherMode cipherMode) =>
             (keySize, cipherMode) switch
             {

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesImplementation.Windows.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesImplementation.Windows.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Security.Cryptography;
 using Internal.NativeCrypto;
 
@@ -22,6 +23,18 @@ namespace Internal.Cryptography
 
             BasicSymmetricCipher cipher = new BasicSymmetricCipherBCrypt(algorithm, cipherMode, blockSize, paddingSize, key, false, iv, encrypting);
             return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
+        }
+
+        private static ILiteSymmetricCipher CreateLiteCipher(
+            CipherMode cipherMode,
+            ReadOnlySpan<byte> key,
+            ReadOnlySpan<byte> iv,
+            int blockSize,
+            int paddingSize,
+            int feedback,
+            bool encrypting)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesImplementation.Windows.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesImplementation.Windows.cs
@@ -31,10 +31,20 @@ namespace Internal.Cryptography
             ReadOnlySpan<byte> iv,
             int blockSize,
             int paddingSize,
-            int feedback,
+            int feedbackSize,
             bool encrypting)
         {
-            throw new NotImplementedException();
+            SafeAlgorithmHandle algorithm = AesBCryptModes.GetSharedHandle(cipherMode, feedbackSize);
+
+            return new BasicSymmetricCipherBCrypt(
+                algorithm,
+                cipherMode,
+                blockSize,
+                paddingSize,
+                key,
+                ownsParentHandle: false,
+                iv.ToArray(),
+                encrypting);
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesImplementation.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesImplementation.cs
@@ -70,7 +70,7 @@ namespace Internal.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-             ILiteSymmetricCipher cipher = CreateLiteCipher(
+            ILiteSymmetricCipher cipher = CreateLiteCipher(
                 CipherMode.ECB,
                 Key,
                 iv: default,

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesImplementation.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesImplementation.cs
@@ -49,19 +49,18 @@ namespace Internal.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            UniversalCryptoTransform transform = CreateTransformCore(
+            ILiteSymmetricCipher cipher = CreateLiteCipher(
                 CipherMode.ECB,
-                paddingMode,
                 Key,
-                iv: null,
+                iv: default,
                 blockSize: BlockSize / BitsPerByte,
                 paddingSize: BlockSize / BitsPerByte,
                 0, /*feedback size */
                 encrypting: false);
 
-            using (transform)
+            using (cipher)
             {
-                return transform.TransformOneShot(ciphertext, destination, out bytesWritten);
+                return UniversalCryptoOneShot.OneShotDecrypt(cipher, paddingMode, ciphertext, destination, out bytesWritten);
             }
         }
 
@@ -71,19 +70,18 @@ namespace Internal.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            UniversalCryptoTransform transform = CreateTransformCore(
+             ILiteSymmetricCipher cipher = CreateLiteCipher(
                 CipherMode.ECB,
-                paddingMode,
                 Key,
-                iv: null,
+                iv: default,
                 blockSize: BlockSize / BitsPerByte,
                 paddingSize: BlockSize / BitsPerByte,
                 0, /*feedback size */
                 encrypting: true);
 
-            using (transform)
+            using (cipher)
             {
-                return transform.TransformOneShot(plaintext, destination, out bytesWritten);
+                return UniversalCryptoOneShot.OneShotEncrypt(cipher, paddingMode, plaintext, destination, out bytesWritten);
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AppleCCCryptor.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AppleCCCryptor.cs
@@ -12,7 +12,7 @@ namespace Internal.Cryptography
     internal sealed class AppleCCCryptor : BasicSymmetricCipher
     {
         private readonly bool _encrypting;
-        private SafeAppleCryptorHandle _cryptor;
+        private AppleCCCryptorLite _cryptor;
 
         // Reset operation is not supported on stream cipher
         private readonly bool _supportsReset;
@@ -62,152 +62,28 @@ namespace Internal.Cryptography
             Debug.Assert(input.Length > 0);
             Debug.Assert((input.Length % PaddingSizeInBytes) == 0);
 
-            return CipherUpdate(input, output);
+            return _cryptor.Transform(input, output);
         }
 
         public override int TransformFinal(ReadOnlySpan<byte> input, Span<byte> output)
         {
-            Debug.Assert((input.Length % PaddingSizeInBytes) == 0);
-            Debug.Assert(input.Length <= output.Length);
-
-            int written = 0;
-
-            if (input.Overlaps(output, out int offset) && offset != 0)
-            {
-                byte[] rented = CryptoPool.Rent(output.Length);
-
-                try
-                {
-                    written = ProcessFinalBlock(input, rented);
-                    rented.AsSpan(0, written).CopyTo(output);
-                }
-                finally
-                {
-                    CryptoPool.Return(rented, clearSize: written);
-                }
-            }
-            else
-            {
-                written = ProcessFinalBlock(input, output);
-            }
-
+            int written = _cryptor.TransformFinal(input, output);
             Reset();
             return written;
-        }
-
-        private unsafe int ProcessFinalBlock(ReadOnlySpan<byte> input, Span<byte> output)
-        {
-            if (input.Length == 0)
-            {
-                return 0;
-            }
-
-            int outputBytes = CipherUpdate(input, output);
-            int ret;
-            int errorCode;
-
-            Debug.Assert(output.Length > 0);
-
-            fixed (byte* outputStart = output)
-            {
-                byte* outputCurrent = outputStart + outputBytes;
-                int bytesWritten;
-
-                ret = Interop.AppleCrypto.CryptorFinal(
-                    _cryptor,
-                    outputCurrent,
-                    output.Length - outputBytes,
-                    out bytesWritten,
-                    out errorCode);
-
-                outputBytes += bytesWritten;
-            }
-
-            ProcessInteropError(ret, errorCode);
-
-            return outputBytes;
-        }
-
-        private unsafe int CipherUpdate(ReadOnlySpan<byte> input, Span<byte> output)
-        {
-            int ret;
-            int ccStatus;
-            int bytesWritten;
-
-            if (input.Length == 0)
-            {
-                return 0;
-            }
-
-            fixed (byte* pInput = input)
-            fixed (byte* pOutput = output)
-            {
-                ret = Interop.AppleCrypto.CryptorUpdate(
-                    _cryptor,
-                    pInput,
-                    input.Length,
-                    pOutput,
-                    output.Length,
-                    out bytesWritten,
-                    out ccStatus);
-            }
-
-            ProcessInteropError(ret, ccStatus);
-
-            return bytesWritten;
         }
 
         [MemberNotNull(nameof(_cryptor))]
         private unsafe void OpenCryptor()
         {
-            int ret;
-            int ccStatus;
-
-            byte[]? iv = IV;
-
-            fixed (byte* pbKey = _key)
-            fixed (byte* pbIv = iv)
-            {
-                ret = Interop.AppleCrypto.CryptorCreate(
-                    _encrypting
-                        ? Interop.AppleCrypto.PAL_SymmetricOperation.Encrypt
-                        : Interop.AppleCrypto.PAL_SymmetricOperation.Decrypt,
-                    _algorithm,
-                    GetPalChainMode(_algorithm, _cipherMode, _feedbackSizeInBytes),
-                    Interop.AppleCrypto.PAL_PaddingMode.None,
-                    pbKey,
-                    _key.Length,
-                    pbIv,
-                    Interop.AppleCrypto.PAL_SymmetricOptions.None,
-                    out _cryptor,
-                    out ccStatus);
-            }
-
-            ProcessInteropError(ret, ccStatus);
-        }
-
-        private Interop.AppleCrypto.PAL_ChainingMode GetPalChainMode(Interop.AppleCrypto.PAL_SymmetricAlgorithm algorithm, CipherMode cipherMode, int feedbackSizeInBytes)
-        {
-            switch (cipherMode)
-            {
-                case CipherMode.CBC:
-                    return Interop.AppleCrypto.PAL_ChainingMode.CBC;
-                case CipherMode.ECB:
-                    return Interop.AppleCrypto.PAL_ChainingMode.ECB;
-                case CipherMode.CFB:
-                    if (feedbackSizeInBytes == 1)
-                    {
-                        return Interop.AppleCrypto.PAL_ChainingMode.CFB8;
-                    }
-
-                    Debug.Assert(
-                        (algorithm == Interop.AppleCrypto.PAL_SymmetricAlgorithm.AES && feedbackSizeInBytes == 16) ||
-                        (algorithm == Interop.AppleCrypto.PAL_SymmetricAlgorithm.TripleDES && feedbackSizeInBytes == 8));
-
-                    return Interop.AppleCrypto.PAL_ChainingMode.CFB;
-                default:
-                    throw new PlatformNotSupportedException(SR.Format(SR.Cryptography_CipherModeNotSupported, cipherMode));
-            }
+            _cryptor = new AppleCCCryptorLite(
+                _algorithm,
+                _cipherMode,
+                BlockSizeInBytes,
+                _key,
+                IV,
+                _encrypting,
+                _feedbackSizeInBytes,
+                PaddingSizeInBytes);
         }
 
         private unsafe void Reset()
@@ -221,40 +97,8 @@ namespace Internal.Cryptography
             }
             else
             {
-                int ret;
-                int ccStatus;
-
-                byte[]? iv = IV;
-
-                fixed (byte* pbIv = iv)
-                {
-                    ret = Interop.AppleCrypto.CryptorReset(_cryptor, pbIv, out ccStatus);
-                }
-
-                ProcessInteropError(ret, ccStatus);
+                _cryptor.Reset(IV);
             }
-        }
-
-        private static void ProcessInteropError(int functionReturnCode, int ccStatus)
-        {
-            // Success
-            if (functionReturnCode == 1)
-            {
-                return;
-            }
-
-            // Platform error
-            if (functionReturnCode == 0)
-            {
-                Debug.Assert(ccStatus != 0, "Interop function returned 0 but a system code of success");
-                throw Interop.AppleCrypto.CreateExceptionForCCError(
-                    ccStatus,
-                    Interop.AppleCrypto.CCCryptorStatus);
-            }
-
-            // Usually this will be -1, a general indication of bad inputs.
-            Debug.Fail($"Interop boundary returned unexpected value {functionReturnCode}");
-            throw new CryptographicException();
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AppleCCCryptorLite.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AppleCCCryptorLite.cs
@@ -1,0 +1,242 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using Microsoft.Win32.SafeHandles;
+
+using PAL_SymmetricAlgorithm = Interop.AppleCrypto.PAL_SymmetricAlgorithm;
+using PAL_ChainingMode = Interop.AppleCrypto.PAL_ChainingMode;
+
+namespace Internal.Cryptography
+{
+    internal sealed class AppleCCCryptorLite : ILiteSymmetricCipher
+    {
+        private readonly SafeAppleCryptorHandle _cryptor;
+        private readonly bool _canReset;
+
+#if DEBUG
+        private bool _isFinalized;
+#endif
+
+        public int BlockSizeInBytes { get; }
+        public int PaddingSizeInBytes { get; }
+
+        public unsafe AppleCCCryptorLite(
+            PAL_SymmetricAlgorithm algorithm,
+            CipherMode cipherMode,
+            int blockSizeInBytes,
+            ReadOnlySpan<byte> key,
+            ReadOnlySpan<byte> iv,
+            bool encrypting,
+            int feedbackSizeInBytes,
+            int paddingSizeInBytes)
+        {
+            int ret;
+            int ccStatus;
+
+            fixed (byte* pbKey = key)
+            fixed (byte* pbIv = iv)
+            {
+                ret = Interop.AppleCrypto.CryptorCreate(
+                    encrypting
+                        ? Interop.AppleCrypto.PAL_SymmetricOperation.Encrypt
+                        : Interop.AppleCrypto.PAL_SymmetricOperation.Decrypt,
+                    algorithm,
+                    GetPalChainMode(algorithm, cipherMode, feedbackSizeInBytes),
+                    Interop.AppleCrypto.PAL_PaddingMode.None,
+                    pbKey,
+                    key.Length,
+                    pbIv,
+                    Interop.AppleCrypto.PAL_SymmetricOptions.None,
+                    out _cryptor,
+                    out ccStatus);
+            }
+
+            ProcessInteropError(ret, ccStatus);
+
+            _canReset = cipherMode != CipherMode.CFB;
+            BlockSizeInBytes = blockSizeInBytes;
+            PaddingSizeInBytes = paddingSizeInBytes;
+        }
+
+        public int TransformFinal(ReadOnlySpan<byte> input, Span<byte> output)
+        {
+#if DEBUG
+            if (_isFinalized)
+            {
+                Debug.Fail("Cipher was reused without being reset.");
+                throw new CryptographicException();
+            }
+
+            _isFinalized = true;
+#endif
+
+            Debug.Assert((input.Length % PaddingSizeInBytes) == 0);
+            Debug.Assert(input.Length <= output.Length);
+
+            int written = 0;
+
+            if (input.Overlaps(output, out int offset) && offset != 0)
+            {
+                byte[] rented = CryptoPool.Rent(output.Length);
+
+                try
+                {
+                    written = ProcessFinalBlock(input, rented);
+                    rented.AsSpan(0, written).CopyTo(output);
+                }
+                finally
+                {
+                    CryptoPool.Return(rented, clearSize: written);
+                }
+            }
+            else
+            {
+                written = ProcessFinalBlock(input, output);
+            }
+
+            return written;
+        }
+
+        public int Transform(ReadOnlySpan<byte> input, Span<byte> output)
+        {
+#if DEBUG
+            if (_isFinalized)
+            {
+                Debug.Fail("Cipher was reused without being reset.");
+                throw new CryptographicException();
+            }
+#endif
+
+            Debug.Assert(input.Length > 0);
+            Debug.Assert((input.Length % PaddingSizeInBytes) == 0);
+
+            return CipherUpdate(input, output);
+        }
+
+        public void Dispose()
+        {
+            _cryptor.Dispose();
+        }
+
+        public unsafe void Reset(ReadOnlySpan<byte> iv)
+        {
+            if (!_canReset)
+            {
+                Debug.Fail("Cipher cannot be reset.");
+                throw new CryptographicException();
+            }
+
+            fixed (byte* pbIv = iv)
+            {
+                int ret = Interop.AppleCrypto.CryptorReset(_cryptor, pbIv, out int ccStatus);
+                ProcessInteropError(ret, ccStatus);
+            }
+
+#if DEBUG
+            _isFinalized = false;
+#endif
+        }
+
+        private unsafe int CipherUpdate(ReadOnlySpan<byte> input, Span<byte> output)
+        {
+            int ret;
+            int ccStatus;
+            int bytesWritten;
+
+            if (input.Length == 0)
+            {
+                return 0;
+            }
+
+            fixed (byte* pInput = input)
+            fixed (byte* pOutput = output)
+            {
+                ret = Interop.AppleCrypto.CryptorUpdate(
+                    _cryptor,
+                    pInput,
+                    input.Length,
+                    pOutput,
+                    output.Length,
+                    out bytesWritten,
+                    out ccStatus);
+            }
+
+            ProcessInteropError(ret, ccStatus);
+
+            return bytesWritten;
+        }
+
+        private PAL_ChainingMode GetPalChainMode(PAL_SymmetricAlgorithm algorithm, CipherMode cipherMode, int feedbackSizeInBytes)
+        {
+            return cipherMode switch
+            {
+                CipherMode.CBC => PAL_ChainingMode.CBC,
+                CipherMode.ECB => PAL_ChainingMode.ECB,
+                CipherMode.CFB when feedbackSizeInBytes == 1 => PAL_ChainingMode.CFB8,
+                CipherMode.CFB => PAL_ChainingMode.CFB,
+                _ => throw new PlatformNotSupportedException(SR.Format(SR.Cryptography_CipherModeNotSupported, cipherMode)),
+            };
+        }
+
+        private unsafe int ProcessFinalBlock(ReadOnlySpan<byte> input, Span<byte> output)
+        {
+            if (input.Length == 0)
+            {
+                return 0;
+            }
+
+            int outputBytes = CipherUpdate(input, output);
+            int ret;
+            int errorCode;
+
+            Debug.Assert(output.Length > 0);
+
+            fixed (byte* outputStart = output)
+            {
+                byte* outputCurrent = outputStart + outputBytes;
+                int bytesWritten;
+
+                ret = Interop.AppleCrypto.CryptorFinal(
+                    _cryptor,
+                    outputCurrent,
+                    output.Length - outputBytes,
+                    out bytesWritten,
+                    out errorCode);
+
+                outputBytes += bytesWritten;
+            }
+
+            ProcessInteropError(ret, errorCode);
+
+            return outputBytes;
+        }
+
+        private static void ProcessInteropError(int functionReturnCode, int ccStatus)
+        {
+            // Success
+            if (functionReturnCode == 1)
+            {
+                return;
+            }
+
+            // Platform error
+            if (functionReturnCode == 0)
+            {
+                Debug.Assert(ccStatus != 0, "Interop function returned 0 but a system code of success");
+                throw Interop.AppleCrypto.CreateExceptionForCCError(
+                    ccStatus,
+                    Interop.AppleCrypto.CCCryptorStatus);
+            }
+
+            // Usually this will be -1, a general indication of bad inputs.
+            Debug.Fail($"Interop boundary returned unexpected value {functionReturnCode}");
+            throw new CryptographicException();
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/DesImplementation.Android.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/DesImplementation.Android.cs
@@ -20,28 +20,36 @@ namespace Internal.Cryptography
             bool encrypting)
         {
             // The algorithm pointer is a static pointer, so not having any cleanup code is correct.
-            IntPtr algorithm = IntPtr.Zero;
-
-            switch (cipherMode)
-            {
-                case CipherMode.CBC:
-                    algorithm = Interop.Crypto.EvpDesCbc();
-                    break;
-                case CipherMode.ECB:
-                    algorithm = Interop.Crypto.EvpDesEcb();
-                    break;
-                case CipherMode.CFB:
-
-                    Debug.Assert(feedbackSize == 1, "DES with CFB should have FeedbackSize set to 1");
-                    algorithm = Interop.Crypto.EvpDesCfb8();
-
-                    break;
-                default:
-                    throw new NotSupportedException();
-            }
+            IntPtr algorithm = GetAlgorithm(cipherMode, feedbackSize);
 
             BasicSymmetricCipher cipher = new OpenSslCipher(algorithm, cipherMode, blockSize, paddingSize, key, 0, iv, encrypting);
             return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
+        }
+
+        private static ILiteSymmetricCipher CreateLiteCipher(
+            CipherMode cipherMode,
+            PaddingMode paddingMode,
+            ReadOnlySpan<byte> key,
+            ReadOnlySpan<byte> iv,
+            int blockSize,
+            int feedbackSize,
+            int paddingSize,
+            bool encrypting)
+        {
+            // The algorithm pointer is a static pointer, so not having any cleanup code is correct.
+            IntPtr algorithm = GetAlgorithm(cipherMode, feedbackSize);
+            return new OpenSslCipherLite(algorithm, cipherMode, blockSize, paddingSize, key, effectiveKeyLength: 0, iv, encrypting);
+        }
+
+        private static IntPtr GetAlgorithm(CipherMode cipherMode, int feedbackSize)
+        {
+            return cipherMode switch
+            {
+                CipherMode.CBC => Interop.Crypto.EvpDesCbc(),
+                CipherMode.ECB => Interop.Crypto.EvpDesEcb(),
+                CipherMode.CFB when feedbackSize == 1 => Interop.Crypto.EvpDesCfb8(),
+                _ => throw new NotSupportedException(),
+            };
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/DesImplementation.OSX.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/DesImplementation.OSX.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Security.Cryptography;
 
 namespace Internal.Cryptography
@@ -28,6 +29,27 @@ namespace Internal.Cryptography
                 paddingSize);
 
             return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
+        }
+
+        private static ILiteSymmetricCipher CreateLiteCipher(
+            CipherMode cipherMode,
+            PaddingMode paddingMode,
+            ReadOnlySpan<byte> key,
+            ReadOnlySpan<byte> iv,
+            int blockSize,
+            int feedbackSizeInBytes,
+            int paddingSize,
+            bool encrypting)
+        {
+            return new AppleCCCryptorLite(
+                Interop.AppleCrypto.PAL_SymmetricAlgorithm.DES,
+                cipherMode,
+                blockSize,
+                key,
+                iv,
+                encrypting,
+                feedbackSizeInBytes,
+                paddingSize);
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/DesImplementation.Unix.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/DesImplementation.Unix.cs
@@ -20,30 +20,40 @@ namespace Internal.Cryptography
             bool encrypting)
         {
             // The algorithm pointer is a static pointer, so not having any cleanup code is correct.
-            IntPtr algorithm = IntPtr.Zero;
-
-            switch (cipherMode)
-            {
-                case CipherMode.CBC:
-                    algorithm = Interop.Crypto.EvpDesCbc();
-                    break;
-                case CipherMode.ECB:
-                    algorithm = Interop.Crypto.EvpDesEcb();
-                    break;
-                case CipherMode.CFB:
-
-                    Debug.Assert(feedbackSize == 1, "DES with CFB should have FeedbackSize set to 1");
-                    algorithm = Interop.Crypto.EvpDesCfb8();
-
-                    break;
-                default:
-                    throw new NotSupportedException();
-            }
+            IntPtr algorithm = GetAlgorithm(cipherMode, feedbackSize);
 
             Interop.Crypto.EnsureLegacyAlgorithmsRegistered();
 
             BasicSymmetricCipher cipher = new OpenSslCipher(algorithm, cipherMode, blockSize, paddingSize, key, 0, iv, encrypting);
             return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
+        }
+
+        private static ILiteSymmetricCipher CreateLiteCipher(
+            CipherMode cipherMode,
+            PaddingMode paddingMode,
+            ReadOnlySpan<byte> key,
+            ReadOnlySpan<byte> iv,
+            int blockSize,
+            int feedbackSize,
+            int paddingSize,
+            bool encrypting)
+        {
+            // The algorithm pointer is a static pointer, so not having any cleanup code is correct.
+            IntPtr algorithm = GetAlgorithm(cipherMode, feedbackSize);
+
+            Interop.Crypto.EnsureLegacyAlgorithmsRegistered();
+            return new OpenSslCipherLite(algorithm, cipherMode, blockSize, paddingSize, key, effectiveKeyLength: 0, iv, encrypting);
+        }
+
+        private static IntPtr GetAlgorithm(CipherMode cipherMode, int feedbackSize)
+        {
+            return cipherMode switch
+            {
+                CipherMode.CBC => Interop.Crypto.EvpDesCbc(),
+                CipherMode.ECB => Interop.Crypto.EvpDesEcb(),
+                CipherMode.CFB when feedbackSize == 1 => Interop.Crypto.EvpDesCfb8(),
+                _ => throw new NotSupportedException(),
+            };
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/DesImplementation.Windows.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/DesImplementation.Windows.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Security.Cryptography;
 using Internal.NativeCrypto;
 
@@ -22,6 +23,29 @@ namespace Internal.Cryptography
 
             BasicSymmetricCipher cipher = new BasicSymmetricCipherBCrypt(algorithm, cipherMode, blockSize, paddingSize, key, false, iv, encrypting);
             return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
+        }
+
+        private static ILiteSymmetricCipher CreateLiteCipher(
+            CipherMode cipherMode,
+            PaddingMode paddingMode,
+            ReadOnlySpan<byte> key,
+            ReadOnlySpan<byte> iv,
+            int blockSize,
+            int feedbackSize,
+            int paddingSize,
+            bool encrypting)
+        {
+            SafeAlgorithmHandle algorithm = DesBCryptModes.GetSharedHandle(cipherMode, feedbackSize);
+
+            return new BasicSymmetricCipherBCrypt(
+                algorithm,
+                cipherMode,
+                blockSize,
+                paddingSize,
+                key,
+                ownsParentHandle: false,
+                iv.ToArray(),
+                encrypting);
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/DesImplementation.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/DesImplementation.cs
@@ -93,7 +93,7 @@ namespace Internal.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            UniversalCryptoTransform transform = CreateTransformCore(
+            ILiteSymmetricCipher cipher = CreateLiteCipher(
                 CipherMode.ECB,
                 paddingMode,
                 Key,
@@ -103,9 +103,9 @@ namespace Internal.Cryptography
                 paddingSize: BlockSize / BitsPerByte,
                 encrypting: false);
 
-            using (transform)
+            using (cipher)
             {
-                return transform.TransformOneShot(ciphertext, destination, out bytesWritten);
+                return UniversalCryptoOneShot.OneShotDecrypt(cipher, paddingMode, ciphertext, destination, out bytesWritten);
             }
         }
 
@@ -115,7 +115,7 @@ namespace Internal.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            UniversalCryptoTransform transform = CreateTransformCore(
+            ILiteSymmetricCipher cipher = CreateLiteCipher(
                 CipherMode.ECB,
                 paddingMode,
                 Key,
@@ -125,9 +125,9 @@ namespace Internal.Cryptography
                 paddingSize: BlockSize / BitsPerByte,
                 encrypting: true);
 
-            using (transform)
+            using (cipher)
             {
-                return transform.TransformOneShot(plaintext, destination, out bytesWritten);
+                return UniversalCryptoOneShot.OneShotEncrypt(cipher, paddingMode, plaintext, destination, out bytesWritten);
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/OpenSslCipher.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/OpenSslCipher.cs
@@ -2,12 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Buffers;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
 using System.Security.Cryptography;
-using Microsoft.Win32.SafeHandles;
 
 namespace Internal.Cryptography
 {

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/OpenSslCipher.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/OpenSslCipher.cs
@@ -13,28 +13,27 @@ namespace Internal.Cryptography
 {
     internal sealed class OpenSslCipher : BasicSymmetricCipher
     {
-        private readonly bool _encrypting;
-        private SafeEvpCipherCtxHandle _ctx;
+        private readonly OpenSslCipherLite _cipherLite;
 
         public OpenSslCipher(IntPtr algorithm, CipherMode cipherMode, int blockSizeInBytes, int paddingSizeInBytes, byte[] key, int effectiveKeyLength, byte[]? iv, bool encrypting)
             : base(cipherMode.GetCipherIv(iv), blockSizeInBytes, paddingSizeInBytes)
         {
-            Debug.Assert(algorithm != IntPtr.Zero);
-
-            _encrypting = encrypting;
-
-            OpenKey(algorithm, key, effectiveKeyLength);
+            _cipherLite = new OpenSslCipherLite(
+                algorithm,
+                cipherMode,
+                blockSizeInBytes,
+                paddingSizeInBytes,
+                key,
+                effectiveKeyLength,
+                iv,
+                encrypting);
         }
 
         protected override void Dispose(bool disposing)
         {
             if (disposing)
             {
-                if (_ctx != null)
-                {
-                    _ctx.Dispose();
-                    _ctx = null!;
-                }
+                _cipherLite.Dispose();
             }
 
             base.Dispose(disposing);
@@ -44,27 +43,7 @@ namespace Internal.Cryptography
         {
             Debug.Assert(input.Length > 0);
             Debug.Assert((input.Length % PaddingSizeInBytes) == 0);
-
-            // OpenSSL 1.1 does not allow partial overlap.
-            if (input.Overlaps(output, out int overlapOffset) && overlapOffset != 0)
-            {
-                byte[] tmp = CryptoPool.Rent(input.Length);
-                Span<byte> tmpSpan = tmp;
-                int written = 0;
-
-                try
-                {
-                    written = CipherUpdate(input, tmpSpan);
-                    tmpSpan.Slice(0, written).CopyTo(output);
-                    return written;
-                }
-                finally
-                {
-                    CryptoPool.Return(tmp, written);
-                }
-            }
-
-            return CipherUpdate(input, output);
+            return _cipherLite.Transform(input, output);
         }
 
         public override int TransformFinal(ReadOnlySpan<byte> input, Span<byte> output)
@@ -72,86 +51,9 @@ namespace Internal.Cryptography
             Debug.Assert((input.Length % PaddingSizeInBytes) == 0);
             Debug.Assert(input.Length <= output.Length);
 
-            int written = ProcessFinalBlock(input, output);
-            Reset();
+            int written = _cipherLite.TransformFinal(input, output);
+            _cipherLite.Reset(IV);
             return written;
-        }
-
-        private int ProcessFinalBlock(ReadOnlySpan<byte> input, Span<byte> output)
-        {
-            // If input and output overlap but are not the same, we need to use a
-            // temp buffer since openssl doesn't seem to like partial overlaps.
-            if (input.Overlaps(output, out int offset) && offset != 0)
-            {
-                byte[] rented = CryptoPool.Rent(input.Length);
-                int written = 0;
-
-                try
-                {
-                    written = CipherUpdate(input, rented);
-                    Span<byte> outputSpan = rented.AsSpan(written);
-                    CheckBoolReturn(Interop.Crypto.EvpCipherFinalEx(_ctx, outputSpan, out int finalWritten));
-                    written += finalWritten;
-                    rented.AsSpan(0, written).CopyTo(output);
-                    return written;
-                }
-                finally
-                {
-                    CryptoPool.Return(rented, clearSize: written);
-                }
-            }
-            else
-            {
-                int written = CipherUpdate(input, output);
-                Span<byte> outputSpan = output.Slice(written);
-                CheckBoolReturn(Interop.Crypto.EvpCipherFinalEx(_ctx, outputSpan, out int finalWritten));
-                written += finalWritten;
-                return written;
-            }
-        }
-
-        private int CipherUpdate(ReadOnlySpan<byte> input, Span<byte> output)
-        {
-            Interop.Crypto.EvpCipherUpdate(
-                _ctx,
-                output,
-                out int bytesWritten,
-                input);
-
-            return bytesWritten;
-        }
-
-        [MemberNotNull(nameof(_ctx))]
-        private void OpenKey(IntPtr algorithm, byte[] key, int effectiveKeyLength)
-        {
-            _ctx = Interop.Crypto.EvpCipherCreate(
-                algorithm,
-                ref MemoryMarshal.GetReference(key.AsSpan()),
-                key.Length * 8,
-                effectiveKeyLength,
-                ref MemoryMarshal.GetReference(IV.AsSpan()),
-                _encrypting ? 1 : 0);
-
-            Interop.Crypto.CheckValidOpenSslHandle(_ctx);
-
-            // OpenSSL will happily do PKCS#7 padding for us, but since we support padding modes
-            // that it doesn't (PaddingMode.Zeros) we'll just always pad the blocks ourselves.
-            CheckBoolReturn(Interop.Crypto.EvpCipherCtxSetPadding(_ctx, 0));
-        }
-
-        private void Reset()
-        {
-            bool status = Interop.Crypto.EvpCipherReset(_ctx);
-
-            CheckBoolReturn(status);
-        }
-
-        private static void CheckBoolReturn(bool returnValue)
-        {
-            if (!returnValue)
-            {
-                throw Interop.Crypto.CreateOpenSslCryptographicException();
-            }
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/OpenSslCipherLite.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/OpenSslCipherLite.cs
@@ -1,0 +1,152 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using Microsoft.Win32.SafeHandles;
+
+namespace Internal.Cryptography
+{
+    internal struct OpenSslCipherLite : ILiteSymmetricCipher
+    {
+        private readonly SafeEvpCipherCtxHandle _ctx;
+
+#if DEBUG
+        private bool _isFinalized;
+#endif
+
+        public int BlockSizeInBytes { get; }
+        public int PaddingSizeInBytes { get; }
+
+        public OpenSslCipherLite(
+            IntPtr algorithm,
+            CipherMode cipherMode,
+            int blockSizeInBytes,
+            int paddingSizeInBytes,
+            ReadOnlySpan<byte> key,
+            int effectiveKeyLength,
+            ReadOnlySpan<byte> iv,
+            bool encrypting)
+        {
+            Debug.Assert(algorithm != IntPtr.Zero);
+
+            _isFinalized = false;
+            BlockSizeInBytes = blockSizeInBytes;
+            PaddingSizeInBytes = paddingSizeInBytes;
+            _ctx = Interop.Crypto.EvpCipherCreate(
+                algorithm,
+                ref MemoryMarshal.GetReference(key),
+                key.Length * 8,
+                effectiveKeyLength,
+                ref MemoryMarshal.GetReference(iv),
+                encrypting ? 1 : 0);
+
+            Interop.Crypto.CheckValidOpenSslHandle(_ctx);
+
+            // OpenSSL will happily do PKCS#7 padding for us, but since we support padding modes
+            // that it doesn't (PaddingMode.Zeros) we'll just always pad the blocks ourselves.
+            CheckBoolReturn(Interop.Crypto.EvpCipherCtxSetPadding(_ctx, 0));
+        }
+
+        public int TransformFinal(ReadOnlySpan<byte> input, Span<byte> output)
+        {
+#if DEBUG
+            if (_isFinalized)
+            {
+                Debug.Fail("Cipher was reused without being reset.");
+                throw new CryptographicException();
+            }
+
+            _isFinalized = true;
+#endif
+
+            // If input and output overlap but are not the same, we need to use a
+            // temp buffer since openssl doesn't seem to like partial overlaps.
+            if (input.Overlaps(output, out int offset) && offset != 0)
+            {
+                byte[] rented = CryptoPool.Rent(input.Length);
+                int written = 0;
+
+                try
+                {
+                    written = CipherUpdate(input, rented);
+                    Span<byte> outputSpan = rented.AsSpan(written);
+                    CheckBoolReturn(Interop.Crypto.EvpCipherFinalEx(_ctx, outputSpan, out int finalWritten));
+                    written += finalWritten;
+                    rented.AsSpan(0, written).CopyTo(output);
+                    return written;
+                }
+                finally
+                {
+                    CryptoPool.Return(rented, clearSize: written);
+                }
+            }
+            else
+            {
+                int written = CipherUpdate(input, output);
+                Span<byte> outputSpan = output.Slice(written);
+                CheckBoolReturn(Interop.Crypto.EvpCipherFinalEx(_ctx, outputSpan, out int finalWritten));
+                written += finalWritten;
+                return written;
+            }
+        }
+
+        public readonly unsafe int Transform(ReadOnlySpan<byte> input, Span<byte> output)
+        {
+            // OpenSSL 1.1 does not allow partial overlap.
+            if (input.Overlaps(output, out int overlapOffset) && overlapOffset != 0)
+            {
+                byte[] tmp = CryptoPool.Rent(input.Length);
+                Span<byte> tmpSpan = tmp;
+                int written = 0;
+
+                try
+                {
+                    written = CipherUpdate(input, tmpSpan);
+                    tmpSpan.Slice(0, written).CopyTo(output);
+                    return written;
+                }
+                finally
+                {
+                    CryptoPool.Return(tmp, written);
+                }
+            }
+
+            return CipherUpdate(input, output);
+        }
+
+        public readonly void Reset(ReadOnlySpan<byte> iv)
+        {
+            bool status = Interop.Crypto.EvpCipherReset(_ctx);
+            CheckBoolReturn(status);
+        }
+
+        public readonly void Dispose()
+        {
+            _ctx.Dispose();
+        }
+
+        private readonly int CipherUpdate(ReadOnlySpan<byte> input, Span<byte> output)
+        {
+            Interop.Crypto.EvpCipherUpdate(
+                _ctx,
+                output,
+                out int bytesWritten,
+                input);
+
+            return bytesWritten;
+        }
+
+        private static void CheckBoolReturn(bool returnValue)
+        {
+            if (!returnValue)
+            {
+                throw Interop.Crypto.CreateOpenSslCryptographicException();
+            }
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC2Implementation.Android.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC2Implementation.Android.cs
@@ -22,5 +22,19 @@ namespace Internal.Cryptography
         {
             throw new PlatformNotSupportedException(SR.Format(SR.Cryptography_AlgorithmNotSupported, nameof(RC2)));
         }
+
+        private static ILiteSymmetricCipher CreateLiteCipher(
+            CipherMode cipherMode,
+            PaddingMode paddingMode,
+            ReadOnlySpan<byte> key,
+            int effectiveKeyLength,
+            ReadOnlySpan<byte> iv,
+            int blockSize,
+            int feedbackSizeInBytes,
+            int paddingSize,
+            bool encrypting)
+        {
+            throw new PlatformNotSupportedException(SR.Format(SR.Cryptography_AlgorithmNotSupported, nameof(RC2)));
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC2Implementation.OSX.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC2Implementation.OSX.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Security.Cryptography;
 
 namespace Internal.Cryptography
@@ -29,6 +30,28 @@ namespace Internal.Cryptography
                 paddingSize);
 
             return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
+        }
+
+        private static ILiteSymmetricCipher CreateLiteCipher(
+            CipherMode cipherMode,
+            PaddingMode paddingMode,
+            ReadOnlySpan<byte> key,
+            int effectiveKeyLength,
+            ReadOnlySpan<byte> iv,
+            int blockSize,
+            int feedbackSizeInBytes,
+            int paddingSize,
+            bool encrypting)
+        {
+            return new AppleCCCryptorLite(
+                Interop.AppleCrypto.PAL_SymmetricAlgorithm.RC2,
+                cipherMode,
+                blockSize,
+                key,
+                iv,
+                encrypting,
+                feedbackSizeInBytes,
+                paddingSize);
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC2Implementation.Windows.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC2Implementation.Windows.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Security.Cryptography;
 using System.Diagnostics;
 using Internal.NativeCrypto;
@@ -25,6 +26,32 @@ namespace Internal.Cryptography
                 // The BasicSymmetricCipherBCrypt ctor will increase algorithm reference count and take ownership.
                 BasicSymmetricCipher cipher = new BasicSymmetricCipherBCrypt(algorithm, cipherMode, blockSize, paddingSize, key, true, iv, encrypting);
                 return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
+            }
+        }
+
+        private static ILiteSymmetricCipher CreateLiteCipher(
+            CipherMode cipherMode,
+            PaddingMode paddingMode,
+            ReadOnlySpan<byte> key,
+            int effectiveKeyLength,
+            ReadOnlySpan<byte> iv,
+            int blockSize,
+            int feedbackSizeInBytes,
+            int paddingSize,
+            bool encrypting)
+        {
+            using (SafeAlgorithmHandle algorithm = RC2BCryptModes.GetHandle(cipherMode, effectiveKeyLength))
+            {
+                // The BasicSymmetricCipherBCrypt ctor will increase algorithm reference count and take ownership.
+                return new BasicSymmetricCipherBCrypt(
+                    algorithm,
+                    cipherMode,
+                    blockSize,
+                    paddingSize,
+                    key,
+                    ownsParentHandle: true,
+                    iv.ToArray(),
+                    encrypting);
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC2Implementation.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/RC2Implementation.cs
@@ -90,7 +90,7 @@ namespace Internal.Cryptography
                 throw new InvalidOperationException(SR.Cryptography_InvalidKeySize);
 
             int effectiveKeySize = EffectiveKeySizeValue == 0 ? keySize : EffectiveKeySize;
-            UniversalCryptoTransform transform = CreateTransformCore(
+            ILiteSymmetricCipher cipher = CreateLiteCipher(
                 CipherMode.ECB,
                 paddingMode,
                 Key,
@@ -101,9 +101,9 @@ namespace Internal.Cryptography
                 paddingSize: BlockSize / BitsPerByte,
                 encrypting: false);
 
-            using (transform)
+            using (cipher)
             {
-                return transform.TransformOneShot(ciphertext, destination, out bytesWritten);
+                return UniversalCryptoOneShot.OneShotDecrypt(cipher, paddingMode, ciphertext, destination, out bytesWritten);
             }
         }
 
@@ -117,20 +117,20 @@ namespace Internal.Cryptography
                 throw new InvalidOperationException(SR.Cryptography_InvalidKeySize);
 
             int effectiveKeySize = EffectiveKeySizeValue == 0 ? keySize : EffectiveKeySize;
-            UniversalCryptoTransform transform = CreateTransformCore(
+            ILiteSymmetricCipher cipher = CreateLiteCipher(
                 CipherMode.ECB,
                 paddingMode,
                 Key,
                 effectiveKeyLength: effectiveKeySize,
-                iv: null,
+                iv: default,
                 blockSize: BlockSize / BitsPerByte,
                 0, /*feedback size */
                 paddingSize: BlockSize / BitsPerByte,
                 encrypting: true);
 
-            using (transform)
+            using (cipher)
             {
-                return transform.TransformOneShot(plaintext, destination, out bytesWritten);
+                return UniversalCryptoOneShot.OneShotEncrypt(cipher, paddingMode, plaintext, destination, out bytesWritten);
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/TripleDesImplementation.OSX.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/TripleDesImplementation.OSX.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Security.Cryptography;
 
 namespace Internal.Cryptography
@@ -28,6 +29,27 @@ namespace Internal.Cryptography
                 paddingSize);
 
             return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
+        }
+
+        private static ILiteSymmetricCipher CreateLiteCipher(
+            CipherMode cipherMode,
+            PaddingMode paddingMode,
+            ReadOnlySpan<byte> key,
+            ReadOnlySpan<byte> iv,
+            int blockSize,
+            int paddingSize,
+            int feedbackSizeInBytes,
+            bool encrypting)
+        {
+            return new AppleCCCryptorLite(
+                Interop.AppleCrypto.PAL_SymmetricAlgorithm.TripleDES,
+                cipherMode,
+                blockSize,
+                key,
+                iv,
+                encrypting,
+                feedbackSizeInBytes,
+                paddingSize);
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/TripleDesImplementation.Unix.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/TripleDesImplementation.Unix.cs
@@ -19,27 +19,43 @@ namespace Internal.Cryptography
             bool encrypting)
         {
             // The algorithm pointer is a static pointer, so not having any cleanup code is correct.
-            IntPtr algorithm;
-            switch ((cipherMode, feedbackSize))
-            {
-                case (CipherMode.CBC, _):
-                    algorithm = Interop.Crypto.EvpDes3Cbc();
-                    break;
-                case (CipherMode.ECB, _):
-                    algorithm = Interop.Crypto.EvpDes3Ecb();
-                    break;
-                case (CipherMode.CFB, 1):
-                    algorithm = Interop.Crypto.EvpDes3Cfb8();
-                    break;
-                case (CipherMode.CFB, 8):
-                    algorithm = Interop.Crypto.EvpDes3Cfb64();
-                    break;
-                default:
-                    throw new NotSupportedException();
-            }
+            IntPtr algorithm = GetAlgorithm(cipherMode, feedbackSize);
 
             BasicSymmetricCipher cipher = new OpenSslCipher(algorithm, cipherMode, blockSize, paddingSize, key, 0, iv, encrypting);
             return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
         }
+
+        private static ILiteSymmetricCipher CreateLiteCipher(
+            CipherMode cipherMode,
+            PaddingMode paddingMode,
+            ReadOnlySpan<byte> key,
+            ReadOnlySpan<byte> iv,
+            int blockSize,
+            int paddingSize,
+            int feedbackSize,
+            bool encrypting)
+        {
+            // The algorithm pointer is a static pointer, so not having any cleanup code is correct.
+            IntPtr algorithm = GetAlgorithm(cipherMode, feedbackSize);
+
+            return new OpenSslCipherLite(
+                algorithm,
+                cipherMode,
+                blockSize,
+                paddingSize,
+                key,
+                effectiveKeyLength: 0,
+                iv,
+                encrypting);
+        }
+
+        private static IntPtr GetAlgorithm(CipherMode cipherMode, int feedbackSizeInBytes) => cipherMode switch
+            {
+                CipherMode.CBC => Interop.Crypto.EvpDes3Cbc(),
+                CipherMode.ECB => Interop.Crypto.EvpDes3Ecb(),
+                CipherMode.CFB when feedbackSizeInBytes == 1 => Interop.Crypto.EvpDes3Cfb8(),
+                CipherMode.CFB when feedbackSizeInBytes == 8 => Interop.Crypto.EvpDes3Cfb64(),
+                _ => throw new NotSupportedException(),
+            };
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/TripleDesImplementation.Windows.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/TripleDesImplementation.Windows.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Security.Cryptography;
 using Internal.NativeCrypto;
 
@@ -22,6 +23,28 @@ namespace Internal.Cryptography
 
             BasicSymmetricCipher cipher = new BasicSymmetricCipherBCrypt(algorithm, cipherMode, blockSize, paddingSize, key, false, iv, encrypting);
             return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
+        }
+
+        private static ILiteSymmetricCipher CreateLiteCipher(
+            CipherMode cipherMode,
+            PaddingMode paddingMode,
+            ReadOnlySpan<byte> key,
+            ReadOnlySpan<byte> iv,
+            int blockSize,
+            int paddingSize,
+            int feedbackSize,
+            bool encrypting)
+        {
+            SafeAlgorithmHandle algorithm = TripleDesBCryptModes.GetSharedHandle(cipherMode, feedbackSize);
+            return new BasicSymmetricCipherBCrypt(
+                algorithm,
+                cipherMode,
+                blockSize,
+                paddingSize,
+                key,
+                ownsParentHandle: false,
+                iv.ToArray(),
+                encrypting);
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/TripleDesImplementation.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/TripleDesImplementation.cs
@@ -98,19 +98,19 @@ namespace Internal.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            UniversalCryptoTransform transform = CreateTransformCore(
+            ILiteSymmetricCipher cipher = CreateLiteCipher(
                 CipherMode.ECB,
                 paddingMode,
                 Key,
-                iv: null,
+                iv: default,
                 blockSize: BlockSize / BitsPerByte,
                 paddingSize: BlockSize / BitsPerByte,
                 0, /*feedback size */
                 encrypting: false);
 
-            using (transform)
+            using (cipher)
             {
-                return transform.TransformOneShot(ciphertext, destination, out bytesWritten);
+                return UniversalCryptoOneShot.OneShotDecrypt(cipher, paddingMode, ciphertext, destination, out bytesWritten);
             }
         }
 
@@ -120,19 +120,19 @@ namespace Internal.Cryptography
             PaddingMode paddingMode,
             out int bytesWritten)
         {
-            UniversalCryptoTransform transform = CreateTransformCore(
+            ILiteSymmetricCipher cipher = CreateLiteCipher(
                 CipherMode.ECB,
                 paddingMode,
                 Key,
-                iv: null,
+                iv: default,
                 blockSize: BlockSize / BitsPerByte,
                 paddingSize: BlockSize / BitsPerByte,
                 0, /*feedback size */
                 encrypting: true);
 
-            using (transform)
+            using (cipher)
             {
-                return transform.TransformOneShot(plaintext, destination, out bytesWritten);
+                return UniversalCryptoOneShot.OneShotEncrypt(cipher, paddingMode, plaintext, destination, out bytesWritten);
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -541,6 +541,7 @@
              Link="Common\System\Security\Cryptography\SecKeyPair.cs" />
     <Compile Include="Internal\Cryptography\AesImplementation.OSX.cs" />
     <Compile Include="Internal\Cryptography\AppleCCCryptor.cs" />
+    <Compile Include="Internal\Cryptography\AppleCCCryptorLite.cs" />
     <Compile Include="Internal\Cryptography\DesImplementation.OSX.cs" />
     <Compile Include="Internal\Cryptography\HashProviderDispenser.OSX.cs" />
     <Compile Include="Internal\Cryptography\RandomNumberGeneratorImplementation.OSX.cs" />

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -110,12 +110,18 @@
              Link="Internal\Cryptography\Helpers.cs" />
     <Compile Include="$(CommonPath)Internal\Cryptography\PemKeyImportHelpers.cs"
              Link="Common\Internal\Cryptography\PemKeyImportHelpers.cs" />
+    <Compile Include="$(CommonPath)Internal\Cryptography\ILiteSymmetricCipher.cs"
+             Link="Internal\Cryptography\ILiteSymmetricCipher.cs" />
+    <Compile Include="$(CommonPath)Internal\Cryptography\SymmetricPadding.cs"
+             Link="Internal\Cryptography\SymmetricPadding.cs" />
     <Compile Include="$(CommonPath)Internal\Cryptography\UniversalCryptoTransform.cs"
              Link="Internal\Cryptography\UniversalCryptoTransform.cs" />
     <Compile Include="$(CommonPath)Internal\Cryptography\UniversalCryptoEncryptor.cs"
              Link="Internal\Cryptography\UniversalCryptoEncryptor.cs" />
     <Compile Include="$(CommonPath)Internal\Cryptography\UniversalCryptoDecryptor.cs"
              Link="Internal\Cryptography\UniversalCryptoDecryptor.cs" />
+    <Compile Include="$(CommonPath)Internal\Cryptography\UniversalCryptoOneShot.cs"
+             Link="Internal\Cryptography\UniversalCryptoOneShot.cs" />
     <Compile Include="$(CommonPath)System\Memory\PointerMemoryManager.cs"
              Link="Common\System\Memory\PointerMemoryManager.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\CryptoPool.cs"
@@ -474,6 +480,7 @@
     <Compile Include="Internal\Cryptography\AesImplementation.Unix.cs" />
     <Compile Include="Internal\Cryptography\HashProviderDispenser.Unix.cs" />
     <Compile Include="Internal\Cryptography\OpenSslCipher.cs" />
+    <Compile Include="Internal\Cryptography\OpenSslCipherLite.cs" />
     <Compile Include="Internal\Cryptography\RandomNumberGeneratorImplementation.Unix.cs" />
     <Compile Include="Internal\Cryptography\TripleDesImplementation.Unix.cs" />
   </ItemGroup>

--- a/src/libraries/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
+++ b/src/libraries/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
@@ -170,6 +170,8 @@
              Link="Internal\Cryptography\BasicSymmetricCipher.cs" />
     <Compile Include="$(CommonPath)Internal\Cryptography\BasicSymmetricCipherBCrypt.cs"
              Link="Internal\Cryptography\BasicSymmetricCipherBCrypt.cs" />
+    <Compile Include="$(CommonPath)Internal\Cryptography\SymmetricPadding.cs"
+             Link="Internal\Cryptography\SymmetricPadding.cs" />
     <Compile Include="$(CommonPath)Internal\Cryptography\UniversalCryptoTransform.cs"
              Link="Internal\Cryptography\UniversalCryptoTransform.cs" />
     <Compile Include="$(CommonPath)Internal\Cryptography\UniversalCryptoEncryptor.cs"

--- a/src/libraries/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
+++ b/src/libraries/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
@@ -170,6 +170,8 @@
              Link="Internal\Cryptography\BasicSymmetricCipher.cs" />
     <Compile Include="$(CommonPath)Internal\Cryptography\BasicSymmetricCipherBCrypt.cs"
              Link="Internal\Cryptography\BasicSymmetricCipherBCrypt.cs" />
+    <Compile Include="$(CommonPath)Internal\Cryptography\ILiteSymmetricCipher.cs"
+             Link="Internal\Cryptography\ILiteSymmetricCipher.cs" />
     <Compile Include="$(CommonPath)Internal\Cryptography\SymmetricPadding.cs"
              Link="Internal\Cryptography\SymmetricPadding.cs" />
     <Compile Include="$(CommonPath)Internal\Cryptography\UniversalCryptoTransform.cs"

--- a/src/libraries/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
+++ b/src/libraries/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
@@ -60,6 +60,8 @@
     <Compile Include="Internal\Cryptography\BasicSymmetricCipherCsp.cs" />
     <Compile Include="$(CommonPath)Internal\Cryptography\BasicSymmetricCipher.cs"
              Link="Internal\Cryptography\BasicSymmetricCipher.cs" />
+    <Compile Include="$(CommonPath)Internal\Cryptography\SymmetricPadding.cs"
+             Link="Internal\Cryptography\SymmetricPadding.cs" />
     <Compile Include="$(CommonPath)Internal\Cryptography\UniversalCryptoTransform.cs"
              Link="Internal\Cryptography\UniversalCryptoTransform.cs" />
     <Compile Include="$(CommonPath)Internal\Cryptography\UniversalCryptoEncryptor.cs"


### PR DESCRIPTION
This is a refactoring of the existing one-shot cryptography for the up-coming CBC/CFB implementations. The goal of the refactoring was to reduce allocations and do less work that the one shots don't need to do.

1. The universal transform one-shot is static for the Implementation symmetric ciphers, so we don't allocation a universal transform.
2. Skipping `Reset` on finalize since the one shot is not going to get used another time.
3. Permits passing the IV as a `ReadOnlySpan<byte>` where possible.

The CNG implementations (`AesCng` and friends) still uses the existing one-shots on the Universal transforms. I would like to remove that in a potential follow up. Then we can remove the one-shots from the universal transform.