### PR TITLE
Change RandomAccess.Write* methods to perform complete writes

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/RandomAccess/Mixed.Windows.cs
+++ b/src/libraries/System.IO.FileSystem/tests/RandomAccess/Mixed.Windows.cs
@@ -62,8 +62,17 @@ namespace System.IO.Tests
                     {
                         writeBuffer[0] = (byte)fileOffset;
 
-                        Assert.Equal(writeBuffer.Length, syncWrite ? RandomAccess.Write(handle, writeBuffer, fileOffset) : await RandomAccess.WriteAsync(handle, writeBuffer, fileOffset));
+                        if (syncWrite)
+                        {
+                            RandomAccess.Write(handle, writeBuffer, fileOffset);
+                        }
+                        else
+                        {
+                            await RandomAccess.WriteAsync(handle, writeBuffer, fileOffset);
+                        }
+
                         Assert.Equal(writeBuffer.Length, syncRead ? RandomAccess.Read(handle, readBuffer, fileOffset) : await RandomAccess.ReadAsync(handle, readBuffer, fileOffset));
+
                         Assert.Equal(writeBuffer[0], readBuffer[0]);
 
                         fileOffset += 1;
@@ -116,8 +125,17 @@ namespace System.IO.Tests
                         writeBuffer_1[0] = (byte)fileOffset;
                         writeBuffer_2[0] = (byte)(fileOffset+1);
 
-                        Assert.Equal(writeBuffer_1.Length + writeBuffer_2.Length, syncWrite ? RandomAccess.Write(handle, writeBuffers, fileOffset) : await RandomAccess.WriteAsync(handle, writeBuffers, fileOffset));
+                        if (syncWrite)
+                        {
+                            RandomAccess.Write(handle, writeBuffers, fileOffset);
+                        }
+                        else
+                        {
+                            await RandomAccess.WriteAsync(handle, writeBuffers, fileOffset);
+                        }
+
                         Assert.Equal(writeBuffer_1.Length + writeBuffer_2.Length, syncRead ? RandomAccess.Read(handle, readBuffers, fileOffset) : await RandomAccess.ReadAsync(handle, readBuffers, fileOffset));
+
                         Assert.Equal(writeBuffer_1[0], readBuffer_1[0]);
                         Assert.Equal(writeBuffer_2[0], readBuffer_2[0]);
 

--- a/src/libraries/System.IO.FileSystem/tests/RandomAccess/NoBuffering.Windows.cs
+++ b/src/libraries/System.IO.FileSystem/tests/RandomAccess/NoBuffering.Windows.cs
@@ -118,9 +118,16 @@ namespace System.IO.Tests
                     int take = Math.Min(content.Length - total, bufferSize);
                     content.AsSpan(total, take).CopyTo(buffer.GetSpan());
 
-                    total += async
-                        ? await RandomAccess.WriteAsync(handle, buffer.Memory, fileOffset: total)
-                        : RandomAccess.Write(handle, buffer.GetSpan(), fileOffset: total);
+                    if (async)
+                    {
+                        await RandomAccess.WriteAsync(handle, buffer.Memory, fileOffset: total);
+                    }
+                    else
+                    {
+                        RandomAccess.Write(handle, buffer.GetSpan(), fileOffset: total);
+                    }
+
+                    total += buffer.Memory.Length;
                 }
             }
 
@@ -154,9 +161,16 @@ namespace System.IO.Tests
                     content.AsSpan((int)total, bufferSize).CopyTo(buffer_1.GetSpan());
                     content.AsSpan((int)total + bufferSize, bufferSize).CopyTo(buffer_2.GetSpan());
 
-                    total += async
-                        ? await RandomAccess.WriteAsync(handle, buffers, fileOffset: total)
-                        : RandomAccess.Write(handle, buffers, fileOffset: total);
+                    if (async)
+                    {
+                        await RandomAccess.WriteAsync(handle, buffers, fileOffset: total);
+                    }
+                    else
+                    {
+                        RandomAccess.Write(handle, buffers, fileOffset: total);
+                    }
+
+                    total += buffer_1.Memory.Length + buffer_2.Memory.Length;
                 }
             }
 

