### PR TITLE
Add timeouts to IPInterfaceProperties tests

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_Linux.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_Linux.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
+using System.Net.Http.Functional.Tests;
 using System.Net.Sockets;
 using System.Net.Test.Common;
 
@@ -15,9 +16,9 @@ namespace System.Net.NetworkInformation.Tests
     {
         private readonly ITestOutputHelper _log;
 
-        public IPInterfacePropertiesTest_Linux()
+        public IPInterfacePropertiesTest_Linux(ITestOutputHelper output)
         {
-            _log = TestLogging.GetInstance();
+            _log = output;
         }
 
         [Fact]
@@ -106,7 +107,7 @@ namespace System.Net.NetworkInformation.Tests
                         _log.WriteLine("-- " + wins.ToString());
                     }
                 }
-            }).WaitAsync(TimeSpan.FromSeconds(30));
+            }).WaitAsync(TestHelper.PassingTestTimeout);
         }
 
         [Fact]
@@ -132,7 +133,7 @@ namespace System.Net.NetworkInformation.Tests
                     _log.WriteLine("Mtu: " + ipv4Properties.Mtu);
                     _log.WriteLine("UsesWins: " + ipv4Properties.UsesWins);
                 }
-            }).WaitAsync(TimeSpan.FromSeconds(30));
+            }).WaitAsync(TestHelper.PassingTestTimeout);
         }
 
         [Fact]
@@ -160,7 +161,7 @@ namespace System.Net.NetworkInformation.Tests
                     _log.WriteLine("Mtu: " + ipv6Properties.Mtu);
                     _log.WriteLine("Scope: " + ipv6Properties.GetScopeId(ScopeLevel.Link));
                 }
-            }).WaitAsync(TimeSpan.FromSeconds(30));
+            }).WaitAsync(TestHelper.PassingTestTimeout);
         }
 
         [Fact]
@@ -190,7 +191,7 @@ namespace System.Net.NetworkInformation.Tests
                         _log.WriteLine("-- Level: " + level + "; " + ipv6Properties.GetScopeId(level));
                     }
                 }
-            }).WaitAsync(TimeSpan.FromSeconds(30));
+            }).WaitAsync(TestHelper.PassingTestTimeout);
         }
 
         [Fact]
@@ -215,7 +216,7 @@ namespace System.Net.NetworkInformation.Tests
                         break;
                     }
                 }
-            }).WaitAsync(TimeSpan.FromSeconds(30));
+            }).WaitAsync(TestHelper.PassingTestTimeout);
         }
 
         [Fact]
@@ -239,7 +240,7 @@ namespace System.Net.NetworkInformation.Tests
                         break;
                     }
                 }
-            }).WaitAsync(TimeSpan.FromSeconds(30));
+            }).WaitAsync(TestHelper.PassingTestTimeout);
         }
     }
 }

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_Linux.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_Linux.cs
@@ -21,207 +21,225 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        public void IPInfoTest_AccessAllProperties_NoErrors()
+        public async Task IPInfoTest_AccessAllProperties_NoErrors()
         {
-            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            await Task.Run(() =>
             {
-                _log.WriteLine("Nic: " + nic.Name);
-                _log.WriteLine("- Speed:" + nic.Speed);
-                _log.WriteLine("- Supports IPv4: " + nic.Supports(NetworkInterfaceComponent.IPv4));
-                _log.WriteLine("- Supports IPv6: " + nic.Supports(NetworkInterfaceComponent.IPv6));
-                Assert.False(nic.IsReceiveOnly);
-
-                IPInterfaceProperties ipProperties = nic.GetIPProperties();
-
-                Assert.NotNull(ipProperties);
-
-                Assert.Throws<PlatformNotSupportedException>(() => ipProperties.AnycastAddresses);
-
-                Assert.NotNull(ipProperties.DhcpServerAddresses);
-                _log.WriteLine("- Dhcp Server Addresses: " + ipProperties.DhcpServerAddresses.Count);
-                foreach (IPAddress dhcp in ipProperties.DhcpServerAddresses)
+                foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
                 {
-                    _log.WriteLine("-- " + dhcp.ToString());
+                    _log.WriteLine("Nic: " + nic.Name);
+                    _log.WriteLine("- Speed:" + nic.Speed);
+                    _log.WriteLine("- Supports IPv4: " + nic.Supports(NetworkInterfaceComponent.IPv4));
+                    _log.WriteLine("- Supports IPv6: " + nic.Supports(NetworkInterfaceComponent.IPv6));
+                    Assert.False(nic.IsReceiveOnly);
+
+                    IPInterfaceProperties ipProperties = nic.GetIPProperties();
+
+                    Assert.NotNull(ipProperties);
+
+                    Assert.Throws<PlatformNotSupportedException>(() => ipProperties.AnycastAddresses);
+
+                    Assert.NotNull(ipProperties.DhcpServerAddresses);
+                    _log.WriteLine("- Dhcp Server Addresses: " + ipProperties.DhcpServerAddresses.Count);
+                    foreach (IPAddress dhcp in ipProperties.DhcpServerAddresses)
+                    {
+                        _log.WriteLine("-- " + dhcp.ToString());
+                    }
+
+                    Assert.NotNull(ipProperties.DnsAddresses);
+                    _log.WriteLine("- Dns Addresses: " + ipProperties.DnsAddresses.Count);
+                    foreach (IPAddress dns in ipProperties.DnsAddresses)
+                    {
+                        _log.WriteLine("-- " + dns.ToString());
+                    }
+
+                    Assert.NotNull(ipProperties.DnsSuffix);
+                    _log.WriteLine("- Dns Suffix: " + ipProperties.DnsSuffix);
+
+                    Assert.NotNull(ipProperties.GatewayAddresses);
+                    _log.WriteLine("- Gateway Addresses: " + ipProperties.GatewayAddresses.Count);
+                    foreach (GatewayIPAddressInformation gateway in ipProperties.GatewayAddresses)
+                    {
+                        _log.WriteLine("-- " + gateway.Address.ToString());
+                    }
+
+                    _log.WriteLine("- Dns Enabled: " + ipProperties.IsDnsEnabled);
+
+                    Assert.Throws<PlatformNotSupportedException>(() => ipProperties.IsDynamicDnsEnabled);
+
+                    Assert.NotNull(ipProperties.MulticastAddresses);
+                    _log.WriteLine("- Multicast Addresses: " + ipProperties.MulticastAddresses.Count);
+                    foreach (IPAddressInformation multi in ipProperties.MulticastAddresses)
+                    {
+                        _log.WriteLine("-- " + multi.Address.ToString());
+                        Assert.Throws<PlatformNotSupportedException>(() => multi.IsDnsEligible);
+                        Assert.Throws<PlatformNotSupportedException>(() => multi.IsTransient);
+                    }
+
+                    Assert.NotNull(ipProperties.UnicastAddresses);
+                    _log.WriteLine("- Unicast Addresses: " + ipProperties.UnicastAddresses.Count);
+                    foreach (UnicastIPAddressInformation uni in ipProperties.UnicastAddresses)
+                    {
+                        _log.WriteLine("-- " + uni.Address.ToString());
+                        Assert.Throws<PlatformNotSupportedException>(() => uni.AddressPreferredLifetime);
+                        Assert.Throws<PlatformNotSupportedException>(() => uni.AddressValidLifetime);
+                        Assert.Throws<PlatformNotSupportedException>(() => uni.DhcpLeaseLifetime);
+                        Assert.Throws<PlatformNotSupportedException>(() => uni.DuplicateAddressDetectionState);
+
+                        Assert.NotNull(uni.IPv4Mask);
+                        _log.WriteLine("--- IPv4 Mask: " + uni.IPv4Mask);
+                        Assert.Throws<PlatformNotSupportedException>(() => uni.IsDnsEligible);
+                        Assert.Throws<PlatformNotSupportedException>(() => uni.IsTransient);
+                        Assert.Throws<PlatformNotSupportedException>(() => uni.PrefixOrigin);
+                        Assert.Throws<PlatformNotSupportedException>(() => uni.SuffixOrigin);
+
+                        // Prefix Length
+                        _log.WriteLine("--- PrefixLength: " + uni.PrefixLength);
+                        Assert.True(uni.PrefixLength > 0);
+                        Assert.True((uni.Address.AddressFamily == AddressFamily.InterNetwork ? 33 : 129) > uni.PrefixLength);
+                    }
+
+                    Assert.NotNull(ipProperties.WinsServersAddresses);
+                    _log.WriteLine("- Wins Addresses: " + ipProperties.WinsServersAddresses.Count);
+                    foreach (IPAddress wins in ipProperties.WinsServersAddresses)
+                    {
+                        _log.WriteLine("-- " + wins.ToString());
+                    }
                 }
-
-                Assert.NotNull(ipProperties.DnsAddresses);
-                _log.WriteLine("- Dns Addresses: " + ipProperties.DnsAddresses.Count);
-                foreach (IPAddress dns in ipProperties.DnsAddresses)
-                {
-                    _log.WriteLine("-- " + dns.ToString());
-                }
-
-                Assert.NotNull(ipProperties.DnsSuffix);
-                _log.WriteLine("- Dns Suffix: " + ipProperties.DnsSuffix);
-
-                Assert.NotNull(ipProperties.GatewayAddresses);
-                _log.WriteLine("- Gateway Addresses: " + ipProperties.GatewayAddresses.Count);
-                foreach (GatewayIPAddressInformation gateway in ipProperties.GatewayAddresses)
-                {
-                    _log.WriteLine("-- " + gateway.Address.ToString());
-                }
-
-                _log.WriteLine("- Dns Enabled: " + ipProperties.IsDnsEnabled);
-
-                Assert.Throws<PlatformNotSupportedException>(() => ipProperties.IsDynamicDnsEnabled);
-
-                Assert.NotNull(ipProperties.MulticastAddresses);
-                _log.WriteLine("- Multicast Addresses: " + ipProperties.MulticastAddresses.Count);
-                foreach (IPAddressInformation multi in ipProperties.MulticastAddresses)
-                {
-                    _log.WriteLine("-- " + multi.Address.ToString());
-                    Assert.Throws<PlatformNotSupportedException>(() => multi.IsDnsEligible);
-                    Assert.Throws<PlatformNotSupportedException>(() => multi.IsTransient);
-                }
-
-                Assert.NotNull(ipProperties.UnicastAddresses);
-                _log.WriteLine("- Unicast Addresses: " + ipProperties.UnicastAddresses.Count);
-                foreach (UnicastIPAddressInformation uni in ipProperties.UnicastAddresses)
-                {
-                    _log.WriteLine("-- " + uni.Address.ToString());
-                    Assert.Throws<PlatformNotSupportedException>(() => uni.AddressPreferredLifetime);
-                    Assert.Throws<PlatformNotSupportedException>(() => uni.AddressValidLifetime);
-                    Assert.Throws<PlatformNotSupportedException>(() => uni.DhcpLeaseLifetime);
-                    Assert.Throws<PlatformNotSupportedException>(() => uni.DuplicateAddressDetectionState);
-
-                    Assert.NotNull(uni.IPv4Mask);
-                    _log.WriteLine("--- IPv4 Mask: " + uni.IPv4Mask);
-                    Assert.Throws<PlatformNotSupportedException>(() => uni.IsDnsEligible);
-                    Assert.Throws<PlatformNotSupportedException>(() => uni.IsTransient);
-                    Assert.Throws<PlatformNotSupportedException>(() => uni.PrefixOrigin);
-                    Assert.Throws<PlatformNotSupportedException>(() => uni.SuffixOrigin);
-
-                    // Prefix Length
-                    _log.WriteLine("--- PrefixLength: " + uni.PrefixLength);
-                    Assert.True(uni.PrefixLength > 0);
-                    Assert.True((uni.Address.AddressFamily == AddressFamily.InterNetwork ? 33 : 129) > uni.PrefixLength);
-                }
-
-                Assert.NotNull(ipProperties.WinsServersAddresses);
-                _log.WriteLine("- Wins Addresses: " + ipProperties.WinsServersAddresses.Count);
-                foreach (IPAddress wins in ipProperties.WinsServersAddresses)
-                {
-                    _log.WriteLine("-- " + wins.ToString());
-                }
-            }
+            }).WaitAsync(TimeSpan.FromSeconds(30));
         }
 
         [Fact]
