### PR TITLE
Require CFB8 for persisted CNG keys in CFB mode

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesContractTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesContractTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Test.Cryptography;
 using Xunit;
 
 namespace System.Security.Cryptography.Encryption.Aes.Tests
@@ -377,6 +378,25 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
 
                 Assert.Equal(firstBlockEncrypted, firstBlockEncryptedFromCount);
                 Assert.Equal(middleHalfEncrypted, middleHalfEncryptedFromOffsetAndCount);
+            }
+        }
+
+        [Fact]
+        public static void Cfb8ModeCanDepadCfb128Padding()
+        {
+            using (Aes aes = AesFactory.Create())
+            {
+                // 1, 2, 3, 4, 5 encrypted with CFB8 but padded with block-size padding.
+                byte[] ciphertext = "68C272ACF16BE005A361DB1C147CA3AD".HexToByteArray();
+                aes.Key = "3279CE2E9669A54E038AA62818672150D0B5A13F6757C27F378115501F83B119".HexToByteArray();
+                aes.IV = new byte[16];
+                aes.Padding = PaddingMode.PKCS7;
+                aes.Mode = CipherMode.CFB;
+                aes.FeedbackSize = 8;
+
+                using ICryptoTransform transform = aes.CreateDecryptor();
+                byte[] decrypted = transform.TransformFinalBlock(ciphertext, 0, ciphertext.Length);
+                Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, decrypted);
             }
         }
 

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/TripleDES/TripleDESContractTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/TripleDES/TripleDESContractTests.cs
@@ -89,5 +89,24 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
                 Assert.NotNull(encryptor);
             }
         }
+
+        [Fact]
+        public static void Cfb8ModeCanDepadCfb64Padding()
+        {
+            using (TripleDES tdes = TripleDESFactory.Create())
+            {
+                // 1, 2, 3, 4, 5 encrypted with CFB8 but padded with block-size padding.
+                byte[] ciphertext = "97F1CE6A6D869A85".HexToByteArray();
+                tdes.Key = "3D1ECCEE6C99B029950ED23688AA229AF85177421609F7BF".HexToByteArray();
+                tdes.IV = new byte[8];
+                tdes.Padding = PaddingMode.PKCS7;
+                tdes.Mode = CipherMode.CFB;
+                tdes.FeedbackSize = 8;
+
+                using ICryptoTransform transform = tdes.CreateDecryptor();
+                byte[] decrypted = transform.TransformFinalBlock(ciphertext, 0, ciphertext.Length);
+                Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, decrypted);
+            }
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Cng/src/Internal/Cryptography/BasicSymmetricCipherNCrypt.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/src/Internal/Cryptography/BasicSymmetricCipherNCrypt.cs
@@ -21,7 +21,7 @@ namespace Internal.Cryptography
         //
         // The delegate must instantiate a new CngKey, based on a new underlying NCryptKeyHandle, each time is called.
         //
-        public BasicSymmetricCipherNCrypt(Func<CngKey> cngKeyFactory, CipherMode cipherMode, int blockSizeInBytes, byte[]? iv, bool encrypting, int feedbackSizeInBytes, int paddingSize)
+        public BasicSymmetricCipherNCrypt(Func<CngKey> cngKeyFactory, CipherMode cipherMode, int blockSizeInBytes, byte[]? iv, bool encrypting, int paddingSize)
             : base(iv, blockSizeInBytes, paddingSize)
         {
             _encrypting = encrypting;

--- a/src/libraries/System.Security.Cryptography.Cng/src/Internal/Cryptography/CngSymmetricAlgorithmCore.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/src/Internal/Cryptography/CngSymmetricAlgorithmCore.cs
@@ -229,6 +229,8 @@ namespace Internal.Cryptography
             }
             else if (feedbackSizeInBits != 8)
             {
+                // Persisted CNG keys in CFB mode always use CFB8 when in CFB mode,
+                // so require the feedback size to be set to 8.
                 throw new CryptographicException(string.Format(SR.Cryptography_CipherModeFeedbackNotSupported, feedbackSizeInBits, CipherMode.CFB));
             }
         }

--- a/src/libraries/System.Security.Cryptography.Cng/src/Internal/Cryptography/CngSymmetricAlgorithmCore.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/src/Internal/Cryptography/CngSymmetricAlgorithmCore.cs
@@ -144,6 +144,8 @@ namespace Internal.Cryptography
             if (rgbKey == null)
                 throw new ArgumentNullException(nameof(rgbKey));
 
+            ValidateFeedbackSize(mode, feedbackSizeInBits);
+
             byte[] key = rgbKey.CloneByteArray();
 
             long keySize = key.Length * (long)BitsPerByte;
