### PR TITLE
Enable skipped SSC.Algorithms tests on Andorid

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
@@ -411,12 +411,7 @@ namespace System.Security.Cryptography
                     // Half, rounded up.
                     int halfModulusLength = (parameters.Modulus.Length + 1) / 2;
 
-                    // The same checks are done by RSACryptoServiceProvider on import (when building the key blob)
-                    // Historically RSACng let CNG handle this (reporting NTE_NOT_SUPPORTED), but on RS1 CNG let the
-                    // import succeed, then on private key use (e.g. signing) it would report NTE_INVALID_PARAMETER.
-                    //
-                    // Doing the check here prevents the state in RS1 where the Import succeeds, but corrupts the key,
-                    // and makes for a friendlier exception message.
+                    // Matching the .NET Framework RSACryptoServiceProvider behavior, as that's the .NET de facto standard
                     if (parameters.D.Length != parameters.Modulus.Length ||
                         parameters.P.Length != halfModulusLength ||
                         parameters.Q.Length != halfModulusLength ||

--- a/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
@@ -386,6 +386,8 @@ namespace System.Security.Cryptography
                     throw new CryptographicException(SR.Cryptography_InvalidRsaParameters);
                 }
 
+                // Check that either all parameters are not null or all are null, if a subset were set, then the parameters are invalid.
+                // If the parameters are all not null, verify the integrity of their lengths.
                 if (parameters.D == null)
                 {
                     if (parameters.P != null ||

--- a/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAAndroid.cs
@@ -381,6 +381,53 @@ namespace System.Security.Cryptography
                 ValidateParameters(ref parameters);
                 ThrowIfDisposed();
 
+                if (parameters.Exponent == null || parameters.Modulus == null)
+                {
+                    throw new CryptographicException(SR.Cryptography_InvalidRsaParameters);
+                }
+
+                if (parameters.D == null)
+                {
+                    if (parameters.P != null ||
+                        parameters.DP != null ||
+                        parameters.Q != null ||
+                        parameters.DQ != null ||
+                        parameters.InverseQ != null)
+                    {
+                        throw new CryptographicException(SR.Cryptography_InvalidRsaParameters);
+                    }
+                }
+                else
+                {
+                    if (parameters.P == null ||
+                        parameters.DP == null ||
+                        parameters.Q == null ||
+                        parameters.DQ == null ||
+                        parameters.InverseQ == null)
+                    {
+                        throw new CryptographicException(SR.Cryptography_InvalidRsaParameters);
+                    }
+
+                    // Half, rounded up.
+                    int halfModulusLength = (parameters.Modulus.Length + 1) / 2;
+
+                    // The same checks are done by RSACryptoServiceProvider on import (when building the key blob)
+                    // Historically RSACng let CNG handle this (reporting NTE_NOT_SUPPORTED), but on RS1 CNG let the
+                    // import succeed, then on private key use (e.g. signing) it would report NTE_INVALID_PARAMETER.
+                    //
+                    // Doing the check here prevents the state in RS1 where the Import succeeds, but corrupts the key,
+                    // and makes for a friendlier exception message.
+                    if (parameters.D.Length != parameters.Modulus.Length ||
+                        parameters.P.Length != halfModulusLength ||
+                        parameters.Q.Length != halfModulusLength ||
+                        parameters.DP.Length != halfModulusLength ||
+                        parameters.DQ.Length != halfModulusLength ||
+                        parameters.InverseQ.Length != halfModulusLength)
+                    {
+                        throw new CryptographicException(SR.Cryptography_InvalidRsaParameters);
+                    }
+                }
+
                 SafeRsaHandle key = Interop.AndroidCrypto.RsaCreate();
                 bool imported = false;
 

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyGeneration.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyGeneration.cs
@@ -24,14 +24,12 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsKeyGeneration))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50580", TestPlatforms.Android)]
         public static void GenerateMinKey()
         {
             GenerateKey(dsa => GetMin(dsa.LegalKeySizes));
         }
 
         [ConditionalFact(nameof(SupportsKeyGeneration), nameof(HasSecondMinSize))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50580", TestPlatforms.Android)]
         public static void GenerateSecondMinKey()
         {
             GenerateKey(dsa => GetSecondMin(dsa.LegalKeySizes));

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAXml.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAXml.cs
@@ -1340,6 +1340,7 @@ zM=
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/29515", TestPlatforms.OSX)]
         public static void FromNonsenseXml()
         {
             // This is DiminishedDPParameters XML, but with a P that is way too long.

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAXml.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAXml.cs
@@ -1340,7 +1340,6 @@ zM=
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/29515", TestPlatforms.OSX | TestPlatforms.Android)]
         public static void FromNonsenseXml()
         {
             // This is DiminishedDPParameters XML, but with a P that is way too long.


### PR DESCRIPTION
DSAKeyGeneration.GenerateSecondMinKey and DSAKeyGeneration.GenerateMinKey no longer fail.  Added validation in RSAAndroid.cs to make RSAXml.FromNonsenseXml pass.

Fixes https://github.com/dotnet/runtime/issues/50580
Fixes https://github.com/dotnet/runtime/issues/50581