### PR TITLE
[draft] hot reload support for adding methods

### DIFF
--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis/AddLambdaCapturingThis.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis/AddLambdaCapturingThis.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+
+
+namespace System.Reflection.Metadata.ApplyUpdate.Test
+{
+    public class AddLambdaCapturingThis
+    {
+	public AddLambdaCapturingThis () {
+	    field = "abcd";
+	}
+
+	public string GetField => field;
+
+	private string field;
+
+	public string TestMethod () {
+	    // capture 'this' but no locals
+	    Func<string,string> fn = s => field;
+	    return "123";
+	}
+
+    }
+}

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis/AddLambdaCapturingThis_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis/AddLambdaCapturingThis_v1.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+
+
+namespace System.Reflection.Metadata.ApplyUpdate.Test
+{
+    public class AddLambdaCapturingThis
+    {
+	public AddLambdaCapturingThis () {
+	    field = "abcd";
+	}
+
+	public string GetField => field;
+
+	private string field;
+
+	public string TestMethod () {
+	    // capture 'this' but no locals
+	    Func<string,string> fn = s => NewMethod (s + field, 42);
+	    return fn ("123");
+	}
+
+	private string NewMethod (string s, int i) {
+	    return i.ToString() + s;
+	}
+
+    }
+}

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis/System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis/System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>System.Runtime.Loader.Tests</RootNamespace>
+    <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <TestRuntime>true</TestRuntime>
+    <DeltaScript>deltascript.json</DeltaScript>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="AddLambdaCapturingThis.cs" />
+  </ItemGroup>
+</Project>

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis/deltascript.json
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis/deltascript.json
@@ -1,0 +1,6 @@
+{
+    "changes": [
+        {"document": "AddLambdaCapturingThis.cs", "update": "AddLambdaCapturingThis_v1.cs"},
+    ]
+}
+

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -112,6 +112,24 @@ namespace System.Reflection.Metadata
             });
         }
 
+	[ConditionalFact(typeof(ApplyUpdateUtil), nameof(ApplyUpdateUtil.IsSupported))]
+	public static void TestAddLambdaCapturingThis()
+	{
+	    ApplyUpdateUtil.TestCase(static () =>
+	    {
+		var assm = typeof(System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis).Assembly;
+
+		var x = new System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis();
+
+		Assert.Equal("123", x.TestMethod());
+
+		ApplyUpdateUtil.ApplyUpdate(assm);
+
+		string result = x.TestMethod();
+		Assert.Equal("42123abcd", result);
+	    });
+	}
+
         class NonRuntimeAssembly : Assembly
         {
         }

--- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
@@ -40,6 +40,7 @@
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.MethodBody1\System.Reflection.Metadata.ApplyUpdate.Test.MethodBody1.csproj" />
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes\System.Reflection.Metadata.ApplyUpdate.Test.ClassWithCustomAttributes.csproj" />
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.CustomAttributeUpdate\System.Reflection.Metadata.ApplyUpdate.Test.CustomAttributeUpdate.csproj" />
+    <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis\System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis.csproj" />
 
   </ItemGroup>
   <ItemGroup Condition="'$(TargetOS)' == 'Browser'">
@@ -61,6 +62,9 @@
           Include="%(ResolvedFileToPublish.FullPath)" />
       <TrimmerRootAssembly
           Condition="$([System.String]::Copy('%(ResolvedFileToPublish.FileName)%(ResolvedFileToPublish.Extension)').EndsWith('System.Reflection.Metadata.ApplyUpdate.Test.CustomAttributeUpdate.dll'))"
+          Include="%(ResolvedFileToPublish.FullPath)" />
+      <TrimmerRootAssembly
+          Condition="$([System.String]::Copy('%(ResolvedFileToPublish.FileName)%(ResolvedFileToPublish.Extension)').EndsWith('System.Reflection.Metadata.ApplyUpdate.Test.AddLambdaCapturingThis.dll'))"
           Include="%(ResolvedFileToPublish.FullPath)" />
     </ItemGroup>
   </Target>

--- a/src/mono/mono/component/hot_reload-stub.c
+++ b/src/mono/mono/component/hot_reload-stub.c
@@ -68,6 +68,12 @@ hot_reload_stub_has_modified_rows (const MonoTableInfo *table);
 static int
 hot_reload_stub_table_num_rows_slow (MonoImage *image, int table_index);
 
