### PR TITLE
Shorten the workload manifest name for MSI generation

### DIFF
--- a/src/workloads/workloads.csproj
+++ b/src/workloads/workloads.csproj
@@ -85,6 +85,9 @@
       <ShortNames Include="microsoft.netcore.app.runtime;Microsoft.NETCore.App.Runtime;microsoft.net.runtime;Microsoft.NET.Runtime">
         <Replacement>Microsoft</Replacement>
       </ShortNames>
+      <ShortNames Include="Microsoft.NET.Workload;microsoft.net.workload">
+        <Replacement>Microsoft</Replacement>
+      </ShortNames>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Bit by Windows MAX_PATH, so add the manifest name to the ShortNames Item. This makes the resulting msi acceptable to VS.