### PR TITLE
Fix nested calls to Assembly Load Start tracing

### DIFF
--- a/src/coreclr/binder/bindertracing.cpp
+++ b/src/coreclr/binder/bindertracing.cpp
@@ -251,7 +251,7 @@ namespace BinderTracing
 
         // ActivityTracker or EventSource may have triggered the system satellite load.
         // Don't track system satellite binding to avoid potential infinite recursion.
-        m_ignoreBind = m_bindRequest.AssemblySpec->IsCoreLibSatellite() || t_AssemblyLoadStartInProgress;
+        m_ignoreBind = m_bindRequest.AssemblySpec->IsCoreLibSatellite() || (t_AssemblyLoadStartInProgress && m_bindRequest.AssemblySpec->IsCoreLib());
         m_checkedIgnoreBind = true;
         return m_ignoreBind;
     }

--- a/src/coreclr/binder/bindertracing.cpp
+++ b/src/coreclr/binder/bindertracing.cpp
@@ -249,9 +249,9 @@ namespace BinderTracing
         if (m_checkedIgnoreBind)
             return m_ignoreBind;
 
-        // ActivityTracker or EventSource may have triggered the system satellite load.
-        // Don't track system satellite binding to avoid potential infinite recursion.
-        m_ignoreBind = m_bindRequest.AssemblySpec->IsCoreLibSatellite() || (t_AssemblyLoadStartInProgress && m_bindRequest.AssemblySpec->IsCoreLib());
+        // ActivityTracker or EventSource may have triggered the system satellite load, or load of System.Private.CoreLib
+        // Don't track such bindings to avoid potential infinite recursion.
+        m_ignoreBind = t_AssemblyLoadStartInProgress && (m_bindRequest.AssemblySpec->IsCoreLib() || m_bindRequest.AssemblySpec->IsCoreLibSatellite());
         m_checkedIgnoreBind = true;
         return m_ignoreBind;
     }

