### PR TITLE
Return null from GetManifestResourceInfo and GetManifestResourceStream when the resource is not found

### DIFF
--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Assemblies/Ecma/EcmaAssembly.ManifestResources.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Assemblies/Ecma/EcmaAssembly.ManifestResources.cs
@@ -11,7 +11,7 @@ namespace System.Reflection.TypeLoading.Ecma
     /// </summary>
     internal sealed partial class EcmaAssembly
     {
-        public sealed override ManifestResourceInfo GetManifestResourceInfo(string resourceName)
+        public sealed override ManifestResourceInfo? GetManifestResourceInfo(string resourceName)
         {
             if (resourceName == null)
                 throw new ArgumentNullException(nameof(resourceName));
@@ -19,6 +19,11 @@ namespace System.Reflection.TypeLoading.Ecma
                 throw new ArgumentException(nameof(resourceName));
 
             InternalManifestResourceInfo internalManifestResourceInfo = GetEcmaManifestModule().GetInternalManifestResourceInfo(resourceName);
+
+            if (!internalManifestResourceInfo.Found)
+            {
+                return null;
+            }
 
             if (internalManifestResourceInfo.ResourceLocation == ResourceLocation.ContainedInAnotherAssembly)
             {
@@ -59,6 +64,12 @@ namespace System.Reflection.TypeLoading.Ecma
                 throw new ArgumentException(nameof(name));
 
             InternalManifestResourceInfo internalManifestResourceInfo = GetEcmaManifestModule().GetInternalManifestResourceInfo(name);
+
+            if (!internalManifestResourceInfo.Found)
+            {
+                return null;
+            }
+
             if ((internalManifestResourceInfo.ResourceLocation & ResourceLocation.Embedded) != 0)
             {
                 unsafe

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Assemblies/RoAssembly.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Assemblies/RoAssembly.cs
@@ -164,7 +164,7 @@ namespace System.Reflection.TypeLoading
         public abstract override MethodInfo? EntryPoint { get; }
 
         // Manifest resource support.
-        public abstract override ManifestResourceInfo GetManifestResourceInfo(string resourceName);
+        public abstract override ManifestResourceInfo? GetManifestResourceInfo(string resourceName);
         public abstract override string[] GetManifestResourceNames();
         public abstract override Stream? GetManifestResourceStream(string name);
         public sealed override Stream? GetManifestResourceStream(Type type, string name)

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Assemblies/RoStubAssembly.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Assemblies/RoStubAssembly.cs
@@ -17,7 +17,7 @@ namespace System.Reflection.TypeLoading
         public sealed override bool IsDynamic => throw null!;
         public sealed override event ModuleResolveEventHandler? ModuleResolve { add { throw null!; } remove { throw null!; } }
         public sealed override IEnumerable<CustomAttributeData> CustomAttributes => throw null!;
-        public sealed override ManifestResourceInfo GetManifestResourceInfo(string resourceName) => throw null!;
+        public sealed override ManifestResourceInfo? GetManifestResourceInfo(string resourceName) => throw null!;
         public sealed override string[] GetManifestResourceNames() => throw null!;
         public sealed override Stream GetManifestResourceStream(string name) => throw null!;
         protected sealed override AssemblyNameData[] ComputeAssemblyReferences() => throw null!;

--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Assembly/AssemblyTests.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Assembly/AssemblyTests.cs
@@ -606,23 +606,23 @@ namespace System.Reflection.Tests
         [Fact]
         public static void ResourceDoesNotExist_GetManifestResourceInfo_ReturnsNull()
         {
-            var resolver = new PathAssemblyResolver(new string[] { typeof(object).Assembly.Location });
-            using var mlc = new MetadataLoadContext(resolver, typeof(object).Assembly.GetName().Name);
-
-            var runtimeAssembly = mlc.LoadFromAssemblyPath(typeof(object).Assembly.Location);
-            var resource = runtimeAssembly.GetManifestResourceInfo("Nonsense");
-            Assert.Null(resource);
+            using (MetadataLoadContext lc = new MetadataLoadContext(new SimpleAssemblyResolver()))
+            {
+                Assembly a = lc.LoadFromByteArray(TestData.s_AssemblyWithEmbeddedResourcesImage);
+                ManifestResourceInfo? r = a.GetManifestResourceInfo("ResourceThatDoesNotExist");
+                Assert.Null(r);
+            }
         }
 
         [Fact]
         public static void ResourceDoesNotExist_GetManifestResourceStream_ReturnsNull()
         {
-            var resolver = new PathAssemblyResolver(new string[] { typeof(object).Assembly.Location });
-            using var mlc = new MetadataLoadContext(resolver, typeof(object).Assembly.GetName().Name);
-
-            var runtimeAssembly = mlc.LoadFromAssemblyPath(typeof(object).Assembly.Location);
-            var resource = runtimeAssembly.GetManifestResourceStream("Nonsense");
-            Assert.Null(resource);
+            using (MetadataLoadContext lc = new MetadataLoadContext(new SimpleAssemblyResolver()))
+            {
+                Assembly a = lc.LoadFromByteArray(TestData.s_AssemblyWithEmbeddedResourcesImage);
+                Stream? r = a.GetManifestResourceStream("ResourceThatDoesNotExist");
+                Assert.Null(r);
+            }
         }
     }
 }

--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Assembly/AssemblyTests.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Assembly/AssemblyTests.cs
@@ -602,5 +602,27 @@ namespace System.Reflection.Tests
                 Assert.Equal(expected, bt);
             }
         }
+
+        [Fact]
+        public static void ResourceDoesNotExist_GetManifestResourceInfo_ReturnsNull()
+        {
+            var resolver = new PathAssemblyResolver(new string[] { typeof(object).Assembly.Location });
+            using var mlc = new MetadataLoadContext(resolver, typeof(object).Assembly.GetName().Name);
+
+            var runtimeAssembly = mlc.LoadFromAssemblyPath(typeof(object).Assembly.Location);
+            var resource = runtimeAssembly.GetManifestResourceInfo("Nonsense");
+            Assert.Null(resource);
+        }
+
+        [Fact]
+        public static void ResourceDoesNotExist_GetManifestResourceStream_ReturnsNull()
+        {
+            var resolver = new PathAssemblyResolver(new string[] { typeof(object).Assembly.Location });
+            using var mlc = new MetadataLoadContext(resolver, typeof(object).Assembly.GetName().Name);
+
+            var runtimeAssembly = mlc.LoadFromAssemblyPath(typeof(object).Assembly.Location);
+            var resource = runtimeAssembly.GetManifestResourceStream("Nonsense");
+            Assert.Null(resource);
+        }
     }
 }


### PR DESCRIPTION
Fixes #44200

Our nullable annotations were incorrect for the implementation of GetManifestResourceInfo, but the ref assembly was correctly annotated to be nullable. When the resource is not found, it's documented that we should return null.

* https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.getmanifestresourceinfo?view=net-5.0
* https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.getmanifestresourcestream?view=net-5.0