### PR TITLE
Reenable DiagnosticSource tests

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceTests.cs
@@ -500,7 +500,7 @@ namespace System.Diagnostics.Tests
         /// Stresses the AllListeners by having many threads be adding and removing.
         /// </summary>
         [OuterLoop]
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process), nameof(PlatformDetection.IsThreadingSupported))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/28772")]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(100, 100)] // run multiple times to stress it further
         [InlineData(100, 101)]
         [InlineData(100, 102)]


### PR DESCRIPTION
A few years ago this test was timing out on ARM64 because of hardware
constraints. I am re-enabling the test to see if this is still an issue
or if the situation has been resolved since then.

Fixes #28772