### PR TITLE
Add private Task.StateFlags property to help with debugging

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
@@ -13,6 +13,7 @@
     <type fullname="System.Threading.Tasks.Task">
       <property name="ParentForDebugger" />
       <property name="StateFlagsForDebugger" />
+      <property name="StateFlags" />
       <method name="GetDelegateContinuationsForDebugger" />
       <method name="SetNotificationForWaitCompletion" />
     </type>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs
@@ -378,8 +378,8 @@ namespace System.Threading.Tasks
             // been recorded, and (4) Cancellation has not been requested.
             //
             // If the reservation is successful, then set the result and finish completion processing.
-            if (AtomicStateUpdate(TASK_STATE_COMPLETION_RESERVED,
-                    TASK_STATE_COMPLETION_RESERVED | TASK_STATE_RAN_TO_COMPLETION | TASK_STATE_FAULTED | TASK_STATE_CANCELED))
+            if (AtomicStateUpdate((int)TaskStateFlags.CompletionReserved,
+                    (int)TaskStateFlags.CompletionReserved | (int)TaskStateFlags.RanToCompletion | (int)TaskStateFlags.Faulted | (int)TaskStateFlags.Canceled))
             {
                 m_result = result;
 
@@ -390,7 +390,7 @@ namespace System.Threading.Tasks
                 // However, that goes through a windy code path, involves many non-inlineable functions
                 // and which can be summarized more concisely with the following snippet from
                 // FinishStageTwo, omitting everything that doesn't pertain to TrySetResult.
-                Interlocked.Exchange(ref m_stateFlags, m_stateFlags | TASK_STATE_RAN_TO_COMPLETION);
+                Interlocked.Exchange(ref m_stateFlags, m_stateFlags | (int)TaskStateFlags.RanToCompletion);
                 ContingentProperties? props = m_contingentProperties;
                 if (props != null)
                 {
@@ -425,7 +425,7 @@ namespace System.Threading.Tasks
             else
             {
                 m_result = result;
-                m_stateFlags |= TASK_STATE_RAN_TO_COMPLETION;
+                m_stateFlags |= (int)TaskStateFlags.RanToCompletion;
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
@@ -216,7 +216,7 @@ namespace System.Threading.Tasks
             Debug.Assert(task != null);
             Debug.Assert(task.m_taskScheduler != null);
 
-            // Set the TASK_STATE_STARTED flag.  This only needs to be done
+            // Set the TaskStateFlags.Started flag.  This only needs to be done
             // if the task may be canceled or if someone else has a reference to it
             // that may try to execute it.
             if (needsProtection)
@@ -226,7 +226,7 @@ namespace System.Threading.Tasks
             }
             else
             {
-                task.m_stateFlags |= Task.TASK_STATE_STARTED;
+                task.m_stateFlags |= (int)Task.TaskStateFlags.Started;
             }
 
             // Try to inline it but queue if we can't

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskScheduler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskScheduler.cs
@@ -166,7 +166,7 @@ namespace System.Threading.Tasks
         {
             // Do not inline unstarted tasks (i.e., task.ExecutingTaskScheduler == null).
             // Do not inline TaskCompletionSource-style (a.k.a. "promise") tasks.
-            // No need to attempt inlining if the task body was already run (i.e. either TASK_STATE_DELEGATE_INVOKED or TASK_STATE_CANCELED bits set)
+            // No need to attempt inlining if the task body was already run (i.e. either TaskStateFlags.DelegateInvoked or TaskStateFlags.Canceled bits set)
             TaskScheduler? ets = task.ExecutingTaskScheduler;
 
             // Delegate cross-scheduler inlining requests to target scheduler
@@ -189,7 +189,7 @@ namespace System.Threading.Tasks
 
             bool inlined = TryExecuteTaskInline(task, taskWasPreviouslyQueued);
 
-            // If the custom scheduler returned true, we should either have the TASK_STATE_DELEGATE_INVOKED or TASK_STATE_CANCELED bit set
+            // If the custom scheduler returned true, we should either have the TaskStateFlags.DelegateInvoked or TaskStateFlags.Canceled bit set
             // Otherwise the scheduler is buggy
             if (inlined && !(task.IsDelegateInvoked || task.IsCanceled))
             {


### PR DESCRIPTION
It's a pain when you want to debug something with tasks, you look at its m_stateFlags, and you're met with an integer you have to decode by looking at consts defined in Task.  This changes those consts to be an enum and adds a private property that returns the flags as that enum, to help with debugging.

![image](https://user-images.githubusercontent.com/2642209/124834258-71d21000-df4d-11eb-8c3a-aedbac706871.png)
