### PR TITLE
[android][debugger] Implement support to debug after hot reload.

### DIFF
--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -19,6 +19,7 @@
 #include "mono/utils/mono-lazy-init.h"
 #include "mono/utils/mono-logger-internals.h"
 #include "mono/utils/mono-path.h"
+#include "mono/metadata/mono-debug.h"
 
 
 #include <mono/component/hot_reload.h>
@@ -322,12 +323,20 @@ static DeltaInfo*
 delta_info_init (MonoImage *image_dmeta, MonoImage *image_base, BaselineInfo *base_info, uint32_t generation);
 
 static void
+free_ppdb_entry (gpointer key, gpointer val, gpointer user_data)
+{
+	g_free (val);
+}
+
+static void
 delta_info_destroy (DeltaInfo *dinfo)
 {
 	if (dinfo->method_table_update)
 		g_hash_table_destroy (dinfo->method_table_update);
-	if (dinfo->method_ppdb_table_update)
+	if (dinfo->method_ppdb_table_update) {
+		g_hash_table_foreach (dinfo->method_ppdb_table_update, free_ppdb_entry, NULL);
 		g_hash_table_destroy (dinfo->method_ppdb_table_update);
+	}
 	g_free (dinfo);
 }
 
@@ -1182,7 +1191,7 @@ apply_enclog_pass1 (MonoImage *image_base, MonoImage *image_dmeta, gconstpointer
 }
 
 static void
-set_update_method (MonoImage *image_base, BaselineInfo *base_info, uint32_t generation, MonoImage *image_dmeta, DeltaInfo *delta_info, uint32_t token_index, const char* il_address, const char* pdb_address)
+set_update_method (MonoImage *image_base, BaselineInfo *base_info, uint32_t generation, MonoImage *image_dmeta, DeltaInfo *delta_info, uint32_t token_index, const char* il_address, MonoDebugInformationEnc* pdb_address)
 {
 	mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_METADATA_UPDATE, "setting method 0x%08x in g=%d IL=%p", token_index, generation, (void*)il_address);
 	/* FIXME: this is a race if other threads are doing a lookup. */
@@ -1191,7 +1200,7 @@ set_update_method (MonoImage *image_base, BaselineInfo *base_info, uint32_t gene
 	g_hash_table_insert (delta_info->method_ppdb_table_update, GUINT_TO_POINTER (token_index), (gpointer) pdb_address);
 }
 
-static const char *
+static MonoDebugInformationEnc *
 hot_reload_get_method_debug_information (MonoImage *image_dppdb, int idx)
 {
 	if (!image_dppdb)
@@ -1204,21 +1213,15 @@ hot_reload_get_method_debug_information (MonoImage *image_dppdb, int idx)
 		mono_metadata_decode_row (table_encmap, i, cols, MONO_ENCMAP_SIZE);
 		int map_token = cols [MONO_ENCMAP_TOKEN];
 		int token_table = mono_metadata_token_table (map_token);
-		if (token_table != MONO_TABLE_METHODBODY)
-			continue;
-		int token_index = mono_metadata_token_index (map_token);
-		if (token_index == idx)
-		{
-			guint32 cols [MONO_METHODBODY_SIZE];
-			MonoTableInfo *methodbody_table = &image_dppdb->tables [MONO_TABLE_METHODBODY];
-			mono_metadata_decode_row (methodbody_table, i, cols, MONO_METHODBODY_SIZE);
-			if (!cols [MONO_METHODBODY_SEQ_POINTS])
-				return NULL;
-
-			const char *ptr = mono_metadata_blob_heap (image_dppdb, cols [MONO_METHODBODY_SEQ_POINTS]);
-			return ptr;
+		if (token_table == MONO_TABLE_METHODBODY) {
+			int token_index = mono_metadata_token_index (map_token);
+			if (token_index == idx)	{
+				MonoDebugInformationEnc *encDebugInfo = g_new0 (MonoDebugInformationEnc, 1);
+				encDebugInfo->idx = i;
+				encDebugInfo->image = image_dppdb;				
+				return encDebugInfo;
+			}
 		}
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "pdb encmap i=%d: token=0x%08x (table=%s)", i, map_token, mono_meta_table_name (token_table));
 	}
 	return NULL;
 }
