### PR TITLE
Update doc and generic parameter name for JsonValue.GetValue

### DIFF
--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -595,7 +595,7 @@ namespace System.Text.Json.Nodes
         public System.Text.Json.Nodes.JsonObject AsObject() { throw null; }
         public System.Text.Json.Nodes.JsonValue AsValue() { throw null; }
         public string GetPath() { throw null; }
-        public virtual TValue GetValue<TValue>() { throw null; }
+        public virtual T GetValue<T>() { throw null; }
         public static explicit operator bool (System.Text.Json.Nodes.JsonNode value) { throw null; }
         public static explicit operator byte (System.Text.Json.Nodes.JsonNode value) { throw null; }
         public static explicit operator char (System.Text.Json.Nodes.JsonNode value) { throw null; }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace System.Text.Json.Nodes
 {
@@ -165,6 +164,15 @@ namespace System.Text.Json.Nodes
         /// <summary>
         ///   Gets the value for the current <see cref="JsonValue"/>.
         /// </summary>
+        /// <remarks>
+        ///   {TValue} can be the type or base type of the underlying value.
+        ///   If the underlying value is a <see cref="JsonElement"/> then {TValue} can also be the type of any primitive
+        ///   value supported by current <see cref="JsonElement"/>.<br />
+        ///   Specifying <see cref="object"/> will always succeed and return the underlying value as <see cref="object"/>.<br />
+        ///   The underlying value of a <see cref="JsonValue"/> after deserialization is <see cref="JsonElement"/>,
+        ///   otherwise it is the value specified when the <see cref="JsonValue"/> was created.
+        /// </remarks>
+        /// <seealso cref="JsonValue.TryGetValue{T}">
         /// <exception cref="FormatException">
         ///   The current <see cref="JsonNode"/> cannot be represented as a {TValue}.
         /// </exception>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.cs
@@ -165,22 +165,22 @@ namespace System.Text.Json.Nodes
         ///   Gets the value for the current <see cref="JsonValue"/>.
         /// </summary>
         /// <remarks>
-        ///   {TValue} can be the type or base type of the underlying value.
-        ///   If the underlying value is a <see cref="JsonElement"/> then {TValue} can also be the type of any primitive
-        ///   value supported by current <see cref="JsonElement"/>.<br />
-        ///   Specifying <see cref="object"/> will always succeed and return the underlying value as <see cref="object"/>.<br />
-        ///   The underlying value of a <see cref="JsonValue"/> after deserialization is <see cref="JsonElement"/>,
-        ///   otherwise it is the value specified when the <see cref="JsonValue"/> was created.
+        ///   {T} can be the type or base type of the underlying value.
+        ///   If the underlying value is a <see cref="JsonElement"/> then {T} can also be the type of any primitive
+        ///   value supported by current <see cref="JsonElement"/>.
+        ///   Specifying the <see cref="object"/> type for {T} will always succeed and return the underlying value as <see cref="object"/>.<br />
+        ///   The underlying value of a <see cref="JsonValue"/> after deserialization is an instance of <see cref="JsonElement"/>,
+        ///   otherwise it's the value specified when the <see cref="JsonValue"/> was created.
         /// </remarks>
-        /// <seealso cref="JsonValue.TryGetValue{T}">
+        /// <seealso cref="System.Text.Json.Nodes.JsonValue.TryGetValue"></seealso>
         /// <exception cref="FormatException">
-        ///   The current <see cref="JsonNode"/> cannot be represented as a {TValue}.
+        ///   The current <see cref="JsonNode"/> cannot be represented as a {T}.
         /// </exception>
         /// <exception cref="InvalidOperationException">
         ///   The current <see cref="JsonNode"/> is not a <see cref="JsonValue"/> or
-        ///   is not compatible with {TValue}.
+        ///   is not compatible with {T}.
         /// </exception>
-        public virtual TValue GetValue<TValue>() =>
+        public virtual T GetValue<T>() =>
             throw new InvalidOperationException(SR.Format(SR.NodeWrongType, nameof(JsonValue)));
 
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.cs
@@ -102,10 +102,10 @@ namespace System.Text.Json.Nodes
         /// <remarks>
         ///   {T} can be the type or base type of the underlying value.
         ///   If the underlying value is a <see cref="JsonElement"/> then {T} can also be the type of any primitive
-        ///   value supported by current <see cref="JsonElement"/>.<br />
-        ///   Specifying <see cref="object"/> will always succeed and return the underlying value as <see cref="object"/>.<br />
-        ///   The underlying value of a <see cref="JsonValue"/> after deserialization is <see cref="JsonElement"/>,
-        ///   otherwise it is the value specified when the <see cref="JsonValue"/> was created.
+        ///   value supported by current <see cref="JsonElement"/>.
+        ///   Specifying the <see cref="object"/> type for {T} will always succeed and return the underlying value as <see cref="object"/>.<br />
+        ///   The underlying value of a <see cref="JsonValue"/> after deserialization is an instance of <see cref="JsonElement"/>,
+        ///   otherwise it's the value specified when the <see cref="JsonValue"/> was created.
         /// </remarks>
         /// <seealso cref="JsonNode.GetValue{TValue}"></seealso>
         /// <typeparam name="T">The type of value to obtain.</typeparam>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.cs
@@ -107,7 +107,7 @@ namespace System.Text.Json.Nodes
         ///   The underlying value of a <see cref="JsonValue"/> after deserialization is an instance of <see cref="JsonElement"/>,
         ///   otherwise it's the value specified when the <see cref="JsonValue"/> was created.
         /// </remarks>
-        /// <seealso cref="JsonNode.GetValue{TValue}"></seealso>
+        /// <seealso cref="JsonNode.GetValue{T}"></seealso>
         /// <typeparam name="T">The type of value to obtain.</typeparam>
         /// <param name="value">When this method returns, contains the parsed value.</param>
         /// <returns><see langword="true"/> if the value can be successfully obtained; otherwise, <see langword="false"/>.</returns>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValue.cs
@@ -99,6 +99,15 @@ namespace System.Text.Json.Nodes
         /// <summary>
         ///   Tries to obtain the current JSON value and returns a value that indicates whether the operation succeeded.
         /// </summary>
+        /// <remarks>
+        ///   {T} can be the type or base type of the underlying value.
+        ///   If the underlying value is a <see cref="JsonElement"/> then {T} can also be the type of any primitive
+        ///   value supported by current <see cref="JsonElement"/>.<br />
+        ///   Specifying <see cref="object"/> will always succeed and return the underlying value as <see cref="object"/>.<br />
+        ///   The underlying value of a <see cref="JsonValue"/> after deserialization is <see cref="JsonElement"/>,
+        ///   otherwise it is the value specified when the <see cref="JsonValue"/> was created.
+        /// </remarks>
+        /// <seealso cref="JsonNode.GetValue{TValue}"></seealso>
         /// <typeparam name="T">The type of value to obtain.</typeparam>
         /// <param name="value">When this method returns, contains the parsed value.</param>
         /// <returns><see langword="true"/> if the value can be successfully obtained; otherwise, <see langword="false"/>.</returns>


### PR DESCRIPTION
Adds additional XML doc for the `GetValue` methods; in particular it wasn't obvious that passing in `<object>` for the generic parameter will always succeed and return the underlying value.

In addition, the `JsonNode.GetValue<TValue>` was changed to `JsonNode.GetValue<T>` to be consistent with `JsonValue.TryGetValue<T>`. Not sure on the guidance here, but I think consistency is better, and `<TValue>` seems redundant.