### PR TITLE
Fix ReliabilityFramework code formatting

### DIFF
--- a/src/tests/GC/Stress/Framework/DetourHelpers.cs
+++ b/src/tests/GC/Stress/Framework/DetourHelpers.cs
@@ -40,7 +40,7 @@ public class DetourHelpers
     }
 
     [DllImport("RFDetours")]
-    private static extern void AddTestToNameMapping(int id, [MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPStr)]string name);
+    private static extern void AddTestToNameMapping(int id, [MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPStr)] string name);
 
     [DllImport("RFDetours")]
     private static extern void InstallDetours();

--- a/src/tests/GC/Stress/Framework/RFLogging.cs
+++ b/src/tests/GC/Stress/Framework/RFLogging.cs
@@ -55,7 +55,7 @@ internal class RFLogging
         while (true)
         {
             bool cachedCloseLogFile = _closeLogFile; // The CloseLog method will set closeLogFile to true indicating we should close the log file
-                                                    // This value is cached here so we can write all of the remaining messages to log before closing it
+                                                     // This value is cached here so we can write all of the remaining messages to log before closing it
             int messageQueueCount = _messageQueue.Count;
             int instrumentationQueueCount = _instrumentationMessageQueue.Count;
 
@@ -141,15 +141,15 @@ internal class RFLogging
         {
             try
             {
-                string logFilename = Path.Combine (logDirectory, "instrmentation.log");
+                string logFilename = Path.Combine(logDirectory, "instrmentation.log");
                 while (File.Exists(logFilename))
                 {
-                    logFilename = Path.Combine (logDirectory, "instrmentation.log-" + DateTime.Now.ToString().Replace('/', '-').Replace(':', '.'));
+                    logFilename = Path.Combine(logDirectory, "instrmentation.log-" + DateTime.Now.ToString().Replace('/', '-').Replace(':', '.'));
                 }
 
-                string logDirname = Path.GetDirectoryName (logFilename);
-                if (!Directory.Exists (logDirname))
-                    Directory.CreateDirectory (logDirname);
+                string logDirname = Path.GetDirectoryName(logFilename);
+                if (!Directory.Exists(logDirname))
+                    Directory.CreateDirectory(logDirname);
                 _instrumentationLogFile = File.Open(logFilename, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.ReadWrite);
             }
             catch
@@ -186,7 +186,7 @@ internal class RFLogging
             {
                 fRetry = false;
 
-                string safeName = Path.Combine (logDirectory, name.Replace('\\', ' ').Replace('*', ' ').Replace('?', ' ').Replace('>', ' ').Replace('<', ' ').Replace('|', ' ').Replace(':', ' ').Replace('/', ' ').Replace('"', ' '));
+                string safeName = Path.Combine(logDirectory, name.Replace('\\', ' ').Replace('*', ' ').Replace('?', ' ').Replace('>', ' ').Replace('<', ' ').Replace('|', ' ').Replace(':', ' ').Replace('/', ' ').Replace('"', ' '));
                 filename = safeName + ".log";
                 if (File.Exists(filename))
                 {
@@ -194,9 +194,9 @@ internal class RFLogging
                 }
                 try
                 {
-                    string dirname = Path.GetDirectoryName (filename);
-                    if (!Directory.Exists (dirname))
-                        Directory.CreateDirectory (dirname);
+                    string dirname = Path.GetDirectoryName(filename);
+                    if (!Directory.Exists(dirname))
+                        Directory.CreateDirectory(dirname);
                     _logFile = File.Open(filename, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.ReadWrite);
                 }
                 catch (IOException e)

--- a/src/tests/GC/Stress/Framework/ReliabilityConfiguration.cs
+++ b/src/tests/GC/Stress/Framework/ReliabilityConfiguration.cs
@@ -388,7 +388,7 @@ public class ReliabilityConfig : IEnumerable, IEnumerator
                                     _curTestSet.MaximumTime = 10;
                                 }
 
-                                    while (currentXML.MoveToNextAttribute())
+                                while (currentXML.MoveToNextAttribute())
                                 {
                                     XmlDebugOut(" " + currentXML.Name + "=\"" + currentXML.Value + "\"");
                                     switch (currentXML.Name)
@@ -456,7 +456,7 @@ public class ReliabilityConfig : IEnumerable, IEnumerator
                                                     cpuCount = Convert.ToInt32(Environment.GetEnvironmentVariable("NUMBER_OF_PROCESSORS"));
                                                 }
 
-                                               if (cpuCount <= 0)
+                                                if (cpuCount <= 0)
                                                     throw new Exception("Invalid Value when reading processor count: " + cpuCount);
                                                 _curTestSet.MinTestsRunning = cpuCount;
                                                 _curTestSet.MaxTestsRunning = (int)(cpuCount * 1.5);
@@ -962,7 +962,7 @@ public class ReliabilityConfig : IEnumerable, IEnumerator
                                 }
 
                                 int testCopies = 1;
-                                if (_curTestSet.AppDomainLoaderMode == AppDomainLoaderMode.FullIsolation || 
+                                if (_curTestSet.AppDomainLoaderMode == AppDomainLoaderMode.FullIsolation ||
                                     _curTestSet.AssemblyLoadContextLoaderMode == AssemblyLoadContextLoaderMode.FullIsolation)
                                 {
                                     // in this mode each copy of the test is ran in it's own app domain or AssemblyLoadContext,

--- a/src/tests/GC/Stress/Framework/ReliabilityFramework.cs
+++ b/src/tests/GC/Stress/Framework/ReliabilityFramework.cs
@@ -113,7 +113,7 @@ public class ReliabilityFramework
 #endif
 {
     // instance members
-    private int _testsRunningCount = 0,_testsRanCount = 0,_failCount = 0;
+    private int _testsRunningCount = 0, _testsRanCount = 0, _failCount = 0;
     private ReliabilityConfig _reliabilityConfig;
     private ReliabilityTestSet _curTestSet;
     private DateTime _startTime;
@@ -127,7 +127,7 @@ public class ReliabilityFramework
 #if !PROJECTK_BUILD
     AppDomain[] _testDomains = null;
 #endif
-    TestAssemblyLoadContext[]  _testALCs = null;
+    TestAssemblyLoadContext[] _testALCs = null;
     private DetourHelpers _detourHelpers;
     private Hashtable _foundTests;
     public int LoadingCount = 0;
@@ -160,7 +160,7 @@ public class ReliabilityFramework
     {
         string configFile = null;
         bool okToContinue = true, doReplay = false;
-        string sTests = "tests", sSeed = "seed",exectime ="maximumExecutionTime";
+        string sTests = "tests", sSeed = "seed", exectime = "maximumExecutionTime";
 
         ReliabilityFramework rf = new ReliabilityFramework();
         rf._logger.WriteToInstrumentationLog(null, LoggingLevels.StartupShutdown, "Started");
@@ -213,8 +213,8 @@ public class ReliabilityFramework
         // if no config file specified, check for [something]_gc.config in the current folder.
         if (configFile == null)
         {
-            var config = IsRunningAsUnitTest ? 
-                "*_gc_ci.config" : 
+            var config = IsRunningAsUnitTest ?
+                "*_gc_ci.config" :
                 "*_gc.config";
 
             configFile = Directory.GetFiles(Environment.CurrentDirectory, config).SingleOrDefault();
@@ -1856,11 +1856,11 @@ public class ReliabilityFramework
 
             if (test.Assembly.ToLower().IndexOf(".exe") == -1 && test.Assembly.ToLower().IndexOf(".dll") == -1)	// must be a simple name or fullname...
             {
-                loadMethod.Invoke(obj, new object[] { test.Assembly, paths});
+                loadMethod.Invoke(obj, new object[] { test.Assembly, paths });
             }
             else			// has an executable extension, must be in local directory.
             {
-                loadFromMethod.Invoke(obj, new object[] { Path.Combine(test.BasePath, test.Assembly), paths});
+                loadFromMethod.Invoke(obj, new object[] { Path.Combine(test.BasePath, test.Assembly), paths });
             }
 
             // check and see if this test is marked as requiring STA.  We only do

--- a/src/tests/GC/Stress/Framework/ReliabilityTest.cs
+++ b/src/tests/GC/Stress/Framework/ReliabilityTest.cs
@@ -98,7 +98,7 @@ public class ReliabilityTest
 {
     private bool _suppressConsoleOutput = false;
 
-    private string _assembly,_debugger,_debuggerOptions;
+    private string _assembly, _debugger, _debuggerOptions;
     private string _basePath;
 #if PROJECTK_BUILD
     private MethodInfo _entryPointMethod = null;
@@ -117,7 +117,7 @@ public class ReliabilityTest
     private int _concurrentCopies = 1;
     private int _runningCount = 0;
     private int _expectedDuration = -1;
-    private bool _requiresSDK = false,_hasFailed = false;
+    private bool _requiresSDK = false, _hasFailed = false;
     private Guid _guid = Guid.Empty;
     private TestStartModeEnum _testStartMode = TestStartModeEnum.AppDomainLoader;
     private DateTime _startTime = DateTime.Now;
@@ -272,7 +272,7 @@ public class ReliabilityTest
     public bool HasAssemblyLoadContext
     {
         [MethodImpl(MethodImplOptions.NoInlining)]
-        get { return _assemblyLoadContext != null;  }
+        get { return _assemblyLoadContext != null; }
     }
 
     public string AssemblyLoadContextName
@@ -436,7 +436,7 @@ public class ReliabilityTest
             // first, check the current directory
             string curDir = Directory.GetCurrentDirectory();
             string theAnswer;
-            if (File.Exists(theAnswer = Path.Combine (curDir, _debugger)))
+            if (File.Exists(theAnswer = Path.Combine(curDir, _debugger)))
             {
                 return (theAnswer);
             }
@@ -451,7 +451,7 @@ public class ReliabilityTest
             string[] splitPath = path.Split(new char[] { ';' });
             foreach (string curPath in splitPath)
             {
-                if (File.Exists(theAnswer = Path.Combine (curPath, _debugger)))
+                if (File.Exists(theAnswer = Path.Combine(curPath, _debugger)))
                 {
                     return (theAnswer);
                 }

--- a/src/tests/GC/Stress/Framework/ReliabilityTestSet.cs
+++ b/src/tests/GC/Stress/Framework/ReliabilityTestSet.cs
@@ -17,11 +17,11 @@ public class ReliabilityTestSet
     private int _percentPassIsPass = System.Environment.GetEnvironmentVariable("PERCENTPASSISPASS") == null ? -1 : Convert.ToInt32(System.Environment.GetEnvironmentVariable("PERCENTPASSISPASS"));
     private int[] _minPercentCPUStaggered_times = null;
     private int[] _minPercentCPUStaggered_usage = null;
-    private int _minimumCPUpercent = 0,_minimumMemoryPercent = 0,_minimumTestsRunning = 0,_maximumTestsRunning = -1;			// minimum CPU & memory requirements.
+    private int _minimumCPUpercent = 0, _minimumMemoryPercent = 0, _minimumTestsRunning = 0, _maximumTestsRunning = -1;			// minimum CPU & memory requirements.
     private ReliabilityTest[] _tests;
     private string[] _discoveryPaths = null;
     private string _friendlyName;
-    private bool _enablePerfCounters = true,_disableLogging = false,_installDetours = false;
+    private bool _enablePerfCounters = true, _disableLogging = false, _installDetours = false;
     private bool _suppressConsoleOutputFromTests = false;
     private bool _debugBreakOnTestHang = true;
     private bool _debugBreakOnBadTest = false;
@@ -29,8 +29,8 @@ public class ReliabilityTestSet
     private bool _debugBreakOnPathTooLong = false;
     private bool _debugBreakOnMissingTest = false;
     private TestStartModeEnum _testStartMode = TestStartModeEnum.AppDomainLoader;
-    private string _defaultDebugger,_defaultDebuggerOptions;
-    private int _ulGeneralUnloadPercent = 0,_ulAppDomainUnloadPercent = 0,_ulAssemblyLoadPercent = 0,_ulWaitTime = 0;
+    private string _defaultDebugger, _defaultDebuggerOptions;
+    private int _ulGeneralUnloadPercent = 0, _ulAppDomainUnloadPercent = 0, _ulAssemblyLoadPercent = 0, _ulWaitTime = 0;
     private bool _reportResults = false;
     private string _reportResultsTo = "http://clrqa/SmartAPI/result.asmx";
     private Guid _bvtCategory = Guid.Empty;


### PR DESCRIPTION
This is pure whitespace changes only - which will make subsequent PR easier to read without these distractions.