### PR TITLE
[QUIC] Move ByteMixingOrNativeAVE_MinimalFailingTest to OuterLoop

### DIFF
--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -453,6 +453,8 @@ namespace System.Net.Quic.Tests
         }
 
         [Fact]
+        [OuterLoop("May take several seconds")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55588")]
         public async Task ByteMixingOrNativeAVE_MinimalFailingTest()
         {
             const int writeSize = 64 * 1024;

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -454,7 +454,6 @@ namespace System.Net.Quic.Tests
 
         [Fact]
         [OuterLoop("May take several seconds")]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55588")]
         public async Task ByteMixingOrNativeAVE_MinimalFailingTest()
         {
             const int writeSize = 64 * 1024;


### PR DESCRIPTION
~~Disable ByteMixingOrNativeAVE_MinimalFailingTest test by ActiveIssue #55588~~
Move ByteMixingOrNativeAVE_MinimalFailingTest to outerloop. Fixes #55588