### PR TITLE
Fix crash with unmapped shuffle thunk stub

### DIFF
--- a/src/coreclr/vm/dynamicmethod.cpp
+++ b/src/coreclr/vm/dynamicmethod.cpp
@@ -380,7 +380,7 @@ HostCodeHeap::~HostCodeHeap()
         delete[] m_pHeapList->pHdrMap;
 
     if (m_pBaseAddr)
-        ClrVirtualFree(m_pBaseAddr, 0, MEM_RELEASE);
+        ExecutableAllocator::Instance()->Release(m_pBaseAddr);
     LOG((LF_BCL, LL_INFO10, "Level1 - CodeHeap destroyed {0x%p}\n", this));
 }
 

--- a/src/coreclr/vm/loaderallocator.cpp
+++ b/src/coreclr/vm/loaderallocator.cpp
@@ -1414,7 +1414,7 @@ void LoaderAllocator::Terminate()
     // This was the block reserved by BaseDomain::Init for the loaderheaps.
     if (m_InitialReservedMemForLoaderHeaps)
     {
-        ClrVirtualFree (m_InitialReservedMemForLoaderHeaps, 0, MEM_RELEASE);
+        ExecutableAllocator::Instance()->Release(m_InitialReservedMemForLoaderHeaps);
         m_InitialReservedMemForLoaderHeaps=NULL;
     }
 
@@ -1687,7 +1687,11 @@ void AssemblyLoaderAllocator::Init(AppDomain* pAppDomain)
     LoaderAllocator::Init((BaseDomain *)pAppDomain);
     if (IsCollectible())
     {
-        m_pShuffleThunkCache = new ShuffleThunkCache(m_pStubHeap);
+        // TODO: the ShuffleThunkCache should really be using the m_pStubHeap, however the unloadability support
+        // doesn't track the stubs or the related delegate classes and so we get crashes when a stub is used after
+        // the AssemblyLoaderAllocator is gone (the stub memory is unmapped).
+        // https://github.com/dotnet/runtime/issues/55697 tracks this issue.
+        m_pShuffleThunkCache = new ShuffleThunkCache(SystemDomain::GetGlobalLoaderAllocator()->GetExecutableHeap());
     }
 }
 


### PR DESCRIPTION
This change fixes an intermittent issue that was showing up in
the System.Linq.Expressions.Tests suite. When the delegate class
was in a collectible ALC, some of the stubs were being used even
after the underlying loader allocator was deleted, thus the memory
the stubs occupied was already unmapped.

Before my recent W^X change, the stubs were always being allocated
from an executable allocator / executable heap in the global loader
allocator due to a bug in the AssemblyLoaderAllocator::SetCollectible
and AssemblyLoaderAllocator::Init ordering (the SetCollectible
was being called before the Init, so the m_pStubHeap was not yet
set and the ShuffleThunkCache was being passed NULL as the heap
pointer. The cache handles that case as a request to allocate from
global executable heap.

In this fix, I've changed the AssemblyLoaderAllocator::Init to pass
the SystemDomain::GetGlobalLoaderAllocator()->GetExecutableHeap()
as the heap to the ShuffleThunkCache constructor. It is a workaround
until the actual issue with stubs outliving the delegate classes
is understood and fixed.

Besides the fix, this change also fixes two unrelated issues that
would only possibly cause trouble when the W^X is enabled. There
were two places where memory was being reserved by the new
ExecutableAllocator, but cleaned up using the ClrVirtualFree.

Close #55536