### PR TITLE
Leverage `cwde` and `cdqe` for sign extensions on xarch

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -6468,30 +6468,6 @@ void CodeGen::genIntToIntCast(GenTreeCast* cast)
         genIntCastOverflowCheck(cast, desc, srcReg);
     }
 
-    // Code size optimization: use "cdqe" and "cdwe" instead
-    // of "movsxd rax, eax" and "movsx eax, ax", respectively.
-    if ((srcReg == REG_EAX) && (srcReg == dstReg))
-    {
-        emitAttr attribute = EA_UNKNOWN;
-#ifdef TARGET_64BIT
-        if (desc.ExtendKind() == GenIntCastDesc::SIGN_EXTEND_INT)
-        {
-            attribute = EA_8BYTE;
-        }
-#endif
-        if ((desc.ExtendKind() == GenIntCastDesc::SIGN_EXTEND_SMALL_INT) && (desc.ExtendSrcSize() == sizeof(int16_t)))
-        {
-            attribute = EA_4BYTE;
-        }
-
-        if (attribute != EA_UNKNOWN)
-        {
-            emit->emitIns(INS_cwde, attribute);
-            genProduceReg(cast);
-            return;
-        }
-    }
-
     instruction ins;
     unsigned    insSize;
     bool        canSkip = false;

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -6468,6 +6468,30 @@ void CodeGen::genIntToIntCast(GenTreeCast* cast)
         genIntCastOverflowCheck(cast, desc, srcReg);
     }
 
+    // Code size optimization: use "cdqe" and "cdwe" instead
+    // of "movsxd rax, eax" and "movsx eax, ax", respectively.
+    if ((srcReg == REG_EAX) && (srcReg == dstReg))
+    {
+        emitAttr attribute = EA_UNKNOWN;
+#ifdef TARGET_64BIT
+        if (desc.ExtendKind() == GenIntCastDesc::SIGN_EXTEND_INT)
+        {
+            attribute = EA_8BYTE;
+        }
+#endif
+        if ((desc.ExtendKind() == GenIntCastDesc::SIGN_EXTEND_SMALL_INT) && (desc.ExtendSrcSize() == sizeof(int16_t)))
+        {
+            attribute = EA_4BYTE;
+        }
+
+        if (attribute != EA_UNKNOWN)
+        {
+            emit->emitIns(INS_cwde, attribute);
+            genProduceReg(cast);
+            return;
+        }
+    }
+
     instruction ins;
     unsigned    insSize;
     bool        canSkip = false;

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -2903,13 +2903,13 @@ void emitter::emitIns(instruction ins)
 }
 
 // Add an instruction with no operands, but whose encoding depends on the size
