### PR TITLE
Use volatile and an early return to prevent race conditions

### DIFF
--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -81,30 +81,31 @@ static gint32 signatures_size;
 void
 mono_loader_init ()
 {
-	static gboolean inited;
+	static volatile gboolean inited = FALSE; // volatile to avoid race conditions
 
-	// FIXME: potential race
-	if (!inited) {
-		mono_coop_mutex_init_recursive (&loader_mutex);
-		mono_os_mutex_init_recursive (&global_loader_data_mutex);
-		loader_lock_inited = TRUE;
-
-		mono_global_loader_cache_init ();
-
-		mono_native_tls_alloc (&loader_lock_nest_id, NULL);
-
-		mono_counters_init ();
-		mono_counters_register ("Inflated signatures size",
-								MONO_COUNTER_GENERICS | MONO_COUNTER_INT, &inflated_signatures_size);
-		mono_counters_register ("Memberref signature cache size",
-								MONO_COUNTER_METADATA | MONO_COUNTER_INT, &memberref_sig_cache_size);
-		mono_counters_register ("MonoMethod size",
-								MONO_COUNTER_METADATA | MONO_COUNTER_INT, &methods_size);
-		mono_counters_register ("MonoMethodSignature size",
-								MONO_COUNTER_METADATA | MONO_COUNTER_INT, &signatures_size);
-
-		inited = TRUE;
+	if (inited) {
+		return;
 	}
+	
+	inited = TRUE;
+
+	mono_coop_mutex_init_recursive (&loader_mutex);
+	mono_os_mutex_init_recursive (&global_loader_data_mutex);
+	loader_lock_inited = TRUE;
+
+	mono_global_loader_cache_init ();
+
+	mono_native_tls_alloc (&loader_lock_nest_id, NULL);
+
+	mono_counters_init ();
+	mono_counters_register ("Inflated signatures size",
+								MONO_COUNTER_GENERICS | MONO_COUNTER_INT, &inflated_signatures_size);
+	mono_counters_register ("Memberref signature cache size",
+								MONO_COUNTER_METADATA | MONO_COUNTER_INT, &memberref_sig_cache_size);
+	mono_counters_register ("MonoMethod size",
+								MONO_COUNTER_METADATA | MONO_COUNTER_INT, &methods_size);
+	mono_counters_register ("MonoMethodSignature size",
+								MONO_COUNTER_METADATA | MONO_COUNTER_INT, &signatures_size);
 }
 
 void


### PR DESCRIPTION
By making the variable volatile, it means other threads know to read it from memory as well as modify it in memory for the other threads. Also, the inited variable is set to true immediately to ensure no other threads evaluate inited while the loader functions run.