### PR TITLE
Update CG2 ArgIterator to match the runtime one

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
@@ -1702,13 +1702,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         private int _x64WindowsCurOfs;           // Current position of the stack iterator
 
         private int _armIdxGenReg;        // Next general register to be assigned a value
-        private int _armOfsStack;         // Offset of next stack slot to be assigned a value
+        private int _armOfsStack;         // Offset of next stack location to be assigned a value
 
         private ushort _armWFPRegs;          // Bitmask of available floating point argument registers (s0-s15/d0-d7)
         private bool _armRequires64BitAlignment; // Cached info about the current arg
 
         private int _arm64IdxGenReg;        // Next general register to be assigned a value
-        private int _arm64OfsStack;         // Offset of next stack slot to be assigned a value
+        private int _arm64OfsStack;         // Offset of next stack location to be assigned a value
         private int _arm64IdxFPReg;         // Next FP register to be assigned a value
 
         // These are enum flags in CallingConventions.h, but that's really ugly in C#, so I've changed them to bools.

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
@@ -230,8 +230,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public bool m_fRequires64BitAlignment;  // ARM - True if the argument should always be aligned (in registers or on the stack
 
-        public int m_idxStack;     // First stack slot used (or -1)
-        public int m_cStack;       // Count of stack slots used (or 0)
+        public int m_byteStackIndex;     // Stack offset in bytes (or -1)
+        public int m_byteStackSize;      // Stack size in bytes
 
         // Initialize to represent a non-placed argument (no register or stack slots referenced).
         public void Init()
@@ -240,8 +240,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             m_cFloatReg = 0;
             m_idxGenReg = -1;
             m_cGenReg = 0;
-            m_idxStack = -1;
-            m_cStack = 0;
+            m_byteStackIndex = -1;
+            m_byteStackSize = 0;
 
             m_fRequires64BitAlignment = false;
         }
@@ -531,6 +531,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             if (!_SIZE_OF_ARG_STACK_COMPUTED)
                 ForceSigWalk();
             Debug.Assert(_SIZE_OF_ARG_STACK_COMPUTED);
+            Debug.Assert((_nSizeOfArgStack % _transitionBlock.PointerSize) == 0);
             return (uint)_nSizeOfArgStack;
         }
 
@@ -550,6 +551,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 size += (uint)_transitionBlock.SizeOfArgumentRegisters;
             }
 
+            Debug.Assert((size % _transitionBlock.PointerSize) == 0);
             return (int)size;
         }
 
@@ -784,14 +786,14 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         {
                             case CallingConventions.StdCall:
                                 _numRegistersUsed = ArchitectureConstants.NUM_ARGUMENT_REGISTERS;
-                                _curOfs = TransitionBlock.GetOffsetOfArgs() + numRegistersUsed * _transitionBlock.PointerSize + initialArgOffset;
+                                _ofsStack = TransitionBlock.GetOffsetOfArgs() + numRegistersUsed * _transitionBlock.PointerSize + initialArgOffset;
                                 break;
 
                             case CallingConventions.ManagedStatic:
                             case CallingConventions.ManagedInstance:
                                 _numRegistersUsed = numRegistersUsed;
                                 // DESKTOP BEHAVIOR     _curOfs = (int)(TransitionBlock.GetOffsetOfArgs() + SizeOfArgStack());
-                                _curOfs = (int)(TransitionBlock.GetOffsetOfArgs() + initialArgOffset);
+                                _ofsStack= (int)(TransitionBlock.GetOffsetOfArgs() + initialArgOffset);
                                 break;
 
                             default:
@@ -801,9 +803,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 #endif
                         _x86NumRegistersUsed = numRegistersUsed;
 #if PROJECTN
-                        _x86CurOfs = (int)(_transitionBlock.OffsetOfArgs + initialArgOffset);
+                        _x86OfsStack = (int)(_transitionBlock.OffsetOfArgs + initialArgOffset);
 #else
-                        _x86CurOfs = (int)(_transitionBlock.OffsetOfArgs + SizeOfArgStack());
+                        _x86OfsStack = (int)(_transitionBlock.OffsetOfArgs + SizeOfArgStack());
 #endif
                         break;
 
@@ -822,14 +824,14 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
                     case TargetArchitecture.ARM:
                         _armIdxGenReg = numRegistersUsed;
-                        _armIdxStack = 0;
+                        _armOfsStack = 0;
 
                         _armWFPRegs = 0;
                         break;
 
                     case TargetArchitecture.ARM64:
                         _arm64IdxGenReg = numRegistersUsed;
-                        _arm64IdxStack = 0;
+                        _arm64OfsStack = 0;
 
                         _arm64IdxFPReg = 0;
                         break;
@@ -879,11 +881,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     }
 
 #if PROJECTN
