### PR TITLE
[wasm][tests] Improve console.log in unit tests

### DIFF
--- a/src/mono/wasm/runtime-test.js
+++ b/src/mono/wasm/runtime-test.js
@@ -18,15 +18,21 @@ globalThis.testConsole = console;
 
 function proxyMethod (prefix, func, asJson) {
 	return function() {
-		var args = [...arguments];
+		const args = [...arguments];
+		var payload= args[0];
+		if(payload === undefined) payload = 'undefined';
+		else if(payload === null) payload = 'null';
+		else if(typeof payload === 'function') payload = payload.toString();
+		else if(typeof payload !== 'string') payload = JSON.stringify(payload);
+
 		if (asJson) {
 			func (JSON.stringify({
 				method: prefix,
-				payload: args[0],
+				payload: payload,
 				arguments: args
 			}));
 		} else {
-			func([prefix + args[0], ...args.slice(1)]);
+			func([prefix + payload, ...args.slice(1)]);
 		}
 	};
 };


### PR DESCRIPTION
To prevent misleading log lines like
[`[15:43:34] info: {"method":"console.error","payload":{},"arguments":[{}]}`](https://github.com/dotnet/runtime/issues/53614#issuecomment-867960860)

or `{"method":"console.log","arguments":[null]}` instead of `undefined`