### PR TITLE
Honor ThrowOnEventWriteErrors for exceptions thrown by EventListeners

### DIFF
--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEventToListener.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEventToListener.cs
@@ -448,5 +448,49 @@ namespace BasicEventSourceTests
 
             TestUtilities.CheckNoEventSourcesRunning("Stop");
         }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Test_EventListenerThrows_ExceptionIsNotRethrownToCaller(bool setThrowOnEventWriteErrorsFlag)
+        {
+            TestUtilities.CheckNoEventSourcesRunning("Start");
+
+            using (var log = new EventSourceTest(throwOnEventWriteErrors: setThrowOnEventWriteErrorsFlag))
+            {
+                using (var listener = new EventListenerListener())
+                {
+                    listener.EventSourceSynchronousEnable(log);
+
+                    var thrownException = new Exception("Oops");
+                    string outOfBandMessage = null;
+
+                    listener.EventWritten += (_, e) =>
+                    {
+                        if (e.EventId == 0)
+                        {
+                            outOfBandMessage = e.Message;
+                        }
+
+                        throw thrownException;
+                    };
+
+                    try
+                    {
+                        log.Event0();
+                        Assert.False(setThrowOnEventWriteErrorsFlag);
+                    }
+                    catch (EventSourceException ex)
+                    {
+                        Assert.True(setThrowOnEventWriteErrorsFlag);
+                        Assert.Same(thrownException, ex.InnerException);
+                    }
+
+                    Assert.Contains(thrownException.Message, outOfBandMessage);
+                }
+            }
+
+            TestUtilities.CheckNoEventSourcesRunning("Stop");
+        }
     }
 }

--- a/src/libraries/System.Diagnostics.Tracing/tests/CustomEventSources/EventSourceTest.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/CustomEventSources/EventSourceTest.cs
@@ -26,8 +26,9 @@ namespace SdtEventSources
     [EventSource(Guid = "69e2aa3e-083b-5014-cad4-3e511a0b94cf", Name = "EventSourceTest")]
     public sealed class EventSourceTest : EventSource
     {
-        public EventSourceTest(bool useSelfDescribingEvents = false)
-            : base(true)
+        public EventSourceTest(bool useSelfDescribingEvents = false, bool throwOnEventWriteErrors = false)
+            : base((useSelfDescribingEvents ? EventSourceSettings.EtwSelfDescribingEventFormat : EventSourceSettings.EtwManifestEventFormat)
+                  | (throwOnEventWriteErrors ? EventSourceSettings.ThrowOnEventWriteErrors : 0))
         { }
 
         protected override void OnEventCommand(EventCommandEventArgs command)

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -2121,7 +2121,7 @@ namespace System.Diagnostics.Tracing
                 }
             }
 
-            if (lastThrownException != null)
+            if (lastThrownException != null && ThrowOnEventWriteErrors)
             {
                 throw new EventSourceException(lastThrownException);
             }


### PR DESCRIPTION
From https://github.com/dotnet/runtime/pull/56208#discussion_r675595395:

`EventSource` will always propagate exceptions thrown by `EventListener`s back to the `WriteEvent` caller, ignoring the `ThrowOnEventWriteErrors` option.
That can lead to problems if producers of events are not aware of it as @stephentoub described.