### PR TITLE
HTTP3: Fix issue with GOAWAY handling and implement graceful shutdown logic in Http3LoopbackServer

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs
@@ -359,6 +359,13 @@ namespace System.Net.Test.Common
             }
         }
 
+        public async Task AbortAndWaitForShutdownAsync(long errorCode)
+        {
+            _stream.AbortRead(errorCode);
+            _stream.AbortWrite(errorCode);
+            await _stream.ShutdownCompleted();
+        }
+
         public async Task<(long? frameType, byte[] payload)> ReadFrameAsync()
         {
             long? frameType = await ReadIntegerAsync().ConfigureAwait(false);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -283,7 +283,7 @@ namespace System.Net.Http
 
             lock (SyncObj)
             {
-                if (lastProcessedStreamId > _lastProcessedStreamId)
+                if (_lastProcessedStreamId != -1 && lastProcessedStreamId > _lastProcessedStreamId)
                 {
                     // Server can send multiple GOAWAY frames.
                     // Spec says a server MUST NOT increase the stream ID in subsequent GOAWAYs,

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/Mock/MockStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/Mock/MockStream.cs
@@ -73,7 +73,7 @@ namespace System.Net.Quic.Implementations.Mock
                 long errorCode = _isInitiator ? _streamState._inboundReadErrorCode : _streamState._outboundReadErrorCode;
                 if (errorCode != 0)
                 {
-                    throw new QuicStreamAbortedException(errorCode);
+                    throw (errorCode == -1) ? new QuicOperationAbortedException() : new QuicStreamAbortedException(errorCode);
                 }
             }
 

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -37,23 +37,141 @@ namespace System.Net.Quic.Tests
             Assert.Equal(ApplicationProtocol.ToString(), serverConnection.NegotiatedApplicationProtocol.ToString());
         }
 
+        private static async Task<QuicStream> OpenAndUseStreamAsync(QuicConnection c)
+        {
+            QuicStream s = c.OpenBidirectionalStream();
+
+            // This will pend
+            await s.ReadAsync(new byte[1]);
+
+            return s;
+        }
+
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/55242", TestPlatforms.Linux)]
-        public async Task AcceptStream_ConnectionAborted_ByClient_Throws()
+        public async Task CloseAsync_WithPendingAcceptAndConnect_PendingAndSubsequentThrowOperationAbortedException()
         {
             using var sync = new SemaphoreSlim(0);
 
             await RunClientServer(
                 async clientConnection =>
                 {
-                    await clientConnection.CloseAsync(ExpectedErrorCode);
-                    sync.Release();
+                    await sync.WaitAsync();
                 },
                 async serverConnection =>
                 {
+                    // Pend operations before the client closes.
+                    Task<QuicStream> acceptTask = serverConnection.AcceptStreamAsync().AsTask();
+                    Assert.False(acceptTask.IsCompleted);
+                    Task<QuicStream> connectTask = OpenAndUseStreamAsync(serverConnection);
+                    Assert.False(acceptTask.IsCompleted);
+
+                    await serverConnection.CloseAsync(ExpectedErrorCode);
+
+                    sync.Release();
+
+                    // Pending ops should fail
+                    await Assert.ThrowsAsync<QuicOperationAbortedException>(() => acceptTask);
+                    await Assert.ThrowsAsync<QuicOperationAbortedException>(() => connectTask);
+
+                    // Subsequent attempts should fail
+                    // TODO: Which exception is correct?
+                    if (IsMockProvider)
+                    {
+                        await Assert.ThrowsAsync<ObjectDisposedException>(async () => await serverConnection.AcceptStreamAsync());
+                        await Assert.ThrowsAsync<ObjectDisposedException>(async () => await OpenAndUseStreamAsync(serverConnection));
+                    }
+                    else
+                    {
+                        await Assert.ThrowsAsync<QuicOperationAbortedException>(async () => await serverConnection.AcceptStreamAsync());
+
+                        // TODO: ActiveIssue https://github.com/dotnet/runtime/issues/56133
+                        // MsQuic fails with System.Net.Quic.QuicException: Failed to open stream to peer. Error Code: INVALID_STATE
+                        //await Assert.ThrowsAsync<QuicOperationAbortedException>(async () => await OpenAndUseStreamAsync(serverConnection));
+                    }
+                });
+        }
+
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55242", TestPlatforms.Linux)]
+        public async Task Dispose_WithPendingAcceptAndConnect_PendingAndSubsequentThrowOperationAbortedException()
+        {
+            using var sync = new SemaphoreSlim(0);
+
+            await RunClientServer(
+                async clientConnection =>
+                {
                     await sync.WaitAsync();
-                    QuicConnectionAbortedException ex = await Assert.ThrowsAsync<QuicConnectionAbortedException>(() => serverConnection.AcceptStreamAsync().AsTask());
+                },
+                async serverConnection =>
+                {
+                    // Pend operations before the client closes.
+                    Task<QuicStream> acceptTask = serverConnection.AcceptStreamAsync().AsTask();
+                    Assert.False(acceptTask.IsCompleted);
+                    Task<QuicStream> connectTask = OpenAndUseStreamAsync(serverConnection);
+                    Assert.False(acceptTask.IsCompleted);
+
+                    serverConnection.Dispose();
+
+                    sync.Release();
+
+                    // Pending ops should fail
+                    await Assert.ThrowsAsync<QuicOperationAbortedException>(() => acceptTask);
+                    await Assert.ThrowsAsync<QuicOperationAbortedException>(() => connectTask);
+
+                    // Subsequent attempts should fail
+                    // TODO: Should these be QuicOperationAbortedException, to match above? Or vice-versa?
+                    await Assert.ThrowsAsync<ObjectDisposedException>(async () => await serverConnection.AcceptStreamAsync());
+                    await Assert.ThrowsAsync<ObjectDisposedException>(async () => await OpenAndUseStreamAsync(serverConnection));
+                });
+        }
+
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55242", TestPlatforms.Linux)]
+        public async Task ConnectionClosedByPeer_WithPendingAcceptAndConnect_PendingAndSubsequentThrowConnectionAbortedException()
+        {
+            if (IsMockProvider)
+            {
+                return;
+            }
+
+            using var sync = new SemaphoreSlim(0);
+
+            await RunClientServer(
+                async clientConnection =>
+                {
+                    await sync.WaitAsync();
+
+                    await clientConnection.CloseAsync(ExpectedErrorCode);
+                },
+                async serverConnection =>
+                {
+                    // Pend operations before the client closes.
+                    Task<QuicStream> acceptTask = serverConnection.AcceptStreamAsync().AsTask();
+                    Assert.False(acceptTask.IsCompleted);
+                    Task<QuicStream> connectTask = OpenAndUseStreamAsync(serverConnection);
+                    Assert.False(acceptTask.IsCompleted);
+
+                    sync.Release();
+
+                    // Pending ops should fail
+                    QuicConnectionAbortedException ex;
+
+                    ex = await Assert.ThrowsAsync<QuicConnectionAbortedException>(() => acceptTask);
                     Assert.Equal(ExpectedErrorCode, ex.ErrorCode);
+                    ex = await Assert.ThrowsAsync<QuicConnectionAbortedException>(() => connectTask);
+                    Assert.Equal(ExpectedErrorCode, ex.ErrorCode);
+
+                    // Subsequent attempts should fail
+                    ex = await Assert.ThrowsAsync<QuicConnectionAbortedException>(() => serverConnection.AcceptStreamAsync().AsTask());
+                    Assert.Equal(ExpectedErrorCode, ex.ErrorCode);
+                    // TODO: ActiveIssue https://github.com/dotnet/runtime/issues/56133
+                    // MsQuic fails with System.Net.Quic.QuicException: Failed to open stream to peer. Error Code: INVALID_STATE
+                    if (!IsMsQuicProvider)
+                    {
+                        ex = await Assert.ThrowsAsync<QuicConnectionAbortedException>(() => OpenAndUseStreamAsync(serverConnection));
+                        Assert.Equal(ExpectedErrorCode, ex.ErrorCode);
+                    }
                 });
         }
 
@@ -79,7 +197,7 @@ namespace System.Net.Quic.Tests
         [InlineData(10)]
         public async Task CloseAsync_WithOpenStream_LocalAndPeerStreamsFailWithQuicOperationAbortedException(int writesBeforeClose)
         {
-            if (typeof(T) == typeof(MockProviderFactory))
+            if (IsMockProvider)
             {
                 return;
             }
@@ -122,7 +240,7 @@ namespace System.Net.Quic.Tests
         [InlineData(10)]
         public async Task Dispose_WithOpenLocalStream_LocalStreamFailsWithQuicOperationAbortedException(int writesBeforeClose)
         {
-            if (typeof(T) == typeof(MockProviderFactory))
+            if (IsMockProvider)
             {
                 return;
             }

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -64,7 +64,7 @@ namespace System.Net.Quic.Tests
                     Task<QuicStream> acceptTask = serverConnection.AcceptStreamAsync().AsTask();
                     Assert.False(acceptTask.IsCompleted);
                     Task<QuicStream> connectTask = OpenAndUseStreamAsync(serverConnection);
-                    Assert.False(acceptTask.IsCompleted);
+                    Assert.False(connectTask.IsCompleted);
 
                     await serverConnection.CloseAsync(ExpectedErrorCode);
 
@@ -88,6 +88,7 @@ namespace System.Net.Quic.Tests
                         // TODO: ActiveIssue https://github.com/dotnet/runtime/issues/56133
                         // MsQuic fails with System.Net.Quic.QuicException: Failed to open stream to peer. Error Code: INVALID_STATE
                         //await Assert.ThrowsAsync<QuicOperationAbortedException>(async () => await OpenAndUseStreamAsync(serverConnection));
+                        await Assert.ThrowsAsync<QuicException>(() => OpenAndUseStreamAsync(serverConnection));
                     }
                 });
         }
