### PR TITLE
[mono] Fix the long opcode decompose pass when using llvm.

### DIFF
--- a/src/mono/mono/mini/decompose.c
+++ b/src/mono/mono/mini/decompose.c
@@ -36,7 +36,10 @@ decompose_long_opcode (MonoCompile *cfg, MonoInst *ins, MonoInst **repl_ins)
 
 	switch (ins->opcode) {
 	case OP_LCONV_TO_I4:
-		ins->opcode = OP_SEXT_I4;
+		if (TARGET_SIZEOF_VOID_P == 4)
+			;
+		else
+			ins->opcode = OP_SEXT_I4;
 		break;
 	case OP_LCONV_TO_I8:
 	case OP_LCONV_TO_U8:
@@ -47,19 +50,15 @@ decompose_long_opcode (MonoCompile *cfg, MonoInst *ins, MonoInst **repl_ins)
 		break;
 	case OP_LCONV_TO_I:
 		if (TARGET_SIZEOF_VOID_P == 4)
-			/* OP_LCONV_TO_I4 */
-			ins->opcode = OP_SEXT_I4;
+			ins->opcode = OP_LCONV_TO_I4;
 		else
 			ins->opcode = OP_MOVE;
 		break;
 	case OP_LCONV_TO_U:
-		if (TARGET_SIZEOF_VOID_P == 4) {
-			/* OP_LCONV_TO_U4 */
-			MONO_EMIT_NEW_BIALU_IMM (cfg, OP_ISHR_UN_IMM, ins->dreg, ins->sreg1, 0);
-			NULLIFY_INS (ins);
-		} else {
+		if (TARGET_SIZEOF_VOID_P == 4)
+			;
+		else
 			ins->opcode = OP_MOVE;
-		}
 		break;
 	case OP_ICONV_TO_I8:
 		ins->opcode = OP_SEXT_I4;


### PR DESCRIPTION
It was replacing 64 bit opcodes with 32 bit ones while keeping the input/output 64 bit
vregs, leading to memory overwrites in later passes. Instead simply keep the 64
bit opcodes, llvm can handle them.

Fixes https://github.com/dotnet/runtime/issues/53546.