### PR TITLE
enable two quic tests

### DIFF
--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -158,7 +158,6 @@ namespace System.Net.Quic.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/52048")]
         public async Task WaitForAvailableUnidirectionStreamsAsyncWorks()
         {
             using QuicListener listener = CreateQuicListener(maxUnidirectionalStreams: 1);

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamConnectedStreamConformanceTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamConnectedStreamConformanceTests.cs
@@ -23,10 +23,6 @@ namespace System.Net.Quic.Tests
         protected override QuicImplementationProvider Provider => QuicImplementationProviders.MsQuic;
         protected override bool UsableAfterCanceledReads => false;
         protected override bool BlocksOnZeroByteReads => true;
-
-        // TODO: new additions, find out the actual reason for hanging
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
-        public override Task ReadAsync_DuringReadAsync_ThrowsIfUnsupported() => base.ReadAsync_DuringReadAsync_ThrowsIfUnsupported();
     }
 
     public abstract class QuicStreamConformanceTests : ConnectedStreamConformanceTests


### PR DESCRIPTION
- WaitForAvailableUnidirectionStreamsAsyncWorks 
#52048 was fixed while ago but O forget one disabled test 
- ReadAsync_DuringReadAsync_ThrowsIfUnsupported
works now with updated read state. probably mostly #55505  