### PR TITLE
Streamline rent/return on ArrayPool

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Utilities.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Utilities.cs
@@ -54,14 +54,5 @@ namespace System.Buffers
 
             return MemoryPressure.Low;
         }
-
-        internal static bool TrimBuffers { get; } =
-#if CORECLR
-            // Environment uses ArrayPool, so we have to hit the API directly.
-            CLRConfig.GetBoolValueWithFallbacks("System.Buffers.ArrayPool.TrimShared", "DOTNET_SYSTEM_BUFFERS_ARRAYPOOL_TRIMSHARED", defaultValue: true);
-#else
-            // P/Invokes are different for CoreCLR/RT- for RT we'll not allow enabling/disabling for now.
-            true;
-#endif
     }
 }


### PR DESCRIPTION
A variety of tweaks to reduce overheads:
- Stop storing and using a _bucketArraySizes.  It's cheaper to recompute the shift on each use than it is to index into the array (with a bounds check).  Plus less memory.
- The 99% case is renting a positive length for pooled array sizes (especially now that we've bumped the limit up to a gig).  Move the checks for lengths <= 0 to after the check for whether the length is poolable.
- Move arrays/counts into locals to enable the JIT to eliminate some bounds checks.
- Use ThrowHelpers where we already have them
- Move non-generic helpers out of generic class into Utilities
- Consolidate buffer allocation in Rent to a single line
- Reorganize TLS checks to be as early as possible
- Use FastMod instead of % in per-core stacks

|       Method |         Toolchain |        Mean |    Error |   StdDev | Ratio | RatioSD | Code Size |
|------------- |------------------ |------------:|---------:|---------:|------:|--------:|----------:|
|      PopPush | \main\corerun.exe |    17.58 ns | 0.357 ns | 0.334 ns |  1.00 |    0.00 |   2,221 B |
|      PopPush |   \pr\corerun.exe |    16.64 ns | 0.021 ns | 0.019 ns |  0.95 |    0.02 |   1,980 B |
|              |                   |             |          |          |       |         |           |
| PopPushMulti | \main\corerun.exe | 1,127.07 ns | 7.303 ns | 6.098 ns |  1.00 |    0.00 |   2,167 B |
| PopPushMulti |   \pr\corerun.exe | 1,082.29 ns | 3.208 ns | 2.679 ns |  0.96 |    0.01 |   1,875 B |

