### PR TITLE
[mono] Enable icall export for ios device builds.

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -346,6 +346,7 @@
       <_MonoCMakeArgs Include="-DENABLE_VISIBILITY_HIDDEN=1"/>
       <_MonoCMakeArgs Include="-DENABLE_LAZY_GC_THREAD_CREATION=1"/>
       <_MonoCMakeArgs Include="-DENABLE_SIGALTSTACK=0"/>
+      <_MonoCMakeArgs Include="-DENABLE_ICALL_EXPORT=1"/>
       <_MonoCFLAGS Include="-Werror=partial-availability" />
       <_MonoCFLAGS Condition="'$(TargetstvOS)' == 'true'" Include="-fno-gnu-inline-asm" />
       <_MonoCFLAGS Include="-fexceptions" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/55000
