### PR TITLE
mitigation for quic tests hangs

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -647,7 +647,9 @@ namespace System.Net.Quic.Implementations.MsQuic
             byte[] rentedBuffer = ArrayPool<byte>.Shared.Rent(buffer.Length);
             try
             {
-                int readLength = ReadAsync(new Memory<byte>(rentedBuffer, 0, buffer.Length)).AsTask().GetAwaiter().GetResult();
+                Task<int> t = ReadAsync(new Memory<byte>(rentedBuffer, 0, buffer.Length)).AsTask();
+                ((IAsyncResult)t).AsyncWaitHandle.WaitOne();
+                int readLength = t.GetAwaiter().GetResult();
                 rentedBuffer.AsSpan(0, readLength).CopyTo(buffer);
                 return readLength;
             }
@@ -662,7 +664,9 @@ namespace System.Net.Quic.Implementations.MsQuic
             ThrowIfDisposed();
 
             // TODO: optimize this.
-            WriteAsync(buffer.ToArray()).AsTask().GetAwaiter().GetResult();
+            Task t = WriteAsync(buffer.ToArray()).AsTask();
+            ((IAsyncResult)t).AsyncWaitHandle.WaitOne();
+            t.GetAwaiter().GetResult();
         }
 
         // MsQuic doesn't support explicit flushing


### PR DESCRIPTION
It seems like the hang is when we run synchronous conformance tests. 
We receive notification, we reset the completion source but the WriteAsync task would never wake up and be finished. 
```
> threadpool -wi
logStart: 191
logSize: 200
CPU utilization: 0 %
Worker Thread: Total: 2 Running: 2 Idle: 0 MaxLimit: 32767 MinLimit: 2
Work Request in Queue: 0

Queued work items:
Queue Address Work Item
[Global] 00007f4468a32b20 System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[[System.Threading.Tasks.VoidTaskResult, System.Private.CoreLib],[System.Net.Quic.Implementations.MsQuic.MsQuicStream+<WriteAsync>d__21, System.Net.Quic]]
[Global] 00007f4468a352e8 System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[[System.Threading.Tasks.VoidTaskResult, System.Private.CoreLib],[System.Net.Quic.Implementations.MsQuic.MsQuicStream+<WriteAsync>d__21, System.Net.Quic]]
[Global] 00007f44688ab968 System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[[System.Threading.Tasks.VoidTaskResult, System.Private.CoreLib],[System.Net.Quic.Tests.QuicStreamTests`1+<>c__DisplayClass14_0+<<ReadWrite_Random_Success>b__1>d[[System.Net.Quic.Tests.MsQuicProviderFactory, System.Net.Quic.Functional.Tests]], System.Net.Quic.Functional.Tests]]
[Global] 00007f44689e8d68 System.Threading.QueueUserWorkItemCallbackDefaultContext`1[[System.Object, System.Private.CoreLib]] => System.Threading.Tasks.ValueTask`1+ValueTaskSourceAsTask+<>c[[System.Int32, System.Private.CoreLib]].<.cctor>b__4_0(System.Object)
Statistics:
MT Count TotalSize Class Name
00007f4497eb4a00 1 32 System.Threading.QueueUserWorkItemCallbackDefaultContext`1[[System.Object, System.Private.CoreLib]]
00007f4497f4c580 1 96 System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[[System.Threading.Tasks.VoidTaskResult, System.Private.CoreLib],[System.Net.Quic.Tests.QuicStreamTests`1+<>c__DisplayClass14_0+<<ReadWrite_Random_Success>b__1>d[[System.Net.Quic.Tests.MsQuicProviderFactory, System.Net.Quic.Functional.Tests]], System.Net.Quic.Functional.Tests]]
00007f4497b02620 2 192 System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[[System.Threading.Tasks.VoidTaskResult, System.Private.CoreLib],[System.Net.Quic.Implementations.MsQuic.MsQuicStream+<WriteAsync>d__21, System.Net.Quic]]
Total 4 objects
``` 

big thanks to @stephentoub who pointed to #53471 and suggested this mitigation. 
This is not final fix but I did few hundreds runs without problem when it would generally hang in less then 10 before on my dev box. This should at least improve PR experience and CI failure rate. 
I will follow-up with details to help find better fix e.g. thread pool.


contributes to #55642 