### PR TITLE
Augment tests for FileMode.Append

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/FileStream/Position.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/Position.cs
@@ -26,6 +26,10 @@ namespace System.IO.Tests
 
                 fs.Position = length + 1;
                 Assert.Equal(length + 1, fs.Position);
+
+                fs.Write(TestBuffer);
+                fs.Position = length + 1;
+                Assert.Equal(length + 1, fs.Position);
             }
         }
 

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/Seek.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/Seek.cs
@@ -32,6 +32,9 @@ namespace System.IO.Tests
                 Assert.Equal(length, fs.Position);
                 Assert.Throws<IOException>(() => fs.Seek(-length, SeekOrigin.End));
                 Assert.Equal(length, fs.Position);
+
+                fs.Write(TestBuffer);
+                Assert.Equal(length, fs.Seek(length, SeekOrigin.Begin));
             }
         }
     }

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/SetLength.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/SetLength.cs
@@ -23,6 +23,12 @@ namespace System.IO.Tests
                 Assert.Equal(length, fs.Length);
                 Assert.Throws<IOException>(() => fs.SetLength(0));
                 Assert.Equal(length, fs.Length);
+
+                fs.Write(TestBuffer);
+                Assert.Equal(length + TestBuffer.Length, fs.Length);
+
+                fs.SetLength(length);
+                Assert.Equal(length, fs.Length);
             }
         }
 


### PR DESCRIPTION
To validate that seeking and writing are valid in the region of the file since its initial length.  Codifying my comments from:
https://github.com/dotnet/runtime/pull/55465#discussion_r667409368
https://github.com/dotnet/runtime/pull/55465#discussion_r667409583
https://github.com/dotnet/runtime/pull/55465#discussion_r667409664