### PR TITLE
Fixing MetricEventSource tests

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricEventSourceTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricEventSourceTests.cs
@@ -37,12 +37,13 @@ namespace System.Diagnostics.Metrics.Tests
             double intervalSecs = 0.3;
             using (MetricsEventListener listener = new MetricsEventListener(_output, MetricsEventListener.TimeSeriesValues, intervalSecs, "TestMeter1"))
             {
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 1);
                 c.Add(5);
                 h.Record(19);
-                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 1);
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 2);
                 c.Add(12);
                 h.Record(26);
-                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 2);
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 3);
                 events = listener.Events.ToArray();
             }
 
@@ -52,7 +53,7 @@ namespace System.Diagnostics.Metrics.Tests
             AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", "", "7");
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "9", "18");
             AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
-            AssertCollectStartStopEventsPresent(events, intervalSecs, 2);
+            AssertCollectStartStopEventsPresent(events, intervalSecs, 3);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
@@ -70,22 +71,23 @@ namespace System.Diagnostics.Metrics.Tests
             double intervalSecs = 0.3;
             using (MetricsEventListener listener = new MetricsEventListener(_output, MetricsEventListener.TimeSeriesValues, intervalSecs, "TestMeter2"))
             {
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 1);
                 c.Add(5);
                 h.Record(19);
-                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 1);
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 2);
                 c.Add(12);
                 h.Record(26);
-                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 2);
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 3);
                 events = listener.Events.ToArray();
             }
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h);
             AssertInitialEnumerationCompleteEventPresent(events);
             AssertCounterEventsPresent(events, meter.Name, c.Name, "", c.Unit, "5", "12");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, "", "7");
-            AssertGaugeEventsPresent(events, meter.Name, og.Name, "", og.Unit, "9", "18");
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, "", "7", "7");
+            AssertGaugeEventsPresent(events, meter.Name, og.Name, "", og.Unit, "9", "18", "27");
             AssertHistogramEventsPresent(events, meter.Name, h.Name, "", h.Unit, "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
-            AssertCollectStartStopEventsPresent(events, intervalSecs, 2);
+            AssertCollectStartStopEventsPresent(events, intervalSecs, 3);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
@@ -212,17 +214,19 @@ namespace System.Diagnostics.Metrics.Tests
             double intervalSecs = 0.3;
             using (MetricsEventListener listener = new MetricsEventListener(_output, MetricsEventListener.TimeSeriesValues, intervalSecs, "TestMeter5"))
             {
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 1);
+
                 c.Add(5, new KeyValuePair<string,object?>("Color", "red"));
                 c.Add(6, new KeyValuePair<string, object?>("Color", "blue"));
                 h.Record(19, new KeyValuePair<string, object?>("Size", 123));
                 h.Record(20, new KeyValuePair<string, object?>("Size", 124));
-                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 1);
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 2);
 
                 c.Add(12, new KeyValuePair<string, object?>("Color", "red"));
                 c.Add(13, new KeyValuePair<string, object?>("Color", "blue"));
                 h.Record(26, new KeyValuePair<string, object?>("Size", 123));
                 h.Record(27, new KeyValuePair<string, object?>("Size", 124));
-                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 2);
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 3);
                 events = listener.Events.ToArray();
             }
 
@@ -236,7 +240,7 @@ namespace System.Diagnostics.Metrics.Tests
             AssertGaugeEventsPresent(events, meter.Name, og.Name, "Color=blue,Size=4", "", "18", "36");
             AssertHistogramEventsPresent(events, meter.Name, h.Name, "Size=123", "", "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
             AssertHistogramEventsPresent(events, meter.Name, h.Name, "Size=124", "", "0.5=20;0.95=20;0.99=20", "0.5=27;0.95=27;0.99=27");
-            AssertCollectStartStopEventsPresent(events, intervalSecs, 2);
+            AssertCollectStartStopEventsPresent(events, intervalSecs, 3);
         }
 
 
@@ -261,6 +265,8 @@ namespace System.Diagnostics.Metrics.Tests
             using (MetricsEventListener listener = new MetricsEventListener(_output, MetricsEventListener.TimeSeriesValues, intervalSecs,
                 "TestMeterA\\counter3;TestMeterB\\counter1;TestMeterC\\counter2;TestMeterB;TestMeterC\\counter3"))
             {
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 1);
+
                 c1a.Add(1);
                 c2a.Add(1);
                 c3a.Add(1);
@@ -270,7 +276,7 @@ namespace System.Diagnostics.Metrics.Tests
                 c1c.Add(1);
                 c2c.Add(1);
                 c3c.Add(1);
-                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 1);
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 2);
 
                 c1a.Add(2);
                 c2a.Add(2);
