### PR TITLE
Fix System.Configuration.ConfigurationManager.Tests on Android and reenable on non-Windows platforms

### DIFF
--- a/src/libraries/System.Configuration.ConfigurationManager/tests/AssemblyInfo.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/AssemblyInfo.cs
@@ -4,4 +4,6 @@
 using System;
 using Xunit;
 
+[assembly: CollectionBehavior(DisableTestParallelization = true, MaxParallelThreads = 1)]
+
 [assembly: SkipOnPlatform(TestPlatforms.Browser, "System.Configuration.ConfigurationManager is not supported on Browser")]

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- XUnit AppDomains BaseDirectory path doesn't contain a trailing slash, which impacts our tests. -->
-    <TestDisableAppDomain>true</TestDisableAppDomain>
-    <TestDisableParallelization>true</TestDisableParallelization>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
-    <TargetFrameworks>$(NetCoreAppCurrent)-windows;net461</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent);net461</TargetFrameworks>
     <IgnoreForCI Condition="'$(TargetOS)' == 'Browser'">true</IgnoreForCI>
   </PropertyGroup>
   <ItemGroup>

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
@@ -31,8 +31,8 @@ namespace System.ConfigurationTests
             // Remove the trailing slash.  Different OS's use a different slash.
             // This is to make the test pass without worrying about adding a slash
             // and which kind of slash.
-            string exePathWithoutTrailingSlash = exePath.Substring(0, exePath.Length - 1);
-            string pathToNonexistentFile = exePath + "TestFileForUrlPathTests.txt";
+            string exePathWithoutTrailingSlash = exePath.TrimEnd(Path.DirectorySeparatorChar);
+            string pathToNonexistentFile = Path.Combine(exePath, "TestFileForUrlPathTests.txt");
 
             string test = UrlPath.GetDirectoryOrRootName(pathToNonexistentFile);
             Assert.Equal(exePathWithoutTrailingSlash, test);


### PR DESCRIPTION
The test assembly got changed to `$(NetCoreAppCurrent)-windows` in https://github.com/dotnet/runtime/commit/809a06f45161ae686a06b9e9ccc2f45097b91657#diff-4d639cb37fe53cdeae4262c1f5be7936cdd81e3b4f256f9c59ad02ec69b300d9R7 but when talking to Viktor we're not sure why, probably a mistake.

Target `$(NetCoreAppCurrent)` instead so it runs on all platforms and fix a test issue that occurs on Android due to BaseDirectory not having a trailing slash.
Fixes https://github.com/dotnet/runtime/issues/37071
Incidentally, that's likely also the reason why the .csproj set `TestDisableAppDomain` so we can remove that as well.

Also replace `TestDisableParallelization` with the assembly attribute equivalent which is what we use everywhere else.