### PR TITLE
Big-endian fix: ApplyMask in System.Net.WebSockets.ManagedWebSocket

### DIFF
--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -1503,7 +1503,15 @@ namespace System.Net.WebSockets
                         maskIndex = (maskIndex + 1) & 3;
                     }
 
-                    int rolledMask = (int)BitOperations.RotateRight((uint)mask, maskIndex * 8);
+                    int rolledMask;
+                    if (BitConverter.IsLittleEndian)
+                    {
+                        rolledMask = (int)BitOperations.RotateRight((uint)mask, maskIndex * 8);
+                    }
+                    else
+                    {
+                        rolledMask = (int)BitOperations.RotateLeft((uint)mask, maskIndex * 8);
+                    }
 
                     // use SIMD if possible.
 


### PR DESCRIPTION
* Fix mask shifting logic for big-endian systems

The mask shifting logic assumed little-endian byte order, which could lead to incorrectly decoded messages depending on buffer alignment.  This caused failures in some aspnetcore tests (Microsoft.AspNetCore.SignalR.Client.FunctionalTests), which are fixed by this patch.