### PR TITLE
JIT: track memory loop dependence of trees during value numbering

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2015,10 +2015,11 @@ void Compiler::compInit(ArenaAllocator*       pAlloc,
     }
 #endif // DEBUG
 
-    vnStore               = nullptr;
-    m_opAsgnVarDefSsaNums = nullptr;
-    fgSsaPassesCompleted  = 0;
-    fgVNPassesCompleted   = 0;
+    vnStore                    = nullptr;
+    m_opAsgnVarDefSsaNums      = nullptr;
+    m_nodeToLoopMemoryBlockMap = nullptr;
+    fgSsaPassesCompleted       = 0;
+    fgVNPassesCompleted        = 0;
 
     // check that HelperCallProperties are initialized
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5057,7 +5057,7 @@ public:
     // The map provides the entry block of the most closely enclosing loop that
     // defines the memory region accessed when defining the nodes's VN.
     //
-    // This information should consulted when considering hoisting node out of a loop, as the VN
+    // This information should be consulted when considering hoisting node out of a loop, as the VN
     // for the node will only be valid within the indicated loop.
     //
     // It is not fine-grained enough to track memory dependence within loops, so cannot be used

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -5486,6 +5486,9 @@ void Compiler::optPerformHoistExpr(GenTree* origExpr, unsigned lnum)
     // so clear the RegNum if it was set in the original expression
     hoistExpr->ClearRegNum();
 
+    // Copy any loop memory dependence.
+    optCopyLoopMemoryDependence(origExpr, hoistExpr);
+
     // At this point we should have a cloned expression, marked with the GTF_MAKE_CSE flag
     assert(hoistExpr != origExpr);
     assert(hoistExpr->gtFlags & GTF_MAKE_CSE);
@@ -6037,6 +6040,106 @@ bool Compiler::optIsProfitableToHoistableTree(GenTree* tree, unsigned lnum)
 }
 
 //------------------------------------------------------------------------
+// optRecordLoopMemoryDependence: record that tree's value number
+//   is dependent on a particular memory VN
+//
+// Arguments:
+//   tree -- tree in question
+//   block -- block containing tree
+//   memoryVN -- VN for a "map" from a select operation encounterd
+//     while computing the tree's VN
+//
+// Notes:
+//   Only tracks trees in loops, and memory updates in the same loop nest.
+//   So this is a coarse-grained dependence that is only usable for
+//   hoisting tree out of its enclosing loops.
+//
+void Compiler::optRecordLoopMemoryDependence(GenTree* tree, BasicBlock* block, ValueNum memoryVN)
+{
+    // If tree is not in a loop, we don't need to track its loop dependence.
+    //
+    unsigned const loopNum = block->bbNatLoopNum;
+
+    if (loopNum == BasicBlock::NOT_IN_LOOP)
+    {
+        return;
+    }
+
+    // Find the loop associated with this memory VN.
+    //
+    unsigned const updateLoopNum = vnStore->LoopOfVN(memoryVN);
+
+    if (updateLoopNum == BasicBlock::NOT_IN_LOOP)
+    {
+        // memoryVN defined outside of any loop, we can ignore.
+        //
+        JITDUMP("      ==> Not updating loop memory dependence of [%06u], memory " FMT_VN " not defined in a loop\n",
+                dspTreeID(tree), memoryVN);
+        return;
+    }
+
+    // If the update block is not the the header of a loop containing
+    // block, we can also ignore the update.
+    //
+    if (!optLoopContains(updateLoopNum, loopNum))
+    {
+        JITDUMP("      ==> Not updating loop memory dependence of [%06u]/" FMT_LP ", memory " FMT_VN "/" FMT_LP
+                " is not defined in an enclosing loop\n",
+                dspTreeID(tree), loopNum, memoryVN, updateLoopNum);
+        return;
+    }
+
+    // If we already have a recorded a loop entry block for this
+    // tree, see if the new update is for a more closely nested
+    // loop.
+    //
+    NodeToLoopMemoryBlockMap* const map      = GetNodeToLoopMemoryBlockMap();
+    BasicBlock*                     mapBlock = nullptr;
+
+    if (map->Lookup(tree, &mapBlock))
+    {
+        unsigned const mapLoopNum = mapBlock->bbNatLoopNum;
+
+        // If the update loop contains the existing map loop,
+        // the existing map loop is more constraining. So no
+        // update needed.
+        //
+        if (optLoopContains(updateLoopNum, mapLoopNum))
+        {
+            JITDUMP("      ==> Not updating loop memory dependence of [%06u]; alrady constrained to " FMT_LP
+                    " nested in " FMT_LP "\n",
+                    dspTreeID(tree), mapLoopNum, updateLoopNum);
+            return;
+        }
+    }
+
+    // MemoryVN now describes the most constraining loop memory dependence
+    // we know of. Update the map.
+    //
+    JITDUMP("      ==> Updating loop memory dependence of [%06u] to " FMT_LP "\n", dspTreeID(tree), updateLoopNum);
+    map->Set(tree, optLoopTable[updateLoopNum].lpEntry);
+}
+
+//------------------------------------------------------------------------
+// optCopyLoopMemoryDependence: record that tree's loop memory dependence
+//   is the same as some other tree.
+//
+// Arguments:
+//   fromTree -- tree to copy dependence from
+//   toTree -- tree in question
+//
+void Compiler::optCopyLoopMemoryDependence(GenTree* fromTree, GenTree* toTree)
+{
+    NodeToLoopMemoryBlockMap* const map      = GetNodeToLoopMemoryBlockMap();
+    BasicBlock*                     mapBlock = nullptr;
+
+    if (map->Lookup(fromTree, &mapBlock))
+    {
+        map->Set(toTree, mapBlock);
+    }
+}
+
+//------------------------------------------------------------------------
 // optHoistLoopBlocks: Hoist invariant expression out of the loop.
 //
 // Arguments:
