### PR TITLE
[wasm] Fix regression in compiling .bc -> .o files

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -161,7 +161,7 @@
     <SQLitePCLRawbundle_greenVersion>2.0.4</SQLitePCLRawbundle_greenVersion>
     <MoqVersion>4.12.0</MoqVersion>
     <FsCheckVersion>2.14.3</FsCheckVersion>
-    <SdkVersionForWorkloadTesting>6.0.100-preview.7.21362.5</SdkVersionForWorkloadTesting>
+    <SdkVersionForWorkloadTesting>6.0.100-rc.1.21370.2</SdkVersionForWorkloadTesting>
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>5.0.0-preview-20201009.2</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -276,7 +276,7 @@
     <EmccCompile
           Condition="@(_BitCodeFile->Count()) > 0"
           SourceFiles="@(_BitCodeFile)"
-          Arguments="&quot;@$(_EmccDefaultFlagsRsp)&quot; &quot;@$(_EmccCompileRsp)&quot;"
+          Arguments="&quot;@$(_EmccDefaultFlagsRsp)&quot; @(_EmccLDFlags, ' ')"
           EnvironmentVariables="@(EmscriptenEnvVars)"
           OutputMessageImportance="$(_EmccCompileOutputMessageImportance)" />
 

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -158,6 +158,8 @@
       <EmccLinkOptimizationFlag    Condition="'$(EmccLinkOptimizationFlag)' == ''"   >$(EmccCompileOptimizationFlag)</EmccLinkOptimizationFlag>
 
       <_EmccCompileRsp>$(_WasmIntermediateOutputPath)emcc-compile.rsp</_EmccCompileRsp>
+      <_EmccCompileOutputMessageImportance Condition="'$(EmccVerbose)' == 'true'">Normal</_EmccCompileOutputMessageImportance>
+      <_EmccCompileOutputMessageImportance Condition="'$(EmccVerbose)' != 'true'">Low</_EmccCompileOutputMessageImportance>
     </PropertyGroup>
 
     <ItemGroup>
@@ -241,7 +243,11 @@
     <Exec Command="$(_EmBuilder) build MINIMAL" EnvironmentVariables="@(EmscriptenEnvVars)" StandardOutputImportance="Low" StandardErrorImportance="Low" />
 
     <Message Text="Compiling native assets with emcc. This may take a while ..." Importance="High" />
-    <EmccCompile SourceFiles="@(_WasmSourceFileToCompile)" Arguments='"@$(_EmccDefaultFlagsRsp)" "@$(_EmccCompileRsp)"' EnvironmentVariables="@(EmscriptenEnvVars)" />
+    <EmccCompile
+          SourceFiles="@(_WasmSourceFileToCompile)"
+          Arguments='"@$(_EmccDefaultFlagsRsp)" "@$(_EmccCompileRsp)"'
+          EnvironmentVariables="@(EmscriptenEnvVars)"
+          OutputMessageImportance="$(_EmccCompileOutputMessageImportance)" />
 
     <ItemGroup>
       <WasmNativeAsset Include="%(_WasmSourceFileToCompile.ObjectFile)" />
@@ -271,7 +277,8 @@
           Condition="@(_BitCodeFile->Count()) > 0"
           SourceFiles="@(_BitCodeFile)"
           Arguments="&quot;@$(_EmccDefaultFlagsRsp)&quot; &quot;@$(_EmccCompileRsp)&quot;"
-          EnvironmentVariables="@(EmscriptenEnvVars)" />
+          EnvironmentVariables="@(EmscriptenEnvVars)"
+          OutputMessageImportance="$(_EmccCompileOutputMessageImportance)" />
 
     <ItemGroup>
       <!-- order seems to matter -->

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -181,6 +181,7 @@
       <_EmccCFlags Include="-DLINK_ICALLS=1"                   Condition="'$(WasmLinkIcalls)' == 'true'" />
       <_EmccCFlags Include="-DCORE_BINDINGS" />
       <_EmccCFlags Include="-DGEN_PINVOKE=1" />
+      <_EmccCFlags Include="-emit-llvm" />
 
       <_EmccCFlags Include="&quot;-I%(_EmccIncludePaths.Identity)&quot;" />
       <_EmccCFlags Include="-g" Condition="'$(WasmNativeDebugSymbols)' == 'true'" />