-                    argOfs = _x86CurOfs;
-                    _x86CurOfs += _transitionBlock.StackElemSize(argSize);
+                    argOfs = _x86OfsStack;
+                    _x86OfsStack += _transitionBlock.StackElemSize(argSize);
 #else
-                    _x86CurOfs -= _transitionBlock.StackElemSize(argSize);
-                    argOfs = _x86CurOfs;
+                    _x86OfsStack -= _transitionBlock.StackElemSize(argSize);
+                    argOfs = _x86OfsStack;
 #endif
                     Debug.Assert(argOfs >= _transitionBlock.OffsetOfArgs);
                     return argOfs;
@@ -988,7 +990,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         _fX64UnixArgInRegisters = false;
 
                         argOfs = _transitionBlock.OffsetOfArgs + _x64UnixIdxStack * 8;
-                        int cArgSlots = cbArg / _transitionBlock.StackElemSize();
+                        int cArgSlots = cbArg / _transitionBlock.PointerSize;
 
                         _x64UnixIdxStack += cArgSlots;
                         return argOfs;
@@ -1081,7 +1083,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         _armRequires64BitAlignment = fRequiresAlign64Bit;
 
                         int cbArg = _transitionBlock.StackElemSize(argSize);
-                        int cArgSlots = cbArg / 4;
+                        Debug.Assert((cbArg % _transitionBlock.PointerSize) == 0);
 
                         // Ignore floating point argument placement in registers if we're dealing with a vararg function (the ABI
                         // specifies this so that vararg processing on the callee side is simplified).
@@ -1127,13 +1129,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
                             // Doubles or HFAs containing doubles need the stack aligned appropriately.
                             if (fRequiresAlign64Bit)
-                                _armIdxStack = ALIGN_UP(_armIdxStack, 2);
+                                _armOfsStack = ALIGN_UP(_armOfsStack, _transitionBlock.PointerSize * 2);
 
                             // Indicate the stack location of the argument to the caller.
-                            int argOfsInner = _transitionBlock.OffsetOfArgs + _armIdxStack * 4;
+                            int argOfsInner = _transitionBlock.OffsetOfArgs + _armOfsStack;
 
                             // Record the stack usage.
-                            _armIdxStack += cArgSlots;
+                            _armOfsStack += cbArg;
 
                             return argOfsInner;
                         }
@@ -1154,10 +1156,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                             int argOfsInner = _transitionBlock.OffsetOfArgumentRegisters + _armIdxGenReg * 4;
 
                             int cRemainingRegs = 4 - _armIdxGenReg;
-                            if (cArgSlots <= cRemainingRegs)
+                            if (cbArg <= cRemainingRegs * _transitionBlock.PointerSize)
                             {
                                 // Mark the registers just allocated as used.
-                                _armIdxGenReg += cArgSlots;
+                                _armIdxGenReg += ALIGN_UP(cbArg, _transitionBlock.PointerSize) / _transitionBlock.PointerSize;
                                 return argOfsInner;
                             }
 
@@ -1168,9 +1170,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
                             _armIdxGenReg = 4;
 
-                            if (_armIdxStack == 0)
+                            if (_armOfsStack == 0)
                             {
-                                _armIdxStack += cArgSlots - cRemainingRegs;
+                                _armOfsStack += cbArg - cRemainingRegs * _transitionBlock.PointerSize;
                                 return argOfsInner;
                             }
                         }
@@ -1179,13 +1181,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         {
                             // The argument requires 64-bit alignment. If it is going to be passed on the stack, align
                             // the next stack slot.  See step C.6 in the algorithm in the ABI spec.  
-                            _armIdxStack = ALIGN_UP(_armIdxStack, 2);
+                            _armOfsStack = ALIGN_UP(_armOfsStack, _transitionBlock.PointerSize * 2);
                         }
 
-                        argOfs = _transitionBlock.OffsetOfArgs + _armIdxStack * 4;
+                        argOfs = _transitionBlock.OffsetOfArgs + _armOfsStack;
 
                         // Advance the stack pointer over the argument just placed.
