### PR TITLE
remove unnecessary call

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -27,7 +27,7 @@ namespace System.Net.Quic.Implementations.MsQuic
 
         // TODO: remove this.
         // This is only used for client-initiated connections, and isn't needed even then once Connect() has been called.
-        private readonly SafeMsQuicConfigurationHandle? _configuration;
+        private SafeMsQuicConfigurationHandle? _configuration;
 
         private readonly State _state = new State();
         private int _disposed;
@@ -574,7 +574,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                 QuicExceptionHelpers.ThrowIfFailed(status, "Failed to connect to peer.");
 
                 // this handle is ref counted by MsQuic, so safe to dispose here.
-                _configuration.Dipose();
+                _configuration.Dispose();
                 _configuration = null;
             }
             catch

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -188,9 +188,6 @@ namespace System.Net.Quic.Implementations.MsQuic
             _state.StateGCHandle = GCHandle.Alloc(_state);
             try
             {
-                // this handle is ref counted by MsQuic, so safe to dispose here.
-                using SafeMsQuicConfigurationHandle config = SafeMsQuicConfigurationHandle.Create(options);
-
                 uint status = MsQuicApi.Api.ConnectionOpenDelegate(
                     MsQuicApi.Api.Registration,
                     s_connectionDelegate,
@@ -575,6 +572,10 @@ namespace System.Net.Quic.Implementations.MsQuic
                     (ushort)port);
 
                 QuicExceptionHelpers.ThrowIfFailed(status, "Failed to connect to peer.");
+
+                // this handle is ref counted by MsQuic, so safe to dispose here.
+                _configuration.Dipose();
+                _configuration = null;
             }
             catch
             {


### PR DESCRIPTION
We call SafeMsQuicConfigurationHandle.Create twice but used only once configuration. 
Since we do not need it past connect I Dispose it there so we don't drag it forward.

Fixes #55158