### PR TITLE
Hostfxr package should depend on host package

### DIFF
--- a/src/installer/pkg/sfx/installers/dotnet-hostfxr.proj
+++ b/src/installer/pkg/sfx/installers/dotnet-hostfxr.proj
@@ -48,9 +48,9 @@
   <Target Name="AddLinuxPackageInformation" BeforeTargets="GetDebInstallerJsonProperties;GetRpmInstallerJsonProperties">
     <ItemGroup Condition="'$(GenerateDeb)' == 'true'">
       <LinuxPackageDependency Include="libc6;libgcc1;libstdc++6" />
-      <LinuxPackageDependency Include="dotnet-host" Version="$(InstallerPackageVersion)" />
     </ItemGroup>
     <ItemGroup>
+      <LinuxPackageDependency Include="dotnet-host" Version="$(InstallerPackageVersion)" />
       <RpmJsonProperty Include="directories" Object="[ &quot;/usr/share/dotnet&quot;, &quot;/usr/share/doc/$(VersionedInstallerName)&quot; ]" />
     </ItemGroup>
   </Target>


### PR DESCRIPTION
Hostfxr RPM package should have a dependency on the host package.

This is a fix for a regression in 6.0 packaging infra.

Old 5.0 infra had this dependency specified in the corresponding json file: https://github.com/dotnet/runtime/blob/74905e767eb7b971636310965b66bf5dfd6a3545/src/installer/pkg/packaging/rpm/dotnet-hostfxr-rpm_config.json#L34-L37

