### PR TITLE
QUIC: fix handling of peer send abort

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -867,7 +867,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                     shouldReadComplete = true;
                 }
 
-                if (state.ReadState != ReadState.ConnectionClosed)
+                if (state.ReadState != ReadState.ConnectionClosed && state.ReadState != ReadState.Aborted)
                 {
                     state.ReadState = ReadState.ReadsCompleted;
                 }

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
@@ -436,7 +436,6 @@ namespace System.Net.Quic.Tests
             }).WaitAsync(TimeSpan.FromSeconds(15));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/53530")]
         [Fact]
         public async Task StreamAbortedWithoutWriting_ReadThrows()
         {
@@ -493,13 +492,7 @@ namespace System.Net.Quic.Tests
 
                     byte[] buffer = new byte[1024 * 1024];
 
-                    // TODO: it should always throw QuicStreamAbortedException, but sometimes it does not https://github.com/dotnet/runtime/issues/53530
-                    //QuicStreamAbortedException ex = await Assert.ThrowsAsync<QuicStreamAbortedException>(() => ReadAll(stream, buffer));
-                    try
-                    {
-                        await ReadAll(stream, buffer);
-                    }
-                    catch (QuicStreamAbortedException) { }
+                    QuicStreamAbortedException ex = await Assert.ThrowsAsync<QuicStreamAbortedException>(() => ReadAll(stream, buffer));
 
                     await stream.ShutdownCompleted();
                 }
@@ -555,13 +548,7 @@ namespace System.Net.Quic.Tests
                         }
                     }
 
-                    // TODO: it should always throw QuicStreamAbortedException, but sometimes it does not https://github.com/dotnet/runtime/issues/53530
-                    //QuicStreamAbortedException ex = await Assert.ThrowsAsync<QuicStreamAbortedException>(() => ReadUntilAborted());
-                    try
-                    {
-                        await ReadUntilAborted().WaitAsync(TimeSpan.FromSeconds(3));
-                    }
-                    catch { }
+                    QuicStreamAbortedException ex = await Assert.ThrowsAsync<QuicStreamAbortedException>(() => ReadUntilAborted());
 
                     await stream.ShutdownCompleted();
                 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/53530

When we receive SHUTDOWN_COMPLETE we should not overwrite ReadState.Aborted if it was previously set due to the peer aborting their send.

I ran StreamAbortedWithoutWriting_ReadThrows in a loop for 2+ minutes and did not see a failure here.
