### PR TITLE
#53285 switch to use MemberInfo.MetadataToken

### DIFF
--- a/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
@@ -831,21 +831,9 @@ namespace System.Reflection
                     else if (right == null)
                         return false;
 
-                    // TODO: switch to use MemberInfo.MetadataToken here.
-                    // It compares honestly referring ECMA-335 I.8.6.1.6 Signature Matching.
-                    if (!Equals(left.DeclaringType, right.DeclaringType))
+                    if (left.Module.Name != right.Module.Name)
                         return false;
-
-                    if (!Equals(left.ReturnType, right.ReturnType))
-                        return false;
-
-                    if (left.CallingConvention != right.CallingConvention)
-                        return false;
-
-                    if (left.IsStatic != right.IsStatic)
-                        return false;
-
-                    if (left.Name != right.Name)
+                    if (left.MetadataToken != right.MetadataToken)
                         return false;
 
                     Type[] leftGenericParameters = left.GetGenericArguments();

--- a/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
@@ -302,7 +302,7 @@ namespace System.Reflection
                 _tb.AddInterfaceImplementation(iface);
 
                 // AccessorMethods -> Metadata mappings.
-                var propertyMap = new Dictionary<MethodInfo, PropertyAccessorInfo>(MethodInfoEqualityComparer.Instance);
+                var propertyMap = new Dictionary<MethodInfo, PropertyAccessorInfo>();
                 foreach (PropertyInfo pi in iface.GetRuntimeProperties())
                 {
                     var ai = new PropertyAccessorInfo(pi.GetMethod, pi.SetMethod);
@@ -312,7 +312,7 @@ namespace System.Reflection
                         propertyMap[pi.SetMethod] = ai;
                 }
 
-                var eventMap = new Dictionary<MethodInfo, EventAccessorInfo>(MethodInfoEqualityComparer.Instance);
+                var eventMap = new Dictionary<MethodInfo, EventAccessorInfo>();
                 foreach (EventInfo ei in iface.GetRuntimeEvents())
                 {
                     var ai = new EventAccessorInfo(ei.AddMethod, ei.RemoveMethod, ei.RaiseMethod);
@@ -336,7 +336,7 @@ namespace System.Reflection
                     MethodBuilder mdb = AddMethodImpl(mi, methodInfoIndex);
                     if (propertyMap.TryGetValue(mi, out PropertyAccessorInfo? associatedProperty))
                     {
-                        if (MethodInfoEqualityComparer.Instance.Equals(associatedProperty.InterfaceGetMethod, mi))
+                        if (mi.Equals(associatedProperty.InterfaceGetMethod))
                             associatedProperty.GetMethodBuilder = mdb;
                         else
                             associatedProperty.SetMethodBuilder = mdb;
@@ -344,9 +344,9 @@ namespace System.Reflection
 
                     if (eventMap.TryGetValue(mi, out EventAccessorInfo? associatedEvent))
                     {
-                        if (MethodInfoEqualityComparer.Instance.Equals(associatedEvent.InterfaceAddMethod, mi))
+                        if (mi.Equals(associatedEvent.InterfaceAddMethod))
                             associatedEvent.AddMethodBuilder = mdb;
-                        else if (MethodInfoEqualityComparer.Instance.Equals(associatedEvent.InterfaceRemoveMethod, mi))
+                        else if (mi.Equals(associatedEvent.InterfaceRemoveMethod))
                             associatedEvent.RemoveMethodBuilder = mdb;
                         else
                             associatedEvent.RaiseMethodBuilder = mdb;
@@ -812,39 +812,6 @@ namespace System.Reflection
                     InterfaceAddMethod = interfaceAddMethod;
                     InterfaceRemoveMethod = interfaceRemoveMethod;
                     InterfaceRaiseMethod = interfaceRaiseMethod;
-                }
-            }
-
-            private sealed class MethodInfoEqualityComparer : EqualityComparer<MethodInfo>
-            {
-                public static readonly MethodInfoEqualityComparer Instance = new MethodInfoEqualityComparer();
-
-                private MethodInfoEqualityComparer() { }
-
-                public sealed override bool Equals(MethodInfo? left, MethodInfo? right)
-                {
-                    if (left == null)
-                        return right == null;
-                    else if (right == null)
-                        return false;
-
-                    return left.Module.Name == right.Module.Name && left.MetadataToken == right.MetadataToken;
-                }
-
-                public sealed override int GetHashCode(MethodInfo obj)
-                {
-                    if (obj == null)
-                        return 0;
-
-                    Debug.Assert(obj.DeclaringType != null);
-                    int hashCode = obj.DeclaringType!.GetHashCode();
-                    hashCode ^= obj.Name.GetHashCode();
-                    foreach (ParameterInfo parameter in obj.GetParameters())
-                    {
-                        hashCode ^= parameter.ParameterType.GetHashCode();
-                    }
-
-                    return hashCode;
                 }
             }
         }

--- a/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
@@ -833,7 +833,7 @@ namespace System.Reflection
 
                     if (left.Module.Name != right.Module.Name)
                         return false;
-                    
+
                     if (left.MetadataToken != right.MetadataToken)
                         return false;
 

--- a/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
@@ -823,43 +823,12 @@ namespace System.Reflection
 
                 public sealed override bool Equals(MethodInfo? left, MethodInfo? right)
                 {
-                    if (ReferenceEquals(left, right))
-                        return true;
-
                     if (left == null)
                         return right == null;
                     else if (right == null)
                         return false;
 
-                    if (left.Module.Name != right.Module.Name)
-                        return false;
-
-                    if (left.MetadataToken != right.MetadataToken)
-                        return false;
-
-                    Type[] leftGenericParameters = left.GetGenericArguments();
-                    Type[] rightGenericParameters = right.GetGenericArguments();
-                    if (leftGenericParameters.Length != rightGenericParameters.Length)
-                        return false;
-
-                    for (int i = 0; i < leftGenericParameters.Length; i++)
-                    {
-                        if (!Equals(leftGenericParameters[i], rightGenericParameters[i]))
-                            return false;
-                    }
-
-                    ParameterInfo[] leftParameters = left.GetParameters();
-                    ParameterInfo[] rightParameters = right.GetParameters();
-                    if (leftParameters.Length != rightParameters.Length)
-                        return false;
-
-                    for (int i = 0; i < leftParameters.Length; i++)
-                    {
-                        if (!Equals(leftParameters[i].ParameterType, rightParameters[i].ParameterType))
-                            return false;
-                    }
-
-                    return true;
+                    return left.Module.Name == right.Module.Name && left.MetadataToken == right.MetadataToken;
                 }
 
                 public sealed override int GetHashCode(MethodInfo obj)

--- a/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
@@ -833,6 +833,7 @@ namespace System.Reflection
 
                     if (left.Module.Name != right.Module.Name)
                         return false;
+                    
                     if (left.MetadataToken != right.MetadataToken)
                         return false;
 


### PR DESCRIPTION
 Switch to use MemberInfo.MetadataToken

With #53283, we won't build a netstandard1.x configuration of this library anymore and the code path can be optimized.

Fix #53285