### PR TITLE
Update SR.cs license

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/SR.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/SR.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
 


### PR DESCRIPTION
The license headers were recently updated in aspnetcore to match the runtime. Syncing this change back.

Replaces https://github.com/dotnet/aspnetcore/pull/34638/
Fixes https://github.com/dotnet/aspnetcore/issues/18943