### PR TITLE
Move DiagnosticsHandler.IsGloballyEnabled back to a method

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
@@ -31,10 +31,13 @@ namespace System.Net.Http
         {
             // check if there is a parent Activity (and propagation is not suppressed)
             // or if someone listens to HttpHandlerDiagnosticListener
-            return IsGloballyEnabled && (Activity.Current != null || s_diagnosticListener.IsEnabled());
+            return IsGloballyEnabled() && (Activity.Current != null || s_diagnosticListener.IsEnabled());
         }
 
-        internal static bool IsGloballyEnabled => GlobalHttpSettings.DiagnosticsHandler.EnableActivityPropagation;
+        internal static bool IsGloballyEnabled()
+        {
+            return GlobalHttpSettings.DiagnosticsHandler.EnableActivityPropagation;
+        }
 
         // SendAsyncCore returns already completed ValueTask for when async: false is passed.
         // Internally, it calls the synchronous Send method of the base class.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
@@ -34,10 +34,7 @@ namespace System.Net.Http
             return IsGloballyEnabled() && (Activity.Current != null || s_diagnosticListener.IsEnabled());
         }
 
-        internal static bool IsGloballyEnabled()
-        {
-            return GlobalHttpSettings.DiagnosticsHandler.EnableActivityPropagation;
-        }
+        internal static bool IsGloballyEnabled() => GlobalHttpSettings.DiagnosticsHandler.EnableActivityPropagation;
 
         // SendAsyncCore returns already completed ValueTask for when async: false is passed.
         // Internally, it calls the synchronous Send method of the base class.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
@@ -28,7 +28,7 @@ namespace System.Net.Http
         public HttpClientHandler()
         {
             _underlyingHandler = new HttpHandlerType();
-            if (DiagnosticsHandler.IsGloballyEnabled)
+            if (DiagnosticsHandler.IsGloballyEnabled())
             {
                 _diagnosticsHandler = new DiagnosticsHandler(_underlyingHandler);
             }


### PR DESCRIPTION
Intent is to make linker substitutions happy and try to unblock https://github.com/dotnet/sdk/pull/18801