### PR TITLE
XmlSerializer dont skip date time offset

### DIFF
--- a/src/libraries/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
@@ -34,8 +34,8 @@
   <Target Name="GenerateSerializationAssembly" DependsOnTargets="CopyFilesToOutputDirectory" AfterTargets="PrepareForRun" Condition=" '$(SkipTestsOnPlatform)' != 'true' ">
     <PropertyGroup>
       <SerializerName>SerializableAssembly.XmlSerializers</SerializerName>
-      <GeneratorCommand>"$(NetCoreAppCurrentTestHostPath)dotnet.exe"</GeneratorCommand>
-      <GeneratorCommand Condition="'$(OS)' == 'Windows_NT'">set COREHOST_TRACE=1 &amp; set DOTNET_MULTILEVEL_LOOKUP=0 &amp; $(GeneratorCommand)</GeneratorCommand>
+      <GeneratorCommand>"$(NetCoreAppCurrentTestHostPath)dotnet"</GeneratorCommand>
+      <GeneratorCommand Condition="'$(OS)' == 'Windows_NT'">set COREHOST_TRACE=1 &amp; set DOTNET_MULTILEVEL_LOOKUP=0 &amp; $(GeneratorCommand).exe</GeneratorCommand>
       <GeneratorCommand Condition="'$(OS)' != 'Windows_NT'">export COREHOST_TRACE=1 &amp;&amp; export DOTNET_MULTILEVEL_LOOKUP=0 &amp;&amp; $(GeneratorCommand)</GeneratorCommand>
     </PropertyGroup>
     <Message Text="Running Serialization Tool" Importance="normal" />

--- a/src/libraries/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
@@ -5,13 +5,6 @@
     <SkipTestsOnPlatform Condition="'$(TargetsMobile)' == 'true' or '$(TargetOS)' == 'FreeBSD' or '$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'arm64' or '$(TargetArchitecture)' == 'armel' or '$(TargetArchitecture)' == 'wasm'">true</SkipTestsOnPlatform>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <GeneratorRuntimeConfig>$(MSBuildThisFileDirectory)..\pkg\build\dotnet-Microsoft.XmlSerializer.Generator.runtimeconfig.json</GeneratorRuntimeConfig>
-    <GeneratorCommand>"$(DotNetTool)"</GeneratorCommand>
-    <GeneratorCommand Condition="'$(OS)' == 'Windows_NT'">set DOTNET_MULTILEVEL_LOOKUP=0 &amp; $(GeneratorCommand)</GeneratorCommand>
-    <GeneratorCommand Condition="'$(OS)' != 'Windows_NT'">export DOTNET_MULTILEVEL_LOOKUP=0 &amp;&amp; $(GeneratorCommand)</GeneratorCommand>
-  </PropertyGroup>
-
   <ItemGroup Condition=" '$(SkipTestsOnPlatform)' != 'true'">
     <Compile Include="SGenTests.cs" />
     <Compile Include="$(CommonTestPath)System\Runtime\Serialization\Utils.cs" />
@@ -32,11 +25,17 @@
     <ProjectReference Include="SerializableAssembly.csproj" />
   </ItemGroup>
 
+
   <!-- This target runs before binplacing as it needs to provide a test assembly to binplace, and depends on CopyFilesToOutputDirectory
        so that the Generator app dll and runtimeconfig will be copied to the OutputPath -->
   <Target Name="GenerateSerializationAssembly" DependsOnTargets="CopyFilesToOutputDirectory" AfterTargets="PrepareForRun" Condition=" '$(SkipTestsOnPlatform)' != 'true' ">
     <PropertyGroup>
       <SerializerName>SerializableAssembly.XmlSerializers</SerializerName>
+
+      <GeneratorRuntimeConfig>$(MSBuildThisFileDirectory)..\pkg\build\dotnet-Microsoft.XmlSerializer.Generator.runtimeconfig.json</GeneratorRuntimeConfig>
+      <GeneratorCommand>"$(NetCoreAppCurrentTestHostPath)dotnet.exe"</GeneratorCommand>
+      <GeneratorCommand Condition="'$(OS)' == 'Windows_NT'">set DOTNET_MULTILEVEL_LOOKUP=0 &amp; $(GeneratorCommand)</GeneratorCommand>
+      <GeneratorCommand Condition="'$(OS)' != 'Windows_NT'">export DOTNET_MULTILEVEL_LOOKUP=0 &amp;&amp; $(GeneratorCommand)</GeneratorCommand>
     </PropertyGroup>
     <Message Text="Running Serialization Tool" Importance="normal" />
     <Exec Command="$(GeneratorCommand) $(OutputPath)dotnet-Microsoft.XmlSerializer.Generator.dll $(OutputPath)SerializableAssembly.dll --force --quiet" />

--- a/src/libraries/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
@@ -3,10 +3,14 @@
     <DefineConstants>$(DefineConstants);XMLSERIALIZERGENERATORTESTS</DefineConstants>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
     <SkipTestsOnPlatform Condition="'$(TargetsMobile)' == 'true' or '$(TargetOS)' == 'FreeBSD' or '$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'arm64' or '$(TargetArchitecture)' == 'armel' or '$(TargetArchitecture)' == 'wasm'">true</SkipTestsOnPlatform>
