### PR TITLE
Fix for Enum.Format change in behavior between .Net Framework and .Net 5

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -1024,7 +1024,7 @@ namespace System
                 {
                     case 'G':
                     case 'g':
-                        return GetEnumName(rtType, ToUInt64(value)) ?? value.ToString()!;
+                        return InternalFormat(rtType, ToUInt64(value)) ?? value.ToString()!;
 
                     case 'D':
                     case 'd':

--- a/src/libraries/System.Runtime/tests/System/EnumTests.cs
+++ b/src/libraries/System.Runtime/tests/System/EnumTests.cs
@@ -1947,6 +1947,9 @@ namespace System.Tests
 
             // Format: F
             yield return new object[] { typeof(SimpleEnum), 1, "F", "Red" };
+
+            // Format: G with Flags Attribute
+            yield return new object[] { typeof(AttributeTargets), (int)(AttributeTargets.Class | AttributeTargets.Delegate), "G", "Class, Delegate" };
         }
 
         [Theory]


### PR DESCRIPTION
Use InternalFormat when formatting an integer
value as an Enum that uses the FlagsAttribute.

Fix #56200