@@ -281,7 +287,7 @@ namespace System.Diagnostics.Metrics.Tests
                 c1c.Add(2);
                 c2c.Add(2);
                 c3c.Add(2);
-                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 2);
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 3);
                 events = listener.Events.ToArray();
             }
 
@@ -296,7 +302,7 @@ namespace System.Diagnostics.Metrics.Tests
             AssertCounterEventsNotPresent(events, meterA.Name, c1a.Name, "");
             AssertCounterEventsNotPresent(events, meterA.Name, c2a.Name, "");
             AssertCounterEventsNotPresent(events, meterC.Name, c1c.Name, "");
-            AssertCollectStartStopEventsPresent(events, intervalSecs, 2);
+            AssertCollectStartStopEventsPresent(events, intervalSecs, 3);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
@@ -310,7 +316,7 @@ namespace System.Diagnostics.Metrics.Tests
             {
                 counterState += 7;
                 counterCollectInterval++;
-                if ((counterCollectInterval % 2) == 1)
+                if ((counterCollectInterval % 2) == 0)
                 {
                     return new Measurement<int>[] { new Measurement<int>(counterState) };
                 }
@@ -326,7 +332,7 @@ namespace System.Diagnostics.Metrics.Tests
             {
                 gaugeState += 9;
                 gaugeCollectInterval++;
-                if ((gaugeCollectInterval % 2) == 1)
+                if ((gaugeCollectInterval % 2) == 0)
                 {
                     return new Measurement<int>[] { new Measurement<int>(gaugeState) };
                 }
@@ -342,16 +348,18 @@ namespace System.Diagnostics.Metrics.Tests
             double intervalSecs = 0.3;
             using (MetricsEventListener listener = new MetricsEventListener(_output, MetricsEventListener.TimeSeriesValues, intervalSecs, "TestMeter6"))
             {
+                // no measurements in interval 1
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 1);
                 c.Add(5);
                 h.Record(19);
-                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 1);
-                // no measurements in interval 2
                 listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 2);
+                // no measurements in interval 3
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 3);
                 c.Add(12);
                 h.Record(26);
-                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 3);
-                // no measurements in interval 4
                 listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 4);
+                // no measurements in interval 5
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 5);
                 events = listener.Events.ToArray();
             }
 
@@ -359,9 +367,9 @@ namespace System.Diagnostics.Metrics.Tests
             AssertInitialEnumerationCompleteEventPresent(events);
             AssertCounterEventsPresent(events, meter.Name, c.Name, "", "", "5", "0", "12");
             AssertCounterEventsPresent(events, meter.Name, oc.Name, "", "", "", "0", "14", "0");
-            AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "9", "", "27", "");
+            AssertGaugeEventsPresent(events, meter.Name, og.Name, "", "", "18", "", "36", "");
             AssertHistogramEventsPresent(events, meter.Name, h.Name, "", "", "0.5=19;0.95=19;0.99=19", "", "0.5=26;0.95=26;0.99=26", "");
-            AssertCollectStartStopEventsPresent(events, intervalSecs, 4);
+            AssertCollectStartStopEventsPresent(events, intervalSecs, 5);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
@@ -379,12 +387,13 @@ namespace System.Diagnostics.Metrics.Tests
             double intervalSecs = 0.3;
             using (MetricsEventListener listener = new MetricsEventListener(_output, MetricsEventListener.TimeSeriesValues, intervalSecs, "TestMeter7"))
             {
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 1);
                 c.Add(5);
                 h.Record(19);
-                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 1);
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 2);
                 c.Add(12);
                 h.Record(26);
-                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 2);
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 3);
 
                 // some alternate listener starts listening
                 using MetricsEventListener listener2 = new MetricsEventListener(_output, MetricsEventListener.TimeSeriesValues, intervalSecs, "ADifferentMeter");
@@ -394,10 +403,10 @@ namespace System.Diagnostics.Metrics.Tests
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h);
             AssertCounterEventsPresent(events, meter.Name, c.Name, "", c.Unit, "5", "12");
-            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, "", "7");
-            AssertGaugeEventsPresent(events, meter.Name, og.Name, "", og.Unit, "9", "18");
+            AssertCounterEventsPresent(events, meter.Name, oc.Name, "", oc.Unit, "", "7", "7");
+            AssertGaugeEventsPresent(events, meter.Name, og.Name, "", og.Unit, "9", "18", "27");
             AssertHistogramEventsPresent(events, meter.Name, h.Name, "", h.Unit, "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26");
-            AssertCollectStartStopEventsPresent(events, intervalSecs, 2);
+            AssertCollectStartStopEventsPresent(events, intervalSecs, 3);
             AssertEndInstrumentReportingEventsPresent(events, c, oc, og, h);
         }
 
