### PR TITLE
Fix the issue that ToString method incorrectly carries "$Port"

### DIFF
--- a/src/libraries/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -584,8 +584,15 @@ namespace System.Net
             {
                 if (string.IsNullOrEmpty(value))
                 {
-                    // "Port" is present but has no value.
-                    m_port_implicit = true;
+                    if(value == null)
+                    {
+                        m_port_implicit = true;
+                    }
+                    else
+                    {
+                        // "Port" is present but has no value.
+                        m_port_implicit = false;
+                    }
                     m_port = string.Empty;
                 }
                 else

--- a/src/libraries/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -582,10 +582,10 @@ namespace System.Net
             }
             set
             {
-                m_port_implicit = false;
                 if (string.IsNullOrEmpty(value))
                 {
                     // "Port" is present but has no value.
+                    m_port_implicit = true;
                     m_port = string.Empty;
                 }
                 else
@@ -619,6 +619,7 @@ namespace System.Net
                             portList.Add(port);
                         }
                     }
+                    m_port_implicit = false;
                     m_port_list = portList.ToArray();
                     m_port = value;
                     m_version = MaxSupportedVersion;


### PR DESCRIPTION
The following code can reproduce the issue. 
```
Cookie cookie = new Cookie("cookie", "1");
Console.WriteLine(cookie);
cookie.Port = null;
Console.WriteLine(cookie);
```
Output: 
```
cookie=1
cookie=1; $Port
```