### PR TITLE
[libraries][tvOS] Update Issue causing System.Net.Requests to fail

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.tvOS.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.tvOS.cs
@@ -12,7 +12,7 @@ namespace System.Net.Http
         private static Task<HttpResponseMessage> InnerSendAsync(HttpRequestMessage request, Uri authUri, bool async, ICredentials credentials, bool isProxyAuth, HttpConnection connection, HttpConnectionPool connectionPool, CancellationToken cancellationToken)
         {
             return isProxyAuth ?
-                SendWithProxyAuthAsync(request, authUri, async, credentials, true, connectionPool, cancellationToken).AsTask() :
+                SendWithProxyAuthAsync(request, authUri, async, credentials, false, connectionPool, cancellationToken).AsTask() :
                 SendWithRequestAuthAsync(request, async, credentials, false, connectionPool, cancellationToken).AsTask();
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.tvOS.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.tvOS.cs
@@ -13,7 +13,7 @@ namespace System.Net.Http
         {
             return isProxyAuth ?
                 SendWithProxyAuthAsync(request, authUri, async, credentials, true, connectionPool, cancellationToken).AsTask() :
-                SendWithRequestAuthAsync(request, async, credentials, true, connectionPool, cancellationToken).AsTask();
+                SendWithRequestAuthAsync(request, async, credentials, false, connectionPool, cancellationToken).AsTask();
         }
 
         public static Task<HttpResponseMessage> SendWithNtProxyAuthAsync(HttpRequestMessage request, Uri proxyUri, bool async, ICredentials proxyCredentials, HttpConnection connection, HttpConnectionPool connectionPool, CancellationToken cancellationToken)

--- a/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -1991,8 +1991,7 @@ namespace System.Net.Tests
             }
         }
 
