### PR TITLE
dotnet-pgo: ignore native libs passed via -r *.dll

### DIFF
--- a/src/coreclr/tools/dotnet-pgo/Program.cs
+++ b/src/coreclr/tools/dotnet-pgo/Program.cs
@@ -999,13 +999,23 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                 {
                     foreach (FileInfo fileReference in commandLineOptions.Reference)
                     {
-                        if (!File.Exists(fileReference.FullName))
+                        try
                         {
-                            PrintError($"Unable to find reference '{fileReference.FullName}'");
-                            filePathError = true;
+                            if (!File.Exists(fileReference.FullName))
+                            {
+                                PrintError($"Unable to find reference '{fileReference.FullName}'");
+                                filePathError = true;
+                            }
+                            else
+                                tsc.GetModuleFromPath(fileReference.FullName);
                         }
-                        else
-                            tsc.GetModuleFromPath(fileReference.FullName);
+                        catch (Internal.TypeSystem.TypeSystemException.BadImageFormatException)
+                        {
+                            // Ignore BadImageFormat in order to allow users to use '-r *.dll'
+                            // in a folder with native dynamic libraries (which have the same extension on Windows).
+
+                            // We don't need to log a warning here - it's already logged in GetModuleFromPath
+                        }
                     }
                 }
 


### PR DESCRIPTION
When I pass `-r *.dll` to dotnet-pgo inside a `publish` directory - it also tries to load native libs (which also have .dll extension on Windows). This PR swallows exceptions for them (but only for libs passed via `-r` arg).


It's needed for traces, collected on remote machines - because they come with hard-coded paths to managed libs like they're located on that server so I have to use `-r` option to override those paths.

/cc @AndyAyersMS @jakobbotsch @davidwrighton 