### PR TITLE
ILLink annotations related to ISerializable and IBindingListView in System.Data.Common

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
@@ -538,7 +538,7 @@ namespace System.ComponentModel
     }
     public partial interface IBindingListView : System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList, System.ComponentModel.IBindingList
     {
-        string? Filter { get; set; }
+        string? Filter { get; [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Members of types used in the filter expression might be trimmed.")] set; }
         System.ComponentModel.ListSortDescriptionCollection SortDescriptions { get; }
         bool SupportsAdvancedSorting { get; }
         bool SupportsFiltering { get; }

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/IBindingListView.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/IBindingListView.cs
@@ -9,7 +9,7 @@ namespace System.ComponentModel
     {
         void ApplySort(ListSortDescriptionCollection sorts);
 
-        string? Filter { get; set; }
+        string? Filter { get; [RequiresUnreferencedCode("Members of types used in the filter expression might be trimmed.")] set; }
 
         ListSortDescriptionCollection SortDescriptions { get; }
 

--- a/src/libraries/System.Data.Common/ref/System.Data.Common.cs
+++ b/src/libraries/System.Data.Common/ref/System.Data.Common.cs
@@ -1003,7 +1003,7 @@ namespace System.Data
         bool System.ComponentModel.IBindingList.SupportsChangeNotification { get { throw null; } }
         bool System.ComponentModel.IBindingList.SupportsSearching { get { throw null; } }
         bool System.ComponentModel.IBindingList.SupportsSorting { get { throw null; } }
-        string? System.ComponentModel.IBindingListView.Filter { get { throw null; } set { } }
+        string? System.ComponentModel.IBindingListView.Filter { get { throw null; } [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Members of types used in the filter expression might be trimmed.")] set { } }
         System.ComponentModel.ListSortDescriptionCollection System.ComponentModel.IBindingListView.SortDescriptions { get { throw null; } }
         bool System.ComponentModel.IBindingListView.SupportsAdvancedSorting { get { throw null; } }
         bool System.ComponentModel.IBindingListView.SupportsFiltering { get { throw null; } }

--- a/src/libraries/System.Data.Common/src/ILLink/ILLink.Suppressions.xml
+++ b/src/libraries/System.Data.Common/src/ILLink/ILLink.Suppressions.xml
@@ -5,12 +5,6 @@
       <argument>ILLink</argument>
       <argument>IL2026</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:System.Data.DataSet.GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2026</argument>
-      <property name="Scope">member</property>
       <property name="Target">M:System.Data.DataSet.System.Xml.Serialization.IXmlSerializable.GetSchema()</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
@@ -29,12 +23,6 @@
       <argument>ILLink</argument>
       <argument>IL2026</argument>
       <property name="Scope">member</property>
-      <property name="Target">M:System.Data.DataTable.GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2026</argument>
-      <property name="Scope">member</property>
       <property name="Target">M:System.Data.DataTable.GetSchema()</property>
     </attribute>
     <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
@@ -48,12 +36,6 @@
       <argument>IL2026</argument>
       <property name="Scope">member</property>
       <property name="Target">M:System.Data.DataTable.WriteXmlCore(System.Xml.XmlWriter)</property>
-    </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2026</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:System.Data.DataView.System.ComponentModel.IBindingListView.set_Filter(System.String)</property>
     </attribute>
   </assembly>
 </linker>

--- a/src/libraries/System.Data.Common/src/System/Data/DataSet.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataSet.cs
@@ -268,6 +268,8 @@ namespace System.Data
             DeserializeDataSet(info, context, remotingFormat, schemaSerializationMode);
         }
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+            Justification = "Binary serialization is unsafe in general and is planned to be obsoleted. We do not want to mark interface or ctors of this class as unsafe as that would show many unnecessary warnings elsewhere.")]
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             SerializationFormat remotingFormat = RemotingFormat;

--- a/src/libraries/System.Data.Common/src/System/Data/DataTable.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataTable.cs
@@ -211,6 +211,8 @@ namespace System.Data
             DeserializeDataTable(info, context, isSingleTable, remotingFormat);
         }
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+            Justification = "Binary serialization is unsafe in general and is planned to be obsoleted. We do not want to mark interface or ctors of this class as unsafe as that would show many unnecessary warnings elsewhere.")]
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             SerializationFormat remotingFormat = RemotingFormat;

--- a/src/libraries/System.Data.Common/src/System/Data/DataView.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataView.cs
@@ -1136,6 +1136,7 @@ namespace System.Data
         string? IBindingListView.Filter
         {
             get { return RowFilter; }
+            [RequiresUnreferencedCode(Select.RequiresUnreferencedCodeMessage)]
             set { RowFilter = value; }
         }
 


### PR DESCRIPTION
Per offline conversations ISerializable related warnings will be suppressed since adding RUC on them would require also adding RUC on the interface or on all ctors of the class which would cause many unnecessary warnings and binary serialization is about to be obsoleted anyway and is unsafe regardless of trimming.