### PR TITLE
Improve resolveVirtualMethodHelper for generic interfaces

### DIFF
--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -8968,27 +8968,19 @@ bool CEEInfo::resolveVirtualMethodHelper(CORINFO_DEVIRTUALIZATION_INFO * info)
         }
 #endif // FEATURE_COMINTEROP
 
+        if (info->context != nullptr)
+        {
+            pBaseMT = GetTypeFromContext(info->context).GetMethodTable();
+        }
+
         // Interface call devirtualization.
         //
         // We must ensure that pObjMT actually implements the
         // interface corresponding to pBaseMD.
         if (!pObjMT->CanCastToInterface(pBaseMT))
         {
-            if ((info->context != nullptr) && !pObjMT->IsSharedByGenericInstantiations())
-            {
-                // If it's "Interface<__Canon>  <-  ConcreteImpl" - try again using current context.
-                pBaseMT = GetTypeFromContext(info->context).GetMethodTable();
-                if (!pObjMT->CanCastToInterface(pBaseMT))
-                {
-                    info->detail = CORINFO_DEVIRTUALIZATION_FAILED_CAST;
-                    return false;
-                }
-            }
-            else
-            {
-                info->detail = CORINFO_DEVIRTUALIZATION_FAILED_CAST;
-                return false;
-            }
+            info->detail = CORINFO_DEVIRTUALIZATION_FAILED_CAST;
+            return false;
         }
 
         // For generic interface methods we must have context to

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -8971,11 +8971,24 @@ bool CEEInfo::resolveVirtualMethodHelper(CORINFO_DEVIRTUALIZATION_INFO * info)
         // Interface call devirtualization.
         //
         // We must ensure that pObjMT actually implements the
-        // interface corresponding to pBaseMD.
+        // interface corresponding to pBaseMD. If it's 
         if (!pObjMT->CanCastToInterface(pBaseMT))
         {
-            info->detail = CORINFO_DEVIRTUALIZATION_FAILED_CAST;
-            return false;
+            if ((info->context != nullptr) && !pObjMT->IsSharedByGenericInstantiations())
+            {
+                // If it's "Interface<__Canon>  <-  ConcreteImpl" - try again using current context.
+                pBaseMT = GetTypeFromContext(info->context).GetMethodTable();
+                if (!pObjMT->CanCastToInterface(pBaseMT))
+                {
+                    info->detail = CORINFO_DEVIRTUALIZATION_FAILED_CAST;
+                    return false;
+                }
+            }
+            else
+            {
+                info->detail = CORINFO_DEVIRTUALIZATION_FAILED_CAST;
+                return false;
+            }
         }
 
         // For generic interface methods we must have context to

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -8971,7 +8971,7 @@ bool CEEInfo::resolveVirtualMethodHelper(CORINFO_DEVIRTUALIZATION_INFO * info)
         // Interface call devirtualization.
         //
         // We must ensure that pObjMT actually implements the
