### PR TITLE
Improve loop cloning, with debugging improvements

### DIFF
--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -29,7 +29,10 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #include "jithashtable.h"
 
 /*****************************************************************************/
-typedef BitVec EXPSET_TP;
+typedef BitVec          EXPSET_TP;
+typedef BitVec_ValArg_T EXPSET_VALARG_TP;
+typedef BitVec_ValRet_T EXPSET_VALRET_TP;
+
 #if LARGE_EXPSET
 #define EXPSET_SZ 64
 #else

--- a/src/coreclr/jit/clrjit.natvis
+++ b/src/coreclr/jit/clrjit.natvis
@@ -5,6 +5,13 @@ Licensed to the .NET Foundation under one or more agreements.
 The .NET Foundation licenses this file to you under the MIT license.
 -->
 
+<!--
+Visual Studio debugger visualizers for RyuJIT.
+
+Documentation for VS natvis format: https://docs.microsoft.com/en-us/visualstudio/debugger/create-custom-views-of-native-objects?view=vs-2019
+
+Documentation for VS debugger format specifiers: https://docs.microsoft.com/en-us/visualstudio/debugger/format-specifiers-in-cpp?view=vs-2019
+-->
 
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
 
@@ -180,6 +187,39 @@ The .NET Foundation licenses this file to you under the MIT license.
         <NextPointer>this-&gt;m_pNext</NextPointer>
         <ValueNode>this-&gt;m_value</ValueNode>
       </LinkedListItems>
+    </Expand>
+  </Type>
+
+  <Type Name="JitExpandArray&lt;*&gt;">
+    <DisplayString Condition="m_size > 0">size={m_size,d}</DisplayString>
+    <DisplayString Condition="m_size == 0">Empty</DisplayString>
+    <Expand>
+      <ArrayItems>
+        <Size>m_size</Size>
+        <ValuePointer>m_members</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+
+  <Type Name="JitExpandArrayStack&lt;*&gt;">
+    <DisplayString Condition="m_size > 0">size={m_size,d} used={m_used,d}</DisplayString>
+    <DisplayString Condition="m_size == 0">Empty</DisplayString>
+    <Expand>
+      <ArrayItems>
+        <Size>m_used</Size>
+        <ValuePointer>m_members</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+
+  <!-- Loop cloning -->
+
+  <!-- LcOptInfo is really one of its derived types, so figure out which one. Set Inheritable=false to prevent recursion. -->
+  <Type Name="LcOptInfo" Inheritable="false">
+    <DisplayString>{optType,en}</DisplayString>
+    <Expand>
+      <ExpandedItem Condition="optType == LcOptInfo::OptType::LcJaggedArray">(LcJaggedArrayOptInfo*)this,nd</ExpandedItem>
+      <ExpandedItem Condition="optType == LcOptInfo::OptType::LcMdArray">(LcMdArrayOptInfo*)this,nd</ExpandedItem>
     </Expand>
   </Type>
 

--- a/src/coreclr/jit/clrjit.natvis
+++ b/src/coreclr/jit/clrjit.natvis
@@ -190,6 +190,17 @@ Documentation for VS debugger format specifiers: https://docs.microsoft.com/en-u
     </Expand>
   </Type>
 
+  <Type Name="jitstd::vector&lt;*&gt;">
+    <DisplayString Condition="m_nSize > 0">size={m_nSize,d} capacity={m_nCapacity,d}</DisplayString>
+    <DisplayString Condition="m_nSize == 0">Empty</DisplayString>
+    <Expand>
+      <ArrayItems>
+        <Size>m_nSize</Size>
+        <ValuePointer>m_pArray</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+
   <Type Name="JitExpandArray&lt;*&gt;">
     <DisplayString Condition="m_size > 0">size={m_size,d}</DisplayString>
     <DisplayString Condition="m_size == 0">Empty</DisplayString>

--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -216,6 +216,7 @@ protected:
     unsigned genCurDispOffset;
 
     static const char* genInsName(instruction ins);
+    const char* genInsDisplayName(emitter::instrDesc* id);
 #endif // DEBUG
 
     //-------------------------------------------------------------------------
@@ -1502,10 +1503,6 @@ public:
     void instGen_Load_Reg_From_Lcl(var_types srcType, regNumber dstReg, int varNum, int offs);
 
     void instGen_Store_Reg_Into_Lcl(var_types dstType, regNumber srcReg, int varNum, int offs);
-
-#ifdef DEBUG
-    void __cdecl instDisp(instruction ins, bool noNL, const char* fmt, ...);
-#endif
 
 #ifdef TARGET_XARCH
     instruction genMapShiftInsToShiftByConstantIns(instruction ins, int shiftByValue);

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2064,9 +2064,8 @@ void CodeGen::genInsertNopForUnwinder(BasicBlock* block)
         // block starts an EH region. If we pointed the existing bbEmitCookie here, then the NOP
         // would be executed, which we would prefer not to do.
 
-        block->bbUnwindNopEmitCookie =
-            GetEmitter()->emitAddLabel(gcInfo.gcVarPtrSetCur, gcInfo.gcRegGCrefSetCur, gcInfo.gcRegByrefSetCur,
-                                       false DEBUG_ARG(block));
+        block->bbUnwindNopEmitCookie = GetEmitter()->emitAddLabel(gcInfo.gcVarPtrSetCur, gcInfo.gcRegGCrefSetCur,
+                                                                  gcInfo.gcRegByrefSetCur, false DEBUG_ARG(block));
 
         instGen(INS_nop);
     }

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1070,7 +1070,7 @@ void CodeGen::genDefineTempLabel(BasicBlock* label)
 {
     genLogLabel(label);
     label->bbEmitCookie = GetEmitter()->emitAddLabel(gcInfo.gcVarPtrSetCur, gcInfo.gcRegGCrefSetCur,
-                                                     gcInfo.gcRegByrefSetCur, false DEBUG_ARG(label->bbNum));
+                                                     gcInfo.gcRegByrefSetCur, false DEBUG_ARG(label));
 }
 
 // genDefineInlineTempLabel: Define an inline label that does not affect the GC
@@ -2066,7 +2066,7 @@ void CodeGen::genInsertNopForUnwinder(BasicBlock* block)
 
         block->bbUnwindNopEmitCookie =
             GetEmitter()->emitAddLabel(gcInfo.gcVarPtrSetCur, gcInfo.gcRegGCrefSetCur, gcInfo.gcRegByrefSetCur,
-                                       false DEBUG_ARG(block->bbNum));
+                                       false DEBUG_ARG(block));
 
         instGen(INS_nop);
     }

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -356,7 +356,7 @@ void CodeGen::genCodeForBBlist()
             // Mark a label and update the current set of live GC refs
 
             block->bbEmitCookie = GetEmitter()->emitAddLabel(gcInfo.gcVarPtrSetCur, gcInfo.gcRegGCrefSetCur,
-                                                             gcInfo.gcRegByrefSetCur, false DEBUG_ARG(block->bbNum));
+                                                             gcInfo.gcRegByrefSetCur, false DEBUG_ARG(block));
         }
 
         if (block == compiler->fgFirstColdBlock)

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2988,6 +2988,7 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
     opts.disAsmSpilled   = false;
     opts.disDiffable     = false;
     opts.disAddr         = false;
+    opts.disAlignment    = false;
     opts.dspCode         = false;
     opts.dspEHTable      = false;
     opts.dspDebugInfo    = false;
@@ -3134,6 +3135,11 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
         if (JitConfig.JitDasmWithAddress() != 0)
         {
             opts.disAddr = true;
+        }
+
+        if (JitConfig.JitDasmWithAlignmentBoundaries() != 0)
+        {
+            opts.disAlignment = true;
         }
 
         if (JitConfig.JitLongAddress() != 0)

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9338,6 +9338,7 @@ public:
         bool disasmWithGC;             // Display GC info interleaved with disassembly.
         bool disDiffable;              // Makes the Disassembly code 'diff-able'
         bool disAddr;                  // Display process address next to each instruction in disassembly code
+        bool disAlignment;             // Display alignment boundaries in disassembly code
         bool disAsm2;                  // Display native code after it is generated using external disassembler
         bool dspOrder;                 // Display names of each of the methods that we ngen/jit
         bool dspUnwind;                // Display the unwind info output

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6209,9 +6209,9 @@ private:
 public:
     void optInit();
 
-    GenTree* Compiler::optRemoveRangeCheck(GenTreeBoundsChk* check, GenTree* comma, Statement* stmt);
-    GenTree* Compiler::optRemoveStandaloneRangeCheck(GenTreeBoundsChk* check, Statement* stmt);
-    void Compiler::optRemoveCommaBasedRangeCheck(GenTree* comma, Statement* stmt);
+    GenTree* optRemoveRangeCheck(GenTreeBoundsChk* check, GenTree* comma, Statement* stmt);
+    GenTree* optRemoveStandaloneRangeCheck(GenTreeBoundsChk* check, Statement* stmt);
+    void optRemoveCommaBasedRangeCheck(GenTree* comma, Statement* stmt);
     bool optIsRangeCheckRemovable(GenTree* tree);
 
 protected:

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -763,25 +763,6 @@ inline double getR8LittleEndian(const BYTE* ptr)
     return *(double*)&val;
 }
 
-/*****************************************************************************
- *
- *  Return the normalized index to use in the EXPSET_TP for the CSE with
- *  the given CSE index.
- *  Each GenTree has the following field:
- *    signed char       gtCSEnum;        // 0 or the CSE index (negated if def)
- *  So zero is reserved to mean this node is not a CSE
- *  and postive values indicate CSE uses and negative values indicate CSE defs.
- *  The caller of this method must pass a non-zero postive value.
- *  This precondition is checked by the assert on the first line of this method.
- */
-
-inline unsigned int genCSEnum2bit(unsigned index)
-{
-    assert((index > 0) && (index <= EXPSET_SZ));
-
-    return (index - 1);
-}
-
 #ifdef DEBUG
 const char* genES2str(BitVecTraits* traits, EXPSET_TP set);
 const char* refCntWtd2str(BasicBlock::weight_t refCntWtd);

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -1184,7 +1184,7 @@ int emitter::instrDesc::idAddrUnion::iiaGetJitDataOffset() const
 
 //----------------------------------------------------------------------------------------
 // insEvaluateExecutionCost:
-//    Returns the estimate execution cost fortyhe current instruction
+//    Returns the estimated execution cost for the current instruction
 //
 // Arguments:
 //    id  - The current instruction descriptor to be evaluated
@@ -1193,8 +1193,6 @@ int emitter::instrDesc::idAddrUnion::iiaGetJitDataOffset() const
 //    calls getInsExecutionCharacteristics and uses the result
 //    to compute an estimated execution cost
 //
-// Notes:
-//
 float emitter::insEvaluateExecutionCost(instrDesc* id)
 {
     insExecutionCharacteristics result        = getInsExecutionCharacteristics(id);
@@ -1202,8 +1200,10 @@ float emitter::insEvaluateExecutionCost(instrDesc* id)
     float                       latency       = result.insLatency;
     unsigned                    memAccessKind = result.insMemoryAccessKind;
 
-    // Check for PERFSCORE_THROUGHPUT_ILLEGAL and PERFSCORE_LATENCY_ILLEGAL
-    assert(throughput > 0.0);
+    // Check for PERFSCORE_THROUGHPUT_ILLEGAL and PERFSCORE_LATENCY_ILLEGAL.
+    // Note that 0.0 throughput is allowed for pseudo-instructions in the instrDesc list that won't actually
+    // generate code.
+    assert(throughput >= 0.0);
     assert(latency >= 0.0);
 
     if (memAccessKind == PERFSCORE_MEMORY_WRITE)

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -3824,7 +3824,7 @@ size_t emitter::emitIssue1Instr(insGroup* ig, instrDesc* id, BYTE** dp)
     }
 
     // Print the alignment boundary
-    if ((emitComp->opts.disAsm || emitComp->verbose) && emitComp->opts.disAddr)
+    if ((emitComp->opts.disAsm || emitComp->verbose) && (emitComp->opts.disAddr || emitComp->opts.disAlignment))
     {
         size_t currAddr         = (size_t)*dp;
         size_t lastBoundaryAddr = currAddr & ~((size_t)emitComp->opts.compJitAlignLoopBoundary - 1);
@@ -3867,7 +3867,7 @@ size_t emitter::emitIssue1Instr(insGroup* ig, instrDesc* id, BYTE** dp)
             printf(" %dB boundary ...............................\n", (emitComp->opts.compJitAlignLoopBoundary));
         }
     }
-#endif
+#endif // DEBUG
 
     return is;
 }

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -1241,7 +1241,7 @@ float emitter::insEvaluateExecutionCost(instrDesc* id)
 void emitter::perfScoreUnhandledInstruction(instrDesc* id, insExecutionCharacteristics* pResult)
 {
 #ifdef DEBUG
-    printf("PerfScore: unhandled instruction: %s, format %s", codeGen->genInsName(id->idIns()),
+    printf("PerfScore: unhandled instruction: %s, format %s", codeGen->genInsDisplayName(id),
            emitIfName(id->idInsFmt()));
     assert(!"PerfScore: unhandled instruction");
 #endif
@@ -6024,7 +6024,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
                         unsigned bytesCrossedBoundary = (unsigned)(afterInstrAddr & jccAlignBoundaryMask);
                         printf("; ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (%s: %d ; jcc erratum) %dB boundary "
                                "...............................\n",
-                               codeGen->genInsName(curIns), bytesCrossedBoundary, jccAlignBoundary);
+                               codeGen->genInsDisplayName(curInstrDesc), bytesCrossedBoundary, jccAlignBoundary);
                     }
                 }
 
