### PR TITLE
PGO: Guarded isinst

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4288,7 +4288,8 @@ public:
     GenTree* impCastClassOrIsInstToTree(GenTree*                op1,
                                         GenTree*                op2,
                                         CORINFO_RESOLVED_TOKEN* pResolvedToken,
-                                        bool                    isCastClass);
+                                        bool                    isCastClass,
+                                        IL_OFFSETX              ilOffset);
 
     GenTree* impOptimizeCastClassOrIsInst(GenTree* op1, CORINFO_RESOLVED_TOKEN* pResolvedToken, bool isCastClass);
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4285,11 +4285,8 @@ public:
                                            GenTreeCall::Use*       args               = nullptr,
                                            CORINFO_LOOKUP_KIND*    pGenericLookupKind = nullptr);
 
-    GenTree* impCastClassOrIsInstToTree(GenTree*                op1,
-                                        GenTree*                op2,
-                                        CORINFO_RESOLVED_TOKEN* pResolvedToken,
-                                        bool                    isCastClass,
-                                        IL_OFFSETX              ilOffset);
+    GenTree* impCastClassOrIsInstToTree(
+        GenTree* op1, GenTree* op2, CORINFO_RESOLVED_TOKEN* pResolvedToken, bool isCastClass, IL_OFFSETX ilOffset);
 
     GenTree* impOptimizeCastClassOrIsInst(GenTree* op1, CORINFO_RESOLVED_TOKEN* pResolvedToken, bool isCastClass);
 

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -1219,7 +1219,7 @@ public:
             {
                 m_functor(m_compiler, call);
             }
-            else if ((call->gtCallType == CT_HELPER) &&
+            else if ((call->gtCallType == CT_HELPER) && (JitConfig.JitIsinstProfiling() > 0) &&
                      (m_compiler->eeGetHelperNum(call->gtCallMethHnd) == CORINFO_HELP_ISINSTANCEOFCLASS))
             {
                 m_functor(m_compiler, call);
@@ -1329,6 +1329,7 @@ public:
         if ((call->gtCallType == CT_HELPER) &&
             (compiler->eeGetHelperNum(call->gtCallMethHnd) == CORINFO_HELP_ISINSTANCEOFCLASS))
         {
+            assert(JitConfig.JitIsinstProfiling() > 0);
             // Grab the second arg of isinst helper call
             objUse = call->gtCallArgs->GetNext();
         }

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -1313,7 +1313,6 @@ public:
         //         ... args ...)
         //
 
-
         // Sanity check that we're looking at the right schema entry
         //
         assert(m_schema[*m_currentSchemaIndex].ILOffset == (int32_t)call->gtClassProfileCandidateInfo->ilOffset);

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -1222,7 +1222,8 @@ public:
             else if ((call->gtCallType == CT_HELPER) && (JitConfig.JitIsinstProfiling() > 0))
             {
                 const CorInfoHelpFunc helper = m_compiler->eeGetHelperNum(call->gtCallMethHnd);
-                if ((helper == CORINFO_HELP_ISINSTANCEOFINTERFACE) || (helper == CORINFO_HELP_ISINSTANCEOFCLASS))
+                if ((helper == CORINFO_HELP_ISINSTANCEOFINTERFACE) || (helper == CORINFO_HELP_ISINSTANCEOFCLASS) ||
+                    (helper == CORINFO_HELP_CHKCASTCLASS))
                 {
                     m_functor(m_compiler, call);
                 }
@@ -1331,7 +1332,8 @@ public:
         if ((call->gtCallType == CT_HELPER) && !call->IsVirtual())
         {
             const CorInfoHelpFunc helper = compiler->eeGetHelperNum(call->gtCallMethHnd);
-            assert((helper == CORINFO_HELP_ISINSTANCEOFINTERFACE) || (helper == CORINFO_HELP_ISINSTANCEOFCLASS));
+            assert((helper == CORINFO_HELP_ISINSTANCEOFINTERFACE) || (helper == CORINFO_HELP_ISINSTANCEOFCLASS) ||
+                   (helper == CORINFO_HELP_CHKCASTCLASS));
             assert(JitConfig.JitIsinstProfiling() > 0);
             // Grab the second arg of isinst helper call
             objUse = call->gtCallArgs->GetNext();

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -10939,6 +10939,8 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
     bool                  partialExpand   = false;
     const CorInfoHelpFunc helper          = info.compCompHnd->getCastingHelper(pResolvedToken, isCastClass);
 
+    GenTree* exactCls = nullptr;
+
     // Legality check.
     //
     // Not all classclass/isinst operations can be inline expanded.
@@ -10980,10 +10982,7 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
                                 eeGetClassName(likelyClass), likelyClass);
                         canExpandInline = true;
                         partialExpand   = true;
-
-                        // Update op2
-                        op2                        = gtClone(op2);
-                        op2->AsIntCon()->gtIconVal = reinterpret_cast<ssize_t>(likelyClass);
+                        exactCls        = gtNewIconEmbClsHndNode(likelyClass);
                     }
                 }
             }
