### PR TITLE
Disabling test that times out in netfx debug runs

### DIFF
--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Stream.Collections.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Stream.Collections.cs
@@ -17,6 +17,9 @@ namespace System.Text.Json.Serialization.Tests
     {
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/35927", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoInterpreter))]
+#if DEBUG
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/35927", typeof(PlatformDetection), nameof(PlatformDetection.IsNetFramework))]
+#endif
         [ActiveIssue("https://github.com/dotnet/runtime/issues/35927", TestPlatforms.Browser)]
         public async Task HandleCollectionsAsync()
         {


### PR DESCRIPTION
Contributes to #35927. Disabling tests that started timing out in net461 debug runs.


cc @layomia @stephentoub @ericstj 