### PR TITLE
Revamp caching scheme in PoolingAsyncValueTaskMethodBuilder

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/Internal/Padding.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Padding.cs
@@ -21,4 +21,12 @@ namespace Internal
     internal struct PaddingFor32
     {
     }
+
+    /// <summary>Padded reference to an object.</summary>
+    [StructLayout(LayoutKind.Explicit, Size = PaddingHelpers.CACHE_LINE_SIZE)]
+    internal struct PaddedReference
+    {
+        [FieldOffset(0)]
+        public object? Object;
+    }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/PoolingAsyncValueTaskMethodBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/PoolingAsyncValueTaskMethodBuilder.cs
@@ -1,10 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-
 using StateMachineBox = System.Runtime.CompilerServices.PoolingAsyncValueTaskMethodBuilder<System.Threading.Tasks.VoidTaskResult>.StateMachineBox;
 
 namespace System.Runtime.CompilerServices
@@ -13,12 +11,6 @@ namespace System.Runtime.CompilerServices
     [StructLayout(LayoutKind.Auto)]
     public struct PoolingAsyncValueTaskMethodBuilder
     {
-        /// <summary>Maximum number of boxes that are allowed to be cached per state machine type.</summary>
-        internal static readonly int s_valueTaskPoolingCacheSize =
-            int.TryParse(Environment.GetEnvironmentVariable("DOTNET_SYSTEM_THREADING_POOLINGASYNCVALUETASKSCACHESIZE"), NumberStyles.Integer, CultureInfo.InvariantCulture, out int result) && result > 0 ?
-                result :
-                Environment.ProcessorCount * 4; // arbitrary default value
-
         /// <summary>Sentinel object used to indicate that the builder completed synchronously and successfully.</summary>
         private static readonly StateMachineBox s_syncSuccessSentinel = PoolingAsyncValueTaskMethodBuilder<VoidTaskResult>.s_syncSuccessSentinel;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Sources/ManualResetValueTaskSourceCore.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Sources/ManualResetValueTaskSourceCore.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 
@@ -91,14 +90,24 @@ namespace System.Threading.Tasks.Sources
         [StackTraceHidden]
         public TResult GetResult(short token)
         {
-            ValidateToken(token);
-            if (!_completed)
+            if (token != _version || !_completed || _error is not null)
+            {
+                ThrowForFailedGetResult(token);
+            }
+
+            return _result!;
+        }
+
+        [StackTraceHidden]
+        private void ThrowForFailedGetResult(short token)
+        {
+            if (token != _version || !_completed)
             {
                 ThrowHelper.ThrowInvalidOperationException();
             }
 
             _error?.Throw();
-            return _result!;
+            Debug.Fail("Should not get here");
         }
 
         /// <summary>Schedules the continuation action for this operation.</summary>


### PR DESCRIPTION
The current scheme caches one instance per thread in a ThreadStatic, and then has a locked stack that all threads contend on; then to avoid blocking a thread while accessing the cache, locking is done with TryEnter rather than Enter, simply skipping the cache if there is any contention.  The locked stack is capped by default at ProcessorCount*4 objects.

The new scheme is simpler: one instance per thread, one instance per core.  This ends up meaning fewer objects may be cached, but it also almost entirely eliminates contention between threads trying to rent/return objects.  As a result, under heavy load it can actually do a better job of using pooled objects as it doesn't bail on using the cache in the face of contention.  It also reduces concerns about larger machines being more negatively impacted by the caching.  Under lighter load, since we don't cache as many objects, it does mean we may end up allocating a bit more, but generally not much more (and the size of the object we do allocate is a reference-field smaller).

This is on my 12-logical core box:

|     Method |         Toolchain |    Mean |    Error |   StdDev | Ratio |        Gen 0 |       Gen 1 |     Allocated |
|----------- |------------------ |--------:|---------:|---------:|------:|-------------:|------------:|--------------:|
| NonPooling | \main\CoreRun.exe | 4.314 s | 0.0795 s | 0.1005 s |  1.00 | 1933000.0000 | 483000.0000 | 11,800,056 KB |
| NonPooling |   \pr\corerun.exe | 4.284 s | 0.0188 s | 0.0167 s |  0.99 | 1933000.0000 | 483000.0000 | 11,800,063 KB |
|            |                   |         |          |          |       |              |             |               |
|    Pooling | \main\CoreRun.exe | 3.010 s | 0.0452 s | 0.0423 s |  1.00 |            - |           - |        323 KB |
|    Pooling |   \pr\corerun.exe | 2.874 s | 0.0452 s | 0.0423 s |  0.95 |            - |           - |        203 KB |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using BenchmarkDotNet.Diagnosers;
using System.Runtime.CompilerServices;

[MemoryDiagnoser]
public class Program
{
    public static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

    private const int Concurrency = 256;
    private const int Iters = 100_000;

    [Benchmark]
    public Task NonPooling()
    {
        return Task.WhenAll(from i in Enumerable.Range(0, Concurrency)
                            select Task.Run(async delegate
                            {
                                for (int i = 0; i < Iters; i++)
                                    await A().ConfigureAwait(false);
                            }));

        static async ValueTask A() => await B().ConfigureAwait(false);

        static async ValueTask B() => await C().ConfigureAwait(false);

        static async ValueTask C() => await D().ConfigureAwait(false);

        static async ValueTask D() => await Task.Yield();
    }

    [Benchmark]
    public Task Pooling()
    {
        return Task.WhenAll(from i in Enumerable.Range(0, Concurrency)
                            select Task.Run(async delegate
                            {
                                for (int i = 0; i < Iters; i++)
                                    await A().ConfigureAwait(false);
                            }));

        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
        static async ValueTask A() => await B().ConfigureAwait(false);

        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
        static async ValueTask B() => await C().ConfigureAwait(false);

        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
        static async ValueTask C() => await D().ConfigureAwait(false);

        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
        static async ValueTask D() => await Task.Yield();
    }
}
```