@@ -11047,7 +11046,7 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
         lvaTable[op2Var->AsLclVarCommon()->GetLclNum()].lvIsCSE = true;
     }
     temp   = gtNewMethodTableLookup(temp);
-    condMT = gtNewOperNode(GT_NE, TYP_INT, temp, op2);
+    condMT = gtNewOperNode(GT_NE, TYP_INT, temp, exactCls != nullptr ? exactCls : op2);
 
     GenTree* condNull;
     //

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -11040,8 +11040,9 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
     //
 
     GenTree* op2Var = op2;
-    if (isCastClass || partialExpand)
+    if (isCastClass)
     {
+        assert(!partialExpand);
         op2Var                                                  = fgInsertCommaFormTemp(&op2);
         lvaTable[op2Var->AsLclVarCommon()->GetLclNum()].lvIsCSE = true;
     }
@@ -11075,7 +11076,7 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
     }
     else if (partialExpand)
     {
-        condTrue = gtNewHelperCallNode(helper, TYP_REF, gtNewCallArgs(op2Var, gtClone(op1)));
+        condTrue = gtNewHelperCallNode(helper, TYP_REF, gtNewCallArgs(op2, gtClone(op1)));
     }
     else
     {

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -10910,11 +10910,8 @@ GenTree* Compiler::impOptimizeCastClassOrIsInst(GenTree* op1, CORINFO_RESOLVED_T
 // Notes:
 //   May expand into a series of runtime checks or a helper call.
 
-GenTree* Compiler::impCastClassOrIsInstToTree(GenTree*                op1,
-                                              GenTree*                op2,
-                                              CORINFO_RESOLVED_TOKEN* pResolvedToken,
-                                              bool                    isCastClass,
-                                              IL_OFFSETX              ilOffset)
+GenTree* Compiler::impCastClassOrIsInstToTree(
+    GenTree* op1, GenTree* op2, CORINFO_RESOLVED_TOKEN* pResolvedToken, bool isCastClass, IL_OFFSETX ilOffset)
 {
     assert(op1->TypeGet() == TYP_REF);
 
@@ -10965,27 +10962,27 @@ GenTree* Compiler::impCastClassOrIsInstToTree(GenTree*                op1,
                 ((helper == CORINFO_HELP_ISINSTANCEOFCLASS) || (helper == CORINFO_HELP_ISINSTANCEOFINTERFACE)))
             {
                 // Check if we see any profile data
-                unsigned             likelihood = 0;
+                unsigned             likelihood      = 0;
                 unsigned             numberOfClasses = 0;
-                CORINFO_CLASS_HANDLE likelyClass = getLikelyClass(fgPgoSchema, fgPgoSchemaCount, fgPgoData,
-                    ilOffset, &likelihood, &numberOfClasses);
+                CORINFO_CLASS_HANDLE likelyClass =
+                    getLikelyClass(fgPgoSchema, fgPgoSchemaCount, fgPgoData, ilOffset, &likelihood, &numberOfClasses);
                 if ((likelyClass != NO_CLASS_HANDLE) &&
                     (likelihood > static_cast<unsigned>(JitConfig.JitGuardedDevirtualizationChainLikelihood())))
                 {
                     if ((info.compCompHnd->compareTypesForEquality(likelyClass, likelyClass) ==
-                        TypeCompareState::Must) &&
+                         TypeCompareState::Must) &&
                         (info.compCompHnd->compareTypesForCast(likelyClass, pResolvedToken->hClass) ==
-                            TypeCompareState::Must))
+                         TypeCompareState::Must))
                     {
-                        const UINT32 attrs = info.compCompHnd->getClassAttribs(pResolvedToken->hClass);
+                        const UINT32 attrs = info.compCompHnd->getClassAttribs(likelyClass);
                         assert((attrs & (CORINFO_FLG_INTERFACE | CORINFO_FLG_ABSTRACT)) == 0);
                         JITDUMP("Adding a check for \"is %s (%X)\" as a fast path for isinst using PGO data.\n",
-                            eeGetClassName(likelyClass), likelyClass);
+                                eeGetClassName(likelyClass), likelyClass);
                         canExpandInline = true;
                         partialExpand   = true;
 
                         // Update op2
-                        op2 = gtClone(op2);
+                        op2                        = gtClone(op2);
                         op2->AsIntCon()->gtIconVal = reinterpret_cast<ssize_t>(likelyClass);
                     }
                 }

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -10959,32 +10959,34 @@ GenTree* Compiler::impCastClassOrIsInstToTree(GenTree*                op1,
             {
                 // If the class is exact, the jit can expand the IsInst check inline.
                 canExpandInline = impIsClassExact(pResolvedToken->hClass);
-                if (!canExpandInline && (JitConfig.JitIsinstProfiling() > 0))
-                {
-                    // Check if we see any profile data
-                    unsigned             likelihood      = 0;
-                    unsigned             numberOfClasses = 0;
-                    CORINFO_CLASS_HANDLE likelyClass     = getLikelyClass(fgPgoSchema, fgPgoSchemaCount, fgPgoData,
-                                                                      ilOffset, &likelihood, &numberOfClasses);
-                    if ((likelyClass != NO_CLASS_HANDLE) &&
-                        (likelihood > static_cast<unsigned>(JitConfig.JitGuardedDevirtualizationChainLikelihood())))
-                    {
-                        if ((info.compCompHnd->compareTypesForEquality(likelyClass, likelyClass) ==
-                             TypeCompareState::Must) &&
-                            (info.compCompHnd->compareTypesForCast(likelyClass, pResolvedToken->hClass) ==
-                             TypeCompareState::Must))
-                        {
-                            const UINT32 attrs = info.compCompHnd->getClassAttribs(pResolvedToken->hClass);
-                            assert((attrs & (CORINFO_FLG_INTERFACE | CORINFO_FLG_ABSTRACT)) == 0);
-                            JITDUMP("Adding a check for \"is %s (%X)\" as a fast path for isinst using PGO data.\n",
-                                    eeGetClassName(likelyClass), likelyClass);
-                            canExpandInline = true;
-                            partialExpand   = true;
+            }
 
-                            // Update op2
-                            op2                        = gtClone(op2);
-                            op2->AsIntCon()->gtIconVal = reinterpret_cast<ssize_t>(likelyClass);
-                        }
+            if (!canExpandInline && (JitConfig.JitIsinstProfiling() > 0) &&
+                ((helper == CORINFO_HELP_ISINSTANCEOFCLASS) || (helper == CORINFO_HELP_ISINSTANCEOFINTERFACE)))
+            {
+                // Check if we see any profile data
+                unsigned             likelihood = 0;
+                unsigned             numberOfClasses = 0;
+                CORINFO_CLASS_HANDLE likelyClass = getLikelyClass(fgPgoSchema, fgPgoSchemaCount, fgPgoData,
+                    ilOffset, &likelihood, &numberOfClasses);
+                if ((likelyClass != NO_CLASS_HANDLE) &&
+                    (likelihood > static_cast<unsigned>(JitConfig.JitGuardedDevirtualizationChainLikelihood())))
+                {
+                    if ((info.compCompHnd->compareTypesForEquality(likelyClass, likelyClass) ==
+                        TypeCompareState::Must) &&
+                        (info.compCompHnd->compareTypesForCast(likelyClass, pResolvedToken->hClass) ==
+                            TypeCompareState::Must))
+                    {
+                        const UINT32 attrs = info.compCompHnd->getClassAttribs(pResolvedToken->hClass);
+                        assert((attrs & (CORINFO_FLG_INTERFACE | CORINFO_FLG_ABSTRACT)) == 0);
+                        JITDUMP("Adding a check for \"is %s (%X)\" as a fast path for isinst using PGO data.\n",
+                            eeGetClassName(likelyClass), likelyClass);
+                        canExpandInline = true;
+                        partialExpand   = true;
+
+                        // Update op2
+                        op2 = gtClone(op2);
+                        op2->AsIntCon()->gtIconVal = reinterpret_cast<ssize_t>(likelyClass);
                     }
                 }
             }
@@ -11004,8 +11006,8 @@ GenTree* Compiler::impCastClassOrIsInstToTree(GenTree*                op1,
         op2->gtFlags |= GTF_DONT_CSE;
 
         GenTreeCall* call = gtNewHelperCallNode(helper, TYP_REF, gtNewCallArgs(op2, op1));
-        if ((JitConfig.JitIsinstProfiling() > 0) && (helper == CORINFO_HELP_ISINSTANCEOFCLASS) &&
-            opts.OptimizationDisabled())
+        if ((JitConfig.JitIsinstProfiling() > 0) && opts.OptimizationDisabled() &&
+            ((helper == CORINFO_HELP_ISINSTANCEOFCLASS) || (helper == CORINFO_HELP_ISINSTANCEOFINTERFACE)))
         {
             ClassProfileCandidateInfo* pInfo  = new (this, CMK_Inlining) ClassProfileCandidateInfo;
             pInfo->ilOffset                   = ilOffset;

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -510,7 +510,7 @@ CONFIG_INTEGER(TC_OnStackReplacement_InitialCounter, W("TC_OnStackReplacement_In
 CONFIG_INTEGER(JitMinimalJitProfiling, W("JitMinimalJitProfiling"), 1)
 CONFIG_INTEGER(JitMinimalPrejitProfiling, W("JitMinimalPrejitProfiling"), 0)
 CONFIG_INTEGER(JitClassProfiling, W("JitClassProfiling"), 1)
-CONFIG_INTEGER(JitIsinstProfiling, W("JitIsinstProfiling"), 0)
+CONFIG_INTEGER(JitIsinstProfiling, W("JitIsinstProfiling"), 1)
 CONFIG_INTEGER(JitEdgeProfiling, W("JitEdgeProfiling"), 1)
 CONFIG_INTEGER(JitCollect64BitCounts, W("JitCollect64BitCounts"), 0) // Collect counts as 64-bit values.
 

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -510,6 +510,7 @@ CONFIG_INTEGER(TC_OnStackReplacement_InitialCounter, W("TC_OnStackReplacement_In
 CONFIG_INTEGER(JitMinimalJitProfiling, W("JitMinimalJitProfiling"), 1)
 CONFIG_INTEGER(JitMinimalPrejitProfiling, W("JitMinimalPrejitProfiling"), 0)
 CONFIG_INTEGER(JitClassProfiling, W("JitClassProfiling"), 1)
+CONFIG_INTEGER(JitIsinstProfiling, W("JitIsinstProfiling"), 1)
 CONFIG_INTEGER(JitEdgeProfiling, W("JitEdgeProfiling"), 1)
 CONFIG_INTEGER(JitCollect64BitCounts, W("JitCollect64BitCounts"), 0) // Collect counts as 64-bit values.
 

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -510,7 +510,7 @@ CONFIG_INTEGER(TC_OnStackReplacement_InitialCounter, W("TC_OnStackReplacement_In
 CONFIG_INTEGER(JitMinimalJitProfiling, W("JitMinimalJitProfiling"), 1)
 CONFIG_INTEGER(JitMinimalPrejitProfiling, W("JitMinimalPrejitProfiling"), 0)
 CONFIG_INTEGER(JitClassProfiling, W("JitClassProfiling"), 1)
-CONFIG_INTEGER(JitIsinstProfiling, W("JitIsinstProfiling"), 1)
+CONFIG_INTEGER(JitIsinstProfiling, W("JitIsinstProfiling"), 0)
 CONFIG_INTEGER(JitEdgeProfiling, W("JitEdgeProfiling"), 1)
 CONFIG_INTEGER(JitCollect64BitCounts, W("JitCollect64BitCounts"), 0) // Collect counts as 64-bit values.
 


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/55325
Insert class probes for all `isinst` and `castclass` opcodes so we can later insert a fast path for a class that showed up in PGO data.
```csharp
using System;
using System.Runtime.CompilerServices;
using System.Threading;

public interface IInterface
{
    void DoWork();
}

public class Impl : IInterface
{
    [MethodImpl(MethodImplOptions.NoInlining)]
    public virtual void DoWork() => Console.Write("DoWork");
}


public class Program
{
    [MethodImpl(MethodImplOptions.NoInlining)]
    public static void Test(object o)
    {
        if (o is IInterface i)
            i.DoWork();

        /*
         The above ^ is optimized into:
        
           if (o != null && (o.GetType() == typeof(Impl) || ISINSTANCEOFINTERFACE(o, typeof(IInterface))))
           {
               o.DoWork();
           }
                
        */
    }

    static void Main()
    {
        for (int i = 0; i < 100; i++)
        {
            // Promote Test from tier0 to tier1
            Test(new Impl());
            Thread.Sleep(16);
        }
    }
}
```
Codegen for `Test` diff: https://www.diffchecker.com/4pbk6Dls (`DOTNET_TieredPGO=1`)
I'll check if it has any affect on TE benchmarks.

/cc @dotnet/jit-contrib @AndyAyersMS 