### PR TITLE
Fix DeserializeAsyncEnumerable streaming behavior

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -388,8 +388,8 @@ namespace System.Text.Json
                     do
                     {
                         bufferState = await ReadFromStreamAsync(utf8Json, bufferState, cancellationToken).ConfigureAwait(false);
-                        Queue<TValue>? queue = ContinueDeserialize<Queue<TValue>>(ref bufferState, ref jsonReaderState, ref readStack, converter, options);
-                        if (queue is not null)
+                        ContinueDeserialize<Queue<TValue>>(ref bufferState, ref jsonReaderState, ref readStack, converter, options);
+                        if (readStack.Current.ReturnValue is Queue<TValue> queue)
                         {
                             while (queue.Count > 0)
                             {


### PR DESCRIPTION
Fixes regression introduced by #51702: the `ContinueDeserialize` method will return 'null' on partial reads so no elements will be yielded by the enumerator until the entire stream has been consumed.

This change reverts to the original implementation where the partially populated queue is being fetched from `ReadStack` instead.

Fixes #56055.