### PR TITLE
Fix one-shot CBC documentation

### DIFF
--- a/src/libraries/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/SymmetricAlgorithm.cs
+++ b/src/libraries/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/SymmetricAlgorithm.cs
@@ -561,7 +561,7 @@ namespace System.Security.Cryptography
         ///   <paramref name="paddingMode" /> is not a valid padding mode.
         /// </exception>
         /// <exception cref="CryptographicException">
-        ///   <see cref="TryEncryptEcbCore" /> could not encrypt the plaintext.
+        ///   The plaintext could not be encrypted successfully.
         /// </exception>
         /// <remarks>
         ///   This method's behavior is defined by <see cref="TryEncryptEcbCore" />.

--- a/src/libraries/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/SymmetricAlgorithm.cs
+++ b/src/libraries/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/SymmetricAlgorithm.cs
@@ -842,7 +842,7 @@ namespace System.Security.Cryptography
         ///   that is exactly <see cref="BlockSize" /> in length, converted to bytes (<c>BlockSize / 8</c>).
         /// </exception>
         /// <exception cref="CryptographicException">
-        ///   <see cref="TryEncryptEcbCore" /> could not encrypt the plaintext.
+        ///   The plaintext could not be encrypted successfully.
         /// </exception>
         /// <remarks>
         ///   This method's behavior is defined by <see cref="TryEncryptCbcCore" />.
@@ -872,7 +872,7 @@ namespace System.Security.Cryptography
         ///   that is exactly <see cref="BlockSize" /> in length, converted to bytes (<c>BlockSize / 8</c>).
         /// </exception>
         /// <exception cref="CryptographicException">
-        ///   <see cref="TryEncryptEcbCore" /> could not encrypt the plaintext.
+        ///   The plaintext could not be encrypted successfully.
         /// </exception>
         /// <remarks>
         ///   This method's behavior is defined by <see cref="TryEncryptCbcCore" />.


### PR DESCRIPTION
The CBC one-shot documentation made a few references to the ECB one shots. This removes them and uses consistent language that is used on the other one-shot methods.