### PR TITLE
Revert "throw PNSE for unsupported SSL options in Quic."

### DIFF
--- a/src/libraries/System.Net.Quic/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Quic/src/Resources/Strings.resx
@@ -150,8 +150,5 @@
   <data name="net_quic_writing_notallowed" xml:space="preserve">
     <value>Writing is not allowed on stream.</value>
   </data>
-  <data name="net_quic_ssl_option" xml:space="preserve">
-    <value>The '{0}' is not supported by System.Net.Quic.</value>
-  </data>
 </root>
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/SafeMsQuicConfigurationHandle.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/SafeMsQuicConfigurationHandle.cs
@@ -36,39 +36,20 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         public static unsafe SafeMsQuicConfigurationHandle Create(QuicClientConnectionOptions options)
         {
             X509Certificate? certificate = null;
-
-            if (options.ClientAuthenticationOptions != null)
+            if (options.ClientAuthenticationOptions?.ClientCertificates != null)
             {
-                if (options.ClientAuthenticationOptions.CipherSuitesPolicy != null)
+                foreach (var cert in options.ClientAuthenticationOptions.ClientCertificates)
                 {
-                    throw new PlatformNotSupportedException(SR.Format(SR.net_quic_ssl_option, nameof(options.ClientAuthenticationOptions.CipherSuitesPolicy)));
-                }
-
-                if (options.ClientAuthenticationOptions.EncryptionPolicy == EncryptionPolicy.NoEncryption)
-                {
-                    throw new PlatformNotSupportedException(SR.Format(SR.net_quic_ssl_option, nameof(options.ClientAuthenticationOptions.EncryptionPolicy)));
-                }
-
-                if (options.ClientAuthenticationOptions.LocalCertificateSelectionCallback != null)
-                {
-                    throw new PlatformNotSupportedException(SR.Format(SR.net_quic_ssl_option, nameof(options.ClientAuthenticationOptions.LocalCertificateSelectionCallback)));
-                }
-
-                if (options.ClientAuthenticationOptions.ClientCertificates != null)
-                {
-                    foreach (var cert in options.ClientAuthenticationOptions.ClientCertificates)
+                    try
                     {
-                        try
+                        if (((X509Certificate2)cert).HasPrivateKey)
                         {
-                            if (((X509Certificate2)cert).HasPrivateKey)
-                            {
-                                // Pick first certificate with private key.
-                                certificate = cert;
-                                break;
-                            }
+                            // Pick first certificate with private key.
+                            certificate = cert;
+                            break;
                         }
-                        catch { }
                     }
+                    catch { }
                 }
             }
 
@@ -78,23 +59,9 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         public static unsafe SafeMsQuicConfigurationHandle Create(QuicListenerOptions options)
         {
             QUIC_CREDENTIAL_FLAGS flags = QUIC_CREDENTIAL_FLAGS.NONE;
-
-            if (options.ServerAuthenticationOptions != null)
+            if (options.ServerAuthenticationOptions != null && options.ServerAuthenticationOptions.ClientCertificateRequired)
             {
-                if (options.ServerAuthenticationOptions.CipherSuitesPolicy != null)
-                {
-                    throw new PlatformNotSupportedException(SR.Format(SR.net_quic_ssl_option, nameof(options.ServerAuthenticationOptions.CipherSuitesPolicy)));
-                }
-
-                if (options.ServerAuthenticationOptions.EncryptionPolicy == EncryptionPolicy.NoEncryption)
-                {
-                    throw new PlatformNotSupportedException(SR.Format(SR.net_quic_ssl_option, nameof(options.ServerAuthenticationOptions.EncryptionPolicy)));
-                }
-
-                if (options.ServerAuthenticationOptions.ClientCertificateRequired)
-                {
-                    flags |= QUIC_CREDENTIAL_FLAGS.REQUIRE_CLIENT_AUTHENTICATION | QUIC_CREDENTIAL_FLAGS.INDICATE_CERTIFICATE_RECEIVED | QUIC_CREDENTIAL_FLAGS.NO_CERTIFICATE_VALIDATION;
-                }
+                flags |= QUIC_CREDENTIAL_FLAGS.REQUIRE_CLIENT_AUTHENTICATION | QUIC_CREDENTIAL_FLAGS.INDICATE_CERTIFICATE_RECEIVED | QUIC_CREDENTIAL_FLAGS.NO_CERTIFICATE_VALIDATION;
             }
 
             return Create(options, flags, options.ServerAuthenticationOptions?.ServerCertificate, options.ServerAuthenticationOptions?.ServerCertificateContext, options.ServerAuthenticationOptions?.ApplicationProtocols);


### PR DESCRIPTION
Reverts #55877 which caused massive CI failures

Fixes #56090