### PR TITLE
Disable JIT xarch asserts on gcref/byref computation

### DIFF
--- a/src/libraries/System.IO.Hashing/tests/Crc32Tests.cs
+++ b/src/libraries/System.IO.Hashing/tests/Crc32Tests.cs
@@ -93,7 +93,6 @@ namespace System.IO.Hashing.Tests
             InstanceAppendAllocateAndResetDriver(testCase);
         }
 
-        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/54007", RuntimeConfiguration.Checked)]
         [Theory]
         [MemberData(nameof(TestCases))]
         public void InstanceMultiAppendGetCurrentHash(TestCase testCase)

--- a/src/libraries/System.IO.Hashing/tests/Crc64Tests.cs
+++ b/src/libraries/System.IO.Hashing/tests/Crc64Tests.cs
@@ -97,7 +97,6 @@ namespace System.IO.Hashing.Tests
             InstanceAppendAllocateAndResetDriver(testCase);
         }
 
-        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/54007", RuntimeConfiguration.Checked)]
         [Theory]
         [MemberData(nameof(TestCases))]
         public void InstanceMultiAppendGetCurrentHash(TestCase testCase)

--- a/src/libraries/System.IO.Hashing/tests/XxHash32Tests.007.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash32Tests.007.cs
@@ -105,7 +105,6 @@ namespace System.IO.Hashing.Tests
             InstanceAppendAllocateAndResetDriver(testCase);
         }
 
-        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/54007", RuntimeConfiguration.Checked)]
         [Theory]
         [MemberData(nameof(TestCases))]
         public void InstanceMultiAppendGetCurrentHash(TestCase testCase)

--- a/src/libraries/System.IO.Hashing/tests/XxHash32Tests.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash32Tests.cs
@@ -118,7 +118,6 @@ namespace System.IO.Hashing.Tests
             InstanceAppendAllocateAndResetDriver(testCase);
         }
 
-        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/54007", RuntimeConfiguration.Checked)]
         [Theory]
         [MemberData(nameof(TestCases))]
         public void InstanceMultiAppendGetCurrentHash(TestCase testCase)

--- a/src/libraries/System.IO.Hashing/tests/XxHash32Tests.f00d.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash32Tests.f00d.cs
@@ -105,7 +105,6 @@ namespace System.IO.Hashing.Tests
             InstanceAppendAllocateAndResetDriver(testCase);
         }
 
-        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/54007", RuntimeConfiguration.Checked)]
         [Theory]
         [MemberData(nameof(TestCases))]
         public void InstanceMultiAppendGetCurrentHash(TestCase testCase)

--- a/src/libraries/System.IO.Hashing/tests/XxHash64Tests.007.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash64Tests.007.cs
@@ -115,7 +115,6 @@ namespace System.IO.Hashing.Tests
             InstanceAppendAllocateAndResetDriver(testCase);
         }
 
-        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/54007", RuntimeConfiguration.Checked)]
         [Theory]
         [MemberData(nameof(TestCases))]
         public void InstanceMultiAppendGetCurrentHash(TestCase testCase)

--- a/src/libraries/System.IO.Hashing/tests/XxHash64Tests.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash64Tests.cs
@@ -131,7 +131,6 @@ namespace System.IO.Hashing.Tests
             InstanceAppendAllocateAndResetDriver(testCase);
         }
 
-        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/54007", RuntimeConfiguration.Checked)]
         [Theory]
         [MemberData(nameof(TestCases))]
         public void InstanceMultiAppendGetCurrentHash(TestCase testCase)

--- a/src/libraries/System.IO.Hashing/tests/XxHash64Tests.f00d.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash64Tests.f00d.cs
@@ -115,7 +115,6 @@ namespace System.IO.Hashing.Tests
             InstanceAppendAllocateAndResetDriver(testCase);
         }
 
-        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/54007", RuntimeConfiguration.Checked)]
         [Theory]
         [MemberData(nameof(TestCases))]
         public void InstanceMultiAppendGetCurrentHash(TestCase testCase)


### PR DESCRIPTION
The emitter has asserts that an xarch RMW inc/dec/add/sub of a byref
must have an incoming gcref/byref to be legal. This is (no longer)
true due to extensive use of Span and Unsafe constructs, where we
often see lclheap or other integer typed values cast to byref. Also,
the emitter only updates its GC info when an instruction is generated.
When one of these casts from integer to byref ends up getting the same
register allocated, and its instruction is thus omitted, the emitter
doesn't get the appropriate gcref update (this problem is being
attempted to be solved elsewhere).

For now, disable these asserts.

Re-enable the tests disabled in #54207

Fixes #51728, #54007