### PR TITLE
Explicit test for service provider IDisposable implementation (dotnet…

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/DependencyInjectionSpecificationTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/DependencyInjectionSpecificationTests.cs
@@ -435,6 +435,14 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
         }
 
         [Fact]
+        public void ServiceProviderIsDisposable()
+        {
+            var provider = CreateServiceProvider(new TestServiceCollection());
+
+            Assert.IsAssignableFrom<IDisposable>(provider);
+        }
+
+        [Fact]
         public void DisposingScopeDisposesService()
         {
             // Arrange
@@ -469,13 +477,10 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
             Assert.True(transient2.Disposed);
             Assert.False(singleton.Disposed);
 
-            var disposableProvider = provider as IDisposable;
-            if (disposableProvider != null)
-            {
-                disposableProvider.Dispose();
-                Assert.True(singleton.Disposed);
-                Assert.True(transient3.Disposed);
-            }
+            (provider as IDisposable).Dispose();
+
+            Assert.True(singleton.Disposed);
+            Assert.True(transient3.Disposed);
         }
 
         [Fact]
@@ -490,7 +495,7 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
 
             // Assert
             Assert.NotNull(serviceProvider);
-            (provider as IDisposable)?.Dispose();
+            (provider as IDisposable).Dispose();
         }
 
         [Fact]
@@ -790,7 +795,7 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
             var multipleServices = outer.MultipleServices.ToArray();
 
             // Act
-            ((IDisposable)serviceProvider).Dispose();
+            (serviceProvider as IDisposable).Dispose();
 
             // Assert
             Assert.Equal(outer, callback.Disposed[0]);

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.External.Tests/StructureMap.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.External.Tests/StructureMap.cs
@@ -12,6 +12,9 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
 
         public override string[] SkippedTests => new[]
         {
+            "ServiceProviderIsDisposable",
+            "SelfResolveThenDispose",
+            "DisposingScopeDisposesService",
             "DisposesInReverseOrderOfCreation",
             "ResolvesMixedOpenClosedGenericsAsEnumerable"
         };


### PR DESCRIPTION
…#56181)

Really quite simple and it does make it more clear which implementation does not conform to which assumptions as seen in `StructureMapDependencyInjectionSpecificationTests`