### PR TITLE
[wasm] Redesign of managed objects marshaling and lifecycle

### DIFF
--- a/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
+++ b/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
@@ -21,41 +21,41 @@ internal static partial class Interop
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern object CompileFunction(string str, out int exceptionalResult);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern object InvokeJSWithArgs(int jsObjHandle, string method, object?[] parms, out int exceptionalResult);
+        internal static extern object InvokeJSWithArgs(int jsHandle, string method, object?[] parms, out int exceptionalResult);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern object GetObjectProperty(int jsObjHandle, string propertyName, out int exceptionalResult);
+        internal static extern object GetObjectProperty(int jsHandle, string propertyName, out int exceptionalResult);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern object SetObjectProperty(int jsObjHandle, string propertyName, object value, bool createIfNotExists, bool hasOwnProperty, out int exceptionalResult);
+        internal static extern object SetObjectProperty(int jsHandle, string propertyName, object value, bool createIfNotExists, bool hasOwnProperty, out int exceptionalResult);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern object GetByIndex(int jsObjHandle, int index, out int exceptionalResult);
+        internal static extern object GetByIndex(int jsHandle, int index, out int exceptionalResult);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern object SetByIndex(int jsObjHandle, int index, object? value, out int exceptionalResult);
+        internal static extern object SetByIndex(int jsHandle, int index, object? value, out int exceptionalResult);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern object GetGlobalObject(string? globalName, out int exceptionalResult);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern object ReleaseHandle(int jsObjHandle, out int exceptionalResult);
+        internal static extern object ReleaseHandle(int jsHandle, out int exceptionalResult);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern object ReleaseObject(int jsObjHandle, out int exceptionalResult);
+        internal static extern object ReleaseObject(int jsHandle, out int exceptionalResult);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern object BindCoreObject(int jsObjHandle, int gcHandle, out int exceptionalResult);
+        internal static extern object BindCoreObject(int jsHandle, int gcHandle, out int exceptionalResult);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern object BindHostObject(int jsObjHandle, int gcHandle, out int exceptionalResult);
+        internal static extern object BindHostObject(int jsHandle, int gcHandle, out int exceptionalResult);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern object New(string className, object[] parms, out int exceptionalResult);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern object TypedArrayToArray(int jsObjHandle, out int exceptionalResult);
+        internal static extern object TypedArrayToArray(int jsHandle, out int exceptionalResult);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern object TypedArrayCopyTo(int jsObjHandle, int arrayPtr, int begin, int end, int bytesPerElement, out int exceptionalResult);
+        internal static extern object TypedArrayCopyTo(int jsHandle, int arrayPtr, int begin, int end, int bytesPerElement, out int exceptionalResult);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern object TypedArrayFrom(int arrayPtr, int begin, int end, int bytesPerElement, int type, out int exceptionalResult);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern object TypedArrayCopyFrom(int jsObjHandle, int arrayPtr, int begin, int end, int bytesPerElement, out int exceptionalResult);
+        internal static extern object TypedArrayCopyFrom(int jsHandle, int arrayPtr, int begin, int end, int bytesPerElement, out int exceptionalResult);
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern string? AddEventListener(int jsObjHandle, string name, int weakDelegateHandle, int optionsObjHandle);
+        internal static extern string? AddEventListener(int jsHandle, string name, int gcHandle, int optionsJsHandle);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern string? RemoveEventListener(int jsObjHandle, string name, int weakDelegateHandle, bool capture);
+        internal static extern string? RemoveEventListener(int jsHandle, string name, int gcHandle, bool capture);
 
         // / <summary>
         // / Execute the provided string in the JavaScript context

--- a/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
+++ b/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
@@ -36,11 +36,7 @@ internal static partial class Interop
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern object ReleaseHandle(int jsHandle, out int exceptionalResult);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern object ReleaseObject(int jsHandle, out int exceptionalResult);
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern object BindCoreObject(int jsHandle, int gcHandle, out int exceptionalResult);
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern object BindHostObject(int jsHandle, int gcHandle, out int exceptionalResult);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern object New(string className, object[] parms, out int exceptionalResult);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/AnyRef.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/AnyRef.cs
@@ -1,9 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.Win32.SafeHandles;
 
@@ -19,7 +17,7 @@ namespace System.Runtime.InteropServices.JavaScript
         internal AnyRef(IntPtr jsHandle, bool ownsHandle) : base(ownsHandle)
         {
             SetHandle(jsHandle);
-            AnyRefHandle = InteropServices.GCHandle.Alloc(this, ownsHandle ? GCHandleType.Weak : GCHandleType.Normal);
+            AnyRefHandle = GCHandle.Alloc(this, ownsHandle ? GCHandleType.Weak : GCHandleType.Normal);
             InFlight = null;
             InFlightCounter = 0;
         }
@@ -33,7 +31,7 @@ namespace System.Runtime.InteropServices.JavaScript
                 if (InFlightCounter == 1)
                 {
                     Debug.Assert(InFlight == null);
-                    InFlight = InteropServices.GCHandle.Alloc(this, GCHandleType.Normal);
+                    InFlight = GCHandle.Alloc(this, GCHandleType.Normal);
                 }
             }
         }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/AnyRef.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/AnyRef.cs
@@ -23,7 +23,7 @@ namespace System.Runtime.InteropServices.JavaScript
             InFlight = null;
             InFlightCounter = 0;
         }
-        internal int GCHandle => (int)(IntPtr)AnyRefHandle;
+        internal int GCHandleValue => (int)(IntPtr)AnyRefHandle;
 
         internal void AddInFlight()
         {

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/AnyRef.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/AnyRef.cs
@@ -16,17 +16,14 @@ namespace System.Runtime.InteropServices.JavaScript
         private GCHandle AnyRefHandle;
         public int JSHandle => (int)handle;
 
-        internal AnyRef(int jsHandle, bool ownsHandle) : this((IntPtr)jsHandle, ownsHandle)
-        { }
-
         internal AnyRef(IntPtr jsHandle, bool ownsHandle) : base(ownsHandle)
         {
             SetHandle(jsHandle);
-            AnyRefHandle = GCHandle.Alloc(this, ownsHandle ? GCHandleType.Weak : GCHandleType.Normal);
+            AnyRefHandle = InteropServices.GCHandle.Alloc(this, ownsHandle ? GCHandleType.Weak : GCHandleType.Normal);
             InFlight = null;
             InFlightCounter = 0;
         }
-        internal int Int32Handle => (int)(IntPtr)AnyRefHandle;
+        internal int GCHandle => (int)(IntPtr)AnyRefHandle;
 
         internal void AddInFlight()
         {
@@ -36,7 +33,7 @@ namespace System.Runtime.InteropServices.JavaScript
                 if (InFlightCounter == 1)
                 {
                     Debug.Assert(InFlight == null);
-                    InFlight = GCHandle.Alloc(this, GCHandleType.Normal);
+                    InFlight = InteropServices.GCHandle.Alloc(this, GCHandleType.Normal);
                 }
             }
         }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/CoreObject.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/CoreObject.cs