-        public void IPInfoTest_AccessAllIPv4Properties_NoErrors()
+        public async Task IPInfoTest_AccessAllIPv4Properties_NoErrors()
         {
-            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            await Task.Run(() =>
             {
-                _log.WriteLine("Nic: " + nic.Name);
+                foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+                {
+                    _log.WriteLine("Nic: " + nic.Name);
 
-                IPInterfaceProperties ipProperties = nic.GetIPProperties();
+                    IPInterfaceProperties ipProperties = nic.GetIPProperties();
 
-                _log.WriteLine("IPv4 Properties:");
+                    _log.WriteLine("IPv4 Properties:");
 
-                IPv4InterfaceProperties ipv4Properties = ipProperties.GetIPv4Properties();
+                    IPv4InterfaceProperties ipv4Properties = ipProperties.GetIPv4Properties();
 
-                _log.WriteLine("Index: " + ipv4Properties.Index);
-                Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.IsAutomaticPrivateAddressingActive);
-                Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.IsAutomaticPrivateAddressingEnabled);
-                Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.IsDhcpEnabled);
-                _log.WriteLine("IsForwardingEnabled: " + ipv4Properties.IsForwardingEnabled);
-                _log.WriteLine("Mtu: " + ipv4Properties.Mtu);
-                _log.WriteLine("UsesWins: " + ipv4Properties.UsesWins);
-            }
+                    _log.WriteLine("Index: " + ipv4Properties.Index);
+                    Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.IsAutomaticPrivateAddressingActive);
+                    Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.IsAutomaticPrivateAddressingEnabled);
+                    Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.IsDhcpEnabled);
+                    _log.WriteLine("IsForwardingEnabled: " + ipv4Properties.IsForwardingEnabled);
+                    _log.WriteLine("Mtu: " + ipv4Properties.Mtu);
+                    _log.WriteLine("UsesWins: " + ipv4Properties.UsesWins);
+                }
+            }).WaitAsync(TimeSpan.FromSeconds(30));
         }
 
         [Fact]
-        public void IPInfoTest_AccessAllIPv6Properties_NoErrors()
+        public async Task IPInfoTest_AccessAllIPv6Properties_NoErrors()
         {
-            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            await Task.Run(() =>
             {
-                _log.WriteLine("Nic: " + nic.Name);
-
-                IPInterfaceProperties ipProperties = nic.GetIPProperties();
-
-                _log.WriteLine("IPv6 Properties:");
-
-                IPv6InterfaceProperties ipv6Properties = ipProperties.GetIPv6Properties();
-
-                if (ipv6Properties == null)
+                foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
                 {
-                    _log.WriteLine("IPv6Properties is null");
-                    continue;
-                }
+                    _log.WriteLine("Nic: " + nic.Name);
 
-                _log.WriteLine("Index: " + ipv6Properties.Index);
-                _log.WriteLine("Mtu: " + ipv6Properties.Mtu);
-                _log.WriteLine("Scope: " + ipv6Properties.GetScopeId(ScopeLevel.Link));
-            }
+                    IPInterfaceProperties ipProperties = nic.GetIPProperties();
+
+                    _log.WriteLine("IPv6 Properties:");
+
+                    IPv6InterfaceProperties ipv6Properties = ipProperties.GetIPv6Properties();
+
+                    if (ipv6Properties == null)
+                    {
+                        _log.WriteLine("IPv6Properties is null");
+                        continue;
+                    }
+
+                    _log.WriteLine("Index: " + ipv6Properties.Index);
+                    _log.WriteLine("Mtu: " + ipv6Properties.Mtu);
+                    _log.WriteLine("Scope: " + ipv6Properties.GetScopeId(ScopeLevel.Link));
+                }
+            }).WaitAsync(TimeSpan.FromSeconds(30));
         }
 
         [Fact]
         [Trait("IPv6", "true")]
