### PR TITLE
Split mobile specific ILLink.Substitutions into its own file

### DIFF
--- a/src/libraries/System.Net.Http/src/ILLink/ILLink.Substitutions.mobile.xml
+++ b/src/libraries/System.Net.Http/src/ILLink/ILLink.Substitutions.mobile.xml
@@ -1,0 +1,7 @@
+<linker>
+  <assembly fullname="System.Net.Http">
+    <type fullname="System.Net.Http.HttpClientHandler">
+      <method signature="System.Boolean get_IsNativeHandlerEnabled()" body="stub" value="false" feature="System.Net.Http.UseNativeHttpHandler" featurevalue="false" />
+    </type>
+  </assembly>
+</linker>

--- a/src/libraries/System.Net.Http/src/ILLink/ILLink.Substitutions.xml
+++ b/src/libraries/System.Net.Http/src/ILLink/ILLink.Substitutions.xml
@@ -3,8 +3,5 @@
     <type fullname="System.Net.Http.DiagnosticsHandler">
       <method signature="System.Boolean IsGloballyEnabled()" body="stub" value="false" feature="System.Net.Http.EnableActivityPropagation" featurevalue="false" />
     </type>
-    <type fullname="System.Net.Http.HttpClientHandler">
-      <method signature="System.Boolean get_IsNativeHandlerEnabled()" body="stub" value="false" feature="System.Net.Http.UseNativeHttpHandler" featurevalue="false" />
-    </type>
   </assembly>
 </linker>

--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <WindowsRID>win</WindowsRID>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -18,6 +18,8 @@
   </PropertyGroup>
   <ItemGroup>
     <ILLinkSubstitutionsXmls Include="$(ILLinkDirectory)ILLink.Substitutions.xml" />
+    <ILLinkSubstitutionsXmls Condition="'$(TargetsAndroid)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetsMacCatalyst)' == 'true' or '$(TargetsTVOS)' == 'true'"
+                             Include="$(ILLinkDirectory)ILLink.Substitutions.mobile.xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="System\Net\Http\ByteArrayContent.cs" />

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -815,16 +815,6 @@ namespace System.Net.Http
             return (pendingRequestsCts, DisposeTokenSource: false, pendingRequestsCts);
         }
 
-        private static bool IsNativeHandlerEnabled()
-        {
-            if (!AppContext.TryGetSwitch("System.Net.Http.UseNativeHttpHandler", out bool isEnabled))
-            {
-                return false;
-            }
-
-            return isEnabled;
-        }
-
         private Uri? CreateUri(string? uri) =>
             string.IsNullOrEmpty(uri) ? null : new Uri(uri, UriKind.RelativeOrAbsolute);
 


### PR DESCRIPTION
It was discovered in https://github.com/dotnet/runtime/pull/56161 that mobile specific HttpClientHandler substitutions were sticking around even for non mobile builds.  This change moves the substitution into ILLink.Substitutions.mobile.xml.