### PR TITLE
Removed nullability checks from FormUrlEncodedContent ctor

### DIFF
--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -37,7 +37,12 @@ namespace System.Net.Http
     }
     public partial class FormUrlEncodedContent : System.Net.Http.ByteArrayContent
     {
-        public FormUrlEncodedContent(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string?, string?>> nameValueCollection) : base (default(byte[])) { }
+        public FormUrlEncodedContent(
+            System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<
+                #nullable disable
+                string, string
+                #nullable restore
+            >> nameValueCollection) : base (default(byte[])) { }
         protected override System.Threading.Tasks.Task SerializeToStreamAsync(System.IO.Stream stream, System.Net.TransportContext? context, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
     public delegate System.Text.Encoding? HeaderEncodingSelector<TContext>(string headerName, TContext context);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/FormUrlEncodedContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/FormUrlEncodedContent.cs
@@ -12,7 +12,12 @@ namespace System.Net.Http
 {
     public class FormUrlEncodedContent : ByteArrayContent
     {
-        public FormUrlEncodedContent(IEnumerable<KeyValuePair<string?, string?>> nameValueCollection)
+        public FormUrlEncodedContent(
+            IEnumerable<KeyValuePair<
+                #nullable disable
+                string, string
+                #nullable restore
+            >> nameValueCollection)
             : base(GetContentByteArray(nameValueCollection))
         {
             Headers.ContentType = new MediaTypeHeaderValue("application/x-www-form-urlencoded");


### PR DESCRIPTION
As @stephentoub suggested, we can just avoid the problem by temporarily disabling nullability checks for the offending ctor.
Works with all following options:
```C#
new FormUrlEncodedContent(new Dictionary<string, string>());
new FormUrlEncodedContent(new Dictionary<string, string?>());
new FormUrlEncodedContent(new List<KeyValuePair<string?, string?>>());
new FormUrlEncodedContent(new List<KeyValuePair<string, string?>>());
new FormUrlEncodedContent(new List<KeyValuePair<string, string>>());
```
But still disallows passing in `null` itself:
```C#
new FormUrlEncodedContent(null); // warning CS8625: Cannot convert null literal to non-nullable reference type.
```


Fixes #38494
Closes #44458