### PR TITLE
Fixes 55107

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3394,6 +3394,10 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, Gen
                 assert(vnStore->ConstantValue<size_t>(vnCns) == 0);
                 printf("null\n");
             }
+            else if (op1->TypeGet() == TYP_BYREF)
+            {
+                printf("%d (byref)\n", static_cast<target_ssize_t>(vnStore->ConstantValue<target_size_t>(vnCns)));
+            }
             else
             {
                 printf("??unknown\n");
@@ -3448,6 +3452,11 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, Gen
             // The only constant of TYP_REF that ValueNumbering supports is 'null'
             noway_assert(vnStore->ConstantValue<size_t>(vnCns) == 0);
             op1->AsIntCon()->gtIconVal = 0;
+        }
+        else if (op1->TypeGet() == TYP_BYREF)
+        {
+            op1->ChangeOperConst(GT_CNS_INT);
+            op1->AsIntCon()->gtIconVal = static_cast<target_ssize_t>(vnStore->ConstantValue<target_size_t>(vnCns));
         }
         else
         {

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3396,7 +3396,7 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, Gen
             }
             else if (op1->TypeGet() == TYP_BYREF)
             {
-                printf("%d (byref)\n", static_cast<target_ssize_t>(vnStore->ConstantValue<target_size_t>(vnCns)));
+                printf("%d (byref)\n", static_cast<target_ssize_t>(vnStore->ConstantValue<size_t>(vnCns)));
             }
             else
             {
@@ -3456,7 +3456,7 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, Gen
         else if (op1->TypeGet() == TYP_BYREF)
         {
             op1->ChangeOperConst(GT_CNS_INT);
-            op1->AsIntCon()->gtIconVal = static_cast<target_ssize_t>(vnStore->ConstantValue<target_size_t>(vnCns));
+            op1->AsIntCon()->gtIconVal = static_cast<target_ssize_t>(vnStore->ConstantValue<size_t>(vnCns));
         }
         else
         {

--- a/src/tests/JIT/Regression/JitBlue/Runtime_55107/Runtime_55107.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_55107/Runtime_55107.cs
@@ -1,0 +1,40 @@
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Runtime_55107
+{
+    class Program
+    {
+        class G
+        {
+        }
+
+        static int Main(string[] args)
+        {
+            G g = new G();
+
+            ref G iprnull = ref Unsafe.NullRef<G>();
+            ref G ipr1 = ref g;
+
+            if(Unsafe.AreSame(ref ipr1, ref iprnull))
+            {
+                // Failure case 1
+                return -101;
+            }
+            else if(Unsafe.AreSame(ref ipr1, ref Unsafe.NullRef<G>()))
+            {
+                // Failure case 2
+                return -102;
+            }
+            else
+            {
+               // Successful exit
+               return 100;
+            }
+        }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_55107/Runtime_55107.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_55107/Runtime_55107.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType />
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_JitDoRedundantBranchOpts=0
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_JitDoRedundantBranchOpts=0
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Add support for the very rare case of a constant byref to Compiler::optAssertionPropGlobal_RelOp