### PR TITLE
Add property ordering to source gen

### DIFF
--- a/src/libraries/System.Text.Json/gen/PropertyGenerationSpec.cs
+++ b/src/libraries/System.Text.Json/gen/PropertyGenerationSpec.cs
@@ -64,6 +64,11 @@ namespace System.Text.Json.SourceGeneration
         public JsonNumberHandling? NumberHandling { get; init; }
 
         /// <summary>
+        /// The serialization order of the property.
+        /// </summary>
+        public int Order { get; init; }
+
+        /// <summary>
         /// Whether the property has the JsonIncludeAttribute. If so, non-public accessors can be used for (de)serialziation.
         /// </summary>
         public bool HasJsonInclude { get; init; }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/ContextClasses.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/ContextClasses.cs
@@ -20,6 +20,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         public JsonTypeInfo<MyType> MyType { get; }
         public JsonTypeInfo<MyType2> MyType2 { get; }
         public JsonTypeInfo<MyTypeWithCallbacks> MyTypeWithCallbacks { get; }
+        public JsonTypeInfo<MyTypeWithPropertyOrdering> MyTypeWithPropertyOrdering { get; }
         public JsonTypeInfo<MyIntermediateType> MyIntermediateType { get; }
         public JsonTypeInfo<HighLowTempsImmutable> HighLowTempsImmutable { get; }
         public JsonTypeInfo<RealWorldContextTests.MyNestedClass> MyNestedClass { get; }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/MetadataAndSerializationContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/MetadataAndSerializationContextTests.cs
@@ -18,6 +18,7 @@ namespace System.Text.Json.SourceGeneration.Tests
     [JsonSerializable(typeof(MyType))]
     [JsonSerializable(typeof(MyType2))]
     [JsonSerializable(typeof(MyTypeWithCallbacks))]
+    [JsonSerializable(typeof(MyTypeWithPropertyOrdering))]
     [JsonSerializable(typeof(MyIntermediateType))]
     [JsonSerializable(typeof(HighLowTempsImmutable))]
     [JsonSerializable(typeof(RealWorldContextTests.MyNestedClass))]
@@ -47,6 +48,7 @@ namespace System.Text.Json.SourceGeneration.Tests
             Assert.NotNull(MetadataAndSerializationContext.Default.MyType.Serialize);
             Assert.NotNull(MetadataAndSerializationContext.Default.MyType2.Serialize);
             Assert.NotNull(MetadataAndSerializationContext.Default.MyTypeWithCallbacks.Serialize);
+            Assert.NotNull(MetadataAndSerializationContext.Default.MyTypeWithPropertyOrdering.Serialize);
             Assert.NotNull(MetadataAndSerializationContext.Default.MyIntermediateType.Serialize);
             Assert.NotNull(MetadataAndSerializationContext.Default.HighLowTempsImmutable.Serialize);
             Assert.NotNull(MetadataAndSerializationContext.Default.MyNestedClass.Serialize);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/MetadataContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/MetadataContextTests.cs
@@ -17,6 +17,7 @@ namespace System.Text.Json.SourceGeneration.Tests
     [JsonSerializable(typeof(MyType), GenerationMode = JsonSourceGenerationMode.Metadata)]
     [JsonSerializable(typeof(MyType2), GenerationMode = JsonSourceGenerationMode.Metadata)]
     [JsonSerializable(typeof(MyTypeWithCallbacks), GenerationMode = JsonSourceGenerationMode.Metadata)]
+    [JsonSerializable(typeof(MyTypeWithPropertyOrdering), GenerationMode = JsonSourceGenerationMode.Metadata)]
     [JsonSerializable(typeof(MyIntermediateType), GenerationMode = JsonSourceGenerationMode.Metadata)]
     [JsonSerializable(typeof(HighLowTempsImmutable), GenerationMode = JsonSourceGenerationMode.Metadata)]
     [JsonSerializable(typeof(RealWorldContextTests.MyNestedClass), GenerationMode = JsonSourceGenerationMode.Metadata)]
