### PR TITLE
[QUIC] Fix QUIC stream handle leak

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -1334,6 +1334,13 @@ namespace System.Net.Quic.Implementations.MsQuic
                     ExceptionDispatchInfo.SetCurrentStackTrace(GetConnectionAbortedException(state)));
             }
 
+            // Dispose was called before complete event.
+            bool releaseHandles = Interlocked.Exchange(ref state.ShutdownDone, 2) == 1;
+            if (releaseHandles)
+            {
+                state.Cleanup();
+            }
+
             return MsQuicStatusCodes.Success;
         }
 


### PR DESCRIPTION
Discovered that while investigating stress tests failures. We had this code in the end of `HandleEventShutdownComplete`, but if we received a flag that connection was closed in that event, we branched early to `HandleEventConnectionClose` which lacked this logic.

Fixes #56151