### PR TITLE
[release/5.0] Disable DNS tests on SLES

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -27,6 +27,7 @@ namespace System
         public static bool IsUbuntu1710OrHigher => IsDistroAndVersionOrHigher("ubuntu", 17, 10);
         public static bool IsUbuntu1804 => IsDistroAndVersion("ubuntu", 18, 04);
         public static bool IsUbuntu1810OrHigher => IsDistroAndVersionOrHigher("ubuntu", 18, 10);
+        public static bool IsSLES => IsDistroAndVersion("sles");
         public static bool IsTizen => IsDistroAndVersion("tizen");
         public static bool IsFedora => IsDistroAndVersion("fedora");
 

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostByNameTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostByNameTest.cs
@@ -105,6 +105,11 @@ namespace System.Net.NameResolution.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/27622")]
         public void DnsObsoleteGetHostByName_EmptyString_ReturnsHostName()
         {
+            if (PlatformDetection.IsSLES) // [ActiveIssue("https://github.com/dotnet/runtime/issues/55271")]
+            {
+                throw new SkipTestException("Test environment is not configured for this test to work.");
+            }
+
             IPHostEntry entry = Dns.GetHostByName("");
 
             // DNS labels should be compared as case insensitive for ASCII characters. See RFC 4343.
@@ -115,6 +120,11 @@ namespace System.Net.NameResolution.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process), nameof(PlatformDetection.IsThreadingSupported))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/27622")]
         public void DnsObsoleteBeginEndGetHostByName_EmptyString_ReturnsHostName()
         {
+            if (PlatformDetection.IsSLES) // [ActiveIssue("https://github.com/dotnet/runtime/issues/55271")]
+            {
+                throw new SkipTestException("Test environment is not configured for this test to work.");
+            }
+
             IPHostEntry entry = Dns.EndGetHostByName(Dns.BeginGetHostByName("", null, null));
 
             // DNS labels should be compared as case insensitive for ASCII characters. See RFC 4343.

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
@@ -19,8 +19,15 @@ namespace System.Net.NameResolution.Tests
             await TestGetHostEntryAsync(() => Dns.GetHostEntryAsync(localIPAddress));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/1488", TestPlatforms.OSX)]
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/27622")]
+        public static bool GetHostEntryWorks =
+            // [ActiveIssue("https://github.com/dotnet/runtime/issues/27622")]
+            !PlatformDetection.IsArm64Process &&
+            // [ActiveIssue("https://github.com/dotnet/runtime/issues/1488", TestPlatforms.OSX)]
+            !PlatformDetection.IsOSX &&
+            // [ActiveIssue("https://github.com/dotnet/runtime/issues/55271")]
+            !PlatformDetection.IsSLES;
+
+        [ConditionalTheory(nameof(GetHostEntryWorks))]
         [InlineData("")]
         [InlineData(TestSettings.LocalHost)]
         public async Task Dns_GetHostEntry_HostString_Ok(string hostName)
@@ -68,8 +75,7 @@ namespace System.Net.NameResolution.Tests
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/1488", TestPlatforms.OSX)]
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/27622")]
+        [ConditionalTheory(nameof(GetHostEntryWorks))]
         [InlineData("")]
         [InlineData(TestSettings.LocalHost)]
         public async Task Dns_GetHostEntryAsync_HostString_Ok(string hostName) =>


### PR DESCRIPTION
Disabled tests tracked by #55271

Disabled tests in System.Net.NameResolution.Functional.Tests:
- GetHostByNameTest.DnsObsoleteBeginEndGetHostByName_EmptyString_ReturnsHostName
- GetHostByNameTest.DnsObsoleteGetHostByName_EmptyString_ReturnsHostName
- GetHostEntryTest.Dns_GetHostEntry_HostString_Ok(hostName: "")
- GetHostEntryTest.Dns_GetHostEntryAsync_HostString_Ok(hostName: "")

The tests started causing troubles in release/5.0 branch on PR #56329 ... they are disabled in main branch (6.0) since 7/10