### PR TITLE
Improve resolving runtime pack in WasmApp targets

### DIFF
--- a/eng/targetingpacks.targets
+++ b/eng/targetingpacks.targets
@@ -11,6 +11,7 @@
 <Project>
   <PropertyGroup>
     <LocalFrameworkOverrideName>$(MicrosoftNetCoreAppFrameworkName)</LocalFrameworkOverrideName>
+    <TargetingpacksTargetsImported>true</TargetingpacksTargetsImported>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(DisableImplicitFrameworkReferences)' != 'true' and
@@ -103,7 +104,7 @@
     </ItemGroup>
   </Target>
 
-  <!-- Use local targeting pack for NetCoreAppCurrent. -->
+  <!-- Use local targeting/runtime pack for NetCoreAppCurrent. -->
   <Target Name="UpdateTargetingAndRuntimePack"
           Condition="'$(UseLocalTargetingRuntimePack)' == 'true'"
           AfterTargets="ResolveFrameworkReferences">

--- a/src/mono/wasm/build/WasmApp.InTree.targets
+++ b/src/mono/wasm/build/WasmApp.InTree.targets
@@ -2,10 +2,20 @@
   <!-- This depends on the root Directory.Build.targets imported this file -->
   <UsingTask TaskName="MonoAOTCompiler" AssemblyFile="$(MonoAOTCompilerTasksAssemblyPath)" />
 
-  <Import Project="$(RepositoryEngineeringDir)targetingpacks.targets" Condition="'$(TargetingpacksTargetsImported)' != 'true'"/>
+  <!-- TODO: this breaks runtime tests on Helix due to the file not being there for some reason. Once this is fixed we can remove the UpdateRuntimePack target here -->
+  <!--<Import Project="$(RepositoryEngineeringDir)targetingpacks.targets" Condition="'$(TargetingpacksTargetsImported)' != 'true'"/>-->
   <Import Project="$(MSBuildThisFileDirectory)WasmApp.targets" />
 
-  <Target Name="PrintRuntimePackLocation" AfterTargets="UpdateTargetingAndRuntimePack">
+  <!-- Use local runtime pack -->
+  <Target Name="UpdateRuntimePack" AfterTargets="ResolveFrameworkReferences">
+    <PropertyGroup>
+      <_LocalMicrosoftNetCoreAppRuntimePackDir>$([MSBuild]::NormalizeDirectory($(ArtifactsBinDir), 'microsoft.netcore.app.runtime.browser-wasm', $(Configuration)))</_LocalMicrosoftNetCoreAppRuntimePackDir>
+    </PropertyGroup>
+    <ItemGroup>
+      <ResolvedRuntimePack PackageDirectory="$(_LocalMicrosoftNetCoreAppRuntimePackDir)"
+                           Condition="'$(_LocalMicrosoftNetCoreAppRuntimePackDir)' != '' and
+                                      '%(ResolvedRuntimePack.FrameworkName)' == 'Microsoft.NETCore.App'" />
+    </ItemGroup>
     <Message Text="Used runtime pack: %(ResolvedRuntimePack.PackageDirectory)" Importance="high" />
   </Target>
 

--- a/src/mono/wasm/build/WasmApp.InTree.targets
+++ b/src/mono/wasm/build/WasmApp.InTree.targets
@@ -2,16 +2,11 @@
   <!-- This depends on the root Directory.Build.targets imported this file -->
   <UsingTask TaskName="MonoAOTCompiler" AssemblyFile="$(MonoAOTCompilerTasksAssemblyPath)" />
 
+  <Import Project="$(RepositoryEngineeringDir)targetingpacks.targets" Condition="'$(TargetingpacksTargetsImported)' != 'true'"/>
   <Import Project="$(MSBuildThisFileDirectory)WasmApp.targets" />
 
