### PR TITLE
Surgical fix for bad assertion generation

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1271,6 +1271,10 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
                     }
 
                     toType = op2->CastToType();
+                    if (toType == TYP_UINT)
+                    {
+                        toType = TYP_INT;
+                    }
                 SUBRANGE_COMMON:
                     if ((assertionKind != OAK_SUBRANGE) && (assertionKind != OAK_EQUAL))
                     {

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1271,6 +1271,15 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
                     }
 
                     toType = op2->CastToType();
+
+                    // Casts to TYP_UINT produce the same ranges as casts to TYP_INT,
+                    // except in overflow cases which we do not yet handle. To avoid
+                    // issues with the propagation code dropping, e. g., CAST_OVF(uint <- int)
+                    // based on an assertion created from CAST(uint <- ulong), normalize the
+                    // type for the range here. Note that TYP_ULONG theoretically has the same
+                    // problem, but we do not create assertions for it.
+                    // TODO-Cleanup: this assertion is not useful - this code exists to preserve
+                    // previous behavior. Refactor it to stop generating such assertions.
                     if (toType == TYP_UINT)
                     {
                         toType = TYP_INT;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_54842/Runtime_54842.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_54842/Runtime_54842.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Runtime.CompilerServices;
+
+public class Runtime_54842
+{
+    public static int Main()
+    {
+        try
+        {
+            DoubleCheckedConvert(uint.MaxValue);
+        }
+        catch (OverflowException)
+        {
+            return 100;
+        }
+
+        return 101;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static uint DoubleCheckedConvert(ulong a)
+    {
+        var b = (int)checked((uint)a);
+
+        // Make sure the importer spills "b" to a local.
+        Use(b);
+
+        return checked((uint)b);
+    }
+
+    private static void Use(int value) { }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_54842/Runtime_54842.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_54842/Runtime_54842.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Say we have a cast like this: `CAST(uint <- long)`.
What value does this tree compute?
`[int.MinValue..int.MaxValue]` - IR operates on signed `TYP_INT`s.
But assertion prop generated `[0..uint.MaxValue]` for it.

The confusion created by this "how to interpret `TYP_UINT`" question
caused a bug where for the assertion generated for the above cast,
in the form of `[0..uint.MaxValue]`, propagation could remove
a checked cast in the form of `CAST_OVF(uint < int)`.

The proper fix is to generate proper ranges for such casts, it is in #55186 and waiting for .NET 7.

The surgical fix proposed here, for .NET 6, is to always treat casts to `TYP_UINT`
as if they were to `TYP_INT`. This is conservative, but always correct.
The generated assertion is useless of course, but that makes this a
zero-diff change (verified via replaying all `win-x64` & `win-x86` collections).

Fixes #54842

cc @kunalspathak