### PR TITLE
[interp] Fix open delegates used with virtual methods of valuetypes

### DIFF
--- a/src/libraries/System.Runtime/tests/System/DelegateTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DelegateTests.cs
@@ -1118,7 +1118,6 @@ namespace System.Tests
             Assert.NotNull(ex.Message);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49839", TestRuntimes.Mono)]
         [Fact]
         public static void CreateDelegate10_Nullable_Method()
         {
@@ -1130,7 +1129,6 @@ namespace System.Tests
             Assert.Equal(num.ToString(), s);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49839", TestRuntimes.Mono)]
         [Fact]
         public static void CreateDelegate10_Nullable_ClosedDelegate()
         {

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -3433,7 +3433,7 @@ main_loop:
 						del_imethod = mono_interp_get_imethod (mono_marshal_get_native_wrapper (del_imethod->method, FALSE, FALSE), error);
 						mono_error_assert_ok (error);
 						del->interp_invoke_impl = del_imethod;
-					} else if (del_imethod->method->flags & METHOD_ATTRIBUTE_VIRTUAL && !del->target) {
+					} else if (del_imethod->method->flags & METHOD_ATTRIBUTE_VIRTUAL && !del->target && !m_class_is_valuetype (del_imethod->method->klass)) {
 						// 'this' is passed dynamically, we need to recompute the target method
 						// with each call
 						del_imethod = get_virtual_method (del_imethod, LOCAL_VAR (call_args_offset + MINT_STACK_SLOT_SIZE, MonoObject*)->vtable);


### PR DESCRIPTION
We were trying to resolve the virtual method on the this pointer (which is a managed pointer and not an object). If the delegate target method is declared on a valuetype, the method does not need resolving.

Fixes #49839