### PR TITLE
[hot_reload] Add support for row modifications; CustomAttribute updates

### DIFF
--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.CustomAttributeUpdate/CustomAttributeUpdate.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.CustomAttributeUpdate/CustomAttributeUpdate.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+
+
+namespace System.Reflection.Metadata.ApplyUpdate.Test
+{
+    [AttributeUsage (AttributeTargets.Method, AllowMultiple=true)]
+    public class MyAttribute : Attribute
+    {
+        public MyAttribute (string stringValue) { StringValue = stringValue; }
+
+        public MyAttribute (Type typeValue) { TypeValue = typeValue; }
+
+        public MyAttribute (int x) { IntValue = x; }
+
+        public string StringValue { get; set; }
+        public Type TypeValue {get; set; }
+        public int IntValue {get; set; }
+    }
+
+    public class ClassWithCustomAttributeUpdates
+    {
+        [MyAttribute ("abcd")]
+        public static string Method1 () => null;
+
+        [MyAttribute (typeof(Exception))]
+        public static string Method2 () => null;
+
+        [MyAttribute (42, StringValue = "hijkl", TypeValue = typeof(Type))]
+        [MyAttribute (17, StringValue = "", TypeValue = typeof(object))]
+        public static string Method3 () => null;
+
+    }
+}

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.CustomAttributeUpdate/CustomAttributeUpdate_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.CustomAttributeUpdate/CustomAttributeUpdate_v1.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+
+
+namespace System.Reflection.Metadata.ApplyUpdate.Test
+{
+    [AttributeUsage (AttributeTargets.Method, AllowMultiple=true)]
+    public class MyAttribute : Attribute
+    {
+        public MyAttribute (string stringValue) { StringValue = stringValue; }
+
+        public MyAttribute (Type typeValue) { TypeValue = typeValue; }
+
+        public MyAttribute (int x) { IntValue = x; }
+
+        public string StringValue { get; set; }
+        public Type TypeValue {get; set; }
+        public int IntValue {get; set; }
+    }
+
+    public class ClassWithCustomAttributeUpdates
+    {
+        [MyAttribute ("rstuv")]
+        public static string Method1 () => null;
+
+        [MyAttribute (typeof(ArgumentException))]
+        public static string Method2 () => null;
+
+        [MyAttribute (2042, StringValue = "qwerty", TypeValue = typeof(byte[]))]
+        [MyAttribute (17, StringValue = "", TypeValue = typeof(object))]
+        public static string Method3 () => null;
+
+    }
+}

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.CustomAttributeUpdate/System.Reflection.Metadata.ApplyUpdate.Test.CustomAttributeUpdate.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.CustomAttributeUpdate/System.Reflection.Metadata.ApplyUpdate.Test.CustomAttributeUpdate.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>System.Runtime.Loader.Tests</RootNamespace>
+    <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <TestRuntime>true</TestRuntime>
+    <DeltaScript>deltascript.json</DeltaScript>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="CustomAttributeUpdate.cs" />
+  </ItemGroup>
+</Project>

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.CustomAttributeUpdate/System.Reflection.Metadata.ApplyUpdate.Test.CustomAttributeUpdate.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.CustomAttributeUpdate/System.Reflection.Metadata.ApplyUpdate.Test.CustomAttributeUpdate.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
     <TestRuntime>true</TestRuntime>
     <DeltaScript>deltascript.json</DeltaScript>
-    <Nullable>disable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CustomAttributeUpdate.cs" />

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.CustomAttributeUpdate/deltascript.json
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.CustomAttributeUpdate/deltascript.json
@@ -1,0 +1,6 @@
+{
+    "changes": [
+        {"document": "CustomAttributeUpdate.cs", "update": "CustomAttributeUpdate_v1.cs"},
+    ]
+}
+

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.MethodBody1/System.Reflection.Metadata.ApplyUpdate.Test.MethodBody1.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.MethodBody1/System.Reflection.Metadata.ApplyUpdate.Test.MethodBody1.csproj
@@ -5,7 +5,6 @@
     <TestRuntime>true</TestRuntime>
     <DeltaScript>deltascript.json</DeltaScript>
     <SkipTestUtilitiesReference>true</SkipTestUtilitiesReference>
-    <Nullable>disable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="MethodBody1.cs" />

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -83,6 +83,22 @@ namespace System.Reflection.Metadata
             });
         }
 
