### PR TITLE
Use Enabled/DisabledFeatureSwitches metadata in TrimmingTests

### DIFF
--- a/src/libraries/System.Runtime/tests/TrimmingTests/System.Runtime.TrimmingTests.proj
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/System.Runtime.TrimmingTests.proj
@@ -12,10 +12,10 @@
     <TestConsoleAppSourceFiles Include="InheritedAttributeTests.cs" />
     <TestConsoleAppSourceFiles Include="InterfacesOnArrays.cs" />
     <TestConsoleAppSourceFiles Include="InvariantGlobalizationFalse.cs">
-      <ExtraTrimmerArgs>--feature System.Globalization.Invariant false</ExtraTrimmerArgs>
+      <DisabledFeatureSwitches>System.Globalization.Invariant</DisabledFeatureSwitches>
     </TestConsoleAppSourceFiles>
     <TestConsoleAppSourceFiles Include="InvariantGlobalizationTrue.cs">
-      <ExtraTrimmerArgs>--feature System.Globalization.Invariant true --feature System.Globalization.PredefinedCulturesOnly true</ExtraTrimmerArgs>
+      <EnabledFeatureSwitches>System.Globalization.Invariant;System.Globalization.PredefinedCulturesOnly</EnabledFeatureSwitches>
     </TestConsoleAppSourceFiles>
     <TestConsoleAppSourceFiles Include="StackFrameHelperTest.cs">
       <!-- There is a bug with the linker where it is corrupting the pdbs while trimming
@@ -33,7 +33,7 @@
     <TestConsoleAppSourceFiles Include="VerifyResourcesGetTrimmedTest.cs">
       <!-- Setting the Trimming feature switch to make sure that the Resources get trimmed by the linker
       as this test will ensure exceptions are using Resource keys -->
-      <ExtraTrimmerArgs>--feature System.Resources.UseSystemResourceKeys true</ExtraTrimmerArgs>
+      <EnabledFeatureSwitches>System.Resources.UseSystemResourceKeys</EnabledFeatureSwitches>
     </TestConsoleAppSourceFiles>
     <TestConsoleAppSourceFiles Include="TypeBuilderComDisabled.cs">
       <DisabledFeatureSwitches>System.Runtime.InteropServices.BuiltInComInterop.IsSupported</DisabledFeatureSwitches>


### PR DESCRIPTION
This makes the trimming tests go through `<RuntimeHostConfigurationOption ... Trim="true"/>` (instead of explicitly setting trimmer args), such that the configuration is applied to both the runtime options and trimmer. This is also a bit closer to the SDK experience.