-                        _armIdxStack += cArgSlots;
+                        _armOfsStack += cbArg;
 
                         return argOfs;
                     }
@@ -1193,6 +1195,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 case TargetArchitecture.ARM64:
                     {
                         int cFPRegs = 0;
+                        bool isFloatHFA = false;
 
                         switch (argType)
                         {
@@ -1216,6 +1219,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                                         _argLocDescForStructInRegs.m_idxFloatReg = _arm64IdxFPReg;
 
                                         int haElementSize = _argTypeHandle.GetHomogeneousAggregateElementSize();
+                                        if (haElementSize == 4)
+                                        {
+                                            isFloatHFA = true;
+                                        }
                                         cFPRegs = argSize / haElementSize;
                                         _argLocDescForStructInRegs.m_cFloatReg = cFPRegs;
 
@@ -1241,8 +1248,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                                 break;
                         }
 
-                        int cbArg = _transitionBlock.StackElemSize(argSize);
-                        int cArgSlots = cbArg / _transitionBlock.StackElemSize();
+                        bool isValueType = (argType == CorElementType.ELEMENT_TYPE_VALUETYPE);
+                        int cbArg = _transitionBlock.StackElemSize(argSize, isValueType, isFloatHFA);
 
                         if (cFPRegs > 0 && !IsVarArg)
                         {
@@ -1260,12 +1267,15 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         }
                         else
                         {
+                            Debug.Assert(_transitionBlock.IsAppleArm64ABI || (cbArg % _transitionBlock.PointerSize) == 0);
+
+                            int regSlots = ALIGN_UP(cbArg, _transitionBlock.PointerSize) / _transitionBlock.PointerSize;
                             // Only x0-x7 are valid argument registers (x8 is always the return buffer)
-                            if (_arm64IdxGenReg + cArgSlots <= 8)
+                            if (_arm64IdxGenReg + regSlots <= 8)
                             {
                                 // The entirety of the arg fits in the register slots.
                                 int argOfsInner = _transitionBlock.OffsetOfArgumentRegisters + _arm64IdxGenReg * 8;
-                                _arm64IdxGenReg += cArgSlots;
+                                _arm64IdxGenReg += regSlots;
                                 return argOfsInner;
                             }
                             else if (_context.Target.IsWindows && IsVarArg && (_arm64IdxGenReg < 8))
@@ -1275,9 +1285,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                                 // into x0-x7, and any remaining stack arguments are placed normally.
                                 int argOfsInner = _transitionBlock.OffsetOfArgumentRegisters + _arm64IdxGenReg * 8;
 
-                                // Increase m_idxStack to account for the space used for the remainder of the arg after
-                                // register slots are filled.
-                                _arm64IdxStack += (_arm64IdxGenReg + cArgSlots - 8);
+                                // Increase m_ofsStack to account for the space used for the remainder of the arg after
+                                // registers are filled.
+                                _arm64OfsStack += cbArg + (_arm64IdxGenReg - 8) * _transitionBlock.PointerSize;
 
                                 // We used up the remaining reg slots.
                                 _arm64IdxGenReg = 8;
@@ -1291,8 +1301,27 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                             }
                         }
 
-                        argOfs = _transitionBlock.OffsetOfArgs + _arm64IdxStack * 8;
-                        _arm64IdxStack += cArgSlots;
+                        if (_transitionBlock.IsAppleArm64ABI)
+                        {
+                            int alignment;
+                            if (!isValueType)
+                            {
+                                Debug.Assert((cbArg & (cbArg - 1)) == 0);
+                                alignment = cbArg;
+                            }
+                            else if (isFloatHFA)
+                            {
+                                alignment = 4;
+                            }
+                            else
+                            {
+                                alignment = 8;
+                            }
+                            _arm64OfsStack = ALIGN_UP(_arm64OfsStack, alignment);
+                        }
+
+                        argOfs = _transitionBlock.OffsetOfArgs + _arm64OfsStack;
+                        _arm64OfsStack += cbArg;
                         return argOfs;
                     }
 
@@ -1319,6 +1348,21 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             //        LIMITED_METHOD_CONTRACT;
             return _argSize;
+        }
+
+        public bool IsValueType()
+        {
+            return (_argType == CorElementType.ELEMENT_TYPE_VALUETYPE);
+        }
+
+        public bool IsFloatHfa()
+        {
+            if (IsValueType() && !IsVarArg && _argTypeHandle.IsHomogeneousAggregate())
+            {
+                int hfaElementSize = _argTypeHandle.GetHomogeneousAggregateElementSize();
+                return hfaElementSize == 4;
+            }
+            return false;
         }
 
         private void ForceSigWalk()
