### PR TITLE
[release/6.0-preview6] Recategorize emsdk dependency

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -210,10 +210,6 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>
       <Sha>4e5bea15eb5a9c8cf9142195b1c9c78437a5b27f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Runtime.Emscripten.2.0.21.Node.win-x64" Version="6.0.0-preview.6.21275.1">
-      <Uri>https://github.com/dotnet/emsdk</Uri>
-      <Sha>defa37b05c734e025292c5747664e970cd2ac444</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.DotNet.HotReload.Utils.Generator.BuildTool" Version="1.0.1-alpha.0.21311.1">
       <Uri>https://github.com/dotnet/hotreload-utils</Uri>
       <Sha>25b814e010cd4796cedfbcce72a274c26928f496</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,6 +4,10 @@
       <Uri>https://github.com/dotnet/icu</Uri>
       <Sha>d7db669b70f4dd67ec001c192f9809c218cab88b</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.NET.Runtime.Emscripten.2.0.21.Node.win-x64" Version="6.0.0-preview.6.21275.1">
+      <Uri>https://github.com/dotnet/emsdk</Uri>
+      <Sha>defa37b05c734e025292c5747664e970cd2ac444</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.21311.3">


### PR DESCRIPTION
## Backport #55028 Recategorize emsdk dependency

Queuing this up in case it is useful.  Without this someone will need to manually push the emsdk packages to the preview feed.