### PR TITLE
Globally disable implicit namespaces

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -280,6 +280,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <!-- By default the SDK produces ref assembly for 5.0 or later -->
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <!-- We have very special projects that don't always contain default references. We also build MSBuild Tasks
+    and there are some implicit namespaces that clash, i.e System.Threading.Tasks. -->
+    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/coreclr/tools/Directory.Build.props
+++ b/src/coreclr/tools/Directory.Build.props
@@ -4,7 +4,6 @@
     <IsShipping>false</IsShipping>
     <SignAssembly>false</SignAssembly>
     <RunAnalyzers>false</RunAnalyzers>
-    <DisableImplicitNamespaceImports_DotNet>true</DisableImplicitNamespaceImports_DotNet>
   </PropertyGroup>
   
   <!-- MSBuild doesn't understand the Checked configuration -->

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -59,10 +59,6 @@
                                                   '$(DisableImplicitFrameworkReferences)' != 'true' and
                                                   '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
                                                   ('$(IsReferenceAssembly)' == 'true' or '$(IsSourceProject)' == 'true')">true</DisableImplicitAssemblyReferences>
-    
-    <!-- When we disable implicit assembly references disabling namespace imports is not handled by the SDK as this is our custom
-    way to disable assembly references for OOBs. -->
-    <DisableImplicitNamespaceImports Condition="'$(DisableImplicitAssemblyReferences)' == 'true'">true</DisableImplicitNamespaceImports>
   </PropertyGroup>
 
   <Import Project="$(RepositoryEngineeringDir)versioning.targets" />


### PR DESCRIPTION
We've hit more instances of this, now when building MSBuild tasks as the MSBuild Task type conflicts with `System.Threading.Tasks.Task` type which its namespace is implicitly defined.
