### PR TITLE
[mono] Fix crash in AssemblyBuilder::GetModules

### DIFF
--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.Mono.cs
@@ -360,7 +360,12 @@ namespace System.Reflection.Emit
             return null;
         }
 
-        public override Module[] GetModules(bool getResourceModules) => (Module[])modules.Clone();
+        public override Module[] GetModules(bool getResourceModules)
+        {
+            if (modules == null)
+                return Array.Empty<Module>();
+            return (Module[])modules.Clone();
+        }
 
         public override AssemblyName GetName(bool copiedName) => AssemblyName.Create(_mono_assembly, null);
 


### PR DESCRIPTION
* The "modules" field may be null if called before the end of the
  AssemblyBuilder ctor (which may happen in an OnAssemblyLoad event
  handler invoked during the basic_init VM call).

This happens during some aspnetcore test cases.  I'm not completely sure if the `OnAssemblyLoad` event handler is supposed to see that singleton module or not (looking at the CoreCLR sources I believe it may there), but that seems difficult to implement in Mono due to interactions between the `basic_init` calls in `AssemblyBuilder` vs. `ModuleBuilder`.

In any case, this patch at least removes the crash by special-casing a null `modules` fields (like several other `AssemblyBuilder` accessor functions already do!), and the aspnetcore tests now pass.