### PR TITLE
[wasm][debugger] Fix step behavior 

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -337,6 +337,12 @@ namespace Microsoft.WebAssembly.Diagnostics
         DebuggerNonUserCode = 8
     }
 
+    internal enum StepSize
+    {
+        Minimal,
+        Line
+    }
+
     internal class MonoBinaryReader : BinaryReader
     {
         public MonoBinaryReader(Stream stream) : base(stream) {}
@@ -897,7 +903,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             commandParamsWriter.Write((byte)1);
             commandParamsWriter.Write((byte)ModifierKind.Step);
             commandParamsWriter.Write(thread_id);
-            commandParamsWriter.Write((int)1);
+            commandParamsWriter.Write((int)StepSize.Line);
             commandParamsWriter.Write((int)kind);
             commandParamsWriter.Write((int)(StepFilter.StaticCtor | StepFilter.DebuggerHidden)); //filter
             var retDebuggerCmdReader = await SendDebuggerAgentCommand<CmdEventRequest>(sessionId, CmdEventRequest.Set, commandParams, token);

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -897,7 +897,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             commandParamsWriter.Write((byte)1);
             commandParamsWriter.Write((byte)ModifierKind.Step);
             commandParamsWriter.Write(thread_id);
-            commandParamsWriter.Write((int)0);
+            commandParamsWriter.Write((int)1);
             commandParamsWriter.Write((int)kind);
             commandParamsWriter.Write((int)(StepFilter.StaticCtor | StepFilter.DebuggerHidden)); //filter
             var retDebuggerCmdReader = await SendDebuggerAgentCommand<CmdEventRequest>(sessionId, CmdEventRequest.Set, commandParams, token);

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -902,6 +902,23 @@ namespace DebuggerTests
             return res;
         }
 
+        internal async Task EvaluateOnCallFrameAndCheck(string call_frame_id, params (string expression, JObject expected)[] args)
+        {
+            foreach (var arg in args)
+            {
+                var (eval_val, _) = await EvaluateOnCallFrame(call_frame_id, arg.expression);
+                try
+                {
+                    await CheckValue(eval_val, arg.expected, arg.expression);
+                }
+                catch
+                {
+                    Console.WriteLine($"CheckValue failed for {arg.expression}. Expected: {arg.expected}, vs {eval_val}");
+                    throw;
+                }
+            }
+        }
+
         internal void AssertEqual(object expected, object actual, string label)
         {
             if (expected?.Equals(actual) == true)

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
@@ -540,6 +540,7 @@ namespace DebuggerTests
                    ("this.CallMethod()", TNumber(1)),
                    ("this.CallMethod()", TNumber(1)),
                    ("this.ParmToTestObj.MyMethod()", TString("methodOK")),
+                   ("this.ParmToTestObj.ToString()", TString("DebuggerTests.EvaluateMethodTestsClass+ParmToTest")),
                    ("this.objToTest.MyMethod()", TString("methodOK")));
            });
 

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
@@ -496,7 +496,7 @@ namespace DebuggerTests
                 var id = pause_location["callFrames"][0]["callFrameId"].Value<string>();
 
                 var (_, res) = await EvaluateOnCallFrame(id, "this.objToTest.MyMethodWrong()", expect_ok: false );
-                AssertEqual("Method 'MyMethodWrong' not found in type 'DebuggerTests.EvaluateMethodTestsClass.ParmToTest'", res.Error["message"]?.Value<string>(), "wrong error message");
+                AssertEqual("Unable to evaluate method 'MyMethodWrong'", res.Error["message"]?.Value<string>(), "wrong error message");
 
                 (_, res) = await EvaluateOnCallFrame(id, "this.objToTest.MyMethod(1)", expect_ok: false );
                 AssertEqual("Unable to evaluate method 'MyMethod'", res.Error["message"]?.Value<string>(), "wrong error message");
@@ -505,10 +505,10 @@ namespace DebuggerTests
                 AssertEqual("Unable to evaluate method 'CallMethodWithParm'", res.Error["message"]?.Value<string>(), "wrong error message");
 
                 (_, res) = await EvaluateOnCallFrame(id, "this.ParmToTestObjNull.MyMethod()", expect_ok: false );