-        // interface corresponding to pBaseMD. If it's 
+        // interface corresponding to pBaseMD.
         if (!pObjMT->CanCastToInterface(pBaseMT))
         {
             if ((info->context != nullptr) && !pObjMT->IsSharedByGenericInstantiations())

--- a/src/tests/JIT/opt/Devirtualization/GDV_GenericInterface.cs
+++ b/src/tests/JIT/opt/Devirtualization/GDV_GenericInterface.cs
@@ -1,0 +1,109 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+public class Program
+{
+    private static int _retCode = 100;
+    private static IFoo<Program> _foo;
+    private static IFooCov<object> _fooCov;
+
+    public static int Main()
+    {
+        _foo = new Foo1<Program>();
+        _fooCov = new Foo1Cov<Program>();
+
+        for (int i = 0; i < 100; i++)
+        {
+            AssertEquals(Test(), 42);
+            AssertEquals(TestCov(), 42);
+            AssertEquals(TestShared<Program>(), 42);
+            Thread.Sleep(16);
+        }
+
+        _foo = new Foo2<Program>();
+        AssertEquals(Test(), 43);
+
+        _fooCov = new Foo1Cov<object>();
+        AssertEquals(TestCov(), 43);
+        _fooCov = new Foo2Cov<Program>();
+        AssertEquals(TestCov(), 142);
+
+        AssertEquals(TestShared<object>(), 43);
+
+        return _retCode;
+    }
+
+    private static void AssertEquals<T>(T t1, T t2)
+    {
+        if (!t1.Equals(t2))
+        {
+            Console.WriteLine($"{t1} != {t2}");
+            _retCode++;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Test() => GetIFoo().GetValue();
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static IFoo<Program> GetIFoo() => _foo;
+
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int TestCov() => GetIFooCov().GetValue();
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static IFooCov<object> GetIFooCov() => _fooCov;
+
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int TestShared<T>() => GetIFooM<T>().GetValue();
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static IFooCov<T> GetIFooM<T>() => new Foo1Cov<T>();
+}
+
+public interface IFoo<T>
+{
+    int GetValue();
+}
+
+public class Foo1<T> : IFoo<T>
+{
+    public int GetValue() => 42;
+}
+
+public class Foo2<T> : IFoo<T>
+{
+    public int GetValue() => 43;
+}
+
+
+public interface IFooCov<out T>
+{
+    int GetValue();
+}
+
+public class Foo1Cov<T> : IFooCov<T>
+{
+    public int GetValue()
+    {
+        if (typeof(T) == typeof(Program))
+            return 42;
+        return 43;
+    }
+}
+
+public class Foo2Cov<T> : IFooCov<T>
+{
+    public int GetValue()
+    {
+        if (typeof(T) == typeof(Program))
+            return 142;
+        return 143;
+    }
+}

--- a/src/tests/JIT/opt/Devirtualization/GDV_GenericInterface.csproj
+++ b/src/tests/JIT/opt/Devirtualization/GDV_GenericInterface.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <!-- This test requires tiered compilation and PGO -->
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set DOTNET_TieredCompilation=1
+set DOTNET_TieredPGO=1
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export DOTNET_TieredCompilation=1
+export DOTNET_TieredPGO=1
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="GDV_GenericInterface.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Example (@stephentoub's repro)
```csharp
using System.Collections.Generic;
using System.Runtime.CompilerServices;
using System.Threading;

public class Program
{
    public static void Main()
    {
        for (int i = 0; i < 100; i++)
        {
            Test();
            Thread.Sleep(16); // promote Test to tier1 (and collect pgo)
        }
    }


    [MethodImpl(MethodImplOptions.NoInlining)]
    static int Test() => GetIList().Count;


    [MethodImpl(MethodImplOptions.NoInlining)]
    // returns IList interface
    static IList<Program> GetIList() => new List<Program>();
}
```
Currently we give up on devirtualizing `GetIList()` call in `Test` method despite the fact we have everything we need to do so:
```
impDevirtualizeCall: Trying to devirtualize interface call:
    class for 'this' is System.Collections.Generic.IList`1[[Program, ConsoleApp1]] (attrib 00200400)
    base method is System.Collections.Generic.ICollection`1[__Canon]::get_Count
Considering guarded devirtualization at IL offset 5 (0x5)
Likely class for 00007FFB2F079158 (System.Collections.Generic.IList`1[[Program, ConsoleApp1]]) is 00007FFB2F079E00
 (System.Collections.Generic.List`1[[Program, ConsoleApp1]]) [likelihood:100 classes seen:1]
Can't figure out which method would be invoked, sorry
```
namely:
```
Likely class for IList`1[Program] is List`1[Program]
```

The problem is in VM's `resolveVirtualMethodHelper` that checks that `List<Program>.CanCastToInterface(IList<__Canon>)` is false and gives up - doesn't try to use the provided generic context.

Codegen for `Test` Before and After: https://www.diffchecker.com/GUi21Vt0

/cc @AndyAyersMS