### PR TITLE
[mono] Mark jit icalls using ICALL_EXPORT so they get exported from l…

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -347,6 +347,7 @@
     <!-- iOS/tvOS simulator specific options -->
     <ItemGroup Condition="('$(TargetsiOS)' == 'true' and '$(TargetsiOSSimulator)' == 'true') or ('$(TargetstvOS)' == 'true' and '$(TargetstvOSSimulator)' == 'true')">
       <_MonoCMakeArgs Include="-DENABLE_MINIMAL=shared_perfcounters"/>
+      <_MonoCMakeArgs Include="-DENABLE_ICALL_EXPORT=1"/>
     </ItemGroup>
     <!-- iOS/tvOS device specific options -->
     <ItemGroup Condition="('$(TargetsiOS)' == 'true' and '$(TargetsiOSSimulator)' != 'true') or ('$(TargetstvOS)' == 'true' and '$(TargetstvOSSimulator)' != 'true')">

--- a/src/mono/mono/metadata/marshal.h
+++ b/src/mono/mono/metadata/marshal.h
@@ -392,7 +392,7 @@ mono_marshal_ftnptr_eh_callback (guint32 gchandle);
 MONO_PAL_API void
 mono_marshal_set_last_error (void);
 
-ICALL_EXTERN_C
+ICALL_EXPORT
 void
 mono_marshal_clear_last_error (void);
 
@@ -539,11 +539,11 @@ mono_marshal_unlock_internal (void);
 void * 
 mono_marshal_alloc (gsize size, MonoError *error);
 
-ICALL_EXTERN_C
+ICALL_EXPORT
 void 
 mono_marshal_free (gpointer ptr);
 
-ICALL_EXTERN_C
+ICALL_EXPORT
 void
 mono_marshal_free_array (gpointer *ptr, int size);
 
@@ -553,11 +553,11 @@ mono_marshal_free_ccw (MonoObject* obj);
 MONO_API void *
 mono_marshal_string_to_utf16 (MonoString *s);
 
-ICALL_EXTERN_C
+ICALL_EXPORT
 void
 mono_marshal_set_last_error_windows (int error);
 
-ICALL_EXTERN_C
+ICALL_EXPORT
 void 
 mono_struct_delete_old (MonoClass *klass, char *ptr);
 
@@ -566,15 +566,15 @@ mono_emit_marshal (EmitMarshalContext *m, int argnum, MonoType *t,
 	      MonoMarshalSpec *spec, int conv_arg, 
 	      MonoType **conv_arg_type, MarshalAction action);
 
-ICALL_EXTERN_C
+ICALL_EXPORT
 MonoObject *
 mono_marshal_isinst_with_cache (MonoObject *obj, MonoClass *klass, uintptr_t *cache);
 
-ICALL_EXTERN_C
+ICALL_EXPORT
 MonoAsyncResult *
 mono_delegate_begin_invoke (MonoDelegate *delegate, gpointer *params);
 
-ICALL_EXTERN_C
+ICALL_EXPORT
 MonoObject *
 mono_delegate_end_invoke (MonoDelegate *delegate, gpointer *params);
 
@@ -605,10 +605,10 @@ mono_pinvoke_is_unicode (MonoMethodPInvoke *piinfo);
 gboolean
 mono_marshal_need_free (MonoType *t, MonoMethodPInvoke *piinfo, MonoMarshalSpec *spec);
 
-ICALL_EXTERN_C
+ICALL_EXPORT
 MonoObject* mono_marshal_get_type_object (MonoClass *klass);
 
-ICALL_EXTERN_C
+ICALL_EXPORT
 gpointer
 mono_marshal_lookup_pinvoke (MonoMethod *method);
 

--- a/src/mono/mono/metadata/monitor.h
+++ b/src/mono/mono/metadata/monitor.h
@@ -106,19 +106,19 @@ mono_locks_dump (gboolean include_untaken);
 void
 mono_monitor_init (void);
 
-ICALL_EXTERN_C
+ICALL_EXPORT
 MonoBoolean
 mono_monitor_enter_internal (MonoObject *obj);
 
-ICALL_EXTERN_C
+ICALL_EXPORT
 void
 mono_monitor_enter_v4_internal (MonoObject *obj, MonoBoolean *lock_taken);
 
