### PR TITLE
Mark HandleProcessCorruptedStateExceptionsAttribute as obsolete

### DIFF
--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -86,6 +86,7 @@ The PR that reveals the implementation of the `<IncludeInternalObsoleteAttribute
 |  __`SYSLIB0029`__ | ProduceLegacyHmacValues is obsolete. Producing legacy HMAC values is no longer supported. |
 |  __`SYSLIB0030`__ | HMACSHA1 always uses the algorithm implementation provided by the platform. Use a constructor without the useManagedSha1 parameter. |
 |  __`SYSLIB0031`__ | EncodeOID is obsolete. Use the ASN.1 functionality provided in System.Formats.Asn1. |
+|  __`SYSLIB0032`__ | Recovery from corrupted process state exceptions is not supported; HandleProcessCorruptedStateExceptionsAttribute is ignored. |
 
 ## Analyzer Warnings
 

--- a/src/libraries/Common/src/System/Obsoletions.cs
+++ b/src/libraries/Common/src/System/Obsoletions.cs
@@ -104,5 +104,8 @@ namespace System
 
         internal const string CryptoConfigEncodeOIDMessage = "EncodeOID is obsolete. Use the ASN.1 functionality provided in System.Formats.Asn1.";
         internal const string CryptoConfigEncodeOIDDiagId = "SYSLIB0031";
+
+        internal const string CorruptedStateRecoveryMessage = "Recovery from corrupted process state exceptions is not supported; HandleProcessCorruptedStateExceptionsAttribute is ignored.";
+        internal const string CorruptedStateRecoveryDiagId = "SYSLIB0032";
     }
 }

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -37,8 +37,9 @@
          SYSLIB0022: Rijndael types.
          SYSLIB0023: RNGCryptoServiceProvider.
          SYSLIB0025: SuppressIldasmAttribute.
+         SYSLIB0032: HandleProcessCorruptedStateExceptionsAttribute.
     -->
-    <NoWarn Condition="'$(IsPartialFacadeAssembly)' == 'true'">$(NoWarn);SYSLIB0003;SYSLIB0004;SYSLIB0015;SYSLIB0017;SYSLIB0021;SYSLIB0022;SYSLIB0023;SYSLIB0025</NoWarn>
+    <NoWarn Condition="'$(IsPartialFacadeAssembly)' == 'true'">$(NoWarn);SYSLIB0003;SYSLIB0004;SYSLIB0015;SYSLIB0017;SYSLIB0021;SYSLIB0022;SYSLIB0023;SYSLIB0025;SYSLIB0032</NoWarn>
     <!-- Reset these properties back to blank, since they are defaulted by Microsoft.NET.Sdk -->
     <WarningsAsErrors Condition="'$(WarningsAsErrors)' == 'NU1605'" />
     <!-- Set the documentation output file globally. -->

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/ExceptionServices/HandleProcessCorruptedStateExceptionsAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/ExceptionServices/HandleProcessCorruptedStateExceptionsAttribute.cs
@@ -6,6 +6,7 @@ namespace System.Runtime.ExceptionServices
     // This attribute can be applied to methods to indicate that ProcessCorruptedState
     // Exceptions should be delivered to them.
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+    [Obsolete(Obsoletions.CorruptedStateRecoveryMessage, DiagnosticId = Obsoletions.CorruptedStateRecoveryDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
     public sealed class HandleProcessCorruptedStateExceptionsAttribute : Attribute
     {
         public HandleProcessCorruptedStateExceptionsAttribute()

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -13234,6 +13234,7 @@ namespace System.Runtime.ExceptionServices
         public System.Exception Exception { get { throw null; } }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Method, AllowMultiple=false, Inherited=false)]
+    [System.ObsoleteAttribute("Recovery from corrupted process state exceptions is not supported; HandleProcessCorruptedStateExceptionsAttribute is ignored.", DiagnosticId = "SYSLIB0032", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
     public sealed partial class HandleProcessCorruptedStateExceptionsAttribute : System.Attribute
     {
         public HandleProcessCorruptedStateExceptionsAttribute() { }

--- a/src/libraries/System.Runtime/tests/System/Runtime/ExceptionServices/HandleProcessCorruptedStateExceptions.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/ExceptionServices/HandleProcessCorruptedStateExceptions.cs
@@ -10,6 +10,8 @@ using System.Threading;
 using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
+#pragma warning disable SYSLIB0032 // HandleProcessCorruptedStateExceptionsAttribute is obsolete
+
 namespace System.Runtime.ExceptionServices.Tests
 {
     public class HandleProcessCorruptedStateExceptionsTests

--- a/src/tests/JIT/RyuJIT/DoWhileBndChk.cs
+++ b/src/tests/JIT/RyuJIT/DoWhileBndChk.cs
@@ -5,6 +5,8 @@
 //
 // Reference: TF Bug 150041
 
+#pragma warning disable SYSLIB0032 // HandleProcessCorruptedStateExceptionsAttribute is obsolete
+
 using System;
 using System.Runtime.ExceptionServices;
 


### PR DESCRIPTION
Fixes #31157

Per [documentation](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.exceptionservices.handleprocesscorruptedstateexceptionsattribute?view=net-5.0#remarks):

> Even though this attribute exists in .NET Core, since the recovery from corrupted process state exceptions is not supported, this attribute is ignored. The CLR doesn't deliver corrupted process state exceptions to the managed code.