### PR TITLE
Fix: XmlWriterSettings.Encoding must be registered in static Encoding

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriter.cs
@@ -161,10 +161,8 @@ namespace System.Xml
             ReadOnlySpan<byte> bom = _encoding.Preamble;
 
             // the encoding instance this creates can differ from the one passed in
-            this._encoding = Encoding.GetEncoding(
-                settings.Encoding.CodePage,
-                _charEntityFallback,
-                settings.Encoding.DecoderFallback);
+            _encoding = (Encoding)settings.Encoding.Clone();
+            _encoding.EncoderFallback = _charEntityFallback;
 
             _encoder = _encoding.GetEncoder();
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriter.cs
@@ -160,7 +160,6 @@ namespace System.Xml
             // grab bom before possibly changing encoding settings
             ReadOnlySpan<byte> bom = _encoding.Preamble;
 
-            // the encoding instance this creates can differ from the one passed in
             _encoding = (Encoding)settings.Encoding.Clone();
             _encoding.EncoderFallback = _charEntityFallback;
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/32164

Bring back full framework behavior to avoid throwing errors when encoding is not registered or custom encoding is used.

https://github.com/microsoft/referencesource/blob/master/System.Xml/System/Xml/Core/XmlEncodedRawTextWriter.cs#L177-L178