-        public void IPv6ScopeId_AccessAllValues_Success()
+        public async Task IPv6ScopeId_AccessAllValues_Success()
         {
-            Assert.True(Capability.IPv6Support());
-
-            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            await Task.Run(() =>
             {
-                _log.WriteLine("Nic: " + nic.Name);
+                Assert.True(Capability.IPv6Support());
 
-                if (!nic.Supports(NetworkInterfaceComponent.IPv6))
+                foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
                 {
-                    continue;
+                    _log.WriteLine("Nic: " + nic.Name);
+
+                    if (!nic.Supports(NetworkInterfaceComponent.IPv6))
+                    {
+                        continue;
+                    }
+
+                    IPInterfaceProperties ipProperties = nic.GetIPProperties();
+
+                    IPv6InterfaceProperties ipv6Properties = ipProperties.GetIPv6Properties();
+
+                    Array values = Enum.GetValues(typeof(ScopeLevel));
+                    foreach (ScopeLevel level in values)
+                    {
+                        _log.WriteLine("-- Level: " + level + "; " + ipv6Properties.GetScopeId(level));
+                    }
                 }
-
-                IPInterfaceProperties ipProperties = nic.GetIPProperties();
-
-                IPv6InterfaceProperties ipv6Properties = ipProperties.GetIPv6Properties();
-
-                Array values = Enum.GetValues(typeof(ScopeLevel));
-                foreach (ScopeLevel level in values)
-                {
-                    _log.WriteLine("-- Level: " + level + "; " + ipv6Properties.GetScopeId(level));
-                }
-            }
+            }).WaitAsync(TimeSpan.FromSeconds(30));
         }
 
         [Fact]
         [Trait("IPv4", "true")]
-        public void IPInfoTest_IPv4Loopback_ProperAddress()
+        public async Task IPInfoTest_IPv4Loopback_ProperAddress()
         {
-            Assert.True(Capability.IPv4Support());
-
-            _log.WriteLine("Loopback IPv4 index: " + NetworkInterface.LoopbackInterfaceIndex);
-
-            NetworkInterface loopback = NetworkInterface.GetAllNetworkInterfaces().First(ni => ni.Name == "lo");
-            Assert.NotNull(loopback);
-
-            foreach (UnicastIPAddressInformation unicast in loopback.GetIPProperties().UnicastAddresses)
+            await Task.Run(() =>
             {
-                if (unicast.Address.Equals(IPAddress.Loopback))
+                Assert.True(Capability.IPv4Support());
+
+                _log.WriteLine("Loopback IPv4 index: " + NetworkInterface.LoopbackInterfaceIndex);
+
+                NetworkInterface loopback = NetworkInterface.GetAllNetworkInterfaces().First(ni => ni.Name == "lo");
+                Assert.NotNull(loopback);
+
+                foreach (UnicastIPAddressInformation unicast in loopback.GetIPProperties().UnicastAddresses)
                 {
-                    Assert.Equal(IPAddress.Parse("255.0.0.0"), unicast.IPv4Mask);
-                    Assert.Equal(8, unicast.PrefixLength);
-                    break;
+                    if (unicast.Address.Equals(IPAddress.Loopback))
+                    {
+                        Assert.Equal(IPAddress.Parse("255.0.0.0"), unicast.IPv4Mask);
+                        Assert.Equal(8, unicast.PrefixLength);
+                        break;
+                    }
                 }
-            }
+            }).WaitAsync(TimeSpan.FromSeconds(30));
         }
 
         [Fact]
         [Trait("IPv6", "true")]
-        public void IPInfoTest_IPv6Loopback_ProperAddress()
+        public async Task IPInfoTest_IPv6Loopback_ProperAddress()
         {
-            Assert.True(Capability.IPv6Support());
-
-            _log.WriteLine("Loopback IPv6 index: " + NetworkInterface.IPv6LoopbackInterfaceIndex);
-
-            NetworkInterface loopback = NetworkInterface.GetAllNetworkInterfaces().First(ni => ni.Name == "lo");
-            Assert.NotNull(loopback);
-
-            foreach (UnicastIPAddressInformation unicast in loopback.GetIPProperties().UnicastAddresses)
+            await Task.Run(() =>
             {
-                if (unicast.Address.Equals(IPAddress.IPv6Loopback))
+                Assert.True(Capability.IPv6Support());
+
+                _log.WriteLine("Loopback IPv6 index: " + NetworkInterface.IPv6LoopbackInterfaceIndex);
+
+                NetworkInterface loopback = NetworkInterface.GetAllNetworkInterfaces().First(ni => ni.Name == "lo");
+                Assert.NotNull(loopback);
+
+                foreach (UnicastIPAddressInformation unicast in loopback.GetIPProperties().UnicastAddresses)
                 {
-                    Assert.Equal(128, unicast.PrefixLength);
-                    break;
+                    if (unicast.Address.Equals(IPAddress.IPv6Loopback))
+                    {
+                        Assert.Equal(128, unicast.PrefixLength);
+                        break;
+                    }
                 }
-            }
+            }).WaitAsync(TimeSpan.FromSeconds(30));
         }
     }
 }

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_Linux.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_Linux.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net.Http.Functional.Tests;
 using System.Net.Sockets;
 using System.Net.Test.Common;
