### PR TITLE
Avoid FileStream allocations in Sockets

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -4,7 +4,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
-using System.Threading.Tasks;
+using Microsoft.Win32.SafeHandles;
 
 namespace System.Net.Sockets
 {
@@ -248,7 +248,7 @@ namespace System.Net.Sockets
         {
             Debug.Assert(_sendPacketsElements != null);
             SendPacketsElement[] elements = (SendPacketsElement[])_sendPacketsElements.Clone();
-            FileStream[] files = new FileStream[elements.Length];
+            SafeFileHandle[] fileHandles = new SafeFileHandle[elements.Length];
 
             // Open all files synchronously ahead of time so that any exceptions are propagated
             // to the caller, to match Windows behavior.
@@ -259,14 +259,14 @@ namespace System.Net.Sockets
                     string? path = elements[i]?.FilePath;
                     if (path != null)
                     {
-                        files[i] = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 0x1000, useAsync: true);
+                        fileHandles[i] = File.OpenHandle(path, FileMode.Open, FileAccess.Read, FileShare.Read, FileOptions.Asynchronous);
                     }
                 }
             }
             catch (Exception exc)
             {
                 // Clean up any files that were already opened.
-                foreach (FileStream s in files)
+                foreach (SafeFileHandle s in fileHandles)
                 {
                     s?.Dispose();
                 }
@@ -288,7 +288,7 @@ namespace System.Net.Sockets
                 throw;
             }
 
-            SocketPal.SendPacketsAsync(socket, SendPacketsFlags, elements, files, cancellationToken, (bytesTransferred, error) =>
+            SocketPal.SendPacketsAsync(socket, SendPacketsFlags, elements, fileHandles, cancellationToken, (bytesTransferred, error) =>
             {
                 if (error == SocketError.Success)
                 {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -1907,10 +1907,10 @@ namespace System.Net.Sockets
             return GetSocketErrorForErrorCode(err);
         }
 
-        private static SocketError SendFileAsync(SafeSocketHandle handle, FileStream fileStream, long offset, long count, CancellationToken cancellationToken, Action<long, SocketError> callback)
+        private static SocketError SendFileAsync(SafeSocketHandle handle, SafeFileHandle fileHandle, long offset, long count, CancellationToken cancellationToken, Action<long, SocketError> callback)
         {
             long bytesSent;
-            SocketError socketError = handle.AsyncContext.SendFileAsync(fileStream.SafeFileHandle, offset, count, out bytesSent, callback, cancellationToken);
+            SocketError socketError = handle.AsyncContext.SendFileAsync(fileHandle, offset, count, out bytesSent, callback, cancellationToken);
             if (socketError == SocketError.Success)
             {
                 callback(bytesSent, SocketError.Success);
@@ -1919,13 +1919,13 @@ namespace System.Net.Sockets
         }
 
         public static async void SendPacketsAsync(
-            Socket socket, TransmitFileOptions options, SendPacketsElement[] elements, FileStream[] files, CancellationToken cancellationToken, Action<long, SocketError> callback)
+            Socket socket, TransmitFileOptions options, SendPacketsElement[] elements, SafeFileHandle[] fileHandles, CancellationToken cancellationToken, Action<long, SocketError> callback)
         {
             SocketError error = SocketError.Success;
             long bytesTransferred = 0;
             try
             {
-                Debug.Assert(elements.Length == files.Length);
+                Debug.Assert(elements.Length == fileHandles.Length);
                 for (int i = 0; i < elements.Length; i++)
                 {
                     SendPacketsElement e = elements[i];
@@ -1937,15 +1937,17 @@ namespace System.Net.Sockets
                         }
                         else
                         {
-                            FileStream fs = files[i] ?? e.FileStream!;
-                            if (e.Count > fs.Length - e.OffsetLong)
+                            SafeFileHandle fileHandle = fileHandles[i] ?? e.FileStream!.SafeFileHandle;
+                            long fsLength = RandomAccess.GetLength(fileHandle);
+
+                            if (e.Count > fsLength - e.OffsetLong)
                             {
                                 throw new ArgumentOutOfRangeException();
                             }
 
                             var tcs = new TaskCompletionSource<SocketError>();
-                            error = SendFileAsync(socket.InternalSafeHandle, fs, e.OffsetLong,
-                                e.Count > 0 ? e.Count : fs.Length - e.OffsetLong,
+                            error = SendFileAsync(socket.InternalSafeHandle, fileHandle, e.OffsetLong,
+                                e.Count > 0 ? e.Count : fsLength - e.OffsetLong,
                                 cancellationToken,
                                 (transferred, se) =>
                                 {
@@ -1975,7 +1977,7 @@ namespace System.Net.Sockets
             }
             catch (Exception exc)
             {
-                foreach (FileStream fs in files)
+                foreach (SafeFileHandle fs in fileHandles)
                 {
                     fs?.Dispose();
                 }


### PR DESCRIPTION
Use File.OpenHandle, as all that's needed is the SafeFileHandle, not the FileStream that wraps it.
cc: @adamsitnik, @geoffkizer 