### PR TITLE
Match xplat event source conditions

### DIFF
--- a/src/coreclr/clr.featuredefines.props
+++ b/src/coreclr/clr.featuredefines.props
@@ -14,7 +14,7 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(TargetsUnix)' == 'true'">
-        <FeatureXplatEventSource Condition="'$(TargetOS)'!='OSX'">true</FeatureXplatEventSource>
+        <FeatureXplatEventSource Condition="'$(TargetOS)' == 'Linux'">true</FeatureXplatEventSource>
 
         <FeatureArrayStubAsIL>true</FeatureArrayStubAsIL>
         <FeatureMulticastStubAsIL>true</FeatureMulticastStubAsIL>

--- a/src/coreclr/vm/ecall.cpp
+++ b/src/coreclr/vm/ecall.cpp
@@ -659,6 +659,13 @@ LPVOID ECall::GetQCallImpl(MethodDesc * pMD)
     if (id == 0)
     {
         id = ECall::GetIDForMethod(pMD);
+
+#ifdef _DEBUG
+    CONSISTENCY_CHECK_MSGF(id != 0,
+        ("%s::%s is not registered in ecall.cpp",
+        pMD->m_pszDebugClassName, pMD->m_pszDebugMethodName));
+#endif
+
         _ASSERTE(id != 0);
 
         // Cache the id

--- a/src/coreclr/vm/ecall.cpp
+++ b/src/coreclr/vm/ecall.cpp
@@ -661,9 +661,9 @@ LPVOID ECall::GetQCallImpl(MethodDesc * pMD)
         id = ECall::GetIDForMethod(pMD);
 
 #ifdef _DEBUG
-    CONSISTENCY_CHECK_MSGF(id != 0,
-        ("%s::%s is not registered in ecall.cpp",
-        pMD->m_pszDebugClassName, pMD->m_pszDebugMethodName));
+        CONSISTENCY_CHECK_MSGF(id != 0,
+            ("%s::%s is not registered in ecall.cpp",
+            pMD->m_pszDebugClassName, pMD->m_pszDebugMethodName));
 #endif
 
         _ASSERTE(id != 0);


### PR DESCRIPTION
* Match the condition in props with: https://github.com/dotnet/runtime/blob/2a3141a5a202e8b86d52b53d346fce145f68d7d1/src/coreclr/clrdefinitions.cmake#L123-L125
* Add consistency check that prints the class and method names with debug configuration to spot easily what went wrong with `COMPlus_ConsistencyCheck=1` (rather than just the `id != 0` assertion failure).

Fixes #56079