### PR TITLE
Efficient `RandomAccess` async I/O on the thread pool.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.OverlappedValueTaskSource.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.OverlappedValueTaskSource.Windows.cs
@@ -12,33 +12,34 @@ namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeFileHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        private ValueTaskSource? _reusableValueTaskSource; // reusable ValueTaskSource that is currently NOT being used
+        private OverlappedValueTaskSource? _reusableOverlappedValueTaskSource; // reusable OverlappedValueTaskSource that is currently NOT being used
 
-        // Rent the reusable ValueTaskSource, or create a new one to use if we couldn't get one (which
-        // should only happen on first use or if the FileStream is being used concurrently).
-        internal ValueTaskSource GetValueTaskSource() => Interlocked.Exchange(ref _reusableValueTaskSource, null) ?? new ValueTaskSource(this);
+        // Rent the reusable OverlappedValueTaskSource, or create a new one to use if we couldn't get one (which
+        // should only happen on first use or if the SafeFileHandle is being used concurrently).
+        internal OverlappedValueTaskSource GetOverlappedValueTaskSource() =>
+            Interlocked.Exchange(ref _reusableOverlappedValueTaskSource, null) ?? new OverlappedValueTaskSource(this);
 
         protected override bool ReleaseHandle()
         {
             bool result = Interop.Kernel32.CloseHandle(handle);
 
-            Interlocked.Exchange(ref _reusableValueTaskSource, null)?.Dispose();
+            Interlocked.Exchange(ref _reusableOverlappedValueTaskSource, null)?.Dispose();
 
             return result;
         }
 
-        private void TryToReuse(ValueTaskSource source)
+        private void TryToReuse(OverlappedValueTaskSource source)
         {
             source._source.Reset();
 
-            if (Interlocked.CompareExchange(ref _reusableValueTaskSource, source, null) is not null)
+            if (Interlocked.CompareExchange(ref _reusableOverlappedValueTaskSource, source, null) is not null)
             {
                 source._preallocatedOverlapped.Dispose();
             }
         }
 
