### PR TITLE
Add missing extra jit flag dump entries

### DIFF
--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/spmidumphelper.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/spmidumphelper.cpp
@@ -285,6 +285,8 @@ std::string SpmiDumpHelper::DumpJitFlags(unsigned long long flags)
     AddFlagNumeric(HAS_EDGE_PROFILE, EXTRA_JIT_FLAGS::HAS_EDGE_PROFILE);
     AddFlagNumeric(HAS_CLASS_PROFILE, EXTRA_JIT_FLAGS::HAS_CLASS_PROFILE);
     AddFlagNumeric(HAS_LIKELY_CLASS, EXTRA_JIT_FLAGS::HAS_LIKELY_CLASS);
+    AddFlagNumeric(HAS_STATIC_PROFILE, EXTRA_JIT_FLAGS::HAS_STATIC_PROFILE);
+    AddFlagNumeric(HAS_DYNAMIC_PROFILE, EXTRA_JIT_FLAGS::HAS_DYNAMIC_PROFILE);
 
 #undef AddFlag
 #undef AddFlagNumeric


### PR DESCRIPTION
Fix missing flag entries that are displayed in various contexts, eg `mcs -jitflags`

Before:
```
Individual Flag Appearances
   ...
   23587   54.18%  TIER0
   15818   36.34%  TIER1
    9531   21.89%  Unknown jit flags-0400000000000000
    1725    3.96%  Unknown jit flags-0800000000000000
     489    1.12%  HAS_LIKELY_CLASS
    2927    6.72%  HAS_CLASS_PROFILE
   11256   25.86%  HAS_EDGE_PROFILE
   11256   25.86%  HAS_PGO
```
After:
```
Individual Flag Appearances
   ...
   23587   54.18%  TIER0
   15818   36.34%  TIER1
    9531   21.89%  HAS_DYNAMIC_PROFILE
    1725    3.96%  HAS_STATIC_PROFILE
     489    1.12%  HAS_LIKELY_CLASS
    2927    6.72%  HAS_CLASS_PROFILE
   11256   25.86%  HAS_EDGE_PROFILE
   11256   25.86%  HAS_PGO
```