### PR TITLE
Fix String.LastIndexOf with string has zero sort weights characters

### DIFF
--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
@@ -850,8 +850,8 @@ int32_t GlobalizationNative_LastIndexOf(
             *pMatchedLength = matchLength;
         }
 
-        // In case the search result pointing at last character (including Surrogate case) of the source string, we need to check if the target string
-        // constructed with characters which have no sort weights. The way we do that is to check the matched length is 0.
+        // In case the search result is pointing at the last character (including Surrogate case) of the source string, we need to check if the target string
+        // was constructed with characters which have no sort weights. The way we do that is to check that the matched length is 0.
         // We need to update the returned index to have consistent behavior with Ordinal and NLS operations, and satisfy the condition:
         //      index = source.LastIndexOf(value, comparisonType);
         //      originalString.Substring(index).StartsWith(value, comparisonType) == true.

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
@@ -842,7 +842,7 @@ int32_t GlobalizationNative_LastIndexOf(
     // if the search was successful, we'll try to get the matched string length.
     if (result != USEARCH_DONE)
     {
-        int32_t matchLength;
+        int32_t matchLength = -1;
 
         if (pMatchedLength != NULL)
         {

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
@@ -850,13 +850,13 @@ int32_t GlobalizationNative_LastIndexOf(
             *pMatchedLength = matchLength;
         }
 
-        // In case the search result pointing at last character of the source string, we need to check if the target string
+        // In case the search result pointing at last character (including Surrogate case) of the source string, we need to check if the target string
         // constructed with characters which have no sort weights. The way we do that is to check the matched length is 0.
         // We need to update the returned index to have consistent behavior with Ordinal and NLS operations, and satisfy the condition:
         //      index = source.LastIndexOf(value, comparisonType);
         //      originalString.Substring(index).StartsWith(value, comparisonType) == true.
         // https://github.com/dotnet/runtime/issues/13383
-        if (result == cwSourceLength - 1)
+        if (result >= cwSourceLength - 2)
         {
             if (pMatchedLength == NULL)
             {

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
@@ -842,20 +842,27 @@ int32_t GlobalizationNative_LastIndexOf(
     // if the search was successful, we'll try to get the matched string length.
     if (result != USEARCH_DONE)
     {
+        int32_t matchLength;
+
         if (pMatchedLength != NULL)
         {
-            *pMatchedLength = usearch_getMatchedLength(pSearch);
+            matchLength = usearch_getMatchedLength(pSearch);
+            *pMatchedLength = matchLength;
         }
 
         // In case the search result pointing at last character of the source string, we need to check if the target string
-        // constructed with characters which have no sort weights. The way we do that is to check the match length is 0.
-        // We need update the returned index to have consistent behavior with Ordinal and NLS operations, and satisfy the condition:
+        // constructed with characters which have no sort weights. The way we do that is to check the matched length is 0.
+        // We need to update the returned index to have consistent behavior with Ordinal and NLS operations, and satisfy the condition:
         //      index = source.LastIndexOf(value, comparisonType);
         //      originalString.Substring(index).StartsWith(value, comparisonType) == true.
         // https://github.com/dotnet/runtime/issues/13383
         if (result == cwSourceLength - 1)
         {
-            int32_t matchLength = pMatchedLength != NULL ? *pMatchedLength : usearch_getMatchedLength(pSearch);
+            if (pMatchedLength == NULL)
+            {
+                matchLength = usearch_getMatchedLength(pSearch);
+            }
+
             if (matchLength == 0)
             {
                 result = cwSourceLength;

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.LastIndexOf.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.LastIndexOf.cs
@@ -97,7 +97,7 @@ namespace System.Globalization.Tests
 
             yield return new object[] { s_invariantCompare, "A\u0303", "\u200d", 1, 2, CompareOptions.None, 2, 0}; // A +  ̃ = Ã
             yield return new object[] { s_invariantCompare, "A\u0303\u200D", "\u200d", 2, 3, CompareOptions.None, 3, 0}; // A +  ̃ = Ã
-            yield return new object[] { s_invariantCompare, "😁", "\u200d", 1, 2, CompareOptions.None, 2, 0}; // 😁 is the surrogate \u0001F601
+            yield return new object[] { s_invariantCompare, "\u0001F601", "\u200d", 1, 2, CompareOptions.None, 2, 0}; // \u0001F601 is GRINNING FACE WITH SMILING EYES surrogate character
             yield return new object[] { s_invariantCompare, "AA\u200DA", "\u200d", 3, 4, CompareOptions.None, 4, 0};
 
             // Ignore symbols

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.LastIndexOf.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.LastIndexOf.cs
@@ -98,7 +98,7 @@ namespace System.Globalization.Tests
             yield return new object[] { s_invariantCompare, "A\u0303", "\u200d", 1, 2, CompareOptions.None, 2, 0}; // A +  ̃ = Ã
             yield return new object[] { s_invariantCompare, "A\u0303\u200D", "\u200d", 2, 3, CompareOptions.None, 3, 0}; // A +  ̃ = Ã
             yield return new object[] { s_invariantCompare, "😁", "\u200d", 1, 2, CompareOptions.None, 2, 0}; // 😁 is the surrogate \u0001F601
-            yield return new object[] { s_invariantCompare, "AA\u200DA", "\u200d", 3, 4, CompareOptions.None, 4, 0}; // 😁 is the surrogate \u0001F601
+            yield return new object[] { s_invariantCompare, "AA\u200DA", "\u200d", 3, 4, CompareOptions.None, 4, 0};
 
             // Ignore symbols
             yield return new object[] { s_invariantCompare, "More Test's", "Tests", 10, 11, CompareOptions.IgnoreSymbols, 5, 6 };

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.LastIndexOf.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.LastIndexOf.cs
@@ -92,7 +92,8 @@ namespace System.Globalization.Tests
             // ICU matches weightless characters at 1 index prior to the end of the string
             yield return new object[] { s_invariantCompare, "", "\u200d", 0, 0, CompareOptions.None, 0, 0 };
             yield return new object[] { s_invariantCompare, "", "\u200d", -1, 0, CompareOptions.None, 0, 0 };
-            yield return new object[] { s_invariantCompare, "hello", "\u200d", 4, 5, CompareOptions.IgnoreCase, useNls ? 5 : 4 , 0};
+            yield return new object[] { s_invariantCompare, "hello", "\u200d", 4, 5, CompareOptions.IgnoreCase, 5, 0};
+            yield return new object[] { s_invariantCompare, "hello", "\0", 4, 5, CompareOptions.None, useNls ? -1 : 5, 0};
 
             // Ignore symbols
             yield return new object[] { s_invariantCompare, "More Test's", "Tests", 10, 11, CompareOptions.IgnoreSymbols, 5, 6 };

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.LastIndexOf.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.LastIndexOf.cs
@@ -95,6 +95,11 @@ namespace System.Globalization.Tests
             yield return new object[] { s_invariantCompare, "hello", "\u200d", 4, 5, CompareOptions.IgnoreCase, 5, 0};
             yield return new object[] { s_invariantCompare, "hello", "\0", 4, 5, CompareOptions.None, useNls ? -1 : 5, 0};
 
+            yield return new object[] { s_invariantCompare, "A\u0303", "\u200d", 1, 2, CompareOptions.None, 2, 0}; // A +  ̃ = Ã
+            yield return new object[] { s_invariantCompare, "A\u0303\u200D", "\u200d", 2, 3, CompareOptions.None, 3, 0}; // A +  ̃ = Ã
+            yield return new object[] { s_invariantCompare, "😁", "\u200d", 1, 2, CompareOptions.None, 2, 0}; // 😁 is the surrogate \u0001F601
+            yield return new object[] { s_invariantCompare, "AA\u200DA", "\u200d", 3, 4, CompareOptions.None, 4, 0}; // 😁 is the surrogate \u0001F601
+
             // Ignore symbols
             yield return new object[] { s_invariantCompare, "More Test's", "Tests", 10, 11, CompareOptions.IgnoreSymbols, 5, 6 };
             yield return new object[] { s_invariantCompare, "More Test's", "Tests", 10, 11, CompareOptions.None, -1, 0 };


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/44439

The issue https://github.com/dotnet/runtime/issues/13383 has more information about the behavior we are trying to fix.