### PR TITLE
Fix race condition caused by updating interface map with exact target

### DIFF
--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -713,8 +713,10 @@ PTR_MethodTable InterfaceInfo_t::GetApproxMethodTable(Module * pContainingModule
 
         return pItfMT;
     }
-#endif
     MethodTable * pItfMT = m_pMethodTable.GetValue();
+#else
+    MethodTable * pItfMT = GetMethodTable();
+#endif
     ClassLoader::EnsureLoaded(TypeHandle(pItfMT), CLASS_LOAD_APPROXPARENTS);
     return pItfMT;
 }
@@ -9269,7 +9271,7 @@ MethodTable::ResolveVirtualStaticMethod(MethodTable* pInterfaceType, MethodDesc*
                     {
                         if (it.CurrentInterfaceMatches(this, pInterfaceType))
                         {
-                            // This is the variant interface check logic, skip the 
+                            // This is the variant interface check logic, skip the exact matches as they were handled above
                             continue;
                         }
 

--- a/src/coreclr/vm/methodtable.inl
+++ b/src/coreclr/vm/methodtable.inl
@@ -1578,7 +1578,16 @@ FORCEINLINE BOOL MethodTable::ImplementsInterfaceInline(MethodTable *pInterface)
 
         do
         {
-            if (pInfo->GetMethodTable()->HasSameTypeDefAs(pInterface) && pInfo->GetMethodTable()->IsSpecialMarkerTypeForGenericCasting())
+            MethodTable *pInterfaceInMap = pInfo->GetMethodTable();
+            if (pInterfaceInMap == pInterface)
+            {
+                // Since there is no locking on updating the interface with an exact match
+                // It is possible to reach here for a match which would ideally have been handled above
+                // GetMethodTable uses a VolatileLoadWithoutBarrier to prevent compiler optimizations
+                // from interfering with this check
+                return TRUE;
+            }
+            if (pInterfaceInMap->HasSameTypeDefAs(pInterface) && pInterfaceInMap->IsSpecialMarkerTypeForGenericCasting())
             {
                 // Extensible RCW's need to be handled specially because they can have interfaces
                 // in their map that are added at runtime. These interfaces will have a start offset

--- a/src/coreclr/vm/siginfo.cpp
+++ b/src/coreclr/vm/siginfo.cpp
@@ -1417,11 +1417,13 @@ TypeHandle SigPointer::GetTypeHandleThrowing(
 
             Instantiation genericLoadInst(thisinst, ntypars);
 
+#ifndef FEATURE_PREJIT // PREJIT doesn't support the volatile update semantics in the interface map that this requires
             if (pMTInterfaceMapOwner != NULL && genericLoadInst.ContainsAllOneType(pMTInterfaceMapOwner))
             {
                 thRet = ClassLoader::LoadTypeDefThrowing(pGenericTypeModule, tkGenericType, ClassLoader::ThrowIfNotFound, ClassLoader::PermitUninstDefOrRef, 0, level);
             }
             else
+#endif // FEATURE_PREJIT
             {
                 // Group together the current signature type context and substitution chain, which
                 // we may later use to instantiate constraints of type arguments that turn out to be


### PR DESCRIPTION
- Change interface map reading to reliably perform a volatile load (without barrier)
- When performing scan for exact interface match/match trhough SpecialMarkerTypeForGenericCasting, be careful to only read the map once and use that value for all comparisons
- All other uses of InterfaceMapIterator have been audited, and look to be safe

This may fix #54941