### PR TITLE
Fix string comparison with ordinal casing with Surrogates

### DIFF
--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.Compare.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.Compare.cs
@@ -273,6 +273,20 @@ namespace System.Globalization.Tests
                 yield return new object[] { new CultureInfo("de-DE_phoneb").CompareInfo, "\u00DC", "UE", CompareOptions.None, useNls ? 0 : -1 };
                 yield return new object[] { new CultureInfo("es-ES_tradnl").CompareInfo, "llegar", "lugar", CompareOptions.None, useNls ? 1 : -1 };
             }
+
+            //
+            // Ordinal comparisons with ignore casing.
+            //
+
+            yield return new object[] { s_invariantCompare, "abcd", "abcd", CompareOptions.OrdinalIgnoreCase, 0};
+            yield return new object[] { s_invariantCompare, "abcd", "ABCD", CompareOptions.OrdinalIgnoreCase, 0};
+            yield return new object[] { s_invariantCompare, "Hello\u00F6", "HELLO\u00D6", CompareOptions.OrdinalIgnoreCase, 0};
+            yield return new object[] { s_invariantCompare, "Hello\uFE6A", "Hello\U0001F601", CompareOptions.OrdinalIgnoreCase, useNls ? 1 : -1};
+            yield return new object[] { s_invariantCompare, "Hello\U0001F601", "Hello\uFE6A", CompareOptions.OrdinalIgnoreCase, useNls ? -1 : 1};
+            yield return new object[] { s_invariantCompare, "\uDBFF", "\uD800\uDC00", CompareOptions.OrdinalIgnoreCase, useNls ? 1 : -1};
+            yield return new object[] { s_invariantCompare, "\uD800\uDC00", "\uDBFF", CompareOptions.OrdinalIgnoreCase, useNls ? -1 : 1};
+            yield return new object[] { s_invariantCompare, "abcdefg\uDBFF", "abcdefg\uD800\uDC00", CompareOptions.OrdinalIgnoreCase, useNls ? 1 : -1};
+            yield return new object[] { s_invariantCompare, "\U00010400", "\U00010428", CompareOptions.OrdinalIgnoreCase, useNls ? -1 : 0};
         }
 
         // There is a regression in Windows 190xx version with the Kana comparison. Avoid running this test there.

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/InvariantModeCasing.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/InvariantModeCasing.cs
@@ -161,14 +161,15 @@ namespace System.Globalization
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static (uint, int) GetScalar(ref char charA, int index, int length)
+        private static (uint, int) GetScalar(ref char source, int index, int length)
         {
+            char charA = source;
             if (!char.IsHighSurrogate(charA) || index >= length - 1)
             {
                 return ((uint)charA, 1);
             }
 
-            ref char charB = ref Unsafe.Add(ref charA, 1);
+            char charB = Unsafe.Add(ref source, 1);
             if (!char.IsLowSurrogate(charB))
             {
                 return ((uint)charA, 1);

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/OrdinalCasing.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/OrdinalCasing.Icu.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text;
 using System.Diagnostics;
 using System.Threading;
 using System.Runtime.InteropServices;
@@ -196,72 +197,90 @@ namespace System.Globalization
             ref char charA = ref strA;
             ref char charB = ref strB;
 
-            while (length != 0)
+            int index = 0;
+
+            while (index < length)
             {
-                 // optimize for Ascii cases
-                if (charA <= '\u00FF' || length == 1 || !char.IsHighSurrogate(charA) || !char.IsHighSurrogate(charB))
-                {
-                    if (charA == charB)
-                    {
-                        length--;
-                        charA = ref Unsafe.Add(ref charA, 1);
-                        charB = ref Unsafe.Add(ref charB, 1);
-                        continue;
-                    }
-
-                    char aUpper = OrdinalCasing.ToUpper(charA);
-                    char bUpper = OrdinalCasing.ToUpper(charB);
-
-                    if (aUpper == bUpper)
-                    {
-                        length--;
-                        charA = ref Unsafe.Add(ref charA, 1);
-                        charB = ref Unsafe.Add(ref charB, 1);
-                        continue;
-                    }
-
-                    return aUpper - bUpper;
-                }
-
-                // We come here only of we have valid high surrogates and length > 1
-
                 char a = charA;
                 char b = charB;
 
-                length--;
-                charA = ref Unsafe.Add(ref charA, 1);
-                charB = ref Unsafe.Add(ref charB, 1);
-
-                if (!char.IsLowSurrogate(charA) || !char.IsLowSurrogate(charB))
+                if (!char.IsHighSurrogate(a) || index >= lengthA - 1 || !char.IsLowSurrogate(Unsafe.Add(ref charA, 1)))
                 {
-                    // malformed Surrogates - should be rare cases
-                    if (a != b)
+                    if (!char.IsHighSurrogate(b) || index >= lengthB - 1 || !char.IsLowSurrogate(Unsafe.Add(ref charB, 1)))
                     {
+                        //
+                        // Neither A or B are surrogates
+                        //
+
+                        if (b == a)
+                        {
+                            index++;
+                            charA = ref Unsafe.Add(ref charA, 1);
+                            charB = ref Unsafe.Add(ref charB, 1);
+                            continue;
+                        }
+
+                        char aUpper = OrdinalCasing.ToUpper(a);
+                        char bUpper = OrdinalCasing.ToUpper(b);
+
+                        if (aUpper == bUpper)
+                        {
+                            index++;
+                            charA = ref Unsafe.Add(ref charA, 1);
+                            charB = ref Unsafe.Add(ref charB, 1);
+                            continue;
+                        }
+
                         return a - b;
                     }
 
-                    // Should be pointing to the right characters in the string to resume at.
-                    // Just in case we could be pointing at high surrogate now.
+                    //
+                    // charA is not surrogate and charB is valid surrogate
+                    //
+
+                    return -1;
+                }
+
+                //
+                // A is Surrogate
+                //
+
+                if (!char.IsHighSurrogate(b) || index >= lengthB - 1 || !char.IsLowSurrogate(Unsafe.Add(ref charB, 1)))
+                {
+                    //
+                    // charB is not surrogate and charA is surrogate
+                    //
+
+                    return 1;
+                }
+
+                //
+                // charA and charB are surrogates
+                //
+
+                char lowSurrogateA = Unsafe.Add(ref charA, 1);
+                char lowSurrogateB = Unsafe.Add(ref charB, 1);
+
+                if (a == b && lowSurrogateA == lowSurrogateB)
+                {
+                    index += 2;
+                    charA = ref Unsafe.Add(ref charA, 2);
+                    charB = ref Unsafe.Add(ref charB, 2);
                     continue;
                 }
 
-                // we come here only if we have valid full surrogates
-                SurrogateCasing.ToUpper(a, charA, out char h1, out char l1);
-                SurrogateCasing.ToUpper(b, charB, out char h2, out char l2);
+                uint upperSurrogateA = CharUnicodeInfo.ToUpper(UnicodeUtility.GetScalarFromUtf16SurrogatePair(a, lowSurrogateA));
+                uint upperSurrogateB = CharUnicodeInfo.ToUpper(UnicodeUtility.GetScalarFromUtf16SurrogatePair(b, lowSurrogateB));
 
-                if (h1 != h2)
+                if (upperSurrogateA == upperSurrogateB)
                 {
-                    return (int)h1 - (int)h2;
+                    index += 2;
+                    charA = ref Unsafe.Add(ref charA, 2);
+                    charB = ref Unsafe.Add(ref charB, 2);
+                    continue;
                 }
 
-                if (l1 != l2)
-                {
-                    return (int)l1 - (int)l2;
-                }
-
-                length--;
-                charA = ref Unsafe.Add(ref charA, 1);
-                charB = ref Unsafe.Add(ref charB, 1);
+                return (int)upperSurrogateA - (int)upperSurrogateB;
             }
 
             return lengthA - lengthB;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/OrdinalCasing.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/OrdinalCasing.Icu.cs
@@ -203,8 +203,9 @@ namespace System.Globalization
             {
                 char a = charA;
                 char b = charB;
+                char lowSurrogateA = '\0';
 
-                if (!char.IsHighSurrogate(a) || index >= lengthA - 1 || !char.IsLowSurrogate(Unsafe.Add(ref charA, 1)))
+                if (!char.IsHighSurrogate(a) || index >= lengthA - 1 || !char.IsLowSurrogate(lowSurrogateA = Unsafe.Add(ref charA, 1)))
                 {
                     if (!char.IsHighSurrogate(b) || index >= lengthB - 1 || !char.IsLowSurrogate(Unsafe.Add(ref charB, 1)))
                     {
@@ -245,7 +246,9 @@ namespace System.Globalization
                 // A is Surrogate
                 //
 
-                if (!char.IsHighSurrogate(b) || index >= lengthB - 1 || !char.IsLowSurrogate(Unsafe.Add(ref charB, 1)))
+                char lowSurrogateB = '\0';
+
+                if (!char.IsHighSurrogate(b) || index >= lengthB - 1 || !char.IsLowSurrogate(lowSurrogateB = Unsafe.Add(ref charB, 1)))
                 {
                     //
                     // charB is not surrogate and charA is surrogate
@@ -258,8 +261,8 @@ namespace System.Globalization
                 // charA and charB are surrogates
                 //
 
-                char lowSurrogateA = Unsafe.Add(ref charA, 1);
-                char lowSurrogateB = Unsafe.Add(ref charB, 1);
+                Debug.Assert(lowSurrogateA != '\0');
+                Debug.Assert(lowSurrogateB != '\0');
 
                 if (a == b && lowSurrogateA == lowSurrogateB)
                 {


### PR DESCRIPTION
This change is fixing the string comparisons with ordinal casing when using surrogate pairs. 
I have measured the perf for ordinal casing comparisons in general to ensure there is no regression introduced because of this change.  

*.NET 6.0 Before changes*

```
|                             Method |      Mean |     Error |    StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------------- |----------:|----------:|----------:|------:|------:|------:|----------:|
|          SimpleAsciiNoCasingNeeded |  1.626 ns | 0.0603 ns | 0.0619 ns |     - |     - |     - |         - |
|            SimpleAsciiCasingNeeded | 31.667 ns | 0.3536 ns | 0.3135 ns |     - |     - |     - |         - |
|              NonSimpleCasingNeeded | 40.866 ns | 0.6449 ns | 0.9453 ns |     - |     - |     - |         - |
| NonSimpleCasingNeededWithSurrogate | 48.083 ns | 0.9228 ns | 0.8180 ns |     - |     - |     - |         - |
```

*.NET 6.0 After changes*

```
|                             Method |      Mean |     Error |    StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------------- |----------:|----------:|----------:|------:|------:|------:|----------:|
|          SimpleAsciiNoCasingNeeded |  1.309 ns | 0.0251 ns | 0.0222 ns |     - |     - |     - |         - |
|            SimpleAsciiCasingNeeded | 30.796 ns | 0.3370 ns | 0.2988 ns |     - |     - |     - |         - |
|              NonSimpleCasingNeeded | 40.400 ns | 0.5521 ns | 0.5164 ns |     - |     - |     - |         - |
| NonSimpleCasingNeededWithSurrogate | 48.030 ns | 0.7178 ns | 0.6715 ns |     - |     - |     - |         - |
```

