### PR TITLE
[wasm] Use compile rsp instead of link, for compiling native files

### DIFF
--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -259,7 +259,7 @@
     <EmccCompile
           Condition="@(_BitCodeFile->Count()) > 0"
           SourceFiles="@(_BitCodeFile)"
-          Arguments="&quot;@$(_EmccDefaultFlagsRsp)&quot; @(_EmccLDFlags->'%(Identity)', ' ')"
+          Arguments="&quot;@$(_EmccDefaultFlagsRsp)&quot; &quot;@$(_EmccCompileRsp)&quot;"
           EnvironmentVariables="@(EmscriptenEnvVars)" />
 
     <ItemGroup>

--- a/src/tasks/AndroidAppBuilder/AndroidApkFileReplacerTask.cs
+++ b/src/tasks/AndroidAppBuilder/AndroidApkFileReplacerTask.cs
@@ -26,8 +26,7 @@ public class AndroidApkFileReplacerTask : Task
 
     public override bool Execute()
     {
-        Utils.Logger = Log;
-        var apkBuilder = new ApkBuilder();
+        var apkBuilder = new ApkBuilder(Log);
         apkBuilder.OutputDir = OutputDir;
         apkBuilder.AndroidSdk = AndroidSdk;
         apkBuilder.MinApiLevel = MinApiLevel;

--- a/src/tasks/AndroidAppBuilder/AndroidAppBuilder.cs
+++ b/src/tasks/AndroidAppBuilder/AndroidAppBuilder.cs
@@ -87,11 +87,9 @@ public class AndroidAppBuilderTask : Task
 
     public override bool Execute()
     {
-        Utils.Logger = Log;
-
         string abi = DetermineAbi();
 
-        var apkBuilder = new ApkBuilder();
+        var apkBuilder = new ApkBuilder(Log);
         apkBuilder.ProjectName = ProjectName;
         apkBuilder.AppDir = AppDir;
         apkBuilder.OutputDir = OutputDir;

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -194,8 +194,6 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
 
     public override bool Execute()
     {
-        Utils.Logger = Log;
-
         if (string.IsNullOrEmpty(CompilerBinaryPath))
         {
             throw new ArgumentException($"'{nameof(CompilerBinaryPath)}' is required.", nameof(CompilerBinaryPath));
@@ -545,15 +543,25 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
 
         Log.LogMessage(MessageImportance.Low, $"AOT compiler arguments: {responseFileContent}");
 
+        string args = $"--response=\"{responseFilePath}\"";
+
+        // Log the command in a compact format which can be copy pasted
+        StringBuilder envStr = new StringBuilder(string.Empty);
+        foreach (KeyValuePair<string, string> kvp in envVariables)
+            envStr.Append($"{kvp.Key}={kvp.Value} ");
+        Log.LogMessage(MessageImportance.Low, $"Exec: {envStr}{CompilerBinaryPath} {args}");
+
         try
         {
             // run the AOT compiler
-            (int exitCode, string output) = Utils.TryRunProcess(CompilerBinaryPath,
-                                                                $"--response=\"{responseFilePath}\"",
+            (int exitCode, string output) = Utils.TryRunProcess(Log,
+                                                                CompilerBinaryPath,
+                                                                args,
                                                                 envVariables,
                                                                 assemblyDir,
                                                                 silent: false,
-                                                                debugMessageImportance: MessageImportance.Low);
+                                                                debugMessageImportance: MessageImportance.Low,
+                                                                label: assembly);
             if (exitCode != 0)
             {
                 Log.LogError($"Precompiling failed for {assembly}: {output}");

--- a/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
+++ b/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
@@ -153,7 +153,6 @@ public class AppleAppBuilderTask : Task
 
     public override bool Execute()
     {
-        Utils.Logger = Log;
         bool isDevice = (TargetOS == TargetNames.iOS || TargetOS == TargetNames.tvOS);
 
         if (!File.Exists(Path.Combine(AppDir, MainLibraryFileName)))
@@ -227,7 +226,7 @@ public class AppleAppBuilderTask : Task
 
         if (GenerateXcodeProject)
         {
-            Xcode generator = new Xcode(TargetOS, Arch);
+            Xcode generator = new Xcode(Log, TargetOS, Arch);
             generator.EnableRuntimeLogging = EnableRuntimeLogging;
             generator.DiagnosticPorts = DiagnosticPorts;
 
@@ -239,7 +238,7 @@ public class AppleAppBuilderTask : Task
                 if (isDevice && string.IsNullOrEmpty(DevTeamProvisioning))
                 {
                     // DevTeamProvisioning shouldn't be empty for arm64 builds
-                    Utils.LogInfo("DevTeamProvisioning is not set, BuildAppBundle step is skipped.");
+                    Log.LogMessage(MessageImportance.High, "DevTeamProvisioning is not set, BuildAppBundle step is skipped.");
                 }
                 else
                 {

--- a/src/tasks/AppleAppBuilder/Xcode.cs
+++ b/src/tasks/AppleAppBuilder/Xcode.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 
 internal class Xcode
 {
@@ -13,27 +15,29 @@ internal class Xcode
     private string SysRoot { get; set; }
     private string Target { get; set; }
     private string XcodeArch { get; set; }
+    private TaskLoggingHelper Logger { get; set; }
 
-    public Xcode(string target, string arch)
+    public Xcode(TaskLoggingHelper logger, string target, string arch)
     {
+        Logger = logger;
         Target = target;
         XcodeArch = (arch == "x64") ? "x86_64" : arch;
         switch (Target)
         {
             case TargetNames.iOS:
-                SysRoot = Utils.RunProcess("xcrun", "--sdk iphoneos --show-sdk-path");
+                SysRoot = Utils.RunProcess(Logger, "xcrun", "--sdk iphoneos --show-sdk-path");
                 break;
             case TargetNames.iOSsim:
-                SysRoot = Utils.RunProcess("xcrun", "--sdk iphonesimulator --show-sdk-path");
+                SysRoot = Utils.RunProcess(Logger, "xcrun", "--sdk iphonesimulator --show-sdk-path");
                 break;
             case TargetNames.tvOS:
-                SysRoot = Utils.RunProcess("xcrun", "--sdk appletvos --show-sdk-path");
+                SysRoot = Utils.RunProcess(Logger, "xcrun", "--sdk appletvos --show-sdk-path");
                 break;
             case TargetNames.tvOSsim:
-                SysRoot = Utils.RunProcess("xcrun", "--sdk appletvsimulator --show-sdk-path");
+                SysRoot = Utils.RunProcess(Logger, "xcrun", "--sdk appletvsimulator --show-sdk-path");
                 break;
             default:
-                SysRoot = Utils.RunProcess("xcrun", "--sdk macosx --show-sdk-path");
+                SysRoot = Utils.RunProcess(Logger, "xcrun", "--sdk macosx --show-sdk-path");
                 break;
         }
 
@@ -145,7 +149,7 @@ internal class Xcode
             // if lib doesn't exist (primarly due to runtime build without static lib support), fallback linking stub lib.
             if (!File.Exists(componentLibToLink))
             {
-                Utils.LogInfo($"\nCouldn't find static component library: {componentLibToLink}, linking static component stub library: {staticComponentStubLib}.\n");
+                Logger.LogMessage(MessageImportance.High, $"\nCouldn't find static component library: {componentLibToLink}, linking static component stub library: {staticComponentStubLib}.\n");
                 componentLibToLink = staticComponentStubLib;
             }
 
@@ -298,7 +302,7 @@ internal class Xcode
                 .Replace("//%APPLE_RUNTIME_IDENTIFIER%", RuntimeIdentifier)
                 .Replace("%EntryPointLibName%", Path.GetFileName(entryPointLib)));
 
-        Utils.RunProcess("cmake", cmakeArgs.ToString(), workingDir: binDir);
+        Utils.RunProcess(Logger, "cmake", cmakeArgs.ToString(), workingDir: binDir);
 
         return Path.Combine(binDir, projectName, projectName + ".xcodeproj");
     }
@@ -391,7 +395,7 @@ internal class Xcode
         string config = optimized ? "Release" : "Debug";
         args.Append(" -configuration ").Append(config);
 
-        Utils.RunProcess("xcodebuild", args.ToString(), workingDir: Path.GetDirectoryName(xcodePrjPath));
+        Utils.RunProcess(Logger, "xcodebuild", args.ToString(), workingDir: Path.GetDirectoryName(xcodePrjPath));
 
         string appPath = Path.Combine(Path.GetDirectoryName(xcodePrjPath)!, config + "-" + sdk,
             Path.GetFileNameWithoutExtension(xcodePrjPath) + ".app");
@@ -400,7 +404,7 @@ internal class Xcode
             .EnumerateFiles("*", SearchOption.AllDirectories)
             .Sum(file => file.Length);
 
-        Utils.LogInfo($"\nAPP size: {(appSize / 1000_000.0):0.#} Mb.\n");
+        Logger.LogMessage(MessageImportance.High, $"\nAPP size: {(appSize / 1000_000.0):0.#} Mb.\n");
 
         return appPath;
     }

--- a/src/tasks/Common/Utils.cs
+++ b/src/tasks/Common/Utils.cs
@@ -22,10 +22,11 @@ internal static class Utils
         return reader.ReadToEnd();
     }
 
-    public static (int exitCode, string output) RunShellCommand(string command,
+    public static (int exitCode, string output) RunShellCommand(
+                                        TaskLoggingHelper logger,
+                                        string command,
                                         IDictionary<string, string> envVars,
                                         string workingDir,
-                                        TaskLoggingHelper logger,
                                         bool silent=false,
                                         bool logStdErrAsMessage=false,
                                         MessageImportance debugMessageImportance=MessageImportance.Low,
@@ -37,16 +38,16 @@ internal static class Utils
                                                     : ("/bin/sh", $"\"{scriptFileName}\"");
 
         string msgPrefix = label == null ? string.Empty : $"[{label}] ";
-        LogMessage(debugMessageImportance, $"Running {command} via script {scriptFileName}:", msgPrefix);
-        LogMessage(debugMessageImportance, File.ReadAllText(scriptFileName), msgPrefix);
+        logger.LogMessage(debugMessageImportance, $"Running {command} via script {scriptFileName}:", msgPrefix);
+        logger.LogMessage(debugMessageImportance, File.ReadAllText(scriptFileName), msgPrefix);
 
-        return TryRunProcess(shell,
+        return TryRunProcess(logger,
+                             shell,
                              args,
                              envVars,
                              workingDir,
                              silent: silent,
                              logStdErrAsMessage: logStdErrAsMessage,
-                             logger: logger,
                              label: label,
                              debugMessageImportance: debugMessageImportance);
 
@@ -74,6 +75,7 @@ internal static class Utils
     }
 
     public static string RunProcess(
+        TaskLoggingHelper logger,
         string path,
         string args = "",
         IDictionary<string, string>? envVars = null,
@@ -83,12 +85,12 @@ internal static class Utils
         MessageImportance debugMessageImportance=MessageImportance.High)
     {
         (int exitCode, string output) = TryRunProcess(
+                                            logger,
                                             path,
                                             args,
                                             envVars,
                                             workingDir,
                                             silent: silent,
-                                            logger: Logger,
                                             debugMessageImportance: debugMessageImportance);
 
         if (exitCode != 0 && !ignoreErrors)
@@ -98,20 +100,18 @@ internal static class Utils
     }
 
     public static (int, string) TryRunProcess(
+        TaskLoggingHelper logger,
         string path,
         string args = "",
         IDictionary<string, string>? envVars = null,
         string? workingDir = null,
         bool silent = true,
         bool logStdErrAsMessage = false,
-        TaskLoggingHelper? logger = null,
         MessageImportance debugMessageImportance=MessageImportance.High,
         string? label=null)
     {
-        Logger = logger;
-
         string msgPrefix = label == null ? string.Empty : $"[{label}] ";
-        LogMessage(debugMessageImportance, $"Running: {path} {args}", msgPrefix);
+        logger.LogMessage(debugMessageImportance, $"Running: {path} {args}", msgPrefix);
         var outputBuilder = new StringBuilder();
         var processStartInfo = new ProcessStartInfo
         {
@@ -126,17 +126,17 @@ internal static class Utils
         if (workingDir != null)
             processStartInfo.WorkingDirectory = workingDir;
 
-        LogMessage(debugMessageImportance, $"Using working directory: {workingDir ?? Environment.CurrentDirectory}", msgPrefix);
+        logger.LogMessage(debugMessageImportance, $"Using working directory: {workingDir ?? Environment.CurrentDirectory}", msgPrefix);
 
         if (envVars != null)
         {
             if (envVars.Count > 0)
-                LogMessage(MessageImportance.Low, $"Setting environment variables for execution:", msgPrefix);
+                logger.LogMessage(MessageImportance.Low, $"Setting environment variables for execution:", msgPrefix);
 
             foreach (KeyValuePair<string, string> envVar in envVars)
             {
                 processStartInfo.EnvironmentVariables[envVar.Key] = envVar.Value;
-                Logger?.LogMessage(MessageImportance.Low, $"{msgPrefix}\t{envVar.Key} = {envVar.Value}");
+                logger.LogMessage(MessageImportance.Low, $"{msgPrefix}\t{envVar.Key} = {envVar.Value}");
             }
         }
 
@@ -155,9 +155,9 @@ internal static class Utils
                 if (!silent)
                 {
                     if (logStdErrAsMessage)
-                        LogMessage(debugMessageImportance, e.Data, msgPrefix);
+                        logger.LogMessage(debugMessageImportance, e.Data, msgPrefix);
                     else
-                        Logger?.LogWarning(msg);
+                        logger.LogWarning(msg);
                 }
                 outputBuilder.AppendLine(e.Data);
             }
@@ -170,7 +170,7 @@ internal static class Utils
                     return;
 
                 if (!silent)
-                    LogMessage(debugMessageImportance, e.Data, msgPrefix);
+                    logger.LogMessage(debugMessageImportance, e.Data, msgPrefix);
                 outputBuilder.AppendLine(e.Data);
             }
         };
@@ -178,7 +178,7 @@ internal static class Utils
         process.BeginErrorReadLine();
         process.WaitForExit();
 
-        Logger?.LogMessage(debugMessageImportance, $"{msgPrefix}Exit code: {process.ExitCode}");
+        logger.LogMessage(debugMessageImportance, $"{msgPrefix}Exit code: {process.ExitCode}");
         return (process.ExitCode, outputBuilder.ToString().Trim('\r', '\n'));
     }
 
@@ -223,24 +223,4 @@ internal static class Utils
         }
     }
 #endif
-
-    public static TaskLoggingHelper? Logger { get; set; }
-
-    public static void LogWarning(string? msg)
-    {
-        if (msg != null)
-            Logger?.LogWarning(msg);
-    }
-
-    public static void LogInfo(string? msg, MessageImportance importance=MessageImportance.High)
-    {
-        if (msg != null)
-            Logger?.LogMessage(importance, msg);
-    }
-
-    public static void LogMessage(MessageImportance importance, string? msg, string prefix="")
-    {
-        if (msg != null)
-            Logger?.LogMessage(importance, $"{prefix}{msg}");
-    }
 }

--- a/src/tasks/WasmAppBuilder/EmccCompile.cs
+++ b/src/tasks/WasmAppBuilder/EmccCompile.cs
@@ -120,10 +120,10 @@ namespace Microsoft.WebAssembly.Build.Tasks
                         envStr.Append($"{key}={envVarsDict[key]} ");
                     Log.LogMessage(MessageImportance.Low, $"Exec: {envStr}{command}");
                     (int exitCode, string output) = Utils.RunShellCommand(
+                                                            Log,
                                                             command,
                                                             envVarsDict,
                                                             workingDir: Environment.CurrentDirectory,
-                                                            logger: Log,
                                                             logStdErrAsMessage: true,
                                                             debugMessageImportance: MessageImportance.High,
                                                             label: Path.GetFileName(srcFile));

--- a/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
+++ b/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
@@ -34,8 +34,6 @@ namespace Microsoft.Workload.Build.Tasks
 
         public override bool Execute()
         {
-            Utils.Logger = Log;
-
             if (!HasMetadata(WorkloadId, nameof(WorkloadId), "Version") ||
                 !HasMetadata(WorkloadId, nameof(WorkloadId), "ManifestName"))
             {
@@ -59,6 +57,7 @@ namespace Microsoft.Workload.Build.Tasks
 
             Log.LogMessage(MessageImportance.High, $"{Environment.NewLine}** workload install **{Environment.NewLine}");
             (int exitCode, string output) = Utils.TryRunProcess(
+                                                    Log,
                                                     Path.Combine(SdkDir, "dotnet"),
                                                     $"workload install --skip-manifest-update --no-cache --configfile \"{nugetConfigPath}\" {WorkloadId.ItemSpec}",
                                                     workingDir: Path.GetTempPath(),

--- a/src/tasks/WorkloadBuildTasks/PackageInstaller.cs
+++ b/src/tasks/WorkloadBuildTasks/PackageInstaller.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Workload.Build.Tasks
             _logger.LogMessage(MessageImportance.Low, $"Restoring packages: {string.Join(", ", references.Select(r => $"{r.Name}/{r.Version}"))}");
 
             string args = $"restore \"{projectPath}\" /p:RestorePackagesPath=\"{_packagesDir}\"";
-            (int exitCode, string output) = Utils.TryRunProcess("dotnet", args, silent: false, debugMessageImportance: MessageImportance.Low);
+            (int exitCode, string output) = Utils.TryRunProcess(_logger, "dotnet", args, silent: false, debugMessageImportance: MessageImportance.Low);
             if (exitCode != 0)
             {
                 LogErrorOrWarning($"Restoring packages failed with exit code: {exitCode}. Output:{Environment.NewLine}{output}", stopOnMissing);


### PR DESCRIPTION
.. and fix logging that broke recently.

`tasks/Common/Utils.cs`:

`TaskLoggingHelper Utils.Logger` is a static field, which must be set by
task else any methods in `Utils`, eg. `RunProcess`, silently fail to log
any messages. Also, this would be a problem when building multiple
projects in parallel, since the logger is a task-specific one.

Instead, we pass logger as an arg to all the methods.