### PR TITLE
use PoolingAsyncValueTaskMethodBuilder in BufferedFileStreamStrategy

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/BufferedFileStreamStrategy.cs
@@ -423,6 +423,7 @@ namespace System.IO.Strategies
             }
         }
 
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
         private async ValueTask<int> ReadAsyncSlowPath(Task semaphoreLockTask, Memory<byte> buffer, CancellationToken cancellationToken)
         {
             Debug.Assert(_asyncActiveSemaphore != null);
@@ -705,6 +706,7 @@ namespace System.IO.Strategies
             }
         }
 
+        [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
         private async ValueTask WriteAsyncSlowPath(Task semaphoreLockTask, ReadOnlyMemory<byte> source, CancellationToken cancellationToken)
         {
             Debug.Assert(_asyncActiveSemaphore != null);


### PR DESCRIPTION
@stephentoub from the initial benchmark run it seems that it saves a lot of allocations when buffering is actually used:

|    Method |         Toolchain | fileSize | userBufferSize |      options |     Mean | Ratio | Allocated |
|---------- |------------------ |--------- |--------------- |------------- |---------:|------:|----------:|
| ReadAsync | \main\corerun.exe |  1048576 |            512 |         None | 1.470 ms |  1.00 |     83 KB |
| ReadAsync | \pool\corerun.exe |  1048576 |            512 |         None | 1.399 ms |  0.95 |     33 KB |
|           |                   |          |                |              |          |       |           |
| ReadAsync | \main\corerun.exe |  1048576 |            512 | Asynchronous | 3.265 ms |  1.00 |     55 KB |
| ReadAsync | \pool\corerun.exe |  1048576 |            512 | Asynchronous | 3.269 ms |  1.00 |      5 KB |

I am going to run all benchmarks MANY times (>1h) and get back with full results. In the meantime, I hope the CI can test it for me