### PR TITLE
Prevent writes during EventSource.Disable

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventProvider.cs
@@ -35,7 +35,9 @@ namespace System.Diagnostics.Tracing
         // Unregister an event provider.
         uint IEventProvider.EventUnregister(long registrationHandle)
         {
-            EventPipeInternal.DeleteProvider(m_provHandle);
+            IntPtr provHandle = m_provHandle;
+            m_provHandle = IntPtr.Zero;
+            EventPipeInternal.DeleteProvider(provHandle);
             return 0;
         }
 
@@ -82,8 +84,13 @@ namespace System.Diagnostics.Tracing
         unsafe IntPtr IEventProvider.DefineEventHandle(uint eventID, string eventName, long keywords, uint eventVersion, uint level,
             byte *pMetadata, uint metadataLength)
         {
-            IntPtr eventHandlePtr = EventPipeInternal.DefineEvent(m_provHandle, eventID, keywords, eventVersion, level, pMetadata, metadataLength);
-            return eventHandlePtr;
+            if (m_provHandle != IntPtr.Zero)
+            {
+                IntPtr eventHandlePtr = EventPipeInternal.DefineEvent(m_provHandle, eventID, keywords, eventVersion, level, pMetadata, metadataLength);
+                return eventHandlePtr;
+            }
+
+            return IntPtr.Zero;
         }
 
         // Get or set the per-thread activity ID.

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -1302,12 +1302,12 @@ namespace System.Diagnostics.Tracing
         [CLSCompliant(false)]
         protected unsafe void WriteEventWithRelatedActivityIdCore(int eventId, Guid* relatedActivityId, int eventDataCount, EventSource.EventData* data)
         {
+            m_activeWritesCount++;
             if (IsEnabled())
             {
                 Debug.Assert(m_eventData != null);  // You must have initialized this if you enabled the source.
                 try
                 {
-                    m_activeWritesCount++;
                     ref EventMetadata metadata = ref m_eventData[eventId];
 
                     EventOpcode opcode = (EventOpcode)metadata.Descriptor.Opcode;
@@ -1464,6 +1464,7 @@ namespace System.Diagnostics.Tracing
                 }
 
                 // Wait till active writes have finished (stop waiting at 1 second)
+                // TODO: determine appropriate break out mechanism. Is 1 second appropriate? Is a timeout appropriate at all?
                 SpinWait.SpinUntil(() => m_activeWritesCount == 0, 1000);
 
                 if (m_etwProvider != null)
@@ -1901,12 +1902,12 @@ namespace System.Diagnostics.Tracing
 #endif
         private unsafe void WriteEventVarargs(int eventId, Guid* childActivityID, object?[] args)
         {
+            m_activeWritesCount++;
             if (IsEnabled())
             {
                 Debug.Assert(m_eventData != null);  // You must have initialized this if you enabled the source.
                 try
                 {
-                    m_activeWritesCount++;
                     ref EventMetadata metadata = ref m_eventData[eventId];
 
                     if (childActivityID != null)

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
@@ -378,7 +378,9 @@ namespace System.Diagnostics.Tracing
 
             if (this.IsEnabled((EventLevel)level, keywords))
             {
+                m_activeWritesCount++;
                 WriteMultiMergeInner(eventName, ref options, eventTypes, activityID, childActivityID, values);
+                m_activeWritesCount--;
             }
         }
 
@@ -555,6 +557,8 @@ namespace System.Diagnostics.Tracing
                 return;
             }
 
+            m_activeWritesCount++;
+
             fixed (EventSourceOptions* pOptions = &options)
             {
                 NameInfo? nameInfo = this.UpdateDescriptor(eventName, eventTypes, ref options, out EventDescriptor descriptor);
@@ -610,6 +614,8 @@ namespace System.Diagnostics.Tracing
                         (IntPtr)descriptors);
                 }
             }
+
+            m_activeWritesCount--;
 #endif // FEATURE_MANAGED_ETW
         }
 
@@ -623,6 +629,7 @@ namespace System.Diagnostics.Tracing
         {
             try
             {
+                m_activeWritesCount++;
                 fixed (EventSourceOptions* pOptions = &options)
                 {
                     options.Opcode = options.IsOpcodeSet ? options.Opcode : GetOpcodeWithDefault(options.Opcode, eventName);
@@ -740,6 +747,10 @@ namespace System.Diagnostics.Tracing
                     throw;
                 else
                     ThrowEventSourceException(eventName, ex);
+            }
+            finally
+            {
+                m_activeWritesCount--;
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
@@ -365,7 +365,7 @@ namespace System.Diagnostics.Tracing
              Guid* childActivityID,
             params object?[] values)
         {
-            m_activeWritesCount++;
+            WriteGuardEnter();
             if (this.IsEnabled())
             {
                 try
@@ -384,7 +384,7 @@ namespace System.Diagnostics.Tracing
                 }
                 finally
                 {
-                    m_activeWritesCount--;
+                    WriteGuardExit();
                 }
             }
         }
@@ -557,7 +557,7 @@ namespace System.Diagnostics.Tracing
             EventData* data)
         {
 #if FEATURE_MANAGED_ETW
-            m_activeWritesCount++;
+            WriteGuardEnter();
             if (this.IsEnabled())
             {
                 try
@@ -620,7 +620,7 @@ namespace System.Diagnostics.Tracing
                 }
                 finally
                 {
-                    m_activeWritesCount--;
+                    WriteGuardExit();
                 }
             }
 
@@ -635,7 +635,7 @@ namespace System.Diagnostics.Tracing
             Guid* pRelatedActivityId,
             TraceLoggingEventTypes eventTypes)
         {
-            m_activeWritesCount++;
+            WriteGuardEnter();
             if (IsEnabled())
             {
                 try
@@ -760,7 +760,7 @@ namespace System.Diagnostics.Tracing
                 }
                 finally
                 {
-                    m_activeWritesCount--;
+                    WriteGuardExit();
                 }
             }
         }


### PR DESCRIPTION
fixes #55441

There is a race in `EventSource.Disable` where any active writers that have passed their `IsEnabled()` checks could end up accessing internal structures _as_ they are being disposed. This patch adds a two phase disable as part of dispose that will prevent writes from happening when resources are being cleaned up.

TODO:
- [ ] performance analysis. Adding a spinwait could be expensive and even with the timeout, it's possible for this to bite us. I want to run this through bdn to see if there is a serious impact to EventSource performance. I also want to check if this impact performance on shutdown. I'll leave this as draft until I'm either convinced I don't need the data, or I've collected it.

CC @brianrob @noahfalk @davmason 