### PR TITLE
[release/6.0-preview7] Build VS installers for WebAssembly and Mobile workloads (#55769)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -59,6 +59,7 @@
     <CoreClrProjectRoot>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'src', 'coreclr'))</CoreClrProjectRoot>
     <MonoProjectRoot>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'src', 'mono'))</MonoProjectRoot>
     <InstallerProjectRoot>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'src', 'installer'))</InstallerProjectRoot>
+    <WorkloadsProjectRoot>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'src', 'workloads'))</WorkloadsProjectRoot>
     <SharedNativeRoot>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'src', 'native'))</SharedNativeRoot>
     <RepoToolsLocalDir>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'tools-local'))</RepoToolsLocalDir>
     <RepoTasksDir>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'src', 'tasks'))</RepoTasksDir>

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -109,7 +109,8 @@
     <SubsetName Include="Mono.Packages" Description="The projects that produce NuGet packages for the Mono runtime." />
     <SubsetName Include="Mono.WasmRuntime" Description="The WebAssembly runtime." />
     <SubsetName Include="Mono.MsCorDbi" Description="The implementation of ICorDebug interface." />
-
+    <SubsetName Include="Mono.Workloads" OnDemand="true" Description="Builds the installers and the insertion metadata for Blazor workloads." />
+    
     <!-- Libs -->
     <SubsetName Include="Libs" Description="The libraries native part, refs and source assemblies, test infra and packages, but NOT the tests (use Libs.Tests to request those explicitly)" />
     <SubsetName Include="Libs.Native" Description="The native libraries used in the shared framework." />
@@ -246,6 +247,10 @@
 
   <ItemGroup Condition="$(_subset.Contains('+mono.corelib+'))">
     <ProjectToBuild Include="$(MonoProjectRoot)System.Private.CoreLib\System.Private.CoreLib.csproj" Category="mono" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="$(_subset.Contains('+mono.workloads+'))">
+    <ProjectToBuild Include="$(WorkloadsProjectRoot)\workloads.csproj" Category="mono" />
   </ItemGroup>
 
   <!-- Libraries sets -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -58,6 +58,10 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>6a8491b61e0c243cbb6a7ff4966b48e6d1e075b1</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="6.0.0-beta.21369.3">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>e97027cf100d2b532adce387e5cb93a373de93c9</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk" Version="6.0.0-beta.21364.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>6a8491b61e0c243cbb6a7ff4966b48e6d1e075b1</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -60,8 +60,10 @@
     <MicrosoftDotNetXUnitExtensionsVersion>6.0.0-beta.21364.3</MicrosoftDotNetXUnitExtensionsVersion>
     <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.21364.3</MicrosoftDotNetXUnitConsoleRunnerVersion>
     <MicrosoftDotNetBuildTasksArchivesVersion>6.0.0-beta.21364.3</MicrosoftDotNetBuildTasksArchivesVersion>
-    <MicrosoftDotNetBuildTasksPackagingVersion>6.0.0-beta.21364.3</MicrosoftDotNetBuildTasksPackagingVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>6.0.0-beta.21369.3</MicrosoftDotNetBuildTasksInstallersPackageVersion>
     <MicrosoftDotNetBuildTasksInstallersVersion>6.0.0-beta.21364.3</MicrosoftDotNetBuildTasksInstallersVersion>
+    <MicrosoftDotNetBuildTasksPackagingVersion>6.0.0-beta.21369.3</MicrosoftDotNetBuildTasksPackagingVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>6.0.0-beta.21369.3</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
     <MicrosoftDotNetRemoteExecutorVersion>6.0.0-beta.21364.3</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetVersionToolsTasksVersion>6.0.0-beta.21364.3</MicrosoftDotNetVersionToolsTasksVersion>
     <MicrosoftDotNetPackageTestingVersion>6.0.0-beta.21364.3</MicrosoftDotNetPackageTestingVersion>
