### PR TITLE
Use scopes to resolve array naming issue.

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriterILGen.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriterILGen.cs
@@ -1176,6 +1176,7 @@ namespace System.Xml.Serialization
                 string aiVar = "ai" + memberTypeDesc.Name;
                 string iVar = "i";
                 string fullTypeName = memberTypeDesc.CSharpName;
+                ilg.EnterScope();
                 WriteArrayLocalDecl(fullTypeName, aVar, source, memberTypeDesc);
                 if (memberTypeDesc.IsNullable)
                 {
@@ -1361,6 +1362,8 @@ namespace System.Xml.Serialization
                 {
                     ilg.EndIf();
                 }
+
+                ilg.ExitScope();    // In a try/catch? But EndIf() above isn't.
             }
             else
             {
@@ -1435,6 +1438,7 @@ namespace System.Xml.Serialization
             if (elements.Length == 0 && text == null) return;
             string arrayTypeName = arrayTypeDesc.CSharpName;
             string aName = "a" + arrayTypeDesc.Name;
+            ilg.EnterScope();
             WriteArrayLocalDecl(arrayTypeName, aName, source, arrayTypeDesc);
             LocalBuilder aLoc = ilg.GetLocal(aName);
             if (arrayTypeDesc.IsNullable)
@@ -1486,6 +1490,8 @@ namespace System.Xml.Serialization
             {
                 ilg.EndIf();
             }
+
+            ilg.ExitScope();
         }
 
         [RequiresUnreferencedCode("calls WriteElements")]

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriterILGen.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriterILGen.cs
@@ -1363,7 +1363,7 @@ namespace System.Xml.Serialization
                     ilg.EndIf();
                 }
 
-                ilg.ExitScope();    // In a try/catch? But EndIf() above isn't.
+                ilg.ExitScope();
             }
             else
             {

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -70,6 +70,44 @@ string.Format(@"<?xml version=""1.0"" encoding=""utf-8""?>
     }
 
     [Fact]
+    public static void Xml_NamespaceTypeNameClashTest()
+    {
+        var serializer = new XmlSerializer(typeof(NamespaceTypeNameClashContainer));
+
+        Assert.NotNull(serializer);
+
+        var root = new NamespaceTypeNameClashContainer
+        {
+            A = new[] { new SerializationTypes.TypeNameClashA.TypeNameClash { Name = "N1" }, new SerializationTypes.TypeNameClashA.TypeNameClash { Name = "N2" } },
+            B = new[] { new SerializationTypes.TypeNameClashB.TypeNameClash { Name = "N3" } }
+        };
+
+        var xml = @"<?xml version=""1.0""?>
+        <Root xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
+          <A>
+            <Name>N1</Name>
+          </A>
+          <A>
+            <Name>N2</Name>
+          </A>
+          <B>
+            <Name>N3</Name>
+          </B>
+        </Root>";
+
+        var actualRoot = SerializeAndDeserialize<NamespaceTypeNameClashContainer>(root, xml);
+
+        Assert.NotNull(actualRoot);
+        Assert.NotNull(actualRoot.A);
+        Assert.NotNull(actualRoot.B);
+        Assert.Equal(root.A.Length, actualRoot.A.Length);
+        Assert.Equal(root.B.Length, actualRoot.B.Length);
+        Assert.Equal(root.A[0].Name, actualRoot.A[0].Name);
+        Assert.Equal(root.A[1].Name, actualRoot.A[1].Name);
+        Assert.Equal(root.B[0].Name, actualRoot.B[0].Name);
+    }
+
+    [Fact]
     public static void Xml_ArrayAsGetSet()
     {
         TypeWithGetSetArrayMembers x = new TypeWithGetSetArrayMembers

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -850,6 +850,35 @@ namespace SerializationTypes
         public object Value2 = new SimpleType[1];
 
     }
+
+    namespace TypeNameClashA
+    {
+        [System.Xml.Serialization.XmlType("TypeClashA")]
+        public class TypeNameClash
+        {
+            public string Name { get; set; }
+        }
+    }
+
+    namespace TypeNameClashB
+    {
+        [System.Xml.Serialization.XmlType("TypeClashB")]
+        public class TypeNameClash
+        {
+            public string Name { get; set; }
+        }
+    }
+
+    [System.Xml.Serialization.XmlRootAttribute("Root")]
+    [System.Xml.Serialization.XmlType("ContainerType")]
+    public class NamespaceTypeNameClashContainer
+    {
+        [System.Xml.Serialization.XmlElementAttribute("A")]
+        public TypeNameClashA.TypeNameClash[] A { get; set; }
+
+        [System.Xml.Serialization.XmlElementAttribute("B")]
+        public TypeNameClashB.TypeNameClash[] B { get; set; }
+    }
 }
 
 public class TypeWithXmlElementProperty
@@ -920,7 +949,6 @@ public class TypeWithXmlNodeArrayProperty
     [XmlText]
     public XmlNode[] CDATA { get; set; }
 }
-
 
 public class Animal
 {


### PR DESCRIPTION
Use scopes to resolve array naming issue.

When generating IL code for serializing arrays, we use a
type-based but namespace agnostic naming scheme for
variables in the IL emitted. This can cause naming collisions
for arrays with similar type names that only differ in
namespace. An easy fix is to serialize each array in it's own
scope, so variable names won't conflict with other serialized
members.

Fixes #46196