-                AssertEqual("Object reference not set to an instance of an object.", res.Error["message"]?.Value<string>(), "wrong error message");
+                AssertEqual("Unable to evaluate method 'MyMethod'", res.Error["message"]?.Value<string>(), "wrong error message");
 
                 (_, res) = await EvaluateOnCallFrame(id, "this.ParmToTestObjException.MyMethod()", expect_ok: false );
-                AssertEqual("Object reference not set to an instance of an object.", res.Error["message"]?.Value<string>(), "wrong error message");
+                AssertEqual("Unable to evaluate method 'MyMethod'", res.Error["message"]?.Value<string>(), "wrong error message");
            });
 
         [Fact]

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
@@ -476,23 +476,6 @@ namespace DebuggerTests
                 await EvaluateOnCallFrameAndCheck(id, ("this.PropertyThrowException", TString("System.Exception: error")));
             });
 
-        async Task EvaluateOnCallFrameAndCheck(string call_frame_id, params (string expression, JObject expected)[] args)
-        {
-            foreach (var arg in args)
-            {
-                var (eval_val, _) = await EvaluateOnCallFrame(call_frame_id, arg.expression);
-                try
-                {
-                    await CheckValue(eval_val, arg.expected, arg.expression);
-                }
-                catch
-                {
-                    Console.WriteLine($"CheckValue failed for {arg.expression}. Expected: {arg.expected}, vs {eval_val}");
-                    throw;
-                }
-            }
-        }
-
         async Task EvaluateOnCallFrameFail(string call_frame_id, params (string expression, string class_name)[] args)
         {
             foreach (var arg in args)

--- a/src/mono/wasm/debugger/DebuggerTestSuite/SteppingTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/SteppingTests.cs
@@ -864,7 +864,7 @@ namespace DebuggerTests
         }
 
         [Fact]
-        public async Task SimpleStepTest()
+        public async Task SimpleStep_RegressionTest_49141()
         {
             await SetBreakpoint("dotnet://debugger-test.dll/debugger-test.cs", 674, 0);
 
@@ -878,13 +878,12 @@ namespace DebuggerTests
         }
 
         [Fact]
-        public async Task StepAndEvaluate()
+        public async Task StepAndEvaluateExpression()
         {
             await SetBreakpoint("dotnet://debugger-test.dll/debugger-test.cs", 682, 0);
 
-            string expression = "window.setTimeout(function() { invoke_static_method ('[debugger-test] Foo:RunBart'); }, 1);";
             await EvaluateAndCheck(
-                expression,
+                "window.setTimeout(function() { invoke_static_method ('[debugger-test] Foo:RunBart'); }, 1);",
                 "dotnet://debugger-test.dll/debugger-test.cs", 682, 8,
                 "RunBart");
             var pause_location = await StepAndCheck(StepKind.Into, "dotnet://debugger-test.dll/debugger-test.cs", 671, 4, "Bart");
@@ -910,6 +909,24 @@ namespace DebuggerTests
             await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 699, 8, "OtherBar");
             await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 701, 8, "OtherBar");
             await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 702, 4, "OtherBar");
+        }
+
+        [Fact]
+        public async Task StepOverWithMoreThanOneCommandInSameLineAsync()
+        {
+            await SetBreakpoint("dotnet://debugger-test.dll/debugger-test.cs", 710, 0);
+
+            string expression = "window.setTimeout(function() { invoke_static_method ('[debugger-test] Foo:RunBart'); }, 1);";
+            await EvaluateAndCheck(
+                expression,
+                "dotnet://debugger-test.dll/debugger-test.cs", 710, 8,
+                "MoveNext");
+            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 711, 8, "MoveNext");
+            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 713, 8, "MoveNext");
+            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 716, 8, "MoveNext");
+            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 718, 8, "MoveNext");
+            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 719, 8, "MoveNext");
+            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 720, 4, "MoveNext");
         }
     }
 }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/SteppingTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/SteppingTests.cs
