### PR TITLE
Support cloning loops with array of struct indexing expressions

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -8523,6 +8523,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
  *      cBlocks,     dBlocks        : Display all the basic blocks of a function (call fgDispBasicBlocks()).
  *      cBlocksV,    dBlocksV       : Display all the basic blocks of a function (call fgDispBasicBlocks(true)).
  *                                    "V" means "verbose", and will dump all the trees.
+ *      cStmt,       dStmt          : Display a Statement (call gtDispStmt()).
  *      cTree,       dTree          : Display a tree (call gtDispTree()).
  *      cTreeLIR,    dTreeLIR       : Display a tree in LIR form (call gtDispLIRNode()).
  *      cTrees,      dTrees         : Display all the trees in a function (call fgDumpTrees()).
@@ -8545,6 +8546,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
  *
  * The following don't require a Compiler* to work:
  *      dRegMask                    : Display a regMaskTP (call dspRegMask(mask)).
+ *      dBlockList                  : Display a BasicBlockList*.
  */
 
 void cBlock(Compiler* comp, BasicBlock* block)
@@ -8717,6 +8719,11 @@ void dBlocks()
 void dBlocksV()
 {
     cBlocksV(JitTls::GetCompiler());
+}
+
+void dStmt(Statement* statement)
+{
+    cStmt(JitTls::GetCompiler(), statement);
 }
 
 void dTree(GenTree* tree)

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3116,6 +3116,8 @@ public:
 
     void gtUpdateNodeOperSideEffects(GenTree* tree);
 
+    void gtUpdateNodeOperSideEffectsPost(GenTree* tree);
+
     // Returns "true" iff the complexity (not formally defined, but first interpretation
     // is #of nodes in subtree) of "tree" is greater than "limit".
     // (This is somewhat redundant with the "GetCostEx()/GetCostSz()" fields, but can be used

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -3253,14 +3253,13 @@ void Compiler::fgDebugCheckFlags(GenTree* tree)
 }
 
 //------------------------------------------------------------------------------
-// fgDebugCheckDispFlags:
-//    Wrapper function that displays two GTF_IND_ flags
-//      and then calls ftDispFlags to display the rest.
+// fgDebugCheckDispFlags: Wrapper function that displays GTF_IND_ flags
+// and then calls gtDispFlags to display the rest.
 //
 // Arguments:
 //    tree       - Tree whose flags are being checked
-//    dispFlags  - the first argument for gtDispFlags
-//                 ands hold GTF_IND_INVARIANT and GTF_IND_NONFLUALTING
+//    dispFlags  - the first argument for gtDispFlags (flags to display),
+//                 including GTF_IND_INVARIANT, GTF_IND_NONFAULTING, GTF_IND_NONNULL
 //    debugFlags - the second argument to gtDispFlags
 //
 void Compiler::fgDebugCheckDispFlags(GenTree* tree, GenTreeFlags dispFlags, GenTreeDebugFlags debugFlags)
