### PR TITLE
H/3 and Quic AppContext switch

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/GlobalHttpSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/GlobalHttpSettings.cs
@@ -26,11 +26,11 @@ namespace System.Net.Http
                 "DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP2SUPPORT",
                 true);
 
-            // Default to disable HTTP/3 and QUIC, but enable that to be overridden
+            // Default to disable HTTP/3 (and by an extent QUIC), but enable that to be overridden
             // by an AppContext switch, or by an environment variable being set to true/1.
-            public static bool AllowHttp3AndQuic { get; } = RuntimeSettingParser.QueryRuntimeSettingSwitch(
-                "System.Net.SocketsHttpHandler.Http3AndQuicSupport",
-                "DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP3ANDQUICSUPPORT",
+            public static bool AllowHttp3 { get; } = RuntimeSettingParser.QueryRuntimeSettingSwitch(
+                "System.Net.SocketsHttpHandler.Http3Support",
+                "DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP3SUPPORT",
                 false);
 
             // Switch to disable the HTTP/2 dynamic window scaling algorithm. Enabled by default.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/GlobalHttpSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/GlobalHttpSettings.cs
@@ -26,12 +26,12 @@ namespace System.Net.Http
                 "DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP2SUPPORT",
                 true);
 
-            // Default to allowing draft HTTP/3, but enable that to be overridden
-            // by an AppContext switch, or by an environment variable being set to false/0.
-            public static bool AllowDraftHttp3 { get; } = RuntimeSettingParser.QueryRuntimeSettingSwitch(
-                "System.Net.SocketsHttpHandler.Http3DraftSupport",
-                "DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP3DRAFTSUPPORT",
-                true);
+            // Default to disable HTTP/3 and QUIC, but enable that to be overridden
+            // by an AppContext switch, or by an environment variable being set to true/1.
+            public static bool AllowHttp3AndQuic { get; } = RuntimeSettingParser.QueryRuntimeSettingSwitch(
+                "System.Net.SocketsHttpHandler.Http3AndQuicSupport",
+                "DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP3ANDQUICSUPPORT",
+                false);
 
             // Switch to disable the HTTP/2 dynamic window scaling algorithm. Enabled by default.
             public static bool DisableDynamicHttp2WindowSizing { get; } = RuntimeSettingParser.QueryRuntimeSettingSwitch(

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -67,7 +67,7 @@ namespace System.Net.Http
         public HttpConnectionSettings()
         {
             bool allowHttp2 = GlobalHttpSettings.SocketsHttpHandler.AllowHttp2;
-            bool allowHttp3 = GlobalHttpSettings.SocketsHttpHandler.AllowDraftHttp3;
+            bool allowHttp3 = GlobalHttpSettings.SocketsHttpHandler.AllowHttp3AndQuic;
             _maxHttpVersion =
                 allowHttp3 && allowHttp2 ? HttpVersion.Version30 :
                 allowHttp2 ? HttpVersion.Version20 :

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -67,7 +67,7 @@ namespace System.Net.Http
         public HttpConnectionSettings()
         {
             bool allowHttp2 = GlobalHttpSettings.SocketsHttpHandler.AllowHttp2;
-            bool allowHttp3 = GlobalHttpSettings.SocketsHttpHandler.AllowHttp3AndQuic;
+            bool allowHttp3 = GlobalHttpSettings.SocketsHttpHandler.AllowHttp3;
             _maxHttpVersion =
                 allowHttp3 && allowHttp2 ? HttpVersion.Version30 :
                 allowHttp2 ? HttpVersion.Version20 :

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <RuntimeHostConfigurationOption Include="System.Net.SocketsHttpHandler.Http3AndQuicSupport" Value="true" />
+    <RuntimeHostConfigurationOption Include="System.Net.SocketsHttpHandler.Http3Support" Value="true" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetOS)' == 'Browser'">

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -9,6 +9,10 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Linux;$(NetCoreAppCurrent)-Browser;$(NetCoreAppCurrent)-OSX</TargetFrameworks>
   </PropertyGroup>
 
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Net.SocketsHttpHandler.Http3AndQuicSupport" Value="true" />
+  </ItemGroup>
+
   <PropertyGroup Condition="'$(TargetOS)' == 'Browser'">
     <Scenario>WasmTestOnBrowser</Scenario>
     <TestArchiveTestsRoot>$(TestArchiveRoot)browseronly/</TestArchiveTestsRoot>

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/HttpStress.csproj
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/HttpStress.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <RuntimeHostConfigurationOption Include="System.Net.SocketsHttpHandler.Http3AndQuicSupport" Value="true" />
+    <RuntimeHostConfigurationOption Include="System.Net.SocketsHttpHandler.Http3Support" Value="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/HttpStress.csproj
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/HttpStress.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Net.SocketsHttpHandler.Http3AndQuicSupport" Value="true" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
@@ -125,11 +125,11 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
 
         static MsQuicApi()
         {
-            if (!IsHttp3AndQuicEnabled())
+            if (!IsHttp3Enabled())
             {
                 if (NetEventSource.Log.IsEnabled())
                 {
-                    NetEventSource.Info(null, $"HTTP/3 and QUIC is not enabled, see 'System.Net.SocketsHttpHandler.Http3AndQuicSupport' AppContext switch.");
+                    NetEventSource.Info(null, $"HTTP/3 and QUIC is not enabled, see 'System.Net.SocketsHttpHandler.Http3Support' AppContext switch.");
                 }
 
                 return;
@@ -174,18 +174,18 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         // Note that this is copy-pasted from S.N.Http just to hide S.N.Quic behind the same AppContext switch
         // since this library is considered "private" for 6.0.
         // We should get rid of this once S.N.Quic API surface is officially exposed.
-        private static bool IsHttp3AndQuicEnabled()
+        private static bool IsHttp3Enabled()
         {
             bool value;
 
             // First check for the AppContext switch, giving it priority over the environment variable.
-            if (AppContext.TryGetSwitch("System.Net.SocketsHttpHandler.Http3AndQuicSupport", out value))
+            if (AppContext.TryGetSwitch("System.Net.SocketsHttpHandler.Http3Support", out value))
             {
                 return value;
             }
 
             // AppContext switch wasn't used. Check the environment variable.
-            string? envVar = Environment.GetEnvironmentVariable("DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP3ANDQUICSUPPORT");
+            string? envVar = Environment.GetEnvironmentVariable("DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP3SUPPORT");
 
             if (bool.TryParse(envVar, out value))
             {

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/System.Net.Quic.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/System.Net.Quic.Functional.Tests.csproj
@@ -5,6 +5,9 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Net.SocketsHttpHandler.Http3AndQuicSupport" Value="true" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/System.Net.Quic.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/System.Net.Quic.Functional.Tests.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <RuntimeHostConfigurationOption Include="System.Net.SocketsHttpHandler.Http3AndQuicSupport" Value="true" />
+    <RuntimeHostConfigurationOption Include="System.Net.SocketsHttpHandler.Http3Support" Value="true" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="*.cs" />


### PR DESCRIPTION
H/3 and Quic are considered preview for .NET 6.0. We'll guard the usage with app context switch and potentially with `[RequiresPreviewFeatures]` attributes.
This PR does both to showcase it, but it's not a problem to decide to forgo one of them (probably the preview feature attribute).

Changes:
- Renamed original switch `Http3DraftSupport` to `Http3AndQuicSupport` to express it turns off/on S.N.Quic as well
- Annotated `HttpVersion.Http3` and S.N.Quic public types with `[RequiresPreviewFeatures]`
- Enabled H/3 and Quic in their testing libraries via project files


This change is also replacement for renaming S.N.Quic to private (#54720), which we decided not to bother with.


Fixes #55024