### PR TITLE
[mono] Add GC unsafe transition to mono_unhandled_exception 

### DIFF
--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -4148,9 +4148,7 @@ mono_unhandled_exception_internal (MonoObject *exc_raw)
 void
 mono_unhandled_exception (MonoObject *exc)
 {
-	MONO_ENTER_GC_UNSAFE;
-	MONO_EXTERNAL_ONLY_VOID (mono_unhandled_exception_internal (exc));
-	MONO_EXIT_GC_UNSAFE;	
+	MONO_EXTERNAL_ONLY_GC_UNSAFE_VOID (mono_unhandled_exception_internal (exc));
 }
 
 static MonoObjectHandle

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -4148,7 +4148,9 @@ mono_unhandled_exception_internal (MonoObject *exc_raw)
 void
 mono_unhandled_exception (MonoObject *exc)
 {
+	MONO_ENTER_GC_UNSAFE;
 	MONO_EXTERNAL_ONLY_VOID (mono_unhandled_exception_internal (exc));
+	MONO_EXIT_GC_UNSAFE;	
 }
 
 static MonoObjectHandle


### PR DESCRIPTION
To fix it: https://github.com/dotnet/runtime/issues/44526