### PR TITLE
[libraries][Android] Reenable tests failing from feature switches being improperly set

### DIFF
--- a/src/libraries/System.Collections.Concurrent/tests/BlockingCollectionCancellationTests.cs
+++ b/src/libraries/System.Collections.Concurrent/tests/BlockingCollectionCancellationTests.cs
@@ -97,7 +97,6 @@ namespace System.Collections.Concurrent.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50576", TestPlatforms.Android)]
         public static void ExternalCancel_AddToAny()
         {
             for (int test = 0; test < 3; test++)

--- a/src/libraries/System.ComponentModel.Primitives/tests/System/ComponentModel/CategoryAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.Primitives/tests/System/ComponentModel/CategoryAttributeTests.cs
@@ -9,7 +9,6 @@ namespace System.ComponentModel.Tests
     public class CategoryAttributeTests
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50881", TestPlatforms.Android)]
         public void Ctor_Default()
         {
             var attribute = new CategoryAttribute();
@@ -24,7 +23,6 @@ namespace System.ComponentModel.Tests
         [InlineData("Misc", true)]
         [InlineData("misc", false)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework throws a NullReferenceException")]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50881", TestPlatforms.Android)]
         public void Ctor_String(string category, bool expectedIsDefaultAttribute)
         {
             var attribute = new CategoryAttribute(category);
@@ -61,7 +59,6 @@ namespace System.ComponentModel.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50881", TestPlatforms.Android)]
         public void Equals_Object_ReturnsExpected(CategoryAttribute attribute, object other, bool expected)
         {
             Assert.Equal(expected, attribute.Equals(other));
@@ -90,7 +87,6 @@ namespace System.ComponentModel.Tests
 
         [Theory]
         [MemberData(nameof(Properties_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50881", TestPlatforms.Android)]
         public void Properties_Get_ReturnsExpected(Func<CategoryAttribute> attributeThunk, string expectedCategory)
         {
             CategoryAttribute attribute = attributeThunk();
@@ -129,7 +125,6 @@ namespace System.ComponentModel.Tests
         [InlineData(null)]
         [InlineData("")]
         [InlineData("value")]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50881", TestPlatforms.Android)]
         public void GetLocalizedString_InvokeNoSuchValue_ReturnsNull(string value)
         {
             var attribute = new SubCategoryAttribute();

--- a/src/libraries/System.ComponentModel.Primitives/tests/System/ComponentModel/InvalidEnumArgumentExceptionTests.cs
+++ b/src/libraries/System.ComponentModel.Primitives/tests/System/ComponentModel/InvalidEnumArgumentExceptionTests.cs
@@ -88,7 +88,6 @@ namespace System.ComponentModel.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50881", TestPlatforms.Android)]
         public void Ctor_SerializationInfo_StreamingContext()
         {
             using (var stream = new MemoryStream())

--- a/src/libraries/System.Composition.Hosting/tests/System/Composition/Hosting/Core/CompositionDependencyTests.cs
+++ b/src/libraries/System.Composition.Hosting/tests/System/Composition/Hosting/Core/CompositionDependencyTests.cs
@@ -37,7 +37,6 @@ namespace System.Composition.Hosting.Core.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50917", TestPlatforms.Android)]
         public void Satisfied_Invoke_ReturnsExpected()
         {
             var contract = new CompositionContract(typeof(int));

--- a/src/libraries/System.Composition.Hosting/tests/System/Composition/Hosting/Core/ExportDescriptorPromiseTests.cs
+++ b/src/libraries/System.Composition.Hosting/tests/System/Composition/Hosting/Core/ExportDescriptorPromiseTests.cs
@@ -252,7 +252,6 @@ namespace System.Composition.Hosting.Core.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50917", TestPlatforms.Android)]
         public void ToString_Invoke_ReturnsExpected()
         {
             var promise = new ExportDescriptorPromise(new CompositionContract(typeof(int)), "Origin", true, () => Enumerable.Empty<CompositionDependency>(), depdendencies =>

--- a/src/libraries/System.Composition.Runtime/tests/System/Composition/Hosting/Core/CompositionContractTests.cs
+++ b/src/libraries/System.Composition.Runtime/tests/System/Composition/Hosting/Core/CompositionContractTests.cs
@@ -279,7 +279,6 @@ namespace System.Composition.Runtime.Tests
 
         [Theory]
         [MemberData(nameof(ToString_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50918", TestPlatforms.Android)]
         public void ToString_Get_ReturnsExpected(CompositionContract contract, string expected)
         {
             Assert.Equal(expected, contract.ToString());

--- a/src/libraries/System.Composition/tests/CardinalityTests.cs
+++ b/src/libraries/System.Composition/tests/CardinalityTests.cs
@@ -31,7 +31,6 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void RequestingOneWhereMultipleArePresentFails()
         {
             var c = CreateContainer(typeof(LogA), typeof(LogB));
@@ -42,7 +41,6 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void ImportingOneWhereMultipleArePresentFails()
         {
             var c = CreateContainer(typeof(LogA), typeof(LogB), typeof(UsesLog));

--- a/src/libraries/System.Composition/tests/ContractTests.cs
+++ b/src/libraries/System.Composition/tests/ContractTests.cs
@@ -67,7 +67,6 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void FormattingTheContractPrintsConstraintKeysAndValues()
         {
             var mcd = new CompositionContract(typeof(AType), null, new Dictionary<string, object> { { "A", 1 }, { "B", "C" } });

--- a/src/libraries/System.Composition/tests/DiscoveryTests.cs
+++ b/src/libraries/System.Composition/tests/DiscoveryTests.cs
@@ -56,7 +56,6 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void InstanceExportsOfIncompatibleContractsAreDetected()
         {
             var x = Assert.Throws<CompositionFailedException>(() => CreateContainer(typeof(IncompatibleRule)));
@@ -64,7 +63,6 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void PropertyExportsOfIncompatibleContractsAreDetected()
         {
             var x = Assert.Throws<CompositionFailedException>(() => CreateContainer(typeof(IncompatibleRuleProperty)));
@@ -124,7 +122,6 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void MultipleImportAttributesAreDetected()
         {
             var c = new ContainerConfiguration()

--- a/src/libraries/System.Composition/tests/ErrorMessageQualityTests.cs
+++ b/src/libraries/System.Composition/tests/ErrorMessageQualityTests.cs
@@ -63,7 +63,6 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void MissingTopLevelExportMessageIsInformative()
         {
             var cc = CreateContainer();
@@ -72,7 +71,6 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void MissingTopLevelNamedExportMessageIsInformative()
         {
             var cc = CreateContainer();
@@ -81,7 +79,6 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void MissingDependencyMessageIsInformative()
         {
             var cc = CreateContainer(typeof(UserOfUnregistered));
@@ -92,7 +89,6 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void CycleMessageIsInformative()
         {
             var cc = CreateContainer(typeof(CycleA), typeof(CycleB), typeof(CycleC));
@@ -106,7 +102,6 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void CardinalityViolationMessageIsInformative()
         {
             var cc = CreateContainer(typeof(ShouldBeOne), typeof(ButThereIsAnother), typeof(RequiresOnlyOne));

--- a/src/libraries/System.Composition/tests/MetadataViewGenerationTests.cs
+++ b/src/libraries/System.Composition/tests/MetadataViewGenerationTests.cs
@@ -77,7 +77,6 @@ namespace System.Composition.Lightweight.UnitTests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void AConcreteTypeWithUnsupportedConstructorsCannotBeUsedAsAMetadataView()
         {
             var cc = new ContainerConfiguration()
@@ -102,7 +101,6 @@ namespace System.Composition.Lightweight.UnitTests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void UnsupportedMetadataViewMessageIsInformative()
         {
             var cc = new ContainerConfiguration().WithParts(typeof(ImportsWithMetadataInterface), typeof(ExportsWithMetadata)).CreateContainer();

--- a/src/libraries/System.Composition/tests/OpenGenericsTests.cs
+++ b/src/libraries/System.Composition/tests/OpenGenericsTests.cs
@@ -123,7 +123,6 @@ namespace System.Composition.UnitTests
         // In future, the set of allowable generic type mappings will be expanded (see
         // ignored tests above).
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void TypesWithMismatchedGenericParameterListsAreDetectedDuringDiscovery()
         {
             var x = Assert.Throws<CompositionFailedException>(() => CreateContainer(typeof(RepositoryWithKey<,>)));
@@ -131,7 +130,6 @@ namespace System.Composition.UnitTests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void TypesWithNonGenericExportsAreDetectedDuringDiscovery()
         {
             var x = Assert.Throws<CompositionFailedException>(() => CreateContainer(typeof(RepositoryWithNonGenericExport<>)));

--- a/src/libraries/System.Composition/tests/SharingTests.cs
+++ b/src/libraries/System.Composition/tests/SharingTests.cs
@@ -318,7 +318,6 @@ namespace System.Composition.UnitTests
         /// we fail only when we create instance of B.. is that correct.
         /// </summary>
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50919", TestPlatforms.Android)]
         public void BoundaryExposedBoundaryButNoneImported()
         {
             try

--- a/src/libraries/System.IO.Pipelines/tests/FlushAsyncCompletionTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/FlushAsyncCompletionTests.cs
@@ -10,7 +10,6 @@ namespace System.IO.Pipelines.Tests
     public class FlushAsyncCompletionTests : PipeTest
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50927", TestPlatforms.Android)]
         public void AwaitingFlushAsyncAwaitableTwiceCompletesReaderWithException()
         {
             async Task Await(ValueTask<FlushResult> a)

--- a/src/libraries/System.IO.Pipelines/tests/FlushAsyncTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/FlushAsyncTests.cs
@@ -71,7 +71,6 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50927", TestPlatforms.Android)]
         public async Task DoubleFlushAsyncThrows()
         {
             Pipe.Writer.WriteEmpty(65);

--- a/src/libraries/System.IO.Pipelines/tests/PipeReaderWriterFacts.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeReaderWriterFacts.cs
@@ -150,7 +150,6 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50927", TestPlatforms.Android)]
         public async Task AdvanceAfterCompleteThrows()
         {
             await _pipe.Writer.WriteAsync(new byte[1]);
@@ -621,7 +620,6 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50927", TestPlatforms.Android)]
         public async Task DoubleAsyncReadThrows()
         {
             ValueTask<ReadResult> readTask1 = _pipe.Reader.ReadAsync();
@@ -658,7 +656,6 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50927", TestPlatforms.Android)]
         public async Task AdvanceWithoutReadThrows()
         {
             await _pipe.Writer.WriteAsync(new byte[3]);

--- a/src/libraries/System.IO.Pipelines/tests/ReadAsyncCompletionTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/ReadAsyncCompletionTests.cs
@@ -9,7 +9,6 @@ namespace System.IO.Pipelines.Tests
     public class ReadAsyncCompletionTests : PipeTest
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50927", TestPlatforms.Android)]
         public void AwaitingReadAsyncAwaitableTwiceCompletesWriterWithException()
         {
             async Task Await(ValueTask<ReadResult> a)

--- a/src/libraries/System.Net.Mail/tests/Functional/LoggingTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/LoggingTest.cs
@@ -13,7 +13,6 @@ namespace System.Net.Mail.Tests
     public class LoggingTest
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50999", TestPlatforms.Android)]
         public void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(SmtpClient).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);

--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpExceptionTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpExceptionTest.cs
@@ -54,7 +54,6 @@ namespace System.Net.Mail.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50999", TestPlatforms.Android)]
         public void TestConstructorWithStringArgument()
         {
             string msg;
@@ -92,7 +91,6 @@ namespace System.Net.Mail.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50999", TestPlatforms.Android)]
         public void TestConstructorWithStatusCodeAndStringArgument()
         {
             string msg;

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/LoggingTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/LoggingTest.cs
@@ -17,7 +17,6 @@ namespace System.Net.NameResolution.Tests
     public class LoggingTest
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50928", TestPlatforms.Android)]
         public static void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(Dns).Assembly.GetType("System.Net.NetEventSource", throwOnError: true, ignoreCase: false);
@@ -30,7 +29,6 @@ namespace System.Net.NameResolution.Tests
         }
 
         [ConditionalFact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50928", TestPlatforms.Android)]
         public void GetHostEntry_InvalidHost_LogsError()
         {
             using (var listener = new TestEventListener("Private.InternalDiagnostics.System.Net.NameResolution", EventLevel.Error))
@@ -65,7 +63,6 @@ namespace System.Net.NameResolution.Tests
         }
 
         [ConditionalFact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50928", TestPlatforms.Android)]
         public async Task GetHostEntryAsync_InvalidHost_LogsError()
         {
             using (var listener = new TestEventListener("Private.InternalDiagnostics.System.Net.NameResolution", EventLevel.Error))
@@ -115,7 +112,6 @@ namespace System.Net.NameResolution.Tests
         }
 
         [ConditionalFact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50928", TestPlatforms.Android)]
         public void GetHostEntry_ValidName_NoErrors()
         {
             using (var listener = new TestEventListener("Private.InternalDiagnostics.System.Net.NameResolution", EventLevel.Verbose))

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/TelemetryTest.cs
@@ -17,7 +17,6 @@ namespace System.Net.NameResolution.Tests
     public class TelemetryTest
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50928", TestPlatforms.Android)]
         public static void EventSource_ExistsWithCorrectId()
         {
             Type esType = typeof(Dns).Assembly.GetType("System.Net.NameResolutionTelemetry", throwOnError: true, ignoreCase: false);

--- a/src/libraries/System.Private.Xml.Linq/tests/xNodeBuilder/CommonTests.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/xNodeBuilder/CommonTests.cs
@@ -3403,7 +3403,6 @@ namespace CoreXml.Test.XLinq
 
                 //[Variation(Id = 5, Desc = "WriteCData with ]]>", Priority = 1)]
                 [Fact]
-                [ActiveIssue("https://github.com/dotnet/runtime/issues/50944", TestPlatforms.Android)]
                 public void WriteCDataWithTwoClosingBrackets_5()
                 {
                     XDocument doc = new XDocument();
@@ -3599,7 +3598,6 @@ namespace CoreXml.Test.XLinq
 
                 //[Variation(Id = 6, Desc = "WriteComment with -- in value", Priority = 1)]
                 [Fact]
-                [ActiveIssue("https://github.com/dotnet/runtime/issues/50944", TestPlatforms.Android)]
                 public void WriteCommentWithDoubleHyphensInValue()
                 {
                     XDocument doc = new XDocument();
@@ -4205,7 +4203,6 @@ namespace CoreXml.Test.XLinq
 
                 //[Variation(Id = 11, Desc = "Include PI end tag ?> as part of the text value", Priority = 1)]
                 [Fact]
-                [ActiveIssue("https://github.com/dotnet/runtime/issues/50944", TestPlatforms.Android)]
                 public void IncludePIEndTagAsPartOfTextValue()
                 {
                     XDocument doc = new XDocument();

--- a/src/libraries/System.Private.Xml/tests/XmlReader/Tests/ReaderEncodingTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlReader/Tests/ReaderEncodingTests.cs
@@ -17,7 +17,6 @@ namespace System.Xml.Tests
         private static string _invalidCharInThisEncoding = "Invalid character in the given encoding";
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50945", TestPlatforms.Android)]
         public static void ReadWithSurrogateCharAndInvalidChar()
         {
             // {60, 0, 0, 0} is a normal char, {0, 34, 1, 0}  is a surrogate char {62, 100, 60, 47} is an invalid char
@@ -30,7 +29,6 @@ namespace System.Xml.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50945", TestPlatforms.Android)]
         public static void ReadWithNormalCharAndInvalidChar()
         {
             // {60, 0, 0, 0, 65, 0, 0, 0} are normal chars, {62, 100, 60, 47} is an invalid char, similar bytes used below tests
@@ -43,7 +41,6 @@ namespace System.Xml.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50945", TestPlatforms.Android)]
         public static void ReadWithSurrogateCharAndInvalidChar_ValidXmlStructure()
         {
             var bytes = new byte[] { 60, 0, 0, 0, 97, 0, 0, 0, 62, 0, 0, 0, 0, 34, 1, 0, 62, 100, 60, 47, 60, 0, 0, 0, 47, 0, 0, 0, 97, 0, 0, 0, 62, 0, 0, 0 };
@@ -55,7 +52,6 @@ namespace System.Xml.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50945", TestPlatforms.Android)]
         public static void ReadWithSurrogateCharAsElementName()
         {
             var bytes = new byte[] { 60, 0, 0, 0, 0, 34, 1, 0, 65, 0, 0, 0, 97, 0, 0, 0 };
@@ -88,7 +84,6 @@ namespace System.Xml.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50945", TestPlatforms.Android)]
         public static void BytesStartingWithInvalidChar()
         {
             var bytes = new byte[] { 62, 100, 60, 47, 60, 0, 0, 0, 0, 34, 1, 0, 65, 0, 0, 0, 97, 0, 0, 0 };
@@ -99,7 +94,6 @@ namespace System.Xml.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50945", TestPlatforms.Android)]
         public static void BytesEndingWithInvalidChar()
         {
             var bytes = new byte[] { 60, 0, 0, 0, 97, 0, 0, 0, 62, 0, 0, 0, 65, 0, 0, 0, 65, 0, 0, 0, 97, 0, 0, 0, 62, 100, 60, 47};
@@ -120,7 +114,6 @@ namespace System.Xml.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50945", TestPlatforms.Android)]
         public static void ReadWithIncompleteBytes()
         {
             var bytes = new byte[] { 60, 0, 0, 0, 97, 0, 0, 0, 65, 0, 0, 0, 97, 62, 10};

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -74,9 +74,6 @@
     <!-- https://github.com/dotnet/runtime/issues/50880 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Collections\tests\System.Collections.Tests.csproj" />
 
-    <!-- https://github.com/dotnet/runtime/issues/50916 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.ComponentModel.TypeConverter\tests\System.ComponentModel.TypeConverter.Tests.csproj" />
-
     <!-- https://github.com/dotnet/runtime/issues/50923 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Data.Common\tests\System.Data.Common.Tests.csproj" />
 
@@ -85,18 +82,6 @@
 
     <!-- https://github.com/dotnet/runtime/issues/49936 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.Tests\System.Text.Json.Tests.csproj" />
-
-    <!-- https://github.com/dotnet/runtime/issues/50946 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml\tests\XmlSchema\XmlSchemaValidatorApi\System.Xml.XmlSchema.XmlSchemaValidatorApi.Tests.csproj" />
-
-    <!-- https://github.com/dotnet/runtime/issues/50947 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml\tests\XmlSchema\XmlSchemaSet\System.Xml.XmlSchemaSet.Tests.csproj" />
-
-    <!-- https://github.com/dotnet/runtime/issues/50948 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml\tests\Xslt\XslCompiledTransformApi\System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj" />
-
-    <!-- https://github.com/dotnet/runtime/issues/50950 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml\tests\Xslt\XslTransformApi\System.Xml.Xsl.XslTransformApi.Tests.csproj" />
 
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
 


### PR DESCRIPTION
Fixes #50576 
Fixes #50881 
Fixes #50916 
Fixes #50917 
Fixes #50918
Fixes #50919
Fixes #50927
Fixes #50928
Fixes #50944
Fixes #50945
Fixes #50946
Fixes #50947
Fixes #50948
Fixes #50999

When setting up functional tests for mobile, the feature switches being used for the tests were misplaced in a broader project, affecting the library tests and causing failures. After moving the feature switches to the scope of functional tests as done in https://github.com/dotnet/runtime/pull/53253, these test suites no longer fail and can be re-enabled.