### PR TITLE
Consider CALLFINALLY block as pred of finally block during assertion props

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -763,7 +763,7 @@ void Compiler::optPrintAssertion(AssertionDsc* curAssertion, AssertionIndex asse
                 break;
 
             case O2K_SUBRANGE:
-                printf("[%d..%d]", curAssertion->op2.u2.loBound, curAssertion->op2.u2.hiBound);
+                printf("[%u..%u]", curAssertion->op2.u2.loBound, curAssertion->op2.u2.hiBound);
                 break;
 
             default:
@@ -2325,7 +2325,7 @@ AssertionIndex Compiler::optFindComplementary(AssertionIndex assertIndex)
 /*****************************************************************************
  *
  *  Given a lclNum, a fromType and a toType, return assertion index of the assertion that
- *  claims that a variable's value is always a valid subrange of the formType.
+ *  claims that a variable's value is always a valid subrange of the fromType.
  *  Thus we can discard or omit a cast to fromType. Returns NO_ASSERTION_INDEX
  *  if one such assertion could not be found in "assertions."
  */
@@ -4830,6 +4830,15 @@ public:
     //   It means we can propagate only assertions that are valid for the whole try region.
     void MergeHandler(BasicBlock* block, BasicBlock* firstTryBlock, BasicBlock* lastTryBlock)
     {
+        if (VerboseDataflow())
+        {
+            JITDUMP("Merge     : " FMT_BB " ", block->bbNum);
+            Compiler::optDumpAssertionIndices("in -> ", block->bbAssertionIn, "; ");
+            JITDUMP("firstTryBlock " FMT_BB " ", firstTryBlock->bbNum);
+            Compiler::optDumpAssertionIndices("in -> ", firstTryBlock->bbAssertionIn, "; ");
+            JITDUMP("lastTryBlock " FMT_BB " ", lastTryBlock->bbNum);
+            Compiler::optDumpAssertionIndices("out -> ", lastTryBlock->bbAssertionOut, "\n");
+        }
         BitVecOps::IntersectionD(apTraits, block->bbAssertionIn, firstTryBlock->bbAssertionIn);
         BitVecOps::IntersectionD(apTraits, block->bbAssertionIn, lastTryBlock->bbAssertionOut);
     }
@@ -4933,8 +4942,8 @@ ASSERT_TP* Compiler::optComputeAssertionGen()
                 }
                 else // is jump edge assertion
                 {
-                    valueAssertionIndex    = optFindComplementary(info.GetAssertionIndex());
                     jumpDestAssertionIndex = info.GetAssertionIndex();
+                    valueAssertionIndex    = optFindComplementary(jumpDestAssertionIndex);
                 }
 
                 if (valueAssertionIndex != NO_ASSERTION_INDEX)

--- a/src/coreclr/jit/clrjit.natvis
+++ b/src/coreclr/jit/clrjit.natvis
@@ -30,6 +30,7 @@ Documentation for VS debugger format specifiers: https://docs.microsoft.com/en-u
   </Type>
 
   <!-- GenTree -->
+
   <Type Name="GenTree">
     <DisplayString>[{gtOper,en}, {gtType,en}]</DisplayString>
   </Type>
@@ -51,6 +52,16 @@ Documentation for VS debugger format specifiers: https://docs.microsoft.com/en-u
     <DisplayString Condition="this->gtOper==GT_SIMD">[{((GenTreeSIMD*)this)-&gt;gtSIMDIntrinsicID,en}, {gtType,en}]</DisplayString>
     <DisplayString Condition="this->gtOper==GT_HWINTRINSIC">[{((GenTreeHWIntrinsic*)this)-&gt;gtHWIntrinsicId,en}, {gtType,en}]</DisplayString>
     <DisplayString>[{gtOper,en}, {gtType,en}]</DisplayString>
+  </Type>
+
+  <Type Name="Statement">
+    <Expand>
+      <LinkedListItems>
+        <HeadPointer>this-&gt;m_treeList</HeadPointer>
+        <NextPointer>this-&gt;gtNext</NextPointer>
+        <ValueNode>this</ValueNode>
+      </LinkedListItems>
+    </Expand>
   </Type>
 
   <Type Name="LclVarDsc">

--- a/src/coreclr/jit/dataflow.h
+++ b/src/coreclr/jit/dataflow.h
@@ -51,15 +51,18 @@ void DataFlow::ForwardAnalysis(TCallback& callback)
         worklist.erase(worklist.begin());
 
         callback.StartMerge(block);
