### PR TITLE
[mono] Allow overriding CustomAttributeData accessors

### DIFF
--- a/src/mono/System.Private.CoreLib/src/System/Reflection/CustomAttributeData.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/CustomAttributeData.cs
@@ -152,30 +152,28 @@ namespace System.Reflection
 
         public virtual Type AttributeType
         {
-            get { return ctorInfo.DeclaringType!; }
+            get { return Constructor.DeclaringType!; }
         }
 
         public override string ToString()
         {
-            ResolveArguments();
-
             StringBuilder sb = new StringBuilder();
 
-            sb.Append('[').Append(ctorInfo.DeclaringType!.FullName).Append('(');
-            for (int i = 0; i < ctorArgs.Count; i++)
+            sb.Append('[').Append(Constructor.DeclaringType!.FullName).Append('(');
+            for (int i = 0; i < ConstructorArguments.Count; i++)
             {
-                sb.Append(ctorArgs[i].ToString());
-                if (i + 1 < ctorArgs.Count)
+                sb.Append(ConstructorArguments[i].ToString());
+                if (i + 1 < ConstructorArguments.Count)
                     sb.Append(", ");
             }
 
-            if (namedArgs.Count > 0)
+            if (NamedArguments.Count > 0)
                 sb.Append(", ");
 
-            for (int j = 0; j < namedArgs.Count; j++)
+            for (int j = 0; j < NamedArguments.Count; j++)
             {
-                sb.Append(namedArgs[j].ToString());
-                if (j + 1 < namedArgs.Count)
+                sb.Append(NamedArguments[j].ToString());
+                if (j + 1 < NamedArguments.Count)
                     sb.Append(", ");
             }
             sb.Append(")]");


### PR DESCRIPTION
* Use Constructor, ConstructorArguments, and NamedArguments in internal
  routines to allow them being overridden (like with CoreCLR).

Even after https://github.com/dotnet/runtime/pull/55726, `System.Text.Json.SourceGeneration.Tests` are still failing when using a Mono-based dotnet runtime.   This new problem is triggered because the source-generation logic provides a class `CustomAttributeDataWrapper` derived from `CustomAttributeData`, which overrides the latter class' accessor routines `Constructor`, `ConstructorArguments`, and `NamedArguments`.

This works with CoreCLR.  However, with the current Mono implementation, other routines in `CustomAttributeData` now crash when called on an instance of the derived class, because they now access internal data members that have never been initialized.  Fix this by instead calling the accessor routines like in CoreCLR.
