### PR TITLE
Optimize division by constant after AND or RSZ

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5215,10 +5215,34 @@ bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
         int    postShift;
         bool   simpleMul = false;
 
+        unsigned bits = type == TYP_INT ? 32 : 64;
+        // if the dividend operand is AND or RSZ with a constant then the number of input bits can be reduced
+        if (dividend->OperIs(GT_AND))
+        {
+            size_t maskCns = static_cast<size_t>(
+                dividend->gtGetOp1()->IsCnsIntOrI()
+                    ? dividend->gtGetOp1()->AsIntCon()->IconValue()
+                    : dividend->gtGetOp2()->IsCnsIntOrI() ? dividend->gtGetOp2()->AsIntCon()->IconValue() : 0);
+            if (maskCns)
+            {
+                unsigned maskBits = 1;
+                while (maskCns >>= 1)
+                    maskBits++;
+                if (maskBits < bits)
+                    bits = maskBits;
+            }
+        }
+        else if (dividend->OperIs(GT_RSZ) && dividend->gtGetOp2()->IsCnsIntOrI())
+        {
+            size_t shiftCns = static_cast<size_t>(dividend->gtGetOp2()->AsIntCon()->IconValue());
+            if (shiftCns < bits)
+                bits -= static_cast<unsigned>(shiftCns);
+        }
+
         if (type == TYP_INT)
         {
-            magic =
-                MagicDivide::GetUnsigned32Magic(static_cast<uint32_t>(divisorValue), &increment, &preShift, &postShift);
+            magic = MagicDivide::GetUnsigned32Magic(static_cast<uint32_t>(divisorValue), &increment, &preShift,
+                                                    &postShift, bits);
 
 #ifdef TARGET_64BIT
             // avoid inc_saturate/multiple shifts by widening to 32x64 MULHI
@@ -5230,7 +5254,7 @@ bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
                               ))
             {
                 magic = MagicDivide::GetUnsigned64Magic(static_cast<uint64_t>(divisorValue), &increment, &preShift,
-                                                        &postShift, 32);
+                                                        &postShift, bits);
             }
             // otherwise just widen to regular multiplication
             else
