### PR TITLE
Widen return values in CallTailCallTarget stubs

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -8338,7 +8338,7 @@ GenTree* Compiler::fgCreateCallDispatcherAndGetResult(GenTreeCall*          orig
             // we don't know which eventual tailcaller may have written it, and
             // the type of that tailcaller could potentially be narrower than
             // this call. See TailCallHelp::NeedsReturnWidening.
-            lvaTable[newRetLcl].lvType = (var_types)origCall->gtType;
+            lvaTable[newRetLcl].lvType = origCall->gtType;
         }
 
         lvaSetVarAddrExposed(newRetLcl);

--- a/src/coreclr/vm/tailcallhelp.cpp
+++ b/src/coreclr/vm/tailcallhelp.cpp
@@ -265,6 +265,8 @@ bool TailCallHelp::NeedsReturnWidening(TypeHandle tyHnd, bool* isSigned)
     case ELEMENT_TYPE_I2:
         *isSigned = true;
         return true;
+    case ELEMENT_TYPE_BOOLEAN:
+    case ELEMENT_TYPE_CHAR:
     case ELEMENT_TYPE_U1:
     case ELEMENT_TYPE_U2:
         *isSigned = false;

--- a/src/coreclr/vm/tailcallhelp.h
+++ b/src/coreclr/vm/tailcallhelp.h
@@ -30,6 +30,7 @@ private:
         MetaSig& callSiteSig, MethodDesc* calleeMD,
         bool storeTarget, bool thisArgByRef, bool hasInstArg, ArgBufferLayout* layout);
     static TypeHandle NormalizeSigType(TypeHandle tyHnd);
+    static bool NeedsReturnWidening(TypeHandle tyHnd, bool* isSigned);
     static bool GenerateGCDescriptor(MethodDesc* pTargetMD, const ArgBufferLayout& values, GCRefMapBuilder* builder);
 
     static MethodDesc* CreateStoreArgsStub(TailCallInfo& info);

--- a/src/tests/JIT/Regression/JitBlue/Runtime_55253/Runtime_55253.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_55253/Runtime_55253.cs
@@ -1,0 +1,21 @@
+class Runtime_55253
+{
+    static int Main()
+    {
+        int errors = 0;
+        if (AsInt32() != -1)
+            errors |= 1;
+        if (AsUInt32() != 255)
+            errors |= 2;
+
+        return 100 + errors;
+    }
+
+    static uint AsUInt32() => AsUInt16();
+    static uint AsUInt16() => AsUInt8();
+    static uint AsUInt8() => 255;
+
+    static int AsInt32() => AsInt16();
+    static short AsInt16() => AsInt8();
+    static sbyte AsInt8() => -1;
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_55253/Runtime_55253.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_55253/Runtime_55253.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>False</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set DOTNET_TailcallStress=1
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export DOTNET_TailcallStress=1
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
In the managed calling convention the callee is responsible for widening
the return value up to 4 bytes. We need to mimic this in portable
tailcall helpers as the JIT cannot know which call eventually produced
the value that was stored in the return value buffer passed to the
dispatcher.

Fix #55253