-// (Only CDQ/CQO currently)
+// (Only CDQ/CQO/CWDE/CDQE currently)
 void emitter::emitIns(instruction ins, emitAttr attr)
 {
     UNATIVE_OFFSET sz;
     instrDesc*     id   = emitNewInstr(attr);
     code_t         code = insCodeMR(ins);
-    assert(ins == INS_cdq);
+    assert((ins == INS_cdq) || (ins == INS_cwde));
     assert((code & 0xFFFFFF00) == 0);
     sz = 1;
 
@@ -13277,7 +13277,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             // Support only scalar AVX instructions and hence size is hard coded to 4-byte.
             code = AddVexPrefixIfNeeded(ins, code, EA_4BYTE);
 
-            if (ins == INS_cdq && TakesRexWPrefix(ins, id->idOpSize()))
+            if (((ins == INS_cdq) || (ins == INS_cwde)) && TakesRexWPrefix(ins, id->idOpSize()))
             {
                 code = AddRexWPrefix(ins, code);
             }
@@ -14758,6 +14758,7 @@ emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(ins
         case INS_mov:
         case INS_movsx:
         case INS_movzx:
+        case INS_cwde:
         case INS_cmp:
         case INS_test:
             if (memFmt == IF_NONE)

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -105,6 +105,7 @@ bool Is4ByteSSEInstruction(instruction ins);
 static bool IsMovInstruction(instruction ins);
 bool IsRedundantMov(
     instruction ins, insFormat fmt, emitAttr size, regNumber dst, regNumber src, bool canIgnoreSideEffects);
+bool EmitMovsxAsCwde(instruction ins, emitAttr size, regNumber dst, regNumber src);
 
 static bool IsJccInstruction(instruction ins);
 static bool IsJmpInstruction(instruction ins);

--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -105,6 +105,39 @@ const char* CodeGen::genInsDisplayName(emitter::instrDesc* id)
         curBuf = (curBuf + 1) % 4;
         return retbuf;
     }
+
+    // Some instructions have different mnemonics depending on the size.
+    switch (ins)
+    {
+        case INS_cdq:
+            switch (id->idOpSize())
+            {
+                case EA_8BYTE:
+                    return "cqo";
+                case EA_4BYTE:
+                    return "cdq";
+                case EA_2BYTE:
+                    return "cwd";
+                default:
+                    unreached();
+            }
+
+        case INS_cwde:
+            switch (id->idOpSize())
+            {
+                case EA_8BYTE:
+                    return "cdqe";
+                case EA_4BYTE:
+                    return "cwde";
+                case EA_2BYTE:
+                    return "cbw";
+                default:
+                    unreached();
+            }
+
+        default:
+            break;
+    }
 #endif // TARGET_XARCH
 
     return insName;

--- a/src/coreclr/jit/instrsxarch.h
+++ b/src/coreclr/jit/instrsxarch.h
@@ -686,11 +686,11 @@ INST1(nop,              "nop",              IUM_RD, 0x000090,                   
 INST1(lock,             "lock",             IUM_RD, 0x0000F0,                                                            INS_FLAGS_None )
 INST1(leave,            "leave",            IUM_RD, 0x0000C9,                                                            INS_FLAGS_None )
 
-
 INST1(neg,              "neg",              IUM_RW, 0x0018F6,                                                            Writes_OF      | Writes_SF     | Writes_ZF     | Writes_AF     | Writes_PF     | Writes_CF     )
 INST1(not,              "not",              IUM_RW, 0x0010F6,                                                            INS_FLAGS_None )
 
-INST1(cdq,              "cdq",              IUM_RD, 0x000099,                                                            INS_FLAGS_None)
+INST1(cwde,             "cwde",             IUM_RD, 0x000098,                                                            INS_FLAGS_None )
+INST1(cdq,              "cdq",              IUM_RD, 0x000099,                                                            INS_FLAGS_None )
 INST1(idiv,             "idiv",             IUM_RD, 0x0038F6,                                                            Undefined_OF   | Undefined_SF  | Undefined_ZF  | Undefined_AF  | Undefined_PF  | Undefined_CF  )
 INST1(imulEAX,          "imul",             IUM_RD, 0x0028F6,                                                            Writes_OF      | Undefined_SF  | Undefined_ZF  | Undefined_AF  | Undefined_PF  | Writes_CF     )
 INST1(div,              "div",              IUM_RD, 0x0030F6,                                                            Undefined_OF   | Undefined_SF  | Undefined_ZF  | Undefined_AF  | Undefined_PF  | Undefined_CF  )


### PR DESCRIPTION
This is a simple code size optimization I spotted while looking at the code MSVC generates for `GenTreeVisitor`s `WalkTree` function.

Other native compilers [generate it as well](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAM1QDsCBlZAQwBtMQBGAFlJvoCqAZ0wAFAB4gA5AAYppAFZdSrZrVDIApACYAQjt2kR7ZATx1KmWugDCqVgFcAtrS4AOUlfQAZPLUwAcs4ARpjEXDKkAA6oQoTmtHaOLu7RsfF0vv5BTqHhnJHGmKYJDATMxARJzq6cHkUldGUVBFmBIWERRuWV1Sl13S1tOXkRAJRGqA7EyBxSOgDMfsiOWADUmgs2QgT49AB0CJvYmjIAgqdnfgQAbNwA%2BgRrNugAjpgQ12sAbpyka19vtoxpdNAB2XRrKGXKFQ4iYAjTWg/ThrAD0P20m3053BABFQecvjYAO5YCBCBAkJ6/f6U6mYkG4iGwmGw%2BGI4jIilUypjCC/dGM7GgsF4qQTVjSACs8lcsnkqGkNgMBjWQimM0wG20C048gI0jkYwmAGsQNLOPs9WDOGCAJxuW3Sm4FG4qaTcOVGxXSeRCECRQ0KiZwWAwKARiBINBOKJ4dhkCgQWPxxMoVTqR7EBy0U18BMEMIBiDBH2kYJ%2BCoAT2k%2BtIsacVgIAHlaKxawrSFgnGpgOxy/h4SVvpgA13MOJig4i3X5NdMFKu6w8MFiDW7FhywRiHgnHOJvxGCwBzw%2BHQCMIxJIu0o/pmNKq9CpVwHIBNUFEzHRxwBaFvaGsv69jMRwLHiABetCjsQCz%2BouxTfq4EBeH0tTaJ41jDB0%2BQYTEcRIWhXB4ekSHYbknScBhDRIc0vT2DUxFGAhjS0HRrR%2BO0FG4YM9HJOhvEcdkOHERMGrTLMXCSjK3pdkqUjiG4Ny/ncawrH2awQDuuammMmm4IQJA6nq/x2HGCZhMZnB6SqegGAaPomqQCCYMwWDhBAZoWpES5eqQ%2B7SpE8pyKQ8n%2BoGpDBsapBhogKCoOZibkJQqYWeEwBCLQzBRPSBAFqwRbECWZZdpWWXEJ29aNs2bYdoOmC9uoA5dkOiF4KO44hZO06zlI9YLkuIUrmuG4YHMIU7nuB7nvQTBsBwZ5HleEjlkovAPigT6GMNb6eaFX4JH%2BAHwSYSGWNYRF/F45GjH8%2BEZIkDH9GkBEJDdlHMadpQ9FUT21J9bVND9735IJl2CSDUmTBJC3SVIsqkMFvoKUpKncGswDIMgmnaXmekQAZRDEFZpkJWmlmLNwNlbQ5IYTC5bmdHt5qBR6Uh%2BUjoV%2BkYEVRRKcPaPIAVBeWYWRY5MVRlGMZk2lyUprL6bqVmuP5lQhbFpQJUhWVNZzg2CVNvQtWdiFPZ9s1Zt4MOZgdeW3XIDOcz9fQi7lsN64VZu40Gru%2B59RKM3HvNXC8EtIgrbeIALCofabXZz47fAH4HT%2B0j/oBwEVMgYF4kIprVqopqYCdgPIahf1cDH12cSMlF3aRCSXTH91kbXImcH8NHfS0RH2gDrHsZDndg5X/c7EM7fcVw1nQ1qUNLgjnPyYpymqcrwA4zmeP6fgRMk88isU7qCzUwnui08aXms75QveYjovcwGQYS7F0bxYlYTy6l6bfMgURRHuL8e09xVBFh2PccQdx8qFWKuWXWFV9bVWNu2U28hzZNR9t2a2bU7YTinI7XqLsiyDXkB7UaW4uyTX9vqQ8F45qnjDheZaN4QpKAwhtLQ58XzBF2inJCR1BYDzOihC6lcrpYSnqMbQkRW5N3ES9B6kMZHCJ7nxRiXcWK0WBlIyi48frgwnpUYe9oxKakkrPReskQor1Uk4IQf8UT2n2GAscTwCZ7yMosP4h9P7E0WMCZ4NNxZ02cq5dylBr4%2BU9NY5G4UX6hKXEI4WD85Lcz5k5c03A3D7BuG4bQ%2BSZBUTcNwBYbh7TSjZnBVJNj0mOQFrErmUhL781IDBOIFhuBAA%3D%3D), both for Intel and AMD.

Diffs for this change are surprisingly sizeable (-2.5K for `libraries.pmi`) on `x64`:
1. [Windows x64](https://gist.github.com/SingleAccretion/f51d3976e163bd04e9a1ef293b64076e)
2. [Windows x86](https://gist.github.com/SingleAccretion/2d6b6030a5a25067bb403a725177137d)

The only regression is because of loop alignment. The larger improvements come from `SHORT` branches and loop alignment changes.