### PR TITLE
Prevent AV in processinfo2 while suspended

### DIFF
--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -1169,7 +1169,22 @@ ep_rt_entrypoint_assembly_name_get_utf8 (void)
 {
 	STATIC_CONTRACT_NOTHROW;
 
-	return reinterpret_cast<const ep_char8_t*>(GetAppDomain ()->GetRootAssembly ()->GetSimpleName ());
+	AppDomain *app_domain_ref = nullptr;
+	Assembly *assembly_ref = nullptr;
+
+	app_domain_ref = GetAppDomain ();
+	if (app_domain_ref != nullptr)
+	{
+		assembly_ref = app_domain_ref->GetRootAssembly ();
+		if (assembly_ref != nullptr)
+		{
+			return reinterpret_cast<const ep_char8_t*>(assembly_ref->GetSimpleName ());
+		}
+	}
+
+	// fallback to the empty string if we can't get assembly info, e.g., if the runtime is
+	// suspended before an assembly is loaded.
+	return reinterpret_cast<const ep_char8_t*>("");
 }
 
 static


### PR DESCRIPTION
fix #54083

This patch attempts to avoid an AV that can occur if the ProcessInfo2 Diagnostics IPC command is sent while the runtime is suspended.

If the main entrypoint assembly is null, the command will return the empty string.

CC @tommcdon @jander-msft 