### PR TITLE
JIT: work around issue with GDV and Boxing

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_53549/Runtime_53549.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_53549/Runtime_53549.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+interface I
+{
+    public Decimal F();
+}
+
+class Runtime_53549 : I
+{
+    Decimal z;
+
+    public Decimal F() => z;
+
+    public static bool G(object o) 
+    {
+        return ((decimal) o).Equals(100M);
+    }
+
+    // This method will have bad codegen if
+    // we allow GDV on i.F().
+    //
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int H(I i)
+    {
+        return G(i.F()) ? 100 : -1;
+    }
+
+    public static int Main()
+    {
+        Runtime_53549 x = new Runtime_53549();
+        x.z = 100M;
+
+        for (int i = 0; i < 100; i++)
+        {
+            _ = H(x);
+            Thread.Sleep(15);
+        }
+
+        return H(x);
+    }
+}
+
+
+    

--- a/src/tests/JIT/Regression/JitBlue/Runtime_53549/Runtime_53549.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_53549/Runtime_53549.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_TieredPGO=1
+set COMPlus_TC_QuickJitForLoops=1
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_TieredPGO=1
+export COMPlus_TC_QuickJitForLoops=1
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
If a call is a GDV candidate and returns a struct via hidden buffer, and that
return value is immediately boxed, the GDV expansion will produce IR in
incorrect order, leading to bad codegen.

This seems to be a rare enough sequence that disabling GDV is a reasonable
workaround for now.

Actually the box expansion is producing IR in the wrong order and GDV fails
to fix the order (unlike inlining, which does fix the order).

Longer term we should avoid producing out of order IR. But that seems a bit
more complicated and may have other CQ impact.

Added a test case.

Closes #53549.