### PR TITLE
Disable ConnectTimeout_PlaintextStreamFilterTimesOut_Throws

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Cancellation.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Cancellation.cs
@@ -80,6 +80,7 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55931")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task ConnectTimeout_PlaintextStreamFilterTimesOut_Throws(bool useSsl)


### PR DESCRIPTION
Disable test ConnectTimeout_PlaintextStreamFilterTimesOut_Throws

Disabled test tracked by #55931