@@ -67,6 +68,7 @@ namespace System.Text.Json.SourceGeneration.Tests
     [JsonSerializable(typeof(MyType))]
     [JsonSerializable(typeof(MyType2))]
     [JsonSerializable(typeof(MyTypeWithCallbacks))]
+    [JsonSerializable(typeof(MyTypeWithPropertyOrdering))]
     [JsonSerializable(typeof(MyIntermediateType))]
     [JsonSerializable(typeof(HighLowTempsImmutable))]
     [JsonSerializable(typeof(RealWorldContextTests.MyNestedClass))]
@@ -96,6 +98,7 @@ namespace System.Text.Json.SourceGeneration.Tests
             Assert.Null(MetadataContext.Default.MyType.Serialize);
             Assert.Null(MetadataContext.Default.MyType2.Serialize);
             Assert.Null(MetadataContext.Default.MyTypeWithCallbacks.Serialize);
+            Assert.Null(MetadataContext.Default.MyTypeWithPropertyOrdering.Serialize);
             Assert.Null(MetadataContext.Default.MyIntermediateType.Serialize);
             Assert.Null(MetadataContext.Default.HighLowTempsImmutable.Serialize);
             Assert.Null(MetadataContext.Default.MyNestedClass.Serialize);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/MixedModeContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/MixedModeContextTests.cs
@@ -17,6 +17,7 @@ namespace System.Text.Json.SourceGeneration.Tests
     [JsonSerializable(typeof(MyType), GenerationMode = JsonSourceGenerationMode.Default)]
     [JsonSerializable(typeof(MyType2), GenerationMode = JsonSourceGenerationMode.Metadata | JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(MyTypeWithCallbacks), GenerationMode = JsonSourceGenerationMode.Metadata | JsonSourceGenerationMode.Serialization)]
+    [JsonSerializable(typeof(MyTypeWithPropertyOrdering), GenerationMode = JsonSourceGenerationMode.Metadata | JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(MyIntermediateType), GenerationMode = JsonSourceGenerationMode.Metadata | JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(HighLowTempsImmutable), GenerationMode = JsonSourceGenerationMode.Metadata)]
     [JsonSerializable(typeof(RealWorldContextTests.MyNestedClass), GenerationMode = JsonSourceGenerationMode.Serialization)]
@@ -45,6 +46,7 @@ namespace System.Text.Json.SourceGeneration.Tests
             Assert.NotNull(MixedModeContext.Default.MyType.Serialize);
             Assert.NotNull(MixedModeContext.Default.MyType2.Serialize);
             Assert.NotNull(MixedModeContext.Default.MyTypeWithCallbacks.Serialize);
+            Assert.NotNull(MixedModeContext.Default.MyTypeWithPropertyOrdering.Serialize);
             Assert.NotNull(MixedModeContext.Default.MyIntermediateType.Serialize);
             Assert.Null(MixedModeContext.Default.HighLowTempsImmutable.Serialize);
             Assert.NotNull(MixedModeContext.Default.MyNestedClass.Serialize);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/RealWorldContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/RealWorldContextTests.cs
@@ -561,5 +561,13 @@ namespace System.Text.Json.SourceGeneration.Tests
 
             JsonTestHelper.AssertJsonEqual(expectedJson, Encoding.UTF8.GetString(ms.ToArray()));
         }
+
+        [Fact]
+        public void PropertyOrdering()
+        {
+            MyTypeWithPropertyOrdering obj = new();
+            string json = JsonSerializer.Serialize(obj, DefaultContext.MyTypeWithPropertyOrdering);
+            Assert.Equal("{\"C\":0,\"B\":0,\"A\":0}", json);
+        }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/SerializationContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/SerializationContextTests.cs
@@ -18,6 +18,7 @@ namespace System.Text.Json.SourceGeneration.Tests
     [JsonSerializable(typeof(MyType))]
     [JsonSerializable(typeof(MyType2))]
     [JsonSerializable(typeof(MyTypeWithCallbacks))]
