### PR TITLE
Fix BufferedStream outerloop test

### DIFF
--- a/src/libraries/System.IO/tests/BufferedStream/BufferedStreamTests.cs
+++ b/src/libraries/System.IO/tests/BufferedStream/BufferedStreamTests.cs
@@ -55,14 +55,13 @@ namespace System.IO.Tests
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
         [OuterLoop]
-        [InlineData(int.MaxValue / 2 + 1)]
-        public void WriteFromByte_InputSizeLargerThanHalfOfMaxInt_ShouldSuccess(int inputSize)
+        public void WriteFromByte_InputSizeLargerThanHalfOfMaxInt_ShouldSuccess()
         {
+            const int InputSize = int.MaxValue / 2 + 1;
             byte[] bytes;
-
             try
             {
-                bytes = new byte[inputSize];
+                bytes = new byte[InputSize];
             }
             catch (OutOfMemoryException)
             {
@@ -72,21 +71,20 @@ namespace System.IO.Tests
             var writableStream = new WriteOnlyStream();
             using (var bs = new BufferedStream(writableStream))
             {
-                bs.Write(bytes, 0, inputSize);
-                Assert.Equal(inputSize, writableStream.Position);
+                bs.Write(bytes, 0, InputSize);
+                Assert.Equal(InputSize, writableStream.Position);
             }
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
         [OuterLoop]
-        [InlineData(int.MaxValue / 2 + 1)]
-        public void WriteFromSpan_InputSizeLargerThanHalfOfMaxInt_ShouldSuccess(int inputSize)
+        public void WriteFromSpan_InputSizeLargerThanHalfOfMaxInt_ShouldSuccess()
         {
+            const int InputSize = int.MaxValue / 2 + 1;
             byte[] bytes;
-
             try
             {
-                bytes = new byte[inputSize];
+                bytes = new byte[InputSize];
             }
             catch (OutOfMemoryException)
             {
@@ -97,7 +95,7 @@ namespace System.IO.Tests
             using (var bs = new BufferedStream(writableStream))
             {
                 bs.Write(new ReadOnlySpan<byte>(bytes));
-                Assert.Equal(inputSize, writableStream.Position);
+                Assert.Equal(InputSize, writableStream.Position);
             }
         }
 


### PR DESCRIPTION
The tests added in #53338 use `[InlineData]` and `[ConditionalFact]` instead of theory. This is failing all `System.IO` outerloop runs. [Example console.log](https://helixre8s23ayyeko0k025g8.blob.core.windows.net/dotnet-runtime-refs-pull-56614-merge-e9e3d6c0193040aa85/System.IO.Tests/console.cf7e768a.log?sv=2019-07-07&se=2021-08-19T11%3A31%3A02Z&sr=c&sp=rl&sig=3uPg85oCw6X3dMdENRisLmKRy0bEGqMVA%2FkqIEKTeb4%3D)