### PR TITLE
Reduce allocations in VersionConverter

### DIFF
--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -323,6 +323,9 @@
   </data>
   <data name="FormatGuid" xml:space="preserve">
     <value>The JSON value is not in a supported Guid format.</value>
+  </data>
+  <data name="FormatVersion" xml:space="preserve">
+    <value>The JSON value is not in a supported Version format.</value>
   </data>
   <data name="ExpectedStartOfPropertyOrValueAfterComment" xml:space="preserve">
     <value>'{0}' is an invalid start of a property name or value, after a comment.</value>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/VersionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/VersionConverter.cs
@@ -1,16 +1,71 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
+using System.Buffers.Text;
+using System.Diagnostics;
+
 namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class VersionConverter : JsonConverter<Version>
     {
+        private const int VersionComponentsCount = 4; // Major, Minor, Build, Revision
+
         public override Version Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            string? versionString = reader.GetString();
-            if (Version.TryParse(versionString, out Version? result))
+            ReadOnlySpan<byte> source = reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan;
+
+            Span<int?> versionComponents = stackalloc int?[VersionComponentsCount] { null, null, null, null };
+            int indexOfDot = GetIndexOfDot(source);
+
+            if (reader._stringHasEscaping || indexOfDot == -1)
             {
-                return result;
+                ThrowHelper.ThrowJsonException();
+            }
+
+            Debug.Assert(source.IndexOf(JsonConstants.BackSlash) == -1, "Version value should have no escaping");
+            Debug.Assert(indexOfDot != -1, "Version should have at least Major and Minor values separated by \".\"");
+
+            for (int i = 0; i < versionComponents.Length; i++)
+            {
+                bool lastComponent = indexOfDot == -1;
+                var readOnlySpan = lastComponent ? source : source.Slice(0, indexOfDot);
+                if (Utf8Parser.TryParse(readOnlySpan, out int value, out _))
+                {
+                    if (value < 0)
+                    {
+                        ThrowHelper.ThrowJsonException();
+                    }
+
+                    versionComponents[i] = value;
+                    source = source.Slice(indexOfDot + 1);
+                    indexOfDot = GetIndexOfDot(source);
+                    if (lastComponent)
+                    {
+                        break;
+                    }
+                }
+                else
+                {
+                    ThrowHelper.ThrowJsonException();
+                }
+            }
+
+            ref int? major = ref versionComponents[0];
+            ref int? minor = ref versionComponents[1];
+            ref int? build = ref versionComponents[2];
+            ref int? revision = ref versionComponents[3];
+            if (major.HasValue && minor.HasValue && build.HasValue && revision.HasValue)
+            {
+                return new Version(major.Value, minor.Value, build.Value, revision.Value);
+            }
+            else if (major.HasValue && minor.HasValue && build.HasValue)
+            {
+                return new Version(major.Value, minor.Value, build.Value);
+            }
+            else if (major.HasValue && minor.HasValue)
+            {
+                return new Version(major.Value, minor.Value);
             }
 
             ThrowHelper.ThrowJsonException();
@@ -21,5 +76,7 @@ namespace System.Text.Json.Serialization.Converters
         {
             writer.WriteStringValue(value.ToString());
         }
+
+        private static int GetIndexOfDot(ReadOnlySpan<byte> source) => source.IndexOf((byte)'.');
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/VersionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/VersionConverter.cs
@@ -81,7 +81,7 @@ namespace System.Text.Json.Serialization.Converters
             }
 #else
             string? versionString = reader.GetString();
