### PR TITLE
Use Ubuntu instead of macOS pool for evaluate-paths-job.yml

### DIFF
--- a/eng/pipelines/common/evaluate-paths-job.yml
+++ b/eng/pipelines/common/evaluate-paths-job.yml
@@ -29,7 +29,7 @@ jobs:
   - job: evaluate_paths
     displayName: Evaluate Paths
     pool:
-      vmImage: 'macOS-10.14'
+      vmImage: 'ubuntu-latest'
 
     steps:
     - checkout: self

--- a/eng/pipelines/common/evaluate-paths-job.yml
+++ b/eng/pipelines/common/evaluate-paths-job.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
     - checkout: self
       clean: true
-      fetchDepth: $(checkoutFetchDepth)
+      fetchDepth: 2
 
     - ${{ if ne(parameters.paths[0], '') }}:
       - ${{ each path in parameters.paths }}:


### PR DESCRIPTION
The script can run on Ubuntu as well so we can take some work off of the congested macOS pool.

Also set a fetch depth of 2 since that's all we need to calculate the changed paths, this shaves ~40 seconds off that step.