### PR TITLE
Build all tasks, regardless of target

### DIFF
--- a/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
+++ b/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
@@ -161,7 +161,7 @@ public class AppleAppBuilderTask : Task
             throw new ArgumentException($"MainLibraryFileName='{MainLibraryFileName}' was not found in AppDir='{AppDir}'");
         }
 
-        if (ProjectName.Contains(" "))
+        if (ProjectName.Contains(' '))
         {
             throw new ArgumentException($"ProjectName='{ProjectName}' should not contain spaces");
         }

--- a/src/tasks/tasks.proj
+++ b/src/tasks/tasks.proj
@@ -1,18 +1,6 @@
 <Project Sdk="Microsoft.Build.Traversal">
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)**\*.csproj" />
-    <ProjectReference Remove="$(MSBuildThisFileDirectory)AndroidAppBuilder\AndroidAppBuilder.csproj"
-                      Condition="'$(TargetOS)' != 'Android'" />
-    <ProjectReference Remove="$(MSBuildThisFileDirectory)AppleAppBuilder\AppleAppBuilder.csproj"
-                      Condition="'$(TargetOS)' != 'MacCatalyst' and '$(TargetOS)' != 'iOS' and '$(TargetOS)' != 'iOSSimulator' and '$(TargetOS)' != 'tvOS' and '$(TargetOS)' != 'tvOSSimulator'" />
-    <ProjectReference Remove="$(MSBuildThisFileDirectory)WasmAppBuilder\WasmAppBuilder.csproj"
-                      Condition="'$(TargetOS)' != 'Browser'" />
-    <ProjectReference Remove="$(MSBuildThisFileDirectory)WasmBuildTasks\WasmBuildTasks.csproj"
-                      Condition="'$(TargetOS)' != 'Browser'" />
-    <ProjectReference Remove="$(MSBuildThisFileDirectory)AotCompilerTask\MonoAOTCompiler.csproj"
-                      Condition="'$(TargetsMobile)' != 'true'" />
-    <ProjectReference Remove="$(MSBuildThisFileDirectory)RuntimeConfigParser\RuntimeConfigParser.csproj"
-                      Condition="'$(TargetsMobile)' != 'true'" />
   </ItemGroup>
 
   <!--
@@ -41,8 +29,7 @@
   <Target Name="GetTasksSrc"
           DependsOnTargets="PrepareProjectReferences">
     <PropertyGroup>
-      <!-- if we build for several architectures in the same dirty tree, the tasks for one may be different from the tasks for another -->
-      <TasksIntermediateFile>$([MSBuild]::NormalizePath('$(ArtifactsObjDir)', '$(MSBuildProjectName)', 'Debug', 'build-semaphore-$(TargetOS).txt'))</TasksIntermediateFile>
+      <TasksIntermediateFile>$([MSBuild]::NormalizePath('$(ArtifactsObjDir)', '$(MSBuildProjectName)', 'Debug', 'build-semaphore.txt'))</TasksIntermediateFile>
     </PropertyGroup>
 
     <!-- Include both the project file and its sources as an input. -->

--- a/src/tasks/tasks.proj
+++ b/src/tasks/tasks.proj
@@ -41,7 +41,9 @@
   <Target Name="GetTasksSrc"
           DependsOnTargets="PrepareProjectReferences">
     <PropertyGroup>
-      <TasksIntermediateFile>$([MSBuild]::NormalizePath('$(ArtifactsObjDir)', '$(MSBuildProjectName)', 'Debug', 'build-semaphore.txt'))</TasksIntermediateFile>
+      <TasksIntermediateFile Condition="'$(TargetOS)' == '' or '$(TargetArchitecture)' == ''">$([MSBuild]::NormalizePath('$(ArtifactsObjDir)', '$(MSBuildProjectName)', 'Debug', 'build-semaphore.txt'))</TasksIntermediateFile>
+      <!-- if we build for several architectures in the same dirty tree, the tasks for one may be different from the tasks for another -->
+      <TasksIntermediateFile Condition="'$(TargetOS)' != '' and '$(TargetArchitecture)' != ''">$([MSBuild]::NormalizePath('$(ArtifactsObjDir)', '$(MSBuildProjectName)', 'Debug', 'build-semaphore-$(TargetOS)-$(TargetArchitecture).txt'))</TasksIntermediateFile>
     </PropertyGroup>
 
     <!-- Include both the project file and its sources as an input. -->

--- a/src/tasks/tasks.proj
+++ b/src/tasks/tasks.proj
@@ -41,9 +41,8 @@
   <Target Name="GetTasksSrc"
           DependsOnTargets="PrepareProjectReferences">
     <PropertyGroup>
-      <TasksIntermediateFile Condition="'$(TargetOS)' == '' or '$(TargetArchitecture)' == ''">$([MSBuild]::NormalizePath('$(ArtifactsObjDir)', '$(MSBuildProjectName)', 'Debug', 'build-semaphore.txt'))</TasksIntermediateFile>
       <!-- if we build for several architectures in the same dirty tree, the tasks for one may be different from the tasks for another -->
-      <TasksIntermediateFile Condition="'$(TargetOS)' != '' and '$(TargetArchitecture)' != ''">$([MSBuild]::NormalizePath('$(ArtifactsObjDir)', '$(MSBuildProjectName)', 'Debug', 'build-semaphore-$(TargetOS)-$(TargetArchitecture).txt'))</TasksIntermediateFile>
+      <TasksIntermediateFile>$([MSBuild]::NormalizePath('$(ArtifactsObjDir)', '$(MSBuildProjectName)', 'Debug', 'build-semaphore-$(TargetOS)-$(TargetArchitecture).txt'))</TasksIntermediateFile>
     </PropertyGroup>
 
     <!-- Include both the project file and its sources as an input. -->

--- a/src/tasks/tasks.proj
+++ b/src/tasks/tasks.proj
@@ -42,7 +42,7 @@
           DependsOnTargets="PrepareProjectReferences">
     <PropertyGroup>
       <!-- if we build for several architectures in the same dirty tree, the tasks for one may be different from the tasks for another -->
-      <TasksIntermediateFile>$([MSBuild]::NormalizePath('$(ArtifactsObjDir)', '$(MSBuildProjectName)', 'Debug', 'build-semaphore-$(TargetOS)-$(TargetArchitecture).txt'))</TasksIntermediateFile>
+      <TasksIntermediateFile>$([MSBuild]::NormalizePath('$(ArtifactsObjDir)', '$(MSBuildProjectName)', 'Debug', 'build-semaphore-$(TargetOS).txt'))</TasksIntermediateFile>
     </PropertyGroup>
 
     <!-- Include both the project file and its sources as an input. -->


### PR DESCRIPTION
In a dirty tree, different architectures require different tasks.

For example,
```
./build.sh --os iossimulator -c Release
./build.sh --os android -c Release
```
the second step will complain that the AndroidAppBuilder task does not exist,
because the build-semaphore.txt was created during the first build which built
the AppleAppBuilder, but not the AndroidAppBuilder.