### PR TITLE
fix CloseAsync_ByServer_AcceptThrows quic test

### DIFF
--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -549,21 +549,18 @@ namespace System.Net.Quic.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/49157")]
         public async Task CloseAsync_ByServer_AcceptThrows()
         {
-            await RunClientServer(
-                clientConnection =>
-                {
-                    return Task.CompletedTask;
-                },
-                async serverConnection =>
-                {
-                    var acceptTask = serverConnection.AcceptStreamAsync();
-                    await serverConnection.CloseAsync(errorCode: 0);
-                    // make sure
-                    await Assert.ThrowsAsync<QuicOperationAbortedException>(() => acceptTask.AsTask());
-                });
+            (QuicConnection clientConnection, QuicConnection serverConnection) = await CreateConnectedQuicConnection();
+
+            using (clientConnection)
+            using (serverConnection)
+            {
+                var acceptTask = serverConnection.AcceptStreamAsync();
+                await serverConnection.CloseAsync(errorCode: 0);
+                // make sure we throw
+                await Assert.ThrowsAsync<QuicOperationAbortedException>(() => acceptTask.AsTask());
+            }
         }
 
         internal static ReadOnlySequence<byte> CreateReadOnlySequenceFromBytes(byte[] data)


### PR DESCRIPTION
this was last disabled test from #49157 mega issue. 

The problem with the test is that `RunClientServer` runs client and server as two independent task without synchronization on connection establishment. 

So the Accept on server can finish and it would call `serverConnection.CloseAsync()`
Than depending on timing, the ConnectAsync() on client can blow up (even if the test does not have any client hook) 

```
     System.Net.Quic.QuicException : Connection has been shutdown by transport. Error Code: USER_CANCELED
      Stack Trace:
        /home/furt/github/wfurt-runtime/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs(256,0): at System.Net.Quic.Implementations.MsQuic.MsQuicConnection.HandleEventShutdownInitiatedByTransport(State state, ConnectionEvent& connectionEvent)
        /home/furt/github/wfurt-runtime/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs(675,0): at System.Net.Quic.Implementations.MsQuic.MsQuicConnection.NativeCallbackHandler(IntPtr connection, IntPtr context, ConnectionEvent& connectionEvent)
        --- End of stack trace from previous location ---
        /home/furt/github/wfurt-runtime/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs(149,0): at System.Net.Quic.Tests.QuicTestBase`1.<>c__DisplayClass29_0.<<RunClientServer>b__1>d.MoveNext()

```

To fix that I use new helper function that would first establish connection and then run the actual test. 


fixes #49157