### PR TITLE
Fix ByteArrayConverter null handling inconsistencies

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ByteArrayConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ByteArrayConverter.cs
@@ -5,14 +5,26 @@ namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class ByteArrayConverter : JsonConverter<byte[]>
     {
-        public override byte[] Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        public override byte[]? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
             return reader.GetBytesFromBase64();
         }
 
-        public override void Write(Utf8JsonWriter writer, byte[] value, JsonSerializerOptions options)
+        public override void Write(Utf8JsonWriter writer, byte[]? value, JsonSerializerOptions options)
         {
-            writer.WriteBase64StringValue(value);
+            if (value == null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                writer.WriteBase64StringValue(value);
+            }
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Array.ReadTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Array.ReadTests.cs
@@ -29,9 +29,22 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadNullByteArray()
         {
-            string json = @"null";
-            byte[] arr = JsonSerializer.Deserialize<byte[]>(json);
+            byte[] arr = JsonSerializer.Deserialize<byte[]>("null");
             Assert.Null(arr);
+
+            PocoWithByteArrayProperty poco = JsonSerializer.Deserialize<PocoWithByteArrayProperty>(@"{""Value"":null}");
+            Assert.Null(poco.Value);
+
+            byte[][] jaggedArr = JsonSerializer.Deserialize<byte[][]>(@"[null]");
+            Assert.Null(jaggedArr[0]);
+
+            Dictionary<string, byte[]> dict = JsonSerializer.Deserialize<Dictionary<string, byte[]>>(@"{""key"":null}");
+            Assert.Null(dict["key"]);
+        }
+
+        public class PocoWithByteArrayProperty
+        {
+            public byte[] Value { get; set; }
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Array.WriteTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Array.WriteTests.cs
@@ -40,12 +40,27 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(@"""""", json);
         }
 
-        [Fact]
-        public static void WriteByteArray()
+        [Theory]
+        [InlineData(null, "null")]
+        [InlineData(new byte[] { }, "\"\"")]
+        [InlineData(new byte[] { 1, 2 }, "\"AQI=\"")]
+        public static void WriteByteArray(byte[]? input, string expectedEncoding)
         {
-            var input = new byte[] { 1, 2 };
+            // root-level serialization
             string json = JsonSerializer.Serialize(input);
-            Assert.Equal($"\"{Convert.ToBase64String(input)}\"", json);
+            Assert.Equal(expectedEncoding, json);
+
+            // object property
+            json = JsonSerializer.Serialize(new { Property = input });
+            Assert.Equal(@$"{{""Property"":{expectedEncoding}}}", json);
+
+            // array element
+            json = JsonSerializer.Serialize(new[] { input });
+            Assert.Equal($"[{expectedEncoding}]", json);
+
+            // dictionary entry
+            json = JsonSerializer.Serialize(new Dictionary<string, byte[]> { ["key"] = input });
+            Assert.Equal(@$"{{""key"":{expectedEncoding}}}", json);
         }
 
         [Fact]


### PR DESCRIPTION
Updates the ByteArrayConverter so that null values are handled in a consistent manner in all serialization contexts. See https://github.com/dotnet/runtime/issues/49728#issuecomment-887468452 for an analysis of the bug and its root cause.

I considered a few approaches on how to fix this, but eventually I ended up adding null checks in the converter imlpementation itself. This directly mirrors the approach followed by [StringConverter](https://github.com/dotnet/runtime/blob/95f4fd00634985aa12b156cb746879dffb90465b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/StringConverter.cs#L16) which is a also an internal `ConverterStrategy.Value` converter that handles a reference type.

This changes the serialization of byte arrays that are elements of collections or dictionary types from `""` to `null`, making them consistent with how root-level byte arrays and property byte arrays are serialized.

Fixes #49728.