### PR TITLE
Introduce new AddEventListener and RemoveEventListener APIs on JSObject

### DIFF
--- a/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
+++ b/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
@@ -52,6 +52,11 @@ internal static partial class Interop
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern object TypedArrayCopyFrom(int jsObjHandle, int arrayPtr, int begin, int end, int bytesPerElement, out int exceptionalResult);
 
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        internal static extern object AddEventListener(int jsObjHandle, string name, int weakDelegateHandle, int optionsObjHandle);
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        internal static extern object RemoveEventListener(int jsObjHandle, string name, int weakDelegateHandle, int capture);
+
         // / <summary>
         // / Execute the provided string in the JavaScript context
         // / </summary>

--- a/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
+++ b/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
@@ -53,9 +53,9 @@ internal static partial class Interop
         internal static extern object TypedArrayCopyFrom(int jsObjHandle, int arrayPtr, int begin, int end, int bytesPerElement, out int exceptionalResult);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern object AddEventListener(int jsObjHandle, string name, int weakDelegateHandle, int optionsObjHandle);
+        internal static extern void AddEventListener(int jsObjHandle, string name, int weakDelegateHandle, int optionsObjHandle);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern object RemoveEventListener(int jsObjHandle, string name, int weakDelegateHandle, int capture);
+        internal static extern void RemoveEventListener(int jsObjHandle, string name, int weakDelegateHandle, bool capture);
 
         // / <summary>
         // / Execute the provided string in the JavaScript context

--- a/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
+++ b/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
@@ -53,9 +53,9 @@ internal static partial class Interop
         internal static extern object TypedArrayCopyFrom(int jsObjHandle, int arrayPtr, int begin, int end, int bytesPerElement, out int exceptionalResult);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern void AddEventListener(int jsObjHandle, string name, int weakDelegateHandle, int optionsObjHandle);
+        internal static extern string? AddEventListener(int jsObjHandle, string name, int weakDelegateHandle, int optionsObjHandle);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern void RemoveEventListener(int jsObjHandle, string name, int weakDelegateHandle, bool capture);
+        internal static extern string? RemoveEventListener(int jsObjHandle, string name, int weakDelegateHandle, bool capture);
 
         // / <summary>
         // / Execute the provided string in the JavaScript context

--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/BrowserWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/BrowserWebSocket.cs
@@ -167,13 +167,13 @@ namespace System.Net.WebSockets
                 _onError = errorEvt => errorEvt.Dispose();
 
                 // Attach the onError callback
-                _innerWebSocket.SetObjectProperty("onerror", _onError);
+                _innerWebSocket.AddEventListener("error", _onError);
 
                 // Setup the onClose callback
                 _onClose = (closeEvent) => OnCloseCallback(closeEvent, cancellationToken);
 
                 // Attach the onClose callback
-                _innerWebSocket.SetObjectProperty("onclose", _onClose);
+                _innerWebSocket.AddEventListener("close", _onClose);
 
                 // Setup the onOpen callback
                 _onOpen = (evt) =>
@@ -203,13 +203,13 @@ namespace System.Net.WebSockets
                 };
 
                 // Attach the onOpen callback
-                _innerWebSocket.SetObjectProperty("onopen", _onOpen);
+                _innerWebSocket.AddEventListener("open", _onOpen);
 
                 // Setup the onMessage callback
                 _onMessage = (messageEvent) => OnMessageCallback(messageEvent);
 
                 // Attach the onMessage callaback
-                _innerWebSocket.SetObjectProperty("onmessage", _onMessage);
+                _innerWebSocket.AddEventListener("message", _onMessage);
                 await _tcsConnect.Task.ConfigureAwait(continueOnCapturedContext: true);
             }
             catch (Exception wse)
@@ -298,7 +298,7 @@ namespace System.Net.WebSockets
                                         }
                                     }
                                 };
