### PR TITLE
[libraries][iOS][tvOS] Skip RoundtripEmptyArray on older tvOS iOS ver…

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
@@ -343,12 +343,13 @@ namespace System.Security.Cryptography.Rsa.Tests
         {
             if (PlatformDetection.IsiOS && !OperatingSystem.IsIOSVersionAtLeast(13, 6))
             {
-                throw new SkipTestException("This test is broken on <iOS 13.6");
+                throw new SkipTestException("iOS prior to 13.6 does not reliably support RSA encryption of empty data.");
             }
             if (PlatformDetection.IstvOS && !OperatingSystem.IsTvOSVersionAtLeast(14, 0))
             {
-                throw new SkipTestException("This test is broken on <tvOS 14.0");
+                throw new SkipTestException("tvOS prior to 14.0 does not reliably support RSA encryption of empty data.");
             }
+
             using (RSA rsa = RSAFactory.Create(TestData.RSA2048Params))
             {
                 void RoundtripEmpty(RSAEncryptionPadding paddingMode)

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Test.Cryptography;
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.Security.Cryptography.Rsa.Tests
@@ -336,11 +337,18 @@ namespace System.Security.Cryptography.Rsa.Tests
             Assert.Equal(TestData.HelloBytes, output);
         }
 
-        [Fact]
+        [ConditionalFact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/52199", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void RoundtripEmptyArray()
         {
+            if (PlatformDetection.IsiOS && !OperatingSystem.IsIOSVersionAtLeast(13, 6))
+            {
+                throw new SkipTestException("This test is broken on <iOS 13.6");
+            }
+            if (PlatformDetection.IstvOS && !OperatingSystem.IsTvOSVersionAtLeast(14, 0))
+            {
+                throw new SkipTestException("This test is broken on <tvOS 14.0");
+            }
             using (RSA rsa = RSAFactory.Create(TestData.RSA2048Params))
             {
                 void RoundtripEmpty(RSAEncryptionPadding paddingMode)

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
@@ -341,11 +341,11 @@ namespace System.Security.Cryptography.Rsa.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void RoundtripEmptyArray()
         {
-            if (PlatformDetection.IsiOS && !OperatingSystem.IsIOSVersionAtLeast(13, 6))
+            if (OperatingSystem.IsIOS() && !OperatingSystem.IsIOSVersionAtLeast(13, 6))
             {
                 throw new SkipTestException("iOS prior to 13.6 does not reliably support RSA encryption of empty data.");
             }
-            if (PlatformDetection.IstvOS && !OperatingSystem.IsTvOSVersionAtLeast(14, 0))
+            if (OperatingSystem.IsTvOS() && !OperatingSystem.IsTvOSVersionAtLeast(14, 0))
             {
                 throw new SkipTestException("tvOS prior to 14.0 does not reliably support RSA encryption of empty data.");
             }


### PR DESCRIPTION
…sions

Fixes https://github.com/dotnet/runtime/issues/52199

Locally checked the test passed on iOS 13.6 and tvOS 14.0
Locally did not have any simulator versions between tvOS 13.4 and 14.0 on my xcode.