### PR TITLE
Fix an issue where we are not injecting more HTTP2 connections when we should

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1822,6 +1822,9 @@ namespace System.Net.Http
                     if (NetEventSource.Log.IsEnabled()) connection.Trace("Dequeued waiting HTTP/2 request.");
                 }
 
+                // Since we only inject one connection at a time, we may want to inject another now.
+                CheckForHttp2ConnectionInjection();
+
                 if (_disposed)
                 {
                     // If the pool has been disposed of, we want to dispose the connection being returned, as the pool is being deactivated.

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -2163,12 +2163,12 @@ namespace System.Net.Http.Functional.Tests
             (int finalStreamId, _) = await c3.ReadAndParseRequestHeaderAsync();
             acceptedRequests.Add((c3, finalStreamId));
 
-            foreach (var request in acceptedRequests)
+            foreach ((Http2LoopbackConnection connection, int streamId) request in acceptedRequests)
             {
                 await request.connection.SendDefaultResponseAsync(request.streamId);
             }
 
-            foreach (var t in sendTasks)
+            foreach (Task<HttpResponseMessage> t in sendTasks)
             {
                 HttpResponseMessage response = await t;
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -2119,6 +2119,63 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ConditionalFact(nameof(SupportsAlpn))]
+        public async Task Http2_MultipleConnectionsEnabled_ManyRequestsEnqueuedSimultaneously_SufficientConnectionsCreated()
+        {
+            // This is equal to Http2Connection.InitialMaxConcurrentStreams, which is the limit we impose before we have received the peer's initial SETTINGS frame.
+            // Setting it to this value avoids any complexity that would occur from having to retry requests if the actual limit from the peer is lower.
+            const int MaxConcurrentStreams = 100;
+
+            const int ConnectionCount = 3;
+
+            // Just enough to force the third connection to be created.
+            const int RequestCount = (ConnectionCount - 1) * MaxConcurrentStreams + 1;
+
+            using Http2LoopbackServer server = Http2LoopbackServer.CreateServer();
+            server.AllowMultipleConnections = true;
+
+            using SocketsHttpHandler handler = CreateHandler();
+            using HttpClient client = CreateHttpClient(handler);
+
+            List<Task<HttpResponseMessage>> sendTasks = new List<Task<HttpResponseMessage>>();
+            for (int i = 0; i < RequestCount; i++)
+            {
+                var sendTask = client.GetAsync(server.Address);
+                sendTasks.Add(sendTask);
+            }
+
+            List<(Http2LoopbackConnection connection, int streamId)> acceptedRequests = new List<(Http2LoopbackConnection connection, int streamId)>();
+
+            using Http2LoopbackConnection c1 = await server.EstablishConnectionAsync(new SettingsEntry { SettingId = SettingId.MaxConcurrentStreams, Value = 100 });
+            for (int i = 0; i < MaxConcurrentStreams; i++)
+            {
+                (int streamId, _) = await c1.ReadAndParseRequestHeaderAsync();
+                acceptedRequests.Add((c1, streamId));
+            }
+
+            using Http2LoopbackConnection c2 = await server.EstablishConnectionAsync(new SettingsEntry { SettingId = SettingId.MaxConcurrentStreams, Value = 100 });
+            for (int i = 0; i < MaxConcurrentStreams; i++)
+            {
+                (int streamId, _) = await c2.ReadAndParseRequestHeaderAsync();
+                acceptedRequests.Add((c2, streamId));
+            }
+
+            using Http2LoopbackConnection c3 = await server.EstablishConnectionAsync(new SettingsEntry { SettingId = SettingId.MaxConcurrentStreams, Value = 100 });
+            (int finalStreamId, _) = await c3.ReadAndParseRequestHeaderAsync();
+            acceptedRequests.Add((c3, finalStreamId));
+
+            foreach (var request in acceptedRequests)
+            {
+                await request.connection.SendDefaultResponseAsync(request.streamId);
+            }
+
+            foreach (var t in sendTasks)
+            {
+                HttpResponseMessage response = await t;
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            }
+        }
+
+        [ConditionalFact(nameof(SupportsAlpn))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/45204")]
         public async Task Http2_MultipleConnectionsEnabled_InfiniteRequestsCompletelyBlockOneConnection_RemaningRequestsAreHandledByNewConnection()
         {


### PR DESCRIPTION
Fixes #55980 

This is a regression caused by my connection pooling changes.

For HTTP2, we constrain our connection injection logic to never inject more than one connection at a time. On successful connection establishment, we should check if we need to create yet another connection to handle the queued requests. Unfortunately, we aren't doing this today.

The specific problem is a scenario like this:

(1) User submits one request. We enqueue it and kick off an HTTP2 connection attempt.
(2) User submits 100 more requests. There are now 101 requests in the queue.
(3) Connection attempt succeeds. We dequeue 100 requests and give them to the new connection to be processed. 
(4) There's still one request in the queue, so we should be kicking off another connection attempt -- but currently we don't.