-                                reader.Invoke("addEventListener", "loadend", loadend);
+                                reader.AddEventListener("loadend", loadend);
                                 reader.Invoke("readAsArrayBuffer", blobData);
                             }
                             break;
@@ -318,26 +318,10 @@ namespace System.Net.WebSockets
         {
             // We need to clear the events on websocket as well or stray events
             // are possible leading to crashes.
-            if (_onClose != null)
-            {
-                _innerWebSocket?.SetObjectProperty("onclose", "");
-                _onClose = null;
-            }
-            if (_onError != null)
-            {
-                _innerWebSocket?.SetObjectProperty("onerror", "");
-                _onError = null;
-            }
-            if (_onOpen != null)
-            {
-                _innerWebSocket?.SetObjectProperty("onopen", "");
-                _onOpen = null;
-            }
-            if (_onMessage != null)
-            {
-                _innerWebSocket?.SetObjectProperty("onmessage", "");
-                _onMessage = null;
-            }
+            _innerWebSocket?.RemoveEventListener("close", _onClose);
+            _innerWebSocket?.RemoveEventListener("error", _onError);
+            _innerWebSocket?.RemoveEventListener("open", _onOpen);
+            _innerWebSocket?.RemoveEventListener("message", _onMessage);
         }
 
         public override void Dispose()

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
@@ -94,7 +94,7 @@ namespace System.Runtime.InteropServices.JavaScript
                 if (options?.Signal != null)
                     throw new NotImplementedException("EventListenerOptions.Signal");
 
-                var jsfunc = Runtime.GetWeakDelegateHandle(listener);
+                var jsfunc = Runtime.GetJSOwnedObjectHandle(listener);
                 // int exception;
                 if (options.HasValue) {
                     // TODO: Optimize this
@@ -121,7 +121,7 @@ namespace System.Runtime.InteropServices.JavaScript
         {
             if (listener == null)
                 return;
-            var jsfunc = Runtime.GetWeakDelegateHandle(listener);
+            var jsfunc = Runtime.GetJSOwnedObjectHandle(listener);
             RemoveEventListener(name, jsfunc, options);
         }
 

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
@@ -123,7 +123,7 @@ namespace System.Runtime.InteropServices.JavaScript
 
         public void RemoveEventListener(string name, int listenerHandle, EventListenerOptions? options = null)
         {
-            Interop.Runtime.RemoveEventListener(JSHandle, name, listenerHandle, (options?.Capture ?? false) ? 1 : 0);
+            Interop.Runtime.RemoveEventListener(JSHandle, name, listenerHandle, options?.Capture ?? false);
         }
 
         /// <summary>

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
@@ -96,7 +96,7 @@ namespace System.Runtime.InteropServices.JavaScript
             return Runtime.CreateJSObjectForCLRObject(d, id);
         }
 
-        public void AddEventListener(string name, Delegate listener, EventListenerOptions? options = null)
+        public JSObject AddEventListener(string name, Delegate listener, EventListenerOptions? options = null)
         {
             var optionsDict = options.HasValue
                 ? new JSObject()
@@ -128,18 +128,27 @@ namespace System.Runtime.InteropServices.JavaScript
                     bool success = false;
                     jsfunc.DangerousAddRef(ref success);
                 }
+                return jsfunc;
             } finally {
                 optionsDict?.Dispose();
             }
         }
 
-        public void RemoveEventListener(string name, Delegate listener, EventListenerOptions? options = null)
+        public void RemoveEventListener(string name, Delegate? listener, EventListenerOptions? options = null)
         {
+            if (listener == null)
+                return;
             var jsfunc = GetJSObjectForDelegate(listener);
             // TODO: Unique syscall
-            Invoke("removeEventListener", jsfunc, options?.Capture ?? false);
+            RemoveEventListener(name, jsfunc, options);
             if (options?.Weak != true)
                 jsfunc.DangerousRelease();
+        }
+
+        public void RemoveEventListener(string name, JSObject listener, EventListenerOptions? options = null)
+        {
+            // TODO: Unique syscall
+            Invoke("removeEventListener", listener, options?.Capture ?? false);
         }
 
         /// <summary>

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
@@ -108,7 +108,9 @@ namespace System.Runtime.InteropServices.JavaScript
                 // TODO: Handle errors
                 // We can't currently do this because adding any additional parameters or a return value causes
                 //  a signature mismatch at runtime
