### PR TITLE
Big-endian fixes: various problems in ilasm

### DIFF
--- a/src/coreclr/ilasm/asmman.cpp
+++ b/src/coreclr/ilasm/asmman.cpp
@@ -353,7 +353,7 @@ void AsmMan::EmitDebuggableAttribute(mdToken tkOwner)
         pbsSig->appendInt8(ELEMENT_TYPE_VOID);
         pbsSig->append(&bsSigArg);
 
-        bsBytes->appendInt32(pAsm->m_dwIncludeDebugInfo);
+        bsBytes->appendInt32(VAL32(pAsm->m_dwIncludeDebugInfo));
     }
     bsBytes->appendInt8(0);
     bsBytes->appendInt8(0);

--- a/src/coreclr/ilasm/asmparse.y
+++ b/src/coreclr/ilasm/asmparse.y
@@ -331,14 +331,14 @@ ownerType               : typeSpec                          { $$ = $1; }
 
 /*  Verbal description of custom attribute initialization blob  */
 customBlobDescr         : customBlobArgs customBlobNVPairs                      { $$ = $1;
-                                                                                  $$->appendInt16(nCustomBlobNVPairs);
+                                                                                  $$->appendInt16(VAL16(nCustomBlobNVPairs));
                                                                                   $$->append($2);
                                                                                   nCustomBlobNVPairs = 0; }
                         ;
 
 customBlobArgs          : /* EMPTY */                                           { $$ = new BinStr(); $$->appendInt16(VAL16(0x0001)); }
                         | customBlobArgs serInit                                { $$ = $1;
-                                                                                  $$->appendFrom($2, (*($2->ptr()) == ELEMENT_TYPE_SZARRAY) ? 2 : 1); }
+                                                                                  AppendFieldToCustomBlob($$,$2); }
                         | customBlobArgs compControl                            { $$ = $1; }
                         ;
 
@@ -347,7 +347,7 @@ customBlobNVPairs       : /* EMPTY */                                           
                                                                                 { $$ = $1; $$->appendInt8($2);
                                                                                   $$->append($3);
                                                                                   AppendStringWithLength($$,$4);
-                                                                                  $$->appendFrom($6, (*($6->ptr()) == ELEMENT_TYPE_SZARRAY) ? 2 : 1);
+                                                                                  AppendFieldToCustomBlob($$,$6);
                                                                                   nCustomBlobNVPairs++; }
                         | customBlobNVPairs compControl                         { $$ = $1; }
                         ;

--- a/src/coreclr/ilasm/assembler.h
+++ b/src/coreclr/ilasm/assembler.h
@@ -429,9 +429,9 @@ public:
         m_TypeSpec = type;
 
         m_pbsBlob = new BinStr();