+    <SkipTestsOnPlatform>true</SkipTestsOnPlatform>
   </PropertyGroup>
 
   <PropertyGroup>
     <GeneratorRuntimeConfig>$(MSBuildThisFileDirectory)..\pkg\build\dotnet-Microsoft.XmlSerializer.Generator.runtimeconfig.json</GeneratorRuntimeConfig>
+    <GeneratorCommand>"$(DotNetTool)"</GeneratorCommand>
+    <GeneratorCommand Condition="'$(OS)' == 'Windows_NT'">set DOTNET_MULTILEVEL_LOOKUP=0 &amp; $(GeneratorCommand)</GeneratorCommand>
+    <GeneratorCommand Condition="'$(OS)' != 'Windows_NT'">export DOTNET_MULTILEVEL_LOOKUP=0 &amp;&amp; $(GeneratorCommand)</GeneratorCommand>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(SkipTestsOnPlatform)' != 'true'">
@@ -34,12 +38,9 @@
   <Target Name="GenerateSerializationAssembly" DependsOnTargets="CopyFilesToOutputDirectory" AfterTargets="PrepareForRun" Condition=" '$(SkipTestsOnPlatform)' != 'true' ">
     <PropertyGroup>
       <SerializerName>SerializableAssembly.XmlSerializers</SerializerName>
-      <GeneratorCommand>"$(DotNetTool)"</GeneratorCommand>
-      <GeneratorCommand Condition="'$(OS)' == 'Windows_NT'">set DOTNET_MULTILEVEL_LOOKUP=0 &amp; $(GeneratorCommand)</GeneratorCommand>
-      <GeneratorCommand Condition="'$(OS)' != 'Windows_NT'">export DOTNET_MULTILEVEL_LOOKUP=0 &amp;&amp; $(GeneratorCommand)</GeneratorCommand>
     </PropertyGroup>
     <Message Text="Running Serialization Tool" Importance="normal" />
-    <Exec Command="$(GeneratorCommand) $(OutputPath)dotnet-Microsoft.XmlSerializer.Generator.dll $(OutputPath)SerializableAssembly.dll --force" />
+    <Exec Command="$(GeneratorCommand) $(OutputPath)dotnet-Microsoft.XmlSerializer.Generator.dll $(OutputPath)SerializableAssembly.dll --force --quiet" />
     <Warning Condition="Exists('$(OutputPath)$(SerializerName).cs') != 'true'" Text="Fail to generate $(OutputPath)$(SerializerName).cs" />
     <Copy SourceFiles="$(OutputPath)$(SerializerName).cs" DestinationFiles="$(OutputPath)LKG.$(SerializerName).cs" />
     <Csc Condition="Exists('$(OutputPath)$(SerializerName).cs') == 'true'" OutputAssembly="$(OutputPath)$(SerializerName).dll" References="@(ReferencePath);@(IntermediateAssembly)" EmitDebugInformation="$(DebugSymbols)" DebugType="$(DebugType)" Sources="$(OutputPath)$(SerializerName).cs" TargetType="Library" ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)" DisabledWarnings="$(NoWarn), 219" UseSharedCompilation="true" />

--- a/src/libraries/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
@@ -29,18 +29,17 @@
     <ProjectReference Include="SerializableAssembly.csproj" />
   </ItemGroup>
 
-
   <!-- This target runs before binplacing as it needs to provide a test assembly to binplace, and depends on CopyFilesToOutputDirectory
        so that the Generator app dll and runtimeconfig will be copied to the OutputPath -->
   <Target Name="GenerateSerializationAssembly" DependsOnTargets="CopyFilesToOutputDirectory" AfterTargets="PrepareForRun" Condition=" '$(SkipTestsOnPlatform)' != 'true' ">
     <PropertyGroup>
       <SerializerName>SerializableAssembly.XmlSerializers</SerializerName>
       <GeneratorCommand>"$(NetCoreAppCurrentTestHostPath)dotnet.exe"</GeneratorCommand>
-      <GeneratorCommand Condition="'$(OS)' == 'Windows_NT'">set DOTNET_MULTILEVEL_LOOKUP=0 &amp; $(GeneratorCommand)</GeneratorCommand>
-      <GeneratorCommand Condition="'$(OS)' != 'Windows_NT'">export DOTNET_MULTILEVEL_LOOKUP=0 &amp;&amp; $(GeneratorCommand)</GeneratorCommand>
+      <GeneratorCommand Condition="'$(OS)' == 'Windows_NT'">set COREHOST_TRACE=1 &amp; set DOTNET_MULTILEVEL_LOOKUP=0 &amp; $(GeneratorCommand)</GeneratorCommand>
+      <GeneratorCommand Condition="'$(OS)' != 'Windows_NT'">export COREHOST_TRACE=1 &amp;&amp; export DOTNET_MULTILEVEL_LOOKUP=0 &amp;&amp; $(GeneratorCommand)</GeneratorCommand>
     </PropertyGroup>
     <Message Text="Running Serialization Tool" Importance="normal" />