@@ -183,5 +185,9 @@
     <!-- emscripten / Node -->
     <MicrosoftNETWorkloadEmscriptenManifest60100Version>6.0.0-preview.7.21365.2</MicrosoftNETWorkloadEmscriptenManifest60100Version>
     <MicrosoftNETRuntimeEmscriptenVersion>$(MicrosoftNETWorkloadEmscriptenManifest60100Version)</MicrosoftNETRuntimeEmscriptenVersion>
+    <!-- workloads -->
+    <SwixPackageVersion>1.1.87-gba258badda</SwixPackageVersion>
+    <WixPackageVersion>3.14.0-dotnet</WixPackageVersion>
+    <MonoWorkloadManifestVersion>6.0.0-preview.5.21275.7</MonoWorkloadManifestVersion>
   </PropertyGroup>
 </Project>

--- a/eng/pipelines/mono/templates/workloads-build.yml
+++ b/eng/pipelines/mono/templates/workloads-build.yml
@@ -1,0 +1,100 @@
+parameters:
+  archType: ''
+  buildConfig: ''
+  container: ''
+  dependOnEvaluatePaths: false
+  dependsOn: []
+  isOfficialBuild: false
+  osGroup: ''
+  osSubgroup: ''
+  platform: ''
+  pool: ''
+  runtimeVariant: ''
+  stagedBuild: false
+  testGroup: ''
+  timeoutInMinutes: ''
+  variables: {}
+
+jobs:
+- template: xplat-pipeline-job.yml
+  parameters:
+    archType: ${{ parameters.archType }}
+    buildConfig: ${{ parameters.buildConfig }}
+    container: ${{ parameters.container }}
+    condition: ${{ parameters.isOfficialBuild }}
+    helixType: 'build/product/'
+    osGroup: ${{ parameters.osGroup }}
+    osSubgroup: ${{ parameters.osSubgroup }}
+    pool: ${{ parameters.pool }}
+    runtimeVariant: ${{ parameters.runtimeVariant }}
+    stagedBuild: ${{ parameters.stagedBuild }}
+    timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+    dependOnEvaluatePaths: ${{ parameters.dependOnEvaluatePaths }}
+
+    dependsOn: ${{ parameters.dependsOn }}
+
+    name: workloadsbuild
+    displayName: Build Workloads
+
+    variables:
+    - name: officialBuildIdArg
+      value: ''
+    - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+      - name: officialBuildIdArg
+        value: '/p:OfficialBuildId=$(Build.BuildNumber)'
+    - name: SignType
+      value: $[ coalesce(variables.OfficialSignType, 'real') ]
+    - ${{ parameters.variables }}
+
+    steps:
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifact: 'IntermediateArtifacts'
+        path: $(workloadPackagesPath)
+        patterns: |
+          IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-*.nupkg
+          IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.browser-wasm*.nupkg
+          IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.android-*.nupkg
+          IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.browser-wasm*.nupkg
+          IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.ios-*.nupkg
+          IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.iossimulator-*.nupkg
+          IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-*.nupkg
+          IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.tvos-*.nupkg
+          IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.tvossimulator-*.nupkg
+          IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Workload.Mono.ToolChain.Manifest*.nupkg
+          IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Runtime.MonoTargets.Sdk*.nupkg
+          IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Runtime.MonoAOTCompiler.Task*.nupkg
+          IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Runtime.WebAssembly.Sdk*.nupkg
+
+    - task: CopyFiles@2
+      displayName: Flatten packages
+      inputs:
+        sourceFolder: $(workloadPackagesPath)
+        contents: '*/Shipping/*.nupkg'
+        cleanTargetFolder: false
+        targetFolder: $(workloadPackagesPath)
+        flattenFolders: true
+
+    - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -subset mono.workloads -arch $(archType) -c $(buildConfig) $(officialBuildIdArg) -ci
+      displayName: Build workload artifacts
+
+    # Upload packages wrapping msis
+    - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+      parameters:
+        name: workloads
+
+    # Delete wixpdb files before they are uploaded to artifacts
+    - task: DeleteFiles@1
+      displayName: Delete wixpdb's
+      inputs:
+        SourceFolder: $(workloadArtifactsPath)
+        Contents: '*.wixpdb'
+
+    # Upload artifacts to be used for generating VS components
+    - task: PublishPipelineArtifact@1
+      displayName: Publish workload artifacts
+      inputs:
+        targetPath: $(Build.SourcesDirectory)/artifacts/VSSetup/$(_BuildConfig)/Insertion
+        artifactName: 'Insertion'
+      continueOnError: true
+      condition: always()

