### PR TITLE
Correctly skip PosixSignalRegistrationTests on mobile

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/PosixSignalRegistrationTests.Unix.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/PosixSignalRegistrationTests.Unix.cs
@@ -14,19 +14,13 @@ namespace System.Tests
     {
         public static IEnumerable<object[]> UninstallableSignals()
         {
-            if (PlatformDetection.IsNotMobile)
-            {
-                yield return new object[] { (PosixSignal)9 };
-            }
+            yield return new object[] { (PosixSignal)9 };
         }
 
         public static IEnumerable<object[]> SupportedSignals()
         {
-            if (PlatformDetection.IsNotMobile)
-            {
-                foreach (PosixSignal value in Enum.GetValues(typeof(PosixSignal)))
-                    yield return new object[] { value };
-            }
+            foreach (PosixSignal value in Enum.GetValues(typeof(PosixSignal)))
+                yield return new object[] { value };
         }
 
         public static IEnumerable<object[]> UnsupportedSignals()


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/55569 didn't fix the issue since xunit retrieves the MemberData and checks for non-empty *before* evaluating the ConditionalTheory condition.