### PR TITLE
Add a unit test from aspnetcore

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -823,6 +823,9 @@ namespace System.Text.RegularExpressions.Tests
             // Empty Match
             yield return new object[] { null, @"([a*]*)+?$", "ab", RegexOptions.None, new string[] { "", "" } };
             yield return new object[] { null, @"(a*)+?$", "b", RegexOptions.None, new string[] { "", "" } };
+
+            // A unit test from aspnetcore
+            yield return new object[] { null, @"(.*)/(.*).aspx", "/pages/homepage.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx", "/pages", "homepage", } };
         }
 
         public static IEnumerable<object[]> Groups_CustomCulture_TestData_enUS()

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -582,7 +582,7 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { null, @"([a-z]*)([\w])", "cat", RegexOptions.IgnoreCase, new string[] { "cat", "ca", "t" } };
             yield return new object[] { null, @"^([a-z]*)([\w])$", "cat", RegexOptions.IgnoreCase, new string[] { "cat", "ca", "t" } };
 
-            // Backtracking with multiple (.*) groups -- important ASP.NET scnario
+            // Backtracking with multiple (.*) groups -- important ASP.NET scenario
             yield return new object[] { null, @"(.*)/(.*).aspx", "/.aspx", RegexOptions.None, new string[] { "/.aspx", string.Empty, string.Empty } };
             yield return new object[] { null, @"(.*)/(.*).aspx", "homepage.aspx", RegexOptions.None, new string[] { string.Empty } };
             yield return new object[] { null, @"(.*)/(.*).aspx", "/homepage.aspx", RegexOptions.None, new string[] { "/homepage.aspx", string.Empty, "homepage" } };

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -584,7 +584,6 @@ namespace System.Text.RegularExpressions.Tests
 
             // Backtracking with multiple (.*) groups -- important ASP.NET scenario
             yield return new object[] { null, @"(.*)/(.*).aspx", "/.aspx", RegexOptions.None, new string[] { "/.aspx", string.Empty, string.Empty } };
-            yield return new object[] { null, @"(.*)/(.*).aspx", "homepage.aspx", RegexOptions.None, new string[] { string.Empty } };
             yield return new object[] { null, @"(.*)/(.*).aspx", "/homepage.aspx", RegexOptions.None, new string[] { "/homepage.aspx", string.Empty, "homepage" } };
             yield return new object[] { null, @"(.*)/(.*).aspx", "pages/.aspx", RegexOptions.None, new string[] { "pages/.aspx", "pages", string.Empty } };
             yield return new object[] { null, @"(.*)/(.*).aspx", "pages/homepage.aspx", RegexOptions.None, new string[] { "pages/homepage.aspx", "pages", "homepage" } };
@@ -594,10 +593,6 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { null, @"(.*)/(.*)/(.*).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages", "homepage.aspx", "index" } };
 
             // Backtracking with multiple (.+) groups
-            yield return new object[] { null, @"(.+)/(.+).aspx", "/.aspx", RegexOptions.None, new string[] { string.Empty } };
-            yield return new object[] { null, @"(.+)/(.+).aspx", "homepage.aspx", RegexOptions.None, new string[] { string.Empty } };
-            yield return new object[] { null, @"(.+)/(.+).aspx", "/homepage.aspx", RegexOptions.None, new string[] { string.Empty } };
-            yield return new object[] { null, @"(.+)/(.+).aspx", "pages/.aspx", RegexOptions.None, new string[] { string.Empty } };
             yield return new object[] { null, @"(.+)/(.+).aspx", "pages/homepage.aspx", RegexOptions.None, new string[] { "pages/homepage.aspx", "pages", "homepage" } };
             yield return new object[] { null, @"(.+)/(.+).aspx", "/pages/homepage.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx", "/pages", "homepage" } };
             yield return new object[] { null, @"(.+)/(.+).aspx", "/pages/homepage/index.aspx", RegexOptions.None, new string[] { "/pages/homepage/index.aspx", "/pages/homepage", "index" } };
@@ -605,9 +600,6 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { null, @"(.+)/(.+)/(.+).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages", "homepage.aspx", "index" } };
 
             // Backtracking with (.+) group followed by (.*)
