### PR TITLE
[wasm] Fix Publish for Blazorwasm projects on VS17

### DIFF
--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -39,8 +39,6 @@
   <Target Name="WasmBuildNativeOnly" DependsOnTargets="$(WasmBuildNativeOnlyDependsOn)" Condition="'$(WasmBuildNative)' == 'true'" />
 
   <Target Name="_PrepareForWasmBuildNativeOnly">
-    <MakeDir Directories="$(_WasmIntermediateOutputPath)" />
-
     <ItemGroup>
       <_WasmAssembliesInternal Remove="@(_WasmAssembliesInternal)" />
       <_WasmAssembliesInternal Include="@(WasmAssembliesToBundle->Distinct())" />

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -82,8 +82,6 @@
     <!--<WasmStripAOTAssemblies Condition="'$(WasmStripAOTAssemblies)' == ''">$(RunAOTCompilation)</WasmStripAOTAssemblies>-->
     <WasmStripAOTAssemblies>false</WasmStripAOTAssemblies>
 
-    <!-- emcc, and mono-aot-cross don't like relative paths for output files -->
-    <_WasmIntermediateOutputPath>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), 'wasm'))</_WasmIntermediateOutputPath>
     <_BeforeWasmBuildAppDependsOn />
   </PropertyGroup>
 
@@ -97,6 +95,7 @@
   <Target Name="_InitializeCommonProperties">
     <Error Condition="'$(MicrosoftNetCoreAppRuntimePackDir)' == '' and ('%(ResolvedRuntimePack.PackageDirectory)' == '' or !Exists(%(ResolvedRuntimePack.PackageDirectory)))"
            Text="Could not find %25(ResolvedRuntimePack.PackageDirectory)=%(ResolvedRuntimePack.PackageDirectory)" />
+    <Error Condition="'$(IntermediateOutputPath)' == ''" Text="%24(IntermediateOutputPath) property needs to be set" />
 
     <PropertyGroup>
       <MicrosoftNetCoreAppRuntimePackDir Condition="'$(MicrosoftNetCoreAppRuntimePackDir)' == ''">%(ResolvedRuntimePack.PackageDirectory)</MicrosoftNetCoreAppRuntimePackDir>
@@ -106,11 +105,14 @@
 
       <_WasmRuntimePackIncludeDir>$([MSBuild]::NormalizeDirectory($(MicrosoftNetCoreAppRuntimePackRidNativeDir), 'include'))</_WasmRuntimePackIncludeDir>
       <_WasmRuntimePackSrcDir>$([MSBuild]::NormalizeDirectory($(MicrosoftNetCoreAppRuntimePackRidNativeDir), 'src'))</_WasmRuntimePackSrcDir>
+
+      <_WasmIntermediateOutputPath>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), 'wasm'))</_WasmIntermediateOutputPath>
     </PropertyGroup>
+
+    <MakeDir Directories="$(_WasmIntermediateOutputPath)" />
   </Target>
 
   <Target Name="_BeforeWasmBuildApp" DependsOnTargets="$(_BeforeWasmBuildAppDependsOn)">
-    <Error Condition="'$(IntermediateOutputPath)' == ''" Text="%24(IntermediateOutputPath) property needs to be set" />
     <Error Condition="!Exists('$(MicrosoftNetCoreAppRuntimePackRidDir)')" Text="MicrosoftNetCoreAppRuntimePackRidDir=$(MicrosoftNetCoreAppRuntimePackRidDir) doesn't exist" />
     <Error Condition="@(WasmAssembliesToBundle->Count()) == 0" Text="WasmAssembliesToBundle item is empty. No assemblies to process" />
 
@@ -122,7 +124,6 @@
       <WasmAppDir>$([MSBuild]::NormalizeDirectory($(WasmAppDir)))</WasmAppDir>
     </PropertyGroup>
 
-    <MakeDir Directories="$(_WasmIntermediateOutputPath)" />
     <ItemGroup>
       <_WasmAssembliesInternal Include="@(WasmAssembliesToBundle->Distinct())" />
 


### PR DESCRIPTION
TL;dr `publish` fails on any blazorwasm project with VS17

A recent commit[1] moved initializing `$(_WasmIntermediateOutputPath)` from
a target, to project level `PropertyGroup`. It is set as:

`<_WasmIntermediateOutputPath>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), 'wasm'))</_WasmIntermediateOutputPath>`

The `NormalizeDirectory` call converts this to a full path, presumably
using the current directory.

Because we are setting `$(_WasmIntermediateOutputPath)` at the project
level, it gets evaluated during the evaluation phase. And the current
directory doesn't seem to be set to the project directory at that point
in VS. So, `$(_WasmIntermediateOutputPath)` gets a wrong path like:

`C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\obj\Release\net6.0\wasm`.

And then when actually publishing, it fails to create this directory
with:

`Unable to create directory "C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\obj\Release\net6.0\wasm\". Access to the path 'C:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\obj\Release\net6.0\wasm\' is denied.`

Fix:
Set the property in `_InitializeCommonProperties` *target*, at which
point the current directory is correctly set.

Note:
- This doesn't seem to be reproducible outside VS
- It happens only on `publish`, because that's when the wasm targets
  come into play.

--
1.
```
commit d574b032793ae752387d32b97ff9840de17420a2
Author: Ankit Jain <radical@gmail.com>
Date:   Mon Jul 19 01:02:01 2021 -0400

    [wasm] Add support for using custom native libraries (#55797)
```