### PR TITLE
Ensure MeterListener.RecordObservableInstruments invoking all instruments callbacks

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MeterListener.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MeterListener.cs
@@ -185,15 +185,29 @@ namespace System.Diagnostics.Metrics
         /// </summary>
         public void RecordObservableInstruments()
         {
+            List<Exception>? exceptionsList = null;
             DiagNode<Instrument>? current = _enabledMeasurementInstruments.First;
             while (current is not null)
             {
                 if (current.Value.IsObservable)
                 {
-                    current.Value.Observe(this);
+                    try
+                    {
+                        current.Value.Observe(this);
+                    }
+                    catch (Exception e)
+                    {
+                        exceptionsList ??= new List<Exception>();
+                        exceptionsList.Add(e);
+                    }
                 }
 
                 current = current.Next;
+            }
+
+            if (exceptionsList is not null)
+            {
+                throw new AggregateException(exceptionsList);
             }
         }
 


### PR DESCRIPTION
When having a MeterListener listening to multiple observable instruments and this listener is calling back all listening to instruments to collect instrumentation data; if one of the callbacks throw exception, we used to let this exception propagate. The remaining instruments callbacks will not get a chance to execute. This change is catching any exception thrown from the instrument callbacks and continue executing calling the remaining instruments. At the end of the operation, we'll throw AggregationException containing the list of all exceptions thrown during the operation.