### PR TITLE
Enable ICU trimming for Invariant=true and PredefinedCulturesOnly unspecified

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.Unix.cs
@@ -8,8 +8,9 @@ namespace System.Globalization
         private static partial class Settings
         {
             /// <summary>
-            /// Load ICU (when not in Invariant mode) in a static cctor to ensure it is loaded early in the process.
-            /// Other places, e.g. CompareInfo.GetSortKey, rely on ICU already being loaded before they are called.
+            /// Load ICU (when not in Invariant mode) in a static cctor to ensure it is loaded as side-effect of
+            /// the GlobalizationMode.Invariant check. Globalization P/Invokes, e.g. in CompareInfo.GetSortKey,
+            /// rely on ICU already being loaded before they are called.
             /// </summary>
             static Settings()
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.Unix.cs
@@ -13,7 +13,9 @@ namespace System.Globalization
             /// </summary>
             static Settings()
             {
-                if (!Invariant)
+                // Use GlobalizationMode.Invariant to allow ICU initialization to be trimmed when Invariant=false
+                // and PredefinedCulturesOnly is unspecified.
+                if (!GlobalizationMode.Invariant)
                 {
                     if (TryGetAppLocalIcuSwitchValue(out string? icuSuffixAndVersion))
                     {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.cs
@@ -12,13 +12,14 @@ namespace System.Globalization
         private static partial class Settings
         {
             internal static bool Invariant { get; } = AppContextConfigHelper.GetBooleanConfig("System.Globalization.Invariant", "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT");
+            internal static bool PredefinedCulturesOnly { get; } = AppContextConfigHelper.GetBooleanConfig("System.Globalization.PredefinedCulturesOnly", "DOTNET_SYSTEM_GLOBALIZATION_PREDEFINED_CULTURES_ONLY", GlobalizationMode.Invariant);
         }
 
         // Note: Invariant=true and Invariant=false are substituted at different levels in the ILLink.Substitutions file.
         // This allows for the whole Settings nested class to be trimmed when Invariant=true, and allows for the Settings
         // static cctor (on Unix) to be preserved when Invariant=false.
         internal static bool Invariant => Settings.Invariant;
-        internal static bool PredefinedCulturesOnly { get; } = AppContextConfigHelper.GetBooleanConfig("System.Globalization.PredefinedCulturesOnly", "DOTNET_SYSTEM_GLOBALIZATION_PREDEFINED_CULTURES_ONLY", Invariant);
+        internal static bool PredefinedCulturesOnly => Settings.PredefinedCulturesOnly;
         private static bool TryGetAppLocalIcuSwitchValue([NotNullWhen(true)] out string? value) =>
             TryGetStringValue("System.Globalization.AppLocalIcu", "DOTNET_SYSTEM_GLOBALIZATION_APPLOCALICU", out value);
         private static bool TryGetStringValue(string switchName, string envVariable, [NotNullWhen(true)] out string? value)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.cs
@@ -8,7 +8,8 @@ namespace System.Globalization
 {
     internal static partial class GlobalizationMode
     {
-        // split from GlobalizationMode so the whole class can be trimmed when Invariant=true.
+        // Split from GlobalizationMode so the whole class can be trimmed when Invariant=true. Trimming tests
+        // validate this implementation detail.
         private static partial class Settings
         {
             internal static bool Invariant { get; } = AppContextConfigHelper.GetBooleanConfig("System.Globalization.Invariant", "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT");
@@ -20,6 +21,7 @@ namespace System.Globalization
         // static cctor (on Unix) to be preserved when Invariant=false.
         internal static bool Invariant => Settings.Invariant;
         internal static bool PredefinedCulturesOnly => Settings.PredefinedCulturesOnly;
+
         private static bool TryGetAppLocalIcuSwitchValue([NotNullWhen(true)] out string? value) =>
             TryGetStringValue("System.Globalization.AppLocalIcu", "DOTNET_SYSTEM_GLOBALIZATION_APPLOCALICU", out value);
         private static bool TryGetStringValue(string switchName, string envVariable, [NotNullWhen(true)] out string? value)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.cs
@@ -12,14 +12,13 @@ namespace System.Globalization
         private static partial class Settings
         {
             internal static bool Invariant { get; } = AppContextConfigHelper.GetBooleanConfig("System.Globalization.Invariant", "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT");
-            internal static bool PredefinedCulturesOnly { get; } = AppContextConfigHelper.GetBooleanConfig("System.Globalization.PredefinedCulturesOnly", "DOTNET_SYSTEM_GLOBALIZATION_PREDEFINED_CULTURES_ONLY", Invariant);
         }
 
         // Note: Invariant=true and Invariant=false are substituted at different levels in the ILLink.Substitutions file.
         // This allows for the whole Settings nested class to be trimmed when Invariant=true, and allows for the Settings
         // static cctor (on Unix) to be preserved when Invariant=false.
         internal static bool Invariant => Settings.Invariant;
-        internal static bool PredefinedCulturesOnly => Settings.PredefinedCulturesOnly;
+        internal static bool PredefinedCulturesOnly { get; } = AppContextConfigHelper.GetBooleanConfig("System.Globalization.PredefinedCulturesOnly", "DOTNET_SYSTEM_GLOBALIZATION_PREDEFINED_CULTURES_ONLY", Invariant);
         private static bool TryGetAppLocalIcuSwitchValue([NotNullWhen(true)] out string? value) =>
             TryGetStringValue("System.Globalization.AppLocalIcu", "DOTNET_SYSTEM_GLOBALIZATION_APPLOCALICU", out value);
         private static bool TryGetStringValue(string switchName, string envVariable, [NotNullWhen(true)] out string? value)


### PR DESCRIPTION
 @RalfKornmannEnvision noticed that ICU initialization is not getting trimmed when Invariant=true and PredefinedCulturesOnly is unspecified (https://gitter.im/dotnet/corert?at=610514ee36b0b97fa2d99aff). The problem is that the Setting class constructor that initializes ICU gets referenced by the PredefinedCulturesOnly property in this case. Moving the PredefinedCulturesOnly out of the Setting class fixes the problem.