### PR TITLE
Disable generic math due to C++/CLI incompatibilities

### DIFF
--- a/src/coreclr/clr.featuredefines.props
+++ b/src/coreclr/clr.featuredefines.props
@@ -9,7 +9,7 @@
         <FeaturePerfTracing>true</FeaturePerfTracing>
         <FeatureTypeEquivalence>true</FeatureTypeEquivalence>
         <FeatureBasicFreeze>true</FeatureBasicFreeze>
-        <FeatureGenericMath>true</FeatureGenericMath>
+        <FeatureGenericMath>false</FeatureGenericMath>
         <ProfilingSupportedBuild>true</ProfilingSupportedBuild>
     </PropertyGroup>
 

--- a/src/libraries/System.Runtime/ref/System.Runtime.csproj
+++ b/src/libraries/System.Runtime/ref/System.Runtime.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <FeatureGenericMath>true</FeatureGenericMath>
+    <FeatureGenericMath>false</FeatureGenericMath>
     <!-- It is a core assembly because it defines System.Object so we need to pass RuntimeMetadataVersion to the compiler -->
     <RuntimeMetadataVersion>v4.0.30319</RuntimeMetadataVersion>
     <!-- disable warnings about obsolete APIs,

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <FeatureGenericMath>true</FeatureGenericMath>
+    <FeatureGenericMath>false</FeatureGenericMath>
     <NoWarn>$(NoWarn),1718,SYSLIB0013</NoWarn>
     <TestRuntime>true</TestRuntime>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>

--- a/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -109,7 +109,7 @@
     <FeatureMono>true</FeatureMono>
     <FeatureManagedEtwChannels>true</FeatureManagedEtwChannels>
     <FeatureManagedEtw>true</FeatureManagedEtw>
-    <FeatureGenericMath>true</FeatureGenericMath>
+    <FeatureGenericMath>false</FeatureGenericMath>
     <FeaturePortableTimer Condition="'$(TargetsBrowser)' != 'true'">true</FeaturePortableTimer>
     <FeaturePortableThreadPool Condition="'$(TargetsBrowser)' != 'true'">true</FeaturePortableThreadPool>
     <FeaturePerfTracing Condition="'$(TargetsBrowser)' != 'true'">true</FeaturePerfTracing>


### PR DESCRIPTION
This disables generic math as its not currently supported by C++/CLI and may cause `error C2253` (with a message similar to `'System::INumber::DivRem': pure specifier or abstract override specifier only allowed on virtual function`) for an imported type that implements an interface with static virtuals.

This is somewhat similar to what happens for C++/CLI when encountering `Span<T>` (or `ref structs` in general), `in`, and other "new" language or runtime features. However, since this directly impacts the "core" types (e.g. `int32`, `int64`, `intptr`, etc) it is much more prevalent and will likely be encountered by all existing C++/CLI codebases.