+using System.Threading.Tasks;
 
 using Xunit;
 using Xunit.Abstractions;

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_OSX.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_OSX.cs
@@ -21,200 +21,218 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        public void IPInfoTest_AccessAllProperties_NoErrors()
+        public async Task IPInfoTest_AccessAllProperties_NoErrors()
         {
-            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            await Task.Run(() =>
             {
-                _log.WriteLine("Nic: " + nic.Name);
-                _log.WriteLine("- Supports IPv4: " + nic.Supports(NetworkInterfaceComponent.IPv4));
-                _log.WriteLine("- Supports IPv6: " + nic.Supports(NetworkInterfaceComponent.IPv6));
-
-                IPInterfaceProperties ipProperties = nic.GetIPProperties();
-
-                Assert.NotNull(ipProperties);
-
-                Assert.Throws<PlatformNotSupportedException>(() => ipProperties.AnycastAddresses);
-
-                Assert.Throws<PlatformNotSupportedException>(() => ipProperties.DhcpServerAddresses);
-
-                try
+                foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
                 {
-                    Assert.NotNull(ipProperties.DnsAddresses);
-                    _log.WriteLine("- Dns Addresses: " + ipProperties.DnsAddresses.Count);
-                    foreach (IPAddress dns in ipProperties.DnsAddresses)
+                    _log.WriteLine("Nic: " + nic.Name);
+                    _log.WriteLine("- Supports IPv4: " + nic.Supports(NetworkInterfaceComponent.IPv4));
+                    _log.WriteLine("- Supports IPv6: " + nic.Supports(NetworkInterfaceComponent.IPv6));
+
+                    IPInterfaceProperties ipProperties = nic.GetIPProperties();
+
+                    Assert.NotNull(ipProperties);
+
+                    Assert.Throws<PlatformNotSupportedException>(() => ipProperties.AnycastAddresses);
+
+                    Assert.Throws<PlatformNotSupportedException>(() => ipProperties.DhcpServerAddresses);
+
+                    try
                     {
-                        _log.WriteLine("-- " + dns.ToString());
+                        Assert.NotNull(ipProperties.DnsAddresses);
+                        _log.WriteLine("- Dns Addresses: " + ipProperties.DnsAddresses.Count);
+                        foreach (IPAddress dns in ipProperties.DnsAddresses)
+                        {
+                            _log.WriteLine("-- " + dns.ToString());
+                        }
+                        Assert.NotNull(ipProperties.DnsSuffix);
+                        _log.WriteLine("- Dns Suffix: " + ipProperties.DnsSuffix);
                     }
-                    Assert.NotNull(ipProperties.DnsSuffix);
-                    _log.WriteLine("- Dns Suffix: " + ipProperties.DnsSuffix);
+                    // If /etc/resolv.conf does not exist, DNS values cannot be retrieved.
+                    catch (PlatformNotSupportedException) { }
+
+                    Assert.NotNull(ipProperties.GatewayAddresses);
+                    _log.WriteLine("- Gateway Addresses: " + ipProperties.GatewayAddresses.Count);
+                    foreach (GatewayIPAddressInformation gateway in ipProperties.GatewayAddresses)
+                    {
+                        _log.WriteLine("-- " + gateway.Address.ToString());
+                    }
+
+                    Assert.Throws<PlatformNotSupportedException>(() => ipProperties.IsDnsEnabled);
+
+                    Assert.Throws<PlatformNotSupportedException>(() => ipProperties.IsDynamicDnsEnabled);
+
+                    Assert.NotNull(ipProperties.MulticastAddresses);
+                    _log.WriteLine("- Multicast Addresses: " + ipProperties.MulticastAddresses.Count);
+                    foreach (IPAddressInformation multi in ipProperties.MulticastAddresses)
+                    {
+                        _log.WriteLine("-- " + multi.Address.ToString());
+                        Assert.Throws<PlatformNotSupportedException>(() => multi.IsDnsEligible);
+                        Assert.Throws<PlatformNotSupportedException>(() => multi.IsTransient);
+                    }
+
+                    Assert.NotNull(ipProperties.UnicastAddresses);
+                    _log.WriteLine("- Unicast Addresses: " + ipProperties.UnicastAddresses.Count);
+                    foreach (UnicastIPAddressInformation uni in ipProperties.UnicastAddresses)
+                    {
+                        _log.WriteLine("-- " + uni.Address.ToString());
+                        Assert.Throws<PlatformNotSupportedException>(() => uni.AddressPreferredLifetime);
+                        Assert.Throws<PlatformNotSupportedException>(() => uni.AddressValidLifetime);
+                        Assert.Throws<PlatformNotSupportedException>(() => uni.DhcpLeaseLifetime);
+                        Assert.Throws<PlatformNotSupportedException>(() => uni.DuplicateAddressDetectionState);
+
+                        Assert.NotNull(uni.IPv4Mask);
+                        _log.WriteLine("--- IPv4 Mask: " + uni.IPv4Mask);
+                        Assert.Throws<PlatformNotSupportedException>(() => uni.IsDnsEligible);
+                        Assert.Throws<PlatformNotSupportedException>(() => uni.IsTransient);
+                        Assert.Throws<PlatformNotSupportedException>(() => uni.PrefixOrigin);
+                        Assert.Throws<PlatformNotSupportedException>(() => uni.SuffixOrigin);
+
+                        // Prefix Length
+                        _log.WriteLine("--- PrefixLength: " + uni.PrefixLength);
+                        Assert.True(uni.PrefixLength > 0);
+                        Assert.True((uni.Address.AddressFamily == AddressFamily.InterNetwork ? 33 : 129) > uni.PrefixLength);
+
+                    }
+
+                    Assert.Throws<PlatformNotSupportedException>(() => ipProperties.WinsServersAddresses);
                 }
-                // If /etc/resolv.conf does not exist, DNS values cannot be retrieved.
-                catch (PlatformNotSupportedException) { }
-
-                Assert.NotNull(ipProperties.GatewayAddresses);
-                _log.WriteLine("- Gateway Addresses: " + ipProperties.GatewayAddresses.Count);
-                foreach (GatewayIPAddressInformation gateway in ipProperties.GatewayAddresses)
-                {
-                    _log.WriteLine("-- " + gateway.Address.ToString());
-                }
-
-                Assert.Throws<PlatformNotSupportedException>(() => ipProperties.IsDnsEnabled);
-
-                Assert.Throws<PlatformNotSupportedException>(() => ipProperties.IsDynamicDnsEnabled);
-
-                Assert.NotNull(ipProperties.MulticastAddresses);
-                _log.WriteLine("- Multicast Addresses: " + ipProperties.MulticastAddresses.Count);
-                foreach (IPAddressInformation multi in ipProperties.MulticastAddresses)
-                {
-                    _log.WriteLine("-- " + multi.Address.ToString());
-                    Assert.Throws<PlatformNotSupportedException>(() => multi.IsDnsEligible);
-                    Assert.Throws<PlatformNotSupportedException>(() => multi.IsTransient);
-                }
-
-                Assert.NotNull(ipProperties.UnicastAddresses);
-                _log.WriteLine("- Unicast Addresses: " + ipProperties.UnicastAddresses.Count);
-                foreach (UnicastIPAddressInformation uni in ipProperties.UnicastAddresses)
-                {
-                    _log.WriteLine("-- " + uni.Address.ToString());
-                    Assert.Throws<PlatformNotSupportedException>(() => uni.AddressPreferredLifetime);
-                    Assert.Throws<PlatformNotSupportedException>(() => uni.AddressValidLifetime);
-                    Assert.Throws<PlatformNotSupportedException>(() => uni.DhcpLeaseLifetime);
-                    Assert.Throws<PlatformNotSupportedException>(() => uni.DuplicateAddressDetectionState);
-
-                    Assert.NotNull(uni.IPv4Mask);
-                    _log.WriteLine("--- IPv4 Mask: " + uni.IPv4Mask);
-                    Assert.Throws<PlatformNotSupportedException>(() => uni.IsDnsEligible);
-                    Assert.Throws<PlatformNotSupportedException>(() => uni.IsTransient);
-                    Assert.Throws<PlatformNotSupportedException>(() => uni.PrefixOrigin);
-                    Assert.Throws<PlatformNotSupportedException>(() => uni.SuffixOrigin);
-
-                    // Prefix Length
-                    _log.WriteLine("--- PrefixLength: " + uni.PrefixLength);
-                    Assert.True(uni.PrefixLength > 0);
-                    Assert.True((uni.Address.AddressFamily == AddressFamily.InterNetwork ? 33 : 129) > uni.PrefixLength);
-
-                }
-
-                Assert.Throws<PlatformNotSupportedException>(() => ipProperties.WinsServersAddresses);
-            }
+            }).WaitAsync(TimeSpan.FromSeconds(30));
         }
 
         [Fact]
-        public void IPInfoTest_AccessAllIPv4Properties_NoErrors()
+        public async Task IPInfoTest_AccessAllIPv4Properties_NoErrors()
         {
-            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            await Task.Run(() =>
             {
-                _log.WriteLine("Nic: " + nic.Name);
+                foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+                {
+                    _log.WriteLine("Nic: " + nic.Name);
 
-                IPInterfaceProperties ipProperties = nic.GetIPProperties();
+                    IPInterfaceProperties ipProperties = nic.GetIPProperties();
 
-                _log.WriteLine("IPv4 Properties:");
+                    _log.WriteLine("IPv4 Properties:");
 
-                IPv4InterfaceProperties ipv4Properties = ipProperties.GetIPv4Properties();
+                    IPv4InterfaceProperties ipv4Properties = ipProperties.GetIPv4Properties();
 
-                _log.WriteLine("Index: " + ipv4Properties.Index);
-                Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.IsAutomaticPrivateAddressingActive);
-                Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.IsAutomaticPrivateAddressingEnabled);
-                Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.IsDhcpEnabled);
-                Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.IsForwardingEnabled);
-                _log.WriteLine("Mtu: " + ipv4Properties.Mtu);
-                Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.UsesWins);
-            }
+                    _log.WriteLine("Index: " + ipv4Properties.Index);
+                    Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.IsAutomaticPrivateAddressingActive);
+                    Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.IsAutomaticPrivateAddressingEnabled);
+                    Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.IsDhcpEnabled);
+                    Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.IsForwardingEnabled);
+                    _log.WriteLine("Mtu: " + ipv4Properties.Mtu);
+                    Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.UsesWins);
+                }
+            }).WaitAsync(TimeSpan.FromSeconds(30));
         }
 
         [Fact]
