### PR TITLE
disable Quic AcceptStream_ConnectionAborted_ByClient_Throws on Linux

### DIFF
--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -36,6 +36,7 @@ namespace System.Net.Quic.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55242", TestPlatforms.Linux)]
         public async Task AcceptStream_ConnectionAborted_ByClient_Throws()
         {
             const int ExpectedErrorCode = 1234;


### PR DESCRIPTION
The underlying issue was fixed in MsQuic and we pulled in new version for Windows in  #55291.
However we don't have updated Linux package so this test is still flaking on Linux and that would block clean CI. 