@@ -417,28 +426,29 @@ namespace System.Diagnostics.Metrics.Tests
             double intervalSecs = 0.3;
             using (MetricsEventListener listener = new MetricsEventListener(_output, MetricsEventListener.TimeSeriesValues, intervalSecs, "TestMeter8;TestMeter9"))
             {
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 1);
                 c.Add(5);
                 h.Record(19);
-                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 1);
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 2);
                 c.Add(12);
                 h.Record(26);
-                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 2);
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 3);
 
                 meterA.Dispose();
                 listener.WaitForEndInstrumentReporting(TimeSpan.FromSeconds(5), 3);
 
                 h.Record(21);
-                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 3);
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 4);
                 events = listener.Events.ToArray();
             }
 
             AssertBeginInstrumentReportingEventsPresent(events, c, oc, og, h);
             AssertInitialEnumerationCompleteEventPresent(events);
             AssertCounterEventsPresent(events, meterA.Name, c.Name, "", c.Unit, "5", "12");
-            AssertCounterEventsPresent(events, meterA.Name, oc.Name, "", oc.Unit, "", "7");
-            AssertGaugeEventsPresent(events, meterA.Name, og.Name, "", og.Unit, "9", "18");
+            AssertCounterEventsPresent(events, meterA.Name, oc.Name, "", oc.Unit, "", "7", "7");
+            AssertGaugeEventsPresent(events, meterA.Name, og.Name, "", og.Unit, "9", "18", "27");
             AssertHistogramEventsPresent(events, meterB.Name, h.Name, "", h.Unit, "0.5=19;0.95=19;0.99=19", "0.5=26;0.95=26;0.99=26", "0.5=21;0.95=21;0.99=21");
-            AssertCollectStartStopEventsPresent(events, intervalSecs, 3);
+            AssertCollectStartStopEventsPresent(events, intervalSecs, 4);
             AssertEndInstrumentReportingEventsPresent(events, c, oc, og);
         }
 
@@ -482,21 +492,6 @@ namespace System.Diagnostics.Metrics.Tests
             double intervalSecs = 0.3;
             using (MetricsEventListener listener = new MetricsEventListener(_output, MetricsEventListener.TimeSeriesValues, intervalSecs, "TestMeter12"))
             {
-                i.Add(1_234_567);
-                s.Add(21_432);
-                b.Add(1);
-                l.Add(123_456_789_012);
-                dec.Add(123_456_789_012_345);
-                f.Add(123_456.789F);
-                d.Add(87_654_321_987_654.4);
-
-                i.Add(1);
-                s.Add(1);
-                b.Add(1);
-                l.Add(1);
-                dec.Add(1);
-                f.Add(1);
-                d.Add(1);
                 listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 1);
 
                 i.Add(1_234_567);
@@ -515,6 +510,23 @@ namespace System.Diagnostics.Metrics.Tests
                 f.Add(1);
                 d.Add(1);
                 listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 2);
+
+                i.Add(1_234_567);
+                s.Add(21_432);
+                b.Add(1);
+                l.Add(123_456_789_012);
+                dec.Add(123_456_789_012_345);
+                f.Add(123_456.789F);
+                d.Add(87_654_321_987_654.4);
+
+                i.Add(1);
+                s.Add(1);
+                b.Add(1);
+                l.Add(1);
+                dec.Add(1);
+                f.Add(1);
+                d.Add(1);
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 3);
                 events = listener.Events.ToArray();
             }
 
@@ -527,7 +539,7 @@ namespace System.Diagnostics.Metrics.Tests
             AssertCounterEventsPresent(events, meter.Name, dec.Name, "", "", "123456789012346", "123456789012346");
             AssertCounterEventsPresent(events, meter.Name, f.Name, "", "", "123457.7890625", "123457.7890625");
             AssertCounterEventsPresent(events, meter.Name, d.Name, "", "", "87654321987655.4", "87654321987655.4");
-            AssertCollectStartStopEventsPresent(events, intervalSecs, 2);
+            AssertCollectStartStopEventsPresent(events, intervalSecs, 3);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
@@ -541,17 +553,19 @@ namespace System.Diagnostics.Metrics.Tests
             double intervalSecs = 0.3;
             using (MetricsEventListener listener = new MetricsEventListener(_output, MetricsEventListener.TimeSeriesValues, intervalSecs, 2, 50, "TestMeter13"))
             {
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 1);
+
                 c.Add(5, new KeyValuePair<string, object?>("Color", "red"));
                 c.Add(6, new KeyValuePair<string, object?>("Color", "blue"));
                 c.Add(7, new KeyValuePair<string, object?>("Color", "green"));
                 c.Add(8, new KeyValuePair<string, object?>("Color", "yellow"));