@@ -198,7 +198,7 @@ namespace DebuggerTests
             CheckObject(locals_m1, "nim", "Math.NestedInMath");
 
             // step back into OuterMethod
-            await StepAndCheck(StepKind.Over, debugger_test_loc, 91, 8, "OuterMethod", times: 9,
+            await StepAndCheck(StepKind.Over, debugger_test_loc, 91, 8, "OuterMethod", times: 6,
                 locals_fn: (locals) =>
                 {
                     Assert.Equal(5, locals.Count());
@@ -236,7 +236,7 @@ namespace DebuggerTests
                 }
             );
 
-            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 92, 8, "OuterMethod", times: 2,
+            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 92, 8, "OuterMethod", times: 1,
                 locals_fn: (locals) =>
                 {
                     Assert.Equal(5, locals.Count());
@@ -284,7 +284,7 @@ namespace DebuggerTests
 
             // Step into InnerMethod
             await StepAndCheck(StepKind.Into, "dotnet://debugger-test.dll/debugger-test.cs", 105, 8, "InnerMethod");
-            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 109, 12, "InnerMethod", times: 5,
+            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 110, 12, "InnerMethod", times: 5,
                 locals_fn: (locals) =>
                 {
                     Assert.Equal(4, locals.Count());
@@ -297,7 +297,7 @@ namespace DebuggerTests
             );
 
             // Step back to OuterMethod
-            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 88, 8, "OuterMethod", times: 6,
+            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 90, 8, "OuterMethod", times: 6,
                 locals_fn: (locals) =>
                 {
                     Assert.Equal(5, locals.Count());
@@ -469,7 +469,7 @@ namespace DebuggerTests
             // ----------- Step back to the caller ---------
 
             pause_location = await StepAndCheck(StepKind.Over, debugger_test_loc, 30, 12, "TestStructsAsMethodArgs",
-                times: 2, locals_fn: (l) => { /* non-null to make sure that locals get fetched */ });
+                times: 1, locals_fn: (l) => { /* non-null to make sure that locals get fetched */ });
             locals = await GetProperties(pause_location["callFrames"][0]["callFrameId"].Value<string>());
             await CheckProps(locals, new
             {
@@ -893,6 +893,20 @@ namespace DebuggerTests
             pause_location = await StepAndCheck(StepKind.Into, "dotnet://debugger-test.dll/debugger-test.cs", 673, 8, "Bart");
             id = pause_location["callFrames"][0]["callFrameId"].Value<string>();
             await EvaluateOnCallFrameAndCheck(id, ("this.Bar", TString("Same of something")));
+        }
+
+        [Fact]
+        public async Task StepOverWithMoreThanOneCommandInSameLine()
+        {
+            await SetBreakpoint("dotnet://debugger-test.dll/debugger-test.cs", 693, 0);
+
+            string expression = "window.setTimeout(function() { invoke_static_method ('[debugger-test] Foo:RunBart'); }, 1);";
+            await EvaluateAndCheck(
+                expression,
+                "dotnet://debugger-test.dll/debugger-test.cs", 693, 8,
+                "OtherBar");
+            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 694, 8, "OtherBar");
+            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 695, 4, "OtherBar");
         }
     }
 }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/SteppingTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/SteppingTests.cs
@@ -864,17 +864,35 @@ namespace DebuggerTests
         }
 
         [Fact]
