### PR TITLE
Upgrade to msbuild version 16.10 to fix big-endian bug

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -142,7 +142,7 @@
       These are used as reference assemblies only, so they must not take a ProdCon/source-build
       version. Insert "RefOnly" to avoid assignment via PVP.
     -->
-    <RefOnlyMicrosoftBuildVersion>16.9.0</RefOnlyMicrosoftBuildVersion>
+    <RefOnlyMicrosoftBuildVersion>16.10.0</RefOnlyMicrosoftBuildVersion>
     <RefOnlyMicrosoftBuildFrameworkVersion>$(RefOnlyMicrosoftBuildVersion)</RefOnlyMicrosoftBuildFrameworkVersion>
     <RefOnlyMicrosoftBuildTasksCoreVersion>$(RefOnlyMicrosoftBuildVersion)</RefOnlyMicrosoftBuildTasksCoreVersion>
     <RefOnlyMicrosoftBuildUtilitiesCoreVersion>$(RefOnlyMicrosoftBuildVersion)</RefOnlyMicrosoftBuildUtilitiesCoreVersion>

--- a/src/libraries/Microsoft.NETCore.Platforms/tests/Microsoft.NETCore.Platforms.Tests.csproj
+++ b/src/libraries/Microsoft.NETCore.Platforms/tests/Microsoft.NETCore.Platforms.Tests.csproj
@@ -8,6 +8,8 @@
     <ProjectReference Include="..\src\Microsoft.NETCore.Platforms.csproj" />
     <!-- Workaround NuGet promoting this to a ProjectReference -->
     <PackageReference Include="System.Memory" Condition="'$(TargetFramework)' == 'net472'" Version="$(SystemMemoryVersion)" />
+    <PackageReference Include="System.Security.AccessControl" Condition="'$(TargetFramework)' == 'net472'" Version="$(SystemSecurityAccessControlVersion)" />
+    <PackageReference Include="System.Security.Principal.Windows" Condition="'$(TargetFramework)' == 'net472'" Version="$(SystemSecurityPrincipalWindowsVersion)" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
* Fixes https://github.com/dotnet/runtime/issues/54826

* Adjust net472 dependencies of Microsoft.NETCore.Platforms.Tests