### PR TITLE
Reimplement dynamic member access for collection converters correctly

### DIFF
--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -90,6 +90,9 @@
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonNumberHandlingAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonPropertyNameAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonPropertyOrderAttribute.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\Collection\ImmutableDictionaryOfTKeyTValueConverterWithReflection.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\Collection\ImmutableEnumerableOfTConverterWithReflection.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\Collection\StackOrQueueConverterWithReflection.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\JsonMetadataServicesConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\IgnoreReferenceResolver.cs" />
     <Compile Include="System\Text\Json\Serialization\IJsonOnDeserialized.cs" />
@@ -121,7 +124,7 @@
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\IEnumerableConverterFactoryHelpers.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\IEnumerableDefaultConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\IEnumerableOfTConverter.cs" />
-    <Compile Include="System\Text\Json\Serialization\Converters\Collection\IEnumerableWithAddMethodConverter.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\Collection\StackOrQueueConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\IListConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\IListOfTConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\ImmutableDictionaryOfTKeyTValueConverter.cs" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverterFactory.cs
@@ -68,7 +68,7 @@ namespace System.Text.Json.Serialization.Converters
             else if (typeToConvert.IsImmutableDictionaryType())
             {
                 genericArgs = typeToConvert.GetGenericArguments();
-                converterType = typeof(ImmutableDictionaryOfTKeyTValueConverter<,,>);
+                converterType = typeof(ImmutableDictionaryOfTKeyTValueConverterWithReflection<,,>);
                 dictionaryKeyType = genericArgs[0];
                 elementType = genericArgs[1];
             }
@@ -91,7 +91,7 @@ namespace System.Text.Json.Serialization.Converters
             // Immutable non-dictionaries from System.Collections.Immutable, e.g. ImmutableStack<T>
             else if (typeToConvert.IsImmutableEnumerableType())
             {
-                converterType = typeof(ImmutableEnumerableOfTConverter<,>);
+                converterType = typeof(ImmutableEnumerableOfTConverterWithReflection<,>);
                 elementType = typeToConvert.GetGenericArguments()[0];
             }
             // IList<>
