### PR TITLE
Some improvements to RF

### DIFF
--- a/src/tests/GC/Stress/Framework/ReliabilityConfiguration.cs
+++ b/src/tests/GC/Stress/Framework/ReliabilityConfiguration.cs
@@ -405,6 +405,9 @@ public class ReliabilityConfig : IEnumerable, IEnumerator
                                             }
 
                                             break;
+                                        case "maximumWaitTime":
+                                            _curTestSet.MaximumWaitTime = ConvertTimeValueToTestRunTime(currentXML.Value);
+                                            break;
                                         case "id":
                                             _curTestSet.FriendlyName = currentXML.Value;
                                             break;

--- a/src/tests/GC/Stress/Framework/ReliabilityTestSet.cs
+++ b/src/tests/GC/Stress/Framework/ReliabilityTestSet.cs
@@ -14,6 +14,7 @@ public class ReliabilityTestSet
 {
     private int _maximumTestLoops = 0;									// default run based on time.
     private int _maximumExecutionTime = 60;	                        // 60 minute run by default.
+    private int _maximumWaitTime = 10;	                            // 10 minute wait by default.
     private int _percentPassIsPass = System.Environment.GetEnvironmentVariable("PERCENTPASSISPASS") == null ? -1 : Convert.ToInt32(System.Environment.GetEnvironmentVariable("PERCENTPASSISPASS"));
     private int[] _minPercentCPUStaggered_times = null;
     private int[] _minPercentCPUStaggered_usage = null;
@@ -91,6 +92,21 @@ public class ReliabilityTestSet
         set
         {
             _maximumExecutionTime = value;
+        }
+    }
+
+    /// <summary>
+    /// Maximum wait time, in minutes.
+    /// </summary>
+    public int MaximumWaitTime
+    {
+        get
+        {
+            return (_maximumWaitTime);
+        }
+        set
+        {
+            _maximumWaitTime = value;
         }
     }
 


### PR DESCRIPTION
usually I use RF to see if I get AVs, but with regions it's uncertain if tests are just taking a very long time. 

+ added a maximumWaitTime config default to 10 mins
+ actually breaks into the debugger when it times out when debugBreakOnTestHang is specified
+ prints out the progress while we wait so it's obvious if it's hung or just because some
  tests are taking a long time. example output -

```
[7/30/2021 6:52:26 PM 1] ============current number of tests running   14, allocated 50,040,808,336 so far, 879,122,336 since last; (GC 439:420:420), waited 55s
[7/30/2021 6:52:26 PM 1] Still running: DirectedGraph.dll
[7/30/2021 6:52:26 PM 1] Still running: LargeObjectAlloc.dll
[7/30/2021 6:52:26 PM 1] Still running: LargeObjectAlloc1.dll
[7/30/2021 6:52:29 PM 1] Still running: LargeObjectAlloc2.dll
```