### PR TITLE
Update System.Net.Security Telemetry tests

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -365,7 +365,7 @@ namespace System.Net.Security
 
             ValidateCreateContext(sslClientAuthenticationOptions, _userCertificateValidationCallback, _certSelectionDelegate);
 
-            return ProcessAuthenticationAsync(true, false, cancellationToken);
+            return ProcessAuthenticationAsync(isAsync: true, isApm: false, cancellationToken);
         }
 
         private Task AuthenticateAsClientApm(SslClientAuthenticationOptions sslClientAuthenticationOptions, CancellationToken cancellationToken = default)
@@ -375,7 +375,7 @@ namespace System.Net.Security
 
             ValidateCreateContext(sslClientAuthenticationOptions, _userCertificateValidationCallback, _certSelectionDelegate);
 
-            return ProcessAuthenticationAsync(true, true, cancellationToken);
+            return ProcessAuthenticationAsync(isAsync: true, isApm: true, cancellationToken);
         }
 
         public virtual Task AuthenticateAsServerAsync(X509Certificate serverCertificate) =>
@@ -418,7 +418,7 @@ namespace System.Net.Security
             SetAndVerifyValidationCallback(sslServerAuthenticationOptions.RemoteCertificateValidationCallback);
             ValidateCreateContext(CreateAuthenticationOptions(sslServerAuthenticationOptions));
 
-            return ProcessAuthenticationAsync(true, false, cancellationToken);
+            return ProcessAuthenticationAsync(isAsync: true, isApm: false, cancellationToken);
         }
 
         private Task AuthenticateAsServerApm(SslServerAuthenticationOptions sslServerAuthenticationOptions, CancellationToken cancellationToken = default)
@@ -426,7 +426,7 @@ namespace System.Net.Security
             SetAndVerifyValidationCallback(sslServerAuthenticationOptions.RemoteCertificateValidationCallback);
             ValidateCreateContext(CreateAuthenticationOptions(sslServerAuthenticationOptions));
 
-            return ProcessAuthenticationAsync(true, true, cancellationToken);
+            return ProcessAuthenticationAsync(isAsync: true, isApm: true, cancellationToken);
         }
 
         public Task AuthenticateAsServerAsync(ServerOptionsSelectionCallback optionsCallback, object? state, CancellationToken cancellationToken = default)

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -293,7 +293,7 @@ namespace System.Net.Security
             SetAndVerifySelectionCallback(sslClientAuthenticationOptions.LocalCertificateSelectionCallback);
 
             ValidateCreateContext(sslClientAuthenticationOptions, _userCertificateValidationCallback, _certSelectionDelegate);
-            ProcessAuthentication();
+            ProcessAuthenticationAsync().GetAwaiter().GetResult();
         }
 
         public virtual void AuthenticateAsServer(X509Certificate serverCertificate)
@@ -330,7 +330,7 @@ namespace System.Net.Security
             SetAndVerifyValidationCallback(sslServerAuthenticationOptions.RemoteCertificateValidationCallback);
 
             ValidateCreateContext(CreateAuthenticationOptions(sslServerAuthenticationOptions));
-            ProcessAuthentication();
+            ProcessAuthenticationAsync().GetAwaiter().GetResult();
         }
         #endregion
 
@@ -365,7 +365,7 @@ namespace System.Net.Security
 
             ValidateCreateContext(sslClientAuthenticationOptions, _userCertificateValidationCallback, _certSelectionDelegate);
 
-            return ProcessAuthentication(true, false, cancellationToken)!;
+            return ProcessAuthenticationAsync(true, false, cancellationToken);
         }
 
         private Task AuthenticateAsClientApm(SslClientAuthenticationOptions sslClientAuthenticationOptions, CancellationToken cancellationToken = default)
@@ -375,7 +375,7 @@ namespace System.Net.Security
 
             ValidateCreateContext(sslClientAuthenticationOptions, _userCertificateValidationCallback, _certSelectionDelegate);
 
-            return ProcessAuthentication(true, true, cancellationToken)!;
+            return ProcessAuthenticationAsync(true, true, cancellationToken);
         }
 
         public virtual Task AuthenticateAsServerAsync(X509Certificate serverCertificate) =>
@@ -418,7 +418,7 @@ namespace System.Net.Security
             SetAndVerifyValidationCallback(sslServerAuthenticationOptions.RemoteCertificateValidationCallback);
             ValidateCreateContext(CreateAuthenticationOptions(sslServerAuthenticationOptions));
 
-            return ProcessAuthentication(true, false, cancellationToken)!;
+            return ProcessAuthenticationAsync(true, false, cancellationToken);
         }
 
         private Task AuthenticateAsServerApm(SslServerAuthenticationOptions sslServerAuthenticationOptions, CancellationToken cancellationToken = default)
