### PR TITLE
Avoid conflicts between default [semi-]voiced sound mark rules and custom rules

### DIFF
--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
@@ -112,6 +112,14 @@ static const UChar g_HalfFullHigherChars[] = {
 };
 static const int32_t g_HalfFullCharsLength = (sizeof(g_HalfFullHigherChars) / sizeof(UChar));
 
+static const UChar g_HiraganaWithoutDakutenChars[] = {
+    0x3041, 0x3042, 0x3043, 0x3044, 0x3045, 0x3046, 0x3047, 0x3048, 0x3049, 0x304A, 0x304B, 0x304D, 0x304F, 0x3051, 0x3053,
+    0x3055, 0x3057, 0x3059, 0x305B, 0x305D, 0x305F, 0x3061, 0x3063, 0x3064, 0x3066, 0x3068, 0x306A, 0x306B, 0x306C, 0x306D,
+    0x306E, 0x306F, 0x3072, 0x3075, 0x3078, 0x307B, 0x307E, 0x307F, 0x3080, 0x3081, 0x3082, 0x3083, 0x3084, 0x3085, 0x3086,
+    0x3087, 0x3088, 0x3089, 0x308A, 0x308B, 0x308C, 0x308D, 0x308E, 0x308F, 0x3090, 0x3091, 0x3092, 0x3093, 0x3095, 0x3096, 0x309D, 
+};
+static const int32_t g_HiraganaWithoutDakutenCharsLength = (sizeof(g_HiraganaWithoutDakutenChars) / sizeof(UChar));
+
 /*
 ICU collation rules reserve any punctuation and whitespace characters for use in the syntax.
 Thus, to use these characters in a rule, they need to be escaped.
@@ -158,11 +166,28 @@ static void FillIgnoreKanaRules(UChar* completeRules, int32_t* fillIndex, int32_
         return;
     }
 
-    for (UChar hiraganaChar = hiraganaStart; hiraganaChar <= hiraganaEnd; hiraganaChar++)
+    if (isIgnoreKanaType)
     {
-        // Hiragana is the range 3041 to 3096 & 309D & 309E
-        if (hiraganaChar <= 0x3096 || hiraganaChar >= 0x309D) // characters between 3096 and 309D are not mapped to katakana
+        for (UChar hiraganaChar = hiraganaStart; hiraganaChar <= hiraganaEnd; hiraganaChar++)
         {
+            // Hiragana is the range 3041 to 3096 & 309D & 309E
+            if (hiraganaChar <= 0x3096 ||
+                hiraganaChar >= 0x309D) // characters between 3096 and 309D are not mapped to katakana
+            {
+                completeRules[*fillIndex] = '&';
+                completeRules[(*fillIndex) + 1] = hiraganaChar;
+                completeRules[(*fillIndex) + 2] = compareChar;
+                completeRules[(*fillIndex) + 3] = hiraganaChar + hiraganaToKatakanaOffset;
+                (*fillIndex) += 4;
+            }
+        }
+    }
+    else
+    {
+        // Avoid conflicts between default dakuten rules and custom rules
+        for (int i = 0; i < g_HiraganaWithoutDakutenCharsLength; i++)
+        {
+            UChar hiraganaChar = g_HiraganaWithoutDakutenChars[i];
             completeRules[*fillIndex] = '&';
             completeRules[(*fillIndex) + 1] = hiraganaChar;
             completeRules[(*fillIndex) + 2] = compareChar;

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
@@ -112,16 +112,16 @@ static const UChar g_HalfFullHigherChars[] = {
 };
 static const int32_t g_HalfFullCharsLength = (sizeof(g_HalfFullHigherChars) / sizeof(UChar));
 
-// Hiragana without dakuten or handakuten for custom collation rules
-// If Hiragana with dakuten or handakuten is added to custom collation rules, there is a conflict
+// Hiragana without [semi-]voiced sound mark for custom collation rules
+// If Hiragana with [semi-]voiced sound mark is added to custom collation rules, there is a conflict
 // between the custom rule and some default rule.
-static const UChar g_HiraganaWithoutDakutenChars[] = {
+static const UChar g_HiraganaWithoutVoicedSoundMarkChars[] = {
     0x3041, 0x3042, 0x3043, 0x3044, 0x3045, 0x3046, 0x3047, 0x3048, 0x3049, 0x304A, 0x304B, 0x304D, 0x304F, 0x3051, 0x3053,
     0x3055, 0x3057, 0x3059, 0x305B, 0x305D, 0x305F, 0x3061, 0x3063, 0x3064, 0x3066, 0x3068, 0x306A, 0x306B, 0x306C, 0x306D,
     0x306E, 0x306F, 0x3072, 0x3075, 0x3078, 0x307B, 0x307E, 0x307F, 0x3080, 0x3081, 0x3082, 0x3083, 0x3084, 0x3085, 0x3086,
     0x3087, 0x3088, 0x3089, 0x308A, 0x308B, 0x308C, 0x308D, 0x308E, 0x308F, 0x3090, 0x3091, 0x3092, 0x3093, 0x3095, 0x3096, 0x309D,
 };
-static const int32_t g_HiraganaWithoutDakutenCharsLength = (sizeof(g_HiraganaWithoutDakutenChars) / sizeof(UChar));
+static const int32_t g_HiraganaWithoutVoicedSoundMarkCharsLength = (sizeof(g_HiraganaWithoutVoicedSoundMarkChars) / sizeof(UChar));
 
 /*
 ICU collation rules reserve any punctuation and whitespace characters for use in the syntax.
@@ -184,10 +184,10 @@ static void FillIgnoreKanaRules(UChar* completeRules, int32_t* fillIndex, int32_
     }
     else
     {
-        // Avoid conflicts between default dakuten rules and custom rules
-        for (int i = 0; i < g_HiraganaWithoutDakutenCharsLength; i++)
+        // Avoid conflicts between default [semi-]voiced sound mark rules and custom rules
+        for (int i = 0; i < g_HiraganaWithoutVoicedSoundMarkCharsLength; i++)
         {
-            UChar hiraganaChar = g_HiraganaWithoutDakutenChars[i];
+            UChar hiraganaChar = g_HiraganaWithoutVoicedSoundMarkChars[i];
             completeRules[*fillIndex] = '&';
             completeRules[(*fillIndex) + 1] = hiraganaChar;
             completeRules[(*fillIndex) + 2] = '<';

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
@@ -112,11 +112,14 @@ static const UChar g_HalfFullHigherChars[] = {
 };
 static const int32_t g_HalfFullCharsLength = (sizeof(g_HalfFullHigherChars) / sizeof(UChar));
 
+// Hiragana without dakuten or handakuten for custom collation rules
+// If Hiragana with dakuten or handakuten is added to custom collation rules, there is a conflict
+// between the custom rule and some default rule.
 static const UChar g_HiraganaWithoutDakutenChars[] = {
     0x3041, 0x3042, 0x3043, 0x3044, 0x3045, 0x3046, 0x3047, 0x3048, 0x3049, 0x304A, 0x304B, 0x304D, 0x304F, 0x3051, 0x3053,
     0x3055, 0x3057, 0x3059, 0x305B, 0x305D, 0x305F, 0x3061, 0x3063, 0x3064, 0x3066, 0x3068, 0x306A, 0x306B, 0x306C, 0x306D,
     0x306E, 0x306F, 0x3072, 0x3075, 0x3078, 0x307B, 0x307E, 0x307F, 0x3080, 0x3081, 0x3082, 0x3083, 0x3084, 0x3085, 0x3086,
-    0x3087, 0x3088, 0x3089, 0x308A, 0x308B, 0x308C, 0x308D, 0x308E, 0x308F, 0x3090, 0x3091, 0x3092, 0x3093, 0x3095, 0x3096, 0x309D, 
+    0x3087, 0x3088, 0x3089, 0x308A, 0x308B, 0x308C, 0x308D, 0x308E, 0x308F, 0x3090, 0x3091, 0x3092, 0x3093, 0x3095, 0x3096, 0x309D,
 };
 static const int32_t g_HiraganaWithoutDakutenCharsLength = (sizeof(g_HiraganaWithoutDakutenChars) / sizeof(UChar));
 
@@ -158,8 +161,6 @@ custom rules in order to support IgnoreKanaType and IgnoreWidth CompareOptions c
 */
 static void FillIgnoreKanaRules(UChar* completeRules, int32_t* fillIndex, int32_t completeRulesLength, int32_t isIgnoreKanaType)
 {
-    UChar compareChar = isIgnoreKanaType ? '=' : '<';
-
     assert((*fillIndex) + (4 * (hiraganaEnd - hiraganaStart + 1)) <= completeRulesLength);
     if ((*fillIndex) + (4 * (hiraganaEnd - hiraganaStart + 1)) > completeRulesLength) // check the allocated the size
     {
@@ -171,12 +172,11 @@ static void FillIgnoreKanaRules(UChar* completeRules, int32_t* fillIndex, int32_
         for (UChar hiraganaChar = hiraganaStart; hiraganaChar <= hiraganaEnd; hiraganaChar++)
         {
             // Hiragana is the range 3041 to 3096 & 309D & 309E
-            if (hiraganaChar <= 0x3096 ||
-                hiraganaChar >= 0x309D) // characters between 3096 and 309D are not mapped to katakana
+            if (hiraganaChar <= 0x3096 || hiraganaChar >= 0x309D) // characters between 3096 and 309D are not mapped to katakana
             {
                 completeRules[*fillIndex] = '&';
                 completeRules[(*fillIndex) + 1] = hiraganaChar;
-                completeRules[(*fillIndex) + 2] = compareChar;
+                completeRules[(*fillIndex) + 2] = '=';
                 completeRules[(*fillIndex) + 3] = hiraganaChar + hiraganaToKatakanaOffset;
                 (*fillIndex) += 4;
             }
@@ -190,7 +190,7 @@ static void FillIgnoreKanaRules(UChar* completeRules, int32_t* fillIndex, int32_
             UChar hiraganaChar = g_HiraganaWithoutDakutenChars[i];
             completeRules[*fillIndex] = '&';
             completeRules[(*fillIndex) + 1] = hiraganaChar;
-            completeRules[(*fillIndex) + 2] = compareChar;
+            completeRules[(*fillIndex) + 2] = '<';
             completeRules[(*fillIndex) + 3] = hiraganaChar + hiraganaToKatakanaOffset;
             (*fillIndex) += 4;
         }

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.Compare.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.Compare.cs
@@ -240,7 +240,7 @@ namespace System.Globalization.Tests
             yield return new object[] { s_invariantCompare, "\u3060", "\u30C0", CompareOptions.IgnoreCase, s_expectedHiraganaToKatakanaCompare };
             yield return new object[] { s_invariantCompare, "c", "C", CompareOptions.IgnoreKanaType, -1 };
 
-            // Japanese Dakuten/Handakuten
+            // Japanese [semi-]voiced sound mark
             yield return new object[] { s_invariantCompare, "\u306F", "\u3070", CompareOptions.IgnoreCase, -1 };
             yield return new object[] { s_invariantCompare, "\u306F", "\u3071", CompareOptions.IgnoreCase, -1 };
             yield return new object[] { s_invariantCompare, "\u3070", "\u3071", CompareOptions.IgnoreCase, -1 };

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.Compare.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.Compare.cs
@@ -240,6 +240,20 @@ namespace System.Globalization.Tests
             yield return new object[] { s_invariantCompare, "\u3060", "\u30C0", CompareOptions.IgnoreCase, s_expectedHiraganaToKatakanaCompare };
             yield return new object[] { s_invariantCompare, "c", "C", CompareOptions.IgnoreKanaType, -1 };
 
+            // Japanese Dakuten/Handakuten
+            yield return new object[] { s_invariantCompare, "\u306F", "\u3070", CompareOptions.IgnoreCase, -1 };
+            yield return new object[] { s_invariantCompare, "\u306F", "\u3071", CompareOptions.IgnoreCase, -1 };
+            yield return new object[] { s_invariantCompare, "\u3070", "\u3071", CompareOptions.IgnoreCase, -1 };
+            yield return new object[] { s_invariantCompare, "\u30CF", "\u30D0", CompareOptions.IgnoreCase, -1 };
+            yield return new object[] { s_invariantCompare, "\u30CF", "\u30D1", CompareOptions.IgnoreCase, -1 };
+            yield return new object[] { s_invariantCompare, "\u30D0", "\u30D1", CompareOptions.IgnoreCase, -1 };
+            yield return new object[] { s_invariantCompare, "\u306F", "\u3070", CompareOptions.IgnoreNonSpace, 0 };
+            yield return new object[] { s_invariantCompare, "\u306F", "\u3071", CompareOptions.IgnoreNonSpace, 0 };
+            yield return new object[] { s_invariantCompare, "\u3070", "\u3071", CompareOptions.IgnoreNonSpace, 0 };
+            yield return new object[] { s_invariantCompare, "\u30CF", "\u30D0", CompareOptions.IgnoreNonSpace, 0 };
+            yield return new object[] { s_invariantCompare, "\u30CF", "\u30D1", CompareOptions.IgnoreNonSpace, 0 };
+            yield return new object[] { s_invariantCompare, "\u30D0", "\u30D1", CompareOptions.IgnoreNonSpace, 0 };
+
             // Spanish
             yield return new object[] { new CultureInfo("es-ES").CompareInfo, "llegar", "lugar", CompareOptions.None, -1 };
 
@@ -483,6 +497,82 @@ namespace System.Globalization.Tests
                                             $"Expect '{(int)hiraganaChar:x4}'  != {(int)hiraganaChar + hiraganaToKatakanaOffset:x4} with CompareOptions.IgnoreCase");
                 Assert.True(string.Compare(new string(hiraganaChar, 1), new string((char)(hiraganaChar + hiraganaToKatakanaOffset), 1), CultureInfo.InvariantCulture, CompareOptions.IgnoreKanaType) == 0,
                                             $"Expect '{(int)hiraganaChar:x4}'  == {(int)hiraganaChar + hiraganaToKatakanaOffset:x4} with CompareOptions.IgnoreKanaType");
+            }
+        }
+
+        [Fact]
+        public void TestHiraganaAndKatakana()
+        {
+            const char hiraganaStart = '\u3041';
+            const char hiraganaEnd = '\u3096';
+            const int hiraganaToKatakanaOffset = 0x30a1 - 0x3041;
+            List<char> hiraganaList = new List<char>();
+            for (char c = hiraganaStart; c <= hiraganaEnd; c++) // Hiragana
+            {
+                // TODO: small hiragana/katakana orders
+                // https://github.com/dotnet/runtime/issues/54987
+                switch (c)
+                {
+                    case '\u3041':
+                    case '\u3043':
+                    case '\u3045':
+                    case '\u3047':
+                    case '\u3049':
+                    case '\u3063':
+                    case '\u3083':
+                    case '\u3085':
+                    case '\u3087':
+                    case '\u308E':
+                    case '\u3095':
+                    case '\u3096':
+                        break;
+                    default:
+                        hiraganaList.Add(c);
+                        break;
+                }
+            }
+            for (char c = '\u309D'; c <= '\u309E'; c++) // Hiragana iteration mark
+            {
+                hiraganaList.Add(c);
+            }
+            CompareOptions[] options = new[] {
+                CompareOptions.None,
+                CompareOptions.IgnoreCase,
+                CompareOptions.IgnoreNonSpace,
+                CompareOptions.IgnoreSymbols,
+                CompareOptions.IgnoreKanaType,
+                CompareOptions.IgnoreWidth,
+                CompareOptions.Ordinal,
+                CompareOptions.OrdinalIgnoreCase,
+                CompareOptions.IgnoreKanaType | CompareOptions.IgnoreCase,
+                CompareOptions.IgnoreKanaType | CompareOptions.IgnoreNonSpace,
+                CompareOptions.IgnoreKanaType | CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace,
+                CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase,
+                CompareOptions.IgnoreWidth | CompareOptions.IgnoreNonSpace,
+                CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace,
+                CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase,
+                CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreNonSpace,
+                CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace,
+            };
+
+            foreach (var option in options)
+            {
+                for (int i = 0; i < hiraganaList.Count; i++)
+                {
+                    char hiraganaChar1 = hiraganaList[i];
+                    char katakanaChar1 = (char)(hiraganaChar1 + hiraganaToKatakanaOffset);
+
+                    for (int j = i; j < hiraganaList.Count; j++)
+                    {
+                        char hiraganaChar2 = hiraganaList[j];
+                        char katakanaChar2 = (char)(hiraganaChar2 + hiraganaToKatakanaOffset);
+
+                        int hiraganaResult = s_invariantCompare.Compare(new string(hiraganaChar1, 1), new string(hiraganaChar2, 1), option);
+                        int katakanaResult = s_invariantCompare.Compare(new string(katakanaChar1, 1), new string(katakanaChar2, 1), option);
+                        Assert.True(hiraganaResult == katakanaResult,
+                            $"Expect Compare({(int)hiraganaChar1:x4}, {(int)hiraganaChar2:x4}) == Compare({(int)katakanaChar1:x4}, {(int)katakanaChar2:x4}) with CompareOptions.{option}");
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #55008, Fixes #55009

**Background**

Let's take `は` as an example. Other characters have the same mechanism.

Default collation rules has `&は<<<ハ<<ば<<<バ<<ぱ<<<パ`. 

If strength is less than tertiary, the default rule can be regarded as `&は=ハ<<ば=バ<<ぱ=パ`.
In the current implementation, a custom rule like `&は<ハ&ば<バ&ぱ<パ` is added.
Merging these rules, it will be **`&は<<ば<<ぱ<パ<バ<ハ`**.

**This PR implimentation**

I change the custom rule to `&は<ハ`.
Merged rule is **`&は<<ば<<ぱ<ハ<<バ<<パ`**.


This PR don't fix small hiragana/katakana order issue which is #54987.

**reference**

- http://www.unicode.org/reports/tr35/tr35-collation.html#Orderings