### PR TITLE
Fix regression where NSE is thrown when serializing string dictionary keys with custom converter

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -594,7 +594,15 @@ namespace System.Text.Json.Serialization
         }
 
         internal virtual void WriteWithQuotes(Utf8JsonWriter writer, [DisallowNull] T value, JsonSerializerOptions options, ref WriteStack state)
-            => ThrowHelper.ThrowNotSupportedException_DictionaryKeyTypeNotSupported(TypeToConvert, this);
+        {
+            if (typeof(T) == typeof(string))
+            {
+                JsonMetadataServices.StringConverter.WriteWithQuotes(writer, (string)(object)value, options, ref state);
+                return;
+            }
+
+            ThrowHelper.ThrowNotSupportedException_DictionaryKeyTypeNotSupported(TypeToConvert, this);
+        }
 
         internal sealed override void WriteWithQuotesAsObject(Utf8JsonWriter writer, object value, JsonSerializerOptions options, ref WriteStack state)
             => WriteWithQuotes(writer, (T)value, options, ref state);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/53241. This roots the string converter for all usage of `JsonSerializer` even when `string` is not present in input object graphs.