### PR TITLE
Import local nodes that may need normalization through common path

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -2338,7 +2338,7 @@ AssertionIndex Compiler::optFindComplementary(AssertionIndex assertIndex)
 /*****************************************************************************
  *
  *  Given a lclNum, a fromType and a toType, return assertion index of the assertion that
- *  claims that a variable's value is always a valid subrange of the formType.
+ *  claims that a variable's value is always a valid subrange of the fromType.
  *  Thus we can discard or omit a cast to fromType. Returns NO_ASSERTION_INDEX
  *  if one such assertion could not be found in "assertions."
  */

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4519,11 +4519,12 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         };
 
         Validator(Compiler* comp) : GenTreeVisitor<Validator>(comp)
-        {}
+        {
+        }
 
         void VisitStmt(Statement* stmt)
         {
-            //m_compiler->gtDispStmt(stmt);
+            // m_compiler->gtDispStmt(stmt);
             WalkTree(stmt->GetRootNodePointer(), nullptr);
         }
 

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4510,48 +4510,6 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     //
     DoPhase(this, PHASE_IMPORTATION, &Compiler::fgImport);
 
-    class Validator : public GenTreeVisitor<Validator>
-    {
-    public:
-        enum
-        {
-            DoPreOrder = true,
-        };
-
-        Validator(Compiler* comp) : GenTreeVisitor<Validator>(comp)
-        {
-        }
-
-        void VisitStmt(Statement* stmt)
-        {
-            // m_compiler->gtDispStmt(stmt);
-            WalkTree(stmt->GetRootNodePointer(), nullptr);
-        }
-
-        fgWalkResult PreOrderVisit(GenTree** use, GenTree* user)
-        {
-            GenTree* node = *use;
-            if (!node->IsLocal())
-                return WALK_CONTINUE;
-
-            LclVarDsc* dsc = m_compiler->lvaGetDesc(node->AsLclVarCommon());
-            if (!dsc->lvNormalizeOnLoad() || user->OperIs(GT_ADDR))
-                return WALK_CONTINUE;
-
-            assert(node->TypeGet() == dsc->TypeGet());
-            return WALK_CONTINUE;
-        }
-    };
-
-    Validator visitor(this);
-    for (BasicBlock* const block : Blocks())
-    {
-        for (Statement* const stmt : block->Statements())
-        {
-            visitor.VisitStmt(stmt);
-        }
-    }
-
     // If instrumenting, add block and class probes.
     //
     if (compileFlags->IsSet(JitFlags::JIT_FLAG_BBINSTR))

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4510,6 +4510,47 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     //
     DoPhase(this, PHASE_IMPORTATION, &Compiler::fgImport);
 
+    class Validator : public GenTreeVisitor<Validator>
+    {
+    public:
+        enum
+        {
+            DoPreOrder = true,
+        };
+
+        Validator(Compiler* comp) : GenTreeVisitor<Validator>(comp)
+        {}
+
+        void VisitStmt(Statement* stmt)
+        {
+            //m_compiler->gtDispStmt(stmt);
+            WalkTree(stmt->GetRootNodePointer(), nullptr);
+        }
+
+        fgWalkResult PreOrderVisit(GenTree** use, GenTree* user)
+        {
+            GenTree* node = *use;
+            if (!node->IsLocal())
+                return WALK_CONTINUE;
+
+            LclVarDsc* dsc = m_compiler->lvaGetDesc(node->AsLclVarCommon());
+            if (!dsc->lvNormalizeOnLoad() || user->OperIs(GT_ADDR))
+                return WALK_CONTINUE;
+
+            assert(node->TypeGet() == dsc->TypeGet());
+            return WALK_CONTINUE;
+        }
+    };
+
+    Validator visitor(this);
+    for (BasicBlock* const block : Blocks())
+    {
+        for (Statement* const stmt : block->Statements())
+        {
+            visitor.VisitStmt(stmt);
+        }
+    }
+
     // If instrumenting, add block and class probes.
     //
     if (compileFlags->IsSet(JitFlags::JIT_FLAG_BBINSTR))

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4515,7 +4515,7 @@ private:
     void impSpillCliqueSetMember(SpillCliqueDir predOrSucc, BasicBlock* blk, BYTE val);
 
     void impPushVar(GenTree* op, typeInfo tiRetVal);
