### PR TITLE
Fix an error printed out when install_location file is missing

### DIFF
--- a/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
+++ b/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
@@ -233,7 +233,7 @@ namespace HostActivation.Tests
                         defaultInstallLocation)
                     .DotNetRoot(null)
                     .Execute()
-                    .Should().NotHaveStdErrContaining("install_location");
+                    .Should().NotHaveStdErrContaining("The install_location file");
             }
         }
 

--- a/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
+++ b/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
@@ -205,6 +205,38 @@ namespace HostActivation.Tests
             }
         }
 
+        [Fact]
+        [SkipOnPlatform(TestPlatforms.Windows, "This test targets the install_location config file which is only used on Linux and macOS.")]
+        public void InstallLocationFile_MissingFile()
+        {
+            var fixture = sharedTestState.PortableAppFixture.Copy();
+
+            var appExe = fixture.TestProject.AppExe;
+            string testArtifactsPath = SharedFramework.CalculateUniqueTestDirectory(Path.Combine(TestArtifact.TestArtifactsPath, "missingInstallLocation"));
+            using (new TestArtifact(testArtifactsPath))
+            using (var testOnlyProductBehavior = TestOnlyProductBehavior.Enable(appExe))
+            {
+                Directory.CreateDirectory(testArtifactsPath);
+
+                string directory = Path.Combine(testArtifactsPath, "installLocationOverride");
+                Directory.CreateDirectory(directory);
+                string nonExistentLocationFile = Path.Combine(directory, "install_location");
+                string defaultInstallLocation = Path.Combine(testArtifactsPath, "defaultInstallLocation");
+
+                Command.Create(appExe)
+                    .CaptureStdErr()
+                    .EnvironmentVariable(
+                        Constants.TestOnlyEnvironmentVariables.InstallLocationFilePath,
+                        nonExistentLocationFile)
+                    .EnvironmentVariable(
+                        Constants.TestOnlyEnvironmentVariables.DefaultInstallPath,
+                        defaultInstallLocation)
+                    .DotNetRoot(null)
+                    .Execute()
+                    .Should().NotHaveStdErrContaining("install_location");
+            }
+        }
+
         public class SharedTestState : IDisposable
         {
             public string BaseDirectory { get; }

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -440,7 +440,15 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
     FILE* install_location_file = pal::file_open(install_location_file_path, "r");
     if (install_location_file == nullptr)
     {
-        trace::error(_X("The install_location file ['%s'] failed to open: %s."), install_location_file_path.c_str(), pal::strerror(errno));
+        if (errno == ENOENT)
+        {
+            trace::verbose(_X("The install_location file ['%s'] does not exist - skipping."), install_location_file_path.c_str());
+        }
+        else
+        {
+            trace::error(_X("The install_location file ['%s'] failed to open: %s."), install_location_file_path.c_str(), pal::strerror(errno));
+        }
+
         return false;
     }
 


### PR DESCRIPTION
The app will still run, but we must not print out anything in that case.

Fixes https://github.com/dotnet/runtime/issues/56219