-        [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
         public void HttpWebRequest_Serialize_Fails()
         {
             using (MemoryStream fs = new MemoryStream())

--- a/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -1500,6 +1500,7 @@ namespace System.Net.Tests
         [InlineData(true)]
         [InlineData(false)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/56798", TestPlatforms.tvOS)]
         public async Task HaveResponse_GetResponseAsync_ExpectTrue(bool useSsl)
         {
             var options = new LoopbackServer.Options { UseSsl = useSsl };

--- a/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -1459,6 +1459,7 @@ namespace System.Net.Tests
         [InlineData(true)]
         [InlineData(false)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/56798", TestPlatforms.tvOS)]
         public async Task GetResponseAsync_UseDefaultCredentials_ExpectSuccess(bool useSsl)
         {
             var options = new LoopbackServer.Options { UseSsl = useSsl };

--- a/src/libraries/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs
@@ -122,8 +122,7 @@ namespace System.Net.Tests
             });
         }
 
-        [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
         public async Task HttpWebResponse_Serialize_ExpectedResult()
         {
             await LoopbackServer.CreateServerAsync(async (server, url) =>

--- a/src/libraries/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs
@@ -123,7 +123,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/56798", TestPlatforms.tvOS)]
         public async Task HttpWebResponse_Serialize_ExpectedResult()
         {
             await LoopbackServer.CreateServerAsync(async (server, url) =>

--- a/src/libraries/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs
@@ -123,6 +123,7 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/56798", TestPlatforms.tvOS)]
         public async Task HttpWebResponse_Serialize_ExpectedResult()
         {
             await LoopbackServer.CreateServerAsync(async (server, url) =>

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -185,8 +185,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj" />
 
     <!-- Crashes or hangs, did not produce testResults.xml -->
-    <!-- https://github.com/dotnet/runtime/issues/56621 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Requests/tests/System.Net.Requests.Tests.csproj" />
     <!-- https://github.com/dotnet/runtime/issues/52120 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj" />
 

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -185,7 +185,7 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.Pipes/tests/System.IO.Pipes.Tests.csproj" />
 
     <!-- Crashes or hangs, did not produce testResults.xml -->
-    <!-- https://github.com/dotnet/runtime/issues/52117 -->
+    <!-- https://github.com/dotnet/runtime/issues/56621 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Requests/tests/System.Net.Requests.Tests.csproj" />
     <!-- https://github.com/dotnet/runtime/issues/52120 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj" />


### PR DESCRIPTION
It was confirmed that `System.Net.Requests` no longer fails for `System.IO.DirectoryNotFoundException`.
However, the tests still crash due to an assert error with `System.Net.Http.AuthenticationHelper.SendWithAuthAsync`.

By not defaulting `preauthenticate` parameter in `SendWithRequestAuthAsync` call in `InnerSendAsync` of `AuthenticationHelper.NtAuth.tvOS.cs` to true, the assert error no longer crashes tests.

Fixes #56621 

Instead, now there are failures with regards to 

```
System.Net.Requests.Tests.dll   Failed: 8

Test collection for System.Net.Tests.HttpWebRequestTest_Sync
System.Net.Tests.HttpWebRequestTest_Sync.HaveResponse_GetResponseAsync_ExpectTrue(useSsl: True)
    System.AggregateException : One or more errors occurred. (One or more errors occurred. (The operation has timed out.)) (One or more errors occurred. (Unexpected EOF trying to read request header))\n---- System.AggregateException : One or more errors occurred. (The operation has timed out.)\n-------- System.Net.WebException : The operation has timed out.\n---- System.AggregateException : One or more errors occurred. (Unexpected EOF trying to read request header)\n-------- System.IO.IOException : Unexpected EOF trying to read request header
System.Net.Tests.HttpWebRequestTest_Sync.HaveResponse_GetResponseAsync_ExpectTrue(useSsl: False)
    System.AggregateException : One or more errors occurred. (One or more errors occurred. (Operation timed out [::ffff:127.0.0.1]:50415 (127.0.0.1:50415))) (One or more errors occurred. (Unexpected EOF trying to read request header))\n---- System.AggregateException : One or more errors occurred. (Operation timed out [::ffff:127.0.0.1]:50415 (127.0.0.1:50415))\n-------- System.Net.WebException : Operation timed out [::ffff:127.0.0.1]:50415 (127.0.0.1:50415)\n------------ System.Net.Http.HttpRequestException : Operation timed out [::ffff:127.0.0.1]:50415 (127.0.0.1:50415)\n---------------- System.Net.Internals.SocketExceptionFactory+ExtendedSocketException : Operation timed out [::ffff:127.0.0.1]:50415\n---- System.AggregateException : One or more errors occurred. (Unexpected EOF trying to read request header)\n-------- System.IO.IOException : Unexpected EOF trying to read request header
System.Net.Tests.HttpWebRequestTest_Sync.GetResponseAsync_UseDefaultCredentials_ExpectSuccess(useSsl: True)
    System.AggregateException : One or more errors occurred. (One or more errors occurred. (The operation has timed out.)) (One or more errors occurred. (Unexpected EOF trying to read request header))\n---- System.AggregateException : One or more errors occurred. (The operation has timed out.)\n-------- System.Net.WebException : The operation has timed out.\n---- System.AggregateException : One or more errors occurred. (Unexpected EOF trying to read request header)\n-------- System.IO.IOException : Unexpected EOF trying to read request header
System.Net.Tests.HttpWebRequestTest_Sync.GetResponseAsync_UseDefaultCredentials_ExpectSuccess(useSsl: False)
    System.AggregateException : One or more errors occurred. (One or more errors occurred. (Operation timed out [::ffff:127.0.0.1]:50515 (127.0.0.1:50515))) (One or more errors occurred. (Unexpected EOF trying to read request header))\n---- System.AggregateException : One or more errors occurred. (Operation timed out [::ffff:127.0.0.1]:50515 (127.0.0.1:50515))\n-------- System.Net.WebException : Operation timed out [::ffff:127.0.0.1]:50515 (127.0.0.1:50515)\n------------ System.Net.Http.HttpRequestException : Operation timed out [::ffff:127.0.0.1]:50515 (127.0.0.1:50515)\n---------------- System.Net.Internals.SocketExceptionFactory+ExtendedSocketException : Operation timed out [::ffff:127.0.0.1]:50515\n---- System.AggregateException : One or more errors occurred. (Unexpected EOF trying to read request header)\n-------- System.IO.IOException : Unexpected EOF trying to read request header

Test collection for System.Net.Tests.HttpWebRequestTest_Async
System.Net.Tests.HttpWebRequestTest_Async.GetResponseAsync_UseDefaultCredentials_ExpectSuccess(useSsl: True)
    System.AggregateException : One or more errors occurred. (One or more errors occurred. (The operation has timed out.)) (One or more errors occurred. (Unexpected EOF trying to read request header))\n---- System.AggregateException : One or more errors occurred. (The operation has timed out.)\n-------- System.Net.WebException : The operation has timed out.\n---- System.AggregateException : One or more errors occurred. (Unexpected EOF trying to read request header)\n-------- System.IO.IOException : Unexpected EOF trying to read request header
System.Net.Tests.HttpWebRequestTest_Async.GetResponseAsync_UseDefaultCredentials_ExpectSuccess(useSsl: False)
    System.AggregateException : One or more errors occurred. (One or more errors occurred. (Operation timed out (127.0.0.1:50645))) (One or more errors occurred. (Unexpected EOF trying to read request header))\n---- System.AggregateException : One or more errors occurred. (Operation timed out (127.0.0.1:50645))\n-------- System.Net.WebException : Operation timed out (127.0.0.1:50645)\n------------ System.Net.Http.HttpRequestException : Operation timed out (127.0.0.1:50645)\n---------------- System.Net.Sockets.SocketException : Operation timed out\n---- System.AggregateException : One or more errors occurred. (Unexpected EOF trying to read request header)\n-------- System.IO.IOException : Unexpected EOF trying to read request header
System.Net.Tests.HttpWebRequestTest_Async.HaveResponse_GetResponseAsync_ExpectTrue(useSsl: True)
    System.AggregateException : One or more errors occurred. (One or more errors occurred. (The operation has timed out.)) (One or more errors occurred. (Unexpected EOF trying to read request header))\n---- System.AggregateException : One or more errors occurred. (The operation has timed out.)\n-------- System.Net.WebException : The operation has timed out.\n---- System.AggregateException : One or more errors occurred. (Unexpected EOF trying to read request header)\n-------- System.IO.IOException : Unexpected EOF trying to read request header
System.Net.Tests.HttpWebRequestTest_Async.HaveResponse_GetResponseAsync_ExpectTrue(useSsl: False)
    System.AggregateException : One or more errors occurred. (One or more errors occurred. (Operation timed out (127.0.0.1:50739))) (One or more errors occurred. (Unexpected EOF trying to read request header))\n---- System.AggregateException : One or more errors occurred. (Operation timed out (127.0.0.1:50739))\n-------- System.Net.WebException : Operation timed out (127.0.0.1:50739)\n------------ System.Net.Http.HttpRequestException : Operation timed out (127.0.0.1:50739)\n---------------- System.Net.Sockets.SocketException : Operation timed out\n---- System.AggregateException : One or more errors occurred. (Unexpected EOF trying to read request header)\n-------- System.IO.IOException : Unexpected EOF trying to read request header
```

This PR does the following:
Modifies the default authentication parameters in `AuthenticationHelper.NtAuth.tvOS.cs`
Removes the test suite project level skip
Adds active issues to the two failing tests for tvOS https://github.com/dotnet/runtime/issues/56798
Conditions two tests that fail for BinaryFormatter not supported reasons.