@@ -426,13 +426,13 @@ namespace System.Net.Security
             SetAndVerifyValidationCallback(sslServerAuthenticationOptions.RemoteCertificateValidationCallback);
             ValidateCreateContext(CreateAuthenticationOptions(sslServerAuthenticationOptions));
 
-            return ProcessAuthentication(true, true, cancellationToken)!;
+            return ProcessAuthenticationAsync(true, true, cancellationToken);
         }
 
         public Task AuthenticateAsServerAsync(ServerOptionsSelectionCallback optionsCallback, object? state, CancellationToken cancellationToken = default)
         {
             ValidateCreateContext(new SslAuthenticationOptions(optionsCallback, state, _userCertificateValidationCallback));
-            return ProcessAuthentication(isAsync: true, isApm: false, cancellationToken)!;
+            return ProcessAuthenticationAsync(isAsync: true, isApm: false, cancellationToken);
         }
 
         public virtual Task ShutdownAsync()

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TelemetryTest.cs
@@ -33,28 +33,44 @@ namespace System.Net.Security.Tests
             RemoteExecutor.Invoke(async () =>
             {
                 using var listener = new TestEventListener("System.Net.Security", EventLevel.Verbose, eventCounterInterval: 0.1d);
+                listener.AddActivityTracking();
 
-                var events = new ConcurrentQueue<EventWrittenEventArgs>();
-                await listener.RunWithCallbackAsync(events.Enqueue, async () =>
+                var events = new ConcurrentQueue<(EventWrittenEventArgs Event, Guid ActivityId)>();
+                await listener.RunWithCallbackAsync(e => events.Enqueue((e, e.ActivityId)), async () =>
                 {
                     // Invoke tests that'll cause some events to be generated
                     var test = new SslStreamStreamToStreamTest_Async();
                     await test.SslStream_StreamToStream_Authentication_Success();
-                    await Task.Delay(300);
+                    await WaitForEventCountersAsync(events);
                 });
-                Assert.DoesNotContain(events, ev => ev.EventId == 0); // errors from the EventSource itself
+                Assert.DoesNotContain(events, ev => ev.Event.EventId == 0); // errors from the EventSource itself
 
-                EventWrittenEventArgs[] starts = events.Where(e => e.EventName == "HandshakeStart").ToArray();
+                (EventWrittenEventArgs Event, Guid ActivityId)[] starts = events.Where(e => e.Event.EventName == "HandshakeStart").ToArray();
                 Assert.Equal(2, starts.Length);
-                Assert.All(starts, s => Assert.Equal(2, s.Payload.Count));
-                Assert.Single(starts, s => s.Payload[0] is bool isServer && isServer);
-                Assert.Single(starts, s => s.Payload[1] is string targetHost && targetHost.Length == 0);
+                Assert.All(starts, s => Assert.Equal(2, s.Event.Payload.Count));
+                Assert.All(starts, s => Assert.NotEqual(Guid.Empty, s.ActivityId));
 
-                EventWrittenEventArgs[] stops = events.Where(e => e.EventName == "HandshakeStop").ToArray();
+                // isServer
+                (EventWrittenEventArgs Event, Guid ActivityId) serverStart = Assert.Single(starts, s => (bool)s.Event.Payload[0]);
+                (EventWrittenEventArgs Event, Guid ActivityId) clientStart = Assert.Single(starts, s => !(bool)s.Event.Payload[0]);
+
+                // targetHost
+                Assert.Empty(Assert.IsType<string>(serverStart.Event.Payload[1]));
+                Assert.NotEmpty(Assert.IsType<string>(clientStart.Event.Payload[1]));
+
+                Assert.NotEqual(serverStart.ActivityId, clientStart.ActivityId);
+
+                (EventWrittenEventArgs Event, Guid ActivityId)[] stops = events.Where(e => e.Event.EventName == "HandshakeStop").ToArray();
                 Assert.Equal(2, stops.Length);
-                Assert.All(stops, s => ValidateHandshakeStopEventPayload(s, failure: false));
 
-                Assert.DoesNotContain(events, e => e.EventName == "HandshakeFailed");
+                EventWrittenEventArgs serverStop = Assert.Single(stops, s => s.ActivityId == serverStart.ActivityId).Event;
+                EventWrittenEventArgs clientStop = Assert.Single(stops, s => s.ActivityId == clientStart.ActivityId).Event;
+
+                SslProtocols serverProtocol = ValidateHandshakeStopEventPayload(serverStop);
+                SslProtocols clientProtocol = ValidateHandshakeStopEventPayload(clientStop);
+                Assert.Equal(serverProtocol, clientProtocol);
+
+                Assert.DoesNotContain(events, e => e.Event.EventName == "HandshakeFailed");
 
                 VerifyEventCounters(events, shouldHaveFailures: false);
             }).Dispose();
@@ -67,38 +83,57 @@ namespace System.Net.Security.Tests
             RemoteExecutor.Invoke(async () =>
             {
                 using var listener = new TestEventListener("System.Net.Security", EventLevel.Verbose, eventCounterInterval: 0.1d);
+                listener.AddActivityTracking();
 
-                var events = new ConcurrentQueue<EventWrittenEventArgs>();
-                await listener.RunWithCallbackAsync(events.Enqueue, async () =>
+                var events = new ConcurrentQueue<(EventWrittenEventArgs Event, Guid ActivityId)>();
+                await listener.RunWithCallbackAsync(e => events.Enqueue((e, e.ActivityId)), async () =>
                 {
                     // Invoke tests that'll cause some events to be generated
                     var test = new SslStreamStreamToStreamTest_Async();
                     await test.SslStream_ServerLocalCertificateSelectionCallbackReturnsNull_Throw();
-                    await Task.Delay(300);
+                    await WaitForEventCountersAsync(events);
                 });
-                Assert.DoesNotContain(events, ev => ev.EventId == 0); // errors from the EventSource itself
+                Assert.DoesNotContain(events, ev => ev.Event.EventId == 0); // errors from the EventSource itself
 
-                EventWrittenEventArgs[] starts = events.Where(e => e.EventName == "HandshakeStart").ToArray();
+                (EventWrittenEventArgs Event, Guid ActivityId)[] starts = events.Where(e => e.Event.EventName == "HandshakeStart").ToArray();
                 Assert.Equal(2, starts.Length);
-                Assert.All(starts, s => Assert.Equal(2, s.Payload.Count));
-                Assert.Single(starts, s => s.Payload[0] is bool isServer && isServer);
-                Assert.Single(starts, s => s.Payload[1] is string targetHost && targetHost.Length == 0);
+                Assert.All(starts, s => Assert.Equal(2, s.Event.Payload.Count));
+                Assert.All(starts, s => Assert.NotEqual(Guid.Empty, s.ActivityId));
 
-                EventWrittenEventArgs[] failures = events.Where(e => e.EventName == "HandshakeFailed").ToArray();
-                Assert.Equal(2, failures.Length);
-                Assert.All(failures, f => Assert.Equal(3, f.Payload.Count));
-                Assert.Single(failures, f => f.Payload[0] is bool isServer && isServer);
-                Assert.All(failures, f => Assert.NotEmpty(f.Payload[2] as string)); // exceptionMessage
+                // isServer
+                (EventWrittenEventArgs Event, Guid ActivityId) serverStart = Assert.Single(starts, s => (bool)s.Event.Payload[0]);
+                (EventWrittenEventArgs Event, Guid ActivityId) clientStart = Assert.Single(starts, s => !(bool)s.Event.Payload[0]);
 
-                EventWrittenEventArgs[] stops = events.Where(e => e.EventName == "HandshakeStop").ToArray();
+                // targetHost
+                Assert.Empty(Assert.IsType<string>(serverStart.Event.Payload[1]));
+                Assert.NotEmpty(Assert.IsType<string>(clientStart.Event.Payload[1]));
+
+                Assert.NotEqual(serverStart.ActivityId, clientStart.ActivityId);
+
+                (EventWrittenEventArgs Event, Guid ActivityId)[] stops = events.Where(e => e.Event.EventName == "HandshakeStop").ToArray();
                 Assert.Equal(2, stops.Length);
-                Assert.All(stops, s => ValidateHandshakeStopEventPayload(s, failure: true));
+                Assert.All(stops, s => ValidateHandshakeStopEventPayload(s.Event, failure: true));
+
+                EventWrittenEventArgs serverStop = Assert.Single(stops, s => s.ActivityId == serverStart.ActivityId).Event;
+                EventWrittenEventArgs clientStop = Assert.Single(stops, s => s.ActivityId == clientStart.ActivityId).Event;
+
+                (EventWrittenEventArgs Event, Guid ActivityId)[] failures = events.Where(e => e.Event.EventName == "HandshakeFailed").ToArray();
+                Assert.Equal(2, failures.Length);
+                Assert.All(failures, f => Assert.Equal(3, f.Event.Payload.Count));
+                Assert.All(failures, f => Assert.NotEmpty(f.Event.Payload[2] as string)); // exceptionMessage
+
+                EventWrittenEventArgs serverFailure = Assert.Single(failures, f => f.ActivityId == serverStart.ActivityId).Event;
+                EventWrittenEventArgs clientFailure = Assert.Single(failures, f => f.ActivityId == clientStart.ActivityId).Event;
+
+                // isServer
+                Assert.Equal(true, serverFailure.Payload[0]);
+                Assert.Equal(false, clientFailure.Payload[0]);
 
                 VerifyEventCounters(events, shouldHaveFailures: true);
             }).Dispose();
         }
 
-        private static void ValidateHandshakeStopEventPayload(EventWrittenEventArgs stopEvent, bool failure)
+        private static SslProtocols ValidateHandshakeStopEventPayload(EventWrittenEventArgs stopEvent, bool failure = false)
         {
             Assert.Equal("HandshakeStop", stopEvent.EventName);
             Assert.Equal(1, stopEvent.Payload.Count);
@@ -114,11 +149,14 @@ namespace System.Net.Security.Tests
             {
                 Assert.NotEqual(SslProtocols.None, protocol);
             }
+
+            return protocol;
         }
 
-        private static void VerifyEventCounters(ConcurrentQueue<EventWrittenEventArgs> events, bool shouldHaveFailures)
+        private static void VerifyEventCounters(ConcurrentQueue<(EventWrittenEventArgs Event, Guid ActivityId)> events, bool shouldHaveFailures)
         {
             Dictionary<string, double[]> eventCounters = events
+                .Select(e => e.Event)
                 .Where(e => e.EventName == "EventCounters")
                 .Select(e => (IDictionary<string, object>)e.Payload.Single())
                 .GroupBy(d => (string)d["Name"], d => (double)(d.ContainsKey("Mean") ? d["Mean"] : d["Increment"]))
@@ -172,6 +210,30 @@ namespace System.Net.Security.Tests
             {
                 Assert.Contains(tlsHandshakeDurations, durations => durations.Any(d => d > 0));
                 Assert.Contains(allHandshakeDurations, d => d > 0);
+            }
+        }
+
+        private static async Task WaitForEventCountersAsync(ConcurrentQueue<(EventWrittenEventArgs Event, Guid ActivityId)> events)
+        {
+            DateTime startTime = DateTime.UtcNow;
+            int startCount = events.Count;
+
+            while (events.Skip(startCount).Count(e => IsTlsHandshakeRateEventCounter(e.Event)) < 3)
+            {
+                if (DateTime.UtcNow.Subtract(startTime) > TimeSpan.FromSeconds(30))
+                    throw new TimeoutException($"Timed out waiting for EventCounters");
+
+                await Task.Delay(100);
+            }
+
+            static bool IsTlsHandshakeRateEventCounter(EventWrittenEventArgs e)
+            {
+                if (e.EventName != "EventCounters")
+                    return false;
+
+                var dictionary = (IDictionary<string, object>)e.Payload.Single();
+
+                return (string)dictionary["Name"] == "tls-handshake-rate";
             }
         }
     }

