### PR TITLE
Fix Task.WhenAny failure mode when passed ICollection of zero tasks

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -6305,8 +6305,14 @@ namespace System.Threading.Tasks
                     return WhenAny(taskArray);
                 }
 
+                int count = taskCollection.Count;
+                if (count <= 0)
+                {
+                    ThrowHelper.ThrowArgumentException(ExceptionResource.Task_MultiTaskContinuation_EmptyTaskList, ExceptionArgument.tasks);
+                }
+
                 int index = 0;
-                taskArray = new Task[taskCollection.Count];
+                taskArray = new Task[count];
                 foreach (Task task in tasks)
                 {
                     if (task == null) ThrowHelper.ThrowArgumentException(ExceptionResource.Task_MultiTaskContinuation_NullTask, ExceptionArgument.tasks);

--- a/src/libraries/System.Threading.Tasks/tests/MethodCoverage.cs
+++ b/src/libraries/System.Threading.Tasks/tests/MethodCoverage.cs
@@ -189,6 +189,20 @@ namespace TaskCoverage
         }
 
         [Fact]
+        public static void Task_WhenAny_NoTasks_Throws()
+        {
+            AssertExtensions.Throws<ArgumentException>("tasks", () => { Task.WhenAny(new Task[0]); });
+            AssertExtensions.Throws<ArgumentException>("tasks", () => { Task.WhenAny(new List<Task>()); });
+            AssertExtensions.Throws<ArgumentException>("tasks", () => { Task.WhenAny(EmptyIterator<Task>()); });
+
+            AssertExtensions.Throws<ArgumentException>("tasks", () => { Task.WhenAny(new Task<int>[0]); });
+            AssertExtensions.Throws<ArgumentException>("tasks", () => { Task.WhenAny(new List<Task<int>>()); });
+            AssertExtensions.Throws<ArgumentException>("tasks", () => { Task.WhenAny(EmptyIterator<Task<int>>()); });
+
+            static IEnumerable<T> EmptyIterator<T>() { yield break; }
+        }
+
+        [Fact]
         public static async Task Task_WhenAny_TwoTasks_OnePreCompleted()
         {
             Task<int> t1 = Task.FromResult(1);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/55578 (regression from https://github.com/dotnet/runtime/pull/38896).
cc: @dotnet/area-system-threading-tasks, @TonyValenti 