--- a/src/coreclr/binder/bindertracing.cpp
+++ b/src/coreclr/binder/bindertracing.cpp
@@ -196,6 +196,8 @@ bool BinderTracing::IsEnabled()
 
 namespace BinderTracing
 {
+    static thread_local bool t_AssemblyLoadStartInProgress = false;
+
     AssemblyBindOperation::AssemblyBindOperation(AssemblySpec *assemblySpec, const WCHAR *assemblyPath)
         : m_bindRequest { assemblySpec, nullptr, assemblyPath }
         , m_populatedBindRequest { false }
@@ -209,6 +211,7 @@ namespace BinderTracing
         if (!BinderTracing::IsEnabled() || ShouldIgnoreBind())
             return;
 
+        t_AssemblyLoadStartInProgress = true;
         PopulateBindRequest(m_bindRequest);
         m_populatedBindRequest = true;
         FireAssemblyLoadStart(m_bindRequest);
@@ -218,6 +221,8 @@ namespace BinderTracing
     {
         if (BinderTracing::IsEnabled() && !ShouldIgnoreBind())
         {
+            t_AssemblyLoadStartInProgress = false;
+
             // Make sure the bind request is populated. Tracing may have been enabled mid-bind.
             if (!m_populatedBindRequest)
                 PopulateBindRequest(m_bindRequest);
@@ -246,7 +251,7 @@ namespace BinderTracing
 
         // ActivityTracker or EventSource may have triggered the system satellite load.
         // Don't track system satellite binding to avoid potential infinite recursion.
-        m_ignoreBind = m_bindRequest.AssemblySpec->IsCoreLibSatellite();
+        m_ignoreBind = m_bindRequest.AssemblySpec->IsCoreLibSatellite() || t_AssemblyLoadStartInProgress;
         m_checkedIgnoreBind = true;
         return m_ignoreBind;
     }

--- a/src/tests/tracing/eventpipe/complus_config/name_config_with_pid.cs
+++ b/src/tests/tracing/eventpipe/complus_config/name_config_with_pid.cs
@@ -38,7 +38,8 @@ class NameConfigWithPid
                 return 100;
             }
 
-            string corerun = Path.Combine(Environment.GetEnvironmentVariable("CORE_ROOT"), "corerun");
+            string coreRoot = Environment.GetEnvironmentVariable("CORE_ROOT");
+            string corerun = Path.Combine(coreRoot, "corerun");
             if (OperatingSystem.IsWindows())
                 corerun = corerun + ".exe";
 
@@ -56,13 +57,21 @@ class NameConfigWithPid
             process.StartInfo.Environment.Add("COMPlus_EnableEventPipe", "1");
             process.StartInfo.Environment.Add("COMPlus_EventPipeConfig", "Microsoft-Windows-DotNETRuntime:4c14fccbd:4");
             process.StartInfo.Environment.Add("COMPlus_EventPipeOutputPath", outputPathPattern);
+            process.StartInfo.Environment.Add("CORE_ROOT", coreRoot);
 
             Console.WriteLine($"Starting process '{process.StartInfo.FileName}' '{process.StartInfo.Arguments}'");
             Console.Out.Flush();
             process.Start();
 
-            process.StandardError.ReadLine();
-            Console.WriteLine($"After readline'");
+            string readFromTargetProcess = process.StandardError.ReadLine(); 
+            Console.WriteLine($"Readline '{readFromTargetProcess}'");
+            if (readFromTargetProcess != "WaitingForInput in ErrorStream")
+            {
+                Console.WriteLine($"Child process terminating");
+                Thread.Sleep(10000);
+                process.Kill();
+                Console.WriteLine($"Child process terminated");
+            }
             Console.Out.Flush();
             uint pid = (uint)process.Id;
             string expectedPath = outputPathPattern.Replace("{pid}", pid.ToString());
@@ -70,6 +79,8 @@ class NameConfigWithPid
             process.StandardInput.WriteLine("input");
             process.StandardInput.Flush();
             process.WaitForExit();
+
+            Console.WriteLine($"StdErr ReadToEnd from child process '{process.StandardError.ReadToEnd()}'");
             if (!File.Exists(expectedPath))
             {
                 Console.WriteLine($"{expectedPath} not found");

--- a/src/tests/tracing/eventpipe/complus_config/name_config_with_pid.cs
+++ b/src/tests/tracing/eventpipe/complus_config/name_config_with_pid.cs
@@ -11,10 +11,17 @@ class NameConfigWithPid
 {
     static int Main(string[] args)
     {
+        if (args.Length == 0)
+            Console.WriteLine("No Args");
+        else
+            Console.WriteLine($"args[0] = `{args[0]}`");
+
         if (args.Length > 0 && args[0] == "waitforinput")
         {
             Console.Error.WriteLine("WaitingForInput in ErrorStream");
             Console.WriteLine("WaitingForInput");
+            Console.Error.Flush();
+            Console.Out.Flush();
             Console.ReadLine();
             return 100;
         }
@@ -50,13 +57,18 @@ class NameConfigWithPid
             process.StartInfo.Environment.Add("COMPlus_EventPipeConfig", "Microsoft-Windows-DotNETRuntime:4c14fccbd:4");
             process.StartInfo.Environment.Add("COMPlus_EventPipeOutputPath", outputPathPattern);
 
+            Console.WriteLine($"Starting process '{process.StartInfo.FileName}' '{process.StartInfo.Arguments}'");
+            Console.Out.Flush();
             process.Start();
 
             process.StandardError.ReadLine();
+            Console.WriteLine($"After readline'");
+            Console.Out.Flush();
             uint pid = (uint)process.Id;
             string expectedPath = outputPathPattern.Replace("{pid}", pid.ToString());
 
             process.StandardInput.WriteLine("input");
+            process.StandardInput.Flush();
             process.WaitForExit();
             if (!File.Exists(expectedPath))
             {


### PR DESCRIPTION
The name_with_pid test ends up testing the behavior of event tracing in the presence of composite images.

In the presence of a composite image, it might happen attempting to send trace data may force an attempt to load System.Private.CoreLib thus causing an stackoverflow as attempting to report the load of System.Private.CoreLib will trigger a load of System.Private.CoreLib, etc. This fix steps around the issue by using a thread local variable to skip subsequent attempts to report the load of System.Private.CoreLib.

Fixes #55786