-            yield return new object[] { null, @"(.+)/(.*).aspx", "/.aspx", RegexOptions.None, new string[] { string.Empty } };
-            yield return new object[] { null, @"(.+)/(.*).aspx", "homepage.aspx", RegexOptions.None, new string[] { string.Empty } };
-            yield return new object[] { null, @"(.+)/(.*).aspx", "/homepage.aspx", RegexOptions.None, new string[] { string.Empty } };
             yield return new object[] { null, @"(.+)/(.*).aspx", "pages/.aspx", RegexOptions.None, new string[] { "pages/.aspx", "pages", string.Empty } };
             yield return new object[] { null, @"(.+)/(.*).aspx", "pages/homepage.aspx", RegexOptions.None, new string[] { "pages/homepage.aspx", "pages", "homepage" } };
             yield return new object[] { null, @"(.+)/(.*).aspx", "/pages/homepage.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx", "/pages", "homepage" } };
@@ -616,10 +608,7 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { null, @"(.+)/(.*)/(.*).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages", "homepage.aspx", "index" } };
 
             // Backtracking with (.*) group followed by (.+)
-            yield return new object[] { null, @"(.*)/(.+).aspx", "/.aspx", RegexOptions.None, new string[] { string.Empty } };
-            yield return new object[] { null, @"(.*)/(.+).aspx", "homepage.aspx", RegexOptions.None, new string[] { string.Empty } };
-            yield return new object[] { null, @"(.*)/(.+).aspx", "/homepage.aspx", RegexOptions.None, new string[] { "homepage.aspx", string.Empty, "homepage" } };
-            yield return new object[] { null, @"(.*)/(.+).aspx", "pages/.aspx", RegexOptions.None, new string[] { string.Empty } };
+            yield return new object[] { null, @"(.*)/(.+).aspx", "/homepage.aspx", RegexOptions.None, new string[] { "/homepage.aspx", string.Empty, "homepage" } };
             yield return new object[] { null, @"(.*)/(.+).aspx", "pages/homepage.aspx", RegexOptions.None, new string[] { "pages/homepage.aspx", "pages", "homepage" } };
             yield return new object[] { null, @"(.*)/(.+).aspx", "/pages/homepage.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx", "/pages", "homepage" } };
             yield return new object[] { null, @"(.*)/(.+).aspx", "/pages/homepage/index.aspx", RegexOptions.None, new string[] { "/pages/homepage/index.aspx", "/pages/homepage", "index" } };

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -582,6 +582,53 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { null, @"([a-z]*)([\w])", "cat", RegexOptions.IgnoreCase, new string[] { "cat", "ca", "t" } };
             yield return new object[] { null, @"^([a-z]*)([\w])$", "cat", RegexOptions.IgnoreCase, new string[] { "cat", "ca", "t" } };
 
