### PR TITLE
[wasm] Update signature of event handler delegates

### DIFF
--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSObject.cs
@@ -84,7 +84,7 @@ namespace System.Runtime.InteropServices.JavaScript
             public object? Signal;
         }
 
-        public int AddEventListener(string name, Delegate listener, EventListenerOptions? options = null)
+        public int AddEventListener(string name, Action<JSObject?> listener, EventListenerOptions? options = null)
         {
             var optionsDict = options.HasValue
                 ? new JSObject()
@@ -117,7 +117,7 @@ namespace System.Runtime.InteropServices.JavaScript
             }
         }
 
-        public void RemoveEventListener(string name, Delegate? listener, EventListenerOptions? options = null)
+        public void RemoveEventListener(string name, Action<JSObject?> listener, EventListenerOptions? options = null)
         {
             if (listener == null)
                 return;

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -263,11 +263,11 @@ namespace System.Runtime.InteropServices.JavaScript
         //  type are usually caused by a JS object (i.e. a WebSocket) receiving an event
         //  after its managed owner has been disposed - throwing in that case is unwanted.
         public static bool TryInvokeJSOwnedDelegateByHandle (int id, JSObject? arg1) {
-            Delegate? del;
+            Action<JSObject?>? del;
             lock (JSOwnedObjectLock) {
                 if (!JSOwnedObjectFromID.TryGetValue(id, out object? o))
                     return false;
-                del = (Delegate)o;
+                del = (Action<JSObject?>)o;
             }
 
             if (del == null)
@@ -276,10 +276,7 @@ namespace System.Runtime.InteropServices.JavaScript
 // error CS0117: 'Array' does not contain a definition for 'Empty' [/home/kate/Projects/dotnet-runtime-wasm/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System.Private.Runtime.InteropServices.JavaScript.csproj]
 #pragma warning disable CA1825
 
-            if (arg1 != null)
-                del.DynamicInvoke(new object[] { arg1 });
-            else
-                del.DynamicInvoke(new object[0]);
+            del.Invoke(arg1);
 
 #pragma warning restore CA1825
 

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -276,7 +276,7 @@ namespace System.Runtime.InteropServices.JavaScript
 // error CS0117: 'Array' does not contain a definition for 'Empty' [/home/kate/Projects/dotnet-runtime-wasm/src/libraries/System.Private.Runtime.InteropServices.JavaScript/src/System.Private.Runtime.InteropServices.JavaScript.csproj]
 #pragma warning disable CA1825
 
-            del.Invoke(arg1);
+            del(arg1);
 
 #pragma warning restore CA1825
 

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JavaScriptTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/JavaScriptTests.cs
@@ -281,7 +281,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         public static void AddEventListenerWorks () {
             var temp = new bool[1];
             var obj = SetupListenerTest("addEventListenerWorks");
-            obj.AddEventListener("test", () => {
+            obj.AddEventListener("test", (JSObject? o) => {
                 temp[0] = true;
             });
             obj.Invoke("fireEvent", "test");
@@ -292,10 +292,10 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         public static void AddEventListenerPassesOptions () {
             var log = new List<string>();
             var obj = SetupListenerTest("addEventListenerPassesOptions");
-            obj.AddEventListener("test", () => {
+            obj.AddEventListener("test", (JSObject? o) => {
                 log.Add("Capture");
             }, new JSObject.EventListenerOptions { Capture = true });
-            obj.AddEventListener("test", () => {
+            obj.AddEventListener("test", (JSObject? o) => {
                 log.Add("Non-capture");
             }, new JSObject.EventListenerOptions { Capture = false });
             obj.Invoke("fireEvent", "test");
@@ -306,7 +306,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [Fact]
         public static void AddEventListenerForwardsExceptions () {
             var obj = SetupListenerTest("addEventListenerForwardsExceptions");
-            obj.AddEventListener("test", () => {
+            obj.AddEventListener("test", (JSObject? o) => {
                 throw new Exception("Test exception");
             });
             var exc = Assert.Throws<JSException>(() => {
@@ -315,7 +315,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             Assert.Contains("Test exception", exc.Message);
 
             exc = Assert.Throws<JSException>(() => {
-                obj.AddEventListener("throwError", () => {
+                obj.AddEventListener("throwError", (JSObject? o) => {
                     throw new Exception("Should not be called");
                 });
             });
@@ -326,7 +326,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [Fact]
         public static void RemovedEventListenerIsNotCalled () {
             var obj = SetupListenerTest("removedEventListenerIsNotCalled");
-            Action del = () => {
+            Action<JSObject?> del = (JSObject? o) => {
                 throw new Exception("Should not be called");
             };
             obj.AddEventListener("test", del);
@@ -342,7 +342,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         public static void RegisterSameEventListener () {
             var counter = new int[1];
             var obj = SetupListenerTest("registerSameDelegateTwice");
-            Action del = () => {
+            Action<JSObject?> del = (JSObject? o) => {
                 counter[0]++;
             };
 
@@ -368,7 +368,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [Fact]
         public static void UseAddEventListenerResultToRemove () {
             var obj = SetupListenerTest("useAddEventListenerResultToRemove");
-            Action del = () => {
+            Action<JSObject?> del = (JSObject? o) => {
                 throw new Exception("Should not be called");
             };
             var handle = obj.AddEventListener("test", del);
@@ -385,7 +385,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             var counter = new int[1];
             var a = SetupListenerTest("registerSameEventListenerToMultipleSourcesA");
             var b = SetupListenerTest("registerSameEventListenerToMultipleSourcesB");
-            Action del = () => {
+            Action<JSObject?> del = (JSObject? o) => {
                 counter[0]++;
             };
 


### PR DESCRIPTION
Making event handler delegates of type Action<JSObject?> instead of Delegate is an easy improvement that will feed into other improvements we want to make later.