-            if (!string.IsNullOrEmpty(versionString) && !char.IsDigit(versionString[0]) && !char.IsDigit(versionString[versionString.Length - 1]))
+            if (!string.IsNullOrEmpty(versionString) && (!char.IsDigit(versionString[0]) || !char.IsDigit(versionString[versionString.Length - 1])))
             {
                 throw ThrowHelper.GetFormatException(DataType.Version);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/VersionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/VersionConverter.cs
@@ -68,8 +68,10 @@ namespace System.Text.Json.Serialization.Converters
             byte lastChar = source[source.Length - 1];
             if (!JsonHelpers.IsDigit(firstChar) || !JsonHelpers.IsDigit(lastChar))
             {
-                // Disallow leading and trailing whitespaces
-                // since Version.Parse allows them
+                // Since leading and trailing whitespaces are forbidden throughout System.Text.Json converters
+                // we need to make sure that our input doesn't have them,
+                // and if it has - we need to throw, to match behaviour of other converters
+                // since Version.TryParse allows them and silently parses input to Version
                 throw ThrowHelper.GetFormatException(DataType.Version);
             }
 
@@ -83,6 +85,10 @@ namespace System.Text.Json.Serialization.Converters
             string? versionString = reader.GetString();
             if (!string.IsNullOrEmpty(versionString) && (!char.IsDigit(versionString[0]) || !char.IsDigit(versionString[versionString.Length - 1])))
             {
+                // Since leading and trailing whitespaces are forbidden throughout System.Text.Json converters
+                // we need to make sure that our input doesn't have them,
+                // and if it has - we need to throw, to match behaviour of other converters
+                // since Version.TryParse allows them and silently parses input to Version
                 throw ThrowHelper.GetFormatException(DataType.Version);
             }
             if (Version.TryParse(versionString, out Version? result))

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/VersionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/VersionConverter.cs
@@ -101,10 +101,8 @@ namespace System.Text.Json.Serialization.Converters
             bool formattedSuccessfully = value.TryFormat(span, out int charsWritten);
             Debug.Assert(formattedSuccessfully && charsWritten >= MinimumVersionLength);
             writer.WriteStringValue(span.Slice(0, charsWritten));
-            return;
 #else
             writer.WriteStringValue(value.ToString());
-            return;
 #endif
         }
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/VersionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/VersionConverter.cs
@@ -2,45 +2,89 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Buffers.Text;
 using System.Diagnostics;
 
 namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class VersionConverter : JsonConverter<Version>
     {
+#if BUILDING_INBOX_LIBRARY
+        private const int MinimumVersionLength = 3; // 0.0
+
+        private const int MaximumVersionLength = 43; // 2147483647.2147483647.2147483647.2147483647
+
+        private const int MaximumEscapedVersionLength = JsonConstants.MaxExpansionFactorWhileEscaping * MaximumVersionLength;
+#endif
+
         public override Version Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader._stringHasEscaping)
+            if (reader.TokenType != JsonTokenType.String)
             {
-                ThrowHelper.ThrowJsonException();
+                throw ThrowHelper.GetInvalidOperationException_ExpectedString(reader.TokenType);
             }
 
 #if BUILDING_INBOX_LIBRARY
+            bool isEscaped = reader._stringHasEscaping;
 
-            ReadOnlySpan<byte> source = reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan;
-
-            int maxCharCount = JsonReaderHelper.s_utf8Encoding.GetMaxCharCount(source.Length);
-            char[]? pooledChars = null;
-            Span<char> charBuffer = maxCharCount * sizeof(char) <= JsonConstants.StackallocThreshold
-                ? stackalloc char[maxCharCount]
-                : pooledChars = ArrayPool<char>.Shared.Rent(maxCharCount);
-            int writtenChars = JsonReaderHelper.s_utf8Encoding.GetChars(source, charBuffer);
-            bool isParsingSuccessful = Version.TryParse(charBuffer.Slice(0, writtenChars), out Version? result);
-
-            if (pooledChars != null)
+            int maxLength = isEscaped ? MaximumEscapedVersionLength : MaximumVersionLength;
+            ReadOnlySpan<byte> source = stackalloc byte[0];
+            if (reader.HasValueSequence)
             {
-                charBuffer.Clear();
-                ArrayPool<char>.Shared.Return(pooledChars);
+                if (!JsonHelpers.IsInRangeInclusive(reader.ValueSequence.Length, MinimumVersionLength, maxLength))
+                {
+                    throw ThrowHelper.GetFormatException(DataType.Version);
+                }
+
+                Span<byte> stackSpan = stackalloc byte[isEscaped ? MaximumEscapedVersionLength : MaximumVersionLength];
+                reader.ValueSequence.CopyTo(stackSpan);
+                source = stackSpan.Slice(0, (int)reader.ValueSequence.Length);
+            }
+            else
+            {
+                source = reader.ValueSpan;
+
+                if (!JsonHelpers.IsInRangeInclusive(source.Length, MinimumVersionLength, maxLength))
+                {
+                    throw ThrowHelper.GetFormatException(DataType.Version);
+                }
             }
 
