### PR TITLE
implement O_DIRECT (NO_BUFFERING) support for Unix

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.OpenFlags.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.OpenFlags.cs
@@ -21,6 +21,7 @@ internal static partial class Interop
             O_EXCL    = 0x0040,
             O_TRUNC   = 0x0080,
             O_SYNC    = 0x0100,
+            O_DIRECT  = 0x1000,
         }
     }
 }

--- a/src/libraries/Native/Unix/System.Native/pal_io.c
+++ b/src/libraries/Native/Unix/System.Native/pal_io.c
@@ -245,7 +245,7 @@ static int32_t ConvertOpenFlags(int32_t flags)
             return -1;
     }
 
-    if (flags & ~(PAL_O_ACCESS_MODE_MASK | PAL_O_CLOEXEC | PAL_O_CREAT | PAL_O_EXCL | PAL_O_TRUNC | PAL_O_SYNC))
+    if (flags & ~(PAL_O_ACCESS_MODE_MASK | PAL_O_CLOEXEC | PAL_O_CREAT | PAL_O_EXCL | PAL_O_TRUNC | PAL_O_SYNC | PAL_O_DIRECT))
     {
         assert_msg(false, "Unknown Open flag", (int)flags);
         return -1;
@@ -263,6 +263,8 @@ static int32_t ConvertOpenFlags(int32_t flags)
         ret |= O_TRUNC;
     if (flags & PAL_O_SYNC)
         ret |= O_SYNC;
+    if (flags & PAL_O_DIRECT)
+        ret |= O_DIRECT;
 
     assert(ret != -1);
     return ret;

--- a/src/libraries/Native/Unix/System.Native/pal_io.h
+++ b/src/libraries/Native/Unix/System.Native/pal_io.h
@@ -154,6 +154,7 @@ enum
     PAL_O_EXCL = 0x0040,    // When combined with CREAT, fails if file already exists
     PAL_O_TRUNC = 0x0080,   // Truncate file to length 0 if it already exists
     PAL_O_SYNC = 0x0100,    // Block writes call will block until physically written
+    PAL_O_DIRECT = 0x1000,  // Direct file IO with kernel buffering disabled
 };
 
 /**

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -254,6 +254,11 @@ namespace Microsoft.Win32.SafeHandles
                 flags |= Interop.Sys.OpenFlags.O_SYNC;
             }
 
+            if ((options & NoBuffering) != 0 && !FileStreamHelpers.UseNet5CompatStrategy)
+            {
+                flags |= Interop.Sys.OpenFlags.O_DIRECT;
+            }
+
             return flags;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Windows.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeFileHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        internal const FileOptions NoBuffering = (FileOptions)0x20000000;
         private volatile FileOptions _fileOptions = (FileOptions)(-1);
         private volatile int _fileType = -1;
 

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.cs
@@ -2,11 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.IO;
 
 namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeFileHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
+        internal const FileOptions NoBuffering = (FileOptions)0x20000000;
         private string? _path;
 
         public SafeFileHandle(IntPtr preexistingHandle, bool ownsHandle) : base(ownsHandle)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.cs
@@ -97,7 +97,7 @@ namespace System.IO.Strategies
             }
 
             // NOTE: any change to FileOptions enum needs to be matched here in the error validation
-            if (options != FileOptions.None && (options & ~(FileOptions.WriteThrough | FileOptions.Asynchronous | FileOptions.RandomAccess | FileOptions.DeleteOnClose | FileOptions.SequentialScan | FileOptions.Encrypted | (FileOptions)0x20000000 /* NoBuffering */)) != 0)
+            if (options != FileOptions.None && (options & ~(FileOptions.WriteThrough | FileOptions.Asynchronous | FileOptions.RandomAccess | FileOptions.DeleteOnClose | FileOptions.SequentialScan | FileOptions.Encrypted | SafeFileHandle.NoBuffering)) != 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(options), SR.ArgumentOutOfRange_Enum);
             }


### PR DESCRIPTION
With the introduction of the new `NativeMemory` API it's much easier to perform direct file IO with .NET.

Since we already support it on Windows by simply allowing the users to pass magic `(FileOptions)0x20000000` as `FileOptions`:

https://github.com/dotnet/runtime/blob/2223babdd49118787c675e04aff711f936a10b26/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs#L166

We could do it on Unix as well.