### PR TITLE
Prevent Segfault in EventPipe on disable

### DIFF
--- a/src/native/eventpipe/ep-provider.c
+++ b/src/native/eventpipe/ep-provider.c
@@ -76,7 +76,7 @@ provider_prepare_callback_data (
 
 	return ep_provider_callback_data_init (
 		provider_callback_data,
-		filter_data,
+		ep_rt_utf8_string_dup (filter_data),
 		provider->callback_func,
 		provider->callback_data,
 		keywords,

--- a/src/native/eventpipe/ep-provider.c
+++ b/src/native/eventpipe/ep-provider.c
@@ -76,7 +76,7 @@ provider_prepare_callback_data (
 
 	return ep_provider_callback_data_init (
 		provider_callback_data,
-		ep_rt_utf8_string_dup (filter_data),
+		filter_data,
 		provider->callback_func,
 		provider->callback_data,
 		keywords,

--- a/src/native/eventpipe/ep-types.h
+++ b/src/native/eventpipe/ep-types.h
@@ -77,7 +77,7 @@ struct _EventPipeProviderCallbackData {
 };
 #endif
 
-EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, ep_char8_t *, filter_data)
+EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, const ep_char8_t *, filter_data)
 EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, EventPipeCallback, callback_function)
 EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, void *, callback_data)
 EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, int64_t, keywords)
@@ -86,7 +86,7 @@ EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, bool, 
 
 EventPipeProviderCallbackData *
 ep_provider_callback_data_alloc (
-	ep_char8_t *filter_data,
+	const ep_char8_t *filter_data,
 	EventPipeCallback callback_function,
 	void *callback_data,
 	int64_t keywords,
@@ -99,7 +99,7 @@ ep_provider_callback_data_alloc_copy (EventPipeProviderCallbackData *provider_ca
 EventPipeProviderCallbackData *
 ep_provider_callback_data_init (
 	EventPipeProviderCallbackData *provider_callback_data,
-	ep_char8_t *filter_data,
+	const ep_char8_t *filter_data,
 	EventPipeCallback callback_function,
 	void *callback_data,
 	int64_t keywords,

--- a/src/native/eventpipe/ep-types.h
+++ b/src/native/eventpipe/ep-types.h
@@ -63,7 +63,7 @@ struct _EventPipeProviderCallbackData {
 #else
 struct _EventPipeProviderCallbackData_Internal {
 #endif
-	const ep_char8_t *filter_data;
+	ep_char8_t *filter_data;
 	EventPipeCallback callback_function;
 	void *callback_data;
 	int64_t keywords;
@@ -77,7 +77,7 @@ struct _EventPipeProviderCallbackData {
 };
 #endif
 
-EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, const ep_char8_t *, filter_data)
+EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, ep_char8_t *, filter_data)
 EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, EventPipeCallback, callback_function)
 EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, void *, callback_data)
 EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, int64_t, keywords)