--- a/src/tasks/WasmAppBuilder/EmccCompile.cs
+++ b/src/tasks/WasmAppBuilder/EmccCompile.cs
@@ -119,7 +119,7 @@ namespace Microsoft.WebAssembly.Build.Tasks
 
                 try
                 {
-                    string command = $"emcc {Arguments} -c -o {objFile} {srcFile}";
+                    string command = $"emcc {Arguments} -c -o \"{objFile}\" \"{srcFile}\"";
 
                     // Log the command in a compact format which can be copy pasted
                     StringBuilder envStr = new StringBuilder(string.Empty);

--- a/src/tasks/WasmAppBuilder/EmccCompile.cs
+++ b/src/tasks/WasmAppBuilder/EmccCompile.cs
@@ -33,6 +33,7 @@ namespace Microsoft.WebAssembly.Build.Tasks
         public bool         DisableParallelCompile { get; set; }
         public string       Arguments              { get; set; } = string.Empty;
         public string?      WorkingDirectory       { get; set; }
+        public string       OutputMessageImportance{ get; set; } = "Low";
 
         [Output]
         public ITaskItem[]? OutputFiles            { get; private set; }
@@ -51,6 +52,12 @@ namespace Microsoft.WebAssembly.Build.Tasks
             if (badItem != null)
             {
                 Log.LogError($"Source file {badItem.ItemSpec} is missing ObjectFile metadata.");
+                return false;
+            }
+
+            if (!Enum.TryParse(OutputMessageImportance, ignoreCase: true, out MessageImportance messageImportance))
+            {
+                Log.LogError($"Invalid value for OutputMessageImportance={OutputMessageImportance}. Valid values: {string.Join(", ", Enum.GetNames(typeof(MessageImportance)))}");
                 return false;
             }
 
@@ -125,7 +132,7 @@ namespace Microsoft.WebAssembly.Build.Tasks
                                                             envVarsDict,
                                                             workingDir: Environment.CurrentDirectory,
                                                             logStdErrAsMessage: true,
-                                                            debugMessageImportance: MessageImportance.High,
+                                                            debugMessageImportance: messageImportance,
                                                             label: Path.GetFileName(srcFile));
 
                     if (exitCode != 0)

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
@@ -332,10 +332,7 @@ namespace Wasm.Build.Tests
                 }
 
                 if (useCache)
-                {
                     _buildContext.CacheBuild(buildArgs, new BuildProduct(_projectDir, logFilePath, true));
-                    Console.WriteLine($"caching build for {buildArgs}");
-                }
 
                 return (_projectDir, result.buildOutput);
             }

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/NativeBuildTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/NativeBuildTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/NativeBuildTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/NativeBuildTests.cs
@@ -1,10 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.IO;
 using Xunit;
 using Xunit.Abstractions;
+using Xunit.Sdk;
 
 #nullable enable
 
@@ -42,6 +41,38 @@ namespace Wasm.Build.Tests
             RunAndTestWasmApp(buildArgs, buildDir: _projectDir, expectedExitCode: 42,
                         test: output => {},
                         host: host, id: id);
+        }
+
+        [Theory]
+        [BuildAndRun(host: RunHost.None, aot: true)]
+        public void IntermediateBitcodeToObjectFilesAreNotLLVMIR(BuildArgs buildArgs, string id)
+        {
+            string printFileTypeTarget = @"
+                <Target Name=""PrintIntermediateFileType"" AfterTargets=""WasmBuildApp"">
+                    <Exec Command=""wasm-dis $(_WasmIntermediateOutputPath)System.Private.CoreLib.dll.o -o $(_WasmIntermediateOutputPath)wasm-dis-out.txt""
+                          ConsoleToMSBuild=""true""
+                          EnvironmentVariables=""@(EmscriptenEnvVars)""
+                          IgnoreExitCode=""true"">
+
+                        <Output TaskParameter=""ExitCode"" PropertyName=""ExitCode"" />
+                    </Exec>
+
+                    <Message Text=""wasm-dis exit code: $(ExitCode)"" Importance=""High"" />
+                </Target>
+                ";
+            string projectName = $"bc_to_o_{buildArgs.Config}";
+
+            buildArgs = buildArgs with { ProjectName = projectName };
+            buildArgs = ExpandBuildArgs(buildArgs, insertAtEnd: printFileTypeTarget);
+
+            (_, string output) = BuildProject(buildArgs,
+                                    initProject: () => File.WriteAllText(Path.Combine(_projectDir!, "Program.cs"), s_mainReturns42),
+                                    dotnetWasmFromRuntimePack: false,
+                                    id: id);
+
+            if (!output.Contains("wasm-dis exit code: 0"))
+                throw new XunitException($"Expected to successfully run wasm-dis on System.Private.CoreLib.dll.o ."
+                                            + " It might fail if it was incorrectly compiled to a bitcode file, instead of wasm.");
         }
     }
 }

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/SharedBuildPerTestClassFixture.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/SharedBuildPerTestClassFixture.cs
@@ -44,7 +44,7 @@ namespace Wasm.Build.Tests
         {
             try
             {
-                 Directory.Delete(path, recursive: true);
+                Directory.Delete(path, recursive: true);
             }
             catch (Exception ex)
             {

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/ToolCommand.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/ToolCommand.cs
@@ -88,6 +88,7 @@ namespace Wasm.Build.Tests
                     return;
 
                 output.Add($"[{_label}] {e.Data}");
+                Console.WriteLine($"[{_label}] {e.Data}");
                 ErrorDataReceived?.Invoke(s, e);
             };
 
@@ -97,6 +98,7 @@ namespace Wasm.Build.Tests
                     return;
 
                 output.Add($"[{_label}] {e.Data}");
+                Console.WriteLine($"[{_label}] {e.Data}");
                 OutputDataReceived?.Invoke(s, e);
             };
 


### PR DESCRIPTION
The `-emit-llvm` arg has been incorrectly added, and removed from the
args used for compiling .bc->.o couple of times. Added a crude test to
avoid regressing in the future.

- And reduces EmccCompile's output to `Low` importance, so it doesn't pollute a normal build output (eg. for Blazor)
- And add some more tests for blazorwasm