### PR TITLE
Allow multiple private key references in Unix PFXes

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Android/AndroidCertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Android/AndroidCertificatePal.cs
@@ -52,6 +52,7 @@ namespace Internal.Cryptography.Pal
         {
             Debug.Assert(password != null);
 
+            bool ephemeralSpecified = keyStorageFlags.HasFlag(X509KeyStorageFlags.EphemeralKeySet);
             X509ContentType contentType = X509Certificate2.GetCertContentType(rawData);
 
             switch (contentType)
@@ -62,7 +63,7 @@ namespace Internal.Cryptography.Pal
                     // We don't support determining this on Android right now, so we throw.
                     throw new CryptographicException(SR.Cryptography_X509_PKCS7_NoSigner);
                 case X509ContentType.Pkcs12:
-                    return ReadPkcs12(rawData, password);
+                    return ReadPkcs12(rawData, password, ephemeralSpecified);
                 case X509ContentType.Cert:
                 default:
                 {
@@ -104,11 +105,11 @@ namespace Internal.Cryptography.Pal
             return true;
         }
 
-        private static ICertificatePal ReadPkcs12(ReadOnlySpan<byte> rawData, SafePasswordHandle password)
+        private static ICertificatePal ReadPkcs12(ReadOnlySpan<byte> rawData, SafePasswordHandle password, bool ephemeralSpecified)
         {
             using (var reader = new AndroidPkcs12Reader(rawData))
             {
-                reader.Decrypt(password);
+                reader.Decrypt(password, ephemeralSpecified);
 
                 UnixPkcs12Reader.CertAndKey certAndKey = reader.GetSingleCert();
                 AndroidCertificatePal pal = (AndroidCertificatePal)certAndKey.Cert!;

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.Pkcs12.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.Pkcs12.cs
@@ -19,7 +19,7 @@ namespace Internal.Cryptography.Pal
         {
             using (ApplePkcs12Reader reader = new ApplePkcs12Reader(rawData))
             {
-                reader.Decrypt(password);
+                reader.Decrypt(password, ephemeralSpecified: false);
 
                 UnixPkcs12Reader.CertAndKey certAndKey = reader.GetSingleCert();
                 AppleCertificatePal pal = (AppleCertificatePal)certAndKey.Cert!;

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/StorePal.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/StorePal.cs
@@ -47,7 +47,7 @@ namespace Internal.Cryptography.Pal
                     ? Interop.AppleCrypto.SecKeychainCopyDefault()
                     : Interop.AppleCrypto.CreateTemporaryKeychain();
 
-                return ImportPkcs12(rawData, password, exportable, keychain);
+                return ImportPkcs12(rawData, password, exportable, ephemeralSpecified: false, keychain);
             }
 
             SafeCFArrayHandle certs = Interop.AppleCrypto.X509ImportCollection(
@@ -64,13 +64,14 @@ namespace Internal.Cryptography.Pal
             ReadOnlySpan<byte> rawData,
             SafePasswordHandle password,
             bool exportable,
+            bool ephemeralSpecified,
             SafeKeychainHandle keychain)
         {
             ApplePkcs12Reader reader = new ApplePkcs12Reader(rawData);
 
             try
             {
-                reader.Decrypt(password);
+                reader.Decrypt(password, ephemeralSpecified);
                 return new ApplePkcs12CertLoader(reader, keychain, password, exportable);
             }
             catch

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
@@ -49,12 +49,13 @@ namespace Internal.Cryptography.Pal
 
             ICertificatePal? cert;
             Exception? openSslException;
+            bool ephemeralSpecified = keyStorageFlags.HasFlag(X509KeyStorageFlags.EphemeralKeySet);
 
             if (TryReadX509Der(rawData, out cert) ||
                 TryReadX509Pem(rawData, out cert) ||
                 PkcsFormatReader.TryReadPkcs7Der(rawData, out cert) ||
                 PkcsFormatReader.TryReadPkcs7Pem(rawData, out cert) ||
-                PkcsFormatReader.TryReadPkcs12(rawData, password, out cert, out openSslException))
+                PkcsFormatReader.TryReadPkcs12(rawData, password, ephemeralSpecified, out cert, out openSslException))
             {
                 if (cert == null)
                 {
@@ -73,6 +74,7 @@ namespace Internal.Cryptography.Pal
         public static ICertificatePal FromFile(string fileName, SafePasswordHandle password, X509KeyStorageFlags keyStorageFlags)
         {
             ICertificatePal? pal;
+            bool ephemeralSpecified = keyStorageFlags.HasFlag(X509KeyStorageFlags.EphemeralKeySet);
 
             // If we can't open the file, fail right away.
             using (SafeBioHandle fileBio = Interop.Crypto.BioNewFile(fileName, "rb"))
@@ -87,6 +89,7 @@ namespace Internal.Cryptography.Pal
                 PkcsFormatReader.TryReadPkcs12(
                     File.ReadAllBytes(fileName),
                     password,
+                    ephemeralSpecified,
                     out pal,
                     out Exception? exception);
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/PkcsFormatReader.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/PkcsFormatReader.cs
@@ -253,24 +253,49 @@ namespace Internal.Cryptography.Pal
             return true;
         }
 
-        internal static bool TryReadPkcs12(ReadOnlySpan<byte> rawData, SafePasswordHandle password, [NotNullWhen(true)] out ICertificatePal? certPal, out Exception? openSslException)
+        internal static bool TryReadPkcs12(
+            ReadOnlySpan<byte> rawData,
+            SafePasswordHandle password,
+            bool ephemeralSpecified,
+            [NotNullWhen(true)] out ICertificatePal? certPal,
+            out Exception? openSslException)
         {
             List<ICertificatePal>? ignored;
 
-            return TryReadPkcs12(rawData, password, true, out certPal!, out ignored, out openSslException);
+            return TryReadPkcs12(
+                rawData,
+                password,
+                single: true,
+                ephemeralSpecified,
+                out certPal!,
+                out ignored,
+                out openSslException);
         }
 
-        internal static bool TryReadPkcs12(ReadOnlySpan<byte> rawData, SafePasswordHandle password, [NotNullWhen(true)] out List<ICertificatePal>? certPals, out Exception? openSslException)
+        internal static bool TryReadPkcs12(
+            ReadOnlySpan<byte> rawData,
+            SafePasswordHandle password,
+            bool ephemeralSpecified,
+            [NotNullWhen(true)] out List<ICertificatePal>? certPals,
+            out Exception? openSslException)
         {
             ICertificatePal? ignored;
 
-            return TryReadPkcs12(rawData, password, false, out ignored, out certPals!, out openSslException);
+            return TryReadPkcs12(
+                rawData,
+                password,
+                single: false,
+                ephemeralSpecified,
+                out ignored,
+                out certPals!,
+                out openSslException);
         }
 
         private static bool TryReadPkcs12(
             ReadOnlySpan<byte> rawData,
             SafePasswordHandle password,
             bool single,
+            bool ephemeralSpecified,
             out ICertificatePal? readPal,
             out List<ICertificatePal>? readCerts,
             out Exception? openSslException)
@@ -287,7 +312,7 @@ namespace Internal.Cryptography.Pal
 
             using (pfx)
             {
-                return TryReadPkcs12(pfx, password, single, out readPal, out readCerts);
+                return TryReadPkcs12(pfx, password, single, ephemeralSpecified, out readPal, out readCerts);
             }
         }
 
@@ -295,10 +320,11 @@ namespace Internal.Cryptography.Pal
             OpenSslPkcs12Reader pfx,
             SafePasswordHandle password,
             bool single,
+            bool ephemeralSpecified,
             out ICertificatePal? readPal,
             out List<ICertificatePal>? readCerts)
         {
-            pfx.Decrypt(password);
+            pfx.Decrypt(password, ephemeralSpecified);
 
             if (single)
             {

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.iOS/AppleCertificatePal.ImportExport.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.iOS/AppleCertificatePal.ImportExport.cs
@@ -103,6 +103,8 @@ namespace Internal.Cryptography.Pal
         {
             Debug.Assert(password != null);
 
+            bool ephemeralSpecified = keyStorageFlags.HasFlag(X509KeyStorageFlags.EphemeralKeySet);
+
             if (contentType == X509ContentType.Pkcs7)
             {
                 throw new CryptographicException(
@@ -116,7 +118,7 @@ namespace Internal.Cryptography.Pal
                 // We ignore keyStorageFlags which is tracked in https://github.com/dotnet/runtime/issues/52434.
                 // The keys are always imported as ephemeral and never persisted. Exportability is ignored for
                 // the moment and it needs to be investigated how to map it to iOS keychain primitives.
-                return ImportPkcs12(rawData, password);
+                return ImportPkcs12(rawData, password, ephemeralSpecified);
             }
 
             SafeSecIdentityHandle identityHandle;

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.iOS/AppleCertificatePal.Pkcs12.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.iOS/AppleCertificatePal.Pkcs12.cs
@@ -22,11 +22,12 @@ namespace Internal.Cryptography.Pal
 
         private static AppleCertificatePal ImportPkcs12(
             ReadOnlySpan<byte> rawData,
-            SafePasswordHandle password)
+            SafePasswordHandle password,
+            bool ephemeralSpecified)
         {
             using (ApplePkcs12Reader reader = new ApplePkcs12Reader(rawData))
             {
-                reader.Decrypt(password);
+                reader.Decrypt(password, ephemeralSpecified);
                 return ImportPkcs12(reader.GetSingleCert());
             }
         }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.iOS/StorePal.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.iOS/StorePal.cs
@@ -37,6 +37,7 @@ namespace Internal.Cryptography.Pal
                 return new CertCollectionLoader(certificateList);
             }
 
+            bool ephemeralSpecified = keyStorageFlags.HasFlag(X509KeyStorageFlags.EphemeralKeySet);
             X509ContentType contentType = AppleCertificatePal.GetDerCertContentType(rawData);
 
             if (contentType == X509ContentType.Pkcs7)
@@ -52,7 +53,7 @@ namespace Internal.Cryptography.Pal
 
                 try
                 {
-                    reader.Decrypt(password);
+                    reader.Decrypt(password, ephemeralSpecified);
                     return new ApplePkcs12CertLoader(reader, password);
                 }
                 catch

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests.cs
@@ -752,8 +752,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                                 {
                                     CheckMultiBoundKeyConsistency(x);
                                 }
-                                else
+                                else if (x.HasPrivateKey)
                                 {
+                                    // On macOS cert2WithKey.HasPrivateKey is
+                                    // false because the SecIdentityRef won't
+                                    // bind the mismatched private key.
                                     CheckMultiBoundKeyConsistencyFails(x);
                                 }
                             });

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests.cs
@@ -29,7 +29,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         protected static readonly X509KeyStorageFlags s_exportableImportFlags =
             s_importFlags | X509KeyStorageFlags.Exportable;
 
+        protected static readonly X509KeyStorageFlags s_perphemeralImportFlags =
+            X509KeyStorageFlags.UserKeySet;
+
         private static readonly Pkcs9LocalKeyId s_keyIdOne = new Pkcs9LocalKeyId(new byte[] { 1 });
+        private static readonly Pkcs9LocalKeyId s_keyIdTwo = new Pkcs9LocalKeyId(new byte[] { 2 });
 
         // Windows 7 and 8.1 both fail the PFX load if any key is unloadable (even if not referenced).
         // Windows 10 1903, 1809, and 1607 all only fail when an unloadable key was actually needed.
@@ -41,10 +45,36 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             OperatingSystem.IsWindows() &&
             !PlatformDetection.IsWindows10Version1607OrGreater;
 
+        private void ReadPfx(
+            byte[] pfxBytes,
+            string correctPassword,
+            X509Certificate2 expectedCert,
+            Action<X509Certificate2> otherWork = null)
+        {
+            ReadPfx(pfxBytes, correctPassword, expectedCert, s_importFlags, otherWork);
+        }
+
+        private void ReadMultiPfx(
+            byte[] pfxBytes,
+            string correctPassword,
+            X509Certificate2 expectedSingleCert,
+            X509Certificate2[] expectedOrder,
+            Action<X509Certificate2> perCertOtherWork = null)
+        {
+            ReadMultiPfx(
+                pfxBytes,
+                correctPassword,
+                expectedSingleCert,
+                expectedOrder,
+                s_importFlags,
+                perCertOtherWork);
+        }
+
         protected abstract void ReadPfx(
             byte[] pfxBytes,
             string correctPassword,
             X509Certificate2 expectedCert,
+            X509KeyStorageFlags nonExportFlags,
             Action<X509Certificate2> otherWork = null);
 
         protected abstract void ReadMultiPfx(
@@ -52,7 +82,18 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             string correctPassword,
             X509Certificate2 expectedSingleCert,
             X509Certificate2[] expectedOrder,
+            X509KeyStorageFlags nonExportFlags,
             Action<X509Certificate2> perCertOtherWork = null);
+
+        private void ReadUnreadablePfx(
+            byte[] pfxBytes,
+            string bestPassword,
+            // NTE_FAIL
+            int win32Error = -2146893792,
+            int altWin32Error = 0)
+        {
+            ReadUnreadablePfx(pfxBytes, bestPassword, s_importFlags, win32Error, altWin32Error);
+        }
 
         protected abstract void ReadEmptyPfx(byte[] pfxBytes, string correctPassword);
         protected abstract void ReadWrongPassword(byte[] pfxBytes, string wrongPassword);
@@ -60,6 +101,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         protected abstract void ReadUnreadablePfx(
             byte[] pfxBytes,
             string bestPassword,
+            X509KeyStorageFlags importFlags,
             // NTE_FAIL
             int win32Error = -2146893792,
             int altWin32Error = 0);
@@ -657,7 +699,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Fact]
         public void TwoCerts_CrossedKeys()
         {
-            string pw = nameof(SameCertTwice_NoKeys);
+            string pw = nameof(TwoCerts_CrossedKeys);
 
             using (var cert = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword, s_exportableImportFlags))
             using (var cert2 = new X509Certificate2(TestData.MsCertificate))
@@ -812,11 +854,104 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 builder.SealWithMac(pw, s_digestAlgorithm, MacCount);
                 byte[] pfxBytes = builder.Encode();
 
-                ReadUnreadablePfx(
+                if (s_importFlags.HasFlag(X509KeyStorageFlags.EphemeralKeySet))
+                {
+                    ReadUnreadablePfx(
+                        pfxBytes,
+                        pw,
+                        // NTE_BAD_DATA
+                        -2146893819);
+                }
+
+                // On Windows with perphemeral import the private key gets written then
+                // erased during import (cleaning resources associated with non-returned certs)
+                // so on Windows with a single-object load using the key will fail.
+                //
+                // The collection import is on a razors edge with the perphemeral import:
+                // once one of the certs gets disposed the other(s) can no longer open
+                // their private key.
+                Action<X509Certificate2> followup = CheckKeyConsistency;
+
+                if (PlatformDetection.IsWindows)
+                {
+                    if (GetType() == typeof(PfxFormatTests_SingleCert))
+                    {
+                        followup = x =>
+                        {
+                            CryptographicException ex = Assert.ThrowsAny<CryptographicException>(
+                                () => x.GetRSAPrivateKey());
+
+                            // NTE_BAD_KEYSET
+                            Assert.Equal(-2146893802, ex.HResult);
+                        };
+                    }
+                }
+
+                ReadMultiPfx(
                     pfxBytes,
                     pw,
-                    // NTE_BAD_DATA
-                    -2146893819);
+                    cert,
+                    new[] { cert, cert },
+                    s_perphemeralImportFlags,
+                    followup);
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void CertTwice_KeyOnce_OtherCertBetter(bool addLocalKeyId)
+        {
+            string pw = nameof(CertTwice_KeyOnce);
+
+            using (var rsaCert = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword, s_exportableImportFlags))
+            using (var ecCert = new X509Certificate2(TestData.ECDsaP256_DigitalSignature_Pfx_Windows, "Test", s_exportableImportFlags))
+            using (RSA rsa = rsaCert.GetRSAPrivateKey())
+            using (ECDsa ecdsa = ecCert.GetECDsaPrivateKey())
+            {
+                Pkcs12Builder builder = new Pkcs12Builder();
+                Pkcs12SafeContents keyContents = new Pkcs12SafeContents();
+                Pkcs12SafeContents certContents = new Pkcs12SafeContents();
+
+                Pkcs12SafeBag rsaKeyBag = keyContents.AddShroudedKey(rsa, pw, s_windowsPbe);
+                Pkcs12SafeBag ecKeyBag = keyContents.AddShroudedKey(ecdsa, pw, s_windowsPbe);
+                Pkcs12SafeBag certBag = certContents.AddCertificate(ecCert);
+                Pkcs12SafeBag certBag2 = certContents.AddCertificate(ecCert);
+                Pkcs12SafeBag rsaCertBag = certContents.AddCertificate(rsaCert);
+
+                if (addLocalKeyId)
+                {
+                    certBag.Attributes.Add(s_keyIdOne);
+                    certBag2.Attributes.Add(s_keyIdOne);
+                    ecKeyBag.Attributes.Add(s_keyIdOne);
+                    rsaCertBag.Attributes.Add(s_keyIdTwo);
+                    rsaKeyBag.Attributes.Add(s_keyIdTwo);
+                }
+
+                AddContents(keyContents, builder, pw, encrypt: false);
+                AddContents(certContents, builder, pw, encrypt: true);
+                builder.SealWithMac(pw, s_digestAlgorithm, MacCount);
+                byte[] pfxBytes = builder.Encode();
+
+                if (s_importFlags.HasFlag(X509KeyStorageFlags.EphemeralKeySet))
+                {
+                    ReadUnreadablePfx(
+                        pfxBytes,
+                        pw,
+                        // NTE_BAD_DATA
+                        -2146893819);
+                }
+
+                // Because cert2 is what gets returned from the single cert ctor, the
+                // multiply referenced key doesn't cause a runtime problem on Windows.
+
+                ReadMultiPfx(
+                    pfxBytes,
+                    pw,
+                    rsaCert,
+                    new[] { rsaCert, ecCert, ecCert },
+                    s_perphemeralImportFlags,
+                    CheckKeyConsistency);
             }
         }
 
@@ -928,15 +1063,38 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         private static void CheckKeyConsistency(X509Certificate2 cert)
         {
-            using (RSA priv = cert.GetRSAPrivateKey())
-            using (RSA pub = cert.GetRSAPublicKey())
-            {
-                byte[] data = { 2, 7, 4 };
-                byte[] signature = priv.SignData(data, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            byte[] data = { 2, 7, 4 };
 
-                Assert.True(
-                    pub.VerifyData(data, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1),
-                    "Cert public key verifies signature from cert private key");
+            switch (cert.GetKeyAlgorithm())
+            {
+                case "1.2.840.113549.1.1.1":
+                {
+                    using (RSA priv = cert.GetRSAPrivateKey())
+                    using (RSA pub = cert.GetRSAPublicKey())
+                    {
+                        byte[] signature = priv.SignData(data, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+                        Assert.True(
+                            pub.VerifyData(data, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1),
+                            "Cert public key verifies signature from cert private key");
+                    }
+
+                    break;
+                }
+                default:
+                {
+                    using (ECDsa priv = cert.GetECDsaPrivateKey())
+                    using (ECDsa pub = cert.GetECDsaPublicKey())
+                    {
+                        byte[] signature = priv.SignData(data, HashAlgorithmName.SHA256);
+
+                        Assert.True(
+                            pub.VerifyData(data, signature, HashAlgorithmName.SHA256),
+                            "Cert public key verifies signature from cert private key");
+                    }
+
+                    break;
+                }
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests_Collection.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests_Collection.cs
@@ -12,10 +12,13 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             byte[] pfxBytes,
             string correctPassword,
             X509Certificate2 expectedCert,
+            X509KeyStorageFlags nonExportFlags,
             Action<X509Certificate2> otherWork)
         {
-            ReadPfx(pfxBytes, correctPassword, expectedCert, null, otherWork, s_importFlags);
-            ReadPfx(pfxBytes, correctPassword, expectedCert, null, otherWork, s_exportableImportFlags);
+            X509KeyStorageFlags exportFlags = nonExportFlags | X509KeyStorageFlags.Exportable;
+
+            ReadPfx(pfxBytes, correctPassword, expectedCert, null, otherWork, nonExportFlags);
+            ReadPfx(pfxBytes, correctPassword, expectedCert, null, otherWork, exportFlags);
         }
 
         protected override void ReadMultiPfx(
@@ -23,6 +26,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             string correctPassword,
             X509Certificate2 expectedSingleCert,
             X509Certificate2[] expectedOrder,
+            X509KeyStorageFlags nonExportFlags,
             Action<X509Certificate2> perCertOtherWork)
         {
             ReadPfx(
@@ -31,7 +35,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 expectedSingleCert,
                 expectedOrder,
                 perCertOtherWork,
-                s_importFlags);
+                nonExportFlags);
 
             ReadPfx(
                 pfxBytes,
@@ -39,7 +43,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 expectedSingleCert,
                 expectedOrder,
                 perCertOtherWork,
-                s_exportableImportFlags);
+                nonExportFlags | X509KeyStorageFlags.Exportable);
         }
 
         private void ReadPfx(
@@ -89,13 +93,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         protected override void ReadUnreadablePfx(
             byte[] pfxBytes,
             string bestPassword,
+            X509KeyStorageFlags importFlags,
             int win32Error,
             int altWin32Error)
         {
             X509Certificate2Collection coll = new X509Certificate2Collection();
 
             CryptographicException ex = Assert.ThrowsAny<CryptographicException>(
-                () => coll.Import(pfxBytes, bestPassword, s_importFlags));
+                () => coll.Import(pfxBytes, bestPassword, importFlags));
 
             if (OperatingSystem.IsWindows())
             {

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests_SingleCert.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests_SingleCert.cs
@@ -87,5 +87,38 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.NotNull(ex.InnerException);
             }
         }
+
+        private static void CheckBadKeyset(X509Certificate2 cert)
+        {
+            CryptographicException ex = Assert.ThrowsAny<CryptographicException>(
+                    () => cert.GetRSAPrivateKey());
+
+            // NTE_BAD_KEYSET
+            Assert.Equal(-2146893802, ex.HResult);
+        }
+
+        protected override void CheckMultiBoundKeyConsistency(X509Certificate2 cert)
+        {
+            if (PlatformDetection.IsWindows)
+            {
+                CheckBadKeyset(cert);
+            }
+            else
+            {
+                base.CheckMultiBoundKeyConsistency(cert);
+            }
+        }
+
+        protected override void CheckMultiBoundKeyConsistencyFails(X509Certificate2 cert)
+        {
+            if (PlatformDetection.IsWindows)
+            {
+                CheckBadKeyset(cert);
+            }
+            else
+            {
+                base.CheckMultiBoundKeyConsistencyFails(cert);
+            }
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests_SingleCert.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests_SingleCert.cs
@@ -11,10 +11,13 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             byte[] pfxBytes,
             string correctPassword,
             X509Certificate2 expectedCert,
+            X509KeyStorageFlags nonExportFlags,
             Action<X509Certificate2> otherWork)
         {
-            ReadPfx(pfxBytes, correctPassword, expectedCert, otherWork, s_importFlags);
-            ReadPfx(pfxBytes, correctPassword, expectedCert, otherWork, s_exportableImportFlags);
+            X509KeyStorageFlags exportFlags = nonExportFlags | X509KeyStorageFlags.Exportable;
+
+            ReadPfx(pfxBytes, correctPassword, expectedCert, otherWork, nonExportFlags);
+            ReadPfx(pfxBytes, correctPassword, expectedCert, otherWork, exportFlags);
         }
 
         protected override void ReadMultiPfx(
@@ -22,10 +25,13 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             string correctPassword,
             X509Certificate2 expectedSingleCert,
             X509Certificate2[] expectedOrder,
+            X509KeyStorageFlags nonExportFlags,
             Action<X509Certificate2> perCertOtherWork)
         {
-            ReadPfx(pfxBytes, correctPassword, expectedSingleCert, perCertOtherWork, s_importFlags);
-            ReadPfx(pfxBytes, correctPassword, expectedSingleCert, perCertOtherWork, s_exportableImportFlags);
+            X509KeyStorageFlags exportFlags = nonExportFlags | X509KeyStorageFlags.Exportable;
+
+            ReadPfx(pfxBytes, correctPassword, expectedSingleCert, perCertOtherWork, nonExportFlags);
+            ReadPfx(pfxBytes, correctPassword, expectedSingleCert, perCertOtherWork, exportFlags);
         }
 
         private void ReadPfx(
@@ -62,11 +68,12 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         protected override void ReadUnreadablePfx(
             byte[] pfxBytes,
             string bestPassword,
+            X509KeyStorageFlags importFlags,
             int win32Error,
             int altWin32Error)
         {
             CryptographicException ex = Assert.ThrowsAny<CryptographicException>(
-                () => new X509Certificate2(pfxBytes, bestPassword, s_importFlags));
+                () => new X509Certificate2(pfxBytes, bestPassword, importFlags));
 
             if (OperatingSystem.IsWindows())
             {


### PR DESCRIPTION
Fixes #44535.

Windows has a complicated state for when a PFX contains two certificates that link to the same private key:

* EphemeralKeySet: The PFX load fails.
* PersistKeySet: Things probably work.
* (normal): "It's complicated".

When the Unix PFX loader was written it was based on the EphemeralKeySet behavior, because that's what the tests used (to avoid disk penalties and problems).

Trying to maintain a balance between Herculean efforts of bug-for-bug compatibility and OS variability, this change takes a simpler approach:

* EphemeralKeySet: The PFX load fails, like it will on Windows.
* Otherwise: Let it work (but always with cloned keys, so some of the subtle Windows undesirable states are lost).