### PR TITLE
Do not prevent Extensions.FileProviders tests from running in browser

### DIFF
--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFileProvider.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFileProvider.cs
@@ -160,13 +160,12 @@ namespace Microsoft.Extensions.FileProviders
         {
             string root = PathUtils.EnsureTrailingSlash(Path.GetFullPath(Root));
 
-            // When both UsePollingFileWatcher & UseActivePolling are set, we won't use a FileSystemWatcher.
-            FileSystemWatcher watcher = UsePollingFileWatcher && UseActivePolling ? null :
+            // When UsePollingFileWatcher & UseActivePolling are set OR when target platform is browser, we won't use a FileSystemWatcher.
+            FileSystemWatcher watcher = UsePollingFileWatcher && UseActivePolling
 #if NETCOREAPP
-                OperatingSystem.IsBrowser() ? throw new PlatformNotSupportedException(SR.Format(SR.FileSystemWatcher_PlatformNotSupported, typeof(FileSystemWatcher))) : new FileSystemWatcher(root);
-#else
-                new FileSystemWatcher(root);
+                 || OperatingSystem.IsBrowser()
 #endif
+                 ? null : new FileSystemWatcher(root);
 
             return new PhysicalFilesWatcher(root, watcher, UsePollingFileWatcher, _filters)
             {

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Resources/Strings.resx
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Resources/Strings.resx
@@ -130,6 +130,6 @@
     <value>Unexpected type of FileSystemInfo</value>
   </data>
   <data name="FileSystemWatcher_PlatformNotSupported" xml:space="preserve">
-    <value>The type {0} is not supported on this platform, use polling instead.</value>
+    <value>The type '{0}' is not supported on this platform, use polling instead.</value>
   </data>
 </root>

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/AssemblyInfo.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/AssemblyInfo.cs
@@ -2,6 +2,4 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using Xunit;
-
-[assembly: SkipOnPlatform(TestPlatforms.Browser, "Microsoft.Extensions.FileProviders.Physical is not supported on Browser")]
+using Xunit;    

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/Microsoft.Extensions.FileProviders.Physical.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/Microsoft.Extensions.FileProviders.Physical.Tests.csproj
@@ -1,10 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RootNamespace>Microsoft.Extensions.FileProviders.Physical</RootNamespace>
     <TargetFrameworks>$(NetCoreAppCurrent);net461</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
-    <IgnoreForCI Condition="'$(TargetOS)' == 'Browser'">true</IgnoreForCI>
     <IncludePlatformAttributes>false</IncludePlatformAttributes>
   </PropertyGroup>
 

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/Microsoft.Extensions.FileProviders.Physical.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/Microsoft.Extensions.FileProviders.Physical.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs"
              Link="Common\System\Threading\Tasks\TaskTimeoutExtensions.cs" />
+    <TrimmerRootDescriptor Include="$(ILLinkDescriptorsPath)ILLink.Descriptors.Castle.xml" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != '$(NetCoreAppCurrent)'">

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PhysicalFileProviderTests.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PhysicalFileProviderTests.cs
@@ -341,7 +341,7 @@ namespace Microsoft.Extensions.FileProviders
 
                     Assert.NotNull(token1);
                     Assert.NotNull(token2);
-                    Assert.Equal(token2, token1);
+                    Assert.Same(token2, token1);
                 }
             }
         }
@@ -834,7 +834,7 @@ namespace Microsoft.Extensions.FileProviders
                     var fileName = Guid.NewGuid().ToString();
                     var token = provider.Watch(fileName);
                     var lowerCaseToken = provider.Watch(fileName.ToLowerInvariant());
-                    Assert.Equal(token, lowerCaseToken);
+                    Assert.Same(token, lowerCaseToken);
                 }
             }
         }
@@ -1208,7 +1208,7 @@ namespace Microsoft.Extensions.FileProviders
                     var token1 = provider.Watch(@"a/b\c");
                     var token2 = provider.Watch(@"a\b/c");
 
