### PR TITLE
Look up the ICustomMarshaler implementation methods based on runtime type

### DIFF
--- a/src/coreclr/vm/custommarshalerinfo.cpp
+++ b/src/coreclr/vm/custommarshalerinfo.cpp
@@ -96,7 +96,7 @@ CustomMarshalerInfo::CustomMarshalerInfo(LoaderAllocator *pLoaderAllocator, Type
     };
 
     // Call the GetCustomMarshaler method to retrieve the custom marshaler to use.
-    OBJECTREF CustomMarshalerObj;
+    OBJECTREF CustomMarshalerObj = NULL;
     GCPROTECT_BEGIN(CustomMarshalerObj);
     CustomMarshalerObj = getCustomMarshaler.Call_RetOBJECTREF(GetCustomMarshalerArgs);
     if (!CustomMarshalerObj)

--- a/src/coreclr/vm/custommarshalerinfo.cpp
+++ b/src/coreclr/vm/custommarshalerinfo.cpp
@@ -67,13 +67,6 @@ CustomMarshalerInfo::CustomMarshalerInfo(LoaderAllocator *pLoaderAllocator, Type
     STRINGREF CookieStringObj = StringObject::NewString(strCookie, cCookieStrBytes);
     GCPROTECT_BEGIN(CookieStringObj);
 #endif
-
-    // Load the method desc's for all the methods in the ICustomMarshaler interface.
-    m_pMarshalNativeToManagedMD = GetCustomMarshalerMD(CustomMarshalerMethods_MarshalNativeToManaged, hndCustomMarshalerType);
-    m_pMarshalManagedToNativeMD = GetCustomMarshalerMD(CustomMarshalerMethods_MarshalManagedToNative, hndCustomMarshalerType);
-    m_pCleanUpNativeDataMD = GetCustomMarshalerMD(CustomMarshalerMethods_CleanUpNativeData, hndCustomMarshalerType);
-    m_pCleanUpManagedDataMD = GetCustomMarshalerMD(CustomMarshalerMethods_CleanUpManagedData, hndCustomMarshalerType);
-
     // Load the method desc for the static method to retrieve the instance.
     MethodDesc *pGetCustomMarshalerMD = GetCustomMarshalerMD(CustomMarshalerMethods_GetInstance, hndCustomMarshalerType);
 
@@ -103,7 +96,9 @@ CustomMarshalerInfo::CustomMarshalerInfo(LoaderAllocator *pLoaderAllocator, Type
     };
 
     // Call the GetCustomMarshaler method to retrieve the custom marshaler to use.
-    OBJECTREF CustomMarshalerObj = getCustomMarshaler.Call_RetOBJECTREF(GetCustomMarshalerArgs);
+    OBJECTREF CustomMarshalerObj;
+    GCPROTECT_BEGIN(CustomMarshalerObj);
+    CustomMarshalerObj = getCustomMarshaler.Call_RetOBJECTREF(GetCustomMarshalerArgs);
     if (!CustomMarshalerObj)
     {
         DefineFullyQualifiedNameForClassW()
@@ -111,7 +106,16 @@ CustomMarshalerInfo::CustomMarshalerInfo(LoaderAllocator *pLoaderAllocator, Type
                      IDS_EE_NOCUSTOMMARSHALER,
                      GetFullyQualifiedNameForClassW(hndCustomMarshalerType.GetMethodTable()));
     }
+    // Load the method desc's for all the methods in the ICustomMarshaler interface based on the type of the marshaler object.
+    TypeHandle customMarshalerObjType = CustomMarshalerObj->GetMethodTable();
+
+    m_pMarshalNativeToManagedMD = GetCustomMarshalerMD(CustomMarshalerMethods_MarshalNativeToManaged, customMarshalerObjType);
+    m_pMarshalManagedToNativeMD = GetCustomMarshalerMD(CustomMarshalerMethods_MarshalManagedToNative, customMarshalerObjType);
+    m_pCleanUpNativeDataMD = GetCustomMarshalerMD(CustomMarshalerMethods_CleanUpNativeData, customMarshalerObjType);
+    m_pCleanUpManagedDataMD = GetCustomMarshalerMD(CustomMarshalerMethods_CleanUpManagedData, customMarshalerObjType);
+
     m_hndCustomMarshaler = pLoaderAllocator->AllocateHandle(CustomMarshalerObj);
+    GCPROTECT_END();
 
     // Retrieve the size of the native data.
     if (m_bDataIsByValue)


### PR DESCRIPTION
Look up the ICustomMarshaler implementation methods based on the runtime type of the object returned from GetInstance, instead of using the type that was declared in the marshalling info.

These two types can differ, which can cause incorrect methods to be called at runtime if the runtime type has a different vtable layout than the method's parent type.

Contributes to #39606