@@ -20,7 +20,7 @@ namespace System.Runtime.InteropServices.JavaScript
     {
         protected CoreObject(int jsHandle) : base(jsHandle, true)
         {
-            object result = Interop.Runtime.BindCoreObject(jsHandle, Int32Handle, out int exception);
+            object result = Interop.Runtime.BindCoreObject(jsHandle, GCHandle, out int exception);
             if (exception != 0)
                 throw new JSException(SR.Format(SR.CoreObjectErrorBinding, result));
         }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/CoreObject.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/CoreObject.cs
@@ -20,7 +20,7 @@ namespace System.Runtime.InteropServices.JavaScript
     {
         protected CoreObject(int jsHandle) : base(jsHandle, true)
         {
-            object result = Interop.Runtime.BindCoreObject(jsHandle, GCHandle, out int exception);
+            object result = Interop.Runtime.BindCoreObject(jsHandle, GCHandleValue, out int exception);
             if (exception != 0)
                 throw new JSException(SR.Format(SR.CoreObjectErrorBinding, result));
         }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/HostObject.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/HostObject.cs
@@ -29,7 +29,7 @@ namespace System.Runtime.InteropServices.JavaScript
     {
         protected HostObjectBase(int jsHandle) : base(jsHandle, true)
         {
-            object result = Interop.Runtime.BindHostObject(jsHandle, GCHandle, out int exception);
+            object result = Interop.Runtime.BindHostObject(jsHandle, GCHandleValue, out int exception);
             if (exception != 0)
                 throw new JSException(SR.Format(SR.HostObjectErrorBinding, result));
         }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/HostObject.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/HostObject.cs
@@ -29,7 +29,7 @@ namespace System.Runtime.InteropServices.JavaScript
     {
         protected HostObjectBase(int jsHandle) : base(jsHandle, true)
         {
-            object result = Interop.Runtime.BindHostObject(jsHandle, GCHandleValue, out int exception);
+            object result = Interop.Runtime.BindCoreObject(jsHandle, GCHandleValue, out int exception);
             if (exception != 0)
                 throw new JSException(SR.Format(SR.HostObjectErrorBinding, result));
         }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/HostObject.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/HostObject.cs
@@ -27,9 +27,9 @@ namespace System.Runtime.InteropServices.JavaScript
 
     public abstract class HostObjectBase : JSObject, IHostObject
     {
-        protected HostObjectBase(int jHandle) : base(jHandle, true)
+        protected HostObjectBase(int jsHandle) : base(jsHandle, true)
         {
-            object result = Interop.Runtime.BindHostObject(jHandle, Int32Handle, out int exception);
+            object result = Interop.Runtime.BindHostObject(jsHandle, GCHandle, out int exception);
             if (exception != 0)
                 throw new JSException(SR.Format(SR.HostObjectErrorBinding, result));
         }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
@@ -84,7 +84,7 @@ namespace System.Runtime.InteropServices.JavaScript
             public object? Signal;
         }
 
-        public int AddEventListener(string name, Delegate listener, EventListenerOptions? options = null)
+        public int AddEventListener(string name, Action<JSObject> listener, EventListenerOptions? options = null)
         {
             var optionsDict = options.HasValue
                 ? new JSObject()
@@ -117,7 +117,7 @@ namespace System.Runtime.InteropServices.JavaScript
             }
         }
 
-        public void RemoveEventListener(string name, Delegate? listener, EventListenerOptions? options = null)
+        public void RemoveEventListener(string name, Action<JSObject>? listener, EventListenerOptions? options = null)
         {
             if (listener == null)
                 return;

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
@@ -23,7 +23,7 @@ namespace System.Runtime.InteropServices.JavaScript
 
         public JSObject() : this(Interop.Runtime.New<object>(), true)
         {
-            object result = Interop.Runtime.BindCoreObject(JSHandle, Int32Handle, out int exception);
+            object result = Interop.Runtime.BindCoreObject(JSHandle, GCHandle, out int exception);
             if (exception != 0)
                 throw new JSException(SR.Format(SR.JSObjectErrorBinding, result));
 
@@ -111,9 +111,9 @@ namespace System.Runtime.InteropServices.JavaScript
             RemoveEventListener(name, jsfunc, options);
         }
 
-        public void RemoveEventListener(string name, int listenerHandle, EventListenerOptions? options = null)
+        public void RemoveEventListener(string name, int listenerGCHandle, EventListenerOptions? options = null)
         {
-            var ret = Interop.Runtime.RemoveEventListener(JSHandle, name, listenerHandle, options?.Capture ?? false);
+            var ret = Interop.Runtime.RemoveEventListener(JSHandle, name, listenerGCHandle, options?.Capture ?? false);
             if (ret != null)
                 throw new JSException(ret);
         }
@@ -164,7 +164,7 @@ namespace System.Runtime.InteropServices.JavaScript
         {
             object setPropResult = Interop.Runtime.SetObjectProperty(JSHandle, name, value, createIfNotExists, hasOwnProperty, out int exception);
             if (exception != 0)
-                throw new JSException($"Error setting {name} on (js-obj js '{JSHandle}' .NET '{Int32Handle})");
+                throw new JSException($"Error setting {name} on (js-obj js '{JSHandle}' .NET '{GCHandle})");
         }
 
         /// <summary>
@@ -236,7 +236,7 @@ namespace System.Runtime.InteropServices.JavaScript
 
         public override string ToString()
         {
-            return $"(js-obj js '{Int32Handle}')";
+            return $"(js-obj js '{GCHandle}')";
         }
     }
 }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
@@ -20,8 +20,6 @@ namespace System.Runtime.InteropServices.JavaScript
     {
         internal object? RawObject;
 
-        private WeakReference<Delegate>? WeakRawObject;
-
         // to detect redundant calls
         public bool IsDisposed { get; private set; }
 
@@ -42,11 +40,6 @@ namespace System.Runtime.InteropServices.JavaScript
         internal JSObject(int jsHandle, object rawObj) : base(jsHandle, false)
         {
             RawObject = rawObj;
-        }
-
-        internal JSObject(int jsHandle, Delegate rawDelegate, bool ownsHandle = true) : base(jsHandle, ownsHandle)
-        {
-            WeakRawObject = new WeakReference<Delegate>(rawDelegate, trackResurrection: false);
         }
 
         /// <summary>
@@ -205,11 +198,9 @@ namespace System.Runtime.InteropServices.JavaScript
         /// <param name="prop">The String name or Symbol of the property to test.</param>
         public bool PropertyIsEnumerable(string prop) => (bool)Invoke("propertyIsEnumerable", prop);
 
-        internal bool IsWeakWrapper => WeakRawObject?.TryGetTarget(out _) == true;
-
         internal object? GetWrappedObject()
         {
-            return RawObject ?? (WeakRawObject is WeakReference<Delegate> wr && wr.TryGetTarget(out Delegate? d) ? d : null);
+            return RawObject;
         }
         internal void FreeHandle()
         {
@@ -217,7 +208,6 @@ namespace System.Runtime.InteropServices.JavaScript
             SetHandleAsInvalid();
             IsDisposed = true;
             RawObject = null;
-            WeakRawObject = null;
             FreeGCHandle();
         }
 
@@ -258,7 +248,7 @@ namespace System.Runtime.InteropServices.JavaScript
 
         public override string ToString()
         {
-            return $"(js-obj js '{Int32Handle}' raw '{RawObject != null}' weak_raw '{WeakRawObject != null}')";
+            return $"(js-obj js '{Int32Handle}' raw '{RawObject != null}')";
         }
     }
 }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
@@ -18,8 +18,6 @@ namespace System.Runtime.InteropServices.JavaScript
     /// </summary>
     public class JSObject : AnyRef, IJSObject, IDisposable
     {
-        internal object? RawObject;
-
         // to detect redundant calls
         public bool IsDisposed { get; private set; }
 
@@ -36,11 +34,6 @@ namespace System.Runtime.InteropServices.JavaScript
 
         internal JSObject(int jsHandle, bool ownsHandle) : base((IntPtr)jsHandle, ownsHandle)
         { }
-
-        internal JSObject(int jsHandle, object rawObj) : base(jsHandle, false)
-        {
-            RawObject = rawObj;
-        }
 
         /// <summary>
         ///   Invoke a named method of the object, or throws a JSException on error.
@@ -171,7 +164,7 @@ namespace System.Runtime.InteropServices.JavaScript
         {
             object setPropResult = Interop.Runtime.SetObjectProperty(JSHandle, name, value, createIfNotExists, hasOwnProperty, out int exception);
             if (exception != 0)
-                throw new JSException($"Error setting {name} on (js-obj js '{JSHandle}' .NET '{Int32Handle} raw '{RawObject != null})");
+                throw new JSException($"Error setting {name} on (js-obj js '{JSHandle}' .NET '{Int32Handle})");
         }
 
         /// <summary>
@@ -198,16 +191,11 @@ namespace System.Runtime.InteropServices.JavaScript
         /// <param name="prop">The String name or Symbol of the property to test.</param>
         public bool PropertyIsEnumerable(string prop) => (bool)Invoke("propertyIsEnumerable", prop);
 
-        internal object? GetWrappedObject()
-        {
-            return RawObject;
-        }
         internal void FreeHandle()
         {
             Runtime.ReleaseJSObject(this);
             SetHandleAsInvalid();
             IsDisposed = true;
-            RawObject = null;
             FreeGCHandle();
         }
 
@@ -248,7 +236,7 @@ namespace System.Runtime.InteropServices.JavaScript
 
         public override string ToString()
         {
-            return $"(js-obj js '{Int32Handle}' raw '{RawObject != null}')";
+            return $"(js-obj js '{Int32Handle}')";
         }
     }
 }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
