### PR TITLE
Handle contained BITCAST for STORE_LCL_FLD

### DIFF
--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -4856,11 +4856,14 @@ void Lowering::ContainCheckStoreLoc(GenTreeLclVarCommon* storeLoc) const
     assert(storeLoc->OperIsLocalStore());
     GenTree* op1 = storeLoc->gtGetOp1();
 
-    if (op1->OperIs(GT_BITCAST))
+    if (op1->OperIs(GT_BITCAST) && !storeLoc->OperIs(GT_STORE_LCL_FLD))
     {
         // If we know that the source of the bitcast will be in a register, then we can make
         // the bitcast itself contained. This will allow us to store directly from the other
         // type if this node doesn't get a register.
+        // 
+        // TODO: Currently, codegen does not handle STORE_LCL_FLD whose src is contained BITCAST.
+        //  In future, support it just how it is done for STORE_LCL_VAR.
         GenTree* bitCastSrc = op1->gtGetOp1();
         if (!bitCastSrc->isContained() && !bitCastSrc->IsRegOptional())
         {

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -4856,14 +4856,11 @@ void Lowering::ContainCheckStoreLoc(GenTreeLclVarCommon* storeLoc) const
     assert(storeLoc->OperIsLocalStore());
     GenTree* op1 = storeLoc->gtGetOp1();
 
-    if (op1->OperIs(GT_BITCAST) && !storeLoc->OperIs(GT_STORE_LCL_FLD))
+    if (op1->OperIs(GT_BITCAST))
     {
         // If we know that the source of the bitcast will be in a register, then we can make
         // the bitcast itself contained. This will allow us to store directly from the other
         // type if this node doesn't get a register.
-        // 
-        // TODO: Currently, codegen does not handle STORE_LCL_FLD whose src is contained BITCAST.
-        //  In future, support it just how it is done for STORE_LCL_VAR.
         GenTree* bitCastSrc = op1->gtGetOp1();
         if (!bitCastSrc->isContained() && !bitCastSrc->IsRegOptional())
         {

--- a/src/tests/JIT/Regression/JitBlue/Runtime_55141/Runtime_55141.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_55141/Runtime_55141.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+struct S0
+{
+    public ulong F0;
+    public ulong F1;
+    public long F2;
+    public uint F4;
+    public uint F6;
+}
+
+public class Runtime_55141
+{
+    // UDIV is lowered to the MULHI/BITCAST nodes and they are stored in field (STORE_LCL_FLD).
+    // BITCAST is marked as contained so the value to be stored can be used from MULHI, but marking
+    // the containment of BITCAST is not supported in codegen for STORE_LCL_FLD.
+    public static void Main()
+    {
+        Run(0);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int Run(long x)
+    {
+        S0 vr1 = default(S0);
+        vr1.F4 = (uint)x / 254;
+        System.Console.WriteLine(vr1.F6);
+        return 100;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_55141/Runtime_55141.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_55141/Runtime_55141.cs
@@ -17,17 +17,16 @@ public class Runtime_55141
     // UDIV is lowered to the MULHI/BITCAST nodes and they are stored in field (STORE_LCL_FLD).
     // BITCAST is marked as contained so the value to be stored can be used from MULHI, but marking
     // the containment of BITCAST is not supported in codegen for STORE_LCL_FLD.
-    public static void Main()
+    public static int Main()
     {
-        Run(0);
+        return (uint)Run(0) == 0 ? 100 : 0;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public static int Run(long x)
+    public static uint Run(long x)
     {
         S0 vr1 = default(S0);
         vr1.F4 = (uint)x / 254;
-        System.Console.WriteLine(vr1.F6);
-        return 100;
+        return vr1.F6;
     }
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_55141/Runtime_55141.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_55141/Runtime_55141.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <DebugType>None</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
`UDIV` is lowered to the `MULHI/BITCAST` nodes and are stored in field using `STORE_LCL_FLD`. `BITCAST` is marked as contained so the value to be stored can be used directly from `MULHI`. However, having `BITCAST` as contained is not supported in codegen for `STORE_LCL_FLD` nodes.

The fix is to  handle the contained `BITCAST` scenario in `genCodeForStoreLclFld()` similar to the way we do in [genCodeForStoreLclVar()](https://github.com/dotnet/runtime/blob/e983168f871dcba090ff6ec08c0d2c7d4353fb8e/src/coreclr/jit/codegenxarch.cpp#L4505-L4516). 

There is a separate question on why we choose to `BITCAST` for xarch and `CAST` for armarch. I have asked it in https://github.com/dotnet/runtime/pull/52893#issuecomment-881680701.

Thanks @sandreenko for helping me investigate.

Fixes: https://github.com/dotnet/runtime/issues/55141