@@ -1445,14 +1489,15 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         {
                             // All stack arguments take just one stack slot on AMD64 because of arguments bigger 
                             // than a stack slot are passed by reference. 
-                            stackElemSize = _transitionBlock.StackElemSize();
+                            stackElemSize = _transitionBlock.PointerSize;
                         }
                     }
                     else
                     {
-                        stackElemSize = _transitionBlock.StackElemSize(GetArgSize());
+                        stackElemSize = _transitionBlock.StackElemSize(GetArgSize(), IsValueType(), IsFloatHfa());
+
                         if (IsArgPassedByRef())
-                            stackElemSize = _transitionBlock.StackElemSize();
+                            stackElemSize = _transitionBlock.PointerSize;
                     }
 
                     int endOfs = ofs + stackElemSize;
@@ -1477,6 +1522,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 }
             }
 
+            // arg stack size is rounded to the pointer size on all platforms.
+            nSizeOfArgStack = ALIGN_UP(nSizeOfArgStack, _transitionBlock.PointerSize);
+
             // Cache the result
             _nSizeOfArgStack = nSizeOfArgStack;
             _SIZE_OF_ARG_STACK_COMPUTED = true;
@@ -1497,12 +1545,14 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
                         pLoc.m_fRequires64BitAlignment = _armRequires64BitAlignment;
 
-                        int cSlots = (GetArgSize() + 3) / 4;
+                        int byteArgSize = GetArgSize();
 
                         if (_transitionBlock.IsFloatArgumentRegisterOffset(argOffset))
                         {
-                            pLoc.m_idxFloatReg = (argOffset - _transitionBlock.OffsetOfFloatArgumentRegisters) / 4;
-                            pLoc.m_cFloatReg = cSlots;
+                            int floatRegOfsInBytes = argOffset - _transitionBlock.OffsetOfFloatArgumentRegisters;
+                            Debug.Assert((floatRegOfsInBytes % _transitionBlock.FloatRegisterSize) == 0);
+                            pLoc.m_idxFloatReg = floatRegOfsInBytes / _transitionBlock.FloatRegisterSize;
+                            pLoc.m_cFloatReg = ALIGN_UP(byteArgSize, _transitionBlock.FloatRegisterSize) / _transitionBlock.FloatRegisterSize;
                             return pLoc;
                         }
 
@@ -1510,22 +1560,22 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         {
                             pLoc.m_idxGenReg = _transitionBlock.GetArgumentIndexFromOffset(argOffset);
 
-                            if (cSlots <= (4 - pLoc.m_idxGenReg))
+                            if (byteArgSize <= (4 - pLoc.m_idxGenReg) * _transitionBlock.PointerSize)
                             {
-                                pLoc.m_cGenReg = (short)cSlots;
+                                pLoc.m_cGenReg = (short)(ALIGN_UP(byteArgSize, _transitionBlock.PointerSize) / _transitionBlock.PointerSize);
                             }
                             else
                             {
                                 pLoc.m_cGenReg = (short)(4 - pLoc.m_idxGenReg);
 
-                                pLoc.m_idxStack = 0;
-                                pLoc.m_cStack = cSlots - pLoc.m_cGenReg;
+                                pLoc.m_byteStackIndex = 0;
+                                pLoc.m_byteStackSize = _transitionBlock.StackElemSize(byteArgSize) - pLoc.m_cGenReg * _transitionBlock.PointerSize;
                             }
                         }
                         else
                         {
-                            pLoc.m_idxStack = _transitionBlock.GetArgumentIndexFromOffset(argOffset) - 4;
-                            pLoc.m_cStack = cSlots;
+                            pLoc.m_byteStackIndex = _transitionBlock.GetStackArgumentByteIndexFromOffset(argOffset);
+                            pLoc.m_byteStackSize = _transitionBlock.StackElemSize(byteArgSize);
                         }
                         return pLoc;
                     }
