### PR TITLE
Improve MetricEventSource error message

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MetricsEventSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MetricsEventSource.cs
@@ -138,9 +138,9 @@ namespace System.Diagnostics.Metrics
         }
 
         [Event(9, Keywords = Keywords.TimeSeriesValues | Keywords.Messages | Keywords.InstrumentPublishing)]
-        public void Error(string sessionId, string errorMessage, string errorStack)
+        public void Error(string sessionId, string errorMessage)
         {
-            WriteEvent(9, sessionId, errorMessage, errorStack);
+            WriteEvent(9, sessionId, errorMessage);
         }
 
         [Event(10, Keywords = Keywords.TimeSeriesValues | Keywords.InstrumentPublishing)]
@@ -203,7 +203,7 @@ namespace System.Diagnostics.Metrics
                         // This limitation shouldn't really matter because browser also doesn't support out-of-proc EventSource communication
                         // which is the intended scenario for this EventSource. If it matters in the future AggregationManager can be
                         // modified to have some other fallback path that works for browser.
-                        Log.Error("", "System.Diagnostics.Metrics EventSource not supported on browser", "");
+                        Log.Error("", "System.Diagnostics.Metrics EventSource not supported on browser");
                         return;
                     }
 #endif
@@ -301,7 +301,7 @@ namespace System.Diagnostics.Metrics
                             i => Log.EndInstrumentReporting(sessionId, i.Meter.Name, i.Meter.Version, i.Name, i.GetType().Name, i.Unit, i.Description),
                             i => Log.InstrumentPublished(sessionId, i.Meter.Name, i.Meter.Version, i.Name, i.GetType().Name, i.Unit, i.Description),
                             () => Log.InitialInstrumentEnumerationComplete(sessionId),
-                            e => Log.Error(sessionId, e.Message, e.StackTrace?.ToString() ?? ""),
+                            e => Log.Error(sessionId, e.ToString()),
                             () => Log.TimeSeriesLimitReached(sessionId),
                             () => Log.HistogramLimitReached(sessionId));
 
@@ -328,7 +328,7 @@ namespace System.Diagnostics.Metrics
 
             private bool LogError(Exception e)
             {
-                Log.Error(_sessionId, e.Message, e.StackTrace?.ToString() ?? "");
+                Log.Error(_sessionId, e.ToString());
                 // this code runs as an exception filter
                 // returning false ensures the catch handler isn't run
                 return false;

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricEventSourceTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricEventSourceTests.cs
@@ -1001,8 +1001,7 @@ namespace System.Diagnostics.Metrics.Tests
                 if (errorEvent != null)
                 {
                     string message = errorEvent.Payload[1].ToString();
-                    string stackTrace = errorEvent.Payload[2].ToString();
-                    Assert.True(errorEvent == null, "Unexpected Error event: " + message + Environment.NewLine + stackTrace);
+                    Assert.True(errorEvent == null, "Unexpected Error event: " + message);
                 }
             }
         }


### PR DESCRIPTION
The Error event wasn't capturing inner exception info in its message. Switching from Exception.Message to
Exception.ToString() captures more useful messages. We no longer split out the stack separately, but that
wasn't important. The error messages are likely only useful for humans anyway.

A failure showed up in CI and it appears the exception is missing inner exception info that would help track it down. The next time this fails we should get better diagnostics.