### PR TITLE
[mono] Add constructor for jagged arrays

### DIFF
--- a/src/mono/mono/metadata/object-internals.h
+++ b/src/mono/mono/metadata/object-internals.h
@@ -1493,6 +1493,9 @@ mono_array_new_checked (MonoClass *eclass, uintptr_t n, MonoError *error);
 MONO_COMPONENT_API MonoArray*
 mono_array_new_full_checked (MonoClass *array_class, uintptr_t *lengths, intptr_t *lower_bounds, MonoError *error);
 
+MonoArray*
+mono_array_new_jagged_checked (MonoClass *klass, int n, uintptr_t *lengths, MonoError *error);
+
 ICALL_EXPORT
 MonoArray*
 ves_icall_array_new_specific (MonoVTable *vtable, uintptr_t n);

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -1060,7 +1060,13 @@ ves_array_create (MonoClass *klass, int param_count, stackval *values, MonoError
 	int rank = m_class_get_rank (klass);
 	uintptr_t *lengths = g_newa (uintptr_t, rank * 2);
 	intptr_t *lower_bounds = NULL;
-	if (2 * rank == param_count) {
+
+	if (param_count > rank && m_class_get_byval_arg (klass)->type == MONO_TYPE_SZARRAY) {
+		// Special constructor for jagged arrays
+		for (int i = 0; i < param_count; ++i)
+			lengths [i] = values [i].data.i;
+		return (MonoObject*) mono_array_new_jagged_checked (klass, param_count, lengths, error);
+	} else if (2 * rank == param_count) {
 		for (int l = 0; l < 2; ++l) {
 			int src = l;
 			int dst = l * rank;

--- a/src/mono/mono/mini/jit-icalls.c
+++ b/src/mono/mono/mini/jit-icalls.c
@@ -728,24 +728,29 @@ mono_array_new_n_icall (MonoMethod *cm, gint32 pcount, intptr_t *params)
 	const int pcount_sig = mono_method_signature_internal (cm)->param_count;
 	const int rank = m_class_get_rank (cm->klass);
 	g_assert (pcount == pcount_sig);
-	g_assert (rank == pcount || rank * 2 == pcount);
 
 	uintptr_t *lengths = (uintptr_t*)params;
+	MonoArray *arr;
 
-	if (rank == pcount) {
-		/* Only lengths provided. */
-		if (m_class_get_byval_arg (cm->klass)->type == MONO_TYPE_ARRAY) {
-			lower_bounds = g_newa (intptr_t, rank);
-			memset (lower_bounds, 0, sizeof (intptr_t) * rank);
-		}
+	if (pcount > rank && m_class_get_byval_arg (cm->klass)->type == MONO_TYPE_SZARRAY) {
+		// Special constructor for jagged arrays
+		arr = mono_array_new_jagged_checked (cm->klass, pcount, lengths, error);
 	} else {
-		g_assert (pcount == (rank * 2));
-		/* lower bounds are first. */
-		lower_bounds = params;
-		lengths += rank;
-	}
+		if (rank == pcount) {
+			/* Only lengths provided. */
+			if (m_class_get_byval_arg (cm->klass)->type == MONO_TYPE_ARRAY) {
+				lower_bounds = g_newa (intptr_t, rank);
+				memset (lower_bounds, 0, sizeof (intptr_t) * rank);
+			}
+		} else {
+			g_assert (pcount == (rank * 2));
+			/* lower bounds are first. */
+			lower_bounds = params;
+			lengths += rank;
+		}
 
-	MonoArray *arr = mono_array_new_full_checked (cm->klass, lengths, lower_bounds, error);
+		arr = mono_array_new_full_checked (cm->klass, lengths, lower_bounds, error);
+	}
 
 	return mono_error_set_pending_exception (error) ? NULL : arr;
 }

--- a/src/mono/mono/mini/jit-icalls.h
+++ b/src/mono/mono/mini/jit-icalls.h
@@ -56,6 +56,8 @@ ICALL_EXTERN_C gint64 mono_lshr (gint64 a, gint32 shamt);
 // For param_count > 4.
 ICALL_EXTERN_C MonoArray *mono_array_new_n_icall (MonoMethod *cm, gint32 param_count, intptr_t *params);
 
+ICALL_EXTERN_C MonoArray *mono_array_new_2_jagged (MonoMethod *cm, guint32 length1, guint32 length2);
+
 ICALL_EXTERN_C MonoArray *mono_array_new_1 (MonoMethod *cm, guint32 length);
 
 ICALL_EXTERN_C MonoArray *mono_array_new_2 (MonoMethod *cm, guint32 length1, guint32 length2);

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -8785,9 +8785,6 @@ calli_end:
 					}
 				}
 
-				/* Instancing jagged arrays should not end up here since ctor (int32, int32) for an array with rank 1 represents length and lbound. */
-				g_assert (!(rank == 1 && fsig->param_count == 2 && m_class_get_rank (m_class_get_element_class (cmethod->klass))));
-
 				/* Regular case, rank > 4 or legnth, lbound specified per rank. */
 				if (function == MONO_JIT_ICALL_ZeroIsReserved) {
 					// FIXME Maximum value of param_count? Realistically 64. Fits in imm?

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1039,9 +1039,6 @@
             <Issue>https://github.com/dotnet/runtime/issues/46174</Issue>
         </ExcludeList>
 
-        <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/Runtimelab_578/arr/*">
-            <Issue>https://github.com/dotnet/runtime/issues/47458</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/TieredCompilation/BasicTestWithMcj/*">
             <Issue>Tests features specific to coreclr</Issue>
         </ExcludeList>


### PR DESCRIPTION
Vectors normally have a single constructor that receives an argument representing the length. However, a vector of vectors can also receive two arguments, the length of the vector and the length of every element. This constructor is not specified in the spec, however it is implemented by coreclr.