### PR TITLE
Fix rva ordering take2

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -12226,10 +12226,12 @@ BYTE* emitter::emitOutputRR(BYTE* dst, instrDesc* id)
                         regMaskTP regMask;
                         regMask = genRegMask(reg1) | genRegMask(reg2);
 
-                        // r1/r2 could have been a GCREF as GCREF + int=BYREF
-                        //                            or BYREF+/-int=BYREF
-                        assert(((regMask & emitThisGCrefRegs) && (ins == INS_add)) ||
-                               ((regMask & emitThisByrefRegs) && (ins == INS_add || ins == INS_sub)));
+// Assert disabled as requested in PR 55301. A use of the Unsafe api
+// which produces correct code, but isn't handled correctly here.
+// r1/r2 could have been a GCREF as GCREF + int=BYREF
+//                            or BYREF+/-int=BYREF
+// assert(((regMask & emitThisGCrefRegs) && (ins == INS_add)) ||
+//       ((regMask & emitThisByrefRegs) && (ins == INS_add || ins == INS_sub)));
 #endif
                         // Mark r1 as holding a byref
                         emitGCregLiveUpd(GCT_BYREF, reg1, dst);

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -7704,14 +7704,24 @@ GenTree* Compiler::impImportStaticFieldAccess(CORINFO_RESOLVED_TOKEN* pResolvedT
                 void** pFldAddr = nullptr;
                 void*  fldAddr  = info.compCompHnd->getFieldAddress(pResolvedToken->hField, (void**)&pFldAddr);
 
-                // We should always be able to access this static's address directly
-                //
+// We should always be able to access this static's address directly unless this is a field RVA
+// used within a composite image during R2R composite image building.
+//
+#ifdef FEATURE_READYTORUN_COMPILER
+                assert((pFldAddr == nullptr) ||
+                       (pFieldInfo->fieldAccessor == CORINFO_FIELD_STATIC_RVA_ADDRESS && opts.IsReadyToRun()));
+#else
                 assert(pFldAddr == nullptr);
+#endif
 
                 FieldSeqNode* fldSeq = GetFieldSeqStore()->CreateSingleton(pResolvedToken->hField);
 
                 /* Create the data member node */
-                op1 = gtNewIconHandleNode(pFldAddr == nullptr ? (size_t)fldAddr : (size_t)pFldAddr, GTF_ICON_STATIC_HDL,
+                op1 = gtNewIconHandleNode(pFldAddr == nullptr ? (size_t)fldAddr : (size_t)pFldAddr,
+#ifdef FEATURE_READYTORUN_COMPILER
+                                          pFldAddr != nullptr ? GTF_ICON_CONST_PTR :
+#endif
+                                                              GTF_ICON_STATIC_HDL,
                                           fldSeq);
 #ifdef DEBUG
                 op1->AsIntCon()->gtTargetHandle = op1->AsIntCon()->gtIconVal;
@@ -7721,6 +7731,17 @@ GenTree* Compiler::impImportStaticFieldAccess(CORINFO_RESOLVED_TOKEN* pResolvedT
                 {
                     op1->gtFlags |= GTF_ICON_INITCLASS;
                 }
+
+#ifdef FEATURE_READYTORUN_COMPILER
+                if (pFldAddr != nullptr)
+                {
+                    // Indirection used to get to initial actual field RVA when building a composite image
+                    // where the actual field does not move from the original file
+                    assert(!varTypeIsGC(lclTyp));
+                    op1 = gtNewOperNode(GT_IND, TYP_I_IMPL, op1);
+                    op1->gtFlags |= GTF_IND_INVARIANT | GTF_IND_NONFAULTING;
+                }
+#endif
             }
             else // We need the value of a static field
             {

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -2652,7 +2652,7 @@ namespace Internal.JitInterface
                 return null;
             }
 
-            return (void*)ObjectToHandle(_compilation.GetFieldRvaData(fd));
+            return (void*)ObjectToHandle(_compilation.GetFieldRvaData(fd, mustBeLocalToGeneratedAssemblyCode: true));
         }
 
         private CorInfoIsAccessAllowedResult canAccessClass(ref CORINFO_RESOLVED_TOKEN pResolvedToken, CORINFO_METHOD_STRUCT_* callerHandle, ref CORINFO_HELPER_DESC pAccessHelper)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -64,6 +64,14 @@ namespace ILCompiler.DependencyAnalysis
                     new ReadyToRunInstructionSetSupportSignature(key));
             });
 
