### PR TITLE
Handle FileOptions.DeleteOnClose on Unix in SafeFileHandle.Dispose

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/File/OpenHandle.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/OpenHandle.cs
@@ -56,15 +56,18 @@ namespace System.IO.Tests
             }
         }
 
-        // Unix doesn't directly support DeleteOnClose
-        // For FileStream created out of path, we mimic it by closing the handle first
-        // and then unlinking the path
-        // Since SafeFileHandle does not always have the path and we can't find path for given file descriptor on Unix
-        // this test runs only on Windows
-        [PlatformSpecific(TestPlatforms.Windows)]
         [Theory]
         [InlineData(FileOptions.DeleteOnClose)]
         [InlineData(FileOptions.DeleteOnClose | FileOptions.Asynchronous)]
-        public override void DeleteOnClose_FileDeletedAfterClose(FileOptions options) => base.DeleteOnClose_FileDeletedAfterClose(options);
+        public void DeleteOnClose_FileDeletedAfterSafeHandleDispose(FileOptions options)
+        {
+            string path = GetTestFilePath();
+            Assert.False(File.Exists(path));
+            using (SafeFileHandle sfh = File.OpenHandle(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None, options))
+            {
+                Assert.True(File.Exists(path));
+            }
+            Assert.False(File.Exists(path));
+        }
     }
 }

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/Name.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/Name.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using System.Tests;
+using Microsoft.Win32.SafeHandles;
 using Xunit;
 
 namespace System.IO.Tests
@@ -35,14 +36,29 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public void NameReturnsUnknownForHandle()
+        public void ConstructFileStreamFromHandle_NameMatchesOriginal()
         {
-            using (new ThreadCultureChange(CultureInfo.InvariantCulture))
-            using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.ReadWrite))
-            using (FileStream fsh = new FileStream(fs.SafeFileHandle, FileAccess.ReadWrite))
-            {
-                Assert.Equal("[Unknown]", fsh.Name);
-            }
+            string path = GetTestFilePath();
+            using var _ = new ThreadCultureChange(CultureInfo.InvariantCulture);
+
+            using FileStream fs = new FileStream(path, FileMode.Create, FileAccess.ReadWrite);
+            Assert.Equal(path, fs.Name);
+
+            using FileStream fsh = new FileStream(fs.SafeFileHandle, FileAccess.ReadWrite);
+            Assert.Equal(path, fsh.Name);
+        }
+
+        [Fact]
+        public void ConstructFileStreamFromHandleClone_NameReturnsUnknown()
+        {
+            string path = GetTestFilePath();
+            using var _ = new ThreadCultureChange(CultureInfo.InvariantCulture);
+
+            using FileStream fs = new FileStream(path, FileMode.Create, FileAccess.ReadWrite);
+            Assert.Equal(path, fs.Name);
+
+            using FileStream fsh = new FileStream(new SafeFileHandle(fs.SafeFileHandle.DangerousGetHandle(), ownsHandle: false), FileAccess.ReadWrite);
+            Assert.Equal("[Unknown]", fsh.Name);
         }
     }
 }

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs_buffer_fo.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs_buffer_fo.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Win32.SafeHandles;
 using Xunit;
 
 namespace System.IO.Tests
@@ -79,7 +80,7 @@ namespace System.IO.Tests
         [Theory]
         [InlineData(FileOptions.DeleteOnClose)]
         [InlineData(FileOptions.DeleteOnClose | FileOptions.Asynchronous)]
-        public virtual void DeleteOnClose_FileDeletedAfterClose(FileOptions options)
+        public void DeleteOnClose_FileDeletedAfterClose(FileOptions options)
         {
             string path = GetTestFilePath();
             Assert.False(File.Exists(path));
@@ -88,6 +89,38 @@ namespace System.IO.Tests
                 Assert.True(File.Exists(path));
             }
             Assert.False(File.Exists(path));