+            foreach (RegexOptions options in new[] { RegexOptions.None, RegexOptions.Compiled })
+            {
+                // Backtracking with multiple (.*) groups -- important ASP.NET scnario
+                yield return new object[] { null, @"(.*)/(.*).aspx", "/.aspx", RegexOptions.None, new string[] { "/.aspx", string.Empty, string.Empty } };
+                yield return new object[] { null, @"(.*)/(.*).aspx", "homepage.aspx", RegexOptions.None, new string[] { string.Empty } };
+                yield return new object[] { null, @"(.*)/(.*).aspx", "/homepage.aspx", RegexOptions.None, new string[] { "/homepage.aspx", string.Empty, "homepage" } };
+                yield return new object[] { null, @"(.*)/(.*).aspx", "pages/.aspx", RegexOptions.None, new string[] { "pages/.aspx", "pages", string.Empty } };
+                yield return new object[] { null, @"(.*)/(.*).aspx", "pages/homepage.aspx", RegexOptions.None, new string[] { "pages/homepage.aspx", "pages", "homepage" } };
+                yield return new object[] { null, @"(.*)/(.*).aspx", "/pages/homepage.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx", "/pages", "homepage" } };
+                yield return new object[] { null, @"(.*)/(.*).aspx", "/pages/homepage/index.aspx", RegexOptions.None, new string[] { "/pages/homepage/index.aspx", "/pages/homepage", "index" } };
+                yield return new object[] { null, @"(.*)/(.*).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages/homepage.aspx", "index" } };
+                yield return new object[] { null, @"(.*)/(.*)/(.*).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages", "homepage.aspx", "index" } };
+
+                // Backtracking with multiple (.+) groups
+                yield return new object[] { null, @"(.+)/(.+).aspx", "/.aspx", RegexOptions.None, new string[] { string.Empty } };
+                yield return new object[] { null, @"(.+)/(.+).aspx", "homepage.aspx", RegexOptions.None, new string[] { string.Empty } };
+                yield return new object[] { null, @"(.+)/(.+).aspx", "/homepage.aspx", RegexOptions.None, new string[] { string.Empty } };
+                yield return new object[] { null, @"(.+)/(.+).aspx", "pages/.aspx", RegexOptions.None, new string[] { string.Empty } };
+                yield return new object[] { null, @"(.+)/(.+).aspx", "pages/homepage.aspx", RegexOptions.None, new string[] { "pages/homepage.aspx", "pages", "homepage" } };
+                yield return new object[] { null, @"(.+)/(.+).aspx", "/pages/homepage.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx", "/pages", "homepage" } };
+                yield return new object[] { null, @"(.+)/(.+).aspx", "/pages/homepage/index.aspx", RegexOptions.None, new string[] { "/pages/homepage/index.aspx", "/pages/homepage", "index" } };
+                yield return new object[] { null, @"(.+)/(.+).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages/homepage.aspx", "index" } };
+                yield return new object[] { null, @"(.+)/(.+)/(.+).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages", "homepage.aspx", "index" } };
+
+                // Backtracking with (.+) group followed by (.*)
+                yield return new object[] { null, @"(.+)/(.*).aspx", "/.aspx", RegexOptions.None, new string[] { string.Empty } };
+                yield return new object[] { null, @"(.+)/(.*).aspx", "homepage.aspx", RegexOptions.None, new string[] { string.Empty } };
+                yield return new object[] { null, @"(.+)/(.*).aspx", "/homepage.aspx", RegexOptions.None, new string[] { string.Empty } };
+                yield return new object[] { null, @"(.+)/(.*).aspx", "pages/.aspx", RegexOptions.None, new string[] { "pages/.aspx", "pages", string.Empty } };
+                yield return new object[] { null, @"(.+)/(.*).aspx", "pages/homepage.aspx", RegexOptions.None, new string[] { "pages/homepage.aspx", "pages", "homepage" } };
+                yield return new object[] { null, @"(.+)/(.*).aspx", "/pages/homepage.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx", "/pages", "homepage" } };
+                yield return new object[] { null, @"(.+)/(.*).aspx", "/pages/homepage/index.aspx", RegexOptions.None, new string[] { "/pages/homepage/index.aspx", "/pages/homepage", "index" } };
+                yield return new object[] { null, @"(.+)/(.*).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages/homepage.aspx", "index" } };
+                yield return new object[] { null, @"(.+)/(.*)/(.*).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages", "homepage.aspx", "index" } };
+
+                // Backtracking with (.*) group followed by (.+)
+                yield return new object[] { null, @"(.*)/(.+).aspx", "/.aspx", RegexOptions.None, new string[] { string.Empty } };
+                yield return new object[] { null, @"(.*)/(.+).aspx", "homepage.aspx", RegexOptions.None, new string[] { string.Empty } };
+                yield return new object[] { null, @"(.*)/(.+).aspx", "/homepage.aspx", RegexOptions.None, new string[] { "homepage.aspx", string.Empty, "homepage" } };
+                yield return new object[] { null, @"(.*)/(.+).aspx", "pages/.aspx", RegexOptions.None, new string[] { string.Empty } };
+                yield return new object[] { null, @"(.*)/(.+).aspx", "pages/homepage.aspx", RegexOptions.None, new string[] { "pages/homepage.aspx", "pages", "homepage" } };
+                yield return new object[] { null, @"(.*)/(.+).aspx", "/pages/homepage.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx", "/pages", "homepage" } };
+                yield return new object[] { null, @"(.*)/(.+).aspx", "/pages/homepage/index.aspx", RegexOptions.None, new string[] { "/pages/homepage/index.aspx", "/pages/homepage", "index" } };
+                yield return new object[] { null, @"(.*)/(.+).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages/homepage.aspx", "index" } };
+                yield return new object[] { null, @"(.*)/(.+)/(.+).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages", "homepage.aspx", "index" } };
+            }
+
             // Quantifiers
             yield return new object[] { null, @"a*", "", RegexOptions.None, new string[] { "" } };
             yield return new object[] { null, @"a*", "a", RegexOptions.None, new string[] { "a" } };
@@ -823,9 +870,6 @@ namespace System.Text.RegularExpressions.Tests
             // Empty Match
             yield return new object[] { null, @"([a*]*)+?$", "ab", RegexOptions.None, new string[] { "", "" } };
             yield return new object[] { null, @"(a*)+?$", "b", RegexOptions.None, new string[] { "", "" } };
