### PR TITLE
Disable test ResponseHeadersRead_SynchronizationContextNotUsedByHandler for WinHttpHandler on Win7/Win81

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Asynchrony.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Asynchrony.cs
@@ -28,7 +28,7 @@ namespace System.Net.Http.Functional.Tests
         {
             if (IsWinHttpHandler && (PlatformDetection.IsWindows7 || PlatformDetection.IsWindows8x))
             {   // [ActiveIssue("https://github.com/dotnet/runtime/issues/54034")]
-                throw new SkipTestException("Win7/Win81 environment often hangs the test for WinHttpHandler.");
+                return;
             }
 
             await Task.Run(async delegate // escape xunit's sync ctx

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Asynchrony.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Asynchrony.cs
@@ -26,6 +26,11 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(ResponseHeadersRead_SynchronizationContextNotUsedByHandler_MemberData))]
         public async Task ResponseHeadersRead_SynchronizationContextNotUsedByHandler(bool responseHeadersRead, LoopbackServer.ContentMode contentMode)
         {
+            if (IsWinHttpHandler && (PlatformDetection.IsWindows7 || PlatformDetection.IsWindows8x))
+            {   // [ActiveIssue("https://github.com/dotnet/runtime/issues/54034")]
+                throw new SkipTestException("Win7/Win81 environment often hangs the test for WinHttpHandler.");
+            }
+
             await Task.Run(async delegate // escape xunit's sync ctx
             {
                 await LoopbackServer.CreateClientAndServerAsync(uri =>


### PR DESCRIPTION
Test types:
- System.Net.Http.Functional.Tests.PlatformHandler_HttpClientHandler_Asynchrony_Test
- System.Net.Http.Functional.Tests.PlatformHandler_HttpClientHandler_Asynchrony_Http2_Test

Disabled test tracked by #54034