### PR TITLE
Fix perf regressions with a recent change.

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3406,6 +3406,8 @@ public:
     void lvaSetVarLiveInOutOfHandler(unsigned varNum);
     bool lvaVarDoNotEnregister(unsigned varNum);
 
+    void lvSetMinOptsDoNotEnreg();
+
     bool lvaEnregEHVars;
     bool lvaEnregMultiRegVars;
 

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1585,11 +1585,6 @@ inline unsigned Compiler::lvaGrabTemp(bool shortLifetime DEBUGARG(const char* re
     lvaTable[tempNum].lvIsTemp  = shortLifetime;
     lvaTable[tempNum].lvOnFrame = true;
 
-    if (!compEnregLocals())
-    {
-        lvaSetVarDoNotEnregister(tempNum DEBUGARG(Compiler::DNER_NoRegVars));
-    }
-
     // If we've started normal ref counting, bump the ref count of this
     // local, as we no longer do any incremental counting, and we presume
     // this new local will be referenced.

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5889,8 +5889,10 @@ PhaseStatus Lowering::DoPhase()
     if (!comp->compEnregLocals())
     {
         // Lowering is checking if lvDoNotEnregister is already set for contained optimizations.
-        // If we are running in min opts and know that we won't enregister any locals
-        // it is better to set this flag before we start reading it.
+        // If we are running without `CLFLG_REGVAR` flag set (`compEnregLocals() == false`)
+        // then we already know that we won't enregister any locals and it is better to set
+        // this flag before we start reading it.
+        // The main reason why this flag is not set is that we are running in minOpts.
         comp->lvSetMinOptsDoNotEnreg();
     }
 

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5891,7 +5891,7 @@ PhaseStatus Lowering::DoPhase()
         // Lowering is checking if lvDoNotEnregister is already set for contained optimizations.
         // If we are running without `CLFLG_REGVAR` flag set (`compEnregLocals() == false`)
         // then we already know that we won't enregister any locals and it is better to set
-        // this flag before we start reading it.
+        // `lvDoNotEnregister` flag before we start reading it.
         // The main reason why this flag is not set is that we are running in minOpts.
         comp->lvSetMinOptsDoNotEnreg();
     }

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5886,6 +5886,14 @@ PhaseStatus Lowering::DoPhase()
     }
 #endif // !defined(TARGET_64BIT)
 
+    if (!comp->compEnregLocals())
+    {
+        // Lowering is checking if lvDoNotEnregister is already set for contained optimizations.
+        // If we are running in min opts and know that we won't enregister any locals
+        // it is better to set this flag before we start reading it.
+        comp->lvSetMinOptsDoNotEnreg();
+    }
+
     for (BasicBlock* const block : comp->Blocks())
     {
         /* Make the block publicly available */

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -16004,6 +16004,14 @@ void Compiler::fgMorphBlocks()
 
 #endif
 
+    if (!compEnregLocals())
+    {
+        // Morph is checking if lvDoNotEnregister is already set for some optimizations.
+        // If we are running in min opts and know that we won't enregister any locals
+        // it is better to set this flag before we start reading it.
+        lvSetMinOptsDoNotEnreg();
+    }
+
     /*-------------------------------------------------------------------------
      * Process all basic blocks in the function
      */

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -16007,8 +16007,10 @@ void Compiler::fgMorphBlocks()
     if (!compEnregLocals())
     {
         // Morph is checking if lvDoNotEnregister is already set for some optimizations.
-        // If we are running in min opts and know that we won't enregister any locals
-        // it is better to set this flag before we start reading it.
+        // If we are running without `CLFLG_REGVAR` flag set (`compEnregLocals() == false`)
+        // then we already know that we won't enregister any locals and it is better to set
+        // this flag before we start reading it.
+        // The main reason why this flag is not set is that we are running in minOpts.
         lvSetMinOptsDoNotEnreg();
     }
 


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/54998 introduced a perf regression that this PR is fixing.

Thanks to @kunalspathak for catching and @EgorBo for repro help.

The regression was happening only when we switched from MinOpts to FullOpts and it was happening because of Tier0 QuickJitForLoops=disabled, so SPMI did not reproduce this scenario so it was not catched in my local testing.

We still want to have `doNotEnreg` flag to be known as soon as possible but with this change, we just add two additional iterations to set it for minopts in comparasing with the previous version that was trying to init it when we created a lclVar.

Why can't we init it when we create a lclVar? It is because at this time we don't know the final optimization level yet and we can't reset `doNotEnreg` flag after the optimization flag is finalized.

No SPMI diffs as expected but CoreRun with Tiering=1 shows improvements on methods with loops.