-
-            // A unit test from aspnetcore
-            yield return new object[] { null, @"(.*)/(.*).aspx", "/pages/homepage.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx", "/pages", "homepage", } };
         }
 
         public static IEnumerable<object[]> Groups_CustomCulture_TestData_enUS()

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -582,52 +582,49 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { null, @"([a-z]*)([\w])", "cat", RegexOptions.IgnoreCase, new string[] { "cat", "ca", "t" } };
             yield return new object[] { null, @"^([a-z]*)([\w])$", "cat", RegexOptions.IgnoreCase, new string[] { "cat", "ca", "t" } };
 
-            foreach (RegexOptions options in new[] { RegexOptions.None, RegexOptions.Compiled })
-            {
-                // Backtracking with multiple (.*) groups -- important ASP.NET scnario
-                yield return new object[] { null, @"(.*)/(.*).aspx", "/.aspx", RegexOptions.None, new string[] { "/.aspx", string.Empty, string.Empty } };
-                yield return new object[] { null, @"(.*)/(.*).aspx", "homepage.aspx", RegexOptions.None, new string[] { string.Empty } };
-                yield return new object[] { null, @"(.*)/(.*).aspx", "/homepage.aspx", RegexOptions.None, new string[] { "/homepage.aspx", string.Empty, "homepage" } };
-                yield return new object[] { null, @"(.*)/(.*).aspx", "pages/.aspx", RegexOptions.None, new string[] { "pages/.aspx", "pages", string.Empty } };
-                yield return new object[] { null, @"(.*)/(.*).aspx", "pages/homepage.aspx", RegexOptions.None, new string[] { "pages/homepage.aspx", "pages", "homepage" } };
-                yield return new object[] { null, @"(.*)/(.*).aspx", "/pages/homepage.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx", "/pages", "homepage" } };
-                yield return new object[] { null, @"(.*)/(.*).aspx", "/pages/homepage/index.aspx", RegexOptions.None, new string[] { "/pages/homepage/index.aspx", "/pages/homepage", "index" } };
-                yield return new object[] { null, @"(.*)/(.*).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages/homepage.aspx", "index" } };
-                yield return new object[] { null, @"(.*)/(.*)/(.*).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages", "homepage.aspx", "index" } };
+            // Backtracking with multiple (.*) groups -- important ASP.NET scnario
+            yield return new object[] { null, @"(.*)/(.*).aspx", "/.aspx", RegexOptions.None, new string[] { "/.aspx", string.Empty, string.Empty } };
+            yield return new object[] { null, @"(.*)/(.*).aspx", "homepage.aspx", RegexOptions.None, new string[] { string.Empty } };
+            yield return new object[] { null, @"(.*)/(.*).aspx", "/homepage.aspx", RegexOptions.None, new string[] { "/homepage.aspx", string.Empty, "homepage" } };
+            yield return new object[] { null, @"(.*)/(.*).aspx", "pages/.aspx", RegexOptions.None, new string[] { "pages/.aspx", "pages", string.Empty } };
+            yield return new object[] { null, @"(.*)/(.*).aspx", "pages/homepage.aspx", RegexOptions.None, new string[] { "pages/homepage.aspx", "pages", "homepage" } };
+            yield return new object[] { null, @"(.*)/(.*).aspx", "/pages/homepage.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx", "/pages", "homepage" } };
+            yield return new object[] { null, @"(.*)/(.*).aspx", "/pages/homepage/index.aspx", RegexOptions.None, new string[] { "/pages/homepage/index.aspx", "/pages/homepage", "index" } };
+            yield return new object[] { null, @"(.*)/(.*).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages/homepage.aspx", "index" } };
+            yield return new object[] { null, @"(.*)/(.*)/(.*).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages", "homepage.aspx", "index" } };
 
