### PR TITLE
Avoid race condition in EventSource_UnsuccessfulRequest_LogsStartFailedStop

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/TelemetryTest.cs
@@ -272,10 +272,10 @@ namespace System.Net.Http.Functional.Tests
                         {
                             await server.AcceptConnectionAsync(async connection =>
                             {
+                                await connection.ReadRequestDataAsync();
                                 await WaitForEventCountersAsync(events);
                                 cts.Cancel();
                                 Assert.True(await semaphore.WaitAsync(TimeSpan.FromSeconds(30)));
-                                connection.Dispose();
                             });
                         });
 


### PR DESCRIPTION
The test is looking at whether an HTTP/X.Y connection has been established. As we were cancelling the request right after the server established the connection (TCP), there is a race condition where the request may fail before constructing the logical HTTP/1.1 connection.

Changed the test to wait for the request line to be sent before cancelling the request.

Fixes #55906