@@ -109,7 +110,7 @@ namespace System.Net.Quic.Tests
                     Task<QuicStream> acceptTask = serverConnection.AcceptStreamAsync().AsTask();
                     Assert.False(acceptTask.IsCompleted);
                     Task<QuicStream> connectTask = OpenAndUseStreamAsync(serverConnection);
-                    Assert.False(acceptTask.IsCompleted);
+                    Assert.False(connectTask.IsCompleted);
 
                     serverConnection.Dispose();
 
@@ -150,7 +151,7 @@ namespace System.Net.Quic.Tests
                     Task<QuicStream> acceptTask = serverConnection.AcceptStreamAsync().AsTask();
                     Assert.False(acceptTask.IsCompleted);
                     Task<QuicStream> connectTask = OpenAndUseStreamAsync(serverConnection);
-                    Assert.False(acceptTask.IsCompleted);
+                    Assert.False(connectTask.IsCompleted);
 
                     sync.Release();
 
@@ -167,7 +168,11 @@ namespace System.Net.Quic.Tests
                     Assert.Equal(ExpectedErrorCode, ex.ErrorCode);
                     // TODO: ActiveIssue https://github.com/dotnet/runtime/issues/56133
                     // MsQuic fails with System.Net.Quic.QuicException: Failed to open stream to peer. Error Code: INVALID_STATE
