### PR TITLE
Fix EventSource tests

### DIFF
--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/Harness/Listeners.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/Harness/Listeners.cs
@@ -235,7 +235,7 @@ namespace BasicEventSourceTests
 
         private void mListenerEventWritten(object sender, EventWrittenEventArgs eventData)
         {
-            OnEvent(new EventListenerEvent(eventData));
+            OnEvent?.Invoke(new EventListenerEvent(eventData));
         }
 
         private class HelperEventListener : EventListener

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestUtilities.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestUtilities.cs
@@ -39,7 +39,12 @@ namespace BasicEventSourceTests
                     eventSource.Name != "System.Runtime.InteropServices.InteropEventProvider" &&
                     eventSource.Name != "System.Reflection.Runtime.Tracing" &&
                     eventSource.Name != "Microsoft-Windows-DotNETRuntime" &&
-                    eventSource.Name != "System.Runtime"
+                    eventSource.Name != "System.Runtime" &&
+
+                    // These event sources show up when hosted in the VS test runner
+                    eventSource.Name != "System.Net.Sockets" &&
+                    eventSource.Name != "Private.InternalDiagnostics.System.Net.Sockets" &&
+                    eventSource.Name != "TestPlatform"
                     )
                 {
                     eventSourceNames += eventSource.Name + " ";


### PR DESCRIPTION
While running EventSource tests in Visual Studio I saw two issues:
1. Not all the tests were setting an OnEvent event giving spurious
NullReferenceExceptions trying to invoke the unneeded null event.
2. VS test runner has more EventSources active that need to be added
to the test's allow list.