### PR TITLE
Assert if we find undefined use during interval validation

### DIFF
--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -2668,7 +2668,8 @@ void LinearScan::validateIntervals()
             }
             Interval* interval = getIntervalForLocalVar(i);
 
-            bool defined = false;
+            bool     defined      = false;
+            unsigned lastUseBBNum = 0;
             JITDUMP("-----------------\n");
             for (RefPosition* ref = interval->firstRefPosition; ref != nullptr; ref = ref->nextRefPosition)
             {
@@ -2677,13 +2678,14 @@ void LinearScan::validateIntervals()
                     ref->dump(this);
                 }
                 RefType refType = ref->refType;
-                if (!defined && RefTypeIsUse(refType))
+                if (!defined && RefTypeIsUse(refType) && (lastUseBBNum == ref->bbNum))
                 {
                     if (compiler->info.compMethodName != nullptr)
                     {
                         JITDUMP("%s: ", compiler->info.compMethodName);
                     }
                     JITDUMP("LocalVar V%02u: undefined use at %u\n", interval->varNum, ref->nodeLocation);
+                    assert(false);
                 }
 
                 // For single-def intervals, the only the first refposition should be a RefTypeDef
@@ -2696,7 +2698,8 @@ void LinearScan::validateIntervals()
                 // so we can't really check the lastUse flag
                 if (ref->lastUse)
                 {
-                    defined = false;
+                    defined      = false;
+                    lastUseBBNum = ref->bbNum;
                 }
                 if (RefTypeIsDef(refType))
                 {

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -2680,12 +2680,15 @@ void LinearScan::validateIntervals()
                 RefType refType = ref->refType;
                 if (!defined && RefTypeIsUse(refType) && (lastUseBBNum == ref->bbNum))
                 {
-                    if (compiler->info.compMethodName != nullptr)
+                    if (!ref->lastUse)
                     {
-                        JITDUMP("%s: ", compiler->info.compMethodName);
+                        if (compiler->info.compMethodName != nullptr)
+                        {
+                            JITDUMP("%s: ", compiler->info.compMethodName);
+                        }
+                        JITDUMP("LocalVar V%02u: undefined use at %u\n", interval->varNum, ref->nodeLocation);
+                        assert(false);
                     }
-                    JITDUMP("LocalVar V%02u: undefined use at %u\n", interval->varNum, ref->nodeLocation);
-                    assert(false);
                 }
 
                 // For single-def intervals, the only the first refposition should be a RefTypeDef


### PR DESCRIPTION
During `validateIntervals()`, we keep track of definition and lastuse of RefPositions. After we encounter `lastUse` RefPosition, we do not expect to see any other `RefPosition` with "use". If we see it, we were simply logging it under JitDump. The only scenario in which this can happen is the "use" RefPosition is 

Earlier, whenever we find a "use" refposition without definition, we were simply logging it under JitDump. It should only happen if the "use" refposition is in a [different block](https://github.com/dotnet/runtime/blob/598c2dae8843a523e2f73271b268aaab58360a2e/src/coreclr/jit/lsrabuild.cpp#L461-L464) then the previous "lastuse" refposition. I fixed it and enabled an assert when this doesn't happen.

Fixes: https://github.com/dotnet/runtime/issues/45238