### PR TITLE
Avoid declaring an object cannot fit in a segment if we already have committed space for it

### DIFF
--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -3182,7 +3182,7 @@ protected:
                                BOOL& should_expand);
 #ifndef USE_REGIONS
     PER_HEAP
-    BOOL sufficient_space_end_seg (uint8_t* start, uint8_t* seg_end,
+    BOOL sufficient_space_end_seg (uint8_t* start, uint8_t* committed, uint8_t* reserved,
                                    size_t end_space_required);
 #endif //!USE_REGIONS
 


### PR DESCRIPTION
The function `sufficient_space_end_seg` is used to check if we have sufficient space at the end of a segment to allocate a certain amount of space. The original implementation checks if we have sufficient reserved space, if not, we fail immediately, otherwise, we check for the hard limit, assuming all the space required has to be extra committed memory. 

But in many cases, the `ephemeral_heap_segment` has committed memory at its end already, we should consider those spaces first before we check if the extra commit fits within the hard limits.

The change deliberately skips the region's case for now, which seems more complicated than I wanted for this change.