### PR TITLE
Re-enable System.IO.FileSystem.DriveInfoTests.DriveInfoUnixTests.PropertiesOfValidDrive on Android

### DIFF
--- a/src/libraries/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Unix.Tests.cs
+++ b/src/libraries/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Unix.Tests.cs
@@ -60,29 +60,30 @@ namespace System.IO.FileSystem.DriveInfoTests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Android)]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
         public void PropertiesOfValidDrive()
         {
-            var root = new DriveInfo("/");
-            var format = root.DriveFormat;
-            Assert.Equal(PlatformDetection.IsBrowser ? DriveType.Unknown : DriveType.Fixed, root.DriveType);
-            Assert.True(root.IsReady);
-            Assert.Equal("/", root.Name);
-            Assert.Equal("/", root.ToString());
-            Assert.Equal("/", root.RootDirectory.FullName);
-            Assert.Equal("/", root.VolumeLabel);
+            var driveName = PlatformDetection.IsAndroid ? "/data" : "/";
+            var driveInfo = new DriveInfo(driveName);
+            var format = driveInfo.DriveFormat;
+            Assert.Equal(PlatformDetection.IsBrowser ? DriveType.Unknown : DriveType.Fixed, driveInfo.DriveType);
+            Assert.True(driveInfo.IsReady);
+            Assert.Equal(driveName, driveInfo.Name);
+            Assert.Equal(driveName, driveInfo.ToString());
+            Assert.Equal(driveName, driveInfo.RootDirectory.FullName);
+            Assert.Equal(driveName, driveInfo.VolumeLabel);
 
             if (PlatformDetection.IsBrowser)
             {
-                Assert.True(root.AvailableFreeSpace == 0);
-                Assert.True(root.TotalFreeSpace == 0);
-                Assert.True(root.TotalSize == 0);
+                Assert.True(driveInfo.AvailableFreeSpace == 0);
+                Assert.True(driveInfo.TotalFreeSpace == 0);
+                Assert.True(driveInfo.TotalSize == 0);
             }
             else
             {
-                Assert.True(root.AvailableFreeSpace > 0);
-                Assert.True(root.TotalFreeSpace > 0);
-                Assert.True(root.TotalSize > 0);
+                Assert.True(driveInfo.AvailableFreeSpace > 0);
+                Assert.True(driveInfo.TotalFreeSpace > 0);
+                Assert.True(driveInfo.TotalSize > 0);
             }
         }
 


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/42548.

Based on Alexander's suggestion https://github.com/dotnet/runtime/pull/42209#discussion_r509430096