### PR TITLE
[mono] Allow overriding GetCustomAttributesData routines

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -12,42 +12,8 @@ using Internal.Runtime.CompilerServices;
 
 namespace System.Reflection
 {
-    public class CustomAttributeData
+    public partial class CustomAttributeData
     {
-        #region Public Static Members
-        public static IList<CustomAttributeData> GetCustomAttributes(MemberInfo target)
-        {
-            if (target is null)
-                throw new ArgumentNullException(nameof(target));
-
-            return target.GetCustomAttributesData();
-        }
-
-        public static IList<CustomAttributeData> GetCustomAttributes(Module target)
-        {
-            if (target is null)
-                throw new ArgumentNullException(nameof(target));
-
-            return target.GetCustomAttributesData();
-        }
-
-        public static IList<CustomAttributeData> GetCustomAttributes(Assembly target)
-        {
-            if (target is null)
-                throw new ArgumentNullException(nameof(target));
-
-            return target.GetCustomAttributesData();
-        }
-
-        public static IList<CustomAttributeData> GetCustomAttributes(ParameterInfo target)
-        {
-            if (target is null)
-                throw new ArgumentNullException(nameof(target));
-
-            return target.GetCustomAttributesData();
-        }
-        #endregion
-
         #region Internal Static Members
         internal static IList<CustomAttributeData> GetCustomAttributesInternal(RuntimeType target)
         {
@@ -448,44 +414,7 @@ namespace System.Reflection
         }
         #endregion
 
-        #region Object Override
-        public override string ToString()
-        {
-            var vsb = new ValueStringBuilder(stackalloc char[256]);
-
-            vsb.Append('[');
-            vsb.Append(Constructor.DeclaringType!.FullName);
-            vsb.Append('(');
-
-            bool first = true;
-
-            int count = ConstructorArguments.Count;
-            for (int i = 0; i < count; i++)
-            {
-                if (!first) vsb.Append(", ");
-                vsb.Append(ConstructorArguments[i].ToString());
-                first = false;
-            }
-
-            count = NamedArguments.Count;
-            for (int i = 0; i < count; i++)
-            {
-                if (!first) vsb.Append(", ");
-                vsb.Append(NamedArguments[i].ToString());
-                first = false;
-            }
-
-            vsb.Append(")]");
-
-            return vsb.ToString();
-        }
-        public override int GetHashCode() => base.GetHashCode();
-        public override bool Equals(object? obj) => obj == (object)this;
-        #endregion
-
         #region Public Members
-        public virtual Type AttributeType => Constructor.DeclaringType!;
-
         public virtual ConstructorInfo Constructor => m_ctor;
 
         public virtual IList<CustomAttributeTypedArgument> ConstructorArguments

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -571,6 +571,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\CallingConventions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\ConstructorInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\CorElementType.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\CustomAttributeData.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\CustomAttributeExtensions.cs" Condition="'$(TargetsCoreRT)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\CustomAttributeFormatException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\CustomAttributeNamedArgument.cs" Condition="'$(TargetsCoreRT)' != 'true'" />

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/CustomAttributeData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/CustomAttributeData.cs
@@ -1,0 +1,84 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.Reflection
+{
+    public partial class CustomAttributeData
+    {
+        #region Public Static Members
+        public static IList<CustomAttributeData> GetCustomAttributes(MemberInfo target)
+        {
+            if (target is null)
+                throw new ArgumentNullException(nameof(target));
+
+            return target.GetCustomAttributesData();
+        }
+
+        public static IList<CustomAttributeData> GetCustomAttributes(Module target)
+        {
+            if (target is null)
+                throw new ArgumentNullException(nameof(target));
+
+            return target.GetCustomAttributesData();
+        }
+
+        public static IList<CustomAttributeData> GetCustomAttributes(Assembly target)
+        {
+            if (target is null)
+                throw new ArgumentNullException(nameof(target));
+
+            return target.GetCustomAttributesData();
+        }
+
+        public static IList<CustomAttributeData> GetCustomAttributes(ParameterInfo target)
+        {
+            if (target is null)
+                throw new ArgumentNullException(nameof(target));
+
+            return target.GetCustomAttributesData();
+        }
+        #endregion
+
+        #region Object Override
+        public override string ToString()
+        {
+            var vsb = new ValueStringBuilder(stackalloc char[256]);
+
+            vsb.Append('[');
+            vsb.Append(Constructor.DeclaringType!.FullName);
+            vsb.Append('(');
+
+            bool first = true;
+
+            int count = ConstructorArguments.Count;
+            for (int i = 0; i < count; i++)
+            {
+                if (!first) vsb.Append(", ");
+                vsb.Append(ConstructorArguments[i].ToString());
+                first = false;
+            }
+
+            count = NamedArguments.Count;
+            for (int i = 0; i < count; i++)
+            {
+                if (!first) vsb.Append(", ");
+                vsb.Append(NamedArguments[i].ToString());
+                first = false;
+            }
+
+            vsb.Append(")]");
+
+            return vsb.ToString();
+        }
+        public override int GetHashCode() => base.GetHashCode();
+        public override bool Equals(object? obj) => obj == (object)this;
+        #endregion
+
+        #region Public Members
+        public virtual Type AttributeType => Constructor.DeclaringType!;
+        #endregion
+    }
+}

--- a/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -195,7 +195,7 @@
       <Compile Include="$(BclSourcesRoot)\System\Reflection\Assembly.Mono.cs" />
       <Compile Include="$(BclSourcesRoot)\System\Reflection\AssemblyName.Mono.cs" />
       <Compile Include="$(BclSourcesRoot)\System\Reflection\CustomAttribute.cs" />
-      <Compile Include="$(BclSourcesRoot)\System\Reflection\CustomAttributeData.cs" />
+      <Compile Include="$(BclSourcesRoot)\System\Reflection\CustomAttributeData.Mono.cs" />
       <Compile Include="$(BclSourcesRoot)\System\Reflection\CustomAttributeTypedArgument.Mono.cs" />
       <Compile Include="$(BclSourcesRoot)\System\Reflection\FieldInfo.Mono.cs" />
       <Compile Include="$(BclSourcesRoot)\System\Reflection\MemberInfo.Mono.cs" />

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/CustomAttributeData.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/CustomAttributeData.Mono.cs
@@ -34,7 +34,7 @@ using System.Text;
 
 namespace System.Reflection
 {
-    public class CustomAttributeData
+    public partial class CustomAttributeData
     {
         private sealed class LazyCAttrData
         {
@@ -125,62 +125,49 @@ namespace System.Reflection
             }
         }
 
-        public static IList<CustomAttributeData> GetCustomAttributes(Assembly target)
-        {
-            return CustomAttribute.GetCustomAttributesData(target);
-        }
-
-        public static IList<CustomAttributeData> GetCustomAttributes(MemberInfo target)
-        {
-            return CustomAttribute.GetCustomAttributesData(target);
-        }
-
         internal static IList<CustomAttributeData> GetCustomAttributesInternal(RuntimeType target)
         {
             return CustomAttribute.GetCustomAttributesData(target);
         }
 
-        public static IList<CustomAttributeData> GetCustomAttributes(Module target)
+        internal static IList<CustomAttributeData> GetCustomAttributesInternal(RuntimeFieldInfo target)
         {
             return CustomAttribute.GetCustomAttributesData(target);
         }
 
-        public static IList<CustomAttributeData> GetCustomAttributes(ParameterInfo target)
+        internal static IList<CustomAttributeData> GetCustomAttributesInternal(RuntimeMethodInfo target)
         {
             return CustomAttribute.GetCustomAttributesData(target);
         }
 
-        public virtual Type AttributeType
+        internal static IList<CustomAttributeData> GetCustomAttributesInternal(RuntimeConstructorInfo target)
         {
-            get { return ctorInfo.DeclaringType!; }
+            return CustomAttribute.GetCustomAttributesData(target);
         }
 
-        public override string ToString()
+        internal static IList<CustomAttributeData> GetCustomAttributesInternal(RuntimeEventInfo target)
         {
-            ResolveArguments();
+            return CustomAttribute.GetCustomAttributesData(target);
+        }
 
-            StringBuilder sb = new StringBuilder();
+        internal static IList<CustomAttributeData> GetCustomAttributesInternal(RuntimePropertyInfo target)
+        {
+            return CustomAttribute.GetCustomAttributesData(target);
+        }
 
-            sb.Append('[').Append(ctorInfo.DeclaringType!.FullName).Append('(');
-            for (int i = 0; i < ctorArgs.Count; i++)
-            {
-                sb.Append(ctorArgs[i].ToString());
-                if (i + 1 < ctorArgs.Count)
-                    sb.Append(", ");
-            }
+        internal static IList<CustomAttributeData> GetCustomAttributesInternal(RuntimeModule target)
+        {
+            return CustomAttribute.GetCustomAttributesData(target);
+        }
 
-            if (namedArgs.Count > 0)
-                sb.Append(", ");
+        internal static IList<CustomAttributeData> GetCustomAttributesInternal(RuntimeAssembly target)
+        {
+            return CustomAttribute.GetCustomAttributesData(target);
+        }
 
-            for (int j = 0; j < namedArgs.Count; j++)
-            {
-                sb.Append(namedArgs[j].ToString());
-                if (j + 1 < namedArgs.Count)
-                    sb.Append(", ");
-            }
-            sb.Append(")]");
-
-            return sb.ToString();
+        internal static IList<CustomAttributeData> GetCustomAttributesInternal(RuntimeParameterInfo target)
+        {
+            return CustomAttribute.GetCustomAttributesData(target);
         }
 
         private static T[] UnboxValues<T>(object[] values)
@@ -190,13 +177,6 @@ namespace System.Reflection
                 retval[i] = (T)values[i];
 
             return retval;
-        }
-
-        public override int GetHashCode() => base.GetHashCode();
-
-        public override bool Equals(object? obj)
-        {
-            return obj == (object)this;
         }
     }
 

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -275,7 +275,7 @@ namespace System.Reflection
 
         public override IList<CustomAttributeData> GetCustomAttributesData()
         {
-            return CustomAttributeData.GetCustomAttributes(this);
+            return CustomAttributeData.GetCustomAttributesInternal(this);
         }
 
         public override object[] GetCustomAttributes(bool inherit)

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeEventInfo.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeEventInfo.cs
@@ -201,7 +201,7 @@ namespace System.Reflection
 
         public override IList<CustomAttributeData> GetCustomAttributesData()
         {
-            return CustomAttributeData.GetCustomAttributes(this);
+            return CustomAttributeData.GetCustomAttributesInternal(this);
         }
 
         public override int MetadataToken

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeFieldInfo.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeFieldInfo.cs
@@ -269,7 +269,7 @@ namespace System.Reflection
 
         public override IList<CustomAttributeData> GetCustomAttributesData()
         {
-            return CustomAttributeData.GetCustomAttributes(this);
+            return CustomAttributeData.GetCustomAttributesInternal(this);
         }
 
         private void CheckGeneric()

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
@@ -750,7 +750,7 @@ namespace System.Reflection
 
         public override IList<CustomAttributeData> GetCustomAttributesData()
         {
-            return CustomAttributeData.GetCustomAttributes(this);
+            return CustomAttributeData.GetCustomAttributesInternal(this);
         }
 
         public sealed override bool HasSameMetadataDefinitionAs(MemberInfo other) => HasSameMetadataDefinitionAsCore<RuntimeMethodInfo>(other);
@@ -988,7 +988,7 @@ namespace System.Reflection
 
         public override IList<CustomAttributeData> GetCustomAttributesData()
         {
-            return CustomAttributeData.GetCustomAttributes(this);
+            return CustomAttributeData.GetCustomAttributesInternal(this);
         }
 
         public sealed override bool HasSameMetadataDefinitionAs(MemberInfo other) => HasSameMetadataDefinitionAsCore<RuntimeConstructorInfo>(other);

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
@@ -341,7 +341,7 @@ namespace System.Reflection
 
         public override IList<CustomAttributeData> GetCustomAttributesData()
         {
-            return CustomAttributeData.GetCustomAttributes(this);
+            return CustomAttributeData.GetCustomAttributesInternal(this);
         }
 
         internal RuntimeAssembly GetRuntimeAssembly()

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeParameterInfo.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeParameterInfo.cs
@@ -206,7 +206,7 @@ namespace System.Reflection
 
         public override IList<CustomAttributeData> GetCustomAttributesData()
         {
-            return CustomAttributeData.GetCustomAttributes(this);
+            return CustomAttributeData.GetCustomAttributesInternal(this);
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
@@ -480,7 +480,7 @@ namespace System.Reflection
 
         public override IList<CustomAttributeData> GetCustomAttributesData()
         {
-            return CustomAttributeData.GetCustomAttributes(this);
+            return CustomAttributeData.GetCustomAttributesInternal(this);
         }
 
         public sealed override bool HasSameMetadataDefinitionAs(MemberInfo other) => HasSameMetadataDefinitionAsCore<RuntimePropertyInfo>(other);


### PR DESCRIPTION
* Have CustomAttributeData.GetCustomAttributes call target.GetCustomAttributesData
  to allow derived classes to override the latter (like in CoreCLR)

`System.Text.Json.SourceGeneration.Tests` are currently failing when using a Mono-based dotnet runtime.  This is because the source-generation logic overrides `GetCustomAttributesData` in various derived classes, and expects this to be called from the generic `CustomAttributeData.GetCustomAttributes` routine.  This works in CoreCLR, because there `CustomAttributeData.GetCustomAttributes` calls _target_`.GetCustomAttributesData` which calls back to `CustomAttributeData.GetCustomAttributesInternal`, which does the actual work.   However, the current Mono code has instead _target_`.GetCustomAttributesData` calling to `CustomAttributeData.GetCustomAttributes`, which does the actual work.

Fix this by introducing `GetCustomAttributesInternal` routines and re-arranging the call sequence to match CoreCLR.
