### PR TITLE
Tweak code gen for Guid parsing

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -398,25 +398,25 @@ namespace System
             }
 
             Span<byte> bytes = MemoryMarshal.AsBytes(new Span<GuidResult>(ref result, 1));
-            uint invalidIfFF = 0;
-            bytes[0] = DecodeByte(guidString[6],   guidString[7],  ref invalidIfFF);
-            bytes[1] = DecodeByte(guidString[4],   guidString[5],  ref invalidIfFF);
-            bytes[2] = DecodeByte(guidString[2],   guidString[3],  ref invalidIfFF);
-            bytes[3] = DecodeByte(guidString[0],   guidString[1],  ref invalidIfFF);
-            bytes[4] = DecodeByte(guidString[11],  guidString[12], ref invalidIfFF);
-            bytes[5] = DecodeByte(guidString[9],   guidString[10], ref invalidIfFF);
-            bytes[6] = DecodeByte(guidString[16],  guidString[17], ref invalidIfFF);
-            bytes[7] = DecodeByte(guidString[14],  guidString[15], ref invalidIfFF);
-            bytes[8] = DecodeByte(guidString[19],  guidString[20], ref invalidIfFF);
-            bytes[9] = DecodeByte(guidString[21],  guidString[22], ref invalidIfFF);
-            bytes[10] = DecodeByte(guidString[24], guidString[25], ref invalidIfFF);
-            bytes[11] = DecodeByte(guidString[26], guidString[27], ref invalidIfFF);
-            bytes[12] = DecodeByte(guidString[28], guidString[29], ref invalidIfFF);
-            bytes[13] = DecodeByte(guidString[30], guidString[31], ref invalidIfFF);
-            bytes[14] = DecodeByte(guidString[32], guidString[33], ref invalidIfFF);
-            bytes[15] = DecodeByte(guidString[34], guidString[35], ref invalidIfFF);
+            int invalidIfNegative = 0;
+            bytes[0] = DecodeByte(guidString[6],   guidString[7],  ref invalidIfNegative);
+            bytes[1] = DecodeByte(guidString[4],   guidString[5],  ref invalidIfNegative);
+            bytes[2] = DecodeByte(guidString[2],   guidString[3],  ref invalidIfNegative);
+            bytes[3] = DecodeByte(guidString[0],   guidString[1],  ref invalidIfNegative);
+            bytes[4] = DecodeByte(guidString[11],  guidString[12], ref invalidIfNegative);
+            bytes[5] = DecodeByte(guidString[9],   guidString[10], ref invalidIfNegative);
+            bytes[6] = DecodeByte(guidString[16],  guidString[17], ref invalidIfNegative);
+            bytes[7] = DecodeByte(guidString[14],  guidString[15], ref invalidIfNegative);
+            bytes[8] = DecodeByte(guidString[19],  guidString[20], ref invalidIfNegative);
+            bytes[9] = DecodeByte(guidString[21],  guidString[22], ref invalidIfNegative);
+            bytes[10] = DecodeByte(guidString[24], guidString[25], ref invalidIfNegative);
+            bytes[11] = DecodeByte(guidString[26], guidString[27], ref invalidIfNegative);
+            bytes[12] = DecodeByte(guidString[28], guidString[29], ref invalidIfNegative);
+            bytes[13] = DecodeByte(guidString[30], guidString[31], ref invalidIfNegative);
+            bytes[14] = DecodeByte(guidString[32], guidString[33], ref invalidIfNegative);
+            bytes[15] = DecodeByte(guidString[34], guidString[35], ref invalidIfNegative);
 
