### PR TITLE
Fix more alloc-dealloc mismatches and use-after-scopes

### DIFF
--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -3543,6 +3543,7 @@ int LinearScan::BuildReturn(GenTree* tree)
                 noway_assert(op1->IsMultiRegCall() || op1->IsMultiRegLclVar());
 
                 int                   srcCount;
+                ReturnTypeDesc        nonCallRetTypeDesc;
                 const ReturnTypeDesc* pRetTypeDesc;
                 if (op1->OperIs(GT_CALL))
                 {
@@ -3552,12 +3553,11 @@ int LinearScan::BuildReturn(GenTree* tree)
                 {
                     assert(compiler->lvaEnregMultiRegVars);
                     LclVarDsc*     varDsc = compiler->lvaGetDesc(op1->AsLclVar()->GetLclNum());
-                    ReturnTypeDesc retTypeDesc;
-                    retTypeDesc.InitializeStructReturnType(compiler, varDsc->GetStructHnd(),
+                    nonCallRetTypeDesc.InitializeStructReturnType(compiler, varDsc->GetStructHnd(),
                                                            compiler->info.compCallConv);
-                    pRetTypeDesc = &retTypeDesc;
+                    pRetTypeDesc = &nonCallRetTypeDesc;
                     assert(compiler->lvaGetDesc(op1->AsLclVar()->GetLclNum())->lvFieldCnt ==
-                           retTypeDesc.GetReturnRegCount());
+                           nonCallRetTypeDesc.GetReturnRegCount());
                 }
                 srcCount = pRetTypeDesc->GetReturnRegCount();
                 // For any source that's coming from a different register file, we need to ensure that

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -3552,9 +3552,9 @@ int LinearScan::BuildReturn(GenTree* tree)
                 else
                 {
                     assert(compiler->lvaEnregMultiRegVars);
-                    LclVarDsc*     varDsc = compiler->lvaGetDesc(op1->AsLclVar()->GetLclNum());
+                    LclVarDsc* varDsc = compiler->lvaGetDesc(op1->AsLclVar()->GetLclNum());
                     nonCallRetTypeDesc.InitializeStructReturnType(compiler, varDsc->GetStructHnd(),
-                                                           compiler->info.compCallConv);
+                                                                  compiler->info.compCallConv);
                     pRetTypeDesc = &nonCallRetTypeDesc;
                     assert(compiler->lvaGetDesc(op1->AsLclVar()->GetLclNum())->lvFieldCnt ==
                            nonCallRetTypeDesc.GetReturnRegCount());

--- a/src/coreclr/vm/threadstatics.cpp
+++ b/src/coreclr/vm/threadstatics.cpp
@@ -97,7 +97,7 @@ void ThreadLocalBlock::FreeTable()
         SpinLock::Holder lock(&m_TLMTableLock);
 
         // Free the table itself
-        delete m_pTLMTable;
+        delete[] m_pTLMTable;
         m_pTLMTable = NULL;
     }
 
@@ -136,7 +136,7 @@ void ThreadLocalBlock::EnsureModuleIndex(ModuleIndex index)
 
     // If this allocation fails, we will throw. If it succeeds,
     // then we are good to go
-    PTR_TLMTableEntry pNewModuleSlots = (PTR_TLMTableEntry) (void*) new BYTE[sizeof(TLMTableEntry) * aModuleIndices];
+    PTR_TLMTableEntry pNewModuleSlots = (PTR_TLMTableEntry) new TLMTableEntry[aModuleIndices];
 
     // Zero out the new TLM table
     memset(pNewModuleSlots, 0 , sizeof(TLMTableEntry) * aModuleIndices);

--- a/src/coreclr/vm/threadstatics.cpp
+++ b/src/coreclr/vm/threadstatics.cpp
@@ -704,9 +704,7 @@ PTR_ThreadLocalModule ThreadStatics::AllocateTLM(Module * pModule)
 
     SIZE_T size = pModule->GetThreadLocalModuleSize();
 
-    _ASSERTE(size >= ThreadLocalModule::OffsetOfDataBlob());
-
-    PTR_ThreadLocalModule pThreadLocalModule = (ThreadLocalModule*)new BYTE[size];
+    PTR_ThreadLocalModule pThreadLocalModule = new({ pModule }) ThreadLocalModule;
 
     // We guarantee alignment for 64-bit regular thread statics on 32-bit platforms even without FEATURE_64BIT_ALIGNMENT for performance reasons.
 

--- a/src/coreclr/vm/threadstatics.cpp
+++ b/src/coreclr/vm/threadstatics.cpp
@@ -136,7 +136,7 @@ void ThreadLocalBlock::EnsureModuleIndex(ModuleIndex index)
 
     // If this allocation fails, we will throw. If it succeeds,
     // then we are good to go
-    PTR_TLMTableEntry pNewModuleSlots = (PTR_TLMTableEntry) new TLMTableEntry[aModuleIndices];
+    PTR_TLMTableEntry pNewModuleSlots = new TLMTableEntry[aModuleIndices];
 
     // Zero out the new TLM table
     memset(pNewModuleSlots, 0 , sizeof(TLMTableEntry) * aModuleIndices);

--- a/src/coreclr/vm/threadstatics.h
+++ b/src/coreclr/vm/threadstatics.h
@@ -450,13 +450,13 @@ public:
         return GetPrecomputedStaticsClassData()[classID] & ClassInitFlags::INITIALIZED_FLAG;
     }
 
-    void* operator new(SIZE_T) = delete;
+    void* operator new(size_t) = delete;
 
     struct ParentModule { PTR_Module pModule; };
 
-    void* operator new(SIZE_T baseSize, ParentModule parentModule)
+    void* operator new(size_t baseSize, ParentModule parentModule)
     {
-        SIZE_T size = parentModule.pModule->GetThreadLocalModuleSize();
+        size_t size = parentModule.pModule->GetThreadLocalModuleSize();
 
         _ASSERTE(size >= baseSize);
         _ASSERTE(size >= ThreadLocalModule::OffsetOfDataBlob());

--- a/src/coreclr/vm/threadstatics.h
+++ b/src/coreclr/vm/threadstatics.h
@@ -450,6 +450,20 @@ public:
         return GetPrecomputedStaticsClassData()[classID] & ClassInitFlags::INITIALIZED_FLAG;
     }
 
+    void* operator new(SIZE_T) = delete;
+
+    struct ParentModule { PTR_Module pModule; };
+
+    void* operator new(SIZE_T baseSize, ParentModule parentModule)
+    {
+        SIZE_T size = parentModule.pModule->GetThreadLocalModuleSize();
+
+        _ASSERTE(size >= baseSize);
+        _ASSERTE(size >= ThreadLocalModule::OffsetOfDataBlob());
+
+        return ::operator new(size);
+    }
+
 #ifndef DACCESS_COMPILE
 
     FORCEINLINE void EnsureClassAllocated(MethodTable * pMT)


### PR DESCRIPTION
Fix another dynamically-sized allocation to use new/delete instead of the mismatched new[]/delete.

Move another local up a scope.

Use a simple new[]/delete[] instead of casting.

Discovered in https://github.com/dotnet/runtime/pull/54580