### PR TITLE
Access modifier cleanup in Task

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -796,7 +796,7 @@ namespace System.Threading.Tasks
         /// harmful).  Derived implementations may choose to only conditionally call down to this base
         /// implementation.
         /// </summary>
-        private protected virtual bool ShouldNotifyDebuggerOfWaitCompletion // ideally would be familyAndAssembly, but that can't be done in C#
+        private protected virtual bool ShouldNotifyDebuggerOfWaitCompletion
         {
             get
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -796,7 +796,7 @@ namespace System.Threading.Tasks
         /// harmful).  Derived implementations may choose to only conditionally call down to this base
         /// implementation.
         /// </summary>
-        internal virtual bool ShouldNotifyDebuggerOfWaitCompletion // ideally would be familyAndAssembly, but that can't be done in C#
+        private protected virtual bool ShouldNotifyDebuggerOfWaitCompletion // ideally would be familyAndAssembly, but that can't be done in C#
         {
             get
             {


### PR DESCRIPTION
This property can be `private protected` (C# 7.2) instead of `internal`.