### PR TITLE
Minor QUIC API changes

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs
@@ -154,12 +154,6 @@ namespace System.Net.Test.Common
             await _stream.WriteAsync(framePayload).ConfigureAwait(false);
         }
 
-        public async Task ShutdownSendAsync()
-        {
-            _stream.Shutdown();
-            await _stream.ShutdownWriteCompleted().ConfigureAwait(false);
-        }
-
         static int EncodeHttpInteger(long longToEncode, Span<byte> buffer)
         {
             Debug.Assert(longToEncode >= 0);
@@ -273,7 +267,7 @@ namespace System.Net.Test.Common
 
             if (isFinal)
             {
-                await ShutdownSendAsync().ConfigureAwait(false);
+                _stream.Shutdown();
                 await _stream.ShutdownCompleted().ConfigureAwait(false);
                 Dispose();
             }

--- a/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs
@@ -267,7 +267,7 @@ namespace System.Net.Test.Common
 
             if (isFinal)
             {
-                _stream.Shutdown();
+                _stream.CompleteWrites();
                 await _stream.ShutdownCompleted().ConfigureAwait(false);
                 Dispose();
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -154,7 +154,7 @@ namespace System.Net.Http
                     }
                     else
                     {
-                        _stream.Shutdown();
+                        _stream.CompleteWrites();
                     }
                 }
 
@@ -374,7 +374,7 @@ namespace System.Net.Http
                 _sendBuffer.Discard(_sendBuffer.ActiveLength);
             }
 
-            _stream.Shutdown();
+            _stream.CompleteWrites();
         }
 
         private async ValueTask WriteRequestContentAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)