@@ -187,6 +189,9 @@ namespace Internal.Cryptography
         {
             // note: iv is guaranteed to be cloned before this method, so no need to clone it again
 
+            ValidateFeedbackSize(mode, feedbackSizeInBits);
+            Debug.Assert(mode == CipherMode.CFB ? feedbackSizeInBits == 8 : true);
+
             int blockSizeInBytes = _outer.BlockSize.BitSizeToByteSize();
             BasicSymmetricCipher cipher = new BasicSymmetricCipherNCrypt(
                 cngKeyFactory,
@@ -194,7 +199,6 @@ namespace Internal.Cryptography
                 blockSizeInBytes,
                 iv,
                 encrypting,
-                feedbackSizeInBits,
                 _outer.GetPaddingSize(mode, feedbackSizeInBits));
             return UniversalCryptoTransform.Create(padding, cipher, encrypting);
         }
@@ -206,9 +210,27 @@ namespace Internal.Cryptography
             return CngKey.Open(_keyName!, _provider!, _optionOptions);
         }
 
-        public bool KeyInPlainText
+        private bool KeyInPlainText
         {
             get { return _keyName == null; }
+        }
+
+        private void ValidateFeedbackSize(CipherMode mode, int feedbackSizeInBits)
+        {
+            if (mode != CipherMode.CFB)
+                return;
+
+            if (KeyInPlainText)
+            {
+                if (!_outer.IsValidEphemeralFeedbackSize(feedbackSizeInBits))
+                {
+                    throw new CryptographicException(string.Format(SR.Cryptography_CipherModeFeedbackNotSupported, feedbackSizeInBits, CipherMode.CFB));
+                }
+            }
+            else if (feedbackSizeInBits != 8)
+            {
+                throw new CryptographicException(string.Format(SR.Cryptography_CipherModeFeedbackNotSupported, feedbackSizeInBits, CipherMode.CFB));
+            }
         }
 
         private readonly ICngSymmetricAlgorithm _outer;

--- a/src/libraries/System.Security.Cryptography.Cng/src/Internal/Cryptography/ICngSymmetricAlgorithm.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/src/Internal/Cryptography/ICngSymmetricAlgorithm.cs
@@ -32,5 +32,6 @@ namespace Internal.Cryptography
         string GetNCryptAlgorithmIdentifier();
         byte[] PreprocessKey(byte[] key);
         int GetPaddingSize(CipherMode mode, int feedbackSizeBits);
+        bool IsValidEphemeralFeedbackSize(int feedbackSizeInBits);
     }
 }

--- a/src/libraries/System.Security.Cryptography.Cng/src/System/Security/Cryptography/AesCng.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/src/System/Security/Cryptography/AesCng.cs
@@ -178,8 +178,6 @@ namespace System.Security.Cryptography
             int feedbackSizeInBits,
             out int bytesWritten)
         {
-            ValidateCFBFeedbackSize(feedbackSizeInBits);
-
             UniversalCryptoTransform transform = _core.CreateCryptoTransform(
                 iv: iv.ToArray(),
                 encrypting: false,
@@ -201,8 +199,6 @@ namespace System.Security.Cryptography
             int feedbackSizeInBits,
             out int bytesWritten)
         {
-            ValidateCFBFeedbackSize(feedbackSizeInBits);
-
             UniversalCryptoTransform transform = _core.CreateCryptoTransform(
                 iv: iv.ToArray(),
                 encrypting: true,
@@ -213,26 +209,6 @@ namespace System.Security.Cryptography
             using (transform)
             {
                 return transform.TransformOneShot(plaintext, destination, out bytesWritten);
-            }
-        }
-
-        private void ValidateCFBFeedbackSize(int feedback)
-        {
-            if (_core.KeyInPlainText)
-            {
-                // CFB8 and CFB128 are valid for bcrypt keys.
-                if (feedback != 8 && feedback != 128)
-                {
-                    throw new CryptographicException(string.Format(SR.Cryptography_CipherModeFeedbackNotSupported, feedback, CipherMode.CFB));
-                }
-            }
-            else
-            {
-                // only CFB8 is supported for ncrypt keys.
-                if (feedback != 8)
-                {
-                    throw new CryptographicException(string.Format(SR.Cryptography_CipherModeFeedbackNotSupported, feedback, CipherMode.CFB));
-                }
             }
         }
 
@@ -274,6 +250,11 @@ namespace System.Security.Cryptography
         byte[] ICngSymmetricAlgorithm.PreprocessKey(byte[] key)
         {
             return key;
+        }
+
+        bool ICngSymmetricAlgorithm.IsValidEphemeralFeedbackSize(int feedbackSizeInBits)
+        {
+            return feedbackSizeInBits == 8 || feedbackSizeInBits == 128;
         }
 
         private CngSymmetricAlgorithmCore _core;

--- a/src/libraries/System.Security.Cryptography.Cng/src/System/Security/Cryptography/TripleDESCng.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/src/System/Security/Cryptography/TripleDESCng.cs
@@ -179,8 +179,6 @@ namespace System.Security.Cryptography
             int feedbackSizeInBits,
             out int bytesWritten)
         {
-            ValidateCFBFeedbackSize(feedbackSizeInBits);
-
             UniversalCryptoTransform transform = _core.CreateCryptoTransform(
                 iv: iv.ToArray(),
                 encrypting: false,
@@ -202,8 +200,6 @@ namespace System.Security.Cryptography
             int feedbackSizeInBits,
             out int bytesWritten)
         {
-            ValidateCFBFeedbackSize(feedbackSizeInBits);
-
             UniversalCryptoTransform transform = _core.CreateCryptoTransform(
                 iv: iv.ToArray(),
                 encrypting: true,
@@ -220,26 +216,6 @@ namespace System.Security.Cryptography
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);
-        }
-
-        private void ValidateCFBFeedbackSize(int feedback)
-        {
-            if (_core.KeyInPlainText)
-            {
-                // CFB8 and CFB164 are valid for bcrypt keys.
-                if (feedback != 8 && feedback != 64)
-                {
-                    throw new CryptographicException(string.Format(SR.Cryptography_CipherModeFeedbackNotSupported, feedback, CipherMode.CFB));
-                }
-            }
-            else
-            {
-                // only CFB8 is supported for ncrypt keys.
-                if (feedback != 8)
-                {
-                    throw new CryptographicException(string.Format(SR.Cryptography_CipherModeFeedbackNotSupported, feedback, CipherMode.CFB));
-                }
-            }
         }
 
         byte[] ICngSymmetricAlgorithm.BaseKey { get { return base.Key; } set { base.Key = value; } }
@@ -278,6 +254,11 @@ namespace System.Security.Cryptography
             }
 
             return key;
+        }
+
+        bool ICngSymmetricAlgorithm.IsValidEphemeralFeedbackSize(int feedbackSizeInBits)
+        {
+            return feedbackSizeInBits == 8 || feedbackSizeInBits == 64;
         }
 
         private CngSymmetricAlgorithmCore _core;

