### PR TITLE
API fix to System.Data batching API

### DIFF
--- a/src/libraries/System.Data.Common/ref/System.Data.Common.cs
+++ b/src/libraries/System.Data.Common/ref/System.Data.Common.cs
@@ -1945,10 +1945,10 @@ namespace System.Data.Common
     public abstract class DbBatchCommand
     {
         public abstract string CommandText { get; set; }
-        public abstract CommandType CommandType { get; set; }
+        public abstract System.Data.CommandType CommandType { get; set; }
         public abstract int RecordsAffected { get; }
-        public DbParameterCollection Parameters { get { throw null; } }
-        protected abstract DbParameterCollection DbParameterCollection { get; }
+        public System.Data.Common.DbParameterCollection Parameters { get { throw null; } }
+        protected abstract System.Data.Common.DbParameterCollection DbParameterCollection { get; }
     }
     public abstract class DbBatchCommandCollection : System.Collections.Generic.IList<DbBatchCommand>
     {
@@ -1964,7 +1964,9 @@ namespace System.Data.Common
         public abstract int IndexOf(DbBatchCommand item);
         public abstract void Insert(int index, DbBatchCommand item);
         public abstract void RemoveAt(int index);
-        public abstract DbBatchCommand this[int index] { get; set; }
+        public System.Data.Common.DbBatchCommand this[int index] { get { throw null; } set { throw null; } }
+        protected abstract System.Data.Common.DbBatchCommand GetBatchCommand(int index);
+        protected abstract void SetBatchCommand(int index, System.Data.Common.DbBatchCommand batchCommand);
     }
     public abstract partial class DbColumn
     {

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbBatchCommandCollection.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbBatchCommandCollection.cs
@@ -32,6 +32,14 @@ namespace System.Data.Common
 
         public abstract void RemoveAt(int index);
 
-        public abstract DbBatchCommand this[int index] { get; set; }
+        public DbBatchCommand this[int index]
+        {
+            get => GetBatchCommand(index);
+            set => SetBatchCommand(index, value);
+        }
+
+        protected abstract DbBatchCommand GetBatchCommand(int index);
+
+        protected abstract void SetBatchCommand(int index, DbBatchCommand batchCommand);
     }
 }


### PR DESCRIPTION
Allow implementations of DbBatchCommandCollection to hide the indexer with a narrower-typed version for their own implementation of DbBatchCommand, as elsewhere in ADO.NET.

This follows the existing pattern in DbParameterCollection.

Fixup for #54467, part of #28633

@bgrainger @bricelam would appreciate a quick review of this (it's small), to make sure this goes into rc1.

/cc @Wraith2 @FransBouma @bgribaudo @yyjdelete @ajcvickers