### PR TITLE
Disable test ResponseCancellation_ServerReceivesCancellation

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -458,6 +458,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ConditionalTheory(nameof(IsMsQuicSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/56194")]
         [InlineData(CancellationType.Dispose)]
         [InlineData(CancellationType.CancellationToken)]
         public async Task ResponseCancellation_ServerReceivesCancellation(CancellationType type)


### PR DESCRIPTION
Test: System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_Http3_MsQuic.ResponseCancellation_ServerReceivesCancellation

Disabled test tracked by #56194