### PR TITLE
Display class names and string literals in asm

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -1155,7 +1155,7 @@ protected:
     void genConsumeHWIntrinsicOperands(GenTreeHWIntrinsic* tree);
 #endif // FEATURE_HW_INTRINSICS
     void genEmitGSCookieCheck(bool pushReg);
-    void genSetRegToIcon(regNumber reg, ssize_t val, var_types type = TYP_INT, insFlags flags = INS_FLAGS_DONT_CARE);
+    void genSetRegToIcon(regNumber reg, ssize_t val, var_types type = TYP_INT, insFlags flags = INS_FLAGS_DONT_CARE DEBUGARG(unsigned gtFlags = 0));
     void genCodeForShift(GenTree* tree);
 
 #if defined(TARGET_X86) || defined(TARGET_ARM)

--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -1158,7 +1158,7 @@ protected:
     void genSetRegToIcon(regNumber reg,
                          ssize_t   val,
                          var_types type = TYP_INT,
-                         insFlags flags = INS_FLAGS_DONT_CARE DEBUGARG(unsigned gtFlags = 0));
+                         insFlags flags = INS_FLAGS_DONT_CARE DEBUGARG(GenTreeFlags gtFlags = GTF_EMPTY));
     void genCodeForShift(GenTree* tree);
 
 #if defined(TARGET_X86) || defined(TARGET_ARM)
@@ -1493,7 +1493,7 @@ public:
                                 regNumber reg,
                                 ssize_t   imm,
                                 insFlags flags = INS_FLAGS_DONT_CARE DEBUGARG(size_t targetHandle = 0)
-                                    DEBUGARG(unsigned gtFlags = 0));
+                                    DEBUGARG(GenTreeFlags gtFlags = GTF_EMPTY));
 
     void instGen_Compare_Reg_To_Zero(emitAttr size, regNumber reg);
 

--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -1155,7 +1155,10 @@ protected:
     void genConsumeHWIntrinsicOperands(GenTreeHWIntrinsic* tree);
 #endif // FEATURE_HW_INTRINSICS
     void genEmitGSCookieCheck(bool pushReg);