+        }
+
+        [Theory]
+        [InlineData(FileOptions.DeleteOnClose)]
+        [InlineData(FileOptions.DeleteOnClose | FileOptions.Asynchronous)]
+        public void DeleteOnClose_FileDeletedAfterSafeHandleRelease(FileOptions options)
+        {
+            string path = GetTestFilePath();
+            Assert.False(File.Exists(path));
+
+            using (FileStream fs = CreateFileStream(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 0x1000, options))
+            {
+                Assert.True(File.Exists(path));
+
+                bool added = false;
+                try
+                {
+                    fs.SafeFileHandle.DangerousAddRef(ref added);
+
+                    fs.Dispose();
+                    Assert.True(File.Exists(path));
+                }
+                finally
+                {
+                    if (added)
+                    {
+                        fs.SafeFileHandle.DangerousRelease();
+                    }
+
+                    Assert.False(File.Exists(path));
+                }
+            }
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.OverlappedValueTaskSource.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.OverlappedValueTaskSource.Windows.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Win32.SafeHandles
             internal static readonly IOCompletionCallback s_ioCallback = IOCallback;
 
             internal readonly PreAllocatedOverlapped _preallocatedOverlapped;
-            private readonly SafeFileHandle _fileHandle;
+            internal readonly SafeFileHandle _fileHandle;
             internal MemoryHandle _memoryHandle;
             internal ManualResetValueTaskSourceCore<int> _source; // mutable struct; do not make this readonly
             private NativeOverlapped* _overlapped;

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Win32.SafeHandles
     {
         // not using bool? as it's not thread safe
         private volatile NullableBool _canSeek = NullableBool.Undefined;
-        private string? _path;
         private bool _deleteOnClose;
 
         public SafeFileHandle() : this(ownsHandle: true)
@@ -38,6 +37,7 @@ namespace Microsoft.Win32.SafeHandles
         {
             Debug.Assert(path != null);
             SafeFileHandle handle = Interop.Sys.Open(path, flags, mode);
+            handle._path = path;
 
             if (handle.IsInvalid)
             {
@@ -53,7 +53,7 @@ namespace Microsoft.Win32.SafeHandles
 
                 bool isDirectory = (error.Error == Interop.Error.ENOENT) &&
                     ((flags & Interop.Sys.OpenFlags.O_CREAT) != 0
-                    || !DirectoryExists(Path.GetDirectoryName(Path.TrimEndingDirectorySeparator(path!))!));
+                    || !DirectoryExists(System.IO.Path.GetDirectoryName(System.IO.Path.TrimEndingDirectorySeparator(path!))!));
 
                 Interop.CheckIo(
                     error.Error,
@@ -246,7 +246,6 @@ namespace Microsoft.Win32.SafeHandles
 
         private void Init(string path, FileMode mode, FileAccess access, FileShare share, FileOptions options, long preallocationSize)
         {
-            _path = path;
             IsAsync = (options & FileOptions.Asynchronous) != 0;
             _deleteOnClose = (options & FileOptions.DeleteOnClose) != 0;
 

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
@@ -103,6 +103,7 @@ namespace Microsoft.Win32.SafeHandles
                 throw Win32Marshal.GetExceptionForWin32Error(errorCode, fullPath);
             }
 
+            fileHandle._path = fullPath;
             fileHandle._fileOptions = options;
             return fileHandle;
         }

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.cs
@@ -7,9 +7,13 @@ namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeFileHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
+        private string? _path;
+
         public SafeFileHandle(IntPtr preexistingHandle, bool ownsHandle) : base(ownsHandle)
         {
             SetHandle(preexistingHandle);
         }
+
+        internal string? Path => _path;
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.Unix.cs
@@ -17,10 +17,10 @@ namespace System.IO
         // that get stackalloced in the Linux kernel.
         private const int IovStackThreshold = 8;
 
-        internal static long GetFileLength(SafeFileHandle handle, string? path)
+        internal static long GetFileLength(SafeFileHandle handle)
         {
             int result = Interop.Sys.FStat(handle, out Interop.Sys.FileStatus status);
-            FileStreamHelpers.CheckFileCall(result, path);
+            FileStreamHelpers.CheckFileCall(result, handle.Path);
             return status.Size;
         }
 
@@ -29,7 +29,7 @@ namespace System.IO
             fixed (byte* bufPtr = &MemoryMarshal.GetReference(buffer))
             {
                 int result = Interop.Sys.PRead(handle, bufPtr, buffer.Length, fileOffset);
-                FileStreamHelpers.CheckFileCall(result, path: null);
+                FileStreamHelpers.CheckFileCall(result, handle.Path);
                 return result;
             }
         }
@@ -64,7 +64,7 @@ namespace System.IO
                 }
             }
 
