### PR TITLE
Fix UMEntryThunkCache::GetUMEntryThunk

### DIFF
--- a/src/coreclr/vm/dllimportcallback.cpp
+++ b/src/coreclr/vm/dllimportcallback.cpp
@@ -163,7 +163,8 @@ UMEntryThunk *UMEntryThunkCache::GetUMEntryThunk(MethodDesc *pMD)
         Holder<UMThunkMarshInfo *, DoNothing, UMEntryThunkCache::DestroyMarshInfo> miHolder;
         miHolder.Assign(pMarshInfo);
 
-        pMarshInfo->LoadTimeInit(pMD);
+        ExecutableWriterHolder<UMThunkMarshInfo> marshInfoWriterHolder(pMarshInfo, sizeof(UMThunkMarshInfo));
+        marshInfoWriterHolder.GetRW()->LoadTimeInit(pMD);
 
         ExecutableWriterHolder<UMEntryThunk> thunkWriterHolder(pThunk, sizeof(UMEntryThunk));
         thunkWriterHolder.GetRW()->LoadTimeInit(pThunk, NULL, NULL, pMarshInfo, pMD);


### PR DESCRIPTION
The function was initializing UMThunkMarshInfo allocated from Stub heap
without using the ExecutableWriterHolder. That causes a crash when a
hosting application calls coreclr_create_delegate.
This was discovered in .NET 6 Preview 6 when running a xamarin app that
uses a special host.

This code path is exercised only by coreclr_create_delegate.

Close #55773