### PR TITLE
set CLOEXEC on diagnostic server FDs

### DIFF
--- a/src/native/eventpipe/ds-ipc-pal-socket.c
+++ b/src/native/eventpipe/ds-ipc-pal-socket.c
@@ -323,7 +323,10 @@ ipc_socket_create_uds (DiagnosticsIpc *ipc)
 	DS_ENTER_BLOCKING_PAL_SECTION;
 	new_socket = socket (ipc->server_address_family, socket_type, 0);
 #ifndef SOCK_CLOEXEC
-	int fcntl_rc = fcntl(new_socket, F_SETFD, FD_CLOEXEC); // best effort; don't validate return value
+#if DEBUG
+	int fcntl_rc =
+#endif // DEBUG
+	fcntl(new_socket, F_SETFD, FD_CLOEXEC); // best effort; don't validate return value
 	EP_ASSERT (fcntl_rc != -1);
 #endif // SOCK_CLOEXEC
 	DS_EXIT_BLOCKING_PAL_SECTION;
@@ -352,7 +355,10 @@ ipc_socket_create_tcp (DiagnosticsIpc *ipc)
 	DS_ENTER_BLOCKING_PAL_SECTION;
 	new_socket = socket (ipc->server_address_family, socket_type, IPPROTO_TCP);
 #ifndef SOCK_CLOEXEC
-	int fcntl_rc = fcntl(new_socket, F_SETFD, FD_CLOEXEC); // best effort; don't validate return value
+#if DEBUG
+	int fcntl_rc =
+#endif // DEBUG
+	fcntl(new_socket, F_SETFD, FD_CLOEXEC); // best effort; don't validate return value
 	EP_ASSERT(fcntl_rc != -1);
 #endif // SOCK_CLOEXEC
 	if (new_socket != DS_IPC_INVALID_SOCKET) {

--- a/src/native/eventpipe/ds-ipc-pal-socket.c
+++ b/src/native/eventpipe/ds-ipc-pal-socket.c
@@ -316,8 +316,15 @@ ipc_socket_create_uds (DiagnosticsIpc *ipc)
 	EP_ASSERT (ipc->server_address_family == AF_UNIX);
 
 	ds_ipc_socket_t new_socket = DS_IPC_INVALID_SOCKET;
+	int socket_type = SOCK_STREAM;
+#ifdef SOCK_CLOEXEC
+	socket_type |= SOCK_CLOEXEC;
+#endif // SOCK_CLOEXEC
 	DS_ENTER_BLOCKING_PAL_SECTION;
-	new_socket = socket (ipc->server_address_family, SOCK_STREAM, 0);
+	new_socket = socket (ipc->server_address_family, socket_type, 0);
+#ifndef SOCK_CLOEXEC
+	fcntl(new_socket, F_SETFD, FD_CLOEXEC);
+#endif // SOCK_CLOEXEC
 	DS_EXIT_BLOCKING_PAL_SECTION;
 	return new_socket;
 #endif
@@ -337,8 +344,15 @@ ipc_socket_create_tcp (DiagnosticsIpc *ipc)
 #endif
 
 	ds_ipc_socket_t new_socket = DS_IPC_INVALID_SOCKET;
+	int socket_type = SOCK_STREAM;
+#ifdef SOCK_CLOEXEC
+	socket_type |= SOCK_CLOEXEC;
+#endif // SOCK_CLOEXEC
 	DS_ENTER_BLOCKING_PAL_SECTION;
-	new_socket = socket (ipc->server_address_family, SOCK_STREAM, IPPROTO_TCP);
+	new_socket = socket (ipc->server_address_family, socket_type, IPPROTO_TCP);
+#ifndef SOCK_CLOEXEC
+	fcntl(new_socket, F_SETFD, FD_CLOEXEC);
+#endif // SOCK_CLOEXEC
 	if (new_socket != DS_IPC_INVALID_SOCKET) {
 		int option_value = 1;
 		setsockopt (new_socket, IPPROTO_TCP, TCP_NODELAY, (const char*)&option_value, sizeof (option_value));

--- a/src/native/eventpipe/ds-ipc-pal-socket.c
+++ b/src/native/eventpipe/ds-ipc-pal-socket.c
@@ -323,7 +323,8 @@ ipc_socket_create_uds (DiagnosticsIpc *ipc)
 	DS_ENTER_BLOCKING_PAL_SECTION;
 	new_socket = socket (ipc->server_address_family, socket_type, 0);
 #ifndef SOCK_CLOEXEC
-	fcntl(new_socket, F_SETFD, FD_CLOEXEC);
+	int fcntl_rc = fcntl(new_socket, F_SETFD, FD_CLOEXEC); // best effort; don't validate return value
+	EP_ASSERT (fcntl_rc != -1);
 #endif // SOCK_CLOEXEC
 	DS_EXIT_BLOCKING_PAL_SECTION;
 	return new_socket;
@@ -351,7 +352,8 @@ ipc_socket_create_tcp (DiagnosticsIpc *ipc)
 	DS_ENTER_BLOCKING_PAL_SECTION;
 	new_socket = socket (ipc->server_address_family, socket_type, IPPROTO_TCP);
 #ifndef SOCK_CLOEXEC
-	fcntl(new_socket, F_SETFD, FD_CLOEXEC);
+	int fcntl_rc = fcntl(new_socket, F_SETFD, FD_CLOEXEC); // best effort; don't validate return value
+	EP_ASSERT(fcntl_rc != -1);
 #endif // SOCK_CLOEXEC
 	if (new_socket != DS_IPC_INVALID_SOCKET) {
 		int option_value = 1;


### PR DESCRIPTION
This sets the `CLOEXEC` flag on socket file descriptors created in the diagnostic server. It attempts to set it directly in the call to `socket` if supported, otherwise it uses `fcntl`.