### PR TITLE
EventSource Manifest Trimmer test

### DIFF
--- a/src/libraries/System.Diagnostics.Tracing/tests/TrimmingTests/EventSourceManifestTest.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/TrimmingTests/EventSourceManifestTest.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using System;
+
+/// <summary>
+/// Tests that using an EventSource to get the manifest works without method references in a trimmed application.
+/// EventSource has DynamicallyAccessedMembersAttribute applied at class level which means derived types keeps members
+/// </summary>
+internal class Program
+{
+    internal class EventSourceTest2 : EventSource
+    {
+        public void EventSourceTest2_Method_0() => WriteEvent(1); 
+
+        public void EventSourceTest2_Method_1(int value) => WriteEvent(2, value); 
+        void EventSourceTest2_Method_2(string name) => WriteEvent(3, name); 
+
+        [NonEvent]
+        public void EventSourceTest2_Method_3(int num1, int num2) => WriteEvent(4, num1, num2); 
+        [NonEvent]
+        void EventSourceTest2_Method_4(){}
+
+        [Event(500)]
+        public void EventSourceTest2_Method_5(byte[] bytes) => WriteEvent(500, bytes); 
+        [Event(1500)]
+        protected virtual void EventSourceTest2_Method_6(long value) => WriteEvent(1500, value); 
+
+        [Event(2500)]
+        int EventSourceTest2_Method_7() => 5; 
+    }
+
+    public static int Main()
+    {
+        string manifest = EventSource.GenerateManifest(typeof(EventSourceTest2), null);
+        // we are going to avoid as much as possible program constructs that could give the trimmer reasons to keep members
+        int testReturnValue = 100;
+        const string baseMethodName = "EventSourceTest2_Method_";
+        int[] exclusions = { 3, 4, 8 };
+        for (int i = 0; i <= 8; i++)
+        {
+            string methodName = $"{baseMethodName}{i}";
+            // We expect the methodName to be in the manifest unless the prefix, i, is in exclusions ([NonEvent] or non-existing methods)
+            if (manifest.Contains(methodName) ? exclusions.Contains(i) : !exclusions.Contains(i))
+                testReturnValue = -1;
+        }
+
+        return testReturnValue;
+    }
+}

--- a/src/libraries/System.Diagnostics.Tracing/tests/TrimmingTests/EventSourceManifestTest.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/TrimmingTests/EventSourceManifestTest.cs
@@ -13,42 +13,45 @@ using System;
 /// </summary>
 internal class Program
 {
-    internal class EventSourceTest2 : EventSource
+    internal class EventSourceTest : EventSource
     {
-        public void EventSourceTest2_Method_0() => WriteEvent(1); 
+        public void EventSourceTest_Method_0() => WriteEvent(1); 
 
-        public void EventSourceTest2_Method_1(int value) => WriteEvent(2, value); 
-        void EventSourceTest2_Method_2(string name) => WriteEvent(3, name); 
+        public void EventSourceTest_Method_1(int value) => WriteEvent(2, value); 
+        void EventSourceTest_Method_2(string name) => WriteEvent(3, name); 
 
         [NonEvent]
-        public void EventSourceTest2_Method_3(int num1, int num2) => WriteEvent(4, num1, num2); 
+        public void EventSourceTest_Method_3(int num1, int num2) => WriteEvent(4, num1, num2); 
         [NonEvent]
-        void EventSourceTest2_Method_4(){}
+        void EventSourceTest_Method_4(){}
 
         [Event(500)]
-        public void EventSourceTest2_Method_5(byte[] bytes) => WriteEvent(500, bytes); 
+        public void EventSourceTest_Method_5(byte[] bytes) => WriteEvent(500, bytes); 
         [Event(1500)]
-        protected virtual void EventSourceTest2_Method_6(long value) => WriteEvent(1500, value); 
+        protected virtual void EventSourceTest_Method_6(long value) => WriteEvent(1500, value); 
 
         [Event(2500)]
-        int EventSourceTest2_Method_7() => 5; 
+        int EventSourceTest_Method_7() => 5; 
     }
 
     public static int Main()
     {
-        string manifest = EventSource.GenerateManifest(typeof(EventSourceTest2), null);
+        string manifest = EventSource.GenerateManifest(typeof(EventSourceTest), null);
         // we are going to avoid as much as possible program constructs that could give the trimmer reasons to keep members
-        int testReturnValue = 100;
-        const string baseMethodName = "EventSourceTest2_Method_";
+        const string baseMethodName = "EventSourceTest_Method_";
         int[] exclusions = { 3, 4, 8 };
         for (int i = 0; i <= 8; i++)
         {
             string methodName = $"{baseMethodName}{i}";
             // We expect the methodName to be in the manifest unless the prefix, i, is in exclusions ([NonEvent] or non-existing methods)
-            if (manifest.Contains(methodName) ? exclusions.Contains(i) : !exclusions.Contains(i))
-                testReturnValue = -1;
+            bool methodExists = manifest.Contains(methodName);
+            bool shouldMethodExist = !exclusions.Contains(i);
+            if (methodExists != shouldMethodExist)
+            {
+                return -1;
+            }
         }
 
-        return testReturnValue;
+        return 100;
     }
 }

--- a/src/libraries/System.Diagnostics.Tracing/tests/TrimmingTests/System.Diagnostics.Tracing.TrimmingTests.proj
+++ b/src/libraries/System.Diagnostics.Tracing/tests/TrimmingTests/System.Diagnostics.Tracing.TrimmingTests.proj
@@ -1,5 +1,10 @@
 <Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
 
+  <ItemGroup>
+    <TestConsoleAppSourceFiles Include="EventSourcePropertyValueTest.cs" />
+    <TestConsoleAppSourceFiles Include="EventSourceManifestTest.cs" />
+  </ItemGroup>
+
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>


### PR DESCRIPTION
Adding a tests that get the manifest and checks that event methods are not trimmed. `EventSource `has `DynamicallyAccessedMembersAttribute `applied at class level which means derived types keeps members
