### PR TITLE
56014 xml writer.create perf regression

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -317,7 +317,7 @@ namespace System.Xml.Serialization
         [RequiresUnreferencedCode(TrimSerializationWarning)]
         public void Serialize(TextWriter textWriter, object? o, XmlSerializerNamespaces? namespaces)
         {
-            XmlWriter xmlWriter = XmlWriter.Create(textWriter, new XmlWriterSettings() { Indent = true });
+            XmlWriter xmlWriter = XmlWriter.Create(textWriter);
             Serialize(xmlWriter, o, namespaces);
         }
 
@@ -330,7 +330,7 @@ namespace System.Xml.Serialization
         [RequiresUnreferencedCode(TrimSerializationWarning)]
         public void Serialize(Stream stream, object? o, XmlSerializerNamespaces? namespaces)
         {
-            XmlWriter xmlWriter = XmlWriter.Create(stream, new XmlWriterSettings() { Indent = true });
+            XmlWriter xmlWriter = XmlWriter.Create(stream);
             Serialize(xmlWriter, o, namespaces);
         }
 

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
@@ -503,6 +503,21 @@ public static partial class XmlSerializerTests
     }
 
     [Fact]
+    public static void Xml_WithXElementWithEmptyNestedElement()
+    {
+        var original = new WithXmlElement(true);
+        original.xml.InnerXml = "<empty></empty>";
+
+        MemoryStream ms = new MemoryStream();
+        new XmlSerializer(typeof(WithXmlElement)).Serialize(ms, original);
+        ms.Position = 0;
+        StreamReader sr = new StreamReader(ms);
+        string output = sr.ReadToEnd();
+
+        Assert.Contains("<empty></empty>", output);   // Self-closed, or completely empty is OK. No added space.
+    }
+
+    [Fact]
     public static void Xml_WithArrayOfXElement()
     {
         var original = new WithArrayOfXElement(true);

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
@@ -510,10 +510,10 @@ public static partial class XmlSerializerTests
 
         MemoryStream ms = new MemoryStream();
         new XmlSerializer(typeof(WithXmlElement)).Serialize(ms, original);
+
         ms.Position = 0;
         StreamReader sr = new StreamReader(ms);
         string output = sr.ReadToEnd();
-
         Assert.Contains("<empty></empty>", output);   // Self-closed, or completely empty is OK. No added space.
     }
 

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.RuntimeOnly.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.RuntimeOnly.cs
@@ -767,6 +767,19 @@ namespace SerializationTypes
         }
     }
 
+    public class WithXmlElement
+    {
+        public XmlElement xml;
+
+        public WithXmlElement() { }
+
+        public WithXmlElement(bool init)
+        {
+            var doc = new XmlDocument();
+            xml = doc.CreateElement("Element1");
+        }
+    }
+
     public class WithXElementWithNestedXElement
     {
         public XElement e1;


### PR DESCRIPTION
Using XmlWriter.Create() instead of XmlTextWriter introduced perf regression.

We have "correctness" reasons for switching to XmlWriter.Create() instead
of sticking with XmlTextWriter. (See #1411 and #46974 as examples.) For
folks who are adversely impacted by this change, they can always get the old
behavior by passing in their own XmlTextWriter when serializing.

In my own playing around with XmlWriter.Create() however, I found there
to be a rather significant penalty for using an "Indent" wrapper. I don't
know why the difference is so large, but I've seen indentation add 60-100%
more time to serialization of large/extensive objects. Removing the
indentation wrapper produces xml that is not very human-readable, but
it is still correct and round-trips serialization. (I don't know what affect
indentation will have on the super-short micro-benchmarks that identified this
regression. My dev machine was not producing consistent or obvious results
wrt which XmlWriter was being used.)

Fixes #56014 and #56352
