### PR TITLE
Raise the max size poolable by ArrayPool

### DIFF
--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/Compression/WebSocketDeflater.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/Compression/WebSocketDeflater.cs
@@ -46,15 +46,11 @@ namespace System.Net.WebSockets.Compression
         {
             Debug.Assert(_buffer is null, "Invalid state, ReleaseBuffer not called.");
 
-            // Do not try to rent more than 1MB initially, because it will actually allocate
-            // instead of renting. Be optimistic that what we're sending is actually going to fit.
-            const int MaxInitialBufferLength = 1024 * 1024;
-
             // For small payloads there might actually be overhead in the compression and the resulting
             // output might be larger than the payload. This is why we rent at least 4KB initially.
             const int MinInitialBufferLength = 4 * 1024;
 
-            _buffer = ArrayPool<byte>.Shared.Rent(Math.Clamp(payload.Length, MinInitialBufferLength, MaxInitialBufferLength));
+            _buffer = ArrayPool<byte>.Shared.Rent(Math.Max(payload.Length, MinInitialBufferLength));
             int position = 0;
 
             while (true)

--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/Compression/WebSocketInflater.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/Compression/WebSocketInflater.cs
@@ -82,10 +82,9 @@ namespace System.Net.WebSockets.Compression
             }
             else
             {
-                // Rent a buffer as close to the size of the user buffer as possible,
-                // but not try to rent anything above 1MB because the array pool will allocate.
+                // Rent a buffer as close to the size of the user buffer as possible.
                 // If the payload is smaller than the user buffer, rent only as much as we need.
-                _buffer = ArrayPool<byte>.Shared.Rent(Math.Min(userBufferLength, (int)Math.Min(payloadLength, 1024 * 1024)));
+                _buffer = ArrayPool<byte>.Shared.Rent((int)Math.Min(userBufferLength, payloadLength));
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/TlsOverPerCoreLockedStacksArrayPool.cs
@@ -24,12 +24,11 @@ namespace System.Buffers
         // TODO https://github.com/dotnet/coreclr/pull/7747: "Investigate optimizing ArrayPool heuristics"
         // - Explore caching in TLS more than one array per size per thread, and moving stale buffers to the global queue.
         // - Explore changing the size of each per-core bucket, potentially dynamically or based on other factors like array size.
-        // - Explore changing number of buckets and what sizes of arrays are cached.
         // - Investigate whether false sharing is causing any issues, in particular on LockedStack's count and the contents of its array.
         // ...
 
         /// <summary>The number of buckets (array sizes) in the pool, one for each array length, starting from length 16.</summary>
-        private const int NumBuckets = 17; // Utilities.SelectBucketIndex(2*1024*1024)
+        private const int NumBuckets = 27; // Utilities.SelectBucketIndex(1024 * 1024 * 1024 + 1)
         /// <summary>Maximum number of per-core stacks to use per array size.</summary>
         private const int MaxPerCorePerArraySizeStacks = 64; // selected to avoid needing to worry about processor groups
         /// <summary>The maximum number of buffers to store in a bucket's global queue.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
@@ -722,7 +722,9 @@ namespace System.Globalization
 
             // according to ICU User Guide the performance of ucol_getSortKey is worse when it is called with null output buffer
             // the solution is to try to fill the sort key in a temporary buffer of size equal 4 x string length
-            // 1MB is the biggest array that can be rented from ArrayPool.Shared without memory allocation
+            // (The ArrayPool used to have a limit on the length of buffers it would cache; this code was avoiding
+            // exceeding that limit to avoid a per-operation allocation, and the performance implications here
+            // were not re-evaluated when the limit was lifted.)
             int sortKeyLength = (source.Length > 1024 * 1024 / 4) ? 0 : 4 * source.Length;
 
             byte[]? borrowedArray = null;


### PR DESCRIPTION
We previously set an arbitrary cut-off of 1MB max array size. That was before we would trim arrays in response to memory pressure.  This now raises the limit as high as we can while maintaining the current power-of-two-based scheme.

Contributes to https://github.com/dotnet/runtime/issues/12800
cc: @jkotas, @Maoni0 