### PR TITLE
Disable S.S.C.OpenSSL tests on the platforms that are PNSE.

### DIFF
--- a/src/libraries/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj
@@ -4,6 +4,8 @@
     <!-- ActiveIssue Apple Silicon No usable version of libssl was found
         https://github.com/dotnet/runtime/issues/49083 -->
     <IgnoreForCI Condition="'$(TargetOS)' == 'OSX' and '$(TargetArchitecture)' == 'arm64' ">true</IgnoreForCI>
+    <!-- The library is not supported on mobile platforms (PNSE) -->
+    <IgnoreForCI Condition="'$(TargetsAndroid)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true'">true</IgnoreForCI>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="EcDsaOpenSslTests.cs" />


### PR DESCRIPTION
Fixes #51414.