### PR TITLE
Clean-up sendtohelix and fix prop ordering issue

### DIFF
--- a/src/libraries/sendtohelix.proj
+++ b/src/libraries/sendtohelix.proj
@@ -12,15 +12,11 @@
     "correlation payload", which is the set of files used by all Helix submissions
     (which we compress into a single file).
 -->
-<Project Sdk="Microsoft.Build.NoTargets">
+<Project Sdk="Microsoft.Build.NoTargets" InitialTargets="_SetTestArchiveRuntimeFile">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
-    <BuildTargetFramework>$([MSBuild]::ValueOrDefault('$(BuildTargetFramework)', '$(NetCoreAppCurrent)'))</BuildTargetFramework>
+    <BuildTargetFramework Condition="'$(BuildTargetFramework)' == ''">$(NetCoreAppCurrent)</BuildTargetFramework>
     <TargetsWindows Condition="'$(TargetOS)' == 'windows'">true</TargetsWindows>
-
-    <!-- The Helix correlation payload file -->
-    <TestArchiveRuntimeFile Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)'">$(TestArchiveRuntimeRoot)test-runtime-$(NetCoreAppCurrentBuildSettings).zip</TestArchiveRuntimeFile>
 
     <!-- Set the name of the scenario file. Note that this is only used in invocations where $(Scenario) is set
          (which is when this project is invoked to call the "CreateOneScenarioTestEnvFile" target). -->
@@ -28,6 +24,14 @@
     <TestEnvFileName Condition=" '$(TargetsWindows)' != 'true' ">SetStressModes_$(Scenario).sh</TestEnvFileName>
 
   </PropertyGroup>
+  
+  <!-- The Helix correlation payload file -->
+  <Target Name="_SetTestArchiveRuntimeFile"
+          Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)'">
+    <PropertyGroup>
+      <TestArchiveRuntimeFile>$(TestArchiveRuntimeRoot)test-runtime-$(NetCoreAppCurrentBuildSettings).zip</TestArchiveRuntimeFile>
+    </PropertyGroup>
+  </Target>
 
   <Target Name="RunInParallelForEachScenario"
           AfterTargets="Build">
@@ -83,12 +87,8 @@
     <MSBuild Projects="@(_ProjectsToBuild)" Targets="Test" BuildInParallel="$(_BuildInParallel)" StopOnFirstFailure="false" />
   </Target>
 
-  <PropertyGroup>
-  </PropertyGroup>
-
   <Target Name="CreateOneScenarioTestEnvFile">
     <!-- This target creates one __TestEnv file for the single $(Scenario). -->
-
     <Error Condition="'$(Scenario)' == ''" Text="No Scenario specified" />
 
     <PropertyGroup>
@@ -157,7 +157,6 @@
           Outputs="$(TestArchiveRuntimeFile)"
           Condition="'$(TargetsMobile)' != 'true' and
                      '$(TestArchiveRuntimeFile)' != ''">
-
     <!-- Compress the test files, testhost, and per-scenario scripts into a single ZIP file for sending to the Helix machines. -->
 
     <Message Importance="High" Text="Compressing runtime directory" />
@@ -168,7 +167,6 @@
     <ZipDirectory SourceDirectory="$(NetCoreAppCurrentTestHostPath)"
                   DestinationFile="$(TestArchiveRuntimeFile)"
                   Overwrite="true" />
-
   </Target>
 
   <!--


### PR DESCRIPTION
The ordering issue was discovered in https://github.com/dotnet/runtime/pull/55074#issuecomment-875296646. Fixing it by not reading from properties which aren't defined in props inside the project file but from within an initial target.

`NetCoreAppCurrentBuildSettings` is defined in a targets file as it relies on properties which could be changed inside a project. That said, that's usually not the case for projects under src/libraries/.