-    <Exec Command="$(GeneratorCommand) $(OutputPath)dotnet-Microsoft.XmlSerializer.Generator.dll $(OutputPath)SerializableAssembly.dll --force --quiet" />
+    <Exec Command="$(GeneratorCommand) $(OutputPath)dotnet-Microsoft.XmlSerializer.Generator.dll $(OutputPath)SerializableAssembly.dll --force" />
     <Warning Condition="Exists('$(OutputPath)$(SerializerName).cs') != 'true'" Text="Fail to generate $(OutputPath)$(SerializerName).cs" />
     <Copy SourceFiles="$(OutputPath)$(SerializerName).cs" DestinationFiles="$(OutputPath)LKG.$(SerializerName).cs" />
     <Csc Condition="Exists('$(OutputPath)$(SerializerName).cs') == 'true'" OutputAssembly="$(OutputPath)$(SerializerName).dll" References="@(ReferencePath);@(IntermediateAssembly)" EmitDebugInformation="$(DebugSymbols)" DebugType="$(DebugType)" Sources="$(OutputPath)$(SerializerName).cs" TargetType="Library" ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)" DisabledWarnings="$(NoWarn), 219" UseSharedCompilation="true" />

--- a/src/libraries/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
@@ -5,6 +5,10 @@
     <SkipTestsOnPlatform Condition="'$(TargetsMobile)' == 'true' or '$(TargetOS)' == 'FreeBSD' or '$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'arm64' or '$(TargetArchitecture)' == 'armel' or '$(TargetArchitecture)' == 'wasm'">true</SkipTestsOnPlatform>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <GeneratorRuntimeConfig>$(MSBuildThisFileDirectory)..\pkg\build\dotnet-Microsoft.XmlSerializer.Generator.runtimeconfig.json</GeneratorRuntimeConfig>
+  </PropertyGroup>
+
   <ItemGroup Condition=" '$(SkipTestsOnPlatform)' != 'true'">
     <Compile Include="SGenTests.cs" />
     <Compile Include="$(CommonTestPath)System\Runtime\Serialization\Utils.cs" />
@@ -31,8 +35,6 @@
   <Target Name="GenerateSerializationAssembly" DependsOnTargets="CopyFilesToOutputDirectory" AfterTargets="PrepareForRun" Condition=" '$(SkipTestsOnPlatform)' != 'true' ">
     <PropertyGroup>
       <SerializerName>SerializableAssembly.XmlSerializers</SerializerName>
-
-      <GeneratorRuntimeConfig>$(MSBuildThisFileDirectory)..\pkg\build\dotnet-Microsoft.XmlSerializer.Generator.runtimeconfig.json</GeneratorRuntimeConfig>
       <GeneratorCommand>"$(NetCoreAppCurrentTestHostPath)dotnet.exe"</GeneratorCommand>
       <GeneratorCommand Condition="'$(OS)' == 'Windows_NT'">set DOTNET_MULTILEVEL_LOOKUP=0 &amp; $(GeneratorCommand)</GeneratorCommand>
       <GeneratorCommand Condition="'$(OS)' != 'Windows_NT'">export DOTNET_MULTILEVEL_LOOKUP=0 &amp;&amp; $(GeneratorCommand)</GeneratorCommand>

--- a/src/libraries/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
@@ -34,9 +34,9 @@
   <Target Name="GenerateSerializationAssembly" DependsOnTargets="CopyFilesToOutputDirectory" AfterTargets="PrepareForRun" Condition=" '$(SkipTestsOnPlatform)' != 'true' ">
     <PropertyGroup>
       <SerializerName>SerializableAssembly.XmlSerializers</SerializerName>
-      <GeneratorCommand>"$(NetCoreAppCurrentTestHostPath)dotnet"</GeneratorCommand>
-      <GeneratorCommand Condition="'$(OS)' == 'Windows_NT'">set COREHOST_TRACE=1 &amp; set DOTNET_MULTILEVEL_LOOKUP=0 &amp; $(GeneratorCommand).exe</GeneratorCommand>
-      <GeneratorCommand Condition="'$(OS)' != 'Windows_NT'">export COREHOST_TRACE=1 &amp;&amp; export DOTNET_MULTILEVEL_LOOKUP=0 &amp;&amp; $(GeneratorCommand)</GeneratorCommand>
+      <GeneratorCommand>"$(DotNetTool)"</GeneratorCommand>
+      <GeneratorCommand Condition="'$(OS)' == 'Windows_NT'">set DOTNET_MULTILEVEL_LOOKUP=0 &amp; $(GeneratorCommand)</GeneratorCommand>
+      <GeneratorCommand Condition="'$(OS)' != 'Windows_NT'">export DOTNET_MULTILEVEL_LOOKUP=0 &amp;&amp; $(GeneratorCommand)</GeneratorCommand>
     </PropertyGroup>
     <Message Text="Running Serialization Tool" Importance="normal" />
     <Exec Command="$(GeneratorCommand) $(OutputPath)dotnet-Microsoft.XmlSerializer.Generator.dll $(OutputPath)SerializableAssembly.dll --force" />

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/CodeGenerator.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/CodeGenerator.cs
@@ -853,6 +853,19 @@ namespace System.Xml.Serialization
                             New(TimeSpan_ctor);
                             break;
                         }
