### PR TITLE
improve quic test stability for cancellation

### DIFF
--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
@@ -126,9 +126,6 @@ namespace System.Net.Quic.Tests
 
         internal async Task RunClientServer(Func<QuicConnection, Task> clientFunction, Func<QuicConnection, Task> serverFunction, int iterations = 1, int millisecondsTimeout = 30_000, QuicListenerOptions listenerOptions = null)
         {
-            const long ClientCloseErrorCode = 11111;
-            const long ServerCloseErrorCode = 22222;
-
             using QuicListener listener = CreateQuicListener(listenerOptions ?? CreateQuicListenerOptions());
 
             using var serverFinished = new SemaphoreSlim(0);
@@ -145,7 +142,6 @@ namespace System.Net.Quic.Tests
 
                         serverFinished.Release();
                         await clientFinished.WaitAsync();
-                        await serverConnection.CloseAsync(ServerCloseErrorCode);
                     }),
                     Task.Run(async () =>
                     {
@@ -155,7 +151,6 @@ namespace System.Net.Quic.Tests
 
                         clientFinished.Release();
                         await serverFinished.WaitAsync();
-                        await clientConnection.CloseAsync(ClientCloseErrorCode);
                     })
                 }.WhenAllOrAnyFailed(millisecondsTimeout);
             }


### PR DESCRIPTION
I think the `CloseAsync` was there for historical reasons to properly close.
This should no longer be needed as well as it creates problem for tests with cancellation or somewhat destructive behavir.
Depending on timing and situation this may fail with "Transport close" or "User aborted" message event if both test function succeeded. 
_if_ we want to keep something in place I think we should replace this with Abort/Reset. (but relying on Dispose looks good to me) 
I did few hundreds runs and I did not see any issue. 