### PR TITLE
[mono][aot] Avoid using direct-icalls on ios simulator.

### DIFF
--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.props
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.props
@@ -5,13 +5,15 @@
     <MonoAOTCompilerDefaultAotArguments Condition="'$(TargetArchitecture)' == 'x64'" Include="mtriple=x86_64-ios" />
     <MonoAOTCompilerDefaultAotArguments Condition="'$(TargetArchitecture)' == 'x86'" Include="mtriple=i386-ios" />
     <MonoAOTCompilerDefaultAotArguments Include="static" />
-    <MonoAOTCompilerDefaultAotArguments Include="direct-icalls" />
     <MonoAOTCompilerDefaultAotArguments Include="dwarfdebug" />
     <MonoAOTCompilerDefaultAotArguments Condition="'$(TargetArchitecture)' == 'arm64' or '$(TargetArchitecture)' == 'arm'" Include="mattr=+crc" /> <!-- enable System.Runtime.Intrinsics.Arm (Crc32 and ArmBase for now) -->
     <!--<MonoAOTCompilerDefaultAotArguments Include="direct-pinvoke" />--> <!-- TODO: enable direct-pinvokes (to get rid of -force_loads)-->
   </ItemGroup>
   <ItemGroup Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'iOSSimulator' or '$(TargetOS)' == 'tvOS' or '$(TargetOS)' == 'tvOSSimulator' or '$(TargetOS)' == 'MacCatalyst'">
     <MonoAOTCompilerDefaultProcessArguments Include="-O=gsharedvt" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS' or '$(TargetOS)' == 'MacCatalyst'">
+    <MonoAOTCompilerDefaultAotArguments Include="direct-icalls" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetOS)' == 'Android'">
     <MonoAOTCompilerDefaultAotArguments Condition="'$(TargetArchitecture)' == 'arm'" Include="mtriple=armv7-linux-gnueabi" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/55000.