### PR TITLE
Consume DistributedContextPropagator APIs in DiagnosticsHandler

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/PropagatorTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/PropagatorTests.cs
@@ -527,6 +527,14 @@ namespace System.Diagnostics.Tests
             return list;
         }
 
+        [Fact]
+        public void TestBuiltInPropagatorsAreCached()
+        {
+            Assert.Same(DistributedContextPropagator.CreateDefaultPropagator(), DistributedContextPropagator.CreateDefaultPropagator());
+            Assert.Same(DistributedContextPropagator.CreateNoOutputPropagator(), DistributedContextPropagator.CreateNoOutputPropagator());
+            Assert.Same(DistributedContextPropagator.CreatePassThroughPropagator(), DistributedContextPropagator.CreatePassThroughPropagator());
+        }
+
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void TestCustomPropagator()
         {

--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -394,6 +394,8 @@ namespace System.Net.Http
         public bool EnableMultipleHttp2Connections { get { throw null; } set { } }
         public Func<SocketsHttpConnectionContext, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<System.IO.Stream>>? ConnectCallback { get { throw null; } set { } }
         public Func<SocketsHttpPlaintextStreamFilterContext, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<System.IO.Stream>>? PlaintextStreamFilter { get { throw null; } set { } }
+        [System.CLSCompliantAttribute(false)]
+        public System.Diagnostics.DistributedContextPropagator? ActivityHeadersPropagator { get { throw null; } set { } }
     }
     public sealed class SocketsHttpConnectionContext
     {

--- a/src/libraries/System.Net.Http/ref/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.csproj
@@ -14,5 +14,6 @@
     <ProjectReference Include="..\..\System.Net.Security\ref\System.Net.Security.csproj" />
     <ProjectReference Include="..\..\System.Security.Cryptography.X509Certificates\ref\System.Security.Cryptography.X509Certificates.csproj" />
     <ProjectReference Include="..\..\System.Text.Encoding\ref\System.Text.Encoding.csproj" />
+    <ProjectReference Include="..\..\System.Diagnostics.DiagnosticSource\ref\System.Diagnostics.DiagnosticSource.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/SocketsHttpHandler.cs
@@ -3,13 +3,12 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Net.Quic;
-using System.Net.Quic.Implementations;
 using System.Net.Security;
 using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics;
 
 namespace System.Net.Http
 {
@@ -168,6 +167,13 @@ namespace System.Net.Http
         }
 
         public HeaderEncodingSelector<HttpRequestMessage>? ResponseHeaderEncodingSelector
+        {
+            get => throw new PlatformNotSupportedException();
+            set => throw new PlatformNotSupportedException();
+        }
+
+        [CLSCompliant(false)]
+        public DistributedContextPropagator? ActivityHeadersPropagator
         {
             get => throw new PlatformNotSupportedException();
             set => throw new PlatformNotSupportedException();

--- a/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandlerLoggingStrings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandlerLoggingStrings.cs
@@ -15,11 +15,5 @@ namespace System.Net.Http
         public const string ExceptionEventName = "System.Net.Http.Exception";
         public const string ActivityName = "System.Net.Http.HttpRequestOut";
         public const string ActivityStartName = "System.Net.Http.HttpRequestOut.Start";
-
-        public const string RequestIdHeaderName = "Request-Id";
-        public const string CorrelationContextHeaderName = "Correlation-Context";
-
-        public const string TraceParentHeaderName = "traceparent";
-        public const string TraceStateHeaderName = "tracestate";
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
@@ -9,6 +9,7 @@ using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Diagnostics;
 #if TARGET_BROWSER
 using HttpHandlerType = System.Net.Http.BrowserHttpHandler;
 #else
@@ -20,7 +21,14 @@ namespace System.Net.Http
     public partial class HttpClientHandler : HttpMessageHandler
     {
         private readonly HttpHandlerType _underlyingHandler;
-        private readonly DiagnosticsHandler? _diagnosticsHandler;
+
+        private HttpMessageHandler Handler
+#if TARGET_BROWSER
+            { get; }
+#else
+            => _underlyingHandler;
+#endif
+
         private ClientCertificateOption _clientCertificateOptions;
 
         private volatile bool _disposed;
@@ -28,10 +36,15 @@ namespace System.Net.Http
         public HttpClientHandler()
         {
             _underlyingHandler = new HttpHandlerType();
+
+#if TARGET_BROWSER
+            Handler = _underlyingHandler;
             if (DiagnosticsHandler.IsGloballyEnabled())
             {
-                _diagnosticsHandler = new DiagnosticsHandler(_underlyingHandler);
+                Handler = new DiagnosticsHandler(Handler, DistributedContextPropagator.Current);
             }
+#endif
+
             ClientCertificateOptions = ClientCertificateOption.Manual;
         }
 
@@ -288,21 +301,11 @@ namespace System.Net.Http
         public IDictionary<string, object?> Properties => _underlyingHandler.Properties;
 
         [UnsupportedOSPlatform("browser")]
-        protected internal override HttpResponseMessage Send(HttpRequestMessage request,
-            CancellationToken cancellationToken)
-        {
-            return DiagnosticsHandler.IsEnabled() && _diagnosticsHandler != null ?
-                _diagnosticsHandler.Send(request, cancellationToken) :
-                _underlyingHandler.Send(request, cancellationToken);
-        }
+        protected internal override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Handler.Send(request, cancellationToken);
 
-        protected internal override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
-            CancellationToken cancellationToken)
-        {
-            return DiagnosticsHandler.IsEnabled() && _diagnosticsHandler != null ?
-                _diagnosticsHandler.SendAsync(request, cancellationToken) :
-                _underlyingHandler.SendAsync(request, cancellationToken);
-        }
+        protected internal override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Handler.SendAsync(request, cancellationToken);
 
         // lazy-load the validator func so it can be trimmed by the ILLinker if it isn't used.
         private static Func<HttpRequestMessage, X509Certificate2?, X509Chain?, SslPolicyErrors, bool>? s_dangerousAcceptAnyServerCertificateValidator;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -8,6 +8,7 @@ using System.Net.Quic.Implementations;
 using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Diagnostics;
 
 namespace System.Net.Http
 {
@@ -46,6 +47,8 @@ namespace System.Net.Http
 
         internal HeaderEncodingSelector<HttpRequestMessage>? _requestHeaderEncodingSelector;
         internal HeaderEncodingSelector<HttpRequestMessage>? _responseHeaderEncodingSelector;
+
+        internal DistributedContextPropagator? _activityHeadersPropagator = DistributedContextPropagator.Current;
 
         internal Version _maxHttpVersion;
 
@@ -119,6 +122,7 @@ namespace System.Net.Http
                 _connectCallback = _connectCallback,
                 _plaintextStreamFilter = _plaintextStreamFilter,
                 _initialHttp2StreamWindowSize = _initialHttp2StreamWindowSize,
+                _activityHeadersPropagator = _activityHeadersPropagator,
             };
 
             // TODO: Remove if/when QuicImplementationProvider is removed from System.Net.Quic.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
@@ -75,6 +75,8 @@ namespace System.Net.Http
                     }
                 }
 