@@ -1538,8 +1588,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
                         if (_transitionBlock.IsFloatArgumentRegisterOffset(argOffset))
                         {
-                            // Dividing by 16 as size of each register in FloatArgumentRegisters is 16 bytes.
-                            pLoc.m_idxFloatReg = (argOffset - _transitionBlock.OffsetOfFloatArgumentRegisters) / 16;
+                            int floatRegOfsInBytes = argOffset - _transitionBlock.OffsetOfFloatArgumentRegisters;
+                            Debug.Assert((floatRegOfsInBytes % _transitionBlock.FloatRegisterSize) == 0);
+                            pLoc.m_idxFloatReg = floatRegOfsInBytes / _transitionBlock.FloatRegisterSize;
 
                             if (!_argTypeHandle.IsNull() && _argTypeHandle.IsHomogeneousAggregate())
                             {
@@ -1553,24 +1604,24 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                             return pLoc;
                         }
 
-                        int cSlots = (GetArgSize() + 7) / 8;
+                        int byteArgSize = GetArgSize();
 
                         // Composites greater than 16bytes are passed by reference
                         TypeHandle dummy;
                         if (GetArgType(out dummy) == CorElementType.ELEMENT_TYPE_VALUETYPE && GetArgSize() > _transitionBlock.EnregisteredParamTypeMaxSize)
                         {
-                            cSlots = 1;
+                            byteArgSize = _transitionBlock.PointerSize;
                         }
 
                         if (!_transitionBlock.IsStackArgumentOffset(argOffset))
                         {
                             pLoc.m_idxGenReg = _transitionBlock.GetArgumentIndexFromOffset(argOffset);
-                            pLoc.m_cGenReg = (short)cSlots;
+                            pLoc.m_cGenReg = (short)(ALIGN_UP(byteArgSize, _transitionBlock.PointerSize) / _transitionBlock.PointerSize);
                         }
                         else
                         {
-                            pLoc.m_idxStack = _transitionBlock.GetStackArgumentIndexFromOffset(argOffset);
-                            pLoc.m_cStack = cSlots;
+                            pLoc.m_byteStackIndex = _transitionBlock.GetStackArgumentByteIndexFromOffset(argOffset);
+                            pLoc.m_byteStackSize = _transitionBlock.StackElemSize(byteArgSize, IsValueType(), IsFloatHfa());
                         }
                         return pLoc;
                     }
@@ -1595,8 +1646,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
                         if (_transitionBlock.IsFloatArgumentRegisterOffset(argOffset))
                         {
-                            // Dividing by 8 as size of each register in FloatArgumentRegisters is 8 bytes.
-                            pLoc.m_idxFloatReg = (argOffset - _transitionBlock.OffsetOfFloatArgumentRegisters) / 8;
+                            int floatRegOfsInBytes = argOffset - _transitionBlock.OffsetOfFloatArgumentRegisters;
+                            Debug.Assert((floatRegOfsInBytes % _transitionBlock.FloatRegisterSize) == 0);
+                            pLoc.m_idxFloatReg = floatRegOfsInBytes / _transitionBlock.FloatRegisterSize;
                             pLoc.m_cFloatReg = 1;
                         }
                         else if (!_transitionBlock.IsStackArgumentOffset(argOffset))
@@ -1606,14 +1658,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         }
                         else
                         {
-                            pLoc.m_idxStack = (argOffset - _transitionBlock.OffsetOfArgs) / 8;
-                            int argOnStackSize;
-                            int stackElemSize = _transitionBlock.StackElemSize();
+                            pLoc.m_byteStackIndex = _transitionBlock.GetStackArgumentByteIndexFromOffset(argOffset);
+                            int argSizeInBytes;
                             if (IsArgPassedByRef())
-                                argOnStackSize = stackElemSize;
+                                argSizeInBytes = _transitionBlock.PointerSize;
                             else
-                                argOnStackSize = GetArgSize();
-                            pLoc.m_cStack = (argOnStackSize + stackElemSize - 1) / stackElemSize;
+                                argSizeInBytes = GetArgSize();
+                            pLoc.m_byteStackSize = _transitionBlock.StackElemSize(argSizeInBytes);
                         }
                         return pLoc;
                     }
@@ -1641,7 +1692,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         private TypeHandle _argTypeHandleOfByRefParam;
         private bool _argForceByRef;
 
-        private int _x86CurOfs;           // Current position of the stack iterator
+        private int _x86OfsStack;           // Current position of the stack iterator
         private int _x86NumRegistersUsed;
 
         private int _x64UnixIdxGenReg;
@@ -1651,13 +1702,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         private int _x64WindowsCurOfs;           // Current position of the stack iterator
 
         private int _armIdxGenReg;        // Next general register to be assigned a value