+                        else if (valueType == typeof(DateTimeOffset))
+                        {
+                            ConstructorInfo DateTimeOffset_ctor = typeof(DateTimeOffset).GetConstructor(
+                            CodeGenerator.InstanceBindingFlags,
+                            null,
+                            new Type[] { typeof(long), typeof(TimeSpan) },
+                            null
+                            )!;
+                            Ldc(((DateTimeOffset)o).Ticks); // ticks
+                            Ldc(((DateTimeOffset)o).Offset); // offset
+                            New(DateTimeOffset_ctor);
+                            break;
+                        }
                         else
                         {
                             throw new NotSupportedException(SR.Format(SR.UnknownConstantType, valueType.AssemblyQualifiedName));

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/PrimitiveXmlSerializers.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/PrimitiveXmlSerializers.cs
@@ -110,6 +110,18 @@ namespace System.Xml.Serialization
             WriteElementStringRaw(@"dateTime", @"", FromDateTime(((System.DateTime)o)));
         }
 
+        internal void Write_dateTimeOffset(object? o)
+        {
+            WriteStartDocument();
+            if (o == null)
+            {
+                WriteEmptyTag(@"dateTimeOffset", @"");
+                return;
+            }
+            DateTimeOffset dto = (DateTimeOffset)o;
+            WriteElementStringRaw(@"dateTimeOffset", @"", System.Xml.XmlConvert.ToString(dto));
+        }
+
         internal void Write_unsignedByte(object? o)
         {
             WriteStartDocument();
@@ -454,6 +466,36 @@ namespace System.Xml.Serialization
             return (object?)o;
         }
 
+        internal object? Read_dateTimeOffset()
+        {
+            object? o = null;
+            Reader.MoveToContent();
+            if (Reader.NodeType == System.Xml.XmlNodeType.Element)
+            {
+                if (((object)Reader.LocalName == (object)_id20_dateTimeOffset && (object)Reader.NamespaceURI == (object)_id2_Item))
+                {
+                    if (Reader.IsEmptyElement)
+                    {
+                        Reader.Skip();
+                        o = default(DateTimeOffset);
+                    }
+                    else
+                    {
+                        o = System.Xml.XmlConvert.ToDateTimeOffset(Reader.ReadElementString());
+                    }
+                }
+                else
+                {
+                    throw CreateUnknownNodeException();
+                }
+            }
+            else
+            {
+                UnknownNode(null);
+            }
+            return (object?)o;
+        }
+
         internal object? Read_unsignedByte()
         {
             object? o = null;
@@ -720,6 +762,7 @@ namespace System.Xml.Serialization
         private string _id15_unsignedLong = null!;
         private string _id7_float = null!;
         private string _id10_dateTime = null!;
+        private string _id20_dateTimeOffset = null!;
         private string _id6_long = null!;
         private string _id9_decimal = null!;
         private string _id8_double = null!;
@@ -743,6 +786,7 @@ namespace System.Xml.Serialization
             _id15_unsignedLong = Reader.NameTable.Add(@"unsignedLong");
             _id7_float = Reader.NameTable.Add(@"float");
             _id10_dateTime = Reader.NameTable.Add(@"dateTime");
+            _id20_dateTimeOffset = Reader.NameTable.Add(@"dateTimeOffset");
             _id6_long = Reader.NameTable.Add(@"long");
             _id9_decimal = Reader.NameTable.Add(@"decimal");
             _id8_double = Reader.NameTable.Add(@"double");

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
@@ -884,6 +884,11 @@ namespace System.Xml.Serialization
                     Reader.Skip();
                     value = default(TimeSpan);
                 }
+                else if (element.Mapping.TypeDesc!.Type == typeof(DateTimeOffset) && Reader.IsEmptyElement)
+                {
+                    Reader.Skip();
+                    value = default(DateTimeOffset);
+                }
                 else
                 {
                     if (element.Mapping.TypeDesc == QnameTypeDesc)
@@ -1219,6 +1224,7 @@ namespace System.Xml.Serialization
                         "Guid" => XmlConvert.ToGuid(value),
                         "Char" => XmlConvert.ToChar(value),
                         "TimeSpan" => XmlConvert.ToTimeSpan(value),
+                        "DateTimeOffset" => XmlConvert.ToDateTimeOffset(value),
                         _ => throw new InvalidOperationException(SR.Format(SR.XmlInternalErrorDetails, $"unknown FormatterName: {mapping.TypeDesc.FormatterName}")),
                     };
                     return retObj;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationWriter.cs
@@ -1195,6 +1195,7 @@ namespace System.Xml.Serialization
                 "Guid" => XmlConvert.ToString((Guid)o),
                 "Char" => XmlConvert.ToString((char)o),
                 "TimeSpan" => XmlConvert.ToString((TimeSpan)o),
+                "DateTimeOffset" => XmlConvert.ToString((DateTimeOffset)o),
                 _ => o.ToString()!,
             };
             return stringValue;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Types.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Types.cs