-ICALL_EXTERN_C
+ICALL_EXPORT
 guint32
 mono_monitor_enter_fast (MonoObject *obj);
 
-ICALL_EXTERN_C
+ICALL_EXPORT
 guint32
 mono_monitor_enter_v4_fast (MonoObject *obj, MonoBoolean *lock_taken);
 

--- a/src/mono/mono/metadata/object-internals.h
+++ b/src/mono/mono/metadata/object-internals.h
@@ -1948,7 +1948,7 @@ mono_string_hash_internal (MonoString *s);
 MONO_COMPONENT_API int
 mono_object_hash_internal (MonoObject* obj);
 
-ICALL_EXTERN_C
+ICALL_EXPORT
 void
 mono_value_copy_internal (void* dest, const void* src, MonoClass *klass);
 
@@ -2033,7 +2033,7 @@ mono_gchandle_new_internal (MonoObject *obj, mono_bool pinned);
 MONO_COMPONENT_API MonoGCHandle
 mono_gchandle_new_weakref_internal (MonoObject *obj, mono_bool track_resurrection);
 
-MONO_COMPONENT_API ICALL_EXTERN_C
+MONO_COMPONENT_API
 MonoObject*
 mono_gchandle_get_target_internal (MonoGCHandle gchandle);
 
@@ -2075,7 +2075,7 @@ mono_gc_wbarrier_generic_store_internal (void volatile* ptr, MonoObject* value);
 void
 mono_gc_wbarrier_generic_store_atomic_internal (void *ptr, MonoObject *value);
 
-ICALL_EXTERN_C
+ICALL_EXPORT
 void
 mono_gc_wbarrier_generic_nostore_internal (void* ptr);
 

