### PR TITLE
Remove a few duplicated S.R.InteropServices tests

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetObjectForNativeVariantTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetObjectForNativeVariantTests.cs
@@ -351,8 +351,8 @@ namespace System.Runtime.InteropServices.Tests
             yield return new object[] { 128 };
             yield return new object[] { 4094 };
             yield return new object[] { VT_BSTR_BLOB };
-            yield return new object[] { VT_ILLEGALMASKED };
-            yield return new object[] { VT_TYPEMASK };
+            Assert.Equal(VT_BSTR_BLOB, VT_ILLEGALMASKED);
+            Assert.Equal(VT_BSTR_BLOB, VT_TYPEMASK);
             yield return new object[] { VT_VECTOR };
             yield return new object[] { 4097 };
             yield return new object[] { 8191 };


### PR DESCRIPTION
```
[xUnit.net 00:00:00.88] System.Runtime.InteropServices.Tests: Skipping test case with duplicate ID '4af38d5703d3fe5f44b9dcd2af662a283b9a8727' ('System.Runtime.InteropServices.Tests.GetObjectForNativeVariantTests.GetObjectForNativeVariant_InvalidVarType_InvalidOleVariantTypeException(vt: 4095)' and 'System.Runtime.InteropServices.Tests.GetObjectForNativeVariantTests.GetObjectForNativeVariant_InvalidVarType_InvalidOleVariantTypeException(vt: 4095)')
[xUnit.net 00:00:00.88] System.Runtime.InteropServices.Tests: Skipping test case with duplicate ID '4af38d5703d3fe5f44b9dcd2af662a283b9a8727' ('System.Runtime.InteropServices.Tests.GetObjectForNativeVariantTests.GetObjectForNativeVariant_InvalidVarType_InvalidOleVariantTypeException(vt: 4095)' and 'System.Runtime.InteropServices.Tests.GetObjectForNativeVariantTests.GetObjectForNativeVariant_InvalidVarType_InvalidOleVariantTypeException(vt: 4095)')
[xUnit.net 00:00:00.88] System.Runtime.InteropServices.Tests: Skipping test case with duplicate ID 'f8da5d641b6da3bcbeb0ff5b8232a33faa733324' ('System.Runtime.InteropServices.Tests.GetObjectForNativeVariantTests.GetObjectForNativeVariant_InvalidVarTypeByRef_InvalidOleVariantTypeException(vt: 4095)' and 'System.Runtime.InteropServices.Tests.GetObjectForNativeVariantTests.GetObjectForNativeVariant_InvalidVarTypeByRef_InvalidOleVariantTypeException(vt: 4095)')
[xUnit.net 00:00:00.88] System.Runtime.InteropServices.Tests: Skipping test case with duplicate ID 'f8da5d641b6da3bcbeb0ff5b8232a33faa733324' ('System.Runtime.InteropServices.Tests.GetObjectForNativeVariantTests.GetObjectForNativeVariant_InvalidVarTypeByRef_InvalidOleVariantTypeException(vt: 4095)' and 'System.Runtime.InteropServices.Tests.GetObjectForNativeVariantTests.GetObjectForNativeVariant_InvalidVarTypeByRef_InvalidOleVariantTypeException(vt: 4095)')
```

Happened to notice while investigating https://github.com/dotnet/runtime/pull/55643