-                Interop.Runtime.AddEventListener(JSHandle, name, jsfunc, optionsDict?.JSHandle ?? 0);
+                var ret = Interop.Runtime.AddEventListener(JSHandle, name, jsfunc, optionsDict?.JSHandle ?? 0);
+                if (ret != null)
+                    throw new JSException(ret);
                 return jsfunc;
             } finally {
                 optionsDict?.Dispose();
@@ -125,7 +127,9 @@ namespace System.Runtime.InteropServices.JavaScript
 
         public void RemoveEventListener(string name, int listenerHandle, EventListenerOptions? options = null)
         {
-            Interop.Runtime.RemoveEventListener(JSHandle, name, listenerHandle, options?.Capture ?? false);
+            var ret = Interop.Runtime.RemoveEventListener(JSHandle, name, listenerHandle, options?.Capture ?? false);
+            if (ret != null)
+                throw new JSException(ret);
         }
 
         /// <summary>

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
@@ -105,7 +105,9 @@ namespace System.Runtime.InteropServices.JavaScript
                 }
 
                 // TODO: Pass options explicitly instead of using the object
-                // FIXME: Exceptions
+                // TODO: Handle errors
+                // We can't currently do this because adding any additional parameters or a return value causes
+                //  a signature mismatch at runtime
                 Interop.Runtime.AddEventListener(JSHandle, name, jsfunc, optionsDict?.JSHandle ?? 0);
                 return jsfunc;
             } finally {

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -250,16 +250,24 @@ namespace System.Runtime.InteropServices.JavaScript
         }
 
         public static bool TryInvokeWeakDelegateByHandle (int id, JSObject? arg1) {
-            Delegate del;
+            Delegate? del;
             lock (WeakDelegateLock) {
                 if (!WeakDelegateFromID.TryGetValue(id, out del))
                     return false;
             }
 
+            if (del == null)
+                return false;
+
+// error CS0117: 'Array' does not contain a definition for 'Empty' [/home/kate/Projects/dotnet-runtime-wasm/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System.Private.Runtime.InteropServices.JavaScript.csproj]
+#pragma warning disable CA1825
+
             if (arg1 != null)
                 del.DynamicInvoke(new object[] { arg1 });
             else
                 del.DynamicInvoke(new object[0]);
+
+#pragma warning restore CA1825
 
             return true;
         }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -272,14 +272,6 @@ namespace System.Runtime.InteropServices.JavaScript
             return true;
         }
 
-        public static JSObject? TryGetJSObjectForCLRObject(object rawObj) {
-            lock (_rawToJS)
-            {
-                _rawToJS.TryGetValue(rawObj, out JSObject? jsObject);
-                return jsObject;
-            }
-        }
-
         public static int GetJSObjectId(object rawObj)
         {
             JSObject? jsObject;

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -218,6 +218,23 @@ namespace System.Runtime.InteropServices.JavaScript
             return jsObject.Int32Handle;
         }
 