@@ -6093,19 +6196,65 @@ void Compiler::optHoistLoopBlocks(unsigned loopNum, ArrayStack<BasicBlock*>* blo
         bool IsTreeVNInvariant(GenTree* tree)
         {
             ValueNum vn = tree->gtVNPair.GetLiberal();
-            if (m_compiler->vnStore->IsVNConstant(vn))
+            bool     vnIsInvariant =
+                m_compiler->optVNIsLoopInvariant(vn, m_loopNum, &m_hoistContext->m_curLoopVnInvariantCache);
+
+            // Even though VN is invariant in the loop (say a constant) its value may depend on position
+            // of tree, so for loop hoisting we must also check that any memory read by tree
+            // is also invariant in the loop.
+            //
+            if (vnIsInvariant)
             {
-                // It is unsafe to allow a GT_CLS_VAR that has been assigned a constant.
-                // The logic in optVNIsLoopInvariant would consider it to be loop-invariant, even
-                // if the assignment of the constant to the GT_CLS_VAR was inside the loop.
-                //
-                if (tree->OperIs(GT_CLS_VAR))
+                vnIsInvariant = IsTreeLoopMemoryInvariant(tree);
+            }
+            return vnIsInvariant;
+        }
+
+        //------------------------------------------------------------------------
+        // IsTreeLoopMemoryInvariant: determine if the value number of tree
+        //   is dependent on the tree being executed within the current loop
+        //
+        // Arguments:
+        //   tree -- tree in question
+        //
+        // Returns:
+        //   true if tree could be evaluated just before loop and get the
+        //   same value.
+        //
+        // Note:
+        //   Calls are optimistically assumed to be invariant.
+        //   Caller must do their own analysis for these tree types.
+        //
+        bool IsTreeLoopMemoryInvariant(GenTree* tree)
+        {
+            if (tree->OperIsIndir() && ((tree->gtFlags & GTF_IND_INVARIANT) != 0))
+            {
+                return true;
+            }
+
+            // Todo: other operators that read memory
+            //
+            if (tree->OperIsIndir() || tree->OperIs(GT_CLS_VAR))
+            {
+                NodeToLoopMemoryBlockMap* const map            = m_compiler->GetNodeToLoopMemoryBlockMap();
+                BasicBlock*                     loopEntryBlock = nullptr;
+                if (map->Lookup(tree, &loopEntryBlock))
                 {
-                    return false;
+                    for (MemoryKind memoryKind : allMemoryKinds())
+                    {
+                        ValueNum loopMemoryVN =
+                            m_compiler->GetMemoryPerSsaData(loopEntryBlock->bbMemorySsaNumIn[memoryKind])
+                                ->m_vnPair.GetLiberal();
+                        if (!m_compiler->optVNIsLoopInvariant(loopMemoryVN, m_loopNum,
+                                                              &m_hoistContext->m_curLoopVnInvariantCache))
+                        {
+                            return false;
+                        }
+                    }
                 }
             }
 
-            return m_compiler->optVNIsLoopInvariant(vn, m_loopNum, &m_hoistContext->m_curLoopVnInvariantCache);
+            return true;
         }
 
     public:
@@ -6576,6 +6725,20 @@ bool Compiler::optVNIsLoopInvariant(ValueNum vn, unsigned lnum, VNToBoolMap* loo
         {
             for (unsigned i = 0; i < funcApp.m_arity; i++)
             {
+                // 4th arg of mapStore identifies the loop where the store happens.
+                //
+                if (funcApp.m_func == VNF_MapStore)
+                {
+                    assert(funcApp.m_arity == 4);
+
+                    if (i == 3)
+                    {
+                        const unsigned vnLoopNum = funcApp.m_args[3];
+                        res                      = !optLoopContains(lnum, vnLoopNum);
+                        break;
+                    }
+                }
+
                 // TODO-CQ: We need to either make sure that *all* VN functions
                 // always take VN args, or else have a list of arg positions to exempt, as implicitly
                 // constant.

--- a/src/coreclr/jit/valuenumfuncs.h
+++ b/src/coreclr/jit/valuenumfuncs.h
@@ -7,7 +7,7 @@
 
 // clang-format off
 ValueNumFuncDef(MemOpaque, 1, false, false, false)  // Args: 0: loop num
-ValueNumFuncDef(MapStore, 3, false, false, false)   // Args: 0: map, 1: index (e. g. field handle), 2: value being stored.
+ValueNumFuncDef(MapStore, 4, false, false, false)   // Args: 0: map, 1: index (e. g. field handle), 2: value being stored, 3: loop num.
 ValueNumFuncDef(MapSelect, 2, false, false, false)  // Args: 0: map, 1: key.
 
 ValueNumFuncDef(FieldSeq, 2, false, false, false)   // Sequence (VN of null == empty) of (VN's of) field handles.

--- a/src/tests/JIT/Regression/JitBlue/Runtime_54118/Runtime_54118.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_54118/Runtime_54118.cs
@@ -1,0 +1,239 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+// Various tests for memory-dependent loop hoisting
+
+class Runtime_54118
+{
+    public static int Main()
+    {
+        _clsVar = -1;
+        int result = 0;
+        int index = 0;
+        void Test(string name, Func<bool> act)
+        {
+            Console.Write("{0}: ", name);
+            if (act())
+            {
+                Console.WriteLine("PASS");
+            }
+            else
+            {
+                Console.WriteLine("FAIL");
+                result |= 1 << index;
+            }
+
+            index++;
+        }
+
+        Test(nameof(TestConstantByref), TestConstantByref);
+        Test(nameof(TestConstantArr), TestConstantArr);
+        Test(nameof(TestConstantClsVar), TestConstantClsVar);
+        Test(nameof(TestParamByref), () => TestParamByref(1));
+        Test(nameof(TestParamArr), () => TestParamArr(1));
+        Test(nameof(TestParamClsVar), () => TestParamClsVar(1));
+        Test(nameof(TestPhiByref), TestPhiByref);
+        Test(nameof(TestPhiArr), TestPhiArr);
+        Test(nameof(TestPhiClsVar), TestPhiClsVar);
+        Test(nameof(TestCastByref), TestCastByref);
+        Test(nameof(TestCastArr), TestCastArr);
+        Test(nameof(TestCastClsVar), TestCastClsVar);
+
+        return 100 + result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool TestConstantByref()
+    {
+        int[] arr = { -1 };
+        ref int r = ref arr[0];
+        int val = -1;
+        for (int i = 0; i < 2; i++)
+        {
+            r = 1;
+            val = r;
+        }
+
+        return val == 1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool TestConstantArr()
+    {
+        int[] arr = { -1 };
+        int val = -1;
+        for (int i = 0; i < 2; i++)
+        {
+            arr[0] = 1;
+            val = arr[0];
+        }
+
+        return val == 1;
+    }
+
+    static int _clsVar;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool TestConstantClsVar()
+    {
+        _clsVar = -1;
+        int val = -1;
+        for (int i = 0; i < 2; i++)
+        {
+            _clsVar = 1;
+            val = _clsVar;
+        }
+
+        return val == 1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool TestParamByref(int one)
+    {
+        int[] arr = { -1 };
+        ref int r = ref arr[0];
+        int val = -1;
+        for (int i = 0; i < 2; i++)
+        {
+            r = one;
+            val = r;
+        }
+
+        return val == 1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool TestParamArr(int one)
+    {
+        int[] arr = { -1 };
+        int val = -1;
+        for (int i = 0; i < 2; i++)
+        {
+            arr[0] = one;
+            val = arr[0];
+        }
+
+        return val == 1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool TestParamClsVar(int one)
+    {
+        _clsVar = -1;
+        int val = -1;
+        for (int i = 0; i < 2; i++)
+        {
+            _clsVar = one;
+            val = _clsVar;
+        }
+
+        return val == 1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool TestPhiByref()
+    {
+        int[] arr = { -1 };
+        ref int r = ref arr[0];
+        int val = -1;
+        for (int i = 0; i < 2; i++)
+        {
+            for (int j = 0; j < 2; j++)
+            {
+                r = i;
+                val = r;
+            }
+        }
+
+        return val == 1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool TestPhiArr()
+    {
+        int[] arr = { -1 };
+        int val = -1;
+        for (int i = 0; i < 2; i++)
+        {
+            for (int j = 0; j < 2; j++)
+            {
+                arr[0] = i;
+                val = arr[0];
+            }
+        }
+
+        return val == 1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool TestPhiClsVar()
+    {
+        _clsVar = -1;
+        int val = -1;
+        for (int i = 0; i < 2; i++)
+        {
+            for (int j = 0; j < 2; j++)
+            {
+                _clsVar = i;
+                val = _clsVar;
+            }
+        }
+
+        return val == 1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool TestCastByref()
+    {
+        int[] arr = { -1 };
+        ref int r = ref arr[0];
+        int val = -1;
+        for (int i = 0; i < 2; i++)
+        {
+            for (int j = 0; j < 2; j++)
+            {
+                r = i;
+                val = (byte)r;
+            }
+        }
+
+        return val == 1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool TestCastArr()
+    {
+        int[] arr = { -1 };
+        int val = -1;
+        for (int i = 0; i < 2; i++)
+        {
+            for (int j = 0; j < 2; j++)
+            {
+                arr[0] = i;
+                val = (byte)arr[0];
+            }
+        }
+
+        return val == 1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool TestCastClsVar()
+    {
+        _clsVar = -1;
+        int val = -1;
+        for (int i = 0; i < 2; i++)
+        {
+            for (int j = 0; j < 2; j++)
+            {
+                _clsVar = i;
+                val = (byte)_clsVar;
+            }
+        }
+
+        return val == 1;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_54118/Runtime_54118.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_54118/Runtime_54118.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_55140/Runtime_55140.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_55140/Runtime_55140.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Runtime.CompilerServices;
 


### PR DESCRIPTION
Leverage value numbering's alias analysis to annotate trees with the loop
memory dependence of the tree's value number.

First, refactor the `mapStore` value number so that it also tracks the loop
number where the store occurs. This is done via an extra non-value-num arg,
so add appropriate bypasses to logic in the jit that expect to only find
value number args. Also update the dumping to display the loop information.

Next, during VN computation, record loop memory dependence from `mapStores`
with the tree currently being value numbered, whenever a value number comes
from a particular map. There may be multiple such recording events per tree,
so add logic on the recording side to track the most constraining dependence.
Note value numbering happens in execution order, so there is an unambiguous
current tree being value numbered.

This dependence info is tracked via a side map.

Finally, during hoisting, for each potentially hoistable tree, consult the side
map to recover the loop memory dependence of a tree, and if that dependence is
at or within the loop that we're hoisting from, block the hoist.

I've also absorbed the former class var (static field) hosting exclusion into
this new logic. This gives us slightly more relaxed dependence in some cases.

Resolves #54118.