### PR TITLE
H/3 Server Cert validation callback exception fix

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -104,8 +104,22 @@ namespace System.Net.Http
         [SupportedOSPlatform("windows")]
         [SupportedOSPlatform("linux")]
         [SupportedOSPlatform("macos")]
-        public static async ValueTask<QuicConnection> ConnectQuicAsync(QuicImplementationProvider quicImplementationProvider, DnsEndPoint endPoint, SslClientAuthenticationOptions? clientAuthenticationOptions, CancellationToken cancellationToken)
+        public static async ValueTask<QuicConnection> ConnectQuicAsync(HttpRequestMessage request, QuicImplementationProvider quicImplementationProvider, DnsEndPoint endPoint, SslClientAuthenticationOptions? clientAuthenticationOptions, CancellationToken cancellationToken)
         {
+            // If there's a cert validation callback, and if it came from HttpClientHandler,
+            // wrap the original delegate in order to change the sender to be the request message (expected by HttpClientHandler's delegate).
+            RemoteCertificateValidationCallback? callback = clientAuthenticationOptions?.RemoteCertificateValidationCallback;
+            if (callback != null && callback.Target is CertificateCallbackMapper mapper)
+            {
+                clientAuthenticationOptions = clientAuthenticationOptions!.ShallowClone(); // Clone as we're about to mutate it and don't want to affect the cached copy
+                Func<HttpRequestMessage, X509Certificate2?, X509Chain?, SslPolicyErrors, bool> localFromHttpClientHandler = mapper.FromHttpClientHandler;
+                clientAuthenticationOptions.RemoteCertificateValidationCallback = (object sender, X509Certificate? certificate, X509Chain? chain, SslPolicyErrors sslPolicyErrors) =>
+                {
+                    bool result = localFromHttpClientHandler(request, certificate as X509Certificate2, chain, sslPolicyErrors);
+                    return result;
+                };
+            }
+
             QuicConnection con = new QuicConnection(quicImplementationProvider, endPoint, clientAuthenticationOptions);
             try
             {
@@ -116,6 +130,17 @@ namespace System.Net.Http
             {
                 con.Dispose();
                 throw CreateWrappedException(ex, endPoint.Host, endPoint.Port, cancellationToken);
+            }
+            finally
+            {
+                if (clientAuthenticationOptions is not null && callback is not null)
+                {
+                    // We cannot unset the request closure variable after the first callaback invocation as we do with SslStream
+                    // since the callback will get triggered multiple times during connection establishment.
+                    // So to ensure the callback don't keep the first HttpRequestMessage alive indefinitely, we reset the callback back to user's provided one.
+                    clientAuthenticationOptions.RemoteCertificateValidationCallback = callback;
+                }
+
             }
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -728,7 +728,7 @@ namespace System.Net.Http
                 QuicConnection quicConnection;
                 try
                 {
-                    quicConnection = await ConnectHelper.ConnectQuicAsync(Settings._quicImplementationProvider ?? QuicImplementationProviders.Default, new DnsEndPoint(authority.IdnHost, authority.Port), _sslOptionsHttp3, cancellationToken).ConfigureAwait(false);
+                    quicConnection = await ConnectHelper.ConnectQuicAsync(request, Settings._quicImplementationProvider ?? QuicImplementationProviders.Default, new DnsEndPoint(authority.IdnHost, authority.Port), _sslOptionsHttp3, cancellationToken).ConfigureAwait(false);
                 }
                 catch
                 {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -728,7 +728,7 @@ namespace System.Net.Http
                 QuicConnection quicConnection;
                 try
                 {
-                    quicConnection = await ConnectHelper.ConnectQuicAsync(request, Settings._quicImplementationProvider ?? QuicImplementationProviders.Default, new DnsEndPoint(authority.IdnHost, authority.Port), _sslOptionsHttp3, cancellationToken).ConfigureAwait(false);
+                    quicConnection = await ConnectHelper.ConnectQuicAsync(request, Settings._quicImplementationProvider ?? QuicImplementationProviders.Default, new DnsEndPoint(authority.IdnHost, authority.Port), _sslOptionsHttp3!, cancellationToken).ConfigureAwait(false);
                 }
                 catch
                 {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -314,6 +314,64 @@ namespace System.Net.Http.Functional.Tests
             await new[] { clientTask, serverTask }.WhenAllOrAnyFailed(20_000);
         }
 
+        [Fact]
+        public async Task ServerCertificateCustomValidationCallback_Succeeds()
+        {
+            // Mock doesn't make use of cart validation callback.
+            if (UseQuicImplementationProvider == QuicImplementationProviders.Mock)
+            {
+                return;
+            }
+
+            HttpRequestMessage? callbackRequest = null;
+            int invocationCount = 0;
+
+            var httpClientHandler = CreateHttpClientHandler();
+            httpClientHandler.ServerCertificateCustomValidationCallback = (request, _, _, _) =>
+            {
+                callbackRequest = request;
+                ++invocationCount;
+                return true;
+            };
+
+            using Http3LoopbackServer server = CreateHttp3LoopbackServer();
+            using HttpClient client = CreateHttpClient(httpClientHandler);
+
+            Task serverTask = Task.Run(async () =>
+            {
+                using Http3LoopbackConnection connection = (Http3LoopbackConnection)await server.EstablishGenericConnectionAsync();
+                using Http3LoopbackStream stream = await connection.AcceptRequestStreamAsync();
+                await stream.HandleRequestAsync();
+                using Http3LoopbackStream stream2 = await connection.AcceptRequestStreamAsync();
+                await stream2.HandleRequestAsync();
+            });
+
+            var request = new HttpRequestMessage(HttpMethod.Get, server.Address);
+            request.Version = HttpVersion.Version30;
+            request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
+
+            var response = await client.SendAsync(request);
+
+            response.EnsureSuccessStatusCode();
+            Assert.Equal(HttpVersion.Version30, response.Version);
+            Assert.Same(request, callbackRequest);
+            Assert.Equal(1, invocationCount);
+
+            // Second request, the callback shouldn't be hit at all.
+            callbackRequest = null;
+
+            request = new HttpRequestMessage(HttpMethod.Get, server.Address);
+            request.Version = HttpVersion.Version30;
+            request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
+
+            response = await client.SendAsync(request);
+
+            response.EnsureSuccessStatusCode();
+            Assert.Equal(HttpVersion.Version30, response.Version);
+            Assert.Null(callbackRequest);
+            Assert.Equal(1, invocationCount);
+        }
+
         [OuterLoop]
         [ConditionalTheory(nameof(IsMsQuicSupported))]
         [MemberData(nameof(InteropUris))]
@@ -395,53 +453,5 @@ namespace System.Net.Http.Functional.Tests
                 { "https://http3-test.litespeedtech.com:4433/" }, // LiteSpeed
                 { "https://quic.tech:8443/" } // Cloudflare
             };
-
-        [Fact]
-        public async Task ServerCertificateCustomValidationCallback_Succeeds()
-        {
-            HttpRequestMessage? callbackRequest = null;
-
-            var httpClientHandler = CreateHttpClientHandler();
-            httpClientHandler.ServerCertificateCustomValidationCallback = (request, _, _, _) =>
-            {
-                callbackRequest = request;
-                return true;
-            };
-
-            using Http3LoopbackServer server = CreateHttp3LoopbackServer();
-            using HttpClient client = CreateHttpClient(httpClientHandler);
-
-            Task serverTask = Task.Run(async () =>
-            {
-                using Http3LoopbackConnection connection = (Http3LoopbackConnection)await server.EstablishGenericConnectionAsync();
-                using Http3LoopbackStream stream = await connection.AcceptRequestStreamAsync();
-                await stream.HandleRequestAsync();
-                using Http3LoopbackStream stream2 = await connection.AcceptRequestStreamAsync();
-                await stream2.HandleRequestAsync();
-            });
-
-            var request = new HttpRequestMessage(HttpMethod.Get, server.Address);
-            request.Version = HttpVersion.Version30;
-            request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
-
-            var response = await client.SendAsync(request);
-
-            response.EnsureSuccessStatusCode();
-            Assert.Equal(HttpVersion.Version30, response.Version);
-            Assert.Same(request, callbackRequest);
-
-            // Second request, the callback shouldn't be hit anymore.
-            callbackRequest = null;
-
-            request = new HttpRequestMessage(HttpMethod.Get, server.Address);
-            request.Version = HttpVersion.Version30;
-            request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
-
-            response = await client.SendAsync(request);
-
-            response.EnsureSuccessStatusCode();
-            Assert.Equal(HttpVersion.Version30, response.Version);
-            Assert.Null(callbackRequest);
-        }
     }
 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -395,6 +395,10 @@ namespace System.Net.Quic.Implementations.MsQuic
                 if (connection._remoteCertificateValidationCallback != null)
                 {
                     bool success = connection._remoteCertificateValidationCallback(connection, certificate, chain, sslPolicyErrors);
+                    // Unset the callback to prevent multiple invocations of the callback per a single connection.
+                    // Return the same value as the custom callback just did.
+                    connection._remoteCertificateValidationCallback = (_, _, _, _) => success;
+
                     if (!success && NetEventSource.Log.IsEnabled())
                         NetEventSource.Error(state, $"[Connection#{state.GetHashCode()}] remote  certificate rejected by verification callback");
                     return success ? MsQuicStatusCodes.Success : MsQuicStatusCodes.HandshakeFailure;


### PR DESCRIPTION
Sets and unsets `HttpMessageRequest` to the cert callback when opening new `QuicConnection`.

Fixes #55192