### PR TITLE
crossgen2: Don't set onlyParseItemsDefinedInAssembly in Composite mode

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ProfileDataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ProfileDataManager.cs
@@ -45,7 +45,11 @@ namespace ILCompiler
             {
                 // Parse MIbc Data
 
-                string onlyParseItemsDefinedInAssembly = nonLocalGenericsHome == null ? inputModules.First().Assembly.GetName().Name : null;
+                string onlyParseItemsDefinedInAssembly = null;
+                if (nonLocalGenericsHome == null && !compilationGroup.IsCompositeBuildMode)
+                {
+                    onlyParseItemsDefinedInAssembly = inputModules.First().Assembly.GetName().Name;
+                }
                 HashSet<string> versionBubbleModuleStrings = new HashSet<string>();
                 foreach (ModuleDesc versionBubbleModule in versionBubble)
                 {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/55695

I have a repro: https://github.com/EgorBo/StaticPGO_Example - it consists of a console app and a lib.
When I run crossgen2 in Composite mode on it - PGO data is just ignored.

Here is the command executed by msbuild during "dotnet publish":
```
_CreateR2RImages:
  C:\Users\bogat\.nuget\packages\microsoft.netcore.app.crossgen2.win-x64\6.0.0-rc.1.21369.2\tools\crossgen2.exe --targetos:windows
  --targetarch:x64
  -O
  --embed-pgo-data
  --mibc:C:\prj\StaticPGO_Example\App\my.mibc
  --composite
  --out:"obj\Release\net6.0\win-x64\R2R\App.r2r.dll"
  obj\Release\net6.0\win-x64\linked\Lib.dll
  obj\Release\net6.0\win-x64\linked\App.dll
  obj\Release\net6.0\win-x64\linked\System.Collections.Immutable.dll
  obj\Release\net6.0\win-x64\linked\System.Console.dll
  obj\Release\net6.0\win-x64\linked\System.Diagnostics.StackTrace.dll
  obj\Release\net6.0\win-x64\linked\System.IO.Compression.dll
  obj\Release\net6.0\win-x64\linked\System.IO.MemoryMappedFiles.dll
  obj\Release\net6.0\win-x64\linked\System.Private.CoreLib.dll
  obj\Release\net6.0\win-x64\linked\System.Reflection.Metadata.dll
  obj\Release\net6.0\win-x64\linked\System.Runtime.dll
```
Lib is the first assembly in the list of input assemblies here and it's set as `onlyParseItemsDefinedInAssembly`:
![image](https://user-images.githubusercontent.com/523221/126400200-d77c219d-41ac-4eae-9716-083fb0ab58b7.png)

My fix sets `onlyParseItemsDefinedInAssembly` to `null` in Composite mode (`--compilebubblegenerics` also does it).


As the result, here is the new R2R asm code for [Test](https://github.com/EgorBo/StaticPGO_Example/blob/main/App/App.cs#L29-L46): https://gist.github.com/EgorBo/6b380e47a3be83720921ea6bb2c76678 - PGO data is used, calls are devirtualized.

Here is the previous (Main) codegen: https://gist.github.com/EgorBo/1d66953706e093a6e5cd284e2ba41105

/cc @AndyAyersMS 