-        private int _armIdxStack;         // Next stack slot to be assigned a value
+        private int _armOfsStack;         // Offset of next stack slot to be assigned a value
 
         private ushort _armWFPRegs;          // Bitmask of available floating point argument registers (s0-s15/d0-d7)
         private bool _armRequires64BitAlignment; // Cached info about the current arg
 
         private int _arm64IdxGenReg;        // Next general register to be assigned a value
-        private int _arm64IdxStack;         // Next stack slot to be assigned a value
+        private int _arm64OfsStack;         // Offset of next stack slot to be assigned a value
         private int _arm64IdxFPReg;         // Next FP register to be assigned a value
 
         // These are enum flags in CallingConventions.h, but that's really ugly in C#, so I've changed them to bools.

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
@@ -467,7 +467,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 #endif
             }
 
-            public override int StackElemSize(int parmSize, bool isValueType = false, bool isFloatHfa = false) => throw new NotImplementedException();
+            public override int StackElemSize(int parmSize, bool isValueType = false, bool isFloatHfa = false)
+            {
+                int stackSlotSize = 4;
+                return ALIGN_UP(parmSize, stackSlotSize);
+            }
         }
 
         public const int SizeOfM128A = 16;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
@@ -66,12 +66,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public virtual bool IsArmelABI => false;
         public virtual bool IsArmhfABI => false;
+        public virtual bool IsAppleArm64ABI => false;
 
         public abstract int PointerSize { get; }
 
-        public int StackElemSize() => PointerSize;
+        public abstract int FloatRegisterSize { get; }
 
-        public int StackElemSize(int size) => (((size) + StackElemSize() - 1) & -StackElemSize());
+        public abstract int StackElemSize(int parmSize, bool isValueType = false, bool isFloatHfa = false);
 
         public abstract int NumArgumentRegisters { get; }
 
@@ -108,7 +109,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         /// <summary>
         /// Default implementation of ThisOffset; X86TransitionBlock provides a slightly different implementation.
         /// </summary>
-        public virtual int ThisOffset { get { return OffsetOfArgumentRegisters;  } }
+        public virtual int ThisOffset { get { return OffsetOfArgumentRegisters; } }
 
         /// <summary>
         /// Recalculate pos in GC ref map to actual offset. This is the default implementation for all architectures
@@ -134,6 +135,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public bool IsArgumentRegisterOffset(int offset)
         {
+            Debug.Assert(!IsX64UnixABI || offset != StructInRegsOffset);
             int ofsArgRegs = OffsetOfArgumentRegisters;
 
             return offset >= ofsArgRegs && offset < (int)(ofsArgRegs + SizeOfArgumentRegisters);
@@ -142,13 +144,21 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public int GetArgumentIndexFromOffset(int offset)
         {
             Debug.Assert(!IsX86);
-            return ((offset - OffsetOfArgumentRegisters) / PointerSize);
+            offset -= OffsetOfArgumentRegisters;
+            Debug.Assert((offset % PointerSize) == 0);
+            return offset / PointerSize;
         }
 
         public int GetStackArgumentIndexFromOffset(int offset)
         {
             Debug.Assert(!IsX86);
-            return (offset - OffsetOfArgs) / StackElemSize();
+            return (offset - OffsetOfArgs) / PointerSize;
+        }
+
+        public int GetStackArgumentByteIndexFromOffset(int offset)
+        {
+            Debug.Assert(!IsX86);
+            return offset - OffsetOfArgs;
         }
 
         /// <summary>
@@ -397,6 +407,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             }
         }
 
+        public static int ALIGN_UP(int input, int align_to)
+        {
+            return (input + (align_to - 1)) & ~(align_to - 1);
+        }
+
         public const int InvalidOffset = -1;
 
         public sealed class X86Constants
@@ -412,6 +427,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             public override TargetArchitecture Architecture => TargetArchitecture.X86;
 
             public override int PointerSize => 4;
+            public override int FloatRegisterSize => throw new NotImplementedException();
 
             public override int NumArgumentRegisters => 2;
             public override int NumCalleeSavedRegisters => 4;
@@ -450,6 +466,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 return hasThis ? X86Constants.OffsetOfEdx : X86Constants.OffsetOfEcx;
 #endif
             }