+static GArray*
+hot_reload_stub_get_added_methods (MonoClass *klass);
+
+static uint32_t
+hot_reload_stub_method_parent (MonoImage *image, uint32_t method_index);
+
 static MonoComponentHotReload fn_table = {
 	{ MONO_COMPONENT_ITF_VERSION, &hot_reload_stub_available },
 	&hot_reload_stub_set_fastpath_data,
@@ -87,6 +93,8 @@ static MonoComponentHotReload fn_table = {
 	&hot_reload_stub_get_updated_method_ppdb,
 	&hot_reload_stub_has_modified_rows,
 	&hot_reload_stub_table_num_rows_slow,
+	&hot_reload_stub_get_added_methods,
+	&hot_reload_stub_method_parent,
 };
 
 static bool
@@ -200,6 +208,18 @@ static int
 hot_reload_stub_table_num_rows_slow (MonoImage *image, int table_index)
 {
 	g_assert_not_reached (); /* should always take the fast path */
+}
+
+static GArray*
+hot_reload_stub_get_added_methods (MonoClass *klass)
+{
+	return NULL;
+}
+
+static uint32_t
+hot_reload_stub_method_parent (MonoImage *image, uint32_t method_index)
+{
+	return 0;
 }
 
 

--- a/src/mono/mono/component/hot_reload-stub.c
+++ b/src/mono/mono/component/hot_reload-stub.c
@@ -65,6 +65,9 @@ hot_reload_stub_get_updated_method_ppdb (MonoImage *base_image, uint32_t idx);
 static gboolean
 hot_reload_stub_has_modified_rows (const MonoTableInfo *table);
 
+static int
+hot_reload_stub_table_num_rows_slow (MonoImage *image, int table_index);
+
 static MonoComponentHotReload fn_table = {
 	{ MONO_COMPONENT_ITF_VERSION, &hot_reload_stub_available },
 	&hot_reload_stub_set_fastpath_data,
@@ -83,6 +86,7 @@ static MonoComponentHotReload fn_table = {
 	&hot_reload_stub_delta_heap_lookup,
 	&hot_reload_stub_get_updated_method_ppdb,
 	&hot_reload_stub_has_modified_rows,
+	&hot_reload_stub_table_num_rows_slow,
 };
 
 static bool
@@ -191,6 +195,13 @@ hot_reload_stub_has_modified_rows (const MonoTableInfo *table)
 {
 	return FALSE;
 }
+
+static int
+hot_reload_stub_table_num_rows_slow (MonoImage *image, int table_index)
+{
+	g_assert_not_reached (); /* should always take the fast path */
+}
+
 
 MONO_COMPONENT_EXPORT_ENTRYPOINT
 MonoComponentHotReload *

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -496,7 +496,8 @@ static int
 metadata_update_local_generation (MonoImage *base, BaselineInfo *base_info, MonoImage *delta);
 
 static void
-add_method_to_baseline (BaselineInfo *base_info, MonoClass *klass, uint32_t method_token);
+add_method_to_baseline (BaselineInfo *base_info, DeltaInfo *delta_info, MonoClass *klass, uint32_t method_token, MonoDebugInformationEnc* pdb_address);
+
 
 void
 hot_reload_init (void)
@@ -1260,13 +1261,19 @@ apply_enclog_pass1 (MonoImage *image_base, MonoImage *image_dmeta, gconstpointer
 }
 
 static void
+set_delta_method_debug_info (DeltaInfo *delta_info, uint32_t token_index, MonoDebugInformationEnc *pdb_address)
+{
+	g_hash_table_insert (delta_info->method_ppdb_table_update, GUINT_TO_POINTER (token_index), (gpointer) pdb_address);
+}
+
+static void
 set_update_method (MonoImage *image_base, BaselineInfo *base_info, uint32_t generation, MonoImage *image_dmeta, DeltaInfo *delta_info, uint32_t token_index, const char* il_address, MonoDebugInformationEnc* pdb_address)
 {
 	mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_METADATA_UPDATE, "setting method 0x%08x in g=%d IL=%p", token_index, generation, (void*)il_address);
 	/* FIXME: this is a race if other threads are doing a lookup. */
 	g_hash_table_insert (base_info->method_table_update, GUINT_TO_POINTER (token_index), GUINT_TO_POINTER (generation));
 	g_hash_table_insert (delta_info->method_table_update, GUINT_TO_POINTER (token_index), (gpointer) il_address);
-	g_hash_table_insert (delta_info->method_ppdb_table_update, GUINT_TO_POINTER (token_index), (gpointer) pdb_address);
+	set_delta_method_debug_info (delta_info, token_index, pdb_address); 
 }
 
 static MonoDebugInformationEnc *
@@ -1393,7 +1400,8 @@ apply_enclog_pass2 (MonoImage *image_base, BaselineInfo *base_info, uint32_t gen
 					g_error ("EnC: new method added but I don't know the class, should be caught by pass1");
 				g_assert (add_method_klass);
 				mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "Adding new method 0x%08x to class %s.%s", token_index, m_class_get_name_space (add_method_klass), m_class_get_name (add_method_klass));
-				add_method_to_baseline (base_info, add_method_klass, token_index);
+				MonoDebugInformationEnc *method_debug_information = hot_reload_get_method_debug_information (image_dppdb, token_index);
+				add_method_to_baseline (base_info, delta_info, add_method_klass, token_index, method_debug_information);
 				add_method_klass = NULL;
 			}
 #endif
