### PR TITLE
Enable `EHCONT` for some DLLs and for PGO instrumentation

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -574,11 +574,11 @@ if (MSVC)
 
   # Enable EH-continuation table for native components for amd64 builds
   # Added using variables instead of add_compile_options to let individual projects override it
-  #if (CLR_CMAKE_HOST_ARCH_AMD64)
-  #  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /guard:ehcont")
-  #  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /guard:ehcont")
-  #  set(CMAKE_ASM_MASM_FLAGS "${CMAKE_C_FLAGS} /guard:ehcont")
-  #endif (CLR_CMAKE_HOST_ARCH_AMD64)
+  if (CLR_CMAKE_HOST_ARCH_AMD64)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /guard:ehcont")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /guard:ehcont")
+    set(CMAKE_ASM_MASM_FLAGS "${CMAKE_C_FLAGS} /guard:ehcont")
+  endif (CLR_CMAKE_HOST_ARCH_AMD64)
 
   # Statically linked CRT (libcmt[d].lib, libvcruntime[d].lib and libucrt[d].lib) by default. This is done to avoid
   # linking in VCRUNTIME140.DLL for a simplified xcopy experience by reducing the dependency on VC REDIST.

--- a/src/coreclr/pgosupport.cmake
+++ b/src/coreclr/pgosupport.cmake
@@ -18,8 +18,10 @@ endif(NOT WIN32)
 function(add_pgo TargetName)
     if(CLR_CMAKE_PGO_INSTRUMENT)
         if(CLR_CMAKE_HOST_WIN32)
-            set_property(TARGET ${TargetName} APPEND_STRING PROPERTY LINK_FLAGS_RELEASE        " /LTCG /GENPROFILE")
-            set_property(TARGET ${TargetName} APPEND_STRING PROPERTY LINK_FLAGS_RELWITHDEBINFO " /LTCG /GENPROFILE")
+            # The /guard:ehcont and /CETCOMPAT switches here are temporary and will be moved to a more global location once new
+            # profile data is published
+            set_property(TARGET ${TargetName} APPEND_STRING PROPERTY LINK_FLAGS_RELEASE        " /LTCG /GENPROFILE /guard:ehcont /CETCOMPAT")
+            set_property(TARGET ${TargetName} APPEND_STRING PROPERTY LINK_FLAGS_RELWITHDEBINFO " /LTCG /GENPROFILE /guard:ehcont /CETCOMPAT")
         else(CLR_CMAKE_HOST_WIN32)
             if(UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE OR UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELWITHDEBINFO)
                 target_compile_options(${TargetName} PRIVATE -flto -fprofile-instr-generate)

--- a/src/coreclr/pgosupport.cmake
+++ b/src/coreclr/pgosupport.cmake
@@ -18,10 +18,15 @@ endif(NOT WIN32)
 function(add_pgo TargetName)
     if(CLR_CMAKE_PGO_INSTRUMENT)
         if(CLR_CMAKE_HOST_WIN32)
-            # The /guard:ehcont and /CETCOMPAT switches here are temporary and will be moved to a more global location once new
-            # profile data is published
-            set_property(TARGET ${TargetName} APPEND_STRING PROPERTY LINK_FLAGS_RELEASE        " /LTCG /GENPROFILE /guard:ehcont /CETCOMPAT")
-            set_property(TARGET ${TargetName} APPEND_STRING PROPERTY LINK_FLAGS_RELWITHDEBINFO " /LTCG /GENPROFILE /guard:ehcont /CETCOMPAT")
+            set_property(TARGET ${TargetName} APPEND_STRING PROPERTY LINK_FLAGS_RELEASE        " /LTCG /GENPROFILE")
+            set_property(TARGET ${TargetName} APPEND_STRING PROPERTY LINK_FLAGS_RELWITHDEBINFO " /LTCG /GENPROFILE")
+
+            if (CLR_CMAKE_HOST_ARCH_AMD64)
+                # The /guard:ehcont and /CETCOMPAT switches here are temporary and will be moved to a more global location once
+                # new profile data is published
+                set_property(TARGET ${TargetName} APPEND_STRING PROPERTY LINK_FLAGS_RELEASE        " /guard:ehcont /CETCOMPAT")
+                set_property(TARGET ${TargetName} APPEND_STRING PROPERTY LINK_FLAGS_RELWITHDEBINFO " /guard:ehcont /CETCOMPAT")
+            endif (CLR_CMAKE_HOST_ARCH_AMD64)
         else(CLR_CMAKE_HOST_WIN32)
             if(UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE OR UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELWITHDEBINFO)
                 target_compile_options(${TargetName} PRIVATE -flto -fprofile-instr-generate)

--- a/src/libraries/Native/Windows/CMakeLists.txt
+++ b/src/libraries/Native/Windows/CMakeLists.txt
@@ -65,12 +65,12 @@ endif ()
 add_compile_options(/guard:cf)
 list(APPEND __SharedLinkArgs /guard:cf)
 
-#if (${CLR_CMAKE_HOST_ARCH} STREQUAL "x86_64" OR ${CLR_CMAKE_HOST_ARCH} STREQUAL "amd64" OR ${CLR_CMAKE_HOST_ARCH} STREQUAL "x64")
-#    # Enable EH continuation table and CETCOMPAT for native components
-#    add_compile_options(/guard:ehcont)
-#    list(APPEND __SharedLinkArgs /guard:ehcont)
-#    list(APPEND __SharedLinkArgs /CETCOMPAT)
-#endif ()
+if (${CLR_CMAKE_HOST_ARCH} STREQUAL "x86_64" OR ${CLR_CMAKE_HOST_ARCH} STREQUAL "amd64" OR ${CLR_CMAKE_HOST_ARCH} STREQUAL "x64")
+    # Enable EH continuation table and CETCOMPAT for native components
+    add_compile_options(/guard:ehcont)
+    list(APPEND __SharedLinkArgs /guard:ehcont)
+    list(APPEND __SharedLinkArgs /CETCOMPAT)
+endif ()
 
 # Statically linked CRT (libcmt[d].lib, libvcruntime[d].lib and libucrt[d].lib) by default. This is done to avoid
 # linking in VCRUNTIME140.DLL for a simplified xcopy experience by reducing the dependency on VC REDIST.


### PR DESCRIPTION
- PGD files used for PGO optimziation need to be collected/used against binaries with identical compiler features
- Enabled `/guard:ehcont` as a compiler option but not as a linker option
- Enabled `/guard:ehcont` and `/cetcompat` as a linker options for PGO instrumentation only for now
- Once new profile data is published, another PR would follow to enable `/guard:ehcont` and `/cetcompat` as linker options