### PR TITLE
Re-enable tests for runtime handles in crossgen2

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -959,24 +959,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/superpmi/superpmicollect/*">
             <Issue>Not compatible with crossgen2</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/coverage/importer/refanytype1/*">
-            <Issue>https://github.com/dotnet/runtime/issues/43460</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/coverage/importer/Desktop/refanytype1_il_r/*">
-            <Issue>https://github.com/dotnet/runtime/issues/43460</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/coverage/importer/Desktop/refanytype1_il_d/*">
-            <Issue>https://github.com/dotnet/runtime/issues/43460</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/V1-M10/b09254/b09254/*">
-            <Issue>https://github.com/dotnet/runtime/issues/43460</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b29583/b29583/*">
-            <Issue>https://github.com/dotnet/runtime/issues/43460</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/IL_Conformance/Old/objectmodel/ldtoken/*">
-            <Issue>https://github.com/dotnet/runtime/issues/43460</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutExp/*">
             <Issue>https://github.com/dotnet/runtime/issues/43461</Issue>
         </ExcludeList>


### PR DESCRIPTION
These tests pass now. This issue was fixed some time ago.

Fixes #43460