--- a/src/libraries/System.IO.FileSystem/tests/RandomAccess/Write.cs
+++ b/src/libraries/System.IO.FileSystem/tests/RandomAccess/Write.cs
@@ -10,7 +10,10 @@ namespace System.IO.Tests
     public class RandomAccess_Write : RandomAccess_Base<int>
     {
         protected override int MethodUnderTest(SafeFileHandle handle, byte[] bytes, long fileOffset)
-            => RandomAccess.Write(handle, bytes, fileOffset);
+        {
+            RandomAccess.Write(handle, bytes, fileOffset);
+            return bytes?.Length ?? 0;
+        }
 
         [Theory]
         [MemberData(nameof(GetSyncAsyncOptions))]
@@ -24,11 +27,11 @@ namespace System.IO.Tests
 
         [Theory]
         [MemberData(nameof(GetSyncAsyncOptions))]
-        public void WriteUsingEmptyBufferReturnsZero(FileOptions options)
+        public void WriteUsingEmptyBufferReturns(FileOptions options)
         {
             using (SafeFileHandle handle = File.OpenHandle(GetTestFilePath(), FileMode.Create, FileAccess.Write, options: options))
             {
-                Assert.Equal(0, RandomAccess.Write(handle, Array.Empty<byte>(), fileOffset: 0));
+                RandomAccess.Write(handle, Array.Empty<byte>(), fileOffset: 0);
             }
         }
 
@@ -41,7 +44,7 @@ namespace System.IO.Tests
 
             using (SafeFileHandle handle = File.OpenHandle(filePath, FileMode.Create, FileAccess.Write, options: options))
             {
-                Assert.Equal(stackAllocated.Length, RandomAccess.Write(handle, stackAllocated, fileOffset: 0));
+                RandomAccess.Write(handle, stackAllocated, fileOffset: 0);
             }
 
             Assert.Equal(stackAllocated.ToArray(), File.ReadAllBytes(filePath));
@@ -58,17 +61,14 @@ namespace System.IO.Tests
             using (SafeFileHandle handle = File.OpenHandle(filePath, FileMode.CreateNew, FileAccess.Write, FileShare.None, options))
             {
                 int total = 0;
-                int current = 0;
 
                 while (total != fileSize)
                 {
                     Span<byte> buffer = content.AsSpan(total, Math.Min(content.Length - total, fileSize / 4));
 
-                    current = RandomAccess.Write(handle, buffer, fileOffset: total);
+                    RandomAccess.Write(handle, buffer, fileOffset: total);
 
-                    Assert.InRange(current, 0, buffer.Length);
-
-                    total += current;
+                    total += buffer.Length;
                 }
             }
 

--- a/src/libraries/System.IO.FileSystem/tests/RandomAccess/WriteAsync.cs
+++ b/src/libraries/System.IO.FileSystem/tests/RandomAccess/WriteAsync.cs
@@ -11,9 +11,9 @@ namespace System.IO.Tests
 {
     [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
     [SkipOnPlatform(TestPlatforms.Browser, "async file IO is not supported on browser")]
-    public class RandomAccess_WriteAsync : RandomAccess_Base<ValueTask<int>>
+    public class RandomAccess_WriteAsync : RandomAccess_Base<ValueTask>
     {
-        protected override ValueTask<int> MethodUnderTest(SafeFileHandle handle, byte[] bytes, long fileOffset)
+        protected override ValueTask MethodUnderTest(SafeFileHandle handle, byte[] bytes, long fileOffset)
             => RandomAccess.WriteAsync(handle, bytes, fileOffset);
 
         [Theory]
@@ -44,11 +44,11 @@ namespace System.IO.Tests
 
         [Theory]
         [MemberData(nameof(GetSyncAsyncOptions))]
-        public async Task WriteUsingEmptyBufferReturnsZeroAsync(FileOptions options)
+        public async Task WriteUsingEmptyBufferReturnsAsync(FileOptions options)
         {
             using (SafeFileHandle handle = File.OpenHandle(GetTestFilePath(), FileMode.Create, FileAccess.Write, options: options))
             {
-                Assert.Equal(0, await RandomAccess.WriteAsync(handle, Array.Empty<byte>(), fileOffset: 0));
+                await RandomAccess.WriteAsync(handle, Array.Empty<byte>(), fileOffset: 0);
             }
         }
 
@@ -63,17 +63,14 @@ namespace System.IO.Tests
             using (SafeFileHandle handle = File.OpenHandle(filePath, FileMode.CreateNew, FileAccess.Write, FileShare.None, options))
             {
                 int total = 0;
-                int current = 0;
 
                 while (total != fileSize)
                 {
                     Memory<byte> buffer = content.AsMemory(total, Math.Min(content.Length - total, fileSize / 4));
 
-                    current = await RandomAccess.WriteAsync(handle, buffer, fileOffset: total);
+                    await RandomAccess.WriteAsync(handle, buffer, fileOffset: total);
 
-                    Assert.InRange(current, 0, buffer.Length);
-
-                    total += current;
+                    total += buffer.Length;
                 }
             }
 

--- a/src/libraries/System.IO.FileSystem/tests/RandomAccess/WriteGather.cs
+++ b/src/libraries/System.IO.FileSystem/tests/RandomAccess/WriteGather.cs
@@ -12,7 +12,10 @@ namespace System.IO.Tests
     public class RandomAccess_WriteGather : RandomAccess_Base<long>
     {
         protected override long MethodUnderTest(SafeFileHandle handle, byte[] bytes, long fileOffset)
-            => RandomAccess.Write(handle, new ReadOnlyMemory<byte>[] { bytes }, fileOffset);
+        {
+            RandomAccess.Write(handle, new ReadOnlyMemory<byte>[] { bytes }, fileOffset);
+            return bytes?.Length ?? 0;
+        }
 
         [Theory]
         [MemberData(nameof(GetSyncAsyncOptions))]
@@ -36,11 +39,11 @@ namespace System.IO.Tests
 
         [Theory]
         [MemberData(nameof(GetSyncAsyncOptions))]
-        public void WriteUsingEmptyBufferReturnsZero(FileOptions options)
+        public void WriteUsingEmptyBufferReturns(FileOptions options)
         {
             using (SafeFileHandle handle = File.OpenHandle(GetTestFilePath(), FileMode.Create, FileAccess.Write, options: options))
             {
-                Assert.Equal(0, RandomAccess.Write(handle, new ReadOnlyMemory<byte>[] { Array.Empty<byte>() }, fileOffset: 0));
+                RandomAccess.Write(handle, new ReadOnlyMemory<byte>[] { Array.Empty<byte>() }, fileOffset: 0);
             }
         }
 
@@ -55,7 +58,6 @@ namespace System.IO.Tests
             using (SafeFileHandle handle = File.OpenHandle(filePath, FileMode.CreateNew, FileAccess.Write, FileShare.None, options))
             {
                 long total = 0;
-                long current = 0;
 
                 while (total != fileSize)
                 {
@@ -63,7 +65,7 @@ namespace System.IO.Tests
                     Memory<byte> buffer_1 = content.AsMemory((int)total, firstBufferLength);
                     Memory<byte> buffer_2 = content.AsMemory((int)total + firstBufferLength);
 
-                    current = RandomAccess.Write(
+                    RandomAccess.Write(
                         handle,
                         new ReadOnlyMemory<byte>[]
                         {
@@ -73,9 +75,7 @@ namespace System.IO.Tests
                         },
                         fileOffset: total);
 
-                    Assert.InRange(current, 0, buffer_1.Length + buffer_2.Length);
-
-                    total += current;
+                    total += buffer_1.Length + buffer_2.Length;
                 }
             }
 
@@ -94,7 +94,7 @@ namespace System.IO.Tests
 
             using (SafeFileHandle handle = File.OpenHandle(filePath, FileMode.Create, FileAccess.Write, options: options))
             {
-                Assert.Equal(repeatCount, RandomAccess.Write(handle, buffers, fileOffset: 0));
+                RandomAccess.Write(handle, buffers, fileOffset: 0);
             }
 
             byte[] actualContent = File.ReadAllBytes(filePath);

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.OverlappedValueTaskSource.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.OverlappedValueTaskSource.Windows.cs
@@ -86,10 +86,8 @@ namespace Microsoft.Win32.SafeHandles
 
             public ValueTaskSourceStatus GetStatus(short token) => _source.GetStatus(token);
             public void OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags) => _source.OnCompleted(continuation, state, token, flags);
-            void IValueTaskSource.GetResult(short token) => GetResultAndRelease(token);
-            int IValueTaskSource<int>.GetResult(short token) => GetResultAndRelease(token);
-
-            private int GetResultAndRelease(short token)
+            void IValueTaskSource.GetResult(short token) => GetResult(token);
+            public int GetResult(short token)
             {
                 try
                 {

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.ThreadPoolValueTaskSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.ThreadPoolValueTaskSource.cs
@@ -54,7 +54,15 @@ namespace Microsoft.Win32.SafeHandles
                 Debug.Assert(op == Operation.None, $"An operation was queued before the previous {op}'s completion.");
             }
 
-            private long GetResultAndRelease(short token)
+            public ValueTaskSourceStatus GetStatus(short token) =>
+                _source.GetStatus(token);
+
+            public void OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags) =>
+                _source.OnCompleted(continuation, state, token, flags);
+
+            void IValueTaskSource.GetResult(short token) => GetResult(token);
+            int IValueTaskSource<int>.GetResult(short token) => (int)GetResult(token);
+            public long GetResult(short token)
             {
                 try
                 {
@@ -66,13 +74,6 @@ namespace Microsoft.Win32.SafeHandles
                     Volatile.Write(ref _fileHandle._reusableThreadPoolValueTaskSource, this);
                 }
             }
-
-            public ValueTaskSourceStatus GetStatus(short token) => _source.GetStatus(token);
-            public void OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags) =>
-                _source.OnCompleted(continuation, state, token, flags);
-            int IValueTaskSource<int>.GetResult(short token) => (int) GetResultAndRelease(token);
-            long IValueTaskSource<long>.GetResult(short token) => GetResultAndRelease(token);
-            void IValueTaskSource.GetResult(short token) => GetResultAndRelease(token);
 
             private void ExecuteInternal()
             {
@@ -96,7 +97,7 @@ namespace Microsoft.Win32.SafeHandles
                                 result = RandomAccess.ReadAtOffset(_fileHandle, writableSingleSegment.Span, _fileOffset);
                                 break;
                             case Operation.Write:
-                                result = RandomAccess.WriteAtOffset(_fileHandle, _singleSegment.Span, _fileOffset);
+                                RandomAccess.WriteAtOffset(_fileHandle, _singleSegment.Span, _fileOffset);
                                 break;
                             case Operation.ReadScatter:
                                 Debug.Assert(_readScatterBuffers != null);
@@ -104,7 +105,7 @@ namespace Microsoft.Win32.SafeHandles
                                 break;
                             case Operation.WriteGather:
                                 Debug.Assert(_writeGatherBuffers != null);
-                                result = RandomAccess.WriteGatherAtOffset(_fileHandle, _writeGatherBuffers, _fileOffset);
+                                RandomAccess.WriteGatherAtOffset(_fileHandle, _writeGatherBuffers, _fileOffset);
                                 break;
                         }
                     }
@@ -164,7 +165,7 @@ namespace Microsoft.Win32.SafeHandles
                 return new ValueTask<int>(this, _source.Version);
             }
 
-            public ValueTask<int> QueueWrite(ReadOnlyMemory<byte> buffer, long fileOffset, CancellationToken cancellationToken)
+            public ValueTask QueueWrite(ReadOnlyMemory<byte> buffer, long fileOffset, CancellationToken cancellationToken)
             {
                 ValidateInvariants();
 
@@ -174,7 +175,7 @@ namespace Microsoft.Win32.SafeHandles
                 _cancellationToken = cancellationToken;
                 QueueToThreadPool();
 
-                return new ValueTask<int>(this, _source.Version);
+                return new ValueTask(this, _source.Version);
             }
 
             public ValueTask<long> QueueReadScatter(IReadOnlyList<Memory<byte>> buffers, long fileOffset, CancellationToken cancellationToken)
@@ -190,7 +191,7 @@ namespace Microsoft.Win32.SafeHandles
                 return new ValueTask<long>(this, _source.Version);
             }
 
-            public ValueTask<long> QueueWriteGather(IReadOnlyList<ReadOnlyMemory<byte>> buffers, long fileOffset, CancellationToken cancellationToken)
+            public ValueTask QueueWriteGather(IReadOnlyList<ReadOnlyMemory<byte>> buffers, long fileOffset, CancellationToken cancellationToken)
             {
                 ValidateInvariants();
 
@@ -200,7 +201,7 @@ namespace Microsoft.Win32.SafeHandles
                 _cancellationToken = cancellationToken;
                 QueueToThreadPool();
 
-                return new ValueTask<long>(this, _source.Version);
+                return new ValueTask(this, _source.Version);
             }
 
             private enum Operation : byte

--- a/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
@@ -134,7 +135,6 @@ namespace System.IO
         /// <param name="handle">The file handle.</param>
         /// <param name="buffer">A region of memory. This method copies the contents of this region to the file.</param>
         /// <param name="fileOffset">The file position to write to.</param>
-        /// <returns>The total number of bytes written into the file. This can be less than the number of bytes provided in the buffer and it's not an error.</returns>
         /// <exception cref="T:System.ArgumentNullException"><paramref name="handle" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException"><paramref name="handle" /> is invalid.</exception>
         /// <exception cref="T:System.ObjectDisposedException">The file is closed.</exception>
@@ -143,11 +143,11 @@ namespace System.IO
         /// <exception cref="T:System.UnauthorizedAccessException"><paramref name="handle" /> was not opened for writing.</exception>
         /// <exception cref="T:System.IO.IOException">An I/O error occurred.</exception>
         /// <remarks>Position of the file is not advanced.</remarks>
-        public static int Write(SafeFileHandle handle, ReadOnlySpan<byte> buffer, long fileOffset)
+        public static void Write(SafeFileHandle handle, ReadOnlySpan<byte> buffer, long fileOffset)
         {
             ValidateInput(handle, fileOffset);
 
-            return WriteAtOffset(handle, buffer, fileOffset);
+            WriteAtOffset(handle, buffer, fileOffset);
         }
 
         /// <summary>
@@ -156,7 +156,6 @@ namespace System.IO
         /// <param name="handle">The file handle.</param>
         /// <param name="buffers">A list of memory buffers. This method copies the contents of these buffers to the file.</param>
         /// <param name="fileOffset">The file position to write to.</param>
-        /// <returns>The total number of bytes written into the file. This can be less than the number of bytes provided in the buffers and it's not an error.</returns>
         /// <exception cref="T:System.ArgumentNullException"><paramref name="handle" /> or <paramref name="buffers" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException"><paramref name="handle" /> is invalid.</exception>
         /// <exception cref="T:System.ObjectDisposedException">The file is closed.</exception>
@@ -165,12 +164,12 @@ namespace System.IO
         /// <exception cref="T:System.UnauthorizedAccessException"><paramref name="handle" /> was not opened for writing.</exception>
         /// <exception cref="T:System.IO.IOException">An I/O error occurred.</exception>
         /// <remarks>Position of the file is not advanced.</remarks>
-        public static long Write(SafeFileHandle handle, IReadOnlyList<ReadOnlyMemory<byte>> buffers, long fileOffset)
+        public static void Write(SafeFileHandle handle, IReadOnlyList<ReadOnlyMemory<byte>> buffers, long fileOffset)
         {
             ValidateInput(handle, fileOffset);
             ValidateBuffers(buffers);
 
-            return WriteGatherAtOffset(handle, buffers, fileOffset);
+            WriteGatherAtOffset(handle, buffers, fileOffset);
         }
 
         /// <summary>
@@ -180,7 +179,7 @@ namespace System.IO
         /// <param name="buffer">A region of memory. This method copies the contents of this region to the file.</param>
         /// <param name="fileOffset">The file position to write to.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="P:System.Threading.CancellationToken.None" />.</param>
-        /// <returns>The total number of bytes written into the file. This can be less than the number of bytes provided in the buffer and it's not an error.</returns>
+        /// <returns>A task representing the asynchronous completion of the write operation.</returns>
         /// <exception cref="T:System.ArgumentNullException"><paramref name="handle" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException"><paramref name="handle" /> is invalid.</exception>
         /// <exception cref="T:System.ObjectDisposedException">The file is closed.</exception>
@@ -189,13 +188,13 @@ namespace System.IO
         /// <exception cref="T:System.UnauthorizedAccessException"><paramref name="handle" /> was not opened for writing.</exception>
         /// <exception cref="T:System.IO.IOException">An I/O error occurred.</exception>
         /// <remarks>Position of the file is not advanced.</remarks>
-        public static ValueTask<int> WriteAsync(SafeFileHandle handle, ReadOnlyMemory<byte> buffer, long fileOffset, CancellationToken cancellationToken = default)
+        public static ValueTask WriteAsync(SafeFileHandle handle, ReadOnlyMemory<byte> buffer, long fileOffset, CancellationToken cancellationToken = default)
         {
             ValidateInput(handle, fileOffset);
 
             if (cancellationToken.IsCancellationRequested)
             {
-                return ValueTask.FromCanceled<int>(cancellationToken);
+                return ValueTask.FromCanceled(cancellationToken);
             }
 
             return WriteAtOffsetAsync(handle, buffer, fileOffset, cancellationToken);
@@ -208,7 +207,7 @@ namespace System.IO
         /// <param name="buffers">A list of memory buffers. This method copies the contents of these buffers to the file.</param>
         /// <param name="fileOffset">The file position to write to.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="P:System.Threading.CancellationToken.None" />.</param>
-        /// <returns>The total number of bytes written into the file. This can be less than the number of bytes provided in the buffers and it's not an error.</returns>
+        /// <returns>A task representing the asynchronous completion of the write operation.</returns>
         /// <exception cref="T:System.ArgumentNullException"><paramref name="handle" /> or <paramref name="buffers"/> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException"><paramref name="handle" /> is invalid.</exception>
         /// <exception cref="T:System.ObjectDisposedException">The file is closed.</exception>
@@ -217,14 +216,14 @@ namespace System.IO
         /// <exception cref="T:System.UnauthorizedAccessException"><paramref name="handle" /> was not opened for writing.</exception>
         /// <exception cref="T:System.IO.IOException">An I/O error occurred.</exception>
         /// <remarks>Position of the file is not advanced.</remarks>
-        public static ValueTask<long> WriteAsync(SafeFileHandle handle, IReadOnlyList<ReadOnlyMemory<byte>> buffers, long fileOffset, CancellationToken cancellationToken = default)
+        public static ValueTask WriteAsync(SafeFileHandle handle, IReadOnlyList<ReadOnlyMemory<byte>> buffers, long fileOffset, CancellationToken cancellationToken = default)
         {
             ValidateInput(handle, fileOffset);
             ValidateBuffers(buffers);
 
             if (cancellationToken.IsCancellationRequested)
             {
-                return ValueTask.FromCanceled<long>(cancellationToken);
+                return ValueTask.FromCanceled(cancellationToken);
             }
 
             return WriteGatherAtOffsetAsync(handle, buffers, fileOffset, cancellationToken);
@@ -276,13 +275,13 @@ namespace System.IO
             return handle.GetThreadPoolValueTaskSource().QueueReadScatter(buffers, fileOffset, cancellationToken);
         }
 
-        private static ValueTask<int> ScheduleSyncWriteAtOffsetAsync(SafeFileHandle handle, ReadOnlyMemory<byte> buffer,
+        private static ValueTask ScheduleSyncWriteAtOffsetAsync(SafeFileHandle handle, ReadOnlyMemory<byte> buffer,
             long fileOffset, CancellationToken cancellationToken)
         {
             return handle.GetThreadPoolValueTaskSource().QueueWrite(buffer, fileOffset, cancellationToken);
         }
 
-        private static ValueTask<long> ScheduleSyncWriteGatherAtOffsetAsync(SafeFileHandle handle, IReadOnlyList<ReadOnlyMemory<byte>> buffers,
+        private static ValueTask ScheduleSyncWriteGatherAtOffsetAsync(SafeFileHandle handle, IReadOnlyList<ReadOnlyMemory<byte>> buffers,
             long fileOffset, CancellationToken cancellationToken)
         {
             return handle.GetThreadPoolValueTaskSource().QueueWriteGather(buffers, fileOffset, cancellationToken);

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/OSFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/OSFileStreamStrategy.cs
@@ -290,10 +290,17 @@ namespace System.IO.Strategies
                 ThrowHelper.ThrowNotSupportedException_UnwritableStream();
             }
 
-            int r = RandomAccess.WriteAtOffset(_fileHandle, buffer, _filePosition);
-            Debug.Assert(r >= 0, $"RandomAccess.WriteAtOffset returned {r}.");
-            _filePosition += r;
+            try
+            {
+                RandomAccess.WriteAtOffset(_fileHandle, buffer, _filePosition);
+            }
+            catch
+            {
+                _length = -1; // invalidate cached length
+                throw;
+            }
 
+            _filePosition += buffer.Length;
             UpdateLengthOnChangePosition();
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/UnixFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/UnixFileStreamStrategy.cs
@@ -58,14 +58,9 @@ namespace System.IO.Strategies
             TaskToApm.End(asyncResult);
 
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
-            WriteAsyncCore(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).AsTask();
+            WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).AsTask();
 
-        public override ValueTask WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken) =>
-#pragma warning disable CA2012 // The analyzer doesn't know the internal AsValueTask is safe.
-            WriteAsyncCore(source, cancellationToken).AsValueTask();
-#pragma warning restore CA2012
-
-        private ValueTask<int> WriteAsyncCore(ReadOnlyMemory<byte> source, CancellationToken cancellationToken)
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken)
         {
             if (!CanWrite)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ValueTask.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ValueTask.cs
@@ -571,31 +571,6 @@ namespace System.Threading.Tasks
         /// <summary>Gets a <see cref="ValueTask{TResult}"/> that may be used at any point in the future.</summary>
         public ValueTask<TResult> Preserve() => _obj == null ? this : new ValueTask<TResult>(AsTask());
 
-        /// <summary>Casts a <see cref="ValueTask{TResult}"/> to <see cref="ValueTask"/>.</summary>
-        internal ValueTask AsValueTask()
-        {
-            object? obj = _obj;
-            Debug.Assert(obj == null || obj is Task<TResult> || obj is IValueTaskSource<TResult>);
-
-            if (obj is null)
-            {
-                return default;
-            }
-
-            if (obj is Task<TResult> t)
-            {
-                return new ValueTask(t);
-            }
-
-            if (obj is IValueTaskSource vts)
-            {
-                // This assumes the token used with IVTS is the same as used with IVTS<TResult>.
-                return new ValueTask(vts, _token);
-            }
-
-            return new ValueTask(GetTaskForValueTaskSource(Unsafe.As<IValueTaskSource<TResult>>(obj)));
-        }
-
         /// <summary>Creates a <see cref="Task{TResult}"/> to represent the <see cref="IValueTaskSource{TResult}"/>.</summary>
         /// <remarks>
         /// The <see cref="IValueTaskSource{TResult}"/> is passed in rather than reading and casting <see cref="_obj"/>

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -10873,10 +10873,10 @@ namespace System.IO
         public static long Read(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.Collections.Generic.IReadOnlyList<System.Memory<byte>> buffers, long fileOffset) { throw null; }
         public static System.Threading.Tasks.ValueTask<int> ReadAsync(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.Memory<byte> buffer, long fileOffset, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static System.Threading.Tasks.ValueTask<long> ReadAsync(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.Collections.Generic.IReadOnlyList<System.Memory<byte>> buffers, long fileOffset, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public static int Write(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.ReadOnlySpan<byte> buffer, long fileOffset) { throw null; }
-        public static long Write(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.Collections.Generic.IReadOnlyList<System.ReadOnlyMemory<byte>> buffers, long fileOffset) { throw null; }
-        public static System.Threading.Tasks.ValueTask<int> WriteAsync(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.ReadOnlyMemory<byte> buffer, long fileOffset, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public static System.Threading.Tasks.ValueTask<long> WriteAsync(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.Collections.Generic.IReadOnlyList<System.ReadOnlyMemory<byte>> buffers, long fileOffset, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static void Write(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.ReadOnlySpan<byte> buffer, long fileOffset) { throw null; }
+        public static void Write(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.Collections.Generic.IReadOnlyList<System.ReadOnlyMemory<byte>> buffers, long fileOffset) { throw null; }
+        public static System.Threading.Tasks.ValueTask WriteAsync(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.ReadOnlyMemory<byte> buffer, long fileOffset, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static System.Threading.Tasks.ValueTask WriteAsync(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.Collections.Generic.IReadOnlyList<System.ReadOnlyMemory<byte>> buffers, long fileOffset, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
 }
 namespace System.IO.Enumeration


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/55473
Replaces https://github.com/dotnet/runtime/pull/55474

@carlossanlop, @Jozkee, @jeffhandley, I would like to get this in for Preview 7.