### PR TITLE
Fix debugger thread context validation after recent change

### DIFF
--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -15911,7 +15911,7 @@ BOOL Debugger::IsThreadContextInvalid(Thread *pThread, CONTEXT *pCtx)
     if (!success)
     {
         ctx.ContextFlags = CONTEXT_CONTROL;
-        BOOL success = pThread->GetThreadContext(&ctx);
+        success = pThread->GetThreadContext(&ctx);
         if (success)
         {
             pCtx = &ctx;


### PR DESCRIPTION
Followup fix to https://github.com/dotnet/runtime/pull/55185