-    GenTreeLclVar* impCreateLocalNode(unsigned lclNum, IL_OFFSET offset);
+    GenTreeLclVar* impCreateLocalNode(unsigned lclNum DEBUGARG(IL_OFFSET offset));
     void impLoadVar(unsigned lclNum, IL_OFFSET offset, const typeInfo& tiRetVal);
     void impLoadVar(unsigned lclNum, IL_OFFSET offset)
     {

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4515,6 +4515,7 @@ private:
     void impSpillCliqueSetMember(SpillCliqueDir predOrSucc, BasicBlock* blk, BYTE val);
 
     void impPushVar(GenTree* op, typeInfo tiRetVal);
+    GenTreeLclVar* impCreateLocalNode(unsigned lclNum, IL_OFFSET offset);
     void impLoadVar(unsigned lclNum, IL_OFFSET offset, const typeInfo& tiRetVal);
     void impLoadVar(unsigned lclNum, IL_OFFSET offset)
     {

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -20105,9 +20105,9 @@ GenTree* Compiler::impInlineFetchArg(unsigned lclNum, InlArgInfo* inlArgInfo, In
         // Directly substitute unaliased caller locals for args that cannot be modified
         //
         // Use the caller-supplied node if this is the first use.
-        op1               = argNode;
+        op1                = argNode;
         unsigned argLclNum = op1->AsLclVarCommon()->GetLclNum();
-        argInfo.argTmpNum = argLclNum;
+        argInfo.argTmpNum  = argLclNum;
 
         // Use an equivalent copy if this is the second or subsequent
         // use, or if we need to retype.

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -11953,7 +11953,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
             ADRVAR:
 
-                op1 = impCreateLocalNode(lclNum, opcodeOffs + sz + 1);
+                op1 = impCreateLocalNode(lclNum DEBUGARG(opcodeOffs + sz + 1));
 
             _PUSH_ADRVAR:
                 assert(op1->gtOper == GT_LCL_VAR);
@@ -16729,7 +16729,7 @@ void Compiler::impPushVar(GenTree* op, typeInfo tiRetVal)
 // Returns:
 //     The node
 //
-GenTreeLclVar* Compiler::impCreateLocalNode(unsigned lclNum, IL_OFFSET offset)
+GenTreeLclVar* Compiler::impCreateLocalNode(unsigned lclNum DEBUGARG(IL_OFFSET offset))
 {
     var_types lclTyp;
 
@@ -16749,7 +16749,7 @@ GenTreeLclVar* Compiler::impCreateLocalNode(unsigned lclNum, IL_OFFSET offset)
 // lclNum is an index into lvaTable *NOT* the arg/lcl index in the IL
 void Compiler::impLoadVar(unsigned lclNum, IL_OFFSET offset, const typeInfo& tiRetVal)
 {
-    impPushVar(impCreateLocalNode(lclNum, offset), tiRetVal);
+    impPushVar(impCreateLocalNode(lclNum DEBUGARG(offset)), tiRetVal);
 }
 
 // Load an argument on the operand stack
@@ -20120,9 +20120,7 @@ GenTree* Compiler::impInlineFetchArg(unsigned lclNum, InlArgInfo* inlArgInfo, In
             assert(lclNum == op1->AsLclVar()->gtLclILoffs);
 
             // Create a new lcl var node - remember the argument lclNum
-            IL_OFFSET offs = BAD_IL_OFFSET;
-            INDEBUG(offs = op1->AsLclVar()->gtLclILoffs);
-            op1 = impCreateLocalNode(argLclNum, offs);
+            op1 = impCreateLocalNode(argLclNum DEBUGARG(op1->AsLclVar()->gtLclILoffs));
         }
     }
     else if (argInfo.argIsByRefToStructLocal && !argInfo.argHasStargOp)

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -20117,13 +20117,19 @@ GenTree* Compiler::impInlineFetchArg(unsigned lclNum, InlArgInfo* inlArgInfo, In
         // but a cast is necessary, we similarly expect it to have been inserted then.
         // So here we may have argument type mismatches that are benign, for instance
         // passing a TYP_SHORT local (eg. normalized-on-load) as a TYP_INT arg.
-        if (argInfo.argIsUsed)
+        // The exception is when the inlining means we should start tracking the argument.
+        if (argInfo.argIsUsed || ((lclTyp == TYP_BYREF) && (op1->TypeGet() != TYP_BYREF)))
         {
             assert(op1->gtOper == GT_LCL_VAR);
             assert(lclNum == op1->AsLclVar()->gtLclILoffs);
 
             // Create a new lcl var node - remember the argument lclNum
             op1 = impCreateLocalNode(argLclNum DEBUGARG(op1->AsLclVar()->gtLclILoffs));
+            // Start tracking things as a byref if the parameter is a byref.
+            if (lclTyp == TYP_BYREF)
+            {
+                op1->gtType = TYP_BYREF;
+            }
         }
     }
     else if (argInfo.argIsByRefToStructLocal && !argInfo.argHasStargOp)

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -20110,11 +20110,14 @@ GenTree* Compiler::impInlineFetchArg(unsigned lclNum, InlArgInfo* inlArgInfo, In
         argInfo.argTmpNum  = argLclNum;
 
         // Use an equivalent copy if this is the second or subsequent
-        // use, or if we need to retype.
+        // use.
         //
         // Note argument type mismatches that prevent inlining should
-        // have been caught in impInlineInitVars.
-        if (argInfo.argIsUsed || (op1->TypeGet() != lclTyp))
+        // have been caught in impInlineInitVars. If inlining is not prevented
+        // but a cast is necessary, we similarly expect it to have been inserted then.
+        // So here we may have argument type mismatches that are benign, for instance
+        // passing a TYP_SHORT local (eg. normalized-on-load) as a TYP_INT arg.
+        if (argInfo.argIsUsed)
         {
             assert(op1->gtOper == GT_LCL_VAR);
             assert(lclNum == op1->AsLclVar()->gtLclILoffs);

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -20120,7 +20120,9 @@ GenTree* Compiler::impInlineFetchArg(unsigned lclNum, InlArgInfo* inlArgInfo, In
             assert(lclNum == op1->AsLclVar()->gtLclILoffs);
 
             // Create a new lcl var node - remember the argument lclNum
-            op1 = impCreateLocalNode(argLclNum, op1->AsLclVar()->gtLclILoffs);
+            IL_OFFSET offs = BAD_IL_OFFSET;
+            INDEBUG(offs = op1->AsLclVar()->gtLclILoffs);
+            op1 = impCreateLocalNode(argLclNum, offs);
         }
     }
     else if (argInfo.argIsByRefToStructLocal && !argInfo.argHasStargOp)

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5991,17 +5991,23 @@ GenTree* Compiler::fgMorphLocalVar(GenTree* tree, bool forceRemorph)
     if (!varAddr && varTypeIsSmall(varDsc->TypeGet()) && varDsc->lvNormalizeOnLoad())
     {
 #if LOCAL_ASSERTION_PROP
-        /* Assertion prop can tell us to omit adding a cast here */
+        // Assertion prop can tell us to omit adding a cast here
         if (optLocalAssertionProp && optAssertionIsSubrange(tree, TYP_INT, varType, apFull) != NO_ASSERTION_INDEX)
         {
+            // The previous assertion can guarantee us that if this node gets
+            // assigned a register, it will be normalized already. It is still
+            // possible that this node ends up being in memory, in which case
+            // normalization will still be needed, so we better have the right
+            // type.
+            assert(tree->TypeGet() == varDsc->TypeGet());
             return tree;
         }
 #endif
-        /* Small-typed arguments and aliased locals are normalized on load.
-           Other small-typed locals are normalized on store.
-           Also, under the debugger as the debugger could write to the variable.
-           If this is one of the former, insert a narrowing cast on the load.
-                   ie. Convert: var-short --> cast-short(var-int) */
+        // Small-typed arguments and aliased locals are normalized on load.
+        // Other small-typed locals are normalized on store.
+        // Also, under the debugger as the debugger could write to the variable.
+        // If this is one of the former, insert a narrowing cast on the load.
+        //         ie. Convert: var-short --> cast-short(var-int)
 
         tree->gtType = TYP_INT;
         fgMorphTreeDone(tree);

--- a/src/tests/JIT/Regression/JitBlue/Runtime_55143/Runtime_55143.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_55143/Runtime_55143.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+struct S0
+{
+    public short F0;
+    public int F1;
+    public S0(short f0, int f1)
+    {
+        F0 = f0;
+        F1 = f1;
+    }
+}
+
+public class Runtime_55143
+{
+    public static int Main()
+    {
+        int value = M47(-1);
+        return value == 0 ? 100 : 101;
+    }
+
+    static int M47(short arg0)
+    {
+        try
+        {
+            S0 var0 = new S0(arg0++, arg0);
+            return var0.F1;
+        }
+        finally
+        {
+            arg0++;
+        }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_55143/Runtime_55143.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_55143/Runtime_55143.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fix issues where we were creating TYP_INT locals that need normalization
in the importer. This could lead to us to read the wrong number of bytes
from such locals.

In particular this happened when passing a small-sized parameter as a
TYP_INT argument, and that call was inlined. We would end up with a
TYP_INT GT_LCL_VAR node referring to the small parameter that required
normalization.

This change seems to have some benefit too; in a few situations, it
seems the old behavior meant that we could not enregister the small
locals.

Fix #55143