### PR TITLE
more fixes for msquic packaging

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -53,6 +53,7 @@
     <_pastShimFiles Include="System.Security.Cryptography.Native.OpenSsl.dylib" />
     <_pastShimFiles Include="System.Security.Cryptography.Native.OpenSsl.so" />
     <_pastShimFiles Include="clrcompression.dll" />
+    <_pastShimFiles Include="msquic.dll" />
     <PlatformManifestFileEntry Include="@(_pastShimFiles)" IsNative="true" />
   </ItemGroup>
 
@@ -161,6 +162,7 @@
     <PlatformManifestFileEntry Include="api-ms-win-crt-utility-l1-1-0.dll" IsNative="true" FallbackFileVersion="$(WindowsForwarderFileVersion)" />
     <PlatformManifestFileEntry Include="API-MS-Win-core-xstate-l2-1-0.dll" IsNative="true" FallbackFileVersion="$(WindowsForwarderFileVersion)" />
     <PlatformManifestFileEntry Include="ucrtbase.dll" IsNative="true" />
+    <PlatformManifestFileEntry Include="msquic.dll" IsNative="true" />
     <PlatformManifestFileEntry Include="System.IO.Compression.Native.dll" IsNative="true" />
     <PlatformManifestFileEntry Include="createdump.exe" IsNative="true" />
     <PlatformManifestFileEntry Include="createdump" IsNative="true" />

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -53,7 +53,6 @@
     <_pastShimFiles Include="System.Security.Cryptography.Native.OpenSsl.dylib" />
     <_pastShimFiles Include="System.Security.Cryptography.Native.OpenSsl.so" />
     <_pastShimFiles Include="clrcompression.dll" />
-    <_pastShimFiles Include="msquic.dll" />
     <PlatformManifestFileEntry Include="@(_pastShimFiles)" IsNative="true" />
   </ItemGroup>
 

--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -89,6 +89,7 @@
     <BinPlaceDir Include="$(MicrosoftNetCoreAppRuntimePackNativeDir)" ItemName="NativeBinPlaceItem" />
     <BinPlaceDir Include="$(NetCoreAppCurrentTestHostSharedFrameworkPath)" ItemName="NativeBinPlaceItem" />
     <BinPlaceDir Include="$(NetCoreAppCurrentRuntimePath)" ItemName="NativeBinPlaceItem" />
+    <BinPlaceDir Include="$(LibrariesNativeArtifactsPath)" ItemName="NativeBinPlaceItem" />
     <NativeBinPlaceItem Include="$(PkgSystem_Net_MsQuic_Transport)\runtimes\win10-$(TargetArchitecture)\native\*" />
   </ItemGroup>
 


### PR DESCRIPTION
It seems like previous change was good enough get it to runtime and run tests but it was _not_ good enough to make it the final product. 
With this, I verified that `msquic.dll` is part of created `dotnet-runtime-6.0.0-dev-win-x64.zip` and I also run the msi installer and I check install shared directory. 

We also crate aspnet transport package and I'm not sure if the native dll needs to be there since it is now part of the runtime. We can possibly re-visit this later if need to. 