### PR TITLE
[FileStream] update Position after ReadAsync completes

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.Windows.cs
@@ -242,14 +242,15 @@ namespace System.IO
             return ScheduleSyncReadAtOffsetAsync(handle, buffer, fileOffset, cancellationToken);
         }
 
-        internal static unsafe (SafeFileHandle.OverlappedValueTaskSource? vts, int errorCode) QueueAsyncReadFile(SafeFileHandle handle, Memory<byte> buffer, long fileOffset, CancellationToken cancellationToken)
+        internal static unsafe (SafeFileHandle.OverlappedValueTaskSource? vts, int errorCode) QueueAsyncReadFile(SafeFileHandle handle, Memory<byte> buffer, long fileOffset,
+            CancellationToken cancellationToken, AsyncWindowsFileStreamStrategy? strategy = null)
         {
             handle.EnsureThreadPoolBindingInitialized();
 
             SafeFileHandle.OverlappedValueTaskSource vts = handle.GetOverlappedValueTaskSource();
             try
             {
-                NativeOverlapped* nativeOverlapped = vts.PrepareForOperation(buffer, fileOffset);
+                NativeOverlapped* nativeOverlapped = vts.PrepareForOperation(buffer, fileOffset, strategy);
                 Debug.Assert(vts._memoryHandle.Pointer != null);
 
                 // Queue an async ReadFile operation.


### PR DESCRIPTION
While working on the blog post I've realized that there is a difference in when the position is updated for `FileStream.ReadAsync()`

The Unix strategy updates the position after the operation completes:

https://github.com/dotnet/runtime/blob/7c72b729ac129c6c7918b5592d30e06c191a6f71/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/UnixFileStreamStrategy.cs#L45

IMO we should align both implementations. 

We can treat it as an edge case bug fix for cases where file length would get updated (in case of a file shared for writing) between the call to `Length`:

https://github.com/dotnet/runtime/blob/b823f14ab759b4cc32c7315b1c278c226dc2af20/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.cs#L41

and the call to `ReadFile`:

https://github.com/dotnet/runtime/blob/b823f14ab759b4cc32c7315b1c278c226dc2af20/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.cs#L55

I am soon going to provide the benchmark results but I don't expect any regressions. Actually, we might even notice a small improvement for small files, where we are going to omit the call to `Length`