### PR TITLE
[class] Add GC Unsafe transitions to a few more external only functions

### DIFF
--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -2965,9 +2965,12 @@ mono_type_get_checked (MonoImage *image, guint32 type_token, MonoGenericContext 
 MonoClass *
 mono_class_get (MonoImage *image, guint32 type_token)
 {
+	MonoClass *result;
+	MONO_ENTER_GC_UNSAFE;
 	ERROR_DECL (error);
-	MonoClass *result = mono_class_get_checked (image, type_token, error);
+	result = mono_class_get_checked (image, type_token, error);
 	mono_error_assert_ok (error);
+	MONO_EXIT_GC_UNSAFE;
 	return result;
 }
 
@@ -4585,9 +4588,12 @@ gpointer
 mono_ldtoken (MonoImage *image, guint32 token, MonoClass **handle_class,
 	      MonoGenericContext *context)
 {
+	gpointer res;
+	MONO_ENTER_GC_UNSAFE;
 	ERROR_DECL (error);
-	gpointer res = mono_ldtoken_checked (image, token, handle_class, context, error);
+	res = mono_ldtoken_checked (image, token, handle_class, context, error);
 	mono_error_assert_ok (error);
+	MONO_EXIT_GC_UNSAFE;
 	return res;
 }
 
@@ -5283,7 +5289,11 @@ mono_class_is_delegate (MonoClass *klass)
 mono_bool
 mono_class_implements_interface (MonoClass* klass, MonoClass* iface)
 {
-	return mono_class_is_assignable_from_internal (iface, klass);
+	mono_bool result;
+	MONO_ENTER_GC_UNSAFE;
+	result = mono_class_is_assignable_from_internal (iface, klass);
+	MONO_EXIT_GC_UNSAFE;
+	return result;
 }
 
 static mono_bool


### PR DESCRIPTION
A couple more functions that are only called by embedders that were missing GC Unsafe transitions.