### PR TITLE
Refactor subrange assertion generation and propagation

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1398,11 +1398,7 @@ bool Compiler::optTryExtractSubrangeAssertion(GenTree* source, ssize_t* pLoBound
             return false;
     }
 
-    if (varTypeIsSmall(sourceType)
-#ifdef TARGET_64BIT
-        || (sourceType == TYP_INT) || (sourceType == TYP_UINT)
-#endif
-        )
+    if (varTypeIsSmall(sourceType))
     {
         *pLoBound = AssertionDsc::GetLowerBoundForIntegralType(sourceType);
         *pHiBound = AssertionDsc::GetUpperBoundForIntegralType(sourceType);

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -2150,7 +2150,7 @@ AssertionIndex Compiler::optAssertionGenCast(GenTreeCast* cast)
     LclVarDsc*     varDsc = lvaGetDesc(lclVar);
 
     // It is not useful to make assertions about address-exposed variables, they will never be proven.
-    if (varDsc->lvAddrExposed)
+    if (varDsc->IsAddressExposed())
     {
         return NO_ASSERTION_INDEX;
     }

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1743,8 +1743,7 @@ bool Compiler::optTryExtractSubrangeAssertion(GenTree* source, IntegralRange* pR
             if (varTypeIsIntegral(source))
             {
                 IntegralRange castRange = IntegralRange::ForCastOutput(source->AsCast());
-                // TODO-Casts: change below to source->TypeGet() when BOX import is fixed to not have CAST(short).
-                IntegralRange nodeRange = IntegralRange::ForType(genActualType(source));
+                IntegralRange nodeRange = IntegralRange::ForType(source->TypeGet());
                 assert(nodeRange.Contains(castRange));
 
                 if (!castRange.Equals(nodeRange))

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -25,37 +25,16 @@ bool IntegralRange::Contains(int64_t value) const
 
 /* static */ int64_t IntegralRange::SymbolicToRealValue(SymbolicIntegerValue value)
 {
-    switch (value)
-    {
-        case SymbolicIntegerValue::LongMin:
-            return INT64_MIN;
-        case SymbolicIntegerValue::IntMin:
-            return INT32_MIN;
-        case SymbolicIntegerValue::ShortMin:
-            return INT16_MIN;
-        case SymbolicIntegerValue::ByteMin:
-            return INT8_MIN;
-        case SymbolicIntegerValue::Zero:
-            return 0;
-        case SymbolicIntegerValue::One:
-            return 1;
-        case SymbolicIntegerValue::ByteMax:
-            return INT8_MAX;
-        case SymbolicIntegerValue::UByteMax:
-            return UINT8_MAX;
-        case SymbolicIntegerValue::ShortMax:
-            return INT16_MAX;
-        case SymbolicIntegerValue::UShortMax:
-            return UINT16_MAX;
-        case SymbolicIntegerValue::IntMax:
-            return INT32_MAX;
-        case SymbolicIntegerValue::UIntMax:
-            return UINT32_MAX;
-        case SymbolicIntegerValue::LongMax:
-            return INT64_MAX;
-        default:
-            unreached();
-    }
+    static const int64_t SymbolicToRealMap[13] = {INT64_MIN, INT32_MIN,  INT16_MIN, INT8_MIN,  0,
+                                                  1,         INT8_MAX,   UINT8_MAX, INT16_MAX, UINT16_MAX,
+                                                  INT32_MAX, UINT32_MAX, INT64_MAX};
+
+    assert(sizeof(SymbolicIntegerValue) == sizeof(int32_t));
+    assert(SymbolicToRealMap[static_cast<int32_t>(SymbolicIntegerValue::LongMin)] == INT64_MIN);
+    assert(SymbolicToRealMap[static_cast<int32_t>(SymbolicIntegerValue::Zero)] == 0);
+    assert(SymbolicToRealMap[static_cast<int32_t>(SymbolicIntegerValue::LongMax)] == INT64_MAX);
+
+    return SymbolicToRealMap[static_cast<int32_t>(value)];
 }
 
 /* static */ SymbolicIntegerValue IntegralRange::LowerBoundForType(var_types type)

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -123,11 +123,7 @@ bool IntegralRange::Contains(int64_t value) const
 //
 // This routine computes the input range for a cast from
 // an integer to an integer for which it will not overflow.
-//
-// Note that the ranges computed by this method are **always** in the
-// "signed" domain. For example, a cast such as CAST_OVF(ulong <- uint)
-// will return [INT32_MIN..INT32_MAX], i. e. the operation does not
-// overflow for any possible input and the GTF_OVERFLOW flag is a no-op.
+// See also the specification comment for IntegralRange.
 //
 // Arguments:
 //    cast - the cast node for which the range will be computed

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4012,11 +4012,7 @@ GenTree* Compiler::optAssertionProp_Cast(ASSERT_VALARG_TP assertions, GenTreeCas
     }
 
     // Skip over a GT_COMMA node(s), if necessary to get to the lcl.
-    GenTree* lcl = op1;
-    while (lcl->OperIs(GT_COMMA))
-    {
-        lcl = lcl->AsOp()->gtGetOp2();
-    }
+    GenTree* lcl = op1->gtEffectiveVal();
 
     // If we don't have a cast of a LCL_VAR then bail.
     if (!lcl->OperIs(GT_LCL_VAR))
@@ -4060,14 +4056,7 @@ GenTree* Compiler::optAssertionProp_Cast(ASSERT_VALARG_TP assertions, GenTreeCas
                 return nullptr;
             }
 
-            GenTree* tmp = op1;
-            while (tmp->OperIs(GT_COMMA))
-            {
-                tmp->gtType = varDsc->TypeGet();
-                tmp         = tmp->AsOp()->gtGetOp2();
-            }
-            noway_assert(tmp == lcl);
-            tmp->gtType = varDsc->TypeGet();
+            op1->ChangeType(varDsc->TypeGet());
         }
 
 #ifdef DEBUG

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1369,6 +1369,24 @@ DONE_ASSERTION:
     return optAddAssertion(&assertion);
 }
 
+//------------------------------------------------------------------------
+// optTryExtractSubrangeAssertion: Extract the bounds of the value a tree produces.
+//
+// Generates [0..1] ranges for relops, [T_MIN..T_MAX] for small-typed indirections
+// and casts to small types.
+//
+// Arguments:
+//    source    - tree producing the value
+//    pLoBound  - out parameter for the lower bound
+//    pHiBound  - out parameter for the upper bound
+//
+// Return Value:
+//    "true" if the "source" computes a value narrower than the range of TYP_INT.
+//    "false" otherwise.
+//
+// Notes:
+//   The out parameters are only written to if the function returns "true".
+//
 bool Compiler::optTryExtractSubrangeAssertion(GenTree* source, ssize_t* pLoBound, ssize_t* pHiBound)
 {
     var_types sourceType = TYP_UNDEF;

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -15,6 +15,15 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #pragma hdrstop
 #endif
 
+//------------------------------------------------------------------------
+// Contains: Whether the range contains a given integral value, inclusive.
+//
+// Arguments:
+//    value - the integral value in question
+//
+// Return Value:
+//    "true" if the value is within the range's bounds, "false" otherwise.
+//
 bool IntegralRange::Contains(int64_t value) const
 {
     int64_t lowerBound = SymbolicToRealValue(m_lowerBound);
@@ -23,11 +32,20 @@ bool IntegralRange::Contains(int64_t value) const
     return (lowerBound <= value) && (value <= upperBound);
 }
 
+//------------------------------------------------------------------------
+// SymbolicToRealValue: Convert a symbolic value to a 64-bit signed integer.
+//
+// Arguments:
+//    value - the symbolic value in question
+//
+// Return Value:
+//    Integer correspoding to the symbolic value.
+//
 /* static */ int64_t IntegralRange::SymbolicToRealValue(SymbolicIntegerValue value)
 {
-    static const int64_t SymbolicToRealMap[13] = {INT64_MIN, INT32_MIN,  INT16_MIN, INT8_MIN,  0,
-                                                  1,         INT8_MAX,   UINT8_MAX, INT16_MAX, UINT16_MAX,
-                                                  INT32_MAX, UINT32_MAX, INT64_MAX};
+    static const int64_t SymbolicToRealMap[]{INT64_MIN, INT32_MIN,  INT16_MIN, INT8_MIN,  0,
+                                             1,         INT8_MAX,   UINT8_MAX, INT16_MAX, UINT16_MAX,
+                                             INT32_MAX, UINT32_MAX, INT64_MAX};
 
     assert(sizeof(SymbolicIntegerValue) == sizeof(int32_t));
     assert(SymbolicToRealMap[static_cast<int32_t>(SymbolicIntegerValue::LongMin)] == INT64_MIN);
@@ -37,6 +55,15 @@ bool IntegralRange::Contains(int64_t value) const
     return SymbolicToRealMap[static_cast<int32_t>(value)];
 }
 
+//------------------------------------------------------------------------
+// LowerBoundForType: Get the symbolic lower bound for a type.
+//
+// Arguments:
+//    type - the integral type in question
+//
+// Return Value:
+//    Symbolic value representing the smallest possible value "type" can represent.
+//
 /* static */ SymbolicIntegerValue IntegralRange::LowerBoundForType(var_types type)
 {
     switch (type)
@@ -58,6 +85,15 @@ bool IntegralRange::Contains(int64_t value) const
     }
 }
 
+//------------------------------------------------------------------------
+// UpperBoundForType: Get the symbolic upper bound for a type.
+//
+// Arguments:
+//    type - the integral type in question
+//
+// Return Value:
+//    Symbolic value representing the largest possible value "type" can represent.
+//
 /* static */ SymbolicIntegerValue IntegralRange::UpperBoundForType(var_types type)
 {
     switch (type)
@@ -83,7 +119,7 @@ bool IntegralRange::Contains(int64_t value) const
 }
 
 //------------------------------------------------------------------------
-// IntegralRange::ForCastInput: Get the non-overflowing input range for a cast.
+// ForCastInput: Get the non-overflowing input range for a cast.
 //
 // This routine computes the input range for a cast from
 // an integer to an integer for which it will not overflow.
@@ -195,7 +231,7 @@ bool IntegralRange::Contains(int64_t value) const
 }
 
 //------------------------------------------------------------------------
