### PR TITLE
Relax LinkTarget so it always returns null when steps on an error

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
@@ -427,20 +427,20 @@ namespace System.IO
         {
             string? targetPath = returnFinalTarget ?
                 GetFinalLinkTarget(linkPath, isDirectory) :
-                GetImmediateLinkTarget(linkPath, isDirectory, throwOnUnreachable: true, returnFullPath: true);
+                GetImmediateLinkTarget(linkPath, isDirectory, throwOnError: true, returnFullPath: true);
 
             return targetPath == null ? null :
                 isDirectory ? new DirectoryInfo(targetPath) : new FileInfo(targetPath);
         }
 
         internal static string? GetLinkTarget(string linkPath, bool isDirectory)
-            => GetImmediateLinkTarget(linkPath, isDirectory, throwOnUnreachable: false, returnFullPath: false);
+            => GetImmediateLinkTarget(linkPath, isDirectory, throwOnError: false, returnFullPath: false);
 
         /// <summary>
         /// Gets reparse point information associated to <paramref name="linkPath"/>.
         /// </summary>
         /// <returns>The immediate link target, absolute or relative or null if the file is not a supported link.</returns>
-        internal static unsafe string? GetImmediateLinkTarget(string linkPath, bool isDirectory, bool throwOnUnreachable, bool returnFullPath)
+        internal static unsafe string? GetImmediateLinkTarget(string linkPath, bool isDirectory, bool throwOnError, bool returnFullPath)
         {
             using SafeFileHandle handle = OpenSafeFileHandle(linkPath,
                     Interop.Kernel32.FileOperations.FILE_FLAG_BACKUP_SEMANTICS |
@@ -448,13 +448,12 @@ namespace System.IO
 
             if (handle.IsInvalid)
             {
-                int error = Marshal.GetLastWin32Error();
-
-                if (!throwOnUnreachable && IsPathUnreachableError(error))
+                if (!throwOnError)
                 {
                     return null;
                 }
 
+                int error = Marshal.GetLastWin32Error();
                 // File not found doesn't make much sense coming from a directory.
                 if (isDirectory && error == Interop.Errors.ERROR_FILE_NOT_FOUND)
                 {
@@ -479,6 +478,11 @@ namespace System.IO
 
                 if (!success)
                 {
+                    if (!throwOnError)
+                    {
+                        return null;
+                    }
+
                     int error = Marshal.GetLastWin32Error();
                     // The file or directory is not a reparse point.
                     if (error == Interop.Errors.ERROR_NOT_A_REPARSE_POINT)
@@ -600,13 +604,15 @@ namespace System.IO
             {
                 // Since all these paths will be passed to CreateFile, which takes a string anyway, it is pointless to use span.
                 // I am not sure if it's possible to change CreateFile's param to ROS<char> and avoid all these allocations.
-                string? current = GetImmediateLinkTarget(linkPath, isDirectory, throwOnUnreachable: false, returnFullPath: true);
+
+                // We don't throw on error since we already did all the proper validations before.
+                string? current = GetImmediateLinkTarget(linkPath, isDirectory, throwOnError: false, returnFullPath: true);
                 string? prev = null;
 
                 while (current != null)
                 {
                     prev = current;
-                    current = GetImmediateLinkTarget(current, isDirectory, throwOnUnreachable: false, returnFullPath: true);
+                    current = GetImmediateLinkTarget(current, isDirectory, throwOnError: false, returnFullPath: true);
                 }
 
                 return prev;


### PR DESCRIPTION
Motivated by https://github.com/dotnet/runtime/pull/55664. When I was testing that PR, I noticed that I was getting ACCESS DENIED errors sporadically, here's the callstack:
```
  Unhandled exception. System.UnauthorizedAccessException: Access to the path 'C:\Users\david\AppData\Local\Temp\tapmbdam.rgw\4d2sb45x.hix_FOO_True' is denied.
     at System.IO.FileSystem.GetImmediateLinkTarget(String linkPath, Boolean isDirectory, Boolean throwOnUnreachable, Boolean returnFullPath) in System.Private.CoreLib.dll:token 0x6005ec9+0x3b
     at System.IO.FileSystem.GetLinkTarget(String linkPath, Boolean isDirectory) in System.Private.CoreLib.dll:token 0x6005ec8+0x0
     at System.IO.FileSystemInfo.get_LinkTarget() in System.Private.CoreLib.dll:token 0x6005ee2+0xf
     at Microsoft.Extensions.FileProviders.Physical.FileSystemInfoHelper.ResolveFileLinkTarget(FileInfo fileInfo) in C:\repos\runtime\src\libraries\Microsoft.Extensions.FileProviders.Physical\src\Internal\FileSystemInfoHelper.cs:line 44
     at Microsoft.Extensions.FileProviders.Physical.FileSystemInfoHelper.ResolveFileLinkTarget(String filePath) in C:\repos\runtime\src\libraries\Microsoft.Extensions.FileProviders.Physical\src\Internal\FileSystemInfoHelper.cs:line 34
     at Microsoft.Extensions.FileProviders.Physical.PollingWildCardChangeToken.GetLastWriteUtc(String path) in C:\repos\runtime\src\libraries\Microsoft.Extensions.FileProviders.Physical\src\PollingWildCardChangeToken.cs:line 147
     at Microsoft.Extensions.FileProviders.Physical.PollingWildCardChangeToken.CalculateChanges() in C:\repos\runtime\src\libraries\Microsoft.Extensions.FileProviders.Physical\src\PollingWildCardChangeToken.cs:line 115
     at Microsoft.Extensions.FileProviders.Physical.PollingWildCardChangeToken.get_HasChanged() in C:\repos\runtime\src\libraries\Microsoft.Extensions.FileProviders.Physical\src\PollingWildCardChangeToken.cs:line 98
     at Microsoft.Extensions.FileProviders.Physical.PhysicalFilesWatcher.RaiseChangeEvents(Object state) in C:\repos\runtime\src\libraries\Microsoft.Extensions.FileProviders.Physical\src\PhysicalFilesWatcher.cs:line 437
     at System.Threading.TimerQueueTimer.CallCallback(Boolean isThreadPool) in System.Private.CoreLib.dll:token 0x600303a+0x2b
     at System.Threading.TimerQueueTimer.Fire(Boolean isThreadPool) in System.Private.CoreLib.dll:token 0x6003038+0x3b
     at System.Threading.TimerQueue.FireNextTimers() in System.Private.CoreLib.dll:token 0x6002d9e+0x1a9
     at System.Threading.TimerQueue.AppDomainTimerCallback(Int32 id) in System.Private.CoreLib.dll:token 0x6002d95+0x0
```


I suspect is because of the following (even though I am getting the error when calling `CreateFileW`):
https://github.com/dotnet/runtime/blob/44f7103e0e420ae81198c6c5301fa5d1cb82b23c/src/libraries/Common/src/System/IO/FileSystem.Attributes.Windows.cs#L73-L76

I wasn't able to create a unit case that consistently could hit this issue but by always returning `null` when the `LinkTarget` property hits an error, we can mitigate the issue.
In addition, this can make developer's life easier by not being afraid of such property breaking their app. 

This also grants us parity with the Unix implementation.