@@ -1678,6 +1686,10 @@ hot_reload_get_updated_method_ppdb (MonoImage *base_image, uint32_t idx)
 		if (G_UNLIKELY (gen > 0)) {
 			loc = get_method_update_rva (base_image, info, idx, TRUE);
 		}
+		/* Check the method_parent table as a way of checking if the method was added by a later generation. If so, still look for its PPDB info in our update tables */
+		if (G_UNLIKELY (loc == 0 && GPOINTER_TO_UINT (g_hash_table_lookup (info->method_parent, GUINT_TO_POINTER (idx))) > 0)) {
+			loc = get_method_update_rva (base_image, info, idx, TRUE);
+		}
 	}
 	return loc;
 }
@@ -1806,7 +1818,7 @@ hot_reload_table_num_rows_slow (MonoImage *base, int table_index)
 }
 
 static void
-add_method_to_baseline (BaselineInfo *base_info, MonoClass *klass, uint32_t method_token)
+add_method_to_baseline (BaselineInfo *base_info, DeltaInfo *delta_info, MonoClass *klass, uint32_t method_token, MonoDebugInformationEnc* pdb_address)
 {
 	if (!base_info->added_methods) {
 		base_info->added_methods = g_hash_table_new (g_direct_hash, g_direct_equal);
@@ -1822,6 +1834,9 @@ add_method_to_baseline (BaselineInfo *base_info, MonoClass *klass, uint32_t meth
 	}
 	g_array_append_val (arr, method_token);
 	g_hash_table_insert (base_info->method_parent, GUINT_TO_POINTER (method_token), GUINT_TO_POINTER (m_class_get_type_token (klass)));
+
+	if (pdb_address)
+		set_delta_method_debug_info (delta_info, method_token, pdb_address);
 }
 
 static GArray*

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -86,6 +86,13 @@ hot_reload_has_modified_rows (const MonoTableInfo *table);
 static int
 hot_reload_table_num_rows_slow (MonoImage *image, int table_index);
 
+static GArray*
+hot_reload_get_added_methods (MonoClass *klass);
+
+static uint32_t
+hot_reload_method_parent  (MonoImage *base, uint32_t method_token);
+
+
 static MonoComponentHotReload fn_table = {
 	{ MONO_COMPONENT_ITF_VERSION, &hot_reload_available },
 	&hot_reload_set_fastpath_data,
@@ -105,6 +112,8 @@ static MonoComponentHotReload fn_table = {
 	&hot_reload_get_updated_method_ppdb,
 	&hot_reload_has_modified_rows,
 	&hot_reload_table_num_rows_slow,
+	&hot_reload_get_added_methods,
+	&hot_reload_method_parent,
 };
 
 MonoComponentHotReload *
@@ -183,6 +192,9 @@ typedef struct _BaselineInfo {
 
 	/* TRUE if any published update modified an existing row */
 	gboolean any_modified_rows [MONO_TABLE_NUM];
+
+	GHashTable *added_methods; /* maps each MonoClass to a GArray of added method tokens */
+	GHashTable *method_parent; /* maps added methoddef tokens to typedef tokens */
 } BaselineInfo;
 
 #define DOTNET_MODIFIABLE_ASSEMBLIES "DOTNET_MODIFIABLE_ASSEMBLIES"
@@ -209,7 +221,8 @@ hot_reload_update_enabled (int *modifiable_assemblies_out)
 		char *val = g_getenv (DOTNET_MODIFIABLE_ASSEMBLIES);
 		if (val && !g_strcasecmp (val, "debug")) {
 			mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "Metadata update enabled for debuggable assemblies");
-			modifiable = MONO_MODIFIABLE_ASSM_DEBUG;
+			modifiable
+				= MONO_MODIFIABLE_ASSM_DEBUG;
 		}
 		g_free (val);
 		inited = TRUE;
@@ -481,6 +494,9 @@ image_append_delta (MonoImage *base, BaselineInfo *base_info, MonoImage *delta, 
 
 static int
 metadata_update_local_generation (MonoImage *base, BaselineInfo *base_info, MonoImage *delta);
+
+static void
+add_method_to_baseline (BaselineInfo *base_info, MonoClass *klass, uint32_t method_token);
 
 void
 hot_reload_init (void)
@@ -1378,6 +1394,7 @@ apply_enclog_pass2 (MonoImage *image_base, BaselineInfo *base_info, uint32_t gen
 					g_error ("EnC: new method added but I don't know the class, should be caught by pass1");
 				g_assert (add_method_klass);
 				mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "Adding new method 0x%08x to class %s.%s", token_index, m_class_get_name_space (add_method_klass), m_class_get_name (add_method_klass));
+				add_method_to_baseline (base_info, add_method_klass, token_index);
 				add_method_klass = NULL;
 			}
 #endif
@@ -1769,4 +1786,52 @@ hot_reload_table_num_rows_slow (MonoImage *base, int table_index)
 		rows = delta_info->count [table_index].prev_gen_rows + delta_info->count [table_index].inserted_rows;
 	}
 	return rows;