-        if (m_pCompiler->bbIsHandlerBeg(block))
+        bool isHandlerBegBlock = m_pCompiler->bbIsHandlerBeg(block);
+        if (isHandlerBegBlock)
         {
             EHblkDsc* ehDsc = m_pCompiler->ehGetBlockHndDsc(block);
             callback.MergeHandler(block, ehDsc->ebdTryBeg, ehDsc->ebdTryLast);
         }
-        else
+
+        flowList* preds = m_pCompiler->BlockPredsWithEH(block);
+        for (flowList* pred = preds; pred; pred = pred->flNext)
         {
-            flowList* preds = m_pCompiler->BlockPredsWithEH(block);
-            for (flowList* pred = preds; pred; pred = pred->flNext)
+            // For handler start block, also consider the block BBJ_CALLFINALLY as one of the pred.
+            if (!isHandlerBegBlock || pred->getBlock()->bbJumpKind == BBJ_CALLFINALLY)
             {
                 callback.Merge(block, pred->getBlock(), pred->flDupCount);
             }

--- a/src/coreclr/jit/dataflow.h
+++ b/src/coreclr/jit/dataflow.h
@@ -51,18 +51,15 @@ void DataFlow::ForwardAnalysis(TCallback& callback)
         worklist.erase(worklist.begin());
 
         callback.StartMerge(block);
-        bool isHandlerBegBlock = m_pCompiler->bbIsHandlerBeg(block);
-        if (isHandlerBegBlock)
+        if (m_pCompiler->bbIsHandlerBeg(block))
         {
             EHblkDsc* ehDsc = m_pCompiler->ehGetBlockHndDsc(block);
             callback.MergeHandler(block, ehDsc->ebdTryBeg, ehDsc->ebdTryLast);
         }
-
-        flowList* preds = m_pCompiler->BlockPredsWithEH(block);
-        for (flowList* pred = preds; pred; pred = pred->flNext)
+        else
         {
-            // For handler start block, also consider the block BBJ_CALLFINALLY as one of the pred.
-            if (!isHandlerBegBlock || pred->getBlock()->bbJumpKind == BBJ_CALLFINALLY)
+            flowList* preds = m_pCompiler->BlockPredsWithEH(block);
+            for (flowList* pred = preds; pred; pred = pred->flNext)
             {
                 callback.Merge(block, pred->getBlock(), pred->flDupCount);
             }

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -297,6 +297,13 @@ bool Compiler::optJumpThread(BasicBlock* const block, BasicBlock* const domBlock
     JITDUMP("Both successors of %sdom " FMT_BB " reach " FMT_BB " -- attempting jump threading\n", isIDom ? "i" : "",
             domBlock->bbNum, block->bbNum);
 
+    // If the block is the first block of try-region, then skip jump threading
+    if (bbIsTryBeg(block))
+    {
+        JITDUMP(FMT_BB " is first block of try-region; no threading\n");
+        return false;
+    }
+
     // Since flow is going to bypass block, make sure there
     // is nothing in block that can cause a side effect.
     //

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -300,7 +300,7 @@ bool Compiler::optJumpThread(BasicBlock* const block, BasicBlock* const domBlock
     // If the block is the first block of try-region, then skip jump threading
     if (bbIsTryBeg(block))
     {
-        JITDUMP(FMT_BB " is first block of try-region; no threading\n");
+        JITDUMP(FMT_BB " is first block of try-region; no threading\n", block->bbNum);
         return false;
     }
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_55131/Runtime_55131.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_55131/Runtime_55131.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+public class Runtime_55131
+{
+    // When merging the assertion props for the finally block, we should consider the assertions
+    // out of the BBJ_CALLFINALLY block. Otherwise, we could propagate the wrong assertions inside
+    // the finally block.
+    //
+    // Althogh there can be several ways to reproduce this problem, an easier way is to turn off
+    // finally cloning for below example.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool False() => false;
+
+    static ushort s_6;
+    static uint[] s_15 = new uint[] { 0 };
+    static bool s_19 = false;
+    private static int Main()
+    {
+        bool condition = False();
+        int result = 100;
+        if (condition)
+        {
+            result -= 1;
+        }
+
+        try
+        {
+            if (condition)
+            {
+                result -= 1;
+            }
+        }
+        finally
+        {
+            if (condition)
+            {
+                result -= 1;
+            }
+        }
+        return result;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_55131/Runtime_55131.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_55131/Runtime_55131.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <DebugType>None</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set DOTNET_JitEnableFinallyCloning=0
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export DOTNET_JitEnableFinallyCloning=0
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/160, we started considering only first and last block of try for calculating assertions of finally block. However, we should also consider the assertion out of CALLFINALLY block.

No asmdiffs.

Fixes: https://github.com/dotnet/runtime/issues/55131