-// IntegralRange::ForCastOutput: Get the output range for a cast.
+// ForCastOutput: Get the output range for a cast.
 //
 // This method is the "output" counterpart to ForCastInput, it returns
 // a range produced by a cast (by definition, non-overflowing one).
@@ -4049,10 +4085,10 @@ GenTree* Compiler::optAssertionProp_Cast(ASSERT_VALARG_TP assertions, GenTreeCas
 }
 
 /*****************************************************************************
-*
-*  Given a tree with an array bounds check node, eliminate it because it was
-*  checked already in the program.
-*/
+ *
+ *  Given a tree with an array bounds check node, eliminate it because it was
+ *  checked already in the program.
+ */
 GenTree* Compiler::optAssertionProp_Comma(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt)
 {
     // Remove the bounds check as part of the GT_COMMA node since we need parent pointer to remove nodes.

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -122,11 +122,14 @@ bool IntegralRange::Contains(int64_t value) const
             return {LowerBoundForType(toType), UpperBoundForType(toType)};
         }
 
-        // Widening/no-op representation-changing casts never "overflow" under our definition.
-        // These are CAST(u/long <- int), CAST(u/long <- uint), CAST(u/int <- u/int).
-        // Narrowing cases "overflow" when the input does not fit into TYP_INT.
-        // These are CAST(u/int <- u/long) - they are all the same operation.
-        return {SymbolicIntegerValue::IntMin, SymbolicIntegerValue::IntMax};
+        // We choose to say here that representation-changing casts never overflow.
+        // It does not really matter what we do here because representation-changing
+        // non-overflowing casts cannot be deleted from the IR in any case.
+        // CAST(uint/int <- uint/int)     - [INT_MIN..INT_MAX]
+        // CAST(uint/int <- ulong/long)   - [LONG_MIN..LONG_MAX]
+        // CAST(ulong/long <- uint/int)   - [INT_MIN..INT_MAX]
+        // CAST(ulong/long <- ulong/long) - [LONG_MIN..LONG_MAX]
+        return ForType(fromType);
     }
 
     SymbolicIntegerValue lowerBound;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7637,6 +7637,7 @@ public:
 
     // Assertion Gen functions.
     void optAssertionGen(GenTree* tree);