-                // Backtracking with multiple (.+) groups
-                yield return new object[] { null, @"(.+)/(.+).aspx", "/.aspx", RegexOptions.None, new string[] { string.Empty } };
-                yield return new object[] { null, @"(.+)/(.+).aspx", "homepage.aspx", RegexOptions.None, new string[] { string.Empty } };
-                yield return new object[] { null, @"(.+)/(.+).aspx", "/homepage.aspx", RegexOptions.None, new string[] { string.Empty } };
-                yield return new object[] { null, @"(.+)/(.+).aspx", "pages/.aspx", RegexOptions.None, new string[] { string.Empty } };
-                yield return new object[] { null, @"(.+)/(.+).aspx", "pages/homepage.aspx", RegexOptions.None, new string[] { "pages/homepage.aspx", "pages", "homepage" } };
-                yield return new object[] { null, @"(.+)/(.+).aspx", "/pages/homepage.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx", "/pages", "homepage" } };
-                yield return new object[] { null, @"(.+)/(.+).aspx", "/pages/homepage/index.aspx", RegexOptions.None, new string[] { "/pages/homepage/index.aspx", "/pages/homepage", "index" } };
-                yield return new object[] { null, @"(.+)/(.+).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages/homepage.aspx", "index" } };
-                yield return new object[] { null, @"(.+)/(.+)/(.+).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages", "homepage.aspx", "index" } };
+            // Backtracking with multiple (.+) groups
+            yield return new object[] { null, @"(.+)/(.+).aspx", "/.aspx", RegexOptions.None, new string[] { string.Empty } };
+            yield return new object[] { null, @"(.+)/(.+).aspx", "homepage.aspx", RegexOptions.None, new string[] { string.Empty } };
+            yield return new object[] { null, @"(.+)/(.+).aspx", "/homepage.aspx", RegexOptions.None, new string[] { string.Empty } };
+            yield return new object[] { null, @"(.+)/(.+).aspx", "pages/.aspx", RegexOptions.None, new string[] { string.Empty } };
+            yield return new object[] { null, @"(.+)/(.+).aspx", "pages/homepage.aspx", RegexOptions.None, new string[] { "pages/homepage.aspx", "pages", "homepage" } };
+            yield return new object[] { null, @"(.+)/(.+).aspx", "/pages/homepage.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx", "/pages", "homepage" } };
+            yield return new object[] { null, @"(.+)/(.+).aspx", "/pages/homepage/index.aspx", RegexOptions.None, new string[] { "/pages/homepage/index.aspx", "/pages/homepage", "index" } };
+            yield return new object[] { null, @"(.+)/(.+).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages/homepage.aspx", "index" } };
+            yield return new object[] { null, @"(.+)/(.+)/(.+).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages", "homepage.aspx", "index" } };
 
-                // Backtracking with (.+) group followed by (.*)
-                yield return new object[] { null, @"(.+)/(.*).aspx", "/.aspx", RegexOptions.None, new string[] { string.Empty } };
-                yield return new object[] { null, @"(.+)/(.*).aspx", "homepage.aspx", RegexOptions.None, new string[] { string.Empty } };
-                yield return new object[] { null, @"(.+)/(.*).aspx", "/homepage.aspx", RegexOptions.None, new string[] { string.Empty } };
-                yield return new object[] { null, @"(.+)/(.*).aspx", "pages/.aspx", RegexOptions.None, new string[] { "pages/.aspx", "pages", string.Empty } };
-                yield return new object[] { null, @"(.+)/(.*).aspx", "pages/homepage.aspx", RegexOptions.None, new string[] { "pages/homepage.aspx", "pages", "homepage" } };
-                yield return new object[] { null, @"(.+)/(.*).aspx", "/pages/homepage.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx", "/pages", "homepage" } };
-                yield return new object[] { null, @"(.+)/(.*).aspx", "/pages/homepage/index.aspx", RegexOptions.None, new string[] { "/pages/homepage/index.aspx", "/pages/homepage", "index" } };
-                yield return new object[] { null, @"(.+)/(.*).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages/homepage.aspx", "index" } };
-                yield return new object[] { null, @"(.+)/(.*)/(.*).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages", "homepage.aspx", "index" } };
+            // Backtracking with (.+) group followed by (.*)
+            yield return new object[] { null, @"(.+)/(.*).aspx", "/.aspx", RegexOptions.None, new string[] { string.Empty } };
+            yield return new object[] { null, @"(.+)/(.*).aspx", "homepage.aspx", RegexOptions.None, new string[] { string.Empty } };
+            yield return new object[] { null, @"(.+)/(.*).aspx", "/homepage.aspx", RegexOptions.None, new string[] { string.Empty } };
+            yield return new object[] { null, @"(.+)/(.*).aspx", "pages/.aspx", RegexOptions.None, new string[] { "pages/.aspx", "pages", string.Empty } };
+            yield return new object[] { null, @"(.+)/(.*).aspx", "pages/homepage.aspx", RegexOptions.None, new string[] { "pages/homepage.aspx", "pages", "homepage" } };
+            yield return new object[] { null, @"(.+)/(.*).aspx", "/pages/homepage.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx", "/pages", "homepage" } };
+            yield return new object[] { null, @"(.+)/(.*).aspx", "/pages/homepage/index.aspx", RegexOptions.None, new string[] { "/pages/homepage/index.aspx", "/pages/homepage", "index" } };
+            yield return new object[] { null, @"(.+)/(.*).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages/homepage.aspx", "index" } };
+            yield return new object[] { null, @"(.+)/(.*)/(.*).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages", "homepage.aspx", "index" } };
 
