### PR TITLE
adjust exception message for headers having non-ASCII chars

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/QPack/QPackEncoder.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Http3/QPack/QPackEncoder.cs
@@ -317,7 +317,7 @@ namespace System.Net.Http.QPack
 
                 if (ch > 127)
                 {
-                    throw new QPackEncodingException("ASCII header value.");
+                    throw new QPackEncodingException(SR.net_http_request_invalid_char_encoding);
                 }
 
                 buffer[i] = (byte)ch;


### PR DESCRIPTION
Adjust exception message for headers having non-ASCII chars

Fixes #55310