+    AssertionIndex optAssertionGenCast(GenTreeCast* cast);
     AssertionIndex optAssertionGenPhiDefn(GenTree* tree);
     AssertionInfo optCreateJTrueBoundsAssertion(GenTree* tree);
     AssertionInfo optAssertionGenJtrue(GenTree* tree);
@@ -7652,6 +7653,8 @@ public:
                                       GenTree*         op2,
                                       optAssertionKind assertionKind,
                                       bool             helperCallArgs = false);
+
+    AssertionIndex optFinalizeCreatingAssertion(AssertionDsc* assertion);
 
     bool optTryExtractSubrangeAssertion(GenTree* source, AssertionDsc::Range* pRange);
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -1184,8 +1184,8 @@ inline constexpr bool operator<=(SymbolicIntegerValue left, SymbolicIntegerValue
 //
 // Some examples of how ranges are computed for casts:
 // 1. CAST_OVF(ubyte <- uint): does not overflow for [0..UBYTE_MAX], produces the
-//    same range - all casts that do not change the representation, i. e.have the
-//    same "actual" input and output type, have the same "input" and "output" range.
+//    same range - all casts that do not change the representation, i. e. have the same
+//    "actual" input and output type, have the same "input" and "output" range.
 // 2. CAST_OVF(ulong <- uint): never oveflows => the "input" range is [INT_MIN..INT_MAX]
 //    (aka all possible 32 bit integers). Produces [0..UINT_MAX] (aka all possible 32
 //    bit integers zero-extended to 64 bits).

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7630,6 +7630,9 @@ public:
                                       GenTree*         op2,
                                       optAssertionKind assertionKind,
                                       bool             helperCallArgs = false);
