### PR TITLE
Update dotnet SDK to latest published 

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "6.0.100-preview.5.21302.13",
+    "version": "6.0.100-rc.1.21379.2",
     "allowPrerelease": true,
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "6.0.100-preview.5.21302.13"
+    "dotnet": "6.0.100-rc.1.21379.2"
   },
   "native-tools": {
     "cmake": "3.16.4",


### PR DESCRIPTION
This change brings an up update to take a threading fix that could improve the symptoms of https://github.com/dotnet/core-eng/issues/13691.  

See issue for details; this is not necessarily the definitive fix, but something we need to try as the available data points to this as a likely culprit.  

I'm making the same PR simultaneously in arcade, runtime, and aspnetcore in an effort to expedite the fix (if this is the fix) as well as exercise package restore in the places this is hitting most.