--- a/src/libraries/System.Security.Cryptography.Cng/tests/AesCngTests.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/AesCngTests.cs
@@ -102,7 +102,7 @@ namespace System.Security.Cryptography.Cng.Tests
         [ConditionalFact(nameof(SupportsPersistedSymmetricKeys))]
         public static void VerifyUnsupportedFeedbackSizeForPersistedCfb()
         {
-            SymmetricCngTestHelpers.VerifyOneShotCfbPersistedUnsupportedFeedbackSize(
+            SymmetricCngTestHelpers.VerifyCfbPersistedUnsupportedFeedbackSize(
                 s_cngAlgorithm,
                 keyName => new AesCng(keyName),
                 notSupportedFeedbackSizeInBits: 128);

--- a/src/libraries/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
@@ -142,6 +142,8 @@
              Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\RSA\SignVerify.netcoreapp.cs" />
     <Compile Condition="'$(TargetsWindows)' == 'true'" Include="AesCngTests.cs" />
     <Compile Condition="'$(TargetsWindows)' == 'true'" Include="TripleDESCngTests.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESContractTests.cs"
+             Link="CommonTest\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESContractTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\AES\AesContractTests.cs"
              Link="CommonTest\AlgorithmImplementations\AES\AesContractTests.cs" />
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESCipherTests.cs"

--- a/src/libraries/System.Security.Cryptography.Cng/tests/TripleDESCngTests.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/tests/TripleDESCngTests.cs
@@ -108,7 +108,7 @@ namespace System.Security.Cryptography.Cng.Tests
         [ConditionalFact(nameof(SupportsPersistedSymmetricKeys))]
         public static void VerifyUnsupportedFeedbackSizeForPersistedCfb()
         {
-            SymmetricCngTestHelpers.VerifyOneShotCfbPersistedUnsupportedFeedbackSize(
+            SymmetricCngTestHelpers.VerifyCfbPersistedUnsupportedFeedbackSize(
                 s_cngAlgorithm,
                 keyName => new TripleDESCng(keyName),
                 notSupportedFeedbackSizeInBits: 64);


### PR DESCRIPTION
This changes `AesCng` and `TripleDESCng` to require the feedback size to be set to '8' when in CFB mode and using a persisted CNG key.

Prior to this change, `BasicSymmetricCipherNCrypt` ignored the feedback size which resulted in CFB8 always being used, even if the FeedbackSize was set to another value. However, when padding was applied, the padding size would be padded to the feedback size. In the case of AesCng, this would mean it would be encrypted with CFB8 and padded as if it were CFB128.

It was also determined that persisted CNG keys also do not support setting the feedback size, so that gives us the only option to throw.

This changes the implementation so that the feedback size is required to be set to 8 for persisted keys. No change is made for ephemeral keys.

-----

Developers that are impacted by this change can work around this by setting the `FeedbackSize` to 8, since that is how it is actually encrypted. Even though it was padded with additional padding, it will be handled by the decryption since this was actually the behavior of .NET Framework (it was always padded to the block size). So the decryption handles the extra padding already, and encryption will start producing smaller ciphertexts since it will contain at most one byte of padding.

As noted in the issue, this breaking change will have a small impact.

Closes #55477.