### PR TITLE
Fix race when signaling waitable objects in managed implementation

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/WaitSubsystem.ThreadWaitInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/WaitSubsystem.ThreadWaitInfo.Unix.cs
@@ -641,6 +641,21 @@ namespace System.Threading
                     }
                 }
 
+                // Like Next, but skip nodes registered on the same thread.
+                public WaitedListNode? NextThread
+                {
+                    get
+                    {
+                        s_lock.VerifyIsLocked();
+                        WaitedListNode? ret = _next;
+                        while (ret != null && ReferenceEquals(ret._waitInfo, _waitInfo))
+                        {
+                            ret = ret._next;
+                        }
+                        return ret;
+                    }
+                }
+
                 public void RegisterWait(WaitableObject waitableObject)
                 {
                     s_lock.VerifyIsLocked();

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/WaitSubsystem.WaitableObject.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/WaitSubsystem.WaitableObject.Unix.cs
@@ -611,7 +611,7 @@ namespace System.Threading
                     waiterNode = nextWaiterNode)
                 {
                     // Signaling a waiter will unregister the waiter node, so keep the next node before trying
-                    nextWaiterNode = waiterNode.Next;
+                    nextWaiterNode = waiterNode.NextThread;
 
                     waiterNode.WaitInfo.TrySignalToSatisfyWait(waiterNode, isAbandonedMutex: false);
                 }
@@ -635,7 +635,7 @@ namespace System.Threading
                 {
                     // Signaling a waiter will unregister the waiter node, but it may only abort the wait without satisfying the
                     // wait, in which case we would try to signal another waiter. So, keep the next node before trying.
-                    nextWaiterNode = waiterNode.Next;
+                    nextWaiterNode = waiterNode.NextThread;
 
                     if (waiterNode.WaitInfo.TrySignalToSatisfyWait(waiterNode, isAbandonedMutex: false))
                     {
@@ -689,7 +689,7 @@ namespace System.Threading
                     waiterNode = nextWaiterNode)
                 {
                     // Signaling the waiter will unregister the waiter node, so keep the next node before trying
-                    nextWaiterNode = waiterNode.Next;
+                    nextWaiterNode = waiterNode.NextThread;
 
                     if (waiterNode.WaitInfo.TrySignalToSatisfyWait(waiterNode, isAbandonedMutex: false) && --count == 0)
                     {
@@ -753,7 +753,7 @@ namespace System.Threading
                 {
                     // Signaling a waiter will unregister the waiter node, but it may only abort the wait without satisfying the
                     // wait, in which case we would try to signal another waiter. So, keep the next node before trying.
-                    nextWaiterNode = waiterNode.Next;
+                    nextWaiterNode = waiterNode.NextThread;
 
                     ThreadWaitInfo waitInfo = waiterNode.WaitInfo;
                     if (waitInfo.TrySignalToSatisfyWait(waiterNode, isAbandoned))

--- a/src/libraries/System.Threading.Tasks/tests/MethodCoverage.cs
+++ b/src/libraries/System.Threading.Tasks/tests/MethodCoverage.cs
@@ -322,7 +322,6 @@ namespace TaskCoverage
         /// FromAsync testing: Not supported in .NET Native
         /// </summary>
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/52614", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void FromAsync()
         {
             Task emptyTask = new Task(() => { });


### PR DESCRIPTION
* TrySignalToSatisfyWait may invalidate multiple elements of the
  WaitedListNode linked list, if the same object occurs multiple
  times in a single WaitForMultipleObjects call.

This race showed up in sporading failures in `System.Threading.Tasks.Tests`, indicated by an assertion failure in `TrySignalToSatisfyWait` when called from `SignalManualResetEvent`.  The problem is that in this loop:

```
                for (ThreadWaitInfo.WaitedListNode? waiterNode = _waitersHead, nextWaiterNode;
                    waiterNode != null;
                    waiterNode = nextWaiterNode)
                {
                    // Signaling a waiter will unregister the waiter node, so keep the next node before trying
                    nextWaiterNode = waiterNode.Next;

                    waiterNode.WaitInfo.TrySignalToSatisfyWait(waiterNode, isAbandonedMutex: false);
                }
```

the `TrySignalToSatisfyWait` call may modify the linked list we're traversing.  The code attempts to address that issue by keeping the next node before the call -- but that next node may itself be modified by the call.   This happens only if that next node has the same `WaitInfo` as the current node, which is normally not the case, but may occur if the same waitable object is used multiple times as argument to a single `WaitAny` / `WaitForMultipleObjects` call.