### PR TITLE
nit: fix doc comments spaces

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -28,7 +28,7 @@ namespace System.Text.Json
         /// The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the read operation.
         /// </param>
         /// <exception cref="System.ArgumentNullException">
-        /// <paramref name="utf8Json"/>is <see langword="null"/>.
+        /// <paramref name="utf8Json"/> is <see langword="null"/>.
         /// </exception>
         /// <exception cref="JsonException">
         /// Thrown when the JSON is invalid,
@@ -61,7 +61,7 @@ namespace System.Text.Json
         /// <param name="utf8Json">JSON data to parse.</param>
         /// <param name="options">Options to control the behavior during reading.</param>
         /// <exception cref="System.ArgumentNullException">
-        /// <paramref name="utf8Json"/>is <see langword="null"/>.
+        /// <paramref name="utf8Json"/> is <see langword="null"/>.
         /// </exception>
         /// <exception cref="JsonException">
         /// Thrown when the JSON is invalid,


### PR DESCRIPTION
This how this was showing in metadata as source.

![image](https://user-images.githubusercontent.com/31348972/124789246-69c4a100-df4a-11eb-9cf2-0d489a8f79b6.png)