@@ -6043,8 +6043,8 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
                         unsigned bytesCrossedBoundary = (unsigned)(afterInstrAddr & alignBoundaryMask);
                         if (bytesCrossedBoundary != 0)
                         {
-                            printf("; ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (%s: %d)", codeGen->genInsName(curIns),
-                                   bytesCrossedBoundary);
+                            printf("; ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (%s: %d)",
+                                   codeGen->genInsDisplayName(curInstrDesc), bytesCrossedBoundary);
                         }
                         else
                         {

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -2586,8 +2586,8 @@ void emitter::emitPrintLabel(insGroup* ig)
 //
 const char* emitter::emitLabelString(insGroup* ig)
 {
-    const int TEMP_BUFFER_LEN = 40;
-    static unsigned curBuf    = 0;
+    const int       TEMP_BUFFER_LEN = 40;
+    static unsigned curBuf          = 0;
     static char     buf[4][TEMP_BUFFER_LEN];
     const char*     retbuf;
 
@@ -5017,10 +5017,10 @@ void emitter::emitLoopAlignAdjustments()
                 alignInstr = prevAlignInstr;
             }
 
-            JITDUMP("Adjusted alignment of %s from %u to %u.\n", emitLabelString(alignIG),
-                    estimatedPaddingNeeded, actualPaddingNeeded);
-            JITDUMP("Adjusted size of %s from %u to %u.\n", emitLabelString(alignIG),
-                    (alignIG->igSize + diff), alignIG->igSize);
+            JITDUMP("Adjusted alignment of %s from %u to %u.\n", emitLabelString(alignIG), estimatedPaddingNeeded,
+                    actualPaddingNeeded);
+            JITDUMP("Adjusted size of %s from %u to %u.\n", emitLabelString(alignIG), (alignIG->igSize + diff),
+                    alignIG->igSize);
         }
 
         // Adjust the offset of all IGs starting from next IG until we reach the IG having the next
@@ -5029,8 +5029,8 @@ void emitter::emitLoopAlignAdjustments()
         insGroup* adjOffUptoIG = alignInstr->idaNext != nullptr ? alignInstr->idaNext->idaIG : emitIGlast;
         while ((adjOffIG != nullptr) && (adjOffIG->igNum <= adjOffUptoIG->igNum))
         {
-            JITDUMP("Adjusted offset of %s from %04X to %04X\n", emitLabelString(adjOffIG),
-                    adjOffIG->igOffs, (adjOffIG->igOffs - alignBytesRemoved));
+            JITDUMP("Adjusted offset of %s from %04X to %04X\n", emitLabelString(adjOffIG), adjOffIG->igOffs,
+                    (adjOffIG->igOffs - alignBytesRemoved));
             adjOffIG->igOffs -= alignBytesRemoved;
             adjOffIG = adjOffIG->igNext;
         }
@@ -5089,8 +5089,8 @@ unsigned emitter::emitCalculatePaddingForLoopAlignment(insGroup* ig, size_t offs
     // No padding if loop is already aligned
     if ((offset & (alignmentBoundary - 1)) == 0)
     {
-        JITDUMP(";; Skip alignment: 'Loop at %s already aligned at %dB boundary.'\n",
-                emitLabelString(ig->igNext), alignmentBoundary);
+        JITDUMP(";; Skip alignment: 'Loop at %s already aligned at %dB boundary.'\n", emitLabelString(ig->igNext),
+                alignmentBoundary);
         return 0;
     }
 
@@ -5114,8 +5114,8 @@ unsigned emitter::emitCalculatePaddingForLoopAlignment(insGroup* ig, size_t offs
     // No padding if loop is big
     if (loopSize > maxLoopSize)
     {
-        JITDUMP(";; Skip alignment: 'Loop at %s is big. LoopSize= %d, MaxLoopSize= %d.'\n",
-                emitLabelString(ig->igNext), loopSize, maxLoopSize);
+        JITDUMP(";; Skip alignment: 'Loop at %s is big. LoopSize= %d, MaxLoopSize= %d.'\n", emitLabelString(ig->igNext),
+                loopSize, maxLoopSize);
         return 0;
     }
 

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -351,7 +351,7 @@ struct insGroup
 
 #ifdef DEBUG
     BasicBlock* igBlock; // The BasicBlock that generated code into this insGroup.
-#endif // DEBUG
+#endif                   // DEBUG
 
 }; // end of struct insGroup
 
@@ -1233,7 +1233,7 @@ protected:
 
 #define PERFSCORE_THROUGHPUT_ILLEGAL -1024.0f
 
-#define PERFSCORE_THROUGHPUT_ZERO 0.0f        // Only used for pseudo-instructions that don't generate code
+#define PERFSCORE_THROUGHPUT_ZERO 0.0f // Only used for pseudo-instructions that don't generate code
 
 #define PERFSCORE_THROUGHPUT_6X (1.0f / 6.0f) // Hextuple issue
 #define PERFSCORE_THROUGHPUT_5X 0.20f         // Pentuple issue
@@ -1908,7 +1908,7 @@ private:
     void* emitAddLabel(VARSET_VALARG_TP GCvars,
                        regMaskTP        gcrefRegs,
                        regMaskTP        byrefRegs,
-                       bool isFinallyTarget = false DEBUG_ARG(BasicBlock* block = nullptr));
+                       bool             isFinallyTarget = false DEBUG_ARG(BasicBlock* block = nullptr));
 
     // Same as above, except the label is added and is conceptually "inline" in
     // the current block. Thus it extends the previous block and the emitter

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1229,6 +1229,8 @@ protected:
 
 #define PERFSCORE_THROUGHPUT_ILLEGAL -1024.0f
 
+#define PERFSCORE_THROUGHPUT_ZERO 0.0f        // Only used for pseudo-instructions that don't generate code
+
 #define PERFSCORE_THROUGHPUT_6X (1.0f / 6.0f) // Hextuple issue
 #define PERFSCORE_THROUGHPUT_5X 0.20f         // Pentuple issue
 #define PERFSCORE_THROUGHPUT_4X 0.25f         // Quad issue

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -350,8 +350,8 @@ struct insGroup
     }
 
 #ifdef DEBUG
-    BasicBlock* lastGeneratedBlock;     // The last block that generated code into this insGroup.
-    jitstd::list<BasicBlock*> igBlocks; // All the blocks that generated code into this insGroup.
+    BasicBlock*               lastGeneratedBlock; // The last block that generated code into this insGroup.
+    jitstd::list<BasicBlock*> igBlocks;           // All the blocks that generated code into this insGroup.
 #endif
 
 }; // end of struct insGroup

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -247,6 +247,11 @@ struct insGroup
     double               igPerfScore; // The PerfScore for this insGroup
 #endif
 
+#ifdef DEBUG
+    BasicBlock*               lastGeneratedBlock; // The last block that generated code into this insGroup.
+    jitstd::list<BasicBlock*> igBlocks;           // All the blocks that generated code into this insGroup.
+#endif
+
     UNATIVE_OFFSET igNum;     // for ordering (and display) purposes
     UNATIVE_OFFSET igOffs;    // offset of this group within method
     unsigned int   igFuncIdx; // Which function/funclet does this belong to? (Index into Compiler::compFuncInfos array.)
@@ -348,11 +353,6 @@ struct insGroup
     {
         return (igFlags & IGF_LOOP_ALIGN) != 0;
     }
-
-#ifdef DEBUG
-    BasicBlock*               lastGeneratedBlock; // The last block that generated code into this insGroup.
-    jitstd::list<BasicBlock*> igBlocks;           // All the blocks that generated code into this insGroup.
-#endif
 
 }; // end of struct insGroup
 

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -349,6 +349,10 @@ struct insGroup
         return (igFlags & IGF_LOOP_ALIGN) != 0;
     }
 
+#ifdef DEBUG
+    BasicBlock* igBlock; // The BasicBlock that generated code into this insGroup.
+#endif // DEBUG
+
 }; // end of struct insGroup
 
 //  For AMD64 the maximum prolog/epilog size supported on the OS is 256 bytes
@@ -1904,12 +1908,17 @@ private:
     void* emitAddLabel(VARSET_VALARG_TP GCvars,
                        regMaskTP        gcrefRegs,
                        regMaskTP        byrefRegs,
-                       bool isFinallyTarget = false DEBUG_ARG(unsigned bbNum = 0));
+                       bool isFinallyTarget = false DEBUG_ARG(BasicBlock* block = nullptr));
 
     // Same as above, except the label is added and is conceptually "inline" in
     // the current block. Thus it extends the previous block and the emitter
     // continues to track GC info as if there was no label.
     void* emitAddInlineLabel();
+
+#ifdef DEBUG
+    void emitPrintLabel(insGroup* ig);
+    const char* emitLabelString(insGroup* ig);
+#endif
 
 #ifdef TARGET_ARMARCH
 

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -350,8 +350,9 @@ struct insGroup
     }
 
 #ifdef DEBUG
-    BasicBlock* igBlock; // The BasicBlock that generated code into this insGroup.
-#endif                   // DEBUG
+    BasicBlock* lastGeneratedBlock;     // The last block that generated code into this insGroup.
+    jitstd::list<BasicBlock*> igBlocks; // All the blocks that generated code into this insGroup.
+#endif
 
 }; // end of struct insGroup
 

--- a/src/coreclr/jit/emitarm.cpp
+++ b/src/coreclr/jit/emitarm.cpp
@@ -7292,7 +7292,7 @@ void emitter::emitDispInsHelp(
                             lab = (insGroup*)emitCodeGetCookie(*bbp++);
                             assert(lab);
 
-                            printf("\n            DD      G_M%03u_IG%02u", emitComp->compMethodID, lab->igNum);
+                            printf("\n            DD      %s", emitLabelString(lab));
                         } while (--cnt);
                     }
                 }
@@ -7601,7 +7601,7 @@ void emitter::emitDispInsHelp(
         case IF_T2_M1: // Load Label
             emitDispReg(id->idReg1(), attr, true);
             if (id->idIsBound())
-                printf("G_M%03u_IG%02u", emitComp->compMethodID, id->idAddr()->iiaIGlabel->igNum);
+                emitPrintLabel(id->idAddr()->iiaIGlabel);
             else
                 printf("L_M%03u_" FMT_BB, emitComp->compMethodID, id->idAddr()->iiaBBlabel->bbNum);
             break;
@@ -7646,7 +7646,7 @@ void emitter::emitDispInsHelp(
                 }
             }
             else if (id->idIsBound())
