### PR TITLE
[mono] Optimize Type.IsRuntimeImplemented

### DIFF
--- a/src/mono/System.Private.CoreLib/src/System/Type.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Type.Mono.cs
@@ -20,7 +20,7 @@ namespace System
             return _impl.Value;
         }
 
-        internal bool IsRuntimeImplemented() => this.UnderlyingSystemType is RuntimeType;
+        internal bool IsRuntimeImplemented() => this is RuntimeType;
 
         internal virtual bool IsTypeBuilder() => false;
 


### PR DESCRIPTION
Avoid virtual call to Type.UnderlyingSystemType. This is same as coreclr.