### PR TITLE
Make Extensions.FileProviders supported in browser and only unsupport FSW usage

### DIFF
--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/Directory.Build.props
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <IsAspNetCoreApp>true</IsAspNetCoreApp>
-    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
   </PropertyGroup>
 </Project>

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Microsoft.Extensions.FileProviders.Physical.csproj
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Microsoft.Extensions.FileProviders.Physical.csproj
@@ -1,16 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RootNamespace>Microsoft.Extensions.FileProviders</RootNamespace>
-    <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppCurrent)-Browser;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent);netstandard2.0;net461</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableDefaultItems>true</EnableDefaultItems>
     <PackageDescription>File provider for physical files for Microsoft.Extensions.FileProviders.</PackageDescription>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition="'$(TargetsBrowser)' == 'true'">
-    <EnableDefaultItems>false</EnableDefaultItems>
-    <GeneratePlatformNotSupportedAssemblyMessage>SR.FileProvidersPhysical_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFileProvider.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFileProvider.cs
@@ -161,7 +161,13 @@ namespace Microsoft.Extensions.FileProviders
             string root = PathUtils.EnsureTrailingSlash(Path.GetFullPath(Root));
 
             // When both UsePollingFileWatcher & UseActivePolling are set, we won't use a FileSystemWatcher.
-            FileSystemWatcher watcher = UsePollingFileWatcher && UseActivePolling ? null : new FileSystemWatcher(root);
+            FileSystemWatcher watcher = UsePollingFileWatcher && UseActivePolling ? null :
+#if NETCOREAPP
+                OperatingSystem.IsBrowser() ? throw new PlatformNotSupportedException(SR.Format(SR.FileSystemWatcher_PlatformNotSupported, typeof(FileSystemWatcher))) : new FileSystemWatcher(root);
+#else
+                new FileSystemWatcher(root);
+#endif
+
             return new PhysicalFilesWatcher(root, watcher, UsePollingFileWatcher, _filters)
             {
                 UseActivePolling = UseActivePolling,

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFilesWatcher.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFilesWatcher.cs
@@ -88,6 +88,13 @@ namespace Microsoft.Extensions.FileProviders.Physical
 
             if (fileSystemWatcher != null)
             {
+#if NETCOREAPP
+                if (OperatingSystem.IsBrowser())
+                {
+                    throw new PlatformNotSupportedException(SR.Format(SR.FileSystemWatcher_PlatformNotSupported, typeof(FileSystemWatcher)));
+                }
+#endif
+
                 _fileWatcher = fileSystemWatcher;
                 _fileWatcher.IncludeSubdirectories = true;
                 _fileWatcher.Created += OnChanged;
@@ -264,6 +271,8 @@ namespace Microsoft.Extensions.FileProviders.Physical
             }
         }
 
+// We made sure that browser never uses FileSystemWatcher.
+#pragma warning disable CA1416 // Validate platform compatibility
         private void OnRenamed(object sender, RenamedEventArgs e)
         {
             // For a file name change or a directory's name change notify registered tokens.
@@ -400,6 +409,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
                 }
             }
         }
+#pragma warning restore CA1416 // Validate platform compatibility
 
         private static string NormalizePath(string filter) => filter = filter.Replace('\\', '/');
 

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFilesWatcher.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFilesWatcher.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.IO;
+using System.Runtime.Versioning;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
@@ -147,7 +148,10 @@ namespace Microsoft.Extensions.FileProviders.Physical
             }
 
             IChangeToken changeToken = GetOrAddChangeToken(filter);
+// We made sure that browser never uses FileSystemWatcher.
+#pragma warning disable CA1416 // Validate platform compatibility
             TryEnableFileSystemWatcher();
+#pragma warning restore CA1416 // Validate platform compatibility
 
             return changeToken;
         }
@@ -271,8 +275,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
             }
         }
 
-// We made sure that browser never uses FileSystemWatcher.
-#pragma warning disable CA1416 // Validate platform compatibility
+        [UnsupportedOSPlatform("browser")]
         private void OnRenamed(object sender, RenamedEventArgs e)
         {
             // For a file name change or a directory's name change notify registered tokens.
@@ -305,11 +308,13 @@ namespace Microsoft.Extensions.FileProviders.Physical
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         private void OnChanged(object sender, FileSystemEventArgs e)
         {
             OnFileSystemEntryChange(e.FullPath);
         }
 
+        [UnsupportedOSPlatform("browser")]
         private void OnError(object sender, ErrorEventArgs e)
         {
             // Notify all cache entries on error.
@@ -319,6 +324,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         private void OnFileSystemEntryChange(string fullPath)
         {
             try
@@ -341,6 +347,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         private void ReportChangeForMatchedEntries(string path)
         {
             if (string.IsNullOrEmpty(path))
@@ -377,6 +384,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         private void TryDisableFileSystemWatcher()
         {
             if (_fileWatcher != null)
@@ -394,6 +402,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
             }
         }
 
+        [UnsupportedOSPlatform("browser")]
         private void TryEnableFileSystemWatcher()
         {
             if (_fileWatcher != null)
@@ -409,7 +418,6 @@ namespace Microsoft.Extensions.FileProviders.Physical
                 }
             }
         }
-#pragma warning restore CA1416 // Validate platform compatibility
 
         private static string NormalizePath(string filter) => filter = filter.Replace('\\', '/');
 

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Resources/Strings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
-    Microsoft ResX Schema
-
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
     value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -129,7 +129,7 @@
   <data name="UnexpectedFileSystemInfo" xml:space="preserve">
     <value>Unexpected type of FileSystemInfo</value>
   </data>
-  <data name="FileProvidersPhysical_PlatformNotSupported" xml:space="preserve">
-    <value>Microsoft.Extensions.FileProviders.Physical is not supported on this platform.</value>
+  <data name="FileSystemWatcher_PlatformNotSupported" xml:space="preserve">
+    <value>The type {0} is not supported on this platform, use polling instead.</value>
   </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostBuilder.cs
@@ -192,9 +192,7 @@ namespace Microsoft.Extensions.Hosting
                 _hostingEnvironment.ApplicationName = Assembly.GetEntryAssembly()?.GetName().Name;
             }
 
-#pragma warning disable CA1416 // 'PhysicalFileProvider' is unsupported on: 'browser' https://github.com/dotnet/runtime/issues/56178
             _hostingEnvironment.ContentRootFileProvider = _defaultProvider = new PhysicalFileProvider(_hostingEnvironment.ContentRootPath);
-#pragma warning restore CA1416 // 'PhysicalFileProvider' is unsupported on: 'browser'
         }
 
         private string ResolveContentRootPath(string contentRootPath, string basePath)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/56178

Since `PhysicalFilesWatcher` can be used without a `FileSystemWatcher` through polling, I reduced the unsupported scenarios to only the ones that actually use FSW in browser with a couple of runtime checks.
Let me know if this is not a good idea and instead we should mark the whole type as unsupported.