-        public async Task StepAndEvaluateProperty()
+        public async Task SimpleStepTest()
         {
-            await SetBreakpoint("dotnet://debugger-test.dll/debugger-test.cs", 663, 0);
+            await SetBreakpoint("dotnet://debugger-test.dll/debugger-test.cs", 674, 0);
 
-            string expression = "window.setTimeout(function() { invoke_static_method ('[debugger-test] Foo:RunBar'); }, 1);";
+            string expression = "window.setTimeout(function() { invoke_static_method ('[debugger-test] Foo:RunBart'); }, 1);";
             await EvaluateAndCheck(
                 expression,
-                "dotnet://debugger-test.dll/debugger-test.cs", 663, 12,
-                "Bar");
-            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 666, 8, "Bar");
-            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 667, 4, "Bar");
+                "dotnet://debugger-test.dll/debugger-test.cs", 674, 12,
+                "Bart");
+            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 677, 8, "Bart");
+            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 678, 4, "Bart");
+        }
+
+        [Fact]
+        public async Task StepAndEvaluate()
+        {
+            await SetBreakpoint("dotnet://debugger-test.dll/debugger-test.cs", 682, 0);
+
+            string expression = "window.setTimeout(function() { invoke_static_method ('[debugger-test] Foo:RunBart'); }, 1);";
+            await EvaluateAndCheck(
+                expression,
+                "dotnet://debugger-test.dll/debugger-test.cs", 682, 8,
+                "RunBart");
+            var pause_location = await StepAndCheck(StepKind.Into, "dotnet://debugger-test.dll/debugger-test.cs", 671, 4, "Bart");
+            var id = pause_location["callFrames"][0]["callFrameId"].Value<string>();
+            await EvaluateOnCallFrameAndCheck(id, ("this.Bar", TString("Same of something")));
+            pause_location = await StepAndCheck(StepKind.Into, "dotnet://debugger-test.dll/debugger-test.cs", 673, 8, "Bart");
+            id = pause_location["callFrames"][0]["callFrameId"].Value<string>();
+            await EvaluateOnCallFrameAndCheck(id, ("this.Bar", TString("Same of something")));
         }
     }
 }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/SteppingTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/SteppingTests.cs
@@ -906,7 +906,10 @@ namespace DebuggerTests
                 "dotnet://debugger-test.dll/debugger-test.cs", 693, 8,
                 "OtherBar");
             await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 694, 8, "OtherBar");
-            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 695, 4, "OtherBar");
+            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 696, 8, "OtherBar");
+            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 699, 8, "OtherBar");
+            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 701, 8, "OtherBar");
+            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 702, 4, "OtherBar");
         }
     }
 }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/SteppingTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/SteppingTests.cs
@@ -862,5 +862,19 @@ namespace DebuggerTests
             Task t = await Task.WhenAny(pause_task, Task.Delay(2000));
             Assert.True(t != pause_task, "Debugger unexpectedly paused");
         }
+
+        [Fact]
+        public async Task StepAndEvaluateProperty()
+        {
+            await SetBreakpoint("dotnet://debugger-test.dll/debugger-test.cs", 663, 0);
+
+            string expression = "window.setTimeout(function() { invoke_static_method ('[debugger-test] Foo:RunBar'); }, 1);";
+            await EvaluateAndCheck(
+                expression,
+                "dotnet://debugger-test.dll/debugger-test.cs", 663, 12,
+                "Bar");
+            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 666, 8, "Bar");
+            await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-test.cs", 667, 4, "Bar");
+        }
     }
 }

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -681,10 +681,10 @@ public class Foo
     {
         Foo foo = new Foo();
         foo.Bart();
-        foo.OtherBar();
-        Console.WriteLine(foo);
+        Console.WriteLine(foo.OtherBar());
+        foo.OtherBarAsync().Wait(10);
     }
-    public void OtherBar()
+    public bool OtherBar()
     {
         var a = 1;
         var b = 2;
@@ -699,7 +699,31 @@ public class Foo
                 x.Contains('S');
         var g = TimeSpan.TryParseExact(y, @"ss\.fff", null, out var ts3) &&
                 x.Contains('S');
-        Console.WriteLine(d);
+        return d && e == true;
+    }
+    public async System.Threading.Tasks.Task OtherBarAsync()
+    {
+        var a = 1;
+        var b = 2;
+        var x = "Stew";
+        var y = "00.123";
+        var c = a + b == 3 || b + a == 2;
+        var d = TimeSpan.TryParseExact(y, @"ss\.fff", null, out var ts) && await AsyncMethod();
+        var e = TimeSpan.TryParseExact(y, @"ss\.fff", null, out var ts1)
+                && await AsyncMethod();
+        var f = TimeSpan.TryParseExact(y, @"ss\.fff", null, out var ts2)
+                &&
+                await AsyncMethod();
+        var g = await AsyncMethod() &&
+                await AsyncMethod();
+        Console.WriteLine(g);
+        await System.Threading.Tasks.Task.CompletedTask;
+    }
+    public async System.Threading.Tasks.Task<bool> AsyncMethod()
+    {
+        await System.Threading.Tasks.Task.Delay(1);
+        Console.WriteLine($"time for await");
+        return true;
     }
 }
 

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -653,3 +653,23 @@ public class LoadDebuggerTestALC {
         }
     }
 
