### PR TITLE
Fix lock during SslStream renegotiation request

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -272,7 +272,6 @@ namespace System.Net.Security
             {
                 if (_decryptedBytesCount is not 0)
                 {
-                    _nestedAuth = 0;
                     throw new InvalidOperationException(SR.net_ssl_renegotiate_buffer);
                 }
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -272,6 +272,7 @@ namespace System.Net.Security
             {
                 if (_decryptedBytesCount is not 0)
                 {
+                    _nestedAuth = 0;
                     throw new InvalidOperationException(SR.net_ssl_renegotiate_buffer);
                 }
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -268,16 +268,17 @@ namespace System.Net.Security
                 throw new NotSupportedException(SR.Format(SR.net_io_invalidnestedcall, nameof(WriteAsync), "write"));
             }
 
-            if (_decryptedBytesCount is not 0)
-            {
-                throw new InvalidOperationException(SR.net_ssl_renegotiate_buffer);
-            }
-
-            _sslAuthenticationOptions!.RemoteCertRequired = true;
-            _isRenego = true;
-
             try
             {
+                if (_decryptedBytesCount is not 0)
+                {
+                    throw new InvalidOperationException(SR.net_ssl_renegotiate_buffer);
+                }
+
+                _sslAuthenticationOptions!.RemoteCertRequired = true;
+                _isRenego = true;
+
+
                 SecurityStatusPal status = _context!.Renegotiate(out byte[]? nextmsg);
 
                 if (nextmsg is {} && nextmsg.Length > 0)
@@ -323,7 +324,7 @@ namespace System.Net.Security
                 _nestedRead = 0;
                 _nestedWrite = 0;
                 _isRenego = false;
-                // We will not release _nestedAuth at this point to prevent another renegotiation attempt.
+                _nestedAuth = 0;
             }
         }
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -324,7 +324,7 @@ namespace System.Net.Security
                 _nestedRead = 0;
                 _nestedWrite = 0;
                 _isRenego = false;
-                _nestedAuth = 0;
+                // We will not release _nestedAuth at this point to prevent another renegotiation attempt.
             }
         }
 

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -403,17 +403,6 @@ namespace System.Net.Security.Tests
                 // Verify that the session is usable even renego request failed.
                 await TestHelper.PingPong(client, server, cts.Token);
                 await TestHelper.PingPong(server, client, cts.Token);
-
-                // Should be possible call renegotiation again.
-                // Client needs to be reading for renegotiation to happen.
-                byte[] buffer = new byte[TestHelper.s_ping.Length];
-                ValueTask<int> t = client.ReadAsync(buffer, cts.Token);
-
-                await server.NegotiateClientCertificateAsync(cts.Token);
-
-                // Finish the client's read
-                await server.WriteAsync(TestHelper.s_ping, cts.Token);
-                await t;
             }
         }
 


### PR DESCRIPTION
When server request renegotiation on client stream with pending data, the server trow exception as expected but lock is not released.

This PR fix this behaviour and extend related test to cover this case. 

Close #56345
