### PR TITLE
[Mono] Fix inconsistent linkage error in dynamic component build on Windows.

### DIFF
--- a/src/mono/mono/sgen/gc-internal-agnostic.h
+++ b/src/mono/mono/sgen/gc-internal-agnostic.h
@@ -110,7 +110,7 @@ word aligned or size is not a multiple of word size.
 */
 void mono_gc_bzero_atomic (void *dest, size_t size);
 void mono_gc_bzero_aligned (void *dest, size_t size);
-void mono_gc_memmove_atomic (void *dest, const void *src, size_t size);
+MONO_COMPONENT_API void mono_gc_memmove_atomic (void *dest, const void *src, size_t size);
 void mono_gc_memmove_aligned (void *dest, const void *src, size_t size);
 
 FILE *mono_gc_get_logfile (void);


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/54887 added `MONO_COMPONENT_API` to mono_gc_memmove_atomic.h, but that function is declared in two different headers, memfuncs.h and gc-internal-agnostic.h and the second one didn't use `MONO_COMPONENT_API` causing inconsistent linking errors on Windows when building dynamic components.