### PR TITLE
Use Task.WaitAsync in SemaphoreSlim.WaitAsync

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
@@ -701,35 +701,13 @@ namespace System.Threading
             Debug.Assert(asyncWaiter != null, "Waiter should have been constructed");
             Debug.Assert(Monitor.IsEntered(m_lockObjAndDisposed), "Requires the lock be held");
 
-            if (millisecondsTimeout != Timeout.Infinite)
+            await new ConfiguredNoThrowAwaiter<bool>(asyncWaiter.WaitAsync(TimeSpan.FromMilliseconds(millisecondsTimeout), cancellationToken));
+            if (asyncWaiter.IsCompleted)
             {
-                // Wait until either the task is completed, cancellation is requested, or the timeout occurs.
-                // We need to ensure that the Task.Delay task is appropriately cleaned up if the await
-                // completes due to the asyncWaiter completing, so we use our own token that we can explicitly
-                // cancel, and we chain the caller's supplied token into it.
-                using (var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
-                {
-                    if (asyncWaiter == await Task.WhenAny(asyncWaiter, Task.Delay(millisecondsTimeout, cts.Token)).ConfigureAwait(false))
-                    {
-                        cts.Cancel(); // ensure that the Task.Delay task is cleaned up
-                        return true; // successfully acquired
-                    }
-                }
-            }
-            else // millisecondsTimeout == Timeout.Infinite
-            {
-                // Wait until either the task is completed or cancellation is requested.
-                var cancellationTask = new Task(null, TaskCreationOptions.RunContinuationsAsynchronously, promiseStyle: true);
-                using (cancellationToken.UnsafeRegister(static s => ((Task)s!).TrySetResult(), cancellationTask))
-                {
-                    if (asyncWaiter == await Task.WhenAny(asyncWaiter, cancellationTask).ConfigureAwait(false))
-                    {
-                        return true; // successfully acquired
-                    }
-                }
+                return true; // successfully acquired
             }
 
-            // If we get here, the wait has timed out or been canceled.
+            // The wait has timed out or been canceled.
 
             // If the await completed synchronously, we still hold the lock.  If it didn't,
             // we no longer hold the lock.  As such, acquire it.
@@ -748,6 +726,19 @@ namespace System.Threading
             // The waiter had already been removed, which means it's already completed or is about to
             // complete, so let it, and don't return until it does.
             return await asyncWaiter.ConfigureAwait(false);
+        }
+
+        // TODO https://github.com/dotnet/runtime/issues/22144: Replace with official nothrow await solution once available.
+        /// <summary>Awaiter used to await a task.ConfigureAwait(false) but without throwing any exceptions for faulted or canceled tasks.</summary>
+        private readonly struct ConfiguredNoThrowAwaiter<T> : ICriticalNotifyCompletion
+        {
+            private readonly Task<T> _task;
+            public ConfiguredNoThrowAwaiter(Task<T> task) => _task = task;
+            public ConfiguredNoThrowAwaiter<T> GetAwaiter() => this;
+            public bool IsCompleted => _task.IsCompleted;
+            public void GetResult() { }
+            public void UnsafeOnCompleted(Action continuation) => _task.ConfigureAwait(false).GetAwaiter().UnsafeOnCompleted(continuation);
+            public void OnCompleted(Action continuation) => _task.ConfigureAwait(false).GetAwaiter().OnCompleted(continuation);
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskScheduler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskScheduler.cs
@@ -529,10 +529,32 @@ namespace System.Threading.Tasks
             // returns the scheduler's GetScheduledTasks
             public IEnumerable<Task>? ScheduledTasks => m_taskScheduler.GetScheduledTasks();
         }
+
+        // TODO https://github.com/dotnet/runtime/issues/20025: Consider exposing publicly.
+        /// <summary>Gets an awaiter used to queue a continuation to this TaskScheduler.</summary>
+        internal TaskSchedulerAwaiter GetAwaiter() => new TaskSchedulerAwaiter(this);
+
+        /// <summary>Awaiter used to queue a continuation to a specified task scheduler.</summary>
+        internal readonly struct TaskSchedulerAwaiter : ICriticalNotifyCompletion
+        {
+            private readonly TaskScheduler _scheduler;
+            public TaskSchedulerAwaiter(TaskScheduler scheduler) => _scheduler = scheduler;
+            public bool IsCompleted => false;
+            public void GetResult() { }
+            public void OnCompleted(Action continuation) => Task.Factory.StartNew(continuation, CancellationToken.None, TaskCreationOptions.DenyChildAttach, _scheduler);
+            public void UnsafeOnCompleted(Action continuation)
+            {
+                if (ReferenceEquals(_scheduler, Default))
+                {
+                    ThreadPool.UnsafeQueueUserWorkItem(s => s(), continuation, preferLocal: true);
+                }
+                else
+                {
+                    OnCompleted(continuation);
+                }
+            }
+        }
     }
-
-
-
 
     /// <summary>
     /// A TaskScheduler implementation that executes all tasks queued to it through a call to


### PR DESCRIPTION
|           Method |         Toolchain |     Mean | Ratio | Allocated |
|----------------- |------------------ |---------:|------:|----------:|
|           WithCT | \main\CoreRun.exe | 1.103 us |  1.00 |     496 B |
|           WithCT |   \pr\CoreRun.exe | 1.032 us |  0.94 |     440 B |
|                  |                   |          |       |           |
|      WithTimeout | \main\CoreRun.exe | 1.492 us |  1.00 |     888 B |
|      WithTimeout |   \pr\CoreRun.exe | 1.103 us |  0.74 |     536 B |
|                  |                   |          |       |           |
| WithCTandTimeout | \main\CoreRun.exe | 1.589 us |  1.00 |     904 B |
| WithCTandTimeout |   \pr\CoreRun.exe | 1.200 us |  0.75 |     536 B |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Diagnosers;
using BenchmarkDotNet.Running;
using System;
using System.Threading.Tasks;
using System.Threading;

[MemoryDiagnoser]
public class Program
{
    public static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

    private SemaphoreSlim _sem = new SemaphoreSlim(0, 1);
    private CancellationTokenSource _cts = new CancellationTokenSource();

    [Benchmark]
    public Task WithCT()
    {
        Task t = _sem.WaitAsync(_cts.Token);
        _sem.Release();
        return t;
    }

    [Benchmark]
    public Task WithTimeout()
    {
        Task t = _sem.WaitAsync(TimeSpan.FromMinutes(1));
        _sem.Release();
        return t;
    }

    [Benchmark]
    public Task WithCTandTimeout()
    {
        Task t = _sem.WaitAsync(TimeSpan.FromMinutes(1), _cts.Token);
        _sem.Release();
        return t;
    }
}
```