### PR TITLE
[libraries] System.Diagnostics.Process skip environment variable access calls for non OSX apple platforms

### DIFF
--- a/src/libraries/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/libraries/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <IsiOSLike Condition="'$(TargetsMacCatalyst)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true'">true</IsiOSLike>
-  </PropertyGroup>  
+  </PropertyGroup>
   <ItemGroup Condition="'$(TargetsAnyOS)' != 'true'">
     <Compile Include="Microsoft\Win32\SafeHandles\SafeProcessHandle.cs" />
     <Compile Include="System\Collections\Specialized\DictionaryWrapper.cs" />

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -30,10 +30,13 @@ namespace System.Diagnostics.Tests
             => PlatformDetection.IsWindowsAndElevated && PlatformDetection.IsNotWindowsNanoServer && RemoteExecutor.IsSupported;
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/51386", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void TestEnvironmentProperty()
         {
-            Assert.NotEqual(0, new Process().StartInfo.Environment.Count);
+            // Whole list of environment variables can no longer be accessed on non-OSX apple platforms
+            if (!PlatformDetection.IsiOS && !PlatformDetection.IstvOS && !PlatformDetection.IsMacCatalyst)
+            {
+                Assert.NotEqual(0, new Process().StartInfo.Environment.Count);
+            }
 
             ProcessStartInfo psi = new ProcessStartInfo();
 
@@ -41,7 +44,11 @@ namespace System.Diagnostics.Tests
             // with current environmental variables.
 
             IDictionary<string, string> environment = psi.Environment;
-            Assert.NotEqual(0, environment.Count);
+            // Whole list of environment variables can no longer be accessed on non-OSX apple platforms
+            if (!PlatformDetection.IsiOS && !PlatformDetection.IstvOS && !PlatformDetection.IsMacCatalyst)
+            {
+                Assert.NotEqual(0, environment.Count);
+            }
 
             int countItems = environment.Count;
 
@@ -772,7 +779,6 @@ namespace System.Diagnostics.Tests
 
         [PlatformSpecific(TestPlatforms.AnyUnix)]  // Test case is specific to Unix
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/51386", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void TestEnvironmentVariablesPropertyUnix()
         {
             ProcessStartInfo psi = new ProcessStartInfo();
@@ -782,7 +788,11 @@ namespace System.Diagnostics.Tests
 
             StringDictionary environmentVariables = psi.EnvironmentVariables;
 
-            Assert.NotEqual(0, environmentVariables.Count);
+            // Whole list of environment variables can no longer be accessed on non-OSX apple platforms
+            if (!PlatformDetection.IsiOS && !PlatformDetection.IstvOS && !PlatformDetection.IsMacCatalyst)
+            {
+                Assert.NotEqual(0, environmentVariables.Count);
+            }
 
             int CountItems = environmentVariables.Count;
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/51386

Because of https://github.com/dotnet/runtime/commit/51e93d0270414424c7117bfe6fb5e6a67a14e9b7, the entire list of environment variables can no longer be accessed on non-OSX apple platforms. `TestEnvironmentProperty` and `TestEnvironmentVariablesPropertyUnix` utilize checks to verify that environment variables are pre-populated, but as we cannot verify that on iOS,tvOS, or macCatalyst, skip those checks for those platforms.