### PR TITLE
Fix morph negation transforms

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -14179,15 +14179,14 @@ DONE_MORPHING_CHILDREN:
                     }
                 }
 
-                if (opts.OptimizationEnabled() && fgGlobalMorph &&
-                    (((op1->gtFlags & GTF_EXCEPT) == 0) || ((op2->gtFlags & GTF_EXCEPT) == 0)))
+                if (opts.OptimizationEnabled() && fgGlobalMorph)
                 {
                     // - a + b = > b - a
                     // ADD((NEG(a), b) => SUB(b, a)
 
                     // Skip optimization if non-NEG operand is constant.
-                    if (op1->OperIs(GT_NEG) && !op2->OperIs(GT_NEG) &&
-                        !(op2->IsCnsIntOrI() && varTypeIsIntegralOrI(typ)))
+                    if (op1->OperIs(GT_NEG) && !op2->OperIs(GT_NEG) && !op2->IsIntegralConst() &&
+                        gtCanSwapOrder(op1, op2))
                     {
                         // tree: ADD
                         // op1: NEG

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13955,8 +13955,7 @@ DONE_MORPHING_CHILDREN:
 
             // Skip optimization if non-NEG operand is constant.
             // Both op1 and op2 are not constant because it was already checked above.
-            if (opts.OptimizationEnabled() && fgGlobalMorph &&
-                (((op1->gtFlags & GTF_EXCEPT) == 0) || ((op2->gtFlags & GTF_EXCEPT) == 0)))
+            if (opts.OptimizationEnabled() && fgGlobalMorph)
             {
                 // a - -b = > a + b
                 // SUB(a, (NEG(b)) => ADD(a, b)
@@ -13981,7 +13980,7 @@ DONE_MORPHING_CHILDREN:
                 // -a - -b = > b - a
                 // SUB(NEG(a), (NEG(b)) => SUB(b, a)
 
-                if (op1->OperIs(GT_NEG) && op2->OperIs(GT_NEG))
+                if (op1->OperIs(GT_NEG) && op2->OperIs(GT_NEG) && gtCanSwapOrder(op1, op2))
                 {
                     // tree: SUB
                     // op1: NEG

--- a/src/tests/JIT/Regression/JitBlue/Runtime_55140/Runtime_55140.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_55140/Runtime_55140.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Runtime.CompilerServices;
+
+public class Runtime_52864
+{
+    private static int _value;
+
+    public static int Main()
+    {
+        _value = 100;
+        if (TestSubNegNeg() is not 1 and var subNegNeg)
+        {
+            Console.WriteLine($"TestSubNegNeg returned: {subNegNeg}. Expected: 1");
+            return 101;
+        }
+
+        _value = 100;
+        if (TestAddNeg() is not 1 and var addNeg)
+        {
+            Console.WriteLine($"TestAddNeg returned: {addNeg}. Expected: 1");
+            return 102;
+        }
+
+        return 100;
+    }
+
+    // Test that the ADD(NEG(a), b) => SUB(b, a) transform does not reorder persistent side effects.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int TestAddNeg()
+    {
+        return -Increment() + _value;
+    }
+
+    // Test that the SUB(NEG(a), NEG(b)) => SUB(b, a) transform does not reorder persistent side effects.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int TestSubNegNeg()
+    {
+        return -Increment() - -_value;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Increment() => _value++;
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_55140/Runtime_55140.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_55140/Runtime_55140.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Runtime.CompilerServices;
 
-public class Runtime_52864
+public class Runtime_55140
 {
     private static int _value;
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_55140/Runtime_55140.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_55140/Runtime_55140.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_55140/Runtime_55140.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_55140/Runtime_55140.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The short version of the bug is that the transforms in question did not account for persistent side effects, which could lead to silent bad codegen. Also, the `GTF_EXCEPT` guards were unnecessary for transforms that did not reorder operands.

This change leads to one diff in the benchmarks, a regression of 2 bytes, caused by the fact that `gtCanSwapOrder` does not understand that we can swap when both trees have `GTF_GLOB_REF` set, but no other effects on them:

```diff
-               [000078] ----G+------              \--*  SUB       int
-               [000077] ----G+------                 +--*  LCL_VAR   int   (AX) V11 loc6
-               [000075] ----G+------                 \--*  LCL_VAR   int   (AX) V08 loc3
+               [000078] ----G+------              \--*  ADD       int
+               [000076] ----G+------                 +--*  NEG       int
+               [000075] ----G+------                 |  \--*  LCL_VAR   int   (AX) V08 loc3
+               [000077] ----G+------                 \--*  LCL_VAR   int   (AX) V11 loc6
```

Fixes #55140.

Note: I am aware that `gtCanSwapOrder` is not without its problems as well, but it still seems decidedly better to use it instead of bespoke guards.