-            return FileStreamHelpers.CheckFileCall(result, path: null);
+            return FileStreamHelpers.CheckFileCall(result, handle.Path);
         }
 
         private static ValueTask<int> ReadAtOffsetAsync(SafeFileHandle handle, Memory<byte> buffer, long fileOffset, CancellationToken cancellationToken)
@@ -79,7 +79,7 @@ namespace System.IO
             fixed (byte* bufPtr = &MemoryMarshal.GetReference(buffer))
             {
                 int result = Interop.Sys.PWrite(handle, bufPtr, buffer.Length, fileOffset);
-                FileStreamHelpers.CheckFileCall(result, path: null);
+                FileStreamHelpers.CheckFileCall(result, handle.Path);
                 return  result;
             }
         }
@@ -114,7 +114,7 @@ namespace System.IO
                 }
             }
 
-            return FileStreamHelpers.CheckFileCall(result, path: null);
+            return FileStreamHelpers.CheckFileCall(result, handle.Path);
         }
 
         private static ValueTask<int> WriteAtOffsetAsync(SafeFileHandle handle, ReadOnlyMemory<byte> buffer, long fileOffset, CancellationToken cancellationToken)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.Windows.cs
@@ -16,23 +16,23 @@ namespace System.IO
     {
         private static readonly IOCompletionCallback s_callback = AllocateCallback();
 
-        internal static unsafe long GetFileLength(SafeFileHandle handle, string? path)
+        internal static unsafe long GetFileLength(SafeFileHandle handle)
         {
             Interop.Kernel32.FILE_STANDARD_INFO info;
 
             if (!Interop.Kernel32.GetFileInformationByHandleEx(handle, Interop.Kernel32.FileStandardInfo, &info, (uint)sizeof(Interop.Kernel32.FILE_STANDARD_INFO)))
             {
-                throw Win32Marshal.GetExceptionForLastWin32Error(path);
+                throw Win32Marshal.GetExceptionForLastWin32Error(handle.Path);
             }
 
             return info.EndOfFile;
         }
 
-        internal static unsafe int ReadAtOffset(SafeFileHandle handle, Span<byte> buffer, long fileOffset, string? path = null)
+        internal static unsafe int ReadAtOffset(SafeFileHandle handle, Span<byte> buffer, long fileOffset)
         {
             if (handle.IsAsync)
             {
-                return ReadSyncUsingAsyncHandle(handle, buffer, fileOffset, path);
+                return ReadSyncUsingAsyncHandle(handle, buffer, fileOffset);
             }
 
             NativeOverlapped overlapped = GetNativeOverlappedForSyncHandle(handle, fileOffset);
@@ -55,12 +55,12 @@ namespace System.IO
                         // For pipes, ERROR_BROKEN_PIPE is the normal end of the pipe.
                         return 0;
                     default:
-                        throw Win32Marshal.GetExceptionForWin32Error(errorCode, path);
+                        throw Win32Marshal.GetExceptionForWin32Error(errorCode, handle.Path);
                 }
             }
         }
 
-        private static unsafe int ReadSyncUsingAsyncHandle(SafeFileHandle handle, Span<byte> buffer, long fileOffset, string? path)
+        private static unsafe int ReadSyncUsingAsyncHandle(SafeFileHandle handle, Span<byte> buffer, long fileOffset)
         {
             handle.EnsureThreadPoolBindingInitialized();
 
@@ -105,7 +105,7 @@ namespace System.IO
                             return 0;
 
                         default:
-                            throw Win32Marshal.GetExceptionForWin32Error(errorCode, path);
+                            throw Win32Marshal.GetExceptionForWin32Error(errorCode, handle.Path);
                     }
                 }
             }
@@ -120,11 +120,11 @@ namespace System.IO
             }
         }
 
