### PR TITLE
Enable skipped CodeDom tests on Android

### DIFF
--- a/src/libraries/System.CodeDom/tests/System/CodeDom/Compiler/CSharpCodeGenerationTests.cs
+++ b/src/libraries/System.CodeDom/tests/System/CodeDom/Compiler/CSharpCodeGenerationTests.cs
@@ -614,7 +614,6 @@ namespace System.CodeDom.Compiler.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50879", TestPlatforms.Android)]
         public void MetadataAttributes()
         {
             using (new ThreadCultureChange(CultureInfo.InvariantCulture))
@@ -1469,7 +1468,6 @@ namespace System.CodeDom.Compiler.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50879", TestPlatforms.Android)]
         public void RegionsSnippetsAndLinePragmas()
         {
             using (new ThreadCultureChange(CultureInfo.InvariantCulture))
@@ -2590,7 +2588,6 @@ namespace System.CodeDom.Compiler.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50879", TestPlatforms.Android)]
         public void ProviderSupports()
         {
             using (new ThreadCultureChange(CultureInfo.InvariantCulture))

--- a/src/libraries/System.CodeDom/tests/System/CodeDom/Compiler/VBCodeGenerationTests.cs
+++ b/src/libraries/System.CodeDom/tests/System/CodeDom/Compiler/VBCodeGenerationTests.cs
@@ -580,7 +580,6 @@ namespace System.CodeDom.Compiler.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50879", TestPlatforms.Android)]
         public void MetadataAttributes()
         {
             using (new ThreadCultureChange(CultureInfo.InvariantCulture))
@@ -1400,7 +1399,6 @@ namespace System.CodeDom.Compiler.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50879", TestPlatforms.Android)]
         public void RegionsSnippetsAndLinePragmas()
         {
             using (new ThreadCultureChange(CultureInfo.InvariantCulture))
@@ -2362,7 +2360,6 @@ namespace System.CodeDom.Compiler.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50879", TestPlatforms.Android)]
         public void ProviderSupports()
         {
             using (new ThreadCultureChange(CultureInfo.InvariantCulture))


### PR DESCRIPTION
Some C# and VB code generation tests were being skipped due to UseSystemResourceKeys being enabled. It no longer is.

Fixes https://github.com/dotnet/runtime/issues/50879