### PR TITLE
Skip finalizer test if precise GC is not supported

### DIFF
--- a/src/libraries/System.ComponentModel.EventBasedAsync/tests/AsyncOperationFinalizerTests.cs
+++ b/src/libraries/System.ComponentModel.EventBasedAsync/tests/AsyncOperationFinalizerTests.cs
@@ -34,7 +34,9 @@ namespace System.ComponentModel.Tests
             Assert.True(tracker.OperationDidComplete);
         }
 
-        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        private static bool IsPreciseGcSupportedAndRemoteExecutorSupported => PlatformDetection.IsPreciseGcSupported && RemoteExecutor.IsSupported;
+
+        [ConditionalFact(nameof(IsPreciseGcSupportedAndRemoteExecutorSupported))]
         public void Finalizer_OperationNotCompleted_CompletesOperation()
         {
             RemoteExecutor.Invoke(() =>


### PR DESCRIPTION
* Finalizer_OperationNotCompleted_CompletesOperation assumes precise GC

This test assumes the `AsyncOperation` object created in `NotCompleted` is collected by the `GC.Collect()` call.  That is not guaranteed with the current Mono GC, which conservatively scans the whole stack.  If a pointer to that object is still visible anywhere on that stack (or in any register, as the stack also contains register context save areas at the time `GC.Collect()` executes), the object may erroneously still be considered live.

Whether or not the test actually fails depends on accidental details of the generated code; the test used to pass on s390x but after some unrelated codegen changes (enabling the linears optimization in Mono), it now fails.

Simply make the test depend on `IsPreciseGcSupported`, like many similar tests already are.