+
+public class Foo
+{
+    public string Lorem { get; set; } = "Safe";
+    public int Bar()
+    {
+        int ret;
+        if (Lorem.StartsWith('S'))
+            ret = 0;
+        else
+            ret = 1;
+        return ret;
+    }
+    public static void RunBar()
+    {
+        Foo foo = new Foo();
+        foo.Bar();
+    }
+}
+

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -681,7 +681,18 @@ public class Foo
     {
         Foo foo = new Foo();
         foo.Bart();
+        foo.OtherBar();
         Console.WriteLine(foo);
+    }
+    public void OtherBar()
+    {
+        var a = 1;
+        var b = 2;
+        var x = "Stew";
+        var y = "00.123";
+        var c = a + b == 3 || b + a == 2;
+        var d = TimeSpan.TryParseExact(y, @"ss\.fff", null, out var ts) && x.Contains('S');
+        Console.WriteLine(d);
     }
 }
 

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -692,6 +692,13 @@ public class Foo
         var y = "00.123";
         var c = a + b == 3 || b + a == 2;
         var d = TimeSpan.TryParseExact(y, @"ss\.fff", null, out var ts) && x.Contains('S');
+        var e = TimeSpan.TryParseExact(y, @"ss\.fff", null, out var ts1)
+                && x.Contains('S');
+        var f = TimeSpan.TryParseExact(y, @"ss\.fff", null, out var ts2)
+                &&
+                x.Contains('S');
+        var g = TimeSpan.TryParseExact(y, @"ss\.fff", null, out var ts3) &&
+                x.Contains('S');
         Console.WriteLine(d);
     }
 }

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Threading.Tasks;
+using System.Linq;
 public partial class Math
 { //Only append content to this class as the test suite depends on line info
     public static int IntAdd(int a, int b)
@@ -361,7 +361,7 @@ public class DebuggerTest
         Console.WriteLine ($"break here");
     }
 
-    public static async Task BoxingTestAsync()
+    public static async System.Threading.Tasks.Task BoxingTestAsync()
     {
         int? n_i = 5;
         object o_i = n_i.Value;
@@ -380,7 +380,7 @@ public class DebuggerTest
         object o_ia = new int[] {918, 58971};
 
         Console.WriteLine ($"break here");
-        await Task.CompletedTask;
+        await System.Threading.Tasks.Task.CompletedTask;
     }
 
     public static void BoxedTypeObjectTest()
@@ -395,7 +395,7 @@ public class DebuggerTest
         object oo0 = oo;
         Console.WriteLine ($"break here");
     }
-    public static async Task BoxedTypeObjectTestAsync()
+    public static async System.Threading.Tasks.Task BoxedTypeObjectTestAsync()
     {
         int i = 5;
         object o0 = i;
@@ -406,7 +406,7 @@ public class DebuggerTest
         object oo = new object();
         object oo0 = oo;
         Console.WriteLine ($"break here");
-        await Task.CompletedTask;
+        await System.Threading.Tasks.Task.CompletedTask;
     }
 
     public static void BoxedAsClass()
@@ -419,7 +419,7 @@ public class DebuggerTest
         Console.WriteLine ($"break here");
     }
 
-    public static async Task BoxedAsClassAsync()
+    public static async System.Threading.Tasks.Task BoxedAsClassAsync()
     {
         ValueType vt_dt = new DateTime(4819, 5, 6, 7, 8, 9);
         ValueType vt_gs = new Math.GenericStruct<string> { StringField = "vt_gs#StringField" };
@@ -427,7 +427,7 @@ public class DebuggerTest
         Enum ee = System.IO.FileMode.Append;
 
         Console.WriteLine ($"break here");
-        await Task.CompletedTask;
+        await System.Threading.Tasks.Task.CompletedTask;
     }
 }
 
