### PR TITLE
Call the jit shutdown logic on crossgen2 shutdown

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -74,8 +74,38 @@ namespace Internal.JitInterface
         [DllImport(JitLibrary)]
         private extern static IntPtr jitStartup(IntPtr host);
 
-        [DllImport(JitLibrary)]
-        private extern static IntPtr getJit();
+        private static class JitPointerAccessor
+        {
+            [DllImport(JitLibrary)]
+            private extern static IntPtr getJit();
+
+            public static IntPtr Get()
+            {
+                if (s_jit != IntPtr.Zero)
+                {
+                    return s_jit;
+                }
+
+                lock(typeof(JitPointerAccessor))
+                {
+                    s_jit = getJit();
+                    return s_jit;
+                }
+            }
+
+            [DllImport(JitSupportLibrary)]
+            private extern static CorJitResult JitProcessShutdownWork(IntPtr jit);
+
+            public static void ShutdownJit()
+            {
+                if (s_jit != IntPtr.Zero)
+                {
+                    JitProcessShutdownWork(s_jit);
+                }
+            }
+
+            private static IntPtr s_jit;
+        }
 
         [DllImport(JitLibrary)]
         private extern static IntPtr getLikelyClass(PgoInstrumentationSchema* schema, uint countSchemaItems, byte*pInstrumentationData, int ilOffset, out uint pLikelihood, out uint pNumberOfClasses);
@@ -129,9 +159,14 @@ namespace Internal.JitInterface
             jitStartup(GetJitHost(JitConfigProvider.Instance.UnmanagedInstance));
         }
 
+        public static void ShutdownJit()
+        {
+            JitPointerAccessor.ShutdownJit();
+        }
+
         public CorInfoImpl()
         {
-            _jit = getJit();
+            _jit = JitPointerAccessor.Get();
             if (_jit == IntPtr.Zero)
             {
                 throw new IOException("Failed to initialize JIT");

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -65,6 +65,12 @@ namespace ILCompiler
             ((ReadyToRunCompilerContext)context).SetCompilationGroup(group);
         }
 
+        // Shutdown the Jit if it has been loaded. This must only be called once per process
+        public static void ShutdownJit()
+        {
+            CorInfoImpl.ShutdownJit();
+        }
+
         public override CompilationBuilder UseBackendOptions(IEnumerable<string> options)
         {
             var builder = new ArrayBuilder<KeyValuePair<string, string>>();

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -983,7 +983,14 @@ namespace ILCompiler
 #if DEBUG
             try
             {
-                return new Program().Run(args);
+                try
+                {
+                    return new Program().Run(args);
+                }
+                finally
+                {
+                    ReadyToRunCodegenCompilationBuilder.ShutdownJit();
+                }
             }
             catch (CodeGenerationFailedException ex) when (DumpReproArguments(ex))
             {
@@ -992,7 +999,14 @@ namespace ILCompiler
 #else
             try
             {
-                return new Program().Run(args);
+                try
+                {
+                    return new Program().Run(args);
+                }
+                finally
+                {
+                    ReadyToRunCodegenCompilationBuilder.ShutdownJit();
+                }
             }
             catch (Exception e)
             {
@@ -1001,6 +1015,7 @@ namespace ILCompiler
                 return 1;
             }
 #endif
+
         }
     }
 }

--- a/src/coreclr/tools/aot/jitinterface/jitwrapper.cpp
+++ b/src/coreclr/tools/aot/jitinterface/jitwrapper.cpp
@@ -43,6 +43,11 @@ DLL_EXPORT int JitCompileMethod(
     return 1;
 }
 
+DLL_EXPORT void JitProcessShutdownWork(ICorJitCompiler * pJit)
+{
+    return pJit->ProcessShutdownWork(nullptr);
+}
+
 DLL_EXPORT unsigned GetMaxIntrinsicSIMDVectorLength(
     ICorJitCompiler * pJit,
     CORJIT_FLAGS * flags)


### PR DESCRIPTION
- Allows the jit shutdown logic to execute reliably on both Windows and Unix

Fixes #49525