### PR TITLE
Properly rebuild optimization data when it changes

### DIFF
--- a/src/coreclr/crossgen-corelib.proj
+++ b/src/coreclr/crossgen-corelib.proj
@@ -66,6 +66,7 @@
       <DotNetPgoCmd>$(DotNetCli) $([MSBuild]::NormalizePath('$(BinDir)', 'dotnet-pgo', 'dotnet-pgo.dll')) merge</DotNetPgoCmd>
       <DotNetPgoCmd>$(DotNetPgoCmd) -o:$(MergedMibcPath)</DotNetPgoCmd>
       <DotNetPgoCmd>$(DotNetPgoCmd) @(OptimizationMibcFiles->'-i:%(Identity)', ' ')</DotNetPgoCmd>
+      <DotNetPgoCmd>$(DotNetPgoCmd) --inherit-timestamp</DotNetPgoCmd> <!-- For incremental builds, otherwise timestamp is too far in the future -->
     </PropertyGroup>
 
     <Message Condition="'$(DotNetBuildFromSource)' != 'true'" Importance="High" Text="$(DotNetPgoCmd)"/>

--- a/src/coreclr/tools/dotnet-pgo/CommandLineOptions.cs
+++ b/src/coreclr/tools/dotnet-pgo/CommandLineOptions.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
         public bool DumpMibc = false;
         public FileInfo InputFileToDump;
         public List<FileInfo> CompareMibc;
+        public bool InheritTimestamp;
 
         public string[] HelpArgs = Array.Empty<string>();
 
@@ -264,6 +265,8 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                         }
                     }
                 }
+
+                syntax.DefineOption(name: "inherit-timestamp", value: ref InheritTimestamp, help: "If specified, set the output's timestamp to the max timestamp of the input files");
 
                 VerbosityOption();
                 CompressedOption();

--- a/src/coreclr/tools/dotnet-pgo/Program.cs
+++ b/src/coreclr/tools/dotnet-pgo/Program.cs
@@ -381,11 +381,8 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                 int result = MibcEmitter.GenerateMibcFile(tsc, commandLineOptions.OutputFileName, mergedProfileData.Values, commandLineOptions.ValidateOutputFile, commandLineOptions.Uncompressed);
                 if (result == 0 && commandLineOptions.InheritTimestamp)
                 {
-                    static DateTime Latest(IEnumerable<DateTime> datetimes)
-                        => datetimes.Aggregate((cur, dt) => dt > cur ? dt : cur);
-
-                    commandLineOptions.OutputFileName.CreationTimeUtc = Latest(commandLineOptions.InputFilesToMerge.Select(fi => fi.CreationTimeUtc));
-                    commandLineOptions.OutputFileName.LastWriteTimeUtc = Latest(commandLineOptions.InputFilesToMerge.Select(fi => fi.LastWriteTimeUtc));
+                    commandLineOptions.OutputFileName.CreationTimeUtc = commandLineOptions.InputFilesToMerge.Max(fi => fi.CreationTimeUtc);
+                    commandLineOptions.OutputFileName.LastWriteTimeUtc = commandLineOptions.InputFilesToMerge.Max(fi => fi.LastWriteTimeUtc);
                 }
 
                 return result;


### PR DESCRIPTION
The timestamp of the merged .mibc file was set to when the tool was
invoked, while the inputs have a timestamp from when they were created
in the training scenarios. That means the target to create the merged
.mibc file would not run incrementally until many weeks later.

To fix add an --inherit-timestamp flag to dotnet-pgo that makes the
merged output inherit the max timestamp from the inputs. This is not
ideal as it means incrementally going backwards does not work, but it's
better than the previous behavior.

Fix #53637