-                    Assert.Equal(token1, token2);
+                    Assert.Same(token1, token2);
                 }
             }
         }

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PhysicalFileProviderTests.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PhysicalFileProviderTests.cs
@@ -348,6 +348,7 @@ namespace Microsoft.Extensions.FileProviders
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public async Task TokensFiredOnFileChange()
         {
             using (var root = new DisposableFileSystem())
@@ -378,6 +379,7 @@ namespace Microsoft.Extensions.FileProviders
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public async Task TokenCallbackInvokedOnFileChange()
         {
             using (var root = new DisposableFileSystem())
@@ -414,6 +416,7 @@ namespace Microsoft.Extensions.FileProviders
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public async Task WatcherWithPolling_ReturnsTrueForFileChangedWhenFileSystemWatcherDoesNotRaiseEvents()
         {
             using (var root = new DisposableFileSystem())
@@ -444,6 +447,7 @@ namespace Microsoft.Extensions.FileProviders
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public async Task WatcherWithPolling_ReturnsTrueForFileRemovedWhenFileSystemWatcherDoesNotRaiseEvents()
         {
             using (var root = new DisposableFileSystem())
@@ -476,6 +480,7 @@ namespace Microsoft.Extensions.FileProviders
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public async Task TokensFiredOnFileDeleted()
         {
             using (var root = new DisposableFileSystem())
@@ -787,6 +792,7 @@ namespace Microsoft.Extensions.FileProviders
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public async Task FileChangeTokenNotNotifiedAfterExpiry()
         {
             using (var root = new DisposableFileSystem())
@@ -835,6 +841,7 @@ namespace Microsoft.Extensions.FileProviders
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public async Task CorrectTokensFiredForMultipleFiles()
         {
             using (var root = new DisposableFileSystem())
@@ -868,6 +875,7 @@ namespace Microsoft.Extensions.FileProviders
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public async Task TokenNotAffectedByExceptions()
         {
             using (var root = new DisposableFileSystem())
@@ -975,6 +983,7 @@ namespace Microsoft.Extensions.FileProviders
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public async Task TokenFiredOnCreation()
         {
             using (var root = new DisposableFileSystem())
@@ -1000,6 +1009,7 @@ namespace Microsoft.Extensions.FileProviders
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public async Task TokenFiredOnDeletion()
         {
             using (var root = new DisposableFileSystem())
@@ -1025,6 +1035,7 @@ namespace Microsoft.Extensions.FileProviders
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public async Task TokenFiredForFilesUnderPathEndingWithSlash()
         {
             using (var root = new DisposableFileSystem())
@@ -1079,6 +1090,7 @@ namespace Microsoft.Extensions.FileProviders
         [InlineData("///")]
         // Testing Unix specific behaviour on leading slashes.
         [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public async Task TokenFiredForRelativePathStartingWithSlash_Unix(string slashes)
         {
             await TokenFiredForRelativePathStartingWithSlash(slashes);
@@ -1121,6 +1133,7 @@ namespace Microsoft.Extensions.FileProviders
         [InlineData("/\0/")]
         // Testing Unix specific behaviour on leading slashes.
         [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public async Task TokenNotFiredForInvalidPathStartingWithSlash_Unix(string slashes)
         {
             await TokenNotFiredForInvalidPathStartingWithSlash(slashes);
@@ -1152,6 +1165,7 @@ namespace Microsoft.Extensions.FileProviders
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public async Task TokenFiredForGlobbingPatternsPointingToSubDirectory()
         {
             using (var root = new DisposableFileSystem())
@@ -1201,6 +1215,7 @@ namespace Microsoft.Extensions.FileProviders
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public async Task TokensFiredForOldAndNewNamesOnRename()
         {
             using (var root = new DisposableFileSystem())
@@ -1230,6 +1245,7 @@ namespace Microsoft.Extensions.FileProviders
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public async Task TokensFiredForNewDirectoryContentsOnRename()
         {
             var tcsShouldNotFire = new TaskCompletionSource<object>();
@@ -1303,6 +1319,7 @@ namespace Microsoft.Extensions.FileProviders
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public async Task TokenNotFiredForFileNameStartingWithPeriod()
         {
             using (var root = new DisposableFileSystem())
@@ -1370,6 +1387,7 @@ namespace Microsoft.Extensions.FileProviders
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public async Task TokensFiredForAllEntriesOnError()
         {
             using (var root = new DisposableFileSystem())
@@ -1398,6 +1416,7 @@ namespace Microsoft.Extensions.FileProviders
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public async Task WildCardToken_RaisesEventsForNewFilesAdded()
         {
             // Arrange
@@ -1424,6 +1443,7 @@ namespace Microsoft.Extensions.FileProviders
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public async Task WildCardToken_RaisesEventsWhenFileSystemWatcherDoesNotFire()
         {
             // Arrange
@@ -1473,6 +1493,7 @@ namespace Microsoft.Extensions.FileProviders
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public void UsePollingFileWatcher_FileWatcherNotNull_SetterThrows()
         {
             // Arrange
@@ -1493,6 +1514,7 @@ namespace Microsoft.Extensions.FileProviders
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public void UsePollingFileWatcher_FileWatcherNotNull_ReturnsFalse()
         {
             // Arrange
@@ -1589,6 +1611,7 @@ namespace Microsoft.Extensions.FileProviders
         [InlineData(false)]
         [InlineData(true)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public async Task CanDeleteWatchedDirectory(bool useActivePolling)
         {
             using (var root = new DisposableFileSystem())

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PhysicalFileProviderTests.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PhysicalFileProviderTests.cs
@@ -325,6 +325,7 @@ namespace Microsoft.Extensions.FileProviders
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [SkipOnPlatform(TestPlatforms.Browser, "Browser always uses Active Polling which doesn't return the same instance between multiple calls to Watch(string)")]
         public void TokenIsSameForSamePath()
         {
             using (var root = new DisposableFileSystem())
@@ -341,7 +342,7 @@ namespace Microsoft.Extensions.FileProviders
 
                     Assert.NotNull(token1);
                     Assert.NotNull(token2);
-                    Assert.Same(token2, token1);
+                    Assert.Equal(token2, token1);
                 }
             }
         }
@@ -825,6 +826,7 @@ namespace Microsoft.Extensions.FileProviders
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [SkipOnPlatform(TestPlatforms.Browser, "Browser always uses Active Polling which doesn't return the same instance between multiple calls to Watch(string)")]
         public void TokenIsSameForSamePathCaseInsensitive()
         {
             using (var root = new DisposableFileSystem())
@@ -834,7 +836,7 @@ namespace Microsoft.Extensions.FileProviders
                     var fileName = Guid.NewGuid().ToString();
                     var token = provider.Watch(fileName);
                     var lowerCaseToken = provider.Watch(fileName.ToLowerInvariant());
-                    Assert.Same(token, lowerCaseToken);
+                    Assert.Equal(token, lowerCaseToken);
                 }
             }
         }
@@ -1199,6 +1201,7 @@ namespace Microsoft.Extensions.FileProviders
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [SkipOnPlatform(TestPlatforms.Browser, "Browser always uses Active Polling which doesn't return the same instance between multiple calls to Watch(string)")]
         public void TokensWithForwardAndBackwardSlashesAreSame()
         {
             using (var root = new DisposableFileSystem())
@@ -1208,7 +1211,7 @@ namespace Microsoft.Extensions.FileProviders
                     var token1 = provider.Watch(@"a/b\c");
                     var token2 = provider.Watch(@"a\b/c");
 
-                    Assert.Same(token1, token2);
+                    Assert.Equal(token1, token2);
                 }
             }
         }

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PhysicalFilesWatcherTests.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PhysicalFilesWatcherTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Extensions.FileProviders.Physical.Tests
         private const int WaitTimeForTokenToFire = 500;
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public void CreateFileChangeToken_DoesNotAllowPathsAboveRoot()
         {
             using (var root = new DisposableFileSystem())
@@ -37,6 +38,7 @@ namespace Microsoft.Extensions.FileProviders.Physical.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public async Task HandlesOnRenamedEventsThatMatchRootPath()
         {
             using (var root = new DisposableFileSystem())
@@ -129,6 +131,7 @@ namespace Microsoft.Extensions.FileProviders.Physical.Tests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public void GetOrAddFilePathChangeToken_AddsPollingChangeTokenWithCancellationToken_WhenActiveCallbackIsTrue()
         {
             using (var root = new DisposableFileSystem())
@@ -155,6 +158,7 @@ namespace Microsoft.Extensions.FileProviders.Physical.Tests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public void GetOrAddFilePathChangeToken_AddsPollingChangeTokenWhenPollingIsEnabled()
         {
             using (var root = new DisposableFileSystem())
@@ -179,6 +183,7 @@ namespace Microsoft.Extensions.FileProviders.Physical.Tests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public void GetOrAddFilePathChangeToken_DoesNotAddsPollingChangeTokenWhenCallbackIsDisabled()
         {
             using (var root = new DisposableFileSystem())
@@ -193,6 +198,7 @@ namespace Microsoft.Extensions.FileProviders.Physical.Tests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.FileSystem.Watcher is not supported on Browser")]
         public void GetOrAddWildcardChangeToken_AddsPollingChangeTokenWithCancellationToken_WhenActiveCallbackIsTrue()
         {
             using (var root = new DisposableFileSystem())


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/runtime/pull/56189#issuecomment-885889936 and to https://github.com/dotnet/runtime/pull/56189#discussion_r676690330. 


~~I might need to add tests that prove the `PlatformNotSupportedException` added in https://github.com/dotnet/runtime/pull/56189.~~ 
EDIT: [CI did indeed caught these errors](https://dnceng.visualstudio.com/public/_build/results?buildId=1271949&view=logs&j=f217f715-90ad-5404-53bd-b93e3b80f465&t=f217f715-90ad-5404-53bd-b93e3b80f465), the proper change now is to skip tests that use `FileSystemWatcher` from running in browser, that is made in https://github.com/dotnet/runtime/pull/56257/commits/57bbe424b2ebfab88ec7041392ad0df69ee1cee0.