+
+    bool optTryExtractSubrangeAssertion(GenTree* source, ssize_t* pLoBound, ssize_t* pHiBound);
+
     void optCreateComplementaryAssertion(AssertionIndex assertionIndex,
                                          GenTree*       op1,
                                          GenTree*       op2,

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -6021,8 +6021,17 @@ GenTree* Compiler::fgMorphLocalVar(GenTree* tree, bool forceRemorph)
     if (!varAddr && varDsc->lvNormalizeOnLoad())
     {
 #if LOCAL_ASSERTION_PROP
-        // Assertion prop can tell us to omit adding a cast here
-        if (optLocalAssertionProp &&
+        // TYP_BOOL quirk: previously, the code in optAssertionIsSubrange did not handle TYP_BOOL.
+        // Now it does, but this leads to some regressions because we lose the uniform VNs for trees
+        // that represent the "reduced" normalize-on-load locals, i. e. LCL_VAR(small type V00), created
+        // here with local assertions, and "expanded", i. e. CAST(small type <- LCL_VAR(int V00)).
+        // This is a pretty fundamental problem with how normalize-on-load locals appear to the optimizer.
+        // This quirk preserves the previous behavior.
+        // TODO-CQ: fix the VNs for normalize-on-load locals and remove this quirk.
+        bool isBoolQuirk = varType == TYP_BOOL;
+
+        // Assertion prop can tell us to omit adding a cast here.
+        if (optLocalAssertionProp && !isBoolQuirk &&
             optAssertionIsSubrange(tree, IntegralRange::ForType(varType), apFull) != NO_ASSERTION_INDEX)
         {
             // The previous assertion can guarantee us that if this node gets

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -6023,7 +6023,7 @@ GenTree* Compiler::fgMorphLocalVar(GenTree* tree, bool forceRemorph)
 #if LOCAL_ASSERTION_PROP
         // Assertion prop can tell us to omit adding a cast here
         if (optLocalAssertionProp &&
-            optAssertionIsSubrange(tree, AssertionDsc::GetRangeForIntegralType(varType), apFull) != NO_ASSERTION_INDEX)
+            optAssertionIsSubrange(tree, IntegralRange::ForType(varType), apFull) != NO_ASSERTION_INDEX)
         {
             // The previous assertion can guarantee us that if this node gets
             // assigned a register, it will be normalized already. It is still

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -6018,11 +6018,12 @@ GenTree* Compiler::fgMorphLocalVar(GenTree* tree, bool forceRemorph)
 
     noway_assert(!(tree->gtFlags & GTF_VAR_DEF) || varAddr); // GTF_VAR_DEF should always imply varAddr
 
-    if (!varAddr && varTypeIsSmall(varDsc->TypeGet()) && varDsc->lvNormalizeOnLoad())
+    if (!varAddr && varDsc->lvNormalizeOnLoad())
     {
 #if LOCAL_ASSERTION_PROP
         // Assertion prop can tell us to omit adding a cast here
-        if (optLocalAssertionProp && optAssertionIsSubrange(tree, TYP_INT, varType, apFull) != NO_ASSERTION_INDEX)
+        if (optLocalAssertionProp &&
+            optAssertionIsSubrange(tree, AssertionDsc::GetRangeForIntegralType(varType), apFull) != NO_ASSERTION_INDEX)
         {
             // The previous assertion can guarantee us that if this node gets
             // assigned a register, it will be normalized already. It is still


### PR DESCRIPTION
This PR adds a new abstraction for dealing with casts, `IntegralRange`, a tuple of two symbolic values that represent the lower and upper bounds for an integral value. The symbolic representation has been chosen so that the range can be efficiently used on 32 hosts, since the alternative (using 64 bit integers) would have been, I feel, unacceptably inefficient. Notably, the range always interprets values produces by IR nodes as signed (since we're already using the signed semantic in a number of places, and it is easier to reason about for the purposes of casts as using unsigned representation would have meant a discontinuous range).

Because assertion propagation was using integral ranges already, that's where `IntegralRange` is used in this PR. This enables reasoning about long checked casts on 32 bit hosts (rare scenario) and ensures the correctness of how the assertions are interpreted, since they're created for both the cast's node output (in local assertion propagation) and input (in global assertion propagation). It also allows for, in the future, shrinking the size of the `AssertionDsc` structure. I note that since we're allocating a pretty sizeable array of them upfront in global assertion propagation (3K+ bytes), any savings in the size here translate into large percentages in memory allocation reduction (e. g., removing 8 bytes from the `AssertionDsc`, I've observed -2.2% reduction, and I think we can reduce the size by at least 20 bytes), though this is somewhat misleading as the memory is only actually used for active assertions. Note that this PR **does not** alter the size of `AssertionDsc`, the added `if !defined(HOST_64BIT)` is for clarity only.

Naturally, code propagating the assertions for casts has also been refactored, mostly to avoid retyping a `long` local to `int` if it happened to have a range of `int`. Such retyping is redundant with what `optNarrowTree` does already, and is in fact incorrect in global assertion propagation as it did not update the value number properly (leaving a node that has `TYP_INT` with a VN of `TYP_LONG`). Also, the retyping has been restricted to the known case where it is needed (and a comment added on _why_ it is needed).

An interesting property of the old code was how it treated `TYP_BOOL`. `TYP_BOOL` in the compiler is pretty much a `TYP_UBYTE`, but with a hint that it comes from `CORINFO_TYPE_BOOL`. Assertion generation treated assignments with a `TYP_BOOL` source as those restricting the destination to a `[0..1]` range, however, that is incorrect as per the IL semantics of booleans being treated as equivalent to `uint8`s. This did not have ill effects except for perhaps dropping a checked cast once in a while, but it was an internal inconsistency in the IR. This PR just makes `TYP_BOOL`s equivalent to `TYP_UBYTE`s for the purposes of assertion generation.

(_Note: the text below is an explanation for the quirk_)

Another interesting property of the old code was that it did not propagate the assertion for casts to `TYP_BOOL` (perhaps hinting at the reason for why it was "safe" to give `TYP_BOOL` `[0..1`] ranges in the first place...). The new code does, by virtue of not special casing it, and that is where the bulk of the diffs ([`win-x64`](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-55186/win-x64.md), [`win-x86`](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-55186/win-x86.md)) come from.

Unfortunately, there are, though a small number of, regressions with this handling of `TYP_BOOL`. There are two sources of them.

First, there is the VN problem, it accounts for the vast majority of the regressions (missing CSEs + missed redundant branch elimination). Say we have the following situation:
```cs
int Function(short a)
{
    a = (sbyte)a;
    
    if (a is 1)
        return 1;

    return a;
}
```
Today, local assertion propagation removes the normalizing cast for `a is 1`. Then in VN we value number the local without the cast and the normalizing cast for the same local differently:
```scala
***** BB01, STMT00002(after)
N004 (  6,  6) [000009] ------------              *  JTRUE     void  
N003 (  4,  4) [000008] N------N-U--              \--*  NE        int    $102
N001 (  2,  2) [000006] ------------                 +--*  LCL_VAR   short  V00 arg0         u:2 $101
N002 (  1,  1) [000007] ------------                 \--*  CNS_INT   int    1 $44


***** BB03, STMT00003(after)
N003 (  4,  5) [000011] ------------              *  RETURN    int    $140
N002 (  3,  4) [000016] ------------              \--*  CAST      int <- short <- int $103
N001 (  2,  2) [000010] ------------                 \--*  LCL_VAR   int    V00 arg0         u:2 (last use) $101
```
The core issue here is that the VNs for "normalize-on-load" locals are fundamentally "wrong". In the example above, both `[000008]` and `[000010]` have the same VN, but say `V00`'s home was on the stack. The first tree would have produced 2 bytes of the value it was assigned, sign-extended, while the second would produce a full `int`, with the upper 2 bytes set to whatever happened to be next to `V00` on the stack (this is how it actually works - the width of the local node signifies to the codegen how wide the load should be). Because of this representation problem, fixing this appears to be not so straightforward.

One possible fix is to recognize, in VN, when a cast a redundant. That runs into regressions with "false CSEs", since we leave the cast tree intact, while in actuality it is redundant and CSEing such a tree has negative profitability (but CSE cannot know that because we leave the costs intact as well).

Another possible fix is to turn these casts into no-ops while renaming the uses (ideally we'd be doing that in early prop, but that's much more expensive TP-wise). That runs into regressions because, sometimes, removing a cast inhibits redundant branch optimization. Consider the following:
```cs
// Say p0 is a `short` parameter.
if (p0 != 0) // here, the normalizing cast cannot be removed.
{
    p1 = p0;
   
    if (p1 != 0) // here, the normalizing cast can be removed.
    {
    }
}

// In this example, the two conditions will have different VNs if we remove the cast above p1.
```
I have spent a considerable amount of time trying out different approaches to fixing the above issues, but they all ran into various regressions, so I tabled fixing it in this PR.

The second source of regressions is the fact that in lowering we can recognize `EQ(CAST(bool/ubyte <- int), SMALL_CONST)` and retype the tree to `UBYTE`, leading to, effectively, containment for the cast. Expanding this to consider small `LCL_VAR`s is not so trivial as well, because it can regress when we have those locals assigned `RSI`, `RDI`, `RBP` or `RSP`, which take up more space to encode in their byte form on Amd64, not to mention we can end up with byte-able register constraints on x86.

Due to the above issues and the fact that I was not able to mitigate them, I will be quirking the handling of `TYP_BOOL` in this PR to get to a near zero substantial regressions state.

Fixes #54842, but [properly](https://github.com/dotnet/runtime/pull/55626).
Fixes #12936