### PR TITLE
Stop special casing LogAlways

### DIFF
--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/Harness/Listeners.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/Harness/Listeners.cs
@@ -235,7 +235,7 @@ namespace BasicEventSourceTests
 
         private void mListenerEventWritten(object sender, EventWrittenEventArgs eventData)
         {
-            OnEvent(new EventListenerEvent(eventData));
+            OnEvent?.Invoke(new EventListenerEvent(eventData));
         }
 
         private class HelperEventListener : EventListener

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/LoudListener.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/LoudListener.cs
@@ -18,7 +18,7 @@ namespace BasicEventSourceTests
 
         public LoudListener(EventSource eventSource)
         {
-            EnableEvents(eventSource, EventLevel.LogAlways, (EventKeywords)0xffffffff);
+            EnableEvents(eventSource, EventLevel.Verbose, (EventKeywords)0xffffffff);
         }
 
         protected override void OnEventWritten(EventWrittenEventArgs eventData)

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestFilter.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestFilter.cs
@@ -34,6 +34,31 @@ namespace BasicEventSourceTests
                 Assert.Equal(0, listener.EventCount);
             }
         }
+
+        /// <summary>
+        /// Tests that Events with a level lower than the logging level will be filtered
+        /// In older versions of .NET there was a bug that special cased LogAlways and caused
+        /// EventListener at the LogAlways level not to do any level filtering. LogAlways isn't
+        /// intended to be a special case, it is merely the name for the most severe level.
+        /// https://github.com/dotnet/runtime/issues/51429
+        /// </summary>
+        [Fact]
+        public static void TestFilterEventLogAlways()
+        {
+            using (EventCountListener listener = new EventCountListener())
+            using (TestSource log = new TestSource())
+            {
+                listener.EnableEvents(log, EventLevel.LogAlways);
+
+                /* This call should be filtered since it is at WarningLevel and we are logging LogAlways */
+                log.WarningEventWithArgs(1, 2, 3, false);
+
+                /* This call should be filtered since it is at Verbose and we are logging LogAlways */
+                log.VerboseEvent();
+
+                Assert.Equal(0, listener.EventCount);
+            }
+        }
     }
 
     /// <summary>

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestUtilities.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestUtilities.cs
@@ -39,7 +39,12 @@ namespace BasicEventSourceTests
                     eventSource.Name != "System.Runtime.InteropServices.InteropEventProvider" &&
                     eventSource.Name != "System.Reflection.Runtime.Tracing" &&
                     eventSource.Name != "Microsoft-Windows-DotNETRuntime" &&
-                    eventSource.Name != "System.Runtime"
+                    eventSource.Name != "System.Runtime" &&
+
+                    // These event sources show up when hosted in the VS test runner
+                    eventSource.Name != "System.Net.Sockets" &&
+                    eventSource.Name != "Private.InternalDiagnostics.System.Net.Sockets" &&
+                    eventSource.Name != "TestPlatform"
                     )
                 {
                     eventSourceNames += eventSource.Name + " ";

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEventToListener.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEventToListener.cs
@@ -257,6 +257,7 @@ namespace BasicEventSourceTests
                 using (var el = new LoudListener(log))
                 {
                     log.WriteTooManyArgs("Hello");
+                    Assert.NotNull(LoudListener.t_lastEvent);
                     Assert.Equal(2, LoudListener.t_lastEvent.EventId);
                     Assert.Equal(1, LoudListener.t_lastEvent.Payload.Count);           // Faked count (compat)
                     Assert.Equal("Hello", LoudListener.t_lastEvent.Payload[0]);

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -2307,7 +2307,7 @@ namespace System.Diagnostics.Tracing
             if (!enabled)
                 return false;
 
-            // does is pass the level test?
+            // does it pass the level test?
             if (currentLevel < eventLevel)
                 return false;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -2308,7 +2308,7 @@ namespace System.Diagnostics.Tracing
                 return false;
 
             // does is pass the level test?
-            if ((currentLevel != 0) && (currentLevel < eventLevel))
+            if (currentLevel < eventLevel)
                 return false;
 
             // if yes, does it pass the keywords test?


### PR DESCRIPTION
Fixes #51429

LogAlways is the name for the most severe logging level but the code was mistakenly treating it as a special case that skipped
all level filtering. I eliminated that special case handling.


@brianrob:
 - does this match your understanding of how a listener at LogAlways filtering level is intended to behave?
 - any concerns that we should avoid fixing this because of the back-compat implications?

@josalem - could you review this?
cc @dotnet/dotnet-diag 