-            if (invalidIfFF != 0xFF)
+            if (invalidIfNegative >= 0)
             {
                 if (!BitConverter.IsLittleEndian)
                 {
@@ -484,25 +484,25 @@ namespace System
             }
 
             Span<byte> bytes = MemoryMarshal.AsBytes(new Span<GuidResult>(ref result, 1));
-            uint invalidIfFF = 0;
-            bytes[0] = DecodeByte(guidString[6], guidString[7], ref invalidIfFF);
-            bytes[1] = DecodeByte(guidString[4], guidString[5], ref invalidIfFF);
-            bytes[2] = DecodeByte(guidString[2], guidString[3], ref invalidIfFF);
-            bytes[3] = DecodeByte(guidString[0], guidString[1], ref invalidIfFF);
-            bytes[4] = DecodeByte(guidString[10], guidString[11], ref invalidIfFF);
-            bytes[5] = DecodeByte(guidString[8], guidString[9], ref invalidIfFF);
-            bytes[6] = DecodeByte(guidString[14], guidString[15], ref invalidIfFF);
-            bytes[7] = DecodeByte(guidString[12], guidString[13], ref invalidIfFF);
-            bytes[8] = DecodeByte(guidString[16], guidString[17], ref invalidIfFF);
-            bytes[9] = DecodeByte(guidString[18], guidString[19], ref invalidIfFF);
-            bytes[10] = DecodeByte(guidString[20], guidString[21], ref invalidIfFF);
-            bytes[11] = DecodeByte(guidString[22], guidString[23], ref invalidIfFF);
-            bytes[12] = DecodeByte(guidString[24], guidString[25], ref invalidIfFF);
-            bytes[13] = DecodeByte(guidString[26], guidString[27], ref invalidIfFF);
-            bytes[14] = DecodeByte(guidString[28], guidString[29], ref invalidIfFF);
-            bytes[15] = DecodeByte(guidString[30], guidString[31], ref invalidIfFF);
+            int invalidIfNegative = 0;
+            bytes[0] = DecodeByte(guidString[6], guidString[7], ref invalidIfNegative);
+            bytes[1] = DecodeByte(guidString[4], guidString[5], ref invalidIfNegative);
+            bytes[2] = DecodeByte(guidString[2], guidString[3], ref invalidIfNegative);
+            bytes[3] = DecodeByte(guidString[0], guidString[1], ref invalidIfNegative);
+            bytes[4] = DecodeByte(guidString[10], guidString[11], ref invalidIfNegative);
+            bytes[5] = DecodeByte(guidString[8], guidString[9], ref invalidIfNegative);
+            bytes[6] = DecodeByte(guidString[14], guidString[15], ref invalidIfNegative);
+            bytes[7] = DecodeByte(guidString[12], guidString[13], ref invalidIfNegative);
+            bytes[8] = DecodeByte(guidString[16], guidString[17], ref invalidIfNegative);
+            bytes[9] = DecodeByte(guidString[18], guidString[19], ref invalidIfNegative);
+            bytes[10] = DecodeByte(guidString[20], guidString[21], ref invalidIfNegative);
+            bytes[11] = DecodeByte(guidString[22], guidString[23], ref invalidIfNegative);
+            bytes[12] = DecodeByte(guidString[24], guidString[25], ref invalidIfNegative);
+            bytes[13] = DecodeByte(guidString[26], guidString[27], ref invalidIfNegative);
+            bytes[14] = DecodeByte(guidString[28], guidString[29], ref invalidIfNegative);
+            bytes[15] = DecodeByte(guidString[30], guidString[31], ref invalidIfNegative);
 
-            if (invalidIfFF != 0xFF)
+            if (invalidIfNegative >= 0)
             {
                 if (!BitConverter.IsLittleEndian)
                 {
@@ -695,21 +695,29 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static byte DecodeByte(char ch1, char ch2, ref uint invalidIfFF)
+        private static byte DecodeByte(char ch1, char ch2, ref int invalidIfNegative)
         {
             // TODO https://github.com/dotnet/runtime/issues/13464:
             // Replace the Unsafe.Add with HexConverter.FromChar once the bounds checks are eliminated.
 
-            uint h1 = 0xFF;
-            if (ch1 < HexConverter.CharToHexLookup.Length)
-                h1 = Unsafe.Add(ref MemoryMarshal.GetReference(HexConverter.CharToHexLookup), ch1);
+            ReadOnlySpan<byte> lookup = HexConverter.CharToHexLookup;
 
-            uint h2 = 0xFF;
-            if (ch2 < HexConverter.CharToHexLookup.Length)
-                h2 = Unsafe.Add(ref MemoryMarshal.GetReference(HexConverter.CharToHexLookup), ch2);
+            int h1 = -1;
+            if (ch1 < lookup.Length)
+            {
+                h1 = (sbyte)Unsafe.Add(ref MemoryMarshal.GetReference(lookup), ch1);
+            }
+            h1 <<= 4;
 
-            invalidIfFF |= h1 | h2;
-            return (byte)(h1 << 4 | h2);
+            int h2 = -1;
+            if (ch2 < lookup.Length)
+            {
+                h2 = (sbyte)Unsafe.Add(ref MemoryMarshal.GetReference(lookup), ch2);
+            }
+
+            int result = h1 | h2;
+            invalidIfNegative |= result;
+            return (byte)result;
         }
 
         private static bool TryParseHex(ReadOnlySpan<char> guidString, out ushort result, ref bool overflow)

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -695,7 +695,7 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static byte DecodeByte(char ch1, char ch2, ref int invalidIfNegative)
+        private static byte DecodeByte(nuint ch1, nuint ch2, ref int invalidIfNegative)
         {
             // TODO https://github.com/dotnet/runtime/issues/13464:
             // Replace the Unsafe.Add with HexConverter.FromChar once the bounds checks are eliminated.
@@ -703,16 +703,16 @@ namespace System
             ReadOnlySpan<byte> lookup = HexConverter.CharToHexLookup;
 
             int h1 = -1;
-            if (ch1 < lookup.Length)
+            if (ch1 < (nuint)lookup.Length)
             {
-                h1 = (sbyte)Unsafe.Add(ref MemoryMarshal.GetReference(lookup), ch1);
+                h1 = (sbyte)Unsafe.Add(ref MemoryMarshal.GetReference(lookup), (nint)ch1);
             }
             h1 <<= 4;
 
             int h2 = -1;
-            if (ch2 < lookup.Length)
+            if (ch2 < (nuint)lookup.Length)
             {
-                h2 = (sbyte)Unsafe.Add(ref MemoryMarshal.GetReference(lookup), ch2);
+                h2 = (sbyte)Unsafe.Add(ref MemoryMarshal.GetReference(lookup), (nint)ch2);
             }
 
             int result = h1 | h2;


### PR DESCRIPTION
Following-up on @GrabYourPitchforks' suggestion in https://github.com/dotnet/runtime/pull/55792#discussion_r675008631

|   Method |         Toolchain |      Mean | Ratio | Code Size |
|--------- |------------------ |----------:|------:|----------:|
|        D | \main\CoreRun.exe |  38.43 ns |  1.00 |   2,951 B |
|        D |   \pr\CoreRun.exe |  37.52 ns |  0.98 |   2,900 B |
|          |                   |           |       |           |
|        N | \main\CoreRun.exe |  37.52 ns |  1.00 |   2,302 B |
|        N |   \pr\CoreRun.exe |  37.08 ns |  0.99 |   2,249 B |
|          |                   |           |       |           |
|        B | \main\CoreRun.exe |  39.30 ns |  1.00 |   3,050 B |
|        B |   \pr\CoreRun.exe |  38.07 ns |  0.97 |   2,999 B |
|          |                   |           |       |           |
|        P | \main\CoreRun.exe |  39.41 ns |  1.00 |   3,055 B |
|        P |   \pr\CoreRun.exe |  38.85 ns |  0.99 |   3,004 B |
|          |                   |           |       |           |
| InvalidD | \main\CoreRun.exe |  42.55 ns |  1.00 |   3,139 B |
| InvalidD |   \pr\CoreRun.exe |  41.01 ns |  0.96 |   3,088 B |
|          |                   |           |       |           |
|   WeirdD | \main\CoreRun.exe | 102.16 ns |  1.00 |   3,418 B |
|   WeirdD |   \pr\CoreRun.exe | 100.44 ns |  0.98 |   3,367 B |