### PR TITLE
Update comments on RequiresAssemblyFiles

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/RequiresAssemblyFilesAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/RequiresAssemblyFilesAttribute.cs
@@ -36,7 +36,7 @@ namespace System.Diagnostics.CodeAnalysis
         }
 
         /// <summary>
-        /// Gets or sets an optional message that contains information about the need for
+        /// Gets an optional message that contains information about the need for
         /// assembly files to be on disk.
         /// </summary>
         public string? Message { get; }


### PR DESCRIPTION
The setter of the Message property in RequiresAssemblyFiles was removed, updating the documentation to reflect that 