### PR TITLE
Make LocalEndPointTest and some Connect tests non-parallel

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -372,7 +372,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55709", TestPlatforms.Linux)]
         public async Task Connect_DualMode_DnsConnect_RetrievedEndPoints_Success()
         {
             var localhostAddresses = Dns.GetHostAddresses("localhost");

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -343,7 +343,7 @@ namespace System.Net.Sockets.Tests
     }
 
     // The test class is declared non-parallel because of possible IPv4/IPv6 port-collision on Unix:
-    // When running these tests in parallel with other tests, there is some chance that the DaulMode client
+    // When running these tests in parallel with other tests, there is some chance that the DualMode client
     // will connect to an IPv4 server of a parallel test case.
     [Collection(nameof(NoParallelTests))]
     public abstract class Connect_NonParallel<T> : SocketTestHelperBase<T> where T : SocketHelperBase, new()

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -84,56 +84,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        public async Task Connect_DualMode_MultiAddressFamilyConnect_RetrievedEndPoints_Success()
-        {
-            if (!SupportsMultiConnect)
-                return;
-
-            int port;
-            using (SocketTestServer.SocketTestServerFactory(SocketImplementationType.Async, IPAddress.Loopback, out port))
-            using (Socket client = new Socket(SocketType.Stream, ProtocolType.Tcp))
-            {
-                Assert.True(client.DualMode);
-
-                await MultiConnectAsync(client, new IPAddress[] { IPAddress.IPv6Loopback, IPAddress.Loopback }, port);
-
-                CheckIsIpv6LoopbackEndPoint(client.LocalEndPoint);
-                CheckIsIpv6LoopbackEndPoint(client.RemoteEndPoint);
-            }
-        }
-
-        [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55709", TestPlatforms.Linux)]
-        public async Task Connect_DualMode_DnsConnect_RetrievedEndPoints_Success()
-        {
-            var localhostAddresses = Dns.GetHostAddresses("localhost");
-            if (Array.IndexOf(localhostAddresses, IPAddress.Loopback) == -1 ||
-                Array.IndexOf(localhostAddresses, IPAddress.IPv6Loopback) == -1)
-            {
-                return;
-            }
-
-            int port;
-            using (SocketTestServer.SocketTestServerFactory(SocketImplementationType.Async, IPAddress.Loopback, out port))
-            using (Socket client = new Socket(SocketType.Stream, ProtocolType.Tcp))
-            {
-                Assert.True(client.DualMode);
-
-                await ConnectAsync(client, new DnsEndPoint("localhost", port));
-
-                CheckIsIpv6LoopbackEndPoint(client.LocalEndPoint);
-                CheckIsIpv6LoopbackEndPoint(client.RemoteEndPoint);
-            }
-        }
-
-        private static void CheckIsIpv6LoopbackEndPoint(EndPoint endPoint)
-        {
-            IPEndPoint ep = endPoint as IPEndPoint;
-            Assert.NotNull(ep);
-            Assert.True(ep.Address.Equals(IPAddress.IPv6Loopback) || ep.Address.Equals(IPAddress.Loopback.MapToIPv6()));
-        }
-
-        [Fact]
         public async Task Connect_OnConnectedSocket_Fails()
         {
             int port;
@@ -390,5 +340,91 @@ namespace System.Net.Sockets.Tests
                 await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await t);
             }
         }
