### PR TITLE
[mono] Fix skipping of static methods during IMT table construction.

### DIFF
--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -1525,10 +1525,8 @@ build_imt_slots (MonoClass *klass, MonoVTable *vt, gpointer* imt, GSList *extra_
 				continue;
 			}
 
-			if (m_method_is_static (method)) {
-				vt_slot ++;
+			if (m_method_is_static (method))
 				continue;
-			}
 
 			if (method->flags & METHOD_ATTRIBUTE_VIRTUAL) {
 				add_imt_builder_entry (imt_builder, method, &imt_collisions_bitmap, vt_slot, slot_num);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/55375.