### PR TITLE
RefTypeZeroInit doesn't need treeNode

### DIFF
--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -1859,25 +1859,6 @@ void LinearScan::buildPhysRegRecords()
 }
 
 //------------------------------------------------------------------------
-// getNonEmptyBlock: Return the first non-empty block starting with 'block'
-//
-// Arguments:
-//    block - the BasicBlock from which we start looking
-//
-// Return Value:
-//    The first non-empty BasicBlock we find.
-//
-BasicBlock* getNonEmptyBlock(BasicBlock* block)
-{
-    while (block != nullptr && block->GetFirstLIRNode() == nullptr)
-    {
-        block = block->GetUniqueSucc();
-    }
-    assert(block != nullptr && block->GetFirstLIRNode() != nullptr);
-    return block;
-}
-
-//------------------------------------------------------------------------
 // insertZeroInitRefPositions: Handle lclVars that are live-in to the first block
 //
 // Notes:
@@ -1927,9 +1908,8 @@ void LinearScan::insertZeroInitRefPositions()
                 }
 
                 JITDUMP(" creating ZeroInit\n");
-                GenTree*     firstNode = getNonEmptyBlock(compiler->fgFirstBB)->firstNode();
-                RefPosition* pos =
-                    newRefPosition(interval, MinLocation, RefTypeZeroInit, firstNode, allRegs(interval->registerType));
+                RefPosition* pos = newRefPosition(interval, MinLocation, RefTypeZeroInit, nullptr /* theTreeNode */,
+                                                  allRegs(interval->registerType));
                 pos->setRegOptional(true);
             }
             else
@@ -1957,9 +1937,8 @@ void LinearScan::insertZeroInitRefPositions()
                     if (interval->recentRefPosition == nullptr)
                     {
                         JITDUMP(" creating ZeroInit\n");
-                        GenTree*     firstNode = getNonEmptyBlock(compiler->fgFirstBB)->firstNode();
-                        RefPosition* pos       = newRefPosition(interval, MinLocation, RefTypeZeroInit, firstNode,
-                                                          allRegs(interval->registerType));
+                        RefPosition* pos = newRefPosition(interval, MinLocation, RefTypeZeroInit,
+                                                          nullptr /* theTreeNode */, allRegs(interval->registerType));
                         pos->setRegOptional(true);
                         varDsc->lvMustInit = true;
                     }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_54100/Runtime_54100.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_54100/Runtime_54100.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+public class Runtime_54100
+{
+    // The test ends up containing an empty try block and we do not find a 
+    // non-empty block from which a treeNode can be extracted to use it for 
+    // creating zero-init refPositions.
+    
+    static ushort[][] s_23 = new ushort[][]{new ushort[]{0}};
+    static short s_32;
+    static short s_33;
+    static int s_45;
+    public static int Main()
+    {
+        ushort[] vr4 = s_23[0];
+        return (int)M45();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static ushort M45()
+    {
+        short var0;
+        try
+        {
+            var0 = s_32;
+        }
+        finally
+        {
+            var0 = s_33;
+            int var1 = s_45;
+            ulong vr8 = default(ulong);
+            var0 = (short)((sbyte)vr8 - var0);
+            try
+            {
+                M46();
+            }
+            finally
+            {
+                M46();
+            }
+
+            System.Console.WriteLine(var1);
+        }
+
+        return 100;
+    }
+
+    static ulong M46()
+    {
+        return default(ulong);
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_54100/Runtime_54100.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_54100/Runtime_54100.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <DebugType>None</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
When we create `RefTypeZeroInit`, we do not have the exact tree node to associate the `RefPosition` with. So we find the first non-empty block and use the first tree node of that block as the `treeNode` of those refpositions. However, this cannot (and almost never) will be corresponding to the varIndex for which we are creating refposition. The `treeNode` is often used to calculate weight of the refposition, and this might led to inaccurate calculation (which happens in the below diff). The solution is to stop tracking `treeNode` for `RefTypeZeroInit`.

In https://github.com/dotnet/runtime/issues/54100 where we try to find the first non-empty block, but in the repro code, there is no non-empty block.

## coreclr_tests.pmi.Linux.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 2935
Total bytes of diff: 2814
Total bytes of delta: -121 (-4.12% of base)
Total relative delta: -0.04
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
        -121 : 218441.dasm (-4.12% of base)

1 total files with Code Size differences (1 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
        -121 (-4.12% of base) : 218441.dasm - BenchmarkConsoleApplication.BenchmarkSystem:RunBenchmark(BenchmarkConsoleApplication.Benchmark):BenchmarkConsoleApplication.Results:this

Top method improvements (percentages):
        -121 (-4.12% of base) : 218441.dasm - BenchmarkConsoleApplication.BenchmarkSystem:RunBenchmark(BenchmarkConsoleApplication.Benchmark):BenchmarkConsoleApplication.Results:this

1 total methods with Code Size differences (1 improved, 0 regressed), 0 unchanged.
ONELINER|Code Size|E:\spmi\asm.coreclr_tests.pmi.Linux.x64.checked\base|2935|2814|-121|-4.12%|1|0|0

```

</details>

--------------------------------------------------------------------------------

## coreclr_tests.pmi.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3067
Total bytes of diff: 3017
Total bytes of delta: -50 (-1.63% of base)
Total relative delta: -0.02
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -50 : 219897.dasm (-1.63% of base)

1 total files with Code Size differences (1 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -50 (-1.63% of base) : 219897.dasm - BenchmarkConsoleApplication.BenchmarkSystem:RunBenchmark(BenchmarkConsoleApplication.Benchmark):BenchmarkConsoleApplication.Results:this

Top method improvements (percentages):
         -50 (-1.63% of base) : 219897.dasm - BenchmarkConsoleApplication.BenchmarkSystem:RunBenchmark(BenchmarkConsoleApplication.Benchmark):BenchmarkConsoleApplication.Results:this

1 total methods with Code Size differences (1 improved, 0 regressed), 0 unchanged.
ONELINER|Code Size|E:\spmi\asm.coreclr_tests.pmi.windows.x64.checked.2\base|3067|3017|-50|-1.63%|1|0|0

```

</details>

--------------------------------------------------------------------------------



Fixes: https://github.com/dotnet/runtime/issues/54100