### PR TITLE
Disable implicit namespace imports

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -279,6 +279,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <!-- By default the SDK produces ref assembly for 5.0 or later -->
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <!-- Since we don't use implicit references in most of our projects we need to disable implicit namespace imports
+    to avoid build failures about missing namespaces. -->
+    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -279,9 +279,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <!-- By default the SDK produces ref assembly for 5.0 or later -->
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
-    <!-- Since we don't use implicit references in most of our projects we need to disable implicit namespace imports
-    to avoid build failures about missing namespaces. -->
-    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -59,6 +59,10 @@
                                                   '$(DisableImplicitFrameworkReferences)' != 'true' and
                                                   '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
                                                   ('$(IsReferenceAssembly)' == 'true' or '$(IsSourceProject)' == 'true')">true</DisableImplicitAssemblyReferences>
+    
+    <!-- When we disable implicit assembly references disabling namespace imports is not handled by the SDK as this is our custom
+    way to disable assembly references for OOBs. -->
+    <DisableImplicitNamespaceImports Condition="'$(DisableImplicitAssemblyReferences)' == 'true'">true</DisableImplicitNamespaceImports>
   </PropertyGroup>
 
   <Import Project="$(RepositoryEngineeringDir)versioning.targets" />


### PR DESCRIPTION
In preview7 SDK some namespace imports are defined by default. Most of our projects don't use implicit references as we are low in the stack and producing those references. This can cause issues when building with a preview7 SDK, i.e:

```
D:\repos\dotnet_runtime_3\artifacts\obj\System.IO.Pipelines\ref\net6.0-Debug\System.IO.Pipelines.ImplicitNamespaceImports.cs(5,29): error CS0234: The type or namespace name 'Linq' does not exist in the namespace 'System' (are you missing an assembly reference?) [D:\repos\dotnet_runtime_3\src\libraries\System.IO.Pipelines\ref\System.IO.Pipelines.csproj]
```

This was introduced to the SDK last week. https://github.com/dotnet/sdk/commit/85943958e5a01d6bbd39a947aec2a4a37b8ba7cf

cc: @dotnet/runtime-infrastructure 