### PR TITLE
Add equality override for KeyValuePairComparer

### DIFF
--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedDictionary.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedDictionary.cs
@@ -947,6 +947,21 @@ namespace System.Collections.Generic
             {
                 return keyComparer.Compare(x.Key, y.Key);
             }
+
+            public override bool Equals(object? obj)
+            {
+                if (obj is KeyValuePairComparer other)
+                {
+                    // Commonly, both comparers will be the default comparer (and reference-equal). Avoid a virtual method call to Equals() in that case.
+                    return this.keyComparer == other.keyComparer || this.keyComparer.Equals(other.keyComparer);
+                }
+                return false;
+            }
+
+            public override int GetHashCode()
+            {
+                return this.keyComparer.GetHashCode();
+            }
         }
     }
 


### PR DESCRIPTION
I noticed that SortedDictionary copying was allocation more memory than iterating the initial dictionary and adding items one at a time. I realized that the optimization done as part of #45659 was not completely successful and we need to override Equals for KeyValuePairComparer so that SortedSets HasEqualComparer will pass to allow efficient deep copy.

https://github.com/dotnet/performance/compare/main...johnthcall:johncall/SortedSetDeepCopy
|               Method | Toolchain |    N |          Mean |         Error |        StdDev | Ratio | Allocated |
|--------------------- |---------- |----- |--------------:|--------------:|--------------:|------:|----------:|
| SortedDictionaryCopy |      main |    1 |     233.25 ns |     14.931 ns |     17.195 ns |  1.00 |     392 B |
| SortedDictionaryCopy |        pr |    1 |     179.63 ns |      4.817 ns |      5.547 ns |  0.77 |     344 B |
|                      |           |      |               |               |               |       |           |
| SortedDictionaryCopy |      main |   10 |   1,353.38 ns |     55.142 ns |     63.501 ns |  1.00 |   1,136 B |
| SortedDictionaryCopy |        pr |   10 |     600.19 ns |     30.233 ns |     34.817 ns |  0.44 |     944 B |
|                      |           |      |               |               |               |       |           |
| SortedDictionaryCopy |      main |  100 |  16,490.14 ns |    785.823 ns |    904.955 ns |  1.00 |   7,664 B |
| SortedDictionaryCopy |        pr |  100 |   4,805.14 ns |     91.329 ns |     89.697 ns |  0.29 |   6,080 B |
|                      |           |      |               |               |               |       |           |
| SortedDictionaryCopy |      main | 1000 | 212,509.48 ns | 10,768.851 ns | 11,969.549 ns |  1.00 |  72,512 B |
| SortedDictionaryCopy |        pr | 1000 |  48,069.80 ns |  1,324.823 ns |  1,525.668 ns |  0.23 |  56,576 B |