-                // Backtracking with (.*) group followed by (.+)
-                yield return new object[] { null, @"(.*)/(.+).aspx", "/.aspx", RegexOptions.None, new string[] { string.Empty } };
-                yield return new object[] { null, @"(.*)/(.+).aspx", "homepage.aspx", RegexOptions.None, new string[] { string.Empty } };
-                yield return new object[] { null, @"(.*)/(.+).aspx", "/homepage.aspx", RegexOptions.None, new string[] { "homepage.aspx", string.Empty, "homepage" } };
-                yield return new object[] { null, @"(.*)/(.+).aspx", "pages/.aspx", RegexOptions.None, new string[] { string.Empty } };
-                yield return new object[] { null, @"(.*)/(.+).aspx", "pages/homepage.aspx", RegexOptions.None, new string[] { "pages/homepage.aspx", "pages", "homepage" } };
-                yield return new object[] { null, @"(.*)/(.+).aspx", "/pages/homepage.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx", "/pages", "homepage" } };
-                yield return new object[] { null, @"(.*)/(.+).aspx", "/pages/homepage/index.aspx", RegexOptions.None, new string[] { "/pages/homepage/index.aspx", "/pages/homepage", "index" } };
-                yield return new object[] { null, @"(.*)/(.+).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages/homepage.aspx", "index" } };
-                yield return new object[] { null, @"(.*)/(.+)/(.+).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages", "homepage.aspx", "index" } };
-            }
+            // Backtracking with (.*) group followed by (.+)
+            yield return new object[] { null, @"(.*)/(.+).aspx", "/.aspx", RegexOptions.None, new string[] { string.Empty } };
+            yield return new object[] { null, @"(.*)/(.+).aspx", "homepage.aspx", RegexOptions.None, new string[] { string.Empty } };
+            yield return new object[] { null, @"(.*)/(.+).aspx", "/homepage.aspx", RegexOptions.None, new string[] { "homepage.aspx", string.Empty, "homepage" } };
+            yield return new object[] { null, @"(.*)/(.+).aspx", "pages/.aspx", RegexOptions.None, new string[] { string.Empty } };
+            yield return new object[] { null, @"(.*)/(.+).aspx", "pages/homepage.aspx", RegexOptions.None, new string[] { "pages/homepage.aspx", "pages", "homepage" } };
+            yield return new object[] { null, @"(.*)/(.+).aspx", "/pages/homepage.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx", "/pages", "homepage" } };
+            yield return new object[] { null, @"(.*)/(.+).aspx", "/pages/homepage/index.aspx", RegexOptions.None, new string[] { "/pages/homepage/index.aspx", "/pages/homepage", "index" } };
+            yield return new object[] { null, @"(.*)/(.+).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages/homepage.aspx", "index" } };
+            yield return new object[] { null, @"(.*)/(.+)/(.+).aspx", "/pages/homepage.aspx/index.aspx", RegexOptions.None, new string[] { "/pages/homepage.aspx/index.aspx", "/pages", "homepage.aspx", "index" } };
 
             // Quantifiers
             yield return new object[] { null, @"a*", "", RegexOptions.None, new string[] { "" } };


### PR DESCRIPTION
Add a unit test that covers a critical scenario from ASP.NET. This scenario was identified when #51508 was merged in and caused a regression in ASP.NET, as reported when the change was backported to [preview 7](https://github.com/dotnet/runtime/pull/55960#issuecomment-883589136). That regression was first observed in dotnet/aspnetcore#34491.

Rule: `(.*)/(.*).aspx`
Input: `/pages/homepage.aspx`

**Expected** backreferences:
1. /pages/homepage.aspx
2. /pages
3. homepage

**Actual** backreferences: None, didn't match

This scenario represents multiple `.*` groups within a pattern and being able to capture all expected backreferences.
