### PR TITLE
Recognize MacCatalyst as a superset of iOS

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
@@ -9,7 +9,7 @@ namespace System
 {
     public sealed class OperatingSystem : ISerializable, ICloneable
     {
-#if TARGET_UNIX && !TARGET_OSX
+#if TARGET_UNIX && !TARGET_OSX && !TARGET_MACCATALYST && !TARGET_IOS
         private static readonly string s_osPlatformName = Interop.Sys.GetUnixName();
 #endif
 

--- a/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
@@ -179,7 +179,6 @@ namespace System
         /// <summary>
         /// Indicates whether the current application is running on iOS or MacCatalyst.
         /// </summary>
-        /// <remarks>
         [SupportedOSPlatformGuard("ios")]
         [SupportedOSPlatformGuard("maccatalyst")]
         public static bool IsIOS() =>

--- a/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
@@ -179,7 +179,6 @@ namespace System
         /// <summary>
         /// Indicates whether the current application is running on iOS or MacCatalyst.
         /// </summary>
-        [SupportedOSPlatformGuard("ios")]
         [SupportedOSPlatformGuard("maccatalyst")]
         public static bool IsIOS() =>
 #if TARGET_IOS || TARGET_MACCATALYST
@@ -191,7 +190,6 @@ namespace System
         /// <summary>
         /// Check for the iOS/MacCatalyst version (returned by 'libobjc.get_operatingSystemVersion') with a >= version comparison. Used to guard APIs that were added in the given iOS release.
         /// </summary>
-        [SupportedOSPlatformGuard("ios")]
         [SupportedOSPlatformGuard("maccatalyst")]
         public static bool IsIOSVersionAtLeast(int major, int minor = 0, int build = 0)
             => IsIOS() && IsOSVersionAtLeast(major, minor, build, 0);

--- a/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Runtime.Serialization;
+using System.Runtime.Versioning;
 
 namespace System
 {
@@ -101,6 +102,10 @@ namespace System
             return platform.Equals("WINDOWS", StringComparison.OrdinalIgnoreCase);
 #elif TARGET_OSX
             return platform.Equals("OSX", StringComparison.OrdinalIgnoreCase) || platform.Equals("MACOS", StringComparison.OrdinalIgnoreCase);
+#elif TARGET_MACCATALYST
+            return platform.Equals("MACCATALYST", StringComparison.OrdinalIgnoreCase) || platform.Equals("IOS", StringComparison.OrdinalIgnoreCase);
+#elif TARGET_IOS
+            return platform.Equals("IOS", StringComparison.OrdinalIgnoreCase);
 #elif TARGET_UNIX
             return platform.Equals(s_osPlatformName, StringComparison.OrdinalIgnoreCase);
 #else
@@ -172,18 +177,23 @@ namespace System
             => IsAndroid() && IsOSVersionAtLeast(major, minor, build, revision);
 
         /// <summary>
-        /// Indicates whether the current application is running on iOS.
+        /// Indicates whether the current application is running on iOS or MacCatalyst.
         /// </summary>
+        /// <remarks>
+        [SupportedOSPlatformGuard("ios")]
+        [SupportedOSPlatformGuard("maccatalyst")]
         public static bool IsIOS() =>
-#if TARGET_IOS
+#if TARGET_IOS || TARGET_MACCATALYST
             true;
 #else
             false;
 #endif
 
         /// <summary>
-        /// Check for the iOS version (returned by 'libobjc.get_operatingSystemVersion') with a >= version comparison. Used to guard APIs that were added in the given iOS release.
+        /// Check for the iOS/MacCatalyst version (returned by 'libobjc.get_operatingSystemVersion') with a >= version comparison. Used to guard APIs that were added in the given iOS release.
         /// </summary>
+        [SupportedOSPlatformGuard("ios")]
+        [SupportedOSPlatformGuard("maccatalyst")]
         public static bool IsIOSVersionAtLeast(int major, int minor = 0, int build = 0)
             => IsIOS() && IsOSVersionAtLeast(major, minor, build, 0);
 

--- a/src/libraries/System.Runtime.Extensions/tests/System/OperatingSystemTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/OperatingSystemTests.cs
@@ -132,6 +132,23 @@ namespace System.Tests
         [Fact, PlatformSpecific(TestPlatforms.MacCatalyst)]
         public static void TestIsOSVersionAtLeast_MacCatalyst() => TestIsOSVersionAtLeast("MacCatalyst");
 
+        [Fact, PlatformSpecific(TestPlatforms.MacCatalyst)]
+        public static void MacCatalyst_Is_Also_iOS()
+        {
+            Assert.True(OperatingSystem.IsOSPlatform("IOS"));
+            Assert.True(OperatingSystem.IsIOS());
+
+            AssertVersionChecks(true, (major, minor, build, revision) => OperatingSystem.IsOSPlatformVersionAtLeast("IOS", major, minor, build, revision));
+            AssertVersionChecks(true, (major, minor, build) => OperatingSystem.IsOSPlatformVersionAtLeast("IOS", major, minor, build));
+        }
+
+        [Fact, PlatformSpecific(TestPlatforms.iOS)]
+        public static void IOS_Is_Not_Also_MacCatalyst()
+        {
+            Assert.False(OperatingSystem.IsOSPlatform("MacCatalyst"));
+            Assert.False(OperatingSystem.IsMacCatalyst());
+        }
+
         [Fact, PlatformSpecific(TestPlatforms.tvOS)]
         public static void TestIsOSPlatform_TvOS() => TestIsOSPlatform("tvOS", OperatingSystem.IsTvOS);
 
@@ -146,13 +163,13 @@ namespace System.Tests
 
         private static void TestIsOSPlatform(string currentOSName, Func<bool> currentOSCheck)
         {
-            foreach (string platfromName in AllKnownPlatformNames)
+            foreach (string platformName in AllKnownPlatformNames)
             {
-                bool expected = currentOSName.Equals(platfromName, StringComparison.OrdinalIgnoreCase);
+                bool expected = currentOSName.Equals(platformName, StringComparison.OrdinalIgnoreCase);
 
-                Assert.Equal(expected, OperatingSystem.IsOSPlatform(platfromName));
-                Assert.Equal(expected, OperatingSystem.IsOSPlatform(platfromName.ToUpper()));
-                Assert.Equal(expected, OperatingSystem.IsOSPlatform(platfromName.ToLower()));
+                Assert.Equal(expected, OperatingSystem.IsOSPlatform(platformName));
+                Assert.Equal(expected, OperatingSystem.IsOSPlatform(platformName.ToUpper()));
+                Assert.Equal(expected, OperatingSystem.IsOSPlatform(platformName.ToLower()));
             }
 
             Assert.True(currentOSCheck());
@@ -176,13 +193,13 @@ namespace System.Tests
 
         private static void TestIsOSVersionAtLeast(string currentOSName)
         {
-            foreach (string platfromName in AllKnownPlatformNames)
+            foreach (string platformName in AllKnownPlatformNames)
             {
-                bool isCurrentOS = currentOSName.Equals(platfromName, StringComparison.OrdinalIgnoreCase);
+                bool isCurrentOS = currentOSName.Equals(platformName, StringComparison.OrdinalIgnoreCase);
 
-                AssertVersionChecks(isCurrentOS, (major, minor, build, revision) => OperatingSystem.IsOSPlatformVersionAtLeast(platfromName, major, minor, build, revision));
-                AssertVersionChecks(isCurrentOS, (major, minor, build, revision) => OperatingSystem.IsOSPlatformVersionAtLeast(platfromName.ToLower(), major, minor, build, revision));
-                AssertVersionChecks(isCurrentOS, (major, minor, build, revision) => OperatingSystem.IsOSPlatformVersionAtLeast(platfromName.ToUpper(), major, minor, build, revision));
+                AssertVersionChecks(isCurrentOS, (major, minor, build, revision) => OperatingSystem.IsOSPlatformVersionAtLeast(platformName, major, minor, build, revision));
+                AssertVersionChecks(isCurrentOS, (major, minor, build, revision) => OperatingSystem.IsOSPlatformVersionAtLeast(platformName.ToLower(), major, minor, build, revision));
+                AssertVersionChecks(isCurrentOS, (major, minor, build, revision) => OperatingSystem.IsOSPlatformVersionAtLeast(platformName.ToUpper(), major, minor, build, revision));
             }
             
             AssertVersionChecks(currentOSName.Equals("Android", StringComparison.OrdinalIgnoreCase), OperatingSystem.IsAndroidVersionAtLeast);

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -4965,10 +4965,8 @@ namespace System
         public static bool IsFreeBSDVersionAtLeast(int major, int minor = 0, int build = 0, int revision = 0) { throw null; }
         public static bool IsAndroid() { throw null; }
         public static bool IsAndroidVersionAtLeast(int major, int minor = 0, int build = 0, int revision = 0) { throw null; }
-        [System.Runtime.Versioning.SupportedOSPlatformGuardAttribute("ios")]
         [System.Runtime.Versioning.SupportedOSPlatformGuardAttribute("maccatalyst")]
         public static bool IsIOS() { throw null; }
-        [System.Runtime.Versioning.SupportedOSPlatformGuardAttribute("ios")]
         [System.Runtime.Versioning.SupportedOSPlatformGuardAttribute("maccatalyst")]
         public static bool IsIOSVersionAtLeast(int major, int minor = 0, int build = 0) { throw null; }
         public static bool IsMacOS() { throw null; }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -4959,13 +4959,18 @@ namespace System
         public override string ToString() { throw null; }
         public static bool IsOSPlatform(string platform) { throw null; }
         public static bool IsOSPlatformVersionAtLeast(string platform, int major, int minor = 0, int build = 0, int revision = 0) { throw null; }
+
         public static bool IsBrowser() { throw null; }
         public static bool IsLinux() { throw null; }
         public static bool IsFreeBSD() { throw null; }
         public static bool IsFreeBSDVersionAtLeast(int major, int minor = 0, int build = 0, int revision = 0) { throw null; }
         public static bool IsAndroid() { throw null; }
         public static bool IsAndroidVersionAtLeast(int major, int minor = 0, int build = 0, int revision = 0) { throw null; }
+        [System.Runtime.Versioning.SupportedOSPlatformGuardAttribute("ios")]
+        [System.Runtime.Versioning.SupportedOSPlatformGuardAttribute("maccatalyst")]
         public static bool IsIOS() { throw null; }
+        [System.Runtime.Versioning.SupportedOSPlatformGuardAttribute("ios")]
+        [System.Runtime.Versioning.SupportedOSPlatformGuardAttribute("maccatalyst")]
         public static bool IsIOSVersionAtLeast(int major, int minor = 0, int build = 0) { throw null; }
         public static bool IsMacOS() { throw null; }
         public static bool IsMacOSVersionAtLeast(int major, int minor = 0, int build = 0) { throw null; }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -4959,7 +4959,6 @@ namespace System
         public override string ToString() { throw null; }
         public static bool IsOSPlatform(string platform) { throw null; }
         public static bool IsOSPlatformVersionAtLeast(string platform, int major, int minor = 0, int build = 0, int revision = 0) { throw null; }
-
         public static bool IsBrowser() { throw null; }
         public static bool IsLinux() { throw null; }
         public static bool IsFreeBSD() { throw null; }


### PR DESCRIPTION
1. `OperatingSystem.IsIOS()` now returns `true` when running on MacCatalyst
2. `OperatingSystem.IsOSPlatform("ios")` now returns true when running on MacCatalyst
3. `[SupportedOSPlatformGuard]` attributes are applied to `OperatingSystem.IsIOS()` and `OperatingSystem.IsIOSVersionAtLeast()` to indicate those methods guard for either "ios" or "maccatalyst"

This contributes to https://github.com/dotnet/runtime/issues/53084#issuecomment-877750424.
