### PR TITLE
[wasm][workload] Use the emsdk workload manifest for the emscripten packages

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -8,7 +8,7 @@
       <Uri>https://github.com/dotnet/msquic</Uri>
       <Sha>d7db669b70f4dd67ec001c192f9809c218cab88b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Runtime.Emscripten.2.0.23.Node.win-x64" Version="6.0.0-preview.7.21330.1">
+    <Dependency Name="Microsoft.NET.Workload.Emscripten.Manifest-6.0.100" Version="6.0.0-preview.7.21330.1">
       <Uri>https://github.com/dotnet/emsdk</Uri>
       <Sha>f5349765b7af1970c5b25cce4ed278544907cbe0</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -180,7 +180,7 @@
     <runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>11.1.0-alpha.1.21328.1</runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>
     <runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>11.1.0-alpha.1.21328.1</runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>
     <!-- emscripten / Node -->
-    <MicrosoftNETRuntimeEmscripten2023Nodewinx64Version>6.0.0-preview.7.21330.1</MicrosoftNETRuntimeEmscripten2023Nodewinx64Version>
-    <MicrosoftNETRuntimeEmscriptenVersion>$(MicrosoftNETRuntimeEmscripten2023Nodewinx64Version)</MicrosoftNETRuntimeEmscriptenVersion>
+    <MicrosoftNETWorkloadEmscriptenManifest60100>6.0.0-preview.7.21330.1</MicrosoftNETWorkloadEmscriptenManifest60100>
+    <MicrosoftNETRuntimeEmscriptenVersion>$(MicrosoftNETWorkloadEmscriptenManifest60100)</MicrosoftNETRuntimeEmscriptenVersion>
   </PropertyGroup>
 </Project>

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.json.in
@@ -1,5 +1,8 @@
 {
   "version": "${WorkloadVersion}",
+  "depends-on": {
+    "Microsoft.NET.Workload.Emscripten": "${EmscriptenVersion}"
+  },
   "workloads": {
     "microsoft-net-sdk-blazorwebassembly-aot": {
       "description": "Browser Runtime native performance tools",
@@ -11,7 +14,7 @@
         "Microsoft.NET.Runtime.Emscripten.Python",
         "Microsoft.NET.Runtime.Emscripten.Sdk"
       ],
-      "extends": [ "microsoft-net-runtime-mono-tooling" ],
+      "extends": [ "microsoft-net-runtime-mono-tooling", "microsoft-net-sdk-emscripten" ],
       "platforms": [ "win-x64", "linux-x64", "osx-x64", "osx-arm64" ]
     },
     "microsoft-net-runtime-android": {
@@ -266,34 +269,5 @@
       "kind": "framework",
       "version": "${PackageVersion}"
     },
-    "Microsoft.NET.Runtime.Emscripten.Node" : {
-      "kind": "Sdk",
-      "version": "${EmscriptenVersion}",
-      "alias-to": {
-        "win-x64": "Microsoft.NET.Runtime.Emscripten.2.0.23.Node.win-x64",
-        "linux-x64": "Microsoft.NET.Runtime.Emscripten.2.0.23.Node.linux-x64",
-        "osx-x64": "Microsoft.NET.Runtime.Emscripten.2.0.23.Node.osx-x64",
-        "osx-arm64": "Microsoft.NET.Runtime.Emscripten.2.0.23.Node.osx-x64"
-      }
-    },
-    "Microsoft.NET.Runtime.Emscripten.Python" : {
-      "kind": "Sdk",
-      "version": "${EmscriptenVersion}",
-      "alias-to": {
-        "win-x64": "Microsoft.NET.Runtime.Emscripten.2.0.23.Python.win-x64",
-        "osx-x64": "Microsoft.NET.Runtime.Emscripten.2.0.23.Python.osx-x64",
-        "osx-arm64": "Microsoft.NET.Runtime.Emscripten.2.0.23.Python.osx-x64"
-      }
-    },
-    "Microsoft.NET.Runtime.Emscripten.Sdk" : {
-      "kind": "Sdk",
-      "version": "${EmscriptenVersion}",
-      "alias-to": {
-        "win-x64": "Microsoft.NET.Runtime.Emscripten.2.0.23.Sdk.win-x64",
-        "linux-x64": "Microsoft.NET.Runtime.Emscripten.2.0.23.Sdk.linux-x64",
-        "osx-x64": "Microsoft.NET.Runtime.Emscripten.2.0.23.Sdk.osx-x64",
-        "osx-arm64": "Microsoft.NET.Runtime.Emscripten.2.0.23.Sdk.osx-x64"
-      }
-    }
   }
 }

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.targets
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.targets
@@ -44,9 +44,6 @@
 
     <ImportGroup Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(UsingBrowserRuntimeWorkload)' == 'true'">
         <Import Project="Sdk.targets" Sdk="Microsoft.NET.Runtime.WebAssembly.Sdk" />
-        <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.Emscripten.Python" Condition="!$([MSBuild]::IsOsPlatform('Linux'))" />
-        <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.Emscripten.Node" />
-        <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.Emscripten.Sdk" />
         <Import Project="Sdk.props" Sdk="Microsoft.NETCore.App.Runtime.AOT.Cross.browser-wasm" />
     </ImportGroup>
 </Project>


### PR DESCRIPTION
Switch to the emscripten workload manifest for the emsdk packs.

This is #54349 with the mobile changes removed again because we decided to validate them separately.