### PR TITLE
Fix BigInteger.Parse returns bogus value for exponents above 1000

### DIFF
--- a/src/libraries/Common/src/System/Globalization/FormatProvider.Number.cs
+++ b/src/libraries/Common/src/System/Globalization/FormatProvider.Number.cs
@@ -517,7 +517,19 @@ namespace System.Globalization
                             {
                                 exp = exp * 10 + (ch - '0');
                                 ch = ++p < strEnd ? *p : '\0';
-                            } while (ch >= '0' && ch <= '9');
+                            } while ((ch >= '0') && (ch <= '9') && (exp < int.MaxValue / 10));
+
+                            if ((ch >= '0') && (ch <= '9'))
+                            {
+                                // We still had remaining characters but bailed early because
+                                // the exponent was going to overflow. If exp is exactly 214748364
+                                // then we can technically handle one more character being 0-9
+                                // but the additional complexity might not be worthwhile.
+
+                                Debug.Assert(exp >= 214748364);
+                                return false;
+                            }
+
                             if (negExp)
                             {
                                 exp = -exp;

--- a/src/libraries/Common/src/System/Globalization/FormatProvider.Number.cs
+++ b/src/libraries/Common/src/System/Globalization/FormatProvider.Number.cs
@@ -517,14 +517,6 @@ namespace System.Globalization
                             {
                                 exp = exp * 10 + (ch - '0');
                                 ch = ++p < strEnd ? *p : '\0';
-                                if (exp > 1000)
-                                {
-                                    exp = 9999;
-                                    while (ch >= '0' && ch <= '9')
-                                    {
-                                        ch = ++p < strEnd ? *p : '\0';
-                                    }
-                                }
                             } while (ch >= '0' && ch <= '9');
                             if (negExp)
                             {

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/BigIntegerToStringTests.cs
@@ -439,6 +439,25 @@ namespace System.Numerics.Tests
             RunCustomFormatToStringTests(s_random, "#\u2030000000", CultureInfo.CurrentCulture.NumberFormat.NegativeSign, 6, PerMilleSymbolFormatter);
         }
 
+        public static IEnumerable<object[]> RunFormatScientificNotationToBigIntegerAndViceVersaData()
+        {
+            yield return new object[] { "1E+1000", "1E+1000" };
+            yield return new object[] { "1E+1001", "1E+1001" };
+        }
+
+        [Theory]
+        [MemberData(nameof(RunFormatScientificNotationToBigIntegerAndViceVersaData))]
+        public static void RunFormatScientificNotationToBigIntegerAndViceVersa(string testingValue, string expectedResult)
+        {
+            BigInteger parsedValue;
+            string actualResult;
+
+            parsedValue = BigInteger.Parse(testingValue, NumberStyles.AllowExponent);
+            actualResult = parsedValue.ToString("E0");
+
+            Assert.Equal(expectedResult, actualResult);
+        }
+
         private static void RunSimpleProviderToStringTests(Random random, string format, NumberFormatInfo provider, int precision, StringFormatter formatter)
         {
             string test;


### PR DESCRIPTION
Fixes [issue 17296](https://github.com/dotnet/runtime/issues/17296)