### PR TITLE
Fix evaluate-changed-paths.sh script

### DIFF
--- a/eng/pipelines/evaluate-changed-paths.sh
+++ b/eng/pipelines/evaluate-changed-paths.sh
@@ -73,12 +73,12 @@ while [[ $# > 0 ]]; do
       ;;
     -excludepaths)
       IFS='+' read -r -a tmp <<< $2
-      exclude_paths+=($tmp)
+      exclude_paths+=(${tmp[@]})
       shift
       ;;
     -includepaths)
       IFS='+' read -r -a tmp <<< $2
-      include_paths+=($tmp)
+      include_paths+=(${tmp[@]})
       shift
       ;;
     -subset)


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/56479 uncovered a bug in the script where it didn't append the full `tmp` array to `include_paths` and `exclude_paths` but just the first element.
Shellcheck actually complained about this with "SC2128: Expanding an array without an index only gives the first element."

The old bash in macOS has a quirk where this doesn't happen so we didn't see it before https://github.com/dotnet/runtime/pull/56479.