### PR TITLE
Remove invalid Castle.DynamicProxy.Internal.AbstractInvocation from ILLink descriptor files

### DIFF
--- a/eng/testing/ILLinkDescriptors/ILLink.Descriptors.Castle.xml
+++ b/eng/testing/ILLinkDescriptors/ILLink.Descriptors.Castle.xml
@@ -2,7 +2,6 @@
   <assembly fullname="Castle.Core">
     <namespace fullname="Castle.DynamicProxy" />
     <type fullname="Castle.DynamicProxy.Internal.CompositionInvocation" />
-    <type fullname="Castle.DynamicProxy.Internal.AbstractInvocation" />
     <type fullname="Castle.DynamicProxy.Internal.InheritanceInvocation" />
   </assembly>
   <assembly fullname="Moq">

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/ILLink.Descriptors.xml
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/ILLink.Descriptors.xml
@@ -8,7 +8,6 @@
   <assembly fullname="Castle.Core">
       <namespace fullname="Castle.DynamicProxy" />
       <type fullname="Castle.DynamicProxy.Internal.CompositionInvocation" />
-      <type fullname="Castle.DynamicProxy.Internal.AbstractInvocation" />
       <type fullname="Castle.DynamicProxy.Internal.InheritanceInvocation" />
   </assembly>
   <assembly fullname="Moq">


### PR DESCRIPTION
The type is actually in the `Castle.DynamicProxy` namespace, not the `.Internal` one.
This causes an error with newer linker versions.

The whole `Castle.DynamicProxy` namespace is already preserved so we can remove the entry for AbstractInvocation.