### PR TITLE
Use correct assignedInterval for SPILL_COST calculation

### DIFF
--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -11264,8 +11264,8 @@ void LinearScan::RegisterSelection::try_SPILL_COST()
         RefPosition* recentRefPosition  = spillCandidateRegRecord->assignedInterval != nullptr
                                              ? spillCandidateRegRecord->assignedInterval->recentRefPosition
                                              : nullptr;
-        if ((recentRefPosition != nullptr) && (recentRefPosition->RegOptional()) &&
-            !(currentInterval->isLocalVar && recentRefPosition->IsActualRef()))
+        if ((recentRefPosition != nullptr) && (recentRefPosition->RegOptional() &&
+             !(spillCandidateRegRecord->assignedInterval->isLocalVar && recentRefPosition->IsActualRef())))
         {
             // We do not "spillAfter" if previous (recent) refPosition was regOptional or if it
             // is not an actual ref. In those cases, we will reload in future (next) refPosition.


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/53853, I changed the `SPILL_COST` heuristic to also consider reload weight if the variable will be reloaded in future location rather than getting  spilled at past location. However, while doing that, I incorrectly checking the wrong interval for `isLocalVar`. I wanted to use similar condition as used in https://github.com/dotnet/runtime/blob/d4b98b91d042513917b964cf78a65bd937ead3e8/src/coreclr/jit/lsra.cpp#L3267 

However, the interval I was using was that of the current refposition for which we are allocating the register rather than the interval to which the candidate register is already assigned.

Here is the sample diff of `Algorithms.VectorDoubleRenderer:RenderSingleThreadedWithADT(float,float,float,float,float)` that we can see: The high weight local variable gets assigned to the register.

![image](https://user-images.githubusercontent.com/12488060/124690582-4a1c7280-de8f-11eb-9ad5-310213782852.png)

With better selection of register, we can now eliminate unnecessary spilling/resolution of expensive variables:

![image](https://user-images.githubusercontent.com/12488060/124690823-9a93d000-de8f-11eb-825b-100eb0e1e05f.png)

Some of the other regressions seen will be fixed by https://github.com/dotnet/runtime/pull/54345.

Fixes: https://github.com/dotnet/runtime/issues/54352