### PR TITLE
Change MonoProfiler provider GUID to be based on algorithm used by TraceEvent library.

### DIFF
--- a/src/coreclr/vm/ClrEtwAll.man
+++ b/src/coreclr/vm/ClrEtwAll.man
@@ -7077,7 +7077,7 @@
 
             <!-- Mono Profiler Publisher-->
             <provider name="Microsoft-DotNETRuntimeMonoProfiler"
-                      guid="{5CF93F63-D58B-4EE3-B884-9EDA84A192DB}"
+                      guid="{7F442D82-0F1D-5155-4B8C-1529EB2E31C2}"
                       symbol="MICROSOFT_DOTNETRUNTIME_MONO_PROFILER_PROVIDER"
                       resourceFileName="%INSTALL_PATH%\clretwrc.dll"
                       messageFileName="%INSTALL_PATH%\clretwrc.dll">


### PR DESCRIPTION
TraceEvent uses an algorithm defined in http://www.ietf.org/rfc/rfc4122.txt to get an EventSource GUID from its name, https://github.com/microsoft/perfview/blob/61fb42dd3b8363f22eec2cee4f3b4a98d50fa2d3/src/TraceEvent/TraceEventSession.cs#L2645. This is used for newer EventSource providers, and doesn't need changes to TraceEvent code to be detected.

This commit adjust MonoProfiler EventSource provider GUID to the version calculated by that algorithm.