### PR TITLE
Disable test SendMoreThanStreamLimitRequests_Succeeds for all QUIC

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -80,17 +80,12 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/55957")]
         [InlineData(10)]
         [InlineData(100)]
         [InlineData(1000)]
         public async Task SendMoreThanStreamLimitRequests_Succeeds(int streamLimit)
         {
-            // [ActiveIssue("https://github.com/dotnet/runtime/issues/55957")]
-            if (this.UseQuicImplementationProvider == QuicImplementationProviders.Mock)
-            {
-                return;
-            }
-
             using Http3LoopbackServer server = CreateHttp3LoopbackServer(new Http3Options(){ MaxBidirectionalStreams = streamLimit });
 
             Task serverTask = Task.Run(async () =>


### PR DESCRIPTION
Disable the test also for MsQuic, not just Mock.

Test types:
- System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_Http3_MsQuic
- System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_Http3_Mock

Disabled test tracked by #55957