### PR TITLE
Add FreeBSD terminfo location

### DIFF
--- a/src/libraries/System.Console/src/System/TermInfo.cs
+++ b/src/libraries/System.Console/src/System/TermInfo.cs
@@ -178,7 +178,8 @@ namespace System
                     "/etc/terminfo",
                     "/lib/terminfo",
                     "/usr/share/terminfo",
-                    "/usr/share/misc/terminfo"
+                    "/usr/share/misc/terminfo",
+                    "/usr/local/share/terminfo"
                 };
 
             /// <summary>Read the database for the specified terminal.</summary>


### PR DESCRIPTION
* terminfo under FreeBSD no longer uses a hashed database but instead uses the more common "directory tree" style. 
* This fixes like 1 failing runtime test for `System.Console` under FreeBSD. 
* Please install `terminfo-db` via `pkg` before building under FreeBSD. `ncurses` no longer covers this.

resolves: https://github.com/dotnet/runtime/issues/23653