--- a/src/mono/mono/metadata/threads-types.h
+++ b/src/mono/mono/metadata/threads-types.h
@@ -267,7 +267,7 @@ mono_thread_set_name (MonoInternalThread *thread,
 
 gboolean mono_thread_interruption_requested (void);
 
-ICALL_EXTERN_C
+ICALL_EXPORT
 MonoException*
 mono_thread_interruption_checkpoint (void);
 
@@ -280,7 +280,7 @@ mono_thread_interruption_checkpoint_void (void);
 MonoExceptionHandle
 mono_thread_interruption_checkpoint_handle (void);
 
-ICALL_EXTERN_C
+ICALL_EXPORT
 MonoException* mono_thread_force_interruption_checkpoint_noraise (void);
 
 /**
@@ -296,7 +296,7 @@ extern gint32 mono_thread_interruption_request_flag;
 
 uint32_t mono_alloc_special_static_data (uint32_t static_type, uint32_t size, uint32_t align, uintptr_t *bitmap, int numbits);
 
-ICALL_EXTERN_C
+ICALL_EXPORT
 void*    mono_get_special_static_data   (uint32_t offset);
 
 MONO_COMPONENT_API gpointer mono_get_special_static_data_for_thread (MonoInternalThread *thread, guint32 offset);

--- a/src/mono/mono/mini/jit-icalls.h
+++ b/src/mono/mono/mini/jit-icalls.h
@@ -9,190 +9,190 @@
 #include "mini.h"
 #include <mono/metadata/icalls.h>
 
-ICALL_EXTERN_C void* mono_ldftn (MonoMethod *method);
+ICALL_EXPORT void* mono_ldftn (MonoMethod *method);
 
-ICALL_EXTERN_C void* mono_ldvirtfn (MonoObject *obj, MonoMethod *method);
+ICALL_EXPORT void* mono_ldvirtfn (MonoObject *obj, MonoMethod *method);
 
-ICALL_EXTERN_C void* mono_ldvirtfn_gshared (MonoObject *obj, MonoMethod *method);
+ICALL_EXPORT void* mono_ldvirtfn_gshared (MonoObject *obj, MonoMethod *method);
 
-ICALL_EXTERN_C void mono_helper_stelem_ref_check (MonoArray *array, MonoObject *val);
+ICALL_EXPORT void mono_helper_stelem_ref_check (MonoArray *array, MonoObject *val);
 
-ICALL_EXTERN_C gint64 mono_llmult (gint64 a, gint64 b);
+ICALL_EXPORT gint64 mono_llmult (gint64 a, gint64 b);
 
-ICALL_EXTERN_C guint64 mono_llmult_ovf_un (guint64 a, guint64 b);
+ICALL_EXPORT guint64 mono_llmult_ovf_un (guint64 a, guint64 b);
 
-ICALL_EXTERN_C guint64 mono_llmult_ovf (gint64 a, gint64 b);
+ICALL_EXPORT guint64 mono_llmult_ovf (gint64 a, gint64 b);
 
-ICALL_EXTERN_C gint32 mono_idiv (gint32 a, gint32 b);
+ICALL_EXPORT gint32 mono_idiv (gint32 a, gint32 b);
 
-ICALL_EXTERN_C guint32 mono_idiv_un (guint32 a, guint32 b);
+ICALL_EXPORT guint32 mono_idiv_un (guint32 a, guint32 b);
 
-ICALL_EXTERN_C gint32 mono_irem (gint32 a, gint32 b);
+ICALL_EXPORT gint32 mono_irem (gint32 a, gint32 b);
 
-ICALL_EXTERN_C guint32 mono_irem_un (guint32 a, guint32 b);
+ICALL_EXPORT guint32 mono_irem_un (guint32 a, guint32 b);
 
-ICALL_EXTERN_C gint32 mono_imul (gint32 a, gint32 b);
+ICALL_EXPORT gint32 mono_imul (gint32 a, gint32 b);
 
-ICALL_EXTERN_C gint32 mono_imul_ovf (gint32 a, gint32 b);
+ICALL_EXPORT gint32 mono_imul_ovf (gint32 a, gint32 b);
 
-ICALL_EXTERN_C gint32 mono_imul_ovf_un (guint32 a, guint32 b);
+ICALL_EXPORT gint32 mono_imul_ovf_un (guint32 a, guint32 b);
 
-ICALL_EXTERN_C double mono_fdiv (double a, double b);
+ICALL_EXPORT double mono_fdiv (double a, double b);
 
-ICALL_EXTERN_C gint64 mono_lldiv (gint64 a, gint64 b);
+ICALL_EXPORT gint64 mono_lldiv (gint64 a, gint64 b);
 
-ICALL_EXTERN_C gint64 mono_llrem (gint64 a, gint64 b);
+ICALL_EXPORT gint64 mono_llrem (gint64 a, gint64 b);
 
-ICALL_EXTERN_C guint64 mono_lldiv_un (guint64 a, guint64 b);
+ICALL_EXPORT guint64 mono_lldiv_un (guint64 a, guint64 b);
 
-ICALL_EXTERN_C guint64 mono_llrem_un (guint64 a, guint64 b);
+ICALL_EXPORT guint64 mono_llrem_un (guint64 a, guint64 b);
 
-ICALL_EXTERN_C guint64 mono_lshl (guint64 a, gint32 shamt);
+ICALL_EXPORT guint64 mono_lshl (guint64 a, gint32 shamt);
 
-ICALL_EXTERN_C guint64 mono_lshr_un (guint64 a, gint32 shamt);
+ICALL_EXPORT guint64 mono_lshr_un (guint64 a, gint32 shamt);
 
-ICALL_EXTERN_C gint64 mono_lshr (gint64 a, gint32 shamt);
+ICALL_EXPORT gint64 mono_lshr (gint64 a, gint32 shamt);
 
 // For param_count > 4.
-ICALL_EXTERN_C MonoArray *mono_array_new_n_icall (MonoMethod *cm, gint32 param_count, intptr_t *params);
+ICALL_EXPORT MonoArray *mono_array_new_n_icall (MonoMethod *cm, gint32 param_count, intptr_t *params);
 
-ICALL_EXTERN_C MonoArray *mono_array_new_2_jagged (MonoMethod *cm, guint32 length1, guint32 length2);
+ICALL_EXPORT MonoArray *mono_array_new_2_jagged (MonoMethod *cm, guint32 length1, guint32 length2);
 
-ICALL_EXTERN_C MonoArray *mono_array_new_1 (MonoMethod *cm, guint32 length);
+ICALL_EXPORT MonoArray *mono_array_new_1 (MonoMethod *cm, guint32 length);
 
-ICALL_EXTERN_C MonoArray *mono_array_new_2 (MonoMethod *cm, guint32 length1, guint32 length2);
+ICALL_EXPORT MonoArray *mono_array_new_2 (MonoMethod *cm, guint32 length1, guint32 length2);
 
-ICALL_EXTERN_C MonoArray *mono_array_new_3 (MonoMethod *cm, guint32 length1, guint32 length2, guint32 length3);
+ICALL_EXPORT MonoArray *mono_array_new_3 (MonoMethod *cm, guint32 length1, guint32 length2, guint32 length3);
 
-ICALL_EXTERN_C MonoArray *mono_array_new_4 (MonoMethod *cm, guint32 length1, guint32 length2, guint32 length3, guint32 length4);
+ICALL_EXPORT MonoArray *mono_array_new_4 (MonoMethod *cm, guint32 length1, guint32 length2, guint32 length3, guint32 length4);
 
-ICALL_EXTERN_C gpointer mono_class_static_field_address (MonoClassField *field);
+ICALL_EXPORT gpointer mono_class_static_field_address (MonoClassField *field);
 
-ICALL_EXTERN_C gpointer mono_ldtoken_wrapper (MonoImage *image, int token, MonoGenericContext *context);
+ICALL_EXPORT gpointer mono_ldtoken_wrapper (MonoImage *image, int token, MonoGenericContext *context);
 
-ICALL_EXTERN_C gpointer mono_ldtoken_wrapper_generic_shared (MonoImage *image, int token, MonoMethod *method);
+ICALL_EXPORT gpointer mono_ldtoken_wrapper_generic_shared (MonoImage *image, int token, MonoMethod *method);
 
-ICALL_EXTERN_C guint64 mono_fconv_u8 (double v);
-ICALL_EXTERN_C guint64 mono_fconv_u8_2 (double v);
+ICALL_EXPORT guint64 mono_fconv_u8 (double v);
+ICALL_EXPORT guint64 mono_fconv_u8_2 (double v);
 
-ICALL_EXTERN_C guint64 mono_rconv_u8 (float v);
+ICALL_EXPORT guint64 mono_rconv_u8 (float v);
 
-ICALL_EXTERN_C gint64 mono_fconv_i8 (double v);
+ICALL_EXPORT gint64 mono_fconv_i8 (double v);
 
-ICALL_EXTERN_C guint32 mono_fconv_u4 (double v);
-ICALL_EXTERN_C guint32 mono_fconv_u4_2 (double v);
+ICALL_EXPORT guint32 mono_fconv_u4 (double v);
+ICALL_EXPORT guint32 mono_fconv_u4_2 (double v);
 
-ICALL_EXTERN_C guint32 mono_rconv_u4 (float v);
+ICALL_EXPORT guint32 mono_rconv_u4 (float v);
 
-ICALL_EXTERN_C gint64 mono_fconv_ovf_i8 (double v);
+ICALL_EXPORT gint64 mono_fconv_ovf_i8 (double v);
 
-ICALL_EXTERN_C guint64 mono_fconv_ovf_u8 (double v);
+ICALL_EXPORT guint64 mono_fconv_ovf_u8 (double v);
 
-ICALL_EXTERN_C gint64 mono_rconv_i8 (float v);
+ICALL_EXPORT gint64 mono_rconv_i8 (float v);
 
-ICALL_EXTERN_C gint64 mono_rconv_ovf_i8 (float v);
+ICALL_EXPORT gint64 mono_rconv_ovf_i8 (float v);
 
-ICALL_EXTERN_C guint64 mono_rconv_ovf_u8 (float v);
+ICALL_EXPORT guint64 mono_rconv_ovf_u8 (float v);
 
-ICALL_EXTERN_C double mono_lconv_to_r8 (gint64 a);
+ICALL_EXPORT double mono_lconv_to_r8 (gint64 a);
 
-ICALL_EXTERN_C double mono_conv_to_r8 (gint32 a);
+ICALL_EXPORT double mono_conv_to_r8 (gint32 a);
 
-ICALL_EXTERN_C double mono_conv_to_r4 (gint32 a);
+ICALL_EXPORT double mono_conv_to_r4 (gint32 a);
 
-ICALL_EXTERN_C float mono_lconv_to_r4 (gint64 a);
+ICALL_EXPORT float mono_lconv_to_r4 (gint64 a);
 
-ICALL_EXTERN_C double mono_conv_to_r8_un (guint32 a);
+ICALL_EXPORT double mono_conv_to_r8_un (guint32 a);
 
-ICALL_EXTERN_C double mono_lconv_to_r8_un (guint64 a);
+ICALL_EXPORT double mono_lconv_to_r8_un (guint64 a);
 
-ICALL_EXTERN_C gpointer mono_helper_compile_generic_method (MonoObject *obj, MonoMethod *method, gpointer *this_arg);
+ICALL_EXPORT gpointer mono_helper_compile_generic_method (MonoObject *obj, MonoMethod *method, gpointer *this_arg);
 
-ICALL_EXTERN_C MonoString *mono_helper_ldstr (MonoImage *image, guint32 idx);
+ICALL_EXPORT MonoString *mono_helper_ldstr (MonoImage *image, guint32 idx);
 
-ICALL_EXTERN_C MonoString *mono_helper_ldstr_mscorlib (guint32 idx);
+ICALL_EXPORT MonoString *mono_helper_ldstr_mscorlib (guint32 idx);
 
-ICALL_EXTERN_C MonoObject *mono_helper_newobj_mscorlib (guint32 idx);
+ICALL_EXPORT MonoObject *mono_helper_newobj_mscorlib (guint32 idx);
 
-ICALL_EXTERN_C double mono_fsub (double a, double b);
+ICALL_EXPORT double mono_fsub (double a, double b);
 
-ICALL_EXTERN_C double mono_fadd (double a, double b);
+ICALL_EXPORT double mono_fadd (double a, double b);
 
-ICALL_EXTERN_C double mono_fmul (double a, double b);
+ICALL_EXPORT double mono_fmul (double a, double b);
 
-ICALL_EXTERN_C double mono_fneg (double a);
+ICALL_EXPORT double mono_fneg (double a);
 
-ICALL_EXTERN_C double mono_fconv_r4 (double a);
+ICALL_EXPORT double mono_fconv_r4 (double a);
 
-ICALL_EXTERN_C gint8 mono_fconv_i1 (double a);
+ICALL_EXPORT gint8 mono_fconv_i1 (double a);
 
-ICALL_EXTERN_C gint16 mono_fconv_i2 (double a);
+ICALL_EXPORT gint16 mono_fconv_i2 (double a);
 
-ICALL_EXTERN_C gint32 mono_fconv_i4 (double a);
+ICALL_EXPORT gint32 mono_fconv_i4 (double a);
 
-ICALL_EXTERN_C guint8 mono_fconv_u1 (double a);
+ICALL_EXPORT guint8 mono_fconv_u1 (double a);
 
-ICALL_EXTERN_C guint16 mono_fconv_u2 (double a);
+ICALL_EXPORT guint16 mono_fconv_u2 (double a);
 
-ICALL_EXTERN_C gboolean mono_fcmp_eq (double a, double b);
+ICALL_EXPORT gboolean mono_fcmp_eq (double a, double b);
 
-ICALL_EXTERN_C gboolean mono_fcmp_ge (double a, double b);
+ICALL_EXPORT gboolean mono_fcmp_ge (double a, double b);
 
-ICALL_EXTERN_C gboolean mono_fcmp_gt (double a, double b);
+ICALL_EXPORT gboolean mono_fcmp_gt (double a, double b);
 
-ICALL_EXTERN_C gboolean mono_fcmp_le (double a, double b);
+ICALL_EXPORT gboolean mono_fcmp_le (double a, double b);
 
-ICALL_EXTERN_C gboolean mono_fcmp_lt (double a, double b);
+ICALL_EXPORT gboolean mono_fcmp_lt (double a, double b);
 
-ICALL_EXTERN_C gboolean mono_fcmp_ne_un (double a, double b);
+ICALL_EXPORT gboolean mono_fcmp_ne_un (double a, double b);
 
-ICALL_EXTERN_C gboolean mono_fcmp_ge_un (double a, double b);
+ICALL_EXPORT gboolean mono_fcmp_ge_un (double a, double b);
 
-ICALL_EXTERN_C gboolean mono_fcmp_gt_un (double a, double b);
+ICALL_EXPORT gboolean mono_fcmp_gt_un (double a, double b);
 
-ICALL_EXTERN_C gboolean mono_fcmp_le_un (double a, double b);
+ICALL_EXPORT gboolean mono_fcmp_le_un (double a, double b);
 
-ICALL_EXTERN_C gboolean mono_fcmp_lt_un (double a, double b);
+ICALL_EXPORT gboolean mono_fcmp_lt_un (double a, double b);
 
-ICALL_EXTERN_C gboolean mono_fceq (double a, double b);
+ICALL_EXPORT gboolean mono_fceq (double a, double b);
 
-ICALL_EXTERN_C gboolean mono_fcgt (double a, double b);
+ICALL_EXPORT gboolean mono_fcgt (double a, double b);
 
-ICALL_EXTERN_C gboolean mono_fcgt_un (double a, double b);
+ICALL_EXPORT gboolean mono_fcgt_un (double a, double b);
 
-ICALL_EXTERN_C gboolean mono_fclt (double a, double b);
+ICALL_EXPORT gboolean mono_fclt (double a, double b);
 
-ICALL_EXTERN_C gboolean mono_fclt_un (double a, double b);
+ICALL_EXPORT gboolean mono_fclt_un (double a, double b);
 
-ICALL_EXTERN_C double   mono_fload_r4 (float *ptr);
+ICALL_EXPORT double   mono_fload_r4 (float *ptr);
 
-ICALL_EXTERN_C void     mono_fstore_r4 (double val, float *ptr);
+ICALL_EXPORT void     mono_fstore_r4 (double val, float *ptr);
 
-ICALL_EXTERN_C guint32  mono_fload_r4_arg (double val);
+ICALL_EXPORT guint32  mono_fload_r4_arg (double val);
 
-ICALL_EXTERN_C double mono_fmod (double a, double b);
+ICALL_EXPORT double mono_fmod (double a, double b);
 
-ICALL_EXTERN_C void     mono_break (void);
+ICALL_EXPORT void     mono_break (void);
 
-ICALL_EXTERN_C MonoException *mono_create_corlib_exception_0 (guint32 token);
+ICALL_EXPORT MonoException *mono_create_corlib_exception_0 (guint32 token);
 
-ICALL_EXTERN_C MonoException *mono_create_corlib_exception_1 (guint32 token, MonoString *arg);
+ICALL_EXPORT MonoException *mono_create_corlib_exception_1 (guint32 token, MonoString *arg);
 
-ICALL_EXTERN_C MonoException *mono_create_corlib_exception_2 (guint32 token, MonoString *arg1, MonoString *arg2);
+ICALL_EXPORT MonoException *mono_create_corlib_exception_2 (guint32 token, MonoString *arg1, MonoString *arg2);
 
-ICALL_EXTERN_C MonoObject* mono_object_castclass_unbox (MonoObject *obj, MonoClass *klass);
+ICALL_EXPORT MonoObject* mono_object_castclass_unbox (MonoObject *obj, MonoClass *klass);
 
-ICALL_EXTERN_C gpointer mono_get_native_calli_wrapper (MonoImage *image, MonoMethodSignature *sig, gpointer func);
+ICALL_EXPORT gpointer mono_get_native_calli_wrapper (MonoImage *image, MonoMethodSignature *sig, gpointer func);
 
-ICALL_EXTERN_C MonoObject* mono_object_isinst_with_cache (MonoObject *obj, MonoClass *klass, gpointer *cache);
+ICALL_EXPORT MonoObject* mono_object_isinst_with_cache (MonoObject *obj, MonoClass *klass, gpointer *cache);
 
-ICALL_EXTERN_C MonoObject* mono_object_castclass_with_cache (MonoObject *obj, MonoClass *klass, gpointer *cache);
+ICALL_EXPORT MonoObject* mono_object_castclass_with_cache (MonoObject *obj, MonoClass *klass, gpointer *cache);
 
 ICALL_EXPORT
 void
 ves_icall_runtime_class_init (MonoVTable *vtable);
 
-ICALL_EXTERN_C void
+ICALL_EXPORT void
 mono_generic_class_init (MonoVTable *vtable);
 
 ICALL_EXPORT
@@ -203,30 +203,30 @@ ICALL_EXPORT
 void
 ves_icall_mono_delegate_ctor_interp (MonoObject *this_obj, MonoObject *target, gpointer addr);
 
-ICALL_EXTERN_C MonoObject* mono_gsharedvt_constrained_call (gpointer mp, MonoMethod *cmethod, MonoClass *klass, gboolean deref_arg, gpointer *args);
+ICALL_EXPORT MonoObject* mono_gsharedvt_constrained_call (gpointer mp, MonoMethod *cmethod, MonoClass *klass, gboolean deref_arg, gpointer *args);
 
-ICALL_EXTERN_C void mono_gsharedvt_value_copy (gpointer dest, gpointer src, MonoClass *klass);
+ICALL_EXPORT void mono_gsharedvt_value_copy (gpointer dest, gpointer src, MonoClass *klass);
 
-ICALL_EXTERN_C gpointer mono_fill_class_rgctx (MonoVTable *vtable, int index);
+ICALL_EXPORT gpointer mono_fill_class_rgctx (MonoVTable *vtable, int index);
 
-ICALL_EXTERN_C gpointer mono_fill_method_rgctx (MonoMethodRuntimeGenericContext *mrgctx, int index);
+ICALL_EXPORT gpointer mono_fill_method_rgctx (MonoMethodRuntimeGenericContext *mrgctx, int index);
 
-ICALL_EXTERN_C MonoObject* mono_get_assembly_object (MonoImage *image);
+ICALL_EXPORT MonoObject* mono_get_assembly_object (MonoImage *image);
 
-ICALL_EXTERN_C MonoObject* mono_get_method_object (MonoMethod *method);
+ICALL_EXPORT MonoObject* mono_get_method_object (MonoMethod *method);
 
-ICALL_EXTERN_C double mono_ckfinite (double d);
+ICALL_EXPORT double mono_ckfinite (double d);
 
-ICALL_EXTERN_C void mono_throw_method_access (MonoMethod *caller, MonoMethod *callee);
+ICALL_EXPORT void mono_throw_method_access (MonoMethod *caller, MonoMethod *callee);
 
-ICALL_EXTERN_C void mono_throw_bad_image (void);
+ICALL_EXPORT void mono_throw_bad_image (void);
 
-ICALL_EXTERN_C void mono_throw_not_supported (void);
+ICALL_EXPORT void mono_throw_not_supported (void);
 
-ICALL_EXTERN_C void mono_throw_platform_not_supported (void);
+ICALL_EXPORT void mono_throw_platform_not_supported (void);
 
-ICALL_EXTERN_C void mono_throw_invalid_program (const char *msg);
+ICALL_EXPORT void mono_throw_invalid_program (const char *msg);
 
-ICALL_EXTERN_C void mono_dummy_jit_icall (void);
+ICALL_EXPORT void mono_dummy_jit_icall (void);
 
 #endif /* __MONO_JIT_ICALLS_H__ */

--- a/src/mono/mono/mini/trace.h
+++ b/src/mono/mono/mini/trace.h
@@ -8,15 +8,15 @@
 #include "mono/utils/mono-compiler.h"
 #include "mono/metadata/icalls.h"
 
-ICALL_EXTERN_C
+ICALL_EXPORT
 void
 mono_trace_enter_method (MonoMethod *method, MonoJitInfo *ji, MonoProfilerCallContext *ctx);
 
-ICALL_EXTERN_C
+ICALL_EXPORT
 void 
 mono_trace_leave_method (MonoMethod *method, MonoJitInfo *ji, MonoProfilerCallContext *ctx);
 
-ICALL_EXTERN_C
+ICALL_EXPORT
 void 
 mono_trace_tail_method (MonoMethod *method, MonoJitInfo *ji, MonoMethod *target);
 

--- a/src/mono/mono/utils/mono-threads-coop.h
+++ b/src/mono/mono/utils/mono-threads-coop.h
@@ -24,7 +24,7 @@ MONO_API_DATA volatile size_t mono_polling_required;
 
 /* Internal API */
 
-ICALL_EXTERN_C
+ICALL_EXPORT
 void
 mono_threads_state_poll (void);
 


### PR DESCRIPTION
…ibmonosgen.so.

Fixes https://github.com/dotnet/runtime/issues/55000.