@@ -86,7 +86,7 @@ EP_DEFINE_GETTER(EventPipeProviderCallbackData *, provider_callback_data, bool, 
 
 EventPipeProviderCallbackData *
 ep_provider_callback_data_alloc (
-	const ep_char8_t *filter_data,
+	ep_char8_t *filter_data,
 	EventPipeCallback callback_function,
 	void *callback_data,
 	int64_t keywords,
@@ -99,7 +99,7 @@ ep_provider_callback_data_alloc_copy (EventPipeProviderCallbackData *provider_ca
 EventPipeProviderCallbackData *
 ep_provider_callback_data_init (
 	EventPipeProviderCallbackData *provider_callback_data,
-	const ep_char8_t *filter_data,
+	ep_char8_t *filter_data,
 	EventPipeCallback callback_function,
 	void *callback_data,
 	int64_t keywords,

--- a/src/native/eventpipe/ep.c
+++ b/src/native/eventpipe/ep.c
@@ -212,7 +212,7 @@ ep_provider_callback_data_queue_fini (EventPipeProviderCallbackDataQueue *provid
 
 EventPipeProviderCallbackData *
 ep_provider_callback_data_alloc (
-	ep_char8_t *filter_data,
+	const ep_char8_t *filter_data,
 	EventPipeCallback callback_function,
 	void *callback_data,
 	int64_t keywords,
@@ -224,7 +224,7 @@ ep_provider_callback_data_alloc (
 
 	ep_raise_error_if_nok (ep_provider_callback_data_init (
 		instance,
-		ep_rt_utf8_string_dup (filter_data),
+		filter_data,
 		callback_function,
 		callback_data,
 		keywords,
@@ -246,7 +246,7 @@ ep_provider_callback_data_alloc_copy (EventPipeProviderCallbackData *provider_ca
 	EventPipeProviderCallbackData *instance = ep_rt_object_alloc (EventPipeProviderCallbackData);
 	ep_raise_error_if_nok (instance != NULL);
 
-	if (provider_callback_data_src != NULL) {
+	if (provider_callback_data_src) {
 		*instance = *provider_callback_data_src;
 		instance->filter_data = ep_rt_utf8_string_dup (provider_callback_data_src->filter_data);
 	}
@@ -263,7 +263,7 @@ ep_on_error:
 EventPipeProviderCallbackData *
 ep_provider_callback_data_init (
 	EventPipeProviderCallbackData *provider_callback_data,
-	ep_char8_t *filter_data,
+	const ep_char8_t *filter_data,
 	EventPipeCallback callback_function,
 	void *callback_data,
 	int64_t keywords,
@@ -272,7 +272,7 @@ ep_provider_callback_data_init (
 {
 	EP_ASSERT (provider_callback_data != NULL);
 
-	provider_callback_data->filter_data = filter_data;
+	provider_callback_data->filter_data = ep_rt_utf8_string_dup (filter_data);
 	provider_callback_data->callback_function = callback_function;
 	provider_callback_data->callback_data = callback_data;
 	provider_callback_data->keywords = keywords;
@@ -298,14 +298,14 @@ ep_provider_callback_data_init_copy (
 void
 ep_provider_callback_data_fini (EventPipeProviderCallbackData *provider_callback_data)
 {
-	;
+	ep_return_void_if_nok (provider_callback_data != NULL);
+	ep_rt_utf8_string_free (provider_callback_data->filter_data);
 }
 
 void
 ep_provider_callback_data_free (EventPipeProviderCallbackData *provider_callback_data)
 {
 	ep_return_void_if_nok (provider_callback_data != NULL);
-	ep_rt_utf8_string_free (provider_callback_data->filter_data);
 	ep_rt_object_free (provider_callback_data);
 }
 

--- a/src/native/eventpipe/ep.c
+++ b/src/native/eventpipe/ep.c
@@ -224,7 +224,7 @@ ep_provider_callback_data_alloc (
 
 	ep_raise_error_if_nok (ep_provider_callback_data_init (
 		instance,
-		filter_data,
+		ep_rt_ut8_string_dup (filter_data),
 		callback_function,
 		callback_data,
 		keywords,
@@ -246,8 +246,10 @@ ep_provider_callback_data_alloc_copy (EventPipeProviderCallbackData *provider_ca
 	EventPipeProviderCallbackData *instance = ep_rt_object_alloc (EventPipeProviderCallbackData);
 	ep_raise_error_if_nok (instance != NULL);
 
-	if (provider_callback_data_src)
+	if (provider_callback_data_src != NULL) {
 		*instance = *provider_callback_data_src;
+		instance->filter_data = ep_rt_utf8_string_dup (provider_callback_data_src->filter_data);
+	}
 
 ep_on_exit:
 	return instance;
@@ -289,6 +291,7 @@ ep_provider_callback_data_init_copy (
 	EP_ASSERT (provider_callback_data_src != NULL);
 
 	*provider_callback_data_dst = *provider_callback_data_src;
+	provider_callback_data_dst->filter_data = ep_rt_utf8_string_dup (provider_callback_data_src->filter_data);
 	return provider_callback_data_dst;
 }
 
@@ -302,6 +305,7 @@ void
 ep_provider_callback_data_free (EventPipeProviderCallbackData *provider_callback_data)
 {
 	ep_return_void_if_nok (provider_callback_data != NULL);
+	ep_rt_utf8_string_free (provider_callback_data->filter_data);
 	ep_rt_object_free (provider_callback_data);
 }
 

--- a/src/native/eventpipe/ep.c
+++ b/src/native/eventpipe/ep.c
@@ -306,6 +306,7 @@ void
 ep_provider_callback_data_free (EventPipeProviderCallbackData *provider_callback_data)
 {
 	ep_return_void_if_nok (provider_callback_data != NULL);
+	ep_provider_callback_data_fini (provider_callback_data);
 	ep_rt_object_free (provider_callback_data);
 }
 

--- a/src/native/eventpipe/ep.c
+++ b/src/native/eventpipe/ep.c
@@ -212,7 +212,7 @@ ep_provider_callback_data_queue_fini (EventPipeProviderCallbackDataQueue *provid
 
 EventPipeProviderCallbackData *
 ep_provider_callback_data_alloc (
-	const ep_char8_t *filter_data,
+	ep_char8_t *filter_data,
 	EventPipeCallback callback_function,
 	void *callback_data,
 	int64_t keywords,
@@ -224,7 +224,7 @@ ep_provider_callback_data_alloc (
 
 	ep_raise_error_if_nok (ep_provider_callback_data_init (
 		instance,
-		ep_rt_ut8_string_dup (filter_data),
+		ep_rt_utf8_string_dup (filter_data),
 		callback_function,
 		callback_data,
 		keywords,
@@ -263,7 +263,7 @@ ep_on_error:
 EventPipeProviderCallbackData *
 ep_provider_callback_data_init (
 	EventPipeProviderCallbackData *provider_callback_data,
-	const ep_char8_t *filter_data,
+	ep_char8_t *filter_data,
 	EventPipeCallback callback_function,
 	void *callback_data,
 	int64_t keywords,


### PR DESCRIPTION
During EventPipe disable, we call perform some work under a lock and queue some data for use after releasing the lock.

https://github.com/dotnet/runtime/blob/52262b88b992a3e8eb292a824102031dff1d6828/src/native/eventpipe/ep.c#L607-L621

The issue is that while under the lock we also call `ep_session_disable`, which clears the list of providers we used to generate the callback queue in the above snippet. Most of the fields on the structs are primitives, but `filter_data` is a utf8 string, so we end up freeing the string and then immediately attempt to use it afterwards. This patch changes ownership rules and dups the string for the `ep_provider_callback_data` struct.