### PR TITLE
Support 8-byte alignment for 12-byte structs on ARM32

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_42723/Runtime_42723.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_42723/Runtime_42723.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+class Runtime_42723
+{
+    static int Main()
+    {
+        return Test(new S { X = 17, Y = 83 });
+    }
+
+    // On ARM32 we were asserting for a 8-byte aligned 12-byte struct as a parameter
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Test(S s) => (int)(s.X + s.Y);
+
+    [StructLayout(LayoutKind.Sequential, Size = 12)]
+    struct S
+    {
+        public double X;
+        public float Y;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_42723/Runtime_42723.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_42723/Runtime_42723.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>False</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Through explicit attributes it is possible that 8-byte aligned structs
are 12 bytes in size, so handle this in arm32 when we figure out if we
need an extra spill to keep the alignment.

Fix #42723