### PR TITLE
Start codesign from executable on apphost creation 

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/AppHost/HostWriter.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/AppHost/HostWriter.cs
@@ -251,6 +251,7 @@ namespace Microsoft.NET.HostModel.AppHost
                 Arguments = $"-s - \"{appHostPath}\"",
                 FileName = codesign,
                 RedirectStandardError = true,
+                UseShellExecute = false,
             };
 
             using (var p = Process.Start(psi))


### PR DESCRIPTION
`UseShellExecute` should be false whenever we are redirecting to standard error (as we are doing when firing `codesign` when creating an apphost).

Fixes #55992.