### PR TITLE
[loader] Call managed resolving events for the default ALC

### DIFF
--- a/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.Mono.cs
@@ -126,24 +126,14 @@ namespace System.Runtime.Loader
         // success.
         private static Assembly? MonoResolveUsingResolvingEvent(IntPtr gchALC, string assemblyName)
         {
-            AssemblyLoadContext context;
-            // This check exists because the function can be called early in startup, before the default ALC is initialized
-            if (gchALC == IntPtr.Zero)
-                context = Default;
-            else
-                context = (AssemblyLoadContext)(GCHandle.FromIntPtr(gchALC).Target)!;
+            AssemblyLoadContext context = GetAssemblyLoadContext(gchALC);
             return context.ResolveUsingEvent(new AssemblyName(assemblyName));
         }
 
         // Invoked by Mono to resolve requests to load satellite assemblies.
         private static Assembly? MonoResolveUsingResolveSatelliteAssembly(IntPtr gchALC, string assemblyName)
         {
-            AssemblyLoadContext context;
-            // This check exists because the function can be called early in startup, before the default ALC is initialized
-            if (gchALC == IntPtr.Zero)
-                context = Default;
-            else
-                context = (AssemblyLoadContext)(GCHandle.FromIntPtr(gchALC).Target)!;
+            AssemblyLoadContext context = GetAssemblyLoadContext(gchALC);
             return context.ResolveSatelliteAssembly(new AssemblyName(assemblyName));
         }
 

