### PR TITLE
[Preview 7] Fix debugger thread context validation after recent change

### DIFF
--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -15911,7 +15911,7 @@ BOOL Debugger::IsThreadContextInvalid(Thread *pThread, CONTEXT *pCtx)
     if (!success)
     {
         ctx.ContextFlags = CONTEXT_CONTROL;
-        BOOL success = pThread->GetThreadContext(&ctx);
+        success = pThread->GetThreadContext(&ctx);
         if (success)
         {
             pCtx = &ctx;


### PR DESCRIPTION
- Port of https://github.com/dotnet/runtime/pull/55839 to preview 7
- Followup fix to https://github.com/dotnet/runtime/pull/55185

### Customer impact

- When a thread in a debuggee process remains in managed code for an extended duration without switching GC modes or hitting a GC poll, it may fail to suspend for the debugger
- This can result in a hang when attaching, breaking, or hitting a breakpoint
- A simple test case is shown in https://github.com/dotnet/runtime/pull/55839#issuecomment-881796963

### Regression?

- Yes, from 6.0 preview 6

### Testing

- Manual test with a repro
- CI tests

### Risk

Very low:
- The change reverts to previous behavior in the affected case