-                printf("G_M%03u_IG%02u", emitComp->compMethodID, id->idAddr()->iiaIGlabel->igNum);
+                emitPrintLabel(id->idAddr()->iiaIGlabel);
             else
                 printf("L_M%03u_" FMT_BB, emitComp->compMethodID, id->idAddr()->iiaBBlabel->bbNum);
         }

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -12286,7 +12286,7 @@ void emitter::emitDispIns(
             }
             else if (id->idIsBound())
             {
-                printf("G_M%03u_IG%02u", emitComp->compMethodID, id->idAddr()->iiaIGlabel->igNum);
+                emitPrintLabel(id->idAddr()->iiaIGlabel);
             }
             else
             {
@@ -12324,7 +12324,7 @@ void emitter::emitDispIns(
             emitDispReg(id->idReg1(), size, true);
             if (id->idIsBound())
             {
-                printf("G_M%03u_IG%02u", emitComp->compMethodID, id->idAddr()->iiaIGlabel->igNum);
+                emitPrintLabel(id->idAddr()->iiaIGlabel);
             }
             else
             {
@@ -12338,7 +12338,7 @@ void emitter::emitDispIns(
             emitDispImm(emitGetInsSC(id), true);
             if (id->idIsBound())
             {
-                printf("G_M%03u_IG%02u", emitComp->compMethodID, id->idAddr()->iiaIGlabel->igNum);
+                emitPrintLabel(id->idAddr()->iiaIGlabel);
             }
             else
             {
@@ -12463,7 +12463,7 @@ void emitter::emitDispIns(
                 }
                 else if (id->idIsBound())
                 {
-                    printf("G_M%03u_IG%02u", emitComp->compMethodID, id->idAddr()->iiaIGlabel->igNum);
+                    emitPrintLabel(id->idAddr()->iiaIGlabel);
                 }
                 else
                 {

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -8452,7 +8452,7 @@ void emitter::emitDispAddrMode(instrDesc* id, bool noDetail)
             lab = (insGroup*)emitCodeGetCookie(*bbp++);
             assert(lab);
 
-            printf("\n            D" SIZE_LETTER "      G_M%03u_IG%02u", emitComp->compMethodID, lab->igNum);
+            printf("\n            D" SIZE_LETTER "      %s", emitLabelString(lab));
         } while (--cnt);
     }
 }
@@ -9649,7 +9649,7 @@ void emitter::emitDispIns(
                 }
                 else
                 {
-                    printf("G_M%03u_IG%02u", emitComp->compMethodID, id->idAddr()->iiaIGlabel->igNum);
+                    emitPrintLabel(id->idAddr()->iiaIGlabel);
                 }
             }
             else

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -14669,6 +14669,17 @@ emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(ins
     switch (ins)
     {
         case INS_align:
+#if FEATURE_LOOP_ALIGN
+            if (id->idCodeSize() == 0)
+            {
+                // We're not going to generate any instruction, so it doesn't count for PerfScore.
+                result.insThroughput = PERFSCORE_THROUGHPUT_ZERO;
+                result.insLatency    = PERFSCORE_LATENCY_ZERO;
+                break;
+            }
+#endif
+            FALLTHROUGH;
+
         case INS_nop:
         case INS_int3:
             assert(memFmt == IF_NONE);

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -4292,6 +4292,38 @@ bool emitter::IsMovInstruction(instruction ins)
     }
 }
 
+//------------------------------------------------------------------------
+// IsJccInstruction: Determine if an instruction is a conditional jump instruction.
+//
+// Arguments:
+//    ins       -- The instruction being checked
+//
+// Return Value:
+//    true if the instruction qualifies; otherwise, false
+//
+bool emitter::IsJccInstruction(instruction ins)
+{
+    return ((ins >= INS_jo) && (ins <= INS_jg)) || ((ins >= INS_l_jo) && (ins <= INS_l_jg));
+}
+
+//------------------------------------------------------------------------
+// IsJmpInstruction: Determine if an instruction is a jump instruction but NOT a conditional jump instruction.
+//
+// Arguments:
+//    ins       -- The instruction being checked
+//
+// Return Value:
+//    true if the instruction qualifies; otherwise, false
+//
+bool emitter::IsJmpInstruction(instruction ins)
+{
+    return
+#ifdef TARGET_AMD64
+        (ins == INS_rex_jmp) ||
+#endif
+        (ins == INS_i_jmp) || (ins == INS_jmp) || (ins == INS_l_jmp);
+}
+
 //----------------------------------------------------------------------------------------
 // IsRedundantMov:
 //    Check if the current `mov` instruction is redundant and can be omitted.

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -24,37 +24,37 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #include "emit.h"
 #include "codegen.h"
 
-bool IsSSEInstruction(instruction ins)
+bool emitter::IsSSEInstruction(instruction ins)
 {
     return (ins >= INS_FIRST_SSE_INSTRUCTION) && (ins <= INS_LAST_SSE_INSTRUCTION);
 }
 
-bool IsSSEOrAVXInstruction(instruction ins)
+bool emitter::IsSSEOrAVXInstruction(instruction ins)
 {
     return (ins >= INS_FIRST_SSE_INSTRUCTION) && (ins <= INS_LAST_AVX_INSTRUCTION);
 }
 
-bool IsAVXOnlyInstruction(instruction ins)
+bool emitter::IsAVXOnlyInstruction(instruction ins)
 {
     return (ins >= INS_FIRST_AVX_INSTRUCTION) && (ins <= INS_LAST_AVX_INSTRUCTION);
 }
 
-bool IsFMAInstruction(instruction ins)
+bool emitter::IsFMAInstruction(instruction ins)
 {
     return (ins >= INS_FIRST_FMA_INSTRUCTION) && (ins <= INS_LAST_FMA_INSTRUCTION);
 }
 
-bool IsAVXVNNIInstruction(instruction ins)
+bool emitter::IsAVXVNNIInstruction(instruction ins)
 {
     return (ins >= INS_FIRST_AVXVNNI_INSTRUCTION) && (ins <= INS_LAST_AVXVNNI_INSTRUCTION);
 }
 
-bool IsBMIInstruction(instruction ins)
+bool emitter::IsBMIInstruction(instruction ins)
 {
     return (ins >= INS_FIRST_BMI_INSTRUCTION) && (ins <= INS_LAST_BMI_INSTRUCTION);
 }
 
-regNumber getBmiRegNumber(instruction ins)
+regNumber emitter::getBmiRegNumber(instruction ins)
 {
     switch (ins)
     {
@@ -81,7 +81,7 @@ regNumber getBmiRegNumber(instruction ins)
     }
 }
 
-regNumber getSseShiftRegNumber(instruction ins)
+regNumber emitter::getSseShiftRegNumber(instruction ins)
 {
     switch (ins)
     {
@@ -123,7 +123,7 @@ regNumber getSseShiftRegNumber(instruction ins)
     }
 }
 
-bool emitter::IsAVXInstruction(instruction ins)
+bool emitter::IsAVXInstruction(instruction ins) const
 {
     return UseVEXEncoding() && IsSSEOrAVXInstruction(ins);
 }
@@ -438,7 +438,7 @@ bool emitter::Is4ByteSSEInstruction(instruction ins)
 
 // Returns true if this instruction requires a VEX prefix
 // All AVX instructions require a VEX prefix
-bool emitter::TakesVexPrefix(instruction ins)
+bool emitter::TakesVexPrefix(instruction ins) const
 {
     // special case vzeroupper as it requires 2-byte VEX prefix
     // special case the fencing, movnti and the prefetch instructions as they never take a VEX prefix
@@ -514,7 +514,7 @@ emitter::code_t emitter::AddVexPrefix(instruction ins, code_t code, emitAttr att
 }
 
 // Returns true if this instruction, for the given EA_SIZE(attr), will require a REX.W prefix
-bool TakesRexWPrefix(instruction ins, emitAttr attr)
+bool emitter::TakesRexWPrefix(instruction ins, emitAttr attr)
 {
     // Because the current implementation of AVX does not have a way to distinguish between the register
     // size specification (128 vs. 256 bits) and the operand size specification (32 vs. 64 bits), where both are
@@ -8716,22 +8716,16 @@ void emitter::emitDispIns(
 
     /* Display the instruction name */
 
-    sstr = codeGen->genInsName(ins);
+    sstr = codeGen->genInsDisplayName(id);
+    printf(" %-9s", sstr);
 
-    if (IsAVXInstruction(ins) && !IsBMIInstruction(ins))
-    {
-        printf(" v%-8s", sstr);
-    }
-    else
-    {
-        printf(" %-9s", sstr);
-    }
 #ifndef HOST_UNIX
-    if (strnlen_s(sstr, 10) >= 8)
+    if (strnlen_s(sstr, 10) >= 9)
 #else  // HOST_UNIX
-    if (strnlen(sstr, 10) >= 8)
+    if (strnlen(sstr, 10) >= 9)
 #endif // HOST_UNIX
     {
+        // Make sure there's at least one space after the instruction name, for very long instruction names.
         printf(" ");
     }
 

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -98,6 +98,9 @@ static bool IsMovInstruction(instruction ins);
 bool IsRedundantMov(
     instruction ins, insFormat fmt, emitAttr size, regNumber dst, regNumber src, bool canIgnoreSideEffects);
 
+static bool IsJccInstruction(instruction ins);
+static bool IsJmpInstruction(instruction ins);
+
 bool AreUpper32BitsZero(regNumber reg);
 
 bool AreFlagsSetToZeroCmp(regNumber reg, emitAttr opSize, genTreeOps treeOps);

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -83,7 +83,15 @@ code_t insEncodeOpreg(instruction ins, regNumber reg, emitAttr size);
 
 unsigned insSSval(unsigned scale);
 
-bool IsAVXInstruction(instruction ins);
+static bool IsSSEInstruction(instruction ins);
+static bool IsSSEOrAVXInstruction(instruction ins);
+static bool IsAVXOnlyInstruction(instruction ins);
+static bool IsFMAInstruction(instruction ins);
+static bool IsAVXVNNIInstruction(instruction ins);
+static bool IsBMIInstruction(instruction ins);
+static regNumber getBmiRegNumber(instruction ins);
+static regNumber getSseShiftRegNumber(instruction ins);
+bool IsAVXInstruction(instruction ins) const;
 code_t insEncodeMIreg(instruction ins, regNumber reg, emitAttr size, code_t code);
 
 code_t AddRexWPrefix(instruction ins, code_t code);
@@ -119,7 +127,8 @@ bool hasRexPrefix(code_t code)
 #define VEX_PREFIX_MASK_3BYTE 0xFF000000000000ULL
 #define VEX_PREFIX_CODE_3BYTE 0xC4000000000000ULL
 
-bool TakesVexPrefix(instruction ins);
+bool TakesVexPrefix(instruction ins) const;
+static bool TakesRexWPrefix(instruction ins, emitAttr attr);
 
 // Returns true if the instruction encoding already contains VEX prefix
 bool hasVexPrefix(code_t code)
@@ -145,7 +154,7 @@ code_t AddVexPrefixIfNeededAndNotPresent(instruction ins, code_t code, emitAttr 
 }
 
 bool useVEXEncodings;
-bool UseVEXEncoding()
+bool UseVEXEncoding() const
 {
     return useVEXEncodings;
 }

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -1620,6 +1620,9 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
             }
         }
         bNext->bbPreds = nullptr;
+
+        // `block` can no longer be a loop pre-header (if it was before).
+        block->bbFlags &= ~BBF_LOOP_PREHEADER;
     }
     else
     {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -10291,7 +10291,7 @@ void Compiler::gtDispNode(GenTree* tree, IndentStack* indentStack, __in __in_z _
     {
         if (IS_CSE_INDEX(tree->gtCSEnum))
         {
-            printf("CSE #%02d (%s)", GET_CSE_INDEX(tree->gtCSEnum), (IS_CSE_USE(tree->gtCSEnum) ? "use" : "def"));
+            printf(FMT_CSE " (%s)", GET_CSE_INDEX(tree->gtCSEnum), (IS_CSE_USE(tree->gtCSEnum) ? "use" : "def"));
         }
         else
         {

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -494,7 +494,7 @@ enum GenTreeFlags : unsigned int
 
     GTF_INX_RNGCHK              = 0x80000000, // GT_INDEX/GT_INDEX_ADDR -- the array reference should be range-checked.
     GTF_INX_STRING_LAYOUT       = 0x40000000, // GT_INDEX -- this uses the special string array layout
-    GTF_INX_NONFAULTING         = 0x20000000, // GT_INDEX -- the INDEX does not throw an exception (morph to GTF_IND_NONFAULTING)
+    GTF_INX_NOFAULT             = 0x20000000, // GT_INDEX -- the INDEX does not throw an exception (morph to GTF_IND_NONFAULTING)
 
     GTF_IND_TGT_NOT_HEAP        = 0x80000000, // GT_IND   -- the target is not on the heap
     GTF_IND_VOLATILE            = 0x40000000, // GT_IND   -- the load or store must use volatile sematics (this is a nop on X86)

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -494,6 +494,7 @@ enum GenTreeFlags : unsigned int
 
     GTF_INX_RNGCHK              = 0x80000000, // GT_INDEX/GT_INDEX_ADDR -- the array reference should be range-checked.
     GTF_INX_STRING_LAYOUT       = 0x40000000, // GT_INDEX -- this uses the special string array layout
+    GTF_INX_NONFAULTING         = 0x20000000, // GT_INDEX -- the INDEX does not throw an exception (morph to GTF_IND_NONFAULTING)
 
     GTF_IND_TGT_NOT_HEAP        = 0x80000000, // GT_IND   -- the target is not on the heap
     GTF_IND_VOLATILE            = 0x40000000, // GT_IND   -- the load or store must use volatile sematics (this is a nop on X86)

--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -105,14 +105,9 @@ const char* CodeGen::genInsDisplayName(emitter::instrDesc* id)
         curBuf = (curBuf + 1) % 4;
         return retbuf;
     }
-    else
-    {
-        // If we don't need any adjustments, just return it directly.
-        return insName;
-    }
-#else
+#endif // TARGET_XARCH
+
     return insName;
-#endif
 }
 
 /*****************************************************************************/

--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -24,11 +24,12 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 /*****************************************************************************/
 #ifdef DEBUG
 
-/*****************************************************************************
- *
- *  Returns the string representation of the given CPU instruction.
- */
-
+//-----------------------------------------------------------------------------
+// genInsName: Returns the string representation of the given CPU instruction, as
+// it exists in the instruction table. Note that some architectures don't encode the
+// name completely in the table: xarch sometimes prepends a "v", and arm sometimes
+// appends a "s". Use `genInsDisplayName()` to get a fully-formed name.
+//
 const char* CodeGen::genInsName(instruction ins)
 {
     // clang-format off
@@ -77,36 +78,41 @@ const char* CodeGen::genInsName(instruction ins)
     return insNames[ins];
 }
 
-void __cdecl CodeGen::instDisp(instruction ins, bool noNL, const char* fmt, ...)
+//-----------------------------------------------------------------------------
+// genInsDisplayName: Get a fully-formed instruction display name. This only handles
+// the xarch case of prepending a "v", not the arm case of appending an "s".
+// This can be called up to four times in a single 'printf' before the static buffers
+// get reused.
+//
+// Returns:
+//    String with instruction name
+//
+const char* CodeGen::genInsDisplayName(emitter::instrDesc* id)
 {
-    if (compiler->opts.dspCode)
+    instruction ins     = id->idIns();
+    const char* insName = genInsName(ins);
+
+    const int       TEMP_BUFFER_LEN = 40;
+    static unsigned curBuf          = 0;
+    static char     buf[4][TEMP_BUFFER_LEN];
+    const char*     retbuf;
+
+#ifdef TARGET_XARCH
+    if (GetEmitter()->IsAVXInstruction(ins) && !GetEmitter()->IsBMIInstruction(ins))
     {
-        /* Display the instruction offset within the emit block */
-
-        //      printf("[%08X:%04X]", GetEmitter().emitCodeCurBlock(), GetEmitter().emitCodeOffsInBlock());
-
-        /* Display the FP stack depth (before the instruction is executed) */
-
-        //      printf("[FP=%02u] ", genGetFPstkLevel());
-
-        /* Display the instruction mnemonic */
-        printf("        ");
-
-        printf("            %-8s", genInsName(ins));
-
-        if (fmt)
-        {
-            va_list args;
-            va_start(args, fmt);
-            vprintf(fmt, args);
-            va_end(args);
-        }
-
-        if (!noNL)
-        {
-            printf("\n");
-        }
+        sprintf_s(buf[curBuf], TEMP_BUFFER_LEN, "v%s", insName);
+        retbuf = buf[curBuf];
+        curBuf = (curBuf + 1) % 4;
+        return retbuf;
     }
+    else
+    {
+        // If we don't need any adjustments, just return it directly.
+        return insName;
+    }
+#else
+    return insName;
+#endif
 }
 
 /*****************************************************************************/

--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -92,12 +92,12 @@ const char* CodeGen::genInsDisplayName(emitter::instrDesc* id)
     instruction ins     = id->idIns();
     const char* insName = genInsName(ins);
 
+#ifdef TARGET_XARCH
     const int       TEMP_BUFFER_LEN = 40;
     static unsigned curBuf          = 0;
     static char     buf[4][TEMP_BUFFER_LEN];
     const char*     retbuf;
 
-#ifdef TARGET_XARCH
     if (GetEmitter()->IsAVXInstruction(ins) && !GetEmitter()->IsBMIInstruction(ins))
     {
         sprintf_s(buf[curBuf], TEMP_BUFFER_LEN, "v%s", insName);

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -68,6 +68,9 @@ CONFIG_INTEGER(JitAlignLoopAdaptive,
                W("JitAlignLoopAdaptive"),
                1) // If set, perform adaptive loop alignment that limits number of padding based on loop size.
 
+// Print the alignment boundaries in disassembly.
+CONFIG_INTEGER(JitDasmWithAlignmentBoundaries, W("JitDasmWithAlignmentBoundaries"), 0)
+
 CONFIG_INTEGER(JitDirectAlloc, W("JitDirectAlloc"), 0)
 CONFIG_INTEGER(JitDoubleAlign, W("JitDoubleAlign"), 1)
 CONFIG_INTEGER(JitDumpASCII, W("JitDumpASCII"), 1)               // Uses only ASCII characters in tree dumps

--- a/src/coreclr/jit/jitstd/algorithm.h
+++ b/src/coreclr/jit/jitstd/algorithm.h
@@ -102,9 +102,9 @@ void quick_sort(RandomAccessIterator first, RandomAccessIterator last, Less less
             //
             // It's not possible for newFirst to go past the end of the sort range:
             //   - If newFirst reaches the pivot before newLast then the pivot is
-            //	   swapped to the right and we'll stop again when we reach it.
+            //     swapped to the right and we'll stop again when we reach it.
             //   - If newLast reaches the pivot before newFirst then the pivot is
-            //	   swapped to the left and the value at newFirst will take its place
+            //     swapped to the left and the value at newFirst will take its place
             //     to the right so less(newFirst, pivot) will again be false when the
             //     old pivot's position is reached.
             do

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -1320,10 +1320,14 @@ void Compiler::optPerformStaticOptimizations(unsigned loopNum, LoopCloneContext*
 
                 for (unsigned dim = 0; dim <= arrIndexInfo->dim; dim++)
                 {
+                    GenTree* bndsChkNode = arrIndexInfo->arrIndex.bndsChks[dim];
+
 #ifdef DEBUG
                     if (verbose)
                     {
-                        printf("Remove bounds check for stmt " FMT_STMT ", dim %d, ", arrIndexInfo->stmt->GetID(), dim);
+                        printf("Remove bounds check ");
+                        printTreeID(bndsChkNode->gtGetOp1());
+                        printf(" for " FMT_STMT ", dim% d, ", arrIndexInfo->stmt->GetID(), dim);
                         arrIndexInfo->arrIndex.Print();
                         printf(", bounds check nodes: ");
                         arrIndexInfo->arrIndex.PrintBoundsCheckNodes();
@@ -1331,7 +1335,6 @@ void Compiler::optPerformStaticOptimizations(unsigned loopNum, LoopCloneContext*
                     }
 #endif // DEBUG
 
-                    GenTree* bndsChkNode = arrIndexInfo->arrIndex.bndsChks[dim];
                     if (bndsChkNode->gtGetOp1()->OperIsBoundsCheck())
                     {
                         // This COMMA node will only represent a bounds check if we've haven't already removed this
@@ -2324,7 +2327,7 @@ Compiler::fgWalkResult Compiler::optCanOptimizeByLoopCloning(GenTree* tree, Loop
 #ifdef DEBUG
         if (verbose)
         {
-            printf("Found ArrIndex at tree ");
+            printf("Found ArrIndex at " FMT_BB " " FMT_STMT " tree ", arrIndex.useBlock->bbNum, info->stmt->GetID());
             printTreeID(tree);
             printf(" which is equivalent to: ");
             arrIndex.Print();

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -1176,6 +1176,7 @@ bool Compiler::optComputeDerefConditions(unsigned loopNum, LoopCloneContext* con
 
     if (maxRank == -1)
     {
+        JITDUMP("> maxRank undefined\n");
         return false;
     }
 
@@ -1184,12 +1185,13 @@ bool Compiler::optComputeDerefConditions(unsigned loopNum, LoopCloneContext* con
     // So add 1 after rank * 2.
     unsigned condBlocks = (unsigned)maxRank * 2 + 1;
 
-    // Heuristic to not create too many blocks.
-    // REVIEW: due to the definition of `condBlocks`, above, the effective max is 3 blocks, meaning
-    // `maxRank` of 1. Question: should the heuristic allow more blocks to be created in some situations?
-    // REVIEW: make this based on a COMPlus configuration?
-    if (condBlocks > 4)
+    // Heuristic to not create too many blocks. Defining as 5 allows, effectively, loop cloning on
+    // triply-nested loops.
+    // REVIEW: make this based on a COMPlus configuration, at least for debug?
+    const unsigned maxAllowedCondBlocks = 5;
+    if (condBlocks > maxAllowedCondBlocks)
     {
+        JITDUMP("> Too many condition blocks (%u > %u)\n", condBlocks, maxAllowedCondBlocks);
         return false;
     }
 

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -77,7 +77,7 @@ GenTree* LC_Array::ToGenTree(Compiler* comp, BasicBlock* bb)
             // Clear the range check flag and mark the index as non-faulting: we guarantee that all necessary range
             // checking has already been done by the time this array index expression is invoked.
             arr->gtFlags &= ~(GTF_INX_RNGCHK | GTF_EXCEPT);
-            arr->gtFlags |= GTF_INX_NONFAULTING;
+            arr->gtFlags |= GTF_INX_NOFAULT;
         }
         // If asked for arrlen invoke arr length operator.
         if (oper == ArrLen)

--- a/src/coreclr/jit/loopcloning.h
+++ b/src/coreclr/jit/loopcloning.h
@@ -739,6 +739,7 @@ struct LoopCloneContext
 #ifdef DEBUG
     // Print the block conditions for the loop.
     void PrintBlockConditions(unsigned loopNum);
+    void PrintBlockLevelConditions(unsigned level, JitExpandArrayStack<LC_Condition>* levelCond);
 #endif
 
     // Does the loop have block conditions?

--- a/src/coreclr/jit/loopcloning.h
+++ b/src/coreclr/jit/loopcloning.h
@@ -220,14 +220,8 @@ struct ArrIndex
     }
 
 #ifdef DEBUG
-    void Print(unsigned dim = -1)
-    {
-        printf("V%02d", arrLcl);
-        for (unsigned i = 0; i < ((dim == (unsigned)-1) ? rank : dim); ++i)
-        {
-            printf("[V%02d]", indLcls.GetRef(i));
-        }
-    }
+    void Print(unsigned dim = -1);
+    void PrintBoundsCheckNodes(unsigned dim = -1);
 #endif
 };
 
@@ -260,9 +254,8 @@ struct LcOptInfo
 #include "loopcloningopts.h"
     };
 
-    void*   optInfo;
     OptType optType;
-    LcOptInfo(void* optInfo, OptType optType) : optInfo(optInfo), optType(optType)
+    LcOptInfo(OptType optType) : optType(optType)
     {
     }
 
@@ -270,6 +263,7 @@ struct LcOptInfo
     {
         return optType;
     }
+
 #define LC_OPT(en)                                                                                                     \
     en##OptInfo* As##en##OptInfo()                                                                                     \
     {                                                                                                                  \
@@ -292,7 +286,7 @@ struct LcMdArrayOptInfo : public LcOptInfo
     ArrIndex* index;         // "index" cached computation in the form of an ArrIndex representation.
 
     LcMdArrayOptInfo(GenTreeArrElem* arrElem, unsigned dim)
-        : LcOptInfo(this, LcMdArray), arrElem(arrElem), dim(dim), index(nullptr)
+        : LcOptInfo(LcMdArray), arrElem(arrElem), dim(dim), index(nullptr)
     {
     }
 
@@ -325,7 +319,7 @@ struct LcJaggedArrayOptInfo : public LcOptInfo
     Statement* stmt;     // "stmt" where the optimization opportunity occurs.
 
     LcJaggedArrayOptInfo(ArrIndex& arrIndex, unsigned dim, Statement* stmt)
-        : LcOptInfo(this, LcJaggedArray), dim(dim), arrIndex(arrIndex), stmt(stmt)
+        : LcOptInfo(LcJaggedArray), dim(dim), arrIndex(arrIndex), stmt(stmt)
     {
     }
 };

--- a/src/coreclr/jit/loopcloning.h
+++ b/src/coreclr/jit/loopcloning.h
@@ -683,12 +683,8 @@ struct LoopCloneContext
     // The array of block levels of conditions for each loop. (loop x level x conditions)
     jitstd::vector<JitExpandArrayStack<JitExpandArrayStack<LC_Condition>*>*> blockConditions;
 
-    LoopCloneContext(unsigned loopCount, CompAllocator alloc) :
-        alloc(alloc),
-        optInfo(alloc),
-        conditions(alloc),
-        derefs(alloc),
-        blockConditions(alloc)
+    LoopCloneContext(unsigned loopCount, CompAllocator alloc)
+        : alloc(alloc), optInfo(alloc), conditions(alloc), derefs(alloc), blockConditions(alloc)
     {
         optInfo.resize(loopCount, nullptr);
         conditions.resize(loopCount, nullptr);

--- a/src/coreclr/jit/loopcloning.h
+++ b/src/coreclr/jit/loopcloning.h
@@ -672,30 +672,28 @@ struct LoopCloneContext
     CompAllocator alloc; // The allocator
 
     // The array of optimization opportunities found in each loop. (loop x optimization-opportunities)
-    JitExpandArrayStack<LcOptInfo*>** optInfo;
+    jitstd::vector<JitExpandArrayStack<LcOptInfo*>*> optInfo;
 
     // The array of conditions that influence which path to take for each loop. (loop x cloning-conditions)
-    JitExpandArrayStack<LC_Condition>** conditions;
+    jitstd::vector<JitExpandArrayStack<LC_Condition>*> conditions;
 
     // The array of dereference conditions found in each loop. (loop x deref-conditions)
-    JitExpandArrayStack<LC_Array>** derefs;
+    jitstd::vector<JitExpandArrayStack<LC_Array>*> derefs;
 
     // The array of block levels of conditions for each loop. (loop x level x conditions)
-    JitExpandArrayStack<JitExpandArrayStack<LC_Condition>*>** blockConditions;
+    jitstd::vector<JitExpandArrayStack<JitExpandArrayStack<LC_Condition>*>*> blockConditions;
 
-    LoopCloneContext(unsigned loopCount, CompAllocator alloc) : alloc(alloc)
+    LoopCloneContext(unsigned loopCount, CompAllocator alloc) :
+        alloc(alloc),
+        optInfo(alloc),
+        conditions(alloc),
+        derefs(alloc),
+        blockConditions(alloc)
     {
-        optInfo         = new (alloc) JitExpandArrayStack<LcOptInfo*>*[loopCount];
-        conditions      = new (alloc) JitExpandArrayStack<LC_Condition>*[loopCount];
-        derefs          = new (alloc) JitExpandArrayStack<LC_Array>*[loopCount];
-        blockConditions = new (alloc) JitExpandArrayStack<JitExpandArrayStack<LC_Condition>*>*[loopCount];
-        for (unsigned i = 0; i < loopCount; ++i)
-        {
-            optInfo[i]         = nullptr;
-            conditions[i]      = nullptr;
-            derefs[i]          = nullptr;
-            blockConditions[i] = nullptr;
-        }
+        optInfo.resize(loopCount, nullptr);
+        conditions.resize(loopCount, nullptr);
+        derefs.resize(loopCount, nullptr);
+        blockConditions.resize(loopCount, nullptr);
     }
 
     // Evaluate conditions into a JTRUE stmt and put it in the block. Reverse condition if 'reverse' is true.

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5577,8 +5577,8 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
     GenTree* arrRef = asIndex->Arr();
     GenTree* index  = asIndex->Index();
 
-    bool chkd             = ((tree->gtFlags & GTF_INX_RNGCHK) != 0);    // if false, range checking will be disabled
-    bool indexNonFaulting = ((tree->gtFlags & GTF_INX_NOFAULT) != 0);   // if true, mark GTF_IND_NONFAULTING
+    bool chkd             = ((tree->gtFlags & GTF_INX_RNGCHK) != 0);  // if false, range checking will be disabled
+    bool indexNonFaulting = ((tree->gtFlags & GTF_INX_NOFAULT) != 0); // if true, mark GTF_IND_NONFAULTING
     bool nCSE             = ((tree->gtFlags & GTF_DONT_CSE) != 0);
 
     GenTree* arrRefDefn = nullptr; // non-NULL if we need to allocate a temp for the arrRef expression

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5577,8 +5577,9 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
     GenTree* arrRef = asIndex->Arr();
     GenTree* index  = asIndex->Index();
 
-    bool chkd = ((tree->gtFlags & GTF_INX_RNGCHK) != 0); // if false, range checking will be disabled
-    bool nCSE = ((tree->gtFlags & GTF_DONT_CSE) != 0);
+    bool chkd             = ((tree->gtFlags & GTF_INX_RNGCHK) != 0);      // if false, range checking will be disabled
+    bool indexNonFaulting = ((tree->gtFlags & GTF_INX_NONFAULTING) != 0); // if true, mark GTF_IND_NONFAULTING
+    bool nCSE             = ((tree->gtFlags & GTF_DONT_CSE) != 0);
 
     GenTree* arrRefDefn = nullptr; // non-NULL if we need to allocate a temp for the arrRef expression
     GenTree* indexDefn  = nullptr; // non-NULL if we need to allocate a temp for the index expression
@@ -5738,9 +5739,9 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
         this->compFloatingPointUsed = true;
     }
 
-    // We've now consumed the GTF_INX_RNGCHK, and the node
+    // We've now consumed the GTF_INX_RNGCHK and GTF_INX_NONFAULTING, and the node
     // is no longer a GT_INDEX node.
-    tree->gtFlags &= ~GTF_INX_RNGCHK;
+    tree->gtFlags &= ~(GTF_INX_RNGCHK | GTF_INX_NONFAULTING);
 
     tree->AsOp()->gtOp1 = addr;
 
@@ -5748,7 +5749,7 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
     tree->gtFlags |= GTF_IND_ARR_INDEX;
 
     // If there's a bounds check, the indir won't fault.
-    if (bndsChk)
+    if (bndsChk || indexNonFaulting)
     {
         tree->gtFlags |= GTF_IND_NONFAULTING;
     }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5577,8 +5577,8 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
     GenTree* arrRef = asIndex->Arr();
     GenTree* index  = asIndex->Index();
 
-    bool chkd             = ((tree->gtFlags & GTF_INX_RNGCHK) != 0);      // if false, range checking will be disabled
-    bool indexNonFaulting = ((tree->gtFlags & GTF_INX_NONFAULTING) != 0); // if true, mark GTF_IND_NONFAULTING
+    bool chkd             = ((tree->gtFlags & GTF_INX_RNGCHK) != 0);    // if false, range checking will be disabled
+    bool indexNonFaulting = ((tree->gtFlags & GTF_INX_NOFAULT) != 0);   // if true, mark GTF_IND_NONFAULTING
     bool nCSE             = ((tree->gtFlags & GTF_DONT_CSE) != 0);
 
     GenTree* arrRefDefn = nullptr; // non-NULL if we need to allocate a temp for the arrRef expression
@@ -5739,9 +5739,9 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
         this->compFloatingPointUsed = true;
     }
 
-    // We've now consumed the GTF_INX_RNGCHK and GTF_INX_NONFAULTING, and the node
+    // We've now consumed the GTF_INX_RNGCHK and GTF_INX_NOFAULT, and the node
     // is no longer a GT_INDEX node.
-    tree->gtFlags &= ~(GTF_INX_RNGCHK | GTF_INX_NONFAULTING);
+    tree->gtFlags &= ~(GTF_INX_RNGCHK | GTF_INX_NOFAULT);
 
     tree->AsOp()->gtOp1 = addr;
 

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -166,7 +166,8 @@ Compiler::fgWalkResult Compiler::optCSE_MaskHelper(GenTree** pTree, fgWalkData* 
     if (IS_CSE_INDEX(tree->gtCSEnum))
     {
         unsigned cseIndex = GET_CSE_INDEX(tree->gtCSEnum);
-        unsigned cseBit   = genCSEnum2bit(cseIndex);
+        // Note that we DO NOT use getCSEAvailBit() here, for the CSE_defMask/CSE_useMask
+        unsigned cseBit = genCSEnum2bit(cseIndex);
         if (IS_CSE_DEF(tree->gtCSEnum))
         {
             BitVecOps::AddElemD(comp->cseMaskTraits, pUserData->CSE_defMask, cseBit);
@@ -424,16 +425,16 @@ unsigned Compiler::optValnumCSE_Index(GenTree* tree, Statement* stmt)
     ValueNum vnLibNorm = vnStore->VNNormalValue(vnLib);
 
     // We use the normal value number because we want the CSE candidate to
-    // represent all expressions that produce the same normal value number
+    // represent all expressions that produce the same normal value number.
     // We will handle the case where we have different exception sets when
     // promoting the candidates.
     //
     // We do this because a GT_IND will usually have a NullPtrExc entry in its
     // exc set, but we may have cleared the GTF_EXCEPT flag and if so, it won't
-    // have an NullPtrExc, or we may have assigned the value of an  GT_IND
+    // have an NullPtrExc, or we may have assigned the value of an GT_IND
     // into a LCL_VAR and then read it back later.
     //
-    // When we are promoting the CSE candidates we insure that any CSE
+    // When we are promoting the CSE candidates we ensure that any CSE
     // uses that we promote have an exc set that is the same as the CSE defs
     // or have an empty set.  And that all of the CSE defs produced the required
     // set of exceptions for the CSE uses.
@@ -502,7 +503,7 @@ unsigned Compiler::optValnumCSE_Index(GenTree* tree, Statement* stmt)
         key = vnLibNorm;
     }
 
-    // Make sure that the result of Is_Shared_Const_CSE(key) matches isSharedConst
+    // Make sure that the result of Is_Shared_Const_CSE(key) matches isSharedConst.
     // Note that when isSharedConst is true then we require that the TARGET_SIGN_BIT is set in the key
     // and otherwise we require that we never create a ValueNumber with the TARGET_SIGN_BIT set.
     //
@@ -709,7 +710,6 @@ unsigned Compiler::optValnumCSE_Index(GenTree* tree, Statement* stmt)
         C_ASSERT((signed char)MAX_CSE_CNT == MAX_CSE_CNT);
 
         unsigned CSEindex = ++optCSECandidateCount;
-        // EXPSET_TP  CSEmask  = genCSEnum2bit(CSEindex);
 
         /* Record the new CSE index in the hashDsc */
         hashDsc->csdIndex = CSEindex;
@@ -746,16 +746,14 @@ unsigned Compiler::optValnumCSE_Index(GenTree* tree, Statement* stmt)
     }
 }
 
-/*****************************************************************************
- *
- *  Locate CSE candidates and assign indices to them
- *  return 0 if no CSE candidates were found
- */
-
-unsigned Compiler::optValnumCSE_Locate()
+//------------------------------------------------------------------------
+// optValnumCSE_Locate: Locate CSE candidates and assign them indices.
+//
+// Returns:
+//    true if there are any CSE candidates, false otherwise
+//
+bool Compiler::optValnumCSE_Locate()
 {
-    // Locate CSE candidates and assign them indices
-
     bool enableConstCSE = true;
 
     int configValue = JitConfig.JitConstCSE();
@@ -871,14 +869,14 @@ unsigned Compiler::optValnumCSE_Locate()
 
     if (!optDoCSE)
     {
-        return 0;
+        return false;
     }
 
     /* We're finished building the expression lookup table */
 
     optCSEstop();
 
-    return 1;
+    return true;
 }
 
 //------------------------------------------------------------------------
@@ -890,7 +888,7 @@ unsigned Compiler::optValnumCSE_Locate()
 //
 // Arguments:
 //    compare - The compare node to check
-
+//
 void Compiler::optCseUpdateCheckedBoundMap(GenTree* compare)
 {
     assert(compare->OperIsCompare());
@@ -999,9 +997,9 @@ void Compiler::optValnumCSE_InitDataFlow()
     // Init traits and cseCallKillsMask bitvectors.
     cseLivenessTraits = new (getAllocator(CMK_CSE)) BitVecTraits(bitCount, this);
     cseCallKillsMask  = BitVecOps::MakeEmpty(cseLivenessTraits);
-    for (unsigned inx = 0; inx < optCSECandidateCount; inx++)
+    for (unsigned inx = 1; inx <= optCSECandidateCount; inx++)
     {
-        unsigned cseAvailBit = inx * 2;
+        unsigned cseAvailBit = getCSEAvailBit(inx);
 
         // a one preserves availability and a zero kills the availability
         // we generate this kind of bit pattern:  101010101010
@@ -1047,7 +1045,7 @@ void Compiler::optValnumCSE_InitDataFlow()
         block->bbCseGen = BitVecOps::MakeEmpty(cseLivenessTraits);
     }
 
-    // We walk the set of CSE candidates and set the bit corresponsing to the CSEindex
+    // We walk the set of CSE candidates and set the bit corresponding to the CSEindex
     // in the block's bbCseGen bitset
     //
     for (unsigned inx = 0; inx < optCSECandidateCount; inx++)
@@ -1060,16 +1058,16 @@ void Compiler::optValnumCSE_InitDataFlow()
         while (lst != nullptr)
         {
             BasicBlock* block                = lst->tslBlock;
-            unsigned    CseAvailBit          = genCSEnum2bit(CSEindex) * 2;
-            unsigned    cseAvailCrossCallBit = CseAvailBit + 1;
+            unsigned    cseAvailBit          = getCSEAvailBit(CSEindex);
+            unsigned    cseAvailCrossCallBit = getCSEAvailCrossCallBit(CSEindex);
 
-            // This CSE is generated in 'block', we always set the CseAvailBit
+            // This CSE is generated in 'block', we always set the cseAvailBit
             // If this block does not contain a call, we also set cseAvailCrossCallBit
             //
             // If we have a call in this block then in the loop below we walk the trees
             // backwards to find any CSEs that are generated after the last call in the block.
             //
-            BitVecOps::AddElemD(cseLivenessTraits, block->bbCseGen, CseAvailBit);
+            BitVecOps::AddElemD(cseLivenessTraits, block->bbCseGen, cseAvailBit);
             if ((block->bbFlags & BBF_HAS_CALL) == 0)
             {
                 BitVecOps::AddElemD(cseLivenessTraits, block->bbCseGen, cseAvailCrossCallBit);
@@ -1113,7 +1111,7 @@ void Compiler::optValnumCSE_InitDataFlow()
                 if (IS_CSE_INDEX(tree->gtCSEnum))
                 {
                     unsigned CSEnum               = GET_CSE_INDEX(tree->gtCSEnum);
-                    unsigned cseAvailCrossCallBit = (genCSEnum2bit(CSEnum) * 2) + 1;
+                    unsigned cseAvailCrossCallBit = getCSEAvailCrossCallBit(CSEnum);
                     BitVecOps::AddElemD(cseLivenessTraits, block->bbCseGen, cseAvailCrossCallBit);
                 }
                 if (tree->OperGet() == GT_CALL)
@@ -1142,15 +1140,16 @@ void Compiler::optValnumCSE_InitDataFlow()
         bool headerPrinted = false;
         for (BasicBlock* const block : Blocks())
         {
-            if (block->bbCseGen != nullptr)
+            if (!BitVecOps::IsEmpty(cseLivenessTraits, block->bbCseGen))
             {
                 if (!headerPrinted)
                 {
                     printf("\nBlocks that generate CSE def/uses\n");
                     headerPrinted = true;
                 }
-                printf(FMT_BB, block->bbNum);
-                printf(" cseGen = %s\n", genES2str(cseLivenessTraits, block->bbCseGen));
+                printf(FMT_BB " cseGen = ", block->bbNum);
+                optPrintCSEDataFlowSet(block->bbCseGen);
+                printf("\n");
             }
         }
     }
@@ -1184,6 +1183,7 @@ public:
         //
         BitVecOps::Assign(m_comp->cseLivenessTraits, m_preMergeOut, block->bbCseOut);
 
+#if 0
 #ifdef DEBUG
         if (m_comp->verbose)
         {
@@ -1191,11 +1191,13 @@ public:
             printf("  :: cseOut    = %s\n", genES2str(m_comp->cseLivenessTraits, block->bbCseOut));
         }
 #endif // DEBUG
+#endif // 0
     }
 
     // Merge: perform the merging of each of the predecessor's liveness values (since this is a forward analysis)
     void Merge(BasicBlock* block, BasicBlock* predBlock, unsigned dupCount)
     {
+#if 0
 #ifdef DEBUG
         if (m_comp->verbose)
         {
@@ -1204,15 +1206,18 @@ public:
             printf("  :: cseOut    = %s\n", genES2str(m_comp->cseLivenessTraits, block->bbCseOut));
         }
 #endif // DEBUG
+#endif // 0
 
         BitVecOps::IntersectionD(m_comp->cseLivenessTraits, block->bbCseIn, predBlock->bbCseOut);
 
+#if 0
 #ifdef DEBUG
         if (m_comp->verbose)
         {
             printf("  => cseIn     = %s\n", genES2str(m_comp->cseLivenessTraits, block->bbCseIn));
         }
 #endif // DEBUG
+#endif // 0
     }
 
     //------------------------------------------------------------------------
@@ -1272,6 +1277,7 @@ public:
         //
         bool notDone = !BitVecOps::Equal(m_comp->cseLivenessTraits, block->bbCseOut, m_preMergeOut);
 
+#if 0
 #ifdef DEBUG
         if (m_comp->verbose)
         {
@@ -1288,6 +1294,7 @@ public:
                    notDone ? "true" : "false");
         }
 #endif // DEBUG
+#endif // 0
 
         return notDone;
     }
@@ -1330,10 +1337,12 @@ void Compiler::optValnumCSE_DataFlow()
 
         for (BasicBlock* const block : Blocks())
         {
-            printf(FMT_BB, block->bbNum);
-            printf(" cseIn  = %s,", genES2str(cseLivenessTraits, block->bbCseIn));
-            printf(" cseGen = %s,", genES2str(cseLivenessTraits, block->bbCseGen));
-            printf(" cseOut = %s", genES2str(cseLivenessTraits, block->bbCseOut));
+            printf(FMT_BB " in gen out\n", block->bbNum);
+            optPrintCSEDataFlowSet(block->bbCseIn);
+            printf("\n");
+            optPrintCSEDataFlowSet(block->bbCseGen);
+            printf("\n");
+            optPrintCSEDataFlowSet(block->bbCseOut);
             printf("\n");
         }
 
@@ -1347,17 +1356,17 @@ void Compiler::optValnumCSE_DataFlow()
 //
 //     Using the information computed by CSE_DataFlow determine for each
 //     CSE whether the CSE is a definition (if the CSE was not available)
-//     or if the CSE is a use (if the CSE was previously made available)
-//     The implementation iterates of all blocks setting 'available_cses'
+//     or if the CSE is a use (if the CSE was previously made available).
+//     The implementation iterates over all blocks setting 'available_cses'
 //     to the CSEs that are available at input to the block.
 //     When a CSE expression is encountered it is classified as either
 //     as a definition (if the CSE is not in the 'available_cses' set) or
-//     as a use (if the CSE is  in the 'available_cses' set).  If the CSE
+//     as a use (if the CSE is in the 'available_cses' set).  If the CSE
 //     is a definition then it is added to the 'available_cses' set.
 //
 //     This algorithm uncovers the defs and uses gradually and as it does
 //     so it also builds the exception set that all defs make: 'defExcSetCurrent'
-//     and the exception set that the uses we have seen depend upon: 'defExcSetPromise'
+//     and the exception set that the uses we have seen depend upon: 'defExcSetPromise'.
 //
 //     Typically expressions with the same normal ValueNum generate exactly the
 //     same exception sets. There are two way that we can get different exception
@@ -1371,11 +1380,10 @@ void Compiler::optValnumCSE_DataFlow()
 //     2. We stored an expression into a LclVar or into Memory and read it later
 //        e.g. t = p.a;
 //             e1 = (t + q.b)    :: e1 has one NullPtrExc and e2 has two.
-//             e2 = (p.a + q.b)     but both compute the same normal value//
+//             e2 = (p.a + q.b)     but both compute the same normal value
 //        e.g. m.a = p.a;
 //             e1 = (m.a + q.b)  :: e1 and e2 have different exception sets.
 //             e2 = (p.a + q.b)     but both compute the same normal value
-//
 //
 void Compiler::optValnumCSE_Availablity()
 {
@@ -1411,12 +1419,12 @@ void Compiler::optValnumCSE_Availablity()
                 if (IS_CSE_INDEX(tree->gtCSEnum))
                 {
                     unsigned             CSEnum               = GET_CSE_INDEX(tree->gtCSEnum);
-                    unsigned             CseAvailBit          = genCSEnum2bit(CSEnum) * 2;
-                    unsigned             cseAvailCrossCallBit = CseAvailBit + 1;
+                    unsigned             cseAvailBit          = getCSEAvailBit(CSEnum);
+                    unsigned             cseAvailCrossCallBit = getCSEAvailCrossCallBit(CSEnum);
                     CSEdsc*              desc                 = optCSEfindDsc(CSEnum);
                     BasicBlock::weight_t stmw                 = block->getBBWeight(this);
 
-                    isUse = BitVecOps::IsMember(cseLivenessTraits, available_cses, CseAvailBit);
+                    isUse = BitVecOps::IsMember(cseLivenessTraits, available_cses, cseAvailBit);
                     isDef = !isUse; // If is isn't a CSE use, it is a CSE def
 
                     // Is this a "use", that we haven't yet marked as live across a call
@@ -1446,7 +1454,7 @@ void Compiler::optValnumCSE_Availablity()
                         printf(FMT_BB " ", block->bbNum);
                         printTreeID(tree);
 
-                        printf(" %s of CSE #%02u [weight=%s]%s\n", isUse ? "Use" : "Def", CSEnum, refCntWtd2str(stmw),
+                        printf(" %s of " FMT_CSE " [weight=%s]%s\n", isUse ? "Use" : "Def", CSEnum, refCntWtd2str(stmw),
                                madeLiveAcrossCall ? " *** Now Live Across Call ***" : "");
                     }
 #endif // DEBUG
@@ -1477,7 +1485,7 @@ void Compiler::optValnumCSE_Availablity()
                         // Is defExcSetCurrent still set to the uninit marker value of VNForNull() ?
                         if (desc->defExcSetCurrent == vnStore->VNForNull())
                         {
-                            // This is the first time visited, so record this defs exeception set
+                            // This is the first time visited, so record this defs exception set
                             desc->defExcSetCurrent = theLiberalExcSet;
                         }
 
@@ -1589,7 +1597,7 @@ void Compiler::optValnumCSE_Availablity()
                         tree->gtCSEnum = TO_CSE_DEF(tree->gtCSEnum);
 
                         // This CSE becomes available after this def
-                        BitVecOps::AddElemD(cseLivenessTraits, available_cses, CseAvailBit);
+                        BitVecOps::AddElemD(cseLivenessTraits, available_cses, cseAvailBit);
                         BitVecOps::AddElemD(cseLivenessTraits, available_cses, cseAvailCrossCallBit);
                     }
                     else // We are visiting a CSE use
@@ -1636,7 +1644,7 @@ void Compiler::optValnumCSE_Availablity()
                             if (!vnStore->VNExcIsSubset(desc->defExcSetPromise, theLiberalExcSet))
                             {
                                 // We can't safely make this into a CSE use, because this
-                                // CSE use has an exeception set item that is not promised
+                                // CSE use has an exception set item that is not promised
                                 // by all of our CSE defs.
                                 //
                                 // We will omit this CSE use from the graph and proceed,
@@ -1660,7 +1668,7 @@ void Compiler::optValnumCSE_Availablity()
 
                 // In order to determine if a CSE is live across a call, we model availablity using two bits and
                 // kill all of the cseAvailCrossCallBit for each CSE whenever we see a GT_CALL (unless the call
-                // generates A cse)
+                // generates a CSE).
                 //
                 if (tree->OperGet() == GT_CALL)
                 {
@@ -1690,7 +1698,7 @@ void Compiler::optValnumCSE_Availablity()
                                 // available_cses
                                 //
                                 unsigned CSEnum               = GET_CSE_INDEX(tree->gtCSEnum);
-                                unsigned cseAvailCrossCallBit = (genCSEnum2bit(CSEnum) * 2) + 1;
+                                unsigned cseAvailCrossCallBit = getCSEAvailCrossCallBit(CSEnum);
 
                                 BitVecOps::AddElemD(cseLivenessTraits, available_cses, cseAvailCrossCallBit);
                             }
@@ -2027,14 +2035,14 @@ public:
 
                 if (!Compiler::Is_Shared_Const_CSE(dsc->csdHashKey))
                 {
-                    printf("CSE #%02u, {$%-3x, $%-3x} useCnt=%d: [def=%3f, use=%3f, cost=%3u%s]\n        :: ",
+                    printf(FMT_CSE ", {$%-3x, $%-3x} useCnt=%d: [def=%3f, use=%3f, cost=%3u%s]\n        :: ",
                            dsc->csdIndex, dsc->csdHashKey, dsc->defExcSetPromise, dsc->csdUseCount, def, use, cost,
                            dsc->csdLiveAcrossCall ? ", call" : "      ");
                 }
                 else
                 {
                     size_t kVal = Compiler::Decode_Shared_Const_CSE_Value(dsc->csdHashKey);
-                    printf("CSE #%02u, {K_%p} useCnt=%d: [def=%3f, use=%3f, cost=%3u%s]\n        :: ", dsc->csdIndex,
+                    printf(FMT_CSE ", {K_%p} useCnt=%d: [def=%3f, use=%3f, cost=%3u%s]\n        :: ", dsc->csdIndex,
                            dspPtr(kVal), dsc->csdUseCount, def, use, cost,
                            dsc->csdLiveAcrossCall ? ", call" : "      ");
                 }
@@ -2814,7 +2822,7 @@ public:
 
         if (dsc->csdDefCount == 1)
         {
-            JITDUMP("CSE #%02u is single-def, so associated CSE temp V%02u will be in SSA\n", dsc->csdIndex,
+            JITDUMP(FMT_CSE " is single-def, so associated CSE temp V%02u will be in SSA\n", dsc->csdIndex,
                     cseLclVarNum);
             m_pCompiler->lvaTable[cseLclVarNum].lvInSsa = true;
 
@@ -2931,7 +2939,7 @@ public:
                         if (IS_CSE_INDEX(lst->tslTree->gtCSEnum))
                         {
                             ValueNum currVN = m_pCompiler->vnStore->VNLiberalNormalValue(lst->tslTree->gtVNPair);
-                            printf("0x%x(%s " FMT_VN ") ", lst->tslTree,
+                            printf("[%06d](%s " FMT_VN ") ", m_pCompiler->dspTreeID(lst->tslTree),
                                    IS_CSE_USE(lst->tslTree->gtCSEnum) ? "use" : "def", currVN);
                         }
                         lst = lst->tslNext;
@@ -2996,7 +3004,7 @@ public:
 #ifdef DEBUG
                 if (m_pCompiler->verbose)
                 {
-                    printf("\nWorking on the replacement of the CSE #%02u use at ", exp->gtCSEnum);
+                    printf("\nWorking on the replacement of the " FMT_CSE " use at ", exp->gtCSEnum);
                     Compiler::printTreeID(exp);
                     printf(" in " FMT_BB "\n", blk->bbNum);
                 }
@@ -3164,7 +3172,7 @@ public:
 #ifdef DEBUG
                 if (m_pCompiler->verbose)
                 {
-                    printf("\nCSE #%02u def at ", GET_CSE_INDEX(exp->gtCSEnum));
+                    printf("\n" FMT_CSE " def at ", GET_CSE_INDEX(exp->gtCSEnum));
                     Compiler::printTreeID(exp);
                     printf(" replaced in " FMT_BB " with def of V%02u\n", blk->bbNum, cseLclVarNum);
                 }
@@ -3314,13 +3322,13 @@ public:
 
             if (dsc->defExcSetPromise == ValueNumStore::NoVN)
             {
-                JITDUMP("Abandoned CSE #%02u because we had defs with different Exc sets\n", candidate.CseIndex());
+                JITDUMP("Abandoned " FMT_CSE " because we had defs with different Exc sets\n", candidate.CseIndex());
                 continue;
             }
 
             if (dsc->csdStructHndMismatch)
             {
-                JITDUMP("Abandoned CSE #%02u because we had mismatching struct handles\n", candidate.CseIndex());
+                JITDUMP("Abandoned " FMT_CSE " because we had mismatching struct handles\n", candidate.CseIndex());
                 continue;
             }
 
@@ -3328,7 +3336,7 @@ public:
 
             if (candidate.UseCount() == 0)
             {
-                JITDUMP("Skipped CSE #%02u because use count is 0\n", candidate.CseIndex());
+                JITDUMP("Skipped " FMT_CSE " because use count is 0\n", candidate.CseIndex());
                 continue;
             }
 
@@ -3337,14 +3345,14 @@ public:
             {
                 if (!Compiler::Is_Shared_Const_CSE(dsc->csdHashKey))
                 {
-                    printf("\nConsidering CSE #%02u {$%-3x, $%-3x} [def=%3f, use=%3f, cost=%3u%s]\n",
+                    printf("\nConsidering " FMT_CSE " {$%-3x, $%-3x} [def=%3f, use=%3f, cost=%3u%s]\n",
                            candidate.CseIndex(), dsc->csdHashKey, dsc->defExcSetPromise, candidate.DefCount(),
                            candidate.UseCount(), candidate.Cost(), dsc->csdLiveAcrossCall ? ", call" : "      ");
                 }
                 else
                 {
                     size_t kVal = Compiler::Decode_Shared_Const_CSE_Value(dsc->csdHashKey);
-                    printf("\nConsidering CSE #%02u {K_%p} [def=%3f, use=%3f, cost=%3u%s]\n", candidate.CseIndex(),
+                    printf("\nConsidering " FMT_CSE " {K_%p} [def=%3f, use=%3f, cost=%3u%s]\n", candidate.CseIndex(),
                            dspPtr(kVal), candidate.DefCount(), candidate.UseCount(), candidate.Cost(),
                            dsc->csdLiveAcrossCall ? ", call" : "      ");
                 }
@@ -3428,11 +3436,6 @@ void Compiler::optValnumCSE_Heuristic()
 void Compiler::optOptimizeValnumCSEs()
 {
 #ifdef DEBUG
-    if (verbose)
-    {
-        printf("\n*************** In optOptimizeValnumCSEs()\n");
-    }
-
     if (optConfigDisableCSE())
     {
         return; // Disabled by JitNoCSE
@@ -3441,22 +3444,13 @@ void Compiler::optOptimizeValnumCSEs()
 
     optValnumCSE_phase = true;
 
-    /* Initialize the expression tracking logic */
-
     optValnumCSE_Init();
 
-    /* Locate interesting expressions and assign indices to them */
-
-    if (optValnumCSE_Locate() > 0)
+    if (optValnumCSE_Locate())
     {
-        optCSECandidateTotal += optCSECandidateCount;
-
         optValnumCSE_InitDataFlow();
-
         optValnumCSE_DataFlow();
-
         optValnumCSE_Availablity();
-
         optValnumCSE_Heuristic();
     }
 
@@ -3807,21 +3801,11 @@ bool Compiler::optConfigDisableCSE2()
 
 void Compiler::optOptimizeCSEs()
 {
-#ifdef DEBUG
-    if (verbose)
-    {
-        printf("\n*************** In optOptimizeCSEs()\n");
-        printf("Blocks/Trees at start of optOptimizeCSE phase\n");
-        fgDispBasicBlocks(true);
-    }
-#endif // DEBUG
-
     optCSECandidateCount = 0;
     optCSEstart          = lvaCount;
 
     INDEBUG(optEnsureClearCSEInfo());
     optOptimizeValnumCSEs();
-    EndPhase(PHASE_OPTIMIZE_VALNUM_CSES);
 }
 
 /*****************************************************************************
@@ -3869,6 +3853,40 @@ void Compiler::optEnsureClearCSEInfo()
             {
                 assert(tree->gtCSEnum == NO_CSE);
             }
+        }
+    }
+}
+
+//------------------------------------------------------------------------
+// optPrintCSEDataFlowSet: Print out one of the CSE dataflow sets bbCseGen, bbCseIn, bbCseOut,
+// interpreting the bits in a more useful way for the dump.
+//
+// Arguments:
+//    cseDataFlowSet - One of the dataflow sets to display
+//    includeBits    - Display the actual bits of the set as well
+//
+void Compiler::optPrintCSEDataFlowSet(EXPSET_VALARG_TP cseDataFlowSet, bool includeBits /* = true */)
+{
+    if (includeBits)
+    {
+        printf("%s ", genES2str(cseLivenessTraits, cseDataFlowSet));
+    }
+
+    bool first = true;
+    for (unsigned cseIndex = 1; cseIndex <= optCSECandidateCount; cseIndex++)
+    {
+        unsigned cseAvailBit          = getCSEAvailBit(cseIndex);
+        unsigned cseAvailCrossCallBit = getCSEAvailCrossCallBit(cseIndex);
+
+        if (BitVecOps::IsMember(cseLivenessTraits, cseDataFlowSet, cseAvailBit))
+        {
+            if (!first)
+            {
+                printf(", ");
+            }
+            const bool isAvailCrossCall = BitVecOps::IsMember(cseLivenessTraits, cseDataFlowSet, cseAvailCrossCallBit);
+            printf(FMT_CSE "%s", cseIndex, isAvailCrossCall ? ".c" : "");
+            first = false;
         }
     }
 }

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -38,7 +38,6 @@ void Compiler::optInit()
     optNativeCallCount   = 0;
     optAssertionCount    = 0;
     optAssertionDep      = nullptr;
-    optCSECandidateTotal = 0;
     optCSEstart          = UINT_MAX;
     optCSEcount          = 0;
 }
@@ -5627,8 +5626,8 @@ void Compiler::optHoistLoopCode()
 #endif
 
 #if 0
-    // The code in this #if has been useful in debugging loop cloning issues, by
-    // enabling selective enablement of the loop cloning optimization according to
+    // The code in this #if has been useful in debugging loop hoisting issues, by
+    // enabling selective enablement of the loop hoisting optimization according to
     // method hash.
 #ifdef DEBUG
     unsigned methHash = info.compMethodHash();
@@ -5650,7 +5649,7 @@ void Compiler::optHoistLoopCode()
         return;
     printf("Doing loop hoisting in %s (0x%x).\n", info.compFullName, methHash);
 #endif // DEBUG
-#endif // 0     -- debugging loop cloning issues
+#endif // 0     -- debugging loop hoisting issues
 
 #ifdef DEBUG
     if (verbose)
@@ -5899,6 +5898,8 @@ void Compiler::optHoistThisLoop(unsigned lnum, LoopHoistContext* hoistCtxt)
 
             printf("\n  LOOPV-FP(%d)=", pLoopDsc->lpLoopVarFPCount);
             lvaDispVarSet(loopFPVars);
+
+            printf("\n");
         }
 #endif
     }

--- a/src/coreclr/jit/phase.cpp
+++ b/src/coreclr/jit/phase.cpp
@@ -84,8 +84,9 @@ void Phase::PrePhase()
     //
     // Currently the list is just the set of phases that have custom
     // derivations from the Phase class.
-    static Phases s_allowlist[] = {PHASE_BUILD_SSA, PHASE_RATIONALIZE, PHASE_LOWERING, PHASE_STACK_LEVEL_SETTER};
-    bool          doPrePhase    = false;
+    static Phases s_allowlist[] = {PHASE_BUILD_SSA, PHASE_OPTIMIZE_VALNUM_CSES, PHASE_RATIONALIZE, PHASE_LOWERING,
+                                   PHASE_STACK_LEVEL_SETTER};
+    bool doPrePhase = false;
 
     for (size_t i = 0; i < sizeof(s_allowlist) / sizeof(Phases); i++)
     {


### PR DESCRIPTION
When loop cloning was creating cloning conditions, it was creating unnecessary bounds checks in some multi-dimensional array index cases. When creating a set of cloning conditions, first a null check is done, then an array length check is done, etc. Thus, the array length expression itself won't fault because we've already done a null check. And a subsequent array index expression won't fault (or need a bounds check) because we've already checked the array length (i.e., we've done a manual bounds check). So, stop creating the unnecessary bounds checks, and mark the appropriate instructions as non-faulting by clearing the GTF_EXCEPT bit.
	
Note that I did not turn on the code to clear GTF_EXCEPT for array length checks because it leads to negative downstream effects in CSE. Namely, there end up being array length expressions that are identical except for the exception bit. When CSE sees this, it gives up on creating a CSE, which leads to regressions in some cases where we don't CSE the array length expression.

Also, for multi-dimension jagged arrays, when optimizing the fast path, we were not removing as many bounds checks as we could. In particular, we weren't removing outer bounds checks, only inner ones. Add code to handle all the bounds checks.

There are some runtime improvements (measured via BenchmarkDotNet on the JIT microbenchmarks), but also some regressions, due, as far as I can tell, to the Intel jcc erratum performance impact. In particular, benchmark ludcmp shows up to a 9% regression due to a `jae` instruction in the hot loop now crossing a 32-byte boundary due to code changes earlier in the function affecting instruction alignment. The hot loop itself is exactly the same (module register allocation differences). As there is nothing that can be done (without mitigating the jcc erratum) -- it's "bad luck".

In addition to those functional changes, there are a number of debugging-related improvements:
1. Loop cloning: (a) Improved dumping of cloning conditions and other things, (b) remove an unnecessary member to `LcOptInfo`, (c) convert the `LoopCloneContext` raw arrays to `jitstd::vector` for easier debugging, as clrjit.natvis can be taught to understand them.
2. CSE improvements: (a) Add `getCSEAvailBit` and `getCSEAvailCrossCallBit` functions to avoid multiple hard-codings of these expresions, (b) stop printing all the details of the CSE dataflow to JitDump; just print the result, (c) add `optPrintCSEDataFlowSet` function to print the CSE dataflow set in symbolic form, not just the raw bits, (d) added `FMT_CSE` string to use for formatting CSE candidates, (e) added `optOptimizeCSEs` to the phase structure for JitDump output, (f) remove unused `optCSECandidateTotal` (remnant of Valnum + lexical CSE)
3. Alignment: (a) Moved printing of alignment boundaries from `emitIssue1Instr` to `emitEndCodeGen`, to avoid the possibility of reading an instruction beyond the basic block. Also, improved the Intel jcc erratum criteria calculations, (b) Change `align` instructions of zero size to have a zero PerfScore throughput number (since they don't generate code), (c) Add `COMPlus_JitDasmWithAlignmentBoundaries` to force disasm output to display alignment boundaries.
4. Codegen / Emitter: (a) Added `emitLabelString` function for constructing a string to display for a bound emitter label. Created `emitPrintLabel` to directly print the label, (b) Add `genInsDisplayName` function to create a string for use when outputting an instruction. For xarch, this prepends the "v" for SIMD instructions, as necessary. This is preferable to calling the raw `genInsName` function, (c) For each insGroup, created a debug-only list of basic blocks that contributed code to that insGroup. Display this set of blocks in the JitDump disasm output, with block ID. This is useful for looking at an IG, and finding the blocks in a .dot flow graph visualization that contributed to it, (d) remove unused `instDisp`
5. Clrjit.natvis: (a) add support for `jitstd::vector`, `JitExpandArray<T>`, `JitExpandArrayStack<T>`, `LcOptInfo`.
6. Misc: (a) When compacting an empty loop preheader block with a subsequent block, clear the preheader flag.

## benchmarks.run.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 25504
Total bytes of diff: 25092
Total bytes of delta: -412 (-1.62% of base)
Total relative delta: -0.31
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -92 : 14861.dasm (-2.57% of base)
         -88 : 2430.dasm (-0.77% of base)
         -68 : 12182.dasm (-3.82% of base)
         -48 : 24678.dasm (-1.61% of base)
         -31 : 21598.dasm (-5.13% of base)
         -26 : 21601.dasm (-4.57% of base)
         -21 : 25069.dasm (-7.14% of base)
         -16 : 14859.dasm (-1.38% of base)
         -11 : 14862.dasm (-1.35% of base)
          -6 : 21600.dasm (-1.83% of base)
          -5 : 25065.dasm (-0.58% of base)

11 total files with Code Size differences (11 improved, 0 regressed), 1 unchanged.

Top method improvements (bytes):
         -92 (-2.57% of base) : 14861.dasm - LUDecomp:ludcmp(System.Double[][],int,System.Int32[],byref):int
         -88 (-0.77% of base) : 2430.dasm - System.DefaultBinder:BindToMethod(int,System.Reflection.MethodBase[],byref,System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[],byref):System.Reflection.MethodBase:this
         -68 (-3.82% of base) : 12182.dasm - AssignJagged:second_assignments(System.Int32[][],System.Int16[][])
         -48 (-1.61% of base) : 24678.dasm - Benchstone.BenchI.MulMatrix:Inner(System.Int32[][],System.Int32[][],System.Int32[][])
         -31 (-5.13% of base) : 21598.dasm - Benchstone.BenchI.Array2:Bench(int):bool
         -26 (-4.57% of base) : 21601.dasm - Benchstone.BenchI.Array2:VerifyCopy(System.Int32[][][],System.Int32[][][]):bool
         -21 (-7.14% of base) : 25069.dasm - Benchstone.BenchF.InProd:InnerProduct(byref,System.Double[][],System.Double[][],int,int)
         -16 (-1.38% of base) : 14859.dasm - LUDecomp:build_problem(System.Double[][],int,System.Double[])
         -11 (-1.35% of base) : 14862.dasm - LUDecomp:lubksb(System.Double[][],int,System.Int32[],System.Double[])
          -6 (-1.83% of base) : 21600.dasm - Benchstone.BenchI.Array2:Initialize(System.Int32[][][])
          -5 (-0.58% of base) : 25065.dasm - Benchstone.BenchF.InProd:Test():bool:this

Top method improvements (percentages):
         -21 (-7.14% of base) : 25069.dasm - Benchstone.BenchF.InProd:InnerProduct(byref,System.Double[][],System.Double[][],int,int)
         -31 (-5.13% of base) : 21598.dasm - Benchstone.BenchI.Array2:Bench(int):bool
         -26 (-4.57% of base) : 21601.dasm - Benchstone.BenchI.Array2:VerifyCopy(System.Int32[][][],System.Int32[][][]):bool
         -68 (-3.82% of base) : 12182.dasm - AssignJagged:second_assignments(System.Int32[][],System.Int16[][])
         -92 (-2.57% of base) : 14861.dasm - LUDecomp:ludcmp(System.Double[][],int,System.Int32[],byref):int
          -6 (-1.83% of base) : 21600.dasm - Benchstone.BenchI.Array2:Initialize(System.Int32[][][])
         -48 (-1.61% of base) : 24678.dasm - Benchstone.BenchI.MulMatrix:Inner(System.Int32[][],System.Int32[][],System.Int32[][])
         -16 (-1.38% of base) : 14859.dasm - LUDecomp:build_problem(System.Double[][],int,System.Double[])
         -11 (-1.35% of base) : 14862.dasm - LUDecomp:lubksb(System.Double[][],int,System.Int32[],System.Double[])
         -88 (-0.77% of base) : 2430.dasm - System.DefaultBinder:BindToMethod(int,System.Reflection.MethodBase[],byref,System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[],byref):System.Reflection.MethodBase:this
          -5 (-0.58% of base) : 25065.dasm - Benchstone.BenchF.InProd:Test():bool:this

11 total methods with Code Size differences (11 improved, 0 regressed), 1 unchanged.

```

</details>

--------------------------------------------------------------------------------

```

Summary of Perf Score diffs:
(Lower is better)

Total PerfScoreUnits of base: 38374.96
Total PerfScoreUnits of diff: 37914.07000000001
Total PerfScoreUnits of delta: -460.89 (-1.20% of base)
Total relative delta: -0.12
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (PerfScoreUnits):
     -220.67 : 24678.dasm (-1.74% of base)
      -99.27 : 14861.dasm (-2.09% of base)
      -66.30 : 21598.dasm (-1.41% of base)
      -18.73 : 2430.dasm (-0.28% of base)
      -18.40 : 21601.dasm (-1.37% of base)
       -9.73 : 25065.dasm (-0.56% of base)
       -9.05 : 14859.dasm (-0.77% of base)
       -5.51 : 21600.dasm (-0.77% of base)
       -4.15 : 12182.dasm (-0.17% of base)
       -3.92 : 14860.dasm (-0.32% of base)
       -3.46 : 25069.dasm (-2.31% of base)
       -1.70 : 14862.dasm (-0.20% of base)

12 total files with Perf Score differences (12 improved, 0 regressed), 0 unchanged.

Top method improvements (PerfScoreUnits):
     -220.67 (-1.74% of base) : 24678.dasm - Benchstone.BenchI.MulMatrix:Inner(System.Int32[][],System.Int32[][],System.Int32[][])
      -99.27 (-2.09% of base) : 14861.dasm - LUDecomp:ludcmp(System.Double[][],int,System.Int32[],byref):int
      -66.30 (-1.41% of base) : 21598.dasm - Benchstone.BenchI.Array2:Bench(int):bool
      -18.73 (-0.28% of base) : 2430.dasm - System.DefaultBinder:BindToMethod(int,System.Reflection.MethodBase[],byref,System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[],byref):System.Reflection.MethodBase:this
      -18.40 (-1.37% of base) : 21601.dasm - Benchstone.BenchI.Array2:VerifyCopy(System.Int32[][][],System.Int32[][][]):bool
       -9.73 (-0.56% of base) : 25065.dasm - Benchstone.BenchF.InProd:Test():bool:this
       -9.05 (-0.77% of base) : 14859.dasm - LUDecomp:build_problem(System.Double[][],int,System.Double[])
       -5.51 (-0.77% of base) : 21600.dasm - Benchstone.BenchI.Array2:Initialize(System.Int32[][][])
       -4.15 (-0.17% of base) : 12182.dasm - AssignJagged:second_assignments(System.Int32[][],System.Int16[][])
       -3.92 (-0.32% of base) : 14860.dasm - LUDecomp:DoLUIteration(System.Double[][],System.Double[],System.Double[][][],System.Double[][],int):long
       -3.46 (-2.31% of base) : 25069.dasm - Benchstone.BenchF.InProd:InnerProduct(byref,System.Double[][],System.Double[][],int,int)
       -1.70 (-0.20% of base) : 14862.dasm - LUDecomp:lubksb(System.Double[][],int,System.Int32[],System.Double[])

Top method improvements (percentages):
       -3.46 (-2.31% of base) : 25069.dasm - Benchstone.BenchF.InProd:InnerProduct(byref,System.Double[][],System.Double[][],int,int)
      -99.27 (-2.09% of base) : 14861.dasm - LUDecomp:ludcmp(System.Double[][],int,System.Int32[],byref):int
     -220.67 (-1.74% of base) : 24678.dasm - Benchstone.BenchI.MulMatrix:Inner(System.Int32[][],System.Int32[][],System.Int32[][])
      -66.30 (-1.41% of base) : 21598.dasm - Benchstone.BenchI.Array2:Bench(int):bool
      -18.40 (-1.37% of base) : 21601.dasm - Benchstone.BenchI.Array2:VerifyCopy(System.Int32[][][],System.Int32[][][]):bool
       -9.05 (-0.77% of base) : 14859.dasm - LUDecomp:build_problem(System.Double[][],int,System.Double[])
       -5.51 (-0.77% of base) : 21600.dasm - Benchstone.BenchI.Array2:Initialize(System.Int32[][][])
       -9.73 (-0.56% of base) : 25065.dasm - Benchstone.BenchF.InProd:Test():bool:this
       -3.92 (-0.32% of base) : 14860.dasm - LUDecomp:DoLUIteration(System.Double[][],System.Double[],System.Double[][][],System.Double[][],int):long
      -18.73 (-0.28% of base) : 2430.dasm - System.DefaultBinder:BindToMethod(int,System.Reflection.MethodBase[],byref,System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[],byref):System.Reflection.MethodBase:this
       -1.70 (-0.20% of base) : 14862.dasm - LUDecomp:lubksb(System.Double[][],int,System.Int32[],System.Double[])
       -4.15 (-0.17% of base) : 12182.dasm - AssignJagged:second_assignments(System.Int32[][],System.Int16[][])

12 total methods with Perf Score differences (12 improved, 0 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## coreclr_tests.pmi.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 25430
Total bytes of diff: 24994
Total bytes of delta: -436 (-1.71% of base)
Total relative delta: -0.42
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -92 : 194668.dasm (-2.57% of base)
         -68 : 194589.dasm (-3.82% of base)
         -48 : 248565.dasm (-1.61% of base)
         -32 : 249053.dasm (-3.58% of base)
         -31 : 251012.dasm (-5.13% of base)
         -26 : 251011.dasm (-4.57% of base)
         -19 : 248561.dasm (-6.76% of base)
         -16 : 194667.dasm (-1.38% of base)
         -15 : 252241.dasm (-0.72% of base)
         -12 : 252242.dasm (-0.81% of base)
         -11 : 194669.dasm (-1.35% of base)
          -9 : 246308.dasm (-1.06% of base)
          -9 : 246307.dasm (-1.06% of base)
          -9 : 246245.dasm (-1.06% of base)
          -9 : 246246.dasm (-1.06% of base)
          -6 : 228622.dasm (-0.77% of base)
          -6 : 251010.dasm (-1.83% of base)
          -5 : 248557.dasm (-0.61% of base)
          -4 : 249054.dasm (-0.50% of base)
          -4 : 249052.dasm (-0.47% of base)

22 total files with Code Size differences (22 improved, 0 regressed), 1 unchanged.

Top method improvements (bytes):
         -92 (-2.57% of base) : 194668.dasm - LUDecomp:ludcmp(System.Double[][],int,System.Int32[],byref):int
         -68 (-3.82% of base) : 194589.dasm - AssignJagged:second_assignments(System.Int32[][],System.Int16[][])
         -48 (-1.61% of base) : 248565.dasm - Benchstone.BenchI.MulMatrix:Inner(System.Int32[][],System.Int32[][],System.Int32[][])
         -32 (-3.58% of base) : 249053.dasm - SimpleArray_01.Test:BadMatrixMul2()
         -31 (-5.13% of base) : 251012.dasm - Benchstone.BenchI.Array2:Bench(int):bool
         -26 (-4.57% of base) : 251011.dasm - Benchstone.BenchI.Array2:VerifyCopy(System.Int32[][][],System.Int32[][][]):bool
         -19 (-6.76% of base) : 248561.dasm - Benchstone.BenchF.InProd:InnerProduct(byref,System.Double[][],System.Double[][],int,int)
         -16 (-1.38% of base) : 194667.dasm - LUDecomp:build_problem(System.Double[][],int,System.Double[])
         -15 (-0.72% of base) : 252241.dasm - Complex_Array_Test:Main(System.String[]):int
         -12 (-0.81% of base) : 252242.dasm - Simple_Array_Test:Main(System.String[]):int
         -11 (-1.35% of base) : 194669.dasm - LUDecomp:lubksb(System.Double[][],int,System.Int32[],System.Double[])
          -9 (-1.06% of base) : 246308.dasm - DefaultNamespace.MulDimJagAry:SetThreeDimJagVarAry(System.Object[][][],int,int):this
          -9 (-1.06% of base) : 246307.dasm - DefaultNamespace.MulDimJagAry:SetThreeDimJagAry(System.Object[][][],int,int):this
          -9 (-1.06% of base) : 246245.dasm - DefaultNamespace.MulDimJagAry:SetThreeDimJagAry(System.Object[][][],int,int):this
          -9 (-1.06% of base) : 246246.dasm - DefaultNamespace.MulDimJagAry:SetThreeDimJagVarAry(System.Object[][][],int,int):this
          -6 (-0.77% of base) : 228622.dasm - SciMark2.LU:solve(System.Double[][],System.Int32[],System.Double[])
          -6 (-1.83% of base) : 251010.dasm - Benchstone.BenchI.Array2:Initialize(System.Int32[][][])
          -5 (-0.61% of base) : 248557.dasm - Benchstone.BenchF.InProd:Bench():bool
          -4 (-0.50% of base) : 249054.dasm - SimpleArray_01.Test:BadMatrixMul3()
          -4 (-0.47% of base) : 249052.dasm - SimpleArray_01.Test:BadMatrixMul1()

Top method improvements (percentages):
         -19 (-6.76% of base) : 248561.dasm - Benchstone.BenchF.InProd:InnerProduct(byref,System.Double[][],System.Double[][],int,int)
         -31 (-5.13% of base) : 251012.dasm - Benchstone.BenchI.Array2:Bench(int):bool
         -26 (-4.57% of base) : 251011.dasm - Benchstone.BenchI.Array2:VerifyCopy(System.Int32[][][],System.Int32[][][]):bool
         -68 (-3.82% of base) : 194589.dasm - AssignJagged:second_assignments(System.Int32[][],System.Int16[][])
         -32 (-3.58% of base) : 249053.dasm - SimpleArray_01.Test:BadMatrixMul2()
         -92 (-2.57% of base) : 194668.dasm - LUDecomp:ludcmp(System.Double[][],int,System.Int32[],byref):int
          -6 (-1.83% of base) : 251010.dasm - Benchstone.BenchI.Array2:Initialize(System.Int32[][][])
         -48 (-1.61% of base) : 248565.dasm - Benchstone.BenchI.MulMatrix:Inner(System.Int32[][],System.Int32[][],System.Int32[][])
         -16 (-1.38% of base) : 194667.dasm - LUDecomp:build_problem(System.Double[][],int,System.Double[])
         -11 (-1.35% of base) : 194669.dasm - LUDecomp:lubksb(System.Double[][],int,System.Int32[],System.Double[])
          -3 (-1.11% of base) : 249057.dasm - SimpleArray_01.Test:Test2()
          -9 (-1.06% of base) : 246308.dasm - DefaultNamespace.MulDimJagAry:SetThreeDimJagVarAry(System.Object[][][],int,int):this
          -9 (-1.06% of base) : 246307.dasm - DefaultNamespace.MulDimJagAry:SetThreeDimJagAry(System.Object[][][],int,int):this
          -9 (-1.06% of base) : 246245.dasm - DefaultNamespace.MulDimJagAry:SetThreeDimJagAry(System.Object[][][],int,int):this
          -9 (-1.06% of base) : 246246.dasm - DefaultNamespace.MulDimJagAry:SetThreeDimJagVarAry(System.Object[][][],int,int):this
         -12 (-0.81% of base) : 252242.dasm - Simple_Array_Test:Main(System.String[]):int
          -6 (-0.77% of base) : 228622.dasm - SciMark2.LU:solve(System.Double[][],System.Int32[],System.Double[])
         -15 (-0.72% of base) : 252241.dasm - Complex_Array_Test:Main(System.String[]):int
          -5 (-0.61% of base) : 248557.dasm - Benchstone.BenchF.InProd:Bench():bool
          -4 (-0.50% of base) : 249054.dasm - SimpleArray_01.Test:BadMatrixMul3()

22 total methods with Code Size differences (22 improved, 0 regressed), 1 unchanged.

```

</details>

--------------------------------------------------------------------------------

```

Summary of Perf Score diffs:
(Lower is better)

Total PerfScoreUnits of base: 161610.68999999997
Total PerfScoreUnits of diff: 160290.10999999996
Total PerfScoreUnits of delta: -1320.58 (-0.82% of base)
Total relative delta: -0.20
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (PerfScoreUnits):
     -639.25 : 252241.dasm (-0.97% of base)
     -220.67 : 248565.dasm (-1.74% of base)
     -132.59 : 252242.dasm (-0.26% of base)
      -99.27 : 194668.dasm (-2.09% of base)
      -66.30 : 251012.dasm (-1.41% of base)
      -62.20 : 249053.dasm (-2.74% of base)
      -18.40 : 251011.dasm (-1.37% of base)
       -9.33 : 248557.dasm (-0.54% of base)
       -9.05 : 194667.dasm (-0.77% of base)
       -8.32 : 249054.dasm (-0.42% of base)
       -5.85 : 246308.dasm (-0.52% of base)
       -5.85 : 246307.dasm (-0.52% of base)
       -5.85 : 246245.dasm (-0.52% of base)
       -5.85 : 246246.dasm (-0.52% of base)
       -5.51 : 251010.dasm (-0.77% of base)
       -4.36 : 249052.dasm (-0.22% of base)
       -4.16 : 253363.dasm (-0.21% of base)
       -4.15 : 194589.dasm (-0.17% of base)
       -3.92 : 194666.dasm (-0.32% of base)
       -3.41 : 248561.dasm (-2.29% of base)

23 total files with Perf Score differences (23 improved, 0 regressed), 0 unchanged.

Top method improvements (PerfScoreUnits):
     -639.25 (-0.97% of base) : 252241.dasm - Complex_Array_Test:Main(System.String[]):int
     -220.67 (-1.74% of base) : 248565.dasm - Benchstone.BenchI.MulMatrix:Inner(System.Int32[][],System.Int32[][],System.Int32[][])
     -132.59 (-0.26% of base) : 252242.dasm - Simple_Array_Test:Main(System.String[]):int
      -99.27 (-2.09% of base) : 194668.dasm - LUDecomp:ludcmp(System.Double[][],int,System.Int32[],byref):int
      -66.30 (-1.41% of base) : 251012.dasm - Benchstone.BenchI.Array2:Bench(int):bool
      -62.20 (-2.74% of base) : 249053.dasm - SimpleArray_01.Test:BadMatrixMul2()
      -18.40 (-1.37% of base) : 251011.dasm - Benchstone.BenchI.Array2:VerifyCopy(System.Int32[][][],System.Int32[][][]):bool
       -9.33 (-0.54% of base) : 248557.dasm - Benchstone.BenchF.InProd:Bench():bool
       -9.05 (-0.77% of base) : 194667.dasm - LUDecomp:build_problem(System.Double[][],int,System.Double[])
       -8.32 (-0.42% of base) : 249054.dasm - SimpleArray_01.Test:BadMatrixMul3()
       -5.85 (-0.52% of base) : 246308.dasm - DefaultNamespace.MulDimJagAry:SetThreeDimJagVarAry(System.Object[][][],int,int):this
       -5.85 (-0.52% of base) : 246307.dasm - DefaultNamespace.MulDimJagAry:SetThreeDimJagAry(System.Object[][][],int,int):this
       -5.85 (-0.52% of base) : 246245.dasm - DefaultNamespace.MulDimJagAry:SetThreeDimJagAry(System.Object[][][],int,int):this
       -5.85 (-0.52% of base) : 246246.dasm - DefaultNamespace.MulDimJagAry:SetThreeDimJagVarAry(System.Object[][][],int,int):this
       -5.51 (-0.77% of base) : 251010.dasm - Benchstone.BenchI.Array2:Initialize(System.Int32[][][])
       -4.36 (-0.22% of base) : 249052.dasm - SimpleArray_01.Test:BadMatrixMul1()
       -4.16 (-0.21% of base) : 253363.dasm - MatrixMul.Test:MatrixMul()
       -4.15 (-0.17% of base) : 194589.dasm - AssignJagged:second_assignments(System.Int32[][],System.Int16[][])
       -3.92 (-0.32% of base) : 194666.dasm - LUDecomp:DoLUIteration(System.Double[][],System.Double[],System.Double[][][],System.Double[][],int):long
       -3.41 (-2.29% of base) : 248561.dasm - Benchstone.BenchF.InProd:InnerProduct(byref,System.Double[][],System.Double[][],int,int)

Top method improvements (percentages):
      -62.20 (-2.74% of base) : 249053.dasm - SimpleArray_01.Test:BadMatrixMul2()
       -3.41 (-2.29% of base) : 248561.dasm - Benchstone.BenchF.InProd:InnerProduct(byref,System.Double[][],System.Double[][],int,int)
      -99.27 (-2.09% of base) : 194668.dasm - LUDecomp:ludcmp(System.Double[][],int,System.Int32[],byref):int
     -220.67 (-1.74% of base) : 248565.dasm - Benchstone.BenchI.MulMatrix:Inner(System.Int32[][],System.Int32[][],System.Int32[][])
       -2.70 (-1.71% of base) : 249057.dasm - SimpleArray_01.Test:Test2()
      -66.30 (-1.41% of base) : 251012.dasm - Benchstone.BenchI.Array2:Bench(int):bool
      -18.40 (-1.37% of base) : 251011.dasm - Benchstone.BenchI.Array2:VerifyCopy(System.Int32[][][],System.Int32[][][]):bool
     -639.25 (-0.97% of base) : 252241.dasm - Complex_Array_Test:Main(System.String[]):int
       -9.05 (-0.77% of base) : 194667.dasm - LUDecomp:build_problem(System.Double[][],int,System.Double[])
       -5.51 (-0.77% of base) : 251010.dasm - Benchstone.BenchI.Array2:Initialize(System.Int32[][][])
       -9.33 (-0.54% of base) : 248557.dasm - Benchstone.BenchF.InProd:Bench():bool
       -5.85 (-0.52% of base) : 246308.dasm - DefaultNamespace.MulDimJagAry:SetThreeDimJagVarAry(System.Object[][][],int,int):this
       -5.85 (-0.52% of base) : 246307.dasm - DefaultNamespace.MulDimJagAry:SetThreeDimJagAry(System.Object[][][],int,int):this
       -5.85 (-0.52% of base) : 246245.dasm - DefaultNamespace.MulDimJagAry:SetThreeDimJagAry(System.Object[][][],int,int):this
       -5.85 (-0.52% of base) : 246246.dasm - DefaultNamespace.MulDimJagAry:SetThreeDimJagVarAry(System.Object[][][],int,int):this
       -8.32 (-0.42% of base) : 249054.dasm - SimpleArray_01.Test:BadMatrixMul3()
       -3.92 (-0.32% of base) : 194666.dasm - LUDecomp:DoLUIteration(System.Double[][],System.Double[],System.Double[][][],System.Double[][],int):long
     -132.59 (-0.26% of base) : 252242.dasm - Simple_Array_Test:Main(System.String[]):int
       -1.89 (-0.22% of base) : 228622.dasm - SciMark2.LU:solve(System.Double[][],System.Int32[],System.Double[])
       -4.36 (-0.22% of base) : 249052.dasm - SimpleArray_01.Test:BadMatrixMul1()

23 total methods with Perf Score differences (23 improved, 0 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.crossgen2.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 10828
Total bytes of diff: 10809
Total bytes of delta: -19 (-0.18% of base)
Total relative delta: -0.00
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -19 : 72504.dasm (-0.18% of base)

1 total files with Code Size differences (1 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -19 (-0.18% of base) : 72504.dasm - System.DefaultBinder:BindToMethod(int,System.Reflection.MethodBase[],byref,System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[],byref):System.Reflection.MethodBase:this

Top method improvements (percentages):
         -19 (-0.18% of base) : 72504.dasm - System.DefaultBinder:BindToMethod(int,System.Reflection.MethodBase[],byref,System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[],byref):System.Reflection.MethodBase:this

1 total methods with Code Size differences (1 improved, 0 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

```

Summary of Perf Score diffs:
(Lower is better)

Total PerfScoreUnits of base: 6597.12
Total PerfScoreUnits of diff: 6586.31
Total PerfScoreUnits of delta: -10.81 (-0.16% of base)
Total relative delta: -0.00
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (PerfScoreUnits):
      -10.81 : 72504.dasm (-0.16% of base)

1 total files with Perf Score differences (1 improved, 0 regressed), 0 unchanged.

Top method improvements (PerfScoreUnits):
      -10.81 (-0.16% of base) : 72504.dasm - System.DefaultBinder:BindToMethod(int,System.Reflection.MethodBase[],byref,System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[],byref):System.Reflection.MethodBase:this

Top method improvements (percentages):
      -10.81 (-0.16% of base) : 72504.dasm - System.DefaultBinder:BindToMethod(int,System.Reflection.MethodBase[],byref,System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[],byref):System.Reflection.MethodBase:this

1 total methods with Perf Score differences (1 improved, 0 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