-        m_pbsBlob->appendInt16(VAL16(1));     // prolog 0x01 0x00
-        m_pbsBlob->appendInt32((int)action);  // 4-byte action
-        if(pbsPairs)                          // name-value pairs if any
+        m_pbsBlob->appendInt16(VAL16(1));           // prolog 0x01 0x00
+        m_pbsBlob->appendInt32(VAL32((int)action)); // 4-byte action
+        if(pbsPairs)                                // name-value pairs if any
         {
             if(pbsPairs->length() > 2)
                 m_pbsBlob->appendFrom(pbsPairs,2);

--- a/src/coreclr/ilasm/grammar_before.cpp
+++ b/src/coreclr/ilasm/grammar_before.cpp
@@ -50,6 +50,7 @@ static char* newStringWDel(__in __nullterminated char* str1, char delimiter, __i
 static char* newString(__in __nullterminated const char* str1);
 static void corEmitInt(BinStr* buff, unsigned data);
 static void AppendStringWithLength(BinStr* pbs, __in __nullterminated char* sz);
+static void AppendFieldToCustomBlob(BinStr* pBlob, __in BinStr* pField);
 bool bParsingByteArray = FALSE;
 int iOpcodeLen = 0;
 int iCallConv = 0;

--- a/src/coreclr/ilasm/prebuilt/asmparse.cpp
+++ b/src/coreclr/ilasm/prebuilt/asmparse.cpp
@@ -2280,7 +2280,7 @@ case 73:
 case 74:
 #line 334 "asmparse.y"
 { yyval.binstr = yypvt[-1].binstr;
-                                                                                  yyval.binstr->appendInt16(nCustomBlobNVPairs);
+                                                                                  yyval.binstr->appendInt16(VAL16(nCustomBlobNVPairs));
                                                                                   yyval.binstr->append(yypvt[-0].binstr);
                                                                                   nCustomBlobNVPairs = 0; } break;
 case 75:
@@ -2289,7 +2289,7 @@ case 75:
 case 76:
 #line 341 "asmparse.y"
 { yyval.binstr = yypvt[-1].binstr;
-                                                                                  yyval.binstr->appendFrom(yypvt[-0].binstr, (*(yypvt[-0].binstr->ptr()) == ELEMENT_TYPE_SZARRAY) ? 2 : 1); } break;
+                                                                                  AppendFieldToCustomBlob(yyval.binstr,yypvt[-0].binstr); } break;
 case 77:
 #line 343 "asmparse.y"
 { yyval.binstr = yypvt[-1].binstr; } break;
@@ -2301,7 +2301,7 @@ case 79:
 { yyval.binstr = yypvt[-5].binstr; yyval.binstr->appendInt8(yypvt[-4].int32);
                                                                                   yyval.binstr->append(yypvt[-3].binstr);
                                                                                   AppendStringWithLength(yyval.binstr,yypvt[-2].string);
-                                                                                  yyval.binstr->appendFrom(yypvt[-0].binstr, (*(yypvt[-0].binstr->ptr()) == ELEMENT_TYPE_SZARRAY) ? 2 : 1);
+                                                                                  AppendFieldToCustomBlob(yyval.binstr,yypvt[-0].binstr);
                                                                                   nCustomBlobNVPairs++; } break;
 case 80:
 #line 353 "asmparse.y"

--- a/src/coreclr/ilasm/writer.cpp
+++ b/src/coreclr/ilasm/writer.cpp
@@ -1223,12 +1223,12 @@ HRESULT Assembler::CreatePEFile(__in __nullterminated WCHAR *pwzOutputFilename)
                 *pb = ELEMENT_TYPE_TYPEDEF;
                 memcpy(++pb,pTDD->m_szName,namesize);
                 pTDD->m_tkTypeSpec = ResolveLocalMemberRef(pTDD->m_tkTypeSpec);
-                memcpy(pb+namesize,&(pTDD->m_tkTypeSpec),sizeof(mdToken));
+                SET_UNALIGNED_VAL32(pb+namesize, pTDD->m_tkTypeSpec);
                 if(TypeFromToken(pTDD->m_tkTypeSpec)==mdtCustomAttribute)
                 {
                     CustomDescr* pCA = pTDD->m_pCA;
-                    pbs->appendInt32(pCA->tkType);
-                    pbs->appendInt32(pCA->tkOwner);
+                    pbs->appendInt32(VAL32(pCA->tkType));
+                    pbs->appendInt32(VAL32(pCA->tkOwner));
                     if(pCA->pBlob) pbs->append(pCA->pBlob);
                 }
                 ResolveTypeSpec(pbs);
@@ -1314,9 +1314,9 @@ HRESULT Assembler::CreatePEFile(__in __nullterminated WCHAR *pwzOutputFilename)
             {
                 Method* pMD;
                 Class* pClass;
-                m_pVTable->appendInt32(pGlobalLabel->m_GlobalOffset);
-                m_pVTable->appendInt16(pVTFEntry->m_wCount);
-                m_pVTable->appendInt16(pVTFEntry->m_wType);
+                m_pVTable->appendInt32(VAL32(pGlobalLabel->m_GlobalOffset));
+                m_pVTable->appendInt16(VAL16(pVTFEntry->m_wCount));
+                m_pVTable->appendInt16(VAL16(pVTFEntry->m_wType));
                 for(int i=0; (pClass = m_lstClass.PEEK(i)); i++)
                 {
                     for(WORD j = 0; (pMD = pClass->m_MethodList.PEEK(j)); j++)


### PR DESCRIPTION
While debugging problems running the roslyn test suite, I noticed a few more big-endian problems in ilasm:

* Byte-swap property and parameter default values of string type
Default values of string type are swapped to little-endian by the parser (`fieldInit`).  This has to be done there since "bytearray" values (which are provided by the user in little-endian format) are also encoded as string type, so we won't be able to tell the two cases apart later.  However, the MD layer expects default values of all types, including strings, to be in native byte order (they're swapped again on big-endian hosts in `CMiniMdBase::SwapConstant`).  In order to fix this mismatch, the default values of fields are already swapped yet another time by ilasm code in `Assembler::EmitField`.  However, that same problem exists for default values of parameters or properties.  This patch adds an equivalent swap operation there.

* Prepare custom attribute blobs in little-endian byte order
Custom attribute blobs (as opposed to default values) are expected to be provided in little-endian order by the MD layer.  This already works for attributes specifies as byte arrays.  But for attributes specified as structured values, values of all types except strings are currently provided in native order by the parser -- this is because `serInit` shares most of its implementation with `fieldInit` above.  To fix this, I've added a new helper `AppendFieldToCustomBlob` that copies a typed value over to the custom attribute blob, byte-swapping as necessary.   There are also a couple of places where ilasm synthesizes attribute blobs; some of those had a few byte swaps missing as well (see `AsmMan::EmitDebuggableAttribute` and the `PermissionDecl` constructor).

* Fix byte order of `ELEMENT_TYPE_TYPEDEF` typespec blobs and of VTable blobs
These two are unrelated to the above, just another set of instances where byte swaps were missing.

