### PR TITLE
Fixes building Host tests from VS

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.props
@@ -155,10 +155,10 @@
     </ItemGroup>
   </Target>
 
-  <Import Project="$(Crossgen2SdkOverridePropsPath)" />
+  <Import Project="$(Crossgen2SdkOverridePropsPath)" Condition="'$(Crossgen2SdkOverridePropsPath)' != ''" />
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.SharedFramework.Sdk" />
-  <Import Project="$(Crossgen2SdkOverrideTargetsPath)" />
+  <Import Project="$(Crossgen2SdkOverrideTargetsPath)" Condition="'$(Crossgen2SdkOverrideTargetsPath)' != ''" />
   <PropertyGroup>
     <PublishReadyToRunComposite Condition="$(ForcePublishReadyToRunComposite) == 'true'">true</PublishReadyToRunComposite>
   </PropertyGroup>


### PR DESCRIPTION
When building the Host tests projects from VS the CrossGen2 related properties are not set (probably because the build type is not set to Core - which doesn't matter for the tests).

Changed the includes to be conditional.