### PR TITLE
Supported contained bitcast under STORE_LCL_VAR/FLD on arm32/64.

### DIFF
--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -1040,7 +1040,7 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
     else
     {
         emitAttr    attr = emitTypeSize(targetType);
-        instruction ins  = ins_Store(targetType);
+        instruction ins  = ins_StoreFromSrc(dataReg, targetType);
         emit->emitIns_S_R(ins, attr, dataReg, varNum, offset);
     }
 
@@ -1107,7 +1107,7 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
             {
                 inst_set_SV_var(tree);
 
-                instruction ins  = ins_Store(targetType);
+                instruction ins  = ins_StoreFromSrc(dataReg, targetType);
                 emitAttr    attr = emitTypeSize(targetType);
 
                 emitter* emit = GetEmitter();

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -1954,7 +1954,7 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
     }
     assert(dataReg != REG_NA);
 
-    instruction ins = ins_Store(targetType);
+    instruction ins = ins_StoreFromSrc(dataReg, targetType);
 
     emitAttr attr = emitActualTypeSize(targetType);
 
@@ -2070,7 +2070,7 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* lclNode)
         {
             inst_set_SV_var(lclNode);
 
-            instruction ins  = ins_Store(targetType);
+            instruction ins  = ins_StoreFromSrc(dataReg, targetType);
             emitAttr    attr = emitActualTypeSize(targetType);
 
             emit->emitIns_S_R(ins, attr, dataReg, varNum, /* offset */ 0);

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -1940,6 +1940,13 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
         assert(data->IsIntegralConst(0));
         dataReg = REG_ZR;
     }
+    else if (data->isContained())
+    {
+        assert(data->OperIs(GT_BITCAST));
+        const GenTree* bitcastSrc = data->AsUnOp()->gtGetOp1();
+        assert(!bitcastSrc->isContained());
+        dataReg = bitcastSrc->GetRegNum();
+    }
     else
     {
         assert(!data->isContained());
@@ -2015,10 +2022,11 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* lclNode)
         regNumber dataReg = REG_NA;
         if (data->isContained())
         {
-            // This is only possible for a zero-init.
-            assert(data->IsIntegralConst(0) || data->IsSIMDZero());
+            // This is only possible for a zero-init or bitcast.
+            const bool zeroInit = (data->IsIntegralConst(0) || data->IsSIMDZero());
+            assert(zeroInit || data->OperIs(GT_BITCAST));
 
-            if (varTypeIsSIMD(targetType))
+            if (zeroInit && varTypeIsSIMD(targetType))
             {
                 if (targetReg != REG_NA)
                 {
@@ -2040,8 +2048,16 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* lclNode)
                 }
                 return;
             }
