### PR TITLE
Fix dependency from EventLog to TraceSource ref

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/ref/Microsoft.Extensions.DependencyInjection.Abstractions.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/ref/Microsoft.Extensions.DependencyInjection.Abstractions.csproj
@@ -11,6 +11,6 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or
                         $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
-    <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Bcl.AsyncInterfaces\src\Microsoft.Bcl.AsyncInterfaces.csproj" />
+    <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Bcl.AsyncInterfaces\ref\Microsoft.Bcl.AsyncInterfaces.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Diagnostics.EventLog/ref/System.Diagnostics.EventLog.csproj
+++ b/src/libraries/System.Diagnostics.EventLog/ref/System.Diagnostics.EventLog.csproj
@@ -10,7 +10,7 @@
     <ProjectReference Include="$(LibrariesProjectRoot)System.Security.Permissions\ref\System.Security.Permissions.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Diagnostics.TraceSource\src\System.Diagnostics.TraceSource.csproj" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Diagnostics.TraceSource\ref\System.Diagnostics.TraceSource.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <Reference Include="System.ComponentModel.Primitives" />


### PR DESCRIPTION
This regressed with https://github.com/dotnet/runtime/commit/663c40dbc4ccedf82e38e96391c28695da0e418f. Reference projects should never reference source projects. This is one of the reasons why slngen creates different solution files now.