### PR TITLE
Swap using the provided indexes

### DIFF
--- a/src/coreclr/tools/Common/Sorting/ArrayAccessor.cs
+++ b/src/coreclr/tools/Common/Sorting/ArrayAccessor.cs
@@ -30,8 +30,8 @@ namespace ILCompiler.Sorting.Implementation
         public void SwapElements(T[] dataStructure, int i, int i2)
         {
             T temp = dataStructure[i];
-            dataStructure[i] = dataStructure[i + 1];
-            dataStructure[i + 1] = temp;
+            dataStructure[i] = dataStructure[i2];
+            dataStructure[i2] = temp;
         }
     }
 }

--- a/src/coreclr/tools/Common/Sorting/ListAccessor.cs
+++ b/src/coreclr/tools/Common/Sorting/ListAccessor.cs
@@ -39,8 +39,8 @@ namespace ILCompiler.Sorting.Implementation
         public void SwapElements(List<T> dataStructure, int i, int i2)
         {
             T temp = dataStructure[i];
-            dataStructure[i] = dataStructure[i + 1];
-            dataStructure[i + 1] = temp;
+            dataStructure[i] = dataStructure[i2];
+            dataStructure[i2] = temp;
         }
     }
 }


### PR DESCRIPTION
SwapElements is passed two indexes, however, it ignored the second index and instead used `index + 1`. It just so happened that the caller uses `index + 1` as the second index (as a result, this change should not change any behaviour) but that might not have been the case and the code is clearly wrong here.