-                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 1);
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 2);
 
                 c.Add(12, new KeyValuePair<string, object?>("Color", "red"));
                 c.Add(13, new KeyValuePair<string, object?>("Color", "blue"));
                 c.Add(14, new KeyValuePair<string, object?>("Color", "green"));
                 c.Add(15, new KeyValuePair<string, object?>("Color", "yellow"));
-                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 2);
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 3);
                 events = listener.Events.ToArray();
             }
 
@@ -562,7 +576,7 @@ namespace System.Diagnostics.Metrics.Tests
             AssertTimeSeriesLimitPresent(events);
             AssertCounterEventsNotPresent(events, meter.Name, c.Name, "Color=green");
             AssertCounterEventsNotPresent(events, meter.Name, c.Name, "Color=yellow");
-            AssertCollectStartStopEventsPresent(events, intervalSecs, 2);
+            AssertCollectStartStopEventsPresent(events, intervalSecs, 3);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]
@@ -576,17 +590,19 @@ namespace System.Diagnostics.Metrics.Tests
             double intervalSecs = 0.3;
             using (MetricsEventListener listener = new MetricsEventListener(_output, MetricsEventListener.TimeSeriesValues, intervalSecs, 50, 2, "TestMeter14"))
             {
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 1);
+
                 h.Record(5, new KeyValuePair<string, object?>("Color", "red"));
                 h.Record(6, new KeyValuePair<string, object?>("Color", "blue"));
                 h.Record(7, new KeyValuePair<string, object?>("Color", "green"));
                 h.Record(8, new KeyValuePair<string, object?>("Color", "yellow"));
-                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 1);
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 2);
 
                 h.Record(12, new KeyValuePair<string, object?>("Color", "red"));
                 h.Record(13, new KeyValuePair<string, object?>("Color", "blue"));
                 h.Record(14, new KeyValuePair<string, object?>("Color", "green"));
                 h.Record(15, new KeyValuePair<string, object?>("Color", "yellow"));
-                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 2);
+                listener.WaitForCollectionStop(TimeSpan.FromSeconds(5), 3);
                 events = listener.Events.ToArray();
             }
 
@@ -597,7 +613,7 @@ namespace System.Diagnostics.Metrics.Tests
             AssertHistogramLimitPresent(events);
             AssertHistogramEventsNotPresent(events, meter.Name, h.Name, "Color=green");
             AssertHistogramEventsNotPresent(events, meter.Name, h.Name, "Color=yellow");
-            AssertCollectStartStopEventsPresent(events, intervalSecs, 2);
+            AssertCollectStartStopEventsPresent(events, intervalSecs, 3);
         }
 
         private void AssertBeginInstrumentReportingEventsPresent(EventWrittenEventArgs[] events, params Instrument[] expectedInstruments)
@@ -746,8 +762,8 @@ namespace System.Diagnostics.Metrics.Tests
             Assert.True(filteredEvents.Length >= expectedValues.Length);
             for (int i = 0; i < expectedValues.Length; i++)
             {
-                Assert.Equal(filteredEvents[i].Unit, expectedUnit);
-                Assert.Equal(filteredEvents[i].Value, expectedValues[i]);
+                Assert.Equal(expectedUnit, filteredEvents[i].Unit);
+                Assert.Equal(expectedValues[i], filteredEvents[i].Value);
             }
         }
 
@@ -906,7 +922,8 @@ namespace System.Diagnostics.Metrics.Tests
 
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
-            if(eventData.EventName != "Message" && eventData.EventName != "Error" && eventData.Payload[0].ToString() != _sessionId)
+            string sessionId = eventData.Payload[0].ToString();
+            if(sessionId != "" && sessionId != _sessionId)
             {
                 return;
             }


### PR DESCRIPTION
I've seen two recent non-deterministic failures:
1. After starting the EventListener there is a delay of one collection
interval (currently 0.3 seconds) where we expect calls to counter.Add
and Histogram.Record() to update stats. On a fast machine this code
would run in well under a millisecond but in some test runs it still wasn't
happening fast enough.
2. We were seeing error events from a previous test get observed in a
later test because session id was being ignored for error events.

Fixes:
1. Added an initial collection interval where no counter APIs will be
invoked and the test will delay up to 5 seconds waiting for this.
Hopefully this delay makes it more likely that the Add/Record APIs
are ready to execute promptly once the 2nd interval begins. If that
still isn't sufficient we can either increase the collection intervals or
disable the tests.
2. Tightened up the session id matching so only error events with
empty id or the expected id are allowed.


Fixes #55315 and #55313 (I hope)