### PR TITLE
Wasm.Build.Tests: `RunProcess` - wait for all async handlers to complete

### DIFF
--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -30,6 +30,7 @@ jobs:
       - src/libraries/System.Private.CoreLib/*
       - src/libraries/Native/Unix/System.Globalization.Native/*
       - src/libraries/Native/Unix/Common/*
+      - src/tests/BuildWasmApps/*
       exclude:
       - eng/Version.Details.xml
       - '*.md'

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs
@@ -542,6 +542,13 @@ namespace Wasm.Build.Tests
                         throw new XunitException($"Process timed out. Last 20 lines of output:{Environment.NewLine}{string.Join(Environment.NewLine, lastLines)}");
                     }
                 }
+                else
+                {
+                    // this will ensure that all the async event handling
+                    // has completed
+                    // https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexit?view=net-5.0#System_Diagnostics_Process_WaitForExit_System_Int32_
+                    process.WaitForExit();
+                }
 
                 process.ErrorDataReceived -= logStdErr;
                 process.OutputDataReceived -= logStdOut;


### PR DESCRIPTION
Earlier commit[1] tried to fix the
[issue](https://github.com/dotnet/runtime/issues/55999) where messages would be
received from a process that had exited, but after the test was
complete.

The exception in that case:
```
System.InvalidOperationException: There is no currently active test.
   at Xunit.Sdk.TestOutputHelper.GuardInitialized() in C:\Dev\xunit\xunit\src\xunit.execution\Sdk\Frameworks\TestOutputHelper.cs:line 51
   at Xunit.Sdk.TestOutputHelper.QueueTestOutput(String output) in C:\Dev\xunit\xunit\src\xunit.execution\Sdk\Frameworks\TestOutputHelper.cs:line 66
   at Wasm.Build.Tests.BuildTestBase.<>c__DisplayClass37_0.<RunProcess>g__LogData|2(String label, String message) in /_/src/tests/BuildWasmApps/Wasm.Build.Tests/BuildTestBase.cs:line 569
   at System.Diagnostics.AsyncStreamReader.FlushMessageQueue(Boolean rethrowInNewThread) in System.Diagnostics.Process.dll:token 0x6000098+0x87
--- End of stack trace from previous location ---
   at System.Diagnostics.AsyncStreamReader.<>c.<FlushMessageQueue>b__18_0(Object edi) in System.Diagnostics.Process.dll:token 0x600009f+0x0
   at System.Threading.QueueUserWorkItemCallbackDefaultContext.Execute() in System.Private.CoreLib.dll:token 0x6002a84+0x14
   at System.Threading.ThreadPoolWorkQueue.Dispatch() in System.Private.CoreLib.dll:token 0x6002a5f+0x10a
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart() in System.Private.CoreLib.dll:token 0x6002b39+0x6c
   at System.Threading.Thread.StartCallback() in System.Private.CoreLib.dll:token 0x60026db+0xe
```

But that commit didn't quite fix the issue, and we now get
https://github.com/dotnet/runtime/issues/56513 , where we still end up missing last few lines.

The reason seems to be that we use `process.WaitForExit(timeout)`, and
once that returns, we return from the method. But the documentation[2]
suggests that we need to call `process.WaitForExit()` after this, to
ensure that all the async event handlers get called. It should mean that
we are not stopping the event handlers early.

Fixes: https://github.com/dotnet/runtime/issues/56513

--

1.
```
commit ec2d25c03fb91d8897277f2b732b71f903b87b1a

Author: Ankit Jain <radical@gmail.com>
Date:   Wed Jul 28 12:35:23 2021 -0400

    [wasm] Wasm.Build.Tests - try to close down the stdout/err readers (#56180)
```

2. https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexit?view=net-6.0#System_Diagnostics_Process_WaitForExit_System_Int32_

```
When standard output has been redirected to asynchronous event handlers,
it is possible that output processing will not have completed when this
method returns. To ensure that asynchronous event handling has been
completed, call the WaitForExit() overload that takes no parameter after
receiving a true from this overload.
```