### PR TITLE
Update NuGet.config in HttpStress

### DIFF
--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/NuGet.config
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/NuGet.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/NuGet.config
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/NuGet.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <!-- Add public nuget feed. -->
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <clear />
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
We can't use nuget.org in this manner to comply with security guidance.