### PR TITLE
[wasm] Wasm.Build.Tests - try to close down the stdout/err readers 

### DIFF
--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -312,7 +312,7 @@
 
     <Message Text="Linking with emcc. This may take a while ..." Importance="High" />
     <Message Text="Running emcc with @(_EmccLinkStepArgs->'%(Identity)', ' ')" Importance="Low" />
-    <Exec Command='emcc "@$(_EmccDefaultFlagsRsp)" "@$(_EmccLinkRsp)"' EnvironmentVariables="@(EmscriptenEnvVars)" />
+    <Exec Command='emcc "@$(_EmccDefaultFlagsRsp)" "@$(_EmccLinkRsp)"' EnvironmentVariables="@(EmscriptenEnvVars)" StandardOutputImportance="Normal" StandardErrorImportance="Normal" />
 
     <Exec Command='wasm-opt$(_ExeExt) --strip-dwarf "$(_WasmIntermediateOutputPath)dotnet.wasm" -o "$(_WasmIntermediateOutputPath)dotnet.wasm"' Condition="'$(WasmNativeStrip)' == 'true'" IgnoreStandardErrorWarningFormat="true" EnvironmentVariables="@(EmscriptenEnvVars)" />
   </Target>

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
@@ -514,8 +514,6 @@ namespace Wasm.Build.Tests
             process.StartInfo = processStartInfo;
             process.EnableRaisingEvents = true;
 
-            process.ErrorDataReceived += (sender, e) => LogData($"[{label}-stderr]", e.Data);
-            process.OutputDataReceived += (sender, e) => LogData($"[{label}]", e.Data);
             // AutoResetEvent resetEvent = new (false);
             // process.Exited += (_, _) => { Console.WriteLine ($"- exited called"); resetEvent.Set(); };
 
@@ -524,6 +522,11 @@ namespace Wasm.Build.Tests
 
             try
             {
+                DataReceivedEventHandler logStdErr = (sender, e) => LogData($"[{label}-stderr]", e.Data);
+                DataReceivedEventHandler logStdOut = (sender, e) => LogData($"[{label}]", e.Data);
+
+                process.ErrorDataReceived += logStdErr;
+                process.OutputDataReceived += logStdOut;
                 process.BeginOutputReadLine();
                 process.BeginErrorReadLine();
 
@@ -536,9 +539,14 @@ namespace Wasm.Build.Tests
                     lock (syncObj)
                     {
                         var lastLines = outputBuilder.ToString().Split('\r', '\n').TakeLast(20);
-                        throw new XunitException($"Process timed out, output: {string.Join(Environment.NewLine, lastLines)}");
+                        throw new XunitException($"Process timed out. Last 20 lines of output:{Environment.NewLine}{string.Join(Environment.NewLine, lastLines)}");
                     }
                 }
+
+                process.ErrorDataReceived -= logStdErr;
+                process.OutputDataReceived -= logStdOut;
+                process.CancelErrorRead();
+                process.CancelOutputRead();
 
                 lock (syncObj)
                 {

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/README.md
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/README.md
@@ -17,3 +17,39 @@ Windows: `.\dotnet.cmd build .\src\tests\BuildWasmApps\Wasm.Build.Tests\Wasm.Bui
 
 - Specific tests can be run via `XUnitClassName`, and `XUnitMethodName`
   - eg. `XUnitClassName=Wasm.Build.Tests.BlazorWasmTests`
+
+## Running on helix
+
+The wasm.build.tests are built, and sent as a payload to helix, alongwith
+either emsdk+tasks+targets, or sdk+workload. And on helix the individual unit
+tests generate test projects, and build those.
+
+## About the tests
+
+Most of the tests are structured on the idea that for a given case (or
+combination of options), we want to:
+
+1. build once
+2. run the same build with different hosts, eg. V8, Chrome, Firefox etc.
+
+For this, the builds get cached using `BuildArgs` as the key.
+
+## notes:
+
+- when running locally, the default is to test with workloads. For this, sdk
+  with `$(SdkVersionForWorkloadTesting)` is installed in
+  `artifacts/bin/dotnet-workload`. And the workload packs are installed there
+  using packages in `artifacts/packages/$(Configuration)/Shipping`.
+    - If the packages get updated, then the workload will get installed again.
+
+    - Keep in mind, that if you have any non-test changes, and don't regenerate
+      the nuget packages, then you will still be running tests against the
+      "old" sdk
+
+- If you aren't explicitly testing workloads, then it can be useful to run the
+  tests with `-p:TestUsingWorkloads=false`, and this will cause the tests to
+  use the build bits from the usual locations in artifacts, without requiring
+  regenerating the nugets, and workload re-install.
+
+- Each test gets a randomly generated "id". This `id` can be used to find the
+  binlogs, or the test directories.


### PR DESCRIPTION
.. when the process ends.

`BuildTestBase.RunProcess` subscribes to messages from stdout/stderr.
It seems that sometimes after the process is done, and the test has also
ended, the streams might still be flushing messages, and ends up
invoking our stdout/stderr message handlers.

And these handlers call xunit's `ITestOutputHelper.WriteLine`, which
then fails with:

```
System.InvalidOperationException: There is no currently active test.
   at Xunit.Sdk.TestOutputHelper.GuardInitialized() in C:\Dev\xunit\xunit\src\xunit.execution\Sdk\Frameworks\TestOutputHelper.cs:line 51
   at Xunit.Sdk.TestOutputHelper.QueueTestOutput(String output) in C:\Dev\xunit\xunit\src\xunit.execution\Sdk\Frameworks\TestOutputHelper.cs:line 66
   at Wasm.Build.Tests.BuildTestBase.<>c__DisplayClass37_0.<RunProcess>g__LogData|2(String label, String message) in /_/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs:line 569
   at System.Diagnostics.AsyncStreamReader.FlushMessageQueue(Boolean rethrowInNewThread) in System.Diagnostics.Process.dll:token 0x6000098+0x87
--- End of stack trace from previous location ---
   at System.Diagnostics.AsyncStreamReader.<>c.<FlushMessageQueue>b__18_0(Object edi) in System.Diagnostics.Process.dll:token 0x600009f+0x0
   at System.Threading.QueueUserWorkItemCallbackDefaultContext.Execute() in System.Private.CoreLib.dll:token 0x6002a84+0x14
   at System.Threading.ThreadPoolWorkQueue.Dispatch() in System.Private.CoreLib.dll:token 0x6002a5f+0x10a
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart() in System.Private.CoreLib.dll:token 0x6002b39+0x6c
   at System.Threading.Thread.StartCallback() in System.Private.CoreLib.dll:token 0x60026db+0xe
```

Note: I couldn't actually reproduce this, so this change is just to be
defensive, and hopefully fix this issue.

Fixes: #55999