-        public void IPInfoTest_AccessAllIPv6Properties_NoErrors()
+        public async Task IPInfoTest_AccessAllIPv6Properties_NoErrors()
         {
-            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            await Task.Run(() =>
             {
-                _log.WriteLine("Nic: " + nic.Name);
-
-                IPInterfaceProperties ipProperties = nic.GetIPProperties();
-
-                _log.WriteLine("IPv6 Properties:");
-
-                IPv6InterfaceProperties ipv6Properties = ipProperties.GetIPv6Properties();
-
-                if (ipv6Properties == null)
+                foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
                 {
-                    _log.WriteLine("IPv6Properties is null");
-                    continue;
-                }
+                    _log.WriteLine("Nic: " + nic.Name);
 
-                _log.WriteLine("Index: " + ipv6Properties.Index);
-                _log.WriteLine("Mtu: " + ipv6Properties.Mtu);
-                Assert.Throws<PlatformNotSupportedException>(() => ipv6Properties.GetScopeId(ScopeLevel.Link));
-            }
+                    IPInterfaceProperties ipProperties = nic.GetIPProperties();
+
+                    _log.WriteLine("IPv6 Properties:");
+
+                    IPv6InterfaceProperties ipv6Properties = ipProperties.GetIPv6Properties();
+
+                    if (ipv6Properties == null)
+                    {
+                        _log.WriteLine("IPv6Properties is null");
+                        continue;
+                    }
+
+                    _log.WriteLine("Index: " + ipv6Properties.Index);
+                    _log.WriteLine("Mtu: " + ipv6Properties.Mtu);
+                    Assert.Throws<PlatformNotSupportedException>(() => ipv6Properties.GetScopeId(ScopeLevel.Link));
+                }
+            }).WaitAsync(TimeSpan.FromSeconds(30));
         }
 
         [Fact]
         [Trait("IPv6", "true")]
-        public void IPv6ScopeId_AccessAllValues_Success()
+        public async Task IPv6ScopeId_AccessAllValues_Success()
         {
-            Assert.True(Capability.IPv6Support());
-
-            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            await Task.Run(() =>
             {
-                _log.WriteLine("Nic: " + nic.Name);
+                Assert.True(Capability.IPv6Support());
 
-                if (!nic.Supports(NetworkInterfaceComponent.IPv6))
+                foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
                 {
-                    continue;
+                    _log.WriteLine("Nic: " + nic.Name);
+
+                    if (!nic.Supports(NetworkInterfaceComponent.IPv6))
+                    {
+                        continue;
+                    }
+
+                    IPInterfaceProperties ipProperties = nic.GetIPProperties();
+
+                    IPv6InterfaceProperties ipv6Properties = ipProperties.GetIPv6Properties();
+
+                    Array values = Enum.GetValues(typeof(ScopeLevel));
+                    foreach (ScopeLevel level in values)
+                    {
+                        Assert.Throws<PlatformNotSupportedException>(() => ipv6Properties.GetScopeId(level));
+                    }
                 }
-
-                IPInterfaceProperties ipProperties = nic.GetIPProperties();
-
-                IPv6InterfaceProperties ipv6Properties = ipProperties.GetIPv6Properties();
-
-                Array values = Enum.GetValues(typeof(ScopeLevel));
-                foreach (ScopeLevel level in values)
-                {
-                    Assert.Throws<PlatformNotSupportedException>(() => ipv6Properties.GetScopeId(level));
-                }
-            }
+            }).WaitAsync(TimeSpan.FromSeconds(30));
         }
 
         [Fact]
         [Trait("IPv4", "true")]
-        public void IPInfoTest_IPv4Loopback_ProperAddress()
+        public async Task IPInfoTest_IPv4Loopback_ProperAddress()
         {
-            Assert.True(Capability.IPv4Support());
-
-            _log.WriteLine("Loopback IPv4 index: " + NetworkInterface.LoopbackInterfaceIndex);
-
-            NetworkInterface loopback = NetworkInterface.GetAllNetworkInterfaces().First(ni => ni.Name == "lo0");
-            Assert.NotNull(loopback);
-
-            foreach (UnicastIPAddressInformation unicast in loopback.GetIPProperties().UnicastAddresses)
+            await Task.Run(() =>
             {
-                if (unicast.Address.Equals(IPAddress.Loopback))
+                Assert.True(Capability.IPv4Support());
+
+                _log.WriteLine("Loopback IPv4 index: " + NetworkInterface.LoopbackInterfaceIndex);
+
+                NetworkInterface loopback = NetworkInterface.GetAllNetworkInterfaces().First(ni => ni.Name == "lo0");
+                Assert.NotNull(loopback);
+
+                foreach (UnicastIPAddressInformation unicast in loopback.GetIPProperties().UnicastAddresses)
                 {
-                    Assert.Equal(IPAddress.Parse("255.0.0.0"), unicast.IPv4Mask);
-                    Assert.Equal(8, unicast.PrefixLength);
-                    break;
+                    if (unicast.Address.Equals(IPAddress.Loopback))
+                    {
+                        Assert.Equal(IPAddress.Parse("255.0.0.0"), unicast.IPv4Mask);
+                        Assert.Equal(8, unicast.PrefixLength);
+                        break;
+                    }
                 }
-            }
+            }).WaitAsync(TimeSpan.FromSeconds(30));
         }
 
         [Fact]
         [Trait("IPv6", "true")]
-        public void IPInfoTest_IPv6Loopback_ProperAddress()
+        public async Task IPInfoTest_IPv6Loopback_ProperAddress()
         {
-            Assert.True(Capability.IPv6Support());
-
-            _log.WriteLine("Loopback IPv6 index: " + NetworkInterface.IPv6LoopbackInterfaceIndex);
-
-            NetworkInterface loopback = NetworkInterface.GetAllNetworkInterfaces().First(ni => ni.Name == "lo0");
-            Assert.NotNull(loopback);
-
-            foreach (UnicastIPAddressInformation unicast in loopback.GetIPProperties().UnicastAddresses)
+            await Task.Run(() =>
             {
-                if (unicast.Address.Equals(IPAddress.IPv6Loopback))
+                Assert.True(Capability.IPv6Support());
+
+                _log.WriteLine("Loopback IPv6 index: " + NetworkInterface.IPv6LoopbackInterfaceIndex);
+
+                NetworkInterface loopback = NetworkInterface.GetAllNetworkInterfaces().First(ni => ni.Name == "lo0");
+                Assert.NotNull(loopback);
+
+                foreach (UnicastIPAddressInformation unicast in loopback.GetIPProperties().UnicastAddresses)
                 {
-                    Assert.Equal(128, unicast.PrefixLength);
-                    break;
+                    if (unicast.Address.Equals(IPAddress.IPv6Loopback))
+                    {
+                        Assert.Equal(128, unicast.PrefixLength);
+                        break;
+                    }
                 }
-            }
+            }).WaitAsync(TimeSpan.FromSeconds(30));
         }
     }
 }

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_OSX.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_OSX.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
+using System.Net.Http.Functional.Tests;
 using System.Net.Sockets;
 using System.Net.Test.Common;
 
@@ -15,9 +16,9 @@ namespace System.Net.NetworkInformation.Tests
     {
         private readonly ITestOutputHelper _log;
 
-        public IPInterfacePropertiesTest_OSX()
+        public IPInterfacePropertiesTest_OSX(ITestOutputHelper output)
         {
-            _log = TestLogging.GetInstance();
+            _log = output;
         }
 
         [Fact]
@@ -99,7 +100,7 @@ namespace System.Net.NetworkInformation.Tests
 
                     Assert.Throws<PlatformNotSupportedException>(() => ipProperties.WinsServersAddresses);
                 }
-            }).WaitAsync(TimeSpan.FromSeconds(30));
+            }).WaitAsync(TestHelper.PassingTestTimeout);
         }
 
         [Fact]
@@ -125,7 +126,7 @@ namespace System.Net.NetworkInformation.Tests
                     _log.WriteLine("Mtu: " + ipv4Properties.Mtu);
                     Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.UsesWins);
                 }
-            }).WaitAsync(TimeSpan.FromSeconds(30));
+            }).WaitAsync(TestHelper.PassingTestTimeout);
         }
 
         [Fact]
@@ -153,7 +154,7 @@ namespace System.Net.NetworkInformation.Tests
                     _log.WriteLine("Mtu: " + ipv6Properties.Mtu);
                     Assert.Throws<PlatformNotSupportedException>(() => ipv6Properties.GetScopeId(ScopeLevel.Link));
                 }
