### PR TITLE
avoid ReadFile syscall if we know that there is nothing to read from file

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.cs
@@ -50,6 +50,12 @@ namespace System.IO.Strategies
                 // touch the file pointer location at all.  We will adjust it
                 // ourselves, but only in memory. This isn't threadsafe.
                 _filePosition += destination.Length;
+
+                // we know for sure that there is nothing to read, so we just return here and avoid a sys-call
+                if (destination.IsEmpty && LengthCachingSupported)
+                {
+                    return ValueTask.FromResult(0);
+                }
             }
 
             (SafeFileHandle.OverlappedValueTaskSource? vts, int errorCode) = RandomAccess.QueueAsyncReadFile(_fileHandle, destination, positionBefore, cancellationToken);

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/AsyncWindowsFileStreamStrategy.cs
@@ -51,7 +51,7 @@ namespace System.IO.Strategies
                 // ourselves, but only in memory. This isn't threadsafe.
                 _filePosition += destination.Length;
 
-                // we know for sure that there is nothing to read, so we just return here and avoid a sys-call
+                // We know for sure that there is nothing to read, so we just return here and avoid a sys-call.
                 if (destination.IsEmpty && LengthCachingSupported)
                 {
                     return ValueTask.FromResult(0);

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/OSFileStreamStrategy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/OSFileStreamStrategy.cs
@@ -115,7 +115,7 @@ namespace System.IO.Strategies
             }
         }
 
-        private bool LengthCachingSupported => OperatingSystem.IsWindows() && _share <= FileShare.Read && !_exposedHandle;
+        protected bool LengthCachingSupported => OperatingSystem.IsWindows() && _share <= FileShare.Read && !_exposedHandle;
 
         /// <summary>Gets or sets the position within the current stream</summary>
         public sealed override long Position


### PR DESCRIPTION
This can save us a single `ReadFile` sys-call for cases when we know that there is nothing to read from the file, which should happen once for every loop like this:

```cs
while (await fileStream.ReadAsync(userBuffer, cancellationToken) != 0)
```

The perf gain depends on the file size and the number of actual reads. For a small file where we read entire content with first call, we can save up to 10%.