+
+            public override int StackElemSize(int parmSize, bool isValueType = false, bool isFloatHfa = false) => throw new NotImplementedException();
         }
 
         public const int SizeOfM128A = 16;
@@ -461,6 +479,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             public override TargetArchitecture Architecture => TargetArchitecture.X64;
             public override int PointerSize => 8;
+            public override int FloatRegisterSize => 16;
 
             public override bool IsArgPassedByRef(TypeHandle th)
             {
@@ -475,6 +494,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             }
 
             public override int GetRetBuffArgOffset(bool hasThis) => OffsetOfArgumentRegisters + (hasThis ? PointerSize : 0);
+            public sealed override int StackElemSize(int parmSize, bool isValueType = false, bool isFloatHfa = false)
+            {
+                int stackSlotSize = 8;
+                return ALIGN_UP(parmSize, stackSlotSize);
+            }
         }
 
         private sealed class X64WindowsTransitionBlock : X64TransitionBlock
@@ -521,6 +545,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             public sealed override TargetArchitecture Architecture => TargetArchitecture.ARM;
             public sealed override int PointerSize => 4;
+            public override int FloatRegisterSize => 4;
             // R0, R1, R2, R3
             public sealed override int NumArgumentRegisters => 4;
             // R4, R5, R6, R7, R8, R9, R10, R11, R14
@@ -538,6 +563,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             public sealed override bool IsArgPassedByRef(TypeHandle th) => false;
 
             public sealed override int GetRetBuffArgOffset(bool hasThis) => OffsetOfArgumentRegisters + (hasThis ? PointerSize : 0);
+
+            public sealed override int StackElemSize(int parmSize, bool isValueType = false, bool isFloatHfa = false)
+            {
+                int stackSlotSize = 4;
+                return ALIGN_UP(parmSize, stackSlotSize);
+            }
         }
 
         private class Arm32ElTransitionBlock : Arm32TransitionBlock
@@ -548,12 +579,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             public override bool IsArmelABI => true;
         }
 
-        private sealed class Arm64TransitionBlock : TransitionBlock
+        private class Arm64TransitionBlock : TransitionBlock
         {
             public static TransitionBlock Instance = new Arm64TransitionBlock();
-
             public override TargetArchitecture Architecture => TargetArchitecture.ARM64;
             public override int PointerSize => 8;
+            public override int FloatRegisterSize => 16;
             // X0 .. X7
             public override int NumArgumentRegisters => 8;
             // X29, X30, X19, X20, X21, X22, X23, X24, X25, X26, X27, X28
@@ -581,6 +612,37 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             public override int GetRetBuffArgOffset(bool hasThis) => OffsetOfX8Register;
 
             public override bool IsRetBuffPassedAsFirstArg => false;
+
+            public override int StackElemSize(int parmSize, bool isValueType = false, bool isFloatHfa = false)
+            {
+                int stackSlotSize = 8;
+                return ALIGN_UP(parmSize, stackSlotSize);
+            }
+        }
+
+        private sealed class AppleArm64TransitionBlock : Arm64TransitionBlock
+        {
+            public new static TransitionBlock Instance = new AppleArm64TransitionBlock();
+            public override bool IsAppleArm64ABI => true;
+
+            public sealed override int StackElemSize(int parmSize, bool isValueType = false, bool isFloatHfa = false)
+            {
+                if (!isValueType)
+                {
+                    // The primitive types' sizes are expected to be powers of 2.
+                    Debug.Assert((parmSize & (parmSize - 1)) == 0);
+                    // No padding/alignment for primitive types.
+                    return parmSize;
+                }
+                if (isFloatHfa)
+                {
+                    Debug.Assert((parmSize % 4) == 0);
+                    // float hfa is not considered a struct type and passed with 4-byte alignment.
+                    return parmSize;
+                }
+
+                return base.StackElemSize(parmSize, isValueType, isFloatHfa);
+            }
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
@@ -39,7 +39,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     }
 
                 case TargetArchitecture.ARM64:
-                    return Arm64TransitionBlock.Instance;
+                    return target.OperatingSystem == TargetOS.OSX ?
+                        AppleArm64TransitionBlock.Instance :
+                        Arm64TransitionBlock.Instance;
 
                 default:
                     throw new NotImplementedException(target.Architecture.ToString());


### PR DESCRIPTION
The goal of the change is primarily to make it correct for the Apple
Silicon where the calling convention slightly differs from the
Unix ARM64 one, especially in passing arguments smaller than a pointer
size on stack.