### PR TITLE
[QUIC] Remove AppContext switch from S.N.Quic

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
@@ -125,16 +125,6 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
 
         static MsQuicApi()
         {
-            if (!IsHttp3Enabled())
-            {
-                if (NetEventSource.Log.IsEnabled())
-                {
-                    NetEventSource.Info(null, $"HTTP/3 and QUIC is not enabled, see 'System.Net.SocketsHttpHandler.Http3Support' AppContext switch.");
-                }
-
-                return;
-            }
-
             if (OperatingSystem.IsWindows() && !IsWindowsVersionSupported())
             {
                 if (NetEventSource.Log.IsEnabled())
@@ -169,34 +159,6 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
                     }
                 }
             }
-        }
-
-        // Note that this is copy-pasted from S.N.Http just to hide S.N.Quic behind the same AppContext switch
-        // since this library is considered "private" for 6.0.
-        // We should get rid of this once S.N.Quic API surface is officially exposed.
-        private static bool IsHttp3Enabled()
-        {
-            bool value;
-
-            // First check for the AppContext switch, giving it priority over the environment variable.
-            if (AppContext.TryGetSwitch("System.Net.SocketsHttpHandler.Http3Support", out value))
-            {
-                return value;
-            }
-
-            // AppContext switch wasn't used. Check the environment variable.
-            string? envVar = Environment.GetEnvironmentVariable("DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP3SUPPORT");
-
-            if (bool.TryParse(envVar, out value))
-            {
-                return value;
-            }
-            else if (uint.TryParse(envVar, out uint intVal))
-            {
-                return intVal != 0;
-            }
-
-            return false;
         }
 
         private static bool IsWindowsVersionSupported() => OperatingSystem.IsWindowsVersionAtLeast(MinWindowsVersion.Major,

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/System.Net.Quic.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/System.Net.Quic.Functional.Tests.csproj
@@ -5,9 +5,6 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <RuntimeHostConfigurationOption Include="System.Net.SocketsHttpHandler.Http3Support" Value="true" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
AppContext switch for H/3 scoped down to `S.N.Http` only. `S.N.Quic` doesn't have any extra guards ATM.

@karelz Could you please help with servicing? 

cc: @davidfowl