### PR TITLE
Fix helloworld on x86 Linux

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6423,6 +6423,9 @@ GenTreeCall* Compiler::gtNewCallNode(
     GenTreeCall* node = new (this, GT_CALL) GenTreeCall(genActualType(type));
 
     node->gtFlags |= (GTF_CALL | GTF_GLOB_REF);
+#ifdef UNIX_X86_ABI
+    node->gtFlags |= GTF_CALL_POP_ARGS;
+#endif // UNIX_X86_ABI
     for (GenTreeCall::Use& use : GenTreeCall::UseList(args))
     {
         node->gtFlags |= (use.GetNode()->gtFlags & GTF_ALL_EFFECT);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -2897,8 +2897,8 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
     }
 
 #ifdef TARGET_X86
-    // Compute the maximum number of arguments that can be passed in registers.
-    // For X86 we handle the varargs and unmanaged calling conventions
+// Compute the maximum number of arguments that can be passed in registers.
+// For X86 we handle the varargs and unmanaged calling conventions
 
 #ifndef UNIX_X86_ABI
     if (call->gtFlags & GTF_CALL_POP_ARGS)

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -74,6 +74,9 @@ GenTree* Compiler::fgMorphIntoHelperCall(GenTree* tree, int helper, GenTreeCall:
     call->gtCallMoreFlags       = GTF_CALL_M_EMPTY;
     call->gtInlineCandidateInfo = nullptr;
     call->gtControlExpr         = nullptr;
+#ifdef UNIX_X86_ABI
+    call->gtFlags |= GTF_CALL_POP_ARGS;
+#endif // UNIX_X86_ABI
 
 #if DEBUG
     // Helper calls are never candidates.
@@ -2897,6 +2900,7 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
     // Compute the maximum number of arguments that can be passed in registers.
     // For X86 we handle the varargs and unmanaged calling conventions
 
+#ifndef UNIX_X86_ABI
     if (call->gtFlags & GTF_CALL_POP_ARGS)
     {
         noway_assert(intArgRegNum < MAX_REG_ARG);
@@ -2907,6 +2911,7 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
         if (callHasRetBuffArg)
             maxRegArgs++;
     }
+#endif // UNIX_X86_ABI
 
     if (call->IsUnmanaged())
     {

--- a/src/coreclr/vm/i386/jitinterfacex86.cpp
+++ b/src/coreclr/vm/i386/jitinterfacex86.cpp
@@ -490,6 +490,12 @@ void *JIT_TrialAlloc::GenBox(Flags flags)
 
     // Do call to CopyValueClassUnchecked(object, data, pMT)
 
+#ifdef UNIX_X86_ABI
+#define STACK_ALIGN_PADDING 12
+    // Make pad to align esp
+    sl.X86EmitSubEsp(STACK_ALIGN_PADDING);
+#endif // UNIX_X86_ABI
+
     // Pass pMT (still in ECX)
     sl.X86EmitPushReg(kECX);
 
@@ -507,6 +513,11 @@ void *JIT_TrialAlloc::GenBox(Flags flags)
 
     // call CopyValueClass
     sl.X86EmitCall(sl.NewExternalCodeLabel((LPVOID) CopyValueClassUnchecked), 12);
+#ifdef UNIX_X86_ABI
+    // Make pad to align esp
+    sl.X86EmitAddEsp(STACK_ALIGN_PADDING);
+#undef STACK_ALIGN_PADDING
+#endif // UNIX_X86_ABI
 
     // Restore the address of the newly allocated object and return it.
     // mov eax,ebx


### PR DESCRIPTION
Working on helloworld.dll x86 linux launch I've got problem during calling convention on managed call from managed code. I fixed it in morph.cpp. After that fix I had got bugs with stack misalignment. Couple of that problems I fixed in compiler.cpp and jitinterfacex86.cpp. It allows to run helloworld.dll and stack dumping with `System.Diagnostics.StackTrace`. But I still have got similar stack misalignment problems on another programs. 
Is that fix-work direction right? Maybe I should fix managed-managed calling convention in another way?
cc @jkotas @alpencolt