@@ -1304,7 +1307,7 @@ apply_enclog_pass2 (MonoImage *image_base, BaselineInfo *base_info, uint32_t gen
 			int rva = mono_metadata_decode_row_col (&image_dmeta->tables [MONO_TABLE_METHOD], mapped_token - 1, MONO_METHOD_RVA);
 			if (rva < dil_length) {
 				char *il_address = ((char *) dil_data) + rva;
-				const char *method_debug_information = hot_reload_get_method_debug_information (image_dppdb, token_index);
+				MonoDebugInformationEnc *method_debug_information = hot_reload_get_method_debug_information (image_dppdb, token_index);
 				set_update_method (image_base, base_info, generation, image_dmeta, delta_info, token_index, il_address, method_debug_information);
 			} else {
 				/* rva points probably into image_base IL stream. can this ever happen? */
@@ -1385,7 +1388,7 @@ hot_reload_apply_changes (MonoImage *image_base, gconstpointer dmeta_bytes, uint
 	MonoImage *image_dpdb = NULL;
 	if (dpdb_length > 0)
 	{
-		MonoImage *image_dpdb = image_open_dmeta_from_data (image_base, generation, dpdb_bytes_orig, dpdb_length);
+		image_dpdb = image_open_dmeta_from_data (image_base, generation, dpdb_bytes_orig, dpdb_length);
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "pdb image string size: 0x%08x", image_dpdb->heap_strings.size);
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "pdb image user string size: 0x%08x", image_dpdb->heap_us.size);
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "pdb image blob heap addr: %p", image_dpdb->heap_blob.data);

--- a/src/mono/mono/metadata/debug-mono-ppdb.h
+++ b/src/mono/mono/metadata/debug-mono-ppdb.h
@@ -32,11 +32,14 @@ mono_ppdb_lookup_location (MonoDebugMethodInfo *minfo, uint32_t offset);
 void
 mono_ppdb_get_seq_points (MonoDebugMethodInfo *minfo, char **source_file, GPtrArray **source_file_list, int **source_files, MonoSymSeqPoint **seq_points, int *n_seq_points);
 
-void 
-mono_ppdb_get_seq_points_enc (const char* ptr, MonoSymSeqPoint **seq_points, int *n_seq_points);
+gboolean 
+mono_ppdb_get_seq_points_enc (MonoImage *image, int idx, MonoSymSeqPoint **seq_points, int *n_seq_points);
 
 MonoDebugLocalsInfo*
 mono_ppdb_lookup_locals (MonoDebugMethodInfo *minfo);
+
+MonoDebugLocalsInfo*
+mono_ppdb_lookup_locals_enc (MonoImage *image, int method_idx);
 
 MonoDebugMethodAsyncInfo*
 mono_ppdb_lookup_method_async_debug_info (MonoDebugMethodInfo *minfo);

--- a/src/mono/mono/metadata/mono-debug.c
+++ b/src/mono/mono/metadata/mono-debug.c
@@ -860,6 +860,18 @@ mono_debug_lookup_locals (MonoMethod *method, mono_bool ignore_pdb)
 {
 	MonoDebugMethodInfo *minfo;
 	MonoDebugLocalsInfo *res;
+	
+	MonoImage* img = m_class_get_image (method->klass);
+	if (img->has_updates) {
+		int idx = mono_metadata_token_index (method->token);
+		MonoDebugInformationEnc *mdie = (MonoDebugInformationEnc *) mono_metadata_update_get_updated_method_ppdb (img, idx);
+		if (mdie != NULL) {
+			int method_idx = mono_metadata_token_index (method->token);
+			res = mono_ppdb_lookup_locals_enc (mdie->image, mdie->idx);
+			if (res != NULL)
+				return res;
+		}
+	}
 
 	if (mono_debug_format == MONO_DEBUG_FORMAT_NONE)
 		return NULL;
@@ -1117,12 +1129,12 @@ void
 mono_debug_get_seq_points (MonoDebugMethodInfo *minfo, char **source_file, GPtrArray **source_file_list, int **source_files, MonoSymSeqPoint **seq_points, int *n_seq_points)
 {
 	MonoImage* img = m_class_get_image (minfo->method->klass);
-	if (img->has_updates) {
+	if (img->has_updates && !source_file_list) {
 		int idx = mono_metadata_token_index (minfo->method->token);
-		gpointer ptr = mono_metadata_update_get_updated_method_ppdb (img, idx);
-		if (ptr != NULL) {
-			mono_ppdb_get_seq_points_enc (ptr, seq_points, n_seq_points);
-			return;
+		MonoDebugInformationEnc *mdie = (MonoDebugInformationEnc *) mono_metadata_update_get_updated_method_ppdb (img, idx);
+		if (mdie != NULL) {
+			if (mono_ppdb_get_seq_points_enc (mdie->image, mdie->idx, seq_points, n_seq_points))
+				return;
 		}
 	} 
 	if (minfo->handle->ppdb)

--- a/src/mono/mono/metadata/mono-debug.c
+++ b/src/mono/mono/metadata/mono-debug.c
@@ -866,7 +866,6 @@ mono_debug_lookup_locals (MonoMethod *method, mono_bool ignore_pdb)
 		int idx = mono_metadata_token_index (method->token);
 		MonoDebugInformationEnc *mdie = (MonoDebugInformationEnc *) mono_metadata_update_get_updated_method_ppdb (img, idx);
 		if (mdie != NULL) {
-			int method_idx = mono_metadata_token_index (method->token);
 			res = mono_ppdb_lookup_locals_enc (mdie->image, mdie->idx);
 			if (res != NULL)
 				return res;

--- a/src/mono/mono/metadata/mono-debug.h
+++ b/src/mono/mono/metadata/mono-debug.h
@@ -33,6 +33,7 @@ typedef struct _MonoDebugMethodInfo		MonoDebugMethodInfo;
 typedef struct _MonoDebugLocalsInfo		MonoDebugLocalsInfo;
 typedef struct _MonoDebugMethodAsyncInfo	MonoDebugMethodAsyncInfo;
 typedef struct _MonoDebugSourceLocation		MonoDebugSourceLocation;
+typedef struct _MonoDebugInformationEnc		MonoDebugInformationEnc;
 
 typedef struct _MonoDebugList			MonoDebugList;
 
@@ -108,6 +109,12 @@ struct _MonoDebugSourceLocation {
 	char *source_file;
 	uint32_t row, column;
 	uint32_t il_offset;
+};
+
+
+struct _MonoDebugInformationEnc {
+	MonoImage *image;
+	int idx;
 };
 
 MONO_API mono_bool mono_debug_enabled (void);

--- a/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
@@ -336,11 +336,11 @@ namespace DebuggerTests
 
             var locals = await GetProperties(pause_location["callFrames"][0]["callFrameId"].Value<string>());
             CheckNumber(locals, "a", 10);
-            pause_location = await SendCommandAndCheck(JObject.FromObject(new { }), "Debugger.resume", "dotnet://ApplyUpdateReferencedAssembly.dll/MethodBody1.cs", 29, 12, "StaticMethod3");
+            pause_location = await SendCommandAndCheck(JObject.FromObject(new { }), "Debugger.resume", "dotnet://ApplyUpdateReferencedAssembly.dll/MethodBody1.cs", 30, 12, "StaticMethod3");
             locals = await GetProperties(pause_location["callFrames"][0]["callFrameId"].Value<string>());
             CheckNumber(locals, "b", 15);
 
-            pause_location = await SendCommandAndCheck(JObject.FromObject(new { }), "Debugger.resume", "dotnet://ApplyUpdateReferencedAssembly.dll/MethodBody1.cs", 29, 12, "StaticMethod3");
+            pause_location = await SendCommandAndCheck(JObject.FromObject(new { }), "Debugger.resume", "dotnet://ApplyUpdateReferencedAssembly.dll/MethodBody1.cs", 30, 12, "StaticMethod3");
             locals = await GetProperties(pause_location["callFrames"][0]["callFrameId"].Value<string>());
             CheckBool(locals, "c", true);
         }


### PR DESCRIPTION
- Fix wasm test.
- Change how seq_points were loaded after hotreload
- Use the same infrastructure to load locals variables

Related to this PR:
https://github.com/mono/debugger-libs/pull/344