### PR TITLE
[Mono] Increase EventPipe profiler sampling thread priority.

### DIFF
--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -530,6 +530,15 @@ ep_rt_mono_thread_setup (bool background_thread)
 static
 inline
 void
+ep_rt_mono_thread_setup_2 (bool background_thread, EventPipeThreadType thread_type)
+{
+	extern void * ep_rt_mono_thread_attach_2 (bool background_thread, EventPipeThreadType thread_type);
+	ep_rt_mono_thread_attach_2 (background_thread, thread_type);
+}
+
+static
+inline
+void
 ep_rt_mono_thread_teardown (void)
 {
 	extern void ep_rt_mono_thread_detach (void);
@@ -1233,7 +1242,7 @@ EP_RT_DEFINE_THREAD_FUNC (ep_rt_thread_mono_start_func)
 {
 	rt_mono_thread_params_internal_t *thread_params = (rt_mono_thread_params_internal_t *)data;
 
-	ep_rt_mono_thread_setup (thread_params->background_thread);
+	ep_rt_mono_thread_setup_2 (thread_params->background_thread, thread_params->thread_params.thread_type);
 
 	thread_params->thread_params.thread = ep_rt_thread_get_handle ();
 	mono_thread_start_return_t result = thread_params->thread_params.thread_func (thread_params);


### PR DESCRIPTION
Mono profiler sampling thread tries to increase thread priority on sample thread if possible, https://github.com/dotnet/runtime/blob/607f98c888b31566c773712c3153236c7cec05d2/src/mono/mono/mini/mini-posix.c#L644. This is not always possible since it requires additional permissions on some platforms and won't work at all on others, but we at least try to increase priority and ignore failure if not possible.

The sampling thread used by EventPipe sample profiler does not raise priority and will run using process default priority. This PR adds logic for EventPipe sample profiler thread when running on Mono to try to increase priority, first trying to set max priority using SCHED_RR (similar to Mono profiler sampling thread) policy and if that doesn't work, fall back to max priority for current policy.