### PR TITLE
Skip System.IO.IsolatedStorage.Tests.HelperTests.GetDataDirectory(scope: Machine) on Android

### DIFF
--- a/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/HelperTests.cs
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/HelperTests.cs
@@ -41,7 +41,7 @@ namespace System.IO.IsolatedStorage.Tests
         {
             // Machine scope is behind a policy that isn't enabled by default
             // https://github.com/dotnet/runtime/issues/21742
-            if (scope == IsolatedStorageScope.Machine && PlatformDetection.IsInAppContainer)
+            if (scope == IsolatedStorageScope.Machine && (PlatformDetection.IsInAppContainer || PlatformDetection.IsAndroid)) 
                 return;
 
             string path = Helper.GetDataDirectory(scope);

--- a/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/HelperTests.cs
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/HelperTests.cs
@@ -41,6 +41,7 @@ namespace System.IO.IsolatedStorage.Tests
         {
             // Machine scope is behind a policy that isn't enabled by default
             // https://github.com/dotnet/runtime/issues/21742
+            // It's also disabled on Android, see https://github.com/dotnet/runtime/issues/55693
             if (scope == IsolatedStorageScope.Machine && (PlatformDetection.IsInAppContainer || PlatformDetection.IsAndroid)) 
                 return;
 


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/55693