### PR TITLE
Refactor repeated invalid character checks in Path.GetFullPath Unix and Windows

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
@@ -51,6 +51,9 @@ namespace System.IO
         // Gets the full path without argument validation
         private static string GetFullPathInternal(string path)
         {
+            Debug.Assert(!string.IsNullOrEmpty(path));
+            Debug.Assert(!path.Contains('\0'));
+            
             // Expand with current directory if necessary
             if (!IsPathRooted(path))
             {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
@@ -22,7 +22,10 @@ namespace System.IO
             if (path.Length == 0)
                 throw new ArgumentException(SR.Arg_PathEmpty, nameof(path));
 
-            return GetPartiallyQualifiedPath(path, false);
+            if (path.Contains('\0'))
+                throw new ArgumentException(SR.Argument_InvalidPathChars, nameof(path));
+
+            return GetFullPathInternal(path);
         }
 
         public static string GetFullPath(string path, string basePath)
@@ -40,16 +43,14 @@ namespace System.IO
                 throw new ArgumentException(SR.Argument_InvalidPathChars);
 
             if (IsPathFullyQualified(path))
-                return GetPartiallyQualifiedPath(path, true);
+                return GetFullPathInternal(path);
 
-            return GetPartiallyQualifiedPath(CombineInternal(basePath, path), true);
+            return GetFullPathInternal(CombineInternal(basePath, path));
         }
 
-        internal static string GetPartiallyQualifiedPath(string path, bool checkedForInvalids)
+        // Gets the full path without argument validation
+        private static string GetFullPathInternal(string path)
         {
-            if (!checkedForInvalids && path.Contains('\0'))
-                throw new ArgumentException(SR.Argument_InvalidPathChars, nameof(path));
-
             // Expand with current directory if necessary
             if (!IsPathRooted(path))
             {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
@@ -22,7 +22,32 @@ namespace System.IO
             if (path.Length == 0)
                 throw new ArgumentException(SR.Arg_PathEmpty, nameof(path));
 
-            if (path.Contains('\0'))
+            return GetPartiallyQualifiedPath(path, false);
+        }
+
+        public static string GetFullPath(string path, string basePath)
+        {
+            if (path == null)
+                throw new ArgumentNullException(nameof(path));
+
+            if (basePath == null)
+                throw new ArgumentNullException(nameof(basePath));
+
+            if (!IsPathFullyQualified(basePath))
+                throw new ArgumentException(SR.Arg_BasePathNotFullyQualified, nameof(basePath));
+
+            if (basePath.Contains('\0') || path.Contains('\0'))
+                throw new ArgumentException(SR.Argument_InvalidPathChars);
+
+            if (IsPathFullyQualified(path))
+                return GetPartiallyQualifiedPath(path, true);
+
+            return GetPartiallyQualifiedPath(CombineInternal(basePath, path), true);
+        }
+
+        internal static string GetPartiallyQualifiedPath(string path, bool checkedForInvalids)
+        {
+            if (!checkedForInvalids && path.Contains('\0'))
                 throw new ArgumentException(SR.Argument_InvalidPathChars, nameof(path));
 
             // Expand with current directory if necessary
@@ -41,26 +66,6 @@ namespace System.IO
             string result = collapsedString.Length == 0 ? PathInternal.DirectorySeparatorCharAsString : collapsedString;
 
             return result;
-        }
-
-        public static string GetFullPath(string path, string basePath)
-        {
-            if (path == null)
-                throw new ArgumentNullException(nameof(path));
-
-            if (basePath == null)
-                throw new ArgumentNullException(nameof(basePath));
-
-            if (!IsPathFullyQualified(basePath))
-                throw new ArgumentException(SR.Arg_BasePathNotFullyQualified, nameof(basePath));
-
-            if (basePath.Contains('\0') || path.Contains('\0'))
-                throw new ArgumentException(SR.Argument_InvalidPathChars);
-
-            if (IsPathFullyQualified(path))
-                return GetFullPath(path);
-
-            return GetFullPath(CombineInternal(basePath, path));
         }
 
         private static string RemoveLongPathPrefix(string path)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
@@ -53,7 +53,7 @@ namespace System.IO
         {
             Debug.Assert(!string.IsNullOrEmpty(path));
             Debug.Assert(!path.Contains('\0'));
-            
+
             // Expand with current directory if necessary
             if (!IsPathRooted(path))
             {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Windows.cs
@@ -128,7 +128,7 @@ namespace System.IO
         {
             Debug.Assert(!string.IsNullOrEmpty(path));
             Debug.Assert(!path.Contains('\0'));
-            
+
             if (PathInternal.IsExtended(path.AsSpan()))
             {
                 // \\?\ paths are considered normalized by definition. Windows doesn't normalize \\?\

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Windows.cs
@@ -126,6 +126,9 @@ namespace System.IO
         // Gets the full path without argument validation
         private static string GetFullPathInternal(string path)
         {
+            Debug.Assert(!string.IsNullOrEmpty(path));
+            Debug.Assert(!path.Contains('\0'));
+            
             if (PathInternal.IsExtended(path.AsSpan()))
             {
                 // \\?\ paths are considered normalized by definition. Windows doesn't normalize \\?\


### PR DESCRIPTION
### Summary

There were repeated, expensive checks on paths in the `Path.GetFullPath` method. This has been refactored with a `GetFullPathInternal` method that contains the shared code between the methods. These repetitions were found on both the Windows and Unix sides, and thus implementations of the `GetFullPathInternal` method were written for both.

Intended to extend PR #55373

Fixes #54993