### PR TITLE
[EnC] Turn off DeterministicSourcePaths for hot reload CI tests

### DIFF
--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/Directory.Build.props
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/Directory.Build.props
@@ -16,6 +16,8 @@
     <!-- to call AsssemblyExtensions.ApplyUpdate we need Optimize=false, EmitDebugInformation=true in all configurations -->
     <Optimize>false</Optimize>
     <EmitDebugInformation>true</EmitDebugInformation>
+    <!-- CI builds turn this on, but it interferes with Roslyn's ability to generate EnC deltas -->
+    <DeterministicSourcePaths>false</DeterministicSourcePaths>
   </PropertyGroup>
 
 </Project>

--- a/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/ApplyUpdateReferencedAssembly/ApplyUpdateReferencedAssembly.csproj
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/ApplyUpdateReferencedAssembly/ApplyUpdateReferencedAssembly.csproj
@@ -11,6 +11,8 @@
     <!-- hot reload is not compatible with trimming -->
     <EnableAggressiveTrimming>false</EnableAggressiveTrimming>
     <PublishTrimmed>false</PublishTrimmed>
+    <!-- CI builds turn this on, but it interferes with Roslyn's ability to generate EnC deltas -->
+    <DeterministicSourcePaths>false</DeterministicSourcePaths>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
DeterministicSourcePaths uses a path map to rewrite the source file locations in the debugger info, which breaks EnC.  Related issue https://github.com/dotnet/roslyn/issues/47194 (roslyn should emit a warning, but doesn't)