### PR TITLE
Fix some DualMode connect test issues

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -95,16 +95,10 @@ namespace System.Net.Sockets.Tests
             {
                 Assert.True(client.DualMode);
 
-                Task connectTask = MultiConnectAsync(client, new IPAddress[] { IPAddress.IPv6Loopback, IPAddress.Loopback }, port);
-                await connectTask;
+                await MultiConnectAsync(client, new IPAddress[] { IPAddress.IPv6Loopback, IPAddress.Loopback }, port);
 
-                var localEndPoint = client.LocalEndPoint as IPEndPoint;
-                Assert.NotNull(localEndPoint);
-                Assert.Equal(IPAddress.Loopback.MapToIPv6(), localEndPoint.Address);
-
-                var remoteEndPoint = client.RemoteEndPoint as IPEndPoint;
-                Assert.NotNull(remoteEndPoint);
-                Assert.Equal(IPAddress.Loopback.MapToIPv6(), remoteEndPoint.Address);
+                CheckIsIpv6LoopbackEndPoint(client.LocalEndPoint);
+                CheckIsIpv6LoopbackEndPoint(client.RemoteEndPoint);
             }
         }
 
@@ -124,17 +118,18 @@ namespace System.Net.Sockets.Tests
             {
                 Assert.True(client.DualMode);
 
-                Task connectTask = ConnectAsync(client, new DnsEndPoint("localhost", port));
-                await connectTask;
+                await ConnectAsync(client, new DnsEndPoint("localhost", port));
 
-                var localEndPoint = client.LocalEndPoint as IPEndPoint;
-                Assert.NotNull(localEndPoint);
-                Assert.True(localEndPoint.Address.Equals(IPAddress.IPv6Loopback) || localEndPoint.Address.Equals(IPAddress.Loopback.MapToIPv6()));
-
-                var remoteEndPoint = client.RemoteEndPoint as IPEndPoint;
-                Assert.NotNull(remoteEndPoint);
-                Assert.Equal(IPAddress.Loopback.MapToIPv6(), remoteEndPoint.Address);
+                CheckIsIpv6LoopbackEndPoint(client.LocalEndPoint);
+                CheckIsIpv6LoopbackEndPoint(client.RemoteEndPoint);
             }
+        }
+
+        private static void CheckIsIpv6LoopbackEndPoint(EndPoint endPoint)
+        {
+            IPEndPoint ep = endPoint as IPEndPoint;
+            Assert.NotNull(ep);
+            Assert.True(ep.Address.Equals(IPAddress.IPv6Loopback) || ep.Address.Equals(IPAddress.Loopback.MapToIPv6()));
         }
 
         [Fact]

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -103,6 +103,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55709", TestPlatforms.Linux)]
         public async Task Connect_DualMode_DnsConnect_RetrievedEndPoints_Success()
         {
             var localhostAddresses = Dns.GetHostAddresses("localhost");

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -84,7 +84,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55053", TestPlatforms.Linux)]
         public async Task Connect_DualMode_MultiAddressFamilyConnect_RetrievedEndPoints_Success()
         {
             if (!SupportsMultiConnect)
@@ -110,8 +109,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/54677", TestPlatforms.Linux)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55709", TestPlatforms.Linux)]
         public async Task Connect_DualMode_DnsConnect_RetrievedEndPoints_Success()
         {
             var localhostAddresses = Dns.GetHostAddresses("localhost");


### PR DESCRIPTION
Fixes #55053 and #54677 which is essentially the generalization of #54681. Both `LocalEndPoint` and `RemoteEndPoint` is allowed to be `::ffff:127.0.0.1`.

/cc @tmds 