### PR TITLE
Fix building S.S.Cryptography.Native with cmake 3.6.2

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
@@ -62,7 +62,7 @@ if (FEATURE_DISTRO_AGNOSTIC_SSL)
     )
     add_definitions(-DFEATURE_DISTRO_AGNOSTIC_SSL)
     add_compile_options(-pthread)
-    add_link_options(-pthread)
+    add_linker_flag(-pthread)
 endif()
 
 add_library(objlib OBJECT ${NATIVECRYPTO_SOURCES} ${VERSION_FILE_PATH})


### PR DESCRIPTION
Thought I would give this a try, but I'm by no means an expert on the build infrastructure.

This uses our add_linker_flag function for adding linker flags instead of add_link_options which is only available in newer cmake versions.

Closes #55646 

/cc @omajid