### PR TITLE
Disable GetHostEntry tests on SLES.

### DIFF
--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
@@ -28,7 +28,9 @@ namespace System.Net.NameResolution.Tests
             // [ActiveIssue("https://github.com/dotnet/runtime/issues/1488", TestPlatforms.OSX)]
             PlatformDetection.IsNotOSX &&
             // [ActiveIssue("https://github.com/dotnet/runtime/issues/51377", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
-            !PlatformDetection.IsiOS && !PlatformDetection.IstvOS && !PlatformDetection.IsMacCatalyst;
+            !PlatformDetection.IsiOS && !PlatformDetection.IstvOS && !PlatformDetection.IsMacCatalyst &&
+            // [ActiveIssue("https://github.com/dotnet/runtime/issues/55271")]
+            !PlatformDetection.IsSLES;
 
         [ConditionalTheory(nameof(GetHostEntryWorks))]
         [InlineData("")]


### PR DESCRIPTION
Other tests like Dns_GetHostEntryAsync_DisableIPv6_ExcludesIPv6Addresses are also failing on SLES as other disabled tests were:

```c#
Child exception:
  System.Net.Internals.SocketExceptionFactory+ExtendedSocketException (00000005, 0xFFFDFFFF): Name or service not known
   at System.Net.Dns.GetHostEntryOrAddressesCore(String hostName, Boolean justAddresses, AddressFamily addressFamily) in /_/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs:line 403
   at System.Net.Dns.GetHostEntryCore(String hostName, AddressFamily addressFamily) in /_/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs:line 384
   at System.Net.Dns.GetHostEntry(String hostNameOrAddress, AddressFamily family) in /_/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs:line 91
   at System.Net.Dns.GetHostEntry(String hostNameOrAddress) in /_/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs:line 60
   at System.Net.NameResolution.Tests.GetHostEntryTest.<Dns_GetHostEntry_DisableIPv6_ExcludesIPv6Addresses>g__RunTest|7_0(String hostnameInner) in /_/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs:line 132
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture) in /_/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs:line 370
```