### PR TITLE
Avoid nullref while trying to throw a more helpful exception.

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.DataContractSerialization/src/Resources/Strings.resx
@@ -1167,4 +1167,7 @@
   <data name="ReadOnlyCollectionDeserialization" xml:space="preserve">
     <value>Collection type '{0}' cannot be deserialized since it</value>
   </data>
+  <data name="UnknownNullType" xml:space="preserve">
+    <value>Unknown Type for null value</value>
+  </data>
 </root>

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerReadContext.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerReadContext.cs
@@ -361,8 +361,8 @@ namespace System.Runtime.Serialization
                 // throw in such cases to allow us add fix-up support in the future if we need to.
                 if (DeserializedObjects.IsObjectReferenced(id))
                 {
-                    var oldType = (oldObj != null) ? DataContract.GetClrTypeFullName(oldObj.GetType()) : "unknown type";
-                    var newType = (newObj != null) ? DataContract.GetClrTypeFullName(newObj.GetType()) : "unknown type";
+                    string oldType = (oldObj != null) ? DataContract.GetClrTypeFullName(oldObj.GetType()) : SR.UnknownNullType;
+                    string newType = (newObj != null) ? DataContract.GetClrTypeFullName(newObj.GetType()) : SR.UnknownNullType;
                     throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.FactoryObjectContainsSelfReference, oldType, newType, id)));
                 }
                 DeserializedObjects.Remove(id);

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerReadContext.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerReadContext.cs
@@ -361,9 +361,9 @@ namespace System.Runtime.Serialization
                 // throw in such cases to allow us add fix-up support in the future if we need to.
                 if (DeserializedObjects.IsObjectReferenced(id))
                 {
-                    // https://github.com/dotnet/runtime/issues/41465 - oldObj or newObj may be null below - suppress compiler error by asserting non-null
-                    Debug.Assert(oldObj != null && newObj != null);
-                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.FactoryObjectContainsSelfReference, DataContract.GetClrTypeFullName(oldObj.GetType()), DataContract.GetClrTypeFullName(newObj.GetType()), id)));
+                    var oldType = (oldObj != null) ? DataContract.GetClrTypeFullName(oldObj.GetType()) : "unknown type";
+                    var newType = (newObj != null) ? DataContract.GetClrTypeFullName(newObj.GetType()) : "unknown type";
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.FactoryObjectContainsSelfReference, oldType, newType, id)));
                 }
                 DeserializedObjects.Remove(id);
                 DeserializedObjects.Add(id, newObj);


### PR DESCRIPTION
Avoid nullref while trying to throw a more helpful exception.

The method checking for referential surrogates during deserialization
(`ReplaceDeserializedObject`) wants to throw a helpful exception when
it can't fix up references post-type-substitution. In order to actually be
helpful, avoid nullref-ing when one of the objects involved in the
replacement is null. Simply use the term "unknown type" instead.

Fixes #41465