### PR TITLE
[Android] Disable some library tests due to failures/crash

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/Enumeration/ErrorHandlingTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Enumeration/ErrorHandlingTests.cs
@@ -82,6 +82,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55821", TestPlatforms.Android)]
         public void DeleteDirectoryAfterOpening()
         {
             // We shouldn't prevent the directory from being deleted, even though we've

--- a/src/libraries/System.IO.FileSystem/tests/Enumeration/RootTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Enumeration/RootTests.cs
@@ -31,6 +31,7 @@ namespace System.IO.Tests.Enumeration
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55821", TestPlatforms.Android)]
         public void CanRecurseFromRoot()
         {
             string root = Path.GetPathRoot(Path.GetTempPath());

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -52,6 +52,9 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Csp\tests\System.Security.Cryptography.Csp.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Thread\tests\System.Threading.Thread.Tests.csproj" />
 
+    <!-- Crash https://github.com/dotnet/runtime/issues/55823 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Experimental\tests\System.Runtime.Experimental.Tests.csproj" />
+
     <!-- Crashes on x64 and x86, but not arm64 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Pkcs\tests\System.Security.Cryptography.Pkcs.Tests.csproj" />
 


### PR DESCRIPTION
The issues:
- https://github.com/dotnet/runtime/issues/55821
- https://github.com/dotnet/runtime/issues/55822
- https://github.com/dotnet/runtime/issues/55823