@@ -163,7 +163,7 @@ namespace System.Text.Json.Serialization.Converters
             }
             else if (typeToConvert.IsNonGenericStackOrQueue())
             {
-                converterType = typeof(IEnumerableWithAddMethodConverter<>);
+                converterType = typeof(StackOrQueueConverterWithReflection<>);
             }
             else
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableDictionaryOfTKeyTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableDictionaryOfTKeyTValueConverter.cs
@@ -3,39 +3,28 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json.Serialization.Converters
 {
-    internal sealed class ImmutableDictionaryOfTKeyTValueConverter<TCollection, TKey, TValue>
+    internal class ImmutableDictionaryOfTKeyTValueConverter<TCollection, TKey, TValue>
         : DictionaryDefaultConverter<TCollection, TKey, TValue>
         where TCollection : IReadOnlyDictionary<TKey, TValue>
         where TKey : notnull
     {
-        [RequiresUnreferencedCode(IEnumerableConverterFactoryHelpers.ImmutableConvertersUnreferencedCodeMessage)]
-        public ImmutableDictionaryOfTKeyTValueConverter()
-        {
-        }
-
-        // Used by source-gen initialization for reflection-free serialization.
-        public ImmutableDictionaryOfTKeyTValueConverter(bool dummy) { }
-
-        protected override void Add(TKey key, in TValue value, JsonSerializerOptions options, ref ReadStack state)
+        protected sealed override void Add(TKey key, in TValue value, JsonSerializerOptions options, ref ReadStack state)
         {
             ((Dictionary<TKey, TValue>)state.Current.ReturnValue!)[key] = value;
         }
 
-        internal override bool CanHaveIdMetadata => false;
+        internal sealed override bool CanHaveIdMetadata => false;
 
-        internal override bool RequiresDynamicMemberAccessors => true;
-
-        protected override void CreateCollection(ref Utf8JsonReader reader, ref ReadStack state)
+        protected sealed override void CreateCollection(ref Utf8JsonReader reader, ref ReadStack state)
         {
             state.Current.ReturnValue = new Dictionary<TKey, TValue>();
         }
 
-        protected override void ConvertCollection(ref ReadStack state, JsonSerializerOptions options)
+        protected sealed override void ConvertCollection(ref ReadStack state, JsonSerializerOptions options)
         {
             Func<IEnumerable<KeyValuePair<TKey, TValue>>, TCollection>? creator =
                 (Func<IEnumerable<KeyValuePair<TKey, TValue>>, TCollection>?)state.Current.JsonTypeInfo.CreateObjectWithArgs;
@@ -43,7 +32,7 @@ namespace System.Text.Json.Serialization.Converters
             state.Current.ReturnValue = creator((Dictionary<TKey, TValue>)state.Current.ReturnValue!);
         }
 
-        protected internal override bool OnWriteResume(Utf8JsonWriter writer, TCollection value, JsonSerializerOptions options, ref WriteStack state)
+        protected internal sealed override bool OnWriteResume(Utf8JsonWriter writer, TCollection value, JsonSerializerOptions options, ref WriteStack state)
         {
             IEnumerator<KeyValuePair<TKey, TValue>> enumerator;
             if (state.Current.CollectionEnumerator == null)
@@ -92,14 +81,6 @@ namespace System.Text.Json.Serialization.Converters
 
             enumerator.Dispose();
             return true;
-        }
-
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-            Justification = "The ctor is marked RequiresUnreferencedCode.")]
-        internal override void Initialize(JsonSerializerOptions options, JsonTypeInfo? jsonTypeInfo = null)
-        {
-            Debug.Assert(jsonTypeInfo != null);
-            jsonTypeInfo.CreateObjectWithArgs = options.MemberAccessorStrategy.CreateImmutableDictionaryCreateRangeDelegate<TCollection, TKey, TValue>();
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableDictionaryOfTKeyTValueConverterWithReflection.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableDictionaryOfTKeyTValueConverterWithReflection.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization.Metadata;
+
+namespace System.Text.Json.Serialization.Converters
+{
+    internal sealed class ImmutableDictionaryOfTKeyTValueConverterWithReflection<TCollection, TKey, TValue>
+        : ImmutableDictionaryOfTKeyTValueConverter<TCollection, TKey, TValue>
+        where TCollection : IReadOnlyDictionary<TKey, TValue>
+        where TKey : notnull
+    {
+        [RequiresUnreferencedCode(IEnumerableConverterFactoryHelpers.ImmutableConvertersUnreferencedCodeMessage)]
+        public ImmutableDictionaryOfTKeyTValueConverterWithReflection()
+        {
+        }
+
+        internal override bool RequiresDynamicMemberAccessors => true;
+
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+            Justification = "The ctor is marked RequiresUnreferencedCode.")]
+        internal override void Initialize(JsonSerializerOptions options, JsonTypeInfo? jsonTypeInfo = null)
+        {
+            Debug.Assert(jsonTypeInfo != null);
+            jsonTypeInfo.CreateObjectWithArgs = options.MemberAccessorStrategy.CreateImmutableDictionaryCreateRangeDelegate<TCollection, TKey, TValue>();
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableEnumerableOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableEnumerableOfTConverter.cs
@@ -3,38 +3,27 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization.Metadata;
 
 namespace System.Text.Json.Serialization.Converters
 {
-    internal sealed class ImmutableEnumerableOfTConverter<TCollection, TElement>
+    internal class ImmutableEnumerableOfTConverter<TCollection, TElement>
         : IEnumerableDefaultConverter<TCollection, TElement>
         where TCollection : IEnumerable<TElement>
     {
-        [RequiresUnreferencedCode(IEnumerableConverterFactoryHelpers.ImmutableConvertersUnreferencedCodeMessage)]
-        public ImmutableEnumerableOfTConverter()
-        {
-        }
-
-        // Used by source-gen initialization for reflection-free serialization.
-        public ImmutableEnumerableOfTConverter(bool dummy) { }
-
-        protected override void Add(in TElement value, ref ReadStack state)
+        protected sealed override void Add(in TElement value, ref ReadStack state)
         {
             ((List<TElement>)state.Current.ReturnValue!).Add(value);
         }
 
-        internal override bool CanHaveIdMetadata => false;
+        internal sealed override bool CanHaveIdMetadata => false;
 
-        internal override bool RequiresDynamicMemberAccessors => true;
-
-        protected override void CreateCollection(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
+        protected sealed override void CreateCollection(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
         {
             state.Current.ReturnValue = new List<TElement>();
         }
 
-        protected override void ConvertCollection(ref ReadStack state, JsonSerializerOptions options)
+        protected sealed override void ConvertCollection(ref ReadStack state, JsonSerializerOptions options)
         {
             JsonTypeInfo typeInfo = state.Current.JsonTypeInfo;
 
@@ -43,7 +32,7 @@ namespace System.Text.Json.Serialization.Converters
             state.Current.ReturnValue = creator((List<TElement>)state.Current.ReturnValue!);
         }
 
-        protected override bool OnWriteResume(Utf8JsonWriter writer, TCollection value, JsonSerializerOptions options, ref WriteStack state)
+        protected sealed override bool OnWriteResume(Utf8JsonWriter writer, TCollection value, JsonSerializerOptions options, ref WriteStack state)
         {
             IEnumerator<TElement> enumerator;
             if (state.Current.CollectionEnumerator == null)
@@ -79,14 +68,6 @@ namespace System.Text.Json.Serialization.Converters
 
             enumerator.Dispose();
             return true;
-        }
-
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-            Justification = "The ctor is marked RequiresUnreferencedCode.")]
-        internal override void Initialize(JsonSerializerOptions options, JsonTypeInfo? jsonTypeInfo = null)
-        {
-            Debug.Assert(jsonTypeInfo != null);
-            jsonTypeInfo.CreateObjectWithArgs = options.MemberAccessorStrategy.CreateImmutableEnumerableCreateRangeDelegate<TCollection, TElement>();
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableEnumerableOfTConverterWithReflection.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableEnumerableOfTConverterWithReflection.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization.Metadata;
+
+namespace System.Text.Json.Serialization.Converters
+{
+    internal sealed class ImmutableEnumerableOfTConverterWithReflection<TCollection, TElement>
+        : ImmutableEnumerableOfTConverter<TCollection, TElement>
+        where TCollection : IEnumerable<TElement>
+    {
+        [RequiresUnreferencedCode(IEnumerableConverterFactoryHelpers.ImmutableConvertersUnreferencedCodeMessage)]
+        public ImmutableEnumerableOfTConverterWithReflection()
+        {
+        }
+
+        internal override bool RequiresDynamicMemberAccessors => true;
+
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+            Justification = "The ctor is marked RequiresUnreferencedCode.")]
+        internal override void Initialize(JsonSerializerOptions options, JsonTypeInfo? jsonTypeInfo = null)
+        {
+            Debug.Assert(jsonTypeInfo != null);
+            jsonTypeInfo.CreateObjectWithArgs = options.MemberAccessorStrategy.CreateImmutableEnumerableCreateRangeDelegate<TCollection, TElement>();
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/StackOrQueueConverterWithReflection.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/StackOrQueueConverterWithReflection.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization.Metadata;
+
+namespace System.Text.Json.Serialization.Converters
+{
+    internal sealed class StackOrQueueConverterWithReflection<TCollection>
+        : StackOrQueueConverter<TCollection>
+        where TCollection : IEnumerable
+    {
+        internal override bool RequiresDynamicMemberAccessors => true;
+
+        [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
+        public StackOrQueueConverterWithReflection() { }
+
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2091:UnrecognizedReflectionPattern",
+            Justification = "The ctor is marked RequiresUnreferencedCode.")]
+        internal override void Initialize(JsonSerializerOptions options, JsonTypeInfo? jsonTypeInfo = null)
+        {
+            Debug.Assert(jsonTypeInfo != null);
+            jsonTypeInfo.AddMethodDelegate = options.MemberAccessorStrategy.CreateAddMethodDelegate<TCollection>();
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Collections.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Collections.cs
@@ -124,7 +124,7 @@ namespace System.Text.Json.Serialization.Metadata
             => new JsonTypeInfoInternal<TCollection>(
                 options,
                 createObjectFunc,
-                () => new ImmutableDictionaryOfTKeyTValueConverter<TCollection, TKey, TValue>(dummy: false),
+                () => new ImmutableDictionaryOfTKeyTValueConverter<TCollection, TKey, TValue>(),
                 keyInfo,
                 valueInfo,
                 numberHandling,
@@ -224,7 +224,7 @@ namespace System.Text.Json.Serialization.Metadata
             => new JsonTypeInfoInternal<TCollection>(
                 options,
                 createObjectFunc,
-                () => new ImmutableEnumerableOfTConverter<TCollection, TElement>(dummy: false),
+                () => new ImmutableEnumerableOfTConverter<TCollection, TElement>(),
                 elementInfo,
                 numberHandling,
                 serializeFunc,
@@ -525,7 +525,7 @@ namespace System.Text.Json.Serialization.Metadata
             => new JsonTypeInfoInternal<TCollection>(
                 options,
                 createObjectFunc,
-                () => new IEnumerableWithAddMethodConverter<TCollection>(dummy: false),
+                () => new StackOrQueueConverter<TCollection>(),
                 elementInfo,
                 numberHandling,
                 serializeFunc,


### PR DESCRIPTION
Addresses feedback from https://github.com/dotnet/runtime/pull/55566#discussion_r670746273.