### PR TITLE
Fix NRE in EncodingProvider

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/EncodingProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/EncodingProvider.cs
@@ -71,7 +71,7 @@ namespace System.Text
 
                 var newProviders = new EncodingProvider[providers.Length + 1];
                 Array.Copy(providers, newProviders, providers.Length);
-                providers[^1] = provider;
+                newProviders[^1] = provider;
 
                 if (Interlocked.CompareExchange(ref s_providers, newProviders, providers) == providers)
                 {

--- a/src/libraries/System.Runtime/tests/System/Text/EncodingTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Text/EncodingTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.DotNet.RemoteExecutor;
 using Moq;
 using Xunit;
 
@@ -104,6 +105,25 @@ namespace System.Text.Tests
                     Assert.NotEqual(codePage, encodingInfo.CodePage);
                 }
             });
+        }
+
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void RegisterProvider_EncodingsAreUsable()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                for (int i = 0; i < 10; i++)
+                {
+                    Encoding.RegisterProvider(new NullEncodingProvider());
+                    Assert.Same(Encoding.UTF8, Encoding.GetEncoding(65001));
+                }
+            }).Dispose();
+        }
+
+        private sealed class NullEncodingProvider : EncodingProvider
+        {
+            public override Encoding GetEncoding(int codepage) => null;
+            public override Encoding GetEncoding(string name) => null;
         }
 
         private sealed class ThreadStaticEncodingProvider : EncodingProvider


### PR DESCRIPTION
Issue https://github.com/dotnet/runtime/issues/55233

Add provider into array copy `newProviders` instead of original array before assigning array copy to `s_providers`