### PR TITLE
Fix lifetime1 test

### DIFF
--- a/src/tests/JIT/Directed/lifetime/lifetime1.cs
+++ b/src/tests/JIT/Directed/lifetime/lifetime1.cs
@@ -53,7 +53,6 @@ internal class Test
     {
         A a = new A();
         a.F();
-        a = null;
 
         // Testcase 3
         Console.WriteLine();
@@ -63,6 +62,7 @@ internal class Test
             Console.WriteLine("Testcase 3 FAILED");
             return -1;
         }
+        GC.KeepAlive(a);
         return 100;
     }
 


### PR DESCRIPTION
The test assumed that a GC didn't occur between the last use of a variable and a check
of a value set in the finalizer. This presumably worked up until now because the test
is set to build in debuggable code mode. But R2R compilations ignore that and build
with optimization enabled, and GCStress exposes the issue.

Fix the test by explicitly marking a variable as KeepAlive until after the requisite check.

Fixes #54042