### PR TITLE
Fix x86 Linux build with clang < 10

### DIFF
--- a/src/coreclr/vm/i386/jithelp.S
+++ b/src/coreclr/vm/i386/jithelp.S
@@ -392,7 +392,9 @@ LEAF_ENTRY JIT_WriteBarrier_Callable, _TEXT
 1:
     pop     eax
 2:
-    add     eax, offset _GLOBAL_OFFSET_TABLE_+1 // (2b - 1b)
+.att_syntax
+    addl     $_GLOBAL_OFFSET_TABLE_+(2b-1b), %eax
+.intel_syntax noprefix
     mov     eax, dword ptr [eax + C_FUNC(JIT_WriteBarrierEAX_Loc)@GOT]
     xchg    eax, dword ptr [esp]
     ret


### PR DESCRIPTION
There is a bug in clang that was fixed in version 10 and that causes
the build of the src/coreclr/vm/i386/jithelp.S to fail with
'error: cannot use more than one symbol in memory operand'.
The problem is that it doesn't support the `offset` keyword and
it thinks it is just another symbol.

The fix is to use att syntax for the offending instruction.

Close #55521