### PR TITLE
Add s390x RIDs to DotNetHost* packages

### DIFF
--- a/src/installer/pkg/projects/netcoreappRIDs.props
+++ b/src/installer/pkg/projects/netcoreappRIDs.props
@@ -46,5 +46,11 @@
     <UnofficialBuildRID Include="tizen.5.0.0-armel">
       <Platform>armel</Platform>
     </UnofficialBuildRID>
+    <UnofficialBuildRID Include="linux-s390x">
+      <Platform>s390x</Platform>
+    </UnofficialBuildRID>
+    <UnofficialBuildRID Include="linux-musl-s390x">
+      <Platform>s390x</Platform>
+    </UnofficialBuildRID>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* Add linux-s390x and linux-musl-s390x as UnofficialBuildRID
  Ensures RIDs are present in DotNetHost* dispatcher packages

While the runtime.linux-s390x.Microsoft.NETCore.DotNetHost* packages are not currently built as official packages, adding those RIDs to the UnofficialBuildRID list will at least cause those packages to be used if they're built and provided separately.  This matches precedent for some other "unofficial" RIDs like freebsd-x64.