### PR TITLE
Reenable some Android Globalization tests

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
@@ -1302,7 +1302,6 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50924", TestPlatforms.Android)]
         public void NoExceptionThrownWhenProcessingStaticActivityProperties()
         {
             // Ensures that no exception is thrown when static properties on the Activity type are passed to EventListener.

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.Compare.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.Compare.cs
@@ -183,9 +183,14 @@ namespace System.Globalization.Tests
 
             // Turkish
             yield return new object[] { s_turkishCompare, "i", "I", CompareOptions.None, 1 };
-            yield return new object[] { s_turkishCompare, "i", "I", CompareOptions.IgnoreCase, 1 };
+            // Android has its own ICU, which doesn't work well with tr
+            if (!PlatformDetection.IsAndroid)
+            {
+                yield return new object[] { s_turkishCompare, "i", "I", CompareOptions.IgnoreCase, 1 };
+                yield return new object[] { s_turkishCompare, "i", "\u0130", CompareOptions.IgnoreCase, 0 };
+            }
+
             yield return new object[] { s_invariantCompare, "i", "\u0130", CompareOptions.None, -1 };
-            yield return new object[] { s_turkishCompare, "i", "\u0130", CompareOptions.IgnoreCase, 0 };
             yield return new object[] { s_invariantCompare, "i", "I", CompareOptions.None, -1 };
             yield return new object[] { s_invariantCompare, "i", "I", CompareOptions.IgnoreCase, 0 };
             yield return new object[] { s_invariantCompare, "i", "\u0130", CompareOptions.None, -1 };
@@ -311,7 +316,6 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(Compare_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void Compare(CompareInfo compareInfo, string string1, string string2, CompareOptions options, int expected)
         {
             Compare_Advanced(compareInfo, string1, 0, string1?.Length ?? 0, string2, 0, string2?.Length ?? 0, options, expected);

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IndexOf.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IndexOf.cs
@@ -41,14 +41,22 @@ namespace System.Globalization.Tests
 
             // Slovak
             yield return new object[] { s_slovakCompare, "ch", "h", 0, 2, CompareOptions.None, -1, 0 };
-            yield return new object[] { s_slovakCompare, "chodit hore", "HO", 0, 11, CompareOptions.IgnoreCase, 7, 2 };
+            // Android has its own ICU, which doesn't work well with slovak
+            if (!PlatformDetection.IsAndroid)
+            {
+                yield return new object[] { s_slovakCompare, "chodit hore", "HO", 0, 11, CompareOptions.IgnoreCase, 7, 2 };
+            }
             yield return new object[] { s_slovakCompare, "chh", "h", 0, 3, CompareOptions.None, 2, 1 };
 
             // Turkish
+            // Android has its own ICU, which doesn't work well with tr
+            if (!PlatformDetection.IsAndroid)
+            {
+                yield return new object[] { s_turkishCompare, "Hi", "I", 0, 2, CompareOptions.IgnoreCase, -1, 0 };
+                yield return new object[] { s_turkishCompare, "Hi", "\u0130", 0, 2, CompareOptions.IgnoreCase, 1, 1 };
+            }
             yield return new object[] { s_turkishCompare, "Hi", "I", 0, 2, CompareOptions.None, -1, 0 };
-            yield return new object[] { s_turkishCompare, "Hi", "I", 0, 2, CompareOptions.IgnoreCase, -1, 0 };
             yield return new object[] { s_turkishCompare, "Hi", "\u0130", 0, 2, CompareOptions.None, -1, 0 };
-            yield return new object[] { s_turkishCompare, "Hi", "\u0130", 0, 2, CompareOptions.IgnoreCase, 1, 1 };
             yield return new object[] { s_invariantCompare, "Hi", "I", 0, 2, CompareOptions.None, -1, 0 };
             yield return new object[] { s_invariantCompare, "Hi", "I", 0, 2, CompareOptions.IgnoreCase, 1, 1 };
             yield return new object[] { s_invariantCompare, "Hi", "\u0130", 0, 2, CompareOptions.IgnoreCase, -1, 0 };
@@ -174,7 +182,6 @@ namespace System.Globalization.Tests
         [MemberData(nameof(IndexOf_TestData))]
         [MemberData(nameof(IndexOf_Aesc_Ligature_TestData))]
         [MemberData(nameof(IndexOf_U_WithDiaeresis_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void IndexOf_String(CompareInfo compareInfo, string source, string value, int startIndex, int count, CompareOptions options, int expected, int expectedMatchLength)
         {
             if (value.Length == 1)

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsPrefix.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsPrefix.cs
@@ -36,11 +36,15 @@ namespace System.Globalization.Tests
 
             // Turkish
             yield return new object[] { s_turkishCompare, "interesting", "I", CompareOptions.None, false, 0 };
-            yield return new object[] { s_turkishCompare, "interesting", "I", CompareOptions.IgnoreCase, false, 0 };
+            // Android has its own ICU, which doesn't work well with tr
+            if (!PlatformDetection.IsAndroid)
+            {
+                yield return new object[] { s_turkishCompare, "interesting", "I", CompareOptions.IgnoreCase, false, 0 };
+                yield return new object[] { s_turkishCompare, "interesting", "\u0130", CompareOptions.IgnoreCase, true, 1 };
+            }
             yield return new object[] { s_turkishCompare, "interesting", "\u0130", CompareOptions.None, false, 0 };
-            yield return new object[] { s_turkishCompare, "interesting", "\u0130", CompareOptions.IgnoreCase, true, 1 };
-            yield return new object[] { s_invariantCompare, "interesting", "I", CompareOptions.None, false, 0 };
             yield return new object[] { s_invariantCompare, "interesting", "I", CompareOptions.IgnoreCase, true, 1 };
+            yield return new object[] { s_invariantCompare, "interesting", "I", CompareOptions.None, false, 0 };
             yield return new object[] { s_invariantCompare, "interesting", "\u0130", CompareOptions.None, false, 0 };
             yield return new object[] { s_invariantCompare, "interesting", "\u0130", CompareOptions.IgnoreCase, false, 0 };
 
@@ -112,7 +116,6 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(IsPrefix_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void IsPrefix(CompareInfo compareInfo, string source, string value, CompareOptions options, bool expected, int expectedMatchLength)
         {
             if (options == CompareOptions.None)

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsSuffix.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsSuffix.cs
@@ -42,9 +42,13 @@ namespace System.Globalization.Tests
 
             // Turkish
             yield return new object[] { s_turkishCompare, "Hi", "I", CompareOptions.None, false, 0 };
-            yield return new object[] { s_turkishCompare, "Hi", "I", CompareOptions.IgnoreCase, false, 0 };
+            // Android has its own ICU, which doesn't work well with tr
+            if (!PlatformDetection.IsAndroid)
+            {
+                yield return new object[] { s_turkishCompare, "Hi", "I", CompareOptions.IgnoreCase, false, 0 };
+                yield return new object[] { s_turkishCompare, "Hi", "\u0130", CompareOptions.IgnoreCase, true, 1 };
+            }
             yield return new object[] { s_turkishCompare, "Hi", "\u0130", CompareOptions.None, false, 0 };
-            yield return new object[] { s_turkishCompare, "Hi", "\u0130", CompareOptions.IgnoreCase, true, 1 };
             yield return new object[] { s_invariantCompare, "Hi", "I", CompareOptions.None, false, 0 };
             yield return new object[] { s_invariantCompare, "Hi", "I", CompareOptions.IgnoreCase, true, 1 };
             yield return new object[] { s_invariantCompare, "Hi", "\u0130", CompareOptions.None, false, 0 };
@@ -112,7 +116,6 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(IsSuffix_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void IsSuffix(CompareInfo compareInfo, string source, string value, CompareOptions options, bool expected, int expectedMatchLength)
         {
             if (options == CompareOptions.None)

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.LastIndexOf.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.LastIndexOf.cs
@@ -54,14 +54,22 @@ namespace System.Globalization.Tests
 
             // Slovak
             yield return new object[] { s_slovakCompare, "ch", "h", 0, 1, CompareOptions.None, -1, 0 };
-            yield return new object[] { s_slovakCompare, "hore chodit", "HO", 11, 12, CompareOptions.IgnoreCase, 0, 2 };
+            // Android has its own ICU, which doesn't work well with slovak
+            if (!PlatformDetection.IsAndroid)
+            {
+                yield return new object[] { s_slovakCompare, "hore chodit", "HO", 11, 12, CompareOptions.IgnoreCase, 0, 2 };
+            }
             yield return new object[] { s_slovakCompare, "chh", "h", 2, 2, CompareOptions.None, 2, 1 };
 
             // Turkish
+            // Android has its own ICU, which doesn't work well with tr
+            if (!PlatformDetection.IsAndroid)
+            {
+                yield return new object[] { s_turkishCompare, "Hi", "I", 1, 2, CompareOptions.IgnoreCase, -1, 0 };
+                yield return new object[] { s_turkishCompare, "Hi", "\u0130", 1, 2, CompareOptions.IgnoreCase, 1, 1 };
+            }
             yield return new object[] { s_turkishCompare, "Hi", "I", 1, 2, CompareOptions.None, -1, 0 };
-            yield return new object[] { s_turkishCompare, "Hi", "I", 1, 2, CompareOptions.IgnoreCase, -1, 0 };
             yield return new object[] { s_turkishCompare, "Hi", "\u0130", 1, 2, CompareOptions.None, -1, 0 };
-            yield return new object[] { s_turkishCompare, "Hi", "\u0130", 1, 2, CompareOptions.IgnoreCase, 1, 1 };
 
             yield return new object[] { s_invariantCompare, "Hi", "I", 1, 2, CompareOptions.None, -1, 0 };
             yield return new object[] { s_invariantCompare, "Hi", "I", 1, 2, CompareOptions.IgnoreCase, 1, 1 };
@@ -151,7 +159,6 @@ namespace System.Globalization.Tests
         [Theory]
         [MemberData(nameof(LastIndexOf_TestData))]
         [MemberData(nameof(LastIndexOf_U_WithDiaeresis_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void LastIndexOf_String(CompareInfo compareInfo, string source, string value, int startIndex, int count, CompareOptions options, int expected, int expectedMatchLength)
         {
             if (value.Length == 1)

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.cs
@@ -259,9 +259,13 @@ namespace System.Globalization.Tests
 
             // Turkish
             yield return new object[] { s_turkishCompare, "i", "I", CompareOptions.None, 1 };
-            yield return new object[] { s_turkishCompare, "i", "I", CompareOptions.IgnoreCase, 1 };
+            // Android has its own ICU, which doesn't work well with tr
+            if (!PlatformDetection.IsAndroid)
+            {
+                yield return new object[] { s_turkishCompare, "i", "I", CompareOptions.IgnoreCase, 1 };
+                yield return new object[] { s_turkishCompare, "i", "\u0130", CompareOptions.IgnoreCase, 0 };
+            }
             yield return new object[] { s_invariantCompare, "i", "\u0130", CompareOptions.None, -1 };
-            yield return new object[] { s_turkishCompare, "i", "\u0130", CompareOptions.IgnoreCase, 0 };
             yield return new object[] { s_invariantCompare, "i", "I", CompareOptions.None, -1 };
             yield return new object[] { s_invariantCompare, "i", "I", CompareOptions.IgnoreCase, 0 };
             yield return new object[] { s_invariantCompare, "i", "\u0130", CompareOptions.None, -1 };
@@ -370,7 +374,6 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(SortKey_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void SortKeyTest(CompareInfo compareInfo, string string1, string string2, CompareOptions options, int expectedSign)
         {
             SortKey sk1 = compareInfo.GetSortKey(string1, options);

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoEnglishName.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoEnglishName.cs
@@ -12,7 +12,8 @@ namespace System.Globalization.Tests
         {
             yield return new object[] { CultureInfo.CurrentCulture.Name, CultureInfo.CurrentCulture.EnglishName };
 
-            if (PlatformDetection.IsNotUsingLimitedCultures)
+            // Android has its own ICU, which doesn't 100% map to UsingLimitedCultures
+            if (PlatformDetection.IsNotUsingLimitedCultures || PlatformDetection.IsAndroid)
             {
                 yield return new object[] { "en-US", "English (United States)" };
                 yield return new object[] { "fr-FR", "French (France)" };
@@ -27,7 +28,6 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(EnglishName_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void EnglishName(string name, string expected)
         {
             CultureInfo myTestCulture = new CultureInfo(name);

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoNativeName.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoNativeName.cs
@@ -11,8 +11,9 @@ namespace System.Globalization.Tests
         public static IEnumerable<object[]> NativeName_TestData()
         {
             yield return new object[] { CultureInfo.CurrentCulture.Name, CultureInfo.CurrentCulture.NativeName };
-            
-            if (PlatformDetection.IsNotUsingLimitedCultures)
+
+            // Android has its own ICU, which doesn't 100% map to UsingLimitedCultures
+            if (PlatformDetection.IsNotUsingLimitedCultures || PlatformDetection.IsAndroid)
             {
                 yield return new object[] { "en-US", "English (United States)" };
                 yield return new object[] { "en-CA", "English (Canada)" };
@@ -27,7 +28,6 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(NativeName_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void NativeName(string name, string expected)
         {
             CultureInfo myTestCulture = new CultureInfo(name);

--- a/src/libraries/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
@@ -111,7 +111,8 @@ namespace System.Globalization.Tests
 
         public static IEnumerable<object[]> NativeName_TestData()
         {
-            if (PlatformDetection.IsNotUsingLimitedCultures)
+            // Android has its own ICU, which doesn't 100% map to UsingLimitedCultures
+            if (PlatformDetection.IsNotUsingLimitedCultures || PlatformDetection.IsAndroid)
             {
                 yield return new object[] { "GB", "United Kingdom" };
                 yield return new object[] { "SE", "Sverige" };
@@ -128,7 +129,6 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(NativeName_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void NativeName(string name, string expected)
         {
             Assert.Equal(expected, new RegionInfo(name).NativeName);
@@ -136,7 +136,8 @@ namespace System.Globalization.Tests
 
         public static IEnumerable<object[]> EnglishName_TestData()
         {
-            if (PlatformDetection.IsNotUsingLimitedCultures)
+            // Android has its own ICU, which doesn't 100% map to UsingLimitedCultures
+            if (PlatformDetection.IsNotUsingLimitedCultures || PlatformDetection.IsAndroid)
             {
                 yield return new object[] { "en-US", new string[] { "United States" } };
                 yield return new object[] { "US", new string[] { "United States" } };
@@ -155,7 +156,6 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(EnglishName_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void EnglishName(string name, string[] expected)
         {
             string result = new RegionInfo(name).EnglishName;
@@ -213,13 +213,13 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(RegionInfo_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void MiscTest(int lcid, int geoId, string currencyEnglishName, string currencyShortName, string alternativeCurrencyEnglishName, string currencyNativeName, string threeLetterISORegionName, string threeLetterWindowsRegionName)
         {
             RegionInfo ri = new RegionInfo(lcid); // create it with lcid
             Assert.Equal(geoId, ri.GeoId);
 
-            if (PlatformDetection.IsUsingLimitedCultures)
+            // Android has its own ICU, which doesn't 100% map to UsingLimitedCultures
+            if (PlatformDetection.IsUsingLimitedCultures && !PlatformDetection.IsAndroid)
             {
                 Assert.Equal(currencyShortName, ri.CurrencyEnglishName);
                 Assert.Equal(currencyShortName, ri.CurrencyNativeName);

--- a/src/libraries/System.Globalization/tests/System/Globalization/TextInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/TextInfoTests.cs
@@ -278,11 +278,16 @@ namespace System.Globalization.Tests
 
             foreach (string cultureName in GetTestLocales())
             {
+                // Android has its own ICU, which doesn't work well with tr
+                if (!PlatformDetection.IsAndroid)
+                {
+                    yield return new object[] { cultureName, "I", "\u0131" };
+                    yield return new object[] { cultureName, "HI!", "h\u0131!" };
+                    yield return new object[] { cultureName, "HI\n\0H\u0130\t!", "h\u0131\n\0hi\u0009!" };
+                }
                 yield return new object[] { cultureName, "\u0130", "i" };
                 yield return new object[] { cultureName, "i", "i" };
-                yield return new object[] { cultureName, "I", "\u0131" };
-                yield return new object[] { cultureName, "HI!", "h\u0131!" };
-                yield return new object[] { cultureName, "HI\n\0H\u0130\t!", "h\u0131\n\0hi\u0009!" };
+                
             }
 
             // ICU has special tailoring for the en-US-POSIX locale which treats "i" and "I" as different letters
@@ -305,7 +310,6 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(ToLower_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void ToLower(string name, string str, string expected)
         {
             TestToLower(name, str, expected);
@@ -402,11 +406,15 @@ namespace System.Globalization.Tests
             // Turkish i
             foreach (string cultureName in GetTestLocales())
             {
-                yield return new object[] { cultureName, "i", "\u0130" };
+                // Android has its own ICU, which doesn't work well with tr
+                if (!PlatformDetection.IsAndroid)
+                {
+                    yield return new object[] { cultureName, "i", "\u0130" };
+                    yield return new object[] { cultureName, "H\u0131\n\0Hi\u0009!", "HI\n\0H\u0130\t!" };
+                }
                 yield return new object[] { cultureName, "\u0130", "\u0130" };
                 yield return new object[] { cultureName, "\u0131", "I" };
                 yield return new object[] { cultureName, "I", "I" };
-                yield return new object[] { cultureName, "H\u0131\n\0Hi\u0009!", "HI\n\0H\u0130\t!" };
             }
 
             // ICU has special tailoring for the en-US-POSIX locale which treats "i" and "I" as different letters
@@ -429,7 +437,6 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(ToUpper_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void ToUpper(string name, string str, string expected)
         {
             TestToUpper(name, str, expected);


### PR DESCRIPTION
Android ICU seems to have slight behavioral differences with Turkish and Slovak cultures.  This change skips the data items that do have difficulty.

Additionally, there are a few other tests that were failing because the test data should have been the same as what we use on desktop.  Adjusted accordingly.

Fixes https://github.com/dotnet/runtime/issues/36672