+    [JsonSerializable(typeof(MyTypeWithPropertyOrdering))]
     [JsonSerializable(typeof(MyIntermediateType))]
     [JsonSerializable(typeof(HighLowTempsImmutable))]
     [JsonSerializable(typeof(RealWorldContextTests.MyNestedClass))]
@@ -40,6 +41,7 @@ namespace System.Text.Json.SourceGeneration.Tests
     [JsonSerializable(typeof(MyType), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(MyType2), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(MyTypeWithCallbacks), GenerationMode = JsonSourceGenerationMode.Serialization)]
+    [JsonSerializable(typeof(MyTypeWithPropertyOrdering), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(MyIntermediateType), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(HighLowTempsImmutable), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(RealWorldContextTests.MyNestedClass), GenerationMode = JsonSourceGenerationMode.Serialization)]
@@ -63,6 +65,7 @@ namespace System.Text.Json.SourceGeneration.Tests
     [JsonSerializable(typeof(MyType), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(MyType2), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(MyTypeWithCallbacks), GenerationMode = JsonSourceGenerationMode.Serialization)]
+    [JsonSerializable(typeof(MyTypeWithPropertyOrdering), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(MyIntermediateType), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(HighLowTempsImmutable), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(RealWorldContextTests.MyNestedClass), GenerationMode = JsonSourceGenerationMode.Serialization)]
@@ -97,6 +100,7 @@ namespace System.Text.Json.SourceGeneration.Tests
             Assert.NotNull(SerializationContext.Default.MyType.Serialize);
             Assert.NotNull(SerializationContext.Default.MyType2.Serialize);
             Assert.NotNull(SerializationContext.Default.MyTypeWithCallbacks.Serialize);
+            Assert.NotNull(SerializationContext.Default.MyTypeWithPropertyOrdering.Serialize);
             Assert.NotNull(SerializationContext.Default.MyIntermediateType.Serialize);
             Assert.NotNull(SerializationContext.Default.HighLowTempsImmutable.Serialize);
             Assert.NotNull(SerializationContext.Default.MyNestedClass.Serialize);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/TestClasses.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/TestClasses.cs
@@ -117,6 +117,18 @@ namespace System.Text.Json.SourceGeneration.Tests
         void IJsonOnSerialized.OnSerialized() => MyProperty = "After";
     }
 
+    public class MyTypeWithPropertyOrdering
+    {
+        public int B { get; set; }
+
+        [JsonPropertyOrder(1)]
+        public int A { get; set; }
+
+        [JsonPropertyOrder(-1)]
+        [JsonInclude]
+        public int C = 0;
+    }
+
     public class JsonMessage
     {
         public string Message { get; set; }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/PropertyOrderTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/PropertyOrderTests.cs
@@ -15,7 +15,8 @@ namespace System.Text.Json.Serialization.Tests
             public int A { get; set; }
 
             [JsonPropertyOrder(-1)]
-            public int C { get; set; }
+            [JsonInclude]
+            public int C = 0;
         }
 
         [Fact]
@@ -28,7 +29,8 @@ namespace System.Text.Json.Serialization.Tests
         private class MyPoco_After
         {
             [JsonPropertyOrder(2)]
-            public int C { get; set; }
+            [JsonInclude]
+            public int C = 0;
 
             public int B { get; set; }
             public int D { get; set; }
@@ -48,7 +50,8 @@ namespace System.Text.Json.Serialization.Tests
         private class MyPoco_Before
         {
             [JsonPropertyOrder(-1)]
-            public int C { get; set; }
+            [JsonInclude]
+            public int C = 0;
 
             public int B { get; set; }
             public int D { get; set; }


### PR DESCRIPTION
Follow up to https://github.com/dotnet/runtime/pull/55586 for source-gen support.

Original issue: https://github.com/dotnet/runtime/issues/54748

This orders the property metadata in source gen; no run-time information regarding ordering is passed to STJ at run-time other than the actual list of properties with the correct ordering.