### PR TITLE
[wasm] Fix invariant globalization test

### DIFF
--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/InvariantGlobalizationTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/InvariantGlobalizationTests.cs
@@ -57,25 +57,21 @@ namespace Wasm.Build.Tests
             string programText = @"
                 using System;
                 using System.Globalization;
-                using System.Threading.Tasks;
 
-                public class TestClass {
-                    public static int Main()
-                    {
-                        CultureInfo culture;
-                        try
-                        {
-                            culture = new CultureInfo(""es-ES"", false);
-                        // https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md#cultures-and-culture-data
-                        }
-                        catch
-                        {
-                            culture = new CultureInfo("""", false);
-                        }
-                        Console.WriteLine($""{culture.LCID == CultureInfo.InvariantCulture.LCID} - {culture.NativeName}"");
-                        return 42;
-                    }
-                }";
+                // https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md#cultures-and-culture-data
+                try
+                {
+                    CultureInfo culture = new (""es-ES"", false);
+                    Console.WriteLine($""es-ES: Is Invariant LCID: {culture.LCID == CultureInfo.InvariantCulture.LCID}, NativeName: {culture.NativeName}"");
+                }
+                catch (CultureNotFoundException cnfe)
+                {
+                    Console.WriteLine($""Could not create es-ES culture: {cnfe.Message}"");
+                }
+
+                Console.WriteLine($""CurrentCulture.NativeName: {CultureInfo.CurrentCulture.NativeName}"");
+                return 42;
+            ";
 
             BuildProject(buildArgs,
                         initProject: () => File.WriteAllText(Path.Combine(_projectDir!, "Program.cs"), programText),
@@ -83,11 +79,19 @@ namespace Wasm.Build.Tests
                         dotnetWasmFromRuntimePack: dotnetWasmFromRuntimePack,
                         hasIcudt: invariantGlobalization == null || invariantGlobalization.Value == false);
 
-            string expectedOutputString = invariantGlobalization == true
-                                            ? "True - Invariant Language (Invariant Country)"
-                                            : "False - es (ES)";
-            RunAndTestWasmApp(buildArgs, expectedExitCode: 42,
-                                test: output => Assert.Contains(expectedOutputString, output), host: host, id: id);
+            if (invariantGlobalization == true)
+            {
+                string output = RunAndTestWasmApp(buildArgs, expectedExitCode: 42, host: host, id: id);
+                Assert.Contains("Could not create es-ES culture", output);
+                Assert.Contains("CurrentCulture.NativeName: Invariant Language (Invariant Country)", output);
+            }
+            else
+            {
+                string output = RunAndTestWasmApp(buildArgs, expectedExitCode: 42, host: host, id: id);
+                Assert.Contains("es-ES: Is Invariant LCID: False, NativeName: es (ES)", output);
+
+                // ignoring the last line of the output which prints the current culture
+            }
         }
     }
 }


### PR DESCRIPTION
The following commit changed the behavior to throw `CultureNotFoundException`
when creating cultures in invariant mode.

```
commit 04dac7b0fede29d44f896c5fd793754f83974175
Author: Tarek Mahmoud Sayed <tarekms@microsoft.com>
Date:   Thu Jul 1 11:55:05 2021 -0700

    Allow restricting cultures creation with any arbitrary names in Globalization Invariant Mode (#54247)
```

This commit updates the corresponding test in `Wasm.Build.Tests` to
handle that explicitly.

Fixes https://github.com/dotnet/runtime/issues/55838