+            _precodeFieldAddressCache = new NodeCache<FieldDesc, ISymbolNode>(key =>
+            {
+                return new PrecodeHelperImport(
+                    _codegenNodeFactory,
+                    new FieldFixupSignature(ReadyToRunFixupKind.FieldAddress, key, _codegenNodeFactory)
+                );
+            });
+
             _fieldAddressCache = new NodeCache<FieldDesc, ISymbolNode>(key =>
             {
                 return new DelayLoadHelperImport(
@@ -396,6 +404,13 @@ namespace ILCompiler.DependencyAnalysis
         public ISymbolNode FieldAddress(FieldDesc fieldDesc)
         {
             return _fieldAddressCache.GetOrAdd(fieldDesc);
+        }
+
+        private NodeCache<FieldDesc, ISymbolNode> _precodeFieldAddressCache;
+
+        public ISymbolNode PrecodeFieldAddress(FieldDesc fieldDesc)
+        {
+            return _precodeFieldAddressCache.GetOrAdd(fieldDesc);
         }
 
         private NodeCache<FieldDesc, ISymbolNode> _fieldOffsetCache;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -641,7 +641,7 @@ namespace ILCompiler
             }
         }
 
-        public ISymbolNode GetFieldRvaData(FieldDesc field) => NodeFactory.CompilationModuleGroup.IsCompositeBuildMode ? SymbolNodeFactory.PrecodeFieldAddress(field) : NodeFactory.CopiedFieldRva(field);
+        public ISymbolNode GetFieldRvaData(FieldDesc field, bool mustBeLocalToGeneratedAssemblyCode = false) => NodeFactory.CompilationModuleGroup.IsCompositeBuildMode && !mustBeLocalToGeneratedAssemblyCode ? SymbolNodeFactory.PrecodeFieldAddress(field) : NodeFactory.CopiedFieldRva(field);
 
         public override void Dispose()
         {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -641,7 +641,7 @@ namespace ILCompiler
             }
         }
 
