### PR TITLE
Use init rather than ms extension syntax

### DIFF
--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -8130,8 +8130,8 @@ void emitter::emitInitIG(insGroup* ig)
 
 #ifdef DEBUG
     ig->lastGeneratedBlock = nullptr;
-    // Explicitly call the constructor, since IGs don't actually have a constructor.
-    ig->igBlocks.jitstd::list<BasicBlock*>::list(emitComp->getAllocator(CMK_LoopOpt));
+    // Explicitly call init, since IGs don't actually have a constructor.
+    ig->igBlocks.jitstd::list<BasicBlock*>::init(emitComp->getAllocator(CMK_LoopOpt));
 #endif
 }
 

--- a/src/coreclr/jit/jitstd/list.h
+++ b/src/coreclr/jit/jitstd/list.h
@@ -160,6 +160,17 @@ public:
         Node* m_pNode;
     };
 
+#ifdef DEBUG
+    void init(const Allocator& a)
+    {
+        m_pHead = nullptr;
+        m_pTail = nullptr;
+        m_nSize = 0;
+        m_allocator = a;
+        m_nodeAllocator = a;
+    }
+#endif
+
     explicit list(const Allocator&);
     list(size_type n, const T& value, const Allocator&);
 


### PR DESCRIPTION
Fixes gcc build.

Clang also gives the error as gcc when calling ctor function explicitly, but clang emits warning with `-fms-extensions`:

> warning: explicit constructor calls are a Microsoft extension

gcc just does not support this extension (even with `-fms-extensions`). So lets fix it by rewriting it in ISO C++ syntax. 

cc @BruceForstall, @janvorli