### PR TITLE
Revert "Handle getting the address of an RVA static correctly in a composite image (#55301)"

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -12226,12 +12226,10 @@ BYTE* emitter::emitOutputRR(BYTE* dst, instrDesc* id)
                         regMaskTP regMask;
                         regMask = genRegMask(reg1) | genRegMask(reg2);
 
-// Assert disabled as requested in PR 55301. A use of the Unsafe api
-// which produces correct code, but isn't handled correctly here.
-// r1/r2 could have been a GCREF as GCREF + int=BYREF
-//                            or BYREF+/-int=BYREF
-// assert(((regMask & emitThisGCrefRegs) && (ins == INS_add)) ||
-//       ((regMask & emitThisByrefRegs) && (ins == INS_add || ins == INS_sub)));
+                        // r1/r2 could have been a GCREF as GCREF + int=BYREF
+                        //                            or BYREF+/-int=BYREF
+                        assert(((regMask & emitThisGCrefRegs) && (ins == INS_add)) ||
+                               ((regMask & emitThisByrefRegs) && (ins == INS_add || ins == INS_sub)));
 #endif
                         // Mark r1 as holding a byref
                         emitGCregLiveUpd(GCT_BYREF, reg1, dst);

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -64,14 +64,6 @@ namespace ILCompiler.DependencyAnalysis
                     new ReadyToRunInstructionSetSupportSignature(key));
             });
 
-            _precodeFieldAddressCache = new NodeCache<FieldDesc, ISymbolNode>(key =>
-            {
-                return new PrecodeHelperImport(
-                    _codegenNodeFactory,
-                    new FieldFixupSignature(ReadyToRunFixupKind.FieldAddress, key, _codegenNodeFactory)
-                );
-            });
-
             _fieldAddressCache = new NodeCache<FieldDesc, ISymbolNode>(key =>
             {
                 return new DelayLoadHelperImport(
@@ -404,13 +396,6 @@ namespace ILCompiler.DependencyAnalysis
         public ISymbolNode FieldAddress(FieldDesc fieldDesc)
         {
             return _fieldAddressCache.GetOrAdd(fieldDesc);
-        }
-
-        private NodeCache<FieldDesc, ISymbolNode> _precodeFieldAddressCache;
-
-        public ISymbolNode PrecodeFieldAddress(FieldDesc fieldDesc)
-        {
-            return _precodeFieldAddressCache.GetOrAdd(fieldDesc);
         }
 
         private NodeCache<FieldDesc, ISymbolNode> _fieldOffsetCache;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -641,7 +641,7 @@ namespace ILCompiler
             }
         }
 
-        public ISymbolNode GetFieldRvaData(FieldDesc field) => NodeFactory.CompilationModuleGroup.IsCompositeBuildMode ? SymbolNodeFactory.PrecodeFieldAddress(field) : NodeFactory.CopiedFieldRva(field);
+        public ISymbolNode GetFieldRvaData(FieldDesc field) => NodeFactory.CopiedFieldRva(field);
 
         public override void Dispose()
         {

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -14034,21 +14034,6 @@ BOOL LoadDynamicInfoEntry(Module *currentModule,
         break;
 #endif // PROFILING_SUPPORTED
 
-    case ENCODE_FIELD_ADDRESS:
-        {
-            FieldDesc *pField = ZapSig::DecodeField(currentModule, pInfoModule, pBlob);
-
-            pField->GetEnclosingMethodTable()->CheckRestore();
-
-            // We can only take address of RVA field here as we don't handle scenarios where the static variable may move
-            // Also, this cannot be used with a ZapImage as it relies on a separate signatures block as an RVA static
-            // address may be unaligned which would interfere with the tagged pointer approach.
-            _ASSERTE(currentModule->IsReadyToRun());
-            _ASSERTE(pField->IsRVA());
-            result = (size_t)pField->GetStaticAddressHandle(NULL);
-        }
-        break;
-
     case ENCODE_STATIC_FIELD_ADDRESS:
         {
             FieldDesc *pField = ZapSig::DecodeField(currentModule, pInfoModule, pBlob);


### PR DESCRIPTION
This reverts commit e3d319bb727efb82f1ab4236f6f58a5dfffcfc5c.
It breaks the crossgen2 outerloop runs