### PR TITLE
Revert UnicodeDebug.cs to not depend on the Debug.Assert interpolated string handler

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/UnicodeDebug.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/UnicodeDebug.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Globalization;
 
 namespace System.Text
 {
@@ -11,39 +10,55 @@ namespace System.Text
         [Conditional("DEBUG")]
         internal static void AssertIsBmpCodePoint(uint codePoint)
         {
-            Debug.Assert(UnicodeUtility.IsBmpCodePoint(codePoint), $"The value {ToHexString(codePoint)} is not a valid BMP code point.");
+            if (!UnicodeUtility.IsBmpCodePoint(codePoint))
+            {
+                Debug.Fail($"The value {ToHexString(codePoint)} is not a valid BMP code point.");
+            }
         }
 
         [Conditional("DEBUG")]
         internal static void AssertIsHighSurrogateCodePoint(uint codePoint)
         {
-            Debug.Assert(UnicodeUtility.IsHighSurrogateCodePoint(codePoint), $"The value {ToHexString(codePoint)} is not a valid UTF-16 high surrogate code point.");
+            if (!UnicodeUtility.IsHighSurrogateCodePoint(codePoint))
+            {
+                Debug.Fail($"The value {ToHexString(codePoint)} is not a valid UTF-16 high surrogate code point.");
+            }
         }
 
         [Conditional("DEBUG")]
         internal static void AssertIsLowSurrogateCodePoint(uint codePoint)
         {
-            Debug.Assert(UnicodeUtility.IsLowSurrogateCodePoint(codePoint), $"The value {ToHexString(codePoint)} is not a valid UTF-16 low surrogate code point.");
+            if (!UnicodeUtility.IsLowSurrogateCodePoint(codePoint))
+            {
+                Debug.Fail($"The value {ToHexString(codePoint)} is not a valid UTF-16 low surrogate code point.");
+            }
         }
 
         [Conditional("DEBUG")]
         internal static void AssertIsValidCodePoint(uint codePoint)
         {
-            Debug.Assert(UnicodeUtility.IsValidCodePoint(codePoint), $"The value {ToHexString(codePoint)} is not a valid Unicode code point.");
+            if (!UnicodeUtility.IsValidCodePoint(codePoint))
+            {
+                Debug.Fail($"The value {ToHexString(codePoint)} is not a valid Unicode code point.");
+            }
         }
 
         [Conditional("DEBUG")]
         internal static void AssertIsValidScalar(uint scalarValue)
         {
-            Debug.Assert(UnicodeUtility.IsValidUnicodeScalar(scalarValue), $"The value {ToHexString(scalarValue)} is not a valid Unicode scalar value.");
+            if (!UnicodeUtility.IsValidUnicodeScalar(scalarValue))
+            {
+                Debug.Fail($"The value {ToHexString(scalarValue)} is not a valid Unicode scalar value.");
+            }
         }
 
         [Conditional("DEBUG")]
         internal static void AssertIsValidSupplementaryPlaneScalar(uint scalarValue)
         {
-            Debug.Assert(
-                UnicodeUtility.IsValidUnicodeScalar(scalarValue) && !UnicodeUtility.IsBmpCodePoint(scalarValue),
-                $"The value {ToHexString(scalarValue)} is not a valid supplementary plane Unicode scalar value.");
+            if (!UnicodeUtility.IsValidUnicodeScalar(scalarValue) || UnicodeUtility.IsBmpCodePoint(scalarValue))
+            {
+                Debug.Fail($"The value {ToHexString(scalarValue)} is not a valid supplementary plane Unicode scalar value.");
+            }
         }
 
         /// <summary>
@@ -52,6 +67,9 @@ namespace System.Text
         /// <remarks>
         /// The input value doesn't have to be a real code point in the Unicode codespace. It can be any integer.
         /// </remarks>
-        private static string ToHexString(uint codePoint) => $"U+{codePoint:X4}";
+        private static string ToHexString(uint codePoint)
+        {
+            return FormattableString.Invariant($"U+{codePoint:X4}");
+        }
     }
 }


### PR DESCRIPTION
Turns out we use this file outside of corelib, in projects that build for pre-.NET 6, and the change was causing lots of string formatting for asserts that pass.

cc: @eiriktsarpalis 