### PR TITLE
Delete old AssemblyExtensions.ApplyUpdate/GetApplyUpdateCapabilities

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
@@ -40,30 +40,5 @@ namespace System.Reflection.Metadata
 
             return InternalTryGetRawMetadata(new QCallAssembly(ref rtAsm), ref blob, ref length);
         }
-
-        /// <summary>
-        /// Updates the specified assembly using the provided metadata, IL and PDB deltas.
-        /// </summary>
-        /// <remarks>
-        /// Currently executing methods will continue to use the existing IL. New executions of modified methods will
-        /// use the new IL. Different runtimes may have different limitations on what kinds of changes are supported,
-        /// and runtimes make no guarantees as to the state of the assembly and process if the delta includes
-        /// unsupported changes.
-        /// </remarks>
-        /// <param name="assembly">The assembly to update.</param>
-        /// <param name="metadataDelta">The metadata changes to be applied.</param>
-        /// <param name="ilDelta">The IL changes to be applied.</param>
-        /// <param name="pdbDelta">The PDB changes to be applied.</param>
-        /// <exception cref="ArgumentNullException">The assembly argument is null.</exception>
-        /// <exception cref="NotSupportedException">The update could not be applied.</exception>
-        public static void ApplyUpdate(Assembly assembly, ReadOnlySpan<byte> metadataDelta, ReadOnlySpan<byte> ilDelta, ReadOnlySpan<byte> pdbDelta)
-        {
-            MetadataUpdater.ApplyUpdate(assembly, metadataDelta, ilDelta, pdbDelta);
-        }
-
-        internal static string GetApplyUpdateCapabilities()
-        {
-            return MetadataUpdater.GetCapabilities();
-        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
@@ -58,8 +58,8 @@
     </type>
 
      <!-- methods used by hot reload --> 
-    <type fullname="System.Reflection.Metadata.AssemblyExtensions">
-      <method name="GetApplyUpdateCapabilities" />
+    <type fullname="System.Reflection.Metadata.MetadataUpdater">
+      <method name="GetCapabilities" />
     </type>
   </assembly>
 </linker>

--- a/src/libraries/System.Runtime.Loader/ref/System.Runtime.Loader.cs
+++ b/src/libraries/System.Runtime.Loader/ref/System.Runtime.Loader.cs
@@ -10,7 +10,6 @@ namespace System.Reflection.Metadata
     {
         [System.CLSCompliantAttribute(false)]
         public unsafe static bool TryGetRawMetadata(this System.Reflection.Assembly assembly, out byte* blob, out int length) { throw null; }
-        public static void ApplyUpdate(Assembly assembly, ReadOnlySpan<byte> metadataDelta, ReadOnlySpan<byte> ilDelta, ReadOnlySpan<byte> pdbDelta) { throw null; }
     }
     public static partial class MetadataUpdater
     {

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
@@ -9,27 +9,5 @@ namespace System.Reflection.Metadata
     {
         [CLSCompliant(false)]
         public static unsafe bool TryGetRawMetadata(this Assembly assembly, out byte* blob, out int length) => throw new NotImplementedException();
-
-        /// <summary>
-        /// Updates the specified assembly using the provided metadata, IL and PDB deltas.
-        /// </summary>
-        /// <remarks>
-        /// Currently executing methods will continue to use the existing IL. New executions of modified methods will
-        /// use the new IL. Different runtimes may have different limitations on what kinds of changes are supported,
-        /// and runtimes make no guarantees as to the state of the assembly and process if the delta includes
-        /// unsupported changes.
-        /// </remarks>
-        /// <param name="assembly">The assembly to update.</param>
-        /// <param name="metadataDelta">The metadata changes to be applied.</param>
-        /// <param name="ilDelta">The IL changes to be applied.</param>
-        /// <param name="pdbDelta">The PDB changes to be applied.</param>
-        /// <exception cref="ArgumentNullException">The assembly argument is null.</exception>
-        /// <exception cref="NotSupportedException">The update could not be applied.</exception>
-        public static void ApplyUpdate(Assembly assembly, ReadOnlySpan<byte> metadataDelta, ReadOnlySpan<byte> ilDelta, ReadOnlySpan<byte> pdbDelta)
-        {
-            MetadataUpdater.ApplyUpdate(assembly, metadataDelta, ilDelta, pdbDelta);
-        }
-
-        internal static string GetApplyUpdateCapabilities() => MetadataUpdater.GetCapabilities();
     }
 }

--- a/src/mono/sample/mbr/DeltaHelper/DeltaHelper.cs
+++ b/src/mono/sample/mbr/DeltaHelper/DeltaHelper.cs
@@ -9,7 +9,7 @@ namespace MonoDelta {
     public class DeltaHelper {
         private static void LoadMetadataUpdate (Assembly assm, byte[] dmeta_data, byte[] dil_data, byte[] dpdb_data)
         {
-            System.Reflection.Metadata.AssemblyExtensions.ApplyUpdate (assm, dmeta_data, dil_data, dpdb_data);
+            System.Reflection.Metadata.MetadataUpdater.ApplyUpdate (assm, dmeta_data, dil_data, dpdb_data);
         }
 
         DeltaHelper () { }

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -606,8 +606,8 @@ public class LoadDebuggerTestALC {
         }
         public static void RunMethod(string className, string methodName)
         {
-            var ty = typeof(System.Reflection.Metadata.AssemblyExtensions);
-            var mi = ty.GetMethod("GetApplyUpdateCapabilities", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static, Array.Empty<Type>());
+            var ty = typeof(System.Reflection.Metadata.MetadataUpdater);
+            var mi = ty.GetMethod("GetCapabilities", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static, Array.Empty<Type>());
 
             if (mi == null)
                 return;
@@ -643,11 +643,11 @@ public class LoadDebuggerTestALC {
 
             if (version == 1)
             {
-                System.Reflection.Metadata.AssemblyExtensions.ApplyUpdate(assm, dmeta_data1_bytes, dil_data1_bytes, dpdb_data1_bytes);
+                System.Reflection.Metadata.MetadataUpdater.ApplyUpdate(assm, dmeta_data1_bytes, dil_data1_bytes, dpdb_data1_bytes);
             }
             else if (version == 2)
             {
-                System.Reflection.Metadata.AssemblyExtensions.ApplyUpdate(assm, dmeta_data2_bytes, dil_data2_bytes, dpdb_data2_bytes);
+                System.Reflection.Metadata.MetadataUpdater.ApplyUpdate(assm, dmeta_data2_bytes, dil_data2_bytes, dpdb_data2_bytes);
             }
 
         }

--- a/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/Program.cs
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/Program.cs
@@ -75,7 +75,7 @@ namespace Sample
             byte[] dil_data = System.IO.File.ReadAllBytes(dil_name);
             byte[] dpdb_data = null; // TODO also use the dpdb data
 
-            System.Reflection.Metadata.AssemblyExtensions.ApplyUpdate(assm, dmeta_data, dil_data, dpdb_data);
+            System.Reflection.Metadata.MetadataUpdater.ApplyUpdate(assm, dmeta_data, dil_data, dpdb_data);
         }
     }
 }

--- a/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/Program.cs
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/Program.cs
@@ -20,8 +20,8 @@ namespace Sample
             const int success = 42;
             const int failure = 1;
 
-            var ty = typeof(System.Reflection.Metadata.AssemblyExtensions);
-            var mi = ty.GetMethod("GetApplyUpdateCapabilities", BindingFlags.NonPublic | BindingFlags.Static, Array.Empty<Type>());
+            var ty = typeof(System.Reflection.Metadata.MetadataUpdater);
+            var mi = ty.GetMethod("GetCapabilities", BindingFlags.NonPublic | BindingFlags.Static, Array.Empty<Type>());
 
             if (mi == null)
                 return failure;


### PR DESCRIPTION
cc: @mikem8361, @pranavkm, @lambdageek 

@pranavkm, have all of the relevant places been updated to consume the new methods such that we can go ahead and delete the old?  Or should we hold off on this?