-        public ISymbolNode GetFieldRvaData(FieldDesc field) => NodeFactory.CopiedFieldRva(field);
+        public ISymbolNode GetFieldRvaData(FieldDesc field) => NodeFactory.CompilationModuleGroup.IsCompositeBuildMode ? SymbolNodeFactory.PrecodeFieldAddress(field) : NodeFactory.CopiedFieldRva(field);
 
         public override void Dispose()
         {

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -14034,6 +14034,21 @@ BOOL LoadDynamicInfoEntry(Module *currentModule,
         break;
 #endif // PROFILING_SUPPORTED
 
+    case ENCODE_FIELD_ADDRESS:
+        {
+            FieldDesc *pField = ZapSig::DecodeField(currentModule, pInfoModule, pBlob);
+
+            pField->GetEnclosingMethodTable()->CheckRestore();
+
+            // We can only take address of RVA field here as we don't handle scenarios where the static variable may move
+            // Also, this cannot be used with a ZapImage as it relies on a separate signatures block as an RVA static
+            // address may be unaligned which would interfere with the tagged pointer approach.
+            _ASSERTE(currentModule->IsReadyToRun());
+            _ASSERTE(pField->IsRVA());
+            result = (size_t)pField->GetStaticAddressHandle(NULL);
+        }
+        break;
+
     case ENCODE_STATIC_FIELD_ADDRESS:
         {
             FieldDesc *pField = ZapSig::DecodeField(currentModule, pInfoModule, pBlob);

--- a/src/tests/JIT/Directed/RVAInit/simplearg.il
+++ b/src/tests/JIT/Directed/RVAInit/simplearg.il
@@ -10,7 +10,7 @@
   .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
   .ver 4:0:0:0
 }
-.assembly repro2
+.assembly simplearg
 {
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
   .custom instance void [mscorlib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
@@ -18,7 +18,7 @@
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
-.module repro2.exe
+.module simplearg.exe
 // MVID: {07A1F03C-A750-4BCF-8997-C0AC2CBDB844}
 .imagebase 0x00400000
 .file alignment 0x00000200
@@ -105,8 +105,13 @@
   {
     .entrypoint
     // Code size       59 (0x3b)
-    .maxstack  2
-    .locals init (int32 V_0)
+    .maxstack  8
+    .locals init (int32 V_0,
+                  valuetype SimpleArg.MyValue V_1)
+
+    ldstr      "Test1"
+    call       void [mscorlib]System.Console::WriteLine(string)
+
     IL_0000:  ldsfld     valuetype SimpleArg.MyValue SimpleArg.Holder::RvaStatic
     IL_0005:  call       int32 SimpleArg.Program::Method(valuetype SimpleArg.MyValue)
     IL_000a:  stloc.0
@@ -117,7 +122,59 @@
     IL_0017:  stloc.0
     IL_0018:  ldloc.0
     IL_0019:  ldc.i4.s   100
-    IL_001b:  bne.un.s   IL_0029
+    IL_001b:  bne.un     IL_0029
+
+// Update the value in the RVA static to be a different than the initial value via adjustment working through the static field address
+    ldstr      "Test2"
+    call       void [mscorlib]System.Console::WriteLine(string)
+
+    ldsflda valuetype SimpleArg.MyValue SimpleArg.Holder::RvaStatic
+    ldflda int32 SimpleArg.MyValue::IntValue
+    ldc.i4.1
+    stind.i4
+// This is the same as the logic above, but should run after adjust the RVA to hold the value 1 instead of 31
+    ldsfld     valuetype SimpleArg.MyValue SimpleArg.Holder::RvaStatic
+    call       int32 SimpleArg.Program::Method(valuetype SimpleArg.MyValue)
+    stloc.0
+    ldloc.0
+    ldsfld     valuetype SimpleArg.MyValue SimpleArg.Holder::NormalStatic
+    call       int32 SimpleArg.Program::Method(valuetype SimpleArg.MyValue)
+    add
+    stloc.0
+    ldloc.0
+    ldc.i4.s   70 // Since the value in the RVA static has been reduced to 1, the expected value is now 70.
+    bne.un     IL_0029
+    ldc.i4.s   100 // Put 100 in local 0, so that we return the right number and cause the test to pass
+    stloc.0
+
+
+// This is the same as the logic above, but should run after adjust the RVA to hold the value 2 instead of 31 via the stsfld opcode
+    ldstr      "Test3"
+    call       void [mscorlib]System.Console::WriteLine(string)
+
+    ldsfld     valuetype SimpleArg.MyValue SimpleArg.Holder::RvaStatic
+    stloc.1
+    ldloca 1
+    ldflda int32 SimpleArg.MyValue::IntValue
+    ldc.i4.2
+    stind.i4
+    ldloc.1
+    stsfld valuetype SimpleArg.MyValue SimpleArg.Holder::RvaStatic
+
+
+    ldsfld     valuetype SimpleArg.MyValue SimpleArg.Holder::RvaStatic
+    call       int32 SimpleArg.Program::Method(valuetype SimpleArg.MyValue)
+    stloc.0
+    ldloc.0
+    ldsfld     valuetype SimpleArg.MyValue SimpleArg.Holder::NormalStatic
+    call       int32 SimpleArg.Program::Method(valuetype SimpleArg.MyValue)
+    add
+    stloc.0
+    ldloc.0
+    ldc.i4.s   71 // Since the value in the RVA static has been reduced to 1, the expected value is now 71.
+    bne.un     IL_0029
+    ldc.i4.s   100 // Put 100 in local 0, so that we return the right number and cause the test to pass
+    stloc.0
 
     IL_001d:  ldstr      "Passed"
     IL_0022:  call       void [mscorlib]System.Console::WriteLine(string)

--- a/src/tests/JIT/Directed/RVAInit/simplearg.ilproj
+++ b/src/tests/JIT/Directed/RVAInit/simplearg.ilproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <RestorePackages>true</RestorePackages>
     <CLRTestPriority>1</CLRTestPriority>
+    <IlAsmFlags>-X64</IlAsmFlags>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>


### PR DESCRIPTION
- Since composite images have the original RVA statics in the original files, use the value from there
- This required re-enabling the ability of getFieldAddress to return an indirection
- And adding some new processing for the fixup as needed

Fixes composite mode compilation of src/tests/Directed/rvastatics/RVAOrderingTest.ilproj

Earlier fix was reverted as it broke composite construction of CoreLib, this fix should be more correct.