-        /// <summary>Reusable IValueTaskSource for FileStream ValueTask-returning async operations.</summary>
-        internal sealed unsafe class ValueTaskSource : IValueTaskSource<int>, IValueTaskSource
+        /// <summary>Reusable IValueTaskSource for RandomAccess async operations based on Overlapped I/O.</summary>
+        internal sealed unsafe class OverlappedValueTaskSource : IValueTaskSource<int>, IValueTaskSource
         {
             internal static readonly IOCompletionCallback s_ioCallback = IOCallback;
 
@@ -55,7 +56,7 @@ namespace Microsoft.Win32.SafeHandles
             /// </summary>
             internal ulong _result;
 
-            internal ValueTaskSource(SafeFileHandle fileHandle)
+            internal OverlappedValueTaskSource(SafeFileHandle fileHandle)
             {
                 _fileHandle = fileHandle;
                 _source.RunContinuationsAsynchronously = true;
@@ -112,7 +113,7 @@ namespace Microsoft.Win32.SafeHandles
                     {
                         _cancellationRegistration = cancellationToken.UnsafeRegister(static (s, token) =>
                         {
-                            ValueTaskSource vts = (ValueTaskSource)s!;
+                            OverlappedValueTaskSource vts = (OverlappedValueTaskSource)s!;
                             if (!vts._fileHandle.IsInvalid)
                             {
                                 try
@@ -156,7 +157,7 @@ namespace Microsoft.Win32.SafeHandles
             // done by that cancellation registration, e.g. unregistering.  As such, we use _result to both track who's
             // responsible for calling Complete and for passing the necessary data between parties.
 
-            /// <summary>Invoked when AsyncWindowsFileStreamStrategy has finished scheduling the async operation.</summary>
+            /// <summary>Invoked when the async operation finished being scheduled.</summary>
             internal void FinishedScheduling()
             {
                 // Set the value to 1.  If it was already non-0, then the asynchronous operation already completed but
@@ -172,7 +173,7 @@ namespace Microsoft.Win32.SafeHandles
             /// <summary>Invoked when the asynchronous operation has completed asynchronously.</summary>
             private static void IOCallback(uint errorCode, uint numBytes, NativeOverlapped* pOverlapped)
             {
-                ValueTaskSource? vts = (ValueTaskSource?)ThreadPoolBoundHandle.GetNativeOverlappedState(pOverlapped);
+                OverlappedValueTaskSource? vts = (OverlappedValueTaskSource?)ThreadPoolBoundHandle.GetNativeOverlappedState(pOverlapped);
                 Debug.Assert(vts is not null);
                 Debug.Assert(vts._overlapped == pOverlapped, "Overlaps don't match");
 

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.ThreadPoolValueTaskSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.ThreadPoolValueTaskSource.cs
@@ -1,0 +1,187 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Sources;
+
+namespace Microsoft.Win32.SafeHandles
+{
+    public sealed partial class SafeFileHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        private ThreadPoolValueTaskSource? _reusableThreadPoolValueTaskSource; // reusable ThreadPoolValueTaskSource that is currently NOT being used
+
+        // Rent the reusable ThreadPoolValueTaskSource, or create a new one to use if we couldn't get one (which
+        // should only happen on first use or if the SafeFileHandle is being used concurrently).
+        internal ThreadPoolValueTaskSource GetThreadPoolValueTaskSource() =>
+            Interlocked.Exchange(ref _reusableThreadPoolValueTaskSource, null) ?? new ThreadPoolValueTaskSource(this);
+
+        private void TryToReuse(ThreadPoolValueTaskSource source)
+        {
+            Interlocked.CompareExchange(ref _reusableThreadPoolValueTaskSource, source, null);
+        }
+
+        /// <summary>
+        /// A reusable <see cref="IValueTaskSource"/> implementation that
+        /// queues asynchronous <see cref="RandomAccess"/> operations to
+        /// be completed synchronously on the thread pool.
+        /// </summary>
+        internal sealed class ThreadPoolValueTaskSource : IThreadPoolWorkItem, IValueTaskSource<int>, IValueTaskSource<long>
+        {
+            private enum Operation : byte
+            {
+                None,
+                Read,
+                Write,
+                ReadScatter,
+                WriteGather
+            }
+
+            private ManualResetValueTaskSourceCore<long> _source;
+            private readonly SafeFileHandle _fileHandle;
+            private Operation _operation = Operation.None;
+
+            // These fields store the parameters for the operation.
+            // The first two are common for all kinds of operations.
+            private long _fileOffset;
+            private CancellationToken _cancellationToken;
+            private Memory<byte> _readMemory;
+            private ReadOnlyMemory<byte> _writeMemory;
+            private IReadOnlyList<Memory<byte>>? _readScatterMemories;
+            private IReadOnlyList<ReadOnlyMemory<byte>>? _writeGatherMemories;
+
+            internal ThreadPoolValueTaskSource(SafeFileHandle fileHandle)
+            {
+                _fileHandle = fileHandle;
+                _source.RunContinuationsAsynchronously = true;
+            }
+
+            private long GetResultAndRelease(short token)
+            {
+                try
+                {
+                    return _source.GetResult(token);
+                } finally
+                {
+                    _source.Reset();
+                    _fileHandle.TryToReuse(this);
+                }
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token) => _source.GetStatus(token);
+            public void OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags) =>
+                _source.OnCompleted(continuation, state, token, flags);
+            int IValueTaskSource<int>.GetResult(short token) => (int) GetResultAndRelease(token);
+            long IValueTaskSource<long>.GetResult(short token) => GetResultAndRelease(token);
+
+            void IThreadPoolWorkItem.Execute()
+            {
+                Debug.Assert(_operation >= Operation.Read && _operation <= Operation.WriteGather);
+
+                long result = 0;
+                try {
+                    bool notifyWhenUnblocked = false;
+                    try
+                    {
+                        // This is the operation's last chance to be cancelled.
+                        if (_cancellationToken.IsCancellationRequested)
+                        {
+                            _source.SetException(new OperationCanceledException(_cancellationToken));
+                            return;
+                        }
+
+                        notifyWhenUnblocked = ThreadPool.NotifyThreadBlocked();
+                        switch (_operation)
+                        {
+                            case Operation.Read:
+                                result = RandomAccess.ReadAtOffset(_fileHandle, _readMemory.Span, _fileOffset);
+                                break;
+                            case Operation.Write:
+                                result = RandomAccess.WriteAtOffset(_fileHandle, _writeMemory.Span, _fileOffset);
+                                break;
+                            case Operation.ReadScatter:
+                                Debug.Assert(_readScatterMemories != null);
+                                result = RandomAccess.ReadScatterAtOffset(_fileHandle, _readScatterMemories!, _fileOffset);
+                                break;
+                            case Operation.WriteGather:
+                                Debug.Assert(_writeGatherMemories != null);
+                                result = RandomAccess.WriteGatherAtOffset(_fileHandle, _writeGatherMemories!, _fileOffset);
+                                break;
+                        }
+                    } finally
+                    {
+                        if (notifyWhenUnblocked)
+                            ThreadPool.NotifyThreadUnblocked();
+                        _operation = Operation.None;
+                        _fileOffset = 0;
+                        _cancellationToken = default;
+                        _readMemory = default;
+                        _writeMemory = default;
+                        _readScatterMemories = null;
+                        _writeGatherMemories = null;
+                    }
+                } catch (Exception e)
+                {
+                    _source.SetException(e);
+                }
+                _source.SetResult(result);
+            }
+
+            public ValueTask<int> QueueRead(Memory<byte> buffer, long fileOffset, CancellationToken cancellationToken)
+            {
+                Debug.Assert(_operation == Operation.None, "An operation was queued before the previous one's completion.");
+
+                _operation = Operation.Read;
+                _readMemory = buffer;
+                _fileOffset = fileOffset;
+                _cancellationToken = cancellationToken;
+                ThreadPool.UnsafeQueueUserWorkItem(this, false);
+
+                return new ValueTask<int>(this, _source.Version);
+            }
+
+            public ValueTask<int> QueueWrite(ReadOnlyMemory<byte> buffer, long fileOffset, CancellationToken cancellationToken)
+            {
+                Debug.Assert(_operation == Operation.None, "An operation was queued before the previous one's completion.");
+
+                _operation = Operation.Write;
+                _writeMemory = buffer;
+                _fileOffset = fileOffset;
+                _cancellationToken = cancellationToken;
+                ThreadPool.UnsafeQueueUserWorkItem(this, false);
+
+                return new ValueTask<int>(this, _source.Version);
+            }
+
+            public ValueTask<long> QueueReadScatter(IReadOnlyList<Memory<byte>> buffers, long fileOffset, CancellationToken cancellationToken)
+            {
+                Debug.Assert(_operation == Operation.None, "An operation was queued before the previous one's completion.");
+
+                _operation = Operation.ReadScatter;
+                _readScatterMemories = buffers;
+                _fileOffset = fileOffset;
+                _cancellationToken = cancellationToken;
+                ThreadPool.UnsafeQueueUserWorkItem(this, false);
+
+                return new ValueTask<long>(this, _source.Version);
+            }
+
+            public ValueTask<long> QueueWriteGather(IReadOnlyList<ReadOnlyMemory<byte>> buffers, long fileOffset, CancellationToken cancellationToken)
+            {
+                Debug.Assert(_operation == Operation.None, "An operation was queued before the previous one's completion.");
+
+                _operation = Operation.WriteGather;
+                _writeGatherMemories = buffers;
+                _fileOffset = fileOffset;
+                _cancellationToken = cancellationToken;
+                ThreadPool.UnsafeQueueUserWorkItem(this, false);
+
+                return new ValueTask<long>(this, _source.Version);
+            }
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.ThreadPoolValueTaskSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.ThreadPoolValueTaskSource.cs
@@ -120,6 +120,7 @@ namespace Microsoft.Win32.SafeHandles
                 finally
                 {
                     _operation = Operation.None;
+                    _context = null;
                     _cancellationToken = default;
                     _singleSegment = default;
                     _multiSegmentCollection = null;

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -8,7 +8,7 @@ using System.IO.Strategies;
 
 namespace Microsoft.Win32.SafeHandles
 {
-    public sealed class SafeFileHandle : SafeHandleZeroOrMinusOneIsInvalid
+    public sealed partial class SafeFileHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         // not using bool? as it's not thread safe
         private volatile NullableBool _canSeek = NullableBool.Undefined;
@@ -21,11 +21,6 @@ namespace Microsoft.Win32.SafeHandles
             : base(ownsHandle)
         {
             SetHandle(new IntPtr(-1));
-        }
-
-        public SafeFileHandle(IntPtr preexistingHandle, bool ownsHandle) : this(ownsHandle)
-        {
-            SetHandle(preexistingHandle);
         }
 
         public bool IsAsync { get; private set; }

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
@@ -20,11 +20,6 @@ namespace Microsoft.Win32.SafeHandles
         {
         }
 
-        public SafeFileHandle(IntPtr preexistingHandle, bool ownsHandle) : base(ownsHandle)
-        {
-            SetHandle(preexistingHandle);
-        }
-
         public bool IsAsync => (GetFileOptions() & FileOptions.Asynchronous) != 0;
 
         internal bool CanSeek => !IsClosed && GetFileType() == Interop.Kernel32.FileTypes.FILE_TYPE_DISK;

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Win32.SafeHandles
+{
+    public sealed partial class SafeFileHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        public SafeFileHandle(IntPtr preexistingHandle, bool ownsHandle) : base(ownsHandle)
+        {
+            SetHandle(preexistingHandle);
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -62,6 +62,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeHandleMinusOneIsInvalid.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeHandleZeroOrMinusOneIsInvalid.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeFileHandle.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeFileHandle.ThreadPoolValueTaskSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeWaitHandle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\AccessViolationException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Action.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -61,6 +61,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\CriticalHandleZeroOrMinusOneIsInvalid.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeHandleMinusOneIsInvalid.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeHandleZeroOrMinusOneIsInvalid.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeFileHandle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeWaitHandle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\AccessViolationException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Action.cs" />
@@ -1517,7 +1518,7 @@
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetModuleFileName.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetModuleFileName.cs</Link>
     </Compile>
-	<Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetOverlappedResult.cs">
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetOverlappedResult.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetOverlappedResult.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.GetProcessMemoryInfo.cs">

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -1777,7 +1777,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Internal\Console.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Internal\Win32\RegistryKey.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeFileHandle.Windows.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeFileHandle.ValueTaskSource.Windows.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeFileHandle.OverlappedValueTaskSource.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeFindHandle.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeRegistryHandle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft\Win32\SafeHandles\SafeRegistryHandle.Windows.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.Unix.cs
@@ -24,7 +24,7 @@ namespace System.IO
             return status.Size;
         }
 
-        private static unsafe int ReadAtOffset(SafeFileHandle handle, Span<byte> buffer, long fileOffset)
+        internal static unsafe int ReadAtOffset(SafeFileHandle handle, Span<byte> buffer, long fileOffset)
         {
             fixed (byte* bufPtr = &MemoryMarshal.GetReference(buffer))
             {
@@ -34,7 +34,7 @@ namespace System.IO
             }
         }
 
-        private static unsafe long ReadScatterAtOffset(SafeFileHandle handle, IReadOnlyList<Memory<byte>> buffers, long fileOffset)
+        internal static unsafe long ReadScatterAtOffset(SafeFileHandle handle, IReadOnlyList<Memory<byte>> buffers, long fileOffset)
         {
             MemoryHandle[] handles = new MemoryHandle[buffers.Count];
             Span<Interop.Sys.IOVector> vectors = buffers.Count <= IovStackThreshold ? stackalloc Interop.Sys.IOVector[IovStackThreshold] : new Interop.Sys.IOVector[buffers.Count];
@@ -74,7 +74,7 @@ namespace System.IO
             long fileOffset, CancellationToken cancellationToken)
             => ScheduleSyncReadScatterAtOffsetAsync(handle, buffers, fileOffset, cancellationToken);
 
-        private static unsafe int WriteAtOffset(SafeFileHandle handle, ReadOnlySpan<byte> buffer, long fileOffset)
+        internal static unsafe int WriteAtOffset(SafeFileHandle handle, ReadOnlySpan<byte> buffer, long fileOffset)
         {
             fixed (byte* bufPtr = &MemoryMarshal.GetReference(buffer))
             {
@@ -84,7 +84,7 @@ namespace System.IO
             }
         }
 
-        private static unsafe long WriteGatherAtOffset(SafeFileHandle handle, IReadOnlyList<ReadOnlyMemory<byte>> buffers, long fileOffset)
+        internal static unsafe long WriteGatherAtOffset(SafeFileHandle handle, IReadOnlyList<ReadOnlyMemory<byte>> buffers, long fileOffset)
         {
             MemoryHandle[] handles = new MemoryHandle[buffers.Count];
             Span<Interop.Sys.IOVector> vectors = buffers.Count <= IovStackThreshold ? stackalloc Interop.Sys.IOVector[IovStackThreshold] : new Interop.Sys.IOVector[buffers.Count ];

--- a/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.Windows.cs
@@ -213,17 +213,17 @@ namespace System.IO
                 ? Map(QueueAsyncReadFile(handle, buffer, fileOffset, cancellationToken))
                 : ScheduleSyncReadAtOffsetAsync(handle, buffer, fileOffset, cancellationToken);
 
-        private static ValueTask<int> Map((SafeFileHandle.ValueTaskSource? vts, int errorCode) tuple)
+        private static ValueTask<int> Map((SafeFileHandle.OverlappedValueTaskSource? vts, int errorCode) tuple)
             => tuple.vts != null
                 ? new ValueTask<int>(tuple.vts, tuple.vts.Version)
                 : tuple.errorCode == 0 ? ValueTask.FromResult(0) : ValueTask.FromException<int>(Win32Marshal.GetExceptionForWin32Error(tuple.errorCode));
 
-        internal static unsafe (SafeFileHandle.ValueTaskSource? vts, int errorCode) QueueAsyncReadFile(
+        internal static unsafe (SafeFileHandle.OverlappedValueTaskSource? vts, int errorCode) QueueAsyncReadFile(
             SafeFileHandle handle, Memory<byte> buffer, long fileOffset, CancellationToken cancellationToken)
         {
             handle.EnsureThreadPoolBindingInitialized();
 
-            SafeFileHandle.ValueTaskSource vts = handle.GetValueTaskSource();
+            SafeFileHandle.OverlappedValueTaskSource vts = handle.GetOverlappedValueTaskSource();
             try
             {
                 NativeOverlapped* nativeOverlapped = vts.PrepareForOperation(buffer, fileOffset);
@@ -274,12 +274,12 @@ namespace System.IO
                 ? Map(QueueAsyncWriteFile(handle, buffer, fileOffset, cancellationToken))
                 : ScheduleSyncWriteAtOffsetAsync(handle, buffer, fileOffset, cancellationToken);
 
-        internal static unsafe (SafeFileHandle.ValueTaskSource? vts, int errorCode) QueueAsyncWriteFile(
+        internal static unsafe (SafeFileHandle.OverlappedValueTaskSource? vts, int errorCode) QueueAsyncWriteFile(
             SafeFileHandle handle, ReadOnlyMemory<byte> buffer, long fileOffset, CancellationToken cancellationToken)
         {
             handle.EnsureThreadPoolBindingInitialized();
 
-            SafeFileHandle.ValueTaskSource vts = handle.GetValueTaskSource();
+            SafeFileHandle.OverlappedValueTaskSource vts = handle.GetOverlappedValueTaskSource();
             try
             {
                 NativeOverlapped* nativeOverlapped = vts.PrepareForOperation(buffer, fileOffset);
@@ -439,7 +439,7 @@ namespace System.IO
         {
             handle.EnsureThreadPoolBindingInitialized();
 
-            SafeFileHandle.ValueTaskSource vts = handle.GetValueTaskSource();
+            SafeFileHandle.OverlappedValueTaskSource vts = handle.GetOverlappedValueTaskSource();
             try
             {
                 NativeOverlapped* nativeOverlapped = vts.PrepareForOperation(Memory<byte>.Empty, fileOffset);
@@ -595,7 +595,7 @@ namespace System.IO
         {
             handle.EnsureThreadPoolBindingInitialized();
 
-            SafeFileHandle.ValueTaskSource vts = handle.GetValueTaskSource();
+            SafeFileHandle.OverlappedValueTaskSource vts = handle.GetOverlappedValueTaskSource();
             try
             {
                 NativeOverlapped* nativeOverlapped = vts.PrepareForOperation(ReadOnlyMemory<byte>.Empty, fileOffset);
@@ -618,7 +618,7 @@ namespace System.IO
                         vts.Dispose();
                         return errorCode == Interop.Errors.ERROR_NO_DATA // EOF on a pipe. IO callback will not be called.
                             ? ValueTask.FromResult<int>(0)
-                            : ValueTask.FromException<int>(SafeFileHandle.ValueTaskSource.GetIOError(errorCode, path: null));
+                            : ValueTask.FromException<int>(SafeFileHandle.OverlappedValueTaskSource.GetIOError(errorCode, path: null));
                     }
                 }
             }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.Windows.cs
@@ -318,7 +318,7 @@ namespace System.IO
             return (vts, -1);
         }
 
-        private static long ReadScatterAtOffset(SafeFileHandle handle, IReadOnlyList<Memory<byte>> buffers, long fileOffset)
+        internal static long ReadScatterAtOffset(SafeFileHandle handle, IReadOnlyList<Memory<byte>> buffers, long fileOffset)
         {
             long total = 0;
 
@@ -340,7 +340,7 @@ namespace System.IO
             return total;
         }
 
-        private static long WriteGatherAtOffset(SafeFileHandle handle, IReadOnlyList<ReadOnlyMemory<byte>> buffers, long fileOffset)
+        internal static long WriteGatherAtOffset(SafeFileHandle handle, IReadOnlyList<ReadOnlyMemory<byte>> buffers, long fileOffset)
         {
             long total = 0;
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.cs
@@ -264,42 +264,28 @@ namespace System.IO
             }
         }
 
-        private static ValueTask<int> ScheduleSyncReadAtOffsetAsync(SafeFileHandle handle, Memory<byte> buffer, long fileOffset, CancellationToken cancellationToken)
+        private static ValueTask<int> ScheduleSyncReadAtOffsetAsync(SafeFileHandle handle, Memory<byte> buffer,
+            long fileOffset, CancellationToken cancellationToken)
         {
-            return new ValueTask<int>(Task.Factory.StartNew(static state =>
-            {
-                var args = ((SafeFileHandle handle, Memory<byte> buffer, long fileOffset))state!;
-                return ReadAtOffset(args.handle, args.buffer.Span, args.fileOffset);
-            }, (handle, buffer, fileOffset), cancellationToken, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default));
+            return handle.GetThreadPoolValueTaskSource().QueueRead(buffer, fileOffset, cancellationToken);
         }
 
         private static ValueTask<long> ScheduleSyncReadScatterAtOffsetAsync(SafeFileHandle handle, IReadOnlyList<Memory<byte>> buffers,
             long fileOffset, CancellationToken cancellationToken)
         {
-            return new ValueTask<long>(Task.Factory.StartNew(static state =>
-            {
-                var args = ((SafeFileHandle handle, IReadOnlyList<Memory<byte>> buffers, long fileOffset))state!;
-                return ReadScatterAtOffset(args.handle, args.buffers, args.fileOffset);
-            }, (handle, buffers, fileOffset), cancellationToken, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default));
+            return handle.GetThreadPoolValueTaskSource().QueueReadScatter(buffers, fileOffset, cancellationToken);
         }
 
-        private static ValueTask<int> ScheduleSyncWriteAtOffsetAsync(SafeFileHandle handle, ReadOnlyMemory<byte> buffer, long fileOffset, CancellationToken cancellationToken)
+        private static ValueTask<int> ScheduleSyncWriteAtOffsetAsync(SafeFileHandle handle, ReadOnlyMemory<byte> buffer,
+            long fileOffset, CancellationToken cancellationToken)
         {
-            return new ValueTask<int>(Task.Factory.StartNew(static state =>
-            {
-                var args = ((SafeFileHandle handle, ReadOnlyMemory<byte> buffer, long fileOffset))state!;
-                return WriteAtOffset(args.handle, args.buffer.Span, args.fileOffset);
-            }, (handle, buffer, fileOffset), cancellationToken, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default));
+            return handle.GetThreadPoolValueTaskSource().QueueWrite(buffer, fileOffset, cancellationToken);
         }
 
         private static ValueTask<long> ScheduleSyncWriteGatherAtOffsetAsync(SafeFileHandle handle, IReadOnlyList<ReadOnlyMemory<byte>> buffers,
             long fileOffset, CancellationToken cancellationToken)
         {
-            return new ValueTask<long>(Task.Factory.StartNew(static state =>
-            {
-                var args = ((SafeFileHandle handle, IReadOnlyList<ReadOnlyMemory<byte>> buffers, long fileOffset))state!;
-                return WriteGatherAtOffset(args.handle, args.buffers, args.fileOffset);
-            }, (handle, buffers, fileOffset), cancellationToken, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default));
+            return handle.GetThreadPoolValueTaskSource().QueueWriteGather(buffers, fileOffset, cancellationToken);
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.cs
@@ -52,7 +52,7 @@ namespace System.IO.Strategies
                 _filePosition += destination.Length;
             }
 
-            (SafeFileHandle.ValueTaskSource? vts, int errorCode) = RandomAccess.QueueAsyncReadFile(_fileHandle, destination, positionBefore, cancellationToken);
+            (SafeFileHandle.OverlappedValueTaskSource? vts, int errorCode) = RandomAccess.QueueAsyncReadFile(_fileHandle, destination, positionBefore, cancellationToken);
             return vts != null
                 ? new ValueTask<int>(vts, vts.Version)
                 : (errorCode == 0) ? ValueTask.FromResult(0) : ValueTask.FromException<int>(HandleIOError(positionBefore, errorCode));
@@ -81,7 +81,7 @@ namespace System.IO.Strategies
                 UpdateLengthOnChangePosition();
             }
 
-            (SafeFileHandle.ValueTaskSource? vts, int errorCode) = RandomAccess.QueueAsyncWriteFile(_fileHandle, source, positionBefore, cancellationToken);
+            (SafeFileHandle.OverlappedValueTaskSource? vts, int errorCode) = RandomAccess.QueueAsyncWriteFile(_fileHandle, source, positionBefore, cancellationToken);
             return vts != null
                 ? new ValueTask(vts, vts.Version)
                 : (errorCode == 0) ? ValueTask.CompletedTask : ValueTask.FromException(HandleIOError(positionBefore, errorCode));
@@ -95,7 +95,7 @@ namespace System.IO.Strategies
                 _filePosition = positionBefore;
             }
 
-            return SafeFileHandle.ValueTaskSource.GetIOError(errorCode, _path);
+            return SafeFileHandle.OverlappedValueTaskSource.GetIOError(errorCode, _path);
         }
 
         public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask; // no buffering = nothing to flush


### PR DESCRIPTION
Until now, every time an async file I/O operation could not complete truly asynchronously (meaning on Windows when the file handle is not opened for async I/O and on non-Windows always), the operation would be scheduled to run on a thread pool thread. This scheduling used to be performed by calling `Task.Factory.StartNew`, and wrapping the `Task` to a `ValueTask`.

The problem with this approach is that contrary to `ValueTask`'s philosophy and to Windows' behavior when using async file handles, every async I/O operation on the thread pool would allocate. This PR addresses that.

A new class named `SafeFileHandle.ThreadPoolValueTaskSource` was created in the mold of the existing Windows-only `ValueTaskSource` (which was renamed to `OverlappedValueTaskSource`) that schedules `RandomAccess` file operations on the thread pool. This class implements `IValueTaskSource` of `int` and `long` (to support both regular and vectored I/O) but also `IThreadPoolWorkItem` to directly queue itself on the thread pool. Combined with a reusing mechanism like `OverlappedValueTaskSource`'s, it allows async `RandomAccess` I/O to be always amortized allocation-free per `SafeFileHandle`, when used non-concurrently.