### PR TITLE
Trim Linq.Expressions when using DependencyInjection

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
@@ -4,11 +4,9 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Threading;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
@@ -263,12 +261,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                         new[] { lockWasTaken },
                         Expression.TryFinally(tryBody, finallyBody))
                 );
-        }
-
-        private static MethodInfo GetMethodInfo<T>(Expression<T> expr)
-        {
-            var mc = (MethodCallExpression)expr.Body;
-            return mc.Method;
         }
 
         public Expression GetCaptureDisposable(ParameterExpression scope)

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
@@ -14,16 +14,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal sealed class ExpressionResolverBuilder : CallSiteVisitor<object, Expression>
     {
-        internal static readonly MethodInfo InvokeFactoryMethodInfo = GetMethodInfo<Action<Func<IServiceProvider, object>, IServiceProvider>>((a, b) => a.Invoke(b));
-        internal static readonly MethodInfo CaptureDisposableMethodInfo = GetMethodInfo<Func<ServiceProviderEngineScope, object, object>>((a, b) => a.CaptureDisposable(b));
-        internal static readonly MethodInfo TryGetValueMethodInfo = GetMethodInfo<Func<IDictionary<ServiceCacheKey, object>, ServiceCacheKey, object, bool>>((a, b, c) => a.TryGetValue(b, out c));
-        internal static readonly MethodInfo ResolveCallSiteAndScopeMethodInfo = GetMethodInfo<Func<CallSiteRuntimeResolver, ServiceCallSite, ServiceProviderEngineScope, object>>((a, b, c) => a.Resolve(b, c));
-        internal static readonly MethodInfo AddMethodInfo = GetMethodInfo<Action<IDictionary<ServiceCacheKey, object>, ServiceCacheKey, object>>((a, b, c) => a.Add(b, c));
-        internal static readonly MethodInfo MonitorEnterMethodInfo = GetMethodInfo<Action<object, bool>>((lockObj, lockTaken) => Monitor.Enter(lockObj, ref lockTaken));
-        internal static readonly MethodInfo MonitorExitMethodInfo = GetMethodInfo<Action<object>>(lockObj => Monitor.Exit(lockObj));
-
-        private static readonly MethodInfo ArrayEmptyMethodInfo = typeof(Array).GetMethod(nameof(Array.Empty));
-
         private static readonly ParameterExpression ScopeParameter = Expression.Parameter(typeof(ServiceProviderEngineScope));
 
         private static readonly ParameterExpression ResolvedServices = Expression.Variable(typeof(IDictionary<ServiceCacheKey, object>), ScopeParameter.Name + "resolvedServices");
@@ -42,7 +32,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         private static readonly ParameterExpression CaptureDisposableParameter = Expression.Parameter(typeof(object));
         private static readonly LambdaExpression CaptureDisposable = Expression.Lambda(
-                    Expression.Call(ScopeParameter, CaptureDisposableMethodInfo, CaptureDisposableParameter),
+                    Expression.Call(ScopeParameter, ServiceLookupHelpers.CaptureDisposableMethodInfo, CaptureDisposableParameter),
                     CaptureDisposableParameter);
 
         private static readonly ConstantExpression CallSiteRuntimeResolverInstanceExpression = Expression.Constant(
@@ -127,7 +117,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             if (callSite.ServiceCallSites.Length == 0)
             {
                 return Expression.Constant(
-                    GetArrayEmptyMethodInfo(callSite.ItemType)
+                    ServiceLookupHelpers.GetArrayEmptyMethodInfo(callSite.ItemType)
                     .Invoke(obj: null, parameters: Array.Empty<object>()));
             }
 
@@ -147,11 +137,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 ScopeParameter,
                 VisitCallSiteMain(callSite, context));
         }
