### PR TITLE
Reduce the nullability bypasses in CryptoPool.Return

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/CngPkcs8.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/CngPkcs8.cs
@@ -198,8 +198,7 @@ namespace System.Security.Cryptography
                         }
                         finally
                         {
-                            CryptographicOperations.ZeroMemory(decryptedSpan);
-                            CryptoPool.Return(decrypted.Array!);
+                            CryptoPool.Return(decrypted);
                         }
                     }
                     catch (AsnContentException e)
@@ -277,8 +276,7 @@ namespace System.Security.Cryptography
                         }
                         finally
                         {
-                            CryptographicOperations.ZeroMemory(decryptedSpan);
-                            CryptoPool.Return(decrypted.Array!, clearSize: 0);
+                            CryptoPool.Return(decrypted);
                         }
                     }
                 }

--- a/src/libraries/Common/src/System/Security/Cryptography/KeyFormatHelper.Encrypted.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/KeyFormatHelper.Encrypted.cs
@@ -189,20 +189,19 @@ namespace System.Security.Cryptography
                 out string encryptionAlgorithmOid,
                 out bool isPkcs12);
 
-            byte[]? encryptedRent = null;
             Span<byte> encryptedSpan = default;
             AsnWriter? writer = null;
 
+            Debug.Assert(cipher.BlockSize <= 128, $"Encountered unexpected block size: {cipher.BlockSize}");
+            Span<byte> iv = stackalloc byte[cipher.BlockSize / 8];
+            Span<byte> salt = stackalloc byte[16];
+
+            // We need at least one block size beyond the input data size.
+            byte[]? encryptedRent = CryptoPool.Rent(
+                checked(pkcs8Writer.GetEncodedLength() + (cipher.BlockSize / 8)));
+
             try
             {
-                Debug.Assert(cipher.BlockSize <= 128, $"Encountered unexpected block size: {cipher.BlockSize}");
-                Span<byte> iv = stackalloc byte[cipher.BlockSize / 8];
-                Span<byte> salt = stackalloc byte[16];
-
-                // We need at least one block size beyond the input data size.
-                encryptedRent = CryptoPool.Rent(
-                    checked(pkcs8Writer.GetEncodedLength() + (cipher.BlockSize / 8)));
-
                 RandomNumberGenerator.Fill(salt);
 
                 int written = PasswordBasedEncryption.Encrypt(
@@ -242,7 +241,7 @@ namespace System.Security.Cryptography
             finally
             {
                 CryptographicOperations.ZeroMemory(encryptedSpan);
-                CryptoPool.Return(encryptedRent!, clearSize: 0);
+                CryptoPool.Return(encryptedRent, clearSize: 0);
 
                 cipher.Dispose();
             }
@@ -348,8 +347,7 @@ namespace System.Security.Cryptography
             }
             finally
             {
-                CryptographicOperations.ZeroMemory(decrypted);
-                CryptoPool.Return(decrypted.Array!, clearSize: 0);
+                CryptoPool.Return(decrypted);
             }
         }
 
@@ -385,8 +383,7 @@ namespace System.Security.Cryptography
             }
             finally
             {
-                CryptographicOperations.ZeroMemory(decrypted);
-                CryptoPool.Return(decrypted.Array!, clearSize: 0);
+                CryptoPool.Return(decrypted);
             }
         }
     }

--- a/src/libraries/Common/src/System/Security/Cryptography/KeyFormatHelper.Encrypted.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/KeyFormatHelper.Encrypted.cs
@@ -197,7 +197,7 @@ namespace System.Security.Cryptography
             Span<byte> salt = stackalloc byte[16];
 
             // We need at least one block size beyond the input data size.
