### PR TITLE
[System.Private.CoreLib] Additional trimming for EventSource.IsSupported feature switch

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.Shared.xml
@@ -1,10 +1,27 @@
 <linker>
   <assembly fullname="System.Private.CoreLib">
     <type fullname="System.Diagnostics.Tracing.EventSource" feature="System.Diagnostics.Tracing.EventSource.IsSupported" featurevalue="false">
+      <method signature="System.Void .cctor()" body="stub" />
+      <method signature="System.Void .ctor()" body="stub" />
       <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
       <method signature="System.Boolean IsEnabled()" body="stub" value="false" />
       <method signature="System.Boolean IsEnabled(System.Diagnostics.Tracing.EventLevel,System.Diagnostics.Tracing.EventKeywords)" body="stub" value="false" />
       <method signature="System.Boolean IsEnabled(System.Diagnostics.Tracing.EventLevel,System.Diagnostics.Tracing.EventKeywords,System.Diagnostics.Tracing.EventChannel)" body="stub" value="false" />
+    </type>
+    <type fullname="System.Buffers.ArrayPoolEventSource" feature="System.Diagnostics.Tracing.EventSource.IsSupported" featurevalue="false">
+      <method signature="System.Void .ctor()" body="stub" />
+    </type>
+    <type fullname="System.Threading.Tasks.TplEventSource" feature="System.Diagnostics.Tracing.EventSource.IsSupported" featurevalue="false">
+      <method signature="System.Void .ctor()" body="stub" />
+    </type>
+    <type fullname="System.Diagnostics.Tracing.FrameworkEventSource" feature="System.Diagnostics.Tracing.EventSource.IsSupported" featurevalue="false">
+      <method signature="System.Void .ctor()" body="stub" />
+    </type>
+    <type fullname="System.Diagnostics.Tracing.NativeRuntimeEventSource" feature="System.Diagnostics.Tracing.EventSource.IsSupported" featurevalue="false">
+      <method signature="System.Void .ctor()" body="stub" />
+    </type>
+    <type fullname="System.Threading.ThreadPoolWorkQueue" feature="System.Diagnostics.Tracing.EventSource.IsSupported" featurevalue="false">
+      <method signature="System.Void RefreshLoggingEnabled()" body="stub" />
     </type>
     <!-- Note: Invariant=true and Invariant=false are substituted at different levels. This allows for the whole Settings nested class
          to be trimmed when Invariant=true, and allows for the Settings static cctor (on Unix) to be preserved when Invariant=false. -->


### PR DESCRIPTION
It's possible to reduce the size a bit more when turning off the `EventSource` feature.

Data from a minimal iOS application

| Directories / Files |  Actual  |  PR | diff |  %  |
| ------------------- | --: | --: | ---: | --: |
| ./_CodeSignature | | | | ||     CodeResources | 5,525 | 5,525 | 0 | 0.0% |
| ./ | | | | ||     archived-expanded-entitlements.xcent | 392 | 392 | 0 | 0.0% |
|     embedded.mobileprovision | 17,863 | 17,863 | 0 | 0.0% |
|     icudt.dat | 1,913,136 | 1,913,136 | 0 | 0.0% |
|     Info.plist | 1,057 | 1,057 | 0 | 0.0% |
|     MySingleView | 7,720,128 | 7,720,128 | 0 | 0.0% |
|     MySingleView.aotdata.arm64 | 792 | 792 | 0 | 0.0% |
|     MySingleView.dll | 4,608 | 4,608 | 0 | 0.0% |
|     PkgInfo | 8 | 8 | 0 | 0.0% |
|     runtimeconfig.bin | 733 | 733 | 0 | 0.0% |
|     System.Private.CoreLib.aotdata.arm64 | 730,240 | 729,976 | -264 | -0.0% |
|     System.Private.CoreLib.dll | 740,864 | 739,328 | -1,536 | -0.2% |
|     System.Runtime.aotdata.arm64 | 504 | 504 | 0 | 0.0% |
|     System.Runtime.dll | 4,608 | 4,608 | 0 | 0.0% |
|     Xamarin.iOS.aotdata.arm64 | 48,288 | 48,288 | 0 | 0.0% |
|     Xamarin.iOS.dll | 72,704 | 72,704 | 0 | 0.0% |
| | | | | |
| **Statistics** | | | | |
| | | | | |
| Native subtotal | 8,499,952 | 8,499,688 | -264 | -0.0% |
|     Executable | 7,720,128 | 7,720,128 | 0 | 0.0% |
|     AOT data | 779,824 | 779,560 | -264 | -0.0% |
| | | | | |
| Managed *.dll/exe | 822,784 | 821,248 | -1,536 | -0.2% |
| | | | | |
| **TOTAL** | 11,261,450 | 11,259,650 | -1,800 | -0.0% |

