### PR TITLE
don't set LastWriteTime when extracting zip files on Android, as it might not be supported and throw

### DIFF
--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
@@ -81,9 +81,12 @@ namespace System.IO.Compression
                 ExtractExternalAttributes(fs, source);
             }
 
-            if (!OperatingSystem.IsAndroid()) // https://github.com/dotnet/runtime/issues/35374, https://github.com/mono/mono/issues/17133
+            try
             {
                 File.SetLastWriteTime(destinationFileName, source.LastWriteTime.DateTime);
+            }
+            catch (UnauthorizedAccessException) when (OperatingSystem.IsAndroid()) // not every Android supports that (#35374)
+            {
             }
         }
 

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
@@ -81,7 +81,10 @@ namespace System.IO.Compression
                 ExtractExternalAttributes(fs, source);
             }
 
-            File.SetLastWriteTime(destinationFileName, source.LastWriteTime.DateTime);
+            if (!OperatingSystem.IsAndroid()) // https://github.com/dotnet/runtime/issues/35374, https://github.com/mono/mono/issues/17133
+            {
+                File.SetLastWriteTime(destinationFileName, source.LastWriteTime.DateTime);
+            }
         }
 
         static partial void ExtractExternalAttributes(FileStream fs, ZipArchiveEntry entry);

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
@@ -85,8 +85,9 @@ namespace System.IO.Compression
             {
                 File.SetLastWriteTime(destinationFileName, source.LastWriteTime.DateTime);
             }
-            catch (UnauthorizedAccessException) when (OperatingSystem.IsAndroid()) // not every Android supports that (#35374)
+            catch (UnauthorizedAccessException)
             {
+                // some OSes like Android (#35374) might not support setting the last write time, the extraction should not fail because of that
             }
         }
 


### PR DESCRIPTION
fixes #35374