### PR TITLE
Add leeway to revocation test

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/TimeoutTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/RevocationTests/TimeoutTests.cs
@@ -59,7 +59,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
                     // OCSP/CRL to root to get intermediate statuses. It should take at least 2x the delay
                     // plus other non-network time, so we can at least ensure it took as long as
                     // the delay for each fetch.
-                    Assert.True(watch.Elapsed >= delay * 2, $"watch.Elapsed: {watch.Elapsed}");
+                    // We expect the chain to build in at least 16 seconds (2 * delay) since each fetch
+                    // should take `delay` number of seconds, and there are two fetchs that need to be
+                    // performed. We allow a small amount of leeway to account for differences between
+                    // how long the the delay is performed and the stopwatch.
+                    Assert.True(watch.Elapsed >= delay * 2 - TimeSpan.FromSeconds(1), $"watch.Elapsed: {watch.Elapsed}");
                 }
             });
         }


### PR DESCRIPTION
Windows 7 has been observed timing out the fetch operation slightly early. For example, 15.9 seconds instead of the expected 16 seconds. Since this is OS behavior that we can't control, the test has been changed to allow a small amount of leeway in the expected timeout.

Closes #55554