@@ -80,7 +80,7 @@ namespace System.Runtime.InteropServices.JavaScript
                 if (options?.Signal != null)
                     throw new NotImplementedException("EventListenerOptions.Signal");
 
-                var jsfunc = Runtime.GetJSOwnedObjectHandle(listener);
+                var jsfunc = Runtime.GetJSOwnedObjectGCHandle(listener);
                 // int exception;
                 if (options.HasValue) {
                     // TODO: Optimize this
@@ -107,7 +107,7 @@ namespace System.Runtime.InteropServices.JavaScript
         {
             if (listener == null)
                 return;
-            var jsfunc = Runtime.GetJSOwnedObjectHandle(listener);
+            var jsfunc = Runtime.GetJSOwnedObjectGCHandle(listener);
             RemoveEventListener(name, jsfunc, options);
         }
 

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
@@ -23,7 +23,7 @@ namespace System.Runtime.InteropServices.JavaScript
 
         public JSObject() : this(Interop.Runtime.New<object>(), true)
         {
-            object result = Interop.Runtime.BindCoreObject(JSHandle, GCHandle, out int exception);
+            object result = Interop.Runtime.BindCoreObject(JSHandle, GCHandleValue, out int exception);
             if (exception != 0)
                 throw new JSException(SR.Format(SR.JSObjectErrorBinding, result));
 
@@ -164,7 +164,7 @@ namespace System.Runtime.InteropServices.JavaScript
         {
             object setPropResult = Interop.Runtime.SetObjectProperty(JSHandle, name, value, createIfNotExists, hasOwnProperty, out int exception);
             if (exception != 0)
-                throw new JSException($"Error setting {name} on (js-obj js '{JSHandle}' .NET '{GCHandle})");
+                throw new JSException($"Error setting {name} on (js-obj js '{JSHandle}' .NET '{GCHandleValue})");
         }
 
         /// <summary>
@@ -236,7 +236,7 @@ namespace System.Runtime.InteropServices.JavaScript
 
         public override string ToString()
         {
-            return $"(js-obj js '{GCHandle}')";
+            return $"(js-obj js '{GCHandleValue}')";
         }
     }
 }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -192,8 +192,8 @@ namespace System.Runtime.InteropServices.JavaScript
             GCHandle handle = (GCHandle)(IntPtr)gcHandle;
             lock (JSOwnedObjectLock) {
                 GCHandleFromJSOwnedObject.Remove(handle.Target!);
+                handle.Free();
             }
-            handle.Free();
         }
 
         public static int GetJSObjectId(object rawObj)

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -140,26 +140,29 @@ namespace System.Runtime.InteropServices.JavaScript
         public static int CreateTaskSource()
         {
             var tcs= new TaskCompletionSource<object>();
-            return GetJSOwnedObjectHandle(tcs);
+            return GetJSOwnedObjectGCHandle(tcs);
         }
 
-        public static void SetTaskSourceResult(int tcsGCHhanle, object result)
+        public static void SetTaskSourceResult(int tcsGCHandle, object result)
         {
-            GCHandle handle = (GCHandle)(IntPtr)tcsGCHhanle;
+            GCHandle handle = (GCHandle)(IntPtr)tcsGCHandle;
+            // this is JS owned Normal handle. We always have a Target
             TaskCompletionSource<object> tcs = (TaskCompletionSource<object>)handle.Target!;
             tcs.SetResult(result);
         }
 
-        public static void SetTaskSourceFailure(int tcsGCHhanle, string reason)
+        public static void SetTaskSourceFailure(int tcsGCHandle, string reason)
         {
-            GCHandle handle = (GCHandle)(IntPtr)tcsGCHhanle;
+            GCHandle handle = (GCHandle)(IntPtr)tcsGCHandle;
+            // this is JS owned Normal handle. We always have a Target
             TaskCompletionSource<object> tcs = (TaskCompletionSource<object>)handle.Target!;
             tcs.SetException(new JSException(reason));
         }
 
-        public static object GetTaskSourceTask(int tcsGCHhanle)
+        public static object GetTaskSourceTask(int tcsGCHandle)
         {
-            GCHandle handle = (GCHandle)(IntPtr)tcsGCHhanle;
+            GCHandle handle = (GCHandle)(IntPtr)tcsGCHandle;
+            // this is JS owned Normal handle. We always have a Target
             TaskCompletionSource<object> tcs = (TaskCompletionSource<object>)handle.Target!;
             return tcs.Task;
         }
@@ -171,7 +174,7 @@ namespace System.Runtime.InteropServices.JavaScript
         //  strong references, allowing the managed object to be collected.
         // This ensures that things like delegates and promises will never 'go away' while JS
         //  is expecting to be able to invoke or await them.
-        public static int GetJSOwnedObjectHandle (object o) {
+        public static int GetJSOwnedObjectGCHandle (object o) {
             if (o == null)
                 return 0;
 

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -73,7 +73,7 @@ namespace System.Runtime.InteropServices.JavaScript
 
             target.AddInFlight();
 
-            return target.GCHandle;
+            return target.GCHandleValue;
         }
 
         public static int BindCoreCLRObject(int jsHandle, int gcHandle)
@@ -86,7 +86,7 @@ namespace System.Runtime.InteropServices.JavaScript
                 if (_boundObjects.TryGetValue(jsHandle, out WeakReference<JSObject>? wr))
                 {
 
-                    if (!wr.TryGetTarget(out JSObject? instance) || (instance.GCHandle != (int)(IntPtr)h && h.IsAllocated))
+                    if (!wr.TryGetTarget(out JSObject? instance) || (instance.GCHandleValue != (int)(IntPtr)h && h.IsAllocated))
                     {
                         throw new JSException(SR.Format(SR.MultipleHandlesPointingJsId, jsHandle));
                     }
@@ -100,7 +100,7 @@ namespace System.Runtime.InteropServices.JavaScript
                 }
             }
 
-            return obj?.GCHandle ?? 0;
+            return obj?.GCHandleValue ?? 0;
         }
 
         private static JSObject BindJSType(IntPtr jsIntPtr, bool ownsHandle, int coreType) =>