@@ -550,6 +550,7 @@ namespace System.Xml.Serialization
             AddNonXsdPrimitive(typeof(Guid), "guid", UrtTypes.Namespace, "Guid", new XmlQualifiedName("string", XmlSchema.Namespace), new XmlSchemaFacet[] { guidPattern }, TypeFlags.CanBeAttributeValue | TypeFlags.CanBeElementValue | TypeFlags.XmlEncodingNotRequired | TypeFlags.IgnoreDefault);
             AddNonXsdPrimitive(typeof(char), "char", UrtTypes.Namespace, "Char", new XmlQualifiedName("unsignedShort", XmlSchema.Namespace), Array.Empty<XmlSchemaFacet>(), TypeFlags.CanBeAttributeValue | TypeFlags.CanBeElementValue | TypeFlags.HasCustomFormatter | TypeFlags.IgnoreDefault);
             AddNonXsdPrimitive(typeof(TimeSpan), "TimeSpan", UrtTypes.Namespace, "TimeSpan", new XmlQualifiedName("duration", XmlSchema.Namespace), Array.Empty<XmlSchemaFacet>(), TypeFlags.CanBeAttributeValue | TypeFlags.CanBeElementValue | TypeFlags.XmlEncodingNotRequired);
+            AddNonXsdPrimitive(typeof(DateTimeOffset), "dateTimeOffset", UrtTypes.Namespace, "DateTimeOffset", new XmlQualifiedName("dateTime", XmlSchema.Namespace), Array.Empty<XmlSchemaFacet>(), TypeFlags.CanBeAttributeValue | TypeFlags.CanBeElementValue | TypeFlags.XmlEncodingNotRequired);
 
             AddSoapEncodedTypes(Soap.Encoding);
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Types.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Types.cs
@@ -597,6 +597,8 @@ namespace System.Xml.Serialization
                         return true;
                     else if (type == typeof(TimeSpan))
                         return true;
+                    else if (type == typeof(DateTimeOffset))
+                        return true;
                     else if (type == typeof(XmlNode[]))
                         return true;
                     break;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReader.cs
@@ -105,6 +105,7 @@ namespace System.Xml.Serialization
         private string _charID = null!;
         private string _guidID = null!;
         private string _timeSpanID = null!;
+        private string _dateTimeOffsetID = null!;
 
         protected abstract void InitIDs();
 
@@ -214,6 +215,7 @@ namespace System.Xml.Serialization
             _charID = _r.NameTable.Add("char");
             _guidID = _r.NameTable.Add("guid");
             _timeSpanID = _r.NameTable.Add("TimeSpan");
+            _dateTimeOffsetID = _r.NameTable.Add("dateTimeOffset");
             _base64ID = _r.NameTable.Add("base64");
 
             _anyURIID = _r.NameTable.Add("anyURI");
@@ -667,6 +669,8 @@ namespace System.Xml.Serialization
                     value = new Guid(CollapseWhitespace(ReadStringValue()));
                 else if ((object)type.Name == (object)_timeSpanID)
                     value = XmlConvert.ToTimeSpan(ReadStringValue());
+                else if ((object)type.Name == (object)_dateTimeOffsetID)
+                    value = XmlConvert.ToDateTimeOffset(ReadStringValue());
                 else
                     value = ReadXmlNodes(elementCanBeType);
             }
@@ -764,6 +768,8 @@ namespace System.Xml.Serialization
                     value = default(Nullable<Guid>);
                 else if ((object)type.Name == (object)_timeSpanID)
                     value = default(Nullable<TimeSpan>);
+                else if ((object)type.Name == (object)_dateTimeOffsetID)
+                    value = default(Nullable<DateTimeOffset>);
                 else
                     value = null;
             }
@@ -4704,13 +4710,20 @@ namespace System.Xml.Serialization
                 }
                 Writer.Indent++;
 
