### PR TITLE
check handle before shutdown in quic connection Dispose

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -712,10 +712,13 @@ namespace System.Net.Quic.Implementations.MsQuic
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(_state, $"{TraceId()} Stream disposing {disposing}");
 
             // If we haven't already shutdown gracefully (via a successful CloseAsync call), then force an abortive shutdown.
-            MsQuicApi.Api.ConnectionShutdownDelegate(
-                _state.Handle,
-                QUIC_CONNECTION_SHUTDOWN_FLAGS.SILENT,
-                0);
+            if (_state.Handle != null)
+            {
+                MsQuicApi.Api.ConnectionShutdownDelegate(
+                    _state.Handle,
+                    QUIC_CONNECTION_SHUTDOWN_FLAGS.SILENT,
+                    0);
+            }
 
             bool releaseHandles = false;
             lock (_state)

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -714,6 +714,7 @@ namespace System.Net.Quic.Implementations.MsQuic
             // If we haven't already shutdown gracefully (via a successful CloseAsync call), then force an abortive shutdown.
             if (_state.Handle != null)
             {
+                // Handle can be null if outbound constructor failed and we are called from finalizer.
                 MsQuicApi.Api.ConnectionShutdownDelegate(
                     _state.Handle,
                     QUIC_CONNECTION_SHUTDOWN_FLAGS.SILENT,


### PR DESCRIPTION
fixes observed NRE failure in CI
https://helixre8s23ayyeko0k025g8.blob.core.windows.net/dotnet-runtime-refs-pull-55877-merge-4b55bf7e17664f8d97/System.Net.Http.Functional.Tests/console.44cb6dd0.log?sv=2019-07-07&se=2021-08-09T20%3A59%3A05Z&sr=c&sp=rl&sig=fcVOgCzStvmdaDVp%2FQRDS0Df0FtzBFqHVkrAh4pCysk%3D
```
      Condition(s) not met: "CanTestCertificates"
Unhandled exception. System.ArgumentNullException: SafeHandle cannot be null. (Parameter 'pHandle')
   at System.StubHelpers.StubHelpers.SafeHandleAddRef(SafeHandle pHandle, Boolean& success) in /_/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs:line 1273
   at System.Net.Quic.Implementations.MsQuic.MsQuicConnection.Dispose(Boolean disposing) in /_/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs:line 715
   at System.Net.Quic.Implementations.MsQuic.MsQuicConnection.Finalize() in /_/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs:line 684
./RunTests.sh: line 162:    22 Aborted                 (core dumped) "$RUNTIME_PATH/dotnet" exec --runtimeconfig System.Net.Http.Functional.Tests.runtimeconfig.json --depsfile System.Net.Http.Functional.Tests.deps.json xunit.console.dll System.Net.Http.Functional.Tests.dll -xml testResults.xml -nologo -nocolor -notrait category=IgnoreForCI -notrait category=OuterLoop -notrait category=failing $RSP_FILE
/root/helix/work/workitem
----- end Tue Jul 20 21:05:32 UTC 2021 ----- exit code 134 ----------------------------------------------------------
exit code 134 means SIGABRT Abort. Managed or native assert, or runtime check such as heap corruption, caused call to abort(). Core dumped.

```

When constructor for  outbound connection fail, `_state.Handle` can be null and this would be called from finalizer. 

