### PR TITLE
Change IOptionsSnapshot to reuse options instances across scopes

### DIFF
--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsServiceCollectionExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsServiceCollectionExtensions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             services.TryAdd(ServiceDescriptor.Singleton(typeof(IOptions<>), typeof(UnnamedOptionsManager<>)));
-            services.TryAdd(ServiceDescriptor.Scoped(typeof(IOptionsSnapshot<>), typeof(OptionsManager<>)));
+            services.TryAdd(ServiceDescriptor.Scoped(typeof(IOptionsSnapshot<>), typeof(OptionsSnapshot<>)));
             services.TryAdd(ServiceDescriptor.Singleton(typeof(IOptionsMonitor<>), typeof(OptionsMonitor<>)));
             services.TryAdd(ServiceDescriptor.Transient(typeof(IOptionsFactory<>), typeof(OptionsFactory<>)));
             services.TryAdd(ServiceDescriptor.Singleton(typeof(IOptionsMonitorCache<>), typeof(OptionsCache<>)));

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsSnapshot.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsSnapshot.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Extensions.Options
+{
+    /// <summary>
+    /// Implementation of <see cref="IOptions{TOptions}"/> and <see cref="IOptionsSnapshot{TOptions}"/>.
+    /// </summary>
+    /// <typeparam name="TOptions">Options type.</typeparam>
+    internal class OptionsSnapshot<[DynamicallyAccessedMembers(Options.DynamicallyAccessedMembers)] TOptions> :
+        IOptionsSnapshot<TOptions>
+        where TOptions : class
+    {
+        private readonly IOptionsMonitor<TOptions> _factory;
+        private readonly ConcurrentDictionary<string, TOptions> _cache = new(concurrencyLevel: 1, capacity: 5, StringComparer.Ordinal);
+
+        /// <summary>
+        /// Initializes a new instance with the specified options configurations.
+        /// </summary>
+        /// <param name="factory">The factory to use to create options.</param>
+        public OptionsSnapshot(IOptionsMonitor<TOptions> factory)
+        {
+            _factory = factory;
+        }
+
+        /// <summary>
+        /// The default configured <typeparamref name="TOptions"/> instance, equivalent to Get(Options.DefaultName).
+        /// </summary>
+        public TOptions Value => Get(Options.DefaultName);
+
+        /// <summary>
+        /// Returns a configured <typeparamref name="TOptions"/> instance with the given <paramref name="name"/>.
+        /// </summary>
+        public TOptions Get(string name)
+        {
+            name ??= Options.DefaultName;
+
+#if NETSTANDARD2_1
+            TOptions options = _cache.GetOrAdd(name, static (name, factory) => factory.Get(name), _factory);
+#else
+            if (!_cache.TryGetValue(name, out TOptions options))
+            {
+                options = _cache.GetOrAdd(name, _factory.Get(name));
+            }
+#endif
+            return options;
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsSnapshot.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsSnapshot.cs
@@ -9,7 +9,7 @@ using System.Threading;
 namespace Microsoft.Extensions.Options
 {
     /// <summary>
-    /// Implementation of <see cref="IOptions{TOptions}"/> and <see cref="IOptionsSnapshot{TOptions}"/>.
+    /// Implementation of <see cref="IOptionsSnapshot{TOptions}"/>.
     /// </summary>
     /// <typeparam name="TOptions">Options type.</typeparam>
     internal sealed class OptionsSnapshot<[DynamicallyAccessedMembers(Options.DynamicallyAccessedMembers)] TOptions> :

--- a/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/OptionsSnapshotTest.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/OptionsSnapshotTest.cs
@@ -131,12 +131,14 @@ namespace Microsoft.Extensions.Options.Tests
         [Fact]
         public void SnapshotOptionsAreCachedPerScope()
         {
+            var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
             var services = new ServiceCollection()
                 .AddOptions()
-                .AddScoped<IConfigureOptions<FakeOptions>, TestConfigure>()
+                .AddSingleton<IConfigureOptions<FakeOptions>, TestConfigure>()
+                .AddSingleton<IOptionsChangeTokenSource<FakeOptions>>(new ConfigurationChangeTokenSource<FakeOptions>(Options.DefaultName, config))
+                .AddSingleton<IOptionsChangeTokenSource<FakeOptions>>(new ConfigurationChangeTokenSource<FakeOptions>("1", config))
                 .BuildServiceProvider();
 
-            var cache = services.GetRequiredService<IOptionsMonitorCache<FakeOptions>>();
             var factory = services.GetRequiredService<IServiceScopeFactory>();
             FakeOptions options = null;
             FakeOptions namedOne = null;
@@ -148,18 +150,29 @@ namespace Microsoft.Extensions.Options.Tests
                 namedOne = scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<FakeOptions>>().Get("1");
                 Assert.Equal(namedOne, scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<FakeOptions>>().Get("1"));
                 Assert.Equal(2, TestConfigure.ConfigureCount);
+
+                // Reload triggers Configure for the two registered change tokens.
+                config.Reload();
+                Assert.Equal(4, TestConfigure.ConfigureCount);
+
+                // Reload should not affect current scope.
+                var options2 = scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<FakeOptions>>().Value;
+                Assert.Equal(options, options2);
+                var namedOne2 = scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<FakeOptions>>().Get("1");
+                Assert.Equal(namedOne, namedOne2);
             }
             Assert.Equal(1, TestConfigure.CtorCount);
+
+            // Reload should be reflected in a fresh scope.
             using (var scope = factory.CreateScope())
             {
                 var options2 = scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<FakeOptions>>().Value;
                 Assert.NotEqual(options, options2);
-                Assert.Equal(3, TestConfigure.ConfigureCount);
                 var namedOne2 = scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<FakeOptions>>().Get("1");
-                Assert.NotEqual(namedOne2, namedOne);
+                Assert.NotEqual(namedOne, namedOne2);
                 Assert.Equal(4, TestConfigure.ConfigureCount);
             }
-            Assert.Equal(2, TestConfigure.CtorCount);
+            Assert.Equal(1, TestConfigure.CtorCount);
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/OptionsSnapshotTest.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/Microsoft.Extensions.Options.Tests/OptionsSnapshotTest.cs
@@ -168,6 +168,7 @@ namespace Microsoft.Extensions.Options.Tests
             {
                 var options2 = scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<FakeOptions>>().Value;
                 Assert.NotEqual(options, options2);
+                Assert.Equal(4, TestConfigure.ConfigureCount);
                 var namedOne2 = scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<FakeOptions>>().Get("1");
                 Assert.NotEqual(namedOne, namedOne2);
                 Assert.Equal(4, TestConfigure.ConfigureCount);


### PR DESCRIPTION
Closes #53793

I decided to keep the cache as a ConcurrentDictionary to head off problematic compatibility issues from switching out the underlying implementation. I'm not clear on the semantics of a DI scope regardless, maybe it's ok to use one in a concurrent fashion?

For the cache I picked capacity 5 for the 99% case, apparently 31 is the default capacity of a ConcurrentDictionary and what was specified in OptionsCache. Capacity 31 sounds fairly wasteful to new up every request but on the flip side you'd get a tiny chance of resizes I guess 🙃

OptionsManager and OptionsCache are effectively dead code now. Something to mark as obsolete in a future version by the api review team?