### PR TITLE
Move the logic to grow the mark list outside of #ifdef GC_CONFIG_DRIVEN.

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -43762,14 +43762,14 @@ void gc_heap::do_post_gc()
     record_interesting_info_per_heap();
 #endif //MULTIPLE_HEAPS
 
+    record_global_mechanisms();
+#endif //GC_CONFIG_DRIVEN
+
     if (mark_list_overflow)
     {
         grow_mark_list();
         mark_list_overflow = false;
     }
-
-    record_global_mechanisms();
-#endif //GC_CONFIG_DRIVEN
 }
 
 unsigned GCHeap::GetGcCount()


### PR DESCRIPTION
I put it there by mistake, and didn't notice because for coreclr.dll, GC_CONFIG_DRIVEN is enabled. For clrgc.dll it is not, and when I did perf experiments with regions, I noticed that sometimes we would take very long in plan_phase.