### PR TITLE
Migrate various parts of the bindings code to use roots

### DIFF
--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -1479,12 +1479,14 @@ var BindingSupportLib = {
 
 			// Check to make sure the delegate is still alive on the CLR side of things.
 			if (typeof delegate_obj.__mono_delegate_alive__ !== "undefined") {
-				if (!delegate_obj.__mono_delegate_alive__)
+				if (!delegate_obj.__mono_delegate_alive__) {
 					// HACK: It is possible (though unlikely) for a delegate to be invoked after it's been collected
 					//  if it's being used as a JavaScript event handler and the host environment decides to fire events
 					//  at a point where we've already disposed of the object the event handler is attached to.
 					// As such, we log here instead of throwing an error. We may want to not log at all...
 					console.log("The delegate target that is being invoked is no longer available.  Please check if it has been prematurely GC'd.");
+					return;
+				}
 			}
 
 			var delegateRoot = MONO.mono_wasm_new_root (this.extract_mono_obj (delegate_obj));

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -1694,7 +1694,7 @@ var BindingSupportLib = {
 	},
 
 	mono_wasm_invoke_js_with_args: function(js_handle, method_name, args, is_exception) {
-		let argsRoot = MONO.mono_wasm_new_root (args);
+		let argsRoot = MONO.mono_wasm_new_root (args), nameRoot = MONO.mono_wasm_new_root (method_name);
 		try {
 			BINDING.bindings_lazy_init ();
 
@@ -1704,7 +1704,7 @@ var BindingSupportLib = {
 				return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "'");
 			}
 
-			var js_name = BINDING.unbox_mono_obj (method_name);
+			var js_name = BINDING._unbox_mono_obj_root (nameRoot);
 			if (!js_name || (typeof(js_name) !== "string")) {
 				setValue (is_exception, 1, "i32");
 				return BINDING.js_string_to_mono_string ("Invalid method name object '" + method_name + "'");
@@ -1730,6 +1730,7 @@ var BindingSupportLib = {
 			}
 		} finally {
 			argsRoot.release();
+			nameRoot.release();
 		}
 	},
 	mono_wasm_get_object_property: function(js_handle, property_name, is_exception) {
@@ -1780,7 +1781,7 @@ var BindingSupportLib = {
 
 			var result = false;
 
-			var js_value = BINDING.unbox_mono_obj_root(valueRoot);
+			var js_value = BINDING._unbox_mono_obj_root(valueRoot);
 			BINDING.mono_wasm_save_LMF();
 
 			if (createIfNotExist) {
@@ -1843,7 +1844,7 @@ var BindingSupportLib = {
 				return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "'");
 			}
 
-			var js_value = BINDING.unbox_mono_obj(value);
+			var js_value = BINDING._unbox_mono_obj_root(valueRoot);
 			BINDING.mono_wasm_save_LMF();
 
 			try {

--- a/src/mono/wasm/runtime/library_mono.js
+++ b/src/mono/wasm/runtime/library_mono.js
@@ -264,12 +264,6 @@ var MonoSupportLib = {
 			/** @returns {ManagedPointer} */
 			get: function () {
 				var result = this.__buffer._unsafe_get (this.__index);
-				/*
-				if (typeof(result) !== "number")
-					throw new Error (`Reading root at address ${this.get_address()} failed`);
-				else
-					console.log(`get(${this.get_address()})==${result}`);
-				*/
 				return result;
 			},
 			set: function (value) {

--- a/src/mono/wasm/runtime/library_mono.js
+++ b/src/mono/wasm/runtime/library_mono.js
@@ -264,6 +264,12 @@ var MonoSupportLib = {
 			/** @returns {ManagedPointer} */
 			get: function () {
 				var result = this.__buffer._unsafe_get (this.__index);
+				/*
+				if (typeof(result) !== "number")
+					throw new Error (`Reading root at address ${this.get_address()} failed`);
+				else
+					console.log(`get(${this.get_address()})==${result}`);
+				*/
 				return result;
 			},
 			set: function (value) {


### PR DESCRIPTION
We have a lot of code that passes raw pointers to managed objects around when they should really be using roots instead (i.e. ```root.value```) so that if the GC relocates the object, they won't be using the old address. This PR migrates a bunch of that code so that it uses root objects.

A lot of code remains that does use raw objects, but I read over all of it and the cases appear to be safe because they immediately return it (or return it without calling any other functions).