### PR TITLE
Mitigate race condition in EventSource_ConnectionPoolAtMaxConnection_LogsRequestLeftQueue test

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
@@ -673,7 +673,7 @@ namespace System.Net.Http.Functional.Tests
             DateTime startTime = DateTime.UtcNow;
             int startCount = events.Count;
 
-            while (events.Skip(startCount).Count(e => IsRequestsStartedEventCounter(e.Event)) < 2)
+            while (events.Skip(startCount).Count(e => IsRequestsStartedEventCounter(e.Event)) < 3)
             {
                 if (DateTime.UtcNow.Subtract(startTime) > TimeSpan.FromSeconds(30))
                     throw new TimeoutException($"Timed out waiting for EventCounters");


### PR DESCRIPTION
There is a unavoidable race condition between updating event counters and reading their values in WaitForEventCountersAsync. It waits for at least 2 sets of EventCounter event groups to ensure the last group is captured after any actual work (tests check that counters reset back to 0 if there is nothing happening).
Since it looks for `requests-started` which occurs before `http11-requests-queue-duration` event, what it may see is only the tail of the last group and the start of the second, without waiting for a fresh `http11-requests-queue-duration`. In this, the assert `Assert.Equal(0, http11requestQueueDurations[^1])` on the line 549 will see a non-zero counter value and fail.

This PR changes the condition to `< 3`  to guarantee there is at least one full group of events in the window.

Co-authored by @MihaZupan 

Fixes #46073