+        [ConditionalFact(typeof(ApplyUpdateUtil), nameof (ApplyUpdateUtil.IsSupported))]
+        public void CustomAttributeUpdates()
+        {
+            // Test that _modifying_ custom attribute constructor/property argumments works as expected.
+            // For this test, we don't change which constructor is called, or how many custom attributes there are.
+            ApplyUpdateUtil.TestCase(static () =>
+            {
+                var assm = typeof(System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributeUpdates).Assembly;
+
+                ApplyUpdateUtil.ApplyUpdate(assm);
+                ApplyUpdateUtil.ClearAllReflectionCaches();
+
+		Assert.True(true); // just check that the update loaded
+            });
+        }
+
         class NonRuntimeAssembly : Assembly
         {
         }

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -95,7 +95,20 @@ namespace System.Reflection.Metadata
                 ApplyUpdateUtil.ApplyUpdate(assm);
                 ApplyUpdateUtil.ClearAllReflectionCaches();
 
-		Assert.True(true); // just check that the update loaded
+                // Just check the updated value on one method
+
+                Type attrType = typeof(System.Reflection.Metadata.ApplyUpdate.Test.MyAttribute);
+                Type ty = assm.GetType("System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributeUpdates");
+                Assert.NotNull(ty);
+                MethodInfo mi = ty.GetMethod(nameof(System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributeUpdates.Method1), BindingFlags.Public | BindingFlags.Static);
+                Assert.NotNull(mi);
+                var cattrs = Attribute.GetCustomAttributes(mi, attrType);
+                Assert.NotNull(cattrs);
+                Assert.Equal(1, cattrs.Length);
+                Assert.NotNull(cattrs[0]);
+                Assert.Equal(attrType, cattrs[0].GetType());
+                string p = (cattrs[0] as System.Reflection.Metadata.ApplyUpdate.Test.MyAttribute).StringValue;
+                Assert.Equal("rstuv", p);
             });
         }
 

--- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
@@ -39,6 +39,7 @@
     <ProjectReference Include="LoaderLinkTest.Dynamic\LoaderLinkTest.Dynamic.csproj" />
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.MethodBody1\System.Reflection.Metadata.ApplyUpdate.Test.MethodBody1.csproj" />
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes\System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes.csproj" />
+    <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.CustomAttributeUpdate\System.Reflection.Metadata.ApplyUpdate.Test.CustomAttributeUpdate.csproj" />
 
   </ItemGroup>
   <ItemGroup Condition="'$(TargetOS)' == 'Browser'">
@@ -57,6 +58,9 @@
           Include="%(ResolvedFileToPublish.FullPath)" />
       <TrimmerRootAssembly
           Condition="$([System.String]::Copy('%(ResolvedFileToPublish.FileName)%(ResolvedFileToPublish.Extension)').EndsWith('System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes.dll'))"
+          Include="%(ResolvedFileToPublish.FullPath)" />
+      <TrimmerRootAssembly
+          Condition="$([System.String]::Copy('%(ResolvedFileToPublish.FileName)%(ResolvedFileToPublish.Extension)').EndsWith('System.Reflection.Metadata.ApplyUpdate.Test.CustomAttributeUpdate.dll'))"
           Include="%(ResolvedFileToPublish.FullPath)" />
     </ItemGroup>
   </Target>

--- a/src/mono/mono/component/hot_reload-stub.c
+++ b/src/mono/mono/component/hot_reload-stub.c
@@ -59,6 +59,9 @@ hot_reload_stub_table_bounds_check (MonoImage *base_image, int table_index, int 
 static gboolean
 hot_reload_stub_delta_heap_lookup (MonoImage *base_image, MetadataHeapGetterFunc get_heap, uint32_t orig_index, MonoImage **image_out, uint32_t *index_out);
 
+static gboolean
+hot_reload_stub_has_modified_rows (const MonoTableInfo *table);
+
 static MonoComponentHotReload fn_table = {
 	{ MONO_COMPONENT_ITF_VERSION, &hot_reload_stub_available },
 	&hot_reload_stub_set_fastpath_data,
@@ -75,6 +78,7 @@ static MonoComponentHotReload fn_table = {
 	&hot_reload_stub_get_updated_method_rva,
 	&hot_reload_stub_table_bounds_check,
 	&hot_reload_stub_delta_heap_lookup,
+	&hot_reload_stub_has_modified_rows,
 };
 
 static bool
@@ -170,6 +174,11 @@ static gboolean
 hot_reload_stub_delta_heap_lookup (MonoImage *base_image, MetadataHeapGetterFunc get_heap, uint32_t orig_index, MonoImage **image_out, uint32_t *index_out)
 {
 	g_assert_not_reached ();
+}
+
+static gboolean
+hot_reload_stub_has_modified_rows (const MonoTableInfo *table){
+	return FALSE;
 }
 
 MONO_COMPONENT_EXPORT_ENTRYPOINT

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -1140,13 +1140,13 @@ apply_enclog_pass1 (MonoImage *image_base, MonoImage *image_dmeta, gconstpointer
 				    ca_base_cols [MONO_CUSTOM_ATTR_TYPE] != ca_upd_cols [MONO_CUSTOM_ATTR_TYPE]) {
 					mono_error_set_type_load_name (error, NULL, image_base->name, "EnC: we do not support patching of existing CA table cols with a different Parent or Type. token=0x%08x", log_token);
 					unsupported_edits = TRUE;
+					continue;
 				}
+				break;
 			} else  {
-				mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_METADATA_UPDATE, "row[0x%02x]:0x%08x we do not support patching of existing table cols.", i, log_token);
-				mono_error_set_type_load_name (error, NULL, image_base->name, "EnC: we do not support patching of existing table cols. token=0x%08x", log_token);
-				unsupported_edits = TRUE;
+				/* Added a row. ok */
+				break;
 			}
