### PR TITLE
Fix static Socket.ConnectAsync for DnsEndPoint containing IPv6-mapped address string

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -710,6 +710,11 @@ namespace System.Net.Sockets
                             if (address.AddressFamily == AddressFamily.InterNetworkV6)
                             {
                                 attemptSocket = tempSocketIPv6 ??= (Socket.OSSupportsIPv6 ? new Socket(AddressFamily.InterNetworkV6, socketType, protocolType) : null);
+                                if (attemptSocket is not null && address.IsIPv4MappedToIPv6)
+                                {
+                                    // We need a DualMode socket to connect to an IPv6-mapped IPv4 address.
+                                    attemptSocket.DualMode = true;
+                                }
                             }
                             else if (address.AddressFamily == AddressFamily.InterNetwork)
                             {

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
@@ -384,6 +384,7 @@ namespace System.Net.Sockets.Tests
             Assert.Null(args.ConnectByNameError);
             Assert.NotNull(args.ConnectSocket);
             Assert.True(args.ConnectSocket.Connected);
+            args.ConnectSocket.Dispose();
         }
 
         [OuterLoop]

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
@@ -363,6 +363,29 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [Fact]
+        public void Socket_StaticConnectAsync_IPv6MappedIPv4_Success()
+        {
+            using SocketTestServer server = SocketTestServer.SocketTestServerFactory(SocketImplementationType.Async, IPAddress.Loopback, out int port);
+
+            SocketAsyncEventArgs args = new SocketAsyncEventArgs();
+            args.RemoteEndPoint = new DnsEndPoint("[::FFFF:127.0.0.1]", port);
+            args.Completed += OnConnectAsyncCompleted;
+
+            ManualResetEvent complete = new ManualResetEvent(false);
+            args.UserToken = complete;
+
+            if (Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, args))
+            {
+                Assert.True(complete.WaitOne(TestSettings.PassingTestTimeout), "Timed out while waiting for connection");
+            }
+
+            Assert.Equal(SocketError.Success, args.SocketError);
+            Assert.Null(args.ConnectByNameError);
+            Assert.NotNull(args.ConnectSocket);
+            Assert.True(args.ConnectSocket.Connected);
+        }
+
         [OuterLoop]
         [Fact]
         public void Socket_StaticConnectAsync_HostNotFound()


### PR DESCRIPTION
Fixes #56099

/cc @stephentoub @wfurt 