### PR TITLE
Update wasm workload name to `wasm-tools`

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.json.in
@@ -4,8 +4,8 @@
     "Microsoft.NET.Workload.Emscripten": "${EmscriptenVersion}"
   },
   "workloads": {
-    "microsoft-net-sdk-blazorwebassembly-aot": {
-      "description": "Browser Runtime native performance tools",
+    "wasm-tools": {
+      "description": ".NET WebAssembly build tools",
       "packs": [
         "Microsoft.NET.Runtime.WebAssembly.Sdk",
         "Microsoft.NETCore.App.Runtime.Mono.browser-wasm",
@@ -14,6 +14,7 @@
       "extends": [ "microsoft-net-runtime-mono-tooling", "microsoft-net-sdk-emscripten" ],
       "platforms": [ "win-x64", "linux-x64", "osx-x64", "osx-arm64" ]
     },
+    "microsoft-net-sdk-blazorwebassembly-aot": { "redirect-to": "wasm-tools" },
     "microsoft-net-runtime-android": {
       "abstract": true,
       "description": "Android Mono Runtime",

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.json.in
@@ -14,7 +14,6 @@
       "extends": [ "microsoft-net-runtime-mono-tooling", "microsoft-net-sdk-emscripten" ],
       "platforms": [ "win-x64", "linux-x64", "osx-x64", "osx-arm64" ]
     },
-    "microsoft-net-sdk-blazorwebassembly-aot": { "redirect-to": "wasm-tools" },
     "microsoft-net-runtime-android": {
       "abstract": true,
       "description": "Android Mono Runtime",


### PR DESCRIPTION
Change `microsoft-net-sdk-blazorwebassembly-aot` to `wasm-tools`

Every other workload in the file is abstract and probably shouldn't have a short name.