### PR TITLE
[sgen] Transition to GC Unsafe in mono_gc_wait_for_bridge_processing

### DIFF
--- a/src/mono/mono/metadata/sgen-bridge-internals.h
+++ b/src/mono/mono/metadata/sgen-bridge-internals.h
@@ -76,6 +76,7 @@ void sgen_set_bridge_implementation (const char *name);
 void sgen_bridge_set_dump_prefix (const char *prefix);
 void sgen_init_bridge (void);
 
+
 #endif
 
 #endif

--- a/src/mono/mono/metadata/sgen-bridge-internals.h
+++ b/src/mono/mono/metadata/sgen-bridge-internals.h
@@ -76,7 +76,6 @@ void sgen_set_bridge_implementation (const char *name);
 void sgen_bridge_set_dump_prefix (const char *prefix);
 void sgen_init_bridge (void);
 
-
 #endif
 
 #endif

--- a/src/mono/mono/metadata/sgen-bridge.c
+++ b/src/mono/mono/metadata/sgen-bridge.c
@@ -55,6 +55,14 @@ volatile gboolean mono_bridge_processing_in_progress = FALSE;
 void
 mono_gc_wait_for_bridge_processing (void)
 {
+	MONO_ENTER_GC_UNSAFE;
+	mono_gc_wait_for_bridge_processing_internal ();
+	MONO_EXIT_GC_UNSAFE;
+}
+
+void
+mono_gc_wait_for_bridge_processing_internal (void)
+{
 	if (!mono_bridge_processing_in_progress)
 		return;
 
@@ -63,6 +71,7 @@ mono_gc_wait_for_bridge_processing (void)
 	sgen_gc_lock ();
 	sgen_gc_unlock ();
 }
+
 
 /**
  * mono_gc_register_bridge_callbacks:
@@ -735,6 +744,11 @@ volatile gboolean mono_bridge_processing_in_progress = FALSE;
 
 void
 mono_gc_wait_for_bridge_processing (void)
+{
+}
+
+void
+mono_gc_wait_for_bridge_processing_internal (void)
 {
 }
 

--- a/src/mono/mono/metadata/sgen-bridge.c
+++ b/src/mono/mono/metadata/sgen-bridge.c
@@ -72,7 +72,6 @@ mono_gc_wait_for_bridge_processing_internal (void)
 	sgen_gc_unlock ();
 }
 
-
 /**
  * mono_gc_register_bridge_callbacks:
  */

--- a/src/mono/mono/metadata/sgen-bridge.h
+++ b/src/mono/mono/metadata/sgen-bridge.h
@@ -103,7 +103,7 @@ typedef struct {
  */
 MONO_API void mono_gc_register_bridge_callbacks (MonoGCBridgeCallbacks *callbacks);
 
-MONO_API void mono_gc_wait_for_bridge_processing (void);
+MONO_API MONO_RT_EXTERNAL_ONLY void mono_gc_wait_for_bridge_processing (void);
 
 MONO_END_DECLS
 

--- a/src/mono/mono/metadata/sgen-client-mono.h
+++ b/src/mono/mono/metadata/sgen-client-mono.h
@@ -250,10 +250,13 @@ sgen_client_bridge_processing_stw_step (void)
 	sgen_bridge_processing_stw_step ();
 }
 
+void
+mono_gc_wait_for_bridge_processing_internal (void);
+
 static void G_GNUC_UNUSED
 sgen_client_bridge_wait_for_processing (void)
 {
-	mono_gc_wait_for_bridge_processing ();
+	mono_gc_wait_for_bridge_processing_internal ();
 }
 
 static void G_GNUC_UNUSED

--- a/src/mono/mono/metadata/sgen-mono.c
+++ b/src/mono/mono/metadata/sgen-mono.c
@@ -2848,7 +2848,7 @@ sgen_client_ensure_weak_gchandles_accessible (void)
 	 * should wait for bridge processing but would fail to do so.
 	 */
 	if (G_UNLIKELY (mono_bridge_processing_in_progress))
-		mono_gc_wait_for_bridge_processing ();
+		mono_gc_wait_for_bridge_processing_internal ();
 }
 
 void*


### PR DESCRIPTION
Mark it as an external only API.  In the runtime, use `mono_gc_wait_for_bridge_processing_internal`