### PR TITLE
reenable ConnectTimeout_PlaintextStreamFilterTimesOut_Throws test

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Cancellation.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Cancellation.cs
@@ -88,7 +88,6 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
-            var releaseServer = new TaskCompletionSource();
             await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
             {
                 using (var handler = CreateHttpClientHandler())
@@ -100,8 +99,6 @@ namespace System.Net.Http.Functional.Tests
                     socketsHandler.PlaintextStreamFilter = async (context, token) => { await Task.Delay(-1, token); return null; };
 
                     await ValidateConnectTimeout(invoker, uri, 500, 85_000);
-
-                    releaseServer.SetResult();
                 }
             }, server => Task.CompletedTask, // doesn't actually connect to server
             options: new GenericLoopbackOptions() { UseSsl = false });

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Cancellation.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Cancellation.cs
@@ -79,11 +79,8 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [OuterLoop]
-        [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55931")]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task ConnectTimeout_PlaintextStreamFilterTimesOut_Throws(bool useSsl)
+        [Fact]
+        public async Task ConnectTimeout_PlaintextStreamFilterTimesOut_Throws()
         {
             if (UseVersion == HttpVersion.Version30)
             {
@@ -100,24 +97,15 @@ namespace System.Net.Http.Functional.Tests
                     handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
                     var socketsHandler = GetUnderlyingSocketsHttpHandler(handler);
                     socketsHandler.ConnectTimeout = TimeSpan.FromSeconds(1);
+                    socketsHandler.ConnectCallback = (context, token) => new ValueTask<Stream>(new MemoryStream());
                     socketsHandler.PlaintextStreamFilter = async (context, token) => { await Task.Delay(-1, token); return null; };
 
                     await ValidateConnectTimeout(invoker, uri, 500, 85_000);
 
                     releaseServer.SetResult();
                 }
-            },
-            async server =>
-            {
-                try
-                {
-                    await server.AcceptConnectionAsync(async c =>
-                    {
-                        await releaseServer.Task;
-                    });
-                }
-                catch (Exception) { } // Eat exception from client timing out
-            }, options: new GenericLoopbackOptions() { UseSsl = useSsl });
+            }, server => Task.CompletedTask, // doesn't actually connect to server
+            options: new GenericLoopbackOptions() { UseSsl = false });
         }
 
         [OuterLoop("Incurs significant delay")]

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Cancellation.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Cancellation.cs
@@ -94,7 +94,6 @@ namespace System.Net.Http.Functional.Tests
                 using (var handler = CreateHttpClientHandler())
                 using (var invoker = new HttpMessageInvoker(handler))
                 {
-                    handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
                     var socketsHandler = GetUnderlyingSocketsHttpHandler(handler);
                     socketsHandler.ConnectTimeout = TimeSpan.FromSeconds(1);
                     socketsHandler.ConnectCallback = (context, token) => new ValueTask<Stream>(new MemoryStream());


### PR DESCRIPTION
I believe the flakiness is caused because in very slow environments (like certain CI machines), the cancellation token may fire before the server accepts the connection, which will cause the server logic to hang.

Fix this by using ConnectCallback to avoid creating a real connection at all.

Fixes #55931