-            if (isParsingSuccessful)
+            if (isEscaped)
             {
-                Debug.Assert(result != null);
+                int backslash = source.IndexOf(JsonConstants.BackSlash);
+                Debug.Assert(backslash != -1);
+
+                Span<byte> sourceUnescaped = stackalloc byte[MaximumEscapedVersionLength];
+
+                JsonReaderHelper.Unescape(source, sourceUnescaped, backslash, out int written);
+                Debug.Assert(written > 0);
+
+                source = sourceUnescaped.Slice(0, written);
+                Debug.Assert(!source.IsEmpty);
+            }
+
+            byte firstChar = source[0];
+            byte lastChar = source[source.Length - 1];
+            if (!JsonHelpers.IsDigit(firstChar) || !JsonHelpers.IsDigit(lastChar))
+            {
+                // Disallow leading and trailing whitespaces
+                // since Version.Parse allows them
+                throw ThrowHelper.GetFormatException(DataType.Version);
+            }
+
+            Span<char> charBuffer = stackalloc char[MaximumVersionLength];
+            int writtenChars = JsonReaderHelper.s_utf8Encoding.GetChars(source, charBuffer);
+            if (Version.TryParse(charBuffer.Slice(0, writtenChars), out Version? result))
+            {
                 return result;
             }
-
 #else
             string? versionString = reader.GetString();
+            if (versionString != null && !char.IsDigit(versionString[0]) && !char.IsDigit(versionString[versionString.Length - 1]))
+            {
+                throw ThrowHelper.GetFormatException(DataType.Version);
+            }
             if (Version.TryParse(versionString, out Version? result))
             {
                 return result;
@@ -53,16 +97,9 @@ namespace System.Text.Json.Serialization.Converters
         public override void Write(Utf8JsonWriter writer, Version value, JsonSerializerOptions options)
         {
 #if BUILDING_INBOX_LIBRARY
-            const int versionComponentsCount = 4; // Major, Minor, Build, Revision
-
-            const int maxStringLengthOfPositiveInt32 = 10; // int.MaxValue.ToString().Length
-
-            const int maxStringLengthOfVersion = (maxStringLengthOfPositiveInt32 * versionComponentsCount) + 1 + 1 + 1; // 43, 1 is length of '.'
-            Debug.Assert(JsonConstants.StackallocThreshold >= maxStringLengthOfVersion * sizeof(char),
-                "Stack allocated buffer should not be bigger than stackalloc threshold defined in JsonConstants");
-            Span<char> span = stackalloc char[maxStringLengthOfVersion];
+            Span<char> span = stackalloc char[MaximumVersionLength];
             bool formattedSuccessfully = value.TryFormat(span, out int charsWritten);
-            Debug.Assert(formattedSuccessfully);
+            Debug.Assert(formattedSuccessfully && charsWritten >= MinimumVersionLength);
             writer.WriteStringValue(span.Slice(0, charsWritten));
             return;
 #else
@@ -70,7 +107,5 @@ namespace System.Text.Json.Serialization.Converters
             return;
 #endif
         }
-
-        private static int GetIndexOfDot(ReadOnlySpan<byte> source) => source.IndexOf((byte)'.');
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/VersionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/VersionConverter.cs
@@ -81,7 +81,7 @@ namespace System.Text.Json.Serialization.Converters
             }
 #else
             string? versionString = reader.GetString();
-            if (versionString != null && !char.IsDigit(versionString[0]) && !char.IsDigit(versionString[versionString.Length - 1]))
+            if (!string.IsNullOrEmpty(versionString) && !char.IsDigit(versionString[0]) && !char.IsDigit(versionString[versionString.Length - 1]))
             {
                 throw ThrowHelper.GetFormatException(DataType.Version);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
@@ -645,6 +645,9 @@ namespace System.Text.Json
                 case DataType.Guid:
                     message = SR.FormatGuid;
                     break;
+                case DataType.Version:
+                    message = SR.FormatVersion;
+                    break;
                 default:
                     Debug.Fail($"The DateType enum value: {dateType} is not part of the switch. Add the appropriate case and exception message.");
                     break;
@@ -729,5 +732,6 @@ namespace System.Text.Json
         TimeSpan,
         Base64String,
         Guid,
+        Version,
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Value.ReadTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Value.ReadTests.cs
@@ -354,6 +354,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("-2147483648.-2147483648.-2147483648")]
         [InlineData("-2147483648.-2147483648.-2147483648.-2147483648")]
         [InlineData("1.-1")]
+        [InlineData("1")]
         [InlineData("   1.2.3.4")] //Valid but has leading whitespace
         [InlineData("1.2.3.4    ")] //Valid but has trailing whitespace
         [InlineData("  1.2.3.4  ")] //Valid but has trailing and leading whitespaces

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Value.ReadTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Value.ReadTests.cs
@@ -309,6 +309,8 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<TimeSpan>(unexpectedString));
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<TimeSpan?>(unexpectedString));
 
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Version>(unexpectedString));
+
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<string>("1"));
 
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<char>("1"));
@@ -318,41 +320,47 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Enum>(unexpectedString));
         }
 