-                    if (!IsMsQuicProvider)
+                    if (IsMsQuicProvider)
+                    {
+                        await Assert.ThrowsAsync<QuicException>(() => OpenAndUseStreamAsync(serverConnection));
+                    }
+                    else
                     {
                         ex = await Assert.ThrowsAsync<QuicConnectionAbortedException>(() => OpenAndUseStreamAsync(serverConnection));
                         Assert.Equal(ExpectedErrorCode, ex.ErrorCode);

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
@@ -23,6 +23,9 @@ namespace System.Net.Quic.Tests
         public static QuicImplementationProvider ImplementationProvider { get; } = s_factory.GetProvider();
         public static bool IsSupported => ImplementationProvider.IsSupported;
 
+        public static bool IsMockProvider => typeof(T) == typeof(MockProviderFactory);
+        public static bool IsMsQuicProvider => typeof(T) == typeof(MsQuicProviderFactory);
+
         public static SslApplicationProtocol ApplicationProtocol { get; } = new SslApplicationProtocol("quictest");
 
         public X509Certificate2 ServerCertificate = System.Net.Test.Common.Configuration.Certificates.GetServerCertificate();


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/55025
Fixes https://github.com/dotnet/runtime/issues/55508

Fix an issue where we are not properly handling a GOAWAY frame because we think we've seen one previously, even though we haven't.

Add graceful shutdown logic to Http3LoopbackServer.

Related QUIC tests and fixes.
 