### PR TITLE
Fix createdump segfault writing crash report json

### DIFF
--- a/src/coreclr/debug/createdump/crashinfo.cpp
+++ b/src/coreclr/debug/createdump/crashinfo.cpp
@@ -16,7 +16,8 @@ CrashInfo::CrashInfo(pid_t pid, bool gatherFrames, pid_t crashThread, uint32_t s
     m_gatherFrames(gatherFrames),
     m_crashThread(crashThread),
     m_signal(signal),
-    m_moduleInfos(&ModuleInfoCompare)
+    m_moduleInfos(&ModuleInfoCompare),
+    m_mainModule(nullptr)
 {
     g_crashInfo = this;
 #ifdef __APPLE__

--- a/src/coreclr/debug/createdump/crashreportwriter.cpp
+++ b/src/coreclr/debug/createdump/crashreportwriter.cpp
@@ -72,12 +72,12 @@ CrashReportWriter::WriteCrashReport()
     WriteValue("version", version.c_str());
     CloseObject();                  // configuration
 
-    // The main module was saved away in the crash info 
-    if (m_crashInfo.MainModule()->BaseAddress() != 0)
+    // The main module (if one) was saved away in the crash info
+    const ModuleInfo* mainModule = m_crashInfo.MainModule();
+    if (mainModule != nullptr && mainModule->BaseAddress() != 0)
     {
-        WriteValue("process_name", GetFileName(m_crashInfo.MainModule()->ModuleName()).c_str());
+        WriteValue("process_name", GetFileName(mainModule->ModuleName()).c_str());
     }
-
     const char* exceptionType = nullptr;
     OpenArray("threads");
     for (const ThreadInfo* thread : m_crashInfo.Threads())


### PR DESCRIPTION
The VS4Mac team (Kyle) found this case where createdump was seg faulting while it was writing the crash report json.