### PR TITLE
[mono] Split iOS/tvOS/MacCatalyst runtime packs into their own workload

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.json.in
@@ -42,31 +42,47 @@
       "abstract": true,
       "description": "iOS Mono Runtime and AOT Workload",
       "packs": [
-        "Microsoft.NETCore.App.Runtime.Mono.ios-arm",
-        "Microsoft.NETCore.App.Runtime.Mono.ios-arm64",
-        "Microsoft.NETCore.App.Runtime.Mono.iossimulator-arm64",
-        "Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64",
-        "Microsoft.NETCore.App.Runtime.Mono.iossimulator-x86",
         "Microsoft.NETCore.App.Runtime.AOT.Cross.ios-arm",
         "Microsoft.NETCore.App.Runtime.AOT.Cross.ios-arm64",
         "Microsoft.NETCore.App.Runtime.AOT.Cross.iossimulator-arm64",
         "Microsoft.NETCore.App.Runtime.AOT.Cross.iossimulator-x64",
         "Microsoft.NETCore.App.Runtime.AOT.Cross.iossimulator-x86"
       ],
-      "extends": [ "microsoft-net-runtime-mono-tooling" ],
+      "extends": [ "runtimes-ios" ],
       "platforms": [ "osx-arm64", "osx-x64" ]
+    },
+    "runtimes-ios": {
+      "abstract": true,
+      "description": "iOS Mono Runtime Packs",
+      "packs": [
+        "Microsoft.NETCore.App.Runtime.Mono.ios-arm",
+        "Microsoft.NETCore.App.Runtime.Mono.ios-arm64",
+        "Microsoft.NETCore.App.Runtime.Mono.iossimulator-arm64",
+        "Microsoft.NETCore.App.Runtime.Mono.iossimulator-x64",
+        "Microsoft.NETCore.App.Runtime.Mono.iossimulator-x86"
+      ],
+      "extends": [ "microsoft-net-runtime-mono-tooling" ],
+      "platforms": [ "win-x64", "osx-arm64", "osx-x64" ]
     },
     "microsoft-net-runtime-maccatalyst": {
       "abstract": true,
       "description": "MacCatalyst Mono Runtime and AOT Workload",
       "packs": [
-        "Microsoft.NETCore.App.Runtime.Mono.maccatalyst-arm64",
-        "Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64",
         "Microsoft.NETCore.App.Runtime.AOT.Cross.maccatalyst-arm64",
         "Microsoft.NETCore.App.Runtime.AOT.Cross.maccatalyst-x64"
       ],
-      "extends": [ "microsoft-net-runtime-mono-tooling" ],
+      "extends": [ "runtimes-maccatalyst" ],
       "platforms": [ "osx-arm64", "osx-x64" ]
+    },
+    "runtimes-maccatalyst": {
+      "abstract": true,
+      "description": "MacCatalyst Mono Runtime Packs",
+      "packs": [
+        "Microsoft.NETCore.App.Runtime.Mono.maccatalyst-arm64",
+        "Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64"
+      ],
+      "extends": [ "microsoft-net-runtime-mono-tooling" ],
+      "platforms": [ "win-x64", "osx-arm64", "osx-x64" ]
     },
     "microsoft-net-runtime-macos": {
       "abstract": true,
@@ -78,21 +94,29 @@
         "Microsoft.NETCore.App.Runtime.osx-x64"
       ],
       "extends": [ "microsoft-net-runtime-mono-tooling" ],
-      "platforms": [ "osx-arm64", "osx-x64" ]
+      "platforms": [ "win-x64", "osx-arm64", "osx-x64" ]
     },
     "microsoft-net-runtime-tvos": {
       "abstract": true,
       "description": "tvOS Mono Runtime and AOT Workload",
       "packs": [
-        "Microsoft.NETCore.App.Runtime.Mono.tvos-arm64",
-        "Microsoft.NETCore.App.Runtime.Mono.tvossimulator-arm64",
-        "Microsoft.NETCore.App.Runtime.Mono.tvossimulator-x64",
         "Microsoft.NETCore.App.Runtime.AOT.Cross.tvos-arm64",
         "Microsoft.NETCore.App.Runtime.AOT.Cross.tvossimulator-arm64",
         "Microsoft.NETCore.App.Runtime.AOT.Cross.tvossimulator-x64"
       ],
-      "extends": [ "microsoft-net-runtime-mono-tooling" ],
+      "extends": [ "runtimes-tvos" ],
       "platforms": [ "osx-arm64", "osx-x64" ]
+    },
+    "runtimes-tvos": {
+      "abstract": true,
+      "description": "tvOS Mono Runtime and AOT Workload",
+      "packs": [
+        "Microsoft.NETCore.App.Runtime.Mono.tvos-arm64",
+        "Microsoft.NETCore.App.Runtime.Mono.tvossimulator-arm64",
+        "Microsoft.NETCore.App.Runtime.Mono.tvossimulator-x64"
+      ],
+      "extends": [ "microsoft-net-runtime-mono-tooling" ],
+      "platforms": [ "win-x64", "osx-arm64", "osx-x64" ]
     },
     "microsoft-net-runtime-mono-tooling": {
       "abstract": true,

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.json.in
@@ -109,7 +109,7 @@
     },
     "runtimes-tvos": {
       "abstract": true,
-      "description": "tvOS Mono Runtime and AOT Workload",
+      "description": "tvOS Mono Runtime Packs",
       "packs": [
         "Microsoft.NETCore.App.Runtime.Mono.tvos-arm64",
         "Microsoft.NETCore.App.Runtime.Mono.tvossimulator-arm64",

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.json.in
@@ -94,7 +94,7 @@
         "Microsoft.NETCore.App.Runtime.osx-x64"
       ],
       "extends": [ "microsoft-net-runtime-mono-tooling" ],
-      "platforms": [ "win-x64", "osx-arm64", "osx-x64" ]
+      "platforms": [ "osx-arm64", "osx-x64" ]
     },
     "microsoft-net-runtime-tvos": {
       "abstract": true,
@@ -200,7 +200,7 @@
       "kind": "framework",
       "version": "${PackageVersion}",
     },
-    "Microsoft.NETCore.App.Runtime.Mono.maccatalyst-64": {
+    "Microsoft.NETCore.App.Runtime.Mono.maccatalyst-x64": {
       "kind": "framework",
       "version": "${PackageVersion}",
     },


### PR DESCRIPTION
The ios/tvos/maccatalyst runtime packs need to be installable on Windows and as a result each need their own workload.

The microsoft-net-runtime-ios/tv/maccatalyst workloads will still function the same by extending the new runtimes-* workloads.