### PR TITLE
[Mono] Add Mono Profiler events into EventPipe.

### DIFF
--- a/src/coreclr/scripts/genEventPipe.py
+++ b/src/coreclr/scripts/genEventPipe.py
@@ -72,10 +72,18 @@ def generateMethodSignatureWrite(eventName, template, extern, runtimeFlavor):
     sig_pieces.append(")")
     return ''.join(sig_pieces)
 
+def includeProvider(providerName, runtimeFlavor):
+    if runtimeFlavor.coreclr and providerName == "Microsoft-DotNETRuntimeMonoProfiler":
+        return False
+    else:
+        return True
+
 def includeEvent(inclusionList, providerName, eventName):
     if len(inclusionList) == 0:
         return True
     if providerName in inclusionList and eventName in inclusionList[providerName]:
+        return True
+    elif providerName in inclusionList and "*" in inclusionList[providerName]:
         return True
     elif "*" in inclusionList and eventName in inclusionList["*"]:
         return True
@@ -339,6 +347,10 @@ def generateWriteEventBody(template, providerName, eventName, runtimeFlavor):
         elif parameter.winType == "win:Double" and runtimeFlavor.mono:
             pack_list.append(
                     "    success &= write_buffer_double_t(%s, &buffer, &offset, &size, &fixedBuffer);" %
+                    (parameter.name,))
+        elif parameter.winType == "win:Pointer" and runtimeFlavor.mono:
+            pack_list.append(
+                    "    success &= write_buffer_uintptr_t((uintptr_t)%s, &buffer, &offset, &size, &fixedBuffer);" %
                     (parameter.name,))
         elif runtimeFlavor.mono:
             pack_list.append(
@@ -669,16 +681,17 @@ def generateEventPipeHelperFile(etwmanifest, eventpipe_directory, target_cpp, ru
 
             for providerNode in tree.getElementsByTagName('provider'):
                 providerName = providerNode.getAttribute('name')
-                providerPrettyName = providerName.replace("Windows-", '')
-                providerPrettyName = providerPrettyName.replace("Microsoft-", '')
-                providerPrettyName = providerPrettyName.replace('-', '_')
-                if extern: helper.write(
-                    'extern "C" '
-                )
-                helper.write(
-                    "void Init" +
-                    providerPrettyName +
-                    "(void);\n\n")
+                if includeProvider(providerName, runtimeFlavor):
+                    providerPrettyName = providerName.replace("Windows-", '')
+                    providerPrettyName = providerPrettyName.replace("Microsoft-", '')
+                    providerPrettyName = providerPrettyName.replace('-', '_')
+                    if extern: helper.write(
+                        'extern "C" '
+                    )
+                    helper.write(
+                        "void Init" +
+                        providerPrettyName +
+                        "(void);\n\n")
 
             if extern: helper.write(
                 'extern "C" '
@@ -687,10 +700,11 @@ def generateEventPipeHelperFile(etwmanifest, eventpipe_directory, target_cpp, ru
             helper.write("void InitProvidersAndEvents(void)\n{\n")
             for providerNode in tree.getElementsByTagName('provider'):
                 providerName = providerNode.getAttribute('name')
-                providerPrettyName = providerName.replace("Windows-", '')
-                providerPrettyName = providerPrettyName.replace("Microsoft-", '')
-                providerPrettyName = providerPrettyName.replace('-', '_')
-                helper.write("    Init" + providerPrettyName + "();\n")
+                if includeProvider(providerName, runtimeFlavor):
+                    providerPrettyName = providerName.replace("Windows-", '')
+                    providerPrettyName = providerPrettyName.replace("Microsoft-", '')
+                    providerPrettyName = providerPrettyName.replace('-', '_')
+                    helper.write("    Init" + providerPrettyName + "();\n")
             helper.write("}\n")
 
             if runtimeFlavor.coreclr:
@@ -894,6 +908,19 @@ write_buffer_bool_t (
 
 static
 inline
+bool
+write_buffer_uintptr_t (
+    uintptr_t value,
+    uint8_t **buffer,
+    size_t *offset,
+    size_t *size,
+    bool *fixed_buffer)
+{
+    return write_buffer ((const uint8_t *)&value, sizeof (uintptr_t), buffer, offset, size, fixed_buffer);
+}
+
+static
+inline
 EventPipeEvent *
 provider_add_event (
     EventPipeProvider *provider,
@@ -949,6 +976,8 @@ def generateEventPipeImplFiles(
 
     for providerNode in tree.getElementsByTagName('provider'):
         providerName = providerNode.getAttribute('name')
+        if not includeProvider(providerName, runtimeFlavor):
+            continue
 
         providerPrettyName = providerName.replace("Windows-", '')
         providerPrettyName = providerPrettyName.replace("Microsoft-", '')

--- a/src/coreclr/vm/ClrEtwAll.man
+++ b/src/coreclr/vm/ClrEtwAll.man
@@ -7052,6 +7052,930 @@
                 </events>
             </provider>
 
+            <!-- Mono Profiler Publisher-->
+            <provider name="Microsoft-DotNETRuntimeMonoProfiler"
+                      guid="{5CF93F63-D58B-4EE3-B884-9EDA84A192DB}"
+                      symbol="MICROSOFT_DOTNETRUNTIME_MONO_PROFILER_PROVIDER"
+                      resourceFileName="%INSTALL_PATH%\clretwrc.dll"
+                      messageFileName="%INSTALL_PATH%\clretwrc.dll">
+
+                <!--Keywords-->
+                <keywords>
+                    <keyword name="GCKeyword" mask="0x1"
+                             message="$(string.MonoProfilerPublisher.GCKeywordMessage)" symbol="CLR_MONO_PROFILER_GC_KEYWORD" />
+                    <keyword name="GCHandleKeyword" mask="0x2"
+                             message="$(string.MonoProfilerPublisher.GCHandleKeywordMessage)" symbol="CLR_MONO_PROFILER_GC_HANDLE_KEYWORD" />
+                    <keyword name="LoaderKeyword" mask="0x8"
+                             message="$(string.MonoProfilerPublisher.LoaderKeywordMessage)" symbol="CLR_MONO_PROFILER_LOADER_KEYWORD" />
+                    <keyword name="JitKeyword" mask="0x10"
+                             message="$(string.MonoProfilerPublisher.JitKeywordMessage)" symbol="CLR_MONO_PROFILER_JIT_KEYWORD" />
+                    <keyword name="ContentionKeyword" mask="0x4000"
+                             message="$(string.MonoProfilerPublisher.ContentionKeywordMessage)" symbol="CLR_MONO_PROFILER_CONTENTION_KEYWORD"/>
+                    <keyword name="ExceptionKeyword" mask="0x8000"
+                             message="$(string.MonoProfilerPublisher.ExceptionKeywordMessage)" symbol="CLR_MONO_PROFILER_EXCEPTION_KEYWORD" />
+                    <keyword name="ThreadingKeyword" mask="0x10000"
+                             message="$(string.MonoProfilerPublisher.ThreadingKeywordMessage)" symbol="CLR_MONO_PROFILER_THREADING_KEYWORD"/>
+                    <keyword name="GCHeapDumpKeyword" mask="0x100000"
+                             message="$(string.MonoProfilerPublisher.GCHeapDumpKeywordMessage)" symbol="CLR_MONO_PROFILER_GC_HEAPDUMP_KEYWORD" />
+                    <keyword name="GCAllocationKeyword" mask="0x200000"
+                             message="$(string.MonoProfilerPublisher.GCAllocationKeywordMessage)" symbol="CLR_MONO_PROFILER_GC_ALLOCATION_KEYWORD" />
+                    <keyword name="GCMovesKeyword" mask="0x400000"
+                             message="$(string.MonoProfilerPublisher.GCMovesKeywordMessage)" symbol="CLR_MONO_PROFILER_GC_MOVES_KEYWORD" />
+                    <keyword name="GCRootKeyword" mask="0x800000"
+                             message="$(string.MonoProfilerPublisher.GCRootKeywordMessage)" symbol="CLR_MONO_PROFILER_GC_ROOT_KEYWORD" />
+                    <keyword name="GCFinalizationKeyword" mask="0x1000000"
+                             message="$(string.MonoProfilerPublisher.GCFinalizationKeywordMessage)" symbol="CLR_MONO_PROFILER_GC_FINALIZATION_KEYWORD" />
+                    <keyword name="GCResizeKeyword" mask="0x2000000"
+                             message="$(string.MonoProfilerPublisher.GCResizeKeywordMessage)" symbol="CLR_MONO_PROFILER_GC_RESIZE_KEYWORD" />
+                    <keyword name="MethodTracingKeyword" mask="0x20000000"
+                             message="$(string.MonoProfilerPublisher.MethodTracingKeywordMessage)" symbol="CLR_MONO_PROFILER_METHOD_TRACING_KEYWORD" />
+                    <keyword name="TypeLoadingKeyword" mask="0x8000000000"
+                             message="$(string.MonoProfilerPublisher.TypeLoadingKeywordMessage)" symbol="CLR_MONO_PROFILER_TYPE_LOADING_KEYWORD" />
+                    <keyword name="MonitorKeyword" mask="0x10000000000"
+                             message="$(string.MonoProfilerPublisher.MonitorKeywordMessage)" symbol="CLR_MONO_PROFILER_MONITOR_KEYWORD" />
+                </keywords>
+
+                <!--Tasks-->
+                <tasks>
+                    <task name="MonoProfiler" symbol="CLR_MONO_PROFILER_TASK"
+                          value="1" eventGUID="{7EC39CC6-C9E3-4328-9B32-CA6C5EC0EF31}"
+                          message="$(string.MonoProfilerPublisher.MonoProfilerTaskMessage)">
+                        <opcodes>
+                            <opcode name="ContextLoaded" message="$(string.MonoProfilerPublisher.ContextLoadedOpcodeMessage)" symbol="CLR_MONO_PROFILER_CONTEXT_LOADED_OPCODE" value="18" />
+                            <opcode name="ContextUnloaded" message="$(string.MonoProfilerPublisher.ContextUnloadedOpcodeMessage)" symbol="CLR_MONO_PROFILER_CONTEXT_UNLOADED_OPCODE" value="19" />
+                            <opcode name="AppDomainLoading" message="$(string.MonoProfilerPublisher.AppDomainLoadingOpcodeMessage)" symbol="CLR_MONO_PROFILER_APP_DOMAIN_LOADING_OPCODE" value="20" />
+                            <opcode name="AppDomainLoaded" message="$(string.MonoProfilerPublisher.AppDomainLoadedOpcodeMessage)" symbol="CLR_MONO_PROFILER_APP_DOMAIN_LOADED_OPCODE" value="21" />
+                            <opcode name="AppDomainUnloading" message="$(string.MonoProfilerPublisher.AppDomainUnloadingOpcodeMessage)" symbol="CLR_MONO_PROFILER_APP_DOMAIN_UNLOADING_OPCODE" value="22" />
+                            <opcode name="AppDomainUnloaded" message="$(string.MonoProfilerPublisher.AppDomainUnloadedOpcodeMessage)" symbol="CLR_MONO_PROFILER_APP_DOMAIN_UNLOADED_OPCODE" value="23" />
+                            <opcode name="AppDomainName" message="$(string.MonoProfilerPublisher.AppDomainNameOpcodeMessage)" symbol="CLR_MONO_PROFILER_APP_DOMAIN_NAME_OPCODE" value="24" />
+                            <opcode name="JitBegin" message="$(string.MonoProfilerPublisher.JitBeginOpcodeMessage)" symbol="CLR_MONO_PROFILER_JIT_BEGIN_OPCODE" value="25" />
+                            <opcode name="JitFailed" message="$(string.MonoProfilerPublisher.JitFailedOpcodeMessage)" symbol="CLR_MONO_PROFILER_JIT_FAILED_OPCODE" value="26" />
+                            <opcode name="JitDone" message="$(string.MonoProfilerPublisher.JitDoneOpcodeMessage)" symbol="CLR_MONO_PROFILER_JIT_DONE_OPCODE" value="27" />
+                            <opcode name="JitChunkCreated" message="$(string.MonoProfilerPublisher.JitChunkCreatedOpcodeMessage)" symbol="CLR_MONO_PROFILER_JIT_CHUNK_CREATED_OPCODE" value="28" />
+                            <opcode name="JitChunkDestroyed" message="$(string.MonoProfilerPublisher.JitChunkDestroyedOpcodeMessage)" symbol="CLR_MONO_PROFILER_JIT_CHUNK_DESTROYED_OPCODE" value="29" />
+                            <opcode name="JitCodeBuffer" message="$(string.MonoProfilerPublisher.JitCodeBufferOpcodeMessage)" symbol="CLR_MONO_PROFILER_JIT_CODE_BUFFER_OPCODE" value="30" />
+                            <opcode name="ClassLoading" message="$(string.MonoProfilerPublisher.ClassLoadingOpcodeMessage)" symbol="CLR_MONO_PROFILER_CLASS_LOADING_OPCODE" value="31" />
+                            <opcode name="ClassFailed" message="$(string.MonoProfilerPublisher.ClassFailedOpcodeMessage)" symbol="CLR_MONO_PROFILER_CLASS_FAILED_OPCODE" value="32" />
+                            <opcode name="ClassLoaded" message="$(string.MonoProfilerPublisher.ClassLoadedOpcodeMessage)" symbol="CLR_MONO_PROFILER_CLASS_LOADED_OPCODE" value="33" />
+                            <opcode name="VTableLoading" message="$(string.MonoProfilerPublisher.VTableLoadingOpcodeMessage)" symbol="CLR_MONO_PROFILER_VTABLE_LOADING_OPCODE" value="34" />
+                            <opcode name="VTableFailed" message="$(string.MonoProfilerPublisher.VTableFailedOpcodeMessage)" symbol="CLR_MONO_PROFILER_VTABLE_FAILED_OPCODE" value="35" />
+                            <opcode name="VTableLoaded" message="$(string.MonoProfilerPublisher.VTableLoadedOpcodeMessage)" symbol="CLR_MONO_PROFILER_VTABLE_LOADED_OPCODE" value="36" />
+                            <opcode name="ModuleLoading" message="$(string.MonoProfilerPublisher.ModuleLoadingOpcodeMessage)" symbol="CLR_MONO_PROFILER_MODULE_LOADING_OPCODE" value="37" />
+                            <opcode name="ModuleFailed" message="$(string.MonoProfilerPublisher.ModuleFailedOpcodeMessage)" symbol="CLR_MONO_PROFILER_MODULE_FAILED_OPCODE" value="38" />
+                            <opcode name="ModuleLoaded" message="$(string.MonoProfilerPublisher.ModuleLoadedOpcodeMessage)" symbol="CLR_MONO_PROFILER_MODULE_LOADED_OPCODE" value="39" />
+                            <opcode name="ModuleUnloading" message="$(string.MonoProfilerPublisher.ModuleUnloadingOpcodeMessage)" symbol="CLR_MONO_PROFILER_MODULE_UNLOADING_OPCODE" value="40" />
+                            <opcode name="ModuleUnloaded" message="$(string.MonoProfilerPublisher.ModuleUnloadedOpcodeMessage)" symbol="CLR_MONO_PROFILER_MODULE_UNLOADED_OPCODE" value="41" />
+                            <opcode name="AssemblyLoading" message="$(string.MonoProfilerPublisher.AssemblyLoadingOpcodeMessage)" symbol="CLR_MONO_PROFILER_ASSEMBLY_LOADING_OPCODE" value="42" />
+                            <opcode name="AssemblyLoaded" message="$(string.MonoProfilerPublisher.AssemblyLoadedOpcodeMessage)" symbol="CLR_MONO_PROFILER_ASSEMBLY_LOADED_OPCODE" value="43" />
+                            <opcode name="AssemblyUnloading" message="$(string.MonoProfilerPublisher.AssemblyUnloadingOpcodeMessage)" symbol="CLR_MONO_PROFILER_ASSEMBLY_UNLOADING_OPCODE" value="44" />
+                            <opcode name="AssemblyUnloaded" message="$(string.MonoProfilerPublisher.AssemblyUnloadedOpcodeMessage)" symbol="CLR_MONO_PROFILER_ASSEMBLY_UNLOADED_OPCODE" value="45" />
+                            <opcode name="MethodEnter" message="$(string.MonoProfilerPublisher.MethodEnterOpcodeMessage)" symbol="CLR_MONO_PROFILER_METHOD_ENTER_OPCODE" value="46" />
+                            <opcode name="MethodLeave" message="$(string.MonoProfilerPublisher.MethodLeaveOpcodeMessage)" symbol="CLR_MONO_PROFILER_METHOD_LEAVE_OPCODE" value="47" />
+                            <opcode name="MethodTailCall" message="$(string.MonoProfilerPublisher.MethodTailCallOpcodeMessage)" symbol="CLR_MONO_PROFILER_METHOD_TAIL_CALL_OPCODE" value="48" />
+                            <opcode name="MethodExceptionLeave" message="$(string.MonoProfilerPublisher.MethodExceptionLeaveOpcodeMessage)" symbol="CLR_MONO_PROFILER_METHOD_EXCEPTION_LEAVE_OPCODE" value="49" />
+                            <opcode name="MethodFree" message="$(string.MonoProfilerPublisher.MethodFreeOpcodeMessage)" symbol="CLR_MONO_PROFILER_METHOD_FREE_OPCODE" value="50" />
+                            <opcode name="MethodBeginInvoke" message="$(string.MonoProfilerPublisher.MethodBeginInvokeOpcodeMessage)" symbol="CLR_MONO_PROFILER_METHOD_BEGIN_INVOKE_OPCODE" value="51" />
+                            <opcode name="MethodEndInvoke" message="$(string.MonoProfilerPublisher.MethodEndInvokeOpcodeMessage)" symbol="CLR_MONO_PROFILER_METHOD_END_INVOKE_OPCODE" value="52" />
+                            <opcode name="ExceptionThrow" message="$(string.MonoProfilerPublisher.ExceptionThrowOpcodeMessage)" symbol="CLR_MONO_PROFILER_EXCEPTION_THROW_OPCODE" value="53" />
+                            <opcode name="ExceptionClause" message="$(string.MonoProfilerPublisher.ExceptionClauseOpcodeMessage)" symbol="CLR_MONO_PROFILER_EXCEPTION_CLAUSE_OPCODE" value="54" />
+                            <opcode name="GCEvent" message="$(string.MonoProfilerPublisher.GCEventOpcodeMessage)" symbol="CLR_MONO_PROFILER_GC_EVENT_OPCODE" value="55" />
+                            <opcode name="GCAllocation" message="$(string.MonoProfilerPublisher.GCAllocationOpcodeMessage)" symbol="CLR_MONO_PROFILER_GC_ALLOCATION_OPCODE" value="56" />
+                            <opcode name="GCMoves" message="$(string.MonoProfilerPublisher.GCMovesOpcodeMessage)" symbol="CLR_MONO_PROFILER_GC_MOVES_OPCODE" value="57" />
+                            <opcode name="GCResize" message="$(string.MonoProfilerPublisher.GCResizeOpcodeMessage)" symbol="CLR_MONO_PROFILER_GC_RESIZE_OPCODE" value="58" />
+                            <opcode name="GCHandleCreated" message="$(string.MonoProfilerPublisher.GCHandleCreatedOpcodeMessage)" symbol="CLR_MONO_PROFILER_GC_HANDLE_CREATED_OPCODE" value="59" />
+                            <opcode name="GCHandleDeleted" message="$(string.MonoProfilerPublisher.GCHandleDeletedOpcodeMessage)" symbol="CLR_MONO_PROFILER_GC_HANDLE_DELETED_OPCODE" value="60" />
+                            <opcode name="GCFinalizing" message="$(string.MonoProfilerPublisher.GCFinalizingOpcodeMessage)" symbol="CLR_MONO_PROFILER_GC_FINALIZING_OPCODE" value="61" />
+                            <opcode name="GCFinalized" message="$(string.MonoProfilerPublisher.GCFinalizedOpcodeMessage)" symbol="CLR_MONO_PROFILER_GC_FINALIZED_OPCODE" value="62" />
+                            <opcode name="GCFinalizingObject" message="$(string.MonoProfilerPublisher.GCFinalizingObjectOpcodeMessage)" symbol="CLR_MONO_PROFILER_GC_FINALIZING_OBJECT_OPCODE" value="63" />
+                            <opcode name="GCFinalizedObject" message="$(string.MonoProfilerPublisher.GCFinalizedObjectOpcodeMessage)" symbol="CLR_MONO_PROFILER_GC_FINALIZED_OBJECT_OPCODE" value="64" />
+                            <opcode name="GCRootRegister" message="$(string.MonoProfilerPublisher.GCRootRegisterOpcodeMessage)" symbol="CLR_MONO_PROFILER_GC_ROOT_REGISTER_OPCODE" value="65" />
+                            <opcode name="GCRootUnregister" message="$(string.MonoProfilerPublisher.GCRootUnregisterOpcodeMessage)" symbol="CLR_MONO_PROFILER_GC_ROOT_UNREGISTER_OPCODE" value="66" />
+                            <opcode name="GCRoots" message="$(string.MonoProfilerPublisher.GCRootsOpcodeMessage)" symbol="CLR_MONO_PROFILER_GC_ROOTS_OPCODE" value="67" />
+                            <opcode name="GCHeapDumpStart" message="$(string.MonoProfilerPublisher.GCHeapDumpStartOpcodeMessage)" symbol="CLR_MONO_PROFILER_GC_HEAP_DUMP_START_OPCODE" value="68" />
+                            <opcode name="GCHeapDumpStop" message="$(string.MonoProfilerPublisher.GCHeapDumpStopOpcodeMessage)" symbol="CLR_MONO_PROFILER_GC_HEAP_DUMP_STOP_OPCODE" value="69" />
+                            <opcode name="GCHeapDumpObjectReference" message="$(string.MonoProfilerPublisher.GCHeapDumpObjectReferenceOpcodeMessage)" symbol="CLR_MONO_PROFILER_GC_HEAP_DUMP_OBJECT_REFERENCE_OPCODE" value="70" />
+                            <opcode name="MonitorContention" message="$(string.MonoProfilerPublisher.MonitorContentionOpcodeMessage)" symbol="CLR_MONO_PROFILER_MONITOR_CONTENTION_OPCODE" value="71" />
+                            <opcode name="MonitorFailed" message="$(string.MonoProfilerPublisher.MonitorFailedOpcodeMessage)" symbol="CLR_MONO_PROFILER_MONITOR_FAILED_OPCODE" value="72" />
+                            <opcode name="MonitorAquired" message="$(string.MonoProfilerPublisher.MonitorAquiredOpcodeMessage)" symbol="CLR_MONO_PROFILER_MONITOR_AQUIRED_OPCODE" value="73" />
+                            <opcode name="ThreadStarted" message="$(string.MonoProfilerPublisher.ThreadStartedOpcodeMessage)" symbol="CLR_MONO_PROFILER_THREAD_STARTED_OPCODE" value="74" />
+                            <opcode name="ThreadStopping" message="$(string.MonoProfilerPublisher.ThreadStoppingOpcodeMessage)" symbol="CLR_MONO_PROFILER_THREAD_STOPPING_OPCODE" value="75" />
+                            <opcode name="ThreadStopped" message="$(string.MonoProfilerPublisher.ThreadStoppedOpcodeMessage)" symbol="CLR_MONO_PROFILER_THREAD_STOPPED_OPCODE" value="76" />
+                            <opcode name="ThreadExited" message="$(string.MonoProfilerPublisher.ThreadExitedOpcodeMessage)" symbol="CLR_MONO_PROFILER_THREAD_EXITED_OPCODE" value="77" />
+                            <opcode name="ThreadName" message="$(string.MonoProfilerPublisher.ThreadNameOpcodeMessage)" symbol="CLR_MONO_PROFILER_THREAD_NAME_OPCODE" value="78" />
+                        </opcodes>
+                    </task>
+                </tasks>
+
+                <maps>
+                    <valueMap name="JitCodeBufferTypeMap">
+                        <map value="0x0" message="$(string.MonoProfilerPublisher.CodeBufferTypeMap.MethodMessage)"/>
+                        <map value="0x1" message="$(string.MonoProfilerPublisher.CodeBufferTypeMap.MethodTrampolineMessage)"/>
+                        <map value="0x2" message="$(string.MonoProfilerPublisher.CodeBufferTypeMap.UnboxTrampolineMessage)"/>
+                        <map value="0x3" message="$(string.MonoProfilerPublisher.CodeBufferTypeMap.IMTTrampolineMessage)"/>
+                        <map value="0x4" message="$(string.MonoProfilerPublisher.CodeBufferTypeMap.GenericsTrampolineMessage)"/>
+                        <map value="0x5" message="$(string.MonoProfilerPublisher.CodeBufferTypeMap.SpecificTrampolineMessage)"/>
+                        <map value="0x6" message="$(string.MonoProfilerPublisher.CodeBufferTypeMap.HelperMessage)"/>
+                    </valueMap>
+                    <valueMap name="ExceptionClauseTypeMap">
+                        <map value="0x0" message="$(string.MonoProfilerPublisher.ExceptionClauseTypeMap.NoneMessage)"/>
+                        <map value="0x1" message="$(string.MonoProfilerPublisher.ExceptionClauseTypeMap.FilterMessage)"/>
+                        <map value="0x2" message="$(string.MonoProfilerPublisher.ExceptionClauseTypeMap.FinallyMessage)"/>
+                        <map value="0x3" message="$(string.MonoProfilerPublisher.ExceptionClauseTypeMap.FaultMessage)"/>
+                    </valueMap>
+                    <valueMap name="GCEventTypeMap">
+                        <map value="0x0" message="$(string.MonoProfilerPublisher.GCEventTypeMap.StartMessage)"/>
+                        <map value="0x5" message="$(string.MonoProfilerPublisher.GCEventTypeMap.EndMessage)"/>
+                        <map value="0x6" message="$(string.MonoProfilerPublisher.GCEventTypeMap.PreStopWorldMessage)"/>
+                        <map value="0x7" message="$(string.MonoProfilerPublisher.GCEventTypeMap.PostStopWorldMessage)"/>
+                        <map value="0x8" message="$(string.MonoProfilerPublisher.GCEventTypeMap.PreStartWorldMessage)"/>
+                        <map value="0x9" message="$(string.MonoProfilerPublisher.GCEventTypeMap.PostStartWorldMessage)"/>
+                        <map value="0xA" message="$(string.MonoProfilerPublisher.GCEventTypeMap.PreStopWorldLockedMessage)"/>
+                        <map value="0xB" message="$(string.MonoProfilerPublisher.GCEventTypeMap.PostStartWorldUnlockedMessage)"/>
+                    </valueMap>
+                    <valueMap name="GCHandleTypeMap">
+                        <map value="0x0" message="$(string.MonoProfilerPublisher.GCHandleTypeMap.WeakMessage)"/>
+                        <map value="0x1" message="$(string.MonoProfilerPublisher.GCHandleTypeMap.WeakTrackResurrectionMessage)"/>
+                        <map value="0x2" message="$(string.MonoProfilerPublisher.GCHandleTypeMap.NormalMessage)"/>
+                        <map value="0x3" message="$(string.MonoProfilerPublisher.GCHandleTypeMap.PinnedMessage)"/>
+                    </valueMap>
+                    <valueMap name="GCRootTypeMap">
+                        <map value="0x0" message="$(string.MonoProfilerPublisher.GCRootTypeMap.ExternalMessage)"/>
+                        <map value="0x1" message="$(string.MonoProfilerPublisher.GCRootTypeMap.StackMessage)"/>
+                        <map value="0x2" message="$(string.MonoProfilerPublisher.GCRootTypeMap.FinalizerQueueMessage)"/>
+                        <map value="0x3" message="$(string.MonoProfilerPublisher.GCRootTypeMap.StaticMessage)"/>
+                        <map value="0x4" message="$(string.MonoProfilerPublisher.GCRootTypeMap.ThreadStaticMessage)"/>
+                        <map value="0x5" message="$(string.MonoProfilerPublisher.GCRootTypeMap.ContextStaticMessage)"/>
+                        <map value="0x6" message="$(string.MonoProfilerPublisher.GCRootTypeMap.GCHandleMessage)"/>
+                        <map value="0x7" message="$(string.MonoProfilerPublisher.GCRootTypeMap.JitMessage)"/>
+                        <map value="0x8" message="$(string.MonoProfilerPublisher.GCRootTypeMap.ThreadingMessage)"/>
+                        <map value="0x9" message="$(string.MonoProfilerPublisher.GCRootTypeMap.DomainMessage)"/>
+                        <map value="0xA" message="$(string.MonoProfilerPublisher.GCRootTypeMap.ReflectionMessage)"/>
+                        <map value="0xB" message="$(string.MonoProfilerPublisher.GCRootTypeMap.MarshalMessage)"/>
+                        <map value="0xC" message="$(string.MonoProfilerPublisher.GCRootTypeMap.ThreadPoolMessage)"/>
+                        <map value="0xD" message="$(string.MonoProfilerPublisher.GCRootTypeMap.DebuggerMessage)"/>
+                        <map value="0xE" message="$(string.MonoProfilerPublisher.GCRootTypeMap.HandleMessage)"/>
+                        <map value="0xF" message="$(string.MonoProfilerPublisher.GCRootTypeMap.EphemeronMessage)"/>
+                        <map value="0x10" message="$(string.MonoProfilerPublisher.GCRootTypeMap.ToggleRefMessage)"/>
+                    </valueMap>
+                </maps>
+
+                <templates>
+                    <template tid="ContextLoadedUnloaded">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="ObjectID" inType="win:Pointer" outType="win:HexInt64" />
+                        <data name="AppDomainID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="ContextID" inType="win:UInt64" outType="win:HexInt64" />
+                        <UserData>
+                            <AppDomainLoadUnload xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <ObjectID> %2 </ObjectID>
+                                <AppDomainID> %3 </AppDomainID>
+                                <ContextID> %4 </ContextID>
+                            </AppDomainLoadUnload>
+                        </UserData>
+                    </template>
+
+                    <template tid="AppDomainLoadUnload">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="AppDomainID" inType="win:UInt64" outType="win:HexInt64" />
+                        <UserData>
+                            <AppDomainLoadUnload xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <AppDomainID> %2 </AppDomainID>
+                            </AppDomainLoadUnload>
+                        </UserData>
+                    </template>
+
+                    <template tid="AppDomainName">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="AppDomainID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="AppDomainName" inType="win:UnicodeString" />
+                        <UserData>
+                            <AppDomainName xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <AppDomainID> %2 </AppDomainID>
+                                <AppDomainName> %3 </AppDomainName>
+                            </AppDomainName>
+                        </UserData>
+                    </template>
+
+                    <template tid="JitBeginFailedDone">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="MethodID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="ModuleID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="MethodToken" inType="win:UInt32" outType="win:HexInt32" />
+                        <UserData>
+                            <JitBeginFailedDone xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <MethodID> %2 </MethodID>
+                                <ModuleID> %3 </ModuleID>
+                                <MethodToken> %4 </MethodToken>
+                            </JitBeginFailedDone>
+                        </UserData>
+                    </template>
+
+                    <template tid="JitChunkCreated">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="ChunkID" inType="win:Pointer" outType="win:HexInt64" />
+                        <data name="ChunkSize" inType="win:UInt64" outType="win:HexInt64" />
+                        <UserData>
+                            <JitChunkCreated xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <ChunkID> %2 </ChunkID>
+                                <ChunkSize> %3 </ChunkSize>
+                            </JitChunkCreated>
+                        </UserData>
+                    </template>
+
+                    <template tid="JitChunkDestroyed">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="ChunkID" inType="win:Pointer" outType="win:HexInt64" />
+                        <UserData>
+                            <JitChunkDestroyed xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <ChunkID> %2 </ChunkID>
+                            </JitChunkDestroyed>
+                        </UserData>
+                    </template>
+
+                    <template tid="JitCodeBuffer">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="BufferID" inType="win:Pointer" outType="win:HexInt64" />
+                        <data name="BufferSize" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="BufferType" inType="win:UInt8" map="JitCodeBufferTypeMap" />
+                        <UserData>
+                            <JitCodeBuffer xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <BufferID> %2 </BufferID>
+                                <BufferSize> %3 </BufferSize>
+                                <BufferType> %3 </BufferType>
+                            </JitCodeBuffer>
+                        </UserData>
+                    </template>
+
+                    <template tid="ClassLoadingFailed">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="ClassID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="ModuleID" inType="win:UInt64" outType="win:HexInt64" />
+                        <UserData>
+                            <ClassLoadingFailed xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <ClassID> %2 </ClassID>
+                                <ModuleID> %3 </ModuleID>
+                            </ClassLoadingFailed>
+                        </UserData>
+                    </template>
+
+                    <template tid="ClassLoaded">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="ClassID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="ModuleID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="ClassName" inType="win:UnicodeString" />
+                        <UserData>
+                            <ClassLoaded xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <ClassID> %2 </ClassID>
+                                <ModuleID> %3 </ModuleID>
+                                <ClassName> %4 </ClassName>
+                            </ClassLoaded>
+                        </UserData>
+                    </template>
+
+                    <template tid="VTableLoadingFailedLoaded">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="VTableID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="ClassID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="AppDomainID" inType="win:UInt64" outType="win:HexInt64" />
+                        <UserData>
+                            <VTableLoadingFailedLoaded xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <VTableID> %2 </VTableID>
+                                <ClassID> %3 </ClassID>
+                                <AppDomainID> %4 </AppDomainID>
+                            </VTableLoadingFailedLoaded>
+                        </UserData>
+                    </template>
+
+                    <template tid="ModuleLoadingUnloadingFailed">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="ModuleID" inType="win:UInt64" outType="win:HexInt64" />
+                        <UserData>
+                            <ModuleLoadingUnloadingFailed xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <ModuleID> %2 </ModuleID>
+                            </ModuleLoadingUnloadingFailed>
+                        </UserData>
+                    </template>
+
+                    <template tid="ModuleLoadedUnloaded">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="ModuleID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="ModuleName" inType="win:UnicodeString" />
+                        <data name="ModuleSignature" inType="win:UnicodeString" />
+                        <UserData>
+                            <ModuleLoadedUnloaded xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <ModuleID> %2 </ModuleID>
+                                <ModuleName> %3 </ModuleName>
+                                <ModuleSignature> %4 </ModuleSignature>
+                            </ModuleLoadedUnloaded>
+                        </UserData>
+                    </template>
+
+                    <template tid="AssemblyLoadingUnloading">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="AssemblyID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="ModuleID" inType="win:UInt64" outType="win:HexInt64" />
+                        <UserData>
+                            <AssemblyLoadingUnloading xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <AssemblyID> %2 </AssemblyID>
+                                <ModuleID> %3 </ModuleID>
+                            </AssemblyLoadingUnloading>
+                        </UserData>
+                    </template>
+
+                    <template tid="AssemblyLoadedUnloaded">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="AssemblyID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="ModuleID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="AssemblyName" inType="win:UnicodeString" />
+                        <UserData>
+                            <ModuleLoadedUnloaded xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <AssemblyID> %2 </AssemblyID>
+                                <ModuleID> %3 </ModuleID>
+                                <AssemblyName> %4 </AssemblyName>
+                            </ModuleLoadedUnloaded>
+                        </UserData>
+                    </template>
+
+                    <template tid="MethodTracing">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="MethodID" inType="win:UInt64" outType="win:HexInt64" />
+                        <UserData>
+                            <MethodTracing xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <MethodID> %2 </MethodID>
+                            </MethodTracing>
+                        </UserData>
+                    </template>
+
+                    <template tid="ExceptionThrow">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="TypeID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="ObjectID" inType="win:Pointer" outType="win:HexInt64" />
+                        <UserData>
+                            <ExceptionThrow xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <TypeID> %2 </TypeID>
+                                <ObjectID> %3 </ObjectID>
+                            </ExceptionThrow>
+                        </UserData>
+                    </template>
+
+                    <template tid="ExceptionClause">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="ClauseType" inType="win:UInt8" map="ExceptionClauseTypeMap" />
+                        <data name="ClauseIdx" inType="win:UInt32" />
+                        <data name="MethodID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="TypeID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="ObjectID" inType="win:Pointer" outType="win:HexInt64" />
+                        <UserData>
+                            <ExceptionClause xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <ClauseType> %2 </ClauseType>
+                                <ClauseIdx> %3 </ClauseIdx>
+                                <MethodID> %4 </MethodID>
+                                <TypeID> %5 </TypeID>
+                                <ObjectID> %6 </ObjectID>
+                            </ExceptionClause>
+                        </UserData>
+                    </template>
+
+                    <template tid="GCEvent">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="GCEventType" inType="win:UInt8" map="GCEventTypeMap" />
+                        <data name="GCGeneration" inType="win:UInt32" />
+                        <UserData>
+                            <GCEvent xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <GCEventType> %2 </GCEventType>
+                                <GCGeneration> %3 </GCGeneration>
+                            </GCEvent>
+                        </UserData>
+                    </template>
+
+                    <template tid="GCAllocation">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="VTableID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="ObjectID" inType="win:Pointer" outType="win:HexInt64" />
+                        <data name="ObjectSize" inType="win:UInt64" outType="win:HexInt64" />
+                        <UserData>
+                            <GCAllocation xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <VTableID> %2 </VTableID>
+                                <ObjectID> %3 </ObjectID>
+                                <ObjectSize> %4 </ObjectSize>
+                            </GCAllocation>
+                        </UserData>
+                    </template>
+
+                    <template tid="GCMoves">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="Count" inType="win:UInt32" outType="win:HexInt32" />
+                        <struct name="Values" count="Count">
+                            <data name="ObjectID" inType="win:Pointer" outType="win:HexInt64" />
+                            <data name="AddressID" inType="win:Pointer" outType="win:HexInt64" />
+                        </struct>
+                        <UserData>
+                            <GCMoves xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <Count> %2 </Count>
+                            </GCMoves>
+                        </UserData>
+                    </template>
+
+                    <template tid="GCResize">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="NewSize" inType="win:UInt64" outType="win:HexInt64" />
+                        <UserData>
+                            <GCResize xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <NewSize> %2 </NewSize>
+                            </GCResize>
+                        </UserData>
+                    </template>
+
+                    <template tid="GCHandleCreated">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="HandleID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="HandleType" inType="win:UInt8" map="GCHandleTypeMap" />
+                        <data name="ObjectID" inType="win:Pointer" outType="win:HexInt64" />
+                        <UserData>
+                            <GCHandleCreated xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <HandleID> %2 </HandleID>
+                                <HandleType> %3 </HandleType>
+                                <ObjectID> %4 </ObjectID>
+                            </GCHandleCreated>
+                        </UserData>
+                    </template>
+
+                    <template tid="GCHandleDeleted">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="HandleID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="HandleType" inType="win:UInt8" map="GCHandleTypeMap" />
+                        <UserData>
+                            <GCHandleDeleted xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <HandleID> %2 </HandleID>
+                                <HandleType> %3 </HandleType>
+                            </GCHandleDeleted>
+                        </UserData>
+                    </template>
+
+                    <template tid="GCFinalizingFinalized">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <UserData>
+                            <GCFinalizingFinalized xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                            </GCFinalizingFinalized>
+                        </UserData>
+                    </template>
+
+                    <template tid="GCFinalizingFinalizedObject">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="ObjectID" inType="win:Pointer" outType="win:HexInt64" />
+                        <UserData>
+                            <GCFinalizingFinalized xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <ObjectID> %2 </ObjectID>
+                            </GCFinalizingFinalized>
+                        </UserData>
+                    </template>
+
+                    <template tid="GCRootRegister">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="RootID" inType="win:Pointer" outType="win:HexInt64" />
+                        <data name="RootSize" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="RootType" inType="win:UInt8" map="GCRootTypeMap" />
+                        <data name="RootKeyID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="RootKeyName" inType="win:UnicodeString" />
+                        <UserData>
+                            <GCRootRegister xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <RootID> %2 </RootID>
+                                <RootSize> %3 </RootSize>
+                                <RootType> %4 </RootType>
+                                <RootKeyID> %5 </RootKeyID>
+                                <RootKeyName> %6 </RootKeyName>
+                            </GCRootRegister>
+                        </UserData>
+                    </template>
+
+                    <template tid="GCRootUnregister">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="RootID" inType="win:Pointer" outType="win:HexInt64" />
+                        <UserData>
+                            <GCRootUnregister xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <RootID> %2 </RootID>
+                            </GCRootUnregister>
+                        </UserData>
+                    </template>
+
+                    <template tid="GCRoots">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="Count" inType="win:UInt32" outType="win:HexInt32" />
+                        <struct name="Values" count="Count">
+                            <data name="ObjectID" inType="win:Pointer" outType="win:HexInt64" />
+                            <data name="AddressID" inType="win:Pointer" outType="win:HexInt64" />
+                        </struct>
+                        <UserData>
+                            <GCRoots xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <Count> %2 </Count>
+                            </GCRoots>
+                        </UserData>
+                    </template>
+
+                    <template tid="GCHeapDumpStartStop">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <UserData>
+                            <GCHeapDumpStartStop xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                            </GCHeapDumpStartStop>
+                        </UserData>
+                    </template>
+
+                    <template tid="GCHeapDumpObjectReference">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="ObjectID" inType="win:Pointer" outType="win:HexInt64" />
+                        <data name="VTableID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="ObjectSize" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="ObjectGeneration" inType="win:UInt32" />
+                        <data name="Count" inType="win:UInt32" outType="win:HexInt32" />
+                        <struct name="Values" count="Count">
+                            <data name="ReferenceOffset" inType="win:UInt32" />
+                            <data name="ObjectID" inType="win:Pointer" outType="win:HexInt64" />
+                        </struct>
+                        <UserData>
+                            <GCHeapDumpObjectReference xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <ObjectID> %2 </ObjectID>
+                                <VTableID> %3 </VTableID>
+                                <ObjectSize> %4 </ObjectSize>
+                                <ObjectGeneration> %5 </ObjectGeneration>
+                                <Count> %6 </Count>
+                            </GCHeapDumpObjectReference>
+                        </UserData>
+                    </template>
+
+                    <template tid="MonitorContentionFailedAcquired">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="ObjectID" inType="win:Pointer" outType="win:HexInt64" />
+                        <UserData>
+                            <GCHeapDumpStartStop xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <ObjectID> %2 </ObjectID>
+                            </GCHeapDumpStartStop>
+                        </UserData>
+                    </template>
+
+                    <template tid="ThreadStartedStoppingStoppedExited">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="ThreadID" inType="win:UInt64" outType="win:HexInt64" />
+                        <UserData>
+                            <ThreadStartedStoppingStoppedExited xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <ThreadID> %2 </ThreadID>
+                            </ThreadStartedStoppingStoppedExited>
+                        </UserData>
+                    </template>
+
+                    <template tid="ThreadName">
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="ThreadID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="ThreadName" inType="win:UnicodeString" />
+                        <UserData>
+                            <ThreadName xmlns="myNs">
+                                <ClrInstanceID> %1 </ClrInstanceID>
+                                <ThreadID> %2 </ThreadID>
+                                <ThreadName> %3 </ThreadName>
+                            </ThreadName>
+                        </UserData>
+                    </template>
+
+                </templates>
+
+                <events>
+                    <event value="1" version="0" level="win:Informational"  template="ContextLoadedUnloaded"
+                           keywords ="LoaderKeyword" opcode="ContextLoaded"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerContextLoaded" message="$(string.MonoProfilerPublisher.ContextLoadedUnloadedEventMessage)" />
+
+                    <event value="2" version="0" level="win:Informational"  template="ContextLoadedUnloaded"
+                           keywords ="LoaderKeyword" opcode="ContextUnloaded"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerContextUnloaded" message="$(string.MonoProfilerPublisher.ContextLoadedUnloadedEventMessage)" />
+
+                    <event value="3" version="0" level="win:Verbose"  template="AppDomainLoadUnload"
+                           keywords ="LoaderKeyword" opcode="AppDomainLoading"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerAppDomainLoading" message="$(string.MonoProfilerPublisher.AppDomainLoadUnloadEventMessage)" />
+
+                    <event value="4" version="0" level="win:Informational"  template="AppDomainLoadUnload"
+                           keywords ="LoaderKeyword" opcode="AppDomainLoaded"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerAppDomainLoaded" message="$(string.MonoProfilerPublisher.AppDomainLoadUnloadEventMessage)" />
+
+                    <event value="5" version="0" level="win:Verbose"  template="AppDomainLoadUnload"
+                           keywords ="LoaderKeyword" opcode="AppDomainUnloading"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerAppDomainUnloading" message="$(string.MonoProfilerPublisher.AppDomainLoadUnloadEventMessage)" />
+
+                    <event value="6" version="0" level="win:Informational"  template="AppDomainLoadUnload"
+                           keywords ="LoaderKeyword" opcode="AppDomainUnloaded"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerAppDomainUnloaded" message="$(string.MonoProfilerPublisher.AppDomainLoadUnloadEventMessage)" />
+
+                    <event value="7" version="0" level="win:Verbose"  template="AppDomainName"
+                           keywords ="LoaderKeyword" opcode="AppDomainName"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerAppDomainName" message="$(string.MonoProfilerPublisher.AppDomainNameEventMessage)" />
+
+                    <event value="8" version="0" level="win:Informational"  template="JitBeginFailedDone"
+                           keywords ="JitKeyword" opcode="JitBegin"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerJitBegin" message="$(string.MonoProfilerPublisher.JitBeginFailedDoneEventMessage)" />
+
+                    <event value="9" version="0" level="win:Informational"  template="JitBeginFailedDone"
+                           keywords ="JitKeyword" opcode="JitFailed"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerJitFailed" message="$(string.MonoProfilerPublisher.JitBeginFailedDoneEventMessage)" />
+
+                    <event value="10" version="0" level="win:Informational"  template="JitBeginFailedDone"
+                           keywords ="JitKeyword" opcode="JitDone"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerJitDone" message="$(string.MonoProfilerPublisher.JitBeginFailedDoneEventMessage)" />
+
+                    <event value="11" version="0" level="win:Informational"  template="JitChunkCreated"
+                           keywords ="JitKeyword" opcode="JitChunkCreated"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerJitChunkCreated" message="$(string.MonoProfilerPublisher.JitChunkCreatedEventMessage)" />
+
+                    <event value="12" version="0" level="win:Informational"  template="JitChunkDestroyed"
+                           keywords ="JitKeyword" opcode="JitChunkDestroyed"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerJitChunkDestroyed" message="$(string.MonoProfilerPublisher.JitChunkDestroyedEventMessage)" />
+
+                    <event value="13" version="0" level="win:Informational"  template="JitCodeBuffer"
+                           keywords ="JitKeyword" opcode="JitCodeBuffer"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerJitCodeBuffer" message="$(string.MonoProfilerPublisher.JitCodeBufferEventMessage)" />
+
+                    <event value="14" version="0" level="win:Verbose"  template="ClassLoadingFailed"
+                           keywords ="TypeLoadingKeyword" opcode="ClassLoading"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerClassLoading" message="$(string.MonoProfilerPublisher.ClassLoadingFailedEventMessage)" />
+
+                    <event value="15" version="0" level="win:Informational"  template="ClassLoadingFailed"
+                           keywords ="TypeLoadingKeyword" opcode="ClassFailed"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerClassFailed" message="$(string.MonoProfilerPublisher.ClassLoadingFailedEventMessage)" />
+
+                    <event value="16" version="0" level="win:Informational"  template="ClassLoaded"
+                           keywords ="TypeLoadingKeyword" opcode="ClassLoaded"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerClassLoaded" message="$(string.MonoProfilerPublisher.ClassLoadedEventMessage)" />
+
+                    <event value="17" version="0" level="win:Verbose"  template="VTableLoadingFailedLoaded"
+                           keywords ="TypeLoadingKeyword" opcode="VTableLoading"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerVTableLoading" message="$(string.MonoProfilerPublisher.VTableLoadingFailedLoadedEventMessage)" />
+
+                    <event value="18" version="0" level="win:Informational"  template="VTableLoadingFailedLoaded"
+                           keywords ="TypeLoadingKeyword" opcode="VTableFailed"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerVTableFailed" message="$(string.MonoProfilerPublisher.VTableLoadingFailedLoadedEventMessage)" />
+
+                    <event value="19" version="0" level="win:Informational"  template="VTableLoadingFailedLoaded"
+                           keywords ="TypeLoadingKeyword" opcode="VTableLoaded"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerVTableLoaded" message="$(string.MonoProfilerPublisher.VTableLoadingFailedLoadedEventMessage)" />
+
+                    <event value="20" version="0" level="win:Verbose"  template="ModuleLoadingUnloadingFailed"
+                           keywords ="LoaderKeyword" opcode="ModuleLoading"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerModuleLoading" message="$(string.MonoProfilerPublisher.ModuleLoadingUnloadingFailedEventMessage)" />
+
+                    <event value="21" version="0" level="win:Informational"  template="ModuleLoadingUnloadingFailed"
+                           keywords ="LoaderKeyword" opcode="ModuleFailed"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerModuleFailed" message="$(string.MonoProfilerPublisher.ModuleLoadingUnloadingFailedEventMessage)" />
+                    
+                    <event value="22" version="0" level="win:Informational"  template="ModuleLoadedUnloaded"
+                           keywords ="LoaderKeyword" opcode="ModuleLoaded"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerModuleLoaded" message="$(string.MonoProfilerPublisher.ModuleLoadedUnloadedEventMessage)" />
+
+                    <event value="23" version="0" level="win:Verbose"  template="ModuleLoadingUnloadingFailed"
+                           keywords ="LoaderKeyword" opcode="ModuleUnloading"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerModuleUnloading" message="$(string.MonoProfilerPublisher.ModuleLoadingUnloadingFailedEventMessage)" />
+                    
+                    <event value="24" version="0" level="win:Informational"  template="ModuleLoadedUnloaded"
+                           keywords ="LoaderKeyword" opcode="ModuleUnloaded"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerModuleUnloaded" message="$(string.MonoProfilerPublisher.ModuleLoadedUnloadedEventMessage)" />
+
+                    <event value="25" version="0" level="win:Verbose"  template="AssemblyLoadingUnloading"
+                           keywords ="LoaderKeyword" opcode="AssemblyLoading"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerAssemblyLoading" message="$(string.MonoProfilerPublisher.AssemblyLoadingUnloadingEventMessage)" />
+                    
+                    <event value="26" version="0" level="win:Informational"  template="AssemblyLoadedUnloaded"
+                           keywords ="LoaderKeyword" opcode="AssemblyLoaded"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerAssemblyLoaded" message="$(string.MonoProfilerPublisher.AssemblyLoadedUnloadedEventMessage)" />
+                    
+                    <event value="27" version="0" level="win:Verbose"  template="AssemblyLoadingUnloading"
+                           keywords ="LoaderKeyword" opcode="AssemblyUnloading"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerAssemblyUnloading" message="$(string.MonoProfilerPublisher.AssemblyLoadingUnloadingEventMessage)" />
+                    
+                    <event value="28" version="0" level="win:Informational"  template="AssemblyLoadedUnloaded"
+                           keywords ="LoaderKeyword" opcode="AssemblyUnloaded"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerAssemblyUnloaded" message="$(string.MonoProfilerPublisher.AssemblyLoadedUnloadedEventMessage)" />
+
+                    <event value="29" version="0" level="win:Informational"  template="MethodTracing"
+                           keywords ="MethodTracingKeyword" opcode="MethodEnter"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerMethodEnter" message="$(string.MonoProfilerPublisher.MethodTracingEventMessage)" />
+
+                    <event value="30" version="0" level="win:Informational"  template="MethodTracing"
+                           keywords ="MethodTracingKeyword" opcode="MethodLeave"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerMethodLeave" message="$(string.MonoProfilerPublisher.MethodTracingEventMessage)" />
+
+                    <event value="31" version="0" level="win:Informational"  template="MethodTracing"
+                           keywords ="MethodTracingKeyword" opcode="MethodTailCall"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerMethodTailCall" message="$(string.MonoProfilerPublisher.MethodTracingEventMessage)" />
+
+                    <event value="32" version="0" level="win:Informational"  template="MethodTracing"
+                           keywords ="MethodTracingKeyword" opcode="MethodExceptionLeave"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerMethodExceptionLeave" message="$(string.MonoProfilerPublisher.MethodTracingEventMessage)" />
+
+                    <event value="33" version="0" level="win:Informational"  template="MethodTracing"
+                           keywords ="MethodTracingKeyword" opcode="MethodFree"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerMethodFree" message="$(string.MonoProfilerPublisher.MethodTracingEventMessage)" />
+
+                    <event value="34" version="0" level="win:Informational"  template="MethodTracing"
+                           keywords ="MethodTracingKeyword" opcode="MethodBeginInvoke"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerMethodBeginInvoke" message="$(string.MonoProfilerPublisher.MethodTracingEventMessage)" />
+
+                    <event value="35" version="0" level="win:Informational"  template="MethodTracing"
+                           keywords ="MethodTracingKeyword" opcode="MethodEndInvoke"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerMethodEndInvoke" message="$(string.MonoProfilerPublisher.MethodTracingEventMessage)" />
+
+                    <event value="36" version="0" level="win:Informational"  template="ExceptionThrow"
+                           keywords ="ExceptionKeyword" opcode="ExceptionThrow"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerExceptionThrow" message="$(string.MonoProfilerPublisher.ExceptionThrowEventMessage)" />
+
+                    <event value="37" version="0" level="win:Informational"  template="ExceptionClause"
+                           keywords ="ExceptionKeyword" opcode="ExceptionClause"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerExceptionClause" message="$(string.MonoProfilerPublisher.ExceptionClauseEventMessage)" />
+
+                    <event value="38" version="0" level="win:Informational"  template="GCEvent"
+                           keywords ="GCKeyword" opcode="GCEvent"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerGCEvent" message="$(string.MonoProfilerPublisher.GCEventEventMessage)" />
+
+                    <event value="39" version="0" level="win:Informational"  template="GCAllocation"
+                           keywords ="GCKeyword GCAllocationKeyword" opcode="GCAllocation"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerGCAllocation" message="$(string.MonoProfilerPublisher.GCAllocationEventMessage)" />
+
+                    <event value="40" version="0" level="win:Informational"  template="GCMoves"
+                           keywords ="GCKeyword GCMovesKeyword" opcode="GCMoves"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerGCMoves" message="$(string.MonoProfilerPublisher.GCMovesEventMessage)" />
+
+                    <event value="41" version="0" level="win:Informational"  template="GCResize"
+                           keywords ="GCKeyword GCResizeKeyword" opcode="GCResize"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerGCResize" message="$(string.MonoProfilerPublisher.GCResizeEventMessage)" />
+
+                    <event value="42" version="0" level="win:Informational"  template="GCHandleCreated"
+                           keywords ="GCKeyword GCHandleKeyword" opcode="GCHandleCreated"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerGCHandleCreated" message="$(string.MonoProfilerPublisher.GCHandleCreatedEventMessage)" />
+
+                    <event value="43" version="0" level="win:Informational"  template="GCHandleDeleted"
+                           keywords ="GCKeyword GCHandleKeyword" opcode="GCHandleDeleted"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerGCHandleDeleted" message="$(string.MonoProfilerPublisher.GCHandleDeletedEventMessage)" />
+
+                    <event value="44" version="0" level="win:Informational"  template="GCFinalizingFinalized"
+                           keywords ="GCKeyword GCFinalizationKeyword" opcode="GCFinalizing"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerGCFinalizing" message="$(string.MonoProfilerPublisher.GCFinalizingFinalizedEventMessage)" />
+
+                    <event value="45" version="0" level="win:Informational"  template="GCFinalizingFinalized"
+                           keywords ="GCKeyword GCFinalizationKeyword" opcode="GCFinalized"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerGCFinalized" message="$(string.MonoProfilerPublisher.GCFinalizingFinalizedEventMessage)" />
+
+                    <event value="46" version="0" level="win:Informational"  template="GCFinalizingFinalizedObject"
+                           keywords ="GCKeyword GCFinalizationKeyword" opcode="GCFinalizingObject"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerGCFinalizingObject" message="$(string.MonoProfilerPublisher.GCFinalizingFinalizedObjectEventMessage)" />
+
+                    <event value="47" version="0" level="win:Informational"  template="GCFinalizingFinalizedObject"
+                           keywords ="GCKeyword GCFinalizationKeyword" opcode="GCFinalizedObject"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerGCFinalizedObject" message="$(string.MonoProfilerPublisher.GCFinalizingFinalizedObjectEventMessage)" />
+
+                    <event value="48" version="0" level="win:Informational"  template="GCRootRegister"
+                           keywords ="GCKeyword GCRootKeyword" opcode="GCRootRegister"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerGCRootRegister" message="$(string.MonoProfilerPublisher.GCRootRegisterEventMessage)" />
+
+                    <event value="49" version="0" level="win:Informational"  template="GCRootUnregister"
+                           keywords ="GCKeyword GCRootKeyword" opcode="GCRootUnregister"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerGCRootUnregister" message="$(string.MonoProfilerPublisher.GCRootUnregisterEventMessage)" />
+
+                    <event value="50" version="0" level="win:Informational"  template="GCRoots"
+                           keywords ="GCKeyword GCRootKeyword" opcode="GCRoots"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerGCRoots" message="$(string.MonoProfilerPublisher.GCRootsEventMessage)" />
+
+                    <event value="51" version="0" level="win:Informational"  template="GCHeapDumpStartStop"
+                           keywords ="GCKeyword GCHeapDumpKeyword" opcode="GCHeapDumpStart"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerGCHeapDumpStart" message="$(string.MonoProfilerPublisher.GCHeapDumpStartStopEventMessage)" />
+
+                    <event value="52" version="0" level="win:Informational"  template="GCHeapDumpStartStop"
+                           keywords ="GCKeyword GCHeapDumpKeyword" opcode="GCHeapDumpStop"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerGCHeapDumpStop" message="$(string.MonoProfilerPublisher.GCHeapDumpStartStopEventMessage)" />
+
+                    <event value="53" version="0" level="win:Informational"  template="GCHeapDumpObjectReference"
+                           keywords ="GCKeyword GCHeapDumpKeyword" opcode="GCHeapDumpObjectReference"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerGCHeapDumpObjectReference" message="$(string.MonoProfilerPublisher.GCHeapDumpObjectReferenceEventMessage)" />
+
+                    <event value="54" version="0" level="win:Informational"  template="MonitorContentionFailedAcquired"
+                           keywords ="MonitorKeyword ContentionKeyword" opcode="MonitorContention"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerMonitorContention" message="$(string.MonoProfilerPublisher.MonitorContentionFailedAcquiredEventMessage)" />
+
+                    <event value="55" version="0" level="win:Informational"  template="MonitorContentionFailedAcquired"
+                           keywords ="MonitorKeyword" opcode="MonitorFailed"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerMonitorFailed" message="$(string.MonoProfilerPublisher.MonitorContentionFailedAcquiredEventMessage)" />
+
+                    <event value="56" version="0" level="win:Informational"  template="MonitorContentionFailedAcquired"
+                           keywords ="MonitorKeyword" opcode="MonitorAquired"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerMonitorAcquired" message="$(string.MonoProfilerPublisher.MonitorContentionFailedAcquiredEventMessage)" />
+
+                    <event value="57" version="0" level="win:Informational"  template="ThreadStartedStoppingStoppedExited"
+                           keywords ="ThreadingKeyword" opcode="ThreadStarted"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerThreadStarted" message="$(string.MonoProfilerPublisher.ThreadStartedStoppingStoppedExitedEventMessage)" />
+
+                    <event value="58" version="0" level="win:Verbose"  template="ThreadStartedStoppingStoppedExited"
+                           keywords ="ThreadingKeyword" opcode="ThreadStopping"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerThreadStopping" message="$(string.MonoProfilerPublisher.ThreadStartedStoppingStoppedExitedEventMessage)" />
+
+                    <event value="59" version="0" level="win:Informational"  template="ThreadStartedStoppingStoppedExited"
+                           keywords ="ThreadingKeyword" opcode="ThreadStopped"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerThreadStopped" message="$(string.MonoProfilerPublisher.ThreadStartedStoppingStoppedExitedEventMessage)" />
+
+                    <event value="60" version="0" level="win:Informational"  template="ThreadStartedStoppingStoppedExited"
+                           keywords ="ThreadingKeyword" opcode="ThreadExited"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerThreadExited" message="$(string.MonoProfilerPublisher.ThreadStartedStoppingStoppedExitedEventMessage)" />
+
+                    <event value="61" version="0" level="win:Verbose"  template="ThreadName"
+                           keywords ="ThreadingKeyword" opcode="ThreadName"
+                           task="MonoProfiler"
+                           symbol="MonoProfilerThreadName" message="$(string.MonoProfilerPublisher.ThreadNameEventMessage)" />
+                </events>
+            </provider>
         </events>
     </instrumentation>
 
@@ -8044,6 +8968,189 @@
 
                 <string id="PrivatePublisher.LoaderHeapPrivateAllocRequestMessage" value="LoaderHeapAllocRequest" />
                 <string id="PrivatePublisher.ModuleRangeLoadOpcodeMessage" value="ModuleRangeLoad" />
+
+                <string id="MonoProfilerPublisher.MonoProfilerTaskMessage" value="MonoProfiler" />
+
+                <string id="MonoProfilerPublisher.GCKeywordMessage" value="GC" />
+                <string id="MonoProfilerPublisher.GCHandleKeywordMessage" value="GCHandle" />
+                <string id="MonoProfilerPublisher.LoaderKeywordMessage" value="Loader" />
+                <string id="MonoProfilerPublisher.JitKeywordMessage" value="Jit" />
+                <string id="MonoProfilerPublisher.ContentionKeywordMessage" value="Contention" />
+                <string id="MonoProfilerPublisher.ExceptionKeywordMessage" value="Exception" />
+                <string id="MonoProfilerPublisher.ThreadingKeywordMessage" value="Threading" />
+                <string id="MonoProfilerPublisher.GCHeapDumpKeywordMessage" value="GCHeapDump" />
+                <string id="MonoProfilerPublisher.GCAllocationKeywordMessage" value="GCAllocation" />
+                <string id="MonoProfilerPublisher.GCMovesKeywordMessage" value="GCMoves" />
+                <string id="MonoProfilerPublisher.GCRootKeywordMessage" value="GCRoot" />
+                <string id="MonoProfilerPublisher.GCFinalizationKeywordMessage" value="GCFinalization" />
+                <string id="MonoProfilerPublisher.GCResizeKeywordMessage" value="GCResize" />
+                <string id="MonoProfilerPublisher.MethodTracingKeywordMessage" value="PerfTrack" />
+                <string id="MonoProfilerPublisher.TypeLoadingKeywordMessage" value="TypeLoading" />
+                <string id="MonoProfilerPublisher.MonitorKeywordMessage" value="Monitor" />
+
+                <string id="MonoProfilerPublisher.ContextLoadedOpcodeMessage" value="ContextLoaded" />
+                <string id="MonoProfilerPublisher.ContextUnloadedOpcodeMessage" value="ContextUnloaded" />
+
+                <string id="MonoProfilerPublisher.AppDomainLoadingOpcodeMessage" value="AppDomainLoading" />
+                <string id="MonoProfilerPublisher.AppDomainLoadedOpcodeMessage" value="AppDomainLoaded" />
+                <string id="MonoProfilerPublisher.AppDomainUnloadingOpcodeMessage" value="AppDomainUnloading" />
+                <string id="MonoProfilerPublisher.AppDomainUnloadedOpcodeMessage" value="AppDomainUnloaded" />
+                <string id="MonoProfilerPublisher.AppDomainNameOpcodeMessage" value="AppDomainName" />
+
+                <string id="MonoProfilerPublisher.JitBeginOpcodeMessage" value="JitBegin" />
+                <string id="MonoProfilerPublisher.JitFailedOpcodeMessage" value="JitFailed" />
+                <string id="MonoProfilerPublisher.JitDoneOpcodeMessage" value="JitDone" />
+                <string id="MonoProfilerPublisher.JitChunkCreatedOpcodeMessage" value="JitChunkCreated" />
+                <string id="MonoProfilerPublisher.JitChunkDestroyedOpcodeMessage" value="JitChunkDestroyed" />
+                <string id="MonoProfilerPublisher.JitCodeBufferOpcodeMessage" value="JitCodeBuffer" />
+
+                <string id="MonoProfilerPublisher.ClassLoadingOpcodeMessage" value="ClassLoading" />
+                <string id="MonoProfilerPublisher.ClassFailedOpcodeMessage" value="ClassFailed" />
+                <string id="MonoProfilerPublisher.ClassLoadedOpcodeMessage" value="ClassLoaded" />
+
+                <string id="MonoProfilerPublisher.VTableLoadingOpcodeMessage" value="VTableLoading" />
+                <string id="MonoProfilerPublisher.VTableFailedOpcodeMessage" value="VTableFailed" />
+                <string id="MonoProfilerPublisher.VTableLoadedOpcodeMessage" value="VTableLoaded" />
+
+                <string id="MonoProfilerPublisher.ModuleLoadingOpcodeMessage" value="ModuleLoading" />
+                <string id="MonoProfilerPublisher.ModuleFailedOpcodeMessage" value="ModuleFailed" />
+                <string id="MonoProfilerPublisher.ModuleLoadedOpcodeMessage" value="ModuleLoaded" />
+                <string id="MonoProfilerPublisher.ModuleUnloadingOpcodeMessage" value="ModuleUnloading" />
+                <string id="MonoProfilerPublisher.ModuleUnloadedOpcodeMessage" value="ModuleUnloaded" />
+
+                <string id="MonoProfilerPublisher.AssemblyLoadingOpcodeMessage" value="AssemblyLoading" />
+                <string id="MonoProfilerPublisher.AssemblyLoadedOpcodeMessage" value="AssemblyLoaded" />
+                <string id="MonoProfilerPublisher.AssemblyUnloadingOpcodeMessage" value="AssemblyUnloading" />
+                <string id="MonoProfilerPublisher.AssemblyUnloadedOpcodeMessage" value="AssemblyUnloaded" />
+
+                <string id="MonoProfilerPublisher.MethodEnterOpcodeMessage" value="MethodEnter" />
+                <string id="MonoProfilerPublisher.MethodLeaveOpcodeMessage" value="MethodLeave" />
+                <string id="MonoProfilerPublisher.MethodTailCallOpcodeMessage" value="MethodTailCall" />
+                <string id="MonoProfilerPublisher.MethodExceptionLeaveOpcodeMessage" value="MethodExceptionLeave" />
+                <string id="MonoProfilerPublisher.MethodFreeOpcodeMessage" value="MethodFree" />
+                <string id="MonoProfilerPublisher.MethodBeginInvokeOpcodeMessage" value="MethodBeginInvoke" />
+                <string id="MonoProfilerPublisher.MethodEndInvokeOpcodeMessage" value="MethodEndInvoke" />
+
+                <string id="MonoProfilerPublisher.ExceptionThrowOpcodeMessage" value="ExceptionThrow" />
+                <string id="MonoProfilerPublisher.ExceptionClauseOpcodeMessage" value="ExceptionClause" />
+
+                <string id="MonoProfilerPublisher.GCEventOpcodeMessage" value="GCEvent" />
+                <string id="MonoProfilerPublisher.GCAllocationOpcodeMessage" value="GCAllocation" />
+                <string id="MonoProfilerPublisher.GCMovesOpcodeMessage" value="GCMoves" />
+                <string id="MonoProfilerPublisher.GCResizeOpcodeMessage" value="GCResize" />
+                <string id="MonoProfilerPublisher.GCHandleCreatedOpcodeMessage" value="GCHandleCreated" />
+                <string id="MonoProfilerPublisher.GCHandleDeletedOpcodeMessage" value="GCHandleDeleted" />
+                <string id="MonoProfilerPublisher.GCFinalizingOpcodeMessage" value="GCFinalizing" />
+                <string id="MonoProfilerPublisher.GCFinalizedOpcodeMessage" value="GCFinalized" />
+                <string id="MonoProfilerPublisher.GCFinalizingObjectOpcodeMessage" value="GCFinalizingObject" />
+                <string id="MonoProfilerPublisher.GCFinalizedObjectOpcodeMessage" value="GCFinalizedObject" />
+                <string id="MonoProfilerPublisher.GCRootRegisterOpcodeMessage" value="GCRootRegister" />
+                <string id="MonoProfilerPublisher.GCRootUnregisterOpcodeMessage" value="GCRootUnregister" />
+                <string id="MonoProfilerPublisher.GCRootsOpcodeMessage" value="GCRoots" />
+                <string id="MonoProfilerPublisher.GCHeapDumpStartOpcodeMessage" value="GCHeapDumpStart" />
+                <string id="MonoProfilerPublisher.GCHeapDumpStopOpcodeMessage" value="GCHeapDumpStop" />
+                <string id="MonoProfilerPublisher.GCHeapDumpObjectReferenceOpcodeMessage" value="GCHeapDumpObjectReference" />
+
+                <string id="MonoProfilerPublisher.MonitorContentionOpcodeMessage" value="MonitorContention" />
+                <string id="MonoProfilerPublisher.MonitorFailedOpcodeMessage" value="MonitorFailed" />
+                <string id="MonoProfilerPublisher.MonitorAquiredOpcodeMessage" value="MonitorAquired" />
+
+                <string id="MonoProfilerPublisher.ThreadStartedOpcodeMessage" value="ThreadStarted" />
+                <string id="MonoProfilerPublisher.ThreadStoppingOpcodeMessage" value="ThreadStopping" />
+                <string id="MonoProfilerPublisher.ThreadStoppedOpcodeMessage" value="ThreadStopped" />
+                <string id="MonoProfilerPublisher.ThreadExitedOpcodeMessage" value="ThreadExited" />
+                <string id="MonoProfilerPublisher.ThreadNameOpcodeMessage" value="ThreadName" />
+
+                <string id="MonoProfilerPublisher.CodeBufferTypeMap.MethodMessage" value="Method" />
+                <string id="MonoProfilerPublisher.CodeBufferTypeMap.MethodTrampolineMessage" value="MethodTrampoline" />
+                <string id="MonoProfilerPublisher.CodeBufferTypeMap.UnboxTrampolineMessage" value="UnboxTrampoline" />
+                <string id="MonoProfilerPublisher.CodeBufferTypeMap.IMTTrampolineMessage" value="IMTTrampoline" />
+                <string id="MonoProfilerPublisher.CodeBufferTypeMap.GenericsTrampolineMessage" value="GenericsTrampoline" />
+                <string id="MonoProfilerPublisher.CodeBufferTypeMap.SpecificTrampolineMessage" value="SpecificTrampoline" />
+                <string id="MonoProfilerPublisher.CodeBufferTypeMap.HelperMessage" value="Helper" />
+
+                <string id="MonoProfilerPublisher.ExceptionClauseTypeMap.NoneMessage" value="None" />
+                <string id="MonoProfilerPublisher.ExceptionClauseTypeMap.FilterMessage" value="Filter" />
+                <string id="MonoProfilerPublisher.ExceptionClauseTypeMap.FinallyMessage" value="Finally" />
+                <string id="MonoProfilerPublisher.ExceptionClauseTypeMap.FaultMessage" value="Fault" />
+
+                <string id="MonoProfilerPublisher.GCEventTypeMap.StartMessage" value="Start" />
+                <string id="MonoProfilerPublisher.GCEventTypeMap.EndMessage" value="End" />
+                <string id="MonoProfilerPublisher.GCEventTypeMap.PreStopWorldMessage" value="PreStopWorld" />
+                <string id="MonoProfilerPublisher.GCEventTypeMap.PostStopWorldMessage" value="PostStopWorld" />
+                <string id="MonoProfilerPublisher.GCEventTypeMap.PreStartWorldMessage" value="PreStartWorld" />
+                <string id="MonoProfilerPublisher.GCEventTypeMap.PostStartWorldMessage" value="PostStartWorld" />
+                <string id="MonoProfilerPublisher.GCEventTypeMap.PreStopWorldLockedMessage" value="PreStopWorldLocked" />
+                <string id="MonoProfilerPublisher.GCEventTypeMap.PostStartWorldUnlockedMessage" value="PostStartWorldUnlocked" />
+
+                <string id="MonoProfilerPublisher.GCHandleTypeMap.WeakMessage" value="Weak" />
+                <string id="MonoProfilerPublisher.GCHandleTypeMap.WeakTrackResurrectionMessage" value="WeakTrackResurrection" />
+                <string id="MonoProfilerPublisher.GCHandleTypeMap.NormalMessage" value="Normal" />
+                <string id="MonoProfilerPublisher.GCHandleTypeMap.PinnedMessage" value="Pinned" />
+
+                <string id="MonoProfilerPublisher.GCRootTypeMap.ExternalMessage" value="External" />
+                <string id="MonoProfilerPublisher.GCRootTypeMap.StackMessage" value="Stack" />
+                <string id="MonoProfilerPublisher.GCRootTypeMap.FinalizerQueueMessage" value="FinalizerQueue" />
+                <string id="MonoProfilerPublisher.GCRootTypeMap.StaticMessage" value="Static" />
+                <string id="MonoProfilerPublisher.GCRootTypeMap.ThreadStaticMessage" value="ThreadStatic" />
+                <string id="MonoProfilerPublisher.GCRootTypeMap.ContextStaticMessage" value="ContextStatic" />
+                <string id="MonoProfilerPublisher.GCRootTypeMap.GCHandleMessage" value="GCHandle" />
+                <string id="MonoProfilerPublisher.GCRootTypeMap.JitMessage" value="Jit" />
+                <string id="MonoProfilerPublisher.GCRootTypeMap.ThreadingMessage" value="Threading" />
+                <string id="MonoProfilerPublisher.GCRootTypeMap.DomainMessage" value="Domain" />
+                <string id="MonoProfilerPublisher.GCRootTypeMap.ReflectionMessage" value="Reflection" />
+                <string id="MonoProfilerPublisher.GCRootTypeMap.MarshalMessage" value="Marshal" />
+                <string id="MonoProfilerPublisher.GCRootTypeMap.ThreadPoolMessage" value="ThreadPool" />
+                <string id="MonoProfilerPublisher.GCRootTypeMap.DebuggerMessage" value="Debugger" />
+                <string id="MonoProfilerPublisher.GCRootTypeMap.HandleMessage" value="Handle" />
+                <string id="MonoProfilerPublisher.GCRootTypeMap.EphemeronMessage" value="Ephemeron" />
+                <string id="MonoProfilerPublisher.GCRootTypeMap.ToggleRefMessage" value="ToggleRef" />
+
+                <string id="MonoProfilerPublisher.ContextLoadedUnloadedEventMessage" value="ClrInstanceID=%1;%nObjectID=%2;%nAppDomainId=%3;%nContextID=%4" />
+
+                <string id="MonoProfilerPublisher.AppDomainLoadUnloadEventMessage" value="ClrInstanceID=%1;%nAppDomainId=%2" />
+                <string id="MonoProfilerPublisher.AppDomainNameEventMessage" value="ClrInstanceID=%1;%nAppDomainId=%2;%nAppDomainName=%3" />
+
+                <string id="MonoProfilerPublisher.JitBeginFailedDoneEventMessage" value="ClrInstanceID=%1;%nMethodId=%2;%nModuleID=%3;%nMethodToken=%4" />
+
+                <string id="MonoProfilerPublisher.JitChunkCreatedEventMessage" value="ClrInstanceID=%1;%nChunkID=%2;%nChunkSize=%3" />
+                <string id="MonoProfilerPublisher.JitChunkDestroyedEventMessage" value="ClrInstanceID=%1;%nChunkID=%2" />
+                <string id="MonoProfilerPublisher.JitCodeBufferEventMessage" value="ClrInstanceID=%1;%nBufferID=%2;%nBufferSize=%3;%nBufferType=%4" />
+
+                <string id="MonoProfilerPublisher.ClassLoadingFailedEventMessage" value="ClrInstanceID=%1;%nClassID=%2;%nModuleID=%3" />
+                <string id="MonoProfilerPublisher.ClassLoadedEventMessage" value="ClrInstanceID=%1;%nClassID=%2;%nModuleID=%3;%nClassName=%4" />
+
+                <string id="MonoProfilerPublisher.VTableLoadingFailedLoadedEventMessage" value="ClrInstanceID=%1;%nVTableID=%2;%nClassID=%3;%nAppDomainID=%4" />
+
+                <string id="MonoProfilerPublisher.ModuleLoadingUnloadingFailedEventMessage" value="ClrInstanceID=%1;%nModuleID=%2" />
+                <string id="MonoProfilerPublisher.ModuleLoadedUnloadedEventMessage" value="ClrInstanceID=%1;%nModuleID=%2;%nModuleName=%3;%nModuleSignature=%4" />
+
+                <string id="MonoProfilerPublisher.AssemblyLoadingUnloadingEventMessage" value="ClrInstanceID=%1;%nAssemblyID=%2;%nModuleID=%3" />
+                <string id="MonoProfilerPublisher.AssemblyLoadedUnloadedEventMessage" value="ClrInstanceID=%1;%nAssemblyID=%2;%nModuleID=%3;%nAssemblyName=%4" />
+
+                <string id="MonoProfilerPublisher.MethodTracingEventMessage" value="ClrInstanceID=%1;%nMethodID=%2" />
+
+                <string id="MonoProfilerPublisher.ExceptionThrowEventMessage" value="ClrInstanceID=%1;%nTypeID=%2;%nObjectID=%3" />
+                <string id="MonoProfilerPublisher.ExceptionClauseEventMessage" value="ClrInstanceID=%1;%nClauseType=%2;%nClauseID=%3;%nMethodID=%4;%nTypeID=%5;%nObjectID=%6" />
+
+                <string id="MonoProfilerPublisher.GCEventEventMessage" value="ClrInstanceID=%1;%nGCEventType=%2;%nGCGeneration=%3" />
+                <string id="MonoProfilerPublisher.GCAllocationEventMessage" value="ClrInstanceID=%1;%nVTableID=%2;%nObjectID=%3;%nObjectSize=%4" />
+                <string id="MonoProfilerPublisher.GCMovesEventMessage" value="ClrInstanceID=%1;%nCount=%2" />
+                <string id="MonoProfilerPublisher.GCResizeEventMessage" value="ClrInstanceID=%1;%nNewSize=%2" />
+                <string id="MonoProfilerPublisher.GCHandleCreatedEventMessage" value="ClrInstanceID=%1;%nHandleID=%2;%nHandleType=%3;%nObjectID=%4" />
+                <string id="MonoProfilerPublisher.GCHandleDeletedEventMessage" value="ClrInstanceID=%1;%nHandleID=%2;%nHandleType=%3" />
+                <string id="MonoProfilerPublisher.GCFinalizingFinalizedEventMessage" value="ClrInstanceID=%1" />
+                <string id="MonoProfilerPublisher.GCFinalizingFinalizedObjectEventMessage" value="ClrInstanceID=%1;%nObjectID=%2" />
+                <string id="MonoProfilerPublisher.GCRootRegisterEventMessage" value="ClrInstanceID=%1;%nRootID=%2;%nRootSize=%3;%nRootType=%4;%nRootKeyID=%5;%nRootKeyName=%6" />
+                <string id="MonoProfilerPublisher.GCRootUnregisterEventMessage" value="ClrInstanceID=%1;%nRootID=%2" />
+                <string id="MonoProfilerPublisher.GCRootsEventMessage" value="ClrInstanceID=%1;%nCount=%2" />
+                <string id="MonoProfilerPublisher.GCHeapDumpStartStopEventMessage" value="ClrInstanceID=%1" />
+                <string id="MonoProfilerPublisher.GCHeapDumpObjectReferenceEventMessage" value="ClrInstanceID=%1;%nObjectID=%2;%nVTableID=%3;%nObjectSize=%4;%nObjectGeneration=%5;%nCount=%6" />
+
+                <string id="MonoProfilerPublisher.MonitorContentionFailedAcquiredEventMessage" value="ClrInstanceID=%1;%nObjectID=%2" />
+
+                <string id="MonoProfilerPublisher.ThreadStartedStoppingStoppedExitedEventMessage" value="ClrInstanceID=%1;%nThreadID=%2" />
+                <string id="MonoProfilerPublisher.ThreadNameEventMessage" value="ClrInstanceID=%1;%nThreadID=%2;%nThreadName=%3" />
             </stringTable>
         </resources>
     </localization>

--- a/src/coreclr/vm/ClrEtwAllMeta.lst
+++ b/src/coreclr/vm/ClrEtwAllMeta.lst
@@ -637,6 +637,7 @@ nomac:CLRStackStress:::CLRStackWalkStress
 #################################
 # Events from the Mono profiler provider
 #################################
+nostack::MonoProfiler::ExceptionClause
 nostack::MonoProfiler::MonoProfilerMethodEnter
 nostack::MonoProfiler::MonoProfilerMethodLeave
 nostack::MonoProfiler::MonoProfilerMethodTailCall

--- a/src/coreclr/vm/ClrEtwAllMeta.lst
+++ b/src/coreclr/vm/ClrEtwAllMeta.lst
@@ -633,3 +633,32 @@ nomac:StressLogTask:::StressLogEvent_V1
 # StackWalk events
 ##################
 nomac:CLRStackStress:::CLRStackWalkStress
+
+#################################
+# Events from the Mono profiler provider
+#################################
+nostack::MonoProfiler::MonoProfilerMethodEnter
+nostack::MonoProfiler::MonoProfilerMethodLeave
+nostack::MonoProfiler::MonoProfilerMethodTailCall
+nostack::MonoProfiler::MonoProfilerMethodExceptionLeave
+nostack::MonoProfiler::MonoProfilerMethodFree
+nostack::MonoProfiler::MonoProfilerMethodBeginInvoke
+nostack::MonoProfiler::MonoProfilerMethodEndInvoke
+nostack::MonoProfiler::MonoProfilerGCEvent
+nostack::MonoProfiler::MonoProfilerGCMoves
+nostack::MonoProfiler::MonoProfilerGCResize
+nostack::MonoProfiler::MonoProfilerGCFinalizing
+nostack::MonoProfiler::MonoProfilerGCFinalized
+nostack::MonoProfiler::MonoProfilerGCFinalizingObject
+nostack::MonoProfiler::MonoProfilerGCFinalizedObject
+nostack::MonoProfiler::MonoProfilerGCRootRegister
+nostack::MonoProfiler::MonoProfilerGCRootUnregister
+nostack::MonoProfiler::MonoProfilerGCRoots
+nostack::MonoProfiler::MonoProfilerGCHeapDumpStart
+nostack::MonoProfiler::MonoProfilerGCHeapDumpStop
+nostack::MonoProfiler::MonoProfilerGCHeapDumpObjectReference
+nostack::MonoProfiler::MonoProfilerThreadStarted
+nostack::MonoProfiler::MonoProfilerThreadStopping
+nostack::MonoProfiler::MonoProfilerThreadStopped
+nostack::MonoProfiler::MonoProfilerThreadExited
+nostack::MonoProfiler::MonoProfilerThreadName

--- a/src/mono/mono/component/event_pipe.c
+++ b/src/mono/mono/component/event_pipe.c
@@ -284,5 +284,7 @@ event_pipe_thread_ctrl_activity_id (
 MonoComponentEventPipe *
 mono_component_event_pipe_init (void)
 {
+	extern void ep_rt_mono_component_init (void);
+	ep_rt_mono_component_init ();
 	return &fn_table;
 }

--- a/src/mono/mono/component/event_pipe.c
+++ b/src/mono/mono/component/event_pipe.c
@@ -11,6 +11,8 @@
 #include <eventpipe/ep-event-instance.h>
 #include <eventpipe/ep-session.h>
 
+static bool _event_pipe_component_inited = false;
+
 struct _EventPipeProviderConfigurationNative {
 	gunichar2 *provider_name;
 	uint64_t keywords;
@@ -284,7 +286,11 @@ event_pipe_thread_ctrl_activity_id (
 MonoComponentEventPipe *
 mono_component_event_pipe_init (void)
 {
-	extern void ep_rt_mono_component_init (void);
-	ep_rt_mono_component_init ();
+	if (!_event_pipe_component_inited) {
+		extern void ep_rt_mono_component_init (void);
+		ep_rt_mono_component_init ();
+		_event_pipe_component_inited = true;
+	}
+
 	return &fn_table;
 }

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -21,6 +21,8 @@
 #include <mono/metadata/gc-internals.h>
 #include <mono/metadata/profiler-private.h>
 #include <mono/mini/mini-runtime.h>
+#include <mono/sgen/sgen-conf.h>
+#include <mono/sgen/sgen-tagged-pointer.h>
 #include <runtime_version.h>
 #include <clretwallmain.h>
 
@@ -49,8 +51,10 @@ char *_ep_rt_mono_managed_cmd_line = NULL;
 static GArray * _ep_rt_mono_sampled_thread_callstacks = NULL;
 static uint32_t _ep_rt_mono_max_sampled_thread_count = 32;
 
-// Mono profiler.
-static MonoProfilerHandle _ep_rt_mono_profiler = NULL;
+// Mono profilers.
+static MonoProfilerHandle _ep_rt_default_profiler = NULL;
+static MonoProfilerHandle _ep_rt_dotnet_runtime_profiler_provider = NULL;
+static MonoProfilerHandle _ep_rt_dotnet_mono_profiler_provider = NULL;
 
 // Phantom JIT compile method.
 MonoMethod *_ep_rt_mono_runtime_helper_compile_method = NULL;
@@ -196,6 +200,37 @@ typedef struct _AssemblyEventData AssemblyEventData;
 #define EXCEPTION_THROWN_FLAGS_IS_CSE 0x8
 #define EXCEPTION_THROWN_FLAGS_IS_CLS_COMPLIANT 0x10
 
+// Provider keyword flags.
+#define GC_KEYWORD 0x1
+#define GC_HANDLE_KEYWORD 0x2
+#define LOADER_KEYWORD 0x8
+#define JIT_KEYWORD 0x10
+#define APP_DOMAIN_RESOURCE_MANAGEMENT_KEYWORD 0x800
+#define CONTENTION_KEYWORD 0x4000
+#define EXCEPTION_KEYWORD 0x8000
+#define THREADING_KEYWORD 0x10000
+#define GC_ALLOCATION_KEYWORD 0x200000
+#define GC_MOVES_KEYWORD 0x400000
+#define GC_ROOT_KEYWORD 0x800000
+#define GC_FINALIZATION_KEYWORD 0x1000000
+#define GC_RESIZE_KEYWORD 0x2000000
+#define METHOD_TRACING_KEYWORD 0x20000000
+#define TYPE_DIAGNOSTIC_KEYWORD 0x8000000000
+#define TYPE_LOADING_KEYWORD 0x8000000000
+#define MONITOR_KEYWORD 0x10000000000
+
+// GC provider types.
+
+typedef struct _GCObjectAddressData {
+	MonoObject *object;
+	void *address;
+} GCObjectAddressData;
+
+typedef struct _GCAddressObjectData {
+	void *address;
+	MonoObject *object;
+} GCAddressObjectData;
+
 /*
  * Forward declares of all static functions.
  */
@@ -328,86 +363,86 @@ get_exception_ip_func (
 
 static
 void
-profiler_jit_begin (
+runtime_profiler_jit_begin (
 	MonoProfiler *prof,
 	MonoMethod *method);
 
 static
 void
-profiler_jit_failed (
+runtime_profiler_jit_failed (
 	MonoProfiler *prof,
 	MonoMethod *method);
 
 static
 void
-profiler_jit_done (
+runtime_profiler_jit_done (
 	MonoProfiler *prof,
 	MonoMethod *method,
 	MonoJitInfo *ji);
 
 static
 void
-profiler_image_loaded (
+runtime_profiler_image_loaded (
 	MonoProfiler *prof,
 	MonoImage *image);
 
 static
 void
-profiler_image_unloaded (
+runtime_profiler_image_unloaded (
 	MonoProfiler *prof,
 	MonoImage *image);
 
 static
 void
-profiler_assembly_loaded (
+runtime_profiler_assembly_loaded (
 	MonoProfiler *prof,
 	MonoAssembly *assembly);
 
 static
 void
-profiler_assembly_unloaded (
+runtime_profiler_assembly_unloaded (
 	MonoProfiler *prof,
 	MonoAssembly *assembly);
 
 static
 void
-profiler_thread_started (
+runtime_profiler_thread_started (
 	MonoProfiler *prof,
 	uintptr_t tid);
 
 static
 void
-profiler_thread_stopped (
+runtime_profiler_thread_stopped (
 	MonoProfiler *prof,
 	uintptr_t tid);
 
 static
 void
-profiler_class_loading (
+runtime_profiler_class_loading (
 	MonoProfiler *prof,
 	MonoClass *klass);
 
 static
 void
-profiler_class_failed (
+runtime_profiler_class_failed (
 	MonoProfiler *prof,
 	MonoClass *klass);
 
 static
 void
-profiler_class_loaded (
+runtime_profiler_class_loaded (
 	MonoProfiler *prof,
 	MonoClass *klass);
 
 static
 void
-profiler_exception_throw (
+runtime_profiler_exception_throw (
 	MonoProfiler *prof,
 	MonoObject *exception);
 
 static
 void
-profiler_exception_clause (
+runtime_profiler_exception_clause (
 	MonoProfiler *prof,
 	MonoMethod *method,
 	uint32_t clause_num,
@@ -416,30 +451,382 @@ profiler_exception_clause (
 
 static
 void
-profiler_monitor_contention (
+runtime_profiler_monitor_contention (
 	MonoProfiler *prof,
 	MonoObject *obj);
 
 static
 void
-profiler_monitor_acquired (
+runtime_profiler_monitor_acquired (
 	MonoProfiler *prof,
 	MonoObject *obj);
 
 static
 void
-profiler_monitor_failed (
+runtime_profiler_monitor_failed (
 	MonoProfiler *prof,
 	MonoObject *obj);
 
 static
 void
-profiler_jit_code_buffer (
+runtime_profiler_jit_code_buffer (
 	MonoProfiler *prof,
 	const mono_byte *buffer,
 	uint64_t size,
 	MonoProfilerCodeBufferType type,
 	const void *data);
+
+static
+void
+mono_profiler_app_domain_loading (
+	MonoProfiler *prof,
+	MonoDomain *domain);
+
+static
+void
+mono_profiler_app_domain_loaded (
+	MonoProfiler *prof,
+	MonoDomain *domain);
+
+static
+void
+mono_profiler_app_domain_unloading (
+	MonoProfiler *prof,
+	MonoDomain *domain);
+
+static
+void
+mono_profiler_app_domain_unloaded (
+	MonoProfiler *prof,
+	MonoDomain *domain);
+
+static
+void
+mono_profiler_app_domain_name (
+	MonoProfiler *prof,
+	MonoDomain *domain,
+	const char *name);
+
+static
+void
+mono_profiler_jit_begin (
+	MonoProfiler *prof,
+	MonoMethod *method);
+
+static
+void
+mono_profiler_jit_failed (
+	MonoProfiler *prof,
+	MonoMethod *method);
+
+static
+void
+mono_profiler_jit_done (
+	MonoProfiler *prof,
+	MonoMethod *method,
+	MonoJitInfo *ji);
+
+static
+void
+mono_profiler_jit_chunk_created (
+	MonoProfiler *prof,
+	const mono_byte *chunk,
+	uintptr_t size);
+
+static
+void
+mono_profiler_jit_chunk_destroyed (
+	MonoProfiler *prof,
+	const mono_byte *chunk);
+
+static
+void
+mono_profiler_jit_code_buffer (
+	MonoProfiler *prof,
+	const mono_byte *buffer,
+	uint64_t size,
+	MonoProfilerCodeBufferType type,
+	const void *data);
+
+static
+void
+mono_profiler_class_loading (
+	MonoProfiler *prof,
+	MonoClass *klass);
+
+static
+void
+mono_profiler_class_failed (
+	MonoProfiler *prof,
+	MonoClass *klass);
+
+static
+void
+mono_profiler_class_loaded (
+	MonoProfiler *prof,
+	MonoClass *klass);
+
+static
+void
+mono_profiler_vtable_loading (
+	MonoProfiler *prof,
+	MonoVTable *vtable);
+
+static
+void
+mono_profiler_vtable_failed (
+	MonoProfiler *prof,
+	MonoVTable *vtable);
+
+static
+void
+mono_profiler_vtable_loaded (
+	MonoProfiler *prof,
+	MonoVTable *vtable);
+
+static
+void
+mono_profiler_module_loading (
+	MonoProfiler *prof,
+	MonoImage *image);
+
+static
+void
+mono_profiler_module_failed (
+	MonoProfiler *prof,
+	MonoImage *image);
+
+static
+void
+mono_profiler_module_loaded (
+	MonoProfiler *prof,
+	MonoImage *image);
+
+static
+void
+mono_profiler_module_unloading (
+	MonoProfiler *prof,
+	MonoImage *image);
+
+static
+void
+mono_profiler_module_unloaded (
+	MonoProfiler *prof,
+	MonoImage *image);
+
+static
+void
+mono_profiler_assembly_loading (
+	MonoProfiler *prof,
+	MonoAssembly *assembly);
+
+static
+void
+mono_profiler_assembly_loaded (
+	MonoProfiler *prof,
+	MonoAssembly *assembly);
+
+static
+void
+mono_profiler_assembly_unloading (
+	MonoProfiler *prof,
+	MonoAssembly *assembly);
+
+static
+void
+mono_profiler_assembly_unloaded (
+	MonoProfiler *prof,
+	MonoAssembly *assembly);
+
+static
+void
+mono_profiler_method_enter (
+	MonoProfiler *prof,
+	MonoMethod *method,
+	MonoProfilerCallContext *context);
+
+static
+void
+mono_profiler_method_leave (
+	MonoProfiler *prof,
+	MonoMethod *method,
+	MonoProfilerCallContext *context);
+
+static
+void
+mono_profiler_method_tail_call (
+	MonoProfiler *prof,
+	MonoMethod *method,
+	MonoMethod *target_method);
+
+static
+void
+mono_profiler_method_exception_leave (
+	MonoProfiler *prof,
+	MonoMethod *method,
+	MonoObject *exc);
+
+static
+void
+mono_profiler_method_free (
+	MonoProfiler *prof,
+	MonoMethod *method);
+
+static
+void
+mono_profiler_method_begin_invoke (
+	MonoProfiler *prof,
+	MonoMethod *method);
+
+static
+void
+mono_profiler_method_end_invoke (
+	MonoProfiler *prof,
+	MonoMethod *method);
+
+static
+MonoProfilerCallInstrumentationFlags
+mono_profiler_method_instrumentation (
+	MonoProfiler *prof,
+	MonoMethod *method);
+
+static
+void
+mono_profiler_exception_throw (
+	MonoProfiler *prof,
+	MonoObject *exc);
+
+static
+void
+mono_profiler_exception_clause (
+	MonoProfiler *prof,
+	MonoMethod *method,
+	uint32_t clause_num,
+	MonoExceptionEnum clause_type,
+	MonoObject *exc);
+
+static
+void
+mono_profiler_gc_event (
+	MonoProfiler *prof,
+	MonoProfilerGCEvent gc_event,
+	uint32_t generation,
+	mono_bool serial);
+
+static
+void
+mono_profiler_gc_allocation (
+	MonoProfiler *prof,
+	MonoObject *object);
+
+static
+void
+mono_profiler_gc_moves (
+	MonoProfiler *prof,
+	MonoObject *const* objects,
+	uint64_t count);
+
+static
+void
+mono_profiler_gc_resize (
+	MonoProfiler *prof,
+	uintptr_t size);
+
+static
+void
+mono_profiler_gc_handle_created (
+	MonoProfiler *prof,
+	uint32_t handle,
+	MonoGCHandleType type,
+	MonoObject * object);
+
+static
+void
+mono_profiler_gc_handle_deleted (
+	MonoProfiler *prof,
+	uint32_t handle,
+	MonoGCHandleType type);
+
+static
+void
+mono_profiler_gc_finalizing (MonoProfiler *prof);
+
+static
+void
+mono_profiler_gc_finalized (MonoProfiler *prof);
+
+static
+void
+mono_profiler_gc_root_register (
+	MonoProfiler *prof,
+	const mono_byte *start,
+	uintptr_t size,
+	MonoGCRootSource source,
+	const void * key,
+	const char * name);
+
+static
+void
+mono_profiler_gc_root_unregister (
+	MonoProfiler *prof,
+	const mono_byte *start);
+
+static
+void
+mono_profiler_gc_roots (
+	MonoProfiler *prof,
+	uint64_t count,
+	const mono_byte *const * addresses,
+	MonoObject *const * objects);
+
+static
+void
+mono_profiler_monitor_contention (
+	MonoProfiler *prof,
+	MonoObject *object);
+
+static
+void
+mono_profiler_monitor_failed (
+	MonoProfiler *prof,
+	MonoObject *object);
+
+static
+void
+mono_profiler_monitor_acquired (
+	MonoProfiler *prof,
+	MonoObject *object);
+
+static
+void
+mono_profiler_thread_started (
+	MonoProfiler *prof,
+	uintptr_t tid);
+
+static
+void
+mono_profiler_thread_stopping (
+	MonoProfiler *prof,
+	uintptr_t tid);
+
+static
+void
+mono_profiler_thread_stopped (
+	MonoProfiler *prof,
+	uintptr_t tid);
+
+static
+void
+mono_profiler_thread_exited (
+	MonoProfiler *prof,
+	uintptr_t tid);
+
+static
+void
+mono_profiler_thread_name (
+	MonoProfiler *prof,
+	uintptr_t tid,
+	const char *name);
 
 /*
  * Forward declares of all private functions (accessed using extern in ep-rt-mono.h).
@@ -525,6 +912,14 @@ ep_rt_mono_method_get_full_name (
 
 void
 ep_rt_mono_execute_rundown (ep_rt_execution_checkpoint_array_t *execution_checkpoints);
+
+static
+inline
+bool
+profiler_callback_is_enabled (uint64_t enabled_keywords, uint64_t keyword)
+{
+	return (enabled_keywords & keyword) == keyword;
+}
 
 static
 inline
@@ -1184,8 +1579,11 @@ ep_rt_mono_init (void)
 
 	_ep_rt_mono_initialized = TRUE;
 
-	_ep_rt_mono_profiler = mono_profiler_create (NULL);
-	mono_profiler_set_thread_stopped_callback (_ep_rt_mono_profiler, profiler_eventpipe_thread_exited);
+	_ep_rt_default_profiler = mono_profiler_create (NULL);
+	mono_profiler_set_thread_stopped_callback (_ep_rt_default_profiler, profiler_eventpipe_thread_exited);
+
+	_ep_rt_dotnet_runtime_profiler_provider = mono_profiler_create (NULL);
+	_ep_rt_dotnet_mono_profiler_provider = mono_profiler_create (NULL);
 
 	MonoMethodSignature *method_signature = mono_metadata_signature_alloc (mono_get_corlib (), 1);
 	if (method_signature) {
@@ -1671,7 +2069,8 @@ ep_rt_mono_providers_validate_all_disabled (void)
 {
 	return (!MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_EVENTPIPE_Context.IsEnabled &&
 		!MICROSOFT_WINDOWS_DOTNETRUNTIME_PRIVATE_PROVIDER_EVENTPIPE_Context.IsEnabled &&
-		!MICROSOFT_WINDOWS_DOTNETRUNTIME_RUNDOWN_PROVIDER_EVENTPIPE_Context.IsEnabled);
+		!MICROSOFT_WINDOWS_DOTNETRUNTIME_RUNDOWN_PROVIDER_EVENTPIPE_Context.IsEnabled &&
+		!MICROSOFT_DOTNETRUNTIME_MONO_PROFILER_PROVIDER_EVENTPIPE_Context.IsEnabled);
 }
 
 void
@@ -2809,7 +3208,7 @@ ep_rt_write_event_threadpool_working_thread_count (
 
 static
 void
-profiler_jit_begin (
+runtime_profiler_jit_begin (
 	MonoProfiler *prof,
 	MonoMethod *method)
 {
@@ -2818,7 +3217,7 @@ profiler_jit_begin (
 
 static
 void
-profiler_jit_failed (
+runtime_profiler_jit_failed (
 	MonoProfiler *prof,
 	MonoMethod *method)
 {
@@ -2827,7 +3226,7 @@ profiler_jit_failed (
 
 static
 void
-profiler_jit_done (
+runtime_profiler_jit_done (
 	MonoProfiler *prof,
 	MonoMethod *method,
 	MonoJitInfo *ji)
@@ -2838,7 +3237,7 @@ profiler_jit_done (
 
 static
 void
-profiler_image_loaded (
+runtime_profiler_image_loaded (
 	MonoProfiler *prof,
 	MonoImage *image)
 {
@@ -2848,7 +3247,7 @@ profiler_image_loaded (
 
 static
 void
-profiler_image_unloaded (
+runtime_profiler_image_unloaded (
 	MonoProfiler *prof,
 	MonoImage *image)
 {
@@ -2858,7 +3257,7 @@ profiler_image_unloaded (
 
 static
 void
-profiler_assembly_loaded (
+runtime_profiler_assembly_loaded (
 	MonoProfiler *prof,
 	MonoAssembly *assembly)
 {
@@ -2867,7 +3266,7 @@ profiler_assembly_loaded (
 
 static
 void
-profiler_assembly_unloaded (
+runtime_profiler_assembly_unloaded (
 	MonoProfiler *prof,
 	MonoAssembly *assembly)
 {
@@ -2876,7 +3275,7 @@ profiler_assembly_unloaded (
 
 static
 void
-profiler_thread_started (
+runtime_profiler_thread_started (
 	MonoProfiler *prof,
 	uintptr_t tid)
 {
@@ -2885,7 +3284,7 @@ profiler_thread_started (
 
 static
 void
-profiler_thread_stopped (
+runtime_profiler_thread_stopped (
 	MonoProfiler *prof,
 	uintptr_t tid)
 {
@@ -2894,7 +3293,7 @@ profiler_thread_stopped (
 
 static
 void
-profiler_class_loading (
+runtime_profiler_class_loading (
 	MonoProfiler *prof,
 	MonoClass *klass)
 {
@@ -2903,7 +3302,7 @@ profiler_class_loading (
 
 static
 void
-profiler_class_failed (
+runtime_profiler_class_failed (
 	MonoProfiler *prof,
 	MonoClass *klass)
 {
@@ -2912,7 +3311,7 @@ profiler_class_failed (
 
 static
 void
-profiler_class_loaded (
+runtime_profiler_class_loaded (
 	MonoProfiler *prof,
 	MonoClass *klass)
 {
@@ -2921,7 +3320,7 @@ profiler_class_loaded (
 
 static
 void
-profiler_exception_throw (
+runtime_profiler_exception_throw (
 	MonoProfiler *prof,
 	MonoObject *exc)
 {
@@ -2930,7 +3329,7 @@ profiler_exception_throw (
 
 static
 void
-profiler_exception_clause (
+runtime_profiler_exception_clause (
 	MonoProfiler *prof,
 	MonoMethod *method,
 	uint32_t clause_num,
@@ -2942,7 +3341,7 @@ profiler_exception_clause (
 
 static
 void
-profiler_monitor_contention (
+runtime_profiler_monitor_contention (
 	MonoProfiler *prof,
 	MonoObject *obj)
 {
@@ -2951,7 +3350,7 @@ profiler_monitor_contention (
 
 static
 void
-profiler_monitor_acquired (
+runtime_profiler_monitor_acquired (
 	MonoProfiler *prof,
 	MonoObject *obj)
 {
@@ -2960,7 +3359,7 @@ profiler_monitor_acquired (
 
 static
 void
-profiler_monitor_failed (
+runtime_profiler_monitor_failed (
 	MonoProfiler *prof,
 	MonoObject *obj)
 {
@@ -2969,7 +3368,7 @@ profiler_monitor_failed (
 
 static
 void
-profiler_jit_code_buffer (
+runtime_profiler_jit_code_buffer (
 	MonoProfiler *prof,
 	const mono_byte *buffer,
 	uint64_t size,
@@ -2992,49 +3391,70 @@ EventPipeEtwCallbackDotNETRuntime (
 	ep_rt_config_requires_lock_not_held ();
 
 	EP_ASSERT(is_enabled == 0 || is_enabled == 1) ;
-	EP_ASSERT (_ep_rt_mono_profiler != NULL);
+	EP_ASSERT (_ep_rt_dotnet_runtime_profiler_provider != NULL);
 
 	EP_LOCK_ENTER (section1)
 		if (is_enabled == 1 && !MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_EVENTPIPE_Context.IsEnabled) {
 			// Add profiler callbacks for DotNETRuntime provider events.
-			mono_profiler_set_jit_begin_callback (_ep_rt_mono_profiler, profiler_jit_begin);
-			mono_profiler_set_jit_failed_callback (_ep_rt_mono_profiler, profiler_jit_failed);
-			mono_profiler_set_jit_done_callback (_ep_rt_mono_profiler, profiler_jit_done);
-			mono_profiler_set_image_loaded_callback (_ep_rt_mono_profiler, profiler_image_loaded);
-			mono_profiler_set_image_unloaded_callback (_ep_rt_mono_profiler, profiler_image_unloaded);
-			mono_profiler_set_assembly_loaded_callback (_ep_rt_mono_profiler, profiler_assembly_loaded);
-			mono_profiler_set_assembly_unloaded_callback (_ep_rt_mono_profiler, profiler_assembly_unloaded);
-			mono_profiler_set_thread_started_callback (_ep_rt_mono_profiler, profiler_thread_started);
-			mono_profiler_set_thread_stopped_callback (_ep_rt_mono_profiler, profiler_thread_stopped);
-			mono_profiler_set_class_loading_callback (_ep_rt_mono_profiler, profiler_class_loading);
-			mono_profiler_set_class_failed_callback (_ep_rt_mono_profiler, profiler_class_failed);
-			mono_profiler_set_class_loaded_callback (_ep_rt_mono_profiler, profiler_class_loaded);
-			mono_profiler_set_exception_throw_callback (_ep_rt_mono_profiler, profiler_exception_throw);
-			mono_profiler_set_exception_clause_callback (_ep_rt_mono_profiler, profiler_exception_clause);
-			mono_profiler_set_monitor_contention_callback (_ep_rt_mono_profiler, profiler_monitor_contention);
-			mono_profiler_set_monitor_acquired_callback (_ep_rt_mono_profiler, profiler_monitor_acquired);
-			mono_profiler_set_monitor_failed_callback (_ep_rt_mono_profiler, profiler_monitor_failed);
-			mono_profiler_set_jit_code_buffer_callback (_ep_rt_mono_profiler, profiler_jit_code_buffer);
+			if (profiler_callback_is_enabled(match_any_keywords, JIT_KEYWORD)) {
+				mono_profiler_set_jit_begin_callback (_ep_rt_dotnet_runtime_profiler_provider, runtime_profiler_jit_begin);
+				mono_profiler_set_jit_failed_callback (_ep_rt_dotnet_runtime_profiler_provider, runtime_profiler_jit_failed);
+				mono_profiler_set_jit_done_callback (_ep_rt_dotnet_runtime_profiler_provider, runtime_profiler_jit_done);
+			}
+			if (profiler_callback_is_enabled(match_any_keywords, LOADER_KEYWORD)) {
+				mono_profiler_set_image_loaded_callback (_ep_rt_dotnet_runtime_profiler_provider, runtime_profiler_image_loaded);
+				mono_profiler_set_image_unloaded_callback (_ep_rt_dotnet_runtime_profiler_provider, runtime_profiler_image_unloaded);
+				mono_profiler_set_assembly_loaded_callback (_ep_rt_dotnet_runtime_profiler_provider, runtime_profiler_assembly_loaded);
+				mono_profiler_set_assembly_unloaded_callback (_ep_rt_dotnet_runtime_profiler_provider, runtime_profiler_assembly_unloaded);
+			}
+			if (profiler_callback_is_enabled(match_any_keywords, APP_DOMAIN_RESOURCE_MANAGEMENT_KEYWORD | THREADING_KEYWORD)) {
+				mono_profiler_set_thread_started_callback (_ep_rt_dotnet_runtime_profiler_provider, runtime_profiler_thread_started);
+				mono_profiler_set_thread_stopped_callback (_ep_rt_dotnet_runtime_profiler_provider, runtime_profiler_thread_stopped);
+			}
+			if (profiler_callback_is_enabled(match_any_keywords, TYPE_DIAGNOSTIC_KEYWORD)) {
+				mono_profiler_set_class_loading_callback (_ep_rt_dotnet_runtime_profiler_provider, runtime_profiler_class_loading);
+				mono_profiler_set_class_failed_callback (_ep_rt_dotnet_runtime_profiler_provider, runtime_profiler_class_failed);
+				mono_profiler_set_class_loaded_callback (_ep_rt_dotnet_runtime_profiler_provider, runtime_profiler_class_loaded);
+			}
+			if (profiler_callback_is_enabled(match_any_keywords, EXCEPTION_KEYWORD)) {
+				mono_profiler_set_exception_throw_callback (_ep_rt_dotnet_runtime_profiler_provider, runtime_profiler_exception_throw);
+				mono_profiler_set_exception_clause_callback (_ep_rt_dotnet_runtime_profiler_provider, runtime_profiler_exception_clause);
+			}
+			if (profiler_callback_is_enabled(match_any_keywords, CONTENTION_KEYWORD)) {
+				mono_profiler_set_monitor_contention_callback (_ep_rt_dotnet_runtime_profiler_provider, runtime_profiler_monitor_contention);
+				mono_profiler_set_monitor_acquired_callback (_ep_rt_dotnet_runtime_profiler_provider, runtime_profiler_monitor_acquired);
+				mono_profiler_set_monitor_failed_callback (_ep_rt_dotnet_runtime_profiler_provider, runtime_profiler_monitor_failed);
+			}
 		} else if (is_enabled == 0 && MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_EVENTPIPE_Context.IsEnabled) {
 			// Remove profiler callbacks for DotNETRuntime provider events.
-			mono_profiler_set_jit_code_buffer_callback (_ep_rt_mono_profiler, NULL);
-			mono_profiler_set_monitor_failed_callback (_ep_rt_mono_profiler, NULL);
-			mono_profiler_set_monitor_acquired_callback (_ep_rt_mono_profiler, NULL);
-			mono_profiler_set_monitor_contention_callback (_ep_rt_mono_profiler, NULL);
-			mono_profiler_set_exception_clause_callback (_ep_rt_mono_profiler, NULL);
-			mono_profiler_set_exception_throw_callback (_ep_rt_mono_profiler, NULL);
-			mono_profiler_set_class_loaded_callback (_ep_rt_mono_profiler, NULL);
-			mono_profiler_set_class_failed_callback (_ep_rt_mono_profiler, NULL);
-			mono_profiler_set_class_loading_callback (_ep_rt_mono_profiler, NULL);
-			mono_profiler_set_thread_started_callback (_ep_rt_mono_profiler, NULL);
-			mono_profiler_set_thread_started_callback (_ep_rt_mono_profiler, NULL);
-			mono_profiler_set_assembly_unloaded_callback (_ep_rt_mono_profiler, NULL);
-			mono_profiler_set_assembly_loaded_callback (_ep_rt_mono_profiler, NULL);
-			mono_profiler_set_image_unloaded_callback (_ep_rt_mono_profiler, NULL);
-			mono_profiler_set_image_loaded_callback (_ep_rt_mono_profiler, NULL);
-			mono_profiler_set_jit_done_callback (_ep_rt_mono_profiler, NULL);
-			mono_profiler_set_jit_failed_callback (_ep_rt_mono_profiler, NULL);
-			mono_profiler_set_jit_begin_callback (_ep_rt_mono_profiler, NULL);
+			// JIT_KEYWORD
+			mono_profiler_set_jit_begin_callback (_ep_rt_dotnet_runtime_profiler_provider, NULL);
+			mono_profiler_set_jit_failed_callback (_ep_rt_dotnet_runtime_profiler_provider, NULL);
+			mono_profiler_set_jit_done_callback (_ep_rt_dotnet_runtime_profiler_provider, NULL);
+
+			// LOADER_KEYWORD
+			mono_profiler_set_image_loaded_callback (_ep_rt_dotnet_runtime_profiler_provider, NULL);
+			mono_profiler_set_image_unloaded_callback (_ep_rt_dotnet_runtime_profiler_provider, NULL);
+			mono_profiler_set_assembly_loaded_callback (_ep_rt_dotnet_runtime_profiler_provider, NULL);
+			mono_profiler_set_assembly_unloaded_callback (_ep_rt_dotnet_runtime_profiler_provider, NULL);
+
+			// APP_DOMAIN_RESOURCE_MANAGEMENT_KEYWORD | THREADING_KEYWORD
+			mono_profiler_set_thread_started_callback (_ep_rt_dotnet_runtime_profiler_provider, NULL);
+			mono_profiler_set_thread_stopped_callback (_ep_rt_dotnet_runtime_profiler_provider, NULL);
+
+			// TYPE_DIAGNOSTIC_KEYWORD
+			mono_profiler_set_class_loading_callback (_ep_rt_dotnet_runtime_profiler_provider, NULL);
+			mono_profiler_set_class_failed_callback (_ep_rt_dotnet_runtime_profiler_provider, NULL);
+			mono_profiler_set_class_loaded_callback (_ep_rt_dotnet_runtime_profiler_provider, NULL);
+
+			// EXCEPTION_KEYWORD
+			mono_profiler_set_exception_throw_callback (_ep_rt_dotnet_runtime_profiler_provider, NULL);
+			mono_profiler_set_exception_clause_callback (_ep_rt_dotnet_runtime_profiler_provider, NULL);
+
+			// CONTENTION_KEYWORD
+			mono_profiler_set_monitor_contention_callback (_ep_rt_dotnet_runtime_profiler_provider, NULL);
+			mono_profiler_set_monitor_acquired_callback (_ep_rt_dotnet_runtime_profiler_provider, NULL);
+			mono_profiler_set_monitor_failed_callback (_ep_rt_dotnet_runtime_profiler_provider, NULL);
 		}
 	EP_LOCK_EXIT (section1)
 
@@ -3093,6 +3513,1524 @@ EventPipeEtwCallbackDotNETRuntimeStress (
 	MICROSOFT_WINDOWS_DOTNETRUNTIME_STRESS_PROVIDER_EVENTPIPE_Context.Level = level;
 	MICROSOFT_WINDOWS_DOTNETRUNTIME_STRESS_PROVIDER_EVENTPIPE_Context.EnabledKeywordsBitmask = match_any_keywords;
 	MICROSOFT_WINDOWS_DOTNETRUNTIME_STRESS_PROVIDER_EVENTPIPE_Context.IsEnabled = (is_enabled == 1 ? true : false);
+}
+
+static
+void
+mono_profiler_app_domain_loading (
+	MonoProfiler *prof,
+	MonoDomain *domain)
+{
+	if (!EventEnabledMonoProfilerAppDomainLoading ())
+		return;
+
+	uint64_t domain_id = (uint64_t)domain;
+	FireEtwMonoProfilerAppDomainLoading (
+		clr_instance_get_id (),
+		domain_id,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_app_domain_loaded (
+	MonoProfiler *prof,
+	MonoDomain *domain)
+{
+	if (!EventEnabledMonoProfilerAppDomainLoaded ())
+		return;
+
+	uint64_t domain_id = (uint64_t)domain;
+	FireEtwMonoProfilerAppDomainLoaded (
+		clr_instance_get_id (),
+		domain_id,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_app_domain_unloading (
+	MonoProfiler *prof,
+	MonoDomain *domain)
+{
+	if (!EventEnabledMonoProfilerAppDomainUnloading ())
+		return;
+
+	uint64_t domain_id = (uint64_t)domain;
+	FireEtwMonoProfilerAppDomainUnloading (
+		clr_instance_get_id (),
+		domain_id,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_app_domain_unloaded (
+	MonoProfiler *prof,
+	MonoDomain *domain)
+{
+	if (!EventEnabledMonoProfilerAppDomainUnloaded ())
+		return;
+
+	uint64_t domain_id = (uint64_t)domain;
+	FireEtwMonoProfilerAppDomainUnloaded (
+		clr_instance_get_id (),
+		domain_id,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_app_domain_name (
+	MonoProfiler *prof,
+	MonoDomain *domain,
+	const char *name)
+{
+	if (!EventEnabledMonoProfilerAppDomainName ())
+		return;
+
+	uint64_t domain_id = (uint64_t)domain;
+	FireEtwMonoProfilerAppDomainName (
+		clr_instance_get_id (),
+		domain_id,
+		(const ep_char8_t *)(name ? name : ""),
+		NULL,
+		NULL);
+}
+
+static
+inline
+void
+get_jit_data (
+	MonoMethod *method,
+	uint64_t *method_id,
+	uint64_t *module_id,
+	uint32_t *method_token)
+{
+	*method_id = (uint64_t)method;
+	*module_id = 0;
+	*method_token = 0;
+
+	if (method) {
+		*method_token = method->token;
+		if (method->klass)
+			*module_id = (uint64_t)m_class_get_image (method->klass);
+	}
+}
+
+static
+void
+mono_profiler_jit_begin (
+	MonoProfiler *prof,
+	MonoMethod *method)
+{
+	if (!EventEnabledMonoProfilerJitBegin())
+		return;
+
+	uint64_t method_id;
+	uint64_t module_id;
+	uint32_t method_token;
+
+	get_jit_data (method, &method_id, &module_id, &method_token);
+
+	FireEtwMonoProfilerJitBegin (
+		clr_instance_get_id (),
+		method_id,
+		module_id,
+		method_token,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_jit_failed (
+	MonoProfiler *prof,
+	MonoMethod *method)
+{
+	if (!EventEnabledMonoProfilerJitFailed())
+		return;
+
+	uint64_t method_id;
+	uint64_t module_id;
+	uint32_t method_token;
+
+	get_jit_data (method, &method_id, &module_id, &method_token);
+
+	FireEtwMonoProfilerJitFailed (
+		clr_instance_get_id (),
+		method_id,
+		module_id,
+		method_token,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_jit_done (
+	MonoProfiler *prof,
+	MonoMethod *method,
+	MonoJitInfo *ji)
+{
+	if (!EventEnabledMonoProfilerJitDone())
+		return;
+
+	uint64_t method_id;
+	uint64_t module_id;
+	uint32_t method_token;
+
+	get_jit_data (method, &method_id, &module_id, &method_token);
+
+	FireEtwMonoProfilerJitDone (
+		clr_instance_get_id (),
+		method_id,
+		module_id,
+		method_token,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_jit_chunk_created (
+	MonoProfiler *prof,
+	const mono_byte *chunk,
+	uintptr_t size)
+{
+	if (!EventEnabledMonoProfilerJitChunkCreated())
+		return;
+
+	FireEtwMonoProfilerJitChunkCreated (
+		clr_instance_get_id (),
+		chunk,
+		(uint64_t)size,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_jit_chunk_destroyed (
+	MonoProfiler *prof,
+	const mono_byte *chunk)
+{
+	if (!EventEnabledMonoProfilerJitChunkDestroyed())
+		return;
+
+	FireEtwMonoProfilerJitChunkDestroyed (
+		clr_instance_get_id (),
+		chunk,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_jit_code_buffer (
+	MonoProfiler *prof,
+	const mono_byte *buffer,
+	uint64_t size,
+	MonoProfilerCodeBufferType type,
+	const void *data)
+{
+	if (!EventEnabledMonoProfilerJitCodeBuffer())
+		return;
+
+	FireEtwMonoProfilerJitCodeBuffer (
+		clr_instance_get_id (),
+		buffer,
+		size,
+		(uint8_t)type,
+		NULL,
+		NULL);
+}
+
+static
+inline
+void
+get_class_data (
+	MonoClass *klass,
+	uint64_t *class_id,
+	uint64_t *module_id,
+	ep_char8_t **class_name)
+{
+	*class_id = (uint64_t)klass;
+	*module_id = 0;
+
+	if (klass)
+		*module_id = (uint64_t)m_class_get_image (klass);
+
+	if (klass && class_name)
+		*class_name = (ep_char8_t *)mono_type_get_name_full (m_class_get_byval_arg (klass), MONO_TYPE_NAME_FORMAT_IL);
+	else if (class_name)
+		*class_name = NULL;
+}
+
+static
+void
+mono_profiler_class_loading (
+	MonoProfiler *prof,
+	MonoClass *klass)
+{
+	if (!EventEnabledMonoProfilerClassLoading())
+		return;
+
+	uint64_t class_id;
+	uint64_t module_id;
+	
+	get_class_data (klass, &class_id, &module_id, NULL);
+
+	FireEtwMonoProfilerClassLoading (
+		clr_instance_get_id (),
+		class_id,
+		module_id,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_class_failed (
+	MonoProfiler *prof,
+	MonoClass *klass)
+{
+	if (!EventEnabledMonoProfilerClassFailed())
+		return;
+
+	uint64_t class_id;
+	uint64_t module_id;
+
+	get_class_data (klass, &class_id, &module_id, NULL);
+
+	FireEtwMonoProfilerClassFailed (
+		clr_instance_get_id (),
+		class_id,
+		module_id,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_class_loaded (
+	MonoProfiler *prof,
+	MonoClass *klass)
+{
+	if (!EventEnabledMonoProfilerClassLoaded())
+		return;
+
+	uint64_t class_id;
+	uint64_t module_id;
+	ep_char8_t *class_name;
+
+	get_class_data (klass, &class_id, &module_id, &class_name);
+
+	FireEtwMonoProfilerClassLoaded (
+		clr_instance_get_id (),
+		class_id,
+		module_id,
+		class_name ? class_name : "",
+		NULL,
+		NULL);
+
+	g_free (class_name);
+}
+
+static
+inline
+void
+get_vtable_data (
+	MonoVTable *vtable,
+	uint64_t *vtable_id,
+	uint64_t *class_id,
+	uint64_t *domain_id)
+{
+	*vtable_id = (uint64_t)vtable;
+	*class_id = 0;
+	*domain_id = 0;
+
+	if (vtable) {
+		*class_id = (uint64_t)mono_vtable_class_internal (vtable);
+		*domain_id = (uint64_t)mono_vtable_domain_internal (vtable);
+	}
+}
+
+static
+void
+mono_profiler_vtable_loading (
+	MonoProfiler *prof,
+	MonoVTable *vtable)
+{
+	if (!EventEnabledMonoProfilerVTableLoading())
+		return;
+
+	uint64_t vtable_id;
+	uint64_t class_id;
+	uint64_t domain_id;
+
+	get_vtable_data (vtable, &vtable_id, &class_id, &domain_id);
+
+	FireEtwMonoProfilerVTableLoading (
+		clr_instance_get_id (),
+		vtable_id,
+		class_id,
+		domain_id,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_vtable_failed (
+	MonoProfiler *prof,
+	MonoVTable *vtable)
+{
+	if (!EventEnabledMonoProfilerVTableFailed())
+		return;
+
+	uint64_t vtable_id;
+	uint64_t class_id;
+	uint64_t domain_id;
+
+	get_vtable_data (vtable, &vtable_id, &class_id, &domain_id);
+		
+	FireEtwMonoProfilerVTableFailed (
+		clr_instance_get_id (),
+		vtable_id,
+		class_id,
+		domain_id,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_vtable_loaded (
+	MonoProfiler *prof,
+	MonoVTable *vtable)
+{
+	if (!EventEnabledMonoProfilerVTableLoaded())
+		return;
+
+	uint64_t vtable_id;
+	uint64_t class_id;
+	uint64_t domain_id;
+
+	get_vtable_data (vtable, &vtable_id, &class_id, &domain_id);
+		
+	FireEtwMonoProfilerVTableLoaded (
+		clr_instance_get_id (),
+		vtable_id,
+		class_id,
+		domain_id,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_module_loading (
+	MonoProfiler *prof,
+	MonoImage *image)
+{
+	if (!EventEnabledMonoProfilerModuleLoading ())
+		return;
+	
+	FireEtwMonoProfilerModuleLoading (
+		clr_instance_get_id (),
+		(uint64_t)image,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_module_failed (
+	MonoProfiler *prof,
+	MonoImage *image)
+{
+	if (!EventEnabledMonoProfilerModuleFailed ())
+		return;
+
+	FireEtwMonoProfilerModuleFailed (
+		clr_instance_get_id (),
+		(uint64_t)image,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_module_loaded (
+	MonoProfiler *prof,
+	MonoImage *image)
+{
+	if (!EventEnabledMonoProfilerModuleLoaded ())
+		return;
+	
+	uint64_t module_id = (uint64_t)image;
+	const ep_char8_t *module_path = NULL;
+	const ep_char8_t *module_guid = NULL;
+
+	if (image) {
+		ModuleEventData module_data;
+		if (get_module_event_data (image, &module_data))
+			module_path = (const ep_char8_t *)module_data.module_il_path;
+		module_guid = (const ep_char8_t *)mono_image_get_guid (image);
+	}
+
+	FireEtwMonoProfilerModuleLoaded (
+		clr_instance_get_id (),
+		module_id,
+		module_path ? module_path : "",
+		module_guid ? module_guid : "",
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_module_unloading (
+	MonoProfiler *prof,
+	MonoImage *image)
+{
+	if (!EventEnabledMonoProfilerModuleUnloading ())
+		return;
+
+	FireEtwMonoProfilerModuleUnloading (
+		clr_instance_get_id (),
+		(uint64_t)image,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_module_unloaded (
+	MonoProfiler *prof,
+	MonoImage *image)
+{
+	if (!EventEnabledMonoProfilerModuleUnloaded ())
+		return;
+	
+	uint64_t module_id = (uint64_t)image;
+	const ep_char8_t *module_path = NULL;
+	const ep_char8_t *module_guid = NULL;
+
+	if (image) {
+		ModuleEventData module_data;
+		if (get_module_event_data (image, &module_data))
+			module_path = (const ep_char8_t *)module_data.module_il_path;
+		module_guid = (const ep_char8_t *)mono_image_get_guid (image);
+	}
+
+	FireEtwMonoProfilerModuleUnloaded (
+		clr_instance_get_id (),
+		module_id,
+		module_path ? module_path : "",
+		module_guid ? module_guid : "",
+		NULL,
+		NULL);
+}
+
+static
+inline
+void
+get_assembly_data (
+	MonoAssembly *assembly,
+	uint64_t *assembly_id,
+	uint64_t *module_id,
+	ep_char8_t **assembly_name)
+{
+	*assembly_id = (uint64_t)assembly;
+	*module_id = 0;
+
+	if (assembly)
+		*module_id = (uint64_t)mono_assembly_get_image (assembly);
+
+	if (assembly && assembly_name)
+		*assembly_name = (ep_char8_t *)mono_stringify_assembly_name (&assembly->aname);
+	else if (assembly_name)
+		*assembly_name = NULL;
+}
+
+static
+void
+mono_profiler_assembly_loading (
+	MonoProfiler *prof,
+	MonoAssembly *assembly)
+{
+	if (!EventEnabledMonoProfilerAssemblyLoading ())
+		return;
+	
+	uint64_t assembly_id;
+	uint64_t module_id;
+
+	get_assembly_data (assembly, &assembly_id, &module_id, NULL);
+
+	FireEtwMonoProfilerAssemblyLoading (
+		clr_instance_get_id (),
+		assembly_id,
+		module_id,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_assembly_loaded (
+	MonoProfiler *prof,
+	MonoAssembly *assembly)
+{
+	if (!EventEnabledMonoProfilerAssemblyLoaded ())
+		return;
+
+	uint64_t assembly_id;
+	uint64_t module_id;
+	ep_char8_t *assembly_name;
+
+	get_assembly_data (assembly, &assembly_id, &module_id, &assembly_name);
+
+	FireEtwMonoProfilerAssemblyLoaded (
+		clr_instance_get_id (),
+		assembly_id,
+		module_id,
+		assembly_name ? assembly_name : "",
+		NULL,
+		NULL);
+
+	g_free (assembly_name);
+}
+
+static
+void
+mono_profiler_assembly_unloading (
+	MonoProfiler *prof,
+	MonoAssembly *assembly)
+{
+	if (!EventEnabledMonoProfilerAssemblyUnloading ())
+		return;
+	
+	uint64_t assembly_id;
+	uint64_t module_id;
+
+	get_assembly_data (assembly, &assembly_id, &module_id, NULL);
+
+	FireEtwMonoProfilerAssemblyUnloading (
+		clr_instance_get_id (),
+		assembly_id,
+		module_id,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_assembly_unloaded (
+	MonoProfiler *prof,
+	MonoAssembly *assembly)
+{
+	if (!EventEnabledMonoProfilerAssemblyUnloaded ())
+		return;
+
+	uint64_t assembly_id;
+	uint64_t module_id;
+	ep_char8_t *assembly_name;
+
+	get_assembly_data (assembly, &assembly_id, &module_id, &assembly_name);
+
+	FireEtwMonoProfilerAssemblyUnloaded (
+		clr_instance_get_id (),
+		assembly_id,
+		module_id,
+		assembly_name ? assembly_name : "",
+		NULL,
+		NULL);
+
+	g_free (assembly_name);
+}
+
+static
+void
+mono_profiler_method_enter (
+	MonoProfiler *prof,
+	MonoMethod *method,
+	MonoProfilerCallContext *context)
+{
+	if (!EventEnabledMonoProfilerMethodEnter ())
+		return;
+
+	FireEtwMonoProfilerMethodEnter (
+		clr_instance_get_id (),
+		(uint64_t)method,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_method_leave (
+	MonoProfiler *prof,
+	MonoMethod *method,
+	MonoProfilerCallContext *context)
+{
+	if (!EventEnabledMonoProfilerMethodLeave ())
+		return;
+
+	FireEtwMonoProfilerMethodLeave (
+		clr_instance_get_id (),
+		(uint64_t)method,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_method_tail_call (
+	MonoProfiler *prof,
+	MonoMethod *method,
+	MonoMethod *target_method)
+{
+	if (!EventEnabledMonoProfilerMethodTailCall ())
+		return;
+
+	FireEtwMonoProfilerMethodTailCall (
+		clr_instance_get_id (),
+		(uint64_t)method,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_method_exception_leave (
+	MonoProfiler *prof,
+	MonoMethod *method,
+	MonoObject *exc)
+{
+	if (!EventEnabledMonoProfilerMethodExceptionLeave ())
+		return;
+
+	FireEtwMonoProfilerMethodExceptionLeave (
+		clr_instance_get_id (),
+		(uint64_t)method,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_method_free (
+	MonoProfiler *prof,
+	MonoMethod *method)
+{
+	if (!EventEnabledMonoProfilerMethodFree ())
+		return;
+
+	FireEtwMonoProfilerMethodFree (
+		clr_instance_get_id (),
+		(uint64_t)method,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_method_begin_invoke (
+	MonoProfiler *prof,
+	MonoMethod *method)
+{
+	if (!EventEnabledMonoProfilerMethodBeginInvoke ())
+		return;
+
+	FireEtwMonoProfilerMethodBeginInvoke (
+		clr_instance_get_id (),
+		(uint64_t)method,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_method_end_invoke (
+	MonoProfiler *prof,
+	MonoMethod *method)
+{
+	if (!EventEnabledMonoProfilerMethodEndInvoke ())
+		return;
+
+	FireEtwMonoProfilerMethodEndInvoke (
+		clr_instance_get_id (),
+		(uint64_t)method,
+		NULL,
+		NULL);
+}
+
+static
+MonoProfilerCallInstrumentationFlags
+mono_profiler_method_instrumentation (
+	MonoProfiler *prof,
+	MonoMethod *method)
+{
+	return MONO_PROFILER_CALL_INSTRUMENTATION_ENTER |
+			MONO_PROFILER_CALL_INSTRUMENTATION_LEAVE |
+			MONO_PROFILER_CALL_INSTRUMENTATION_TAIL_CALL |
+			MONO_PROFILER_CALL_INSTRUMENTATION_EXCEPTION_LEAVE;
+}
+
+static
+void
+mono_profiler_exception_throw (
+	MonoProfiler *prof,
+	MonoObject *exc)
+{
+	if (!EventEnabledMonoProfilerExceptionThrow ())
+		return;
+
+	uint64_t type_id = 0;
+
+	if (exc && mono_object_get_class(exc))
+		type_id = (uint64_t)m_class_get_byval_arg (mono_object_get_class(exc));
+
+	FireEtwMonoProfilerExceptionThrow (
+		clr_instance_get_id (),
+		type_id,
+		SGEN_POINTER_UNTAG_ALL (exc),
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_exception_clause (
+	MonoProfiler *prof,
+	MonoMethod *method,
+	uint32_t clause_num,
+	MonoExceptionEnum clause_type,
+	MonoObject *exc)
+{
+	if (!EventEnabledMonoProfilerExceptionClause ())
+		return;
+
+	uint64_t type_id = 0;
+
+	if (exc && mono_object_get_class(exc))
+		type_id = (uint64_t)m_class_get_byval_arg (mono_object_get_class(exc));
+
+	FireEtwMonoProfilerExceptionClause (
+		clr_instance_get_id (),
+		(uint8_t)clause_type,
+		clause_num,
+		(uint64_t)method,
+		type_id,
+		SGEN_POINTER_UNTAG_ALL (exc),
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_gc_event (
+	MonoProfiler *prof,
+	MonoProfilerGCEvent gc_event,
+	uint32_t generation,
+	mono_bool serial)
+{
+	if (!EventEnabledMonoProfilerGCEvent ())
+		return;
+
+	// TODO: Needs to be async safe.
+	/*FireEtwMonoProfilerGCEvent (
+		clr_instance_get_id (),
+		(uint8_t)gc_event,
+		generation,
+		NULL,
+		NULL);*/
+}
+
+static
+void
+mono_profiler_gc_allocation (
+	MonoProfiler *prof,
+	MonoObject *object)
+{
+	if (!EventEnabledMonoProfilerGCAllocation ())
+		return;
+
+	uint64_t vtable_id = 0;
+	uint64_t object_size = 0;
+
+	if (object) {
+		vtable_id = (uint64_t)mono_object_get_vtable_internal (object);
+		object_size = (uint64_t)mono_object_get_size_internal (object);
+		
+		/* account for object alignment */
+		object_size += 7;
+		object_size &= ~7;
+	}
+
+	FireEtwMonoProfilerGCAllocation (
+		clr_instance_get_id (),
+		vtable_id,
+		SGEN_POINTER_UNTAG_ALL (object),
+		object_size,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_gc_moves (
+	MonoProfiler *prof,
+	MonoObject *const* objects,
+	uint64_t count)
+{
+	if (!EventEnabledMonoProfilerGCMoves ())
+		return;
+
+	// TODO: Needs to be async safe.
+	/*uint64_t obj_count = count / 2;
+
+	GCObjectAddressData data [32];
+	uint64_t data_chunks = obj_count / G_N_ELEMENTS (data);
+	uint64_t data_rest = obj_count % G_N_ELEMENTS (data);
+	uint64_t current_obj = 0;
+
+	for (int chunk = 0; chunk < data_chunks; chunk++) {
+		for (int i = 0; i < G_N_ELEMENTS (data); i++) {
+			data [i].object = SGEN_POINTER_UNTAG_ALL (objects [current_obj++]);
+			data [i].address = objects [current_obj++];
+		}
+
+		FireEtwMonoProfilerGCMoves (
+			clr_instance_get_id (),
+			G_N_ELEMENTS (data),
+			sizeof (GCObjectAddressData),
+			data,
+			NULL,
+			NULL);
+	}
+
+	if ((data_rest != 0)&& (data_rest % 2 == 0)) {
+		for (int i = 0; i < data_rest; i++) {
+			data [i].object = SGEN_POINTER_UNTAG_ALL (objects [current_obj++]);
+			data [i].address = objects [current_obj++];
+		}
+
+		FireEtwMonoProfilerGCMoves (
+			clr_instance_get_id (),
+			data_rest,
+			sizeof (GCObjectAddressData),
+			data,
+			NULL,
+			NULL);
+	}*/
+}
+
+static
+void
+mono_profiler_gc_resize (
+	MonoProfiler *prof,
+	uintptr_t size)
+{
+	if (!EventEnabledMonoProfilerGCResize ())
+		return;
+
+	// TODO: Needs to be async safe.
+	/*FireEtwMonoProfilerGCResize (
+		clr_instance_get_id (),
+		(uint64_t)size,
+		NULL,
+		NULL);*/
+}
+
+static
+void
+mono_profiler_gc_handle_created (
+	MonoProfiler *prof,
+	uint32_t handle,
+	MonoGCHandleType type,
+	MonoObject *object)
+{
+	if (!EventEnabledMonoProfilerGCHandleCreated ())
+		return;
+
+	FireEtwMonoProfilerGCHandleCreated (
+		clr_instance_get_id (),
+		handle,
+		(uint8_t)type,
+		SGEN_POINTER_UNTAG_ALL (object),
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_gc_handle_deleted (
+	MonoProfiler *prof,
+	uint32_t handle,
+	MonoGCHandleType type)
+{
+	if (!EventEnabledMonoProfilerGCHandleDeleted ())
+		return;
+
+	FireEtwMonoProfilerGCHandleDeleted (
+		clr_instance_get_id (),
+		handle,
+		(uint8_t)type,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_gc_finalizing (MonoProfiler *prof)
+{
+	if (!EventEnabledMonoProfilerGCFinalizing ())
+		return;
+
+	FireEtwMonoProfilerGCFinalizing (
+		clr_instance_get_id (),
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_gc_finalized (MonoProfiler *prof)
+{
+	if (!EventEnabledMonoProfilerGCFinalized ())
+		return;
+
+	FireEtwMonoProfilerGCFinalized (
+		clr_instance_get_id (),
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_gc_finalizing_object (
+	MonoProfiler *prof,
+	MonoObject *object)
+{
+	if (!EventEnabledMonoProfilerGCFinalizingObject ())
+		return;
+
+	FireEtwMonoProfilerGCFinalizingObject (
+		clr_instance_get_id (),
+		SGEN_POINTER_UNTAG_ALL (object),
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_gc_finalized_object (
+	MonoProfiler *prof,
+	MonoObject * object)
+{
+	if (!EventEnabledMonoProfilerGCFinalizedObject ())
+		return;
+
+	FireEtwMonoProfilerGCFinalizedObject (
+		clr_instance_get_id (),
+		SGEN_POINTER_UNTAG_ALL (object),
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_gc_root_register (
+	MonoProfiler *prof,
+	const mono_byte *start,
+	uintptr_t size,
+	MonoGCRootSource source,
+	const void * key,
+	const char * name)
+{
+	if (!EventEnabledMonoProfilerGCRootRegister ())
+		return;
+
+	FireEtwMonoProfilerGCRootRegister (
+		clr_instance_get_id (),
+		start,
+		(uint64_t)size,
+		(uint8_t) source,
+		(uint64_t)key,
+		(const ep_char8_t *)(name ? name : ""),
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_gc_root_unregister (
+	MonoProfiler *prof,
+	const mono_byte *start)
+{
+	if (!EventEnabledMonoProfilerGCRootUnregister ())
+		return;
+
+	FireEtwMonoProfilerGCRootUnregister (
+		clr_instance_get_id (),
+		start,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_gc_roots (
+	MonoProfiler *prof,
+	uint64_t count,
+	const mono_byte *const * addresses,
+	MonoObject *const * objects)
+{
+	if (!EventEnabledMonoProfilerGCRoots ())
+		return;
+
+	// TODO: Needs to be async safe.
+	/*GCAddressObjectData data [32];
+	uint64_t data_chunks = count / G_N_ELEMENTS (data);
+	uint64_t data_rest = count % G_N_ELEMENTS (data);
+	uint64_t current_obj = 0;
+
+	for (int chunk = 0; chunk < data_chunks; chunk++) {
+		for (int i = 0; i < G_N_ELEMENTS (data); i++) {
+			data [i].address = addresses [current_obj];
+			data [i].object = SGEN_POINTER_UNTAG_ALL (objects [current_obj]);
+			current_obj++;
+		}
+
+		FireEtwMonoProfilerGCRoots (
+			clr_instance_get_id (),
+			G_N_ELEMENTS (data),
+			sizeof (GCAddressObjectData),
+			data,
+			NULL,
+			NULL);
+	}
+
+	if (data_rest != 0) {
+		for (int i = 0; i < data_rest; i++) {
+			data [i].address = addresses [current_obj];
+			data [i].object = SGEN_POINTER_UNTAG_ALL (objects [current_obj]);
+			current_obj++;
+		}
+
+		FireEtwMonoProfilerGCRoots (
+			clr_instance_get_id (),
+			data_rest,
+			sizeof (GCAddressObjectData),
+			data,
+			NULL,
+			NULL);
+	}*/
+}
+
+static
+void
+mono_profiler_monitor_contention (
+	MonoProfiler *prof,
+	MonoObject *object)
+{
+	if (!EventEnabledMonoProfilerMonitorContention ())
+		return;
+
+	FireEtwMonoProfilerMonitorContention (
+		clr_instance_get_id (),
+		SGEN_POINTER_UNTAG_ALL (object),
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_monitor_failed (
+	MonoProfiler *prof,
+	MonoObject *object)
+{
+	if (!EventEnabledMonoProfilerMonitorFailed ())
+		return;
+
+	FireEtwMonoProfilerMonitorFailed (
+		clr_instance_get_id (),
+		SGEN_POINTER_UNTAG_ALL (object),
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_monitor_acquired (
+	MonoProfiler *prof,
+	MonoObject *object)
+{
+	if (!EventEnabledMonoProfilerMonitorAcquired ())
+		return;
+
+	FireEtwMonoProfilerMonitorAcquired (
+		clr_instance_get_id (),
+		SGEN_POINTER_UNTAG_ALL (object),
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_thread_started (
+	MonoProfiler *prof,
+	uintptr_t tid)
+{
+	if (!EventEnabledMonoProfilerThreadStarted ())
+		return;
+
+	FireEtwMonoProfilerThreadStarted (
+		clr_instance_get_id (),
+		(uint64_t)tid,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_thread_stopping (
+	MonoProfiler *prof,
+	uintptr_t tid)
+{
+	if (!EventEnabledMonoProfilerThreadStopping ())
+		return;
+
+	FireEtwMonoProfilerThreadStopping (
+		clr_instance_get_id (),
+		(uint64_t)tid,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_thread_stopped (
+	MonoProfiler *prof,
+	uintptr_t tid)
+{
+	if (!EventEnabledMonoProfilerThreadStopped ())
+		return;
+
+	FireEtwMonoProfilerThreadStopped (
+		clr_instance_get_id (),
+		(uint64_t)tid,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_thread_exited (
+	MonoProfiler *prof,
+	uintptr_t tid)
+{
+	if (!EventEnabledMonoProfilerThreadExited ())
+		return;
+
+	FireEtwMonoProfilerThreadExited (
+		clr_instance_get_id (),
+		(uint64_t)tid,
+		NULL,
+		NULL);
+}
+
+static
+void
+mono_profiler_thread_name (
+	MonoProfiler *prof,
+	uintptr_t tid,
+	const char *name)
+{
+	if (!EventEnabledMonoProfilerThreadName ())
+		return;
+
+	FireEtwMonoProfilerThreadName (
+		clr_instance_get_id (),
+		(uint64_t)tid,
+		(ep_char8_t *)(name ? name : ""),
+		NULL,
+		NULL);
+}
+
+void
+EventPipeEtwCallbackDotNETRuntimeMonoProfiler (
+	const uint8_t *source_id,
+	unsigned long is_enabled,
+	uint8_t level,
+	uint64_t match_any_keywords,
+	uint64_t match_all_keywords,
+	EventFilterDescriptor *filter_data,
+	void *callback_data)
+{
+	ep_rt_config_requires_lock_not_held ();
+
+	EP_ASSERT(is_enabled == 0 || is_enabled == 1) ;
+	EP_ASSERT (_ep_rt_dotnet_mono_profiler_provider != NULL);
+
+	EP_LOCK_ENTER (section1)
+		if (is_enabled == 1 && !MICROSOFT_DOTNETRUNTIME_MONO_PROFILER_PROVIDER_EVENTPIPE_Context.IsEnabled) {
+			// Add profiler callbacks for Mono profiler provider events.
+			if (profiler_callback_is_enabled(match_any_keywords, LOADER_KEYWORD)) {
+				if (EventEnabledMonoProfilerAppDomainLoading ())
+					mono_profiler_set_domain_loading_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_app_domain_loading);
+				if (EventEnabledMonoProfilerAppDomainLoaded ())
+					mono_profiler_set_domain_loaded_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_app_domain_loaded);
+				if (EventEnabledMonoProfilerAppDomainUnloading ())
+					mono_profiler_set_domain_unloading_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_app_domain_unloading);
+				if (EventEnabledMonoProfilerAppDomainUnloaded ())
+					mono_profiler_set_domain_unloaded_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_app_domain_unloaded);
+				if (EventEnabledMonoProfilerAppDomainName ())
+					mono_profiler_set_domain_name_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_app_domain_name);
+				if (EventEnabledMonoProfilerModuleLoading ())
+					mono_profiler_set_image_loading_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_module_loading);
+				if (EventEnabledMonoProfilerModuleFailed ())
+					mono_profiler_set_image_failed_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_module_failed);
+				if (EventEnabledMonoProfilerModuleLoaded ())
+					mono_profiler_set_image_loaded_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_module_loaded);
+				if (EventEnabledMonoProfilerModuleUnloading ())
+					mono_profiler_set_image_unloading_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_module_unloading);
+				if (EventEnabledMonoProfilerModuleUnloaded ())
+					mono_profiler_set_image_unloaded_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_module_unloaded);
+				if (EventEnabledMonoProfilerModuleUnloading ())
+					mono_profiler_set_assembly_loading_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_assembly_loading);
+				if (EventEnabledMonoProfilerAssemblyLoaded ())
+					mono_profiler_set_assembly_loaded_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_assembly_loaded);
+				if (EventEnabledMonoProfilerAssemblyUnloading ())
+					mono_profiler_set_assembly_unloading_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_assembly_unloading);
+				if (EventEnabledMonoProfilerAssemblyUnloaded ())
+					mono_profiler_set_assembly_unloaded_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_assembly_unloaded);
+			}
+			if (profiler_callback_is_enabled(match_any_keywords, JIT_KEYWORD)) {
+				if (EventEnabledMonoProfilerJitBegin ())
+					mono_profiler_set_jit_begin_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_jit_begin);
+				if (EventEnabledMonoProfilerJitFailed ())
+					mono_profiler_set_jit_failed_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_jit_failed);
+				if (EventEnabledMonoProfilerJitDone ())
+					mono_profiler_set_jit_done_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_jit_done);
+				if (EventEnabledMonoProfilerJitChunkCreated ())
+					mono_profiler_set_jit_chunk_created_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_jit_chunk_created);
+				if (EventEnabledMonoProfilerJitChunkDestroyed ())
+					mono_profiler_set_jit_chunk_destroyed_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_jit_chunk_destroyed);
+				if (EventEnabledMonoProfilerJitCodeBuffer ())
+					mono_profiler_set_jit_code_buffer_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_jit_code_buffer);
+			}
+			if (profiler_callback_is_enabled(match_any_keywords, TYPE_LOADING_KEYWORD)) {
+				if (EventEnabledMonoProfilerClassLoading ())
+					mono_profiler_set_class_loading_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_class_loading);
+				if (EventEnabledMonoProfilerClassFailed ())
+					mono_profiler_set_class_failed_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_class_failed);
+				if (EventEnabledMonoProfilerClassLoaded ())
+					mono_profiler_set_class_loaded_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_class_loaded);
+				if (EventEnabledMonoProfilerVTableLoading ())
+					mono_profiler_set_vtable_loading_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_vtable_loading);
+				if (EventEnabledMonoProfilerVTableFailed ())
+					mono_profiler_set_vtable_failed_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_vtable_failed);
+				if (EventEnabledMonoProfilerVTableLoaded ())
+					mono_profiler_set_vtable_loaded_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_vtable_loaded);
+			}
+			if (profiler_callback_is_enabled(match_any_keywords, METHOD_TRACING_KEYWORD)) {
+				if (EventEnabledMonoProfilerMethodEnter ())
+					mono_profiler_set_method_enter_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_method_enter);
+				if (EventEnabledMonoProfilerMethodLeave ())
+					mono_profiler_set_method_leave_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_method_leave);
+				if (EventEnabledMonoProfilerMethodTailCall ())
+					mono_profiler_set_method_tail_call_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_method_tail_call);
+				if (EventEnabledMonoProfilerMethodExceptionLeave ())
+					mono_profiler_set_method_exception_leave_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_method_exception_leave);
+				if (EventEnabledMonoProfilerMethodFree ())
+					mono_profiler_set_method_free_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_method_free);
+				if (EventEnabledMonoProfilerMethodBeginInvoke ())
+					mono_profiler_set_method_begin_invoke_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_method_begin_invoke);
+				if (EventEnabledMonoProfilerMethodEndInvoke ())
+					mono_profiler_set_method_end_invoke_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_method_end_invoke);
+				if (EventEnabledMonoProfilerMethodEnter () || 
+						EventEnabledMonoProfilerMethodLeave () ||
+						EventEnabledMonoProfilerMethodTailCall () ||
+						EventEnabledMonoProfilerMethodExceptionLeave ())
+					mono_profiler_set_call_instrumentation_filter_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_method_instrumentation);
+			}
+			if (profiler_callback_is_enabled(match_any_keywords, EXCEPTION_KEYWORD)) {
+				if (EventEnabledMonoProfilerExceptionThrow ())
+					mono_profiler_set_exception_throw_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_exception_throw);
+				if (EventEnabledMonoProfilerExceptionClause ())
+					mono_profiler_set_exception_clause_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_exception_clause);
+			}
+			if (profiler_callback_is_enabled(match_any_keywords, GC_KEYWORD)) {
+				if (EventEnabledMonoProfilerGCEvent ())
+					mono_profiler_set_gc_event_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_gc_event);
+			}
+			if (profiler_callback_is_enabled(match_any_keywords, GC_KEYWORD | GC_ALLOCATION_KEYWORD)) {
+				if (EventEnabledMonoProfilerGCAllocation ())
+					mono_profiler_set_gc_allocation_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_gc_allocation);
+			}
+			if (profiler_callback_is_enabled(match_any_keywords, GC_KEYWORD | GC_MOVES_KEYWORD)) {
+				if (EventEnabledMonoProfilerGCMoves ())
+					mono_profiler_set_gc_moves_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_gc_moves);
+			}
+			if (profiler_callback_is_enabled(match_any_keywords, GC_KEYWORD | GC_RESIZE_KEYWORD)) {
+				if (EventEnabledMonoProfilerGCResize ())
+					mono_profiler_set_gc_resize_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_gc_resize);
+			}
+			if (profiler_callback_is_enabled(match_any_keywords, GC_KEYWORD | GC_HANDLE_KEYWORD)) {
+				if (EventEnabledMonoProfilerGCHandleCreated ())
+					mono_profiler_set_gc_handle_created_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_gc_handle_created);
+				if (EventEnabledMonoProfilerGCHandleDeleted ())
+					mono_profiler_set_gc_handle_deleted_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_gc_handle_deleted);
+			}
+			if (profiler_callback_is_enabled(match_any_keywords, GC_KEYWORD | GC_FINALIZATION_KEYWORD)) {
+				if (EventEnabledMonoProfilerGCFinalizing ())
+					mono_profiler_set_gc_finalizing_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_gc_finalizing);
+				if (EventEnabledMonoProfilerGCFinalized ())
+					mono_profiler_set_gc_finalized_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_gc_finalized);
+				if (EventEnabledMonoProfilerGCFinalizingObject ())
+					mono_profiler_set_gc_finalizing_object_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_gc_finalizing_object);
+				if (EventEnabledMonoProfilerGCFinalizedObject ())
+					mono_profiler_set_gc_finalized_object_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_gc_finalized_object);
+			}
+			if (profiler_callback_is_enabled(match_any_keywords, GC_KEYWORD | GC_ROOT_KEYWORD)) {
+				if (EventEnabledMonoProfilerGCRootRegister ())
+					mono_profiler_set_gc_root_register_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_gc_root_register);
+				if (EventEnabledMonoProfilerGCRootUnregister ())
+					mono_profiler_set_gc_root_unregister_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_gc_root_unregister);
+				if (EventEnabledMonoProfilerGCRoots ())
+					mono_profiler_set_gc_roots_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_gc_roots);
+			}
+			if (profiler_callback_is_enabled(match_any_keywords, MONITOR_KEYWORD | CONTENTION_KEYWORD)) {
+				if (EventEnabledMonoProfilerMonitorContention ())
+					mono_profiler_set_monitor_contention_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_monitor_contention);
+			}
+			if (profiler_callback_is_enabled(match_any_keywords, MONITOR_KEYWORD)) {
+				if (EventEnabledMonoProfilerMonitorFailed ())
+					mono_profiler_set_monitor_failed_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_monitor_failed);
+				if (EventEnabledMonoProfilerMonitorAcquired ())
+					mono_profiler_set_monitor_acquired_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_monitor_acquired);
+			}
+			if (profiler_callback_is_enabled(match_any_keywords, THREADING_KEYWORD)) {
+				if (EventEnabledMonoProfilerThreadStarted ())
+					mono_profiler_set_thread_started_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_thread_started);
+				if (EventEnabledMonoProfilerThreadStopping ())
+					mono_profiler_set_thread_stopping_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_thread_stopping);
+				if (EventEnabledMonoProfilerThreadStopped ())
+					mono_profiler_set_thread_stopped_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_thread_stopped);
+				if (EventEnabledMonoProfilerThreadExited ())
+					mono_profiler_set_thread_exited_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_thread_exited);
+				if (EventEnabledMonoProfilerThreadName ())
+					mono_profiler_set_thread_name_callback (_ep_rt_dotnet_mono_profiler_provider, mono_profiler_thread_name);
+			}
+		} else if (is_enabled == 0 && MICROSOFT_DOTNETRUNTIME_MONO_PROFILER_PROVIDER_EVENTPIPE_Context.IsEnabled) {
+			// Remove profiler callbacks for Mono profiler provider events.
+			// LOADER_KEYWORD
+			mono_profiler_set_domain_loading_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_domain_loaded_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_domain_unloading_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_domain_unloaded_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_domain_name_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_image_loading_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_image_failed_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_image_loaded_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_image_unloading_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_image_unloaded_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_assembly_loading_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_assembly_loaded_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_assembly_unloading_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_assembly_unloaded_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+
+			// JIT_KEYWORD
+			mono_profiler_set_jit_begin_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_jit_failed_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_jit_done_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_jit_chunk_created_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_jit_chunk_destroyed_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_jit_code_buffer_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+
+			// TYPE_LOADING_KEYWORD
+			mono_profiler_set_class_loading_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_class_failed_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_class_loaded_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_vtable_loading_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_vtable_failed_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_vtable_loaded_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+
+			// METHOD_TRACING_KEYWORD
+			mono_profiler_set_method_enter_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_method_leave_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_method_tail_call_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_method_exception_leave_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_method_free_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_method_begin_invoke_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_method_end_invoke_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_call_instrumentation_filter_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+
+			// EXCEPTION_KEYWORD
+			mono_profiler_set_exception_throw_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_exception_clause_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			
+			// GC_KEYWORD
+			mono_profiler_set_gc_event_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+
+			// GC_KEYWORD | GC_ALLOCATION_KEYWORD
+			mono_profiler_set_gc_allocation_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+
+			// GC_KEYWORD | GC_MOVES_KEYWORD
+			mono_profiler_set_gc_moves_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+
+			// GC_KEYWORD | GC_RESIZE_KEYWORD
+			mono_profiler_set_gc_resize_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+
+			// GC_KEYWORD | GC_HANDLE_KEYWORD
+			mono_profiler_set_gc_handle_created_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_gc_handle_deleted_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+
+			// GC_KEYWORD | GC_FINALIZATION_KEYWORD
+			mono_profiler_set_gc_finalizing_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_gc_finalized_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_gc_finalizing_object_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_gc_finalized_object_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			
+			// GC_KEYWORD | GC_ROOT_KEYWORD
+			mono_profiler_set_gc_root_register_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_gc_root_unregister_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_gc_roots_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+
+			// MONITOR_KEYWORD | CONTENTION_KEYWORD
+			mono_profiler_set_monitor_contention_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+
+			// MONITOR_KEYWORD
+			mono_profiler_set_monitor_failed_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_monitor_acquired_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+
+			// THREADING_KEYWORD
+			mono_profiler_set_thread_started_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_thread_stopping_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_thread_stopped_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_thread_exited_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+			mono_profiler_set_thread_name_callback (_ep_rt_dotnet_mono_profiler_provider, NULL);
+		}
+	EP_LOCK_EXIT (section1)
+
+	MICROSOFT_DOTNETRUNTIME_MONO_PROFILER_PROVIDER_EVENTPIPE_Context.Level = level;
+	MICROSOFT_DOTNETRUNTIME_MONO_PROFILER_PROVIDER_EVENTPIPE_Context.EnabledKeywordsBitmask = match_any_keywords;
+	MICROSOFT_DOTNETRUNTIME_MONO_PROFILER_PROVIDER_EVENTPIPE_Context.IsEnabled = (is_enabled == 1 ? true : false);
+
+ep_on_exit:
+	ep_rt_config_requires_lock_not_held ();
+	return;
+
+ep_on_error:
+	ep_exit_error_handler ();
 }
 
 #endif /* ENABLE_PERFTRACING */

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -16,6 +16,7 @@
 #include <mono/metadata/profiler.h>
 #include <mono/metadata/appdomain.h>
 #include <mono/metadata/assembly.h>
+#include <mono/metadata/assembly-internals.h>
 #include <mono/metadata/class-internals.h>
 #include <mono/metadata/debug-internals.h>
 #include <mono/metadata/gc-internals.h>
@@ -4051,7 +4052,7 @@ get_assembly_data (
 	*module_id = 0;
 
 	if (assembly)
-		*module_id = (uint64_t)mono_assembly_get_image (assembly);
+		*module_id = (uint64_t)mono_assembly_get_image_internal (assembly);
 
 	if (assembly && assembly_name)
 		*assembly_name = (ep_char8_t *)mono_stringify_assembly_name (&assembly->aname);
@@ -4294,8 +4295,8 @@ mono_profiler_exception_throw (
 
 	uint64_t type_id = 0;
 
-	if (exc && mono_object_get_class(exc))
-		type_id = (uint64_t)m_class_get_byval_arg (mono_object_get_class(exc));
+	if (exc && mono_object_class(exc))
+		type_id = (uint64_t)m_class_get_byval_arg (mono_object_class(exc));
 
 	FireEtwMonoProfilerExceptionThrow (
 		clr_instance_get_id (),
@@ -4319,8 +4320,8 @@ mono_profiler_exception_clause (
 
 	uint64_t type_id = 0;
 
-	if (exc && mono_object_get_class(exc))
-		type_id = (uint64_t)m_class_get_byval_arg (mono_object_get_class(exc));
+	if (exc && mono_object_class(exc))
+		type_id = (uint64_t)m_class_get_byval_arg (mono_object_class(exc));
 
 	FireEtwMonoProfilerExceptionClause (
 		clr_instance_get_id (),

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -2344,6 +2344,16 @@ EventPipeEtwCallbackDotNETRuntimeStress (
 	EventFilterDescriptor *filter_data,
 	void *callback_data);
 
+void
+EventPipeEtwCallbackDotNETRuntimeMonoProfiler (
+	const uint8_t *source_id,
+	unsigned long is_enabled,
+	uint8_t level,
+	uint64_t match_any_keywords,
+	uint64_t match_all_keywords,
+	EventFilterDescriptor *filter_data,
+	void *callback_data);
+
 
 #endif /* ENABLE_PERFTRACING */
 #endif /* __EVENTPIPE_RT_MONO_H__ */

--- a/src/mono/mono/eventpipe/gen-eventing-event-inc.lst
+++ b/src/mono/mono/eventpipe/gen-eventing-event-inc.lst
@@ -45,3 +45,4 @@ ThreadPoolWorkingThreadCount
 ThreadTerminated
 TypeLoadStart
 TypeLoadStop
+Microsoft-DotNETRuntimeMonoProfiler:*


### PR DESCRIPTION
Add Mono profiler events into EventPipe opening up for ability to emit events directly from Mono profiler callbacks into a EventPipe provider. PR maps all existing Mono profiler callbacks to Mono specific EventPipe events in new native EventPipe provider, Microsoft-DotNETRuntimeMonoProfiler.

PR also prepares for GC events and some of them will work as is, but a couple of events fires from within GC STW and since EventPipe is not async safe, those needs additional work to be correctly handled, and are currently disabled, gc_event, gc_moves, gc_resize, gc_roots.

A couple of events needs to be enabled in Mono profiler to fire (even when enabled in EventPipe) like exception_clause and gc_allocation. Added a new env variable, MONO_DIAGNOSTICS that opens up ability to configure this. I added ability to add additional config into that variable, and you can also use it to set DOTNET_DiagnosticPorts variable as well, meaning you can control all setting MONO_DIAGNOSTICS env variable. For example:

MONO_DIAGNOSTICS=--diagnostic-ports=127.0.0.1:9000,connect,suspend

will be the same as setting DOTNET_DiagnosticPorts=127.0.0.1:9000,connect,suspend

MONO_DIAGNOSTICS=---diagnostic-mono-profiler=alloc,exception

will enable both mono profiler GC alloc as well as exception clause instrumentation (needs to be set before starting profiler).

And if you just want to use one env variable, you can combine above in MONO_DIAGNOSTICS:

MONO_DIAGNOSTICS=--diagnostic-ports=127.0.0.1:9000,connect,suspend ---diagnostic-mono-profiler=alloc,exception