-
-            dataReg = REG_ZR;
+            if (zeroInit)
+            {
+                dataReg = REG_ZR;
+            }
+            else
+            {
+                const GenTree* bitcastSrc = data->AsUnOp()->gtGetOp1();
+                assert(!bitcastSrc->isContained());
+                dataReg = bitcastSrc->GetRegNum();
+            }
         }
         else
         {

--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -2024,31 +2024,38 @@ instruction CodeGenInterface::ins_Store(var_types dstType, bool aligned /*=false
 // Return Value:
 //   the instruction to use
 //
-// Notes:
-//   The function currently does not expect float srcReg with integral dstType and will assert on such cases.
-//
 instruction CodeGenInterface::ins_StoreFromSrc(regNumber srcReg, var_types dstType, bool aligned /*=false*/)
 {
+    assert(srcReg != REG_NA);
+
     bool dstIsFloatType = isFloatRegType(dstType);
     bool srcIsFloatReg  = genIsValidFloatReg(srcReg);
     if (srcIsFloatReg == dstIsFloatType)
     {
         return ins_Store(dstType, aligned);
     }
-
-    assert(!srcIsFloatReg && dstIsFloatType && "not expecting an integer type passed in a float reg");
-    assert(!varTypeIsSmall(dstType) && "not expecting small float types");
-
-    instruction ins = INS_invalid;
-#if defined(TARGET_XARCH)
-    ins = INS_mov;
-#elif defined(TARGET_ARMARCH)
-    ins     = INS_str;
-#else
-    NYI("ins_Store");
-#endif
-    assert(ins != INS_invalid);
-    return ins;
+    else
+    {
+        // We know that we are writing to memory, so we can treat destination as any type,
+        // so we will treat it as the source type.
+        var_types srcTypeForStore = TYP_UNDEF;
+        unsigned  dstSize         = genTypeSize(dstType);
+        switch (dstSize)
+        {
+            case 4:
+                srcTypeForStore = srcIsFloatReg ? TYP_FLOAT : TYP_INT;
+                break;
+#if defined(TARGET_64BIT)
+            case 8:
+                srcTypeForStore = srcIsFloatReg ? TYP_DOUBLE : TYP_LONG;
+                break;
+#endif // TARGET_64BIT
+            default:
+                assert("unexpected write to the stack.");
+                break;
+        }
+        return ins_Store(srcTypeForStore, aligned);
+    }
 }
 
 #if defined(TARGET_XARCH)

--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -2051,7 +2051,7 @@ instruction CodeGenInterface::ins_StoreFromSrc(regNumber srcReg, var_types dstTy
                 break;
 #endif // TARGET_64BIT
             default:
-                assert("unexpected write to the stack.");
+                assert(!"unexpected write to the stack.");
                 break;
         }
         return ins_Store(srcTypeForStore, aligned);

--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -2036,25 +2036,25 @@ instruction CodeGenInterface::ins_StoreFromSrc(regNumber srcReg, var_types dstTy
     }
     else
     {
-        // We know that we are writing to memory, so we can treat destination as any type,
-        // so we will treat it as the source type.
-        var_types srcTypeForStore = TYP_UNDEF;
+        // We know that we are writing to memory, so make the destination type same
+        // as the source type.
+        var_types dstTypeForStore = TYP_UNDEF;
         unsigned  dstSize         = genTypeSize(dstType);
         switch (dstSize)
         {
             case 4:
-                srcTypeForStore = srcIsFloatReg ? TYP_FLOAT : TYP_INT;
+                dstTypeForStore = srcIsFloatReg ? TYP_FLOAT : TYP_INT;
                 break;
 #if defined(TARGET_64BIT)
             case 8:
-                srcTypeForStore = srcIsFloatReg ? TYP_DOUBLE : TYP_LONG;
+                dstTypeForStore = srcIsFloatReg ? TYP_DOUBLE : TYP_LONG;
                 break;
 #endif // TARGET_64BIT
             default:
                 assert(!"unexpected write to the stack.");
                 break;
         }
-        return ins_Store(srcTypeForStore, aligned);
+        return ins_Store(dstTypeForStore, aligned);
     }
 }
 

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -1555,9 +1555,6 @@ void Lowering::ContainCheckStoreLoc(GenTreeLclVarCommon* storeLoc) const
     assert(storeLoc->OperIsLocalStore());
     GenTree* op1 = storeLoc->gtGetOp1();
 
-#if 0
-    // TODO-ARMARCH-CQ: support contained bitcast under STORE_LCL_VAR/FLD,
-    // currently codegen does not expect it.
     if (op1->OperIs(GT_BITCAST))
     {
         // If we know that the source of the bitcast will be in a register, then we can make
@@ -1570,7 +1567,6 @@ void Lowering::ContainCheckStoreLoc(GenTreeLclVarCommon* storeLoc) const
             return;
         }
     }
-#endif
 
     const LclVarDsc* varDsc = comp->lvaGetDesc(storeLoc);
 

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -3410,7 +3410,7 @@ int LinearScan::BuildStoreLoc(GenTreeLclVarCommon* storeLoc)
 
     // Second, use source registers.
 
-    if (op1->IsMultiRegNode())
+    if (op1->IsMultiRegNode() && (op1->GetMultiRegCount() > 1))
     {
         // This is the case where the source produces multiple registers.
         // This must be a store lclvar.


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/54841, closes https://github.com/DrewScoggins/performance-2/issues/7131.

```
coreclr_tests.pmi.Linux.arm64.checked.mch
Total bytes of delta: -36
6 total files with Code Size differences (6 improved, 0 regressed)

libraries_tests.pmi.Linux.arm64.checked.mch
Total bytes of delta: -16
2 total methods with Code Size differences (2 improved, 0 regressed)

coreclr_tests.pmi.windows.arm64.checked.mch
Total bytes of delta: -60
12 total files with Code Size differences (12 improved, 0 regressed)

libraries_tests.pmi.windows.arm64.checked.mch
Total bytes of delta: -16 
2 total files with Code Size differences (2 improved, 0 regressed)

coreclr_tests.pmi.Linux.arm.checked.mch
Total bytes of delta: -12
3 total methods with Code Size differences (3 improved, 0 regressed), 0 unchanged
```