### PR TITLE
[HTTP/3] Suppress LocalCertificateSelectionCallback when QUIC is used

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.SocketsHttpHandler.cs
@@ -50,6 +50,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 SocketsHttpHandler socketsHttpHandler = (SocketsHttpHandler)GetUnderlyingSocketsHttpHandler(handler);
                 SetQuicImplementationProvider(socketsHttpHandler, quicImplementationProvider);
+                socketsHttpHandler.SslOptions.LocalCertificateSelectionCallback = null;
                 socketsHttpHandler.SslOptions.RemoteCertificateValidationCallback = (sender, certificate, chain, errors) => true;
             }
 


### PR DESCRIPTION
Fixes #56090