### PR TITLE
[Release/5.0] fix validation callback on Windows with Tls 1.3

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.SslProtocols.cs
@@ -100,10 +100,12 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(GetAsync_AllowedSSLVersion_Succeeds_MemberData))]
         public async Task GetAsync_AllowedSSLVersion_Succeeds(SslProtocols acceptedProtocol, bool requestOnlyThisProtocol)
         {
+            int count = 0;
             using (HttpClientHandler handler = CreateHttpClientHandler())
             using (HttpClient client = CreateHttpClient(handler))
             {
-                handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
+                handler.ServerCertificateCustomValidationCallback =
+                    (request, cert, chain, errors) => { count++; return true; };
 
                 if (requestOnlyThisProtocol)
                 {
@@ -131,6 +133,8 @@ namespace System.Net.Http.Functional.Tests
                         server.AcceptConnectionSendResponseAndCloseAsync(),
                         client.GetAsync(url));
                 }, options);
+
+                Assert.Equal(1, count);
             }
         }
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -948,7 +948,17 @@ namespace System.Net.Security
 
             try
             {
-                _remoteCertificate = CertificateValidationPal.GetRemoteCertificate(_securityContext, out remoteCertificateStore);
+                X509Certificate2? certificate = CertificateValidationPal.GetRemoteCertificate(_securityContext, out remoteCertificateStore);
+
+                if (_remoteCertificate != null && certificate != null &&
+                    certificate.RawData.AsSpan().SequenceEqual(_remoteCertificate.RawData))
+                {
+                    // This is renegotiation or TLS 1.3 and the certificate did not change.
+                    // There is no reason to process callback again as we already established trust.
+                    return true;
+                }
+
+                _remoteCertificate = certificate;
 
                 if (_remoteCertificate == null)
                 {

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAllowRenegotiationTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAllowRenegotiationTests.cs
@@ -54,15 +54,14 @@ namespace System.Net.Security.Tests
                 Assert.True(ssl.IsAuthenticated);
                 Assert.True(ssl.IsEncrypted);
 
-                // Issue request that triggers regotiation from server.
+                // Issue request that triggers renegotiation from server.
                 byte[] message = Encoding.UTF8.GetBytes("GET /EchoClientCertificate.ashx HTTP/1.1\r\nHost: corefx-net-tls.azurewebsites.net\r\n\r\n");
                 await ssl.WriteAsync(message, 0, message.Length);
 
                 // Initiate Read operation, that results in starting renegotiation as per server response to the above request.
                 int bytesRead = await ssl.ReadAsync(message, 0, message.Length);
 
-                // Renegotiation will trigger another validation callback/
-                Assert.InRange(validationCount, 2, int.MaxValue);
+                Assert.Equal(1, validationCount);
                 Assert.InRange(bytesRead, 1, message.Length);
                 Assert.Contains("HTTP/1.1 200 OK", Encoding.UTF8.GetString(message));
             }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -205,8 +205,7 @@ namespace System.Net.Security.Tests
                 // Initiate Read operation, that results in starting renegotiation as per server response to the above request.
                 int bytesRead = useSync ? ssl.Read(message, 0, message.Length) : await ssl.ReadAsync(message, 0, message.Length);
 
-                // renegotiation will trigger validation callback again.
-                Assert.InRange(validationCount, 2, int.MaxValue);
+                Assert.Equal(1, validationCount);
                 Assert.InRange(bytesRead, 1, message.Length);
                 Assert.Contains("HTTP/1.1 200 OK", Encoding.UTF8.GetString(message));
             }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -234,6 +234,7 @@ namespace System.Net.Security.Tests
         public async Task SslStream_TargetHostName_Succeeds(bool useEmptyName)
         {
             string targetName = useEmptyName ? string.Empty : Guid.NewGuid().ToString("N");
+            int count = 0;
 
             (Stream clientStream, Stream serverStream) = TestHelper.GetConnectedStreams();
             using (clientStream)
@@ -252,7 +253,7 @@ namespace System.Net.Security.Tests
                     {
                         SslStream stream = (SslStream)sender;
                         Assert.Equal(targetName, stream.TargetHostName);
-
+                        count++;
                         return true;
                     };
 
@@ -269,8 +270,12 @@ namespace System.Net.Security.Tests
                 await TestConfiguration.WhenAllOrAnyFailedWithTimeout(
                                 client.AuthenticateAsClientAsync(clientOptions),
                                 server.AuthenticateAsServerAsync(serverOptions));
+
+                await TestHelper.PingPong(client, server);
+
                 Assert.Equal(targetName, client.TargetHostName);
                 Assert.Equal(targetName, server.TargetHostName);
+                Assert.Equal(1, count);
             }
         }
 


### PR DESCRIPTION
## Customer Impact

This may break existing `HttpClient` code after upgrade to Windows 11 (where TLS 1.3 is enabled by default).
Validation callback will be called multiple times and it would pass `null` for non-nullable parameter.
That can create unexpected behavior for anybody who expects `HttpRequest` to be valid.

Reported by customer in #55334

## Regression? 
E2E regression when upgrading to Windows 11 (because it has TLS 1.3 enabled by default).
Not a regression from .NET code perspective -- 3.1 did not offer TLS 1.3 and Windows 10 has it disabled by default.

## Risk
Very low. This was fixed and verified with 6.0 long time ago and it is also fixed on .NET Framework 4.8 (as part of initial support).

## Testing
New tests were added to be sure callback is called only once.

Fixes #55334


Original fixes for main are in PR #42836 and PR #43123 (from October 2020).