--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
@@ -104,7 +104,6 @@ namespace System.Net.Quic
         public override void SetLength(long value) { }
         public void Shutdown() { }
         public System.Threading.Tasks.ValueTask ShutdownCompleted(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public System.Threading.Tasks.ValueTask ShutdownWriteCompleted(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override void Write(byte[] buffer, int offset, int count) { }
         public override void Write(System.ReadOnlySpan<byte> buffer) { }
         public System.Threading.Tasks.ValueTask WriteAsync(System.Buffers.ReadOnlySequence<byte> buffers, bool endStream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }

--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
@@ -102,7 +102,7 @@ namespace System.Net.Quic
         public override System.Threading.Tasks.ValueTask<int> ReadAsync(System.Memory<byte> buffer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override long Seek(long offset, System.IO.SeekOrigin origin) { throw null; }
         public override void SetLength(long value) { }
-        public void Shutdown() { }
+        public void CompleteWrites() { }
         public System.Threading.Tasks.ValueTask ShutdownCompleted(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override void Write(byte[] buffer, int offset, int count) { }
         public override void Write(System.ReadOnlySpan<byte> buffer) { }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/Mock/MockStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/Mock/MockStream.cs
@@ -210,7 +210,7 @@ namespace System.Net.Quic.Implementations.Mock
             return default;
         }
 
-        internal override void Shutdown()
+        internal override void CompleteWrites()
         {
             CheckDisposed();
 
@@ -239,7 +239,7 @@ namespace System.Net.Quic.Implementations.Mock
         {
             if (!_disposed)
             {
-                Shutdown();
+                CompleteWrites();
 
                 _disposed = true;
             }
@@ -249,7 +249,7 @@ namespace System.Net.Quic.Implementations.Mock
         {
             if (!_disposed)
             {
-                Shutdown();
+                CompleteWrites();
 
                 _disposed = true;
             }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/Mock/MockStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/Mock/MockStream.cs
@@ -203,14 +203,6 @@ namespace System.Net.Quic.Implementations.Mock
             WriteStreamBuffer?.EndWrite();
         }
 
-        internal override ValueTask ShutdownWriteCompleted(CancellationToken cancellationToken = default)
-        {
-            CheckDisposed();
-
-            return default;
-        }
-
-
         internal override ValueTask ShutdownCompleted(CancellationToken cancellationToken = default)
         {
             CheckDisposed();

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -567,7 +567,7 @@ namespace System.Net.Quic.Implementations.MsQuic
             await _state.ShutdownCompletionSource.Task.ConfigureAwait(false);
         }
 
-        internal override void Shutdown()
+        internal override void CompleteWrites()
         {
             ThrowIfDisposed();
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/QuicStreamProvider.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/QuicStreamProvider.cs
@@ -37,8 +37,6 @@ namespace System.Net.Quic.Implementations
 
         internal abstract ValueTask WriteAsync(ReadOnlyMemory<ReadOnlyMemory<byte>> buffers, bool endStream, CancellationToken cancellationToken = default);
 
-        internal abstract ValueTask ShutdownWriteCompleted(CancellationToken cancellationToken = default);
-
         internal abstract ValueTask ShutdownCompleted(CancellationToken cancellationToken = default);
 
         internal abstract void Shutdown();

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/QuicStreamProvider.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/QuicStreamProvider.cs
@@ -39,7 +39,7 @@ namespace System.Net.Quic.Implementations
 
         internal abstract ValueTask ShutdownCompleted(CancellationToken cancellationToken = default);
 
-        internal abstract void Shutdown();
+        internal abstract void CompleteWrites();
 
         internal abstract void Flush();
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -99,8 +99,6 @@ namespace System.Net.Quic
 
         public ValueTask WriteAsync(ReadOnlyMemory<ReadOnlyMemory<byte>> buffers, bool endStream, CancellationToken cancellationToken = default) => _provider.WriteAsync(buffers, endStream, cancellationToken);
 
-        public ValueTask ShutdownWriteCompleted(CancellationToken cancellationToken = default) => _provider.ShutdownWriteCompleted(cancellationToken);
-
         public ValueTask ShutdownCompleted(CancellationToken cancellationToken = default) => _provider.ShutdownCompleted(cancellationToken);
 
         public void Shutdown() => _provider.Shutdown();

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -101,7 +101,7 @@ namespace System.Net.Quic
 
         public ValueTask ShutdownCompleted(CancellationToken cancellationToken = default) => _provider.ShutdownCompleted(cancellationToken);
 
-        public void Shutdown() => _provider.Shutdown();
+        public void CompleteWrites() => _provider.CompleteWrites();
 
         protected override void Dispose(bool disposing)
         {

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -280,7 +280,7 @@ namespace System.Net.Quic.Tests
                         }
                     }
 
-                    stream.Shutdown();
+                    stream.CompleteWrites();
                     await stream.ShutdownCompleted();
                 },
                 async serverConnection =>
@@ -298,7 +298,7 @@ namespace System.Net.Quic.Tests
                     int expectedTotalBytes = writes.SelectMany(x => x).Sum();
                     Assert.Equal(expectedTotalBytes, totalBytes);
 
-                    stream.Shutdown();
+                    stream.CompleteWrites();
                     await stream.ShutdownCompleted();
                 });
         }

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
@@ -445,7 +445,7 @@ namespace System.Net.Quic.Tests
                 {
                     await clientStream.WriteAsync(new byte[1]);
                     sem.Release();
-                    clientStream.Shutdown();
+                    clientStream.CompleteWrites();
                     sem.Release();
                 },
                 async serverStream =>

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
@@ -157,7 +157,7 @@ namespace System.Net.Quic.Tests
 
                     await clientFunction(stream);
 
-                    stream.Shutdown();
+                    stream.CompleteWrites();
                     await stream.ShutdownCompleted();
                 },
                 serverFunction: async connection =>
@@ -167,7 +167,7 @@ namespace System.Net.Quic.Tests
 
                     await serverFunction(stream);
 
-                    stream.Shutdown();
+                    stream.CompleteWrites();
                     await stream.ShutdownCompleted();
                 },
                 iterations,


### PR DESCRIPTION
Remove `ShutdownWriteCompleted()`
Rename `Shutdown()` to `CompleteWrites()`