### PR TITLE
JIT: don't report profile for methods with insufficient samples during prejitting

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -19061,17 +19061,31 @@ void Compiler::impMakeDiscretionaryInlineObservations(InlineInfo* pInlineInfo, I
 
     // If the call site has profile data, report the relative frequency of the site.
     //
-    if ((pInlineInfo != nullptr) && pInlineInfo->iciBlock->hasProfileWeight())
+    if ((pInlineInfo != nullptr) && rootCompiler->fgHaveProfileData() &&
+        pInlineInfo->iciBlock->hasProfileWeight())
     {
-        double callSiteWeight = (double)pInlineInfo->iciBlock->bbWeight;
-        double entryWeight    = (double)impInlineRoot()->fgFirstBB->bbWeight;
+        BasicBlock::weight_t callSiteWeight = pInlineInfo->iciBlock->bbWeight;
+        BasicBlock::weight_t entryWeight    = rootCompiler->fgFirstBB->bbWeight;
+        BasicBlock::weight_t profileFreq    = entryWeight == 0.0f ? 0.0f : callSiteWeight / entryWeight;
 
         assert(callSiteWeight >= 0);
         assert(entryWeight >= 0);
 
+        BasicBlock::weight_t sufficientSamples = 1000.0f;
+
+        if (!rootCompiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PREJIT) ||
+            ((callSiteWeight + entryWeight) > sufficientSamples))
+        {
+            // Let's not report profiles for methods with insufficient samples during prejitting.
+            inlineResult->NoteBool(InlineObservation::CALLSITE_HAS_PROFILE, true);
+            inlineResult->NoteDouble(InlineObservation::CALLSITE_PROFILE_FREQUENCY, profileFreq);
+        }
+    }
+    else if ((pInlineInfo == nullptr) && rootCompiler->fgHaveProfileData())
+    {
+        // Simulate a hot callsite for PrejitRoot mode.
         inlineResult->NoteBool(InlineObservation::CALLSITE_HAS_PROFILE, true);
-        double frequency = entryWeight == 0.0 ? 0.0 : callSiteWeight / entryWeight;
-        inlineResult->NoteDouble(InlineObservation::CALLSITE_PROFILE_FREQUENCY, frequency);
+        inlineResult->NoteDouble(InlineObservation::CALLSITE_PROFILE_FREQUENCY, 1.0);
     }
 }
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -19061,8 +19061,7 @@ void Compiler::impMakeDiscretionaryInlineObservations(InlineInfo* pInlineInfo, I
 
     // If the call site has profile data, report the relative frequency of the site.
     //
-    if ((pInlineInfo != nullptr) && rootCompiler->fgHaveProfileData() &&
-        pInlineInfo->iciBlock->hasProfileWeight())
+    if ((pInlineInfo != nullptr) && rootCompiler->fgHaveProfileData() && pInlineInfo->iciBlock->hasProfileWeight())
     {
         BasicBlock::weight_t callSiteWeight = pInlineInfo->iciBlock->bbWeight;
         BasicBlock::weight_t entryWeight    = rootCompiler->fgFirstBB->bbWeight;

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -462,7 +462,7 @@ CONFIG_STRING(JitInlineReplayFile, W("JitInlineReplayFile"))
 CONFIG_INTEGER(JitExtDefaultPolicy, W("JitExtDefaultPolicy"), 1)
 CONFIG_INTEGER(JitExtDefaultPolicyMaxIL, W("JitExtDefaultPolicyMaxIL"), 0x64)
 CONFIG_INTEGER(JitExtDefaultPolicyMaxBB, W("JitExtDefaultPolicyMaxBB"), 7)
-CONFIG_INTEGER(JitExtDefaultPolicyProfScale, W("JitExtDefaultPolicyProfScale"), 0x22)
+CONFIG_INTEGER(JitExtDefaultPolicyProfScale, W("JitExtDefaultPolicyProfScale"), 0x2A)
 CONFIG_INTEGER(JitExtDefaultPolicyProfTrust, W("JitExtDefaultPolicyProfTrust"), 0x7)
 
 CONFIG_INTEGER(JitInlinePolicyModel, W("JitInlinePolicyModel"), 0)


### PR DESCRIPTION
Profile for AOT is collected via a special build of an app (all methods stay in tier0 and are instrumented). Let's assume all methods in hot paths are executed at least 1000 times.
I use `entryWeight + callSiteWeight > 1000` formula in order to handle hot loops inside cold methods.

![image](https://user-images.githubusercontent.com/523221/124346967-65b31f00-dbea-11eb-8ce0-f5520f77086d.png)
^ Histogram for `entryWeight + callSiteWeight` for SPC.dll

This PR drastically reduces R2R size when `--Ot` is passed to crossgen2 (it means `ExtendedDefaultPolicy` is used).

New size: 10.06Mb
