### PR TITLE
Add runtime capability to allow updating parameters

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/MetadataUpdater.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/MetadataUpdater.cs
@@ -53,7 +53,7 @@ namespace System.Reflection.Metadata
         /// <summary>
         /// Returns the metadata update capabilities.
         /// </summary>
-        internal static string GetCapabilities() => "Baseline AddMethodToExistingType AddStaticFieldToExistingType AddInstanceFieldToExistingType NewTypeDefinition ChangeCustomAttributes";
+        internal static string GetCapabilities() => "Baseline AddMethodToExistingType AddStaticFieldToExistingType AddInstanceFieldToExistingType NewTypeDefinition ChangeCustomAttributes UpdateParameters";
 
         /// <summary>
         /// Returns true if the apply assembly update is enabled and available.


### PR DESCRIPTION
For https://github.com/dotnet/roslyn/issues/52563 Roslyn is allowing parameter renames during EnC/Hot Reload, but mono doesn't support updating the Param metadata table, so it will be a rude edit without the presence of the right capability.

The check for the capability is in https://github.com/dotnet/roslyn/pull/54856, but this doesn't need to wait for that, or vice versa.

Hopefully this is the right spot @mikem8361, since it was the only one I found 😁