### PR TITLE
Use pthread_once instead of attempted idempotentcy when initializing OpenSSL

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
@@ -61,6 +61,8 @@ if (FEATURE_DISTRO_AGNOSTIC_SSL)
         opensslshim.c
     )
     add_definitions(-DFEATURE_DISTRO_AGNOSTIC_SSL)
+    add_compile_options(-pthread)
+    add_link_options(-pthread)
 endif()
 
 add_library(objlib OBJECT ${NATIVECRYPTO_SOURCES} ${VERSION_FILE_PATH})
@@ -82,9 +84,6 @@ set_target_properties(System.Security.Cryptography.Native.OpenSsl-Static PROPERT
 
 if (GEN_SHARED_LIB)
     if (FEATURE_DISTRO_AGNOSTIC_SSL)
-        target_compile_options(System.Security.Cryptography.Native.OpenSsl PRIVATE -pthread)
-        target_link_options(System.Security.Cryptography.Native.OpenSsl PRIVATE -pthread)
-
         # on macOS the link step fails with undefined symbols, and the script doesn't run.
         # if the build succeeds, the script would succeed, except it uses a Linux-only command.
         #

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
@@ -82,6 +82,9 @@ set_target_properties(System.Security.Cryptography.Native.OpenSsl-Static PROPERT
 
 if (GEN_SHARED_LIB)
     if (FEATURE_DISTRO_AGNOSTIC_SSL)
+        target_compile_options(System.Security.Cryptography.Native.OpenSsl PRIVATE -pthread)
+        target_link_options(System.Security.Cryptography.Native.OpenSsl PRIVATE -pthread)
+
         # on macOS the link step fails with undefined symbols, and the script doesn't run.
         # if the build succeeds, the script would succeed, except it uses a Linux-only command.
         #

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/extra_libs.cmake
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/extra_libs.cmake
@@ -13,7 +13,7 @@ macro(append_extra_cryptography_libs NativeLibsExtra)
     
     if (FEATURE_DISTRO_AGNOSTIC_SSL OR CLR_CMAKE_TARGET_OSX OR CLR_CMAKE_TARGET_MACCATALYST)
         # Link with libdl.so to get the dlopen / dlsym / dlclose
-        list(APPEND ${NativeLibsExtra} dl)
+        list(APPEND ${NativeLibsExtra} dl pthread)
     else()
         list(APPEND ${NativeLibsExtra} ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
     endif()

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/extra_libs.cmake
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/extra_libs.cmake
@@ -13,7 +13,7 @@ macro(append_extra_cryptography_libs NativeLibsExtra)
     
     if (FEATURE_DISTRO_AGNOSTIC_SSL OR CLR_CMAKE_TARGET_OSX OR CLR_CMAKE_TARGET_MACCATALYST)
         # Link with libdl.so to get the dlopen / dlsym / dlclose
-        list(APPEND ${NativeLibsExtra} dl pthread)
+        list(APPEND ${NativeLibsExtra} dl)
     else()
         list(APPEND ${NativeLibsExtra} ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
     endif()

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/openssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/openssl.c
@@ -1330,7 +1330,9 @@ int32_t CryptoNative_OpenSslAvailable()
 #endif
 }
 
-int32_t CryptoNative_EnsureOpenSslInitialized()
+static int32_t g_initStatus = 1;
+
+static int32_t EnsureOpenSslInitializedCore()
 {
     // If portable then decide which OpenSSL we are, and call the right one.
     // If 1.0, call the 1.0 one.
@@ -1351,4 +1353,17 @@ int32_t CryptoNative_EnsureOpenSslInitialized()
 #else
     return EnsureOpenSsl11Initialized();
 #endif
+}
+
+static void EnsureOpenSslInitializedOnce()
+{
+    g_initStatus = EnsureOpenSslInitializedCore();
+}
+
+static pthread_once_t g_initializeShim = PTHREAD_ONCE_INIT;
+
+int32_t CryptoNative_EnsureOpenSslInitialized()
+{
+    pthread_once(&g_initializeShim, EnsureOpenSslInitializedOnce);
+    return g_initStatus;
 }

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.c
@@ -50,7 +50,7 @@ static void DlOpen(const char* libraryName)
     }
 }
 
-int OpenLibrary()
+static void OpenLibraryOnce()
 {
     // If there is an override of the version specified using the CLR_OPENSSL_VERSION_OVERRIDE
     // env variable, try to load that first.
@@ -122,6 +122,13 @@ int OpenLibrary()
     {
         DlOpen(MAKELIB("8"));
     }
+}
+
+static pthread_once_t g_openLibrary = PTHREAD_ONCE_INIT;
+
+int OpenLibrary()
+{
+    pthread_once(&g_openLibrary, OpenLibraryOnce);
 
     if (libssl != NULL)
     {

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.c
@@ -4,6 +4,7 @@
 
 #include <assert.h>
 #include <dlfcn.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <string.h>
 


### PR DESCRIPTION
This is a followup to #51657.

When adding support for OpenSSL 3 we let the function binder do multiple assignments to the _ptr values, which ended up causing potential race conditions where the _ptr values turned to NULL momentarily after they had been assigned.

We didn't expect this race condition because "the initializer only runs once".  Why'd we think that? Because the initializer is called by a cctor, and cctors only run once.

Except that isn't true.  cctors run once per (Assembly,AppDomain) tuple.

OK, so it only runs once, because .NET (nee Core) no longer has multiple AppDomains per process.  Except that's not quite right, either.

The CryptoInitializer fires for each of the System.Security.Cryptography.Algorithms, Encoding, OpenSsl, and X509Certificates libraries, which is where the race condition came in that #51657 mitigated.

So, now we've broken absolute idempotency for the function binder, then restored it.  Everything left is idempotent, right? Why fix this?

Well... Ubuntu 18.04 has OpenSSL 1.1 without NO_ATEXIT support.  So we register an atexit handler.  Adding some printing and running the X509 tests:

```
$ ../../../../.dotnet/dotnet msbuild /t:Test
Microsoft (R) Build Engine version 16.11.0-preview-21254-21+e73d08c28 for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  System.Runtime -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Runtime/ref/net6.0-Debug/System.Runtime.dll
  Microsoft.Win32.Primitives -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/Microsoft.Win32.Primitives/ref/net6.0-Debug/Microsoft.Win32.Primitives.dll
  System.Runtime.Extensions -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Runtime.Extensions/ref/net6.0-Debug/System.Runtime.Extensions.dll
  System.ComponentModel -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.ComponentModel/ref/net6.0-Debug/System.ComponentModel.dll
  System.Security.Principal -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Principal/ref/net6.0-Debug/System.Security.Principal.dll
  System.Collections.NonGeneric -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Collections.NonGeneric/ref/net6.0-Debug/System.Collections.NonGeneric.dll
  System.Collections -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Collections/ref/net6.0-Debug/System.Collections.dll
  System.Runtime.InteropServices -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Runtime.InteropServices/ref/net6.0-Debug/System.Runtime.InteropServices.dll
  System.IO.Pipes -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.IO.Pipes/ref/net6.0-Debug/System.IO.Pipes.dll
  System.Runtime.Numerics -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Runtime.Numerics/ref/net6.0-Debug/System.Runtime.Numerics.dll
  System.ObjectModel -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.ObjectModel/ref/net6.0-Debug/System.ObjectModel.dll
  System.Formats.Asn1 -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Formats.Asn1/ref/net6.0-Debug/System.Formats.Asn1.dll
  System.Memory -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Memory/ref/net6.0-Debug/System.Memory.dll
  System.ComponentModel.Primitives -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.ComponentModel.Primitives/ref/net6.0-Debug/System.ComponentModel.Primitives.dll
  System.Formats.Asn1 -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Formats.Asn1/net6.0-Debug/System.Formats.Asn1.dll
  System.Net.Primitives -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Net.Primitives/ref/net6.0-Debug/System.Net.Primitives.dll
  System.Collections.Specialized -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Collections.Specialized/ref/net6.0-Debug/System.Collections.Specialized.dll
  System.Net.WebSockets -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Net.WebSockets/ref/net6.0-Debug/System.Net.WebSockets.dll
  System.Security.Cryptography.Primitives -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Cryptography.Primitives/ref/net6.0-Debug/System.Security.Cryptography.Primitives.dll
  System.Security.Claims -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Claims/ref/net6.0-Debug/System.Security.Claims.dll
  System.Security.Principal.Windows -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Principal.Windows/ref/net6.0-Debug/System.Security.Principal.Windows.dll
  System.Security.Cryptography.Encoding -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Cryptography.Encoding/ref/net6.0-Debug/System.Security.Cryptography.Encoding.dll
  System.Security.Cryptography.Algorithms -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Cryptography.Algorithms/ref/net6.0-Debug/System.Security.Cryptography.Algorithms.dll
  System.Security.AccessControl -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.AccessControl/ref/net6.0-Debug/System.Security.AccessControl.dll
  System.Security.Cryptography.Cng -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Cryptography.Cng/ref/net6.0-Debug/System.Security.Cryptography.Cng.dll
  System.IO.Pipes.AccessControl -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.IO.Pipes.AccessControl/ref/net6.0-Debug/System.IO.Pipes.AccessControl.dll
  System.Security.Cryptography.Cng -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Cryptography.Cng/net6.0-Debug/System.Security.Cryptography.Cng.dll
  Microsoft.Win32.Registry -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/Microsoft.Win32.Registry/ref/net6.0-Debug/Microsoft.Win32.Registry.dll
  TestUtilities -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/TestUtilities/net6.0-Debug/TestUtilities.dll
  System.Security.Cryptography.Csp -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Cryptography.Csp/ref/net6.0-Debug/System.Security.Cryptography.Csp.dll
  System.Security.Cryptography.X509Certificates -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Cryptography.X509Certificates/ref/net6.0-Debug/System.Security.Cryptography.X509Certificates.dll
  System.Security.Cryptography.Pkcs -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Cryptography.Pkcs/ref/net6.0-Debug/System.Security.Cryptography.Pkcs.dll
  System.Security.Cryptography.Pkcs -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Cryptography.Pkcs/net6.0-Debug/System.Security.Cryptography.Pkcs.dll
  System.Security.Cryptography.X509Certificates.Tests -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Cryptography.X509Certificates.Tests/net6.0-Unix-Debug/System.Security.Cryptography.X509Certificates.Tests.dll
  ----- start Thu Jul 8 13:36:25 PDT 2021 =============== To repro directly: =====================================================
  pushd /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Cryptography.X509Certificates.Tests/net6.0-Unix-Debug
  /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/testhost/net6.0-Linux-Debug-x64/dotnet exec --runtimeconfig System.Security.Cryptography.X509Certificates.Tests.runtimeconfig.json --depsfile System.Security.Cryptography.X509Certificates.Tests.deps.json xunit.console.dll System.Security.Cryptography.X509Certificates.Tests.dll -xml testResults.xml -nologo -notrait category=OuterLoop -notrait category=failing
  popd
  ===========================================================================================================
  ~/git/bartonjs/runtime.2/artifacts/bin/System.Security.Cryptography.X509Certificates.Tests/net6.0-Unix-Debug ~/git/bartonjs/runtime.2/src/libraries/System.Security.Cryptography.X509Certificates/tests
    Discovering: System.Security.Cryptography.X509Certificates.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.Security.Cryptography.X509Certificates.Tests (found 606 of 700 test cases)
    Starting:    System.Security.Cryptography.X509Certificates.Tests (parallel test collections = on, max threads = 8)
  ==> Handling shutdown.
  ==> Handling shutdown.
    Finished:    System.Security.Cryptography.X509Certificates.Tests
  === TEST EXECUTION SUMMARY ===
     System.Security.Cryptography.X509Certificates.Tests  Total: 1093, Errors: 0, Failed: 0, Skipped: 0, Time: 6.339s
  ==> Handling shutdown.
  ==> Handling shutdown.
  ==> Handling shutdown.
  ==> Handling shutdown.
  ~/git/bartonjs/runtime.2/src/libraries/System.Security.Cryptography.X509Certificates/tests
```

Now with pthread_once:

```
$ ../../../../.dotnet/dotnet msbuild /t:Test
Microsoft (R) Build Engine version 16.11.0-preview-21254-21+e73d08c28 for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  System.Runtime -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Runtime/ref/net6.0-Debug/System.Runtime.dll
  System.Runtime.Numerics -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Runtime.Numerics/ref/net6.0-Debug/System.Runtime.Numerics.dll
  System.Collections -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Collections/ref/net6.0-Debug/System.Collections.dll
  System.Formats.Asn1 -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Formats.Asn1/ref/net6.0-Debug/System.Formats.Asn1.dll
  System.Formats.Asn1 -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Formats.Asn1/net6.0-Debug/System.Formats.Asn1.dll
  System.Runtime.Extensions -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Runtime.Extensions/ref/net6.0-Debug/System.Runtime.Extensions.dll
  System.Security.Principal -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Principal/ref/net6.0-Debug/System.Security.Principal.dll
  System.ObjectModel -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.ObjectModel/ref/net6.0-Debug/System.ObjectModel.dll
  Microsoft.Win32.Primitives -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/Microsoft.Win32.Primitives/ref/net6.0-Debug/Microsoft.Win32.Primitives.dll
  System.ComponentModel -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.ComponentModel/ref/net6.0-Debug/System.ComponentModel.dll
  System.IO.Pipes -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.IO.Pipes/ref/net6.0-Debug/System.IO.Pipes.dll
  System.Collections.NonGeneric -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Collections.NonGeneric/ref/net6.0-Debug/System.Collections.NonGeneric.dll
  System.Runtime.InteropServices -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Runtime.InteropServices/ref/net6.0-Debug/System.Runtime.InteropServices.dll
  System.ComponentModel.Primitives -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.ComponentModel.Primitives/ref/net6.0-Debug/System.ComponentModel.Primitives.dll
  System.Collections.Specialized -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Collections.Specialized/ref/net6.0-Debug/System.Collections.Specialized.dll
  System.Memory -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Memory/ref/net6.0-Debug/System.Memory.dll
  System.Net.Primitives -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Net.Primitives/ref/net6.0-Debug/System.Net.Primitives.dll
  System.Security.Cryptography.Primitives -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Cryptography.Primitives/ref/net6.0-Debug/System.Security.Cryptography.Primitives.dll
  System.Net.WebSockets -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Net.WebSockets/ref/net6.0-Debug/System.Net.WebSockets.dll
  System.Security.Cryptography.Encoding -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Cryptography.Encoding/ref/net6.0-Debug/System.Security.Cryptography.Encoding.dll
  System.Security.Cryptography.Algorithms -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Cryptography.Algorithms/ref/net6.0-Debug/System.Security.Cryptography.Algorithms.dll
  System.Security.Claims -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Claims/ref/net6.0-Debug/System.Security.Claims.dll
  System.Security.Cryptography.Cng -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Cryptography.Cng/ref/net6.0-Debug/System.Security.Cryptography.Cng.dll
  System.Security.Principal.Windows -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Principal.Windows/ref/net6.0-Debug/System.Security.Principal.Windows.dll
  System.Security.AccessControl -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.AccessControl/ref/net6.0-Debug/System.Security.AccessControl.dll
  System.Security.Cryptography.Cng -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Cryptography.Cng/net6.0-Debug/System.Security.Cryptography.Cng.dll
  System.IO.Pipes.AccessControl -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.IO.Pipes.AccessControl/ref/net6.0-Debug/System.IO.Pipes.AccessControl.dll
  Microsoft.Win32.Registry -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/Microsoft.Win32.Registry/ref/net6.0-Debug/Microsoft.Win32.Registry.dll
  System.Security.Cryptography.Csp -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Cryptography.Csp/ref/net6.0-Debug/System.Security.Cryptography.Csp.dll
  TestUtilities -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/TestUtilities/net6.0-Debug/TestUtilities.dll
  System.Security.Cryptography.X509Certificates -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Cryptography.X509Certificates/ref/net6.0-Debug/System.Security.Cryptography.X509Certificates.dll
  System.Security.Cryptography.Pkcs -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Cryptography.Pkcs/ref/net6.0-Debug/System.Security.Cryptography.Pkcs.dll
  System.Security.Cryptography.Pkcs -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Cryptography.Pkcs/net6.0-Debug/System.Security.Cryptography.Pkcs.dll
  System.Security.Cryptography.X509Certificates.Tests -> /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Cryptography.X509Certificates.Tests/net6.0-Unix-Debug/System.Security.Cryptography.X509Certificates.Tests.dll
  ----- start Thu Jul 8 13:37:38 PDT 2021 =============== To repro directly: =====================================================
  pushd /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/System.Security.Cryptography.X509Certificates.Tests/net6.0-Unix-Debug
  /home/jbarton/git/bartonjs/runtime.2/artifacts/bin/testhost/net6.0-Linux-Debug-x64/dotnet exec --runtimeconfig System.Security.Cryptography.X509Certificates.Tests.runtimeconfig.json --depsfile System.Security.Cryptography.X509Certificates.Tests.deps.json xunit.console.dll System.Security.Cryptography.X509Certificates.Tests.dll -xml testResults.xml -nologo -notrait category=OuterLoop -notrait category=failing
  popd
  ===========================================================================================================
  ~/git/bartonjs/runtime.2/artifacts/bin/System.Security.Cryptography.X509Certificates.Tests/net6.0-Unix-Debug ~/git/bartonjs/runtime.2/src/libraries/System.Security.Cryptography.X509Certificates/tests
    Discovering: System.Security.Cryptography.X509Certificates.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.Security.Cryptography.X509Certificates.Tests (found 606 of 700 test cases)
    Starting:    System.Security.Cryptography.X509Certificates.Tests (parallel test collections = on, max threads = 8)
  ==> Handling shutdown.
    Finished:    System.Security.Cryptography.X509Certificates.Tests
  === TEST EXECUTION SUMMARY ===
     System.Security.Cryptography.X509Certificates.Tests  Total: 1093, Errors: 0, Failed: 0, Skipped: 0, Time: 7.303s
  ==> Handling shutdown.
  ~/git/bartonjs/runtime.2/src/libraries/System.Security.Cryptography.X509Certificates/tests
```