### PR TITLE
Remove requirement that --input-bubble be specified if an instruction set is specified

### DIFF
--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -234,11 +234,6 @@ namespace ILCompiler
             {
                 List<string> instructionSetParams = new List<string>();
 
-                // At this time, instruction sets may only be specified with --input-bubble, as
-                // we do not yet have a stable ABI for all vector parameter/return types.
-                if (!_commandLineOptions.InputBubble)
-                    throw new CommandLineException(SR.InstructionSetWithoutInputBubble);
-
                 // Normalize instruction set format to include implied +.
                 string[] instructionSetParamsInput = _commandLineOptions.InstructionSet.Split(",");
                 for (int i = 0; i < instructionSetParamsInput.Length; i++)

--- a/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
@@ -171,9 +171,6 @@
   <data name="InstructionSetMustNotBe" xml:space="preserve">
     <value>Instruction set '{0}' is not valid for this architecture and operating system</value>
   </data>
-  <data name="InstructionSetWithoutInputBubble" xml:space="preserve">
-    <value>Instruction set(s) specified without also specifying input-bubble</value>
-  </data>
   <data name="InstructionSetInvalidImplication" xml:space="preserve">
     <value>Instruction set '{0}' implies support for instruction set '{1}'</value>
   </data>


### PR DESCRIPTION
- This was here to protect against ABI breaking changes causing R2R misbehavior
- We don't actually need this as if there is an ABI breaking change, we can detect it at runtime by looking at a combination of the R2R version and the required instruction sets encoded in the R2R image

Fixes (dotnet/sdk#17760)