### PR TITLE
Improve SortedSet DeepCopy performance

### DIFF
--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedDictionary.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedDictionary.cs
@@ -947,6 +947,21 @@ namespace System.Collections.Generic
             {
                 return keyComparer.Compare(x.Key, y.Key);
             }
+
+            public override bool Equals(object? obj)
+            {
+                if (obj is KeyValuePairComparer other)
+                {
+                    // Commonly, both comparers will be the default comparer (and reference-equal). Avoid a virtual method call to Equals() in that case.
+                    return this.keyComparer == other.keyComparer || this.keyComparer.Equals(other.keyComparer);
+                }
+                return false;
+            }
+
+            public override int GetHashCode()
+            {
+                return this.keyComparer.GetHashCode();
+            }
         }
     }
 

--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedDictionary.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedDictionary.cs
@@ -947,21 +947,6 @@ namespace System.Collections.Generic
             {
                 return keyComparer.Compare(x.Key, y.Key);
             }
-
-            public override bool Equals(object? obj)
-            {
-                if (obj is KeyValuePairComparer other)
-                {
-                    // Commonly, both comparers will be the default comparer (and reference-equal). Avoid a virtual method call to Equals() in that case.
-                    return this.keyComparer == other.keyComparer || this.keyComparer.Equals(other.keyComparer);
-                }
-                return false;
-            }
-
-            public override int GetHashCode()
-            {
-                return this.keyComparer.GetHashCode();
-            }
         }
     }
 

--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -97,7 +97,7 @@ namespace System.Collections.Generic
                 {
                     Debug.Assert(sortedSet.root != null);
                     this.count = sortedSet.count;
-                    root = sortedSet.root.DeepClone(this.count);
+                    root = sortedSet.root.DeepClone();
                 }
                 return;
             }
@@ -1676,50 +1676,13 @@ namespace System.Collections.Generic
 
             public void ColorRed() => Color = NodeColor.Red;
 
-            public Node DeepClone(int count)
+            public Node DeepClone()
             {
-#if DEBUG
-                Debug.Assert(count == GetCount());
-#endif
+                Node newNode = ShallowClone();
+                newNode.Left = Left?.DeepClone();
+                newNode.Right = Right?.DeepClone();
 
-                // Breadth-first traversal to recreate nodes, preorder traversal to replicate nodes.
-
-                var originalNodes = new Stack<Node>(2 * Log2(count) + 2);
-                var newNodes = new Stack<Node>(2 * Log2(count) + 2);
-                Node newRoot = ShallowClone();
-
-                Node? originalCurrent = this;
-                Node newCurrent = newRoot;
-
-                while (originalCurrent != null)
-                {
-                    originalNodes.Push(originalCurrent);
-                    newNodes.Push(newCurrent);
-                    newCurrent.Left = originalCurrent.Left?.ShallowClone();
-                    originalCurrent = originalCurrent.Left;
-                    newCurrent = newCurrent.Left!;
-                }
-
-                while (originalNodes.Count != 0)
-                {
-                    originalCurrent = originalNodes.Pop();
-                    newCurrent = newNodes.Pop();
-
-                    Node? originalRight = originalCurrent.Right;
-                    Node? newRight = originalRight?.ShallowClone();
-                    newCurrent.Right = newRight;
-
-                    while (originalRight != null)
-                    {
-                        originalNodes.Push(originalRight);
-                        newNodes.Push(newRight!);
-                        newRight!.Left = originalRight.Left?.ShallowClone();
-                        originalRight = originalRight.Left;
-                        newRight = newRight.Left;
-                    }
-                }
-
-                return newRoot;
+                return newNode;
             }
 
             /// <summary>


### PR DESCRIPTION
I noticed that SortedDictionary copying was allocation more memory than iterating the initial dictionary and adding items one at a time. I realized that the optimization done as part of #45659 was not completely successful and that the SortedSet deep copy could be improved.

For SortedSet prefer recursion through the tree over allocating multiple stacks.
For SortedDictionary override Equals for KeyValuePairComparer so that SortedSets HasEqualComparer will pass to allow efficient deep copy.

https://github.com/dotnet/performance/compare/main...johnthcall:johncall/SortedSetDeepCopy
|               Method | Toolchain |    N |          Mean |        Error |       StdDev | Ratio | Allocated |
|--------------------- |---------- |----- |--------------:|-------------:|-------------:|------:|----------:|
| SortedDictionaryCopy |      main |    1 |     123.74 ns |     3.476 ns |     4.002 ns |  1.00 |     392 B |
| SortedDictionaryCopy |        pr |    1 |      54.46 ns |     0.877 ns |     0.777 ns |  0.44 |     168 B |
|                      |           |      |               |              |              |       |           |
|        SortedSetCopy |      main |    1 |      70.85 ns |     0.821 ns |     0.768 ns |  1.00 |     272 B |
|        SortedSetCopy |        pr |    1 |      29.43 ns |     0.661 ns |     0.618 ns |  0.42 |      96 B |
|                      |           |      |               |              |              |       |           |
| SortedDictionaryCopy |      main |   10 |     699.64 ns |    13.457 ns |    11.929 ns |  1.00 |   1,136 B |
| SortedDictionaryCopy |        pr |   10 |     218.58 ns |     2.036 ns |     1.904 ns |  0.31 |     672 B |
|                      |           |      |               |              |              |       |           |
|        SortedSetCopy |      main |   10 |     297.74 ns |     2.702 ns |     2.110 ns |  1.00 |     800 B |
|        SortedSetCopy |        pr |   10 |     150.63 ns |     1.824 ns |     1.617 ns |  0.51 |     528 B |
|                      |           |      |               |              |              |       |           |
| SortedDictionaryCopy |      main |  100 |  10,101.19 ns |   175.585 ns |   187.874 ns |  1.00 |   7,664 B |
| SortedDictionaryCopy |        pr |  100 |   1,896.56 ns |    36.241 ns |    41.735 ns |  0.19 |   5,712 B |
|                      |           |      |               |              |              |       |           |
|        SortedSetCopy |      main |  100 |   2,755.01 ns |    41.014 ns |    36.358 ns |  1.00 |   5,216 B |
|        SortedSetCopy |        pr |  100 |   1,438.86 ns |    20.528 ns |    18.197 ns |  0.52 |   4,848 B |
|                      |           |      |               |              |              |       |           |
| SortedDictionaryCopy |      main | 1000 | 140,422.29 ns | 1,514.264 ns | 1,264.479 ns |  1.00 |  72,512 B |
| SortedDictionaryCopy |        pr | 1000 |  21,330.74 ns |   233.688 ns |   195.140 ns |  0.15 |  56,112 B |
|                      |           |      |               |              |              |       |           |
|        SortedSetCopy |      main | 1000 |  28,099.61 ns |   244.839 ns |   217.043 ns |  1.00 |  48,512 B |
|        SortedSetCopy |        pr | 1000 |  17,571.99 ns |   154.552 ns |   144.568 ns |  0.63 |  48,048 B |