-
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060:MakeGenericMethod",
-            Justification = "Calling Array.Empty<T>() is safe since the T doesn't have trimming annotations.")]
-        internal static MethodInfo GetArrayEmptyMethodInfo(Type itemType) =>
-            ArrayEmptyMethodInfo.MakeGenericMethod(itemType);
 
         private Expression TryCaptureDisposable(ServiceCallSite callSite, ParameterExpression scope, Expression service)
         {
@@ -212,7 +197,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             // Avoid the compilation for singletons (or promoted singletons)
             MethodCallExpression resolveRootScopeExpression = Expression.Call(
                 CallSiteRuntimeResolverInstanceExpression,
-                ResolveCallSiteAndScopeMethodInfo,
+                ServiceLookupHelpers.ResolveCallSiteAndScopeMethodInfo,
                 callSiteExpression,
                 ScopeParameter);
 
@@ -226,7 +211,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
             MethodCallExpression tryGetValueExpression = Expression.Call(
                 resolvedServices,
-                TryGetValueMethodInfo,
+                ServiceLookupHelpers.TryGetValueMethodInfo,
                 keyExpression,
                 resolvedVariable);
 
@@ -238,7 +223,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
             MethodCallExpression addValueExpression = Expression.Call(
                 resolvedServices,
-                AddMethodInfo,
+                ServiceLookupHelpers.AddMethodInfo,
                 keyExpression,
                 resolvedVariable);
 
@@ -261,8 +246,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             ParameterExpression lockWasTaken = Expression.Variable(typeof(bool), "lockWasTaken");
             ParameterExpression sync = Sync;
 
-            MethodCallExpression monitorEnter = Expression.Call(MonitorEnterMethodInfo, sync, lockWasTaken);
-            MethodCallExpression monitorExit = Expression.Call(MonitorExitMethodInfo, sync);
+            MethodCallExpression monitorEnter = Expression.Call(ServiceLookupHelpers.MonitorEnterMethodInfo, sync, lockWasTaken);
+            MethodCallExpression monitorExit = Expression.Call(ServiceLookupHelpers.MonitorExitMethodInfo, sync);
 
             BlockExpression tryBody = Expression.Block(monitorEnter, blockExpression);
             ConditionalExpression finallyBody = Expression.IfThen(lockWasTaken, monitorExit);

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
@@ -6,7 +6,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
-using Microsoft.Extensions.DependencyInjection.ServiceLookup;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
@@ -198,7 +197,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             if (enumerableCallSite.ServiceCallSites.Length == 0)
             {
-                argument.Generator.Emit(OpCodes.Call, ExpressionResolverBuilder.GetArrayEmptyMethodInfo(enumerableCallSite.ItemType));
+                argument.Generator.Emit(OpCodes.Call, ServiceLookupHelpers.GetArrayEmptyMethodInfo(enumerableCallSite.ItemType));
             }
             else
             {
@@ -245,7 +244,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             argument.Generator.Emit(OpCodes.Ldelem, typeof(Func<IServiceProvider, object>));
 
             argument.Generator.Emit(OpCodes.Ldarg_1);
-            argument.Generator.Emit(OpCodes.Call, ExpressionResolverBuilder.InvokeFactoryMethodInfo);
+            argument.Generator.Emit(OpCodes.Call, ServiceLookupHelpers.InvokeFactoryMethodInfo);
 
             argument.Factories.Add(factoryCallSite.Factory);
             return null;
@@ -357,7 +356,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 // Load address of lockTaken
                 context.Generator.Emit(OpCodes.Ldloca_S, lockTakenLocal.LocalIndex);
                 // Monitor.Enter
-                context.Generator.Emit(OpCodes.Call, ExpressionResolverBuilder.MonitorEnterMethodInfo);
+                context.Generator.Emit(OpCodes.Call, ServiceLookupHelpers.MonitorEnterMethodInfo);
 
                 // Load resolved services
                 Ldloc(context.Generator, resolvedServicesLocal.LocalIndex);
@@ -366,7 +365,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 // Load address of result local
                 context.Generator.Emit(OpCodes.Ldloca_S, resultLocal.LocalIndex);
                 // .TryGetValue
-                context.Generator.Emit(OpCodes.Callvirt, ExpressionResolverBuilder.TryGetValueMethodInfo);
+                context.Generator.Emit(OpCodes.Callvirt, ServiceLookupHelpers.TryGetValueMethodInfo);
 
                 // Jump to the end if already in cache
                 context.Generator.Emit(OpCodes.Brtrue, skipCreationLabel);
@@ -391,7 +390,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 // load value
                 Ldloc(context.Generator, resultLocal.LocalIndex);
                 // .Add
-                context.Generator.Emit(OpCodes.Callvirt, ExpressionResolverBuilder.AddMethodInfo);
+                context.Generator.Emit(OpCodes.Callvirt, ServiceLookupHelpers.AddMethodInfo);
 
                 context.Generator.MarkLabel(skipCreationLabel);
 
@@ -404,7 +403,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 // Load syncLocal
                 Ldloc(context.Generator, syncLocal.LocalIndex);
                 // Monitor.Exit
-                context.Generator.Emit(OpCodes.Call, ExpressionResolverBuilder.MonitorExitMethodInfo);
+                context.Generator.Emit(OpCodes.Call, ServiceLookupHelpers.MonitorExitMethodInfo);
 
                 context.Generator.MarkLabel(returnLabel);
 
@@ -438,7 +437,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         private static void EndCaptureDisposable(ILEmitResolverBuilderContext argument)
         {
             // Call CaptureDisposabl we expect calee and arguments to be on the stackcontext.Generator.BeginExceptionBlock
-            argument.Generator.Emit(OpCodes.Callvirt, ExpressionResolverBuilder.CaptureDisposableMethodInfo);
+            argument.Generator.Emit(OpCodes.Callvirt, ServiceLookupHelpers.CaptureDisposableMethodInfo);
         }
 
         private void Ldloc(ILGenerator generator, int index)

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceLookupHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceLookupHelpers.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Threading;
+
+namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
+{
+    internal static class ServiceLookupHelpers
+    {
+        private const BindingFlags LookupFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+        private static readonly MethodInfo ArrayEmptyMethodInfo = typeof(Array).GetMethod(nameof(Array.Empty));
+
+        internal static readonly MethodInfo InvokeFactoryMethodInfo = typeof(Func<IServiceProvider, object>)
+            .GetMethod(nameof(Func<IServiceProvider, object>.Invoke), LookupFlags);
+
+        internal static readonly MethodInfo CaptureDisposableMethodInfo = typeof(ServiceProviderEngineScope)
+            .GetMethod(nameof(ServiceProviderEngineScope.CaptureDisposable), LookupFlags);
+
+        internal static readonly MethodInfo TryGetValueMethodInfo = typeof(IDictionary<ServiceCacheKey, object>)
+            .GetMethod(nameof(IDictionary<ServiceCacheKey, object>.TryGetValue), LookupFlags);
+
+        internal static readonly MethodInfo ResolveCallSiteAndScopeMethodInfo = typeof(CallSiteRuntimeResolver)
+            .GetMethod(nameof(CallSiteRuntimeResolver.Resolve), LookupFlags);
+
+        internal static readonly MethodInfo AddMethodInfo = typeof(IDictionary<ServiceCacheKey, object>)
+            .GetMethod(nameof(IDictionary<ServiceCacheKey, object>.Add), LookupFlags);
+
+        internal static readonly MethodInfo MonitorEnterMethodInfo = typeof(Monitor)
+            .GetMethod(nameof(Monitor.Enter), BindingFlags.Public | BindingFlags.Static, null, new Type[] { typeof(object), typeof(bool).MakeByRefType() }, null);
+        internal static readonly MethodInfo MonitorExitMethodInfo = typeof(Monitor)
+            .GetMethod(nameof(Monitor.Exit), BindingFlags.Public | BindingFlags.Static, null, new Type[] { typeof(object) }, null);
+
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060:MakeGenericMethod",
+            Justification = "Calling Array.Empty<T>() is safe since the T doesn't have trimming annotations.")]
+        internal static MethodInfo GetArrayEmptyMethodInfo(Type itemType) =>
+            ArrayEmptyMethodInfo.MakeGenericMethod(itemType);
+    }
+}


### PR DESCRIPTION
Because ILEmitResolverBuilder (the default resolver) has a dependency on ExpressionResolverBuilder, this forces apps that use DI to bring in System.Linq.Expressions.

Refactoring the logic so Expressions can be trimmed in apps using DI.