@@ -128,7 +128,7 @@ namespace System.Runtime.InteropServices.JavaScript
         {
             Interop.Runtime.ReleaseHandle(objToRelease.JSHandle, out int exception);
             if (exception != 0)
-                throw new JSException($"Error releasing handle on (js-obj js '{objToRelease.JSHandle}' mono '{objToRelease.GCHandle})");
+                throw new JSException($"Error releasing handle on (js-obj js '{objToRelease.JSHandle}' mono '{objToRelease.GCHandleValue})");
 
             lock (_boundObjects)
             {

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -82,13 +82,10 @@ namespace System.Runtime.InteropServices.JavaScript
             {
                 if (_boundObjects.TryGetValue(jsHandle, out WeakReference<JSObject>? wr))
                 {
-                    if (!wr.TryGetTarget(out JSObject? instance))
+
+                    if (!wr.TryGetTarget(out JSObject? instance) || (instance.GCHandle != (int)(IntPtr)h && h.IsAllocated))
                     {
-                        throw new JSException("bound object was collected");
-                    }
-                    else if (instance.GCHandle != (int)(IntPtr)h && h.IsAllocated)
-                    {
-                        throw new JSException(instance.GetType().FullName + SR.Format(SR.MultipleHandlesPointingJsHandle, jsHandle));
+                        throw new JSException(SR.Format(SR.MultipleHandlesPointingJsId, jsHandle));
                     }
 
                     obj = instance;

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -43,18 +43,6 @@ namespace System.Runtime.InteropServices.JavaScript
             return Interop.Runtime.New(hostClassName, parms);
         }
 
-        public static void FreeObject(object obj)
-        {
-            JSObject? jsobj;
-            lock (_rawToJS)
-            {
-                if (!_rawToJS.Remove(obj, out jsobj))
-                {
-                    throw new JSException(SR.Format(SR.ErrorReleasingObject, obj));
-                }
-            }
-        }
-
         public static object GetGlobalObject(string? str = null)
         {
             return Interop.Runtime.GetGlobalObject(str);
@@ -391,7 +379,6 @@ namespace System.Runtime.InteropServices.JavaScript
                 finally
                 {
                     continuationObj.Dispose();
-                    FreeObject(task);
                 }
             }
         }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System.Private.Runtime.InteropServices.JavaScript.Tests.csproj
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System.Private.Runtime.InteropServices.JavaScript.Tests.csproj
@@ -3,6 +3,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>$(NetCoreAppCurrent)-Browser</TargetFrameworks>
     <TestRuntime>true</TestRuntime>
+    <WasmXHarnessArgs>$(WasmXHarnessArgs) --engine-arg=--expose-gc</WasmXHarnessArgs>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Runtime\InteropServices\JavaScript\JavaScriptTests.cs" />

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/DelegateTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/DelegateTests.cs
@@ -293,8 +293,26 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
 
             var promise = (Task<object>)factory.Call();
 
-            await Assert.ThrowsAsync<JSException>(async () => await promise);
+            var ex = await Assert.ThrowsAsync<JSException>(async () => await promise);
+            Assert.Equal("fail", ex.Message);
         }
+
+        [Fact]
+        public static async Task RejectPromiseError()
+        {
+            var factory = new Function(@"
+                return new Promise((resolve, reject) => {
+                  setTimeout(() => {
+                    reject(new Error('fail'));
+                  }, 300);
+                });");
+
+            var promise = (Task<object>)factory.Call();
+
+            var ex = await Assert.ThrowsAsync<JSException>(async () => await promise);
+            Assert.Equal("Error: fail", ex.Message);
+        }
+
 
         [ActiveIssue("not implemented")]
         [Fact]

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/DelegateTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/DelegateTests.cs
@@ -230,7 +230,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             {
                 var evnti = dispatcher.Invoke("eventFactory", i);
                 dispatcher.Invoke("fireEvent", evnti);
-                Runtime.InvokeJS("gc();");// needs v8 flag --expose-gc
+                Runtime.InvokeJS("if (gc) gc();");// needs v8 flag --expose-gc
             }
         }
 
@@ -286,7 +286,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
 
                 Assert.Equal("bar", value.GetObjectProperty("foo"));
 
-                Runtime.InvokeJS("gc();");// needs v8 flag --expose-gc
+                Runtime.InvokeJS("if (gc) gc();");// needs v8 flag --expose-gc
             }
         }
 

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/DelegateTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/DelegateTests.cs
@@ -228,6 +228,24 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
 
         [Fact]
+        public static void NullDelegate()
+        {
+            var tcs = new TaskCompletionSource<int>();
+            var factory = new Function("delegate", "callback", @"
+                callback(delegate);
+            ");
+
+            Delegate check = null;
+            Action<Delegate> callback = (Delegate data) =>
+            {
+                check = data;
+            };
+            Assert.Null(check);
+            factory.Call(null, null, callback);
+            Assert.Null(check);
+        }
+
+        [Fact]
         public static async Task ResolvePromise()
         {
             var factory = new Function(@"
@@ -305,5 +323,22 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             Assert.Contains("System.Exception: test", check);
         }
 
+        [Fact]
+        public static void NullTask()
+        {
+            var tcs = new TaskCompletionSource<int>();
+            var factory = new Function("task", "callback", @"
+                callback(task);
+            ");
+
+            Task check = null;
+            Action<Task> callback = (Task data) =>
+            {
+                check = data;
+            };
+            Assert.Null(check);
+            factory.Call(null, null, callback);
+            Assert.Null(check);
+        }
     }
 }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/DelegateTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/DelegateTests.cs
@@ -211,7 +211,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 }
             };");
             var dispatcher = (JSObject)factory.Call();
-            var temp = new bool[2];
+            var temp = new bool[100];
             Action<JSObject> cb = (JSObject envt) =>
             {
                 var data = (int)envt.GetObjectProperty("data");
@@ -225,6 +225,13 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             dispatcher.Invoke("fireEvent", evnt1);
             Assert.True(temp[0]);
             Assert.True(temp[1]);
+
+            for (int i = 0; i < 100; i++)
+            {
+                var evnti = dispatcher.Invoke("eventFactory", i);
+                dispatcher.Invoke("fireEvent", evnti);
+                Runtime.InvokeJS("gc();");// needs v8 flag --expose-gc
+            }
         }
 
         [Fact]
@@ -278,6 +285,8 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 var value = (JSObject)await promise;
 
                 Assert.Equal("bar", value.GetObjectProperty("foo"));
+
+                Runtime.InvokeJS("gc();");// needs v8 flag --expose-gc
             }
         }
 

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/DelegateTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/DelegateTests.cs
@@ -246,7 +246,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
 
         [Fact]
