### PR TITLE
Fix StreamWindowScaleThresholdMultiplier_HighValue_WindowScalesSlower

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http2FlowControl.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http2FlowControl.cs
@@ -148,7 +148,7 @@ namespace System.Net.Http.Functional.Tests
             }
 
             RemoteInvokeOptions options = new RemoteInvokeOptions();
-            options.StartInfo.EnvironmentVariables["DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_FLOWCONTROL_STREAMWINDOWSCALETHRESHOLDMULTIPLIER"] = "1000"; // Extreme value
+            options.StartInfo.EnvironmentVariables["DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_FLOWCONTROL_STREAMWINDOWSCALETHRESHOLDMULTIPLIER"] = "10000"; // Extreme value
 
             RemoteExecutor.Invoke(RunTest, options).Dispose();
         }


### PR DESCRIPTION
This will likely fix #56372. Although the test is inherently timing dependent, the failure rates are already very low IMO. The higher constant will hopefully make the failure rates much less likely to happen.

Closes #56372