### PR TITLE
Check _abortException before checking _shutdown flag

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1492,6 +1492,11 @@ namespace System.Net.Http
                     Shutdown();
                 }
 
+                if (_abortException is not null)
+                {
+                    throw GetRequestAbortedException(_abortException);
+                }
+
                 if (_shutdown)
                 {
                     // The connection has shut down. Throw a retryable exception so that this request will be handled on another connection.

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -247,18 +247,17 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(SettingId.MaxFrameSize, 16383)]
         [InlineData(SettingId.MaxFrameSize, 162777216)]
         [InlineData(SettingId.InitialWindowSize, 0x80000000)]
-        public void Http2_ServerSendsInvalidSettingsValue_Error(SettingId settingId, uint value)
+        public async Task Http2_ServerSendsInvalidSettingsValue_Error(SettingId settingId, uint value)
         {
             using (Http2LoopbackServer server = Http2LoopbackServer.CreateServer())
             using (HttpClient client = CreateHttpClient())
             {
-                Http2LoopbackConnection connection = null;
-                Parallel.Invoke(
-                    () => Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(server.Address)),
-                    () => {
-                        // Send invalid initial SETTINGS value
-                        connection = server.EstablishConnectionAsync(new SettingsEntry { SettingId = settingId, Value = value }).Result;
-                    });
+                Task<HttpResponseMessage> sendTask = client.GetAsync(server.Address);
+
+                // Send invalid initial SETTINGS value
+                Http2LoopbackConnection connection = await server.EstablishConnectionAsync(new SettingsEntry { SettingId = settingId, Value = value });
+
+                await Assert.ThrowsAsync<HttpRequestException>(() => sendTask);
 
                 connection.Dispose();
             }


### PR DESCRIPTION
In case of an error aborting the connection, there is a race between a thread creating new `Http2Stream` to send a request and the thread looping in `ProcessIncomingFrames` that sets _shutdown flag and `_abortException`. If the request thread first sees `_shutdown == true`, then it won't see the `_abortException` even if it's set, so the request will be retried when it shouldn't.

This PR adds `_abortException` check just before the `_shutdown == true` check to make sure an abort exception is observed.

Fixes #1581 
Fixes #56138
Fixes #56026