-            }).WaitAsync(TimeSpan.FromSeconds(30));
+            }).WaitAsync(TestHelper.PassingTestTimeout);
         }
 
         [Fact]
@@ -183,7 +184,7 @@ namespace System.Net.NetworkInformation.Tests
                         Assert.Throws<PlatformNotSupportedException>(() => ipv6Properties.GetScopeId(level));
                     }
                 }
-            }).WaitAsync(TimeSpan.FromSeconds(30));
+            }).WaitAsync(TestHelper.PassingTestTimeout);
         }
 
         [Fact]
@@ -208,7 +209,7 @@ namespace System.Net.NetworkInformation.Tests
                         break;
                     }
                 }
-            }).WaitAsync(TimeSpan.FromSeconds(30));
+            }).WaitAsync(TestHelper.PassingTestTimeout);
         }
 
         [Fact]
@@ -232,7 +233,7 @@ namespace System.Net.NetworkInformation.Tests
                         break;
                     }
                 }
-            }).WaitAsync(TimeSpan.FromSeconds(30));
+            }).WaitAsync(TestHelper.PassingTestTimeout);
         }
     }
 }

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_OSX.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_OSX.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net.Http.Functional.Tests;
 using System.Net.Sockets;
 using System.Net.Test.Common;
+using System.Threading.Tasks;
 
 using Xunit;
 using Xunit.Abstractions;

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_Windows.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_Windows.cs
@@ -20,205 +20,220 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        public void IPInfoTest_AccessAllProperties_NoErrors()
+        public async Task IPInfoTest_AccessAllProperties_NoErrors()
         {
-            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            await Task.Run(() =>
             {
-                _log.WriteLine("Nic: " + nic.Name);
-                _log.WriteLine("- Supports IPv4: " + nic.Supports(NetworkInterfaceComponent.IPv4));
-                _log.WriteLine("- Supports IPv6: " + nic.Supports(NetworkInterfaceComponent.IPv6));
-
-                IPInterfaceProperties ipProperties = nic.GetIPProperties();
-
-                Assert.NotNull(ipProperties);
-
-                Assert.NotNull(ipProperties.AnycastAddresses);
-                _log.WriteLine("- Anycast Addresses: " + ipProperties.AnycastAddresses.Count);
-                foreach (IPAddressInformation anyAddr in ipProperties.AnycastAddresses)
+                foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
                 {
-                    _log.WriteLine("-- " + anyAddr.Address.ToString());
-                    _log.WriteLine("--- Dns Eligible: " + anyAddr.IsDnsEligible);
-                    _log.WriteLine("--- Transient: " + anyAddr.IsTransient);
+                    _log.WriteLine("Nic: " + nic.Name);
+                    _log.WriteLine("- Supports IPv4: " + nic.Supports(NetworkInterfaceComponent.IPv4));
+                    _log.WriteLine("- Supports IPv6: " + nic.Supports(NetworkInterfaceComponent.IPv6));
+
+                    IPInterfaceProperties ipProperties = nic.GetIPProperties();
+
+                    Assert.NotNull(ipProperties);
+
+                    Assert.NotNull(ipProperties.AnycastAddresses);
+                    _log.WriteLine("- Anycast Addresses: " + ipProperties.AnycastAddresses.Count);
+                    foreach (IPAddressInformation anyAddr in ipProperties.AnycastAddresses)
+                    {
+                        _log.WriteLine("-- " + anyAddr.Address.ToString());
+                        _log.WriteLine("--- Dns Eligible: " + anyAddr.IsDnsEligible);
+                        _log.WriteLine("--- Transient: " + anyAddr.IsTransient);
+                    }
+
+                    Assert.NotNull(ipProperties.DhcpServerAddresses);
+                    _log.WriteLine("- Dhcp Server Addresses: " + ipProperties.DhcpServerAddresses.Count);
+                    foreach (IPAddress dhcp in ipProperties.DhcpServerAddresses)
+                    {
+                        _log.WriteLine("-- " + dhcp.ToString());
+                    }
+
+                    Assert.NotNull(ipProperties.DnsAddresses);
+                    _log.WriteLine("- Dns Addresses: " + ipProperties.DnsAddresses.Count);
+                    foreach (IPAddress dns in ipProperties.DnsAddresses)
+                    {
+                        _log.WriteLine("-- " + dns.ToString());
+                    }
+
+                    Assert.NotNull(ipProperties.DnsSuffix);
+                    _log.WriteLine("- Dns Suffix: " + ipProperties.DnsSuffix);
+
+                    Assert.NotNull(ipProperties.GatewayAddresses);
+                    _log.WriteLine("- Gateway Addresses: " + ipProperties.GatewayAddresses.Count);
+                    foreach (GatewayIPAddressInformation gateway in ipProperties.GatewayAddresses)
+                    {
+                        _log.WriteLine("-- " + gateway.Address.ToString());
+                    }
+
+                    _log.WriteLine("- Dns Enabled: " + ipProperties.IsDnsEnabled);
+
+                    _log.WriteLine("- Dynamic Dns Enabled: " + ipProperties.IsDynamicDnsEnabled);
+
+                    Assert.NotNull(ipProperties.MulticastAddresses);
+                    _log.WriteLine("- Multicast Addresses: " + ipProperties.MulticastAddresses.Count);
+                    foreach (IPAddressInformation multi in ipProperties.MulticastAddresses)
+                    {
+                        _log.WriteLine("-- " + multi.Address.ToString());
+                        _log.WriteLine("--- Dns Eligible: " + multi.IsDnsEligible);
+                        _log.WriteLine("--- Transient: " + multi.IsTransient);
+                    }
+
+                    Assert.NotNull(ipProperties.UnicastAddresses);
+                    _log.WriteLine("- Unicast Addresses: " + ipProperties.UnicastAddresses.Count);
+                    foreach (UnicastIPAddressInformation uni in ipProperties.UnicastAddresses)
+                    {
+                        _log.WriteLine("-- " + uni.Address.ToString());
+                        _log.WriteLine("--- Preferred Lifetime: " + uni.AddressPreferredLifetime);
+                        _log.WriteLine("--- Valid Lifetime: " + uni.AddressValidLifetime);
+                        _log.WriteLine("--- Dhcp lease Lifetime: " + uni.DhcpLeaseLifetime);
+                        _log.WriteLine("--- Duplicate Address Detection State: " + uni.DuplicateAddressDetectionState);
+
+                        Assert.NotNull(uni.IPv4Mask);
+                        _log.WriteLine("--- IPv4 Mask: " + uni.IPv4Mask);
+                        _log.WriteLine("--- Dns Eligible: " + uni.IsDnsEligible);
+                        _log.WriteLine("--- Transient: " + uni.IsTransient);
+                        _log.WriteLine("--- Prefix Origin: " + uni.PrefixOrigin);
+                        _log.WriteLine("--- Suffix Origin: " + uni.SuffixOrigin);
+
+                        // Prefix Length
+                        _log.WriteLine("--- Prefix Length: " + uni.PrefixLength);
+                        Assert.NotEqual(0, uni.PrefixLength);
+                    }
+
+                    Assert.NotNull(ipProperties.WinsServersAddresses);
+                    _log.WriteLine("- Wins Addresses: " + ipProperties.WinsServersAddresses.Count);
+                    foreach (IPAddress wins in ipProperties.WinsServersAddresses)
+                    {
+                        _log.WriteLine("-- " + wins.ToString());
+                    }
                 }
-
-                Assert.NotNull(ipProperties.DhcpServerAddresses);
-                _log.WriteLine("- Dhcp Server Addresses: " + ipProperties.DhcpServerAddresses.Count);
-                foreach (IPAddress dhcp in ipProperties.DhcpServerAddresses)
-                {
-                    _log.WriteLine("-- " + dhcp.ToString());
-                }
-
-                Assert.NotNull(ipProperties.DnsAddresses);
-                _log.WriteLine("- Dns Addresses: " + ipProperties.DnsAddresses.Count);
-                foreach (IPAddress dns in ipProperties.DnsAddresses)
-                {
-                    _log.WriteLine("-- " + dns.ToString());
-                }
-
-                Assert.NotNull(ipProperties.DnsSuffix);
-                _log.WriteLine("- Dns Suffix: " + ipProperties.DnsSuffix);
-
-                Assert.NotNull(ipProperties.GatewayAddresses);
-                _log.WriteLine("- Gateway Addresses: " + ipProperties.GatewayAddresses.Count);
-                foreach (GatewayIPAddressInformation gateway in ipProperties.GatewayAddresses)
-                {
-                    _log.WriteLine("-- " + gateway.Address.ToString());
-                }
-
-                _log.WriteLine("- Dns Enabled: " + ipProperties.IsDnsEnabled);
-
-                _log.WriteLine("- Dynamic Dns Enabled: " + ipProperties.IsDynamicDnsEnabled);
-
-                Assert.NotNull(ipProperties.MulticastAddresses);
-                _log.WriteLine("- Multicast Addresses: " + ipProperties.MulticastAddresses.Count);
-                foreach (IPAddressInformation multi in ipProperties.MulticastAddresses)
-                {
-                    _log.WriteLine("-- " + multi.Address.ToString());
-                    _log.WriteLine("--- Dns Eligible: " + multi.IsDnsEligible);
-                    _log.WriteLine("--- Transient: " + multi.IsTransient);
-                }
-
-                Assert.NotNull(ipProperties.UnicastAddresses);
-                _log.WriteLine("- Unicast Addresses: " + ipProperties.UnicastAddresses.Count);
-                foreach (UnicastIPAddressInformation uni in ipProperties.UnicastAddresses)
-                {
-                    _log.WriteLine("-- " + uni.Address.ToString());
-                    _log.WriteLine("--- Preferred Lifetime: " + uni.AddressPreferredLifetime);
-                    _log.WriteLine("--- Valid Lifetime: " + uni.AddressValidLifetime);
-                    _log.WriteLine("--- Dhcp lease Lifetime: " + uni.DhcpLeaseLifetime);
-                    _log.WriteLine("--- Duplicate Address Detection State: " + uni.DuplicateAddressDetectionState);
-
-                    Assert.NotNull(uni.IPv4Mask);
-                    _log.WriteLine("--- IPv4 Mask: " + uni.IPv4Mask);
-                    _log.WriteLine("--- Dns Eligible: " + uni.IsDnsEligible);
-                    _log.WriteLine("--- Transient: " + uni.IsTransient);
-                    _log.WriteLine("--- Prefix Origin: " + uni.PrefixOrigin);
-                    _log.WriteLine("--- Suffix Origin: " + uni.SuffixOrigin);
-
-                    // Prefix Length
-                    _log.WriteLine("--- Prefix Length: " + uni.PrefixLength);
-                    Assert.NotEqual(0, uni.PrefixLength);
-                }
-
-                Assert.NotNull(ipProperties.WinsServersAddresses);
-                _log.WriteLine("- Wins Addresses: " + ipProperties.WinsServersAddresses.Count);
-                foreach (IPAddress wins in ipProperties.WinsServersAddresses)
-                {
-                    _log.WriteLine("-- " + wins.ToString());
-                }
-            }
+            }).WaitAsync(TimeSpan.FromSeconds(30));
         }
 
         [Fact]