-        public static async Task ResolvePromise()
+        public static async Task ResolveStringPromise()
         {
             var factory = new Function(@"
                 return new Promise((resolve, reject) => {
@@ -260,6 +260,25 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
 
             Assert.Equal("foo", (string)value);
             
+        }
+
+        [Fact]
+        public static async Task ResolveJSObjectPromise()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                var factory = new Function(@"
+                return new Promise((resolve, reject) => {
+                  setTimeout(() => {
+                    resolve({foo:'bar'});
+                  }, 300);
+                });");
+
+                var promise = (Task<object>)factory.Call();
+                var value = (JSObject)await promise;
+
+                Assert.Equal("bar", value.GetObjectProperty("foo"));
+            }
         }
 
         [Fact]

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/DelegateTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/DelegateTests.cs
@@ -199,6 +199,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [Fact]
         public static void DispatchToDelegate()
         {
+            const int attempts = 100; // we fire 100 events in a loop, to try that it's GC same
             var factory = new Function(@"return {
                 callback: null,
                 eventFactory:function(data){
@@ -211,7 +212,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 }
             };");
             var dispatcher = (JSObject)factory.Call();
-            var temp = new bool[100];
+            var temp = new bool[attempts];
             Action<JSObject> cb = (JSObject envt) =>
             {
                 var data = (int)envt.GetObjectProperty("data");
@@ -226,7 +227,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             Assert.True(temp[0]);
             Assert.True(temp[1]);
 
-            for (int i = 0; i < 100; i++)
+            for (int i = 0; i < attempts; i++)
             {
                 var evnti = dispatcher.Invoke("eventFactory", i);
                 dispatcher.Invoke("fireEvent", evnti);

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/DelegateTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/DelegateTests.cs
@@ -277,6 +277,28 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             await Assert.ThrowsAsync<JSException>(async () => await promise);
         }
 
+        [ActiveIssue("not implemented")]
+        [Fact]
+        public static void RoundtripPromise()
+        {
+            var factory = new Function(@"
+                var dummy=new Promise((resolve, reject) => {});
+                return {
+                    dummy:dummy,
+                    check:(promise)=>{
+                        console.log(JSON.stringify(promise));
+                        return promise===dummy ? 1:0;
+                    }
+                }");
+
+            var obj = (JSObject)factory.Call();
+            var dummy = obj.GetObjectProperty("dummy");
+            Assert.IsType<Task<object>>(dummy);
+            var check = obj.Invoke("check", dummy);
+            Assert.Equal(1, check);
+        }
+
+
         [Fact]
         public static async Task ResolveTask()
         {
@@ -339,6 +361,21 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             Assert.Null(check);
             factory.Call(null, null, callback);
             Assert.Null(check);
+        }
+
+        [ActiveIssue("not implemented")]
+        [Fact]
+        public static void RoundtripTask()
+        {
+            var tcs = new TaskCompletionSource<int>();
+            var factory = new Function("dummy", @"
+                return {
+                    dummy:dummy,
+                }");
+
+            var obj = (JSObject)factory.Call(tcs.Task);
+            var dummy = obj.GetObjectProperty("dummy");
+            Assert.IsType<Task<int>>(dummy);
         }
     }
 }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/DelegateTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/DelegateTests.cs
@@ -199,8 +199,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [Fact]
         public static void DispatchToDelegate()
         {
-            var factory = new Function(@"return
-            {
+            var factory = new Function(@"return {
                 callback: null,
                 eventFactory:function(data){
                     return {

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/DelegateTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/DelegateTests.cs
@@ -257,7 +257,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 var evnti = dispatcher.Invoke("eventFactory", i);
                 dispatcher.Invoke("fireEvent", evnti);
                 dispatcher.Invoke("fireEvent", evnt);
-                Runtime.InvokeJS("if (gc) gc();");// needs v8 flag --expose-gc
+                Runtime.InvokeJS("if (globalThis.gc) globalThis.gc();");// needs v8 flag --expose-gc
             }
         }
 
@@ -311,7 +311,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 var value = (JSObject)await promise;
 
                 Assert.Equal("bar", value.GetObjectProperty("foo"));
-                Runtime.InvokeJS("if (gc) gc();");// needs v8 flag --expose-gc
+                Runtime.InvokeJS("if (globalThis.gc) globalThis.gc();");// needs v8 flag --expose-gc
             }
         }
 

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JavaScriptTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JavaScriptTests.cs
@@ -151,7 +151,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                     var x = new byte[100 + attempt / 100];
                     if (attempt % 1000 == 0)
                     {
-                        Runtime.InvokeJS("if (gc) gc();");// needs v8 flag --expose-gc
+                        Runtime.InvokeJS("if (globalThis.gc) globalThis.gc();");// needs v8 flag --expose-gc
                         GC.Collect();
                     }
                 }
@@ -315,7 +315,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 obj.Invoke("fireEvent", "test", evnt);
                 obj.Invoke("fireEvent", "test", evnti);
                 // we are trying to test that managed side doesn't lose strong reference to evnt instance
-                Runtime.InvokeJS("if (gc) gc();");// needs v8 flag --expose-gc
+                Runtime.InvokeJS("if (globalThis.gc) globalThis.gc();");// needs v8 flag --expose-gc
                 GC.Collect();
             }
         }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JavaScriptTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JavaScriptTests.cs
@@ -151,7 +151,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                     var x = new byte[100 + attempt / 100];
                     if (attempt % 1000 == 0)
                     {
-                        Runtime.InvokeJS("gc();");// needs v8 flag --expose-gc
+                        Runtime.InvokeJS("if (gc) gc();");// needs v8 flag --expose-gc
                         GC.Collect();
                     }
                 }
@@ -293,7 +293,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             var evnt0 = obj.Invoke("eventFactory", 0);
             var evnt1 = obj.Invoke("eventFactory", 1);
             obj.Invoke("fireEvent", "test", evnt0);
-            Runtime.InvokeJS("gc();");// needs v8 flag --expose-gc
+            Runtime.InvokeJS("if (gc) gc();");// needs v8 flag --expose-gc
             GC.Collect();
             obj.Invoke("fireEvent", "test", evnt0);
             obj.Invoke("fireEvent", "test", evnt1);

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JavaScriptTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JavaScriptTests.cs
@@ -281,7 +281,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         public static void AddEventListenerWorks () {
             var temp = new bool[1];
             var obj = SetupListenerTest("addEventListenerWorks");
-            obj.AddEventListener("test", () => {
+            obj.AddEventListener("test", (JSObject envt) => {
                 temp[0] = true;
             });
             obj.Invoke("fireEvent", "test");
@@ -292,10 +292,10 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         public static void AddEventListenerPassesOptions () {
             var log = new List<string>();
             var obj = SetupListenerTest("addEventListenerPassesOptions");
-            obj.AddEventListener("test", () => {
+            obj.AddEventListener("test", (JSObject envt) => {
                 log.Add("Capture");
             }, new JSObject.EventListenerOptions { Capture = true });
-            obj.AddEventListener("test", () => {
+            obj.AddEventListener("test", (JSObject envt) => {
                 log.Add("Non-capture");
             }, new JSObject.EventListenerOptions { Capture = false });
             obj.Invoke("fireEvent", "test");
@@ -306,7 +306,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [Fact]
         public static void AddEventListenerForwardsExceptions () {
             var obj = SetupListenerTest("addEventListenerForwardsExceptions");
-            obj.AddEventListener("test", () => {
+            obj.AddEventListener("test", (JSObject envt) => {
                 throw new Exception("Test exception");
             });
             var exc = Assert.Throws<JSException>(() => {
@@ -315,7 +315,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             Assert.Contains("Test exception", exc.Message);
 
             exc = Assert.Throws<JSException>(() => {
-                obj.AddEventListener("throwError", () => {
+                obj.AddEventListener("throwError", (JSObject envt) => {
                     throw new Exception("Should not be called");
                 });
             });
@@ -326,7 +326,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [Fact]
         public static void RemovedEventListenerIsNotCalled () {
             var obj = SetupListenerTest("removedEventListenerIsNotCalled");
-            Action del = () => {
+            Action<JSObject> del = (JSObject envt) => {
                 throw new Exception("Should not be called");
             };
             obj.AddEventListener("test", del);
@@ -342,7 +342,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         public static void RegisterSameEventListener () {
             var counter = new int[1];
             var obj = SetupListenerTest("registerSameDelegateTwice");
-            Action del = () => {
+            Action<JSObject> del = (JSObject envt) => {
                 counter[0]++;
             };
 
@@ -368,7 +368,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [Fact]
         public static void UseAddEventListenerResultToRemove () {
             var obj = SetupListenerTest("useAddEventListenerResultToRemove");
-            Action del = () => {
+            Action<JSObject> del = (JSObject envt) => {
                 throw new Exception("Should not be called");
             };
             var handle = obj.AddEventListener("test", del);
@@ -385,7 +385,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             var counter = new int[1];
             var a = SetupListenerTest("registerSameEventListenerToMultipleSourcesA");
             var b = SetupListenerTest("registerSameEventListenerToMultipleSourcesB");
-            Action del = () => {
+            Action<JSObject> del = (JSObject envt) => {
                 counter[0]++;
             };
 

--- a/src/mono/wasm/runtime-test.js
+++ b/src/mono/wasm/runtime-test.js
@@ -23,7 +23,13 @@ function proxyMethod (prefix, func, asJson) {
 		if(payload === undefined) payload = 'undefined';
 		else if(payload === null) payload = 'null';
 		else if(typeof payload === 'function') payload = payload.toString();
-		else if(typeof payload !== 'string') payload = JSON.stringify(payload);
+		else if(typeof payload !== 'string') {
+			try{
+				payload = JSON.stringify(payload);
+			}catch(e){
+				payload = payload.toString();
+			}
+		}
 
 		if (asJson) {
 			func (JSON.stringify({

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -1711,13 +1711,13 @@ var BindingSupportLib = {
 			var js_name = BINDING.conv_string (nameRoot.value);
 			if (!js_name || (typeof(js_name) !== "string")) {
 				setValue (is_exception, 1, "i32");
-				return BINDING.js_string_to_mono_string ("Invalid method name object '" + nameRoot.value + "' at mono_wasm_invoke_js_with_args");
+				return BINDING.js_string_to_mono_string ("ERR12: Invalid method name object '" + nameRoot.value + "'");
 			}
 
 			var obj = BINDING.get_js_obj (js_handle);
 			if (!obj) {
 				setValue (is_exception, 1, "i32");
-				return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "' at mono_wasm_invoke_js_with_args while invoking '"+js_name+"'");
+				return BINDING.js_string_to_mono_string ("ERR13: Invalid JS object handle '" + js_handle + "' while invoking '"+js_name+"'");
 			}
 
 			var js_args = BINDING.mono_wasm_parse_args_root(argsRoot);
@@ -1751,13 +1751,13 @@ var BindingSupportLib = {
 			var js_name = BINDING.conv_string (nameRoot.value);
 			if (!js_name) {
 				setValue (is_exception, 1, "i32");
-				return BINDING.js_string_to_mono_string ("Invalid property name object '" + nameRoot.value + "' at mono_wasm_get_object_property");
+				return BINDING.js_string_to_mono_string ("Invalid property name object '" + nameRoot.value + "'");
 			}
 
 			var obj = BINDING.mono_wasm_get_jsobj_from_js_handle (js_handle);
 			if (!obj) {
 				setValue (is_exception, 1, "i32");
-				return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "' at mono_wasm_get_object_property while geting '"+js_name+"'");
+				return BINDING.js_string_to_mono_string ("ERR01: Invalid JS object handle '" + js_handle + "' while geting '"+js_name+"'");
 			}
 
 			var res;
@@ -1785,13 +1785,13 @@ var BindingSupportLib = {
 			var property = BINDING.conv_string (nameRoot.value);
 			if (!property) {
 				setValue (is_exception, 1, "i32");
-				return BINDING.js_string_to_mono_string ("Invalid property name object '" + property_name + "' at mono_wasm_set_object_property");
+				return BINDING.js_string_to_mono_string ("Invalid property name object '" + property_name + "'");
 			}
 
 			var js_obj = BINDING.mono_wasm_get_jsobj_from_js_handle (js_handle);
 			if (!js_obj) {
 				setValue (is_exception, 1, "i32");
-				return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "' at mono_wasm_set_object_property while setting '"+property+"'");
+				return BINDING.js_string_to_mono_string ("ERR02: Invalid JS object handle '" + js_handle + "' while setting '"+property+"'");
 			}
 
 			var result = false;
@@ -1835,7 +1835,7 @@ var BindingSupportLib = {
 		var obj = BINDING.mono_wasm_get_jsobj_from_js_handle (js_handle);
 		if (!obj) {
 			setValue (is_exception, 1, "i32");
-			return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "' at mono_wasm_get_by_index while getting ["+property_index+"]");
+			return BINDING.js_string_to_mono_string ("ERR03: Invalid JS object handle '" + js_handle + "' while getting ["+property_index+"]");
 		}
 
 		try {
@@ -1857,7 +1857,7 @@ var BindingSupportLib = {
 			var obj = BINDING.mono_wasm_get_jsobj_from_js_handle (js_handle);
 			if (!obj) {
 				setValue (is_exception, 1, "i32");
-				return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "' at mono_wasm_set_by_index while setting ["+property_index+"]");
+				return BINDING.js_string_to_mono_string ("ERR04: Invalid JS object handle '" + js_handle + "' while setting ["+property_index+"]");
 			}
 
 			var js_value = BINDING._unbox_mono_obj_root(valueRoot);
@@ -1914,7 +1914,7 @@ var BindingSupportLib = {
 		var js_obj = BINDING.mono_wasm_get_jsobj_from_js_handle (js_handle);
 		if (!js_obj) {
 			setValue (is_exception, 1, "i32");
-			return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "' at mono_wasm_bind_core_object");
+			return BINDING.js_string_to_mono_string ("ERR05: Invalid JS object handle '" + js_handle + "'");
 		}
 
 		BINDING.wasm_bind_core_clr_obj(js_handle, gc_handle );
@@ -1978,7 +1978,7 @@ var BindingSupportLib = {
 		var js_obj = BINDING.mono_wasm_get_jsobj_from_js_handle (js_handle);
 		if (!js_obj) {
 			setValue (is_exception, 1, "i32");
-			return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "' at mono_wasm_typed_array_to_array");
+			return BINDING.js_string_to_mono_string ("ERR06: Invalid JS object handle '" + js_handle + "'");
 		}
 
 		return BINDING.js_typed_array_to_array(js_obj);
@@ -1989,7 +1989,7 @@ var BindingSupportLib = {
 		var js_obj = BINDING.mono_wasm_get_jsobj_from_js_handle (js_handle);
 		if (!js_obj) {
 			setValue (is_exception, 1, "i32");
-			return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "' at mono_wasm_typed_array_copy_to");
+			return BINDING.js_string_to_mono_string ("ERR07: Invalid JS object handle '" + js_handle + "'");
 		}
 
 		var res = BINDING.typedarray_copy_to(js_obj, pinned_array, begin, end, bytes_per_element);
@@ -2006,7 +2006,7 @@ var BindingSupportLib = {
 		var js_obj = BINDING.mono_wasm_get_jsobj_from_js_handle (js_handle);
 		if (!js_obj) {
 			setValue (is_exception, 1, "i32");
-			return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "' at mono_wasm_typed_array_copy_from");
+			return BINDING.js_string_to_mono_string ("ERR08: Invalid JS object handle '" + js_handle + "'");
 		}
 
 		var res = BINDING.typedarray_copy_from(js_obj, pinned_array, begin, end, bytes_per_element);
@@ -2020,10 +2020,10 @@ var BindingSupportLib = {
 
 			var obj = BINDING.mono_wasm_get_jsobj_from_js_handle(objHandle);
 			if (!obj)
-				throw new Error("Invalid JS object handle at mono_wasm_add_event_listener for '"+sName+"'");
+				throw new Error("ERR09: Invalid JS object handle for '"+sName+"'");
 			var listener = BINDING._wrap_delegate_gc_handle_as_function(listener_gc_handle);
 			if (!listener)
-				throw new Error("Invalid listener gc_handle");
+				throw new Error("ERR10: Invalid listener gc_handle");
 
 			var options = optionsHandle
 				? BINDING.mono_wasm_get_jsobj_from_js_handle(optionsHandle)
@@ -2046,7 +2046,7 @@ var BindingSupportLib = {
 			BINDING.bindings_lazy_init ();
 			var obj = BINDING.mono_wasm_get_jsobj_from_js_handle(objHandle);
 			if (!obj)
-				throw new Error("Invalid JS object handle at mono_wasm_remove_event_listener");
+				throw new Error("ERR11: Invalid JS object handle");
 			var listener = BINDING._wrap_delegate_gc_handle_as_function(listener_gc_handle);
 			// Removing a nonexistent listener should not be treated as an error
 			if (!listener)

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -197,11 +197,11 @@ var BindingSupportLib = {
 			thenable.then ((result) => {
 				this.set_tcs_result(tcs_gc_handle, result);
 				// let go of the thenable reference
-				this.mono_wasm_unregister_obj(thenable_js_handle);
+				this._mono_wasm_release_js_handle(thenable_js_handle);
 			}, (reason) => {
 				this.set_tcs_failure(tcs_gc_handle, reason ? reason.toString() : "");
 				// let go of the thenable reference
-				this.mono_wasm_unregister_obj(thenable_js_handle);
+				this._mono_wasm_release_js_handle(thenable_js_handle);
 			});
 
 			// collect the TaskCompletionSource with its Task after js doesn't hold the thenable anymore
@@ -530,6 +530,19 @@ var BindingSupportLib = {
 				return mono_array;
 			} finally {
 				MONO.mono_wasm_release_roots (arrayRoot, elemRoot);
+			}
+		},
+
+		// this is only used from Blazor
+		unbox_mono_obj: function (mono_obj) {
+			if (mono_obj === 0)
+				return undefined;
+
+			var root = MONO.mono_wasm_new_root (mono_obj);
+			try {
+				return this._unbox_mono_obj_root (root);
+			} finally {
+				root.release();
 			}
 		},
 

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -1883,7 +1883,7 @@ var BindingSupportLib = {
 	mono_wasm_release_handle: function(js_handle, is_exception) {
 		BINDING.bindings_lazy_init ();
 
-		var obj = this.mono_wasm_object_registry[js_handle - 1];
+		var obj = BINDING.mono_wasm_object_registry[js_handle - 1];
 		if (typeof obj  !== "undefined" && obj !== null) {
 			// if this is the global object then do not
 			// unregister it.
@@ -1895,8 +1895,8 @@ var BindingSupportLib = {
 				obj.__mono_jshandle__ = undefined;
 			}
 
-			delete this.mono_wasm_object_registry[js_handle - 1];
-			this.mono_wasm_free_list.push(js_handle - 1);
+			delete BINDING.mono_wasm_object_registry[js_handle - 1];
+			BINDING.mono_wasm_free_list.push(js_handle - 1);
 		}
 		return obj;
 	},

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -199,7 +199,7 @@ var BindingSupportLib = {
 				// let go of the thenable reference
 				this.mono_wasm_unregister_obj(thenable_js_handle);
 			}, (reason) => {
-				this.set_tcs_failure(tcs_gc_handle, reason);
+				this.set_tcs_failure(tcs_gc_handle, reason ? reason.toString() : "");
 				// let go of the thenable reference
 				this.mono_wasm_unregister_obj(thenable_js_handle);
 			});
@@ -406,7 +406,7 @@ var BindingSupportLib = {
 			else if (typeof (string) === "symbol")
 				return this.js_string_to_mono_string_interned (string);
 			else if (typeof (string) !== "string")
-				throw new Error ("Expected string argument");
+				throw new Error ("Expected string argument, got "+ typeof (string));
 
 			// Always use an interned pointer for empty strings
 			if (string.length === 0)

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -144,7 +144,6 @@ var BindingSupportLib = {
 			this.create_date_time = get_method ("CreateDateTime");
 			this.create_uri = get_method ("CreateUri");
 
-			this.safehandle_addref = get_method ("SafeHandleAddRef");
 			this.safehandle_release = get_method ("SafeHandleRelease");
 			this.safehandle_get_handle = get_method ("SafeHandleGetHandle");
 			this.safehandle_release_by_handle = get_method ("SafeHandleReleaseByHandle");

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -142,7 +142,6 @@ var BindingSupportLib = {
 			this.create_date_time = get_method ("CreateDateTime");
 			this.create_uri = get_method ("CreateUri");
 
-			this.safehandle_release = get_method ("SafeHandleRelease");
 			this.safehandle_get_handle = get_method ("SafeHandleGetHandle");
 			this.safehandle_release_by_handle = get_method ("SafeHandleReleaseByHandle");
 			this.release_js_owned_object_by_handle = bind_runtime_method ("ReleaseJSOwnedObjectByHandle", "i");
@@ -549,7 +548,7 @@ var BindingSupportLib = {
 		_unbox_safehandle_root: function (root) {
 			var addRef = true;
 			var js_handle = this.call_method(this.safehandle_get_handle, null, "mi", [ root.value, addRef ]);
-			var requiredObject = BINDING.mono_wasm_get_jsobj_from_js_handle (js_handle);
+			var js_obj = BINDING.mono_wasm_get_jsobj_from_js_handle (js_handle);
 			if (addRef)
 			{
 				if (typeof this.mono_wasm_owned_objects_LMF === "undefined")
@@ -557,7 +556,7 @@ var BindingSupportLib = {
 
 				this.mono_wasm_owned_objects_LMF.push(js_handle);
 			}
-			return requiredObject;
+			return js_obj;
 		},
 
 		_unbox_mono_obj_root_with_known_nonprimitive_type: function (root, type) {

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -197,11 +197,11 @@ var BindingSupportLib = {
 			thenable.then ((result) => {
 				this.set_tcs_result(tcs_gchandle, result);
 				// let go of the thenable reference
-				this.mono_wasm_release_handle(thenable_js_handle);
+				this.mono_wasm_unregister_obj(thenable_js_handle);
 			}, (reason) => {
 				this.set_tcs_failure(tcs_gchandle, reason);
 				// let go of the thenable reference
-				this.mono_wasm_release_handle(thenable_js_handle);
+				this.mono_wasm_unregister_obj(thenable_js_handle);
 			});
 
 			// collect the TaskCompletionSource with its Task after js doesn't hold the thenable anymore
@@ -1647,6 +1647,24 @@ var BindingSupportLib = {
 				return this.mono_wasm_object_registry[handle - 1];
 			return null;
 		},
+		mono_wasm_unregister_obj: function(js_handle, is_exception) {
+			var obj = BINDING.mono_wasm_object_registry[js_handle - 1];
+			if (typeof obj  !== "undefined" && obj !== null) {
+				// if this is the global object then do not
+				// unregister it.
+				if (globalThis === obj)
+					return obj;
+
+				if (typeof obj.__mono_gchandle__  !== "undefined") {
+					obj.__mono_gchandle__ = undefined;
+					obj.__mono_jshandle__ = undefined;
+				}
+
+				delete BINDING.mono_wasm_object_registry[js_handle - 1];
+				BINDING.mono_wasm_free_list.push(js_handle - 1);
+			}
+			return obj;
+		},
 		mono_wasm_free_raw_object: function(js_id) {
 			var obj = this.mono_wasm_object_registry[js_id - 1];
 			if (typeof obj  !== "undefined" && obj !== null) {
@@ -1901,23 +1919,7 @@ var BindingSupportLib = {
 	},
 	mono_wasm_release_handle: function(js_handle, is_exception) {
 		BINDING.bindings_lazy_init ();
-
-		var obj = BINDING.mono_wasm_object_registry[js_handle - 1];
-		if (typeof obj  !== "undefined" && obj !== null) {
-			// if this is the global object then do not
-			// unregister it.
-			if (globalThis === obj)
-				return obj;
-
-			if (typeof obj.__mono_gchandle__  !== "undefined") {
-				obj.__mono_gchandle__ = undefined;
-				obj.__mono_jshandle__ = undefined;
-			}
-
-			delete BINDING.mono_wasm_object_registry[js_handle - 1];
-			BINDING.mono_wasm_free_list.push(js_handle - 1);
-		}
-		return obj;
+		BINDING.mono_wasm_unregister_obj(js_handle);
 	},
 	mono_wasm_release_object: function(js_handle, is_exception) {
 		BINDING.bindings_lazy_init ();

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -1721,16 +1721,16 @@ var BindingSupportLib = {
 		try {
 			BINDING.bindings_lazy_init ();
 
-			var obj = BINDING.get_js_obj (js_handle);
-			if (!obj) {
-				setValue (is_exception, 1, "i32");
-				return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "'");
-			}
-
 			var js_name = BINDING.conv_string (nameRoot.value);
 			if (!js_name || (typeof(js_name) !== "string")) {
 				setValue (is_exception, 1, "i32");
-				return BINDING.js_string_to_mono_string ("Invalid method name object '" + nameRoot.value + "'");
+				return BINDING.js_string_to_mono_string ("Invalid method name object '" + nameRoot.value + "' at mono_wasm_invoke_js_with_args");
+			}
+
+			var obj = BINDING.get_js_obj (js_handle);
+			if (!obj) {
+				setValue (is_exception, 1, "i32");
+				return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "' at mono_wasm_invoke_js_with_args while invoking '"+js_name+"'");
 			}
 
 			var js_args = BINDING.mono_wasm_parse_args_root(argsRoot);
@@ -1761,16 +1761,16 @@ var BindingSupportLib = {
 
 		var nameRoot = MONO.mono_wasm_new_root (property_name);
 		try {
-			var obj = BINDING.mono_wasm_require_handle (js_handle);
-			if (!obj) {
-				setValue (is_exception, 1, "i32");
-				return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "'");
-			}
-
 			var js_name = BINDING.conv_string (nameRoot.value);
 			if (!js_name) {
 				setValue (is_exception, 1, "i32");
-				return BINDING.js_string_to_mono_string ("Invalid property name object '" + nameRoot.value + "'");
+				return BINDING.js_string_to_mono_string ("Invalid property name object '" + nameRoot.value + "' at mono_wasm_get_object_property");
+			}
+
+			var obj = BINDING.mono_wasm_require_handle (js_handle);
+			if (!obj) {
+				setValue (is_exception, 1, "i32");
+				return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "' at mono_wasm_get_object_property while geting '"+js_name+"'");
 			}
 
 			var res;
@@ -1795,16 +1795,16 @@ var BindingSupportLib = {
 		var valueRoot = MONO.mono_wasm_new_root (value), nameRoot = MONO.mono_wasm_new_root (property_name);
 		try {
 			BINDING.bindings_lazy_init ();
-			var requireObject = BINDING.mono_wasm_require_handle (js_handle);
-			if (!requireObject) {
-				setValue (is_exception, 1, "i32");
-				return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "'");
-			}
-
 			var property = BINDING.conv_string (nameRoot.value);
 			if (!property) {
 				setValue (is_exception, 1, "i32");
-				return BINDING.js_string_to_mono_string ("Invalid property name object '" + property_name + "'");
+				return BINDING.js_string_to_mono_string ("Invalid property name object '" + property_name + "' at mono_wasm_set_object_property");
+			}
+
+			var requireObject = BINDING.mono_wasm_require_handle (js_handle);
+			if (!requireObject) {
+				setValue (is_exception, 1, "i32");
+				return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "' at mono_wasm_set_object_property while setting '"+property+"'");
 			}
 
 			var result = false;
@@ -1848,7 +1848,7 @@ var BindingSupportLib = {
 		var obj = BINDING.mono_wasm_require_handle (js_handle);
 		if (!obj) {
 			setValue (is_exception, 1, "i32");
-			return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "'");
+			return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "' at mono_wasm_get_by_index while getting ["+property_index+"]");
 		}
 
 		try {
@@ -1870,7 +1870,7 @@ var BindingSupportLib = {
 			var obj = BINDING.mono_wasm_require_handle (js_handle);
 			if (!obj) {
 				setValue (is_exception, 1, "i32");
-				return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "'");
+				return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "' at mono_wasm_set_by_index while setting ["+property_index+"]");
 			}
 
 			var js_value = BINDING._unbox_mono_obj_root(valueRoot);
@@ -1932,7 +1932,7 @@ var BindingSupportLib = {
 		var requireObject = BINDING.mono_wasm_require_handle (js_handle);
 		if (!requireObject) {
 			setValue (is_exception, 1, "i32");
-			return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "'");
+			return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "' at mono_wasm_bind_core_object");
 		}
 
 		BINDING.wasm_bind_core_clr_obj(js_handle, gc_handle );
@@ -1946,7 +1946,7 @@ var BindingSupportLib = {
 		var requireObject = BINDING.mono_wasm_require_handle (js_handle);
 		if (!requireObject) {
 			setValue (is_exception, 1, "i32");
-			return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "'");
+			return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "' as mono_wasm_bind_host_object");
 		}
 
 		BINDING.wasm_bind_core_clr_obj(js_handle, gc_handle );
@@ -2010,7 +2010,7 @@ var BindingSupportLib = {
 		var requireObject = BINDING.mono_wasm_require_handle (js_handle);
 		if (!requireObject) {
 			setValue (is_exception, 1, "i32");
-			return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "'");
+			return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "' at mono_wasm_typed_array_to_array");
 		}
 
 		return BINDING.js_typed_array_to_array(requireObject);
@@ -2021,7 +2021,7 @@ var BindingSupportLib = {
 		var requireObject = BINDING.mono_wasm_require_handle (js_handle);
 		if (!requireObject) {
 			setValue (is_exception, 1, "i32");
-			return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "'");
+			return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "' at mono_wasm_typed_array_copy_to");
 		}
 
 		var res = BINDING.typedarray_copy_to(requireObject, pinned_array, begin, end, bytes_per_element);
@@ -2038,7 +2038,7 @@ var BindingSupportLib = {
 		var requireObject = BINDING.mono_wasm_require_handle (js_handle);
 		if (!requireObject) {
 			setValue (is_exception, 1, "i32");
-			return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "'");
+			return BINDING.js_string_to_mono_string ("Invalid JS object handle '" + js_handle + "' at mono_wasm_typed_array_copy_from");
 		}
 
 		var res = BINDING.typedarray_copy_from(requireObject, pinned_array, begin, end, bytes_per_element);
@@ -2048,13 +2048,14 @@ var BindingSupportLib = {
 		var nameRoot = MONO.mono_wasm_new_root (name);
 		try {
 			BINDING.bindings_lazy_init ();
+			var sName = BINDING.conv_string(nameRoot.value);
+
 			var obj = BINDING.mono_wasm_require_handle(objHandle);
 			if (!obj)
-				throw new Error("Invalid JS object handle");
+				throw new Error("Invalid JS object handle at mono_wasm_add_event_listener for '"+sName+"'");
 			var listener = BINDING._wrap_delegate_gchandle_as_function(listener_gchandle);
 			if (!listener)
-				throw new Error("Invalid listener ID");
-			var sName = BINDING.conv_string(nameRoot.value);
+				throw new Error("Invalid listener gchandle");
 
 			var options = optionsHandle
 				? BINDING.mono_wasm_require_handle(optionsHandle)
@@ -2077,7 +2078,7 @@ var BindingSupportLib = {
 			BINDING.bindings_lazy_init ();
 			var obj = BINDING.mono_wasm_require_handle(objHandle);
 			if (!obj)
-				throw new Error("Invalid JS object handle");
+				throw new Error("Invalid JS object handle at mono_wasm_remove_event_listener");
 			var listener = BINDING._wrap_delegate_gchandle_as_function(listener_gchandle);
 			// Removing a nonexistent listener should not be treated as an error
 			if (!listener)

--- a/src/mono/wasm/runtime/corebindings.c
+++ b/src/mono/wasm/runtime/corebindings.c
@@ -17,10 +17,8 @@ extern MonoObject* mono_wasm_set_object_property (int js_handle, MonoString *pro
 extern MonoObject* mono_wasm_set_by_index (int js_handle, int property_index, MonoObject *value, int *is_exception);
 extern MonoObject* mono_wasm_get_global_object (MonoString *global_name, int *is_exception);
 extern void* mono_wasm_release_handle (int js_handle, int *is_exception);
-extern void* mono_wasm_release_object (int js_handle, int *is_exception);
 extern MonoObject* mono_wasm_new (MonoString *core_name, MonoArray *args, int *is_exception);
 extern int mono_wasm_bind_core_object (int js_handle, int gc_handle, int *is_exception);
-extern int mono_wasm_bind_host_object (int js_handle, int gc_handle, int *is_exception);
 extern MonoObject* mono_wasm_typed_array_to_array (int js_handle, int *is_exception);
 extern MonoObject* mono_wasm_typed_array_copy_to (int js_handle, int ptr, int begin, int end, int bytes_per_element, int *is_exception);
 extern MonoObject* mono_wasm_typed_array_from (int ptr, int begin, int end, int bytes_per_element, int type, int *is_exception);
@@ -78,9 +76,7 @@ void core_initialize_internals ()
 	mono_add_internal_call ("Interop/Runtime::SetByIndex", mono_wasm_set_by_index);
 	mono_add_internal_call ("Interop/Runtime::GetGlobalObject", mono_wasm_get_global_object);
 	mono_add_internal_call ("Interop/Runtime::ReleaseHandle", mono_wasm_release_handle);
-	mono_add_internal_call ("Interop/Runtime::ReleaseObject", mono_wasm_release_object);
 	mono_add_internal_call ("Interop/Runtime::BindCoreObject", mono_wasm_bind_core_object);
-	mono_add_internal_call ("Interop/Runtime::BindHostObject", mono_wasm_bind_host_object);
 	mono_add_internal_call ("Interop/Runtime::New", mono_wasm_new);
 	mono_add_internal_call ("Interop/Runtime::TypedArrayToArray", mono_wasm_typed_array_to_array);
 	mono_add_internal_call ("Interop/Runtime::TypedArrayCopyTo", mono_wasm_typed_array_copy_to);
@@ -89,7 +85,6 @@ void core_initialize_internals ()
 	mono_add_internal_call ("Interop/Runtime::CompileFunction", mono_wasm_compile_function);
 	mono_add_internal_call ("Interop/Runtime::AddEventListener", mono_wasm_add_event_listener);
 	mono_add_internal_call ("Interop/Runtime::RemoveEventListener", mono_wasm_remove_event_listener);
-
 }
 
 // Int8Array 		| int8_t	| byte or SByte (signed byte)


### PR DESCRIPTION
# Redesign of all managed object marshaling and lifecycle
- file cycle of js owned C# instances is driven by [FinalizationRegistry](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry)
    - got rid of `Runtime._weakDelegateTable` and `Runtime._rawToJS`
    - got rid of `JSObject.WeakRawObject` and `JSObject.RawObject`
    - GCHandle instead of JSObject double proxy for plain managed ref types
    - GCHandle instead of int sequence for delegates + redesign of invocation
    - GCHandle for task + redesign of invocation
    - improved in-flight retention of thenable/promise and Task
- explicitly delegate type of parameter for EventListener 
- moved and renamed some binding functions
- renamed all handles to `jsHandle` or `gcHandle` as appropriate
- removed `jsHandle` _math_
- cleanup of unused functions
- improved error messages for invalid handles
- more unit tests

Fixes https://github.com/dotnet/runtime/issues/55735 delegate GC
Fixes https://github.com/dotnet/runtime/issues/55679 delegate GC
Fixes https://github.com/dotnet/runtime/issues/53614 task GC
