### PR TITLE
Remove unnecessary intrinsics in mono/mini/intrinsics.c

### DIFF
--- a/src/mono/mono/mini/intrinsics.c
+++ b/src/mono/mono/mini/intrinsics.c
@@ -1624,16 +1624,6 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 			return ins;
 		}
 	} else if (in_corlib &&
-	        	(strcmp (cmethod_klass_name_space, "System") == 0) &&
-	        	(strcmp (cmethod_klass_name, "Environment") == 0)) {
-		if (!strcmp (cmethod->name, "get_IsRunningOnWindows") && fsig->param_count == 0) {
-#ifdef TARGET_WIN32
-			EMIT_NEW_ICONST (cfg, ins, 1);
-#else
-			EMIT_NEW_ICONST (cfg, ins, 0);
-#endif
-		}
-	} else if (in_corlib &&
 			(strcmp (cmethod_klass_name_space, "System.Reflection") == 0) &&
 			(strcmp (cmethod_klass_name, "Assembly") == 0)) {
 		if (cfg->llvm_only && !strcmp (cmethod->name, "GetExecutingAssembly")) {
@@ -1936,15 +1926,6 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 	if (in_corlib && !strcmp ("System.Numerics", cmethod_klass_name_space) && !strcmp ("Vector", cmethod_klass_name)) {
 		if (!strcmp (cmethod->name, "get_IsHardwareAccelerated")) {
 			EMIT_NEW_ICONST (cfg, ins, 0);
-			ins->type = STACK_I4;
-			return ins;
-		}
-	}
-
-	/* Workaround for the compiler server IsMemoryAvailable. */
-	if (!strcmp ("Microsoft.CodeAnalysis.CompilerServer", cmethod_klass_name_space) && !strcmp ("MemoryHelper", cmethod_klass_name)) {
-		if (!strcmp (cmethod->name, "IsMemoryAvailable")) {
-			EMIT_NEW_ICONST (cfg, ins, 1);
 			ins->type = STACK_I4;
 			return ins;
 		}


### PR DESCRIPTION
- `System.Environment.IsRunningOnWindows` doesn't exist in the dotnet/runtime corelib
- `Microsoft.CodeAnalysis.CompilerServer.MemoryHelper.IsMemoryAvailable` was used to workaround a bug that was fixed 2 years ago with https://github.com/dotnet/roslyn/pull/38239 and should no longer be relevant