### PR TITLE
Support in-process named mutexes in managed implementation

### DIFF
--- a/src/libraries/System.IO.IsolatedStorage/tests/AssemblyInfo.cs
+++ b/src/libraries/System.IO.IsolatedStorage/tests/AssemblyInfo.cs
@@ -8,5 +8,4 @@ using Xunit;
 // create unique identities for every test to allow every test to have
 // it's own store.
 [assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true)]
-[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/48720", TestPlatforms.AnyUnix, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
 [assembly: SkipOnPlatform(TestPlatforms.Browser, "System.IO.IsolatedStorage is not supported on Browser")]

--- a/src/libraries/System.Threading/tests/MutexTests.cs
+++ b/src/libraries/System.Threading/tests/MutexTests.cs
@@ -45,7 +45,6 @@ namespace System.Threading.Tests
         }
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/48720", TestPlatforms.AnyUnix, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         [MemberData(nameof(GetValidNames))]
         public void Ctor_ValidName(string name)
         {
@@ -97,7 +96,6 @@ namespace System.Threading.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/48720", TestPlatforms.AnyUnix, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         [MemberData(nameof(GetValidNames))]
         public void OpenExisting(string name)
         {
@@ -132,7 +130,6 @@ namespace System.Threading.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/48720", TestPlatforms.AnyUnix, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public void OpenExisting_UnavailableName()
         {
             string name = Guid.NewGuid().ToString("N");
@@ -228,7 +225,6 @@ namespace System.Threading.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/48720", TestPlatforms.AnyUnix, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         [MemberData(nameof(AbandonExisting_MemberData))]
         public void AbandonExisting(
             string name,
@@ -469,7 +465,6 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/48720", TestPlatforms.AnyUnix, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public void NamedMutex_ThreadExitDisposeRaceTest()
         {
             var mutexName = Guid.NewGuid().ToString("N");
@@ -530,7 +525,6 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/48720", TestPlatforms.AnyUnix, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public void NamedMutex_DisposeWhenLockedRaceTest()
         {
             var mutexName = Guid.NewGuid().ToString("N");


### PR DESCRIPTION
* Partially addresses https://github.com/dotnet/runtime/issues/48720

* Use a dictionary to perform the name to object lookup

* Allow multiple handles to refer to a single waitable object

* Abandon mutex only when all handles refering to it are closed

* Re-enable test cases disabled due to the above issue


This follows the suggestion in https://github.com/dotnet/runtime/issues/48720#issuecomment-818389962

Note that the current managed Mutex implementation considers a mutex abandoned not only if the thread holding it terminates, but also when the SafeEventHandle refering to it is closed.  This is clearly not correct for named mutexes, which can have multiple handles refering to it.  In this patch, I've chosen to consider a named mutex abandoned once **all** handles to it are closed -- an alternate approach would be to just not have that special case at all and only abandon the mutex on thread exit (because as long as the mutex is held, it would in principle be possible to re-open another handle to it by name).  Let me know if that alternate approach would be preferable.
