### PR TITLE
Disable test ResponseCancellation_BothCancellationTokenAndDispose_Success

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -545,6 +545,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/56265")]
         public async Task ResponseCancellation_BothCancellationTokenAndDispose_Success()
         {
             if (UseQuicImplementationProvider != QuicImplementationProviders.MsQuic)


### PR DESCRIPTION
Test: System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_Http3_MsQuic.ResponseCancellation_BothCancellationTokenAndDispose_Success

Disabled test tracked by #56265