### PR TITLE
fix read abort handling and revert CanRead/CanWrite to previous behavior

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -20,6 +20,9 @@ namespace System.Net.Quic.Implementations.MsQuic
 
         private readonly State _state = new State();
 
+        private readonly bool _canRead;
+        private readonly bool _canWrite;
+
         // Backing for StreamId
         private long _streamId = -1;
 
@@ -80,8 +83,10 @@ namespace System.Net.Quic.Implementations.MsQuic
         internal MsQuicStream(MsQuicConnection.State connectionState, SafeMsQuicStreamHandle streamHandle, QUIC_STREAM_OPEN_FLAGS flags)
         {
             _state.Handle = streamHandle;
+            _canRead = true;
+            _canWrite = !flags.HasFlag(QUIC_STREAM_OPEN_FLAGS.UNIDIRECTIONAL);
             _started = true;
-            if (flags.HasFlag(QUIC_STREAM_OPEN_FLAGS.UNIDIRECTIONAL))
+            if (!_canWrite)
             {
                 _state.SendState = SendState.Closed;
             }
@@ -122,8 +127,11 @@ namespace System.Net.Quic.Implementations.MsQuic
         {
             Debug.Assert(connectionState.Handle != null);
 
+            _canRead = !flags.HasFlag(QUIC_STREAM_OPEN_FLAGS.UNIDIRECTIONAL);
+            _canWrite = true;
+
             _state.StateGCHandle = GCHandle.Alloc(_state);
-            if (flags.HasFlag(QUIC_STREAM_OPEN_FLAGS.UNIDIRECTIONAL))
+            if (!_canRead)
             {
                 _state.ReadState = ReadState.Closed;
             }
@@ -167,9 +175,9 @@ namespace System.Net.Quic.Implementations.MsQuic
             }
         }
 
-        internal override bool CanRead => _disposed == 0 && _state.ReadState < ReadState.Aborted;
+        internal override bool CanRead => _disposed == 0 && _canRead;
 
-        internal override bool CanWrite => _disposed == 0 && _state.SendState < SendState.Aborted;
+        internal override bool CanWrite => _disposed == 0 && _canWrite;
 
         internal override long StreamId
         {
@@ -242,6 +250,11 @@ namespace System.Net.Quic.Implementations.MsQuic
             }
             else if ( _state.SendState == SendState.Aborted)
             {
+                if (_state.SendErrorCode != -1)
+                {
+                    throw new QuicStreamAbortedException(_state.SendErrorCode);
+                }
+
                 throw new OperationCanceledException(cancellationToken);
             }
 
@@ -292,6 +305,12 @@ namespace System.Net.Quic.Implementations.MsQuic
                 if (_state.SendState == SendState.Aborted)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
+
+                    if (_state.SendErrorCode != -1)
+                    {
+                        throw new QuicStreamAbortedException(_state.SendErrorCode);
+                    }
+
                     throw new OperationCanceledException(SR.net_quic_sending_aborted);
                 }
                 else if (_state.SendState == SendState.ConnectionClosed)

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
@@ -437,17 +437,15 @@ namespace System.Net.Quic.Tests
         }
 
         [Fact]
-        public async Task StreamAbortedWithoutWriting_ReadThrows()
+        public async Task WriteAbortedWithoutWriting_ReadThrows()
         {
-            long expectedErrorCode = 1234;
+            const long expectedErrorCode = 1234;
 
             await RunClientServer(
                 clientFunction: async connection =>
                 {
                     await using QuicStream stream = connection.OpenUnidirectionalStream();
                     stream.AbortWrite(expectedErrorCode);
-
-                    await stream.ShutdownCompleted();
                 },
                 serverFunction: async connection =>
                 {
@@ -458,7 +456,32 @@ namespace System.Net.Quic.Tests
                     QuicStreamAbortedException ex = await Assert.ThrowsAsync<QuicStreamAbortedException>(() => ReadAll(stream, buffer));
                     Assert.Equal(expectedErrorCode, ex.ErrorCode);
 
-                    await stream.ShutdownCompleted();
+                    // We should still return true from CanRead, even though the read has been aborted.
+                    Assert.True(stream.CanRead);
+                }
+            );
+        }
+
+        [Fact]
+        public async Task ReadAbortedWithoutReading_WriteThrows()
+        {
+            const long expectedErrorCode = 1234;
+
+            await RunClientServer(
+                clientFunction: async connection =>
+                {
+                    await using QuicStream stream = connection.OpenBidirectionalStream();
+                    stream.AbortRead(expectedErrorCode);
+                },
+                serverFunction: async connection =>
+                {
+                    await using QuicStream stream = await connection.AcceptStreamAsync();
+
+                    QuicStreamAbortedException ex = await Assert.ThrowsAsync<QuicStreamAbortedException>(() => WriteForever(stream));
+                    Assert.Equal(expectedErrorCode, ex.ErrorCode);
+
+                    // We should still return true from CanWrite, even though the write has been aborted.
+                    Assert.True(stream.CanWrite);
                 }
             );
         }
@@ -466,7 +489,7 @@ namespace System.Net.Quic.Tests
         [Fact]
         public async Task WritePreCanceled_Throws()
         {
-            long expectedErrorCode = 1234;
+            const long expectedErrorCode = 1234;
 
             await RunClientServer(
                 clientFunction: async connection =>
@@ -502,7 +525,7 @@ namespace System.Net.Quic.Tests
         [Fact]
         public async Task WriteCanceled_NextWriteThrows()
         {
-            long expectedErrorCode = 1234;
+            const long expectedErrorCode = 1234;
 
             await RunClientServer(
                 clientFunction: async connection =>

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
@@ -130,6 +130,15 @@ namespace System.Net.Quic.Tests
             return bytesRead;
         }
 
+        internal static async Task<int> WriteForever(QuicStream stream)
+        {
+            Memory<byte> buffer = new byte[] { 123 };
+            while (true)
+            {
+                await stream.WriteAsync(buffer);
+            }
+        }
+
         internal static void AssertArrayEqual(byte[] expected, byte[] actual)
         {
             for (int i = 0; i < expected.Length; ++i)


### PR DESCRIPTION
We are currently throwing OperationCancelledException when the peer aborts our write. We should be throwing QuicStreamAbortedException with the appropriate error code. Also fix mock provider to handle write abort and add test.

Also, https://github.com/dotnet/runtime/pull/54798 changed CanRead/CanWrite behavior to return false when completed or aborted, which broke some tests that rely on CanRead/CanWrite to distinguish between unidirectional and bidirectional streams. Revert the behavior of CanRead/CanWrite to previous behavior -- that is, only change these to false when the object is disposed.