-        internal static unsafe int WriteAtOffset(SafeFileHandle handle, ReadOnlySpan<byte> buffer, long fileOffset, string? path = null)
+        internal static unsafe int WriteAtOffset(SafeFileHandle handle, ReadOnlySpan<byte> buffer, long fileOffset)
         {
             if (handle.IsAsync)
             {
-                return WriteSyncUsingAsyncHandle(handle, buffer, fileOffset, path);
+                return WriteSyncUsingAsyncHandle(handle, buffer, fileOffset);
             }
 
             NativeOverlapped overlapped = GetNativeOverlappedForSyncHandle(handle, fileOffset);
@@ -141,12 +141,12 @@ namespace System.IO
                     case Interop.Errors.ERROR_NO_DATA: // EOF on a pipe
                         return 0;
                     default:
-                        throw Win32Marshal.GetExceptionForWin32Error(errorCode, path);
+                        throw Win32Marshal.GetExceptionForWin32Error(errorCode, handle.Path);
                 }
             }
         }
 
-        private static unsafe int WriteSyncUsingAsyncHandle(SafeFileHandle handle, ReadOnlySpan<byte> buffer, long fileOffset, string? path)
+        private static unsafe int WriteSyncUsingAsyncHandle(SafeFileHandle handle, ReadOnlySpan<byte> buffer, long fileOffset)
         {
             handle.EnsureThreadPoolBindingInitialized();
 
@@ -193,7 +193,7 @@ namespace System.IO
                             throw new IOException(SR.IO_FileTooLong);
 
                         default:
-                            throw Win32Marshal.GetExceptionForWin32Error(errorCode, path);
+                            throw Win32Marshal.GetExceptionForWin32Error(errorCode, handle.Path);
                     }
                 }
             }
@@ -469,7 +469,7 @@ namespace System.IO
                         default:
                             // Error. Callback will not be called.
                             vts.Dispose();
-                            return ValueTask.FromException<int>(Win32Marshal.GetExceptionForWin32Error(errorCode));
+                            return ValueTask.FromException<int>(Win32Marshal.GetExceptionForWin32Error(errorCode, handle.Path));
                     }
                 }
             }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.cs
@@ -23,7 +23,7 @@ namespace System.IO
         {
             ValidateInput(handle, fileOffset: 0);
 
-            return GetFileLength(handle, path: null);
+            return GetFileLength(handle);
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.cs
@@ -95,7 +95,7 @@ namespace System.IO.Strategies
                 _filePosition = positionBefore;
             }
 
-            return SafeFileHandle.OverlappedValueTaskSource.GetIOError(errorCode, _path);
+            return SafeFileHandle.OverlappedValueTaskSource.GetIOError(errorCode, _fileHandle.Path);
         }
 
         public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask; // no buffering = nothing to flush
@@ -131,7 +131,7 @@ namespace System.IO.Strategies
             try
             {
                 await FileStreamHelpers
-                    .AsyncModeCopyToAsync(_fileHandle, _path, CanSeek, _filePosition, destination, bufferSize, cancellationToken)
+                    .AsyncModeCopyToAsync(_fileHandle, CanSeek, _filePosition, destination, bufferSize, cancellationToken)
                     .ConfigureAwait(false);
             }
             finally

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/Net5CompatFileStreamStrategy.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/Net5CompatFileStreamStrategy.Unix.cs
@@ -108,7 +108,7 @@ namespace System.IO.Strategies
 
                         if (SafeFileHandle.t_lastCloseErrorInfo != null)
                         {
-                            throw Interop.GetExceptionForIoErrno(SafeFileHandle.t_lastCloseErrorInfo.GetValueOrDefault(), _path, isDirectory: false);
+                            throw Interop.GetExceptionForIoErrno(SafeFileHandle.t_lastCloseErrorInfo.GetValueOrDefault(), _fileHandle.Path, isDirectory: false);
                         }
                     }
                 }
@@ -156,7 +156,7 @@ namespace System.IO.Strategies
                         // doesn't support synchronization.  In such cases there's nothing to flush.
                         break;
                     default:
-                        throw Interop.GetExceptionForIoErrno(errorInfo, _path, isDirectory: false);
+                        throw Interop.GetExceptionForIoErrno(errorInfo, _fileHandle.Path, isDirectory: false);
                 }
             }
         }