+    }
+
+    // The test class is declared non-parallel because of possible IPv4/IPv6 port-collision on Unix:
+    // When running these tests in parallel with other tests, there is some chance that the DaulMode client
+    // will connect to an IPv4 server of a parallel test case.
+    [Collection(nameof(NoParallelTests))]
+    public abstract class Connect_NonParallel<T> : SocketTestHelperBase<T> where T : SocketHelperBase, new()
+    {
+        protected Connect_NonParallel(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task Connect_DualMode_MultiAddressFamilyConnect_RetrievedEndPoints_Success()
+        {
+            if (!SupportsMultiConnect)
+                return;
+
+            int port;
+            using (SocketTestServer.SocketTestServerFactory(SocketImplementationType.Async, IPAddress.Loopback, out port))
+            using (Socket client = new Socket(SocketType.Stream, ProtocolType.Tcp))
+            {
+                Assert.True(client.DualMode);
+
+                await MultiConnectAsync(client, new IPAddress[] { IPAddress.IPv6Loopback, IPAddress.Loopback }, port);
+
+                CheckIsIpv6LoopbackEndPoint(client.LocalEndPoint);
+                CheckIsIpv6LoopbackEndPoint(client.RemoteEndPoint);
+            }
+        }
+
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55709", TestPlatforms.Linux)]
+        public async Task Connect_DualMode_DnsConnect_RetrievedEndPoints_Success()
+        {
+            var localhostAddresses = Dns.GetHostAddresses("localhost");
+            if (Array.IndexOf(localhostAddresses, IPAddress.Loopback) == -1 ||
+                Array.IndexOf(localhostAddresses, IPAddress.IPv6Loopback) == -1)
+            {
+                return;
+            }
+
+            int port;
+            using (SocketTestServer.SocketTestServerFactory(SocketImplementationType.Async, IPAddress.Loopback, out port))
+            using (Socket client = new Socket(SocketType.Stream, ProtocolType.Tcp))
+            {
+                Assert.True(client.DualMode);
+
+                await ConnectAsync(client, new DnsEndPoint("localhost", port));
+
+                CheckIsIpv6LoopbackEndPoint(client.LocalEndPoint);
+                CheckIsIpv6LoopbackEndPoint(client.RemoteEndPoint);
+            }
+        }
+
+        private static void CheckIsIpv6LoopbackEndPoint(EndPoint endPoint)
+        {
+            IPEndPoint ep = endPoint as IPEndPoint;
+            Assert.NotNull(ep);
+            Assert.True(ep.Address.Equals(IPAddress.IPv6Loopback) || ep.Address.Equals(IPAddress.Loopback.MapToIPv6()));
+        }
+    }
+
+    public sealed class ConnectSync_NonParallel : Connect_NonParallel<SocketHelperArraySync>
+    {
+        public ConnectSync_NonParallel(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class ConnectSyncForceNonBlocking_NonParallel : Connect_NonParallel<SocketHelperSyncForceNonBlocking>
+    {
+        public ConnectSyncForceNonBlocking_NonParallel(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class ConnectApm_NonParallel : Connect_NonParallel<SocketHelperApm>
+    {
+        public ConnectApm_NonParallel(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class ConnectTask_NonParallel : Connect_NonParallel<SocketHelperTask>
+    {
+        public ConnectTask_NonParallel(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class ConnectEap_NonParallel : Connect_NonParallel<SocketHelperEap>
+    {
+        public ConnectEap_NonParallel(ITestOutputHelper output) : base(output) { }
     }
 }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/LocalEndPointTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/LocalEndPointTest.cs
@@ -7,6 +7,11 @@ using Xunit.Abstractions;
 
 namespace System.Net.Sockets.Tests
 {
+    // The test class is declared non-parallel because of possible IPv4/IPv6 port-collision on Unix:
+    // When running in parallel with other tests, there is some chance that Accept() calls in LocalEndPointTest will
+    // accept a connection request from another, DualMode client living in a parallel test
+    // that is intended to connect to a server of opposite AddressFamily in the parallel test.
+    [Collection(nameof(NoParallelTests))]
     public abstract class LocalEndPointTest<T> : SocketTestHelperBase<T> where T : SocketHelperBase, new()
     {
         protected abstract bool IPv6 { get; }


### PR DESCRIPTION
There is some chance that sockets in these tests are connecting to, or being connected by sockets of other, unrelated parallel tests.

Fixes #52141. Hopefully fixes #55709 too, although I don't have a proof that the reported socket error can be the result of unrelated accepts. We can reopen the issues if we'll keep experiencing them in the CI.

Fixes #52141
Fixes #55709
Fixes #56042