+                request.MarkAsRedirected();
+
                 // Issue the redirected request.
                 response = await _redirectInnerHandler.SendAsync(request, async, cancellationToken).ConfigureAwait(false);
             }


### PR DESCRIPTION
- Replace `InjectHeaders` logic in `DiagnosticsHandler` with a call to `DistributedContextPropagator.Inject` which adds a lot of configurability to the user
  - Using `PassThroughPropagator` or a custom propagator addresses #41072
  - Using `NoOutputPropagator` addresses #35337
- Insert `DiagnosticsHandler` into the `SocketsHttpHandler` handler chain
  - This lights up distributed tracing for customized `SocketsHttpHandler` instances #31261
  - Placing the `DiagnosticsHandler` before `RedirectHandler` lights up propagation for redirect requests #40777

Side effects:
- By moving `DiagnosticsHandler` into `SocketsHttpHandler`, any custom instance lights up for distributed tracing when moving to 6.0 by default
  - Some people don't want that, but there is now an easier off switch available (`NoOutputPropagator` or the `ActivityHeadersPropagator` property on the handler)
  - The behaviour is now the same regardless of whether a `SocketsHttpHandler` instance was created on its own / within `HttpClientHandler`.

Fixes #35337
Fixes #41072
Fixes #40777
Fixes #31261
Fixes #55556

cc: @tarekgh @noahfalk @shirhatti 