### PR TITLE
Disable QuicStreamTests_MsQuicProvider.ReadOutstanding_ReadAborted_Throws

### DIFF
--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
@@ -471,6 +471,7 @@ namespace System.Net.Quic.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55948")]
         public async Task ReadOutstanding_ReadAborted_Throws()
         {
             // aborting doesn't work properly on mock


### PR DESCRIPTION
Disable test: System.Net.Quic.Tests.QuicStreamTests_MsQuicProvider.ReadOutstanding_ReadAborted_Throws

Tracked by #55948