### PR TITLE
Update EnumerateLines docs

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.Globalization.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.Globalization.cs
@@ -385,7 +385,7 @@ namespace System
         /// Returns an enumeration of lines over the provided span.
         /// </summary>
         /// <remarks>
-        /// It is not recommended that protocol parsers utilize this API. See the documentation
+        /// It is recommended that protocol parsers not utilize this API. See the documentation
         /// for <see cref="string.ReplaceLineEndings"/> for more information on how newline
         /// sequences are detected.
         /// </remarks>
@@ -398,7 +398,7 @@ namespace System
         /// Returns an enumeration of lines over the provided span.
         /// </summary>
         /// <remarks>
-        /// It is not recommended that protocol parsers utilize this API. See the documentation
+        /// It is recommended that protocol parsers not utilize this API. See the documentation
         /// for <see cref="string.ReplaceLineEndings"/> for more information on how newline
         /// sequences are detected.
         /// </remarks>

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.Globalization.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.Globalization.cs
@@ -385,8 +385,9 @@ namespace System
         /// Returns an enumeration of lines over the provided span.
         /// </summary>
         /// <remarks>
-        /// See the documentation for <see cref="string.ReplaceLineEndings"/> for more information
-        /// on how newline sequences are detected.
+        /// It is not recommended that protocol parsers utilize this API. See the documentation
+        /// for <see cref="string.ReplaceLineEndings"/> for more information on how newline
+        /// sequences are detected.
         /// </remarks>
         public static SpanLineEnumerator EnumerateLines(this ReadOnlySpan<char> span)
         {
@@ -397,8 +398,9 @@ namespace System
         /// Returns an enumeration of lines over the provided span.
         /// </summary>
         /// <remarks>
-        /// See the documentation for <see cref="string.ReplaceLineEndings"/> for more information
-        /// on how newline sequences are detected.
+        /// It is not recommended that protocol parsers utilize this API. See the documentation
+        /// for <see cref="string.ReplaceLineEndings"/> for more information on how newline
+        /// sequences are detected.
         /// </remarks>
         public static SpanLineEnumerator EnumerateLines(this Span<char> span)
         {


### PR DESCRIPTION
Updates devdoc for `MemoryExtensions.EnumerateLines` to clarify that protocol parsers should not utilize this API. The exact reasoning for this is stated more explicitly in the `string.ReplaceLineEndings` devdoc, but I didn't want to copy and paste a huge block of text here.

This is a __doc-only change__; no runtime code is changed.