--- a/src/mono/mono/metadata/assembly-load-context.c
+++ b/src/mono/mono/metadata/assembly-load-context.c
@@ -445,9 +445,6 @@ invoke_resolve_method (MonoMethod *resolve_method, MonoAssemblyLoadContext *alc,
 	if (mono_runtime_get_no_exec ())
 		return NULL;
 
-	if (!mono_gchandle_get_target_internal (alc->gchandle))
-		return NULL;
-
 	HANDLE_FUNCTION_ENTER ();
 
 	aname_str = mono_stringify_assembly_name (aname);
@@ -457,7 +454,14 @@ invoke_resolve_method (MonoMethod *resolve_method, MonoAssemblyLoadContext *alc,
 
 	MonoReflectionAssemblyHandle assm;
 	gpointer gchandle;
-	gchandle = (gpointer)alc->gchandle;
+	/* for the default ALC, pass NULL to ask for the Default ALC - see
+	 * AssemblyLoadContext.GetAssemblyLoadContext(IntPtr gchManagedAssemblyLoadContext) - which
+	 * will create the managed ALC object if it hasn't been created yet
+	 */
+	if (alc->gchandle == default_alc->gchandle)
+		gchandle = NULL;
+	else
+		gchandle = GUINT_TO_POINTER (alc->gchandle);
 	gpointer args [2];
 	args [0] = &gchandle;
 	args [1] = MONO_HANDLE_RAW (aname_obj);

--- a/src/mono/mono/metadata/assembly-load-context.c
+++ b/src/mono/mono/metadata/assembly-load-context.c
@@ -453,15 +453,7 @@ invoke_resolve_method (MonoMethod *resolve_method, MonoAssemblyLoadContext *alc,
 	goto_if_nok (error, leave);
 
 	MonoReflectionAssemblyHandle assm;
-	gpointer gchandle;
-	/* for the default ALC, pass NULL to ask for the Default ALC - see
-	 * AssemblyLoadContext.GetAssemblyLoadContext(IntPtr gchManagedAssemblyLoadContext) - which
-	 * will create the managed ALC object if it hasn't been created yet
-	 */
-	if (alc->gchandle == default_alc->gchandle)
-		gchandle = NULL;
-	else
-		gchandle = GUINT_TO_POINTER (alc->gchandle);
+	gpointer gchandle = mono_alc_get_gchandle_for_resolving (alc);
 	gpointer args [2];
 	args [0] = &gchandle;
 	args [1] = MONO_HANDLE_RAW (aname_obj);

--- a/src/mono/mono/metadata/loader-internals.h
+++ b/src/mono/mono/metadata/loader-internals.h
@@ -269,6 +269,19 @@ mono_alc_get_ambient (void)
 	return mono_alc_get_default ();
 }
 
+static inline MonoGCHandle
+mono_alc_get_gchandle_for_resolving (MonoAssemblyLoadContext *alc)
+{
+	/* for the default ALC, pass NULL to ask for the Default ALC - see
+	 * AssemblyLoadContext.GetAssemblyLoadContext(IntPtr gchManagedAssemblyLoadContext) - which
+	 * will create the managed ALC object if it hasn't been created yet
+	 */
+	if (alc->gchandle == mono_alc_get_default ()->gchandle)
+		return NULL;
+	else
+		return GUINT_TO_POINTER (alc->gchandle);
+}
+
 MonoAssemblyLoadContext *
 mono_alc_from_gchandle (MonoGCHandle alc_gchandle);
 

--- a/src/mono/mono/metadata/native-library.c
+++ b/src/mono/mono/metadata/native-library.c
@@ -698,9 +698,6 @@ netcore_resolve_with_resolving_event (MonoAssemblyLoadContext *alc, MonoAssembly
 	if (mono_runtime_get_no_exec ())
 		return NULL;
 
-	if (!mono_gchandle_get_target_internal (alc->gchandle))
-		return NULL;
-
 	HANDLE_FUNCTION_ENTER ();
 
 	MonoStringHandle scope_handle;

--- a/src/mono/mono/metadata/native-library.c
+++ b/src/mono/mono/metadata/native-library.c
@@ -628,9 +628,6 @@ netcore_resolve_with_load (MonoAssemblyLoadContext *alc, const char *scope, Mono
 	if (mono_runtime_get_no_exec ())
 		return NULL;
 
-	if (!mono_gchandle_get_target_internal (alc->gchandle))
-		return NULL;
-
 	HANDLE_FUNCTION_ENTER ();
 
 	MonoStringHandle scope_handle;
@@ -638,7 +635,14 @@ netcore_resolve_with_load (MonoAssemblyLoadContext *alc, const char *scope, Mono
 	goto_if_nok (error, leave);
 
 	gpointer gchandle;
-	gchandle = GUINT_TO_POINTER (alc->gchandle);
+	/* for the default ALC, pass NULL to ask for the Default ALC - see
+	 * AssemblyLoadContext.GetAssemblyLoadContext(IntPtr gchManagedAssemblyLoadContext) - which
+	 * will create the managed ALC object if it hasn't been created yet
+	 */
+	if (alc->gchandle == mono_alc_get_default ()->gchandle)
+		gchandle = NULL;
+	else
+		gchandle = GUINT_TO_POINTER (alc->gchandle);
 	gpointer args [3];
 	args [0] = MONO_HANDLE_RAW (scope_handle);
 	args [1] = &gchandle;
@@ -708,7 +712,14 @@ netcore_resolve_with_resolving_event (MonoAssemblyLoadContext *alc, MonoAssembly
 	goto_if_nok (error, leave);
 
 	gpointer gchandle;
-	gchandle = GUINT_TO_POINTER (alc->gchandle);
+	/* for the default ALC, pass NULL to ask for the Default ALC - see
+	 * AssemblyLoadContext.GetAssemblyLoadContext(IntPtr gchManagedAssemblyLoadContext) - which
+	 * will create the managed ALC object if it hasn't been created yet
+	 */
+	if (alc->gchandle == mono_alc_get_default ()->gchandle)
+		gchandle = NULL;
+	else
+		gchandle = GUINT_TO_POINTER (alc->gchandle);
 	gpointer args [4];
 	args [0] = MONO_HANDLE_RAW (scope_handle);
 	args [1] = MONO_HANDLE_RAW (assembly_handle);

--- a/src/mono/mono/metadata/native-library.c
+++ b/src/mono/mono/metadata/native-library.c
@@ -634,15 +634,7 @@ netcore_resolve_with_load (MonoAssemblyLoadContext *alc, const char *scope, Mono
 	scope_handle = mono_string_new_handle (scope, error);
 	goto_if_nok (error, leave);
 
-	gpointer gchandle;
-	/* for the default ALC, pass NULL to ask for the Default ALC - see
-	 * AssemblyLoadContext.GetAssemblyLoadContext(IntPtr gchManagedAssemblyLoadContext) - which
-	 * will create the managed ALC object if it hasn't been created yet
-	 */
-	if (alc->gchandle == mono_alc_get_default ()->gchandle)
-		gchandle = NULL;
-	else
-		gchandle = GUINT_TO_POINTER (alc->gchandle);
+	gpointer gchandle = mono_alc_get_gchandle_for_resolving (alc);
 	gpointer args [3];
 	args [0] = MONO_HANDLE_RAW (scope_handle);
 	args [1] = &gchandle;
@@ -708,15 +700,7 @@ netcore_resolve_with_resolving_event (MonoAssemblyLoadContext *alc, MonoAssembly
 	assembly_handle = mono_assembly_get_object_handle (assembly, error);
 	goto_if_nok (error, leave);
 
-	gpointer gchandle;
-	/* for the default ALC, pass NULL to ask for the Default ALC - see
-	 * AssemblyLoadContext.GetAssemblyLoadContext(IntPtr gchManagedAssemblyLoadContext) - which
-	 * will create the managed ALC object if it hasn't been created yet
-	 */
-	if (alc->gchandle == mono_alc_get_default ()->gchandle)
-		gchandle = NULL;
-	else
-		gchandle = GUINT_TO_POINTER (alc->gchandle);
+	gpointer gchandle = mono_alc_get_gchandle_for_resolving (alc);
 	gpointer args [4];
 	args [0] = MONO_HANDLE_RAW (scope_handle);
 	args [1] = MONO_HANDLE_RAW (assembly_handle);


### PR DESCRIPTION
Refine the work in https://github.com/dotnet/runtime/commit/f70b5b7aef21a70478e9b86dba7d996a57a9add9

The issue is that even if we know that the ALC gchandle points to null in native, we can't automatically skip the call to the managed resolving event (for native library, for example) because the native event is indirectly responsible for creating the default ALC managed object.

Instead, check in native if the gchandle is equal to the default ALC's gchandle (which is initially allocated with a null target) and if so pass `IntPtr.Zero` to the managed code, which will call `AssemblyLoadContext.GetAssemblyLoadContext (IntPtr gch)` which in turn will construct the managed object for the default ALC.

Fixes https://github.com/dotnet/runtime/issues/55921