@@ -3277,15 +3276,14 @@ void Compiler::fgDebugCheckDispFlags(GenTree* tree, GenTreeFlags dispFlags, GenT
 //------------------------------------------------------------------------------
 // fgDebugCheckFlagsHelper : Check if all bits that are set in chkFlags are also set in treeFlags.
 //
-//
 // Arguments:
-//    tree  - Tree whose flags are being checked
+//    tree      - Tree whose flags are being checked
 //    treeFlags - Actual flags on the tree
-//    chkFlags - Expected flags
+//    chkFlags  - Expected flags
 //
 // Note:
 //    Checking that all bits that are set in treeFlags are also set in chkFlags is currently disabled.
-
+//
 void Compiler::fgDebugCheckFlagsHelper(GenTree* tree, GenTreeFlags treeFlags, GenTreeFlags chkFlags)
 {
     if (chkFlags & ~treeFlags)

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -933,13 +933,12 @@ GenTreeCall* Compiler::fgGetSharedCCtor(CORINFO_CLASS_HANDLE cls)
 //------------------------------------------------------------------------------
 // fgAddrCouldBeNull : Check whether the address tree can represent null.
 //
-//
 // Arguments:
 //    addr     -  Address to check
 //
 // Return Value:
 //    True if address could be null; false otherwise
-
+//
 bool Compiler::fgAddrCouldBeNull(GenTree* addr)
 {
     addr = addr->gtEffectiveVal();

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -8533,7 +8533,7 @@ void Compiler::gtUpdateSideEffects(Statement* stmt, GenTree* tree)
 //
 // Arguments:
 //    tree            - Tree to update the side effects for
-
+//
 void Compiler::gtUpdateTreeAncestorsSideEffects(GenTree* tree)
 {
     assert(fgStmtListThreaded);
@@ -8549,7 +8549,7 @@ void Compiler::gtUpdateTreeAncestorsSideEffects(GenTree* tree)
 //
 // Arguments:
 //    stmt            - The statement to update side effects on
-
+//
 void Compiler::gtUpdateStmtSideEffects(Statement* stmt)
 {
     fgWalkTree(stmt->GetRootNodePointer(), fgUpdateSideEffectsPre, fgUpdateSideEffectsPost);
@@ -8565,7 +8565,7 @@ void Compiler::gtUpdateStmtSideEffects(Statement* stmt)
 //    This method currently only updates GTF_EXCEPT, GTF_ASG, and GTF_CALL flags.
 //    The other side effect flags may remain unnecessarily (conservatively) set.
 //    The caller of this method is expected to update the flags based on the children's flags.
-
+//
 void Compiler::gtUpdateNodeOperSideEffects(GenTree* tree)
 {
     if (tree->OperMayThrow(this))
@@ -8601,6 +8601,46 @@ void Compiler::gtUpdateNodeOperSideEffects(GenTree* tree)
 }
 
 //------------------------------------------------------------------------
+// gtUpdateNodeOperSideEffectsPost: Update the side effects based on the node operation,
+// in the post-order visit of a tree walk. It is expected that the pre-order visit cleared
+// the bits, so the post-order visit only sets them. This is important for binary nodes
+// where one child already may have set the GTF_EXCEPT bit. Note that `SetIndirExceptionFlags`
+// looks at its child, which is why we need to do this in a bottom-up walk.
+//
+// Arguments:
+//    tree            - Tree to update the side effects on
+//
+// Notes:
+//    This method currently only updates GTF_EXCEPT, GTF_ASG, and GTF_CALL flags.
+//    The other side effect flags may remain unnecessarily (conservatively) set.
+//    The caller of this method is expected to update the flags based on the children's flags.
+//
+void Compiler::gtUpdateNodeOperSideEffectsPost(GenTree* tree)
+{
+    if (tree->OperMayThrow(this))
+    {
+        tree->gtFlags |= GTF_EXCEPT;
+    }
+    else
+    {
+        if (tree->OperIsIndirOrArrLength())
+        {
+            tree->SetIndirExceptionFlags(this);
+        }
+    }
+
+    if (tree->OperRequiresAsgFlag())
+    {
+        tree->gtFlags |= GTF_ASG;
+    }
+
+    if (tree->OperRequiresCallFlag(this))
+    {
+        tree->gtFlags |= GTF_CALL;
+    }
+}
+
+//------------------------------------------------------------------------
 // gtUpdateNodeSideEffects: Update the side effects based on the node operation and
 //                          children's side efects.
 //
@@ -8608,9 +8648,9 @@ void Compiler::gtUpdateNodeOperSideEffects(GenTree* tree)
 //    tree            - Tree to update the side effects on
 //
 // Notes:
-//    This method currently only updates GTF_EXCEPT and GTF_ASG flags. The other side effect
-//    flags may remain unnecessarily (conservatively) set.
-
+//    This method currently only updates GTF_EXCEPT, GTF_ASG, and GTF_CALL flags.
+//    The other side effect flags may remain unnecessarily (conservatively) set.
+//
 void Compiler::gtUpdateNodeSideEffects(GenTree* tree)
 {
     gtUpdateNodeOperSideEffects(tree);
@@ -8627,24 +8667,23 @@ void Compiler::gtUpdateNodeSideEffects(GenTree* tree)
 
 //------------------------------------------------------------------------
 // fgUpdateSideEffectsPre: Update the side effects based on the tree operation.
+// The pre-visit of the walk only clears the GTF_EXCEPT bit; the post-visit sets
+// the bits as necessary.
 //
 // Arguments:
 //    pTree            - Pointer to the tree to update the side effects
 //    fgWalkPre        - Walk data
 //
-// Notes:
-//    This method currently only updates GTF_EXCEPT and GTF_ASG flags. The other side effect
-//    flags may remain unnecessarily (conservatively) set.
-
 Compiler::fgWalkResult Compiler::fgUpdateSideEffectsPre(GenTree** pTree, fgWalkData* fgWalkPre)
 {
-    fgWalkPre->compiler->gtUpdateNodeOperSideEffects(*pTree);
+    GenTree* tree = *pTree;
+    tree->gtFlags &= ~(GTF_EXCEPT | GTF_CALL | GTF_ASG);
 
     return WALK_CONTINUE;
 }
 
 //------------------------------------------------------------------------
-// fgUpdateSideEffectsPost: Update the side effects of the parent based on the tree's flags.
+// fgUpdateSideEffectsPost: Update the side effects of the node and parent based on the tree's flags.
 //
 // Arguments:
 //    pTree            - Pointer to the tree
@@ -8653,10 +8692,18 @@ Compiler::fgWalkResult Compiler::fgUpdateSideEffectsPre(GenTree** pTree, fgWalkD
 // Notes:
 //    The routine is used for updating the stale side effect flags for ancestor
 //    nodes starting from treeParent up to the top-level stmt expr.
-
+//
+//    This method currently only updates GTF_EXCEPT and GTF_ASG flags. The other side effect
+//    flags may remain unnecessarily (conservatively) set.
+//
 Compiler::fgWalkResult Compiler::fgUpdateSideEffectsPost(GenTree** pTree, fgWalkData* fgWalkPost)
 {
-    GenTree* tree   = *pTree;
+    GenTree* tree = *pTree;
+
+    // Update the node's side effects first.
+    fgWalkPost->compiler->gtUpdateNodeOperSideEffectsPost(tree);
+
+    // Then update the parent's side effects based on this node.
     GenTree* parent = fgWalkPost->parent;
     if (parent != nullptr)
     {
@@ -9908,9 +9955,14 @@ bool GenTree::Precedes(GenTree* other)
 // Arguments:
 //    comp  - compiler instance
 //
-
 void GenTree::SetIndirExceptionFlags(Compiler* comp)
 {
+    if (OperMayThrow(comp))
+    {
+        gtFlags |= GTF_EXCEPT;
+        return;
+    }
+
     GenTree* addr = nullptr;
     if (OperIsIndir())
     {
@@ -9922,7 +9974,7 @@ void GenTree::SetIndirExceptionFlags(Compiler* comp)
         addr = AsArrLen()->ArrRef();
     }
 
-    if (OperMayThrow(comp) || ((addr->gtFlags & GTF_EXCEPT) != 0))
+    if ((addr->gtFlags & GTF_EXCEPT) != 0)
     {
         gtFlags |= GTF_EXCEPT;
     }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5440,7 +5440,7 @@ BasicBlock* Compiler::fgSetRngChkTargetInner(SpecialCodeKind kind, bool delay)
  *  The orginal GT_INDEX node is bashed into the GT_IND node that accesses
  *  the array element.  We expand the GT_INDEX node into a larger tree that
  *  evaluates the array base and index.  The simplest expansion is a GT_COMMA
- *  with a GT_ARR_BOUND_CHK and a GT_IND with a GTF_INX_RNGCHK flag.
+ *  with a GT_ARR_BOUNDS_CHECK and a GT_IND with a GTF_INX_RNGCHK flag.
  *  For complex array or index expressions one or more GT_COMMA assignments
  *  are inserted so that we only evaluate the array or index expressions once.
  *
@@ -5530,7 +5530,7 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
     //    side-effecting.
     // 2. Evaluate the array index expression and store the result in a temp if the expression is complex or
     //    side-effecting.
-    // 3. Perform an explicit bounds check: GT_ARR_BOUNDS_CHK(index, GT_ARR_LENGTH(array))
+    // 3. Perform an explicit bounds check: GT_ARR_BOUNDS_CHECK(index, GT_ARR_LENGTH(array))
     // 4. Compute the address of the element that will be accessed:
     //    GT_ADD(GT_ADD(array, firstElementOffset), GT_MUL(index, elementSize))
     // 5. Dereference the address with a GT_IND.
@@ -5716,9 +5716,6 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
     // play) to create a "partial" byref that doesn't point exactly to the correct object; there is risk that
     // the partial byref will not point within the object, and thus not get updated correctly during a GC.
     // This is mostly a risk in fully-interruptible code regions.
-    //
-    // NOTE: the tree form created here is pattern matched by optExtractArrIndex(), so changes here must
-    // be reflected there.
 
     /* Add the first element's offset */
 
@@ -5798,10 +5795,16 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
         tree = gtNewOperNode(GT_COMMA, tree->TypeGet(), arrRefDefn, tree);
     }
 
+    JITDUMP("fgMorphArrayIndex (before remorph):\n");
+    DISPTREE(tree);
+
     // Currently we morph the tree to perform some folding operations prior
     // to attaching fieldSeq info and labeling constant array index contributions
     //
     fgMorphTree(tree);
+
+    JITDUMP("fgMorphArrayIndex (after remorph):\n");
+    DISPTREE(tree);
 
     // Ideally we just want to proceed to attaching fieldSeq info and labeling the
     // constant array index contributions, but the morphing operation may have changed

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -7417,8 +7417,10 @@ GenTree* Compiler::optRemoveRangeCheck(GenTreeBoundsChk* check, GenTree* comma, 
 #ifdef DEBUG
     if (verbose)
     {
-        printf("After optRemoveRangeCheck:\n");
-        gtDispTree(tree);
+        // gtUpdateSideEffects can update the side effects for ancestors in the tree, so display the whole statement
+        // tree, not just the sub-tree.
+        printf("After optRemoveRangeCheck for [%06u]:\n", dspTreeID(tree));
+        gtDispTree(stmt->GetRootNode());
     }
 #endif
 


### PR DESCRIPTION
Loop cloning, in `optExtractArrIndex()`, was matching the post-morph
trees representing array index expressions. This was not necessary,
as all the information we actually need is in the array bound check node,
namely the array base and the array index. The code was verifying that the
bounds check information matched the morph expression, but we don't really
need to do that anyway, as the main thing we care about it whether or not
we can remove the bounds check.

The full array index expression morphed tree can be complex, especially
for arrays of structs. Simply deleting this parsing code enables cloning to
kick in for arrays of structs.

There was one bug needing fixing, though: after removing the array bounds
check, the GTF_EXCEPT bits are recalculated over the entire Statement tree.
It was doing this top-down, but needs to do it bottom-up to handle the array
of structs case where we have `IND(COMMA(..., ADDR()))`, to propagate the bit
through the COMMA.

Fixes #48897

There are a few microbenchmark wins ("runtime2" is baseline, "runtime" is diff), as well as a couple losses (ludcmp, BenchAssignJagged).

Method |        Job |                                                                         Toolchain |     Mean |   Error |  StdDev |   Median |      Min |      Max | Ratio
---------- |----------- |---------------------------------------------------------------------------------- |---------|--------|--------|---------|---------|---------|------
MulMatrix | Job-LARQLS | \runtime2\artifacts\tests\coreclr\windows.x64.Checked\Tests\Core_Root\CoreRun.exe | 370.8 ms | 1.32 ms | 1.17 ms | 370.5 ms | 369.3 ms | 373.1 ms |  1.00
MulMatrix | Job-GYTYVK |  \runtime\artifacts\tests\coreclr\windows.x64.Checked\Tests\Core_Root\CoreRun.exe | 351.6 ms | 1.92 ms | 1.60 ms | 351.6 ms | 349.2 ms | 355.2 ms |  0.95
SpectralNorm_1 | Job-LARQLS | \runtime2\artifacts\tests\coreclr\windows.x64.Checked\Tests\Core_Root\CoreRun.exe | 865.0 us | 16.71 us | 18.57 us | 858.8 us | 843.3 us | 896.0 us |  1.00
SpectralNorm_1 | Job-GYTYVK |  \runtime\artifacts\tests\coreclr\windows.x64.Checked\Tests\Core_Root\CoreRun.exe | 844.6 us |  9.47 us |  8.40 us | 841.5 us | 836.3 us | 860.6 us |  0.97
BenchEmFloat | Job-LARQLS | \runtime2\artifacts\tests\coreclr\windows.x64.Checked\Tests\Core_Root\CoreRun.exe | 3,183.1 ms | 14.45 ms | 13.52 ms | 3,188.8 ms | 3,157.0 ms | 3,205.5 ms |  1.00 |    0.00
BenchEmFloat | Job-GYTYVK |  \runtime\artifacts\tests\coreclr\windows.x64.Checked\Tests\Core_Root\CoreRun.exe | 3,115.8 ms | 13.19 ms | 12.34 ms | 3,109.3 ms | 3,105.3 ms | 3,147.1 ms |  0.98 |    0.00
BenchAssignJagged | Job-LARQLS | \runtime2\artifacts\tests\coreclr\windows.x64.Checked\Tests\Core_Root\CoreRun.exe |   938.1 ms |  5.26 ms |  4.66 ms |   937.8 ms |   932.3 ms |   946.4 ms |  1.00 |    0.00
BenchAssignJagged | Job-GYTYVK |  \runtime\artifacts\tests\coreclr\windows.x64.Checked\Tests\Core_Root\CoreRun.exe |   954.0 ms | 12.19 ms | 10.18 ms |   951.8 ms |   943.6 ms |   978.7 ms |  1.02 |    0.01
BenchLUDecomp | Job-LARQLS | \runtime2\artifacts\tests\coreclr\windows.x64.Checked\Tests\Core_Root\CoreRun.exe | 1,094.6 ms | 14.91 ms | 13.95 ms | 1,095.0 ms | 1,072.5 ms | 1,117.7 ms |  1.00 |    0.00
BenchLUDecomp | Job-GYTYVK |  \runtime\artifacts\tests\coreclr\windows.x64.Checked\Tests\Core_Root\CoreRun.exe | 1,133.9 ms | 16.55 ms | 15.48 ms | 1,139.1 ms | 1,107.9 ms | 1,154.0 ms |  1.04 |    0.02

spmi diffs:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 10605
Total bytes of diff: 13993
Total bytes of delta: 3388 (31.95% of base)
Total relative delta: 13.43
    diff is a regression.
    relative diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```

Top file regressions (bytes):
         190 : 41209.dasm (89.62% of base)
         190 : 19281.dasm (89.62% of base)
         163 : 41303.dasm (67.08% of base)
         163 : 19393.dasm (67.08% of base)
         126 : 38635.dasm (50.00% of base)
         126 : 17973.dasm (50.00% of base)
         125 : 35718.dasm (29.07% of base)
         125 : 18582.dasm (29.07% of base)
         125 : 39316.dasm (29.07% of base)
         124 : 12493.dasm (47.51% of base)
         124 : 15994.dasm (47.51% of base)
         124 : 31342.dasm (49.80% of base)
         124 : 36770.dasm (48.44% of base)
         124 : 30776.dasm (48.44% of base)
         106 : 32284.dasm (39.85% of base)
         106 : 19181.dasm (39.85% of base)
         105 : 41328.dasm (53.85% of base)
         105 : 19427.dasm (53.85% of base)
          94 : 19275.dasm (19.34% of base)
          94 : 41203.dasm (19.34% of base)

Top file improvements (bytes):
         -32 : 22627.dasm (-12.55% of base)
         -32 : 35972.dasm (-12.55% of base)
         -32 : 30648.dasm (-12.55% of base)

36 total files with Code Size differences (3 improved, 33 regressed), 1 unchanged.

Top method regressions (bytes):
         190 (89.62% of base) : 41209.dasm - Dictionary`2:CopyEntries(ref,int):this
         190 (89.62% of base) : 19281.dasm - Dictionary`2:CopyEntries(ref,int):this
         163 (67.08% of base) : 41303.dasm - Dictionary`2:CopyTo(ref,int):this
         163 (67.08% of base) : 19393.dasm - Dictionary`2:CopyTo(ref,int):this
         126 (50.00% of base) : 38635.dasm - Dictionary`2:Resize(int,bool):this
         126 (50.00% of base) : 17973.dasm - Dictionary`2:Resize(int,bool):this
         125 (29.07% of base) : 35718.dasm - Dictionary`2:Resize(int,bool):this
         125 (29.07% of base) : 18582.dasm - Dictionary`2:Resize(int,bool):this
         125 (29.07% of base) : 39316.dasm - Dictionary`2:Resize(int,bool):this
         124 (47.51% of base) : 12493.dasm - Dictionary`2:Resize(int,bool):this
         124 (47.51% of base) : 15994.dasm - Dictionary`2:Resize(int,bool):this
         124 (49.80% of base) : 31342.dasm - Dictionary`2:Resize(int,bool):this
         124 (48.44% of base) : 36770.dasm - Dictionary`2:Resize(int,bool):this
         124 (48.44% of base) : 30776.dasm - Dictionary`2:Resize(int,bool):this
         106 (39.85% of base) : 32284.dasm - EnumerableSorter`2:ComputeKeys(ref,int):this
         106 (39.85% of base) : 19181.dasm - EnumerableSorter`2:ComputeKeys(ref,int):this
         105 (53.85% of base) : 41328.dasm - EnumerableSorter`2:ComputeKeys(ref,int):this
         105 (53.85% of base) : 19427.dasm - EnumerableSorter`2:ComputeKeys(ref,int):this
          94 (19.34% of base) : 19275.dasm - Dictionary`2:AddRange(IEnumerable`1):this
          94 (19.34% of base) : 41203.dasm - Dictionary`2:AddRange(IEnumerable`1):this

Top method improvements (bytes):
         -32 (-12.55% of base) : 22627.dasm - ObjectEqualityComparer`1:IndexOf(ref,__Canon,int,int):int:this
         -32 (-12.55% of base) : 35972.dasm - ObjectEqualityComparer`1:IndexOf(ref,__Canon,int,int):int:this
         -32 (-12.55% of base) : 30648.dasm - ObjectEqualityComparer`1:IndexOf(ref,__Canon,int,int):int:this

Top method regressions (percentages):
         190 (89.62% of base) : 41209.dasm - Dictionary`2:CopyEntries(ref,int):this
         190 (89.62% of base) : 19281.dasm - Dictionary`2:CopyEntries(ref,int):this
         163 (67.08% of base) : 41303.dasm - Dictionary`2:CopyTo(ref,int):this
         163 (67.08% of base) : 19393.dasm - Dictionary`2:CopyTo(ref,int):this
         105 (53.85% of base) : 41328.dasm - EnumerableSorter`2:ComputeKeys(ref,int):this
         105 (53.85% of base) : 19427.dasm - EnumerableSorter`2:ComputeKeys(ref,int):this
          78 (51.66% of base) : 37496.dasm - RouteValueDictionary:TryFindItem(String,byref):bool:this
         126 (50.00% of base) : 38635.dasm - Dictionary`2:Resize(int,bool):this
         126 (50.00% of base) : 17973.dasm - Dictionary`2:Resize(int,bool):this
         124 (49.80% of base) : 31342.dasm - Dictionary`2:Resize(int,bool):this
         124 (48.44% of base) : 36770.dasm - Dictionary`2:Resize(int,bool):this
         124 (48.44% of base) : 30776.dasm - Dictionary`2:Resize(int,bool):this
          88 (47.57% of base) : 37495.dasm - RouteValueDictionary:TryGetValue(String,byref):bool:this
          88 (47.57% of base) : 22930.dasm - RouteValueDictionary:TryGetValue(String,byref):bool:this
         124 (47.51% of base) : 12493.dasm - Dictionary`2:Resize(int,bool):this
         124 (47.51% of base) : 15994.dasm - Dictionary`2:Resize(int,bool):this
          76 (44.97% of base) : 18170.dasm - ValueCollection:CopyTo(ref,int):this
          76 (44.97% of base) : 38751.dasm - ValueCollection:CopyTo(ref,int):this
          76 (44.19% of base) : 30837.dasm - ValueCollection:CopyTo(ref,int):this
          76 (44.19% of base) : 36738.dasm - ValueCollection:CopyTo(ref,int):this

Top method improvements (percentages):
         -32 (-12.55% of base) : 22627.dasm - ObjectEqualityComparer`1:IndexOf(ref,__Canon,int,int):int:this
         -32 (-12.55% of base) : 35972.dasm - ObjectEqualityComparer`1:IndexOf(ref,__Canon,int,int):int:this
         -32 (-12.55% of base) : 30648.dasm - ObjectEqualityComparer`1:IndexOf(ref,__Canon,int,int):int:this

36 total methods with Code Size differences (3 improved, 33 regressed), 1 unchanged.

```

</details>

--------------------------------------------------------------------------------

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 19656
Total bytes of diff: 21755
Total bytes of delta: 2099 (10.68% of base)
Total relative delta: 6.71
    diff is a regression.
    relative diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```

Top file regressions (bytes):
         314 : 10636.dasm (65.42% of base)
         281 : 25723.dasm (9.59% of base)
         276 : 10626.dasm (85.98% of base)
         191 : 17802.dasm (46.81% of base)
         113 : 9414.dasm (49.78% of base)
          98 : 11859.dasm (19.72% of base)
          98 : 11860.dasm (19.72% of base)
          89 : 7680.dasm (51.45% of base)
          84 : 7683.dasm (48.00% of base)
          84 : 15110.dasm (8.06% of base)
          80 : 7673.dasm (13.01% of base)
          80 : 3345.dasm (47.62% of base)
          77 : 9246.dasm (82.80% of base)
          76 : 2291.dasm (44.19% of base)
          62 : 14611.dasm (13.45% of base)
          62 : 14612.dasm (13.36% of base)
          57 : 25481.dasm (36.54% of base)
          45 : 20229.dasm (22.39% of base)
          28 : 24281.dasm (31.11% of base)
          28 : 12802.dasm (1.63% of base)

Top file improvements (bytes):
         -48 : 1274.dasm (-14.20% of base)
         -36 : 2717.dasm (-10.17% of base)
         -14 : 14028.dasm (-2.84% of base)
         -13 : 24210.dasm (-3.06% of base)
         -11 : 20189.dasm (-6.25% of base)
         -10 : 24211.dasm (-2.35% of base)
          -8 : 21902.dasm (-7.69% of base)
          -6 : 17322.dasm (-4.44% of base)
          -5 : 8348.dasm (-1.40% of base)
          -4 : 15533.dasm (-0.35% of base)
          -3 : 13358.dasm (-4.76% of base)
          -3 : 15111.dasm (-0.43% of base)
          -2 : 15133.dasm (-0.35% of base)
          -2 : 19751.dasm (-0.36% of base)
          -2 : 15621.dasm (-0.35% of base)

39 total files with Code Size differences (15 improved, 24 regressed), 2 unchanged.

Top method regressions (bytes):
         314 (65.42% of base) : 10636.dasm - EMFloat:DoEmFloatIteration(EMFloat+InternalFPF[],EMFloat+InternalFPF[],EMFloat+InternalFPF[],int,int):long
         281 ( 9.59% of base) : 25723.dasm - Benchstone.BenchI.MulMatrix:Inner(System.Int32[][],System.Int32[][],System.Int32[][])
         276 (85.98% of base) : 10626.dasm - EMFloat:SetupCPUEmFloatArrays(EMFloat+InternalFPF[],EMFloat+InternalFPF[],EMFloat+InternalFPF[],int)
         191 (46.81% of base) : 17802.dasm - Microsoft.CodeAnalysis.MetadataDecoder`5[__Canon,__Canon,__Canon,__Canon,__Canon][System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon]:DoPropertySignaturesMatch(Microsoft.CodeAnalysis.ParamInfo`1[System.__Canon][],Microsoft.CodeAnalysis.ParamInfo`1[System.__Canon][],bool,bool,bool):bool:this
         113 (49.78% of base) : 9414.dasm - System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]:CopyTo(System.Collections.Generic.KeyValuePair`2[System.__Canon,System.__Canon][],int):this
          98 (19.72% of base) : 11859.dasm - KeyCollection[Int32,Int32][System.Int32,System.Int32]:System.Collections.ICollection.CopyTo(System.Array,int):this
          98 (19.72% of base) : 11860.dasm - ValueCollection[Int32,Int32][System.Int32,System.Int32]:System.Collections.ICollection.CopyTo(System.Array,int):this
          89 (51.45% of base) : 7680.dasm - KeyCollection[Int32,Int32][System.Int32,System.Int32]:CopyTo(System.Int32[],int):this
          84 (48.00% of base) : 7683.dasm - ValueCollection[Int32,Int32][System.Int32,System.Int32]:CopyTo(System.Int32[],int):this
          84 ( 8.06% of base) : 15110.dasm - ProtoBuf.Compiler.CompilerContext:Switch(ProtoBuf.Compiler.CodeLabel[]):this
          80 (13.01% of base) : 7673.dasm - System.Collections.Generic.Dictionary`2[Int32,Int32][System.Int32,System.Int32]:AddRange(System.Collections.Generic.IEnumerable`1[KeyValuePair`2]):this
          80 (47.62% of base) : 3345.dasm - KeyCollection[__Canon,__Canon][System.__Canon,System.__Canon]:CopyTo(System.__Canon[],int):this
          77 (82.80% of base) : 9246.dasm - System.Collections.Generic.GenericEqualityComparer`1[OpCode][System.Reflection.Emit.OpCode]:IndexOf(System.Reflection.Emit.OpCode[],System.Reflection.Emit.OpCode,int,int):int:this
          76 (44.19% of base) : 2291.dasm - ValueCollection[__Canon,__Canon][System.__Canon,System.__Canon]:CopyTo(System.__Canon[],int):this
          62 (13.45% of base) : 14611.dasm - KeyCollection[__Canon,__Canon][System.__Canon,System.__Canon]:System.Collections.ICollection.CopyTo(System.Array,int):this
          62 (13.36% of base) : 14612.dasm - ValueCollection[__Canon,__Canon][System.__Canon,System.__Canon]:System.Collections.ICollection.CopyTo(System.Array,int):this
          57 (36.54% of base) : 25481.dasm - System.Collections.Tests.Perf_PriorityQueue`2[__Canon,__Canon][System.__Canon,System.__Canon]:K_Max_Elements():this
          45 (22.39% of base) : 20229.dasm - WithManyWeakChildren:.ctor(WithManyChildrenBase,Microsoft.CodeAnalysis.SyntaxNode,int):this
          28 (31.11% of base) : 24281.dasm - SciMark2.FFT:inverse(System.Double[])
          28 ( 1.63% of base) : 12802.dasm - AssignJagged:second_assignments(System.Int32[][],System.Int16[][])

Top method improvements (bytes):
         -48 (-14.20% of base) : 1274.dasm - System.Collections.Generic.ObjectEqualityComparer`1[__Canon][System.__Canon]:IndexOf(System.__Canon[],System.__Canon,int,int):int:this
         -36 (-10.17% of base) : 2717.dasm - System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]:IndexOf(System.__Canon[],System.__Canon,int,int):int:this
         -14 (-2.84% of base) : 14028.dasm - Microsoft.Extensions.Caching.Memory.Tests.MemoryCacheTests:AddThenRemove_NoExpiration():this
         -13 (-3.06% of base) : 24210.dasm - BenchmarksGame.SpectralNorm_1:MultiplyAv(int,System.Double[],System.Double[]):this
         -11 (-6.25% of base) : 20189.dasm - Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList:List(Microsoft.CodeAnalysis.GreenNode[],int):Microsoft.CodeAnalysis.GreenNode
         -10 (-2.35% of base) : 24211.dasm - BenchmarksGame.SpectralNorm_1:MultiplyAtv(int,System.Double[],System.Double[]):this
          -8 (-7.69% of base) : 21902.dasm - System.Reflection.Internal.ObjectPool`1[__Canon][System.__Canon]:Allocate():System.__Canon:this
          -6 (-4.44% of base) : 17322.dasm - Microsoft.CodeAnalysis.CommonReferenceManager`2[__Canon,__Canon][System.__Canon,System.__Canon]:CheckCircularReference(System.Collections.Generic.IReadOnlyList`1[__Canon]):bool
          -5 (-1.40% of base) : 8348.dasm - Internal.Cryptography.Pal.ChainPal:GetChainStatusInformation(int):System.Security.Cryptography.X509Certificates.X509ChainStatus[]
          -4 (-0.35% of base) : 15533.dasm - LUDecomp:build_problem(System.Double[][],int,System.Double[])
          -3 (-4.76% of base) : 13358.dasm - BenchmarksGame.Fasta_1:MakeCumulative(BenchmarksGame.Fasta_1+Frequency[])
          -3 (-0.43% of base) : 15111.dasm - DynamicClass:proto_1(System.Object,ProtoBuf.ProtoWriter)
          -2 (-0.35% of base) : 15133.dasm - Microsoft.Extensions.Caching.Memory.Tests.MemoryCacheTests:AddThenRemove_RelativeExpiration():this
          -2 (-0.36% of base) : 19751.dasm - Microsoft.Extensions.Caching.Memory.Tests.MemoryCacheTests:AddThenRemove_ExpirationTokens():this
          -2 (-0.35% of base) : 15621.dasm - Microsoft.Extensions.Caching.Memory.Tests.MemoryCacheTests:AddThenRemove_SlidingExpiration():this

Top method regressions (percentages):
         276 (85.98% of base) : 10626.dasm - EMFloat:SetupCPUEmFloatArrays(EMFloat+InternalFPF[],EMFloat+InternalFPF[],EMFloat+InternalFPF[],int)
          77 (82.80% of base) : 9246.dasm - System.Collections.Generic.GenericEqualityComparer`1[OpCode][System.Reflection.Emit.OpCode]:IndexOf(System.Reflection.Emit.OpCode[],System.Reflection.Emit.OpCode,int,int):int:this
         314 (65.42% of base) : 10636.dasm - EMFloat:DoEmFloatIteration(EMFloat+InternalFPF[],EMFloat+InternalFPF[],EMFloat+InternalFPF[],int,int):long
          89 (51.45% of base) : 7680.dasm - KeyCollection[Int32,Int32][System.Int32,System.Int32]:CopyTo(System.Int32[],int):this
         113 (49.78% of base) : 9414.dasm - System.Collections.Generic.Dictionary`2[__Canon,__Canon][System.__Canon,System.__Canon]:CopyTo(System.Collections.Generic.KeyValuePair`2[System.__Canon,System.__Canon][],int):this
          84 (48.00% of base) : 7683.dasm - ValueCollection[Int32,Int32][System.Int32,System.Int32]:CopyTo(System.Int32[],int):this
          80 (47.62% of base) : 3345.dasm - KeyCollection[__Canon,__Canon][System.__Canon,System.__Canon]:CopyTo(System.__Canon[],int):this
         191 (46.81% of base) : 17802.dasm - Microsoft.CodeAnalysis.MetadataDecoder`5[__Canon,__Canon,__Canon,__Canon,__Canon][System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon]:DoPropertySignaturesMatch(Microsoft.CodeAnalysis.ParamInfo`1[System.__Canon][],Microsoft.CodeAnalysis.ParamInfo`1[System.__Canon][],bool,bool,bool):bool:this
          76 (44.19% of base) : 2291.dasm - ValueCollection[__Canon,__Canon][System.__Canon,System.__Canon]:CopyTo(System.__Canon[],int):this
          57 (36.54% of base) : 25481.dasm - System.Collections.Tests.Perf_PriorityQueue`2[__Canon,__Canon][System.__Canon,System.__Canon]:K_Max_Elements():this
          28 (31.11% of base) : 24281.dasm - SciMark2.FFT:inverse(System.Double[])
          45 (22.39% of base) : 20229.dasm - WithManyWeakChildren:.ctor(WithManyChildrenBase,Microsoft.CodeAnalysis.SyntaxNode,int):this
          98 (19.72% of base) : 11859.dasm - KeyCollection[Int32,Int32][System.Int32,System.Int32]:System.Collections.ICollection.CopyTo(System.Array,int):this
          98 (19.72% of base) : 11860.dasm - ValueCollection[Int32,Int32][System.Int32,System.Int32]:System.Collections.ICollection.CopyTo(System.Array,int):this
          27 (16.17% of base) : 10346.dasm - System.Security.Cryptography.Primitives.Tests.Performance.Perf_FixedTimeEquals:Setup(System.String,System.String):this
          62 (13.45% of base) : 14611.dasm - KeyCollection[__Canon,__Canon][System.__Canon,System.__Canon]:System.Collections.ICollection.CopyTo(System.Array,int):this
          62 (13.36% of base) : 14612.dasm - ValueCollection[__Canon,__Canon][System.__Canon,System.__Canon]:System.Collections.ICollection.CopyTo(System.Array,int):this
          80 (13.01% of base) : 7673.dasm - System.Collections.Generic.Dictionary`2[Int32,Int32][System.Int32,System.Int32]:AddRange(System.Collections.Generic.IEnumerable`1[KeyValuePair`2]):this
         281 ( 9.59% of base) : 25723.dasm - Benchstone.BenchI.MulMatrix:Inner(System.Int32[][],System.Int32[][],System.Int32[][])
          84 ( 8.06% of base) : 15110.dasm - ProtoBuf.Compiler.CompilerContext:Switch(ProtoBuf.Compiler.CodeLabel[]):this

Top method improvements (percentages):
         -48 (-14.20% of base) : 1274.dasm - System.Collections.Generic.ObjectEqualityComparer`1[__Canon][System.__Canon]:IndexOf(System.__Canon[],System.__Canon,int,int):int:this
         -36 (-10.17% of base) : 2717.dasm - System.Collections.Generic.GenericEqualityComparer`1[__Canon][System.__Canon]:IndexOf(System.__Canon[],System.__Canon,int,int):int:this
          -8 (-7.69% of base) : 21902.dasm - System.Reflection.Internal.ObjectPool`1[__Canon][System.__Canon]:Allocate():System.__Canon:this
         -11 (-6.25% of base) : 20189.dasm - Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList:List(Microsoft.CodeAnalysis.GreenNode[],int):Microsoft.CodeAnalysis.GreenNode
          -3 (-4.76% of base) : 13358.dasm - BenchmarksGame.Fasta_1:MakeCumulative(BenchmarksGame.Fasta_1+Frequency[])
          -6 (-4.44% of base) : 17322.dasm - Microsoft.CodeAnalysis.CommonReferenceManager`2[__Canon,__Canon][System.__Canon,System.__Canon]:CheckCircularReference(System.Collections.Generic.IReadOnlyList`1[__Canon]):bool
         -13 (-3.06% of base) : 24210.dasm - BenchmarksGame.SpectralNorm_1:MultiplyAv(int,System.Double[],System.Double[]):this
         -14 (-2.84% of base) : 14028.dasm - Microsoft.Extensions.Caching.Memory.Tests.MemoryCacheTests:AddThenRemove_NoExpiration():this
         -10 (-2.35% of base) : 24211.dasm - BenchmarksGame.SpectralNorm_1:MultiplyAtv(int,System.Double[],System.Double[]):this
          -5 (-1.40% of base) : 8348.dasm - Internal.Cryptography.Pal.ChainPal:GetChainStatusInformation(int):System.Security.Cryptography.X509Certificates.X509ChainStatus[]
          -3 (-0.43% of base) : 15111.dasm - DynamicClass:proto_1(System.Object,ProtoBuf.ProtoWriter)
          -2 (-0.36% of base) : 19751.dasm - Microsoft.Extensions.Caching.Memory.Tests.MemoryCacheTests:AddThenRemove_ExpirationTokens():this
          -2 (-0.35% of base) : 15133.dasm - Microsoft.Extensions.Caching.Memory.Tests.MemoryCacheTests:AddThenRemove_RelativeExpiration():this
          -2 (-0.35% of base) : 15621.dasm - Microsoft.Extensions.Caching.Memory.Tests.MemoryCacheTests:AddThenRemove_SlidingExpiration():this
          -4 (-0.35% of base) : 15533.dasm - LUDecomp:build_problem(System.Double[][],int,System.Double[])

39 total methods with Code Size differences (15 improved, 24 regressed), 2 unchanged.

```

</details>

--------------------------------------------------------------------------------

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 50789
Total bytes of diff: 57962
Total bytes of delta: 7173 (14.12% of base)
Total relative delta: 10.94
    diff is a regression.
    relative diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```

Top file regressions (bytes):
         314 : 194633.dasm (65.42% of base)
         310 : 169017.dasm (26.12% of base)
         310 : 168630.dasm (26.12% of base)
         310 : 168802.dasm (26.12% of base)
         310 : 169110.dasm (26.12% of base)
         310 : 168724.dasm (26.12% of base)
         310 : 168920.dasm (26.12% of base)
         281 : 248723.dasm (9.59% of base)
         276 : 194632.dasm (85.98% of base)
         267 : 168730.dasm (16.11% of base)
         267 : 168808.dasm (16.11% of base)
         267 : 169021.dasm (16.11% of base)
         267 : 168926.dasm (16.11% of base)
         267 : 169114.dasm (16.11% of base)
         267 : 168636.dasm (16.11% of base)
         259 : 213032.dasm (102.37% of base)
         249 : 167322.dasm (66.58% of base)
         216 : 251496.dasm (91.14% of base)
         216 : 194592.dasm (12.80% of base)
         174 : 249196.dasm (20.67% of base)

Top file improvements (bytes):
         -26 : 166707.dasm (-10.36% of base)
         -13 : 248646.dasm (-3.06% of base)
         -10 : 248647.dasm (-2.35% of base)
          -5 : 166775.dasm (-0.69% of base)
          -4 : 194691.dasm (-0.35% of base)
          -3 : 168634.dasm (-1.91% of base)
          -3 : 168918.dasm (-2.75% of base)
          -3 : 168803.dasm (-1.91% of base)
          -3 : 168631.dasm (-1.91% of base)
          -3 : 168800.dasm (-2.75% of base)
          -3 : 168921.dasm (-1.91% of base)
          -3 : 168628.dasm (-2.75% of base)
          -3 : 168806.dasm (-1.91% of base)
          -3 : 168924.dasm (-1.91% of base)
          -3 : 241130.dasm (-0.99% of base)
          -3 : 168722.dasm (-2.75% of base)
          -3 : 168728.dasm (-1.91% of base)
          -3 : 239163.dasm (-4.76% of base)
          -3 : 168725.dasm (-1.91% of base)
          -2 : 241128.dasm (-0.77% of base)

70 total files with Code Size differences (20 improved, 50 regressed), 0 unchanged.

Top method regressions (bytes):
         314 (65.42% of base) : 194633.dasm - EMFloat:DoEmFloatIteration(EMFloat+InternalFPF[],EMFloat+InternalFPF[],EMFloat+InternalFPF[],int,int):long
         310 (26.12% of base) : 169017.dasm - Helper:ValidateInnerArraySequential(InnerArraySequential,InnerArraySequential,System.String):bool
         310 (26.12% of base) : 168630.dasm - Helper:ValidateInnerArraySequential(InnerArraySequential,InnerArraySequential,System.String):bool
         310 (26.12% of base) : 168802.dasm - Helper:ValidateInnerArraySequential(InnerArraySequential,InnerArraySequential,System.String):bool
         310 (26.12% of base) : 169110.dasm - Helper:ValidateInnerArraySequential(InnerArraySequential,InnerArraySequential,System.String):bool
         310 (26.12% of base) : 168724.dasm - Helper:ValidateInnerArraySequential(InnerArraySequential,InnerArraySequential,System.String):bool
         310 (26.12% of base) : 168920.dasm - Helper:ValidateInnerArraySequential(InnerArraySequential,InnerArraySequential,System.String):bool
         281 ( 9.59% of base) : 248723.dasm - Benchstone.BenchI.MulMatrix:Inner(System.Int32[][],System.Int32[][],System.Int32[][])
         276 (85.98% of base) : 194632.dasm - EMFloat:SetupCPUEmFloatArrays(EMFloat+InternalFPF[],EMFloat+InternalFPF[],EMFloat+InternalFPF[],int)
         267 (16.11% of base) : 168730.dasm - Helper:ValidateOUTER3(OUTER3,OUTER3,System.String):bool
         267 (16.11% of base) : 168808.dasm - Helper:ValidateOUTER3(OUTER3,OUTER3,System.String):bool
         267 (16.11% of base) : 169021.dasm - Helper:ValidateOUTER3(OUTER3,OUTER3,System.String):bool
         267 (16.11% of base) : 168926.dasm - Helper:ValidateOUTER3(OUTER3,OUTER3,System.String):bool
         267 (16.11% of base) : 169114.dasm - Helper:ValidateOUTER3(OUTER3,OUTER3,System.String):bool
         267 (16.11% of base) : 168636.dasm - Helper:ValidateOUTER3(OUTER3,OUTER3,System.String):bool
         259 (102.37% of base) : 213032.dasm - ArrayMarshal:IsCorrect(ArrayMarshal+S2[],ArrayMarshal+S2[]):bool
         249 (66.58% of base) : 167322.dasm - Internal.IL.EcmaMethodIL:GetExceptionRegions():Internal.IL.ILExceptionRegion[]:this
         216 (91.14% of base) : 251496.dasm - VectorMathTests.Program:sum(System.Numerics.Vector4[]):float
         216 (12.80% of base) : 194592.dasm - Huffman:DoHuffIteration(System.Byte[],System.Byte[],System.Byte[],int,int,huff_node[]):long
         174 (20.67% of base) : 249196.dasm - SimpleArray_01.Test:BadMatrixMul1()

Top method improvements (bytes):
         -26 (-10.36% of base) : 166707.dasm - Internal.TypeSystem.TypeSystemHelpers:RequiresSlotUnification(Internal.TypeSystem.MethodDesc):bool
         -13 (-3.06% of base) : 248646.dasm - BenchmarksGame.SpectralNorm_1:MultiplyAv(int,System.Double[],System.Double[]):this
         -10 (-2.35% of base) : 248647.dasm - BenchmarksGame.SpectralNorm_1:MultiplyAtv(int,System.Double[],System.Double[]):this
          -5 (-0.69% of base) : 166775.dasm - Internal.TypeSystem.MetadataVirtualMethodAlgorithm:ResolveInterfaceMethodToDefaultImplementationOnType(Internal.TypeSystem.MethodDesc,Internal.TypeSystem.MetadataType,byref):int
          -4 (-0.35% of base) : 194691.dasm - LUDecomp:build_problem(System.Double[][],int,System.Double[])
          -3 (-1.91% of base) : 168634.dasm - Helper:NewOUTER3(int,float,System.String,System.String):OUTER3
          -3 (-2.75% of base) : 168918.dasm - Helper:NewInnerArraySequential(int,float,System.String):InnerArraySequential
          -3 (-1.91% of base) : 168803.dasm - Helper:NewInnerArrayExplicit(int,float,System.String,System.String):InnerArrayExplicit
          -3 (-1.91% of base) : 168631.dasm - Helper:NewInnerArrayExplicit(int,float,System.String,System.String):InnerArrayExplicit
          -3 (-2.75% of base) : 168800.dasm - Helper:NewInnerArraySequential(int,float,System.String):InnerArraySequential
          -3 (-1.91% of base) : 168921.dasm - Helper:NewInnerArrayExplicit(int,float,System.String,System.String):InnerArrayExplicit
          -3 (-2.75% of base) : 168628.dasm - Helper:NewInnerArraySequential(int,float,System.String):InnerArraySequential
          -3 (-1.91% of base) : 168806.dasm - Helper:NewOUTER3(int,float,System.String,System.String):OUTER3
          -3 (-1.91% of base) : 168924.dasm - Helper:NewOUTER3(int,float,System.String,System.String):OUTER3
          -3 (-0.99% of base) : 241130.dasm - Vector3Test:VectorArray(float):int
          -3 (-2.75% of base) : 168722.dasm - Helper:NewInnerArraySequential(int,float,System.String):InnerArraySequential
          -3 (-1.91% of base) : 168728.dasm - Helper:NewOUTER3(int,float,System.String,System.String):OUTER3
          -3 (-4.76% of base) : 239163.dasm - BenchmarksGame.Fasta_1:MakeCumulative(BenchmarksGame.Fasta_1+Frequency[])
          -3 (-1.91% of base) : 168725.dasm - Helper:NewInnerArrayExplicit(int,float,System.String,System.String):InnerArrayExplicit
          -2 (-0.77% of base) : 241128.dasm - Vector4Test:VectorArray(float):int

Top method regressions (percentages):
         259 (102.37% of base) : 213032.dasm - ArrayMarshal:IsCorrect(ArrayMarshal+S2[],ArrayMarshal+S2[]):bool
         216 (91.14% of base) : 251496.dasm - VectorMathTests.Program:sum(System.Numerics.Vector4[]):float
         276 (85.98% of base) : 194632.dasm - EMFloat:SetupCPUEmFloatArrays(EMFloat+InternalFPF[],EMFloat+InternalFPF[],EMFloat+InternalFPF[],int)
          49 (74.24% of base) : 81558.dasm - Test:Check(int)
         249 (66.58% of base) : 167322.dasm - Internal.IL.EcmaMethodIL:GetExceptionRegions():Internal.IL.ILExceptionRegion[]:this
         314 (65.42% of base) : 194633.dasm - EMFloat:DoEmFloatIteration(EMFloat+InternalFPF[],EMFloat+InternalFPF[],EMFloat+InternalFPF[],int,int):long
         123 (60.89% of base) : 246188.dasm - ToBoxOrNotToBox.Program:PerfTest1(int,int)
         151 (52.61% of base) : 213030.dasm - ArrayMarshal:NewS2arr(int,int,int,short,ushort,ubyte,byte,short,ushort,long,long,float,double):ArrayMarshal+S2[]
          28 (31.11% of base) : 228715.dasm - SciMark2.FFT:inverse(System.Double[])
          89 (27.73% of base) : 167364.dasm - Internal.IL.InstantiatedMethodIL:GetLocals():Internal.TypeSystem.LocalVariableDefinition[]:this
         310 (26.12% of base) : 169017.dasm - Helper:ValidateInnerArraySequential(InnerArraySequential,InnerArraySequential,System.String):bool
         310 (26.12% of base) : 168630.dasm - Helper:ValidateInnerArraySequential(InnerArraySequential,InnerArraySequential,System.String):bool
         310 (26.12% of base) : 168802.dasm - Helper:ValidateInnerArraySequential(InnerArraySequential,InnerArraySequential,System.String):bool
         310 (26.12% of base) : 169110.dasm - Helper:ValidateInnerArraySequential(InnerArraySequential,InnerArraySequential,System.String):bool
         310 (26.12% of base) : 168724.dasm - Helper:ValidateInnerArraySequential(InnerArraySequential,InnerArraySequential,System.String):bool
         310 (26.12% of base) : 168920.dasm - Helper:ValidateInnerArraySequential(InnerArraySequential,InnerArraySequential,System.String):bool
         174 (20.67% of base) : 249196.dasm - SimpleArray_01.Test:BadMatrixMul1()
         158 (19.90% of base) : 253494.dasm - MatrixMul.Test:MatrixMul()
         141 (16.34% of base) : 249197.dasm - SimpleArray_01.Test:BadMatrixMul2()
         267 (16.11% of base) : 168730.dasm - Helper:ValidateOUTER3(OUTER3,OUTER3,System.String):bool

Top method improvements (percentages):
         -26 (-10.36% of base) : 166707.dasm - Internal.TypeSystem.TypeSystemHelpers:RequiresSlotUnification(Internal.TypeSystem.MethodDesc):bool
          -3 (-4.76% of base) : 239163.dasm - BenchmarksGame.Fasta_1:MakeCumulative(BenchmarksGame.Fasta_1+Frequency[])
         -13 (-3.06% of base) : 248646.dasm - BenchmarksGame.SpectralNorm_1:MultiplyAv(int,System.Double[],System.Double[]):this
          -3 (-2.75% of base) : 168918.dasm - Helper:NewInnerArraySequential(int,float,System.String):InnerArraySequential
          -3 (-2.75% of base) : 168800.dasm - Helper:NewInnerArraySequential(int,float,System.String):InnerArraySequential
          -3 (-2.75% of base) : 168628.dasm - Helper:NewInnerArraySequential(int,float,System.String):InnerArraySequential
          -3 (-2.75% of base) : 168722.dasm - Helper:NewInnerArraySequential(int,float,System.String):InnerArraySequential
         -10 (-2.35% of base) : 248647.dasm - BenchmarksGame.SpectralNorm_1:MultiplyAtv(int,System.Double[],System.Double[]):this
          -3 (-1.91% of base) : 168634.dasm - Helper:NewOUTER3(int,float,System.String,System.String):OUTER3
          -3 (-1.91% of base) : 168803.dasm - Helper:NewInnerArrayExplicit(int,float,System.String,System.String):InnerArrayExplicit
          -3 (-1.91% of base) : 168631.dasm - Helper:NewInnerArrayExplicit(int,float,System.String,System.String):InnerArrayExplicit
          -3 (-1.91% of base) : 168921.dasm - Helper:NewInnerArrayExplicit(int,float,System.String,System.String):InnerArrayExplicit
          -3 (-1.91% of base) : 168806.dasm - Helper:NewOUTER3(int,float,System.String,System.String):OUTER3
          -3 (-1.91% of base) : 168924.dasm - Helper:NewOUTER3(int,float,System.String,System.String):OUTER3
          -3 (-1.91% of base) : 168728.dasm - Helper:NewOUTER3(int,float,System.String,System.String):OUTER3
          -3 (-1.91% of base) : 168725.dasm - Helper:NewInnerArrayExplicit(int,float,System.String,System.String):InnerArrayExplicit
          -3 (-0.99% of base) : 241130.dasm - Vector3Test:VectorArray(float):int
          -2 (-0.77% of base) : 241128.dasm - Vector4Test:VectorArray(float):int
          -5 (-0.69% of base) : 166775.dasm - Internal.TypeSystem.MetadataVirtualMethodAlgorithm:ResolveInterfaceMethodToDefaultImplementationOnType(Internal.TypeSystem.MethodDesc,Internal.TypeSystem.MetadataType,byref):int
          -4 (-0.35% of base) : 194691.dasm - LUDecomp:build_problem(System.Double[][],int,System.Double[])

70 total methods with Code Size differences (20 improved, 50 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 66954
Total bytes of diff: 74145
Total bytes of delta: 7191 (10.74% of base)
Total relative delta: 20.86
    diff is a regression.
    relative diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```

Top file regressions (bytes):
         528 : 2571.dasm (72.53% of base)
         450 : 25232.dasm (15.59% of base)
         293 : 92711.dasm (50.96% of base)
         274 : 73747.dasm (53.83% of base)
         271 : 171367.dasm (17.96% of base)
         241 : 204928.dasm (60.10% of base)
         224 : 171366.dasm (17.39% of base)
         188 : 21977.dasm (12.56% of base)
         171 : 181569.dasm (71.25% of base)
         168 : 75937.dasm (12.19% of base)
         162 : 44518.dasm (114.89% of base)
         160 : 151231.dasm (44.08% of base)
         155 : 95335.dasm (7.05% of base)
         152 : 84491.dasm (77.95% of base)
         139 : 216480.dasm (25.88% of base)
         139 : 45298.dasm (46.96% of base)
         138 : 73748.dasm (66.03% of base)
         134 : 181566.dasm (54.92% of base)
         134 : 52201.dasm (29.39% of base)
         131 : 22122.dasm (15.45% of base)

Top file improvements (bytes):
         -37 : 73754.dasm (-0.81% of base)
         -36 : 24021.dasm (-10.14% of base)
         -32 : 24016.dasm (-9.61% of base)
         -20 : 192694.dasm (-7.14% of base)
         -16 : 161256.dasm (-6.20% of base)
         -16 : 216474.dasm (-1.03% of base)
         -11 : 173459.dasm (-4.78% of base)
         -10 : 179730.dasm (-1.86% of base)
         -10 : 149598.dasm (-1.34% of base)
          -9 : 150742.dasm (-7.14% of base)
          -8 : 85767.dasm (-7.02% of base)
          -8 : 174207.dasm (-0.52% of base)
          -6 : 10430.dasm (-3.66% of base)
          -6 : 174026.dasm (-1.29% of base)
          -6 : 174027.dasm (-1.36% of base)
          -5 : 93729.dasm (-0.40% of base)
          -5 : 203938.dasm (-1.65% of base)
          -4 : 150744.dasm (-0.31% of base)
          -3 : 173392.dasm (-0.47% of base)
          -3 : 174233.dasm (-0.09% of base)

103 total files with Code Size differences (33 improved, 70 regressed), 8 unchanged.

Top method regressions (bytes):
         528 (72.53% of base) : 2571.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE.PEPropertySymbol:GetParameters(Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE.PEModuleSymbol,Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE.PEPropertySymbol,Microsoft.CodeAnalysis.ParamInfo`1[Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol][],Microsoft.CodeAnalysis.ParamInfo`1[Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol][],byref):System.Collections.Immutable.ImmutableArray`1[Microsoft.CodeAnalysis.CSharp.Symbols.ParameterSymbol]
         450 (15.59% of base) : 25232.dasm - System.Diagnostics.Tracing.EventProvider:WriteEvent(byref,long,long,long,System.Object[]):bool:this
         293 (50.96% of base) : 92711.dasm - System.Xml.Xsl.IlGen.XmlILVisitor:VisitChoice(System.Xml.Xsl.Qil.QilChoice):System.Xml.Xsl.Qil.QilNode:this
         274 (53.83% of base) : 73747.dasm - System.Data.Common.DbDataAdapter:UpdatedRowStatusErrors(System.Data.Common.RowUpdatedEventArgs,System.Data.Common.DbDataAdapter+BatchCommandInfo[],int):int:this
         271 (17.96% of base) : 171367.dasm - BatchBlockTargetCore:RetrievePostponedItemsNonGreedy(bool):this
         241 (60.10% of base) : 204928.dasm - System.Net.WebSockets.WebSocketBuffer:ValidateNativeBuffers(int,int,Interop+WebSocket+Buffer[],int):this
         224 (17.39% of base) : 171366.dasm - BatchBlockTargetCore:RetrievePostponedItemsGreedyBounded(bool):this
         188 (12.56% of base) : 21977.dasm - Microsoft.CodeAnalysis.CSharp.Binder:BindArrayCreationWithInitializer(Microsoft.CodeAnalysis.DiagnosticBag,Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax,Microsoft.CodeAnalysis.CSharp.Syntax.InitializerExpressionSyntax,Microsoft.CodeAnalysis.CSharp.Symbols.ArrayTypeSymbol,System.Collections.Immutable.ImmutableArray`1[Microsoft.CodeAnalysis.CSharp.BoundExpression],System.Collections.Immutable.ImmutableArray`1[Microsoft.CodeAnalysis.CSharp.BoundExpression]):Microsoft.CodeAnalysis.CSharp.BoundArrayCreation:this
         171 (71.25% of base) : 181569.dasm - System.Reflection.TypeLoading.Ecma.EcmaCustomAttributeHelpers:ToApiForm(System.Collections.Generic.IList`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[System.Reflection.TypeLoading.RoType]]):System.Collections.Generic.IList`1[System.Reflection.CustomAttributeTypedArgument]
         168 (12.19% of base) : 75937.dasm - System.Data.Select:CreateIndex():this
         162 (114.89% of base) : 44518.dasm - System.Collections.Generic.NullableEqualityComparer`1:IndexOf(System.Nullable`1[System.Int32][],System.Nullable`1[System.Int32],int,int):int:this
         160 (44.08% of base) : 151231.dasm - Microsoft.CodeAnalysis.MetadataDecoder`5:DoPropertySignaturesMatch(Microsoft.CodeAnalysis.ParamInfo`1[System.__Canon][],Microsoft.CodeAnalysis.ParamInfo`1[System.__Canon][],bool,bool,bool):bool:this
         155 ( 7.05% of base) : 95335.dasm - System.Xml.Xsl.Xslt.XsltInput:GetAttributes(System.Xml.Xsl.Xslt.XsltInput+XsltAttribute[]):System.Xml.Xsl.Xslt.XsltInput+ContextInfo:this
         152 (77.95% of base) : 84491.dasm - System.Speech.Internal.Synthesis.EngineSiteSapi:System.Speech.Internal.Synthesis.ISpEngineSite.AddEvents(System.Speech.Internal.Synthesis.SpeechEventSapi[],int):this
         139 (25.88% of base) : 216480.dasm - System.Runtime.Caching.ExpiresBucket:Expand():this
         139 (46.96% of base) : 45298.dasm - AttributeSorter:Sort():this
         138 (66.03% of base) : 73748.dasm - System.Data.Common.DbDataAdapter:UpdatedRowStatusContinue(System.Data.Common.RowUpdatedEventArgs,System.Data.Common.DbDataAdapter+BatchCommandInfo[],int):int:this
         134 (54.92% of base) : 181566.dasm - System.Reflection.TypeLoading.Ecma.EcmaCustomAttributeHelpers:ToApiForm(System.Collections.Generic.IList`1[System.Reflection.Metadata.CustomAttributeNamedArgument`1[System.Reflection.TypeLoading.RoType]],System.Type):System.Collections.Generic.IList`1[System.Reflection.CustomAttributeNamedArgument]
         134 (29.39% of base) : 52201.dasm - System.Data.OleDb.OleDbCommand:ApplyParameterBindings(System.Data.Common.UnsafeNativeMethods+ICommandWithParameters,System.Data.OleDb.tagDBPARAMBINDINFO[]):this
         131 (15.45% of base) : 22122.dasm - Microsoft.CodeAnalysis.CSharp.Binder:GetParamArrayArgument(Microsoft.CodeAnalysis.CSharp.Symbols.ParameterSymbol,System.Collections.Immutable.ImmutableArray`1[Microsoft.CodeAnalysis.TypedConstant],int,int,Microsoft.CodeAnalysis.CSharp.Conversions):Microsoft.CodeAnalysis.TypedConstant

Top method improvements (bytes):
         -37 (-0.81% of base) : 73754.dasm - System.Data.Common.DbDataAdapter:Update(System.Data.DataRow[],System.Data.Common.DataTableMapping):int:this
         -36 (-10.14% of base) : 24021.dasm - System.Collections.Generic.GenericEqualityComparer`1:IndexOf(System.__Canon[],System.__Canon,int,int):int:this
         -32 (-9.61% of base) : 24016.dasm - System.Collections.Generic.ObjectEqualityComparer`1:IndexOf(System.__Canon[],System.__Canon,int,int):int:this
         -20 (-7.14% of base) : 192694.dasm - Internal.Cryptography.Helpers:FixupKeyParity(System.Byte[]):System.Byte[]
         -16 (-6.20% of base) : 161256.dasm - System.Drawing.Drawing2D.PathGradientBrush:set_SurroundColors(System.Drawing.Color[]):this
         -16 (-1.03% of base) : 216474.dasm - System.Runtime.Caching.ExpiresBucket:FlushExpiredItems(System.DateTime,bool):int:this
         -11 (-4.78% of base) : 173459.dasm - Internal.TypeSystem.TypeSystemHelpers:RequiresSlotUnification(Internal.TypeSystem.MethodDesc):bool
         -10 (-1.86% of base) : 179730.dasm - System.Security.Cryptography.Pkcs.SignedCms:AddCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2):this
         -10 (-1.34% of base) : 149598.dasm - Microsoft.CodeAnalysis.VersionHelper:TryParse(System.String,bool,ushort,byref):bool
          -9 (-7.14% of base) : 150742.dasm - Microsoft.CodeAnalysis.CommonReferenceManager`2:CheckCircularReference(System.Collections.Generic.IReadOnlyList`1[Microsoft.CodeAnalysis.CommonReferenceManager`2+AssemblyReferenceBinding[System.__Canon, System.__Canon][]]):bool
          -8 (-7.02% of base) : 85767.dasm - System.Reflection.Internal.ObjectPool`1:Allocate():System.__Canon:this
          -8 (-0.52% of base) : 174207.dasm - Internal.IL.ILStackHelper:ComputeMaxStack(Internal.IL.MethodIL):int
          -6 (-3.66% of base) : 10430.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxList:List(Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.CSharpSyntaxNode[],int):Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.CSharpSyntaxNode
          -6 (-1.29% of base) : 174026.dasm - Internal.TypeSystem.DefType:ComputeStaticFieldLayout(int):this
          -6 (-1.36% of base) : 174027.dasm - Internal.TypeSystem.DefType:ComputeInstanceLayout(int):this
          -5 (-0.40% of base) : 93729.dasm - System.Xml.Xsl.Runtime.XmlQueryStaticData:GetObjectData(byref,byref):this
          -5 (-1.65% of base) : 203938.dasm - Internal.Cryptography.Pal.ChainPal:GetChainStatusInformation(int):System.Security.Cryptography.X509Certificates.X509ChainStatus[]
          -4 (-0.31% of base) : 150744.dasm - Microsoft.CodeAnalysis.CommonReferenceManager`2:ReuseAssemblySymbolsWithNoPiaLocalTypes(Microsoft.CodeAnalysis.CommonReferenceManager`2+BoundInputAssembly[System.__Canon, System.__Canon][],System.__Canon[],System.Collections.Immutable.ImmutableArray`1[Microsoft.CodeAnalysis.CommonReferenceManager`2+AssemblyData[System.__Canon, System.__Canon]],int):bool:this
          -3 (-0.47% of base) : 173392.dasm - Internal.TypeSystem.MetadataVirtualMethodAlgorithm:ResolveInterfaceMethodToDefaultImplementationOnType(Internal.TypeSystem.MethodDesc,Internal.TypeSystem.MetadataType,byref):int
          -3 (-0.09% of base) : 174233.dasm - Internal.IL.MethodILDebugView:get_Disassembly():System.String:this

Top method regressions (percentages):
         162 (114.89% of base) : 44518.dasm - System.Collections.Generic.NullableEqualityComparer`1:IndexOf(System.Nullable`1[System.Int32][],System.Nullable`1[System.Int32],int,int):int:this
         116 (89.23% of base) : 75940.dasm - System.Data.Select:CompareClosestCandidateIndexDesc(System.Data.IndexField[]):int:this
         152 (77.95% of base) : 84491.dasm - System.Speech.Internal.Synthesis.EngineSiteSapi:System.Speech.Internal.Synthesis.ISpEngineSite.AddEvents(System.Speech.Internal.Synthesis.SpeechEventSapi[],int):this
         528 (72.53% of base) : 2571.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE.PEPropertySymbol:GetParameters(Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE.PEModuleSymbol,Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE.PEPropertySymbol,Microsoft.CodeAnalysis.ParamInfo`1[Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol][],Microsoft.CodeAnalysis.ParamInfo`1[Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol][],byref):System.Collections.Immutable.ImmutableArray`1[Microsoft.CodeAnalysis.CSharp.Symbols.ParameterSymbol]
         171 (71.25% of base) : 181569.dasm - System.Reflection.TypeLoading.Ecma.EcmaCustomAttributeHelpers:ToApiForm(System.Collections.Generic.IList`1[System.Reflection.Metadata.CustomAttributeTypedArgument`1[System.Reflection.TypeLoading.RoType]]):System.Collections.Generic.IList`1[System.Reflection.CustomAttributeTypedArgument]
         138 (66.03% of base) : 73748.dasm - System.Data.Common.DbDataAdapter:UpdatedRowStatusContinue(System.Data.Common.RowUpdatedEventArgs,System.Data.Common.DbDataAdapter+BatchCommandInfo[],int):int:this
          63 (61.76% of base) : 204826.dasm - System.Net.WebSockets.WebSocketProtocolComponent:MarshalHttpHeaders(long,int):Interop+WebSocket+HttpHeader[]
         241 (60.10% of base) : 204928.dasm - System.Net.WebSockets.WebSocketBuffer:ValidateNativeBuffers(int,int,Interop+WebSocket+Buffer[],int):this
          51 (60.00% of base) : 73746.dasm - System.Data.Common.DbDataAdapter:UpdatedRowStatusSkip(System.Data.Common.DbDataAdapter+BatchCommandInfo[],int):int:this
         130 (58.82% of base) : 182039.dasm - System.Reflection.TypeLoading.CustomAttributeHelpers:CloneForApiReturn(System.Collections.Generic.IList`1[System.Reflection.CustomAttributeNamedArgument]):System.Collections.ObjectModel.ReadOnlyCollection`1[System.Reflection.CustomAttributeNamedArgument]
         107 (58.47% of base) : 43851.dasm - System.Collections.Generic.Dictionary`2:CopyTo(System.Collections.Generic.KeyValuePair`2[System.UInt64, System.Char][],int):this
          93 (58.13% of base) : 44836.dasm - System.Collections.Generic.GenericEqualityComparer`1:IndexOf(System.ValueTuple`3[System.IntPtr, System.__Canon, System.Int32][],System.ValueTuple`3[System.IntPtr, System.__Canon, System.Int32],int,int):int:this
         114 (57.00% of base) : 182040.dasm - System.Reflection.TypeLoading.CustomAttributeHelpers:CloneForApiReturn(System.Collections.Generic.IList`1[System.Reflection.CustomAttributeTypedArgument]):System.Collections.ObjectModel.ReadOnlyCollection`1[System.Reflection.CustomAttributeTypedArgument]
          97 (55.43% of base) : 44834.dasm - System.Collections.Generic.EqualityComparer`1:IndexOf(System.Resources.ResourceLocator[],System.Resources.ResourceLocator,int,int):int:this
          95 (55.23% of base) : 44715.dasm - ValueCollection:CopyTo(System.Char[],int):this
         134 (54.92% of base) : 181566.dasm - System.Reflection.TypeLoading.Ecma.EcmaCustomAttributeHelpers:ToApiForm(System.Collections.Generic.IList`1[System.Reflection.Metadata.CustomAttributeNamedArgument`1[System.Reflection.TypeLoading.RoType]],System.Type):System.Collections.Generic.IList`1[System.Reflection.CustomAttributeNamedArgument]
         274 (53.83% of base) : 73747.dasm - System.Data.Common.DbDataAdapter:UpdatedRowStatusErrors(System.Data.Common.RowUpdatedEventArgs,System.Data.Common.DbDataAdapter+BatchCommandInfo[],int):int:this
         118 (51.30% of base) : 23975.dasm - System.Collections.Generic.Dictionary`2:CopyTo(System.Collections.Generic.KeyValuePair`2[System.__Canon, System.__Canon][],int):this
          63 (51.22% of base) : 179690.dasm - System.Security.Cryptography.Pkcs.SignerInfo:FindAttributeIndexByOid(System.Security.Cryptography.Asn1.AttributeAsn[],System.Security.Cryptography.Oid,int):int
         293 (50.96% of base) : 92711.dasm - System.Xml.Xsl.IlGen.XmlILVisitor:VisitChoice(System.Xml.Xsl.Qil.QilChoice):System.Xml.Xsl.Qil.QilNode:this

Top method improvements (percentages):
         -36 (-10.14% of base) : 24021.dasm - System.Collections.Generic.GenericEqualityComparer`1:IndexOf(System.__Canon[],System.__Canon,int,int):int:this
         -32 (-9.61% of base) : 24016.dasm - System.Collections.Generic.ObjectEqualityComparer`1:IndexOf(System.__Canon[],System.__Canon,int,int):int:this
         -20 (-7.14% of base) : 192694.dasm - Internal.Cryptography.Helpers:FixupKeyParity(System.Byte[]):System.Byte[]
          -9 (-7.14% of base) : 150742.dasm - Microsoft.CodeAnalysis.CommonReferenceManager`2:CheckCircularReference(System.Collections.Generic.IReadOnlyList`1[Microsoft.CodeAnalysis.CommonReferenceManager`2+AssemblyReferenceBinding[System.__Canon, System.__Canon][]]):bool
          -8 (-7.02% of base) : 85767.dasm - System.Reflection.Internal.ObjectPool`1:Allocate():System.__Canon:this
         -16 (-6.20% of base) : 161256.dasm - System.Drawing.Drawing2D.PathGradientBrush:set_SurroundColors(System.Drawing.Color[]):this
         -11 (-4.78% of base) : 173459.dasm - Internal.TypeSystem.TypeSystemHelpers:RequiresSlotUnification(Internal.TypeSystem.MethodDesc):bool
          -6 (-3.66% of base) : 10430.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxList:List(Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.CSharpSyntaxNode[],int):Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.CSharpSyntaxNode
          -2 (-2.78% of base) : 33665.dasm - MultiElementAsyncLocalValueMap:TryGetValue(System.Threading.IAsyncLocal,byref):bool:this
          -2 (-2.67% of base) : 193636.dasm - System.Net.ContextFlagsAdapterPal:GetInteropFromContextFlagsPal(int):int
          -2 (-2.67% of base) : 83190.dasm - System.Net.ContextFlagsAdapterPal:GetInteropFromContextFlagsPal(int):int
          -2 (-2.67% of base) : 215902.dasm - System.Net.ContextFlagsAdapterPal:GetInteropFromContextFlagsPal(int):int
          -2 (-2.56% of base) : 205146.dasm - System.Net.ContextFlagsAdapterPal:GetInteropFromContextFlagsPal(int):int
         -10 (-1.86% of base) : 179730.dasm - System.Security.Cryptography.Pkcs.SignedCms:AddCertificate(System.Security.Cryptography.X509Certificates.X509Certificate2):this
          -5 (-1.65% of base) : 203938.dasm - Internal.Cryptography.Pal.ChainPal:GetChainStatusInformation(int):System.Security.Cryptography.X509Certificates.X509ChainStatus[]
          -6 (-1.36% of base) : 174027.dasm - Internal.TypeSystem.DefType:ComputeInstanceLayout(int):this
          -1 (-1.35% of base) : 215903.dasm - System.Net.ContextFlagsAdapterPal:GetContextFlagsPalFromInterop(int):int
          -1 (-1.35% of base) : 83191.dasm - System.Net.ContextFlagsAdapterPal:GetContextFlagsPalFromInterop(int):int
          -1 (-1.35% of base) : 193637.dasm - System.Net.ContextFlagsAdapterPal:GetContextFlagsPalFromInterop(int):int
         -10 (-1.34% of base) : 149598.dasm - Microsoft.CodeAnalysis.VersionHelper:TryParse(System.String,bool,ushort,byref):bool

103 total methods with Code Size differences (33 improved, 70 regressed), 8 unchanged.

```

</details>

--------------------------------------------------------------------------------

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 70371
Total bytes of diff: 77796
Total bytes of delta: 7425 (10.55% of base)
Total relative delta: 25.59
    diff is a regression.
    relative diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```

Top file regressions (bytes):
         491 : 45068.dasm (69.55% of base)
         310 : 145953.dasm (43.79% of base)
         299 : 203675.dasm (61.40% of base)
         260 : 117169.dasm (43.12% of base)
         249 : 160923.dasm (66.58% of base)
         216 : 220005.dasm (74.23% of base)
         184 : 20289.dasm (127.78% of base)
         163 : 152884.dasm (76.53% of base)
         160 : 20380.dasm (21.22% of base)
         160 : 20410.dasm (70.18% of base)
         158 : 40560.dasm (15.24% of base)
         156 : 115022.dasm (11.76% of base)
         156 : 132472.dasm (41.71% of base)
         154 : 20309.dasm (105.48% of base)
         147 : 41852.dasm (76.17% of base)
         144 : 20362.dasm (50.35% of base)
         144 : 40912.dasm (41.14% of base)
         140 : 214346.dasm (24.39% of base)
         140 : 214409.dasm (24.39% of base)
         139 : 117168.dasm (73.54% of base)

Top file improvements (bytes):
         -71 : 208247.dasm (-6.07% of base)
         -42 : 117208.dasm (-0.83% of base)
         -26 : 161794.dasm (-10.36% of base)
         -23 : 20296.dasm (-9.24% of base)
         -23 : 20312.dasm (-9.24% of base)
         -23 : 20302.dasm (-9.39% of base)
         -23 : 20299.dasm (-9.16% of base)
         -22 : 20270.dasm (-13.17% of base)
         -22 : 20276.dasm (-13.17% of base)
         -22 : 20306.dasm (-6.43% of base)
         -20 : 216496.dasm (-6.94% of base)
         -17 : 148574.dasm (-0.33% of base)
         -15 : 49464.dasm (-0.54% of base)
         -15 : 8645.dasm (-2.91% of base)
         -11 : 35759.dasm (-6.25% of base)
         -10 : 20287.dasm (-7.04% of base)
          -8 : 151645.dasm (-7.69% of base)
          -5 : 144804.dasm (-0.35% of base)
          -5 : 221018.dasm (-1.40% of base)
          -5 : 161876.dasm (-0.70% of base)

123 total files with Code Size differences (36 improved, 87 regressed), 5 unchanged.

Top method regressions (bytes):
         491 (69.55% of base) : 45068.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE.PEPropertySymbol:GetParameters(Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE.PEModuleSymbol,Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE.PEPropertySymbol,Microsoft.CodeAnalysis.ParamInfo`1[Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol][],Microsoft.CodeAnalysis.ParamInfo`1[Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol][],byref):System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.CSharp.Symbols.ParameterSymbol, Microsoft.CodeAnalysis.CSharp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]
         310 (43.79% of base) : 145953.dasm - System.Xml.Xsl.IlGen.XmlILVisitor:VisitChoice(System.Xml.Xsl.Qil.QilChoice):System.Xml.Xsl.Qil.QilNode:this
         299 (61.40% of base) : 203675.dasm - System.Net.WebSockets.WebSocketBuffer:ValidateNativeBuffers(int,int,Interop+WebSocket+Buffer[],int):this
         260 (43.12% of base) : 117169.dasm - System.Data.Common.DbDataAdapter:UpdatedRowStatusErrors(System.Data.Common.RowUpdatedEventArgs,System.Data.Common.DbDataAdapter+BatchCommandInfo[],int):int:this
         249 (66.58% of base) : 160923.dasm - Internal.IL.EcmaMethodIL:GetExceptionRegions():Internal.IL.ILExceptionRegion[]:this
         216 (74.23% of base) : 220005.dasm - System.Security.Cryptography.Pkcs.SignerInfo:FindAttributeIndexByOid(System.Security.Cryptography.Asn1.AttributeAsn[],System.Security.Cryptography.Oid,int):int
         184 (127.78% of base) : 20289.dasm - System.Collections.Generic.NullableEqualityComparer`1[Byte][System.Byte]:IndexOf(System.Nullable`1[System.Byte][],System.Nullable`1[Byte],int,int):int:this
         163 (76.53% of base) : 152884.dasm - System.Speech.Internal.Synthesis.EngineSiteSapi:System.Speech.Internal.Synthesis.ISpEngineSite.AddEvents(System.Speech.Internal.Synthesis.SpeechEventSapi[],int):this
         160 (21.22% of base) : 20380.dasm - System.Collections.Generic.Dictionary`2[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:System.Collections.ICollection.CopyTo(System.Array,int):this
         160 (70.18% of base) : 20410.dasm - System.Collections.Generic.Dictionary`2[Byte,Nullable`1][System.Byte,System.Nullable`1[System.Int32]]:CopyTo(System.Collections.Generic.KeyValuePair`2[System.Byte,System.Nullable`1[System.Int32]][],int):this
         158 (15.24% of base) : 40560.dasm - Microsoft.CodeAnalysis.CSharp.Emit.CSharpDefinitionMap:CreateLocalSlotMap(Microsoft.CodeAnalysis.Emit.EditAndContinueMethodDebugInformation,System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.LocalInfo`1[[Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol, Microsoft.CodeAnalysis.CSharp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]], Microsoft.CodeAnalysis, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]):System.Collections.Immutable.ImmutableArray`1[EncLocalInfo]
         156 (11.76% of base) : 115022.dasm - System.Data.Select:CreateIndex():this
         156 (41.71% of base) : 132472.dasm - AttributeSorter:Sort():this
         154 (105.48% of base) : 20309.dasm - System.Collections.Generic.ObjectEqualityComparer`1[Vector`1][System.Numerics.Vector`1[System.Single]]:IndexOf(System.Numerics.Vector`1[System.Single][],System.Numerics.Vector`1[Single],int,int):int:this
         147 (76.17% of base) : 41852.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.AnonymousTypeDescriptor:Equals(Microsoft.CodeAnalysis.CSharp.Symbols.AnonymousTypeDescriptor,bool,bool):bool:this
         144 (50.35% of base) : 20362.dasm - System.Collections.Generic.Dictionary`2[__Canon,Nullable`1][System.__Canon,System.Nullable`1[System.Int32]]:CopyTo(System.Collections.Generic.KeyValuePair`2[System.__Canon,System.Nullable`1[System.Int32]][],int):this
         144 (41.14% of base) : 40912.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.AnonymousTypeManager:IsSameType(Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol,Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol,bool,bool):bool
         140 (24.39% of base) : 214346.dasm - System.Runtime.Caching.ExpiresBucket:Expand():this
         140 (24.39% of base) : 214409.dasm - System.Runtime.Caching.UsageBucket:Expand():this
         139 (73.54% of base) : 117168.dasm - System.Data.Common.DbDataAdapter:UpdatedRowStatusContinue(System.Data.Common.RowUpdatedEventArgs,System.Data.Common.DbDataAdapter+BatchCommandInfo[],int):int:this

Top method improvements (bytes):
         -71 (-6.07% of base) : 208247.dasm - System.Net.Security.SslStreamCertificateContext:.ctor(System.Security.Cryptography.X509Certificates.X509Certificate2,System.Security.Cryptography.X509Certificates.X509Certificate2[],System.Net.Security.SslCertificateTrust):this
         -42 (-0.83% of base) : 117208.dasm - System.Data.Common.DbDataAdapter:Update(System.Data.DataRow[],System.Data.Common.DataTableMapping):int:this
         -26 (-10.36% of base) : 161794.dasm - Internal.TypeSystem.TypeSystemHelpers:RequiresSlotUnification(Internal.TypeSystem.MethodDesc):bool
         -23 (-9.24% of base) : 20296.dasm - System.Collections.Generic.ObjectEqualityComparer`1[Byte][System.Byte]:IndexOf(System.Byte[],ubyte,int,int):int:this
         -23 (-9.24% of base) : 20312.dasm - System.Collections.Generic.ObjectEqualityComparer`1[Int64][System.Int64]:IndexOf(System.Int64[],long,int,int):int:this
         -23 (-9.39% of base) : 20302.dasm - System.Collections.Generic.ObjectEqualityComparer`1[Int32][System.Int32]:IndexOf(System.Int32[],int,int,int):int:this
         -23 (-9.16% of base) : 20299.dasm - System.Collections.Generic.ObjectEqualityComparer`1[Int16][System.Int16]:IndexOf(System.Int16[],short,int,int):int:this
         -22 (-13.17% of base) : 20270.dasm - System.Collections.Generic.GenericEqualityComparer`1[Byte][System.Byte]:IndexOf(System.Byte[],ubyte,int,int):int:this
         -22 (-13.17% of base) : 20276.dasm - System.Collections.Generic.GenericEqualityComparer`1[Int16][System.Int16]:IndexOf(System.Int16[],short,int,int):int:this
         -22 (-6.43% of base) : 20306.dasm - System.Collections.Generic.ObjectEqualityComparer`1[Double][System.Double]:IndexOf(System.Double[],double,int,int):int:this
         -20 (-6.94% of base) : 216496.dasm - Internal.Cryptography.Helpers:FixupKeyParity(System.Byte[]):System.Byte[]
         -17 (-0.33% of base) : 148574.dasm - System.Reflection.PortableExecutable.PEBuilder:WritePEHeader(System.Reflection.Metadata.BlobBuilder,System.Reflection.PortableExecutable.PEDirectoriesBuilder,System.Collections.Immutable.ImmutableArray`1[SerializedSection]):this
         -15 (-0.54% of base) : 49464.dasm - Microsoft.CodeAnalysis.VisualBasic.IteratorAndAsyncCaptureWalker:Analyze(Microsoft.CodeAnalysis.VisualBasic.FlowAnalysisInfo,Microsoft.CodeAnalysis.DiagnosticBag):Result
         -15 (-2.91% of base) : 8645.dasm - Microsoft.FSharp.Collections.ArrayModule:Zip(System.Byte[],System.Nullable`1[System.Int32][]):System.Tuple`2[System.Byte,System.Nullable`1[System.Int32]][]
         -11 (-6.25% of base) : 35759.dasm - Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.SyntaxList:List(Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.CSharpSyntaxNode[],int):Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax.CSharpSyntaxNode
         -10 (-7.04% of base) : 20287.dasm - System.Collections.Generic.GenericEqualityComparer`1[Int64][System.Int64]:IndexOf(System.Int64[],long,int,int):int:this
          -8 (-7.69% of base) : 151645.dasm - System.Reflection.Internal.ObjectPool`1[__Canon][System.__Canon]:Allocate():System.__Canon:this
          -5 (-0.35% of base) : 144804.dasm - System.Xml.Xsl.Runtime.XmlQueryStaticData:GetObjectData(byref,byref):this
          -5 (-1.40% of base) : 221018.dasm - Internal.Cryptography.Pal.ChainPal:GetChainStatusInformation(int):System.Security.Cryptography.X509Certificates.X509ChainStatus[]
          -5 (-0.70% of base) : 161876.dasm - Internal.TypeSystem.MetadataVirtualMethodAlgorithm:ResolveInterfaceMethodToDefaultImplementationOnType(Internal.TypeSystem.MethodDesc,Internal.TypeSystem.MetadataType,byref):int

Top method regressions (percentages):
         184 (127.78% of base) : 20289.dasm - System.Collections.Generic.NullableEqualityComparer`1[Byte][System.Byte]:IndexOf(System.Nullable`1[System.Byte][],System.Nullable`1[Byte],int,int):int:this
         154 (105.48% of base) : 20309.dasm - System.Collections.Generic.ObjectEqualityComparer`1[Vector`1][System.Numerics.Vector`1[System.Single]]:IndexOf(System.Numerics.Vector`1[System.Single][],System.Numerics.Vector`1[Single],int,int):int:this
         108 (91.53% of base) : 115019.dasm - System.Data.Select:CompareClosestCandidateIndexDesc(System.Data.IndexField[]):int:this
         122 (81.88% of base) : 41851.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.AnonymousTypeDescriptor:Equals(Microsoft.CodeAnalysis.CSharp.Symbols.AnonymousTypeDescriptor):bool:this
         163 (76.53% of base) : 152884.dasm - System.Speech.Internal.Synthesis.EngineSiteSapi:System.Speech.Internal.Synthesis.ISpEngineSite.AddEvents(System.Speech.Internal.Synthesis.SpeechEventSapi[],int):this
         147 (76.17% of base) : 41852.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.AnonymousTypeDescriptor:Equals(Microsoft.CodeAnalysis.CSharp.Symbols.AnonymousTypeDescriptor,bool,bool):bool:this
          82 (74.55% of base) : 20283.dasm - System.Collections.Generic.GenericEqualityComparer`1[Vector`1][System.Numerics.Vector`1[System.Single]]:IndexOf(System.Numerics.Vector`1[System.Single][],System.Numerics.Vector`1[Single],int,int):int:this
         216 (74.23% of base) : 220005.dasm - System.Security.Cryptography.Pkcs.SignerInfo:FindAttributeIndexByOid(System.Security.Cryptography.Asn1.AttributeAsn[],System.Security.Cryptography.Oid,int):int
         139 (73.54% of base) : 117168.da…