### PR TITLE
[debugger] Fix debugging after hot reloading

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -508,6 +508,7 @@
       <_Objcopy Condition="'$(_ObjcopyFound)' != '0'">objcopy</_Objcopy>
     </PropertyGroup>
     <ItemGroup>
+      <FilesToStrip Include="$(_MonoRuntimeFilePath)" />
       <FilesToStrip Include="$([System.IO.Directory]::GetParent($(_MonoRuntimeFilePath)))\libmono-component-*$(SharedLibExt)" />
       <FilesToStrip Include="$([System.IO.Directory]::GetParent($(_MonoRuntimeFilePath)))\Mono*framework\**\Mono*" Exclude="$([System.IO.Directory]::GetParent($(_MonoRuntimeFilePath)))\Mono*framework\**\*.dwarf" />
     </ItemGroup>

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -508,7 +508,6 @@
       <_Objcopy Condition="'$(_ObjcopyFound)' != '0'">objcopy</_Objcopy>
     </PropertyGroup>
     <ItemGroup>
-      <FilesToStrip Include="$(_MonoRuntimeFilePath)" />
       <FilesToStrip Include="$([System.IO.Directory]::GetParent($(_MonoRuntimeFilePath)))\libmono-component-*$(SharedLibExt)" />
       <FilesToStrip Include="$([System.IO.Directory]::GetParent($(_MonoRuntimeFilePath)))\Mono*framework\**\Mono*" Exclude="$([System.IO.Directory]::GetParent($(_MonoRuntimeFilePath)))\Mono*framework\**\*.dwarf" />
     </ItemGroup>

--- a/src/mono/mono/metadata/mono-debug.c
+++ b/src/mono/mono/metadata/mono-debug.c
@@ -1120,8 +1120,13 @@ mono_debug_get_seq_points (MonoDebugMethodInfo *minfo, char **source_file, GPtrA
 	if (img->has_updates) {
 		int idx = mono_metadata_token_index (minfo->method->token);
 		gpointer ptr = mono_metadata_update_get_updated_method_ppdb (img, idx);
-		mono_ppdb_get_seq_points_enc (ptr, seq_points,  n_seq_points);
-	} else if (minfo->handle->ppdb)
+		if (ptr != NULL)
+		{
+			mono_ppdb_get_seq_points_enc (ptr, seq_points,  n_seq_points);
+			return;
+		}
+	} 
+	if (minfo->handle->ppdb)
 		mono_ppdb_get_seq_points (minfo, source_file, source_file_list, source_files, seq_points, n_seq_points);
 	else
 		mono_debug_symfile_get_seq_points (minfo, source_file, source_file_list, source_files, seq_points, n_seq_points);

--- a/src/mono/mono/metadata/mono-debug.c
+++ b/src/mono/mono/metadata/mono-debug.c
@@ -1120,8 +1120,7 @@ mono_debug_get_seq_points (MonoDebugMethodInfo *minfo, char **source_file, GPtrA
 	if (img->has_updates) {
 		int idx = mono_metadata_token_index (minfo->method->token);
 		gpointer ptr = mono_metadata_update_get_updated_method_ppdb (img, idx);
-		if (ptr != NULL)
-		{
+		if (ptr != NULL) {
 			mono_ppdb_get_seq_points_enc (ptr, seq_points,  n_seq_points);
 			return;
 		}

--- a/src/mono/mono/metadata/mono-debug.c
+++ b/src/mono/mono/metadata/mono-debug.c
@@ -1121,7 +1121,7 @@ mono_debug_get_seq_points (MonoDebugMethodInfo *minfo, char **source_file, GPtrA
 		int idx = mono_metadata_token_index (minfo->method->token);
 		gpointer ptr = mono_metadata_update_get_updated_method_ppdb (img, idx);
 		if (ptr != NULL) {
-			mono_ppdb_get_seq_points_enc (ptr, seq_points,  n_seq_points);
+			mono_ppdb_get_seq_points_enc (ptr, seq_points, n_seq_points);
 			return;
 		}
 	} 

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -9758,7 +9758,10 @@ mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, Mon
 
 	MonoJitMemoryManager *jit_mm = get_default_jit_mm ();
 	jit_mm_lock (jit_mm);
-	g_hash_table_replace (jit_mm->seq_points, imethod->method, imethod->jinfo->seq_points);
+	gpointer seq_points = g_hash_table_lookup (jit_mm->seq_points, imethod->method);
+	if (!seq_points || seq_points != imethod->jinfo->seq_points)
+		g_hash_table_replace (jit_mm->seq_points, imethod->method, imethod->jinfo->seq_points);
+
 	jit_mm_unlock (jit_mm);
 
 	// FIXME: Add a different callback ?


### PR DESCRIPTION
- If there is no change like add new lines or create new variables, `mono_metadata_update_get_updated_method_ppdb ` will return null.
- While transforming code it passes on `mono_interp_transform_method ` with same seq_points, only replace on `jit_mm->seq_points` when it's really changed (in hot reload case)