+}
+
+static void
+add_method_to_baseline (BaselineInfo *base_info, MonoClass *klass, uint32_t method_token)
+{
+	if (!base_info->added_methods) {
+		base_info->added_methods = g_hash_table_new (g_direct_hash, g_direct_equal);
+	}
+	if (!base_info->method_parent) {
+		base_info->method_parent = g_hash_table_new (g_direct_hash, g_direct_equal);
+	}
+	/* FIXME: locking for readers/writers of the GArray */
+	GArray *arr = g_hash_table_lookup (base_info->added_methods, klass);
+	if (!arr) {
+		arr = g_array_new (FALSE, FALSE, sizeof(uint32_t));
+		g_hash_table_insert (base_info->added_methods, klass, arr);
+	}
+	g_array_append_val (arr, method_token);
+	g_hash_table_insert (base_info->method_parent, GUINT_TO_POINTER (method_token), GUINT_TO_POINTER (m_class_get_type_token (klass)));
+}
+
+static GArray*
+hot_reload_get_added_methods (MonoClass *klass)
+{
+	/* FIXME: locking for the GArray? */
+	MonoImage *image = m_class_get_image (klass);
+	if (!image->has_updates)
+		return NULL;
+	BaselineInfo *base_info = baseline_info_lookup (image);
+	if (!base_info || base_info->added_methods == NULL)
+		return NULL;
+
+	return g_hash_table_lookup (base_info->added_methods, klass);
+}
+
+static uint32_t
+hot_reload_method_parent  (MonoImage *base_image, uint32_t method_token)
+{
+	if (!base_image->has_updates)
+		return 0;
+	BaselineInfo *base_info = baseline_info_lookup (base_image);
+	if (!base_info || base_info->method_parent == NULL)
+		return 0;
+
+	uint32_t res = GPOINTER_TO_UINT (g_hash_table_lookup (base_info->method_parent, GUINT_TO_POINTER (method_token)));
+	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "method_parent lookup: 0x%08x returned 0x%08x\n", method_token, res);
+
+	return res;
 }

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -26,6 +26,9 @@
 
 #include <mono/utils/mono-compiler.h>
 
+#define ALLOW_METHOD_ADD
+
+
 static void
 hot_reload_init (void);
 
@@ -1012,6 +1015,15 @@ delta_info_compute_table_records (MonoImage *image_dmeta, MonoImage *image_base,
 	return TRUE;
 }
 