@@ -5243,8 +5267,8 @@ bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
         else
         {
 #ifdef TARGET_64BIT
-            magic =
-                MagicDivide::GetUnsigned64Magic(static_cast<uint64_t>(divisorValue), &increment, &preShift, &postShift);
+            magic = MagicDivide::GetUnsigned64Magic(static_cast<uint64_t>(divisorValue), &increment, &preShift,
+                                                    &postShift, bits);
 #else
             unreached();
 #endif

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5217,13 +5217,10 @@ bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
 
         unsigned bits = type == TYP_INT ? 32 : 64;
         // if the dividend operand is AND or RSZ with a constant then the number of input bits can be reduced
-        if (dividend->OperIs(GT_AND))
+        if (dividend->OperIs(GT_AND) && dividend->gtGetOp2()->IsCnsIntOrI())
         {
-            size_t maskCns = static_cast<size_t>(
-                dividend->gtGetOp1()->IsCnsIntOrI()
-                    ? dividend->gtGetOp1()->AsIntCon()->IconValue()
-                    : dividend->gtGetOp2()->IsCnsIntOrI() ? dividend->gtGetOp2()->AsIntCon()->IconValue() : 0);
-            if (maskCns)
+            size_t maskCns = static_cast<size_t>(dividend->gtGetOp2()->AsIntCon()->IconValue());
+            if (maskCns != 0)
             {
                 unsigned maskBits = 1;
                 while (maskCns >>= 1)
@@ -5236,7 +5233,9 @@ bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
         {
             size_t shiftCns = static_cast<size_t>(dividend->gtGetOp2()->AsIntCon()->IconValue());
             if (shiftCns < bits)
+            {
                 bits -= static_cast<unsigned>(shiftCns);
+            }
         }
 
         if (type == TYP_INT)

--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -2417,6 +2417,7 @@ T GetUnsignedMagic(T d, bool* increment /*out*/, int* preShift /*out*/, int* pos
 uint32_t GetUnsigned32Magic(
     uint32_t d, bool* increment /*out*/, int* preShift /*out*/, int* postShift /*out*/, unsigned bits)
 {
+    assert(bits <= 32);
     return GetUnsignedMagic<uint32_t>(d, increment, preShift, postShift, bits);
 }
 
@@ -2424,6 +2425,7 @@ uint32_t GetUnsigned32Magic(
 uint64_t GetUnsigned64Magic(
     uint64_t d, bool* increment /*out*/, int* preShift /*out*/, int* postShift /*out*/, unsigned bits)
 {
+    assert(bits <= 64);
     return GetUnsignedMagic<uint64_t>(d, increment, preShift, postShift, bits);
 }
 #endif

--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -2414,9 +2414,10 @@ T GetUnsignedMagic(T d, bool* increment /*out*/, int* preShift /*out*/, int* pos
     }
 }
 
-uint32_t GetUnsigned32Magic(uint32_t d, bool* increment /*out*/, int* preShift /*out*/, int* postShift /*out*/)
+uint32_t GetUnsigned32Magic(
+    uint32_t d, bool* increment /*out*/, int* preShift /*out*/, int* postShift /*out*/, unsigned bits)
 {
-    return GetUnsignedMagic<uint32_t>(d, increment, preShift, postShift, 32);
+    return GetUnsignedMagic<uint32_t>(d, increment, preShift, postShift, bits);
 }
 
 #ifdef TARGET_64BIT

--- a/src/coreclr/jit/utils.h
+++ b/src/coreclr/jit/utils.h
@@ -762,10 +762,10 @@ private:
 namespace MagicDivide
 {
 uint32_t GetUnsigned32Magic(
-    uint32_t d, bool* increment /*out*/, int* preShift /*out*/, int* postShift /*out*/, unsigned bits = 32);
+    uint32_t d, bool* increment /*out*/, int* preShift /*out*/, int* postShift /*out*/, unsigned bits);
 #ifdef TARGET_64BIT
 uint64_t GetUnsigned64Magic(
-    uint64_t d, bool* increment /*out*/, int* preShift /*out*/, int* postShift /*out*/, unsigned bits = 64);
+    uint64_t d, bool* increment /*out*/, int* preShift /*out*/, int* postShift /*out*/, unsigned bits);
 #endif
 int32_t GetSigned32Magic(int32_t d, int* shift /*out*/);
 #ifdef TARGET_64BIT

--- a/src/coreclr/jit/utils.h
+++ b/src/coreclr/jit/utils.h
@@ -761,7 +761,8 @@ private:
 
 namespace MagicDivide
 {
-uint32_t GetUnsigned32Magic(uint32_t d, bool* increment /*out*/, int* preShift /*out*/, int* postShift /*out*/);
+uint32_t GetUnsigned32Magic(
+    uint32_t d, bool* increment /*out*/, int* preShift /*out*/, int* postShift /*out*/, unsigned bits = 32);
 #ifdef TARGET_64BIT
 uint64_t GetUnsigned64Magic(
     uint64_t d, bool* increment /*out*/, int* preShift /*out*/, int* postShift /*out*/, unsigned bits = 64);

--- a/src/libraries/System.Private.CoreLib/src/System/Convert.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Convert.cs
@@ -2528,14 +2528,14 @@ namespace System
         private static int ToBase64_CalculateAndValidateOutputLength(int inputLength, bool insertLineBreaks)
         {
             // the base length - we want integer division here, at most 4 more chars for the remainder
-            long outlen = ((long)inputLength + 2) / 3 * 4;
+            uint outlen = ((uint)inputLength + 2) / 3 * 4;
 
             if (outlen == 0)
                 return 0;
 
             if (insertLineBreaks)
             {
-                (long newLines, long remainder) = Math.DivRem(outlen, base64LineBreakPosition);
+                (uint newLines, uint remainder) = Math.DivRem(outlen, base64LineBreakPosition);
                 if (remainder == 0)
                 {
                     --newLines;

--- a/src/libraries/System.Private.CoreLib/src/System/DateOnly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateOnly.cs
@@ -28,7 +28,7 @@ namespace System
         // Maps to December 31 year 9999. The value calculated from "new DateTime(9999, 12, 31).Ticks / TimeSpan.TicksPerDay"
         private const int MaxDayNumber = 3_652_058;
 
-        private static int DayNumberFromDateTime(DateTime dt) => (int)(dt.Ticks / TimeSpan.TicksPerDay);
+        private static int DayNumberFromDateTime(DateTime dt) => (int)((ulong)dt.Ticks / TimeSpan.TicksPerDay);
 
         private DateTime GetEquivalentDateTime() => DateTime.UnsafeCreate(_dayNumber * TimeSpan.TicksPerDay);
 
@@ -97,7 +97,7 @@ namespace System
         /// <summary>
         /// Gets the day of the week represented by this instance.
         /// </summary>
-        public DayOfWeek DayOfWeek => GetEquivalentDateTime().DayOfWeek;
+        public DayOfWeek DayOfWeek => (DayOfWeek)(((uint)_dayNumber + 1) % 7);
 
         /// <summary>
         /// Gets the day of the year represented by this instance.

--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -461,17 +461,9 @@ namespace System
             GetDate(out int year, out int month, out int day);
             int y = year, d = day;
             int m = month + months;
-            if (m > 0)
-            {
-                int q = (int)((uint)(m - 1) / 12);
-                y += q;
-                m -= q * 12;
-            }
-            else
-            {
-                y += m / 12 - 1;
-                m = 12 + m % 12;
-            }
+            int q = m > 0 ? (int)((uint)(m - 1) / 12) : m / 12 - 1;
+            y += q;
+            m -= q * 12;
             if (y < 1 || y > 9999) ThrowDateArithmetic(2);
             uint[] daysTo = IsLeapYear(y) ? s_daysToMonth366 : s_daysToMonth365;
             uint daysToMonth = daysTo[m - 1];


### PR DESCRIPTION
If the dividend operand is `AND` or `RSZ` with a constant then the number of input bits can be reduced which helps generate more optimal magic numbers.
Also adopted a couple more functions to use unsigned division.

Diff example:
```diff
 G_M59169_IG02:
        48B8FFFFFFFFFFFFFF3F mov      rax, 0x3FFFFFFFFFFFFFFF
        488BD0               mov      rdx, rax
        482311               and      rdx, qword ptr [rcx]
        48B94B598638D6C56D34 mov      rcx, 0x346DC5D63886594B
        488BC2               mov      rax, rdx
        48F7E1               mul      rdx:rax, rcx
        488BCA               mov      rcx, rdx
        48C1E90B             shr      rcx, 11
-       48BACFF753E3A59BC420 mov      rdx, 0x20C49BA5E353F7CF
+       48BAF0A7C64B37894100 mov      rdx, 0x4189374BC6A7F0
        488BC1               mov      rax, rcx
-       48C1E803             shr      rax, 3
        48F7E2               mul      rdx:rax, rdx
-       48C1EA04             shr      rdx, 4
        4869C2E8030000       imul     rax, rdx, 0x3E8
        482BC8               sub      rcx, rax
        8BC1                 mov      eax, ecx
-						;; bbWeight=1    PerfScore 13.75
+						;; bbWeight=1    PerfScore 12.75
 G_M59169_IG03:
        C3                   ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 76, prolog size 0, PerfScore 22.35, instruction count 17, allocated bytes for code 76 (MethodHash=439618de) for method DateTime:get_Millisecond():int:this
+; Total bytes of code 68, prolog size 0, PerfScore 20.55, instruction count 15, allocated bytes for code 68 (MethodHash=439618de) for method DateTime:get_Millisecond():int:this
```