-			continue;
 		}
 		default:
 			/* FIXME: this bounds check is wrong for cumulative updates - need to look at the DeltaInfo:count.prev_gen_rows */

--- a/src/mono/mono/component/hot_reload.h
+++ b/src/mono/mono/component/hot_reload.h
@@ -29,6 +29,8 @@ typedef struct _MonoComponentHotReload {
 	gpointer (*get_updated_method_rva) (MonoImage *base_image, uint32_t idx);
 	gboolean (*table_bounds_check) (MonoImage *base_image, int table_index, int token_index);
 	gboolean (*delta_heap_lookup) (MonoImage *base_image, MetadataHeapGetterFunc get_heap, uint32_t orig_index, MonoImage **image_out, uint32_t *index_out);
+	gboolean (*has_modified_rows) (const MonoTableInfo *table);
+
 } MonoComponentHotReload;
 
 MONO_COMPONENT_EXPORT_ENTRYPOINT

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -805,11 +805,14 @@ mono_metadata_has_updates (void)
 void
 mono_image_effective_table_slow (const MonoTableInfo **t, int *idx);
 
+gboolean
+mono_metadata_update_has_modified_rows (const MonoTableInfo *t);
+
 static inline void
 mono_image_effective_table (const MonoTableInfo **t, int *idx)
 {
 	if (G_UNLIKELY (mono_metadata_has_updates ())) {
-		if (G_UNLIKELY (*idx >= table_info_get_rows ((*t)))) {
+		if (G_UNLIKELY (*idx >= table_info_get_rows ((*t)) || mono_metadata_update_has_modified_rows (*t))) {
 			mono_image_effective_table_slow (t, idx);
 		}
 	}

--- a/src/mono/mono/metadata/metadata-update.c
+++ b/src/mono/mono/metadata/metadata-update.c
@@ -121,3 +121,8 @@ mono_metadata_update_delta_heap_lookup (MonoImage *base_image, MetadataHeapGette
 }
 
 
+gboolean
+mono_metadata_update_has_modified_rows (const MonoTableInfo *table)
+{
+	return mono_component_hot_reload ()->has_modified_rows (table);
+}

--- a/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/ApplyUpdateReferencedAssembly/ApplyUpdateReferencedAssembly.csproj
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/ApplyUpdateReferencedAssembly/ApplyUpdateReferencedAssembly.csproj
@@ -11,7 +11,6 @@
     <!-- hot reload is not compatible with trimming -->
     <EnableAggressiveTrimming>false</EnableAggressiveTrimming>
     <PublishTrimmed>false</PublishTrimmed>
-    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This fixes https://github.com/dotnet/runtime/issues/55097 - which allows us to support C# nullability analysis once again in hot reload deltas.

Specifically we allow EnC deltas to include modifications of existing rows in the CustomAttribute table as long as the Parent and Type columns stay the same (that is: a custom attribute modification that still applies to the same element - and uses the same custom attribute constructor, but may have a different value).

---

To support this, we add a new `BaselineInfo:any_modified_rows` array that keeps track for each table whether any rows have been modified (as opposed to added) by any EnC delta.  When the runtime calls `mono_metadata_decode_row`, if there have been any deltas that modified a row in the requested table, we call `hot_reload_effective_table_slow` which find the latest delta that modified that row.  If there have only been additions, we stop at the first delta that added the row we're looking for, if there are modifications, we look through all the deltas and return the latest one.

