### PR TITLE
[Release/5.0] Prevent race condition by using volatile

### DIFF
--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -83,6 +83,7 @@ mono_loader_init ()
 	static volatile gboolean inited = FALSE;
 
 	if (inited) {
+		/* Do nothing if this function has already been called */
 		return;
 	}
 	

--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -80,7 +80,7 @@ static gint32 signatures_size;
 void
 mono_loader_init ()
 {
-	static volatile gboolean inited = FALSE;
+	static volatile gboolean inited = FALSE; // We make this volatile to avoid race conditions
 
 	if (inited) {
 		/* Do nothing if this function has already been called */

--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -82,7 +82,7 @@ mono_loader_init ()
 {
 	static volatile gboolean inited = FALSE;
 
-	if (!inited) {
+	if (inited) {
 		return;
 	}
 	

--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -80,30 +80,31 @@ static gint32 signatures_size;
 void
 mono_loader_init ()
 {
-	static gboolean inited;
+	static volatile gboolean inited = FALSE;
 
-	// FIXME: potential race
 	if (!inited) {
-		mono_coop_mutex_init_recursive (&loader_mutex);
-		mono_os_mutex_init_recursive (&global_loader_data_mutex);
-		loader_lock_inited = TRUE;
-
-		mono_global_loader_cache_init ();
-
-		mono_native_tls_alloc (&loader_lock_nest_id, NULL);
-
-		mono_counters_init ();
-		mono_counters_register ("Inflated signatures size",
-								MONO_COUNTER_GENERICS | MONO_COUNTER_INT, &inflated_signatures_size);
-		mono_counters_register ("Memberref signature cache size",
-								MONO_COUNTER_METADATA | MONO_COUNTER_INT, &memberref_sig_cache_size);
-		mono_counters_register ("MonoMethod size",
-								MONO_COUNTER_METADATA | MONO_COUNTER_INT, &methods_size);
-		mono_counters_register ("MonoMethodSignature size",
-								MONO_COUNTER_METADATA | MONO_COUNTER_INT, &signatures_size);
-
-		inited = TRUE;
+		return;
 	}
+	
+	inited = TRUE;
+
+	mono_coop_mutex_init_recursive (&loader_mutex);
+	mono_os_mutex_init_recursive (&global_loader_data_mutex);
+	loader_lock_inited = TRUE;
+
+	mono_global_loader_cache_init ();
+
+	mono_native_tls_alloc (&loader_lock_nest_id, NULL);
+
+	mono_counters_init ();
+	mono_counters_register ("Inflated signatures size",
+							MONO_COUNTER_GENERICS | MONO_COUNTER_INT, &inflated_signatures_size);
+	mono_counters_register ("Memberref signature cache size",
+							MONO_COUNTER_METADATA | MONO_COUNTER_INT, &memberref_sig_cache_size);
+	mono_counters_register ("MonoMethod size",
+							MONO_COUNTER_METADATA | MONO_COUNTER_INT, &methods_size);
+	mono_counters_register ("MonoMethodSignature size",
+							MONO_COUNTER_METADATA | MONO_COUNTER_INT, &signatures_size);
 }
 
 void


### PR DESCRIPTION
As well as setting inited to TRUE first thing to avoid any issues with threads while the loading code is running.