### PR TITLE
Fix NullReferenceException in background thread emitting IL in Depend…

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/DynamicServiceProviderEngine.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/DynamicServiceProviderEngine.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
@@ -37,6 +38,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                         catch (Exception ex)
                         {
                             DependencyInjectionEventSource.Log.ServiceRealizationFailed(ex);
+
+                            Debug.Fail($"We should never get exceptions from the background compilation.{Environment.NewLine}{ex}");
                         }
                     },
                     null);

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
@@ -32,11 +32,11 @@ namespace Microsoft.Extensions.DependencyInjection
 
         internal ServiceProvider(IEnumerable<ServiceDescriptor> serviceDescriptors, ServiceProviderOptions options)
         {
+            Root = new ServiceProviderEngineScope(this, isRootScope: true);
             _engine = GetEngine();
             _createServiceAccessor = CreateServiceAccessor;
             _realizedServices = new ConcurrentDictionary<Type, Func<ServiceProviderEngineScope, object>>();
 
-            Root = new ServiceProviderEngineScope(this, isRootScope: true);
             CallSiteFactory = new CallSiteFactory(serviceDescriptors);
             // The list of built in services that aren't part of the list of service descriptors
             // keep this in sync with CallSiteFactory.IsService

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         internal ServiceProvider(IEnumerable<ServiceDescriptor> serviceDescriptors, ServiceProviderOptions options)
         {
+            // note that Root needs to be set before calling GetEngine(), because the engine may need to access Root
             Root = new ServiceProviderEngineScope(this, isRootScope: true);
             _engine = GetEngine();
             _createServiceAccessor = CreateServiceAccessor;


### PR DESCRIPTION
…encyInjection

When ILEmitResolverBuilder is getting created, it grabs the "Root" scope off of the ServiceProvider. However, the Root scope isn't set on ServiceProvider yet. So later when it tries to get used, it null refs. But this exception gets caught an eaten since it happens on a background thread.

The fix is to set Root before creating the ServiceProviderEngine.

See description of the issue in https://github.com/dotnet/runtime/issues/55255#issuecomment-875994975.