### PR TITLE
Fix "Buffer too small" assert in emitOffsetToLabel

### DIFF
--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -8735,11 +8735,7 @@ const char* emitter::emitOffsetToLabel(unsigned offs)
 
         if (ig->igOffs == offs)
         {
-            // Found it!
-            sprintf_s(buf[curBuf], TEMP_BUFFER_LEN, "%s", emitLabelString(ig));
-            retbuf = buf[curBuf];
-            curBuf = (curBuf + 1) % 4;
-            return retbuf;
+            return emitLabelString(ig);
         }
         else if (ig->igOffs > offs)
         {


### PR DESCRIPTION
When I run `jit-diff` with `crossgen2` I always hit an assert:

![image](https://user-images.githubusercontent.com/523221/126910437-d068ace4-18e8-493a-85aa-f445d004e778.png)

I'm not sure I fully understand that logic but it fixes the issue, `emitLabelString` caches 4 buffers inside itself too.

/cc @BruceForstall @dotnet/jit-contrib 