--- a/eng/pipelines/mono/templates/xplat-pipeline-job.yml
+++ b/eng/pipelines/mono/templates/xplat-pipeline-job.yml
@@ -90,6 +90,12 @@ jobs:
     - name: nativeTestArtifactRootFolderPath
       value: '$(binTestsPath)/obj/$(osGroup).$(archType).$(buildConfigUpper)'
 
+    - name: workloadPackagesPath
+      value: $(Build.SourcesDirectory)/artifacts/workloadPackages
+
+    - name: workloadArtifactsPath
+      value: $(Build.SourcesDirectory)/artifacts/workloads
+
     - name: liveRuntimeBuildConfigUpper
       ${{ if eq(parameters.liveRuntimeBuildConfig, 'release') }}:
         value: 'Release'

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -372,6 +372,35 @@ stages:
       - windows_x86
       - Linux_x64
 
+  #
+  # Build Blazor Workload
+  #
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/mono/templates/workloads-build.yml
+      buildConfig: release
+      platforms:
+      - windows_x64
+      jobParameters:
+        isOfficialBuild: ${{ variables.isOfficialBuild }}
+        dependsOn:
+        - Build_Android_arm_release_AllSubsets_Mono
+        - Build_Android_arm64_release_AllSubsets_Mono
+        - Build_Android_x86_release_AllSubsets_Mono
+        - Build_Android_x64_release_AllSubsets_Mono
+        - Build_Browser_wasm_release_AllSubsets_Mono
+        - Build_iOS_arm_release_AllSubsets_Mono
+        - Build_iOS_arm64_release_AllSubsets_Mono
+        - Build_iOSSimulator_x64_release_AllSubsets_Mono
+        - Build_iOSSimulator_x86_release_AllSubsets_Mono
+        - Build_iOSSimulator_arm64_release_AllSubsets_Mono
+        - Build_MacCatalyst_arm64_release_AllSubsets_Mono
+        - Build_MacCatalyst_x64_release_AllSubsets_Mono
+        - Build_tvOS_arm64_release_AllSubsets_Mono
+        - Build_tvOSSimulator_arm64_release_AllSubsets_Mono
+        - Build_tvOSSimulator_x64_release_AllSubsets_Mono
+        - Build_Windows_x64_release_CrossAOT_Mono
+
 - ${{ if eq(variables.isOfficialBuild, true) }}:
   - template: /eng/pipelines/official/stages/publish.yml
     parameters:

--- a/src/workloads/VSSetup.props
+++ b/src/workloads/VSSetup.props
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <VSSetupProps>1</VSSetupProps>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <VSDropServiceUri>https://vsdrop.corp.microsoft.com/file/v1/</VSDropServiceUri>
+        <DropServiceUri>https://devdiv.artifacts.visualstudio.com/</DropServiceUri>
+        <DropExe>$(MSBuildThisDirectory)Tools\Drop.App\lib\net45\Drop.exe</DropExe>
+        <!-- Default drop expiration date is 10 years from now -->
+        <DropExpiration Condition="'$(DropExpiration)' == ''">10</DropExpiration>
+        <DropExpirationDate>$([System.DateTime]::Now.AddYears($(DropExpiration)).ToString("M/d/yyyy h:m:s tt"))</DropExpirationDate>
+        <!-- Timeout in minutes -->
+        <DropTimeout>10</DropTimeout>
+        <!-- Can be set to 'info', 'warn', 'error', 'verbose' -->
+        <DropTraceLevel>verbose</DropTraceLevel>
+
+        <!-- Commandline parameters for drop.exe -->
+        <DropParamService>-s &quot;$(DropServiceUri)&quot;</DropParamService>
+        <DropParamTimeout>--timeout &quot;$(DropTimeout)&quot;</DropParamTimeout>
+        <DropParamTraceLevel>--tracelevel &quot;$(DropTraceLevel)&quot;</DropParamTraceLevel>
+        <DropParamExpirationDate>-x &quot;$(DropExpirationDate)&quot;</DropParamExpirationDate>
+        <!-- Use AAD for authentication -->
+        <DropParamAuth>-a</DropParamAuth>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <ManifestTeamProject Condition="'$(ManifestTeamProject)' == ''">dotnet</ManifestTeamProject>
+        <ManifestRepositoryName Condition="'$(ManifestRepositoryName)' == ''">installer</ManifestRepositoryName>
+        <ManifestBuildBranch Condition="'$(ManifestBuildBranch)' == ''">local_build</ManifestBuildBranch>
+        <ManifestBuildNumber Condition="'$(ManifestBuildNumber)' == ''">$([System.DateTime]::Now.ToString("yyMMdd")).1</ManifestBuildNumber>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <ManifestPublishUrl>https://vsdrop.corp.microsoft.com/file/v1/Products/$(ManifestTeamProject)/$(ManifestRepositoryName)/$(ManifestBuildBranch)/$(ManifestBuildNumber);</ManifestPublishUrl>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <ManifestIntermediateOutputPath>$(OutputPath)\obj\$(MSBuildProject)</ManifestIntermediateOutputPath>
+    </PropertyGroup>
+</Project>

--- a/src/workloads/VSSetup.targets
+++ b/src/workloads/VSSetup.targets
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="VSSetup.props" Condition="'$(VSSetupProps)' != '1'"/>
+
+    <Target Name="PublishToVSDrop" DependsOnTargets="GetDropCmdLine">
+        <Exec Command="$(DropUpgradeCmd)" />
+        <Exec Command="$(DropCreateCmd)" />
+        <Exec Command="$(DropPublishCmd)" />
+        <Exec Command="$(DropFinalizeCmd)" />
+        <Exec Command="$(DropUpdateCmd)" />
+
+        <ItemGroup>
+            <DropManifests Include="$(VSDropSource)\*.vsman" />
+        </ItemGroup>
+
+        <WriteLinesToFile File="$(VSDropTxt)" Overwrite="true" Lines="@(DropManifests->'$(ManifestPublishUrl)%(Filename)%(Extension)')" />
+    </Target>
+
+    <Target Name="GetDropCmdLine">
+        <!-- Properties that will depend on each build configuration. We can only build the commandlines onces these are defined -->
+        <Error Text="VSDropSource property undefined" Condition="'$(VSDropSource)' == ''" />
+
+        <PropertyGroup>
+            <DropName>Products/$(ManifestTeamProject)/$(ManifestRepositoryName)/$(ManifestBuildBranch)/$(ManifestBuildNumber)</DropName>
+
+            <DropParamName>-n &quot;$(DropName)&quot;</DropParamName>
+            <DropParamSource>-d &quot;$(VSDropSource)&quot;</DropParamSource>
+
+            <DropUpgradeCmd>$(DropExe) Upgrade $(DropParamService) $(DropParamAuth) $(DropParamTimeout) $(DropParamTraceLevel)</DropUpgradeCmd>
+            <DropCreateCmd>$(DropExe) Create $(DropParamService) $(DropParamAuth) $(DropParamTimeout) $(DropParamTraceLevel) $(DropParamExpirationDate) $(DropParamName)</DropCreateCmd>
+            <DropPublishCmd>$(DropExe) Publish $(DropParamService) $(DropParamAuth) $(DropParamTimeout) $(DropParamTraceLevel) $(DropParamName) $(DropParamSource)</DropPublishCmd>
+            <DropFinalizeCmd>$(DropExe) Finalize $(DropParamService) $(DropParamAuth) $(DropParamTimeout) $(DropParamTraceLevel) $(DropParamName)</DropFinalizeCmd>
+            <DropUpdateCmd>$(DropExe) Update $(DropParamService) $(DropParamAuth) $(DropParamTimeout) $(DropParamTraceLevel) $(DropParamName) --neverExpire</DropUpdateCmd>
+        </PropertyGroup>
+    </Target>
+
+    <Target Name="VSSetupDiagnostic" DependsOnTargets="GetDropCmdLine">
+        <ItemGroup>
+            <VSSetupProperties Include="Drop cmd: $(DropUpgradeCmd)" />
+            <VSSetupProperties Include="Drop cmd: $(DropCreateCmd)" />
+            <VSSetupProperties Include="Drop cmd: $(DropPublishCmd)" />
+            <VSSetupProperties Include="Drop cmd: $(DropFinalizeCmd)" />
+            <VSSetupProperties Include="Drop cmd: $(DropUpdateCmd)" />
+            <VSSetupProperties Include="DropName: $(DropName)" />
+        </ItemGroup>
+
+        <Message Text="%(VSSetupProperties.Identity)" />
+    </Target>
+</Project>