@@ -604,14 +604,14 @@ namespace System.IO.Strategies
             Debug.Assert(fileHandle.CanSeek);
             Debug.Assert(origin >= SeekOrigin.Begin && origin <= SeekOrigin.End);
 
-            long pos = FileStreamHelpers.CheckFileCall(Interop.Sys.LSeek(fileHandle, offset, (Interop.Sys.SeekWhence)(int)origin), _path); // SeekOrigin values are the same as Interop.libc.SeekWhence values
+            long pos = FileStreamHelpers.CheckFileCall(Interop.Sys.LSeek(fileHandle, offset, (Interop.Sys.SeekWhence)(int)origin), fileHandle.Path); // SeekOrigin values are the same as Interop.libc.SeekWhence values
             _filePosition = pos;
             return pos;
         }
 
         private int CheckFileCall(int result, bool ignoreNotSupported = false)
         {
-            FileStreamHelpers.CheckFileCall(result, _path, ignoreNotSupported);
+            FileStreamHelpers.CheckFileCall(result, _fileHandle?.Path, ignoreNotSupported);
 
             return result;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/Net5CompatFileStreamStrategy.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/Net5CompatFileStreamStrategy.Unix.cs
@@ -66,7 +66,7 @@ namespace System.IO.Strategies
             get
             {
                 // Get the length of the file as reported by the OS
-                long length = RandomAccess.GetFileLength(_fileHandle, _path);
+                long length = RandomAccess.GetFileLength(_fileHandle);
 
                 // But we may have buffered some data to be written that puts our length
                 // beyond what the OS is aware of.  Update accordingly.

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/Net5CompatFileStreamStrategy.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/Net5CompatFileStreamStrategy.Unix.cs
@@ -98,16 +98,6 @@ namespace System.IO.Strategies
                         // e.g. if this stream is wrapping a pipe and the pipe is now broken.
                     }
 
-                    // If DeleteOnClose was requested when constructed, delete the file now.
-                    // (Unix doesn't directly support DeleteOnClose, so we mimic it here.)
-                    if (_path != null && (_options & FileOptions.DeleteOnClose) != 0)
-                    {
-                        // Since we still have the file open, this will end up deleting
-                        // it (assuming we're the only link to it) once it's closed, but the
-                        // name will be removed immediately.
-                        Interop.Sys.Unlink(_path); // ignore errors; it's valid that the path may no longer exist
-                    }
-
                     // Closing the file handle can fail, e.g. due to out of disk space
                     // Throw these errors as exceptions when disposing
                     if (_fileHandle != null && !_fileHandle.IsClosed && disposing)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/Net5CompatFileStreamStrategy.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/Net5CompatFileStreamStrategy.Windows.cs
@@ -374,7 +374,7 @@ namespace System.IO.Strategies
                     if (errorCode == Interop.Errors.ERROR_INVALID_PARAMETER)
                         ThrowHelper.ThrowArgumentException_HandleNotSync(nameof(_fileHandle));
 
-                    throw Win32Marshal.GetExceptionForWin32Error(errorCode, _path);
+                    throw Win32Marshal.GetExceptionForWin32Error(errorCode, _fileHandle.Path);
                 }
             }
             Debug.Assert(r >= 0, "FileStream's ReadNative is likely broken.");
@@ -578,7 +578,7 @@ namespace System.IO.Strategies
                     // to a handle opened asynchronously.
                     if (errorCode == Interop.Errors.ERROR_INVALID_PARAMETER)
                         throw new IOException(SR.IO_FileTooLongOrHandleNotSync);
-                    throw Win32Marshal.GetExceptionForWin32Error(errorCode, _path);
+                    throw Win32Marshal.GetExceptionForWin32Error(errorCode, _fileHandle.Path);
                 }
             }
             Debug.Assert(r >= 0, "FileStream's WriteCore is likely broken.");
@@ -776,7 +776,7 @@ namespace System.IO.Strategies
                     }
                     else
                     {
-                        throw Win32Marshal.GetExceptionForWin32Error(errorCode, _path);
+                        throw Win32Marshal.GetExceptionForWin32Error(errorCode, _fileHandle.Path);
                     }
                 }
                 else if (cancellationToken.CanBeCanceled) // ERROR_IO_PENDING