-    void genSetRegToIcon(regNumber reg, ssize_t val, var_types type = TYP_INT, insFlags flags = INS_FLAGS_DONT_CARE DEBUGARG(unsigned gtFlags = 0));
+    void genSetRegToIcon(regNumber reg,
+                         ssize_t   val,
+                         var_types type = TYP_INT,
+                         insFlags flags = INS_FLAGS_DONT_CARE DEBUGARG(unsigned gtFlags = 0));
     void genCodeForShift(GenTree* tree);
 
 #if defined(TARGET_X86) || defined(TARGET_ARM)

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -159,7 +159,7 @@ void CodeGen::genEHCatchRet(BasicBlock* block)
 void CodeGen::instGen_Set_Reg_To_Imm(emitAttr  size,
                                      regNumber reg,
                                      ssize_t   imm,
-                                     insFlags flags DEBUGARG(size_t targetHandle) DEBUGARG(unsigned gtFlags))
+                                     insFlags flags DEBUGARG(size_t targetHandle) DEBUGARG(GenTreeFlags gtFlags))
 {
     // reg cannot be a FP register
     assert(!genIsValidFloatReg(reg));

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -1594,7 +1594,7 @@ void CodeGen::genEHCatchRet(BasicBlock* block)
 void CodeGen::instGen_Set_Reg_To_Imm(emitAttr  size,
                                      regNumber reg,
                                      ssize_t   imm,
-                                     insFlags flags DEBUGARG(size_t targetHandle) DEBUGARG(unsigned gtFlags))
+                                     insFlags flags DEBUGARG(size_t targetHandle) DEBUGARG(GenTreeFlags gtFlags))
 {
     // reg cannot be a FP register
     assert(!genIsValidFloatReg(reg));

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -560,7 +560,7 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
 //------------------------------------------------------------------------
 // genSetRegToIcon: Generate code that will set the given register to the integer constant.
 //
-void CodeGen::genSetRegToIcon(regNumber reg, ssize_t val, var_types type, insFlags flags DEBUGARG(unsigned gtFlags))
+void CodeGen::genSetRegToIcon(regNumber reg, ssize_t val, var_types type, insFlags flags DEBUGARG(GenTreeFlags gtFlags))
 {
     // Reg cannot be a FP reg
     assert(!genIsValidFloatReg(reg));
@@ -603,7 +603,7 @@ void CodeGen::genSetGSSecurityCookie(regNumber initReg, bool* pInitRegZeroed)
     else
     {
         instGen_Set_Reg_To_Imm(EA_PTR_DSP_RELOC, initReg, (ssize_t)compiler->gsGlobalSecurityCookieAddr,
-                               INS_FLAGS_DONT_CARE DEBUGARG((size_t)THT_SetGSCookie) DEBUGARG(0));
+                               INS_FLAGS_DONT_CARE DEBUGARG((size_t)THT_SetGSCookie) DEBUGARG(GTF_EMPTY));
         GetEmitter()->emitIns_R_R_I(INS_ldr, EA_PTRSIZE, initReg, initReg, 0);
         regSet.verifyRegUsed(initReg);
         GetEmitter()->emitIns_S_R(INS_str, EA_PTRSIZE, initReg, compiler->lvaGSSecurityCookie, 0);

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -560,7 +560,7 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
 //------------------------------------------------------------------------
 // genSetRegToIcon: Generate code that will set the given register to the integer constant.
 //
-void CodeGen::genSetRegToIcon(regNumber reg, ssize_t val, var_types type, insFlags flags)
+void CodeGen::genSetRegToIcon(regNumber reg, ssize_t val, var_types type, insFlags flags DEBUGARG(unsigned gtFlags))
 {
     // Reg cannot be a FP reg
     assert(!genIsValidFloatReg(reg));

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1799,7 +1799,7 @@ void CodeGen::genEmitGSCookieCheck(bool pushReg)
     {
         // Ngen case - GS cookie constant needs to be accessed through an indirection.
         instGen_Set_Reg_To_Imm(EA_HANDLE_CNS_RELOC, regGSConst, (ssize_t)compiler->gsGlobalSecurityCookieAddr,
-                               INS_FLAGS_DONT_CARE DEBUGARG((size_t)THT_GSCookieCheck) DEBUGARG(0));
+                               INS_FLAGS_DONT_CARE DEBUGARG((size_t)THT_GSCookieCheck) DEBUGARG(GTF_EMPTY));
         GetEmitter()->emitIns_R_R_I(INS_ldr, EA_PTRSIZE, regGSConst, regGSConst, 0);
     }
     // Load this method's GS value from the stack frame

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -28,7 +28,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
  *  Generate code that will set the given register to the integer constant.
  */
 
-void CodeGen::genSetRegToIcon(regNumber reg, ssize_t val, var_types type, insFlags flags DEBUGARG(unsigned gtFlags))
+void CodeGen::genSetRegToIcon(regNumber reg, ssize_t val, var_types type, insFlags flags DEBUGARG(GenTreeFlags gtFlags))
 {
     // Reg cannot be a FP reg
     assert(!genIsValidFloatReg(reg));
@@ -440,7 +440,7 @@ void CodeGen::genEHFinallyOrFilterRet(BasicBlock* block)
 void CodeGen::instGen_Set_Reg_To_Imm(emitAttr  size,
                                      regNumber reg,
                                      ssize_t   imm,
-                                     insFlags flags DEBUGARG(size_t targetHandle) DEBUGARG(unsigned gtFlags))
+                                     insFlags flags DEBUGARG(size_t targetHandle) DEBUGARG(GenTreeFlags gtFlags))
 {
     // reg cannot be a FP register
     assert(!genIsValidFloatReg(reg));

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -28,7 +28,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
  *  Generate code that will set the given register to the integer constant.
  */
 
-void CodeGen::genSetRegToIcon(regNumber reg, ssize_t val, var_types type, insFlags flags)
+void CodeGen::genSetRegToIcon(regNumber reg, ssize_t val, var_types type, insFlags flags DEBUGARG(unsigned gtFlags))
 {
     // Reg cannot be a FP reg
     assert(!genIsValidFloatReg(reg));
@@ -45,7 +45,7 @@ void CodeGen::genSetRegToIcon(regNumber reg, ssize_t val, var_types type, insFla
     else
     {
         // TODO-XArch-CQ: needs all the optimized cases
-        GetEmitter()->emitIns_R_I(INS_mov, emitActualTypeSize(type), reg, val);
+        GetEmitter()->emitIns_R_I(INS_mov, emitActualTypeSize(type), reg, val, gtFlags);
     }
 }
 
@@ -505,7 +505,7 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
             }
             else
             {
-                genSetRegToIcon(targetReg, cnsVal, targetType);
+                genSetRegToIcon(targetReg, cnsVal, targetType, INS_FLAGS_DONT_CARE DEBUGARG(tree->gtFlags));
             }
         }
         break;

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -45,7 +45,7 @@ void CodeGen::genSetRegToIcon(regNumber reg, ssize_t val, var_types type, insFla
     else
     {
         // TODO-XArch-CQ: needs all the optimized cases
-        GetEmitter()->emitIns_R_I(INS_mov, emitActualTypeSize(type), reg, val, gtFlags);
+        GetEmitter()->emitIns_R_I(INS_mov, emitActualTypeSize(type), reg, val DEBUGARG(gtFlags));
     }
 }
 

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -3933,12 +3933,10 @@ void emitter::emitDispCommentForHandle(size_t handle, GenTreeFlags flag)
     if (flag == GTF_ICON_STR_HDL)
     {
         const WCHAR* wstr = emitComp->eeGetCPString(handle);
-        // Note that eGetCPString isn't currently implemented on Linux/ARM
-        // and instead always returns nullptr. However, use it here, so in
-        // future, once it is is implemented, no changes will be needed here.
+        // NOTE: eGetCPString always returns nullptr on Linux/ARM
         if (wstr == nullptr)
         {
-            wstr = L"string handle";
+            printf("%s string handle", commentPrefix);
         }
         else
         {
@@ -3946,14 +3944,15 @@ void emitter::emitDispCommentForHandle(size_t handle, GenTreeFlags flag)
             const size_t maxLength = 63;
             const size_t newLen    = min(maxLength, actualLen);
 
-            WCHAR buf[maxLength + 1 /*for null terminator*/] = {0};
+            // +1 for null terminator
+            const WCHAR buf[maxLength + 1] = {0};
             wcsncpy(buf, wstr, newLen);
             for (size_t i = 0; i < newLen; i++)
             {
                 // Escape \n and \r symbols
                 if (buf[i] == L'\n' || buf[i] == L'\r')
                 {
-                    buf[i] = ' ';
+                    buf[i] = L' ';
                 }
             }
             if (actualLen > maxLength)
@@ -3963,9 +3962,8 @@ void emitter::emitDispCommentForHandle(size_t handle, GenTreeFlags flag)
                 buf[maxLength - 2] = L'.';
                 buf[maxLength - 1] = L'.';
             }
-            wstr = buf;
+            printf("%s \"%S\"", commentPrefix, buf);
         }
-        printf("%s \"%S\"", commentPrefix, wstr);
     }
     else if (flag == GTF_ICON_CLASS_HDL)
     {

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -3972,7 +3972,7 @@ void emitter::emitDispCommentForHandle(size_t handle, GenTreeFlags flag)
 
 #ifndef TARGET_XARCH
     // These are less useful for xarch:
-    if (flag == GTF_ICON_CONST_PTR)
+    else if (flag == GTF_ICON_CONST_PTR)
     {
         str = "const ptr";
     }

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -3945,7 +3945,7 @@ void emitter::emitDispCommentForHandle(size_t handle, GenTreeFlags flag)
             const size_t newLen    = min(maxLength, actualLen);
 
             // +1 for null terminator
-            const WCHAR buf[maxLength + 1] = {0};
+            WCHAR buf[maxLength + 1] = {0};
             wcsncpy(buf, wstr, newLen);
             for (size_t i = 0; i < newLen; i++)
             {

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -3969,7 +3969,6 @@ void emitter::emitDispCommentForHandle(size_t handle, GenTreeFlags flag)
     {
         str = emitComp->eeGetClassName(reinterpret_cast<CORINFO_CLASS_HANDLE>(handle));
     }
-
 #ifndef TARGET_XARCH
     // These are less useful for xarch:
     else if (flag == GTF_ICON_CONST_PTR)
@@ -4000,11 +3999,15 @@ void emitter::emitDispCommentForHandle(size_t handle, GenTreeFlags flag)
     {
         str = "token handle";
     }
+    else
+    {
+        str = "unknown";
+    }
 #endif // TARGET_XARCH
 
     if (str != nullptr)
     {
-        printf("%s %.64s", commentPrefix, str);
+        printf("%s %s", commentPrefix, str);
     }
 #endif // DEBUG
 }

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -510,6 +510,8 @@ protected:
 
     void emitRecomputeIGoffsets();
 
+    void emitDispCommentForHandle(size_t handle, GenTreeFlags flags);
+
     /************************************************************************/
     /*          The following describes a single instruction                */
     /************************************************************************/
@@ -545,7 +547,7 @@ protected:
         size_t            idSize;        // size of the instruction descriptor
         unsigned          idVarRefOffs;  // IL offset for LclVar reference
         size_t            idMemCookie;   // for display of method name  (also used by switch table)
-        unsigned          idFlags;       // for determining type of handle in idMemCookie
+        GenTreeFlags      idFlags;       // for determining type of handle in idMemCookie
         bool              idFinallyCall; // Branch instruction is a call to finally
         bool              idCatchRet;    // Instruction is for a catch 'return'
         CORINFO_SIG_INFO* idCallSig;     // Used to report native call site signatures to the EE

--- a/src/coreclr/jit/emitarm.cpp
+++ b/src/coreclr/jit/emitarm.cpp
@@ -2009,7 +2009,7 @@ void emitter::emitIns_R_I(instruction    ins,
     id->idInsSize(isz);
     id->idInsFlags(sf);
     id->idReg1(reg);
-    id->idDebugOnlyInfo()->idFlags = gtFlags;
+    INDEBUG(id->idDebugOnlyInfo()->idFlags = gtFlags);
 
     dispIns(id);
     appendToCurIG(id);

--- a/src/coreclr/jit/emitarm.cpp
+++ b/src/coreclr/jit/emitarm.cpp
@@ -1705,7 +1705,7 @@ void emitter::emitIns_R_I(instruction    ins,
                           emitAttr       attr,
                           regNumber      reg,
                           target_ssize_t imm,
-                          insFlags flags /* = INS_FLAGS_DONT_CARE */ DEBUGARG(unsigned gtFlags))
+                          insFlags flags /* = INS_FLAGS_DONT_CARE */ DEBUGARG(GenTreeFlags gtFlags))
 
 {
     insFormat fmt = IF_NONE;

--- a/src/coreclr/jit/emitarm.cpp
+++ b/src/coreclr/jit/emitarm.cpp
@@ -1701,8 +1701,11 @@ void emitter::emitIns_R(instruction ins, emitAttr attr, regNumber reg)
  *  Add an instruction referencing a register and a constant.
  */
 
-void emitter::emitIns_R_I(
-    instruction ins, emitAttr attr, regNumber reg, target_ssize_t imm, insFlags flags /* = INS_FLAGS_DONT_CARE */ DEBUGARG(unsigned gtFlags))
+void emitter::emitIns_R_I(instruction    ins,
+                          emitAttr       attr,
+                          regNumber      reg,
+                          target_ssize_t imm,
+                          insFlags flags /* = INS_FLAGS_DONT_CARE */ DEBUGARG(unsigned gtFlags))
 
 {
     insFormat fmt = IF_NONE;

--- a/src/coreclr/jit/emitarm.cpp
+++ b/src/coreclr/jit/emitarm.cpp
@@ -1702,7 +1702,7 @@ void emitter::emitIns_R(instruction ins, emitAttr attr, regNumber reg)
  */
 
 void emitter::emitIns_R_I(
-    instruction ins, emitAttr attr, regNumber reg, target_ssize_t imm, insFlags flags /* = INS_FLAGS_DONT_CARE */)
+    instruction ins, emitAttr attr, regNumber reg, target_ssize_t imm, insFlags flags /* = INS_FLAGS_DONT_CARE */ DEBUGARG(unsigned gtFlags))
 
 {
     insFormat fmt = IF_NONE;
@@ -2006,6 +2006,7 @@ void emitter::emitIns_R_I(
     id->idInsSize(isz);
     id->idInsFlags(sf);
     id->idReg1(reg);
+    id->idDebugOnlyInfo()->idFlags = gtFlags;
 
     dispIns(id);
     appendToCurIG(id);

--- a/src/coreclr/jit/emitarm.h
+++ b/src/coreclr/jit/emitarm.h
@@ -220,8 +220,11 @@ void emitIns_I(instruction ins, emitAttr attr, target_ssize_t imm);
 
 void emitIns_R(instruction ins, emitAttr attr, regNumber reg);
 
-void emitIns_R_I(
-    instruction ins, emitAttr attr, regNumber reg, target_ssize_t imm, insFlags flags = INS_FLAGS_DONT_CARE DEBUGARG(unsigned gtFlags = 0));
+void emitIns_R_I(instruction    ins,
+                 emitAttr       attr,
+                 regNumber      reg,
+                 target_ssize_t imm,
+                 insFlags flags = INS_FLAGS_DONT_CARE DEBUGARG(unsigned gtFlags = 0));
 void emitIns_MovRelocatableImmediate(instruction ins, emitAttr attr, regNumber reg, BYTE* addr);
 
 void emitIns_Mov(instruction ins,

--- a/src/coreclr/jit/emitarm.h
+++ b/src/coreclr/jit/emitarm.h
@@ -221,7 +221,7 @@ void emitIns_I(instruction ins, emitAttr attr, target_ssize_t imm);
 void emitIns_R(instruction ins, emitAttr attr, regNumber reg);
 
 void emitIns_R_I(
-    instruction ins, emitAttr attr, regNumber reg, target_ssize_t imm, insFlags flags = INS_FLAGS_DONT_CARE);
+    instruction ins, emitAttr attr, regNumber reg, target_ssize_t imm, insFlags flags = INS_FLAGS_DONT_CARE DEBUGARG(unsigned gtFlags = 0));
 void emitIns_MovRelocatableImmediate(instruction ins, emitAttr attr, regNumber reg, BYTE* addr);
 
 void emitIns_Mov(instruction ins,

--- a/src/coreclr/jit/emitarm.h
+++ b/src/coreclr/jit/emitarm.h
@@ -224,7 +224,7 @@ void emitIns_R_I(instruction    ins,
                  emitAttr       attr,
                  regNumber      reg,
                  target_ssize_t imm,
-                 insFlags flags = INS_FLAGS_DONT_CARE DEBUGARG(unsigned gtFlags = 0));
+                 insFlags flags = INS_FLAGS_DONT_CARE DEBUGARG(GenTreeFlags gtFlags = GTF_EMPTY));
 void emitIns_MovRelocatableImmediate(instruction ins, emitAttr attr, regNumber reg, BYTE* addr);
 
 void emitIns_Mov(instruction ins,

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -3715,7 +3715,11 @@ void emitter::emitIns_R(instruction ins, emitAttr attr, regNumber reg)
  *  Add an instruction referencing a register and a constant.
  */
 
-void emitter::emitIns_R_I(instruction ins, emitAttr attr, regNumber reg, ssize_t imm, insOpts opt /* = INS_OPTS_NONE */ DEBUGARG(unsigned gtFlags))
+void emitter::emitIns_R_I(instruction ins,
+                          emitAttr    attr,
+                          regNumber   reg,
+                          ssize_t     imm,
+                          insOpts opt /* = INS_OPTS_NONE */ DEBUGARG(unsigned gtFlags))
 {
     emitAttr  size      = EA_SIZE(attr);
     emitAttr  elemsize  = EA_UNKNOWN;

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -3719,7 +3719,7 @@ void emitter::emitIns_R_I(instruction ins,
                           emitAttr    attr,
                           regNumber   reg,
                           ssize_t     imm,
-                          insOpts opt /* = INS_OPTS_NONE */ DEBUGARG(unsigned gtFlags))
+                          insOpts opt /* = INS_OPTS_NONE */ DEBUGARG(GenTreeFlags gtFlags))
 {
     emitAttr  size      = EA_SIZE(attr);
     emitAttr  elemsize  = EA_UNKNOWN;
@@ -8103,7 +8103,7 @@ void emitter::emitIns_R_AR(instruction ins, emitAttr attr, regNumber ireg, regNu
 void emitter::emitIns_R_AI(instruction ins,
                            emitAttr    attr,
                            regNumber   ireg,
-                           ssize_t addr DEBUGARG(size_t targetHandle) DEBUGARG(unsigned gtFlags))
+                           ssize_t addr DEBUGARG(size_t targetHandle) DEBUGARG(GenTreeFlags gtFlags))
 {
     assert(EA_IS_RELOC(attr));
     emitAttr      size    = EA_SIZE(attr);
@@ -12262,7 +12262,6 @@ void emitter::emitDispIns(
         ssize_t      index2;
         unsigned     registerListSize;
         const char*  targetName;
-        const WCHAR* stringLiteral;
 
         case IF_BI_0A: // BI_0A   ......iiiiiiiiii iiiiiiiiiiiiiiii               simm26:00
         case IF_BI_0B: // BI_0B   ......iiiiiiiiii iiiiiiiiiii.....               simm19:00
@@ -12368,9 +12367,8 @@ void emitter::emitDispIns(
         case IF_LARGEADR:
             assert(insOptsNone(id->idInsOpt()));
             emitDispReg(id->idReg1(), size, true);
-            imm           = emitGetInsSC(id);
-            targetName    = nullptr;
-            stringLiteral = nullptr;
+            imm        = emitGetInsSC(id);
+            targetName = nullptr;
 
             /* Is this actually a reference to a data section? */
             if (fmt == IF_LARGEADR)
@@ -12403,8 +12401,7 @@ void emitter::emitDispIns(
                 {
                     printf("HIGH RELOC ");
                     emitDispImm((ssize_t)id->idAddr()->iiaAddr, false);
-                    size_t   targetHandle = id->idDebugOnlyInfo()->idMemCookie;
-                    unsigned idFlags      = id->idDebugOnlyInfo()->idFlags & GTF_ICON_HDL_MASK;
+                    size_t targetHandle = id->idDebugOnlyInfo()->idMemCookie;
 
                     if (targetHandle == THT_IntializeArrayIntrinsics)
                     {
@@ -12417,53 +12414,6 @@ void emitter::emitDispIns(
                     else if (targetHandle == THT_SetGSCookie)
                     {
                         targetName = "SetGlobalSecurityCookie";
-                    }
-                    else if (idFlags == GTF_ICON_CONST_PTR)
-                    {
-                        targetName = "const ptr";
-                    }
-                    else if (idFlags == GTF_ICON_GLOBAL_PTR)
-                    {
-                        targetName = "global ptr";
-                    }
-                    else if (idFlags == GTF_ICON_STR_HDL)
-                    {
-                        stringLiteral = emitComp->eeGetCPString(targetHandle);
-                        // Note that eGetCPString isn't currently implemented on Linux/ARM
-                        // and instead always returns nullptr. However, use it here, so in
-                        // future, once it is is implemented, no changes will be needed here.
-                        if (stringLiteral == nullptr)
-                        {
-                            targetName = "String handle";
-                        }
-                    }
-                    else if (idFlags == GTF_ICON_FIELD_HDL)
-                    {
-                        targetName = emitComp->eeGetFieldName((CORINFO_FIELD_HANDLE)targetHandle);
-                    }
-                    else if (idFlags == GTF_ICON_STATIC_HDL)
-                    {
-                        targetName = "Static handle";
-                    }
-                    else if (idFlags == GTF_ICON_METHOD_HDL)
-                    {
-                        targetName = emitComp->eeGetMethodFullName((CORINFO_METHOD_HANDLE)targetHandle);
-                    }
-                    else if (idFlags == GTF_ICON_FTN_ADDR)
-                    {
-                        targetName = "Function address";
-                    }
-                    else if (idFlags == GTF_ICON_CLASS_HDL)
-                    {
-                        targetName = emitComp->eeGetClassName((CORINFO_CLASS_HANDLE)targetHandle);
-                    }
-                    else if (idFlags == GTF_ICON_TOKEN_HDL)
-                    {
-                        targetName = "Token handle";
-                    }
-                    else
-                    {
-                        targetName = "Unknown";
                     }
                 }
                 else if (id->idIsBound())
@@ -12480,9 +12430,9 @@ void emitter::emitDispIns(
             {
                 printf("      // [%s]", targetName);
             }
-            else if (stringLiteral != nullptr)
+            else
             {
-                printf("      // [%S]", stringLiteral);
+                emitDispCommentForHandle(id->idDebugOnlyInfo()->idMemCookie, id->idDebugOnlyInfo()->idFlags);
             }
             break;
 

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -3969,7 +3969,7 @@ void emitter::emitIns_R_I(instruction ins,
     id->idInsOpt(opt);
 
     id->idReg1(reg);
-    id->idDebugOnlyInfo()->idFlags = gtFlags;
+    INDEBUG(id->idDebugOnlyInfo()->idFlags = gtFlags);
 
     dispIns(id);
     appendToCurIG(id);

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -3715,7 +3715,7 @@ void emitter::emitIns_R(instruction ins, emitAttr attr, regNumber reg)
  *  Add an instruction referencing a register and a constant.
  */
 
-void emitter::emitIns_R_I(instruction ins, emitAttr attr, regNumber reg, ssize_t imm, insOpts opt /* = INS_OPTS_NONE */)
+void emitter::emitIns_R_I(instruction ins, emitAttr attr, regNumber reg, ssize_t imm, insOpts opt /* = INS_OPTS_NONE */ DEBUGARG(unsigned gtFlags))
 {
     emitAttr  size      = EA_SIZE(attr);
     emitAttr  elemsize  = EA_UNKNOWN;
@@ -3965,6 +3965,7 @@ void emitter::emitIns_R_I(instruction ins, emitAttr attr, regNumber reg, ssize_t
     id->idInsOpt(opt);
 
     id->idReg1(reg);
+    id->idDebugOnlyInfo()->idFlags = gtFlags;
 
     dispIns(id);
     appendToCurIG(id);

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -728,7 +728,7 @@ void emitIns_I(instruction ins, emitAttr attr, ssize_t imm);
 
 void emitIns_R(instruction ins, emitAttr attr, regNumber reg);
 
-void emitIns_R_I(instruction ins, emitAttr attr, regNumber reg, ssize_t imm, insOpts opt = INS_OPTS_NONE);
+void emitIns_R_I(instruction ins, emitAttr attr, regNumber reg, ssize_t imm, insOpts opt = INS_OPTS_NONE DEBUGARG(unsigned gtFlags = 0));
 
 void emitIns_R_F(instruction ins, emitAttr attr, regNumber reg, double immDbl, insOpts opt = INS_OPTS_NONE);
 

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -728,7 +728,11 @@ void emitIns_I(instruction ins, emitAttr attr, ssize_t imm);
 
 void emitIns_R(instruction ins, emitAttr attr, regNumber reg);
 
-void emitIns_R_I(instruction ins, emitAttr attr, regNumber reg, ssize_t imm, insOpts opt = INS_OPTS_NONE DEBUGARG(unsigned gtFlags = 0));
+void emitIns_R_I(instruction ins,
+                 emitAttr    attr,
+                 regNumber   reg,
+                 ssize_t     imm,
+                 insOpts opt = INS_OPTS_NONE DEBUGARG(unsigned gtFlags = 0));
 
 void emitIns_R_F(instruction ins, emitAttr attr, regNumber reg, double immDbl, insOpts opt = INS_OPTS_NONE);
 

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -732,7 +732,7 @@ void emitIns_R_I(instruction ins,
                  emitAttr    attr,
                  regNumber   reg,
                  ssize_t     imm,
-                 insOpts opt = INS_OPTS_NONE DEBUGARG(unsigned gtFlags = 0));
+                 insOpts opt = INS_OPTS_NONE DEBUGARG(GenTreeFlags gtFlags = GTF_EMPTY));
 
 void emitIns_R_F(instruction ins, emitAttr attr, regNumber reg, double immDbl, insOpts opt = INS_OPTS_NONE);
 
@@ -831,7 +831,7 @@ void emitIns_R_AR(instruction ins, emitAttr attr, regNumber ireg, regNumber reg,
 void emitIns_R_AI(instruction ins,
                   emitAttr    attr,
                   regNumber   ireg,
-                  ssize_t disp DEBUGARG(size_t targetHandle = 0) DEBUGARG(unsigned gtFlags = 0));
+                  ssize_t disp DEBUGARG(size_t targetHandle = 0) DEBUGARG(GenTreeFlags gtFlags = GTF_EMPTY));
 
 void emitIns_AR_R(instruction ins, emitAttr attr, regNumber ireg, regNumber reg, int offs);
 

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -4090,7 +4090,7 @@ void emitter::emitIns_R_I(instruction ins, emitAttr attr, regNumber reg, ssize_t
     id->idInsFmt(fmt);
     id->idReg1(reg);
     id->idCodeSize(sz);
-    id->idDebugOnlyInfo()->idFlags = gtFlags;
+    INDEBUG(id->idDebugOnlyInfo()->idFlags = gtFlags);
 
     dispIns(id);
     emitCurIGsize += sz;

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -3965,7 +3965,7 @@ void emitter::emitIns_R(instruction ins, emitAttr attr, regNumber reg)
  *  Add an instruction referencing a register and a constant.
  */
 
-void emitter::emitIns_R_I(instruction ins, emitAttr attr, regNumber reg, ssize_t val DEBUGARG(unsigned gtFlags))
+void emitter::emitIns_R_I(instruction ins, emitAttr attr, regNumber reg, ssize_t val DEBUGARG(GenTreeFlags gtFlags))
 {
     emitAttr size = EA_SIZE(attr);
 
@@ -8873,41 +8873,7 @@ void emitter::emitDispIns(
                     printf("-0x%IX", -val);
                 }
 
-                unsigned iconType = id->idDebugOnlyInfo()->idFlags & GTF_ICON_HDL_MASK;
-                if ((val != 0) && id->idIsLargeCns())
-                {
-                    if (iconType == GTF_ICON_CLASS_HDL)
-                    {
-                        printf(" ; %.32s", emitComp->eeGetClassName(reinterpret_cast<CORINFO_CLASS_HANDLE>(val)));
-                    }
-                    else if (iconType == GTF_ICON_STR_HDL)
-                    {
-                        const WCHAR* str = emitComp->eeGetCPString(static_cast<size_t>(val));
-                        if (str != nullptr)
-                        {
-                            size_t    len            = wcslen(str);
-                            const int maxLength      = 32;
-                            WCHAR     buf[maxLength] = {0};
-                            wcsncpy(buf, str, min(maxLength, len));
-                            for (size_t i = 0; i < min(maxLength, len); i++)
-                            {
-                                // Escape \n and \r symbols
-                                if (buf[i] == L'\n' || buf[i] == L'\r')
-                                {
-                                    buf[i] = ' ';
-                                }
-                            }
-                            if (len > maxLength)
-                            {
-                                // Append "..." for long strings
-                                buf[maxLength - 3] = L'.';
-                                buf[maxLength - 2] = L'.';
-                                buf[maxLength - 1] = L'.';
-                            }
-                            printf(" ; \"%.32ls\"", buf);
-                        }
-                    }
-                }
+                emitDispCommentForHandle(val, id->idDebugOnlyInfo()->idFlags & GTF_ICON_HDL_MASK);
             }
             break;
 

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -3965,7 +3965,7 @@ void emitter::emitIns_R(instruction ins, emitAttr attr, regNumber reg)
  *  Add an instruction referencing a register and a constant.
  */
 
-void emitter::emitIns_R_I(instruction ins, emitAttr attr, regNumber reg, ssize_t val)
+void emitter::emitIns_R_I(instruction ins, emitAttr attr, regNumber reg, ssize_t val DEBUGARG(unsigned gtFlags))
 {
     emitAttr size = EA_SIZE(attr);
 
@@ -4089,8 +4089,8 @@ void emitter::emitIns_R_I(instruction ins, emitAttr attr, regNumber reg, ssize_t
     id->idIns(ins);
     id->idInsFmt(fmt);
     id->idReg1(reg);
-
     id->idCodeSize(sz);
+    id->idDebugOnlyInfo()->idFlags = gtFlags;
 
     dispIns(id);
     emitCurIGsize += sz;
@@ -8871,6 +8871,19 @@ void emitter::emitDispIns(
                 else
                 { // (val < 0)
                     printf("-0x%IX", -val);
+                }
+
+                unsigned iconType = id->idDebugOnlyInfo()->idFlags & GTF_ICON_HDL_MASK;
+                if ((val != 0) && id->idIsLargeCns())
+                {
+                    if (iconType == GTF_ICON_CLASS_HDL)
+                    {
+                        printf(" ; \"%.32s\"", emitComp->eeGetClassName((CORINFO_CLASS_HANDLE)val));
+                    }
+                    else if (iconType == GTF_ICON_STR_HDL)
+                    {
+                        printf(" ; %.32ls", emitComp->eeGetCPString((size_t)val));
+                    }
                 }
             }
             break;

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -8878,11 +8878,34 @@ void emitter::emitDispIns(
                 {
                     if (iconType == GTF_ICON_CLASS_HDL)
                     {
-                        printf(" ; %.32s", emitComp->eeGetClassName((CORINFO_CLASS_HANDLE)val));
+                        printf(" ; %.32s", emitComp->eeGetClassName(reinterpret_cast<CORINFO_CLASS_HANDLE>(val)));
                     }
                     else if (iconType == GTF_ICON_STR_HDL)
                     {
-                        printf(" ; \"%.32ls\"", emitComp->eeGetCPString((size_t)val));
+                        const WCHAR* str = emitComp->eeGetCPString(static_cast<size_t>(val));
+                        if (str != nullptr)
+                        {
+                            size_t    len            = wcslen(str);
+                            const int maxLength      = 32;
+                            WCHAR     buf[maxLength] = {0};
+                            wcsncpy(buf, str, min(maxLength, len));
+                            for (size_t i = 0; i < min(maxLength, len); i++)
+                            {
+                                // Escape \n and \r symbols
+                                if (buf[i] == L'\n' || buf[i] == L'\r')
+                                {
+                                    buf[i] = ' ';
+                                }
+                            }
+                            if (len > maxLength)
+                            {
+                                // Append "..." for long strings
+                                buf[maxLength - 3] = L'.';
+                                buf[maxLength - 2] = L'.';
+                                buf[maxLength - 1] = L'.';
+                            }
+                            printf(" ; \"%.32ls\"", buf);
+                        }
                     }
                 }
             }

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -8878,11 +8878,11 @@ void emitter::emitDispIns(
                 {
                     if (iconType == GTF_ICON_CLASS_HDL)
                     {
-                        printf(" ; \"%.32s\"", emitComp->eeGetClassName((CORINFO_CLASS_HANDLE)val));
+                        printf(" ; %.32s", emitComp->eeGetClassName((CORINFO_CLASS_HANDLE)val));
                     }
                     else if (iconType == GTF_ICON_STR_HDL)
                     {
-                        printf(" ; %.32ls", emitComp->eeGetCPString((size_t)val));
+                        printf(" ; \"%.32ls\"", emitComp->eeGetCPString((size_t)val));
                     }
                 }
             }

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -327,7 +327,7 @@ void emitIns_R(instruction ins, emitAttr attr, regNumber reg);
 
 void emitIns_C(instruction ins, emitAttr attr, CORINFO_FIELD_HANDLE fdlHnd, int offs);
 
-void emitIns_R_I(instruction ins, emitAttr attr, regNumber reg, ssize_t val);
+void emitIns_R_I(instruction ins, emitAttr attr, regNumber reg, ssize_t val DEBUGARG(unsigned gtFlags = 0));
 
 void emitIns_Mov(instruction ins, emitAttr attr, regNumber dstReg, regNumber srgReg, bool canSkip);
 

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -327,7 +327,7 @@ void emitIns_R(instruction ins, emitAttr attr, regNumber reg);
 
 void emitIns_C(instruction ins, emitAttr attr, CORINFO_FIELD_HANDLE fdlHnd, int offs);
 
-void emitIns_R_I(instruction ins, emitAttr attr, regNumber reg, ssize_t val DEBUGARG(unsigned gtFlags = 0));
+void emitIns_R_I(instruction ins, emitAttr attr, regNumber reg, ssize_t val DEBUGARG(GenTreeFlags gtFlags = GTF_EMPTY));
 
 void emitIns_Mov(instruction ins, emitAttr attr, regNumber dstReg, regNumber srgReg, bool canSkip);
 


### PR DESCRIPTION
Just a little change to display class names and string literals in the asm, e.g.:

![image](https://user-images.githubusercontent.com/523221/126232093-e937f702-af5e-4028-a83c-dfb02d2e144b.png)
xarch for now (slightly more verbose changes to enable it for arm)

GDV emits class handles a lot so it's quite useful to be able to see actual types in asm without DUMPs.