### PR TITLE
Revert recent update of a docker image in eng/common

### DIFF
--- a/eng/common/templates/jobs/source-build.yml
+++ b/eng/common/templates/jobs/source-build.yml
@@ -14,7 +14,7 @@ parameters:
   # This is the default platform provided by Arcade, intended for use by a managed-only repo.
   defaultManagedPlatform:
     name: 'Managed'
-    container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-20210714125435-9b5bbc2'
+    container: 'mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-3e800f1-20190501005343'
 
   # Defines the platforms on which to run build jobs. One job is created for each platform, and the
   # object in this array is sent to the job template as 'platform'. If no platforms are specified,


### PR DESCRIPTION
This change (if it was really needed) should be made in the arcade repo as this
file is regularly updated from there. However, I can see that the change I am
reverting was not really needed as the docker image is meant for managed stuff
only and so it doesn't need to be updated to the new version that added the
LLD linker.