### PR TITLE
Add missing float32 instruction

### DIFF
--- a/src/mono/mono/mini/cpu-s390x.md
+++ b/src/mono/mono/mini/cpu-s390x.md
@@ -163,6 +163,7 @@ r4_clt_un: dest:i src1:f src2:f len:42
 r4_cneq: dest:i src1:f src2:f len:42
 r4_cge: dest:i src1:f src2:f len:35
 r4_cle: dest:i src1:f src2:f len:35
+rmove: dest:f src1:f len:4
 
 fmove: dest:f src1:f len:4
 move_f_to_i4: dest:i src1:f len:14

--- a/src/mono/mono/mini/mini-s390x.c
+++ b/src/mono/mono/mini/mini-s390x.c
@@ -3453,9 +3453,12 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
                        s390_ldebr (code, ins->dreg, ins->sreg1);
                        break;
 		case OP_FMOVE:
-			if (ins->dreg != ins->sreg1) {
+			if (ins->dreg != ins->sreg1)
 				s390_ldr   (code, ins->dreg, ins->sreg1);
-			}
+			break;
+		case OP_RMOVE:
+			if (ins->dreg != ins->sreg1) 
+				s390_ler   (code, ins->dreg, ins->sreg1);
 			break;
 		case OP_MOVE_F_TO_I8: 
 			s390_lgdr (code, ins->dreg, ins->sreg1);
@@ -5706,7 +5709,7 @@ mono_arch_emit_prolog (MonoCompile *cfg)
     			   cfg->rgctx_var->inst_offset);
 	}
 
-#if 1
+#if 0
 char *methodName = getenv("MONO_TRACE_METHOD");
 if (methodName != NULL) {
 printf("ns: %s k: %s m: %s\n",method->klass->name_space,method->klass->name,method->name);fflush(stdout);


### PR DESCRIPTION
- rmove specification in cpu-s390x.md
- OP_RMOVE implementation in mini-s390x.c