-        [Fact]
-        public static void ReadVersion()
+        [Theory]
+        [InlineData("1.2")]
+        [InlineData("\\u0031\\u002e\\u0032", "1.2")]
+        [InlineData("1.2.3")]
+        [InlineData("\\u0031\\u002e\\u0032\\u002e\\u0033", "1.2.3")]
+        [InlineData("1.2.3.4")]
+        [InlineData("\\u0031\\u002e\\u0032\\u002e\\u0033\\u002e\\u0034", "1.2.3.4")]
+        [InlineData("2147483647.2147483647")]
+        [InlineData("\\u0032\\u0031\\u0034\\u0037\\u0034\\u0038\\u0033\\u0036\\u0034\\u0037\\u002e\\u0032\\u0031\\u0034\\u0037\\u0034\\u0038\\u0033\\u0036\\u0034\\u0037",
+            "2147483647.2147483647")]
+        [InlineData("2147483647.2147483647.2147483647")]
+        [InlineData("\\u0032\\u0031\\u0034\\u0037\\u0034\\u0038\\u0033\\u0036\\u0034\\u0037\\u002e\\u0032\\u0031\\u0034\\u0037\\u0034\\u0038\\u0033\\u0036\\u0034\\u0037\\u002e\\u0032\\u0031\\u0034\\u0037\\u0034\\u0038\\u0033\\u0036\\u0034\\u0037",
+            "2147483647.2147483647.2147483647")]
+        [InlineData("2147483647.2147483647.2147483647.2147483647")]
+        [InlineData("\\u0032\\u0031\\u0034\\u0037\\u0034\\u0038\\u0033\\u0036\\u0034\\u0037\\u002e\\u0032\\u0031\\u0034\\u0037\\u0034\\u0038\\u0033\\u0036\\u0034\\u0037\\u002e\\u0032\\u0031\\u0034\\u0037\\u0034\\u0038\\u0033\\u0036\\u0034\\u0037\\u002e\\u0032\\u0031\\u0034\\u0037\\u0034\\u0038\\u0033\\u0036\\u0034\\u0037",
+            "2147483647.2147483647.2147483647.2147483647")]
+        public static void Version_Read_Success(string json, string? actual = null)
         {
-            Version version;
+            actual ??= json;
+            Version value = JsonSerializer.Deserialize<Version>($"\"{json}\"");
 
-            version = JsonSerializer.Deserialize<Version>(@"""1.2""");
-            Assert.Equal(new Version(1, 2), version);
+            Assert.Equal(Version.Parse(actual), value);
+        }
 
-            version = JsonSerializer.Deserialize<Version>(@"""1.2.3""");
-            Assert.Equal(new Version(1, 2, 3), version);
+        [Theory]
+        [InlineData("")]
+        [InlineData("-2147483648.-2147483648")]
+        [InlineData("-2147483648.-2147483648.-2147483648")]
+        [InlineData("-2147483648.-2147483648.-2147483648.-2147483648")]
+        [InlineData("1.-1")]
+        [InlineData("   1.2.3.4")] //Valid but has leading whitespace
+        [InlineData("1.2.3.4    ")] //Valid but has trailing whitespace
+        [InlineData("{}", false)]
+        [InlineData("[]", false)]
+        [InlineData("true", false)]
+        public static void Version_Read_Failure(string json, bool addQuotes = true)
+        {
+            if (addQuotes)
+                json = $"\"{json}\"";
 
-            version = JsonSerializer.Deserialize<Version>(@"""1.2.3.4""");
-            Assert.Equal(new Version(1, 2, 3, 4), version);
-
-            version = JsonSerializer.Deserialize<Version>(@"""2147483647.2147483647""");
-            Assert.Equal(new Version(int.MaxValue, int.MaxValue), version);
-
-            version = JsonSerializer.Deserialize<Version>(@"""2147483647.2147483647.2147483647""");
-            Assert.Equal(new Version(int.MaxValue, int.MaxValue, int.MaxValue), version);
-
-            version = JsonSerializer.Deserialize<Version>(@"""2147483647.2147483647.2147483647.2147483647""");
-            Assert.Equal(new Version(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue), version);
-
-            version = JsonSerializer.Deserialize<Version>("null");
-            Assert.Null(version);
-
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Version>(@""""""));
-
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Version>(@"""-2147483648.-2147483648"""));
-
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Version>(@"""-2147483648.-2147483648.-2147483648"""));
-
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Version>(@"""-2147483648.-2147483648.-2147483648.-2147483648"""));
-
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Version>(@"""1.-1"""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Version>(json));
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Value.ReadTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Value.ReadTests.cs
@@ -356,6 +356,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("1.-1")]
         [InlineData("   1.2.3.4")] //Valid but has leading whitespace
         [InlineData("1.2.3.4    ")] //Valid but has trailing whitespace
