### PR TITLE
Place the CMake command line cache file in the intermediates dir instead of the output dir

### DIFF
--- a/eng/native/gen-buildsys.sh
+++ b/eng/native/gen-buildsys.sh
@@ -98,7 +98,7 @@ if [[ "$build_arch" == "wasm" ]]; then
 fi
 
 cmake_args_to_cache="$scan_build\n$SCAN_BUILD_COMMAND\n$generator\n$__UnprocessedCMakeArgs"
-cmake_args_cache_file="$__CMakeBinDir/cmake_cmd_line.txt"
+cmake_args_cache_file="$2/cmake_cmd_line.txt"
 if [[ -z "$__ConfigureOnly" ]]; then
     if [[ -e "$cmake_args_cache_file" ]]; then
         cmake_args_cache=$(<"$cmake_args_cache_file")


### PR DESCRIPTION
Fixes an issue where deleting the intermediates folder locally would get the build in a bad state where the command-line check would be up to date but the CMake files would not be generated.