### PR TITLE
Handle incomplete writes

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/File.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/File.cs
@@ -379,7 +379,15 @@ namespace System.IO
             fs.Write(bytes, 0, bytes.Length);
 #else
             using SafeFileHandle sfh = OpenHandle(path, FileMode.Create, FileAccess.Write, FileShare.Read);
-            RandomAccess.WriteAtOffset(sfh, bytes, 0);
+
+            long offset = 0;
+            Span<byte> buffer = bytes;
+            do
+            {
+                int bytesWritten = RandomAccess.WriteAtOffset(sfh, buffer, offset);
+                offset += bytesWritten;
+                buffer = buffer.Slice(bytesWritten);
+            } while (!buffer.IsEmpty);
 #endif
         }
         public static string[] ReadAllLines(string path)


### PR DESCRIPTION
This is a short term solution for #55473. It solves the problem, but only for `FileStream` and it's introducing a performance regression (allocations).

I can't provide a better solution right now because I am on vacations. I'll be back in a week, then I can provide a long-term fix.