### PR TITLE
Fix UMThunkMarshInfo delete

### DIFF
--- a/src/coreclr/vm/comdelegate.cpp
+++ b/src/coreclr/vm/comdelegate.cpp
@@ -1263,7 +1263,7 @@ LPVOID COMDelegate::ConvertToCallback(OBJECTREF pDelegateObj)
                                                         pUMThunkMarshInfo,
                                                         NULL ) != NULL)
                 {
-                    delete pUMThunkMarshInfo;
+                    pMT->GetLoaderAllocator()->GetStubHeap()->BackoutMem(pUMThunkMarshInfo, sizeof(UMThunkMarshInfo));
                     pUMThunkMarshInfo = pClass->m_pUMThunkMarshInfo;
                 }
             }


### PR DESCRIPTION
There was a forgotten call to c++ delete that should have been converted
to LoaderHeap::BackoutMem in a code path invoked only if two threads
raced for allocating the UMThunkMarshInfo and the one that lost the race
needed to delete it.

Close #55517