### PR TITLE
Allow System.Linq.Enumerable.OfType to use the passed in IEnumerable

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Cast.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Cast.cs
@@ -10,6 +10,11 @@ namespace System.Linq
     {
         public static IEnumerable<TResult> OfType<TResult>(this IEnumerable source)
         {
+            if (source is IEnumerable<TResult> typedSource)
+            {
+                return typedSource;
+            }
+
             if (source == null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);


### PR DESCRIPTION
System.Linq.Enumerable.Cast already does this.

It reduces the number of allocations required when `OfType` is used to treat a sequence as a sequence of a base type