--- a/src/workloads/mono_wasm_mobile.vsmanproj
+++ b/src/workloads/mono_wasm_mobile.vsmanproj
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="VSSetup.targets" />
+
+  <PropertyGroup>
+    <DebugSymbols>false</DebugSymbols>
+    <IsShippingAssembly>false</IsShippingAssembly>
+    <PublishWindowsPdb>false</PublishWindowsPdb>
+    <TargetType>build-manifest</TargetType>
+    <FinalizeManifest>true</FinalizeManifest>
+    <FinalizeSkipLayout>false</FinalizeSkipLayout>
+    <ProductName>DotNetOptionalWorkloads</ProductName>
+    <ProductFamily>vs</ProductFamily>
+    <ProductFamilyVersion Condition="$(ProductFamilyVersion) == ''">42.42.42</ProductFamilyVersion>
+    <ComputeRelativeUrls>true</ComputeRelativeUrls>
+    <OutputPath>$(ManifestOutputPath)</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <MergeManifest Include="$(ManifestOutputPath)\*.json">
+      <RelativeUrl>/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\CHS\*.json">
+      <RelativeUrl>/CHS/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\CHT\*.json">
+      <RelativeUrl>/CHT/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\CSY\*.json">
+      <RelativeUrl>/CSY/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\DEU\*.json">
+      <RelativeUrl>/DEU/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\ENU\*.json">
+      <RelativeUrl>/ENU/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\ESN\*.json">
+      <RelativeUrl>/ESN/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\FRA\*.json">
+      <RelativeUrl>/FRA/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\ITA\*.json">
+      <RelativeUrl>/ITA/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\JPN\*.json">
+      <RelativeUrl>/JPN/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\KOR\*.json">
+      <RelativeUrl>/KOR/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\PLK\*.json">
+      <RelativeUrl>/PLK/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\PTB\*.json">
+      <RelativeUrl>/PTB/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\RUS\*.json">
+      <RelativeUrl>/RUS/</RelativeUrl>
+    </MergeManifest>
+    <MergeManifest Include="$(ManifestOutputPath)\TRK\*.json">
+      <RelativeUrl>/TRK/</RelativeUrl>
+    </MergeManifest>
+  </ItemGroup>
+
+  <Import Project="$(SwixBuildTargets)"/>
+</Project>

--- a/src/workloads/readme.md
+++ b/src/workloads/readme.md
@@ -1,0 +1,2 @@
+# Building
+The workloads project can only be built using .NET Framework msbuild. To build locally, run ```build -project src\workloads\workloads.csproj -msbuildEngine vs```