-  <!-- Redirect 'dotnet publish' to in-tree runtime pack -->
-  <Target Name="TrickRuntimePackLocation" AfterTargets="ProcessFrameworkReferences" Condition="@(RuntimePack->Count()) != 0">
-    <ItemGroup>
-      <RuntimePack>
-        <PackageDirectory>$([MSBuild]::NormalizeDirectory($(ArtifactsBinDir), 'microsoft.netcore.app.runtime.browser-wasm', $(Configuration)))</PackageDirectory>
-      </RuntimePack>
-    </ItemGroup>
-    <Message Text="Using RuntimePack.PackageDirectory: %(RuntimePack.PackageDirectory)" Importance="Low" />
+  <Target Name="PrintRuntimePackLocation" AfterTargets="UpdateTargetingAndRuntimePack">
+    <Message Text="Used runtime pack: %(ResolvedRuntimePack.PackageDirectory)" Importance="high" />
   </Target>
 
   <Target Name="RebuildWasmAppBuilder">

--- a/src/mono/wasm/build/WasmApp.LocalBuild.targets
+++ b/src/mono/wasm/build/WasmApp.LocalBuild.targets
@@ -40,7 +40,6 @@
 
   <!-- Use local runtime pack -->
   <Target Name="UpdateRuntimePack" AfterTargets="ResolveFrameworkReferences" DependsOnTargets="_PrepareAndValidateWasmInputs">
-    <Error Condition="@(ResolvedRuntimePack->Count()) == 0" Text="No runtime pack was resolved!" />
     <ItemGroup>
       <ResolvedRuntimePack PackageDirectory="$(MicrosoftNetCoreAppRuntimePackLocationToUse)"
                            Condition="'$(MicrosoftNetCoreAppRuntimePackLocationToUse)' != '' and

--- a/src/mono/wasm/build/WasmApp.LocalBuild.targets
+++ b/src/mono/wasm/build/WasmApp.LocalBuild.targets
@@ -26,6 +26,7 @@
   <PropertyGroup>
     <PublishTrimmed>true</PublishTrimmed>
     <TrimMode>link</TrimMode>
+    <UseMonoRuntime>true</UseMonoRuntime>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
@@ -37,14 +38,15 @@
     <DebuggerSupport>false</DebuggerSupport>
   </PropertyGroup>
 
-  <Target Name="UpdateTargetingAndRuntimePack" AfterTargets="ResolveFrameworkReferences" DependsOnTargets="_PrepareAndValidateWasmInputs">
+  <!-- Use local runtime pack -->
+  <Target Name="UpdateRuntimePack" AfterTargets="ResolveFrameworkReferences" DependsOnTargets="_PrepareAndValidateWasmInputs">
+    <Error Condition="@(ResolvedRuntimePack->Count()) == 0" Text="No runtime pack was resolved!" />
     <ItemGroup>
-      <RuntimePack>
-        <PackageDirectory>$(MicrosoftNetCoreAppRuntimePackLocationToUse)</PackageDirectory>
-      </RuntimePack>
-      <ResolvedRuntimePack PackageDirectory="$(MicrosoftNetCoreAppRuntimePackLocationToUse)" />
+      <ResolvedRuntimePack PackageDirectory="$(MicrosoftNetCoreAppRuntimePackLocationToUse)"
+                           Condition="'$(MicrosoftNetCoreAppRuntimePackLocationToUse)' != '' and
+                                      '%(ResolvedRuntimePack.FrameworkName)' == 'Microsoft.NETCore.App'" />
     </ItemGroup>
-    <Message Text="Using Runtime pack from: %(ResolvedRuntimePack.PackageDirectory)" Importance="high" />
+    <Message Text="Used runtime pack: %(ResolvedRuntimePack.PackageDirectory)" Importance="high" />
   </Target>
 
   <!-- the actual properties need to get set in the props, so because UsingTasks depend on those. -->


### PR DESCRIPTION
Use similar logic to `eng/targetingpacks.targets` in `WasmApp.InTree.targets` and `WasmApp.LocalBuild.targets`.

Also set `UseMonoRuntime=true` to make sure we get the Mono-based runtime pack.