-                if (element.Mapping.TypeDesc!.Type == typeof(TimeSpan))
+                if (element.Mapping.TypeDesc!.Type == typeof(TimeSpan) || element.Mapping.TypeDesc!.Type == typeof(DateTimeOffset))
                 {
                     Writer.WriteLine("if (Reader.IsEmptyElement) {");
                     Writer.Indent++;
                     Writer.WriteLine("Reader.Skip();");
                     WriteSourceBegin(source);
-                    Writer.Write("default(System.TimeSpan)");
+                    if (element.Mapping.TypeDesc!.Type == typeof(TimeSpan))
+                    {
+                        Writer.Write("default(System.TimeSpan)");
+                    }
+                    else if (element.Mapping.TypeDesc!.Type == typeof(DateTimeOffset))
+                    {
+                        Writer.Write("default(System.DateTimeOffset)");
+                    }
                     WriteSourceEnd(source);
                     Writer.WriteLine(";");
                     Writer.Indent--;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
@@ -3100,7 +3100,7 @@ namespace System.Xml.Serialization
                 {
                 }
 
-                if (element.Mapping.TypeDesc!.Type == typeof(TimeSpan))
+                if ((element.Mapping.TypeDesc!.Type == typeof(TimeSpan)) || element.Mapping.TypeDesc!.Type == typeof(DateTimeOffset))
                 {
                     MethodInfo XmlSerializationReader_get_Reader = typeof(XmlSerializationReader).GetMethod(
                        "get_Reader",
@@ -3125,14 +3125,29 @@ namespace System.Xml.Serialization
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_get_Reader);
                     ilg.Call(XmlReader_Skip);
-                    ConstructorInfo TimeSpan_ctor = typeof(TimeSpan).GetConstructor(
-                        CodeGenerator.InstanceBindingFlags,
-                        null,
-                        new Type[] { typeof(long) },
-                        null
-                        )!;
-                    ilg.Ldc(default(TimeSpan).Ticks);
-                    ilg.New(TimeSpan_ctor);
+                    if (element.Mapping.TypeDesc!.Type == typeof(TimeSpan))
+                    {
+                        ConstructorInfo TimeSpan_ctor = typeof(TimeSpan).GetConstructor(
+                            CodeGenerator.InstanceBindingFlags,
+                            null,
+                            new Type[] { typeof(long) },
+                            null
+                            )!;
+                        ilg.Ldc(default(TimeSpan).Ticks);
+                        ilg.New(TimeSpan_ctor);
+                    }
+                    else if (element.Mapping.TypeDesc!.Type == typeof(DateTimeOffset))
+                    {
+                        ConstructorInfo DateTimeOffset_ctor = typeof(DateTimeOffset).GetConstructor(
+                            CodeGenerator.InstanceBindingFlags,
+                            null,
+                            new Type[] { typeof(long), typeof(TimeSpan) },
+                            null
+                            )!;
+                        ilg.Ldc(default(DateTimeOffset).Ticks);
+                        ilg.Ldc(default(DateTimeOffset).Offset);
+                        ilg.New(DateTimeOffset_ctor);
+                    }
                     WriteSourceEnd(source, element.Mapping.TypeDesc.Type);
                     ilg.Else();
                     WriteSourceBegin(source);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
@@ -3125,29 +3125,10 @@ namespace System.Xml.Serialization
                     ilg.Ldarg(0);
                     ilg.Call(XmlSerializationReader_get_Reader);
                     ilg.Call(XmlReader_Skip);
-                    if (element.Mapping.TypeDesc!.Type == typeof(TimeSpan))
-                    {
-                        ConstructorInfo TimeSpan_ctor = typeof(TimeSpan).GetConstructor(
-                            CodeGenerator.InstanceBindingFlags,
-                            null,
-                            new Type[] { typeof(long) },
-                            null
-                            )!;
-                        ilg.Ldc(default(TimeSpan).Ticks);
-                        ilg.New(TimeSpan_ctor);
-                    }
-                    else if (element.Mapping.TypeDesc!.Type == typeof(DateTimeOffset))
-                    {
-                        ConstructorInfo DateTimeOffset_ctor = typeof(DateTimeOffset).GetConstructor(
-                            CodeGenerator.InstanceBindingFlags,
-                            null,
-                            new Type[] { typeof(long), typeof(TimeSpan) },
-                            null
-                            )!;
-                        ilg.Ldc(default(DateTimeOffset).Ticks);
-                        ilg.Ldc(default(DateTimeOffset).Offset);
-                        ilg.New(DateTimeOffset_ctor);
-                    }
+                    LocalBuilder tmpLoc = ilg.GetTempLocal(element.Mapping.TypeDesc!.Type);
+                    ilg.Ldloca(tmpLoc);
+                    ilg.InitObj(element.Mapping.TypeDesc!.Type);
+                    ilg.Ldloc(tmpLoc);
                     WriteSourceEnd(source, element.Mapping.TypeDesc.Type);
                     ilg.Else();
                     WriteSourceBegin(source);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriter.cs
@@ -227,6 +227,11 @@ namespace System.Xml.Serialization
                         typeName = "TimeSpan";
                         typeNs = UrtTypes.Namespace;
                     }
+                    else if (type == typeof(DateTimeOffset))
+                    {
+                        typeName = "dateTimeOffset";
+                        typeNs = UrtTypes.Namespace;
+                    }
                     else if (type == typeof(XmlNode[]))
                     {
                         typeName = Soap.UrType;
@@ -343,6 +348,12 @@ namespace System.Xml.Serialization
                     {
                         value = XmlConvert.ToString((TimeSpan)o);
                         type = "TimeSpan";
+                        typeNs = UrtTypes.Namespace;
+                    }
+                    else if (t == typeof(DateTimeOffset))
+                    {
+                        value = XmlConvert.ToString((DateTimeOffset)o);
+                        type = "dateTimeOffset";
                         typeNs = UrtTypes.Namespace;
                     }
                     else if (typeof(XmlNode[]).IsAssignableFrom(t))
@@ -4320,6 +4331,18 @@ namespace System.Xml.Serialization
                     Writer.Write("(");
                     Writer.Write(((DateTime)value).Ticks.ToString(CultureInfo.InvariantCulture));
                     Writer.Write(")");
+                }
+                else if (type == typeof(DateTimeOffset))
+                {
+                    Writer.Write(" new ");
+                    Writer.Write(type.FullName);
+                    Writer.Write("(");
+                    Writer.Write(((DateTimeOffset)value).Ticks.ToString(CultureInfo.InvariantCulture));
+                    Writer.Write(", new ");
+                    Writer.Write(((DateTimeOffset)value).Offset.GetType().FullName);
+                    Writer.Write("(");
+                    Writer.Write(((DateTimeOffset)value).Offset.Ticks.ToString(CultureInfo.InvariantCulture));
+                    Writer.Write("))");
                 }
                 else if (type == typeof(TimeSpan))
                 {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -900,6 +900,10 @@ namespace System.Xml.Serialization
                     {
                         writer.Write_TimeSpan(o);
                     }
+                    else if (_primitiveType == typeof(DateTimeOffset))
+                    {
+                        writer.Write_dateTimeOffset(o);
+                    }
                     else
                     {
                         throw new InvalidOperationException(SR.Format(SR.XmlUnxpectedType, _primitiveType!.FullName));
@@ -977,6 +981,10 @@ namespace System.Xml.Serialization
                     else if (_primitiveType == typeof(TimeSpan))
                     {
                         o = reader.Read_TimeSpan();
+                    }
+                    else if (_primitiveType == typeof(DateTimeOffset))
+                    {
+                        o = reader.Read_dateTimeOffset();
                     }
                     else
                     {

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -714,6 +714,82 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
     }
 
     [Fact]
+    public static void Xml_TypeWithDateTimeOffsetProperty()
+    {
+        var now = new DateTimeOffset(DateTime.Now);
+        var obj = new TypeWithDateTimeOffsetProperties { DTO = now };
+        var deserializedObj = SerializeAndDeserialize(obj,
+@"<?xml version=""1.0""?>
+<TypeWithDateTimeOffsetProperties xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
+  <DTO>" + now.ToString("o") + @"</DTO>
+  <DTO2>0001-01-01T00:00:00Z</DTO2>
+  <NullableDTO xsi:nil=""true"" />
+  <NullableDefaultDTO xsi:nil=""true"" />
+</TypeWithDateTimeOffsetProperties>");
+        Assert.StrictEqual(obj.DTO, deserializedObj.DTO);
+        Assert.StrictEqual(obj.DTO2, deserializedObj.DTO2);
+        Assert.StrictEqual(default(DateTimeOffset), deserializedObj.DTO2);
+        Assert.StrictEqual(obj.DTOWithDefault, deserializedObj.DTOWithDefault);
+        Assert.StrictEqual(default(DateTimeOffset), deserializedObj.DTOWithDefault);
+        Assert.StrictEqual(obj.NullableDTO, deserializedObj.NullableDTO);
+        Assert.True(deserializedObj.NullableDTO == null);
+        Assert.StrictEqual(obj.NullableDTOWithDefault, deserializedObj.NullableDTOWithDefault);
+        Assert.True(deserializedObj.NullableDTOWithDefault == null);
+    }
+
+    [Fact]
+    public static void Xml_DeserializeTypeWithEmptyDateTimeOffsetProperties()
+    {
+        var def = DateTimeOffset.Parse("3/17/1977 5:00:01 PM -05:00");  //  "1977-03-17T17:00:01-05:00"
+        string xml = @"<?xml version=""1.0""?>
+            <TypeWithDateTimeOffsetProperties xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
+              <DTO />
+              <DTO2 />
+              <DTOWithDefault />
+              <NullableDefaultDTO />
+            </TypeWithDateTimeOffsetProperties>";
+        XmlSerializer serializer = new XmlSerializer(typeof(TypeWithDateTimeOffsetProperties));
+
+        using (StringReader reader = new StringReader(xml))
+        {
+            TypeWithDateTimeOffsetProperties deserializedObj = (TypeWithDateTimeOffsetProperties)serializer.Deserialize(reader);
+            Assert.NotNull(deserializedObj);
+            Assert.Equal(default(DateTimeOffset), deserializedObj.DTO);
+            Assert.Equal(default(DateTimeOffset), deserializedObj.DTO2);
+            //Assert.Equal(def, deserializedObj.DTOWithDefault);
+            Assert.True(deserializedObj.NullableDTO == null);
+            //Assert.Equal(def, deserializedObj.NullableDTOWithDefault);
+        }
+    }
+
+    [Fact]
+    public static void Xml_DeserializeDateTimeOffsetType()
+    {
+        var now = new DateTimeOffset(DateTime.Now);
+        string xml = @"<?xml version=""1.0""?><dateTimeOffset>" + now.ToString("o") + "</dateTimeOffset>";
+        XmlSerializer serializer = new XmlSerializer(typeof(DateTimeOffset));
+
+        using (StringReader reader = new StringReader(xml))
+        {
+            DateTimeOffset deserializedObj = (DateTimeOffset)serializer.Deserialize(reader);
+            Assert.Equal(now, deserializedObj);
+        }
+    }
+
+    [Fact]
+    public static void Xml_DeserializeEmptyDateTimeOffsetType()
+    {
+        string xml = @"<?xml version=""1.0""?><dateTimeOffset />";
+        XmlSerializer serializer = new XmlSerializer(typeof(DateTimeOffset));
+
+        using (StringReader reader = new StringReader(xml))
+        {
+            DateTimeOffset deserializedObj = (DateTimeOffset)serializer.Deserialize(reader);
+            Assert.Equal(default(DateTimeOffset), deserializedObj);
+        }
+    }
+
+    [Fact]
     public static void Xml_TypeWithByteProperty()
     {
         var obj = new TypeWithByteProperty() { ByteProperty = 123 };

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -717,20 +717,21 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
     public static void Xml_TypeWithDateTimeOffsetProperty()
     {
         var now = new DateTimeOffset(DateTime.Now);
+        var defDTO = default(DateTimeOffset);
         var obj = new TypeWithDateTimeOffsetProperties { DTO = now };
         var deserializedObj = SerializeAndDeserialize(obj,
 @"<?xml version=""1.0""?>
 <TypeWithDateTimeOffsetProperties xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
-  <DTO>" + now.ToString("o") + @"</DTO>
-  <DTO2>0001-01-01T00:00:00Z</DTO2>
+  <DTO>" + XmlConvert.ToString(now) + @"</DTO>
+  <DTO2>" + XmlConvert.ToString(defDTO) + @"</DTO2>
   <NullableDTO xsi:nil=""true"" />
   <NullableDefaultDTO xsi:nil=""true"" />
 </TypeWithDateTimeOffsetProperties>");
         Assert.StrictEqual(obj.DTO, deserializedObj.DTO);
         Assert.StrictEqual(obj.DTO2, deserializedObj.DTO2);
-        Assert.StrictEqual(default(DateTimeOffset), deserializedObj.DTO2);
+        Assert.StrictEqual(defDTO, deserializedObj.DTO2);
         Assert.StrictEqual(obj.DTOWithDefault, deserializedObj.DTOWithDefault);
-        Assert.StrictEqual(default(DateTimeOffset), deserializedObj.DTOWithDefault);
+        Assert.StrictEqual(defDTO, deserializedObj.DTOWithDefault);
         Assert.StrictEqual(obj.NullableDTO, deserializedObj.NullableDTO);
         Assert.True(deserializedObj.NullableDTO == null);
         Assert.StrictEqual(obj.NullableDTOWithDefault, deserializedObj.NullableDTOWithDefault);
@@ -740,7 +741,8 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
     [Fact]
     public static void Xml_DeserializeTypeWithEmptyDateTimeOffsetProperties()
     {
-        var def = DateTimeOffset.Parse("3/17/1977 5:00:01 PM -05:00");  //  "1977-03-17T17:00:01-05:00"
+        //var def = DateTimeOffset.Parse("3/17/1977 5:00:01 PM -05:00");  //  "1977-03-17T17:00:01-05:00"
+        var defDTO = default(DateTimeOffset);
         string xml = @"<?xml version=""1.0""?>
             <TypeWithDateTimeOffsetProperties xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
               <DTO />
@@ -754,11 +756,11 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
         {
             TypeWithDateTimeOffsetProperties deserializedObj = (TypeWithDateTimeOffsetProperties)serializer.Deserialize(reader);
             Assert.NotNull(deserializedObj);
-            Assert.Equal(default(DateTimeOffset), deserializedObj.DTO);
-            Assert.Equal(default(DateTimeOffset), deserializedObj.DTO2);
-            //Assert.Equal(def, deserializedObj.DTOWithDefault);
+            Assert.Equal(defDTO, deserializedObj.DTO);
+            Assert.Equal(defDTO, deserializedObj.DTO2);
+            Assert.Equal(defDTO, deserializedObj.DTOWithDefault);
             Assert.True(deserializedObj.NullableDTO == null);
-            //Assert.Equal(def, deserializedObj.NullableDTOWithDefault);
+            Assert.Equal(defDTO, deserializedObj.NullableDTOWithDefault);
         }
     }
 

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -871,6 +871,22 @@ public class TypeWithBinaryProperty
     public byte[] Base64Content { get; set; }
 }
 
+public class TypeWithDateTimeOffsetProperties
+{
+    public DateTimeOffset DTO { get; set; }
+    public DateTimeOffset DTO2 { get; set; }
+
+    [XmlElement(ElementName = "DefaultDTO")]
+    [DefaultValue(typeof(DateTimeOffset), "1/1/0001 0:00:00 AM +00:00")]
+    public DateTimeOffset DTOWithDefault { get; set; }
+
+    public DateTimeOffset? NullableDTO { get; set; }
+
+    [XmlElement(ElementName = "NullableDefaultDTO")]
+    [DefaultValue(typeof(DateTimeOffset), "1/1/0001 0:00:00 AM +00:00")]
+    public DateTimeOffset? NullableDTOWithDefault { get; set; }
+}
+
 public class TypeWithTimeSpanProperty
 {
     public TimeSpan TimeSpanProperty;


### PR DESCRIPTION
Add support for DateTimeOffset to XmlSerializer

Treat DateTimeOffset as a primitive XmlSerializer. We map this to a
derivation of the xsd 'datetime' datatype which we call 'dateTimeOffset.'
Treatment is similar to how we handle TimeSpan.

Fixes #1406