### PR TITLE
Fix createdump crash on alpine 3.12 and above.

### DIFF
--- a/src/coreclr/debug/createdump/crashinfo.cpp
+++ b/src/coreclr/debug/createdump/crashinfo.cpp
@@ -361,8 +361,9 @@ bool
 CrashInfo::UnwindAllThreads(IXCLRDataProcess* pClrDataProcess)
 {
     ReleaseHolder<ISOSDacInterface> pSos = nullptr;
-    pClrDataProcess->QueryInterface(__uuidof(ISOSDacInterface), (void**)&pSos);
-
+    if (pClrDataProcess != nullptr) {
+        pClrDataProcess->QueryInterface(__uuidof(ISOSDacInterface), (void**)&pSos);
+    }
     // For each native and managed thread
     for (ThreadInfo* thread : m_threads)
     {

--- a/src/coreclr/debug/createdump/crashinfo.h
+++ b/src/coreclr/debug/createdump/crashinfo.h
@@ -106,12 +106,12 @@ public:
     inline const std::string& Name() const { return m_name; }
     inline const ModuleInfo* MainModule() const { return m_mainModule; }
 
-    inline const std::vector<ThreadInfo*> Threads() const { return m_threads; }
-    inline const std::set<MemoryRegion> ModuleMappings() const { return m_moduleMappings; }
-    inline const std::set<MemoryRegion> OtherMappings() const { return m_otherMappings; }
-    inline const std::set<MemoryRegion> MemoryRegions() const { return m_memoryRegions; }
+    inline const std::vector<ThreadInfo*>& Threads() const { return m_threads; }
+    inline const std::set<MemoryRegion>& ModuleMappings() const { return m_moduleMappings; }
+    inline const std::set<MemoryRegion>& OtherMappings() const { return m_otherMappings; }
+    inline const std::set<MemoryRegion>& MemoryRegions() const { return m_memoryRegions; }
 #ifndef __APPLE__
-    inline const std::vector<elf_aux_entry> AuxvEntries() const { return m_auxvEntries; }
+    inline const std::vector<elf_aux_entry>& AuxvEntries() const { return m_auxvEntries; }
     inline size_t GetAuxvSize() const { return m_auxvEntries.size() * sizeof(elf_aux_entry); }
 #endif
 


### PR DESCRIPTION
Finally hit an existing problem in createdump (since 2.1) where the std::set<MemoryRegions> in
ThreadInfo::GetThreadStack() where it is calling CrashInfo::SearchMemoryRegions with m_crashInfo.OtherMappings()
which returns a copy of the set of MemoryRegions instead of a reference. On alpine 3.12 musl, this set copy
is freed right away when it goes out of scope as soon as SearchMemoryRegions returns. On any other Linux distro
and MacOS the set doesn't get freed/invalidated as soon.

Return references to the threads and memory region sets in the CrashInfo functions.