### PR TITLE
Simplify JIT shutdown logic in crossgen2

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -79,32 +79,26 @@ namespace Internal.JitInterface
             [DllImport(JitLibrary)]
             private extern static IntPtr getJit();
 
-            public static IntPtr Get()
-            {
-                if (s_jit != IntPtr.Zero)
-                {
-                    return s_jit;
-                }
-
-                lock(typeof(JitPointerAccessor))
-                {
-                    s_jit = getJit();
-                    return s_jit;
-                }
-            }
-
             [DllImport(JitSupportLibrary)]
             private extern static CorJitResult JitProcessShutdownWork(IntPtr jit);
 
-            public static void ShutdownJit()
+            static JitPointerAccessor()
             {
+                s_jit = getJit();
+
                 if (s_jit != IntPtr.Zero)
                 {
-                    JitProcessShutdownWork(s_jit);
+                    AppDomain.CurrentDomain.ProcessExit += (_, _) => JitProcessShutdownWork(s_jit);
+                    AppDomain.CurrentDomain.UnhandledException += (_, _) => JitProcessShutdownWork(s_jit);
                 }
             }
 
-            private static IntPtr s_jit;
+            public static IntPtr Get()
+            {
+                return s_jit;
+            }
+
+            private static readonly IntPtr s_jit;
         }
 
         [DllImport(JitLibrary)]
@@ -157,11 +151,6 @@ namespace Internal.JitInterface
         public static void Startup()
         {
             jitStartup(GetJitHost(JitConfigProvider.Instance.UnmanagedInstance));
-        }
-
-        public static void ShutdownJit()
-        {
-            JitPointerAccessor.ShutdownJit();
         }
 
         public CorInfoImpl()

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -65,12 +65,6 @@ namespace ILCompiler
             ((ReadyToRunCompilerContext)context).SetCompilationGroup(group);
         }
 
-        // Shutdown the Jit if it has been loaded. This must only be called once per process
-        public static void ShutdownJit()
-        {
-            CorInfoImpl.ShutdownJit();
-        }
-
         public override CompilationBuilder UseBackendOptions(IEnumerable<string> options)
         {
             var builder = new ArrayBuilder<KeyValuePair<string, string>>();

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -989,14 +989,7 @@ namespace ILCompiler
 #if DEBUG
             try
             {
-                try
-                {
-                    return new Program().Run(args);
-                }
-                finally
-                {
-                    ReadyToRunCodegenCompilationBuilder.ShutdownJit();
-                }
+                return new Program().Run(args);
             }
             catch (CodeGenerationFailedException ex) when (DumpReproArguments(ex))
             {
@@ -1005,14 +998,7 @@ namespace ILCompiler
 #else
             try
             {
-                try
-                {
-                    return new Program().Run(args);
-                }
-                finally
-                {
-                    ReadyToRunCodegenCompilationBuilder.ShutdownJit();
-                }
+                return new Program().Run(args);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
There was unanswered comment about thread safety in https://github.com/dotnet/runtime/pull/56187/files#r675461236 so I just decided to fix it myself.

While on it, I simplified shutdown to use `AppDomain.ProcessExit`.

I'm not sure `AppDomain.UnhandledException` is needed but the original code had this in a `finally`.

The better fix would be to allow JIT to be initialized right before we start a compilation and shut down after, but that would require no process wide state in the JIT. As it stands now, JIT is once-per-process-global.

Cc @dotnet/crossgen-contrib 