-            byte[]? encryptedRent = CryptoPool.Rent(
+            byte[] encryptedRent = CryptoPool.Rent(
                 checked(pkcs8Writer.GetEncodedLength() + (cipher.BlockSize / 8)));
 
             try

--- a/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
@@ -85,7 +85,7 @@ namespace System.Security.Cryptography
 
                 int rsaSize = Interop.AndroidCrypto.RsaSize(key);
                 Span<byte> destination = default;
-                byte[]? buf = CryptoPool.Rent(rsaSize);
+                byte[] buf = CryptoPool.Rent(rsaSize);
 
                 try
                 {
@@ -102,7 +102,7 @@ namespace System.Security.Cryptography
                 finally
                 {
                     CryptographicOperations.ZeroMemory(destination);
-                    CryptoPool.Return(buf!, clearSize: 0);
+                    CryptoPool.Return(buf, clearSize: 0);
                 }
             }
 

--- a/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
@@ -84,12 +84,11 @@ namespace System.Security.Cryptography
                 SafeRsaHandle key = GetKey();
 
                 int rsaSize = Interop.AndroidCrypto.RsaSize(key);
-                byte[]? buf = null;
                 Span<byte> destination = default;
+                byte[]? buf = CryptoPool.Rent(rsaSize);
 
                 try
                 {
-                    buf = CryptoPool.Rent(rsaSize);
                     destination = new Span<byte>(buf, 0, rsaSize);
 
                     if (!TryDecrypt(key, data, destination, rsaPadding, oaepProcessor, out int bytesWritten))

--- a/src/libraries/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -87,12 +87,11 @@ namespace System.Security.Cryptography
             ValidatePadding(padding);
             SafeEvpPKeyHandle key = GetKey();
             int rsaSize = Interop.Crypto.EvpPKeySize(key);
-            byte[]? buf = null;
             Span<byte> destination = default;
+            byte[]? buf = CryptoPool.Rent(rsaSize);
 
             try
             {
-                buf = CryptoPool.Rent(rsaSize);
                 destination = new Span<byte>(buf, 0, rsaSize);
 
                 int bytesWritten = Decrypt(key, data, destination, padding);
@@ -101,7 +100,7 @@ namespace System.Security.Cryptography
             finally
             {
                 CryptographicOperations.ZeroMemory(destination);
-                CryptoPool.Return(buf!, clearSize: 0);
+                CryptoPool.Return(buf, clearSize: 0);
             }
         }
 

--- a/src/libraries/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -88,7 +88,7 @@ namespace System.Security.Cryptography
             SafeEvpPKeyHandle key = GetKey();
             int rsaSize = Interop.Crypto.EvpPKeySize(key);
             Span<byte> destination = default;
-            byte[]? buf = CryptoPool.Rent(rsaSize);
+            byte[] buf = CryptoPool.Rent(rsaSize);
 
             try
             {

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs8PrivateKeyInfo.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs8PrivateKeyInfo.cs
@@ -197,8 +197,7 @@ namespace System.Security.Cryptography.Pkcs
             }
             finally
             {
-                CryptographicOperations.ZeroMemory(decryptedMemory.Span);
-                CryptoPool.Return(decrypted.Array!, clearSize: 0);
+                CryptoPool.Return(decrypted);
             }
         }
 
@@ -229,8 +228,7 @@ namespace System.Security.Cryptography.Pkcs
             }
             finally
             {
-                CryptographicOperations.ZeroMemory(decryptedMemory.Span);
-                CryptoPool.Return(decrypted.Array!, clearSize: 0);
+                CryptoPool.Return(decrypted);
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/UnixPkcs12Reader.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/UnixPkcs12Reader.cs
@@ -786,7 +786,7 @@ namespace Internal.Cryptography.Pal
                 }
                 finally
                 {
-                    CryptoPool.Return(decrypted.Array!, clearSize: decrypted.Count);
+                    CryptoPool.Return(decrypted);
                 }
             }
 


### PR DESCRIPTION
This is a walk over src/libraries/.../*.cs to find any calls to
CryptoPool.Return which needed a "!" because of nullability
flow.

A couple of the bypasses were identifying legitimate issues,
and were resolved by moving the Rent to the last thing before
the try.

A couple were because of the use of ArraySegment which
can't structurally promise the array is non-null. But those
were usually preceded by a call to ZeroMemory, and there
is a CryptoPool.Return(ArraySegment) which does that
already, so those "!"s were removed by changing to that
overload.