-        public void IPInfoTest_AccessAllIPv4Properties_NoErrors()
+        public async Task IPInfoTest_AccessAllIPv4Properties_NoErrors()
         {
-            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            await Task.Run(() =>
             {
-                _log.WriteLine("Nic: " + nic.Name);
-
-                IPInterfaceProperties ipProperties = nic.GetIPProperties();
-
-                _log.WriteLine("IPv4 Properties:");
-
-                if (!nic.Supports(NetworkInterfaceComponent.IPv4))
+                foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
                 {
-                    var nie = Assert.Throws<NetworkInformationException>(() => ipProperties.GetIPv4Properties());
-                    Assert.Equal(SocketError.ProtocolNotSupported, (SocketError)nie.ErrorCode);
-                    continue;
+                    _log.WriteLine("Nic: " + nic.Name);
+
+                    IPInterfaceProperties ipProperties = nic.GetIPProperties();
+
+                    _log.WriteLine("IPv4 Properties:");
+
+                    if (!nic.Supports(NetworkInterfaceComponent.IPv4))
+                    {
+                        var nie = Assert.Throws<NetworkInformationException>(() => ipProperties.GetIPv4Properties());
+                        Assert.Equal(SocketError.ProtocolNotSupported, (SocketError)nie.ErrorCode);
+                        continue;
+                    }
+
+                    IPv4InterfaceProperties ipv4Properties = ipProperties.GetIPv4Properties();
+
+                    _log.WriteLine("Index: " + ipv4Properties.Index);
+                    _log.WriteLine("IsAutomaticPrivateAddressingActive: " + ipv4Properties.IsAutomaticPrivateAddressingActive);
+                    _log.WriteLine("IsAutomaticPrivateAddressingEnabled: " + ipv4Properties.IsAutomaticPrivateAddressingEnabled);
+                    _log.WriteLine("IsDhcpEnabled: " + ipv4Properties.IsDhcpEnabled);
+                    _log.WriteLine("IsForwardingEnabled: " + ipv4Properties.IsForwardingEnabled);
+                    _log.WriteLine("Mtu: " + ipv4Properties.Mtu);
+                    _log.WriteLine("UsesWins: " + ipv4Properties.UsesWins);
                 }
-
-                IPv4InterfaceProperties ipv4Properties = ipProperties.GetIPv4Properties();
-
-                _log.WriteLine("Index: " + ipv4Properties.Index);
-                _log.WriteLine("IsAutomaticPrivateAddressingActive: " + ipv4Properties.IsAutomaticPrivateAddressingActive);
-                _log.WriteLine("IsAutomaticPrivateAddressingEnabled: " + ipv4Properties.IsAutomaticPrivateAddressingEnabled);
-                _log.WriteLine("IsDhcpEnabled: " + ipv4Properties.IsDhcpEnabled);
-                _log.WriteLine("IsForwardingEnabled: " + ipv4Properties.IsForwardingEnabled);
-                _log.WriteLine("Mtu: " + ipv4Properties.Mtu);
-                _log.WriteLine("UsesWins: " + ipv4Properties.UsesWins);
-            }
+            }).WaitAsync(TimeSpan.FromSeconds(30));
         }
 
         [Fact]
-        public void IPInfoTest_AccessAllIPv6Properties_NoErrors()
+        public async Task IPInfoTest_AccessAllIPv6Properties_NoErrors()
         {
-            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            await Task.Run(() =>
             {
-                _log.WriteLine("Nic: " + nic.Name);
-
-                IPInterfaceProperties ipProperties = nic.GetIPProperties();
-
-                _log.WriteLine("IPv6 Properties:");
-
-                if (!nic.Supports(NetworkInterfaceComponent.IPv6))
+                foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
                 {
-                    var nie = Assert.Throws<NetworkInformationException>(() => ipProperties.GetIPv6Properties());
-                    Assert.Equal(SocketError.ProtocolNotSupported, (SocketError)nie.ErrorCode);
-                    continue;
+                    _log.WriteLine("Nic: " + nic.Name);
+
+                    IPInterfaceProperties ipProperties = nic.GetIPProperties();
+
+                    _log.WriteLine("IPv6 Properties:");
+
+                    if (!nic.Supports(NetworkInterfaceComponent.IPv6))
+                    {
+                        var nie = Assert.Throws<NetworkInformationException>(() => ipProperties.GetIPv6Properties());
+                        Assert.Equal(SocketError.ProtocolNotSupported, (SocketError)nie.ErrorCode);
+                        continue;
+                    }
+
+                    IPv6InterfaceProperties ipv6Properties = ipProperties.GetIPv6Properties();
+
+                    if (ipv6Properties == null)
+                    {
+                        _log.WriteLine("IPv6Properties is null");
+                        continue;
+                    }
+
+                    _log.WriteLine("Index: " + ipv6Properties.Index);
+                    _log.WriteLine("Mtu: " + ipv6Properties.Mtu);
+                    _log.WriteLine("ScopeID: " + ipv6Properties.GetScopeId(ScopeLevel.Link));
                 }
-
-                IPv6InterfaceProperties ipv6Properties = ipProperties.GetIPv6Properties();
-
-                if (ipv6Properties == null)
-                {
-                    _log.WriteLine("IPv6Properties is null");
-                    continue;
-                }
-
-                _log.WriteLine("Index: " + ipv6Properties.Index);
-                _log.WriteLine("Mtu: " + ipv6Properties.Mtu);
-                _log.WriteLine("ScopeID: " + ipv6Properties.GetScopeId(ScopeLevel.Link));
-            }
-        }
-
-        [Fact]
-        [Trait("IPv6", "true")]
-        public void IPv6ScopeId_GetLinkLevel_MatchesIndex()
-        {
-            Assert.True(Capability.IPv6Support());
-
-            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
-            {
-                IPInterfaceProperties ipProperties = nic.GetIPProperties();
-
-                if (!nic.Supports(NetworkInterfaceComponent.IPv6))
-                {
-                    continue;
-                }
-
-                IPv6InterfaceProperties ipv6Properties = ipProperties.GetIPv6Properties();
-                // This is not officially guaranteed by Windows, but it's what gets used.
-                Assert.Equal(ipv6Properties.Index, ipv6Properties.GetScopeId(ScopeLevel.Link));
-            }
+            }).WaitAsync(TimeSpan.FromSeconds(30));
         }
 
         [Fact]
         [Trait("IPv6", "true")]
