### PR TITLE
Catch TcpClient ctor exceptions in FtpWebRequest.CreateConnectionAsync

### DIFF
--- a/src/libraries/System.Net.Requests/src/System/Net/FtpWebRequest.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/FtpWebRequest.cs
@@ -967,15 +967,11 @@ namespace System.Net
 
         private async void CreateConnectionAsync()
         {
-            string hostname = _uri.Host;
-            int port = _uri.Port;
-
-            TcpClient client = new TcpClient();
-
             object result;
             try
             {
-                await client.ConnectAsync(hostname, port).ConfigureAwait(false);
+                var client = new TcpClient();
+                await client.ConnectAsync(_uri.Host, _uri.Port).ConfigureAwait(false);
                 result = new FtpControlStream(client);
             }
             catch (Exception e)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/56376