### PR TITLE
Fix iOS/Android InvariantMode functional test

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -103,9 +103,6 @@
     <!-- Execution may be compromised -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Caching.Memory\tests\Microsoft.Extensions.Caching.Memory.Tests.csproj" />
 
-    <!-- https://github.com/dotnet/runtime/issues/51016 -->
-    <ProjectExclusions Include="$(RepoRoot)\src\tests\FunctionalTests\Android\Device_Emulator\InvariantCultureOnlyMode\Android.Device_Emulator.InvariantCultureOnlyMode.Test.csproj" />
-
     <!-- PSNE -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Console/tests/System.Console.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.NetworkInformation/tests/FunctionalTests/System.Net.NetworkInformation.Functional.Tests.csproj" />

--- a/src/tests/FunctionalTests/Android/Device_Emulator/InvariantCultureOnlyMode/Program.cs
+++ b/src/tests/FunctionalTests/Android/Device_Emulator/InvariantCultureOnlyMode/Program.cs
@@ -8,9 +8,20 @@ public static class Program
 {
     public static int Main(string[] args)
     {
-        var culture = new CultureInfo("es-ES", false);
-        // https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md#cultures-and-culture-data
-        int result = culture.LCID == 0x1000 && culture.NativeName == "Invariant Language (Invariant Country)" ? 42 : 1;
+        CultureInfo culture;
+        int result = 1;
+
+        try
+        {
+            // only invariant culture is supported, so it should error.
+            culture = new CultureInfo("es-ES", false);
+        }
+        catch(CultureNotFoundException)
+        {
+            culture = CultureInfo.InvariantCulture;
+            // https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md#cultures-and-culture-data
+            result = culture.LCID == 127 && culture.NativeName == "Invariant Language (Invariant Country)" ? 42 : 1;
+        }
 
         return result;
     }

--- a/src/tests/FunctionalTests/iOS/Simulator/InvariantCultureOnlyMode/Program.cs
+++ b/src/tests/FunctionalTests/iOS/Simulator/InvariantCultureOnlyMode/Program.cs
@@ -16,21 +16,21 @@ public static class Program
     {
         mono_ios_set_summary($"Starting functional test");
         CultureInfo culture;
-        try 
+        int result = 1;
+
+        try
         {
+            // only invariant culture is supported, so it should error.
             culture = new CultureInfo("es-ES", false);
         }
-        catch
+        catch(CultureNotFoundException)
         {
-            culture = new CultureInfo("", false);
+            culture = CultureInfo.InvariantCulture;
+            // https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md#cultures-and-culture-data
+            result = culture.LCID == 127 && culture.NativeName == "Invariant Language (Invariant Country)" ? 42 : 1;
         }
 
-        // https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md#cultures-and-culture-data
-        int result = culture.LCID == CultureInfo.InvariantCulture.LCID && culture.NativeName == "Invariant Language (Invariant Country)" ? 42 : 1;
-
-        Console.WriteLine("Done!");
         await Task.Delay(5000);
-        
         return result;
     }
 }


### PR DESCRIPTION
The android test was not handling CultureNotFoundException and was crashing.

Fixes https://github.com/dotnet/runtime/issues/51016