### PR TITLE
Fix MetricsEventSource tests

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricEventSourceTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricEventSourceTests.cs
@@ -16,7 +16,7 @@ namespace System.Diagnostics.Metrics.Tests
     public class MetricEventSourceTests
     {
         ITestOutputHelper _output;
-        const double IntervalSecs = 1;
+        const double IntervalSecs = 5;
         static readonly TimeSpan s_waitForEventTimeout = TimeSpan.FromSeconds(60);
 
         public MetricEventSourceTests(ITestOutputHelper output)


### PR DESCRIPTION
Fixes #55313

The metrics test has to collect different events that
update counters in a specific interval of time. Previously
those intervals were 1 second long but ARM64 appears to
run slowly enough that some of the events didn't complete
until 2 seconds had passed.

I increased the intervals to 5 seconds each. We could go
longer to reduce the risk further, but I am trying not to
make the tests take overly long. The full set of tests uses
~45 intervals.