### PR TITLE
[release/6.0-preview7] Create manifest installers and VS manifests (#56308)

### DIFF
--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -8,8 +8,9 @@
     <MicrosoftDotNetBuildTasksInstallersTaskAssembly>$(NuGetPackageRoot)microsoft.dotnet.build.tasks.installers\$(MicrosoftDotNetBuildTasksInstallersVersion)\tools\$(MicrosoftDotNetBuildTasksInstallersTaskTargetFramework)\Microsoft.DotNet.Build.Tasks.Installers.dll</MicrosoftDotNetBuildTasksInstallersTaskAssembly>
   </PropertyGroup>
 
+  <UsingTask AssemblyFile="$(PkgMicrosoft_DotNet_Build_Tasks_Workloads)\tools\net472\Microsoft.DotNet.Build.Tasks.Workloads.dll" TaskName="GenerateManifestMsi" />
   <UsingTask AssemblyFile="$(PkgMicrosoft_DotNet_Build_Tasks_Workloads)\tools\net472\Microsoft.DotNet.Build.Tasks.Workloads.dll" TaskName="GenerateVisualStudioWorkload" />
-
+  <UsingTask TaskName="GenerateMsiVersion" AssemblyFile="$(MicrosoftDotNetBuildTasksInstallersTaskAssembly)" />
   <UsingTask TaskName="CreateLightCommandPackageDrop" AssemblyFile="$(MicrosoftDotNetBuildTasksInstallersTaskAssembly)" />
 
   <PropertyGroup>
@@ -90,6 +91,23 @@
       <ManifestPackages Include="$(PackageSource)Microsoft.NET.Workload.Mono.ToolChain.Manifest-*.nupkg" />
     </ItemGroup>
 
+    <GenerateMsiVersion
+        Major="$([System.Version]::Parse('$(SDKBundleVersion)').Major)"
+        Minor="$([System.Version]::Parse('$(SDKBundleVersion)').Minor)"
+        Patch="$([System.Version]::Parse('$(SDKBundleVersion)').Build)"
+        BuildNumber="$([System.Version]::Parse('$(SDKBundleVersion)').Revision)" >
+      <Output TaskParameter="MsiVersion" PropertyName="MsiVersion" />
+    </GenerateMsiVersion>
+
+    <GenerateManifestMsi
+        IntermediateBaseOutputPath="$(IntermediateOutputPath)"
+        OutputPath="$(OutputPath)"
+        MsiVersion="$(MsiVersion)"
+        WixToolsetPath="$(WixToolsetPath)"
+        WorkloadManifestPackage="%(ManifestPackages.Identity)" >
+      <Output TaskParameter="Msis" ItemName="ManifestMsis" />
+    </GenerateManifestMsi>
+
     <GenerateVisualStudioWorkload IntermediateBaseOutputPath="$(WorkloadIntermediateOutputPath)"
                                   WixToolsetPath="$(WixToolsetPath)"
                                   GenerateMsis="true"
@@ -103,9 +121,11 @@
     </GenerateVisualStudioWorkload>
 
     <!-- Build all the SWIX projects. This requires full framework MSBuild-->
+    <MSBuild Projects="%(ManifestMsis.SwixProject)" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=$(VersionedVisualStudioSetupInsertionPath)" />
     <MSBuild Projects="@(SwixProjects)" Properties="SwixBuildTargets=$(SwixBuildTargets);ManifestOutputPath=$(VersionedVisualStudioSetupInsertionPath)" />
 
     <!-- Gather .wixobj files for post-build signing. We'll have to batch since we generated multiple MSIs in the previous step. -->
+    <MSBuild Projects="$(MSBuildProjectFile)" Properties="_WixObjDir=%(ManifestMsis.WixObj);_Msi=%(ManifestMsis.Identity)" Targets="CreateWixPack" />
     <MSBuild Projects="$(MSBuildProjectFile)" Properties="_WixObjDir=%(Msis.WixObj);_Msi=%(Msis.Identity)" Targets="CreateWixPack" />
 
     <!-- Build the Visual Studio manifest project. -->
@@ -117,6 +137,7 @@
 
     <!-- Build all the MSI payload packages for NuGet. -->
     <ItemGroup>
+      <MsiPackageProjects Include="%(ManifestMsis.PackageProject)" />
       <MsiPackageProjects Include="%(Msis.PackageProject)" />
     </ItemGroup>
 


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/56308 to release/6.0-preview7

/cc @steveisok @directhex 

## Customer Impact
Needed for installing the runtime workload manifest into VS
## Testing
Official build validated on main
## Risk
Very low