### PR TITLE
Make open function calls in coreclr EINTR resilient on macOS

### DIFF
--- a/src/coreclr/pal/src/cruntime/filecrt.cpp
+++ b/src/coreclr/pal/src/cruntime/filecrt.cpp
@@ -229,11 +229,16 @@ CorUnix::InternalOpen(
         va_end(ap);
     }
 
+    do
+    {
 #if OPEN64_IS_USED_INSTEAD_OF_OPEN
         nRet = open64(szPath, nFlags, mode);
 #else
         nRet = open(szPath, nFlags, mode);
 #endif
+    }
+    while ((nRet == -1) && (errno == EINTR));
+
     return nRet;
 }
 


### PR DESCRIPTION
It was reported that on macOS, the open syscall can sometimes
return EINTR if it is interrupted by a signal even if the
signal has a handler installed with SA_RESTART.

There was just one call to open in the coreclr that
didn't have EINTR handled and that can be called on macOS, so
this change fixes it.

There are two places in the libraries in the included 3rd party
code - the brotli and the zlib - that don't have this treatment yet.
We may want to update them unless the policy we have for them is
to make changes upstream.

Close #48663