### PR TITLE
Fix standalone GC critical section reentrancy

### DIFF
--- a/src/coreclr/gc/env/gcenv.os.h
+++ b/src/coreclr/gc/env/gcenv.os.h
@@ -34,7 +34,7 @@ class CLRCriticalSection
 
 public:
     // Initialize the critical section
-    void Initialize();
+    bool Initialize();
 
     // Destroy the critical section
     void Destroy();

--- a/src/coreclr/gc/env/gcenv.sync.h
+++ b/src/coreclr/gc/env/gcenv.sync.h
@@ -28,8 +28,7 @@ class CrstStatic
 public:
     bool InitNoThrow(CrstType eType, CrstFlags eFlags = CRST_DEFAULT)
     {
-        m_cs.Initialize();
-        return true;
+        return m_cs.Initialize();
     }
 
     void Destroy()

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -1467,10 +1467,24 @@ bool GCToOSInterface::ParseGCHeapAffinitizeRangesEntry(const char** config_strin
 }
 
 // Initialize the critical section
-void CLRCriticalSection::Initialize()
+bool CLRCriticalSection::Initialize()
 {
-    int st = pthread_mutex_init(&m_cs.mutex, NULL);
-    assert(st == 0);
+    pthread_mutexattr_t mutexAttributes;
+    int st = pthread_mutexattr_init(&mutexAttributes);
+    if (st != 0)
+    {
+        return false;
+    }
+
+    st = pthread_mutexattr_settype(&mutexAttributes, PTHREAD_MUTEX_RECURSIVE);
+    if (st == 0)
+    {
+        st = pthread_mutex_init(&m_cs.mutex, &mutexAttributes);
+    }
+
+    pthread_mutexattr_destroy(&mutexAttributes);
+
+    return (st == 0);
 }
 
 // Destroy the critical section

--- a/src/coreclr/gc/windows/gcenv.windows.cpp
+++ b/src/coreclr/gc/windows/gcenv.windows.cpp
@@ -1317,9 +1317,10 @@ static DWORD GCThreadStub(void* param)
 }
 
 // Initialize the critical section
-void CLRCriticalSection::Initialize()
+bool CLRCriticalSection::Initialize()
 {
     ::InitializeCriticalSection(&m_cs);
+    return true;
 }
 
 // Destroy the critical section

--- a/src/coreclr/vm/gcenv.os.cpp
+++ b/src/coreclr/vm/gcenv.os.cpp
@@ -1204,10 +1204,12 @@ bool GCToOSInterface::ParseGCHeapAffinitizeRangesEntry(const char** config_strin
 }
 
 // Initialize the critical section
-void CLRCriticalSection::Initialize()
+bool CLRCriticalSection::Initialize()
 {
     WRAPPER_NO_CONTRACT;
     InitializeCriticalSection(&m_cs);
+
+    return true;
 }
 
 // Destroy the critical section


### PR DESCRIPTION
The standalone GC on Unix uses pthread mutex to implement critical
sections. However, these critical sections are expected to be reentrant
and the current implementation wasn't setting the mutex attribute that
would make it reentrant. The result is a hang during GC.

This change fixes it by adding that attribute. Since allocating that
attribute may fail in low memory cases, the
CLRCriticalSection::Initialize was updated to return success status.