-        public void IPv6ScopeId_AccessAllValues_Success()
+        public async Task IPv6ScopeId_GetLinkLevel_MatchesIndex()
         {
-            Assert.True(Capability.IPv6Support());
-
-            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            await Task.Run(() =>
             {
-                _log.WriteLine("Nic: " + nic.Name);
+                Assert.True(Capability.IPv6Support());
 
-                if (!nic.Supports(NetworkInterfaceComponent.IPv6))
+                foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
                 {
-                    continue;
+                    IPInterfaceProperties ipProperties = nic.GetIPProperties();
+
+                    if (!nic.Supports(NetworkInterfaceComponent.IPv6))
+                    {
+                        continue;
+                    }
+
+                    IPv6InterfaceProperties ipv6Properties = ipProperties.GetIPv6Properties();
+                    // This is not officially guaranteed by Windows, but it's what gets used.
+                    Assert.Equal(ipv6Properties.Index, ipv6Properties.GetScopeId(ScopeLevel.Link));
                 }
+            }).WaitAsync(TimeSpan.FromSeconds(30));
+        }
 
-                IPInterfaceProperties ipProperties = nic.GetIPProperties();
+        [Fact]
+        [Trait("IPv6", "true")]
+        public async Task IPv6ScopeId_AccessAllValues_Success()
+        {
+            await Task.Run(() =>
+            {
+                Assert.True(Capability.IPv6Support());
 
-                _log.WriteLine("- IPv6 Scope levels:");
-
-                IPv6InterfaceProperties ipv6Properties = ipProperties.GetIPv6Properties();
-
-                Array values = Enum.GetValues(typeof(ScopeLevel));
-                foreach (ScopeLevel level in values)
+                foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
                 {
-                    _log.WriteLine("-- Level: " + level + "; " + ipv6Properties.GetScopeId(level));
+                    _log.WriteLine("Nic: " + nic.Name);
+
+                    if (!nic.Supports(NetworkInterfaceComponent.IPv6))
+                    {
+                        continue;
+                    }
+
+                    IPInterfaceProperties ipProperties = nic.GetIPProperties();
+
+                    _log.WriteLine("- IPv6 Scope levels:");
+
+                    IPv6InterfaceProperties ipv6Properties = ipProperties.GetIPv6Properties();
+
+                    Array values = Enum.GetValues(typeof(ScopeLevel));
+                    foreach (ScopeLevel level in values)
+                    {
+                        _log.WriteLine("-- Level: " + level + "; " + ipv6Properties.GetScopeId(level));
+                    }
                 }
-            }
+            }).WaitAsync(TimeSpan.FromSeconds(30));
         }
     }
 }

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_Windows.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_Windows.cs
@@ -4,6 +4,7 @@
 using System.Net.Http.Functional.Tests;
 using System.Net.Sockets;
 using System.Net.Test.Common;
+using System.Threading.Tasks;
 
 using Xunit;
 using Xunit.Abstractions;

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_Windows.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_Windows.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net.Http.Functional.Tests;
 using System.Net.Sockets;
 using System.Net.Test.Common;
 
@@ -14,9 +15,9 @@ namespace System.Net.NetworkInformation.Tests
     {
         private readonly ITestOutputHelper _log;
 
-        public IPInterfacePropertiesTest_Windows()
+        public IPInterfacePropertiesTest_Windows(ITestOutputHelper output)
         {
-            _log = TestLogging.GetInstance();
+            _log = output;
         }
 
         [Fact]
@@ -109,7 +110,7 @@ namespace System.Net.NetworkInformation.Tests
                         _log.WriteLine("-- " + wins.ToString());
                     }
                 }
-            }).WaitAsync(TimeSpan.FromSeconds(30));
+            }).WaitAsync(TestHelper.PassingTestTimeout);
         }
 
         [Fact]
@@ -142,7 +143,7 @@ namespace System.Net.NetworkInformation.Tests
                     _log.WriteLine("Mtu: " + ipv4Properties.Mtu);
                     _log.WriteLine("UsesWins: " + ipv4Properties.UsesWins);
                 }
-            }).WaitAsync(TimeSpan.FromSeconds(30));
+            }).WaitAsync(TestHelper.PassingTestTimeout);
         }
 
         [Fact]
@@ -177,7 +178,7 @@ namespace System.Net.NetworkInformation.Tests
                     _log.WriteLine("Mtu: " + ipv6Properties.Mtu);
                     _log.WriteLine("ScopeID: " + ipv6Properties.GetScopeId(ScopeLevel.Link));
                 }
-            }).WaitAsync(TimeSpan.FromSeconds(30));
+            }).WaitAsync(TestHelper.PassingTestTimeout);
         }
 
         [Fact]
@@ -201,7 +202,7 @@ namespace System.Net.NetworkInformation.Tests
                     // This is not officially guaranteed by Windows, but it's what gets used.
                     Assert.Equal(ipv6Properties.Index, ipv6Properties.GetScopeId(ScopeLevel.Link));
                 }
-            }).WaitAsync(TimeSpan.FromSeconds(30));
+            }).WaitAsync(TestHelper.PassingTestTimeout);
         }
 
         [Fact]
@@ -233,7 +234,7 @@ namespace System.Net.NetworkInformation.Tests
                         _log.WriteLine("-- Level: " + level + "; " + ipv6Properties.GetScopeId(level));
                     }
                 }
-            }).WaitAsync(TimeSpan.FromSeconds(30));
+            }).WaitAsync(TestHelper.PassingTestTimeout);
         }
     }
 }

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/System.Net.NetworkInformation.Functional.Tests.csproj
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/System.Net.NetworkInformation.Functional.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StringResourcesPath>../../src/Resources/Strings.resx</StringResourcesPath>
@@ -41,6 +41,10 @@
     <Compile Include="ConnectionsParsingTests.cs" />
     <Compile Include="StatisticsParsingTests.cs" />
     <!-- Common test files -->
+    <Compile Include="$(CommonTestPath)System\Net\Http\TestHelper.cs"
+             Link="Common\System\Net\Http\TestHelper.cs" />
+    <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs"
+             Link="Common\System\Threading\Tasks\TaskTimeoutExtensions.cs" />
     <Compile Include="$(CommonTestPath)System\Net\TestLogging.cs"
              Link="Common\System\Net\TestLogging.cs" />
     <Compile Include="$(CommonTestPath)System\Net\VerboseTestLogging.cs"


### PR DESCRIPTION
Tests are doing sync, non-cancellable work, so I wrapped them in `Task.Run(() => ... ).WaitAsync(TimeSpan.FromSeconds(30))`.

May give us more info for #47288 and #48469.

**Should be reviewed [without whitespace changes](https://github.com/dotnet/runtime/pull/56319/files?diff=split&w=1).**