### PR TITLE
Remove unnecessary reflection in Environment.GetFolderPathCore.Unix.cs

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Environment.GetFolderPathCore.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.GetFolderPathCore.Unix.cs
@@ -14,8 +14,6 @@ namespace System
 {
     public static partial class Environment
     {
-        private static Func<string, object>? s_directoryCreateDirectory;
-
         private static string GetFolderPathCore(SpecialFolder folder, SpecialFolderOption option)
         {
             // Get the path for the SpecialFolder
@@ -40,16 +38,7 @@ namespace System
 
             Debug.Assert(option == SpecialFolderOption.Create);
 
-            Func<string, object>? createDirectory = Volatile.Read(ref s_directoryCreateDirectory);
-            if (createDirectory is null)
-            {
-                Type dirType = Type.GetType("System.IO.Directory, System.IO.FileSystem, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", throwOnError: true)!;
-                MethodInfo mi = dirType.GetMethod("CreateDirectory", BindingFlags.Public | BindingFlags.Static)!;
-                createDirectory = mi.CreateDelegate<Func<string, object>>();
-                Volatile.Write(ref s_directoryCreateDirectory, createDirectory);
-            }
-
-            createDirectory(path);
+            Directory.CreateDirectory(path);
 
             return path;
         }


### PR DESCRIPTION
System.IO.Directory was moved into CoreLib with https://github.com/dotnet/runtime/pull/53231 so we can call it directly now. Thanks to @andreakarasho for noticing this on Discord!