### PR TITLE
Disable BeginReceiveFrom_RemoteEpIsReturnedWhenCompletedSynchronously on Mac Catalyst

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/ReceiveFrom.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/ReceiveFrom.cs
@@ -310,6 +310,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/54418", TestPlatforms.MacCatalyst)]
         public void BeginReceiveFrom_RemoteEpIsReturnedWhenCompletedSynchronously()
         {
             EndPoint anyEp = new IPEndPoint(IPAddress.Any, 0);


### PR DESCRIPTION
I don't think it's worth to investigate the issue for 6.0 (see https://github.com/dotnet/runtime/issues/54418#issuecomment-886728079). Disabling the test on Mac Catalyst for cleaner CI.