### PR TITLE
make Quic tracing easier to correlate with MsQuic

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -83,6 +83,7 @@ namespace System.Net.Quic.Implementations.MsQuic
 
                 if (releaseHandles)
                 {
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"{TraceId()} releasing handle after last stream.");
                     Handle?.Dispose();
                 }
             }
@@ -123,7 +124,14 @@ namespace System.Net.Quic.Implementations.MsQuic
                     _closing = true;
                 }
             }
+
+            internal string TraceId()
+            {
+                return $"[MsQuicConnection#{this.GetHashCode()}/{Handle?.DangerousGetHandle():x}]";
+            }
         }
+
+        internal string TraceId() => _state.TraceId();
 
         // constructor for inbound connections
         public MsQuicConnection(IPEndPoint localEndPoint, IPEndPoint remoteEndPoint, SafeMsQuicConnectionHandle handle, bool remoteCertificateRequired = false, X509RevocationMode revocationMode = X509RevocationMode.Offline, RemoteCertificateValidationCallback? remoteCertificateValidationCallback = null)
@@ -162,7 +170,7 @@ namespace System.Net.Quic.Implementations.MsQuic
 
             if (NetEventSource.Log.IsEnabled())
             {
-                NetEventSource.Info(_state, $"[Connection#{_state.GetHashCode()}] inbound connection created");
+                NetEventSource.Info(_state, $"{TraceId()} inbound connection created");
             }
         }
 
@@ -201,7 +209,7 @@ namespace System.Net.Quic.Implementations.MsQuic
 
             if (NetEventSource.Log.IsEnabled())
             {
-                NetEventSource.Info(_state, $"[Connection#{_state.GetHashCode()}] outbound connection created");
+                NetEventSource.Info(_state, $"{TraceId()} outbound connection created");
             }
         }
 
@@ -621,7 +629,7 @@ namespace System.Net.Quic.Implementations.MsQuic
 
             if (NetEventSource.Log.IsEnabled())
             {
-                NetEventSource.Info(state, $"[Connection#{state.GetHashCode()}] received event {connectionEvent.Type}");
+                NetEventSource.Info(state, $"{state.TraceId()} received event {connectionEvent.Type}");
             }
 
             try
@@ -697,6 +705,8 @@ namespace System.Net.Quic.Implementations.MsQuic
                 return;
             }
 
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(_state, $"{TraceId()} disposing {disposing}");
+
             bool releaseHandles = false;
             lock (_state)
             {
@@ -716,6 +726,8 @@ namespace System.Net.Quic.Implementations.MsQuic
             _configuration?.Dispose();
             if (releaseHandles)
             {
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(_state, $"{TraceId()} releasing handle");
+
                 // We may not be fully initialized if constructor fails.
                 _state.Handle?.Dispose();
             }


### PR DESCRIPTION
This PR adds Handle to the trace and create little helpers for it. 
With that we can do:
```
[MsQuicConnection#20974680/7fe2a4004460] received event IDEAL_PROCESSOR_CHANGED
[MsQuicConnection#58366981/7fe2940ad370] received event PEER_CERTIFICATE_RECEIVED

$ grep 7fe2a4004460 quic.log

[0][27cf3a.27cf49][04:01:00.363544][conn][0x7fe2a4004460] Created, IsServer=1, CorrelationId=1
[0][27cf3a.27cf49][04:01:00.363544][conn][0x7fe2a4004460] OUT: BytesSent=0 InFlight=0 InFlightMax=0 CWnd=0 SSThresh=4294967295 ConnFC=0 ISB=131072 PostedBytes=0 SRtt=0
[0][27cf3a.27cf49][04:01:00.363545][conn][0x7fe2a4004460] OUT: StreamFC=0 StreamSendWindow=0
[0][27cf3a.27cf49][04:01:00.363545][conn][0x7fe2a4004460] CUBIC: SlowStartThreshold=4294967295 K=0 WindowMax=0 WindowLastMax=0
[0][27cf3a.27cf49][04:01:00.363547][conn][0x7fe2a4004460] Path[0] Initialized
[0][27cf3a.27cf49][04:01:00.363547][conn][0x7fe2a4004460] QUIC Version: 16777216
```

not only we have hash that is pretty useless (aside from providing somewhat unique identifier) but we can also directly to native MsQuic tracing. 


Note that I updated only critical events e.g. creation/destruction and native callback handler.
I'd be happy to update all tracing instances if we want to.