@@ -978,7 +978,7 @@ namespace System.IO.Strategies
                     }
                     else
                     {
-                        throw Win32Marshal.GetExceptionForWin32Error(errorCode, _path);
+                        throw Win32Marshal.GetExceptionForWin32Error(errorCode, _fileHandle.Path);
                     }
                 }
                 else if (cancellationToken.CanBeCanceled) // ERROR_IO_PENDING

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/Net5CompatFileStreamStrategy.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/Net5CompatFileStreamStrategy.Windows.cs
@@ -99,7 +99,7 @@ namespace System.IO.Strategies
         {
             get
             {
-                long len = RandomAccess.GetFileLength(_fileHandle, _path);
+                long len = RandomAccess.GetFileLength(_fileHandle);
 
                 // If we're writing near the end of the file, we must include our
                 // internal buffer in our Length calculation.  Don't flush because
@@ -179,7 +179,7 @@ namespace System.IO.Strategies
             }
         }
 
-        private void FlushOSBuffer() => FileStreamHelpers.FlushToDisk(_fileHandle, _path);
+        private void FlushOSBuffer() => FileStreamHelpers.FlushToDisk(_fileHandle);
 
         // Returns a task that flushes the internal write buffer
         private Task FlushWriteAsync(CancellationToken cancellationToken)
@@ -266,7 +266,7 @@ namespace System.IO.Strategies
             Debug.Assert(value >= 0, "value >= 0");
             VerifyOSHandlePosition();
 
-            FileStreamHelpers.SetFileLength(_fileHandle, _path, value);
+            FileStreamHelpers.SetFileLength(_fileHandle, value);
 
             if (_filePosition > value)
             {
@@ -473,7 +473,7 @@ namespace System.IO.Strategies
         {
             Debug.Assert(fileHandle.CanSeek, "fileHandle.CanSeek");
 
-            return _filePosition = FileStreamHelpers.Seek(fileHandle, _path, offset, origin, closeInvalidHandle);
+            return _filePosition = FileStreamHelpers.Seek(fileHandle, offset, origin, closeInvalidHandle);
         }
 
         partial void OnBufferAllocated()
@@ -1100,7 +1100,7 @@ namespace System.IO.Strategies
             try
             {
                 await FileStreamHelpers
-                    .AsyncModeCopyToAsync(_fileHandle, _path, canSeek, _filePosition, destination, bufferSize, cancellationToken)
+                    .AsyncModeCopyToAsync(_fileHandle, canSeek, _filePosition, destination, bufferSize, cancellationToken)
                     .ConfigureAwait(false);
             }
             finally
@@ -1113,8 +1113,8 @@ namespace System.IO.Strategies
             }
         }
 
-        internal override void Lock(long position, long length) => FileStreamHelpers.Lock(_fileHandle, _path, position, length);
+        internal override void Lock(long position, long length) => FileStreamHelpers.Lock(_fileHandle, position, length);
 
-        internal override void Unlock(long position, long length) => FileStreamHelpers.Unlock(_fileHandle, _path, position, length);
+        internal override void Unlock(long position, long length) => FileStreamHelpers.Unlock(_fileHandle, position, length);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/Net5CompatFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/Net5CompatFileStreamStrategy.cs
@@ -19,9 +19,6 @@ namespace System.IO.Strategies
         /// <summary>Whether the file is opened for reading, writing, or both.</summary>
         private readonly FileAccess _access;
 
-        /// <summary>The path to the opened file.</summary>
-        private readonly string? _path;
-
         /// <summary>The next available byte to be read from the _buffer.</summary>
         private int _readPos;
 
@@ -82,7 +79,6 @@ namespace System.IO.Strategies
         {
             string fullPath = Path.GetFullPath(path);
 
-            _path = fullPath;
             _access = access;
             _bufferLength = bufferSize;
 
@@ -293,7 +289,7 @@ namespace System.IO.Strategies
             }
         }
 
-        internal override string Name => _path ?? SR.IO_UnknownFileName;
+        internal override string Name => _fileHandle.Path ?? SR.IO_UnknownFileName;
 
         internal override bool IsAsync => _useAsyncIO;
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/55132
cc: @dotnet/area-system-io 