### PR TITLE
Fix fr-CA culture time formatting and parsing

### DIFF
--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoTests.cs
@@ -210,5 +210,17 @@ namespace System.Globalization.Tests
                 Assert.Equal(i + 1, ci.DateTimeFormat.GetEra(eraNames[i]));
             }
         }
+
+        [Fact]
+        public void TestFrenchCanadaTimeFormat()
+        {
+            CultureInfo ci = CultureInfo.GetCultureInfo("fr-CA");
+            Assert.Equal(":", ci.DateTimeFormat.TimeSeparator);
+
+            DateTime time = new DateTime(2021, 10, 1, 5, 36, 50);
+            string formattedTime = time.ToString("HH 'h' mm 'min' ss 's'", ci);
+            DateTime dt = DateTime.Parse(formattedTime, ci);
+            Assert.Equal(time.TimeOfDay, dt.TimeOfDay);
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -1926,14 +1926,23 @@ namespace System.Globalization
             {
                 if (_sTimeSeparator == null && !GlobalizationMode.Invariant)
                 {
-                    string? longTimeFormat = ShouldUseUserOverrideNlsData ? NlsGetTimeFormatString() : IcuGetTimeFormatString();
-                    if (string.IsNullOrEmpty(longTimeFormat))
+                    // fr-CA culture uses time format as "HH 'h' mm 'min' ss 's'" which we cannot derive the time separator from such pattern.
+                    // We special case such culture and force ':' as time separator.
+                    if (_sName == "fr-CA")
                     {
-                        longTimeFormat = LongTimes[0];
+                        _sTimeSeparator = ":";
                     }
+                    else
+                    {
+                        string? longTimeFormat = ShouldUseUserOverrideNlsData ? NlsGetTimeFormatString() : IcuGetTimeFormatString();
+                        if (string.IsNullOrEmpty(longTimeFormat))
+                        {
+                            longTimeFormat = LongTimes[0];
+                        }
 
-                    // Compute STIME from time format
-                    _sTimeSeparator = GetTimeSeparator(longTimeFormat);
+                        // Compute STIME from time format
+                        _sTimeSeparator = GetTimeSeparator(longTimeFormat);
+                    }
                 }
                 return _sTimeSeparator!;
             }
@@ -1956,7 +1965,7 @@ namespace System.Globalization
                 // changing the default pattern is likely will happen in the near future which can easily break formatting
                 // and parsing.
                 // We are forcing here the date separator to '/' to ensure the parsing is not going to break when changing
-                // the default short date pattern. The application still can override this in the code by DateTimeFormatInfo.DateSeparartor.
+                // the default short date pattern. The application still can override this in the code by DateTimeFormatInfo.DateSeparator.
                 return "/";
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
@@ -282,7 +282,7 @@ namespace System.Globalization
         }
 
         /// <summary>
-        /// Return a specific culture. A tad irrelevent now since we always
+        /// Return a specific culture. A tad irrelevant now since we always
         /// return valid data for neutral locales.
         ///
         /// Note that there's interesting behavior that tries to find a

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
@@ -2054,6 +2054,16 @@ namespace System.Globalization
                     InsertHash(temp, TimeSeparator, TokenType.SEP_Time, 0);
                 }
 
+                if (_name == "fr-CA")
+                {
+                    InsertHash(temp, " h", TokenType.SEP_HourSuff, 0);
+                    InsertHash(temp, " h ", TokenType.SEP_HourSuff, 0);
+                    InsertHash(temp, " min", TokenType.SEP_MinuteSuff, 0);
+                    InsertHash(temp, " min ", TokenType.SEP_MinuteSuff, 0);
+                    InsertHash(temp, " s", TokenType.SEP_SecondSuff, 0);
+                    InsertHash(temp, " s ", TokenType.SEP_SecondSuff, 0);
+                }
+
                 InsertHash(temp, AMDesignator, TokenType.SEP_Am | TokenType.Am, 0);
                 InsertHash(temp, PMDesignator, TokenType.SEP_Pm | TokenType.Pm, 1);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/54021

`fr-CA` culture is using time format pattern like `HH 'h' mm 'min' ss 's'` which is causing 2 problems:
- First, we usually derive the time separator from the time pattern. That causing us to use ` h ` as time separator. So, when formatting any DateTime object using this culture we produce wrong formatted time e.g., `10 h 5 h 50 h`. note that ` h ` is used to separate the hour, minute, and second parts in the formatted string.
- Second, the formatted time cannot get parsed back when using `DateTime.Parse`. This is because we cannot recognize the parts like `min' and 's' in the formatted time.

The fix here is we are special casing this culture to explicitly setting the time separator to `:` which is other French cultures are using. Also, we added some support for this culture in the date/time parser to recognize such formats. 