### PR TITLE
Stabilize TestToString_OnExitedProcess

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -487,11 +487,9 @@ namespace System.Diagnostics.Tests
             Process p = CreateDefaultProcess();
             KillWait(p);
 
-            Assert.True(p.HasExited); // Refresh process object
-
             // Ensure ToString does not throw an exception, but still returns
             // a representation of the object.
-            Assert.Equal("System.Diagnostics.Process", p.ToString());
+            Assert.Contains("System.Diagnostics.Process", p.ToString());
         }
 
         [Fact]

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -487,6 +487,8 @@ namespace System.Diagnostics.Tests
             Process p = CreateDefaultProcess();
             KillWait(p);
 
+            Assert.True(p.HasExited); // Refresh process object
+
             // Ensure ToString does not throw an exception, but still returns
             // a representation of the object.
             Assert.Equal("System.Diagnostics.Process", p.ToString());


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/56649

It's not clear how this can happen, but it's not important so make the assert accept either value.