@@ -452,14 +452,14 @@ public class MulticastDelegateTestClass
         TestEvent?.Invoke(this, Delegate?.ToString());
     }
 
-    public async Task TestAsync()
+    public async System.Threading.Tasks.Task TestAsync()
     {
         TestEvent += (_, s) => Console.WriteLine(s);
         TestEvent += (_, s) => Console.WriteLine(s + "qwe");
         Delegate = TestEvent;
 
         TestEvent?.Invoke(this, Delegate?.ToString());
-        await Task.CompletedTask;
+        await System.Threading.Tasks.Task.CompletedTask;
     }
 }
 
@@ -470,10 +470,10 @@ public class EmptyClass
         Console.WriteLine($"break here");
     }
 
-    public static async Task StaticMethodWithNoLocalsAsync()
+    public static async System.Threading.Tasks.Task StaticMethodWithNoLocalsAsync()
     {
         Console.WriteLine($"break here");
-        await Task.CompletedTask;
+        await System.Threading.Tasks.Task.CompletedTask;
     }
 
     public static void run()
@@ -490,10 +490,10 @@ public struct EmptyStruct
         Console.WriteLine($"break here");
     }
 
-    public static async Task StaticMethodWithNoLocalsAsync()
+    public static async System.Threading.Tasks.Task StaticMethodWithNoLocalsAsync()
     {
         Console.WriteLine($"break here");
-        await Task.CompletedTask;
+        await System.Threading.Tasks.Task.CompletedTask;
     }
 
     public static void StaticMethodWithLocalEmptyStruct()
@@ -502,11 +502,11 @@ public struct EmptyStruct
         Console.WriteLine($"break here");
     }
 
-    public static async Task StaticMethodWithLocalEmptyStructAsync()
+    public static async System.Threading.Tasks.Task StaticMethodWithLocalEmptyStructAsync()
     {
         var es = new EmptyStruct();
         Console.WriteLine($"break here");
-        await Task.CompletedTask;
+        await System.Threading.Tasks.Task.CompletedTask;
     }
 
     public static void run()
@@ -654,10 +654,21 @@ public class LoadDebuggerTestALC {
     }
 
 
+public class Something
+{
+    public string Name { get; set; }
+    public Something() => Name = "Same of something";
+    public override string ToString() => Name;
+}
+
 public class Foo
 {
+    public string Bar => Stuffs.First(x => x.Name.StartsWith('S')).Name;
+    public System.Collections.Generic.List<Something> Stuffs { get; } = Enumerable.Range(0, 10).Select(x => new Something()).ToList();
     public string Lorem { get; set; } = "Safe";
-    public int Bar()
+    public string Ipsum { get; set; } = "Side";
+    public Something What { get; } = new Something();
+    public int Bart()
     {
         int ret;
         if (Lorem.StartsWith('S'))
@@ -666,10 +677,11 @@ public class Foo
             ret = 1;
         return ret;
     }
-    public static void RunBar()
+    public static void RunBart()
     {
         Foo foo = new Foo();
-        foo.Bar();
+        foo.Bart();
+        Console.WriteLine(foo);
     }
 }
 


### PR DESCRIPTION
The case that we would get a different behavior is when we have more than one command being executed in the same line:
`var d = TimeSpan.TryParseExact(y, @"ss\.fff", null, out var ts) && x.Contains('S');`
When we step over we stop in the same line again, then we need to step over again to go to next line.

- Creating test to test https://github.com/dotnet/runtime/issues/49142
- Fix behavior of step to be the same of what we see when debugging using debugger-libs+mono or coreclr.
- Creating test to close https://github.com/dotnet/runtime/issues/49143
- Creating test to close https://github.com/dotnet/runtime/issues/49141
- Creating test to close https://github.com/dotnet/runtime/issues/49218.
- Fix error message of evaluate calling methods.

NOTE: If we want to backport it to preview7 we also need to backport https://github.com/dotnet/runtime/pull/55869, otherwise it will break step after hotreload for wasm.