--- a/src/libraries/System.Net.Security/tests/UnitTests/Fakes/FakeSslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/Fakes/FakeSslStream.Implementation.cs
@@ -54,7 +54,7 @@ namespace System.Net.Security
         // This method assumes that a SSPI context is already in a good shape.
         // For example it is either a fresh context or already authenticated context that needs renegotiation.
         //
-        private Task ProcessAuthentication(bool isAsync = false, bool isApm = false, CancellationToken cancellationToken = default)
+        private Task ProcessAuthenticationAsync(bool isAsync = false, bool isApm = false, CancellationToken cancellationToken = default)
         {
             return Task.Run(() => {});
         }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
@@ -357,7 +357,7 @@ namespace System.Net.Sockets.Tests
             DateTime startTime = DateTime.UtcNow;
             int startCount = events.Count;
 
-            while (events.Skip(startCount).Count(e => IsBytesSentEventCounter(e.Event)) < 2)
+            while (events.Skip(startCount).Count(e => IsBytesSentEventCounter(e.Event)) < 3)
             {
                 if (DateTime.UtcNow.Subtract(startTime) > TimeSpan.FromSeconds(30))
                     throw new TimeoutException($"Timed out waiting for EventCounters");


### PR DESCRIPTION
Updated the NetSecurity telemetry tests to use a `WaitForEventCounters` helper instead of relying on a racy `Task.Delay`.
Enhanced the test to also check for correct ActivityIds.

Updated the product instrumentation to use a real async method instead of `.ContinueWith` to ensure events fire under the right ExecutionContext. Similar to the fix in `NameResolution` from #42188 (https://github.com/dotnet/runtime/issues/41670#issuecomment-685038205).

Fixes #42613