### PR TITLE
Fix error message when publishing logs in Restore internal tools step

### DIFF
--- a/eng/pipelines/common/restore-internal-tools.yml
+++ b/eng/pipelines/common/restore-internal-tools.yml
@@ -7,6 +7,7 @@ steps:
   - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt)
             -ci
             -restore
+            -configuration $(_BuildConfig)
             -projects $(Build.SourcesDirectory)/eng/common/internal/Tools.csproj
             /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/RestoreInternal.binlog
             /v:normal


### PR DESCRIPTION
In https://dev.azure.com/dnceng/internal/_build/results?buildId=1250178&view=results we hit an issue where the 'Restore internal tools' step failed, but AzDO only highlights the failure in the 'Publish Logs' step because the directory didn't exist.

This happens because the restore step was not passing along the build configuration so it defaults to Debug instead of Release, leading to the log directory we try to publish not existing.