### PR TITLE
Seal JsonSourceGenerationOptionsAttribute

### DIFF
--- a/src/libraries/System.Text.Json/Common/JsonSourceGenerationOptionsAttribute.cs
+++ b/src/libraries/System.Text.Json/Common/JsonSourceGenerationOptionsAttribute.cs
@@ -13,7 +13,7 @@ namespace System.Text.Json.Serialization
 #else
     public
 #endif
-    class JsonSourceGenerationOptionsAttribute : JsonAttribute
+    sealed class JsonSourceGenerationOptionsAttribute : JsonAttribute
     {
         /// <summary>
         /// Specifies the default ignore condition.

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -852,7 +852,7 @@ namespace System.Text.Json.Serialization
         public abstract System.Text.Json.Serialization.Metadata.JsonTypeInfo? GetTypeInfo(System.Type type);
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=false)]
-    public partial class JsonSourceGenerationOptionsAttribute : System.Text.Json.Serialization.JsonAttribute
+    public sealed partial class JsonSourceGenerationOptionsAttribute : System.Text.Json.Serialization.JsonAttribute
     {
         public JsonSourceGenerationOptionsAttribute() { }
         public System.Text.Json.Serialization.JsonIgnoreCondition DefaultIgnoreCondition { get { throw null; } set { } }


### PR DESCRIPTION
Missed in the original implementation. Related to https://github.com/dotnet/runtime/issues/56206. Not a breaking change because sub-classing the attribute currently has no effect.