### PR TITLE
Fix thread pool hang

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -595,9 +595,7 @@ namespace System.Net.Quic.Implementations.MsQuic
             byte[] rentedBuffer = ArrayPool<byte>.Shared.Rent(buffer.Length);
             try
             {
-                Task<int> t = ReadAsync(new Memory<byte>(rentedBuffer, 0, buffer.Length)).AsTask();
-                ((IAsyncResult)t).AsyncWaitHandle.WaitOne();
-                int readLength = t.GetAwaiter().GetResult();
+                int readLength = ReadAsync(new Memory<byte>(rentedBuffer, 0, buffer.Length)).AsTask().GetAwaiter().GetResult();
                 rentedBuffer.AsSpan(0, readLength).CopyTo(buffer);
                 return readLength;
             }
@@ -612,9 +610,7 @@ namespace System.Net.Quic.Implementations.MsQuic
             ThrowIfDisposed();
 
             // TODO: optimize this.
-            Task t = WriteAsync(buffer.ToArray()).AsTask();
-            ((IAsyncResult)t).AsyncWaitHandle.WaitOne();
-            t.GetAwaiter().GetResult();
+            WriteAsync(buffer.ToArray()).AsTask().GetAwaiter().GetResult();
         }
 
         // MsQuic doesn't support explicit flushing

--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -946,6 +947,50 @@ namespace System.Threading.ThreadPools.Tests
                         null,
                         new object[] { name, value });
                 }
+            }).Dispose();
+        }
+
+        [ConditionalFact(nameof(IsThreadingAndRemoteExecutorSupported))]
+        public static void CooperativeBlockingWithProcessingThreadsAndGoalThreadsAndAddWorkerRaceTest()
+        {
+            // Avoid contaminating the main process' environment
+            RemoteExecutor.Invoke(() =>
+            {
+                // The test is run affinitized to at most 2 processors for more frequent repros. The actual test process below
+                // will inherit the affinity.
+                Process testParentProcess = Process.GetCurrentProcess();
+                testParentProcess.ProcessorAffinity = (nint)testParentProcess.ProcessorAffinity & 0x3;
+
+                RemoteExecutor.Invoke(() =>
+                {
+                    const uint TestDurationMs = 4000;
+
+                    var done = new ManualResetEvent(false);
+                    int startTimeMs = Environment.TickCount;
+                    Action<object> completingTask = data => ((TaskCompletionSource<int>)data).SetResult(0);
+                    Action repeatingTask = null;
+                    repeatingTask = () =>
+                    {
+                        if ((uint)(Environment.TickCount - startTimeMs) >= TestDurationMs)
+                        {
+                            done.Set();
+                            return;
+                        }
+
+                        Task.Run(repeatingTask);
+
+                        var tcs = new TaskCompletionSource<int>();
+                        Task.Factory.StartNew(completingTask, tcs);
+                        tcs.Task.Wait();
+                    };
+
+                    for (int i = 0; i < Environment.ProcessorCount; ++i)
+                    {
+                        Task.Run(repeatingTask);
+                    }
+
+                    done.CheckedWait();
+                }).Dispose();
             }).Dispose();
         }
 

--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -956,10 +956,17 @@ namespace System.Threading.ThreadPools.Tests
             // Avoid contaminating the main process' environment
             RemoteExecutor.Invoke(() =>
             {
-                // The test is run affinitized to at most 2 processors for more frequent repros. The actual test process below
-                // will inherit the affinity.
-                Process testParentProcess = Process.GetCurrentProcess();
-                testParentProcess.ProcessorAffinity = (nint)testParentProcess.ProcessorAffinity & 0x3;
+                try
+                {
+                    // The test is run affinitized to at most 2 processors for more frequent repros. The actual test process below
+                    // will inherit the affinity.
+                    Process testParentProcess = Process.GetCurrentProcess();
+                    testParentProcess.ProcessorAffinity = (nint)testParentProcess.ProcessorAffinity & 0x3;
+                }
+                catch (PlatformNotSupportedException)
+                {
+                    // Processor affinity is not supported on some platforms, try to run the test anyway
+                }
 
                 RemoteExecutor.Invoke(() =>
                 {


### PR DESCRIPTION
- In https://github.com/dotnet/runtime/pull/53471 the thread count goal was moved out of `ThreadCounts`, it turns out that there are a few subtle races that it was avoiding. There are other ways to fix it, but I've added the goal back into `ThreadCounts` for now.
- Reverted PR https://github.com/dotnet/runtime/pull/55985, which worked around the issue in the CI

Fixes https://github.com/dotnet/runtime/issues/55642