### PR TITLE
Fix nullref in r2rdump

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -1078,7 +1078,7 @@ namespace ILCompiler.Reflection.ReadyToRun
 
                 GetPgoOffsetAndVersion(decoder.Offset, out int pgoFormatVersion, out int pgoOffset);
 
-                PgoInfoKey key = new PgoInfoKey(GetGlobalMetadata(), owningType, methodHandle, methodTypeArgs);
+                PgoInfoKey key = new PgoInfoKey(mdReader, owningType, methodHandle, methodTypeArgs);
                 PgoInfo info = new PgoInfo(key, this, pgoFormatVersion, Image, pgoOffset);
                 _pgoInfos.Add(key, info);
                 curParser = allEntriesEnum.GetNext();


### PR DESCRIPTION
When I compile an app in R2R-Composite mode with a PGO data (my.mibc) - I can't open the resulting App.r2r.dll in R2RDump tool - it crashes with a NullReferenceException.

#### Steps:
1) Clone https://github.com/EgorBo/StaticPGO_Example
2) Execute:
```ps1
# test run
dotnet publish -c Release -r win-x64 /p:CollectMibc=true

# optimized build
dotnet publish -c Release -r win-x64 /p:PgoData=pgo.mibc
```
Try to open `App.r2r.dll` in r2rdump.

  
  
`GetGlobalMetadata()` always return `null` for composite mode: https://github.com/dotnet/runtime/blob/e3dd9857748814c2d56672838657a367b70c2452/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs#L597 so it then fails with a nullref here https://github.com/dotnet/runtime/blob/a036594cb3766f70db9f5c6e7681454e6894da50/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/PgoInfoKey.cs#L49

/cc @davidwrighton @AndyAyersMS 