+enum MonoEnCFuncCode {
+	ENC_FUNC_DEFAULT = 0,
+	ENC_FUNC_ADD_METHOD = 1,
+	ENC_FUNC_ADD_FIELD = 2,
+	ENC_FUNC_ADD_PARAM = 3,
+	ENC_FUNC_ADD_PROPERTY = 4,
+	ENC_FUNC_ADD_EVENT = 5,
+};
+
 static const char*
 funccode_to_str (int func_code)
 {
@@ -1056,17 +1068,19 @@ apply_enclog_pass1 (MonoImage *image_base, MonoImage *image_dmeta, gconstpointer
 		int token_table = mono_metadata_token_table (log_token);
 		int token_index = mono_metadata_token_index (log_token);
 
-		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "row[0x%02x]:0x%08x (%s idx=0x%02x) (base table has 0x%04x rows)\tfunc=0x%02x\n", i, log_token, mono_meta_table_name (token_table), token_index, table_info_get_rows (&image_base->tables [token_table]), func_code);
+		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "row[0x%02x]:0x%08x (%s idx=0x%02x) (base table has 0x%04x rows)\tfunc=0x%02x (\"%s\")\n", i, log_token, mono_meta_table_name (token_table), token_index, table_info_get_rows (&image_base->tables [token_table]), func_code, funccode_to_str (func_code));
 
 
 		if (token_table != MONO_TABLE_METHOD)
 			continue;
 
+#ifndef ALLOW_METHOD_ADD
 		if (token_index > table_info_get_rows (&image_base->tables [token_table])) {
 			mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_METADATA_UPDATE, "\tcannot add new method with token 0x%08x", log_token);
 			mono_error_set_type_load_name (error, NULL, image_base->name, "EnC: cannot add new method with token 0x%08x", log_token);
 			unsupported_edits = TRUE;
 		}
+#endif
 
 		g_assert (func_code == 0); /* anything else doesn't make sense here */
 	}
@@ -1161,6 +1175,28 @@ apply_enclog_pass1 (MonoImage *image_base, MonoImage *image_dmeta, gconstpointer
 				break;
 			}
 		}
