### PR TITLE
Dump the environment variable prefix in ToString

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
         /// </summary>
         public override void Load() =>
             Load(Environment.GetEnvironmentVariables());
-        
+
         /// <summary>
         /// Generates a string representing this provider name and relevant details.
         /// </summary>

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
@@ -37,6 +37,13 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
         /// </summary>
         public override void Load() =>
             Load(Environment.GetEnvironmentVariables());
+        
+        /// <summary>
+        /// Generates a string representing this provider name and relevant details.
+        /// </summary>
+        /// <returns> The configuration name. </returns>
+        public override string ToString()
+            => $"{GetType().Name} Prefix: '{_prefix}'";
 
         internal void Load(IDictionary envVariables)
         {


### PR DESCRIPTION
- This allows tools that dump the providers (like GetDebugView) to see a little more data about the configured providers when debugging.