### PR TITLE
Prevent divide-by-zero in ImageAnimator for images with 0 delay between frames

### DIFF
--- a/src/libraries/System.Drawing.Common/src/System/Drawing/ImageAnimator.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/ImageAnimator.cs
@@ -35,6 +35,8 @@ namespace System.Drawing
     /// </summary>
     public sealed partial class ImageAnimator
     {
+        internal const int AnimationDelayMS = 40;
+
         /// <summary>
         ///     A list of images to be animated.
         /// </summary>
@@ -387,7 +389,7 @@ namespace System.Drawing
 
             while (true)
             {
-                Thread.Sleep(40);
+                Thread.Sleep(AnimationDelayMS);
 
                 // Because Thread.Sleep is not accurate, capture how much time has actually elapsed during the animation
                 long timeElapsed = stopwatch.ElapsedMilliseconds;

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/ImageAnimator.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/ImageAnimator.cs
@@ -35,6 +35,10 @@ namespace System.Drawing
     /// </summary>
     public sealed partial class ImageAnimator
     {
+        // We use a timer to apply an animation tick speeds of something a bit shorter than 50ms
+        // such that if the requested frame rate is about 20 frames per second, we will rarely skip
+        // a frame entirely. Sometimes we'll show a few more frames if available, but we will never
+        // show more than 25 frames a second and that's OK.
         internal const int AnimationDelayMS = 40;
 
         /// <summary>

--- a/src/libraries/System.Drawing.Common/tests/System/Drawing/ImageAnimator.ManualTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/System/Drawing/ImageAnimator.ManualTests.cs
@@ -43,6 +43,7 @@ namespace System.Drawing.Tests
                 "animated-timer-10fps-repeat-infinite.gif",
                 "animated-timer-100fps-repeat-2.gif",
                 "animated-timer-100fps-repeat-infinite.gif",
+                "animated-timer-0-delay-all-frames.gif",
             };
 
             Dictionary<string, EventHandler> handlers = new();


### PR DESCRIPTION
Fixes #55972

Per the GIF spec, a frame delay can have a value of 0. That was historically used for 2 purposes:

1. Allow the animation to progress as fast as the renderer chose to animate
2. Utilize the GIF spec feature that has animation wait for user input (mouse click, key press)

While the latter of those features is archaic, we still need to handle 0-delay frames. We assign them our animation delay speed to be "1 tick". It's possible the frame could get skipped if a tick takes longer than the tick time, but this gives a uniform speed for GIFs where all frame delays are 0.

To prevent the divide-by-zero:

1. If a frame delay is <= 0, apply the tick speed
2. Ensure the total animation time increases with each frame, guarding against overflows
3. Update the `ShouldAnimate` property to check that the total animation time is > 0