### PR TITLE
update MsQuic to get client certificate fixes

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -4,7 +4,7 @@
       <Uri>https://github.com/dotnet/icu</Uri>
       <Sha>08293141bc33a81b7e58120535079d8eac36519f</Sha>
     </Dependency>
-    <Dependency Name="System.Net.MsQuic.Transport" Version="6.0.0-preview.7.21376.1">
+    <Dependency Name="System.Net.MsQuic.Transport" Version="6.0.0-preview.7.21379.5">
       <Uri>https://github.com/dotnet/msquic</Uri>
       <Sha>d7db669b70f4dd67ec001c192f9809c218cab88b</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -171,7 +171,7 @@
     <!-- ICU -->
     <MicrosoftNETCoreRuntimeICUTransportVersion>6.0.0-rc.1.21369.1</MicrosoftNETCoreRuntimeICUTransportVersion>
     <!-- MsQuic -->
-    <SystemNetMsQuicTransportVersion>6.0.0-preview.7.21376.1</SystemNetMsQuicTransportVersion>
+    <SystemNetMsQuicTransportVersion>6.0.0-preview.7.21379.5</SystemNetMsQuicTransportVersion>
     <!-- Mono LLVM -->
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>11.1.0-alpha.1.21369.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>11.1.0-alpha.1.21369.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -310,7 +310,6 @@ namespace System.Net.Quic.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
-        [ActiveIssue("https://github.com/microsoft/msquic/pull/1728")]
         public async Task ConnectWithClientCertificate()
         {
             bool clientCertificateOK = false;


### PR DESCRIPTION
This has two parts:
1) updates MsQuic to build from prerelease 1.6 branch instead main (as part of the closing game) 
(thanks to @MattGal  who helped to sort out building issues) 
2) that picks up final fixes for client certificate authentication on Windows 
(contribues to #56362 and unblocking Kestrel/gRPC)
cc: @JamesNK  