--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -1,0 +1,185 @@
+﻿<Project DefaultTargets="Restore;Build">
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+
+  <PropertyGroup>
+    <MicrosoftDotNetBuildTasksInstallersTaskTargetFramework Condition="'$(MSBuildRuntimeType)' == 'Core'">netcoreapp3.1</MicrosoftDotNetBuildTasksInstallersTaskTargetFramework>
+    <MicrosoftDotNetBuildTasksInstallersTaskTargetFramework Condition="'$(DotNetBuildFromSource)' == 'true'">net5.0</MicrosoftDotNetBuildTasksInstallersTaskTargetFramework>
+    <MicrosoftDotNetBuildTasksInstallersTaskTargetFramework Condition="'$(MSBuildRuntimeType)' != 'Core'">net472</MicrosoftDotNetBuildTasksInstallersTaskTargetFramework>
+    <MicrosoftDotNetBuildTasksInstallersTaskAssembly>$(NuGetPackageRoot)microsoft.dotnet.build.tasks.installers\$(MicrosoftDotNetBuildTasksInstallersPackageVersion)\tools\$(MicrosoftDotNetBuildTasksInstallersTaskTargetFramework)\Microsoft.DotNet.Build.Tasks.Installers.dll</MicrosoftDotNetBuildTasksInstallersTaskAssembly>
+  </PropertyGroup>
+
+  <UsingTask AssemblyFile="$(PkgMicrosoft_DotNet_Build_Tasks_Workloads)\tools\net472\Microsoft.DotNet.Build.Tasks.Workloads.dll" TaskName="GenerateVisualStudioWorkload" />
+
+  <UsingTask TaskName="CreateLightCommandPackageDrop" AssemblyFile="$(MicrosoftDotNetBuildTasksInstallersTaskAssembly)" />
+
+  <PropertyGroup>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+
+    <WorkloadIntermediateOutputPath>$(ArtifactsObjDir)workloads/</WorkloadIntermediateOutputPath>
+    <WorkloadOutputPath>$(ArtifactsBinDir)workloads/</WorkloadOutputPath>
+    <WorkloadOutputPath Condition="'$(workloadArtifactsPath)' != ''">$(workloadArtifactsPath)/</WorkloadOutputPath>
+    <PackageSource>$(ArtifactsShippingPackagesDir)</PackageSource>
+    <PackageSource Condition="'$(workloadPackagesPath)' != ''">$(workloadPackagesPath)/</PackageSource>
+  </PropertyGroup>
+
+  <!-- Arcade -->
+  <PropertyGroup>
+    <!-- Temp directory for light command layouts -->
+    <LightCommandObjDir>$(ArtifactsObjDir)/LightCommandPackages</LightCommandObjDir>
+    <!-- Directory for the zipped up light command package -->
+    <LightCommandPackagesDir>$(ArtifactsNonShippingPackagesDir)</LightCommandPackagesDir>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <WixToolsetPath>$(PkgWix)\tools</WixToolsetPath>
+    <SwixPluginPath>$(PkgMicroBuild_Plugins_SwixBuild_Dotnet)</SwixPluginPath>
+    <SwixBuildTargets>$(SwixPluginPath)\build\MicroBuild.Plugins.SwixBuild.targets</SwixBuildTargets>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Workloads" Version="$(MicrosoftDotNetBuildTasksWorkloadsPackageVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="WiX" Version="$(WixPackageVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="MicroBuild.Plugins.SwixBuild.Dotnet" Version="$(SwixPackageVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Installers" Version="$(MicrosoftDotNetBuildTasksInstallersPackageVersion)" GeneratePathProperty="True" />
+  </ItemGroup>
+
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+
+  <Target Name="Build" DependsOnTargets="GenerateVersions">
+    <ItemGroup>
+      <!-- Overrides for Visual Studio setup generation. If the workload definition IDs change,
+           these must be updated. -->
+      <ComponentResources Include="wasm-tools" Title=".NET WebAssembly Build Tools"
+                          Description="Build tools for WebAssembly ahead-of-time (AoT) compilation and native linking."/>
+      <ComponentResources Include="microsoft-net-runtime-android" Title=".NET Android Build Tools"
+                          Description="Build tools for Android compilation and native linking."/>
+      <ComponentResources Include="microsoft-net-runtime-android-aot" Title=".NET Android Build Tools (AoT)"
+                          Description="Build tools for Android ahead-of-time (AoT) compilation and native linking."/>
+      <ComponentResources Include="runtimes-ios" Title=".NET iOS Build Tools"
+                          Description="Build tools for iOS compilation and native linking."/>
+      <ComponentResources Include="runtimes-tvos" Title=".NET tvOS Build Tools"
+                          Description="Build tools for tvOS compilation and native linking."/>
+      <ComponentResources Include="runtimes-maccatalyst" Title=".NET Mac Catalyst Build Tools"
+                          Description="Build tools for Mac Catalyst compilation and native linking."/>
+
+      <!-- Visual Studio components must be versioned. Build tasks will fall back to cobbling a version number from
+           the manifest information unless it's overridden. -->
+      <ComponentVersions Include="wasm-tools" Version="$(FileVersion)" />
+      <ComponentVersions Include="microsoft-net-runtime-android" Version="$(FileVersion)" />
+      <ComponentVersions Include="microsoft-net-runtime-android-aot" Version="$(FileVersion)" />
+      <ComponentVersions Include="runtimes-ios" Version="$(FileVersion)" />
+      <ComponentVersions Include="runtimes-tvos" Version="$(FileVersion)" />
+      <ComponentVersions Include="runtimes-maccatalyst" Version="$(FileVersion)" />
+    </ItemGroup>
+
+    <!-- BAR requires having version information in blobs -->
+    <PropertyGroup>
+      <VersionedVisualStudioSetupInsertionPath>$(VisualStudioSetupInsertionPath)$(SDKBundleVersion)\</VersionedVisualStudioSetupInsertionPath>
+    </PropertyGroup>
+
+    <!-- Shorten package names to avoid long path issues in Visual Studio -->
+    <ItemGroup>
+      <ShortNames Include="microsoft.netcore.app.runtime;Microsoft.NETCore.App.Runtime;microsoft.net.runtime;Microsoft.NET.Runtime">
+        <Replacement>Microsoft</Replacement>
+      </ShortNames>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ManifestPackages Include="$(PackageSource)Microsoft.NET.Workload.Mono.ToolChain.Manifest-*.nupkg" />
+    </ItemGroup>
+
+    <GenerateVisualStudioWorkload IntermediateBaseOutputPath="$(WorkloadIntermediateOutputPath)"
+                                  WixToolsetPath="$(WixToolsetPath)"
+                                  GenerateMsis="true"
+                                  ComponentVersions="@(ComponentVersions)"
+                                  OutputPath="$(WorkloadOutputPath)"
+                                  PackagesPath="$(PackageSource)"
+                                  ShortNames="@(ShortNames)"
+                                  WorkloadPackages="@(ManifestPackages)">
+      <Output TaskParameter="SwixProjects" ItemName="SwixProjects" />
+      <Output TaskParameter="Msis" ItemName="Msis" />
+    </GenerateVisualStudioWorkload>
+
+    <!-- Build all the SWIX projects. This requires full framework MSBuild-->
+    <MSBuild Projects="@(SwixProjects)" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=$(VersionedVisualStudioSetupInsertionPath)" />
+
+    <!-- Gather .wixobj files for post-build signing. We'll have to batch since we generated multiple MSIs in the previous step. -->
+    <MSBuild Projects="$(MSBuildProjectFile)" Properties="_WixObjDir=%(Msis.WixObj);_Msi=%(Msis.Identity)" Targets="CreateWixPack" />
+
+    <!-- Build the Visual Studio manifest project. -->
+    <ItemGroup>
+      <VisualStudioManifestProjects Include="mono_wasm_mobile.vsmanproj" />
+    </ItemGroup>
+
+    <MSBuild Projects="@(VisualStudioManifestProjects)" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=$(VersionedVisualStudioSetupInsertionPath);OutputPath=$(VersionedVisualStudioSetupInsertionPath)" />
+
+    <!-- Build all the MSI payload packages for NuGet. -->
+    <ItemGroup>
+      <MsiPackageProjects Include="%(Msis.PackageProject)" />
+    </ItemGroup>
+
+    <MSBuild Projects="@(MsiPackageProjects)" Properties="OutputPath=$(ArtifactsShippingPackagesDir)" Targets="restore;pack" />
+  </Target>
+
+  <!-- Target to create a single wixpack for signing -->
+  <Target Name="CreateWixPack">
+    <ItemGroup>
+      <_WixObj Include="$(_WixObjDir)\**\*.wixobj" />
+    </ItemGroup>
+
+    <CreateLightCommandPackageDrop
+      LightCommandWorkingDir="$(LightCommandObjDir)"
+      OutputFolder="$(LightCommandPackagesDir)"
+      NoLogo="true"
+      Cultures="en-us"
+      InstallerFile="$(_Msi)"
+      WixExtensions="WixUIExtension;WixDependencyExtension;WixUtilExtension"
+      WixSrcFiles="@(_WixObj)">
+      <Output TaskParameter="OutputFile" PropertyName="_LightCommandPackageNameOutput" />
+    </CreateLightCommandPackageDrop>
+  </Target>
+
+  <!-- These are just individual targets for testing local builds. -->
+  <Target Name="BuildSwixProjects">
+    <ItemGroup>
+      <SwixProjects Include="$(WorkloadIntermediateOutputPath)**\*.swixproj" />
+    </ItemGroup>
+
+    <MSBuild Projects="@(SwixProjects)" BuildInParallel="true" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=$(VersionedVisualStudioSetupInsertionPath)" />
+  </Target>
+
+  <Target Name="BuildVisualStudioManifest">
+    <ItemGroup>
+      <VisualStudioManifestProjects Include="Microsoft.NET.vsmanproj" />
+    </ItemGroup>
+
+    <MSBuild Projects="@(VisualStudioManifestProjects)" BuildInParallel="true" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=$(VersionedVisualStudioSetupInsertionPath);OutputPath=$(VersionedVisualStudioSetupInsertionPath)" />
+  </Target>
+
+  <Target Name="GenerateVersions" DependsOnTargets="GetAssemblyVersion">
+    <Exec Command="git rev-list --count HEAD"
+          ConsoleToMSBuild="true"
+          Condition=" '$(GitCommitCount)' == '' ">
+      <Output TaskParameter="ConsoleOutput" PropertyName="GitCommitCount" />
+    </Exec>
+
+    <Error Condition=" '$(OfficialBuild)' == 'true' And '$(_PatchNumber)' == '' "
+           Text="_PatchNumber should not be empty in an official build. Check if there were changes in Arcade." />
+
+    <PropertyGroup>
+      <GitCommitCount>$(GitCommitCount.PadLeft(6,'0'))</GitCommitCount>
+
+      <!-- This number comes from arcade and combines the date based build number id and the revision (incremental number per day) -->
+      <CombinedBuildNumberAndRevision>$(_PatchNumber)</CombinedBuildNumberAndRevision>
+      <!-- Fallback to commit count when patch number is not set. This happens only during CI. -->
+      <CombinedBuildNumberAndRevision Condition=" '$(CombinedBuildNumberAndRevision)' == '' ">$(GitCommitCount)</CombinedBuildNumberAndRevision>
+
+      <!-- This number comes from arcade and combines the date based build number id and the revision (incremental number per day) -->
+      <SDKBundleVersion>$(FileVersion)</SDKBundleVersion>
+      <!-- Fallback to commit count when patch number is not set. This happens only during CI. -->
+      <SDKBundleVersion Condition=" '$(SDKBundleVersion)' == '' ">$(VersionPrefix).$(CombinedBuildNumberAndRevision)</SDKBundleVersion>
+    </PropertyGroup>
+  </Target>
+</Project>


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/55769 to release/6.0-preview7.

## Customer Impact
Without this PR, customers will not be able to install mono workloads (wasm, iOS/tvOS/MacCatalyst, and Android) workloads into Visual Studio
## Testing
We validated the packages produced are satisfactory to be inserted into VS.
## Risk
Very low.
