### PR TITLE
JIT: spill exception-causing entries from stack for finalizable newobj

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -14430,6 +14430,18 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     }
                     else
                     {
+                        // If we're newing up a finalizable object, spill anything that can cause exceptions.
+                        //
+                        bool            hasSideEffects = false;
+                        CorInfoHelpFunc newHelper =
+                            info.compCompHnd->getNewHelper(&resolvedToken, info.compMethodHnd, &hasSideEffects);
+
+                        if (hasSideEffects)
+                        {
+                            JITDUMP("\nSpilling stack for finalizable newobj\n");
+                            impSpillSideEffects(true, (unsigned)CHECK_SPILL_ALL DEBUGARG("finalizable newobj spill"));
+                        }
+
                         const bool useParent = true;
                         op1                  = gtNewAllocObjNode(&resolvedToken, useParent);
                         if (op1 == nullptr)

--- a/src/tests/JIT/Regression/JitBlue/Runtime_4781/Runtime_4781.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_4781/Runtime_4781.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+// Test for proper ordering of exception-causing ctor args and
+// the newobj allocation
+
+class Foo : IDisposable
+{
+    public bool IsConstructed { get; } = true;
+    public Foo(int ignored) { }
+    
+    ~Foo()
+    {
+        if (!IsConstructed)
+        {
+            Console.WriteLine("Finalizing a non-constructed object?!");
+            Runtime_4781.Fail();
+        }
+    }
+    
+    public void Dispose() => GC.SuppressFinalize(this);
+}
+
+class Runtime_4781
+{
+    private static int Throw() => throw new NotSupportedException();
+    private static bool failed = false;
+    public static void Fail() { failed = true; }
+    
+    private static IDisposable Test()
+    {
+        try
+        {
+            int x = Throw();
+            return new Foo(x);
+        }
+        catch
+        {
+        }
+        return new Foo(2);
+    }
+    
+    static int Main(string[] args)
+    {
+        Test().Dispose();
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        return failed ? -1 : 100;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_4781/Runtime_4781.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_4781/Runtime_4781.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_4781/Runtime_4781_1.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_4781/Runtime_4781_1.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+// Test for proper ordering of a gc safepoint inducing arg and
+// the newobj allocation
+
+class Bar
+{
+    public Bar() 
+    { 
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+    }
+}
+
+static class Observer
+{
+    public static bool failed;
+}
+
+class Foo : IDisposable
+{
+    
+    public Foo(Bar b)
+    {
+        Console.WriteLine($"new Foo");
+    }
+
+    ~Foo() 
+    {
+        Console.WriteLine($"~Foo");
+        Observer.failed = true;
+    }
+
+    public void Dispose() => GC.SuppressFinalize(this);
+}
+
+class Runtime_4781_1
+{
+    static Bar s_bar = new Bar();
+
+    static int Main(string[] args)
+    {
+        var f = new Foo(s_bar);
+        return Observer.failed ? -1 : 100;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_4781/Runtime_4781_1.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_4781/Runtime_4781_1.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fix a long-standing issue where in some rare cases an object could be finalized
even though its constructor was never called.

The problem was that the jit was allocating the object before evaluating any of
the arguments to the constructor, so that if an argument evaluation threw, a
default-initialized version of the object still lived on the heap.

The fix is to spill any side-effecting stack entry if the jit is going to
create a finalizable object. This improves on previous attempts by only spilling
for the finalizable case.

Closes #4871.