### PR TITLE
[Mono]Fix jit dump enable flag

### DIFF
--- a/src/mono/CMakeLists.txt
+++ b/src/mono/CMakeLists.txt
@@ -726,6 +726,10 @@ else()
   # FIXME:
   set(NAME_DEV_RANDOM "\"/dev/random\"")
 endif()
+
+if(HOST_LINUX AND HAVE_SYS_MMAN_H AND HAVE_ELF_H AND HAVE_SYS_SYSCALL_H)
+  set(ENABLE_JIT_DUMP 1)
+endif()
 ### End of other checks
 
 ######################################

--- a/src/mono/cmake/config.h.in
+++ b/src/mono/cmake/config.h.in
@@ -1073,6 +1073,9 @@
 /* Enable static linking of mono runtime components */
 #cmakedefine STATIC_COMPONENTS
 
+/* Enable perf jit dump support */
+#cmakedefine ENABLE_JIT_DUMP 1
+
 #if defined(ENABLE_LLVM) && defined(HOST_WIN32) && defined(TARGET_WIN32) && (!defined(TARGET_AMD64) || !defined(_MSC_VER))
 #error LLVM for host=Windows and target=Windows is only supported on x64 MSVC build.
 #endif

--- a/src/mono/cmake/configure.cmake
+++ b/src/mono/cmake/configure.cmake
@@ -57,8 +57,8 @@ endfunction()
 ac_check_headers (
   sys/types.h sys/stat.h sys/filio.h sys/sockio.h sys/utime.h sys/un.h sys/syscall.h sys/uio.h sys/param.h sys/sysctl.h
   sys/prctl.h sys/socket.h sys/utsname.h sys/select.h sys/user.h sys/poll.h sys/wait.h sts/auxv.h sys/resource.h
-  sys/ioctl.h sys/errno.h sys/sendfile.h sys/statvfs.h sys/statfs.h sys/mman.h sys/mount.h sys/time.h sys/random.h
-  strings.h stdint.h unistd.h netdb.h utime.h semaphore.h libproc.h alloca.h ucontext.h pwd.h
+  sys/ioctl.h sys/errno.h sys/sendfile.h sys/statvfs.h sys/statfs.h sys/mman.h sys/mount.h sys/time.h sys/random.h sys/mman.h
+  strings.h stdint.h unistd.h netdb.h utime.h semaphore.h libproc.h alloca.h ucontext.h pwd.h elf.h
   gnu/lib-names.h netinet/tcp.h netinet/in.h link.h arpa/inet.h unwind.h poll.h wchar.h linux/magic.h
   android/legacy_signal_inlines.h android/ndk-version.h execinfo.h pthread.h pthread_np.h net/if.h dirent.h
   CommonCrypto/CommonDigest.h dlfcn.h getopt.h pwd.h iconv.h alloca.h


### PR DESCRIPTION
The original logic of defining 'ENABLE_JIT_DUMP' lives inside `configure.ac`
https://github.com/fanyang-mono/mono/blob/ef2bc8241023f3090efac8ab3f66240aa96820b8/configure.ac#L758-L762

During the process of converting to build with cmake, `configure.ac` was eliminated. However, the logic of defining 'ENABLE_JIT_DUMP' wasn't preserved. Adding it back.
