### PR TITLE
remove Steve as the os-mac-os-x owner

### DIFF
--- a/docs/area-owners.md
+++ b/docs/area-owners.md
@@ -146,7 +146,7 @@ Note: Editing this file doesn't update the mapping used by the `@msftbot` issue 
 | os-alpine        |               |                                                     |              |
 | os-android       | @steveisok    | @akoeplinger                                        |              |
 | os-freebsd       |               |                                                     |              |
-| os-mac-os-x      | @steveisok    |                                                     |              |
+| os-mac-os-x      |               |                                                     |              |
 | os-maccatalyst   | @steveisok    |                                                     |              |
 | os-ios           | @steveisok    | @vargaz                                             |              |
 | os-tvos          | @steveisok    | @vargaz                                             |              |


### PR DESCRIPTION
The live data in area-owners.md is used to identify area ownership.  os-mac-os-x is a broad OS and spans a lot of areas.  @steveisok and I discussed removing him to help clarify the area of ownership.