### PR TITLE
Fix tizen arm32 issue.

### DIFF
--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -1911,15 +1911,19 @@ instruction CodeGen::ins_Copy(regNumber srcReg, var_types dstType)
         return INS_mov;
     }
 #elif defined(TARGET_ARM)
-    // No SIMD support yet
+    // No SIMD support yet.
     assert(!varTypeIsSIMD(dstType));
     if (dstIsFloatReg)
     {
-        return (dstType == TYP_DOUBLE) ? INS_vmov_i2d : INS_vmov_i2f;
+        // Can't have LONG in a register.
+        assert(dstType == TYP_FLOAT);
+        return INS_vmov_i2f;
     }
     else
     {
-        return (dstType == TYP_LONG) ? INS_vmov_d2i : INS_vmov_f2i;
+        // Can't have LONG in a register.
+        assert(dstType == TYP_INT);
+        return INS_vmov_f2i;
     }
 #else // TARGET*
 #error "Unknown TARGET"

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -1507,6 +1507,11 @@ GenTree* Lowering::LowerFloatArgReg(GenTree* arg, regNumber regNum)
 #ifdef TARGET_ARM
     if (floatType == TYP_DOUBLE)
     {
+        // A special case when we introduce TYP_LONG
+        // during lowering for arm32 softFP to pass double
+        // in int registers.
+        assert(comp->opts.compUseSoftFP);
+
         regNumber nextReg                  = REG_NEXT(regNum);
         intArg->AsMultiRegOp()->gtOtherReg = nextReg;
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/55794, introduced by https://github.com/dotnet/runtime/pull/55558.

I have decided to go with this fix (see discussion in https://github.com/dotnet/runtime/issues/55794#issuecomment-882856171) for now because:
1. RC1 and the other fixes are more disturbing;
2. fix during morph:fgInitArgInfo looks like:
```
ASG(LCL_VAR double temp, originalArg)
LCL_FLD long temp
CALL
```
and it causes the argument to be read from memory when before it could stay in float registers.
3. it is dangerous to do morph arg changes when we don't have actual armel testing.

