### PR TITLE
Fix Apple arm64 SIMD12(SIMD16) passing.

### DIFF
--- a/src/coreclr/jit/lsraarmarch.cpp
+++ b/src/coreclr/jit/lsraarmarch.cpp
@@ -460,6 +460,15 @@ int LinearScan::BuildPutArgStk(GenTreePutArgStk* argNode)
     {
         assert(!putArgChild->isContained());
         srcCount = BuildOperandUses(putArgChild);
+#if defined(FEATURE_SIMD) && defined(OSX_ARM64_ABI)
+        if (argNode->GetStackByteSize() == 12)
+        {
+            // Vector3 is read/written as two reads/writes: 8 byte and 4 byte.
+            // To assemble the vector properly we would need an additional int register.
+            // The other platforms can write it as 16-byte using 1 write.
+            buildInternalIntRegisterDefForNode(argNode);
+        }
+#endif // FEATURE_SIMD && OSX_ARM64_ABI
     }
     buildInternalRegisterUses();
     return srcCount;

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -342,9 +342,6 @@
     <!-- ActiveIssue Apple Silicon No usable version of libssl was found https://github.com/dotnet/runtime/issues/49083 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.OpenSsl/tests/System.Security.Cryptography.OpenSsl.Tests.csproj" />
-    <!-- ActiveIssue XUnit crashes on Apple Silicon https://github.com/dotnet/runtime/issues/49110 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Numerics.Vectors/tests/System.Numerics.Vectors.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime/tests/System.Runtime.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TestSingleFile)' == 'true'">


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/49453, and closing https://github.com/dotnet/runtime/issues/49110 (was fixed by JanV's changes).