+		case MONO_TABLE_TYPEDEF: {
+#ifdef ALLOW_METHOD_ADD
+			/* FIXME: wrong for cumulative updates - need to look at DeltaInfo:count.prev_gen_rows */
+			gboolean new_class = token_index > table_info_get_rows (&image_base->tables [token_table]);
+			/* only allow adding methods to existing classes for now */
+			if (!new_class && func_code == ENC_FUNC_ADD_METHOD) {
+				/* next record should be a MONO_TABLE_METHOD addition (func == default) */
+				g_assert (i + 1 < rows);
+				guint32 next_cols [MONO_ENCLOG_SIZE];
+				mono_metadata_decode_row (table_enclog, i + 1, next_cols, MONO_ENCLOG_SIZE);
+				g_assert (next_cols [MONO_ENCLOG_FUNC_CODE] == ENC_FUNC_DEFAULT);
+				int next_token = next_cols [MONO_ENCLOG_TOKEN];
+				int next_table = mono_metadata_token_table (next_token);
+				int next_index = mono_metadata_token_index (next_token);
+				g_assert (next_table == MONO_TABLE_METHOD);
+				g_assert (next_index > table_info_get_rows (&image_base->tables [next_table]));
+				i++; /* skip the next record */
+				continue;
+			}
+#endif
+			/* fallthru */
+		}
 		default:
 			/* FIXME: this bounds check is wrong for cumulative updates - need to look at the DeltaInfo:count.prev_gen_rows */
 			if (token_index <= table_info_get_rows (&image_base->tables [token_table])) {
@@ -1178,7 +1214,7 @@ apply_enclog_pass1 (MonoImage *image_base, MonoImage *image_dmeta, gconstpointer
 		 * the preceeding MONO_TABLE_TYPEDEF enc record that identifies the parent type).
 		 */
 		switch (func_code) {
-			case 0: /* default */
+			case ENC_FUNC_DEFAULT: /* default */
 				break;
 			default:
 				mono_trace (G_LOG_LEVEL_INFO, MONO_TRACE_METADATA_UPDATE, "row[0x%02x]:0x%08x FunCode %d (%s) not supported (token=0x%08x)", i, log_token, func_code, funccode_to_str (func_code), log_token);
@@ -1233,6 +1269,8 @@ apply_enclog_pass2 (MonoImage *image_base, BaselineInfo *base_info, uint32_t gen
 	MonoTableInfo *table_enclog = &image_dmeta->tables [MONO_TABLE_ENCLOG];
 	int rows = table_info_get_rows (table_enclog);
 
+	MonoClass *add_method_klass = NULL;
+
 	gboolean assemblyref_updated = FALSE;
 	for (int i = 0; i < rows ; ++i) {
 		guint32 cols [MONO_ENCLOG_SIZE];
@@ -1248,11 +1286,25 @@ apply_enclog_pass2 (MonoImage *image_base, BaselineInfo *base_info, uint32_t gen
 		/* TODO: See CMiniMdRW::ApplyDelta for how to drive this.
 		 */
 		switch (func_code) {
-			case 0: /* default */
-				break;
-			default:
-				g_error ("EnC: unsupported FuncCode, should be caught by pass1");
-				break;
+		case ENC_FUNC_DEFAULT: /* default */
+			break;
+#ifdef ALLOW_METHOD_ADD
+		case ENC_FUNC_ADD_METHOD: {
+			g_assert (token_table == MONO_TABLE_TYPEDEF);
+			/* FIXME: this bounds check is wrong for cumulative updates - need to look at the DeltaInfo:count.prev_gen_rows */
+			/* should've been caught by pass1 if we're adding a new method to a new class. */
+			MonoClass *klass = mono_class_get_checked (image_base, log_token, error);
+			if (!is_ok (error)) {
+				mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "Can't get class with token 0x%08x due to: %s", log_token, mono_error_get_message (error));
+				return FALSE;
+			}
+			add_method_klass = klass;
+			break;
+		}
+#endif
+		default:
+			g_error ("EnC: unsupported FuncCode, should be caught by pass1");
+			break;
 		}
 
 		switch (token_table) {
@@ -1292,7 +1344,10 @@ apply_enclog_pass2 (MonoImage *image_base, BaselineInfo *base_info, uint32_t gen
 		}
 		case MONO_TABLE_METHOD: {
 			if (token_index > table_info_get_rows (&image_base->tables [token_table])) {
-				g_error ("EnC: new method added, should be caught by pass1");
+				if (!add_method_klass)
+					g_error ("EnC: new method added but I don't know the class, should be caught by pass1");
+				g_assert (add_method_klass);
+				mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "Adding new method 0x%08x to class %s.%s", token_index, m_class_get_name_space (add_method_klass), m_class_get_name (add_method_klass));
 			}
 
 			if (!base_info->method_table_update)
@@ -1313,6 +1368,7 @@ apply_enclog_pass2 (MonoImage *image_base, BaselineInfo *base_info, uint32_t gen
 				/* rva points probably into image_base IL stream. can this ever happen? */
 				g_print ("TODO: this case is still a bit contrived. token=0x%08x with rva=0x%04x\n", log_token, rva);
 			}
+			add_method_klass = NULL;
 			break;
 		}
 		case MONO_TABLE_TYPEDEF: {

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -1338,7 +1338,6 @@ apply_enclog_pass2 (MonoImage *image_base, BaselineInfo *base_info, uint32_t gen
 
 		case ENC_FUNC_ADD_PARAM: {
 			g_assert (token_table == MONO_TABLE_METHOD);
-			/* assert that the token_index is equal to the number of rows in the table.  We only allow adding a param to the newest method def */
 			add_param_method_index = token_index;
 			break;
 		}
@@ -1441,7 +1440,25 @@ apply_enclog_pass2 (MonoImage *image_base, BaselineInfo *base_info, uint32_t gen
 		}
 #ifdef ALLOW_METHOD_ADD
 		case MONO_TABLE_PARAM: {
-			/* here we would really like to update the method's paramlist column to point to the new params. */
+			/* if there were multiple added methods, this comes in as several method
+			 * additions, followed by the parameter additions.
+			 *
+			 * 10: 0x02000002 (TypeDef)          0x00000001 (AddMethod)
+			 * 11: 0x06000006 (MethodDef)        0
+			 * 12: 0x02000002 (TypeDef)          0x00000001 (AddMethod)
+			 * 13: 0x06000007 (MethodDef)        0
+			 * 14: 0x06000006 (MethodDef)        0x00000003 (AddParameter)
+			 * 15: 0x08000003 (Param)            0
+			 * 16: 0x06000006 (MethodDef)        0x00000003 (AddParameter)
+			 * 17: 0x08000004 (Param)            0
+			 * 18: 0x06000007 (MethodDef)        0x00000003 (AddParameter)
+			 * 19: 0x08000005 (Param)            0
+			 *
+			 * So by the time we see the param additions, the methods are already in.
+			 *
+			 * FIXME: we need a lookaside table (like method_parent) for every place
+			 * that looks at MONO_METHOD_PARAMLIST
+			 */
 			break;
 		}
 #endif

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -83,6 +83,9 @@ hot_reload_get_updated_method_ppdb (MonoImage *base_image, uint32_t idx);
 static gboolean
 hot_reload_has_modified_rows (const MonoTableInfo *table);
 
+static int
+hot_reload_table_num_rows_slow (MonoImage *image, int table_index);
+
 static MonoComponentHotReload fn_table = {
 	{ MONO_COMPONENT_ITF_VERSION, &hot_reload_available },
 	&hot_reload_set_fastpath_data,
@@ -101,6 +104,7 @@ static MonoComponentHotReload fn_table = {
 	&hot_reload_delta_heap_lookup,
 	&hot_reload_get_updated_method_ppdb,
 	&hot_reload_has_modified_rows,
+	&hot_reload_table_num_rows_slow,
 };
 
 MonoComponentHotReload *
@@ -1712,3 +1716,23 @@ hot_reload_has_modified_rows (const MonoTableInfo *table)
 	return info->any_modified_rows[tbl_index];
 }
 
+static int
+hot_reload_table_num_rows_slow (MonoImage *base, int table_index)
+{
+	BaselineInfo *base_info = baseline_info_lookup (base);
+	if (!base_info)
+		return FALSE;
+
+	uint32_t current_gen = hot_reload_get_thread_generation ();
+
+	int rows = table_info_get_rows (&base->tables [table_index]);
+	GList *cur;
+	for (cur = base_info->delta_image; cur; cur = cur->next) {
+		MonoImage *delta_image = (MonoImage*)cur->data;
+		DeltaInfo *delta_info = delta_info_lookup (delta_image);
+		if (delta_info->generation > current_gen)
+			break;
+		rows = delta_info->count [table_index].prev_gen_rows + delta_info->count [table_index].inserted_rows;
+	}
+	return rows;
+}

--- a/src/mono/mono/component/hot_reload.h
+++ b/src/mono/mono/component/hot_reload.h
@@ -32,6 +32,8 @@ typedef struct _MonoComponentHotReload {
 	gpointer (*get_updated_method_ppdb) (MonoImage *base_image, uint32_t idx);
 	gboolean (*has_modified_rows) (const MonoTableInfo *table);
 	gboolean (*table_num_rows_slow) (MonoImage *base_image, int table_index);
+	GArray* (*get_added_methods) (MonoClass *klass);
+	uint32_t (*method_parent) (MonoImage *base_image, uint32_t method_index);
 } MonoComponentHotReload;
 
 MONO_COMPONENT_EXPORT_ENTRYPOINT

--- a/src/mono/mono/component/hot_reload.h
+++ b/src/mono/mono/component/hot_reload.h
@@ -31,6 +31,7 @@ typedef struct _MonoComponentHotReload {
 	gboolean (*delta_heap_lookup) (MonoImage *base_image, MetadataHeapGetterFunc get_heap, uint32_t orig_index, MonoImage **image_out, uint32_t *index_out);
 	gpointer (*get_updated_method_ppdb) (MonoImage *base_image, uint32_t idx);
 	gboolean (*has_modified_rows) (const MonoTableInfo *table);
+	gboolean (*table_num_rows_slow) (MonoImage *base_image, int table_index);
 } MonoComponentHotReload;
 
 MONO_COMPONENT_EXPORT_ENTRYPOINT

--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -427,6 +427,8 @@ find_method_in_class (MonoClass *klass, const char *name, const char *qname, con
 {
  	int i;
 
+	/* FIXME: method refs from metadata-upate probably end up here */
+
 	/* Search directly in the metadata to avoid calling setup_methods () */
 	error_init (error);
 
@@ -1159,6 +1161,8 @@ mono_get_method_checked (MonoImage *image, guint32 token, MonoClass *klass, Mono
 {
 	MonoMethod *result = NULL;
 	gboolean used_context = FALSE;
+
+	/* FIXME: method definition lookups for metadata-update probably end up here */
 
 	/* We do everything inside the lock to prevent creation races */
 

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -1255,4 +1255,18 @@ mono_type_get_array_type_internal (MonoType *type)
 	return type->data.array;
 }
 
+static inline int
+mono_metadata_table_to_ptr_table (int table_num)
+{
+	switch (table_num) {
+	case MONO_TABLE_FIELD: return MONO_TABLE_FIELD_POINTER;
+	case MONO_TABLE_METHOD: return MONO_TABLE_METHOD_POINTER;
+	case MONO_TABLE_PARAM: return MONO_TABLE_PARAM_POINTER;
+	case MONO_TABLE_PROPERTY: return MONO_TABLE_PROPERTY_POINTER;
+	case MONO_TABLE_EVENT: return MONO_TABLE_EVENT_POINTER;
+	default:
+		g_assert_not_reached ();
+	}
+}
+
 #endif /* __MONO_METADATA_INTERNALS_H__ */

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -865,6 +865,18 @@ mono_metadata_clean_generic_classes_for_image (MonoImage *image);
 gboolean
 mono_metadata_table_bounds_check_slow (MonoImage *image, int table_index, int token_index);
 
+int
+mono_metadata_table_num_rows_slow (MonoImage *image, int table_index);
+
+static inline int
+mono_metadata_table_num_rows (MonoImage *image, int table_index)
+{
+	if (G_LIKELY (!image->has_updates))
+		return table_info_get_rows (&image->tables [table_index]);
+	else
+		return mono_metadata_table_num_rows_slow (image, table_index);
+}
+
 /* token_index is 1-based */
 static inline gboolean
 mono_metadata_table_bounds_check (MonoImage *image, int table_index, int token_index)

--- a/src/mono/mono/metadata/metadata-update.c
+++ b/src/mono/mono/metadata/metadata-update.c
@@ -141,3 +141,15 @@ mono_metadata_has_updates_api (void)
 {
         return mono_metadata_has_updates ();
 }
+
+/**
+ * mono_metadata_table_num_rows:
+ *
+ * Returns the number of rows from the specified table that the current thread can see.
+ * If there's a EnC metadata update, this number may change.
+ */
+int
+mono_metadata_table_num_rows_slow (MonoImage *base_image, int table_index)
+{
+	return mono_component_hot_reload()->table_num_rows_slow (base_image, table_index);
+}

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -2203,8 +2203,12 @@ mono_metadata_get_param_attrs (MonoImage *m, int def, int param_count)
 	guint lastp, i, param_index = mono_metadata_decode_row_col (methodt, def - 1, MONO_METHOD_PARAMLIST);
 	int *pattrs = NULL;
 
+	/* hot reload deltas may specify 0 for the param table index */
+	if (param_index == 0)
+		return NULL;
+
 	/* FIXME: metadata-update */
-	int rows = table_info_get_rows (methodt);
+	int rows = mono_metadata_table_num_rows (m, MONO_TABLE_METHOD);
 	if (def < rows)
 		lastp = mono_metadata_decode_row_col (methodt, def, MONO_METHOD_PARAMLIST);
 	else

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -4723,7 +4723,12 @@ mono_metadata_typedef_from_method (MonoImage *meta, guint32 index)
 	if (meta->uncompressed_metadata)
 		loc.idx = search_ptr_table (meta, MONO_TABLE_METHOD_POINTER, loc.idx);
 
-	/* FIXME: metadata-update */
+	/* if it's not in the base image, look in the hot reload table */
+	gboolean added = (loc.idx > table_info_get_rows (&meta->tables [MONO_TABLE_METHOD]));
+	if (added) {
+		uint32_t res = mono_component_hot_reload ()->method_parent (meta, loc.idx);
+		return res; /* 0 if not found, otherwise 1-based */
+	}
 
 	if (!mono_binary_search (&loc, tdef->base, table_info_get_rows (tdef), tdef->row_size, typedef_locator))
 		return 0;


### PR DESCRIPTION
Just a draft to check that the non-reload paths are ok.

I took a different approach than CoreCLR for dealing with the link between a method and the class that it is parented by.
They essentially always add a MethodPointer table and in-place update all the classes in the assembly to go through the indirection.  That way they maintain the invariant that a TypeDef method column points at a contiguous sequence of rows in a  table (originally Method, after an update MethodPointer).

Instead I just keep a hash table of the parents of the newly-added methods.  And another one that returns all the methods that have been added to a given class.  Not sure if this will really work out.  But it works for toy examples.

---

This is enough to support modifications to lambdas that capture `this` but don't capture any local variables.  (lambdas that don't capture anything are compiled to methods in a new hidden class, but that also has a static field that caches the delegate for the lambda - and we don't support field additions yet.  Lambdas that capture locals compile to a class that has  instance fields for the captured variables - which again we dont' support yet.  Lambdas that capture only `this` and nothing else compile to instance methods of the enclosing class, which is just what this PR supports).