### PR TITLE
Fix potential race by using volatile

### DIFF
--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -81,7 +81,7 @@ static gint32 signatures_size;
 void
 mono_loader_init ()
 {
-	static volatile gboolean inited;
+	static volatile gboolean inited = FALSE;
 
 	if (!inited) {
 		mono_coop_mutex_init_recursive (&loader_mutex);

--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -81,9 +81,11 @@ static gint32 signatures_size;
 void
 mono_loader_init ()
 {
-	static volatile gboolean inited = FALSE;
+	static volatile gboolean runInit = TRUE;
 
-	if (!inited) {
+	if (runInit) {
+		runInit = FALSE;
+
 		mono_coop_mutex_init_recursive (&loader_mutex);
 		mono_os_mutex_init_recursive (&global_loader_data_mutex);
 		loader_lock_inited = TRUE;
@@ -101,8 +103,6 @@ mono_loader_init ()
 								MONO_COUNTER_METADATA | MONO_COUNTER_INT, &methods_size);
 		mono_counters_register ("MonoMethodSignature size",
 								MONO_COUNTER_METADATA | MONO_COUNTER_INT, &signatures_size);
-
-		inited = TRUE;
 	}
 }
 

--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -81,29 +81,31 @@ static gint32 signatures_size;
 void
 mono_loader_init ()
 {
-	static volatile gboolean runInit = TRUE;
+	static volatile gboolean inited = FALSE;
 
-	if (runInit) {
-		runInit = FALSE;
-
-		mono_coop_mutex_init_recursive (&loader_mutex);
-		mono_os_mutex_init_recursive (&global_loader_data_mutex);
-		loader_lock_inited = TRUE;
-
-		mono_global_loader_cache_init ();
-
-		mono_native_tls_alloc (&loader_lock_nest_id, NULL);
-
-		mono_counters_init ();
-		mono_counters_register ("Inflated signatures size",
-								MONO_COUNTER_GENERICS | MONO_COUNTER_INT, &inflated_signatures_size);
-		mono_counters_register ("Memberref signature cache size",
-								MONO_COUNTER_METADATA | MONO_COUNTER_INT, &memberref_sig_cache_size);
-		mono_counters_register ("MonoMethod size",
-								MONO_COUNTER_METADATA | MONO_COUNTER_INT, &methods_size);
-		mono_counters_register ("MonoMethodSignature size",
-								MONO_COUNTER_METADATA | MONO_COUNTER_INT, &signatures_size);
+	if (inited) {
+		return;
 	}
+	
+	runInit = TRUE;
+
+	mono_coop_mutex_init_recursive (&loader_mutex);
+	mono_os_mutex_init_recursive (&global_loader_data_mutex);
+	loader_lock_inited = TRUE;
+
+	mono_global_loader_cache_init ();
+
+	mono_native_tls_alloc (&loader_lock_nest_id, NULL);
+
+	mono_counters_init ();
+	mono_counters_register ("Inflated signatures size",
+								MONO_COUNTER_GENERICS | MONO_COUNTER_INT, &inflated_signatures_size);
+	mono_counters_register ("Memberref signature cache size",
+								MONO_COUNTER_METADATA | MONO_COUNTER_INT, &memberref_sig_cache_size);
+	mono_counters_register ("MonoMethod size",
+								MONO_COUNTER_METADATA | MONO_COUNTER_INT, &methods_size);
+	mono_counters_register ("MonoMethodSignature size",
+								MONO_COUNTER_METADATA | MONO_COUNTER_INT, &signatures_size);
 }
 
 void

--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -81,9 +81,8 @@ static gint32 signatures_size;
 void
 mono_loader_init ()
 {
-	static gboolean inited;
+	static volatile gboolean inited;
 
-	// FIXME: potential race
 	if (!inited) {
 		mono_coop_mutex_init_recursive (&loader_mutex);
 		mono_os_mutex_init_recursive (&global_loader_data_mutex);


### PR DESCRIPTION
Using volatile means race conditions are much less likely, as it could be read by any other thread.