Code diff

```diff
--- c.cs	2021-07-29 13:38:11.000000000 -0400
+++ d.cs	2021-07-29 13:38:20.000000000 -0400
@@ -13008,36 +13008,6 @@

 		private readonly byte _k;

-		public Guid(uint P_0, ushort P_1, ushort P_2, byte P_3, byte P_4, byte P_5, byte P_6, byte P_7, byte P_8, byte P_9, byte P_10)
-		{
-			_a = (int)P_0;
-			_b = (short)P_1;
-			_c = (short)P_2;
-			_d = P_3;
-			_e = P_4;
-			_f = P_5;
-			_g = P_6;
-			_h = P_7;
-			_i = P_8;
-			_j = P_9;
-			_k = P_10;
-		}
-
-		public Guid(int P_0, short P_1, short P_2, byte P_3, byte P_4, byte P_5, byte P_6, byte P_7, byte P_8, byte P_9, byte P_10)
-		{
-			_a = P_0;
-			_b = P_1;
-			_c = P_2;
-			_d = P_3;
-			_e = P_4;
-			_f = P_5;
-			_g = P_6;
-			_h = P_7;
-			_i = P_8;
-			_j = P_9;
-			_k = P_10;
-		}
-
 		public override string ToString()
 		{
 			return ToString("D", null);
@@ -90583,7 +90553,6 @@
 		internal static readonly ArrayPoolEventSource Log = new ArrayPoolEventSource();

 		private ArrayPoolEventSource()
-			: base(new Guid(140948152, 23791, 23993, 38, 18, 12, 15, 253, 129, 74, 68), "System.Buffers.ArrayPoolEventSource")
 		{
 		}
 	}
@@ -95230,11 +95199,6 @@
 		[MethodImpl(256)]
 		public void RefreshLoggingEnabled()
 		{
-			FrameworkEventSource.Log.IsEnabled();
-			if (loggingEnabled)
-			{
-				loggingEnabled = false;
-			}
 		}

 		internal void EnsureThreadRequested()
@@ -101582,7 +101546,6 @@
 		}

 		private TplEventSource()
-			: base(new Guid(777894471u, 41938, 19734, 142, 224, 102, 113, 255, 220, 215, 181), "System.Threading.Tasks.TplEventSource")
 		{
 		}
 	}
@@ -112925,14 +112888,11 @@
 		public static readonly NativeRuntimeEventSource Log = new NativeRuntimeEventSource();

 		private NativeRuntimeEventSource()
-			: base(new Guid(3778809123u, 52412, 19986, 147, 27, 217, 204, 46, 238, 39, 228), "Microsoft-Windows-DotNETRuntime")
 		{
 		}
 	}
 	public class EventSource : IDisposable
 	{
-		private IntPtr m_writeEventStringEventHandle = IntPtr.Zero;
-
 		internal static bool IsSupported
 		{
 			[CompilerGenerated]
@@ -112940,16 +112900,6 @@
 			{
 				return false;
 			}
-		} = InitializeIsSupported();
-
-
-		private static bool InitializeIsSupported()
-		{
-			if (!AppContext.TryGetSwitch("System.Diagnostics.Tracing.EventSource.IsSupported", out bool result))
-			{
-				return true;
-			}
-			return result;
 		}

 		public bool IsEnabled()
@@ -112973,6 +112923,10 @@
 			_ = IsSupported;
 		}

+		protected EventSource()
+		{
+		}
+
 		protected void WriteEvent(int P_0, long P_1, long P_2, long P_3)
 		{
 			if (!IsEnabled())
@@ -112995,33 +112949,12 @@
 		{
 			Dispose(false);
 		}
-
-		internal EventSource(Guid P_0, string P_1)
-			: this(P_0, P_1, EventSourceSettings.EtwManifestEventFormat)
-		{
-		}
-
-		internal EventSource(Guid P_0, string P_1, EventSourceSettings P_2, string[] P_3 = null)
-		{
-			if (!IsSupported)
-			{
-			}
-		}
-	}
-	[Flags]
-	public enum EventSourceSettings
-	{
-		Default = 0x0,
-		ThrowOnEventWriteErrors = 0x1,
-		EtwManifestEventFormat = 0x4,
-		EtwSelfDescribingEventFormat = 0x8
 	}
 	internal sealed class FrameworkEventSource : EventSource
 	{
 		public static readonly FrameworkEventSource Log = new FrameworkEventSource();

 		private FrameworkEventSource()
-			: base(new Guid(2392805520u, 11637, 19715, 138, 129, 229, 175, 191, 133, 218, 241), "System.Diagnostics.Eventing.FrameworkEventSource")
 		{
 		}
 	}
```