### PR TITLE
[libraries][iOS][tvOS][MacCatalyst] Remove ActiveIssue from no longer…

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostBuilderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostBuilderTests.cs
@@ -310,7 +310,6 @@ namespace Microsoft.Extensions.Hosting.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/52114", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void RelativeContentRootIsResolved()
         {
             using (var host = new HostBuilder()

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/HostTests.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Extensions.Hosting.Tests
     public partial class HostTests
     {
         [Fact]
-        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.MacCatalyst | TestPlatforms.tvOS, "Not supported on iOS, MacCatalyst, or tvOS.")]
         public async Task StopAsyncWithCancellation()
         {
             var builder = new HostBuilder();

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
@@ -19,7 +19,6 @@ using Xunit;
 
 namespace Microsoft.Extensions.Hosting.Internal
 {
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/52114", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
     public class HostTests
     {
         [Fact]
@@ -678,7 +677,7 @@ namespace Microsoft.Extensions.Hosting.Internal
 
         [Fact]
         public async Task HostStopsApplicationWithOneBackgroundServiceErrorAndOthersWithoutError()
-        { 
+        {
             var wasOtherServiceStarted = false;
 
             TaskCompletionSource<bool> throwingTcs = new();

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/OptionsBuilderExtensionsTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/OptionsBuilderExtensionsTests.cs
@@ -26,7 +26,6 @@ namespace Microsoft.Extensions.Hosting.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/52114", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public async Task ValidateOnStart_ConfigureAndValidateThenCallValidateOnStart_ValidatesFailure()
         {
             var hostBuilder = CreateHostBuilder(services =>
@@ -50,7 +49,6 @@ namespace Microsoft.Extensions.Hosting.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/52114", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public async Task ValidateOnStart_CallFirstThenConfigureAndValidate_ValidatesFailure()
         {
             var hostBuilder = CreateHostBuilder(services =>
@@ -74,7 +72,6 @@ namespace Microsoft.Extensions.Hosting.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/52114", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public async Task ValidateOnStart_ErrorMessageSpecified_FailsWithCustomError()
         {
             var hostBuilder = CreateHostBuilder(services =>
@@ -105,7 +102,6 @@ namespace Microsoft.Extensions.Hosting.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/52114", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public async Task ValidateOnStart_NamedOptions_ValidatesFailureOnStart()
         {
             var hostBuilder = CreateHostBuilder(services =>
@@ -134,7 +130,6 @@ namespace Microsoft.Extensions.Hosting.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/52114", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         private async Task ValidateOnStart_AddNamedOptionsMultipleTimesForSameType_BothGetTriggered()
         {
             bool firstOptionsBuilderTriggered = false;
@@ -181,7 +176,6 @@ namespace Microsoft.Extensions.Hosting.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/52114", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         private async Task ValidateOnStart_AddEagerValidation_DoesValidationWhenHostStartsWithNoFailure()
         {
             bool validateCalled = false;
@@ -193,7 +187,7 @@ namespace Microsoft.Extensions.Hosting.Tests
                     .Configure(o => o.Boolean = true)
                     .Validate(o =>
                     {
-                        validateCalled = true; 
+                        validateCalled = true;
                         return o.Boolean;
                     }, "correct_configuration")
                     .ValidateOnStart();
@@ -209,7 +203,6 @@ namespace Microsoft.Extensions.Hosting.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/52114", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         private async Task ValidateOnStart_AddLazyValidation_SkipsValidationWhenHostStarts()
         {
             bool validateCalled = false;
@@ -227,7 +220,7 @@ namespace Microsoft.Extensions.Hosting.Tests
                     .Configure(o => o.Boolean = false)
                     .Validate(o =>
                     {
-                        validateCalled = true; 
+                        validateCalled = true;
                         return o.Boolean;
                     }, "bad_configuration");
             });
@@ -243,7 +236,6 @@ namespace Microsoft.Extensions.Hosting.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/52114", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public async Task ValidateOnStart_AddBothLazyAndEagerValidationOnDifferentTypes_ValidatesWhenHostStartsOnlyForEagerValidations()
         {
             bool validateCalledForNested = false;
@@ -254,7 +246,7 @@ namespace Microsoft.Extensions.Hosting.Tests
                 // Lazy validation for NestedOptions
                 services.AddOptions<NestedOptions>()
                     .Configure(o => o.Integer = 11)
-                    .Validate(o => 
+                    .Validate(o =>
                     {
                         validateCalledForNested = true;
                         return o.Integer > 12;
@@ -263,7 +255,7 @@ namespace Microsoft.Extensions.Hosting.Tests
                 // Eager validation for ComplexOptions
                 services.AddOptions<ComplexOptions>()
                     .Configure(o => o.Boolean = false)
-                    .Validate(o => 
+                    .Validate(o =>
                     {
                         validateCalledForComplexOptions = true;
                         return o.Boolean;
@@ -287,7 +279,6 @@ namespace Microsoft.Extensions.Hosting.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/52114", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public async Task ValidateOnStart_MultipleErrorsInOneValidationCall_ValidatesFailureWithMultipleErrors()
         {
             var hostBuilder = CreateHostBuilder(services =>
@@ -316,7 +307,6 @@ namespace Microsoft.Extensions.Hosting.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34582", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/52114", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public async Task ValidateOnStart_MultipleErrorsInOneValidationCallUsingCustomErrors_FailuresContainCustomErrors()
         {
             var hostBuilder = CreateHostBuilder(services =>


### PR DESCRIPTION
… failing Microsoft.Extensions.Hosting.Unit.Tests

Reran the test suite locally based on 513fa6ccf90 and none of the tests fail or PNSE any longer.

Only `Microsoft.Extensions.Hosting.Tests.OptionsBuilderExtensionsTests.ValidateOnStart_AddOptionsMultipleTimesForSameType_LastOneGetsTriggered` does not exist any more.

Fixes https://github.com/dotnet/runtime/issues/52114