+        public static JSObject CreateJSObjectForCLRObject(object rawObj, int jsId) {
+            var jsObject = new JSObject(jsId, rawObj);
+            lock (_rawToJS)
+            {
+                _rawToJS.Add(rawObj, jsObject);
+            }
+            return jsObject;
+        }
+
+        public static JSObject? TryGetJSObjectForCLRObject(object rawObj) {
+            lock (_rawToJS)
+            {
+                _rawToJS.TryGetValue(rawObj, out JSObject? jsObject);
+                return jsObject;
+            }
+        }
+
         public static int GetJSObjectId(object rawObj)
         {
             JSObject? jsObject;

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -248,7 +248,7 @@ namespace System.Runtime.InteropServices.JavaScript
 
         // The JS layer invokes this method when the JS wrapper for a JS owned object
         //  has been collected by the JS garbage collector
-        internal static void ReleaseJSOwnedObjectByHandle (int id) {
+        public static void ReleaseJSOwnedObjectByHandle (int id) {
             lock (JSOwnedObjectLock) {
                 if (!JSOwnedObjectFromID.TryGetValue(id, out object? o))
                     throw new Exception($"JS-owned object with id {id} was already released");
@@ -260,9 +260,9 @@ namespace System.Runtime.InteropServices.JavaScript
         // The JS layer invokes this API when the JS wrapper for a delegate is invoked.
         // In multiple places this function intentionally returns false instead of throwing
         //  in an unexpected condition. This is done because unexpected conditions of this
-        //  type are usually caused by a JS object (i.e. a WebSocket) receiving an event 
-        //  after its managed owner has been disposed - throwing in that case is unwanted.        
-        internal static bool TryInvokeJSOwnedDelegateByHandle (int id, JSObject? arg1) {
+        //  type are usually caused by a JS object (i.e. a WebSocket) receiving an event
+        //  after its managed owner has been disposed - throwing in that case is unwanted.
+        public static bool TryInvokeJSOwnedDelegateByHandle (int id, JSObject? arg1) {
             Delegate? del;
             lock (JSOwnedObjectLock) {
                 if (!JSOwnedObjectFromID.TryGetValue(id, out object? o))

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -252,14 +252,14 @@ namespace System.Runtime.InteropServices.JavaScript
         public static bool TryInvokeWeakDelegateByHandle (int id, JSObject? arg1) {
             Delegate del;
             lock (WeakDelegateLock) {
-                if (!IDFromWeakDelegate.TryGetValue(id, out del))
+                if (!WeakDelegateFromID.TryGetValue(id, out del))
                     return false;
             }
 
             if (arg1 != null)
                 del.DynamicInvoke(new object[] { arg1 });
             else
-                del.DynamicInvoke(Array.Empty<object>());
+                del.DynamicInvoke(new object[0]);
 
             return true;
         }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JavaScriptTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JavaScriptTests.cs
@@ -379,5 +379,33 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             obj.RemoveEventListener("test", handle);
             obj.Invoke("fireEvent", "test");
         }
+
+        [Fact]
+        public static void RegisterSameEventListenerToMultipleSources () {
+            var counter = new int[1];
+            var a = SetupListenerTest("registerSameEventListenerToMultipleSourcesA");
+            var b = SetupListenerTest("registerSameEventListenerToMultipleSourcesB");
+            Action del = () => {
+                counter[0]++;
+            };
+
+            a.AddEventListener("test", del);
+            b.AddEventListener("test", del);
+
+            a.Invoke("fireEvent", "test");
+            Assert.Equal(1, counter[0]);
+            b.Invoke("fireEvent", "test");
+            Assert.Equal(2, counter[0]);
+
+            a.RemoveEventListener("test", del);
+            a.Invoke("fireEvent", "test");
+            b.Invoke("fireEvent", "test");
+            Assert.Equal(3, counter[0]);
+
+            b.RemoveEventListener("test", del);
+            a.Invoke("fireEvent", "test");
+            b.Invoke("fireEvent", "test");
+            Assert.Equal(3, counter[0]);
+        }
     }
 }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JavaScriptTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JavaScriptTests.cs
@@ -364,5 +364,20 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             obj.Invoke("fireEvent", "test2");
             Assert.Equal(3, counter[0]);
         }
+
+        [Fact]
+        public static void UseAddEventListenerResultToRemove () {
+            var obj = SetupListenerTest("useAddEventListenerResultToRemove");
+            Action del = () => {
+                throw new Exception("Should not be called");
+            };
+            var handle = obj.AddEventListener("test", del);
+            Assert.Throws<JSException>(() => {
+                obj.Invoke("fireEvent", "test");
+            });
+
+            obj.RemoveEventListener("test", handle);
+            obj.Invoke("fireEvent", "test");
+        }
     }
 }

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -2091,7 +2091,10 @@ var BindingSupportLib = {
 			if (options)
 				obj.addEventListener(sName, listener, options);
 			else
-				obj.addEventListener(sName, listener);			
+				obj.addEventListener(sName, listener);
+			return 0;
+		} catch (exc) {
+			return BINDING.js_string_to_mono_string(exc.message);
 		} finally {
 			nameRoot.release();
 		}
@@ -2112,6 +2115,9 @@ var BindingSupportLib = {
 			// console.log(`${obj}.removeEventListener(${sName}, ${listener}, ${capture})`);
 
 			obj.removeEventListener(sName, listener, !!capture);
+			return 0;
+		} catch (exc) {
+			return BINDING.js_string_to_mono_string(exc.message);
 		} finally {
 			nameRoot.release();
 		}

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -26,8 +26,6 @@ var BindingSupportLib = {
 			module ["mono_bind_assembly_entry_point"] = BINDING.bind_assembly_entry_point.bind(BINDING);
 			module ["mono_call_assembly_entry_point"] = BINDING.call_assembly_entry_point.bind(BINDING);
 			module ["mono_intern_string"] = BINDING.mono_intern_string.bind(BINDING);
-			module ["mono_wasm_add_event_listener"] = BINDING.mono_wasm_add_event_listener.bind(BINDING);
-			module ["mono_wasm_remove_event_listener"] = BINDING.mono_wasm_remove_event_listener.bind(BINDING);
 		},
 
 		bindings_lazy_init: function () {
@@ -2072,11 +2070,28 @@ var BindingSupportLib = {
 		return BINDING.js_to_mono_obj (res)
 	},
 
-	mono_wasm_add_event_listener: function () {
+	mono_wasm_add_event_listener: function (objHandle, name, listenerId, optionsHandle) {
+		BINDING.bindings_lazy_init ();
+		var obj = BINDING.mono_wasm_require_handle(objHandle);
+		if (!obj)
+			throw new Error("Invalid JS object handle");
+		var listener = BINDING._get_weak_delegate_from_handle(listenerId);
+		if (!listener)
+			throw new Error("Invalid listener ID");
+
+		if (optionsHandle) {
+			var options = BINDING.mono_wasm_require_handle(optionsHandle);
+			console.log(`${obj}.addEventListener(${name}, ${listener}, ${options})`);
+			obj.addEventListener(name, listener, options);
+		} else {
+			console.log(`${obj}.addEventListener(${name}, ${listener})`);
+			obj.addEventListener(name, listener);
+		}
 		throw new Error("nyi: add event listener");
 	},
 
-	mono_wasm_remove_event_listener: function () {
+	mono_wasm_remove_event_listener: function (objHandle, name, listenerId, capture) {
+		BINDING.bindings_lazy_init ();
 		throw new Error("nyi: remove event listener");
 	},
 

--- a/src/mono/wasm/runtime/corebindings.c
+++ b/src/mono/wasm/runtime/corebindings.c
@@ -25,8 +25,8 @@ extern MonoObject* mono_wasm_typed_array_to_array (int js_handle, int *is_except
 extern MonoObject* mono_wasm_typed_array_copy_to (int js_handle, int ptr, int begin, int end, int bytes_per_element, int *is_exception);
 extern MonoObject* mono_wasm_typed_array_from (int ptr, int begin, int end, int bytes_per_element, int type, int *is_exception);
 extern MonoObject* mono_wasm_typed_array_copy_from (int js_handle, int ptr, int begin, int end, int bytes_per_element, int *is_exception);
-extern void mono_wasm_add_event_listener (int jsObjHandle, MonoString *name, int weakDelegateHandle, int optionsObjHandle);
-extern void mono_wasm_remove_event_listener (int jsObjHandle, MonoString *name, int weakDelegateHandle, int capture);
+extern MonoString* mono_wasm_add_event_listener (int jsObjHandle, MonoString *name, int weakDelegateHandle, int optionsObjHandle);
+extern MonoString* mono_wasm_remove_event_listener (int jsObjHandle, MonoString *name, int weakDelegateHandle, int capture);
 
 // Compiles a JavaScript function from the function data passed.
 // Note: code snippet is not a function definition. Instead it must create and return a function instance.

--- a/src/mono/wasm/runtime/corebindings.c
+++ b/src/mono/wasm/runtime/corebindings.c
@@ -25,6 +25,8 @@ extern MonoObject* mono_wasm_typed_array_to_array (int js_handle, int *is_except
 extern MonoObject* mono_wasm_typed_array_copy_to (int js_handle, int ptr, int begin, int end, int bytes_per_element, int *is_exception);
 extern MonoObject* mono_wasm_typed_array_from (int ptr, int begin, int end, int bytes_per_element, int type, int *is_exception);
 extern MonoObject* mono_wasm_typed_array_copy_from (int js_handle, int ptr, int begin, int end, int bytes_per_element, int *is_exception);
+extern void mono_wasm_add_event_listener (int jsObjHandle, MonoString *name, int weakDelegateHandle, int optionsObjHandle);
+extern void mono_wasm_remove_event_listener (int jsObjHandle, MonoString *name, int weakDelegateHandle, int optionsObjHandle);
 
 // Compiles a JavaScript function from the function data passed.
 // Note: code snippet is not a function definition. Instead it must create and return a function instance.
@@ -85,6 +87,8 @@ void core_initialize_internals ()
 	mono_add_internal_call ("Interop/Runtime::TypedArrayFrom", mono_wasm_typed_array_from);
 	mono_add_internal_call ("Interop/Runtime::TypedArrayCopyFrom", mono_wasm_typed_array_copy_from);
 	mono_add_internal_call ("Interop/Runtime::CompileFunction", mono_wasm_compile_function);
+	mono_add_internal_call ("Interop/Runtime::AddEventListener", mono_wasm_add_event_listener);
+	mono_add_internal_call ("Interop/Runtime::RemoveEventListener", mono_wasm_remove_event_listener);
 
 }
 

--- a/src/mono/wasm/runtime/corebindings.c
+++ b/src/mono/wasm/runtime/corebindings.c
@@ -26,7 +26,7 @@ extern MonoObject* mono_wasm_typed_array_copy_to (int js_handle, int ptr, int be
 extern MonoObject* mono_wasm_typed_array_from (int ptr, int begin, int end, int bytes_per_element, int type, int *is_exception);
 extern MonoObject* mono_wasm_typed_array_copy_from (int js_handle, int ptr, int begin, int end, int bytes_per_element, int *is_exception);
 extern void mono_wasm_add_event_listener (int jsObjHandle, MonoString *name, int weakDelegateHandle, int optionsObjHandle);
-extern void mono_wasm_remove_event_listener (int jsObjHandle, MonoString *name, int weakDelegateHandle, int optionsObjHandle);
+extern void mono_wasm_remove_event_listener (int jsObjHandle, MonoString *name, int weakDelegateHandle, int capture);
 
 // Compiles a JavaScript function from the function data passed.
 // Note: code snippet is not a function definition. Instead it must create and return a function instance.


### PR DESCRIPTION
Code does event listener management kind of ad-hoc right now, and this creates a lot of space for lifetime management or removal to get messed up. This is a draft of new APIs to simplify things and make it harder to make mistakes.