+        [InlineData("  1.2.3.4  ")] //Valid but has trailing and leading whitespaces
         [InlineData("{}", false)]
         [InlineData("[]", false)]
         [InlineData("true", false)]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Value.ReadTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Value.ReadTests.cs
@@ -332,10 +332,27 @@ namespace System.Text.Json.Serialization.Tests
             version = JsonSerializer.Deserialize<Version>(@"""1.2.3.4""");
             Assert.Equal(new Version(1, 2, 3, 4), version);
 
+            version = JsonSerializer.Deserialize<Version>(@"""2147483647.2147483647""");
+            Assert.Equal(new Version(int.MaxValue, int.MaxValue), version);
+
+            version = JsonSerializer.Deserialize<Version>(@"""2147483647.2147483647.2147483647""");
+            Assert.Equal(new Version(int.MaxValue, int.MaxValue, int.MaxValue), version);
+
+            version = JsonSerializer.Deserialize<Version>(@"""2147483647.2147483647.2147483647.2147483647""");
+            Assert.Equal(new Version(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue), version);
+
             version = JsonSerializer.Deserialize<Version>("null");
             Assert.Null(version);
 
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Version>(@""""""));
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Version>(@"""-2147483648.-2147483648"""));
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Version>(@"""-2147483648.-2147483648.-2147483648"""));
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Version>(@"""-2147483648.-2147483648.-2147483648.-2147483648"""));
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Version>(@"""1.-1"""));
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Value.ReadTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Value.ReadTests.cs
@@ -346,6 +346,10 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [InlineData("")]
+        [InlineData("     ")]
+        [InlineData(" ")]
+        [InlineData("2147483648.2147483648.2147483648.2147483648")] //int.MaxValue + 1
+        [InlineData("2147483647.2147483647.2147483647.21474836477")] // Slightly bigger in size than max length of Version
         [InlineData("-2147483648.-2147483648")]
         [InlineData("-2147483648.-2147483648.-2147483648")]
         [InlineData("-2147483648.-2147483648.-2147483648.-2147483648")]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Value.WriteTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Value.WriteTests.cs
@@ -111,6 +111,21 @@ namespace System.Text.Json.Serialization.Tests
                 Version version = new Version(1, 2, 3, 4);
                 Assert.Equal(@"""1.2.3.4""", JsonSerializer.Serialize(version));
             }
+
+            {
+                Version version = new Version(int.MaxValue, int.MaxValue);
+                Assert.Equal(@"""2147483647.2147483647""", JsonSerializer.Serialize(version));
+            }
+
+            {
+                Version version = new Version(int.MaxValue, int.MaxValue, int.MaxValue);
+                Assert.Equal(@"""2147483647.2147483647.2147483647""", JsonSerializer.Serialize(version));
+            }
+
+            {
+                Version version = new Version(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue);
+                Assert.Equal(@"""2147483647.2147483647.2147483647.2147483647""", JsonSerializer.Serialize(version));
+            }
         }
 
         [Theory]


### PR DESCRIPTION
Resolves #55179  

I didn't find any info on creating custom benchmarks to measure performance of `VersionConverter` for current implementation of .NET runtime and custom build with proposed changes, so I would much appreciate if you can point to docs on how to do it, so I can create and run benchmark and attach its results here.  

Few notes on implementation:
- In proposed version, converter currently doesn't check for `reader.TokenType` being `string`, probably we can add this check, the only problem is [`ThrowHelper.GetInvalidOperationException_ExpectedString`](https://github.com/dotnet/runtime/blob/d5f95444d74a6ce2e1d09915ed0fdb3bba727f4c/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.cs#L220) returns exception instead of throwing it, so we would have `throw` statement directly in `Read` method, but i guess it's fine since this method is overriden and won't be inlined anyway;
- Unlike current implementation of `Write` method, proposed one is more fragile to changes inside `Version` class, since it needs to know what size of buffer it needs to allocate, ans therefore is more dependent on concrete implementation like, `Version` only having 4 components and components being `Int32`, so probably additional `Debug.Assert`'s can be added to make sure they would fail in case of breaking changes inside `Version` class, but unfortunately I can not think of any. 