### PR TITLE
Remove old fwlink from Obsolete messages and make message improvements

### DIFF
--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -20,7 +20,7 @@ The acceptance criteria for adding an obsoletion includes:
         * `<Compile Include="$(CommonPath)System\Obsoletions.cs" Link="Common\System\Obsoletions.cs" />`
 * Annotate `ref` files using the hard-coded strings copied from `Obsoletions.cs`
     * This matches our general pattern of `ref` files using hard-coded attribute strings
-    * Example: `[System.ObsoleteAttribute("The UTF-7 encoding is insecure and should not be used. Consider using UTF-8.", DiagnosticId = "SYSLIB0001", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]`
+    * Example: `[System.ObsoleteAttribute("The UTF-7 encoding is insecure and should not be used. Consider using UTF-8 instead.", DiagnosticId = "SYSLIB0001", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]`
 * If the library builds against downlevel targets earlier than .NET 5.0, then add an internal copy of `ObsoleteAttribute`
     * The compiler recognizes internal implementations of `ObsoleteAttribute` to enable the `DiagnosticId` and `UrlFormat` properties to light up downlevel
     * An MSBuild property can be added to the project's first `<PropertyGroup>` to achieve this easily
@@ -55,7 +55,7 @@ The PR that reveals the implementation of the `<IncludeInternalObsoleteAttribute
 
 | Diagnostic ID     | Description |
 | :---------------- | :---------- |
-|  __`SYSLIB0001`__ | The UTF-7 encoding is insecure and should not be used. Consider using UTF-8. |
+|  __`SYSLIB0001`__ | The UTF-7 encoding is insecure and should not be used. Consider using UTF-8 instead. |
 |  __`SYSLIB0002`__ | PrincipalPermissionAttribute is not honored by the runtime and must not be used. |
 |  __`SYSLIB0003`__ | Code Access Security is not supported or honored by the runtime. |
 |  __`SYSLIB0004`__ | The Constrained Execution Region (CER) feature is not supported. |
@@ -66,24 +66,24 @@ The PR that reveals the implementation of the `<IncludeInternalObsoleteAttribute
 |  __`SYSLIB0009`__ | The AuthenticationManager Authenticate and PreAuthenticate methods are not supported and throw PlatformNotSupportedException. |
 |  __`SYSLIB0010`__ | This Remoting API is not supported and throws PlatformNotSupportedException. |
 |  __`SYSLIB0011`__ | `BinaryFormatter` serialization is obsolete and should not be used. See https://aka.ms/binaryformatter for recommended alternatives. |
-|  __`SYSLIB0012`__ | Assembly.CodeBase and Assembly.EscapedCodeBase are only included for .NET Framework compatibility. Use Assembly.Location. |
-|  __`SYSLIB0013`__ | Uri.EscapeUriString can corrupt the Uri string in some cases. Consider using Uri.EscapeDataString for query string components. |
-|  __`SYSLIB0014`__ | WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient. |
+|  __`SYSLIB0012`__ | Assembly.CodeBase and Assembly.EscapedCodeBase are only included for .NET Framework compatibility. Use Assembly.Location instead. |
+|  __`SYSLIB0013`__ | Uri.EscapeUriString can corrupt the Uri string in some cases. Consider using Uri.EscapeDataString for query string components instead. |
+|  __`SYSLIB0014`__ | WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead. |
 |  __`SYSLIB0015`__ | DisablePrivateReflectionAttribute has no effect in .NET 6.0+. |
 |  __`SYSLIB0016`__ | Use the Graphics.GetContextInfo overloads that accept arguments for better performance and fewer allocations. |
 |  __`SYSLIB0017`__ | Strong name signing is not supported and throws PlatformNotSupportedException. |
 |  __`SYSLIB0018`__ | ReflectionOnly loading is not supported and throws PlatformNotSupportedException. |
 |  __`SYSLIB0019`__ | RuntimeEnvironment members SystemConfigurationFile, GetRuntimeInterfaceAsIntPtr, and GetRuntimeInterfaceAsObject are no longer supported and throw PlatformNotSupportedException. |
 |  __`SYSLIB0020`__ | JsonSerializerOptions.IgnoreNullValues is obsolete. To ignore null values when serializing, set DefaultIgnoreCondition to JsonIgnoreCondition.WhenWritingNull. |
-|  __`SYSLIB0021`__ | Derived cryptographic types are obsolete. Use the Create method on the base type. |
-|  __`SYSLIB0022`__ | The Rijndael and RijndaelManaged types are obsolete. Use Aes. |
-|  __`SYSLIB0023`__ | RNGCryptoServiceProvider is obsolete. To generate a random number, use one of the RandomNumberGenerator static methods. |
+|  __`SYSLIB0021`__ | Derived cryptographic types are obsolete. Use the Create method on the base type instead. |
+|  __`SYSLIB0022`__ | The Rijndael and RijndaelManaged types are obsolete. Use Aes instead. |
+|  __`SYSLIB0023`__ | RNGCryptoServiceProvider is obsolete. To generate a random number, use one of the RandomNumberGenerator static methods instead. |
 |  __`SYSLIB0024`__ | Creating and unloading AppDomains is not supported and throws an exception. |
 |  __`SYSLIB0025`__ | SuppressIldasmAttribute has no effect in .NET 6.0+. |
 |  __`SYSLIB0026`__ | X509Certificate and X509Certificate2 are immutable. Use the appropriate constructor to create a new certificate. |
 |  __`SYSLIB0027`__ | PublicKey.Key is obsolete. Use the appropriate method to get the public key, such as GetRSAPublicKey. |
 |  __`SYSLIB0028`__ | X509Certificate2.PrivateKey is obsolete. Use the appropriate method to get the private key, such as GetRSAPrivateKey, or use the CopyWithPrivateKey method to create a new instance with a private key. |
-|  __`SYSLIB0029`__ | ProduceLegacyHmacValues is obsolete. Producing legacy HMAC values is no longer supported. |
+|  __`SYSLIB0029`__ | ProduceLegacyHmacValues is obsolete. Producing legacy HMAC values is not supported. |
 |  __`SYSLIB0030`__ | HMACSHA1 always uses the algorithm implementation provided by the platform. Use a constructor without the useManagedSha1 parameter. |
 |  __`SYSLIB0031`__ | EncodeOID is obsolete. Use the ASN.1 functionality provided in System.Formats.Asn1. |
 

--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -73,7 +73,7 @@ The PR that reveals the implementation of the `<IncludeInternalObsoleteAttribute
 |  __`SYSLIB0016`__ | Use the Graphics.GetContextInfo overloads that accept arguments for better performance and fewer allocations. |
 |  __`SYSLIB0017`__ | Strong name signing is not supported and throws PlatformNotSupportedException. |
 |  __`SYSLIB0018`__ | ReflectionOnly loading is not supported and throws PlatformNotSupportedException. |
-|  __`SYSLIB0019`__ | RuntimeEnvironment members SystemConfigurationFile, GetRuntimeInterfaceAsIntPtr, and GetRuntimeInterfaceAsObject are no longer supported and throw PlatformNotSupportedException. |
+|  __`SYSLIB0019`__ | RuntimeEnvironment members SystemConfigurationFile, GetRuntimeInterfaceAsIntPtr, and GetRuntimeInterfaceAsObject are not supported and throw PlatformNotSupportedException. |
 |  __`SYSLIB0020`__ | JsonSerializerOptions.IgnoreNullValues is obsolete. To ignore null values when serializing, set DefaultIgnoreCondition to JsonIgnoreCondition.WhenWritingNull. |
 |  __`SYSLIB0021`__ | Derived cryptographic types are obsolete. Use the Create method on the base type instead. |
 |  __`SYSLIB0022`__ | The Rijndael and RijndaelManaged types are obsolete. Use Aes instead. |

--- a/docs/project/list-of-diagnostics.md
+++ b/docs/project/list-of-diagnostics.md
@@ -20,7 +20,7 @@ The acceptance criteria for adding an obsoletion includes:
         * `<Compile Include="$(CommonPath)System\Obsoletions.cs" Link="Common\System\Obsoletions.cs" />`
 * Annotate `ref` files using the hard-coded strings copied from `Obsoletions.cs`
     * This matches our general pattern of `ref` files using hard-coded attribute strings
-    * Example: `[System.ObsoleteAttribute("The UTF-7 encoding is insecure and should not be used. Consider using UTF-8 instead.", DiagnosticId = "SYSLIB0001", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]`
+    * Example: `[System.ObsoleteAttribute("The UTF-7 encoding is insecure and should not be used. Consider using UTF-8.", DiagnosticId = "SYSLIB0001", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]`
 * If the library builds against downlevel targets earlier than .NET 5.0, then add an internal copy of `ObsoleteAttribute`
     * The compiler recognizes internal implementations of `ObsoleteAttribute` to enable the `DiagnosticId` and `UrlFormat` properties to light up downlevel
     * An MSBuild property can be added to the project's first `<PropertyGroup>` to achieve this easily
@@ -55,7 +55,7 @@ The PR that reveals the implementation of the `<IncludeInternalObsoleteAttribute
 
 | Diagnostic ID     | Description |
 | :---------------- | :---------- |
-|  __`SYSLIB0001`__ | The UTF-7 encoding is insecure and should not be used. Consider using UTF-8 instead. |
+|  __`SYSLIB0001`__ | The UTF-7 encoding is insecure and should not be used. Consider using UTF-8. |
 |  __`SYSLIB0002`__ | PrincipalPermissionAttribute is not honored by the runtime and must not be used. |
 |  __`SYSLIB0003`__ | Code Access Security is not supported or honored by the runtime. |
 |  __`SYSLIB0004`__ | The Constrained Execution Region (CER) feature is not supported. |
@@ -66,18 +66,18 @@ The PR that reveals the implementation of the `<IncludeInternalObsoleteAttribute
 |  __`SYSLIB0009`__ | The AuthenticationManager Authenticate and PreAuthenticate methods are not supported and throw PlatformNotSupportedException. |
 |  __`SYSLIB0010`__ | This Remoting API is not supported and throws PlatformNotSupportedException. |
 |  __`SYSLIB0011`__ | `BinaryFormatter` serialization is obsolete and should not be used. See https://aka.ms/binaryformatter for recommended alternatives. |
-|  __`SYSLIB0012`__ | Assembly.CodeBase and Assembly.EscapedCodeBase are only included for .NET Framework compatibility. Use Assembly.Location instead. |
-|  __`SYSLIB0013`__ | Uri.EscapeUriString can corrupt the Uri string in some cases. Consider using Uri.EscapeDataString for query string components instead. |
-|  __`SYSLIB0014`__ | WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead. |
+|  __`SYSLIB0012`__ | Assembly.CodeBase and Assembly.EscapedCodeBase are only included for .NET Framework compatibility. Use Assembly.Location. |
+|  __`SYSLIB0013`__ | Uri.EscapeUriString can corrupt the Uri string in some cases. Consider using Uri.EscapeDataString for query string components. |
+|  __`SYSLIB0014`__ | WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient. |
 |  __`SYSLIB0015`__ | DisablePrivateReflectionAttribute has no effect in .NET 6.0+. |
 |  __`SYSLIB0016`__ | Use the Graphics.GetContextInfo overloads that accept arguments for better performance and fewer allocations. |
 |  __`SYSLIB0017`__ | Strong name signing is not supported and throws PlatformNotSupportedException. |
 |  __`SYSLIB0018`__ | ReflectionOnly loading is not supported and throws PlatformNotSupportedException. |
 |  __`SYSLIB0019`__ | RuntimeEnvironment members SystemConfigurationFile, GetRuntimeInterfaceAsIntPtr, and GetRuntimeInterfaceAsObject are no longer supported and throw PlatformNotSupportedException. |
 |  __`SYSLIB0020`__ | JsonSerializerOptions.IgnoreNullValues is obsolete. To ignore null values when serializing, set DefaultIgnoreCondition to JsonIgnoreCondition.WhenWritingNull. |
-|  __`SYSLIB0021`__ | Derived cryptographic types are obsolete. Use the Create method on the base type instead. |
-|  __`SYSLIB0022`__ | The Rijndael and RijndaelManaged types are obsolete. Use Aes instead. |
-|  __`SYSLIB0023`__ | RNGCryptoServiceProvider is obsolete. To generate a random number, use one of the RandomNumberGenerator static methods instead. |
+|  __`SYSLIB0021`__ | Derived cryptographic types are obsolete. Use the Create method on the base type. |
+|  __`SYSLIB0022`__ | The Rijndael and RijndaelManaged types are obsolete. Use Aes. |
+|  __`SYSLIB0023`__ | RNGCryptoServiceProvider is obsolete. To generate a random number, use one of the RandomNumberGenerator static methods. |
 |  __`SYSLIB0024`__ | Creating and unloading AppDomains is not supported and throws an exception. |
 |  __`SYSLIB0025`__ | SuppressIldasmAttribute has no effect in .NET 6.0+. |
 |  __`SYSLIB0026`__ | X509Certificate and X509Certificate2 are immutable. Use the appropriate constructor to create a new certificate. |

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Assembly.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Assembly.CoreCLR.cs
@@ -21,7 +21,7 @@ namespace System.Reflection
             return RuntimeAssembly.InternalLoad(assemblyString, ref stackMark, AssemblyLoadContext.CurrentContextualReflectionContext);
         }
 
-        [Obsolete("This method has been deprecated. Please use Assembly.Load() instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("Assembly.LoadWithPartialName has been deprecated. Use Assembly.Load().")]
         [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
         public static Assembly? LoadWithPartialName(string partialName)
         {

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Assembly.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Assembly.CoreCLR.cs
@@ -21,7 +21,7 @@ namespace System.Reflection
             return RuntimeAssembly.InternalLoad(assemblyString, ref stackMark, AssemblyLoadContext.CurrentContextualReflectionContext);
         }
 
-        [Obsolete("Assembly.LoadWithPartialName has been deprecated. Use Assembly.Load().")]
+        [Obsolete("Assembly.LoadWithPartialName has been deprecated. Use Assembly.Load() instead.")]
         [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
         public static Assembly? LoadWithPartialName(string partialName)
         {

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/Overlapped.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/Overlapped.cs
@@ -171,7 +171,7 @@ namespace System.Threading
             _overlappedData._asyncResult = ar;
         }
 
-        [Obsolete("This constructor is not 64-bit compatible.  Use the constructor that takes an IntPtr for the event handle.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("This constructor is not 64-bit compatible and has been deprecated. Use the constructor that accepts an IntPtr for the event handle.")]
         public Overlapped(int offsetLo, int offsetHi, int hEvent, IAsyncResult? ar) : this(offsetLo, offsetHi, new IntPtr(hEvent), ar)
         {
         }
@@ -194,7 +194,7 @@ namespace System.Threading
             set => _overlappedData!.OffsetHigh = value;
         }
 
-        [Obsolete("This property is not 64-bit compatible.  Use EventHandleIntPtr instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("Overlapped.EventHandle is not 64-bit compatible and has been deprecated. Use EventHandleIntPtr.")]
         public int EventHandle
         {
             get => EventHandleIntPtr.ToInt32();
@@ -212,7 +212,7 @@ namespace System.Threading
         *  Roots the iocb and stores it in the ReservedCOR field of native Overlapped
         *  Pins the native Overlapped struct and returns the pinned index.
         ====================================================================*/
-        [Obsolete("This method is not safe.  Use Pack (iocb, userData) instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("This overload is not safe and has been deprecated. Use Pack(IOCompletionCallback?, object?).")]
         [CLSCompliant(false)]
         public unsafe NativeOverlapped* Pack(IOCompletionCallback? iocb)
         {
@@ -225,7 +225,7 @@ namespace System.Threading
             return _overlappedData!.Pack(iocb, userData);
         }
 
-        [Obsolete("This method is not safe.  Use UnsafePack (iocb, userData) instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("This overload is not safe and has been deprecated. Use UnsafePack(IOCompletionCallback?, object?).")]
         [CLSCompliant(false)]
         public unsafe NativeOverlapped* UnsafePack(IOCompletionCallback? iocb)
         {

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/Overlapped.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/Overlapped.cs
@@ -171,7 +171,7 @@ namespace System.Threading
             _overlappedData._asyncResult = ar;
         }
 
-        [Obsolete("This constructor is not 64-bit compatible and has been deprecated. Use the constructor that accepts an IntPtr for the event handle.")]
+        [Obsolete("This constructor is not 64-bit compatible and has been deprecated. Use the constructor that accepts an IntPtr for the event handle instead.")]
         public Overlapped(int offsetLo, int offsetHi, int hEvent, IAsyncResult? ar) : this(offsetLo, offsetHi, new IntPtr(hEvent), ar)
         {
         }
@@ -194,7 +194,7 @@ namespace System.Threading
             set => _overlappedData!.OffsetHigh = value;
         }
 
-        [Obsolete("Overlapped.EventHandle is not 64-bit compatible and has been deprecated. Use EventHandleIntPtr.")]
+        [Obsolete("Overlapped.EventHandle is not 64-bit compatible and has been deprecated. Use EventHandleIntPtr instead.")]
         public int EventHandle
         {
             get => EventHandleIntPtr.ToInt32();
@@ -212,7 +212,7 @@ namespace System.Threading
         *  Roots the iocb and stores it in the ReservedCOR field of native Overlapped
         *  Pins the native Overlapped struct and returns the pinned index.
         ====================================================================*/
-        [Obsolete("This overload is not safe and has been deprecated. Use Pack(IOCompletionCallback?, object?).")]
+        [Obsolete("This overload is not safe and has been deprecated. Use Pack(IOCompletionCallback?, object?) instead.")]
         [CLSCompliant(false)]
         public unsafe NativeOverlapped* Pack(IOCompletionCallback? iocb)
         {
@@ -225,7 +225,7 @@ namespace System.Threading
             return _overlappedData!.Pack(iocb, userData);
         }
 
-        [Obsolete("This overload is not safe and has been deprecated. Use UnsafePack(IOCompletionCallback?, object?).")]
+        [Obsolete("This overload is not safe and has been deprecated. Use UnsafePack(IOCompletionCallback?, object?) instead.")]
         [CLSCompliant(false)]
         public unsafe NativeOverlapped* UnsafePack(IOCompletionCallback? iocb)
         {

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/ThreadPool.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/ThreadPool.CoreCLR.cs
@@ -547,7 +547,7 @@ namespace System.Threading
              RegisteredWaitHandle registeredWaitHandle
              );
 
-        [Obsolete("ThreadPool.BindHandle(IntPtr) has been deprecated. Use ThreadPool.BindHandle(SafeHandle) instead.", false)]
+        [Obsolete("ThreadPool.BindHandle(IntPtr) has been deprecated. Use ThreadPool.BindHandle(SafeHandle) instead.")]
         [SupportedOSPlatform("windows")]
         public static bool BindHandle(IntPtr osHandle)
         {

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/ThreadPool.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/ThreadPool.CoreCLR.cs
@@ -547,7 +547,7 @@ namespace System.Threading
              RegisteredWaitHandle registeredWaitHandle
              );
 
-        [Obsolete("ThreadPool.BindHandle(IntPtr) has been deprecated.  Please use ThreadPool.BindHandle(SafeHandle) instead.", false)]
+        [Obsolete("ThreadPool.BindHandle(IntPtr) has been deprecated. Use ThreadPool.BindHandle(SafeHandle).", false)]
         [SupportedOSPlatform("windows")]
         public static bool BindHandle(IntPtr osHandle)
         {

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/ThreadPool.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/ThreadPool.CoreCLR.cs
@@ -547,7 +547,7 @@ namespace System.Threading
              RegisteredWaitHandle registeredWaitHandle
              );
 
-        [Obsolete("ThreadPool.BindHandle(IntPtr) has been deprecated. Use ThreadPool.BindHandle(SafeHandle).", false)]
+        [Obsolete("ThreadPool.BindHandle(IntPtr) has been deprecated. Use ThreadPool.BindHandle(SafeHandle) instead.", false)]
         [SupportedOSPlatform("windows")]
         public static bool BindHandle(IntPtr osHandle)
         {

--- a/src/libraries/Common/src/System/Obsoletions.cs
+++ b/src/libraries/Common/src/System/Obsoletions.cs
@@ -12,7 +12,7 @@ namespace System
         // and ensure the "aka.ms/dotnet-warnings/{0}" URL points to documentation for the obsoletion
         // The diagnostic ids reserved for obsoletions are SYSLIB0### (SYSLIB0001 - SYSLIB0999).
 
-        internal const string SystemTextEncodingUTF7Message = "The UTF-7 encoding is insecure and should not be used. Consider using UTF-8.";
+        internal const string SystemTextEncodingUTF7Message = "The UTF-7 encoding is insecure and should not be used. Consider using UTF-8 instead.";
         internal const string SystemTextEncodingUTF7DiagId = "SYSLIB0001";
 
         internal const string PrincipalPermissionAttributeMessage = "PrincipalPermissionAttribute is not honored by the runtime and must not be used.";
@@ -45,13 +45,13 @@ namespace System
         internal const string BinaryFormatterMessage = "BinaryFormatter serialization is obsolete and should not be used. See https://aka.ms/binaryformatter for more information.";
         internal const string BinaryFormatterDiagId = "SYSLIB0011";
 
-        internal const string CodeBaseMessage = "Assembly.CodeBase and Assembly.EscapedCodeBase are only included for .NET Framework compatibility. Use Assembly.Location.";
+        internal const string CodeBaseMessage = "Assembly.CodeBase and Assembly.EscapedCodeBase are only included for .NET Framework compatibility. Use Assembly.Location instead.";
         internal const string CodeBaseDiagId = "SYSLIB0012";
 
-        internal const string EscapeUriStringMessage = "Uri.EscapeUriString can corrupt the Uri string in some cases. Consider using Uri.EscapeDataString for query string components.";
+        internal const string EscapeUriStringMessage = "Uri.EscapeUriString can corrupt the Uri string in some cases. Consider using Uri.EscapeDataString for query string components instead.";
         internal const string EscapeUriStringDiagId = "SYSLIB0013";
 
-        internal const string WebRequestMessage = "WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient.";
+        internal const string WebRequestMessage = "WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.";
         internal const string WebRequestDiagId = "SYSLIB0014";
 
         internal const string DisablePrivateReflectionAttributeMessage = "DisablePrivateReflectionAttribute has no effect in .NET 6.0+.";
@@ -72,13 +72,13 @@ namespace System
         internal const string JsonSerializerOptionsIgnoreNullValuesMessage = "JsonSerializerOptions.IgnoreNullValues is obsolete. To ignore null values when serializing, set DefaultIgnoreCondition to JsonIgnoreCondition.WhenWritingNull.";
         internal const string JsonSerializerOptionsIgnoreNullValuesDiagId = "SYSLIB0020";
 
-        internal const string DerivedCryptographicTypesMessage = "Derived cryptographic types are obsolete. Use the Create method on the base type.";
+        internal const string DerivedCryptographicTypesMessage = "Derived cryptographic types are obsolete. Use the Create method on the base type instead.";
         internal const string DerivedCryptographicTypesDiagId = "SYSLIB0021";
 
-        internal const string RijndaelMessage = "The Rijndael and RijndaelManaged types are obsolete. Use Aes.";
+        internal const string RijndaelMessage = "The Rijndael and RijndaelManaged types are obsolete. Use Aes instead.";
         internal const string RijndaelDiagId = "SYSLIB0022";
 
-        internal const string RNGCryptoServiceProviderMessage = "RNGCryptoServiceProvider is obsolete. To generate a random number, use one of the RandomNumberGenerator static methods.";
+        internal const string RNGCryptoServiceProviderMessage = "RNGCryptoServiceProvider is obsolete. To generate a random number, use one of the RandomNumberGenerator static methods instead.";
         internal const string RNGCryptoServiceProviderDiagId = "SYSLIB0023";
 
         internal const string AppDomainCreateUnloadMessage = "Creating and unloading AppDomains is not supported and throws an exception.";
@@ -96,7 +96,7 @@ namespace System
         internal const string X509CertificatePrivateKeyMessage = "X509Certificate2.PrivateKey is obsolete. Use the appropriate method to get the private key, such as GetRSAPrivateKey, or use the CopyWithPrivateKey method to create a new instance with a private key.";
         internal const string X509CertificatePrivateKeyDiagId = "SYSLIB0028";
 
-        internal const string ProduceLegacyHmacValuesMessage = "ProduceLegacyHmacValues is obsolete. Producing legacy HMAC values is no longer supported.";
+        internal const string ProduceLegacyHmacValuesMessage = "ProduceLegacyHmacValues is obsolete. Producing legacy HMAC values is not supported.";
         internal const string ProduceLegacyHmacValuesDiagId = "SYSLIB0029";
 
         internal const string UseManagedSha1Message = "HMACSHA1 always uses the algorithm implementation provided by the platform. Use a constructor without the useManagedSha1 parameter.";

--- a/src/libraries/Common/src/System/Obsoletions.cs
+++ b/src/libraries/Common/src/System/Obsoletions.cs
@@ -66,7 +66,7 @@ namespace System
         internal const string ReflectionOnlyLoadingMessage = "ReflectionOnly loading is not supported and throws PlatformNotSupportedException.";
         internal const string ReflectionOnlyLoadingDiagId = "SYSLIB0018";
 
-        internal const string RuntimeEnvironmentMessage = "RuntimeEnvironment members SystemConfigurationFile, GetRuntimeInterfaceAsIntPtr, and GetRuntimeInterfaceAsObject are no longer supported and throw PlatformNotSupportedException.";
+        internal const string RuntimeEnvironmentMessage = "RuntimeEnvironment members SystemConfigurationFile, GetRuntimeInterfaceAsIntPtr, and GetRuntimeInterfaceAsObject are not supported and throw PlatformNotSupportedException.";
         internal const string RuntimeEnvironmentDiagId = "SYSLIB0019";
 
         internal const string JsonSerializerOptionsIgnoreNullValuesMessage = "JsonSerializerOptions.IgnoreNullValues is obsolete. To ignore null values when serializing, set DefaultIgnoreCondition to JsonIgnoreCondition.WhenWritingNull.";

--- a/src/libraries/Common/src/System/Obsoletions.cs
+++ b/src/libraries/Common/src/System/Obsoletions.cs
@@ -12,7 +12,7 @@ namespace System
         // and ensure the "aka.ms/dotnet-warnings/{0}" URL points to documentation for the obsoletion
         // The diagnostic ids reserved for obsoletions are SYSLIB0### (SYSLIB0001 - SYSLIB0999).
 
-        internal const string SystemTextEncodingUTF7Message = "The UTF-7 encoding is insecure and should not be used. Consider using UTF-8 instead.";
+        internal const string SystemTextEncodingUTF7Message = "The UTF-7 encoding is insecure and should not be used. Consider using UTF-8.";
         internal const string SystemTextEncodingUTF7DiagId = "SYSLIB0001";
 
         internal const string PrincipalPermissionAttributeMessage = "PrincipalPermissionAttribute is not honored by the runtime and must not be used.";
@@ -45,13 +45,13 @@ namespace System
         internal const string BinaryFormatterMessage = "BinaryFormatter serialization is obsolete and should not be used. See https://aka.ms/binaryformatter for more information.";
         internal const string BinaryFormatterDiagId = "SYSLIB0011";
 
-        internal const string CodeBaseMessage = "Assembly.CodeBase and Assembly.EscapedCodeBase are only included for .NET Framework compatibility. Use Assembly.Location instead.";
+        internal const string CodeBaseMessage = "Assembly.CodeBase and Assembly.EscapedCodeBase are only included for .NET Framework compatibility. Use Assembly.Location.";
         internal const string CodeBaseDiagId = "SYSLIB0012";
 
-        internal const string EscapeUriStringMessage = "Uri.EscapeUriString can corrupt the Uri string in some cases. Consider using Uri.EscapeDataString for query string components instead.";
+        internal const string EscapeUriStringMessage = "Uri.EscapeUriString can corrupt the Uri string in some cases. Consider using Uri.EscapeDataString for query string components.";
         internal const string EscapeUriStringDiagId = "SYSLIB0013";
 
-        internal const string WebRequestMessage = "WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.";
+        internal const string WebRequestMessage = "WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient.";
         internal const string WebRequestDiagId = "SYSLIB0014";
 
         internal const string DisablePrivateReflectionAttributeMessage = "DisablePrivateReflectionAttribute has no effect in .NET 6.0+.";
@@ -72,13 +72,13 @@ namespace System
         internal const string JsonSerializerOptionsIgnoreNullValuesMessage = "JsonSerializerOptions.IgnoreNullValues is obsolete. To ignore null values when serializing, set DefaultIgnoreCondition to JsonIgnoreCondition.WhenWritingNull.";
         internal const string JsonSerializerOptionsIgnoreNullValuesDiagId = "SYSLIB0020";
 
-        internal const string DerivedCryptographicTypesMessage = "Derived cryptographic types are obsolete. Use the Create method on the base type instead.";
+        internal const string DerivedCryptographicTypesMessage = "Derived cryptographic types are obsolete. Use the Create method on the base type.";
         internal const string DerivedCryptographicTypesDiagId = "SYSLIB0021";
 
-        internal const string RijndaelMessage = "The Rijndael and RijndaelManaged types are obsolete. Use Aes instead.";
+        internal const string RijndaelMessage = "The Rijndael and RijndaelManaged types are obsolete. Use Aes.";
         internal const string RijndaelDiagId = "SYSLIB0022";
 
-        internal const string RNGCryptoServiceProviderMessage = "RNGCryptoServiceProvider is obsolete. To generate a random number, use one of the RandomNumberGenerator static methods instead.";
+        internal const string RNGCryptoServiceProviderMessage = "RNGCryptoServiceProvider is obsolete. To generate a random number, use one of the RandomNumberGenerator static methods.";
         internal const string RNGCryptoServiceProviderDiagId = "SYSLIB0023";
 
         internal const string AppDomainCreateUnloadMessage = "Creating and unloading AppDomains is not supported and throws an exception.";

--- a/src/libraries/Microsoft.Extensions.DependencyModel/ref/Microsoft.Extensions.DependencyModel.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/ref/Microsoft.Extensions.DependencyModel.cs
@@ -7,7 +7,7 @@
 namespace Microsoft.DotNet.PlatformAbstractions
 {
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-    [System.ObsoleteAttribute("This type is obsolete and will be removed in a future version. The recommended alternative is System.HashCode.")]
+    [System.ObsoleteAttribute("HashCodeCombiner has been deprecated. Use System.HashCode instead.")]
     public partial struct HashCodeCombiner
     {
         private int _dummyPrimitive;

--- a/src/libraries/Microsoft.Extensions.DependencyModel/src/HashCodeCombiner.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/src/HashCodeCombiner.cs
@@ -9,7 +9,7 @@ using System.Runtime.CompilerServices;
 namespace Microsoft.DotNet.PlatformAbstractions
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    [Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is System.HashCode.")]
+    [Obsolete("HashCodeCombiner has been deprecated. Use System.HashCode instead.")]
     public struct HashCodeCombiner
     {
         private long _combinedHash64;

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/ref/Microsoft.Extensions.Hosting.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/ref/Microsoft.Extensions.Hosting.Abstractions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Extensions.Hosting
         public virtual System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public virtual System.Threading.Tasks.Task StopAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
     }
-    [System.ObsoleteAttribute("This type is obsolete and will be removed in a future version. The recommended alternative is Microsoft.Extensions.Hosting.Environments.", false)]
+    [System.ObsoleteAttribute("EnvironmentName has been deprecated. Use Microsoft.Extensions.Hosting.Environments instead.", false)]
     public static partial class EnvironmentName
     {
         public static readonly string Development;
@@ -77,7 +77,7 @@ namespace Microsoft.Extensions.Hosting
         public static bool IsProduction(this Microsoft.Extensions.Hosting.IHostingEnvironment hostingEnvironment) { throw null; }
         public static bool IsStaging(this Microsoft.Extensions.Hosting.IHostingEnvironment hostingEnvironment) { throw null; }
     }
-    [System.ObsoleteAttribute("This type is obsolete and will be removed in a future version. The recommended alternative is Microsoft.Extensions.Hosting.IHostApplicationLifetime.", false)]
+    [System.ObsoleteAttribute("IApplicationLifetime has been deprecated. Use Microsoft.Extensions.Hosting.IHostApplicationLifetime instead.", false)]
     public partial interface IApplicationLifetime
     {
         System.Threading.CancellationToken ApplicationStarted { get; }
@@ -121,7 +121,7 @@ namespace Microsoft.Extensions.Hosting
         string ContentRootPath { get; set; }
         string EnvironmentName { get; set; }
     }
-    [System.ObsoleteAttribute("This type is obsolete and will be removed in a future version. The recommended alternative is Microsoft.Extensions.Hosting.IHostEnvironment.", false)]
+    [System.ObsoleteAttribute("IHostingEnvironment has been deprecated. Use Microsoft.Extensions.Hosting.IHostEnvironment instead.", false)]
     public partial interface IHostingEnvironment
     {
         string ApplicationName { get; set; }

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/ref/Microsoft.Extensions.Hosting.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/ref/Microsoft.Extensions.Hosting.Abstractions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Extensions.Hosting
         public virtual System.Threading.Tasks.Task StartAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         public virtual System.Threading.Tasks.Task StopAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
     }
-    [System.ObsoleteAttribute("EnvironmentName has been deprecated. Use Microsoft.Extensions.Hosting.Environments instead.", false)]
+    [System.ObsoleteAttribute("EnvironmentName has been deprecated. Use Microsoft.Extensions.Hosting.Environments instead.")]
     public static partial class EnvironmentName
     {
         public static readonly string Development;
@@ -77,7 +77,7 @@ namespace Microsoft.Extensions.Hosting
         public static bool IsProduction(this Microsoft.Extensions.Hosting.IHostingEnvironment hostingEnvironment) { throw null; }
         public static bool IsStaging(this Microsoft.Extensions.Hosting.IHostingEnvironment hostingEnvironment) { throw null; }
     }
-    [System.ObsoleteAttribute("IApplicationLifetime has been deprecated. Use Microsoft.Extensions.Hosting.IHostApplicationLifetime instead.", false)]
+    [System.ObsoleteAttribute("IApplicationLifetime has been deprecated. Use Microsoft.Extensions.Hosting.IHostApplicationLifetime instead.")]
     public partial interface IApplicationLifetime
     {
         System.Threading.CancellationToken ApplicationStarted { get; }
@@ -121,7 +121,7 @@ namespace Microsoft.Extensions.Hosting
         string ContentRootPath { get; set; }
         string EnvironmentName { get; set; }
     }
-    [System.ObsoleteAttribute("IHostingEnvironment has been deprecated. Use Microsoft.Extensions.Hosting.IHostEnvironment instead.", false)]
+    [System.ObsoleteAttribute("IHostingEnvironment has been deprecated. Use Microsoft.Extensions.Hosting.IHostEnvironment instead.")]
     public partial interface IHostingEnvironment
     {
         string ApplicationName { get; set; }

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/EnvironmentName.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/EnvironmentName.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Extensions.Hosting
     ///  The recommended alternative is Microsoft.Extensions.Hosting.Environments.
     /// </para>
     /// </summary>
-    [System.Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is Microsoft.Extensions.Hosting.Environments.", error: false)]
+    [System.Obsolete("EnvironmentName has been deprecated. Use Microsoft.Extensions.Hosting.Environments instead.", error: false)]
     public static class EnvironmentName
     {
         public static readonly string Development = "Development";

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/EnvironmentName.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/EnvironmentName.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Extensions.Hosting
     ///  The recommended alternative is Microsoft.Extensions.Hosting.Environments.
     /// </para>
     /// </summary>
-    [System.Obsolete("EnvironmentName has been deprecated. Use Microsoft.Extensions.Hosting.Environments instead.", error: false)]
+    [System.Obsolete("EnvironmentName has been deprecated. Use Microsoft.Extensions.Hosting.Environments instead.")]
     public static class EnvironmentName
     {
         public static readonly string Development = "Development";

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IApplicationLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IApplicationLifetime.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.Hosting
     ///  The recommended alternative is Microsoft.Extensions.Hosting.IHostApplicationLifetime.
     /// </para>
     /// </summary>
-    [Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is Microsoft.Extensions.Hosting.IHostApplicationLifetime.", error: false)]
+    [Obsolete("IApplicationLifetime has been deprecated. Use Microsoft.Extensions.Hosting.IHostApplicationLifetime instead.", error: false)]
     public interface IApplicationLifetime
     {
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IApplicationLifetime.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IApplicationLifetime.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.Hosting
     ///  The recommended alternative is Microsoft.Extensions.Hosting.IHostApplicationLifetime.
     /// </para>
     /// </summary>
-    [Obsolete("IApplicationLifetime has been deprecated. Use Microsoft.Extensions.Hosting.IHostApplicationLifetime instead.", error: false)]
+    [Obsolete("IApplicationLifetime has been deprecated. Use Microsoft.Extensions.Hosting.IHostApplicationLifetime instead.")]
     public interface IApplicationLifetime
     {
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostingEnvironment.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostingEnvironment.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.Hosting
     ///  The recommended alternative is Microsoft.Extensions.Hosting.IHostEnvironment.
     /// </para>
     /// </summary>
-    [Obsolete("IHostingEnvironment has been deprecated. Use Microsoft.Extensions.Hosting.IHostEnvironment instead.", error: false)]
+    [Obsolete("IHostingEnvironment has been deprecated. Use Microsoft.Extensions.Hosting.IHostEnvironment instead.")]
     public interface IHostingEnvironment
     {
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostingEnvironment.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/IHostingEnvironment.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.Hosting
     ///  The recommended alternative is Microsoft.Extensions.Hosting.IHostEnvironment.
     /// </para>
     /// </summary>
-    [Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is Microsoft.Extensions.Hosting.IHostEnvironment.", error: false)]
+    [Obsolete("IHostingEnvironment has been deprecated. Use Microsoft.Extensions.Hosting.IHostEnvironment instead.", error: false)]
     public interface IHostingEnvironment
     {
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Logging.Console/ref/Microsoft.Extensions.Logging.Console.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/ref/Microsoft.Extensions.Logging.Console.cs
@@ -53,17 +53,17 @@ namespace Microsoft.Extensions.Logging.Console
     public partial class ConsoleLoggerOptions
     {
         public ConsoleLoggerOptions() { }
-        [System.ObsoleteAttribute("ConsoleLoggerOptions.DisableColors has been deprecated. Please use SimpleConsoleFormatterOptions.ColorBehavior instead.", false)]
+        [System.ObsoleteAttribute("ConsoleLoggerOptions.DisableColors has been deprecated. Use SimpleConsoleFormatterOptions.ColorBehavior instead.", false)]
         public bool DisableColors { get { throw null; } set { } }
-        [System.ObsoleteAttribute("ConsoleLoggerOptions.Format has been deprecated. Please use ConsoleLoggerOptions.FormatterName instead.", false)]
+        [System.ObsoleteAttribute("ConsoleLoggerOptions.Format has been deprecated. Use ConsoleLoggerOptions.FormatterName instead.", false)]
         public Microsoft.Extensions.Logging.Console.ConsoleLoggerFormat Format { get { throw null; } set { } }
         public string FormatterName { get { throw null; } set { } }
-        [System.ObsoleteAttribute("ConsoleLoggerOptions.IncludeScopes has been deprecated. Please use ConsoleFormatterOptions.IncludeScopes instead.", false)]
+        [System.ObsoleteAttribute("ConsoleLoggerOptions.IncludeScopes has been deprecated. Use ConsoleFormatterOptions.IncludeScopes instead.", false)]
         public bool IncludeScopes { get { throw null; } set { } }
         public Microsoft.Extensions.Logging.LogLevel LogToStandardErrorThreshold { get { throw null; } set { } }
-        [System.ObsoleteAttribute("ConsoleLoggerOptions.TimestampFormat has been deprecated. Please use ConsoleFormatterOptions.TimestampFormat instead.", false)]
+        [System.ObsoleteAttribute("ConsoleLoggerOptions.TimestampFormat has been deprecated. Use ConsoleFormatterOptions.TimestampFormat instead.", false)]
         public string TimestampFormat { get { throw null; } set { } }
-        [System.ObsoleteAttribute("ConsoleLoggerOptions.UseUtcTimestamp has been deprecated. Please use ConsoleFormatterOptions.UseUtcTimestamp instead.", false)]
+        [System.ObsoleteAttribute("ConsoleLoggerOptions.UseUtcTimestamp has been deprecated. Use ConsoleFormatterOptions.UseUtcTimestamp instead.", false)]
         public bool UseUtcTimestamp { get { throw null; } set { } }
     }
     [System.Runtime.Versioning.UnsupportedOSPlatform("browser")]

--- a/src/libraries/Microsoft.Extensions.Logging.Console/ref/Microsoft.Extensions.Logging.Console.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/ref/Microsoft.Extensions.Logging.Console.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Extensions.Logging.Console
         public string TimestampFormat { get { throw null; } set { } }
         public bool UseUtcTimestamp { get { throw null; } set { } }
     }
-    [System.ObsoleteAttribute("ConsoleLoggerFormat has been deprecated.", false)]
+    [System.ObsoleteAttribute("ConsoleLoggerFormat has been deprecated.")]
     public enum ConsoleLoggerFormat
     {
         Default = 0,
@@ -53,17 +53,17 @@ namespace Microsoft.Extensions.Logging.Console
     public partial class ConsoleLoggerOptions
     {
         public ConsoleLoggerOptions() { }
-        [System.ObsoleteAttribute("ConsoleLoggerOptions.DisableColors has been deprecated. Use SimpleConsoleFormatterOptions.ColorBehavior instead.", false)]
+        [System.ObsoleteAttribute("ConsoleLoggerOptions.DisableColors has been deprecated. Use SimpleConsoleFormatterOptions.ColorBehavior instead.")]
         public bool DisableColors { get { throw null; } set { } }
-        [System.ObsoleteAttribute("ConsoleLoggerOptions.Format has been deprecated. Use ConsoleLoggerOptions.FormatterName instead.", false)]
+        [System.ObsoleteAttribute("ConsoleLoggerOptions.Format has been deprecated. Use ConsoleLoggerOptions.FormatterName instead.")]
         public Microsoft.Extensions.Logging.Console.ConsoleLoggerFormat Format { get { throw null; } set { } }
         public string FormatterName { get { throw null; } set { } }
-        [System.ObsoleteAttribute("ConsoleLoggerOptions.IncludeScopes has been deprecated. Use ConsoleFormatterOptions.IncludeScopes instead.", false)]
+        [System.ObsoleteAttribute("ConsoleLoggerOptions.IncludeScopes has been deprecated. Use ConsoleFormatterOptions.IncludeScopes instead.")]
         public bool IncludeScopes { get { throw null; } set { } }
         public Microsoft.Extensions.Logging.LogLevel LogToStandardErrorThreshold { get { throw null; } set { } }
-        [System.ObsoleteAttribute("ConsoleLoggerOptions.TimestampFormat has been deprecated. Use ConsoleFormatterOptions.TimestampFormat instead.", false)]
+        [System.ObsoleteAttribute("ConsoleLoggerOptions.TimestampFormat has been deprecated. Use ConsoleFormatterOptions.TimestampFormat instead.")]
         public string TimestampFormat { get { throw null; } set { } }
-        [System.ObsoleteAttribute("ConsoleLoggerOptions.UseUtcTimestamp has been deprecated. Use ConsoleFormatterOptions.UseUtcTimestamp instead.", false)]
+        [System.ObsoleteAttribute("ConsoleLoggerOptions.UseUtcTimestamp has been deprecated. Use ConsoleFormatterOptions.UseUtcTimestamp instead.")]
         public bool UseUtcTimestamp { get { throw null; } set { } }
     }
     [System.Runtime.Versioning.UnsupportedOSPlatform("browser")]

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerFormat.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerFormat.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Extensions.Logging.Console
     /// <summary>
     /// Format of <see cref="ConsoleLogger" /> messages.
     /// </summary>
-    [System.ObsoleteAttribute("ConsoleLoggerFormat has been deprecated.", false)]
+    [System.ObsoleteAttribute("ConsoleLoggerFormat has been deprecated.")]
     public enum ConsoleLoggerFormat
     {
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.Logging.Console
         /// <summary>
         /// Disables colors when <see langword="true" />.
         /// </summary>
-        [System.ObsoleteAttribute("ConsoleLoggerOptions.DisableColors has been deprecated. Please use SimpleConsoleFormatterOptions.ColorBehavior instead.", false)]
+        [System.ObsoleteAttribute("ConsoleLoggerOptions.DisableColors has been deprecated. Use SimpleConsoleFormatterOptions.ColorBehavior instead.", false)]
         public bool DisableColors { get; set; }
 
 #pragma warning disable CS0618
@@ -21,7 +21,7 @@ namespace Microsoft.Extensions.Logging.Console
         /// <summary>
         /// Gets or sets log message format. Defaults to <see cref="ConsoleLoggerFormat.Default" />.
         /// </summary>
-        [System.ObsoleteAttribute("ConsoleLoggerOptions.Format has been deprecated. Please use ConsoleLoggerOptions.FormatterName instead.", false)]
+        [System.ObsoleteAttribute("ConsoleLoggerOptions.Format has been deprecated. Use ConsoleLoggerOptions.FormatterName instead.", false)]
         public ConsoleLoggerFormat Format
         {
             get => _format;
@@ -44,7 +44,7 @@ namespace Microsoft.Extensions.Logging.Console
         /// <summary>
         /// Includes scopes when <see langword="true" />.
         /// </summary>
-        [System.ObsoleteAttribute("ConsoleLoggerOptions.IncludeScopes has been deprecated. Please use ConsoleFormatterOptions.IncludeScopes instead.", false)]
+        [System.ObsoleteAttribute("ConsoleLoggerOptions.IncludeScopes has been deprecated. Use ConsoleFormatterOptions.IncludeScopes instead.", false)]
         public bool IncludeScopes { get; set; }
 
         /// <summary>
@@ -55,13 +55,13 @@ namespace Microsoft.Extensions.Logging.Console
         /// <summary>
         /// Gets or sets format string used to format timestamp in logging messages. Defaults to <c>null</c>.
         /// </summary>
-        [System.ObsoleteAttribute("ConsoleLoggerOptions.TimestampFormat has been deprecated. Please use ConsoleFormatterOptions.TimestampFormat instead.", false)]
+        [System.ObsoleteAttribute("ConsoleLoggerOptions.TimestampFormat has been deprecated. Use ConsoleFormatterOptions.TimestampFormat instead.", false)]
         public string TimestampFormat { get; set; }
 
         /// <summary>
         /// Gets or sets indication whether or not UTC timezone should be used to for timestamps in logging messages. Defaults to <c>false</c>.
         /// </summary>
-        [System.ObsoleteAttribute("ConsoleLoggerOptions.UseUtcTimestamp has been deprecated. Please use ConsoleFormatterOptions.UseUtcTimestamp instead.", false)]
+        [System.ObsoleteAttribute("ConsoleLoggerOptions.UseUtcTimestamp has been deprecated. Use ConsoleFormatterOptions.UseUtcTimestamp instead.", false)]
         public bool UseUtcTimestamp { get; set; }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.Logging.Console
         /// <summary>
         /// Disables colors when <see langword="true" />.
         /// </summary>
-        [System.ObsoleteAttribute("ConsoleLoggerOptions.DisableColors has been deprecated. Use SimpleConsoleFormatterOptions.ColorBehavior instead.", false)]
+        [System.ObsoleteAttribute("ConsoleLoggerOptions.DisableColors has been deprecated. Use SimpleConsoleFormatterOptions.ColorBehavior instead.")]
         public bool DisableColors { get; set; }
 
 #pragma warning disable CS0618
@@ -21,7 +21,7 @@ namespace Microsoft.Extensions.Logging.Console
         /// <summary>
         /// Gets or sets log message format. Defaults to <see cref="ConsoleLoggerFormat.Default" />.
         /// </summary>
-        [System.ObsoleteAttribute("ConsoleLoggerOptions.Format has been deprecated. Use ConsoleLoggerOptions.FormatterName instead.", false)]
+        [System.ObsoleteAttribute("ConsoleLoggerOptions.Format has been deprecated. Use ConsoleLoggerOptions.FormatterName instead.")]
         public ConsoleLoggerFormat Format
         {
             get => _format;
@@ -44,7 +44,7 @@ namespace Microsoft.Extensions.Logging.Console
         /// <summary>
         /// Includes scopes when <see langword="true" />.
         /// </summary>
-        [System.ObsoleteAttribute("ConsoleLoggerOptions.IncludeScopes has been deprecated. Use ConsoleFormatterOptions.IncludeScopes instead.", false)]
+        [System.ObsoleteAttribute("ConsoleLoggerOptions.IncludeScopes has been deprecated. Use ConsoleFormatterOptions.IncludeScopes instead.")]
         public bool IncludeScopes { get; set; }
 
         /// <summary>
@@ -55,13 +55,13 @@ namespace Microsoft.Extensions.Logging.Console
         /// <summary>
         /// Gets or sets format string used to format timestamp in logging messages. Defaults to <c>null</c>.
         /// </summary>
-        [System.ObsoleteAttribute("ConsoleLoggerOptions.TimestampFormat has been deprecated. Use ConsoleFormatterOptions.TimestampFormat instead.", false)]
+        [System.ObsoleteAttribute("ConsoleLoggerOptions.TimestampFormat has been deprecated. Use ConsoleFormatterOptions.TimestampFormat instead.")]
         public string TimestampFormat { get; set; }
 
         /// <summary>
         /// Gets or sets indication whether or not UTC timezone should be used to for timestamps in logging messages. Defaults to <c>false</c>.
         /// </summary>
-        [System.ObsoleteAttribute("ConsoleLoggerOptions.UseUtcTimestamp has been deprecated. Use ConsoleFormatterOptions.UseUtcTimestamp instead.", false)]
+        [System.ObsoleteAttribute("ConsoleLoggerOptions.UseUtcTimestamp has been deprecated. Use ConsoleFormatterOptions.UseUtcTimestamp instead.")]
         public bool UseUtcTimestamp { get; set; }
     }
 }

--- a/src/libraries/Microsoft.VisualBasic.Core/ref/Microsoft.VisualBasic.Core.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/ref/Microsoft.VisualBasic.Core.cs
@@ -130,7 +130,7 @@ namespace Microsoft.VisualBasic
         public const Microsoft.VisualBasic.MsgBoxStyle vbMsgBoxRtlReading = Microsoft.VisualBasic.MsgBoxStyle.MsgBoxRtlReading;
         public const Microsoft.VisualBasic.MsgBoxStyle vbMsgBoxSetForeground = Microsoft.VisualBasic.MsgBoxStyle.MsgBoxSetForeground;
         public const Microsoft.VisualBasic.VbStrConv vbNarrow = Microsoft.VisualBasic.VbStrConv.Narrow;
-        [System.ObsoleteAttribute("For a carriage return and line feed, use vbCrLf.  For the current platform's newline, use System.Environment.NewLine.")]
+        [System.ObsoleteAttribute("vbNewLine has been deprecated. For a carriage return and line feed, use vbCrLf. For the current platform's newline, use System.Environment.NewLine.")]
         public const string vbNewLine = "\r\n";
         public const Microsoft.VisualBasic.MsgBoxResult vbNo = Microsoft.VisualBasic.MsgBoxResult.No;
         public const Microsoft.VisualBasic.FileAttribute vbNormal = Microsoft.VisualBasic.FileAttribute.Normal;
@@ -806,7 +806,7 @@ namespace Microsoft.VisualBasic.CompilerServices
         internal Conversions() { }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The Expression origin object cannot be statically analyzed and may be trimmed")]
         public static object? ChangeType(object? Expression, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] System.Type TargetType) { throw null; }
-        [System.ObsoleteAttribute("do not use this method", true)]
+        [System.ObsoleteAttribute("FallbackUserDefinedConversion has been deprecated and is not supported.", true)]
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The Expression origin object cannot be statically analyzed and may be trimmed")]
         public static object FallbackUserDefinedConversion(object Expression, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] System.Type TargetType) { throw null; }
         public static string FromCharAndCount(char Value, int Count) { throw null; }
@@ -973,35 +973,35 @@ namespace Microsoft.VisualBasic.CompilerServices
     {
         internal NewLateBinding() { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("do not use this method", true)]
+        [System.ObsoleteAttribute("FallbackCall has been deprecated and is not supported.", true)]
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Late binding is dynamic and cannot be statically analyzed. The referenced types and members may be trimmed")]
         public static object? FallbackCall(object Instance, string MemberName, object[] Arguments, string[] ArgumentNames, bool IgnoreReturn) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("do not use this method", true)]
+        [System.ObsoleteAttribute("FallbackGet has been deprecated and is not supported.", true)]
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Late binding is dynamic and cannot be statically analyzed. The referenced types and members may be trimmed")]
         public static object? FallbackGet(object Instance, string MemberName, object[] Arguments, string[] ArgumentNames) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("do not use this method", true)]
+        [System.ObsoleteAttribute("FallbackIndexSet has been deprecated and is not supported.", true)]
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Late binding is dynamic and cannot be statically analyzed. The referenced types and members may be trimmed")]
         public static void FallbackIndexSet(object Instance, object[] Arguments, string[] ArgumentNames) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("do not use this method", true)]
+        [System.ObsoleteAttribute("FallbackIndexSetComplex has been deprecated and is not supported.", true)]
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Late binding is dynamic and cannot be statically analyzed. The referenced types and members may be trimmed")]
         public static void FallbackIndexSetComplex(object Instance, object[] Arguments, string[] ArgumentNames, bool OptimisticSet, bool RValueBase) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("do not use this method", true)]
+        [System.ObsoleteAttribute("FallbackInvokeDefault1 has been deprecated and is not supported.", true)]
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Late binding is dynamic and cannot be statically analyzed. The referenced types and members may be trimmed")]
         public static object? FallbackInvokeDefault1(object Instance, object[] Arguments, string[] ArgumentNames, bool ReportErrors) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("do not use this method", true)]
+        [System.ObsoleteAttribute("FallbackInvokeDefault2 has been deprecated and is not supported.", true)]
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Late binding is dynamic and cannot be statically analyzed. The referenced types and members may be trimmed")]
         public static object? FallbackInvokeDefault2(object Instance, object[] Arguments, string[] ArgumentNames, bool ReportErrors) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("do not use this method", true)]
+        [System.ObsoleteAttribute("FallbackSet has been deprecated and is not supported.", true)]
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Late binding is dynamic and cannot be statically analyzed. The referenced types and members may be trimmed")]
         public static void FallbackSet(object Instance, string MemberName, object[] Arguments) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("do not use this method", true)]
+        [System.ObsoleteAttribute("FallbackSetComplex has been deprecated and is not supported.", true)]
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Late binding is dynamic and cannot be statically analyzed. The referenced types and members may be trimmed")]
         public static void FallbackSetComplex(object Instance, string MemberName, object[] Arguments, bool OptimisticSet, bool RValueBase) { }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Late binding is dynamic and cannot be statically analyzed. The referenced types and members may be trimmed")]
@@ -1109,7 +1109,7 @@ namespace Microsoft.VisualBasic.CompilerServices
         public static object? DivideObject(object? Left, object? Right) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The object types cannot be statically analyzed so their operators may be trimmed")]
         public static object? ExponentObject(object? Left, object? Right) { throw null; }
-        [System.ObsoleteAttribute("do not use this method", true)]
+        [System.ObsoleteAttribute("FallbackInvokeUserDefinedOperator has been deprecated and is not supported.", true)]
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The object types cannot be statically analyzed so their operators may be trimmed")]
         public static object? FallbackInvokeUserDefinedOperator(object? vbOp, object?[]? arguments) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The object types cannot be statically analyzed so their operators may be trimmed")]

--- a/src/libraries/Microsoft.VisualBasic.Core/ref/Microsoft.VisualBasic.Core.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/ref/Microsoft.VisualBasic.Core.cs
@@ -383,7 +383,7 @@ namespace Microsoft.VisualBasic
         public static void FilePut(int FileNumber, string Value, long RecordNumber = (long)-1, bool StringIsFixedLength = false) { }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The origin object type could not be statically analyzed and may be trimmed")]
         public static void FilePut(int FileNumber, System.ValueType Value, long RecordNumber = (long)-1) { }
-        [System.ObsoleteAttribute("This member has been deprecated. Please use FilePutObject to write Object types, or coerce FileNumber and RecordNumber to Integer for writing non-Object types. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("FileSystem.FilePut has been deprecated. Use FilePutObject to write Object types, or coerce FileNumber and RecordNumber to Integer for writing non-Object types.")]
         public static void FilePut(object FileNumber, object Value, object RecordNumber) { }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The origin object type could not be statically analyzed and may be trimmed")]
         public static void FilePutObject(int FileNumber, object Value, long RecordNumber = (long)-1) { }

--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/FileSystem.vb
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/FileSystem.vb
@@ -725,7 +725,7 @@ Namespace Microsoft.VisualBasic
             End Try
         End Sub
 
-        <ObsoleteAttribute("This member has been deprecated. Please use FilePutObject to write Object types, or coerce FileNumber and RecordNumber to Integer for writing non-Object types. https://go.microsoft.com/fwlink/?linkid=14202")>
+        <ObsoleteAttribute("FileSystem.FilePut has been deprecated. Use FilePutObject to write Object types, or coerce FileNumber and RecordNumber to Integer for writing non-Object types.")>
         Public Sub FilePut(ByVal FileNumber As Object, ByVal Value As Object, Optional ByVal RecordNumber As Object = -1)
             Throw New ArgumentException(SR.UseFilePutObject)
         End Sub

--- a/src/libraries/Microsoft.Win32.SystemEvents/ref/Microsoft.Win32.SystemEvents.cs
+++ b/src/libraries/Microsoft.Win32.SystemEvents/ref/Microsoft.Win32.SystemEvents.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Win32
         public static event System.EventHandler? InstalledFontsChanged { add { } remove { } }
         [System.ComponentModel.BrowsableAttribute(false)]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("The LowMemory event has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("The LowMemory event has been deprecated and is not supported.")]
         public static event System.EventHandler? LowMemory { add { } remove { } }
         public static event System.EventHandler? PaletteChanged { add { } remove { } }
         public static event Microsoft.Win32.PowerModeChangedEventHandler? PowerModeChanged { add { } remove { } }

--- a/src/libraries/Microsoft.Win32.SystemEvents/ref/Microsoft.Win32.SystemEvents.cs
+++ b/src/libraries/Microsoft.Win32.SystemEvents/ref/Microsoft.Win32.SystemEvents.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Win32
         public static event System.EventHandler? InstalledFontsChanged { add { } remove { } }
         [System.ComponentModel.BrowsableAttribute(false)]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("The LowMemory event is obsolete and no longer supported.")]
+        [System.ObsoleteAttribute("The LowMemory event has been deprecated and is no longer supported.")]
         public static event System.EventHandler? LowMemory { add { } remove { } }
         public static event System.EventHandler? PaletteChanged { add { } remove { } }
         public static event Microsoft.Win32.PowerModeChangedEventHandler? PowerModeChanged { add { } remove { } }

--- a/src/libraries/Microsoft.Win32.SystemEvents/ref/Microsoft.Win32.SystemEvents.cs
+++ b/src/libraries/Microsoft.Win32.SystemEvents/ref/Microsoft.Win32.SystemEvents.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Win32
         public static event System.EventHandler? InstalledFontsChanged { add { } remove { } }
         [System.ComponentModel.BrowsableAttribute(false)]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("This event has been deprecated. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("The LowMemory event is obsolete and no longer supported.")]
         public static event System.EventHandler? LowMemory { add { } remove { } }
         public static event System.EventHandler? PaletteChanged { add { } remove { } }
         public static event Microsoft.Win32.PowerModeChangedEventHandler? PowerModeChanged { add { } remove { } }

--- a/src/libraries/Microsoft.Win32.SystemEvents/src/Microsoft/Win32/SystemEvents.cs
+++ b/src/libraries/Microsoft.Win32.SystemEvents/src/Microsoft/Win32/SystemEvents.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Win32
         /// <summary>
         ///  Occurs when the system is running out of available RAM.
         /// </summary>
-        [Obsolete("The LowMemory event is obsolete and no longer supported.")]
+        [Obsolete("The LowMemory event has been deprecated and is no longer supported.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         public static event EventHandler? LowMemory
         {

--- a/src/libraries/Microsoft.Win32.SystemEvents/src/Microsoft/Win32/SystemEvents.cs
+++ b/src/libraries/Microsoft.Win32.SystemEvents/src/Microsoft/Win32/SystemEvents.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Win32
         /// <summary>
         ///  Occurs when the system is running out of available RAM.
         /// </summary>
-        [Obsolete("The LowMemory event has been deprecated and is no longer supported.")]
+        [Obsolete("The LowMemory event has been deprecated and is not supported.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         public static event EventHandler? LowMemory
         {

--- a/src/libraries/Microsoft.Win32.SystemEvents/src/Microsoft/Win32/SystemEvents.cs
+++ b/src/libraries/Microsoft.Win32.SystemEvents/src/Microsoft/Win32/SystemEvents.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Win32
         /// <summary>
         ///  Occurs when the system is running out of available RAM.
         /// </summary>
-        [Obsolete("This event has been deprecated. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("The LowMemory event is obsolete and no longer supported.")]
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         public static event EventHandler? LowMemory
         {

--- a/src/libraries/System.CodeDom/ref/System.CodeDom.cs
+++ b/src/libraries/System.CodeDom/ref/System.CodeDom.cs
@@ -11,9 +11,9 @@ namespace Microsoft.CSharp
         public CSharpCodeProvider() { }
         public CSharpCodeProvider(System.Collections.Generic.IDictionary<string, string> providerOptions) { }
         public override string FileExtension { get { throw null; } }
-        [System.ObsoleteAttribute("Callers should not use the ICodeCompiler interface and should instead use the methods directly on the CodeDomProvider class.")]
+        [System.ObsoleteAttribute("ICodeCompiler has been deprecated. Use the methods directly on the CodeDomProvider class instead.")]
         public override System.CodeDom.Compiler.ICodeCompiler CreateCompiler() { throw null; }
-        [System.ObsoleteAttribute("Callers should not use the ICodeGenerator interface and should instead use the methods directly on the CodeDomProvider class.")]
+        [System.ObsoleteAttribute("ICodeGenerator has been deprecated. Use the methods directly on the CodeDomProvider class instead.")]
         public override System.CodeDom.Compiler.ICodeGenerator CreateGenerator() { throw null; }
         public override void GenerateCodeFromMember(System.CodeDom.CodeTypeMember member, System.IO.TextWriter writer, System.CodeDom.Compiler.CodeGeneratorOptions options) { }
         public override System.ComponentModel.TypeConverter GetConverter(System.Type type) { throw null; }
@@ -27,9 +27,9 @@ namespace Microsoft.VisualBasic
         public VBCodeProvider(System.Collections.Generic.IDictionary<string, string> providerOptions) { }
         public override string FileExtension { get { throw null; } }
         public override System.CodeDom.Compiler.LanguageOptions LanguageOptions { get { throw null; } }
-        [System.ObsoleteAttribute("Callers should not use the ICodeCompiler interface and should instead use the methods directly on the CodeDomProvider class.")]
+        [System.ObsoleteAttribute("ICodeCompiler has been deprecated. Use the methods directly on the CodeDomProvider class instead.")]
         public override System.CodeDom.Compiler.ICodeCompiler CreateCompiler() { throw null; }
-        [System.ObsoleteAttribute("Callers should not use the ICodeGenerator interface and should instead use the methods directly on the CodeDomProvider class.")]
+        [System.ObsoleteAttribute("ICodeGenerator has been deprecated. Use the methods directly on the CodeDomProvider class instead.")]
         public override System.CodeDom.Compiler.ICodeGenerator CreateGenerator() { throw null; }
         public override void GenerateCodeFromMember(System.CodeDom.CodeTypeMember member, System.IO.TextWriter writer, System.CodeDom.Compiler.CodeGeneratorOptions options) { }
         public override System.ComponentModel.TypeConverter GetConverter(System.Type type) { throw null; }
@@ -884,14 +884,14 @@ namespace System.CodeDom.Compiler
         public virtual System.CodeDom.Compiler.CompilerResults CompileAssemblyFromDom(System.CodeDom.Compiler.CompilerParameters options, params System.CodeDom.CodeCompileUnit[] compilationUnits) { throw null; }
         public virtual System.CodeDom.Compiler.CompilerResults CompileAssemblyFromFile(System.CodeDom.Compiler.CompilerParameters options, params string[] fileNames) { throw null; }
         public virtual System.CodeDom.Compiler.CompilerResults CompileAssemblyFromSource(System.CodeDom.Compiler.CompilerParameters options, params string[] sources) { throw null; }
-        [System.ObsoleteAttribute("Callers should not use the ICodeCompiler interface and should instead use the methods directly on the CodeDomProvider class. Those inheriting from CodeDomProvider must still implement this interface, and should exclude this warning or also obsolete this method.")]
+        [System.ObsoleteAttribute("ICodeCompiler has been deprecated. Use the methods directly on the CodeDomProvider class instead. Classes inheriting from CodeDomProvider must still implement this interface, and should suppress this warning or also mark this method as obsolete.")]
         public abstract System.CodeDom.Compiler.ICodeCompiler CreateCompiler();
         public virtual string CreateEscapedIdentifier(string value) { throw null; }
-        [System.ObsoleteAttribute("Callers should not use the ICodeGenerator interface and should instead use the methods directly on the CodeDomProvider class. Those inheriting from CodeDomProvider must still implement this interface, and should exclude this warning or also obsolete this method.")]
+        [System.ObsoleteAttribute("ICodeGenerator has been deprecated. Use the methods directly on the CodeDomProvider class instead. Classes inheriting from CodeDomProvider must still implement this interface, and should suppress this warning or also mark this method as obsolete.")]
         public abstract System.CodeDom.Compiler.ICodeGenerator CreateGenerator();
         public virtual System.CodeDom.Compiler.ICodeGenerator CreateGenerator(System.IO.TextWriter output) { throw null; }
         public virtual System.CodeDom.Compiler.ICodeGenerator CreateGenerator(string fileName) { throw null; }
-        [System.ObsoleteAttribute("Callers should not use the ICodeParser interface and should instead use the methods directly on the CodeDomProvider class. Those inheriting from CodeDomProvider must still implement this interface, and should exclude this warning or also obsolete this method.")]
+        [System.ObsoleteAttribute("ICodeParser has been deprecated. Use the methods directly on the CodeDomProvider class instead. Classes inheriting from CodeDomProvider must still implement this interface, and should suppress this warning or also mark this method as obsolete.")]
         public virtual System.CodeDom.Compiler.ICodeParser CreateParser() { throw null; }
         public static System.CodeDom.Compiler.CodeDomProvider CreateProvider(string language) { throw null; }
         public static System.CodeDom.Compiler.CodeDomProvider CreateProvider(string language, System.Collections.Generic.IDictionary<string, string> providerOptions) { throw null; }

--- a/src/libraries/System.CodeDom/src/Microsoft/CSharp/CSharpCodeProvider.cs
+++ b/src/libraries/System.CodeDom/src/Microsoft/CSharp/CSharpCodeProvider.cs
@@ -32,10 +32,10 @@ namespace Microsoft.CSharp
 
         public override string FileExtension => "cs";
 
-        [Obsolete("Callers should not use the ICodeGenerator interface and should instead use the methods directly on the CodeDomProvider class.")]
+        [Obsolete("ICodeGenerator has been deprecated. Use the methods directly on the CodeDomProvider class instead.")]
         public override ICodeGenerator CreateGenerator() => _generator;
 
-        [Obsolete("Callers should not use the ICodeCompiler interface and should instead use the methods directly on the CodeDomProvider class.")]
+        [Obsolete("ICodeCompiler has been deprecated. Use the methods directly on the CodeDomProvider class instead.")]
         public override ICodeCompiler CreateCompiler() => _generator;
 
         public override TypeConverter GetConverter(Type type) =>

--- a/src/libraries/System.CodeDom/src/Microsoft/VisualBasic/VBCodeProvider.cs
+++ b/src/libraries/System.CodeDom/src/Microsoft/VisualBasic/VBCodeProvider.cs
@@ -34,10 +34,10 @@ namespace Microsoft.VisualBasic
 
         public override LanguageOptions LanguageOptions => LanguageOptions.CaseInsensitive;
 
-        [Obsolete("Callers should not use the ICodeGenerator interface and should instead use the methods directly on the CodeDomProvider class.")]
+        [Obsolete("ICodeGenerator has been deprecated. Use the methods directly on the CodeDomProvider class instead.")]
         public override ICodeGenerator CreateGenerator() => _generator;
 
-        [Obsolete("Callers should not use the ICodeCompiler interface and should instead use the methods directly on the CodeDomProvider class.")]
+        [Obsolete("ICodeCompiler has been deprecated. Use the methods directly on the CodeDomProvider class instead.")]
         public override ICodeCompiler CreateCompiler() => _generator;
 
         public override TypeConverter GetConverter(Type type) =>

--- a/src/libraries/System.CodeDom/src/System/CodeDom/Compiler/CodeDomProvider.cs
+++ b/src/libraries/System.CodeDom/src/System/CodeDom/Compiler/CodeDomProvider.cs
@@ -116,7 +116,7 @@ namespace System.CodeDom.Compiler
 
         public virtual LanguageOptions LanguageOptions => LanguageOptions.None;
 
-        [Obsolete("Callers should not use the ICodeGenerator interface and should instead use the methods directly on the CodeDomProvider class. Those inheriting from CodeDomProvider must still implement this interface, and should exclude this warning or also obsolete this method.")]
+        [Obsolete("ICodeGenerator has been deprecated. Use the methods directly on the CodeDomProvider class instead. Classes inheriting from CodeDomProvider must still implement this interface, and should suppress this warning or also mark this method as obsolete.")]
         public abstract ICodeGenerator CreateGenerator();
 
 #pragma warning disable 618 // obsolete
@@ -125,10 +125,10 @@ namespace System.CodeDom.Compiler
         public virtual ICodeGenerator CreateGenerator(string fileName) => CreateGenerator();
 #pragma warning restore 618
 
-        [Obsolete("Callers should not use the ICodeCompiler interface and should instead use the methods directly on the CodeDomProvider class. Those inheriting from CodeDomProvider must still implement this interface, and should exclude this warning or also obsolete this method.")]
+        [Obsolete("ICodeCompiler has been deprecated. Use the methods directly on the CodeDomProvider class instead. Classes inheriting from CodeDomProvider must still implement this interface, and should suppress this warning or also mark this method as obsolete.")]
         public abstract ICodeCompiler CreateCompiler();
 
-        [Obsolete("Callers should not use the ICodeParser interface and should instead use the methods directly on the CodeDomProvider class. Those inheriting from CodeDomProvider must still implement this interface, and should exclude this warning or also obsolete this method.")]
+        [Obsolete("ICodeParser has been deprecated. Use the methods directly on the CodeDomProvider class instead. Classes inheriting from CodeDomProvider must still implement this interface, and should suppress this warning or also mark this method as obsolete.")]
         public virtual ICodeParser CreateParser() => null;
 
         public virtual TypeConverter GetConverter(Type type) => TypeDescriptor.GetConverter(type);

--- a/src/libraries/System.CodeDom/src/System/CodeDom/Compiler/CompilerParameters.Evidence.cs
+++ b/src/libraries/System.CodeDom/src/System/CodeDom/Compiler/CompilerParameters.Evidence.cs
@@ -12,8 +12,7 @@ namespace System.CodeDom.Compiler
     {
         private Evidence _evidence;
 
-        [Obsolete("CAS policy is obsolete and will be removed in a future release of the .NET Framework."
-                + " Please see https://go2.microsoft.com/fwlink/?LinkId=131738 for more information.")]
+        [Obsolete("Code Access Security is not supported or honored by the runtime")]
         public Evidence Evidence
         {
             get { return _evidence?.Clone(); }

--- a/src/libraries/System.CodeDom/src/System/CodeDom/Compiler/CompilerResults.Evidence.cs
+++ b/src/libraries/System.CodeDom/src/System/CodeDom/Compiler/CompilerResults.Evidence.cs
@@ -12,7 +12,7 @@ namespace System.CodeDom.Compiler
     {
         private Evidence _evidence;
 
-        [Obsolete("CAS policy is obsolete and will be removed in a future release of the .NET Framework. Please see https://go2.microsoft.com/fwlink/?LinkId=131738 for more information.")]
+        [Obsolete("Code Access Security is not supported or honored by the runtime.")]
         public Evidence Evidence
         {
             get { return _evidence?.Clone(); }

--- a/src/libraries/System.Collections.NonGeneric/ref/System.Collections.NonGeneric.cs
+++ b/src/libraries/System.Collections.NonGeneric/ref/System.Collections.NonGeneric.cs
@@ -14,7 +14,7 @@ namespace System.Collections
         public static System.Collections.CaseInsensitiveComparer DefaultInvariant { get { throw null; } }
         public int Compare(object? a, object? b) { throw null; }
     }
-    [System.ObsoleteAttribute("Please use StringComparer instead.")]
+    [System.ObsoleteAttribute("CaseInsensitiveHashCodeProvider has been deprecated. Use StringComparer instead.")]
     public partial class CaseInsensitiveHashCodeProvider : System.Collections.IHashCodeProvider
     {
         public CaseInsensitiveHashCodeProvider() { }

--- a/src/libraries/System.Collections.NonGeneric/src/System/Collections/CaseInsensitiveHashCodeProvider.cs
+++ b/src/libraries/System.Collections.NonGeneric/src/System/Collections/CaseInsensitiveHashCodeProvider.cs
@@ -9,7 +9,7 @@ namespace System.Collections
     /// Designed to support hashtables which require case-insensitive behavior while still maintaining case,
     /// this provides an efficient mechanism for getting the hashcode of the string ignoring case.
     /// </summary>
-    [Obsolete("Please use StringComparer instead.")]
+    [Obsolete("CaseInsensitiveHashCodeProvider has been deprecated. Use StringComparer instead.")]
     public class CaseInsensitiveHashCodeProvider : IHashCodeProvider
     {
         private static volatile CaseInsensitiveHashCodeProvider? s_invariantCaseInsensitiveHashCodeProvider;

--- a/src/libraries/System.Collections.Specialized/ref/System.Collections.Specialized.cs
+++ b/src/libraries/System.Collections.Specialized/ref/System.Collections.Specialized.cs
@@ -89,11 +89,11 @@ namespace System.Collections.Specialized
     {
         protected NameObjectCollectionBase() { }
         protected NameObjectCollectionBase(System.Collections.IEqualityComparer? equalityComparer) { }
-        [System.ObsoleteAttribute("Please use NameObjectCollectionBase(IEqualityComparer) instead.")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use NameObjectCollectionBase(IEqualityComparer) instead.")]
         protected NameObjectCollectionBase(System.Collections.IHashCodeProvider? hashProvider, System.Collections.IComparer? comparer) { }
         protected NameObjectCollectionBase(int capacity) { }
         protected NameObjectCollectionBase(int capacity, System.Collections.IEqualityComparer? equalityComparer) { }
-        [System.ObsoleteAttribute("Please use NameObjectCollectionBase(Int32, IEqualityComparer) instead.")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use NameObjectCollectionBase(Int32, IEqualityComparer) instead.")]
         protected NameObjectCollectionBase(int capacity, System.Collections.IHashCodeProvider? hashProvider, System.Collections.IComparer? comparer) { }
         protected NameObjectCollectionBase(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public virtual int Count { get { throw null; } }
@@ -134,12 +134,12 @@ namespace System.Collections.Specialized
     {
         public NameValueCollection() { }
         public NameValueCollection(System.Collections.IEqualityComparer? equalityComparer) { }
-        [System.ObsoleteAttribute("Please use NameValueCollection(IEqualityComparer) instead.")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use NameValueCollection(IEqualityComparer) instead.")]
         public NameValueCollection(System.Collections.IHashCodeProvider? hashProvider, System.Collections.IComparer? comparer) { }
         public NameValueCollection(System.Collections.Specialized.NameValueCollection col) { }
         public NameValueCollection(int capacity) { }
         public NameValueCollection(int capacity, System.Collections.IEqualityComparer? equalityComparer) { }
-        [System.ObsoleteAttribute("Please use NameValueCollection(Int32, IEqualityComparer) instead.")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use NameValueCollection(Int32, IEqualityComparer) instead.")]
         public NameValueCollection(int capacity, System.Collections.IHashCodeProvider? hashProvider, System.Collections.IComparer? comparer) { }
         public NameValueCollection(int capacity, System.Collections.Specialized.NameValueCollection col) { }
         protected NameValueCollection(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }

--- a/src/libraries/System.Collections.Specialized/src/System/Collections/Specialized/NameObjectCollectionBase.cs
+++ b/src/libraries/System.Collections.Specialized/src/System/Collections/Specialized/NameObjectCollectionBase.cs
@@ -52,14 +52,14 @@ namespace System.Collections.Specialized
             Reset(capacity);
         }
 
-        [Obsolete("Please use NameObjectCollectionBase(IEqualityComparer) instead.")]
+        [Obsolete("This constructor has been deprecated. Use NameObjectCollectionBase(IEqualityComparer) instead.")]
         protected NameObjectCollectionBase(IHashCodeProvider? hashProvider, IComparer? comparer)
         {
             _keyComparer = new CompatibleComparer(hashProvider, comparer);
             Reset();
         }
 
-        [Obsolete("Please use NameObjectCollectionBase(Int32, IEqualityComparer) instead.")]
+        [Obsolete("This constructor has been deprecated. Use NameObjectCollectionBase(Int32, IEqualityComparer) instead.")]
         protected NameObjectCollectionBase(int capacity, IHashCodeProvider? hashProvider, IComparer? comparer)
         {
             _keyComparer = new CompatibleComparer(hashProvider, comparer);

--- a/src/libraries/System.Collections.Specialized/src/System/Collections/Specialized/NameValueCollection.cs
+++ b/src/libraries/System.Collections.Specialized/src/System/Collections/Specialized/NameValueCollection.cs
@@ -46,7 +46,7 @@ namespace System.Collections.Specialized
             Add(col!);
         }
 
-        [Obsolete("Please use NameValueCollection(IEqualityComparer) instead.")]
+        [Obsolete("This constructor has been deprecated. Use NameValueCollection(IEqualityComparer) instead.")]
         public NameValueCollection(IHashCodeProvider? hashProvider, IComparer? comparer)
             : base(hashProvider, comparer)
         {
@@ -88,7 +88,7 @@ namespace System.Collections.Specialized
             Add(col);
         }
 
-        [Obsolete("Please use NameValueCollection(Int32, IEqualityComparer) instead.")]
+        [Obsolete("This constructor has been deprecated. Use NameValueCollection(Int32, IEqualityComparer) instead.")]
         public NameValueCollection(int capacity, IHashCodeProvider? hashProvider, IComparer? comparer)
             : base(capacity, hashProvider, comparer)
         {

--- a/src/libraries/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
+++ b/src/libraries/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
@@ -16,7 +16,7 @@ namespace System.ComponentModel.DataAnnotations
     }
 #nullable enable
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Property, AllowMultiple=false, Inherited=true)]
-    [System.ObsoleteAttribute("This attribute is no longer in use and will be ignored if applied.")]
+    [System.ObsoleteAttribute("AssociationAttribute has been deprecated and is no longer supported.")]
     public sealed partial class AssociationAttribute : System.Attribute
     {
         public AssociationAttribute(string name, string thisKey, string otherKey) { }
@@ -165,7 +165,7 @@ namespace System.ComponentModel.DataAnnotations
         public override bool IsValid(object? value) { throw null; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Property, AllowMultiple=false)]
-    [System.ObsoleteAttribute("This attribute is no longer in use and will be ignored if applied.")]
+    [System.ObsoleteAttribute("FilterUIHintAttribute has been deprecated and is no longer supported.")]
     public sealed partial class FilterUIHintAttribute : System.Attribute
     {
         public FilterUIHintAttribute(string filterUIHint) { }

--- a/src/libraries/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
+++ b/src/libraries/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
@@ -16,7 +16,7 @@ namespace System.ComponentModel.DataAnnotations
     }
 #nullable enable
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Property, AllowMultiple=false, Inherited=true)]
-    [System.ObsoleteAttribute("AssociationAttribute has been deprecated and is no longer supported.")]
+    [System.ObsoleteAttribute("AssociationAttribute has been deprecated and is not supported.")]
     public sealed partial class AssociationAttribute : System.Attribute
     {
         public AssociationAttribute(string name, string thisKey, string otherKey) { }
@@ -165,7 +165,7 @@ namespace System.ComponentModel.DataAnnotations
         public override bool IsValid(object? value) { throw null; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Property, AllowMultiple=false)]
-    [System.ObsoleteAttribute("FilterUIHintAttribute has been deprecated and is no longer supported.")]
+    [System.ObsoleteAttribute("FilterUIHintAttribute has been deprecated and is not supported.")]
     public sealed partial class FilterUIHintAttribute : System.Attribute
     {
         public FilterUIHintAttribute(string filterUIHint) { }

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AssociationAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AssociationAttribute.cs
@@ -10,7 +10,7 @@ namespace System.ComponentModel.DataAnnotations
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false,
         Inherited = true)]
-    [Obsolete("This attribute is no longer in use and will be ignored if applied.")]
+    [Obsolete("AssociationAttribute has been deprecated and is no longer supported.")]
     public sealed class AssociationAttribute : Attribute
     {
         /// <summary>

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AssociationAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AssociationAttribute.cs
@@ -10,7 +10,7 @@ namespace System.ComponentModel.DataAnnotations
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false,
         Inherited = true)]
-    [Obsolete("AssociationAttribute has been deprecated and is no longer supported.")]
+    [Obsolete("AssociationAttribute has been deprecated and is not supported.")]
     public sealed class AssociationAttribute : Attribute
     {
         /// <summary>

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/FilterUIHintAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/FilterUIHintAttribute.cs
@@ -10,7 +10,7 @@ namespace System.ComponentModel.DataAnnotations
     /// An attribute used to specify the filtering behavior for a column.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
-    [Obsolete("This attribute is no longer in use and will be ignored if applied.")]
+    [Obsolete("FilterUIHintAttribute has been deprecated and is no longer supported.")]
     public sealed class FilterUIHintAttribute : Attribute
     {
         private readonly UIHintAttribute.UIHintImplementation _implementation;

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/FilterUIHintAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/FilterUIHintAttribute.cs
@@ -10,7 +10,7 @@ namespace System.ComponentModel.DataAnnotations
     /// An attribute used to specify the filtering behavior for a column.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
-    [Obsolete("FilterUIHintAttribute has been deprecated and is no longer supported.")]
+    [Obsolete("FilterUIHintAttribute has been deprecated and is not supported.")]
     public sealed class FilterUIHintAttribute : Attribute
     {
         private readonly UIHintAttribute.UIHintImplementation _implementation;

--- a/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
@@ -2195,7 +2195,7 @@ namespace System.ComponentModel.Design.Serialization
     }
     public delegate void ResolveNameEventHandler(object? sender, System.ComponentModel.Design.Serialization.ResolveNameEventArgs e);
     [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Interface, AllowMultiple=true, Inherited=true)]
-    [System.ObsoleteAttribute("RootDesignerSerializerAttribute has been deprecated. Use DesignerSerializerAttribute. For example, to specify a root designer for CodeDom, use DesignerSerializerAttribute(...,typeof(TypeCodeDomSerializer)) instead.")]
+    [System.ObsoleteAttribute("RootDesignerSerializerAttribute has been deprecated. Use DesignerSerializerAttribute instead. For example, to specify a root designer for CodeDom, use DesignerSerializerAttribute(...,typeof(TypeCodeDomSerializer)) instead.")]
     public sealed partial class RootDesignerSerializerAttribute : System.Attribute
     {
         public RootDesignerSerializerAttribute(string? serializerTypeName, string? baseSerializerTypeName, bool reloadable) { }

--- a/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
@@ -1379,7 +1379,7 @@ namespace System.ComponentModel
     {
         internal TypeDescriptor() { }
         [System.Diagnostics.CodeAnalysis.DisallowNullAttribute]
-        [System.ObsoleteAttribute("This property has been deprecated. Use a type description provider to supply type information for COM types instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("TypeDescriptor.ComNativeDescriptorHandler has been deprecated. Use a type description provider to supply type information for COM types.")]
         public static System.ComponentModel.IComNativeDescriptorHandler? ComNativeDescriptorHandler { get { throw null; } set { } }
         public static System.Type ComObjectType { [return: System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] get { throw null; } }
         public static System.Type InterfaceType { [return: System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] get { throw null; } }
@@ -1661,7 +1661,7 @@ namespace System.ComponentModel.Design
     }
     public partial class DesignerTransactionCloseEventArgs : System.EventArgs
     {
-        [System.ObsoleteAttribute("This constructor is obsolete. Use DesignerTransactionCloseEventArgs(bool, bool) instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use DesignerTransactionCloseEventArgs(bool, bool).")]
         public DesignerTransactionCloseEventArgs(bool commit) { }
         public DesignerTransactionCloseEventArgs(bool commit, bool lastTransaction) { }
         public bool LastTransaction { get { throw null; } }
@@ -1947,17 +1947,17 @@ namespace System.ComponentModel.Design
     public enum SelectionTypes
     {
         Auto = 1,
-        [System.ObsoleteAttribute("This value has been deprecated. Use SelectionTypes.Auto instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("SelectionTypes.Normal has been deprecated. Use SelectionTypes.Auto.")]
         Normal = 1,
         Replace = 2,
-        [System.ObsoleteAttribute("This value has been deprecated. It is no longer supported. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("SelectionTypes.MouseDown has been deprecated and is no longer supported.")]
         MouseDown = 4,
-        [System.ObsoleteAttribute("This value has been deprecated. It is no longer supported. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("SelectionTypes.MouseUp has been deprecated and is no longer supported.")]
         MouseUp = 8,
-        [System.ObsoleteAttribute("This value has been deprecated. Use SelectionTypes.Primary instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("SelectionTypes.Click has been deprecated. Use SelectionTypes.Primary.")]
         Click = 16,
         Primary = 16,
-        [System.ObsoleteAttribute("This value has been deprecated. Use Enum class methods to determine valid values, or use a type converter. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("SelectionTypes.Valid has been deprecated. Use Enum class methods to determine valid values, or use a type converter.")]
         Valid = 31,
         Toggle = 32,
         Add = 64,
@@ -2058,9 +2058,9 @@ namespace System.ComponentModel.Design
     }
     public enum ViewTechnology
     {
-        [System.ObsoleteAttribute("This value has been deprecated. Use ViewTechnology.Default instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("ViewTechnology.Passthrough has been deprecated. Use ViewTechnology.Default.")]
         Passthrough = 0,
-        [System.ObsoleteAttribute("This value has been deprecated. Use ViewTechnology.Default instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("ViewTechnology.WindowsForms has been deprecated. Use ViewTechnology.Default.")]
         WindowsForms = 1,
         Default = 2,
     }
@@ -2195,7 +2195,7 @@ namespace System.ComponentModel.Design.Serialization
     }
     public delegate void ResolveNameEventHandler(object? sender, System.ComponentModel.Design.Serialization.ResolveNameEventArgs e);
     [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Interface, AllowMultiple=true, Inherited=true)]
-    [System.ObsoleteAttribute("This attribute has been deprecated. Use DesignerSerializerAttribute instead. For example, to specify a root designer for CodeDom, use DesignerSerializerAttribute(...,typeof(TypeCodeDomSerializer)). https://go.microsoft.com/fwlink/?linkid=14202")]
+    [System.ObsoleteAttribute("RootDesignerSerializerAttribute has been deprecated. Use DesignerSerializerAttribute. For example, to specify a root designer for CodeDom, use DesignerSerializerAttribute(...,typeof(TypeCodeDomSerializer)).")]
     public sealed partial class RootDesignerSerializerAttribute : System.Attribute
     {
         public RootDesignerSerializerAttribute(string? serializerTypeName, string? baseSerializerTypeName, bool reloadable) { }

--- a/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
@@ -1950,9 +1950,9 @@ namespace System.ComponentModel.Design
         [System.ObsoleteAttribute("SelectionTypes.Normal has been deprecated. Use SelectionTypes.Auto instead.")]
         Normal = 1,
         Replace = 2,
-        [System.ObsoleteAttribute("SelectionTypes.MouseDown has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("SelectionTypes.MouseDown has been deprecated and is not supported.")]
         MouseDown = 4,
-        [System.ObsoleteAttribute("SelectionTypes.MouseUp has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("SelectionTypes.MouseUp has been deprecated and is not supported.")]
         MouseUp = 8,
         [System.ObsoleteAttribute("SelectionTypes.Click has been deprecated. Use SelectionTypes.Primary instead.")]
         Click = 16,

--- a/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
@@ -1379,7 +1379,7 @@ namespace System.ComponentModel
     {
         internal TypeDescriptor() { }
         [System.Diagnostics.CodeAnalysis.DisallowNullAttribute]
-        [System.ObsoleteAttribute("TypeDescriptor.ComNativeDescriptorHandler has been deprecated. Use a type description provider to supply type information for COM types.")]
+        [System.ObsoleteAttribute("TypeDescriptor.ComNativeDescriptorHandler has been deprecated. Use a type description provider to supply type information for COM types instead.")]
         public static System.ComponentModel.IComNativeDescriptorHandler? ComNativeDescriptorHandler { get { throw null; } set { } }
         public static System.Type ComObjectType { [return: System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] get { throw null; } }
         public static System.Type InterfaceType { [return: System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] get { throw null; } }
@@ -1661,7 +1661,7 @@ namespace System.ComponentModel.Design
     }
     public partial class DesignerTransactionCloseEventArgs : System.EventArgs
     {
-        [System.ObsoleteAttribute("This constructor has been deprecated. Use DesignerTransactionCloseEventArgs(bool, bool).")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use DesignerTransactionCloseEventArgs(bool, bool) instead.")]
         public DesignerTransactionCloseEventArgs(bool commit) { }
         public DesignerTransactionCloseEventArgs(bool commit, bool lastTransaction) { }
         public bool LastTransaction { get { throw null; } }
@@ -1947,17 +1947,17 @@ namespace System.ComponentModel.Design
     public enum SelectionTypes
     {
         Auto = 1,
-        [System.ObsoleteAttribute("SelectionTypes.Normal has been deprecated. Use SelectionTypes.Auto.")]
+        [System.ObsoleteAttribute("SelectionTypes.Normal has been deprecated. Use SelectionTypes.Auto instead.")]
         Normal = 1,
         Replace = 2,
         [System.ObsoleteAttribute("SelectionTypes.MouseDown has been deprecated and is no longer supported.")]
         MouseDown = 4,
         [System.ObsoleteAttribute("SelectionTypes.MouseUp has been deprecated and is no longer supported.")]
         MouseUp = 8,
-        [System.ObsoleteAttribute("SelectionTypes.Click has been deprecated. Use SelectionTypes.Primary.")]
+        [System.ObsoleteAttribute("SelectionTypes.Click has been deprecated. Use SelectionTypes.Primary instead.")]
         Click = 16,
         Primary = 16,
-        [System.ObsoleteAttribute("SelectionTypes.Valid has been deprecated. Use Enum class methods to determine valid values, or use a type converter.")]
+        [System.ObsoleteAttribute("SelectionTypes.Valid has been deprecated. Use Enum class methods to determine valid values, or use a type converter instead.")]
         Valid = 31,
         Toggle = 32,
         Add = 64,
@@ -2058,9 +2058,9 @@ namespace System.ComponentModel.Design
     }
     public enum ViewTechnology
     {
-        [System.ObsoleteAttribute("ViewTechnology.Passthrough has been deprecated. Use ViewTechnology.Default.")]
+        [System.ObsoleteAttribute("ViewTechnology.Passthrough has been deprecated. Use ViewTechnology.Default instead.")]
         Passthrough = 0,
-        [System.ObsoleteAttribute("ViewTechnology.WindowsForms has been deprecated. Use ViewTechnology.Default.")]
+        [System.ObsoleteAttribute("ViewTechnology.WindowsForms has been deprecated. Use ViewTechnology.Default instead.")]
         WindowsForms = 1,
         Default = 2,
     }
@@ -2195,7 +2195,7 @@ namespace System.ComponentModel.Design.Serialization
     }
     public delegate void ResolveNameEventHandler(object? sender, System.ComponentModel.Design.Serialization.ResolveNameEventArgs e);
     [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Interface, AllowMultiple=true, Inherited=true)]
-    [System.ObsoleteAttribute("RootDesignerSerializerAttribute has been deprecated. Use DesignerSerializerAttribute. For example, to specify a root designer for CodeDom, use DesignerSerializerAttribute(...,typeof(TypeCodeDomSerializer)).")]
+    [System.ObsoleteAttribute("RootDesignerSerializerAttribute has been deprecated. Use DesignerSerializerAttribute. For example, to specify a root designer for CodeDom, use DesignerSerializerAttribute(...,typeof(TypeCodeDomSerializer)) instead.")]
     public sealed partial class RootDesignerSerializerAttribute : System.Attribute
     {
         public RootDesignerSerializerAttribute(string? serializerTypeName, string? baseSerializerTypeName, bool reloadable) { }

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerTransactionCloseEventArgs.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerTransactionCloseEventArgs.cs
@@ -9,7 +9,7 @@ namespace System.ComponentModel.Design
         /// Creates a new event args. Commit is true if the transaction is committed. This
         /// defaults the LastTransaction property to true.
         /// </summary>
-        [Obsolete("This constructor is obsolete. Use DesignerTransactionCloseEventArgs(bool, bool) instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("This constructor is obsolete. Use DesignerTransactionCloseEventArgs(bool, bool).")]
         public DesignerTransactionCloseEventArgs(bool commit) : this(commit, lastTransaction: true)
         {
         }

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerTransactionCloseEventArgs.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerTransactionCloseEventArgs.cs
@@ -9,7 +9,7 @@ namespace System.ComponentModel.Design
         /// Creates a new event args. Commit is true if the transaction is committed. This
         /// defaults the LastTransaction property to true.
         /// </summary>
-        [Obsolete("This constructor is obsolete. Use DesignerTransactionCloseEventArgs(bool, bool).")]
+        [Obsolete("This constructor has been deprecated. Use DesignerTransactionCloseEventArgs(bool, bool) instead.")]
         public DesignerTransactionCloseEventArgs(bool commit) : this(commit, lastTransaction: true)
         {
         }

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/SelectionTypes.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/SelectionTypes.cs
@@ -22,7 +22,7 @@ namespace System.ComponentModel.Design
         /// to the control and shift keys to support appending or toggling components into the
         /// selection as needed.
         /// </summary>
-        [Obsolete("This value has been deprecated. Use SelectionTypes.Auto instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("SelectionTypes.Normal has been deprecated. Use SelectionTypes.Auto.")]
         Normal = 0x0001,
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace System.ComponentModel.Design
         /// component in the selection list is already selected, it does not remove the
         /// existing selection, but promotes that component to be the primary selection.
         /// </summary>
-        [Obsolete("This value has been deprecated. It is no longer supported. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("SelectionTypes.MouseDown has been deprecated and is no longer supported.")]
         MouseDown = 0x0004,
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace System.ComponentModel.Design
         /// in the selection list is already selected, it does not remove the
         /// existing selection, but promotes that component to be the primary selection.
         /// </summary>
-        [Obsolete("This value has been deprecated. It is no longer supported. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("SelectionTypes.MouseUp has been deprecated and is no longer supported.")]
         MouseUp = 0x0008,
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace System.ComponentModel.Design
         /// selected, it does not remove the existing selection, but promotes that component to be the
         /// primary selection.
         /// </summary>
-        [Obsolete("This value has been deprecated. Use SelectionTypes.Primary instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("SelectionTypes.Click has been deprecated. Use SelectionTypes.Primary.")]
         Click = 0x0010,
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace System.ComponentModel.Design
         /// Limits valid selection types to Normal, Replace, MouseDown, MouseUp,
         /// Click, Toggle or Add.
         /// </summary>
-        [Obsolete("This value has been deprecated. Use Enum class methods to determine valid values, or use a type converter. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("This value has been deprecated. Use Enum class methods to determine valid values, or use a type converter.")]
         Valid = 0x1F,
     }
 }

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/SelectionTypes.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/SelectionTypes.cs
@@ -37,7 +37,7 @@ namespace System.ComponentModel.Design
         /// component in the selection list is already selected, it does not remove the
         /// existing selection, but promotes that component to be the primary selection.
         /// </summary>
-        [Obsolete("SelectionTypes.MouseDown has been deprecated and is no longer supported.")]
+        [Obsolete("SelectionTypes.MouseDown has been deprecated and is not supported.")]
         MouseDown = 0x0004,
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace System.ComponentModel.Design
         /// in the selection list is already selected, it does not remove the
         /// existing selection, but promotes that component to be the primary selection.
         /// </summary>
-        [Obsolete("SelectionTypes.MouseUp has been deprecated and is no longer supported.")]
+        [Obsolete("SelectionTypes.MouseUp has been deprecated and is not supported.")]
         MouseUp = 0x0008,
 
         /// <summary>

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/SelectionTypes.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/SelectionTypes.cs
@@ -22,7 +22,7 @@ namespace System.ComponentModel.Design
         /// to the control and shift keys to support appending or toggling components into the
         /// selection as needed.
         /// </summary>
-        [Obsolete("SelectionTypes.Normal has been deprecated. Use SelectionTypes.Auto.")]
+        [Obsolete("SelectionTypes.Normal has been deprecated. Use SelectionTypes.Auto instead.")]
         Normal = 0x0001,
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace System.ComponentModel.Design
         /// selected, it does not remove the existing selection, but promotes that component to be the
         /// primary selection.
         /// </summary>
-        [Obsolete("SelectionTypes.Click has been deprecated. Use SelectionTypes.Primary.")]
+        [Obsolete("SelectionTypes.Click has been deprecated. Use SelectionTypes.Primary instead.")]
         Click = 0x0010,
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace System.ComponentModel.Design
         /// Limits valid selection types to Normal, Replace, MouseDown, MouseUp,
         /// Click, Toggle or Add.
         /// </summary>
-        [Obsolete("This value has been deprecated. Use Enum class methods to determine valid values, or use a type converter.")]
+        [Obsolete("SelectionTypes.Valid has been deprecated. Use Enum class methods to determine valid values, or use a type converter instead.")]
         Valid = 0x1F,
     }
 }

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/RootDesignerSerializerAttribute.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/RootDesignerSerializerAttribute.cs
@@ -9,7 +9,7 @@ namespace System.ComponentModel.Design.Serialization
     /// being used as a root object.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = true, Inherited = true)]
-    [Obsolete("This attribute has been deprecated. Use DesignerSerializerAttribute instead. For example, to specify a root designer for CodeDom, use DesignerSerializerAttribute(...,typeof(TypeCodeDomSerializer)). https://go.microsoft.com/fwlink/?linkid=14202")]
+    [Obsolete("RootDesignerSerializerAttribute has been deprecated. Use DesignerSerializerAttribute. For example, to specify a root designer for CodeDom, use DesignerSerializerAttribute(...,typeof(TypeCodeDomSerializer)).")]
     public sealed class RootDesignerSerializerAttribute : Attribute
     {
         private string? _typeId;

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/RootDesignerSerializerAttribute.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/RootDesignerSerializerAttribute.cs
@@ -9,7 +9,7 @@ namespace System.ComponentModel.Design.Serialization
     /// being used as a root object.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = true, Inherited = true)]
-    [Obsolete("RootDesignerSerializerAttribute has been deprecated. Use DesignerSerializerAttribute. For example, to specify a root designer for CodeDom, use DesignerSerializerAttribute(...,typeof(TypeCodeDomSerializer)).")]
+    [Obsolete("RootDesignerSerializerAttribute has been deprecated. Use DesignerSerializerAttribute instead. For example, to specify a root designer for CodeDom, use DesignerSerializerAttribute(...,typeof(TypeCodeDomSerializer)).")]
     public sealed class RootDesignerSerializerAttribute : Attribute
     {
         private string? _typeId;

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ViewTechnology.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ViewTechnology.cs
@@ -18,7 +18,7 @@ namespace System.ComponentModel.Design
         /// COM2 interface technologies such as doc objects and ActiveX
         /// controls.
         /// </summary>
-        [Obsolete("This value has been deprecated. Use ViewTechnology.Default instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("ViewTechnology.Passthrough has been deprecated. Use ViewTechnology.Default.")]
         Passthrough = 0,
 
         /// <summary>
@@ -26,7 +26,7 @@ namespace System.ComponentModel.Design
         /// a Windows Forms control object. The designer host will fill the
         /// development environment's document window with this control.
         /// </summary>
-        [Obsolete("This value has been deprecated. Use ViewTechnology.Default instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("ViewTechnology.WindowsForms has been deprecated. Use ViewTechnology.Default.")]
         WindowsForms = 1,
 
         /// <summary>

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ViewTechnology.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/ViewTechnology.cs
@@ -18,7 +18,7 @@ namespace System.ComponentModel.Design
         /// COM2 interface technologies such as doc objects and ActiveX
         /// controls.
         /// </summary>
-        [Obsolete("ViewTechnology.Passthrough has been deprecated. Use ViewTechnology.Default.")]
+        [Obsolete("ViewTechnology.Passthrough has been deprecated. Use ViewTechnology.Default instead.")]
         Passthrough = 0,
 
         /// <summary>
@@ -26,7 +26,7 @@ namespace System.ComponentModel.Design
         /// a Windows Forms control object. The designer host will fill the
         /// development environment's document window with this control.
         /// </summary>
-        [Obsolete("ViewTechnology.WindowsForms has been deprecated. Use ViewTechnology.Default.")]
+        [Obsolete("ViewTechnology.WindowsForms has been deprecated. Use ViewTechnology.Default instead.")]
         WindowsForms = 1,
 
         /// <summary>

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/IComNativeDescriptorHandler.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/IComNativeDescriptorHandler.cs
@@ -6,7 +6,7 @@ namespace System.ComponentModel
     /// <summary>
     /// Top level mapping layer between a COM object and TypeDescriptor.
     /// </summary>
-    [Obsolete("This interface has been deprecated. Add a TypeDescriptionProvider to handle type TypeDescriptor.ComObjectType instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+    [Obsolete("IComNativeDescriptorHandler has been deprecated. Add a TypeDescriptionProvider to handle type TypeDescriptor.ComObjectType.")]
     public interface IComNativeDescriptorHandler
     {
         AttributeCollection GetAttributes(object component);

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/IComNativeDescriptorHandler.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/IComNativeDescriptorHandler.cs
@@ -6,7 +6,7 @@ namespace System.ComponentModel
     /// <summary>
     /// Top level mapping layer between a COM object and TypeDescriptor.
     /// </summary>
-    [Obsolete("IComNativeDescriptorHandler has been deprecated. Add a TypeDescriptionProvider to handle type TypeDescriptor.ComObjectType.")]
+    [Obsolete("IComNativeDescriptorHandler has been deprecated. Add a TypeDescriptionProvider to handle type TypeDescriptor.ComObjectType instead.")]
     public interface IComNativeDescriptorHandler
     {
         AttributeCollection GetAttributes(object component);

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/MemberDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/MemberDescriptor.cs
@@ -465,7 +465,7 @@ namespace System.ComponentModel
         /// </summary>
         protected static ISite? GetSite(object? component) => (component as IComponent)?.Site;
 
-        [Obsolete("This method has been deprecated. Use GetInvocationTarget instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("MemberDescriptor.GetInvokee has been deprecated. Use GetInvocationTarget.")]
         protected static object GetInvokee(Type componentClass, object component)
         {
 

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/MemberDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/MemberDescriptor.cs
@@ -465,7 +465,7 @@ namespace System.ComponentModel
         /// </summary>
         protected static ISite? GetSite(object? component) => (component as IComponent)?.Site;
 
-        [Obsolete("MemberDescriptor.GetInvokee has been deprecated. Use GetInvocationTarget.")]
+        [Obsolete("MemberDescriptor.GetInvokee has been deprecated. Use GetInvocationTarget instead.")]
         protected static object GetInvokee(Type componentClass, object component)
         {
 

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/RecommendedAsConfigurableAttribute.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/RecommendedAsConfigurableAttribute.cs
@@ -9,7 +9,7 @@ namespace System.ComponentModel
     /// Specifies that the property can be used as an application setting.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
-    [Obsolete("Use System.ComponentModel.SettingsBindableAttribute instead to work with the new settings model.")]
+    [Obsolete("RecommendedAsConfigurableAttribute has been deprecated. Use System.ComponentModel.SettingsBindableAttribute instead.")]
     public class RecommendedAsConfigurableAttribute : Attribute
     {
         /// <summary>

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -2443,7 +2443,7 @@ namespace System.ComponentModel
             return result;
         }
 
-        [Obsolete("TypeDescriptor.ComNativeDescriptorHandler has been deprecated. Use a type description provider to supply type information for COM types.")]
+        [Obsolete("TypeDescriptor.ComNativeDescriptorHandler has been deprecated. Use a type description provider to supply type information for COM types instead.")]
         [DisallowNull]
         public static IComNativeDescriptorHandler? ComNativeDescriptorHandler
         {

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -2443,7 +2443,7 @@ namespace System.ComponentModel
             return result;
         }
 
-        [Obsolete("This property has been deprecated. Use a type description provider to supply type information for COM types instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("TypeDescriptor.ComNativeDescriptorHandler has been deprecated. Use a type description provider to supply type information for COM types.")]
         [DisallowNull]
         public static IComNativeDescriptorHandler? ComNativeDescriptorHandler
         {

--- a/src/libraries/System.Configuration.ConfigurationManager/ref/System.Configuration.ConfigurationManager.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/ref/System.Configuration.ConfigurationManager.cs
@@ -1215,7 +1215,7 @@ namespace System.Configuration
     {
         String = 0,
         Xml = 1,
-        [System.ObsoleteAttribute(System.Obsoletions.BinaryFormatterMessage + @". Consider using Xml instead.", false)]
+        [System.ObsoleteAttribute(System.Obsoletions.BinaryFormatterMessage + @". Consider using Xml instead.")]
         Binary = 2,
         ProviderSpecific = 3,
     }

--- a/src/libraries/System.Configuration.ConfigurationManager/ref/System.Configuration.ConfigurationManager.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/ref/System.Configuration.ConfigurationManager.cs
@@ -290,29 +290,29 @@ namespace System.Configuration
     }
     public partial class ConfigurationException : System.SystemException
     {
-        [System.ObsoleteAttribute("This class is obsolete, to create a new exception create a System.Configuration.ConfigurationErrorsException")]
+        [System.ObsoleteAttribute("ConfigurationException has been deprecated. Use System.Configuration.ConfigurationErrorsException instead.")]
         public ConfigurationException() { }
         protected ConfigurationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        [System.ObsoleteAttribute("This class is obsolete, to create a new exception create a System.Configuration.ConfigurationErrorsException")]
+        [System.ObsoleteAttribute("ConfigurationException has been deprecated. Use System.Configuration.ConfigurationErrorsException instead.")]
         public ConfigurationException(string message) { }
-        [System.ObsoleteAttribute("This class is obsolete, to create a new exception create a System.Configuration.ConfigurationErrorsException")]
+        [System.ObsoleteAttribute("ConfigurationException has been deprecated. Use System.Configuration.ConfigurationErrorsException instead.")]
         public ConfigurationException(string message, System.Exception inner) { }
-        [System.ObsoleteAttribute("This class is obsolete, to create a new exception create a System.Configuration.ConfigurationErrorsException")]
+        [System.ObsoleteAttribute("ConfigurationException has been deprecated. Use System.Configuration.ConfigurationErrorsException instead.")]
         public ConfigurationException(string message, System.Exception inner, string filename, int line) { }
-        [System.ObsoleteAttribute("This class is obsolete, to create a new exception create a System.Configuration.ConfigurationErrorsException")]
+        [System.ObsoleteAttribute("ConfigurationException has been deprecated. Use System.Configuration.ConfigurationErrorsException instead.")]
         public ConfigurationException(string message, System.Exception inner, System.Xml.XmlNode node) { }
-        [System.ObsoleteAttribute("This class is obsolete, to create a new exception create a System.Configuration.ConfigurationErrorsException")]
+        [System.ObsoleteAttribute("ConfigurationException has been deprecated. Use System.Configuration.ConfigurationErrorsException instead.")]
         public ConfigurationException(string message, string filename, int line) { }
-        [System.ObsoleteAttribute("This class is obsolete, to create a new exception create a System.Configuration.ConfigurationErrorsException")]
+        [System.ObsoleteAttribute("ConfigurationException has been deprecated. Use System.Configuration.ConfigurationErrorsException instead.")]
         public ConfigurationException(string message, System.Xml.XmlNode node) { }
         public virtual string BareMessage { get { throw null; } }
         public virtual string Filename { get { throw null; } }
         public virtual int Line { get { throw null; } }
         public override string Message { get { throw null; } }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        [System.ObsoleteAttribute("This class is obsolete, use System.Configuration.ConfigurationErrorsException.GetFilename instead")]
+        [System.ObsoleteAttribute("ConfigurationException has been deprecated. Use System.Configuration.ConfigurationErrorsException.GetFilename instead.")]
         public static string GetXmlNodeFilename(System.Xml.XmlNode node) { throw null; }
-        [System.ObsoleteAttribute("This class is obsolete, use System.Configuration.ConfigurationErrorsException.GetLinenumber instead")]
+        [System.ObsoleteAttribute("ConfigurationException has been deprecated. Use System.Configuration.ConfigurationErrorsException.GetLinenumber instead.")]
         public static int GetXmlNodeLineNumber(System.Xml.XmlNode node) { throw null; }
     }
     public partial class ConfigurationFileMap : System.ICloneable
@@ -494,9 +494,9 @@ namespace System.Configuration
     public sealed partial class ConfigurationSettings
     {
         internal ConfigurationSettings() { }
-        [System.ObsoleteAttribute("This property is obsolete, it has been replaced by System.Configuration.ConfigurationManager.AppSettings")]
+        [System.ObsoleteAttribute("ConfigurationSettings.AppSettings has been deprecated. Use System.Configuration.ConfigurationManager.AppSettings instead.")]
         public static System.Collections.Specialized.NameValueCollection AppSettings { get { throw null; } }
-        [System.ObsoleteAttribute("This method is obsolete, it has been replaced by System.Configuration.ConfigurationManager.GetSection")]
+        [System.ObsoleteAttribute("ConfigurationSettings.GetConfig has been deprecated. Use System.Configuration.ConfigurationManager.GetSection instead.")]
         public static object GetConfig(string sectionName) { throw null; }
     }
     public enum ConfigurationUserLevel

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationException.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationException.cs
@@ -29,29 +29,29 @@ namespace System.Configuration
             Init(info.GetString("filename"), info.GetInt32("line"));
         }
 
-        [Obsolete("This class is obsolete, to create a new exception create a System.Configuration.ConfigurationErrorsException")]
+        [Obsolete("ConfigurationException has been deprecated. Use System.Configuration.ConfigurationErrorsException instead.")]
         public ConfigurationException() : this(null, null, null, 0) { }
 
-        [Obsolete("This class is obsolete, to create a new exception create a System.Configuration.ConfigurationErrorsException")]
+        [Obsolete("ConfigurationException has been deprecated. Use System.Configuration.ConfigurationErrorsException instead.")]
         public ConfigurationException(string message) : this(message, null, null, 0) { }
 
-        [Obsolete("This class is obsolete, to create a new exception create a System.Configuration.ConfigurationErrorsException")]
+        [Obsolete("ConfigurationException has been deprecated. Use System.Configuration.ConfigurationErrorsException instead.")]
         public ConfigurationException(string message, Exception inner) : this(message, inner, null, 0) { }
 
-        [Obsolete("This class is obsolete, to create a new exception create a System.Configuration.ConfigurationErrorsException")]
+        [Obsolete("ConfigurationException has been deprecated. Use System.Configuration.ConfigurationErrorsException instead.")]
         public ConfigurationException(string message, XmlNode node)
             : this(message, null, GetXmlNodeFilename(node), GetXmlNodeLineNumber(node))
         { }
 
-        [Obsolete("This class is obsolete, to create a new exception create a System.Configuration.ConfigurationErrorsException")]
+        [Obsolete("ConfigurationException has been deprecated. Use System.Configuration.ConfigurationErrorsException instead.")]
         public ConfigurationException(string message, Exception inner, XmlNode node)
             : this(message, inner, GetXmlNodeFilename(node), GetXmlNodeLineNumber(node))
         { }
 
-        [Obsolete("This class is obsolete, to create a new exception create a System.Configuration.ConfigurationErrorsException")]
+        [Obsolete("ConfigurationException has been deprecated. Use System.Configuration.ConfigurationErrorsException instead.")]
         public ConfigurationException(string message, string filename, int line) : this(message, null, filename, line) { }
 
-        [Obsolete("This class is obsolete, to create a new exception create a System.Configuration.ConfigurationErrorsException")]
+        [Obsolete("ConfigurationException has been deprecated. Use System.Configuration.ConfigurationErrorsException instead.")]
         public ConfigurationException(string message, Exception inner, string filename, int line) : base(message, inner)
         {
             Init(filename, line);
@@ -97,10 +97,10 @@ namespace System.Configuration
             info.AddValue("line", _line);
         }
 
-        [Obsolete("This class is obsolete, use System.Configuration.ConfigurationErrorsException.GetFilename instead")]
+        [Obsolete("ConfigurationException has been deprecated. Use System.Configuration.ConfigurationErrorsException.GetFilename instead.")]
         public static string GetXmlNodeFilename(XmlNode node) => (node as IConfigErrorInfo)?.Filename ?? string.Empty;
 
-        [Obsolete("This class is obsolete, use System.Configuration.ConfigurationErrorsException.GetFilename instead")]
+        [Obsolete("ConfigurationException has been deprecated. Use System.Configuration.ConfigurationErrorsException.GetFilename instead.")]
         public static int GetXmlNodeLineNumber(XmlNode node) => (node as IConfigErrorInfo)?.LineNumber ?? 0;
     }
 }

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationSettings.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationSettings.cs
@@ -9,7 +9,7 @@ namespace System.Configuration
     {
         internal ConfigurationSettings() { }
 
-        [Obsolete("This property is obsolete, it has been replaced by System.Configuration.ConfigurationManager.AppSettings")]
+        [Obsolete("ConfigurationSettings.AppSettings has been deprecated. Use System.Configuration.ConfigurationManager.AppSettings instead.")]
         public static NameValueCollection AppSettings
         {
             get
@@ -18,7 +18,7 @@ namespace System.Configuration
             }
         }
 
-        [Obsolete("This method is obsolete, it has been replaced by System.Configuration.ConfigurationManager.GetSection")]
+        [Obsolete("ConfigurationSettings.GetConfig has been deprecated. Use System.Configuration.ConfigurationManager.GetSection instead.")]
         public static object GetConfig(string sectionName)
         {
             return ConfigurationManager.GetSection(sectionName);

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/SettingsSerializeAs.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/SettingsSerializeAs.cs
@@ -9,7 +9,7 @@ namespace System.Configuration
     {
         String = 0,
         Xml = 1,
-        [Obsolete(Obsoletions.BinaryFormatterMessage + @". Consider using Xml instead.", false)]
+        [Obsolete(Obsoletions.BinaryFormatterMessage + @". Consider using Xml instead.")]
         Binary = 2,
         ProviderSpecific = 3
     }

--- a/src/libraries/System.Data.Common/ref/System.Data.Common.cs
+++ b/src/libraries/System.Data.Common/ref/System.Data.Common.cs
@@ -658,10 +658,10 @@ namespace System.Data
         Utc = 4,
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.All)]
-    [System.ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated and is not supported.", false)]
+    [System.ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated and is not supported.")]
     public partial class DataSysDescriptionAttribute : System.ComponentModel.DescriptionAttribute
     {
-        [System.ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated and is not supported.", false)]
+        [System.ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated and is not supported.")]
         public DataSysDescriptionAttribute(string description) { }
         public override string Description { get { throw null; } }
     }

--- a/src/libraries/System.Data.Common/ref/System.Data.Common.cs
+++ b/src/libraries/System.Data.Common/ref/System.Data.Common.cs
@@ -658,10 +658,10 @@ namespace System.Data
         Utc = 4,
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.All)]
-    [System.ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated.  https://go.microsoft.com/fwlink/?linkid=14202", false)]
+    [System.ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated.", false)]
     public partial class DataSysDescriptionAttribute : System.ComponentModel.DescriptionAttribute
     {
-        [System.ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated.  https://go.microsoft.com/fwlink/?linkid=14202", false)]
+        [System.ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated.", false)]
         public DataSysDescriptionAttribute(string description) { }
         public override string Description { get { throw null; } }
     }
@@ -1758,7 +1758,7 @@ namespace System.Data.Common
         [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Content)]
         public System.Data.Common.DataTableMappingCollection TableMappings { get { throw null; } }
         public event System.Data.FillErrorEventHandler? FillError { add { } remove { } }
-        [System.ObsoleteAttribute("CloneInternals() has been deprecated.  Use the DataAdapter(DataAdapter from) constructor.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("CloneInternals() has been deprecated.  Use the DataAdapter(DataAdapter from) constructor.")]
         protected virtual System.Data.Common.DataAdapter CloneInternals() { throw null; }
         protected virtual System.Data.Common.DataTableMappingCollection CreateTableMappings() { throw null; }
         protected override void Dispose(bool disposing) { }

--- a/src/libraries/System.Data.Common/ref/System.Data.Common.cs
+++ b/src/libraries/System.Data.Common/ref/System.Data.Common.cs
@@ -658,10 +658,10 @@ namespace System.Data
         Utc = 4,
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.All)]
-    [System.ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated and is no longer supported.", false)]
+    [System.ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated and is not supported.", false)]
     public partial class DataSysDescriptionAttribute : System.ComponentModel.DescriptionAttribute
     {
-        [System.ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated and is no longer supported.", false)]
+        [System.ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated and is not supported.", false)]
         public DataSysDescriptionAttribute(string description) { }
         public override string Description { get { throw null; } }
     }
@@ -3713,7 +3713,7 @@ namespace System.Data.SqlTypes
 }
 namespace System.Xml
 {
-    [System.ObsoleteAttribute("XmlDataDocument has been deprecated and is no longer supported.")]
+    [System.ObsoleteAttribute("XmlDataDocument has been deprecated and is not supported.")]
     public partial class XmlDataDocument : System.Xml.XmlDocument
     {
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("XmlDataDocument is used for serialization and deserialization. Members from serialized types may be trimmed if not referenced directly.")]

--- a/src/libraries/System.Data.Common/ref/System.Data.Common.cs
+++ b/src/libraries/System.Data.Common/ref/System.Data.Common.cs
@@ -658,10 +658,10 @@ namespace System.Data
         Utc = 4,
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.All)]
-    [System.ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated.", false)]
+    [System.ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated and is no longer supported.", false)]
     public partial class DataSysDescriptionAttribute : System.ComponentModel.DescriptionAttribute
     {
-        [System.ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated.", false)]
+        [System.ObsoleteAttribute("DataSysDescriptionAttribute has been deprecated and is no longer supported.", false)]
         public DataSysDescriptionAttribute(string description) { }
         public override string Description { get { throw null; } }
     }
@@ -1758,7 +1758,7 @@ namespace System.Data.Common
         [System.ComponentModel.DesignerSerializationVisibilityAttribute(System.ComponentModel.DesignerSerializationVisibility.Content)]
         public System.Data.Common.DataTableMappingCollection TableMappings { get { throw null; } }
         public event System.Data.FillErrorEventHandler? FillError { add { } remove { } }
-        [System.ObsoleteAttribute("CloneInternals() has been deprecated.  Use the DataAdapter(DataAdapter from) constructor.")]
+        [System.ObsoleteAttribute("CloneInternals() has been deprecated. Use the DataAdapter(DataAdapter from) constructor instead.")]
         protected virtual System.Data.Common.DataAdapter CloneInternals() { throw null; }
         protected virtual System.Data.Common.DataTableMappingCollection CreateTableMappings() { throw null; }
         protected override void Dispose(bool disposing) { }
@@ -3713,7 +3713,7 @@ namespace System.Data.SqlTypes
 }
 namespace System.Xml
 {
-    [System.ObsoleteAttribute("XmlDataDocument class will be removed in a future release.")]
+    [System.ObsoleteAttribute("XmlDataDocument has been deprecated and is no longer supported.")]
     public partial class XmlDataDocument : System.Xml.XmlDocument
     {
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("XmlDataDocument is used for serialization and deserialization. Members from serialized types may be trimmed if not referenced directly.")]

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DataAdapter.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DataAdapter.cs
@@ -201,7 +201,7 @@ namespace System.Data.Common
             }
         }
 
-        [Obsolete("CloneInternals() has been deprecated. Use the DataAdapter(DataAdapter from) constructor.")]
+        [Obsolete("CloneInternals() has been deprecated. Use the DataAdapter(DataAdapter from) constructor instead.")]
         protected virtual DataAdapter CloneInternals()
         {
             DataAdapter clone = (DataAdapter)Activator.CreateInstance(GetType())!;

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DataAdapter.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DataAdapter.cs
@@ -201,7 +201,7 @@ namespace System.Data.Common
             }
         }
 
-        [Obsolete("CloneInternals() has been deprecated.  Use the DataAdapter(DataAdapter from) constructor.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("CloneInternals() has been deprecated. Use the DataAdapter(DataAdapter from) constructor.")]
         protected virtual DataAdapter CloneInternals()
         {
             DataAdapter clone = (DataAdapter)Activator.CreateInstance(GetType())!;

--- a/src/libraries/System.Data.Common/src/System/Data/DataSysAttribute.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataSysAttribute.cs
@@ -11,7 +11,7 @@ namespace System.Data
     /// the member.
     /// </summary>
     [AttributeUsage(AttributeTargets.All)]
-    [Obsolete("DataSysDescriptionAttribute has been deprecated.  https://go.microsoft.com/fwlink/?linkid=14202", false)]
+    [Obsolete("DataSysDescriptionAttribute has been deprecated.", false)]
     public class DataSysDescriptionAttribute : DescriptionAttribute
     {
         private bool _replaced;
@@ -19,7 +19,7 @@ namespace System.Data
         /// <summary>
         /// Constructs a new sys description.
         /// </summary>
-        [Obsolete("DataSysDescriptionAttribute has been deprecated.  https://go.microsoft.com/fwlink/?linkid=14202", false)]
+        [Obsolete("DataSysDescriptionAttribute has been deprecated.", false)]
         public DataSysDescriptionAttribute(string description) : base(description)
         {
         }

--- a/src/libraries/System.Data.Common/src/System/Data/DataSysAttribute.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataSysAttribute.cs
@@ -11,7 +11,7 @@ namespace System.Data
     /// the member.
     /// </summary>
     [AttributeUsage(AttributeTargets.All)]
-    [Obsolete("DataSysDescriptionAttribute has been deprecated and is not supported.", false)]
+    [Obsolete("DataSysDescriptionAttribute has been deprecated and is not supported.")]
     public class DataSysDescriptionAttribute : DescriptionAttribute
     {
         private bool _replaced;
@@ -19,7 +19,7 @@ namespace System.Data
         /// <summary>
         /// Constructs a new sys description.
         /// </summary>
-        [Obsolete("DataSysDescriptionAttribute has been deprecated and is not supported.", false)]
+        [Obsolete("DataSysDescriptionAttribute has been deprecated and is not supported.")]
         public DataSysDescriptionAttribute(string description) : base(description)
         {
         }

--- a/src/libraries/System.Data.Common/src/System/Data/DataSysAttribute.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataSysAttribute.cs
@@ -11,7 +11,7 @@ namespace System.Data
     /// the member.
     /// </summary>
     [AttributeUsage(AttributeTargets.All)]
-    [Obsolete("DataSysDescriptionAttribute has been deprecated and is no longer supported.", false)]
+    [Obsolete("DataSysDescriptionAttribute has been deprecated and is not supported.", false)]
     public class DataSysDescriptionAttribute : DescriptionAttribute
     {
         private bool _replaced;
@@ -19,7 +19,7 @@ namespace System.Data
         /// <summary>
         /// Constructs a new sys description.
         /// </summary>
-        [Obsolete("DataSysDescriptionAttribute has been deprecated and is no longer supported.", false)]
+        [Obsolete("DataSysDescriptionAttribute has been deprecated and is not supported.", false)]
         public DataSysDescriptionAttribute(string description) : base(description)
         {
         }

--- a/src/libraries/System.Data.Common/src/System/Data/DataSysAttribute.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataSysAttribute.cs
@@ -11,7 +11,7 @@ namespace System.Data
     /// the member.
     /// </summary>
     [AttributeUsage(AttributeTargets.All)]
-    [Obsolete("DataSysDescriptionAttribute has been deprecated.", false)]
+    [Obsolete("DataSysDescriptionAttribute has been deprecated and is no longer supported.", false)]
     public class DataSysDescriptionAttribute : DescriptionAttribute
     {
         private bool _replaced;
@@ -19,7 +19,7 @@ namespace System.Data
         /// <summary>
         /// Constructs a new sys description.
         /// </summary>
-        [Obsolete("DataSysDescriptionAttribute has been deprecated.", false)]
+        [Obsolete("DataSysDescriptionAttribute has been deprecated and is no longer supported.", false)]
         public DataSysDescriptionAttribute(string description) : base(description)
         {
         }

--- a/src/libraries/System.Data.Common/src/System/Xml/XmlDataDocument.cs
+++ b/src/libraries/System.Data.Common/src/System/Xml/XmlDataDocument.cs
@@ -16,7 +16,7 @@ namespace System.Xml
     /// Represents an entire document. An XmlDataDocument can contain XML
     /// data or relational data (DataSet).
     /// </summary>
-    [Obsolete("XmlDataDocument class will be removed in a future release.")]
+    [Obsolete("XmlDataDocument has been deprecated and is no longer supported.")]
     public class XmlDataDocument : XmlDocument
     {
         private const string RequiresUnreferencedCodeMessage = "XmlDataDocument is used for serialization and deserialization. Members from serialized types may be trimmed if not referenced directly.";

--- a/src/libraries/System.Data.Common/src/System/Xml/XmlDataDocument.cs
+++ b/src/libraries/System.Data.Common/src/System/Xml/XmlDataDocument.cs
@@ -16,7 +16,7 @@ namespace System.Xml
     /// Represents an entire document. An XmlDataDocument can contain XML
     /// data or relational data (DataSet).
     /// </summary>
-    [Obsolete("XmlDataDocument has been deprecated and is no longer supported.")]
+    [Obsolete("XmlDataDocument has been deprecated and is not supported.")]
     public class XmlDataDocument : XmlDocument
     {
         private const string RequiresUnreferencedCodeMessage = "XmlDataDocument is used for serialization and deserialization. Members from serialized types may be trimmed if not referenced directly.";

--- a/src/libraries/System.Data.Odbc/ref/System.Data.Odbc.cs
+++ b/src/libraries/System.Data.Odbc/ref/System.Data.Odbc.cs
@@ -311,7 +311,7 @@ namespace System.Data.Odbc
         public System.Data.Odbc.OdbcParameter Add(string? parameterName, System.Data.Odbc.OdbcType odbcType, int size) { throw null; }
         public System.Data.Odbc.OdbcParameter Add(string? parameterName, System.Data.Odbc.OdbcType odbcType, int size, string? sourceColumn) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("Add(String parameterName, Object value) has been deprecated. Use AddWithValue(String parameterName, Object value) instead.", false)]
+        [System.ObsoleteAttribute("Add(String parameterName, Object value) has been deprecated. Use AddWithValue(String parameterName, Object value) instead.")]
         public System.Data.Odbc.OdbcParameter Add(string? parameterName, object? value) { throw null; }
         public override void AddRange(System.Array values) { }
         public void AddRange(System.Data.Odbc.OdbcParameter[] values) { }

--- a/src/libraries/System.Data.Odbc/ref/System.Data.Odbc.cs
+++ b/src/libraries/System.Data.Odbc/ref/System.Data.Odbc.cs
@@ -311,7 +311,7 @@ namespace System.Data.Odbc
         public System.Data.Odbc.OdbcParameter Add(string? parameterName, System.Data.Odbc.OdbcType odbcType, int size) { throw null; }
         public System.Data.Odbc.OdbcParameter Add(string? parameterName, System.Data.Odbc.OdbcType odbcType, int size, string? sourceColumn) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("Add(String parameterName, Object value) has been deprecated.  Use AddWithValue(String parameterName, Object value).  https://go.microsoft.com/fwlink/?linkid=14202", false)]
+        [System.ObsoleteAttribute("Add(String parameterName, Object value) has been deprecated. Use AddWithValue(String parameterName, Object value).", false)]
         public System.Data.Odbc.OdbcParameter Add(string? parameterName, object? value) { throw null; }
         public override void AddRange(System.Array values) { }
         public void AddRange(System.Data.Odbc.OdbcParameter[] values) { }

--- a/src/libraries/System.Data.Odbc/ref/System.Data.Odbc.cs
+++ b/src/libraries/System.Data.Odbc/ref/System.Data.Odbc.cs
@@ -311,7 +311,7 @@ namespace System.Data.Odbc
         public System.Data.Odbc.OdbcParameter Add(string? parameterName, System.Data.Odbc.OdbcType odbcType, int size) { throw null; }
         public System.Data.Odbc.OdbcParameter Add(string? parameterName, System.Data.Odbc.OdbcType odbcType, int size, string? sourceColumn) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("Add(String parameterName, Object value) has been deprecated. Use AddWithValue(String parameterName, Object value).", false)]
+        [System.ObsoleteAttribute("Add(String parameterName, Object value) has been deprecated. Use AddWithValue(String parameterName, Object value) instead.", false)]
         public System.Data.Odbc.OdbcParameter Add(string? parameterName, object? value) { throw null; }
         public override void AddRange(System.Array values) { }
         public void AddRange(System.Data.Odbc.OdbcParameter[] values) { }

--- a/src/libraries/System.Data.Odbc/src/System/Data/Odbc/OdbcParameterCollection.cs
+++ b/src/libraries/System.Data.Odbc/src/System/Data/Odbc/OdbcParameterCollection.cs
@@ -64,7 +64,7 @@ namespace System.Data.Odbc
         }
 
         [EditorBrowsableAttribute(EditorBrowsableState.Never)]
-        [ObsoleteAttribute("Add(String parameterName, Object value) has been deprecated. Use AddWithValue(String parameterName, Object value).", false)] // 79027
+        [ObsoleteAttribute("Add(String parameterName, Object value) has been deprecated. Use AddWithValue(String parameterName, Object value) instead.", false)] // 79027
         public OdbcParameter Add(string? parameterName, object? value)
         {
             // MDAC 59206

--- a/src/libraries/System.Data.Odbc/src/System/Data/Odbc/OdbcParameterCollection.cs
+++ b/src/libraries/System.Data.Odbc/src/System/Data/Odbc/OdbcParameterCollection.cs
@@ -64,7 +64,7 @@ namespace System.Data.Odbc
         }
 
         [EditorBrowsableAttribute(EditorBrowsableState.Never)]
-        [ObsoleteAttribute("Add(String parameterName, Object value) has been deprecated.  Use AddWithValue(String parameterName, Object value).  https://go.microsoft.com/fwlink/?linkid=14202", false)] // 79027
+        [ObsoleteAttribute("Add(String parameterName, Object value) has been deprecated. Use AddWithValue(String parameterName, Object value).", false)] // 79027
         public OdbcParameter Add(string? parameterName, object? value)
         {
             // MDAC 59206

--- a/src/libraries/System.Data.Odbc/src/System/Data/Odbc/OdbcParameterCollection.cs
+++ b/src/libraries/System.Data.Odbc/src/System/Data/Odbc/OdbcParameterCollection.cs
@@ -64,7 +64,7 @@ namespace System.Data.Odbc
         }
 
         [EditorBrowsableAttribute(EditorBrowsableState.Never)]
-        [ObsoleteAttribute("Add(String parameterName, Object value) has been deprecated. Use AddWithValue(String parameterName, Object value) instead.", false)] // 79027
+        [ObsoleteAttribute("Add(String parameterName, Object value) has been deprecated. Use AddWithValue(String parameterName, Object value) instead.")] // 79027
         public OdbcParameter Add(string? parameterName, object? value)
         {
             // MDAC 59206

--- a/src/libraries/System.Data.Odbc/src/System/Data/Odbc/OdbcParameterCollection.cs
+++ b/src/libraries/System.Data.Odbc/src/System/Data/Odbc/OdbcParameterCollection.cs
@@ -64,7 +64,7 @@ namespace System.Data.Odbc
         }
 
         [EditorBrowsableAttribute(EditorBrowsableState.Never)]
-        [ObsoleteAttribute("Add(String parameterName, Object value) has been deprecated. Use AddWithValue(String parameterName, Object value) instead.")] // 79027
+        [ObsoleteAttribute("Add(String parameterName, Object value) has been deprecated. Use AddWithValue(String parameterName, Object value) instead.")]
         public OdbcParameter Add(string? parameterName, object? value)
         {
             // MDAC 59206

--- a/src/libraries/System.Data.OleDb/src/OleDbParameterCollection.cs
+++ b/src/libraries/System.Data.OleDb/src/OleDbParameterCollection.cs
@@ -65,7 +65,7 @@ namespace System.Data.OleDb
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Add(String parameterName, Object value) has been deprecated.  Use AddWithValue(String parameterName, Object value).  https://go.microsoft.com/fwlink/?linkid=14202", false)]
+        [Obsolete("Add(String parameterName, Object value) has been deprecated. Use AddWithValue(String parameterName, Object value).", false)]
         public OleDbParameter Add(string? parameterName, object? value)
         {
             return Add(new OleDbParameter(parameterName, value));

--- a/src/libraries/System.Data.OleDb/src/OleDbParameterCollection.cs
+++ b/src/libraries/System.Data.OleDb/src/OleDbParameterCollection.cs
@@ -65,7 +65,7 @@ namespace System.Data.OleDb
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Add(String parameterName, Object value) has been deprecated. Use AddWithValue(String parameterName, Object value) instead.", false)]
+        [Obsolete("Add(String parameterName, Object value) has been deprecated. Use AddWithValue(String parameterName, Object value) instead.")]
         public OleDbParameter Add(string? parameterName, object? value)
         {
             return Add(new OleDbParameter(parameterName, value));

--- a/src/libraries/System.Data.OleDb/src/OleDbParameterCollection.cs
+++ b/src/libraries/System.Data.OleDb/src/OleDbParameterCollection.cs
@@ -65,7 +65,7 @@ namespace System.Data.OleDb
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Add(String parameterName, Object value) has been deprecated. Use AddWithValue(String parameterName, Object value).", false)]
+        [Obsolete("Add(String parameterName, Object value) has been deprecated. Use AddWithValue(String parameterName, Object value) instead.", false)]
         public OleDbParameter Add(string? parameterName, object? value)
         {
             return Add(new OleDbParameter(parameterName, value));

--- a/src/libraries/System.Diagnostics.EventLog/ref/System.Diagnostics.EventLog.cs
+++ b/src/libraries/System.Diagnostics.EventLog/ref/System.Diagnostics.EventLog.cs
@@ -64,7 +64,7 @@ namespace System.Diagnostics
         public void Close() { }
         public static void CreateEventSource(System.Diagnostics.EventSourceCreationData sourceData) { }
         public static void CreateEventSource(string source, string logName) { }
-        [System.ObsoleteAttribute("This method has been deprecated.  Please use System.Diagnostics.EventLog.CreateEventSource(EventSourceCreationData sourceData) instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("EventLog.CreateEventSource has been deprecated. Use System.Diagnostics.EventLog.CreateEventSource(EventSourceCreationData sourceData) instead.")]
         public static void CreateEventSource(string source, string logName, string machineName) { }
         public static void Delete(string logName) { }
         public static void Delete(string logName, string machineName) { }
@@ -105,7 +105,7 @@ namespace System.Diagnostics
         public short CategoryNumber { get { throw null; } }
         public byte[] Data { get { throw null; } }
         public System.Diagnostics.EventLogEntryType EntryType { get { throw null; } }
-        [System.ObsoleteAttribute("This property has been deprecated.  Please use System.Diagnostics.EventLogEntry.InstanceId instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("EventLogEntry.EventID has been deprecated. Use System.Diagnostics.EventLogEntry.InstanceId.")]
         public int EventID { get { throw null; } }
         public int Index { get { throw null; } }
         public long InstanceId { get { throw null; } }

--- a/src/libraries/System.Diagnostics.EventLog/ref/System.Diagnostics.EventLog.cs
+++ b/src/libraries/System.Diagnostics.EventLog/ref/System.Diagnostics.EventLog.cs
@@ -514,7 +514,7 @@ namespace System.Diagnostics.Eventing.Reader
         WdiDiagnostic = (long)1125899906842624,
         Sqm = (long)2251799813685248,
         AuditFailure = (long)4503599627370496,
-        [System.ObsoleteAttribute("StandardEventKeywords.CorrelationHint has an incorrect value and has been deprecated. Use CorrelationHint2 instead.", false)]
+        [System.ObsoleteAttribute("StandardEventKeywords.CorrelationHint has an incorrect value and has been deprecated. Use CorrelationHint2 instead.")]
         CorrelationHint = (long)4503599627370496,
         AuditSuccess = (long)9007199254740992,
         CorrelationHint2 = (long)18014398509481984,

--- a/src/libraries/System.Diagnostics.EventLog/ref/System.Diagnostics.EventLog.cs
+++ b/src/libraries/System.Diagnostics.EventLog/ref/System.Diagnostics.EventLog.cs
@@ -105,7 +105,7 @@ namespace System.Diagnostics
         public short CategoryNumber { get { throw null; } }
         public byte[] Data { get { throw null; } }
         public System.Diagnostics.EventLogEntryType EntryType { get { throw null; } }
-        [System.ObsoleteAttribute("EventLogEntry.EventID has been deprecated. Use System.Diagnostics.EventLogEntry.InstanceId.")]
+        [System.ObsoleteAttribute("EventLogEntry.EventID has been deprecated. Use System.Diagnostics.EventLogEntry.InstanceId instead.")]
         public int EventID { get { throw null; } }
         public int Index { get { throw null; } }
         public long InstanceId { get { throw null; } }
@@ -514,7 +514,7 @@ namespace System.Diagnostics.Eventing.Reader
         WdiDiagnostic = (long)1125899906842624,
         Sqm = (long)2251799813685248,
         AuditFailure = (long)4503599627370496,
-        [System.ObsoleteAttribute("Incorrect value: use CorrelationHint2 instead", false)]
+        [System.ObsoleteAttribute("StandardEventKeywords.CorrelationHint has an incorrect value and has been deprecated. Use CorrelationHint2 instead.", false)]
         CorrelationHint = (long)4503599627370496,
         AuditSuccess = (long)9007199254740992,
         CorrelationHint2 = (long)18014398509481984,

--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/EventLog.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/EventLog.cs
@@ -237,7 +237,7 @@ namespace System.Diagnostics
             CreateEventSource(new EventSourceCreationData(source, logName, "."));
         }
 
-        [Obsolete("This method has been deprecated.  Please use System.Diagnostics.EventLog.CreateEventSource(EventSourceCreationData sourceData) instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("EventLog.CreateEventSource has been deprecated. Use System.Diagnostics.EventLog.CreateEventSource(EventSourceCreationData sourceData).")]
         public static void CreateEventSource(string source, string logName, string machineName)
         {
             CreateEventSource(new EventSourceCreationData(source, logName, machineName));

--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/EventLog.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/EventLog.cs
@@ -237,7 +237,7 @@ namespace System.Diagnostics
             CreateEventSource(new EventSourceCreationData(source, logName, "."));
         }
 
-        [Obsolete("EventLog.CreateEventSource has been deprecated. Use System.Diagnostics.EventLog.CreateEventSource(EventSourceCreationData sourceData).")]
+        [Obsolete("EventLog.CreateEventSource has been deprecated. Use System.Diagnostics.EventLog.CreateEventSource(EventSourceCreationData sourceData) instead.")]
         public static void CreateEventSource(string source, string logName, string machineName)
         {
             CreateEventSource(new EventSourceCreationData(source, logName, machineName));

--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/EventLogEntry.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/EventLogEntry.cs
@@ -117,7 +117,7 @@ namespace System.Diagnostics
         /// <summary>
         /// The number identifying the message for this source.
         /// </summary>
-        [Obsolete("This property has been deprecated.  Please use System.Diagnostics.EventLogEntry.InstanceId instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("EventLogEntry.EventID has been deprecated. Use System.Diagnostics.EventLogEntry.InstanceId.")]
         public int EventID
         {
             get

--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/EventLogEntry.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/EventLogEntry.cs
@@ -117,7 +117,7 @@ namespace System.Diagnostics
         /// <summary>
         /// The number identifying the message for this source.
         /// </summary>
-        [Obsolete("EventLogEntry.EventID has been deprecated. Use System.Diagnostics.EventLogEntry.InstanceId.")]
+        [Obsolete("EventLogEntry.EventID has been deprecated. Use System.Diagnostics.EventLogEntry.InstanceId instead.")]
         public int EventID
         {
             get

--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/Winmeta.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/Winmeta.cs
@@ -135,7 +135,7 @@ namespace System.Diagnostics.Eventing.Reader
         /// <summary>
         /// Incorrect CorrelationHint value mistakenly shipped in .NET 3.5. Don't use: duplicates AuditFailure.
         /// </summary>
-        [Obsolete("StandardEventKeywords.CorrelationHint has an incorrect value. Use CorrelationHint2 instead.", false)]
+        [Obsolete("StandardEventKeywords.CorrelationHint has an incorrect value. Use CorrelationHint2 instead.")]
         CorrelationHint = 0x10000000000000,
         /// <summary>
         /// Transfer events where the related Activity ID is a computed value and not a GUID

--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/Winmeta.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/Winmeta.cs
@@ -135,7 +135,7 @@ namespace System.Diagnostics.Eventing.Reader
         /// <summary>
         /// Incorrect CorrelationHint value mistakenly shipped in .NET 3.5. Don't use: duplicates AuditFailure.
         /// </summary>
-        [Obsolete("Incorrect value: use CorrelationHint2 instead", false)]
+        [Obsolete("StandardEventKeywords.CorrelationHint has an incorrect value. Use CorrelationHint2 instead.", false)]
         CorrelationHint = 0x10000000000000,
         /// <summary>
         /// Transfer events where the related Activity ID is a computed value and not a GUID

--- a/src/libraries/System.Diagnostics.PerformanceCounter/ref/System.Diagnostics.PerformanceCounter.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/ref/System.Diagnostics.PerformanceCounter.cs
@@ -72,7 +72,7 @@ namespace System.Diagnostics
     }
     public partial class InstanceDataCollection : System.Collections.DictionaryBase
     {
-        [System.ObsoleteAttribute("This constructor has been deprecated.  Please use System.Diagnostics.InstanceDataCollectionCollection.get_Item to get an instance of this collection instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use System.Diagnostics.InstanceDataCollectionCollection.get_Item to get an instance of this collection.")]
         public InstanceDataCollection(string counterName) { }
         public string CounterName { get { throw null; } }
         public System.Diagnostics.InstanceData this[string instanceName] { get { throw null; } }
@@ -83,7 +83,7 @@ namespace System.Diagnostics
     }
     public partial class InstanceDataCollectionCollection : System.Collections.DictionaryBase
     {
-        [System.ObsoleteAttribute("This constructor has been deprecated.  Please use System.Diagnostics.PerformanceCounterCategory.ReadCategory() to get an instance of this collection instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use System.Diagnostics.PerformanceCounterCategory.ReadCategory() to get an instance of this collection.")]
         public InstanceDataCollectionCollection() { }
         public System.Diagnostics.InstanceDataCollection this[string counterName] { get { throw null; } }
         public System.Collections.ICollection Keys { get { throw null; } }
@@ -93,7 +93,7 @@ namespace System.Diagnostics
     }
     public sealed partial class PerformanceCounter : System.ComponentModel.Component, System.ComponentModel.ISupportInitialize
     {
-        [System.ObsoleteAttribute("This field has been deprecated and is not used.  Use machine.config or an application configuration file to set the size of the PerformanceCounter file mapping.")]
+        [System.ObsoleteAttribute("This field has been deprecated and is not used. Use machine.config or an application configuration file to set the size of the PerformanceCounter file mapping.")]
         public static int DefaultFileMappingSize;
         public PerformanceCounter() { }
         public PerformanceCounter(string categoryName, string counterName) { }
@@ -134,11 +134,11 @@ namespace System.Diagnostics
         public bool CounterExists(string counterName) { throw null; }
         public static bool CounterExists(string counterName, string categoryName) { throw null; }
         public static bool CounterExists(string counterName, string categoryName, string machineName) { throw null; }
-        [System.ObsoleteAttribute("This method has been deprecated.  Please use System.Diagnostics.PerformanceCounterCategory.Create(string categoryName, string categoryHelp, PerformanceCounterCategoryType categoryType, CounterCreationDataCollection counterData) instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("This overload of PerformanceCounterCategory.Create has been deprecated. Use System.Diagnostics.PerformanceCounterCategory.Create(string categoryName, string categoryHelp, PerformanceCounterCategoryType categoryType, CounterCreationDataCollection counterData).")]
         public static System.Diagnostics.PerformanceCounterCategory Create(string categoryName, string categoryHelp, System.Diagnostics.CounterCreationDataCollection counterData) { throw null; }
         public static System.Diagnostics.PerformanceCounterCategory Create(string categoryName, string categoryHelp, System.Diagnostics.PerformanceCounterCategoryType categoryType, System.Diagnostics.CounterCreationDataCollection counterData) { throw null; }
         public static System.Diagnostics.PerformanceCounterCategory Create(string categoryName, string categoryHelp, System.Diagnostics.PerformanceCounterCategoryType categoryType, string counterName, string counterHelp) { throw null; }
-        [System.ObsoleteAttribute("This method has been deprecated.  Please use System.Diagnostics.PerformanceCounterCategory.Create(string categoryName, string categoryHelp, PerformanceCounterCategoryType categoryType, string counterName, string counterHelp) instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("This overload of PerformanceCounterCategory.Create has been deprecated. Use System.Diagnostics.PerformanceCounterCategory.Create(string categoryName, string categoryHelp, PerformanceCounterCategoryType categoryType, string counterName, string counterHelp).")]
         public static System.Diagnostics.PerformanceCounterCategory Create(string categoryName, string categoryHelp, string counterName, string counterHelp) { throw null; }
         public static void Delete(string categoryName) { }
         public static bool Exists(string categoryName) { throw null; }
@@ -166,11 +166,11 @@ namespace System.Diagnostics
     }
     public sealed partial class PerformanceCounterManager : System.Diagnostics.ICollectData
     {
-        [System.ObsoleteAttribute("This class has been deprecated.  Use the PerformanceCounters through the System.Diagnostics.PerformanceCounter class instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("PerformanceCounterManager has been deprecated. Use the PerformanceCounters through the System.Diagnostics.PerformanceCounter class.")]
         public PerformanceCounterManager() { }
-        [System.ObsoleteAttribute("This class has been deprecated.  Use the PerformanceCounters through the System.Diagnostics.PerformanceCounter class instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("PerformanceCounterManager has been deprecated. Use the PerformanceCounters through the System.Diagnostics.PerformanceCounter class.")]
         void System.Diagnostics.ICollectData.CloseData() { }
-        [System.ObsoleteAttribute("This class has been deprecated.  Use the PerformanceCounters through the System.Diagnostics.PerformanceCounter class instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("PerformanceCounterManager has been deprecated. Use the PerformanceCounters through the System.Diagnostics.PerformanceCounter class.")]
         void System.Diagnostics.ICollectData.CollectData(int callIdx, System.IntPtr valueNamePtr, System.IntPtr dataPtr, int totalBytes, out System.IntPtr res) { throw null; }
     }
     public enum PerformanceCounterType

--- a/src/libraries/System.Diagnostics.PerformanceCounter/ref/System.Diagnostics.PerformanceCounter.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/ref/System.Diagnostics.PerformanceCounter.cs
@@ -72,7 +72,7 @@ namespace System.Diagnostics
     }
     public partial class InstanceDataCollection : System.Collections.DictionaryBase
     {
-        [System.ObsoleteAttribute("This constructor has been deprecated. Use System.Diagnostics.InstanceDataCollectionCollection.get_Item to get an instance of this collection.")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use System.Diagnostics.InstanceDataCollectionCollection.get_Item to get an instance of this collection instead.")]
         public InstanceDataCollection(string counterName) { }
         public string CounterName { get { throw null; } }
         public System.Diagnostics.InstanceData this[string instanceName] { get { throw null; } }
@@ -83,7 +83,7 @@ namespace System.Diagnostics
     }
     public partial class InstanceDataCollectionCollection : System.Collections.DictionaryBase
     {
-        [System.ObsoleteAttribute("This constructor has been deprecated. Use System.Diagnostics.PerformanceCounterCategory.ReadCategory() to get an instance of this collection.")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use System.Diagnostics.PerformanceCounterCategory.ReadCategory() to get an instance of this collection instead.")]
         public InstanceDataCollectionCollection() { }
         public System.Diagnostics.InstanceDataCollection this[string counterName] { get { throw null; } }
         public System.Collections.ICollection Keys { get { throw null; } }
@@ -93,7 +93,7 @@ namespace System.Diagnostics
     }
     public sealed partial class PerformanceCounter : System.ComponentModel.Component, System.ComponentModel.ISupportInitialize
     {
-        [System.ObsoleteAttribute("This field has been deprecated and is not used. Use machine.config or an application configuration file to set the size of the PerformanceCounter file mapping.")]
+        [System.ObsoleteAttribute("This field has been deprecated and is not used. Use machine.config or an application configuration file to set the size of the PerformanceCounter file mapping instead.")]
         public static int DefaultFileMappingSize;
         public PerformanceCounter() { }
         public PerformanceCounter(string categoryName, string counterName) { }
@@ -134,11 +134,11 @@ namespace System.Diagnostics
         public bool CounterExists(string counterName) { throw null; }
         public static bool CounterExists(string counterName, string categoryName) { throw null; }
         public static bool CounterExists(string counterName, string categoryName, string machineName) { throw null; }
-        [System.ObsoleteAttribute("This overload of PerformanceCounterCategory.Create has been deprecated. Use System.Diagnostics.PerformanceCounterCategory.Create(string categoryName, string categoryHelp, PerformanceCounterCategoryType categoryType, CounterCreationDataCollection counterData).")]
+        [System.ObsoleteAttribute("This overload of PerformanceCounterCategory.Create has been deprecated. Use System.Diagnostics.PerformanceCounterCategory.Create(string categoryName, string categoryHelp, PerformanceCounterCategoryType categoryType, CounterCreationDataCollection counterData) instead.")]
         public static System.Diagnostics.PerformanceCounterCategory Create(string categoryName, string categoryHelp, System.Diagnostics.CounterCreationDataCollection counterData) { throw null; }
         public static System.Diagnostics.PerformanceCounterCategory Create(string categoryName, string categoryHelp, System.Diagnostics.PerformanceCounterCategoryType categoryType, System.Diagnostics.CounterCreationDataCollection counterData) { throw null; }
         public static System.Diagnostics.PerformanceCounterCategory Create(string categoryName, string categoryHelp, System.Diagnostics.PerformanceCounterCategoryType categoryType, string counterName, string counterHelp) { throw null; }
-        [System.ObsoleteAttribute("This overload of PerformanceCounterCategory.Create has been deprecated. Use System.Diagnostics.PerformanceCounterCategory.Create(string categoryName, string categoryHelp, PerformanceCounterCategoryType categoryType, string counterName, string counterHelp).")]
+        [System.ObsoleteAttribute("This overload of PerformanceCounterCategory.Create has been deprecated. Use System.Diagnostics.PerformanceCounterCategory.Create(string categoryName, string categoryHelp, PerformanceCounterCategoryType categoryType, string counterName, string counterHelp) instead.")]
         public static System.Diagnostics.PerformanceCounterCategory Create(string categoryName, string categoryHelp, string counterName, string counterHelp) { throw null; }
         public static void Delete(string categoryName) { }
         public static bool Exists(string categoryName) { throw null; }
@@ -166,11 +166,11 @@ namespace System.Diagnostics
     }
     public sealed partial class PerformanceCounterManager : System.Diagnostics.ICollectData
     {
-        [System.ObsoleteAttribute("PerformanceCounterManager has been deprecated. Use the PerformanceCounters through the System.Diagnostics.PerformanceCounter class.")]
+        [System.ObsoleteAttribute("PerformanceCounterManager has been deprecated. Use the PerformanceCounters through the System.Diagnostics.PerformanceCounter class instead.")]
         public PerformanceCounterManager() { }
-        [System.ObsoleteAttribute("PerformanceCounterManager has been deprecated. Use the PerformanceCounters through the System.Diagnostics.PerformanceCounter class.")]
+        [System.ObsoleteAttribute("PerformanceCounterManager has been deprecated. Use the PerformanceCounters through the System.Diagnostics.PerformanceCounter class instead.")]
         void System.Diagnostics.ICollectData.CloseData() { }
-        [System.ObsoleteAttribute("PerformanceCounterManager has been deprecated. Use the PerformanceCounters through the System.Diagnostics.PerformanceCounter class.")]
+        [System.ObsoleteAttribute("PerformanceCounterManager has been deprecated. Use the PerformanceCounters through the System.Diagnostics.PerformanceCounter class instead.")]
         void System.Diagnostics.ICollectData.CollectData(int callIdx, System.IntPtr valueNamePtr, System.IntPtr dataPtr, int totalBytes, out System.IntPtr res) { throw null; }
     }
     public enum PerformanceCounterType

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/InstanceDataCollection.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/InstanceDataCollection.cs
@@ -14,7 +14,7 @@ namespace System.Diagnostics
     /// </summary>
     public class InstanceDataCollection : DictionaryBase
     {
-        [Obsolete("This constructor has been deprecated.  Please use System.Diagnostics.InstanceDataCollectionCollection.get_Item to get an instance of this collection instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("This constructor has been deprecated. Use System.Diagnostics.InstanceDataCollectionCollection.get_Item to get an instance of this collection.")]
         public InstanceDataCollection(string counterName)
         {
             if (counterName == null)

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/InstanceDataCollection.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/InstanceDataCollection.cs
@@ -14,7 +14,7 @@ namespace System.Diagnostics
     /// </summary>
     public class InstanceDataCollection : DictionaryBase
     {
-        [Obsolete("This constructor has been deprecated. Use System.Diagnostics.InstanceDataCollectionCollection.get_Item to get an instance of this collection.")]
+        [Obsolete("This constructor has been deprecated. Use System.Diagnostics.InstanceDataCollectionCollection.get_Item to get an instance of this collection instead.")]
         public InstanceDataCollection(string counterName)
         {
             if (counterName == null)

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/InstanceDataCollectionCollection.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/InstanceDataCollectionCollection.cs
@@ -15,7 +15,7 @@ namespace System.Diagnostics
     /// </summary>
     public class InstanceDataCollectionCollection : DictionaryBase
     {
-        [Obsolete("This constructor has been deprecated.  Please use System.Diagnostics.PerformanceCounterCategory.ReadCategory() to get an instance of this collection instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("This constructor has been deprecated. Use System.Diagnostics.PerformanceCounterCategory.ReadCategory() to get an instance of this collection.")]
         public InstanceDataCollectionCollection() : base() { }
 
         public InstanceDataCollection this[string counterName]

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/InstanceDataCollectionCollection.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/InstanceDataCollectionCollection.cs
@@ -15,7 +15,7 @@ namespace System.Diagnostics
     /// </summary>
     public class InstanceDataCollectionCollection : DictionaryBase
     {
-        [Obsolete("This constructor has been deprecated. Use System.Diagnostics.PerformanceCounterCategory.ReadCategory() to get an instance of this collection.")]
+        [Obsolete("This constructor has been deprecated. Use System.Diagnostics.PerformanceCounterCategory.ReadCategory() to get an instance of this collection instead.")]
         public InstanceDataCollectionCollection() : base() { }
 
         public InstanceDataCollection this[string counterName]

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounter.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounter.cs
@@ -35,7 +35,7 @@ namespace System.Diagnostics
         // Cached IP Shared Performanco counter
         private SharedPerformanceCounter _sharedCounter;
 
-        [ObsoleteAttribute("This field has been deprecated and is not used.  Use machine.config or an application configuration file to set the size of the PerformanceCounter file mapping.")]
+        [ObsoleteAttribute("PerformanceCounter.DefaultFileMappingSize has been deprecated and is not used. Use machine.config or an application configuration file to set the size of the PerformanceCounter file mapping instead.")]
         public static int DefaultFileMappingSize = 524288;
 
         private object _instanceLockObject;

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterCategory.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterCategory.cs
@@ -192,7 +192,7 @@ namespace System.Diagnostics
         /// <summary>
         ///     Registers one extensible performance category of type NumberOfItems32 with the system
         /// </summary>
-        [Obsolete("This overload of PerformanceCounterCategory.Create has been deprecated. Use System.Diagnostics.PerformanceCounterCategory.Create(string categoryName, string categoryHelp, PerformanceCounterCategoryType categoryType, string counterName, string counterHelp).")]
+        [Obsolete("This overload of PerformanceCounterCategory.Create has been deprecated. Use System.Diagnostics.PerformanceCounterCategory.Create(string categoryName, string categoryHelp, PerformanceCounterCategoryType categoryType, string counterName, string counterHelp) instead.")]
         public static PerformanceCounterCategory Create(string categoryName, string categoryHelp, string counterName, string counterHelp)
         {
             CounterCreationData customData = new CounterCreationData(counterName, counterHelp, PerformanceCounterType.NumberOfItems32);
@@ -208,7 +208,7 @@ namespace System.Diagnostics
         /// <summary>
         ///     Registers the extensible performance category with the system on the local machine
         /// </summary>
-        [Obsolete("This overload of PerformanceCounterCategory.Create has been deprecated. Use System.Diagnostics.PerformanceCounterCategory.Create(string categoryName, string categoryHelp, PerformanceCounterCategoryType categoryType, CounterCreationDataCollection counterData).")]
+        [Obsolete("This overload of PerformanceCounterCategory.Create has been deprecated. Use System.Diagnostics.PerformanceCounterCategory.Create(string categoryName, string categoryHelp, PerformanceCounterCategoryType categoryType, CounterCreationDataCollection counterData) instead.")]
         public static PerformanceCounterCategory Create(string categoryName, string categoryHelp, CounterCreationDataCollection counterData)
         {
             return Create(categoryName, categoryHelp, PerformanceCounterCategoryType.Unknown, counterData);

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterCategory.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterCategory.cs
@@ -192,7 +192,7 @@ namespace System.Diagnostics
         /// <summary>
         ///     Registers one extensible performance category of type NumberOfItems32 with the system
         /// </summary>
-        [Obsolete("This method has been deprecated.  Please use System.Diagnostics.PerformanceCounterCategory.Create(string categoryName, string categoryHelp, PerformanceCounterCategoryType categoryType, string counterName, string counterHelp) instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("This overload of PerformanceCounterCategory.Create has been deprecated. Use System.Diagnostics.PerformanceCounterCategory.Create(string categoryName, string categoryHelp, PerformanceCounterCategoryType categoryType, string counterName, string counterHelp).")]
         public static PerformanceCounterCategory Create(string categoryName, string categoryHelp, string counterName, string counterHelp)
         {
             CounterCreationData customData = new CounterCreationData(counterName, counterHelp, PerformanceCounterType.NumberOfItems32);
@@ -208,7 +208,7 @@ namespace System.Diagnostics
         /// <summary>
         ///     Registers the extensible performance category with the system on the local machine
         /// </summary>
-        [Obsolete("This method has been deprecated.  Please use System.Diagnostics.PerformanceCounterCategory.Create(string categoryName, string categoryHelp, PerformanceCounterCategoryType categoryType, CounterCreationDataCollection counterData) instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("This overload of PerformanceCounterCategory.Create has been deprecated. Use System.Diagnostics.PerformanceCounterCategory.Create(string categoryName, string categoryHelp, PerformanceCounterCategoryType categoryType, CounterCreationDataCollection counterData).")]
         public static PerformanceCounterCategory Create(string categoryName, string categoryHelp, CounterCreationDataCollection counterData)
         {
             return Create(categoryName, categoryHelp, PerformanceCounterCategoryType.Unknown, counterData);

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterManager.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterManager.cs
@@ -7,18 +7,18 @@ namespace System.Diagnostics
 {
     public sealed class PerformanceCounterManager : ICollectData
     {
-        [ObsoleteAttribute("PerformanceCounterManager has been deprecated. Use the PerformanceCounters through the System.Diagnostics.PerformanceCounter class.")]
+        [ObsoleteAttribute("PerformanceCounterManager has been deprecated. Use the PerformanceCounters through the System.Diagnostics.PerformanceCounter class instead.")]
         public PerformanceCounterManager()
         {
         }
 
-        [ObsoleteAttribute("PerformanceCounterManager has been deprecated. Use the PerformanceCounters through the System.Diagnostics.PerformanceCounter class.")]
+        [ObsoleteAttribute("PerformanceCounterManager has been deprecated. Use the PerformanceCounters through the System.Diagnostics.PerformanceCounter class instead.")]
         void ICollectData.CollectData(int callIdx, IntPtr valueNamePtr, IntPtr dataPtr, int totalBytes, out IntPtr res)
         {
             res = (IntPtr)(-1);
         }
 
-        [ObsoleteAttribute("PerformanceCounterManager has been deprecated. Use the PerformanceCounters through the System.Diagnostics.PerformanceCounter class.")]
+        [ObsoleteAttribute("PerformanceCounterManager has been deprecated. Use the PerformanceCounters through the System.Diagnostics.PerformanceCounter class instead.")]
         void ICollectData.CloseData()
         {
         }

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterManager.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterManager.cs
@@ -7,18 +7,18 @@ namespace System.Diagnostics
 {
     public sealed class PerformanceCounterManager : ICollectData
     {
-        [ObsoleteAttribute("This class has been deprecated.  Use the PerformanceCounters through the System.Diagnostics.PerformanceCounter class instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [ObsoleteAttribute("PerformanceCounterManager has been deprecated. Use the PerformanceCounters through the System.Diagnostics.PerformanceCounter class.")]
         public PerformanceCounterManager()
         {
         }
 
-        [ObsoleteAttribute("This class has been deprecated.  Use the PerformanceCounters through the System.Diagnostics.PerformanceCounter class instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [ObsoleteAttribute("PerformanceCounterManager has been deprecated. Use the PerformanceCounters through the System.Diagnostics.PerformanceCounter class.")]
         void ICollectData.CollectData(int callIdx, IntPtr valueNamePtr, IntPtr dataPtr, int totalBytes, out IntPtr res)
         {
             res = (IntPtr)(-1);
         }
 
-        [ObsoleteAttribute("This class has been deprecated.  Use the PerformanceCounters through the System.Diagnostics.PerformanceCounter class instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [ObsoleteAttribute("PerformanceCounterManager has been deprecated. Use the PerformanceCounters through the System.Diagnostics.PerformanceCounter class.")]
         void ICollectData.CloseData()
         {
         }

--- a/src/libraries/System.Diagnostics.Process/ref/System.Diagnostics.Process.cs
+++ b/src/libraries/System.Diagnostics.Process/ref/System.Diagnostics.Process.cs
@@ -46,27 +46,27 @@ namespace System.Diagnostics
         public System.IntPtr MaxWorkingSet { [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("ios"), System.Runtime.Versioning.UnsupportedOSPlatformAttribute("maccatalyst"), System.Runtime.Versioning.UnsupportedOSPlatformAttribute("tvos")] get { throw null; } [System.Runtime.Versioning.SupportedOSPlatformAttribute("freebsd"), System.Runtime.Versioning.SupportedOSPlatformAttribute("macos"), System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] set { } }
         public System.IntPtr MinWorkingSet { [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("ios"), System.Runtime.Versioning.UnsupportedOSPlatformAttribute("maccatalyst"), System.Runtime.Versioning.UnsupportedOSPlatformAttribute("tvos")] get { throw null; } [System.Runtime.Versioning.SupportedOSPlatformAttribute("freebsd"), System.Runtime.Versioning.SupportedOSPlatformAttribute("macos"), System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] set { } }
         public System.Diagnostics.ProcessModuleCollection Modules { get { throw null; } }
-        [System.ObsoleteAttribute("Process.NonpagedSystemMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.NonpagedSystemMemorySize64.")]
+        [System.ObsoleteAttribute("Process.NonpagedSystemMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.NonpagedSystemMemorySize64 instead.")]
         public int NonpagedSystemMemorySize { get { throw null; } }
         public long NonpagedSystemMemorySize64 { get { throw null; } }
-        [System.ObsoleteAttribute("Process.PagedMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PagedMemorySize64.")]
+        [System.ObsoleteAttribute("Process.PagedMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PagedMemorySize64 instead.")]
         public int PagedMemorySize { get { throw null; } }
         public long PagedMemorySize64 { get { throw null; } }
-        [System.ObsoleteAttribute("Process.PagedSystemMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PagedSystemMemorySize64.")]
+        [System.ObsoleteAttribute("Process.PagedSystemMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PagedSystemMemorySize64 instead.")]
         public int PagedSystemMemorySize { get { throw null; } }
         public long PagedSystemMemorySize64 { get { throw null; } }
-        [System.ObsoleteAttribute("Process.PeakPagedMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PeakPagedMemorySize64.")]
+        [System.ObsoleteAttribute("Process.PeakPagedMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PeakPagedMemorySize64 instead.")]
         public int PeakPagedMemorySize { get { throw null; } }
         public long PeakPagedMemorySize64 { get { throw null; } }
-        [System.ObsoleteAttribute("Process.PeakVirtualMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PeakVirtualMemorySize64.")]
+        [System.ObsoleteAttribute("Process.PeakVirtualMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PeakVirtualMemorySize64 instead.")]
         public int PeakVirtualMemorySize { get { throw null; } }
         public long PeakVirtualMemorySize64 { get { throw null; } }
-        [System.ObsoleteAttribute("Process.PeakWorkingSet has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PeakWorkingSet64.")]
+        [System.ObsoleteAttribute("Process.PeakWorkingSet has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PeakWorkingSet64 instead.")]
         public int PeakWorkingSet { get { throw null; } }
         public long PeakWorkingSet64 { get { throw null; } }
         public bool PriorityBoostEnabled { get { throw null; } set { } }
         public System.Diagnostics.ProcessPriorityClass PriorityClass { get { throw null; } set { } }
-        [System.ObsoleteAttribute("Process.PrivateMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PrivateMemorySize64.")]
+        [System.ObsoleteAttribute("Process.PrivateMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PrivateMemorySize64 instead.")]
         public int PrivateMemorySize { get { throw null; } }
         public long PrivateMemorySize64 { get { throw null; } }
         public System.TimeSpan PrivilegedProcessorTime { get { throw null; } }
@@ -84,10 +84,10 @@ namespace System.Diagnostics
         public System.Diagnostics.ProcessThreadCollection Threads { get { throw null; } }
         public System.TimeSpan TotalProcessorTime { get { throw null; } }
         public System.TimeSpan UserProcessorTime { get { throw null; } }
-        [System.ObsoleteAttribute("Process.VirtualMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.VirtualMemorySize64.")]
+        [System.ObsoleteAttribute("Process.VirtualMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.VirtualMemorySize64 instead.")]
         public int VirtualMemorySize { get { throw null; } }
         public long VirtualMemorySize64 { get { throw null; } }
-        [System.ObsoleteAttribute("Process.WorkingSet has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.WorkingSet64.")]
+        [System.ObsoleteAttribute("Process.WorkingSet has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.WorkingSet64 instead.")]
         public int WorkingSet { get { throw null; } }
         public long WorkingSet64 { get { throw null; } }
         public event System.Diagnostics.DataReceivedEventHandler? ErrorDataReceived { add { } remove { } }

--- a/src/libraries/System.Diagnostics.Process/ref/System.Diagnostics.Process.cs
+++ b/src/libraries/System.Diagnostics.Process/ref/System.Diagnostics.Process.cs
@@ -46,27 +46,27 @@ namespace System.Diagnostics
         public System.IntPtr MaxWorkingSet { [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("ios"), System.Runtime.Versioning.UnsupportedOSPlatformAttribute("maccatalyst"), System.Runtime.Versioning.UnsupportedOSPlatformAttribute("tvos")] get { throw null; } [System.Runtime.Versioning.SupportedOSPlatformAttribute("freebsd"), System.Runtime.Versioning.SupportedOSPlatformAttribute("macos"), System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] set { } }
         public System.IntPtr MinWorkingSet { [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("ios"), System.Runtime.Versioning.UnsupportedOSPlatformAttribute("maccatalyst"), System.Runtime.Versioning.UnsupportedOSPlatformAttribute("tvos")] get { throw null; } [System.Runtime.Versioning.SupportedOSPlatformAttribute("freebsd"), System.Runtime.Versioning.SupportedOSPlatformAttribute("macos"), System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")] set { } }
         public System.Diagnostics.ProcessModuleCollection Modules { get { throw null; } }
-        [System.ObsoleteAttribute("This property has been deprecated because the type of the property can't represent all valid results. Please use System.Diagnostics.Process.NonpagedSystemMemorySize64 instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Process.NonpagedSystemMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.NonpagedSystemMemorySize64.")]
         public int NonpagedSystemMemorySize { get { throw null; } }
         public long NonpagedSystemMemorySize64 { get { throw null; } }
-        [System.ObsoleteAttribute("This property has been deprecated because the type of the property can't represent all valid results. Please use System.Diagnostics.Process.PagedMemorySize64 instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Process.PagedMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PagedMemorySize64.")]
         public int PagedMemorySize { get { throw null; } }
         public long PagedMemorySize64 { get { throw null; } }
-        [System.ObsoleteAttribute("This property has been deprecated because the type of the property can't represent all valid results. Please use System.Diagnostics.Process.PagedSystemMemorySize64 instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Process.PagedSystemMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PagedSystemMemorySize64.")]
         public int PagedSystemMemorySize { get { throw null; } }
         public long PagedSystemMemorySize64 { get { throw null; } }
-        [System.ObsoleteAttribute("This property has been deprecated because the type of the property can't represent all valid results. Please use System.Diagnostics.Process.PeakPagedMemorySize64 instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Process.PeakPagedMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PeakPagedMemorySize64.")]
         public int PeakPagedMemorySize { get { throw null; } }
         public long PeakPagedMemorySize64 { get { throw null; } }
-        [System.ObsoleteAttribute("This property has been deprecated because the type of the property can't represent all valid results. Please use System.Diagnostics.Process.PeakVirtualMemorySize64 instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Process.PeakVirtualMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PeakVirtualMemorySize64.")]
         public int PeakVirtualMemorySize { get { throw null; } }
         public long PeakVirtualMemorySize64 { get { throw null; } }
-        [System.ObsoleteAttribute("This property has been deprecated because the type of the property can't represent all valid results. Please use System.Diagnostics.Process.PeakWorkingSet64 instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Process.PeakWorkingSet has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PeakWorkingSet64.")]
         public int PeakWorkingSet { get { throw null; } }
         public long PeakWorkingSet64 { get { throw null; } }
         public bool PriorityBoostEnabled { get { throw null; } set { } }
         public System.Diagnostics.ProcessPriorityClass PriorityClass { get { throw null; } set { } }
-        [System.ObsoleteAttribute("This property has been deprecated because the type of the property can't represent all valid results. Please use System.Diagnostics.Process.PrivateMemorySize64 instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Process.PrivateMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PrivateMemorySize64.")]
         public int PrivateMemorySize { get { throw null; } }
         public long PrivateMemorySize64 { get { throw null; } }
         public System.TimeSpan PrivilegedProcessorTime { get { throw null; } }
@@ -84,10 +84,10 @@ namespace System.Diagnostics
         public System.Diagnostics.ProcessThreadCollection Threads { get { throw null; } }
         public System.TimeSpan TotalProcessorTime { get { throw null; } }
         public System.TimeSpan UserProcessorTime { get { throw null; } }
-        [System.ObsoleteAttribute("This property has been deprecated because the type of the property can't represent all valid results. Please use System.Diagnostics.Process.VirtualMemorySize64 instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Process.VirtualMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.VirtualMemorySize64.")]
         public int VirtualMemorySize { get { throw null; } }
         public long VirtualMemorySize64 { get { throw null; } }
-        [System.ObsoleteAttribute("This property has been deprecated because the type of the property can't represent all valid results. Please use System.Diagnostics.Process.WorkingSet64 instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Process.WorkingSet has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.WorkingSet64.")]
         public int WorkingSet { get { throw null; } }
         public long WorkingSet64 { get { throw null; } }
         public event System.Diagnostics.DataReceivedEventHandler? ErrorDataReceived { add { } remove { } }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -322,7 +322,7 @@ namespace System.Diagnostics
             }
         }
 
-        [ObsoleteAttribute("This property has been deprecated because the type of the property can't represent all valid results. Please use System.Diagnostics.Process.NonpagedSystemMemorySize64 instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [ObsoleteAttribute("Process.NonpagedSystemMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.NonpagedSystemMemorySize64.")]
         public int NonpagedSystemMemorySize
         {
             get
@@ -342,7 +342,7 @@ namespace System.Diagnostics
             }
         }
 
-        [ObsoleteAttribute("This property has been deprecated because the type of the property can't represent all valid results. Please use System.Diagnostics.Process.PagedMemorySize64 instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [ObsoleteAttribute("Process.PagedMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PagedMemorySize64.")]
         public int PagedMemorySize
         {
             get
@@ -362,7 +362,7 @@ namespace System.Diagnostics
             }
         }
 
-        [ObsoleteAttribute("This property has been deprecated because the type of the property can't represent all valid results. Please use System.Diagnostics.Process.PagedSystemMemorySize64 instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [ObsoleteAttribute("Process.PagedSystemMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PagedSystemMemorySize64.")]
         public int PagedSystemMemorySize
         {
             get
@@ -382,7 +382,7 @@ namespace System.Diagnostics
             }
         }
 
-        [ObsoleteAttribute("This property has been deprecated because the type of the property can't represent all valid results. Please use System.Diagnostics.Process.PeakPagedMemorySize64 instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [ObsoleteAttribute("Process.PeakPagedMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PeakPagedMemorySize64.")]
         public int PeakPagedMemorySize
         {
             get
@@ -401,7 +401,7 @@ namespace System.Diagnostics
             }
         }
 
-        [ObsoleteAttribute("This property has been deprecated because the type of the property can't represent all valid results. Please use System.Diagnostics.Process.PeakWorkingSet64 instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [ObsoleteAttribute("Process.PeakWorkingSet has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PeakWorkingSet64.")]
         public int PeakWorkingSet
         {
             get
@@ -420,7 +420,7 @@ namespace System.Diagnostics
             }
         }
 
-        [ObsoleteAttribute("This property has been deprecated because the type of the property can't represent all valid results. Please use System.Diagnostics.Process.PeakVirtualMemorySize64 instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [ObsoleteAttribute("Process.PeakVirtualMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PeakVirtualMemorySize64.")]
         public int PeakVirtualMemorySize
         {
             get
@@ -495,7 +495,7 @@ namespace System.Diagnostics
             }
         }
 
-        [ObsoleteAttribute("This property has been deprecated because the type of the property can't represent all valid results. Please use System.Diagnostics.Process.PrivateMemorySize64 instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [ObsoleteAttribute("Process.PrivateMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PrivateMemorySize64.")]
         public int PrivateMemorySize
         {
             get
@@ -638,7 +638,7 @@ namespace System.Diagnostics
             }
         }
 
-        [ObsoleteAttribute("This property has been deprecated because the type of the property can't represent all valid results. Please use System.Diagnostics.Process.VirtualMemorySize64 instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [ObsoleteAttribute("Process.VirtualMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.VirtualMemorySize64.")]
         public int VirtualMemorySize
         {
             get
@@ -761,7 +761,7 @@ namespace System.Diagnostics
             }
         }
 
-        [ObsoleteAttribute("This property has been deprecated because the type of the property can't represent all valid results. Please use System.Diagnostics.Process.WorkingSet64 instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [ObsoleteAttribute("Process.WorkingSet has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.WorkingSet64.")]
         public int WorkingSet
         {
             get

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -322,7 +322,7 @@ namespace System.Diagnostics
             }
         }
 
-        [ObsoleteAttribute("Process.NonpagedSystemMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.NonpagedSystemMemorySize64.")]
+        [ObsoleteAttribute("Process.NonpagedSystemMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.NonpagedSystemMemorySize64 instead.")]
         public int NonpagedSystemMemorySize
         {
             get
@@ -342,7 +342,7 @@ namespace System.Diagnostics
             }
         }
 
-        [ObsoleteAttribute("Process.PagedMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PagedMemorySize64.")]
+        [ObsoleteAttribute("Process.PagedMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PagedMemorySize64 instead.")]
         public int PagedMemorySize
         {
             get
@@ -362,7 +362,7 @@ namespace System.Diagnostics
             }
         }
 
-        [ObsoleteAttribute("Process.PagedSystemMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PagedSystemMemorySize64.")]
+        [ObsoleteAttribute("Process.PagedSystemMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PagedSystemMemorySize64 instead.")]
         public int PagedSystemMemorySize
         {
             get
@@ -382,7 +382,7 @@ namespace System.Diagnostics
             }
         }
 
-        [ObsoleteAttribute("Process.PeakPagedMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PeakPagedMemorySize64.")]
+        [ObsoleteAttribute("Process.PeakPagedMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PeakPagedMemorySize64 instead.")]
         public int PeakPagedMemorySize
         {
             get
@@ -401,7 +401,7 @@ namespace System.Diagnostics
             }
         }
 
-        [ObsoleteAttribute("Process.PeakWorkingSet has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PeakWorkingSet64.")]
+        [ObsoleteAttribute("Process.PeakWorkingSet has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PeakWorkingSet64 instead.")]
         public int PeakWorkingSet
         {
             get
@@ -420,7 +420,7 @@ namespace System.Diagnostics
             }
         }
 
-        [ObsoleteAttribute("Process.PeakVirtualMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PeakVirtualMemorySize64.")]
+        [ObsoleteAttribute("Process.PeakVirtualMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PeakVirtualMemorySize64 instead.")]
         public int PeakVirtualMemorySize
         {
             get
@@ -495,7 +495,7 @@ namespace System.Diagnostics
             }
         }
 
-        [ObsoleteAttribute("Process.PrivateMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PrivateMemorySize64.")]
+        [ObsoleteAttribute("Process.PrivateMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.PrivateMemorySize64 instead.")]
         public int PrivateMemorySize
         {
             get
@@ -638,7 +638,7 @@ namespace System.Diagnostics
             }
         }
 
-        [ObsoleteAttribute("Process.VirtualMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.VirtualMemorySize64.")]
+        [ObsoleteAttribute("Process.VirtualMemorySize has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.VirtualMemorySize64 instead.")]
         public int VirtualMemorySize
         {
             get
@@ -761,7 +761,7 @@ namespace System.Diagnostics
             }
         }
 
-        [ObsoleteAttribute("Process.WorkingSet has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.WorkingSet64.")]
+        [ObsoleteAttribute("Process.WorkingSet has been deprecated because the type of the property can't represent all valid results. Use System.Diagnostics.Process.WorkingSet64 instead.")]
         public int WorkingSet
         {
             get

--- a/src/libraries/System.Diagnostics.StackTrace/ref/System.Diagnostics.StackTrace.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/ref/System.Diagnostics.StackTrace.cs
@@ -54,7 +54,7 @@ namespace System.Diagnostics.SymbolStore
 {
     public partial interface ISymbolBinder
     {
-        [System.ObsoleteAttribute("The recommended alternative is ISymbolBinder1.GetReader. ISymbolBinder1.GetReader takes the importer interface pointer as an IntPtr instead of an Int32, and thus works on both 32-bit and 64-bit architectures. https://go.microsoft.com/fwlink/?linkid=14202=14202")]
+        [System.ObsoleteAttribute("ISymbolBinder.GetReader is deprecated and not 64-bit compatible. The recommended alternative is ISymbolBinder1.GetReader. ISymbolBinder1.GetReader takes the importer interface pointer as an IntPtr instead of an Int32, and thus works on both 32-bit and 64-bit architectures.")]
         System.Diagnostics.SymbolStore.ISymbolReader? GetReader(int importer, string filename, string searchPath);
     }
     public partial interface ISymbolBinder1

--- a/src/libraries/System.Diagnostics.StackTrace/ref/System.Diagnostics.StackTrace.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/ref/System.Diagnostics.StackTrace.cs
@@ -54,7 +54,7 @@ namespace System.Diagnostics.SymbolStore
 {
     public partial interface ISymbolBinder
     {
-        [System.ObsoleteAttribute("ISymbolBinder.GetReader is deprecated and not 64-bit compatible. The recommended alternative is ISymbolBinder1.GetReader. ISymbolBinder1.GetReader takes the importer interface pointer as an IntPtr instead of an Int32, and thus works on both 32-bit and 64-bit architectures.")]
+        [System.ObsoleteAttribute("ISymbolBinder.GetReader has been deprecated because it is not 64-bit compatible. Use ISymbolBinder1.GetReader instead. ISymbolBinder1.GetReader accepts the importer interface pointer as an IntPtr instead of an Int32, and thus works on both 32-bit and 64-bit architectures.")]
         System.Diagnostics.SymbolStore.ISymbolReader? GetReader(int importer, string filename, string searchPath);
     }
     public partial interface ISymbolBinder1

--- a/src/libraries/System.Diagnostics.StackTrace/src/System/Diagnostics/SymbolStore/ISymbolBinder.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/src/System/Diagnostics/SymbolStore/ISymbolBinder.cs
@@ -7,7 +7,7 @@ namespace System.Diagnostics.SymbolStore
     {
         // The importer parameter should be an IntPtr, not an int. This interface can not be modified without
         // a breaking change, and so ISymbolBinderEx.GetReader() has been added with the correct marshalling layout.
-        [Obsolete("The recommended alternative is ISymbolBinder1.GetReader. ISymbolBinder1.GetReader takes the importer interface pointer as an IntPtr instead of an Int32, and thus works on both 32-bit and 64-bit architectures. https://go.microsoft.com/fwlink/?linkid=14202=14202")]
+        [Obsolete("ISymbolBinder.GetReader is deprecated and not 64-bit compatible. The recommended alternative is ISymbolBinder1.GetReader. ISymbolBinder1.GetReader takes the importer interface pointer as an IntPtr instead of an Int32, and thus works on both 32-bit and 64-bit architectures.")]
         ISymbolReader? GetReader(int importer, string filename, string searchPath);
     }
 

--- a/src/libraries/System.Diagnostics.StackTrace/src/System/Diagnostics/SymbolStore/ISymbolBinder.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/src/System/Diagnostics/SymbolStore/ISymbolBinder.cs
@@ -7,7 +7,7 @@ namespace System.Diagnostics.SymbolStore
     {
         // The importer parameter should be an IntPtr, not an int. This interface can not be modified without
         // a breaking change, and so ISymbolBinderEx.GetReader() has been added with the correct marshalling layout.
-        [Obsolete("ISymbolBinder.GetReader is deprecated and not 64-bit compatible. The recommended alternative is ISymbolBinder1.GetReader. ISymbolBinder1.GetReader takes the importer interface pointer as an IntPtr instead of an Int32, and thus works on both 32-bit and 64-bit architectures.")]
+        [Obsolete("ISymbolBinder.GetReader has been deprecated because it is not 64-bit compatible. Use ISymbolBinder1.GetReader instead. ISymbolBinder1.GetReader takes the importer interface pointer as an IntPtr instead of an Int32, and thus works on both 32-bit and 64-bit architectures.")]
         ISymbolReader? GetReader(int importer, string filename, string searchPath);
     }
 

--- a/src/libraries/System.Drawing.Common/ref/System.Drawing.Common.cs
+++ b/src/libraries/System.Drawing.Common/ref/System.Drawing.Common.cs
@@ -2184,7 +2184,7 @@ namespace System.Drawing.Imaging
         public EncoderParameter(System.Drawing.Imaging.Encoder encoder, short[] value) { }
         public EncoderParameter(System.Drawing.Imaging.Encoder encoder, int numberValues, System.Drawing.Imaging.EncoderParameterValueType type, System.IntPtr value) { }
         public EncoderParameter(System.Drawing.Imaging.Encoder encoder, int numerator, int denominator) { }
-        [System.ObsoleteAttribute("This constructor has been deprecated. Use EncoderParameter(Encoder encoder, int numberValues, EncoderParameterValueType type, IntPtr value) instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use EncoderParameter(Encoder encoder, int numberValues, EncoderParameterValueType type, IntPtr value).")]
         public EncoderParameter(System.Drawing.Imaging.Encoder encoder, int NumberOfValues, int Type, int Value) { }
         public EncoderParameter(System.Drawing.Imaging.Encoder encoder, int numerator1, int demoninator1, int numerator2, int demoninator2) { }
         public EncoderParameter(System.Drawing.Imaging.Encoder encoder, int[] numerator, int[] denominator) { }

--- a/src/libraries/System.Drawing.Common/ref/System.Drawing.Common.cs
+++ b/src/libraries/System.Drawing.Common/ref/System.Drawing.Common.cs
@@ -382,7 +382,7 @@ namespace System.Drawing
         public int GetCellAscent(System.Drawing.FontStyle style) { throw null; }
         public int GetCellDescent(System.Drawing.FontStyle style) { throw null; }
         public int GetEmHeight(System.Drawing.FontStyle style) { throw null; }
-        [System.ObsoleteAttribute("Do not use method GetFamilies, use property Families instead")]
+        [System.ObsoleteAttribute("FontFamily.GetFamilies has been deprecated. Use Families instead.")]
         public static System.Drawing.FontFamily[] GetFamilies(System.Drawing.Graphics graphics) { throw null; }
         public override int GetHashCode() { throw null; }
         public int GetLineSpacing(System.Drawing.FontStyle style) { throw null; }
@@ -2184,7 +2184,7 @@ namespace System.Drawing.Imaging
         public EncoderParameter(System.Drawing.Imaging.Encoder encoder, short[] value) { }
         public EncoderParameter(System.Drawing.Imaging.Encoder encoder, int numberValues, System.Drawing.Imaging.EncoderParameterValueType type, System.IntPtr value) { }
         public EncoderParameter(System.Drawing.Imaging.Encoder encoder, int numerator, int denominator) { }
-        [System.ObsoleteAttribute("This constructor has been deprecated. Use EncoderParameter(Encoder encoder, int numberValues, EncoderParameterValueType type, IntPtr value).")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use EncoderParameter(Encoder encoder, int numberValues, EncoderParameterValueType type, IntPtr value) instead.")]
         public EncoderParameter(System.Drawing.Imaging.Encoder encoder, int NumberOfValues, int Type, int Value) { }
         public EncoderParameter(System.Drawing.Imaging.Encoder encoder, int numerator1, int demoninator1, int numerator2, int demoninator2) { }
         public EncoderParameter(System.Drawing.Imaging.Encoder encoder, int[] numerator, int[] denominator) { }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/FontFamily.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/FontFamily.cs
@@ -225,7 +225,7 @@ namespace System.Drawing
         /// Returns an array that contains all of the <see cref='FontFamily'/> objects associated with the specified
         /// graphics context.
         /// </summary>
-        [Obsolete("Do not use method GetFamilies, use property Families instead")]
+        [Obsolete("FontFamily.GetFamilies has been deprecated. Use Families instead.")]
         public static FontFamily[] GetFamilies(Graphics graphics)
         {
             if (graphics == null)

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Imaging/EncoderParameter.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Imaging/EncoderParameter.cs
@@ -311,7 +311,7 @@ namespace System.Drawing.Imaging
             GC.KeepAlive(this);
         }
 
-        [Obsolete("This constructor has been deprecated. Use EncoderParameter(Encoder encoder, int numberValues, EncoderParameterValueType type, IntPtr value).")]
+        [Obsolete("This constructor has been deprecated. Use EncoderParameter(Encoder encoder, int numberValues, EncoderParameterValueType type, IntPtr value) instead.")]
         public EncoderParameter(Encoder encoder, int NumberOfValues, int Type, int Value)
         {
             int size;

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Imaging/EncoderParameter.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Imaging/EncoderParameter.cs
@@ -311,7 +311,7 @@ namespace System.Drawing.Imaging
             GC.KeepAlive(this);
         }
 
-        [Obsolete("This constructor has been deprecated. Use EncoderParameter(Encoder encoder, int numberValues, EncoderParameterValueType type, IntPtr value) instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("This constructor has been deprecated. Use EncoderParameter(Encoder encoder, int numberValues, EncoderParameterValueType type, IntPtr value).")]
         public EncoderParameter(Encoder encoder, int NumberOfValues, int Type, int Value)
         {
             int size;

--- a/src/libraries/System.IO.IsolatedStorage/ref/System.IO.IsolatedStorage.cs
+++ b/src/libraries/System.IO.IsolatedStorage/ref/System.IO.IsolatedStorage.cs
@@ -104,7 +104,7 @@ namespace System.IO.IsolatedStorage
         public override bool CanRead { get { throw null; } }
         public override bool CanSeek { get { throw null; } }
         public override bool CanWrite { get { throw null; } }
-        [System.ObsoleteAttribute("This property has been deprecated.  Please use IsolatedStorageFileStream's SafeFileHandle property instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("IsolatedStorageFileStream.Handle has been deprecated. Use IsolatedStorageFileStream's SafeFileHandle property.")]
         public override System.IntPtr Handle { get { throw null; } }
         public override bool IsAsync { get { throw null; } }
         public override long Length { get { throw null; } }

--- a/src/libraries/System.IO.IsolatedStorage/ref/System.IO.IsolatedStorage.cs
+++ b/src/libraries/System.IO.IsolatedStorage/ref/System.IO.IsolatedStorage.cs
@@ -17,11 +17,11 @@ namespace System.IO.IsolatedStorage
         public object AssemblyIdentity { get { throw null; } }
         public virtual long AvailableFreeSpace { get { throw null; } }
         [System.CLSCompliantAttribute(false)]
-        [System.ObsoleteAttribute("IsolatedStorage.CurrentSize has been deprecated because it is not CLS Compliant.  To get the current size use IsolatedStorage.UsedSize")]
+        [System.ObsoleteAttribute("IsolatedStorage.CurrentSize has been deprecated because it is not CLS Compliant. To get the current size use IsolatedStorage.UsedSize instead.")]
         public virtual ulong CurrentSize { get { throw null; } }
         public object DomainIdentity { get { throw null; } }
         [System.CLSCompliantAttribute(false)]
-        [System.ObsoleteAttribute("IsolatedStorage.MaximumSize has been deprecated because it is not CLS Compliant.  To get the maximum size use IsolatedStorage.Quota")]
+        [System.ObsoleteAttribute("IsolatedStorage.MaximumSize has been deprecated because it is not CLS Compliant. To get the maximum size use IsolatedStorage.Quota instead.")]
         public virtual ulong MaximumSize { get { throw null; } }
         public virtual long Quota { get { throw null; } }
         public System.IO.IsolatedStorage.IsolatedStorageScope Scope { get { throw null; } }
@@ -45,11 +45,11 @@ namespace System.IO.IsolatedStorage
         internal IsolatedStorageFile() { }
         public override long AvailableFreeSpace { get { throw null; } }
         [System.CLSCompliantAttribute(false)]
-        [System.ObsoleteAttribute("IsolatedStorageFile.CurrentSize has been deprecated because it is not CLS Compliant.  To get the current size use IsolatedStorageFile.UsedSize")]
+        [System.ObsoleteAttribute("IsolatedStorageFile.CurrentSize has been deprecated because it is not CLS Compliant. To get the current size use IsolatedStorageFile.UsedSize instead.")]
         public override ulong CurrentSize { get { throw null; } }
         public static bool IsEnabled { get { throw null; } }
         [System.CLSCompliantAttribute(false)]
-        [System.ObsoleteAttribute("IsolatedStorageFile.MaximumSize has been deprecated because it is not CLS Compliant.  To get the maximum size use IsolatedStorageFile.Quota")]
+        [System.ObsoleteAttribute("IsolatedStorageFile.MaximumSize has been deprecated because it is not CLS Compliant. To get the maximum size use IsolatedStorageFile.Quota instead.")]
         public override ulong MaximumSize { get { throw null; } }
         public override long Quota { get { throw null; } }
         public override long UsedSize { get { throw null; } }
@@ -104,7 +104,7 @@ namespace System.IO.IsolatedStorage
         public override bool CanRead { get { throw null; } }
         public override bool CanSeek { get { throw null; } }
         public override bool CanWrite { get { throw null; } }
-        [System.ObsoleteAttribute("IsolatedStorageFileStream.Handle has been deprecated. Use IsolatedStorageFileStream's SafeFileHandle property.")]
+        [System.ObsoleteAttribute("IsolatedStorageFileStream.Handle has been deprecated. Use IsolatedStorageFileStream's SafeFileHandle property instead.")]
         public override System.IntPtr Handle { get { throw null; } }
         public override bool IsAsync { get { throw null; } }
         public override long Length { get { throw null; } }

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorage.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorage.cs
@@ -50,7 +50,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [CLSCompliant(false)]
-        [Obsolete("IsolatedStorage.CurrentSize has been deprecated because it is not CLS Compliant.  To get the current size use IsolatedStorage.UsedSize")]
+        [Obsolete("IsolatedStorage.CurrentSize has been deprecated because it is not CLS Compliant. To get the current size use IsolatedStorage.UsedSize instead.")]
         public virtual ulong CurrentSize
         {
             get
@@ -76,7 +76,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [CLSCompliant(false)]
-        [Obsolete("IsolatedStorage.MaximumSize has been deprecated because it is not CLS Compliant.  To get the maximum size use IsolatedStorage.Quota")]
+        [Obsolete("IsolatedStorage.MaximumSize has been deprecated because it is not CLS Compliant. To get the maximum size use IsolatedStorage.Quota instead.")]
         public virtual ulong MaximumSize
         {
             get

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
@@ -542,7 +542,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [CLSCompliant(false)]
-        [Obsolete("IsolatedStorage.MaximumSize has been deprecated because it is not CLS Compliant.  To get the maximum size use IsolatedStorage.Quota")]
+        [Obsolete("IsolatedStorage.MaximumSize has been deprecated because it is not CLS Compliant. To get the maximum size use IsolatedStorage.Quota instead.")]
         public override ulong MaximumSize
         {
             get
@@ -568,7 +568,7 @@ namespace System.IO.IsolatedStorage
         }
 
         [CLSCompliant(false)]
-        [Obsolete("IsolatedStorage.CurrentSize has been deprecated because it is not CLS Compliant.  To get the current size use IsolatedStorage.UsedSize")]
+        [Obsolete("IsolatedStorage.CurrentSize has been deprecated because it is not CLS Compliant. To get the current size use IsolatedStorage.UsedSize instead.")]
         public override ulong CurrentSize
         {
             get

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFileStream.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFileStream.cs
@@ -322,7 +322,7 @@ namespace System.IO.IsolatedStorage
             _fs.EndWrite(asyncResult);
         }
 
-        [Obsolete("This property has been deprecated.  Please use IsolatedStorageFileStream's SafeFileHandle property instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("IsolatedStorageFileStream.Handle has been deprecated. Use IsolatedStorageFileStream's SafeFileHandle property.")]
         public override IntPtr Handle
         {
             get { return _fs.Handle; }

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFileStream.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFileStream.cs
@@ -322,7 +322,7 @@ namespace System.IO.IsolatedStorage
             _fs.EndWrite(asyncResult);
         }
 
-        [Obsolete("IsolatedStorageFileStream.Handle has been deprecated. Use IsolatedStorageFileStream's SafeFileHandle property.")]
+        [Obsolete("IsolatedStorageFileStream.Handle has been deprecated. Use IsolatedStorageFileStream's SafeFileHandle property instead.")]
         public override IntPtr Handle
         {
             get { return _fs.Handle; }

--- a/src/libraries/System.IO.Pipelines/ref/System.IO.Pipelines.cs
+++ b/src/libraries/System.IO.Pipelines/ref/System.IO.Pipelines.cs
@@ -51,7 +51,7 @@ namespace System.IO.Pipelines
         public virtual System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static System.IO.Pipelines.PipeReader Create(System.Buffers.ReadOnlySequence<byte> sequence) { throw null; }
         public static System.IO.Pipelines.PipeReader Create(System.IO.Stream stream, System.IO.Pipelines.StreamPipeReaderOptions? readerOptions = null) { throw null; }
-        [System.ObsoleteAttribute("OnWriterCompleted may not be invoked on all implementations of PipeReader. This will be removed in a future release.")]
+        [System.ObsoleteAttribute("OnWriterCompleted has been deprecated and may not be invoked on all implementations of PipeReader.")]
         public virtual void OnWriterCompleted(System.Action<System.Exception?, object?> callback, object? state) { }
         public abstract System.Threading.Tasks.ValueTask<System.IO.Pipelines.ReadResult> ReadAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         public System.Threading.Tasks.ValueTask<System.IO.Pipelines.ReadResult> ReadAtLeastAsync(int minimumSize, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -79,7 +79,7 @@ namespace System.IO.Pipelines
         public abstract System.Threading.Tasks.ValueTask<System.IO.Pipelines.FlushResult> FlushAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         public abstract System.Memory<byte> GetMemory(int sizeHint = 0);
         public abstract System.Span<byte> GetSpan(int sizeHint = 0);
-        [System.ObsoleteAttribute("OnReaderCompleted may not be invoked on all implementations of PipeWriter. This will be removed in a future release.")]
+        [System.ObsoleteAttribute("OnReaderCompleted has been deprecated and may not be invoked on all implementations of PipeWriter.")]
         public virtual void OnReaderCompleted(System.Action<System.Exception?, object?> callback, object? state) { }
         public virtual long UnflushedBytes => throw null;
         public virtual System.Threading.Tasks.ValueTask<System.IO.Pipelines.FlushResult> WriteAsync(System.ReadOnlyMemory<byte> source, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeReader.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeReader.cs
@@ -126,7 +126,7 @@ namespace System.IO.Pipelines
         /// > [!IMPORTANT]
         /// > `OnWriterCompleted` may not be invoked on all implementations of <xref:System.IO.Pipelines.PipeWriter>. This method will be removed in a future release.
         /// ]]></format></remarks>
-        [Obsolete("OnWriterCompleted may not be invoked on all implementations of PipeReader. This will be removed in a future release.")]
+        [Obsolete("OnWriterCompleted has been deprecated and may not be invoked on all implementations of PipeReader.")]
         public virtual void OnWriterCompleted(Action<Exception?, object?> callback, object? state)
         {
 

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeWriter.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeWriter.cs
@@ -47,7 +47,7 @@ namespace System.IO.Pipelines
         /// > [!IMPORTANT]
         /// > `OnReaderCompleted` may not be invoked on all implementations of <xref:System.IO.Pipelines.PipeWriter>. This method will be removed in a future release.
         /// ]]></format></remarks>
-        [Obsolete("OnReaderCompleted may not be invoked on all implementations of PipeWriter. This will be removed in a future release.")]
+        [Obsolete("OnReaderCompleted has been deprecated and may not be invoked on all implementations of PipeWriter.")]
         public virtual void OnReaderCompleted(Action<Exception?, object?> callback, object? state)
         {
 

--- a/src/libraries/System.Linq.Expressions/ref/System.Linq.Expressions.cs
+++ b/src/libraries/System.Linq.Expressions/ref/System.Linq.Expressions.cs
@@ -372,7 +372,7 @@ namespace System.Linq.Expressions
     public abstract partial class Expression
     {
         protected Expression() { }
-        [System.ObsoleteAttribute("use a different constructor that does not take ExpressionType. Then override NodeType and Type properties to provide the values that would be specified to this constructor.")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use a different constructor that does not take ExpressionType. Then override NodeType and Type properties to provide the values that would be specified to this constructor.")]
         protected Expression(System.Linq.Expressions.ExpressionType nodeType, System.Type type) { }
         public virtual bool CanReduce { get { throw null; } }
         public virtual System.Linq.Expressions.ExpressionType NodeType { get { throw null; } }
@@ -970,7 +970,7 @@ namespace System.Linq.Expressions
     }
     public abstract partial class MemberBinding
     {
-        [System.ObsoleteAttribute("Do not use this constructor. It will be removed in future releases.")]
+        [System.ObsoleteAttribute("This constructor has been deprecated and is not supported.")]
         protected MemberBinding(System.Linq.Expressions.MemberBindingType type, System.Reflection.MemberInfo member) { }
         public System.Linq.Expressions.MemberBindingType BindingType { get { throw null; } }
         public System.Reflection.MemberInfo Member { get { throw null; } }

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/ExpandoObject.cs
@@ -1152,7 +1152,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="ignoreCase">true if the name should be matched ignoring case; false otherwise.</param>
         /// <param name="value">The out parameter containing the value of the member.</param>
         /// <returns>True if the member exists in the expando object, otherwise false.</returns>
-        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("RuntimeOps has been deprecated and is not supported.", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static bool ExpandoTryGetValue(ExpandoObject expando, object? indexClass, int index, string name, bool ignoreCase, out object? value)
         {
             return expando.TryGetValue(indexClass, index, name, ignoreCase, out value);
@@ -1170,7 +1170,7 @@ namespace System.Runtime.CompilerServices
         /// <returns>
         /// Returns the index for the set member.
         /// </returns>
-        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("RuntimeOps has been deprecated and is not supported.", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static object? ExpandoTrySetValue(ExpandoObject expando, object? indexClass, int index, object? value, string name, bool ignoreCase)
         {
             expando.TrySetValue(indexClass, index, value, name, ignoreCase, false);
@@ -1186,7 +1186,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="name">The name of the member.</param>
         /// <param name="ignoreCase">true if the name should be matched ignoring case; false otherwise.</param>
         /// <returns>true if the item was successfully removed; otherwise, false.</returns>
-        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("RuntimeOps has been deprecated and is not supported.", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static bool ExpandoTryDeleteValue(ExpandoObject expando, object? indexClass, int index, string name, bool ignoreCase)
         {
             return expando.TryDeleteValue(indexClass, index, name, ignoreCase, ExpandoObject.Uninitialized);
@@ -1198,7 +1198,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="expando">The expando object.</param>
         /// <param name="version">The version to check.</param>
         /// <returns>true if the version is equal; otherwise, false.</returns>
-        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("RuntimeOps has been deprecated and is not supported.", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static bool ExpandoCheckVersion(ExpandoObject expando, object? version)
         {
             return expando.Class == version;
@@ -1210,7 +1210,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="expando">The expando object.</param>
         /// <param name="oldClass">The old class of the expando object.</param>
         /// <param name="newClass">The new class of the expando object.</param>
-        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("RuntimeOps has been deprecated and is not supported.", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static void ExpandoPromoteClass(ExpandoObject expando, object oldClass, object newClass)
         {
             expando.PromoteClass(oldClass, newClass);

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Expression.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Expression.cs
@@ -50,7 +50,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="nodeType">The <see ctype="ExpressionType"/> of the <see cref="Expression"/>.</param>
         /// <param name="type">The <see cref="Type"/> of the <see cref="Expression"/>.</param>
-        [Obsolete("use a different constructor that does not take ExpressionType. Then override NodeType and Type properties to provide the values that would be specified to this constructor.")]
+        [Obsolete("This constructor has been deprecated. Use a different constructor that does not take ExpressionType. Then override NodeType and Type properties to provide the values that would be specified to this constructor.")]
         protected Expression(ExpressionType nodeType, Type type)
         {
             // Can't enforce anything that V1 didn't

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/MemberBinding.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/MemberBinding.cs
@@ -34,7 +34,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="type">The type of member binding.</param>
         /// <param name="member">The field or property to be initialized.</param>
-        [Obsolete("Do not use this constructor. It will be removed in future releases.")]
+        [Obsolete("This constructor has been deprecated and is not supported.")]
         protected MemberBinding(MemberBindingType type, MemberInfo member)
         {
             BindingType = type;

--- a/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSiteOps.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSiteOps.cs
@@ -20,7 +20,7 @@ namespace System.Runtime.CompilerServices
         /// </summary>
         /// <typeparam name="T">The type of the delegate of the <see cref="CallSite"/>.</typeparam>
         /// <returns>The new call site.</returns>
-        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("CallSiteOps has been deprecated and is not supported.", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static CallSite<T> CreateMatchmaker<T>(CallSite<T> site) where T : class
         {
             var mm = site.CreateMatchMaker();
@@ -34,7 +34,7 @@ namespace System.Runtime.CompilerServices
         /// </summary>
         /// <param name="site">An instance of the dynamic call site.</param>
         /// <returns>true if rule does not need updating, false otherwise.</returns>
-        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("CallSiteOps has been deprecated and is not supported.", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static bool SetNotMatched(CallSite site)
         {
             var res = site._match;
@@ -47,7 +47,7 @@ namespace System.Runtime.CompilerServices
         /// </summary>
         /// <param name="site">An instance of the dynamic call site.</param>
         /// <returns>true if rule matched, false otherwise.</returns>
-        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("CallSiteOps has been deprecated and is not supported.", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static bool GetMatch(CallSite site)
         {
             return site._match;
@@ -57,7 +57,7 @@ namespace System.Runtime.CompilerServices
         /// Clears the match flag on the matchmaker call site.
         /// </summary>
         /// <param name="site">An instance of the dynamic call site.</param>
-        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("CallSiteOps has been deprecated and is not supported.", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static void ClearMatch(CallSite site)
         {
             site._match = true;
@@ -69,7 +69,7 @@ namespace System.Runtime.CompilerServices
         /// <typeparam name="T">The type of the delegate of the <see cref="CallSite"/>.</typeparam>
         /// <param name="site">An instance of the dynamic call site.</param>
         /// <param name="rule">An instance of the call site rule.</param>
-        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("CallSiteOps has been deprecated and is not supported.", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static void AddRule<T>(CallSite<T> site, T rule) where T : class
         {
             site.AddRule(rule);
@@ -81,7 +81,7 @@ namespace System.Runtime.CompilerServices
         /// <typeparam name="T">The type of the delegate of the <see cref="CallSite"/>.</typeparam>
         /// <param name="this">An instance of the dynamic call site.</param>
         /// <param name="matched">The matched rule index.</param>
-        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("CallSiteOps has been deprecated and is not supported.", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static void UpdateRules<T>(CallSite<T> @this, int matched) where T : class
         {
             if (matched > 1)
@@ -96,7 +96,7 @@ namespace System.Runtime.CompilerServices
         /// <typeparam name="T">The type of the delegate of the <see cref="CallSite"/>.</typeparam>
         /// <param name="site">An instance of the dynamic call site.</param>
         /// <returns>An array of dynamic binding rules.</returns>
-        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("CallSiteOps has been deprecated and is not supported.", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static T[]? GetRules<T>(CallSite<T> site) where T : class
         {
             return site.Rules;
@@ -108,7 +108,7 @@ namespace System.Runtime.CompilerServices
         /// <typeparam name="T">The type of the delegate of the <see cref="CallSite"/>.</typeparam>
         /// <param name="site">An instance of the dynamic call site.</param>
         /// <returns>The cache.</returns>
-        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("CallSiteOps has been deprecated and is not supported.", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static RuleCache<T> GetRuleCache<T>(CallSite<T> site) where T : class
         {
             return site.Binder!.GetRuleCache<T>();
@@ -121,7 +121,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="cache">The call site rule cache.</param>
         /// <param name="rule">An instance of the call site rule.</param>
         /// <param name="i">An index of the call site rule.</param>
-        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("CallSiteOps has been deprecated and is not supported.", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static void MoveRule<T>(RuleCache<T> cache, T rule, int i) where T : class
         {
             if (i > 1)
@@ -136,7 +136,7 @@ namespace System.Runtime.CompilerServices
         /// <typeparam name="T">The type of the delegate of the <see cref="CallSite"/>.</typeparam>
         /// <param name="cache">The cache.</param>
         /// <returns>The collection of applicable rules.</returns>
-        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("CallSiteOps has been deprecated and is not supported.", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static T[] GetCachedRules<T>(RuleCache<T> cache) where T : class
         {
             return cache.GetRules();
@@ -150,7 +150,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="site">An instance of the dynamic call site.</param>
         /// <param name="args">Arguments to the call site.</param>
         /// <returns>The new call site target.</returns>
-        [Obsolete("do not use this method", error: true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("CallSiteOps has been deprecated and is not supported.", error: true), EditorBrowsable(EditorBrowsableState.Never)]
         public static T Bind<T>(CallSiteBinder binder, CallSite<T> site, object[] args) where T : class
         {
             return binder.BindCore(site, args);

--- a/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/RuntimeOps.ExpressionQuoter.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/RuntimeOps.ExpressionQuoter.cs
@@ -21,7 +21,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="hoistedLocals">The hoisted local state provided by the compiler.</param>
         /// <param name="locals">The actual hoisted local values.</param>
         /// <returns>The quoted expression.</returns>
-        [Obsolete("do not use this method", true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("RuntimeOps has been deprecated and is not supported.", true), EditorBrowsable(EditorBrowsableState.Never)]
         [return: NotNullIfNotNull("expression")]
         public static Expression? Quote(Expression? expression, object hoistedLocals, object[] locals)
         {
@@ -37,7 +37,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="second">The second list.</param>
         /// <param name="indexes">The index array indicating which list to get variables from.</param>
         /// <returns>The merged runtime variables.</returns>
-        [Obsolete("do not use this method", true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("RuntimeOps has been deprecated and is not supported.", true), EditorBrowsable(EditorBrowsableState.Never)]
         public static IRuntimeVariables MergeRuntimeVariables(IRuntimeVariables first, IRuntimeVariables second, int[] indexes)
         {
             return new MergedRuntimeVariables(first, second, indexes);

--- a/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/RuntimeOps.RuntimeVariableList.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/RuntimeOps.RuntimeVariableList.cs
@@ -20,7 +20,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="data">The closure array.</param>
         /// <param name="indexes">An array of indexes into the closure array where variables are found.</param>
         /// <returns>An interface to access variables.</returns>
-        [Obsolete("do not use this method", true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("RuntimeOps has been deprecated and is not supported.", true), EditorBrowsable(EditorBrowsableState.Never)]
         public static IRuntimeVariables CreateRuntimeVariables(object[] data, long[] indexes)
         {
             return new RuntimeVariableList(data, indexes);
@@ -30,7 +30,7 @@ namespace System.Runtime.CompilerServices
         /// Creates an interface that can be used to modify closed over variables at runtime.
         /// </summary>
         /// <returns>An interface to access variables.</returns>
-        [Obsolete("do not use this method", true), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("RuntimeOps has been deprecated and is not supported.", true), EditorBrowsable(EditorBrowsableState.Never)]
         public static IRuntimeVariables CreateRuntimeVariables()
         {
             return new EmptyRuntimeVariables();

--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -308,7 +308,7 @@ namespace System.Net.Http
         public System.Net.Http.HttpContent? Content { get { throw null; } set { } }
         public System.Net.Http.Headers.HttpRequestHeaders Headers { get { throw null; } }
         public System.Net.Http.HttpMethod Method { get { throw null; } set { } }
-        [Obsolete("Use Options instead.")]
+        [Obsolete("HttpRequestMessage.Properties has been deprecated. Use Options instead.")]
         public System.Collections.Generic.IDictionary<string, object?> Properties { get { throw null; } }
         public HttpRequestOptions Options { get { throw null; } }
         public System.Uri? RequestUri { get { throw null; } set { } }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
@@ -112,7 +112,7 @@ namespace System.Net.Http
 
         internal bool HasHeaders => _headers != null;
 
-        [Obsolete("Use Options instead.")]
+        [Obsolete("HttpRequestMessage.Properties has been deprecated. Use Options instead.")]
         public IDictionary<string, object?> Properties => Options;
 
         public HttpRequestOptions Options => _options ??= new HttpRequestOptions();

--- a/src/libraries/System.Net.Mail/ref/System.Net.Mail.cs
+++ b/src/libraries/System.Net.Mail/ref/System.Net.Mail.cs
@@ -146,7 +146,7 @@ namespace System.Net.Mail
         public System.Text.Encoding? HeadersEncoding { get { throw null; } set { } }
         public bool IsBodyHtml { get { throw null; } set { } }
         public System.Net.Mail.MailPriority Priority { get { throw null; } set { } }
-        [System.ObsoleteAttribute("ReplyTo is deprecated. Use ReplyToList instead which can accept multiple addresses.")]
+        [System.ObsoleteAttribute("ReplyTo has been deprecated. Use ReplyToList instead, which can accept multiple addresses.")]
         public System.Net.Mail.MailAddress? ReplyTo { get { throw null; } set { } }
         public System.Net.Mail.MailAddressCollection ReplyToList { get { throw null; } }
         [System.Diagnostics.CodeAnalysis.DisallowNullAttribute]

--- a/src/libraries/System.Net.Mail/ref/System.Net.Mail.cs
+++ b/src/libraries/System.Net.Mail/ref/System.Net.Mail.cs
@@ -146,7 +146,7 @@ namespace System.Net.Mail
         public System.Text.Encoding? HeadersEncoding { get { throw null; } set { } }
         public bool IsBodyHtml { get { throw null; } set { } }
         public System.Net.Mail.MailPriority Priority { get { throw null; } set { } }
-        [System.ObsoleteAttribute("ReplyTo is obsoleted for this type.  Please use ReplyToList instead which can accept multiple addresses. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("ReplyTo is deprecated. Use ReplyToList instead which can accept multiple addresses.")]
         public System.Net.Mail.MailAddress? ReplyTo { get { throw null; } set { } }
         public System.Net.Mail.MailAddressCollection ReplyToList { get { throw null; } }
         [System.Diagnostics.CodeAnalysis.DisallowNullAttribute]

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/MailMessage.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/MailMessage.cs
@@ -102,7 +102,7 @@ namespace System.Net.Mail
             }
         }
 
-        [Obsolete("ReplyTo is deprecated. Use ReplyToList instead which can accept multiple addresses.")]
+        [Obsolete("ReplyTo has been deprecated. Use ReplyToList instead, which can accept multiple addresses.")]
         public MailAddress? ReplyTo
         {
             get

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/MailMessage.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/MailMessage.cs
@@ -102,7 +102,7 @@ namespace System.Net.Mail
             }
         }
 
-        [Obsolete("ReplyTo is obsoleted for this type.  Please use ReplyToList instead which can accept multiple addresses. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("ReplyTo is deprecated. Use ReplyToList instead which can accept multiple addresses.")]
         public MailAddress? ReplyTo
         {
             get

--- a/src/libraries/System.Net.NameResolution/ref/System.Net.NameResolution.cs
+++ b/src/libraries/System.Net.NameResolution/ref/System.Net.NameResolution.cs
@@ -9,28 +9,28 @@ namespace System.Net
     public static partial class Dns
     {
         public static System.IAsyncResult BeginGetHostAddresses(string hostNameOrAddress, System.AsyncCallback? requestCallback, object? state) { throw null; }
-        [System.ObsoleteAttribute("BeginGetHostByName is obsoleted for this type, please use BeginGetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("BeginGetHostByName has been deprecated. Use BeginGetHostEntry.")]
         public static System.IAsyncResult BeginGetHostByName(string hostName, System.AsyncCallback? requestCallback, object? stateObject) { throw null; }
         public static System.IAsyncResult BeginGetHostEntry(System.Net.IPAddress address, System.AsyncCallback? requestCallback, object? stateObject) { throw null; }
         public static System.IAsyncResult BeginGetHostEntry(string hostNameOrAddress, System.AsyncCallback? requestCallback, object? stateObject) { throw null; }
-        [System.ObsoleteAttribute("BeginResolve is obsoleted for this type, please use BeginGetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("BeginResolve has been deprecated. Use BeginGetHostEntry.")]
         public static System.IAsyncResult BeginResolve(string hostName, System.AsyncCallback? requestCallback, object? stateObject) { throw null; }
         public static System.Net.IPAddress[] EndGetHostAddresses(System.IAsyncResult asyncResult) { throw null; }
-        [System.ObsoleteAttribute("EndGetHostByName is obsoleted for this type, please use EndGetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("EndGetHostByName has been deprecated. Use EndGetHostEntry.")]
         public static System.Net.IPHostEntry EndGetHostByName(System.IAsyncResult asyncResult) { throw null; }
         public static System.Net.IPHostEntry EndGetHostEntry(System.IAsyncResult asyncResult) { throw null; }
-        [System.ObsoleteAttribute("EndResolve is obsoleted for this type, please use EndGetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("EndResolve has been deprecated. Use EndGetHostEntry.")]
         public static System.Net.IPHostEntry EndResolve(System.IAsyncResult asyncResult) { throw null; }
         public static System.Net.IPAddress[] GetHostAddresses(string hostNameOrAddress) { throw null; }
         public static System.Net.IPAddress[] GetHostAddresses(string hostNameOrAddress, System.Net.Sockets.AddressFamily family) { throw null; }
         public static System.Threading.Tasks.Task<System.Net.IPAddress[]> GetHostAddressesAsync(string hostNameOrAddress) { throw null; }
         public static System.Threading.Tasks.Task<System.Net.IPAddress[]> GetHostAddressesAsync(string hostNameOrAddress, System.Net.Sockets.AddressFamily family, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static System.Threading.Tasks.Task<System.Net.IPAddress[]> GetHostAddressesAsync(string hostNameOrAddress, System.Threading.CancellationToken cancellationToken) { throw null; }
-        [System.ObsoleteAttribute("GetHostByAddress is obsoleted for this type, please use GetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("GetHostByAddress has been deprecated. Use GetHostEntry.")]
         public static System.Net.IPHostEntry GetHostByAddress(System.Net.IPAddress address) { throw null; }
-        [System.ObsoleteAttribute("GetHostByAddress is obsoleted for this type, please use GetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("GetHostByAddress has been deprecated. Use GetHostEntry.")]
         public static System.Net.IPHostEntry GetHostByAddress(string address) { throw null; }
-        [System.ObsoleteAttribute("GetHostByName is obsoleted for this type, please use GetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("GetHostByName has been deprecated. Use GetHostEntry.")]
         public static System.Net.IPHostEntry GetHostByName(string hostName) { throw null; }
         public static System.Net.IPHostEntry GetHostEntry(System.Net.IPAddress address) { throw null; }
         public static System.Net.IPHostEntry GetHostEntry(string hostNameOrAddress) { throw null; }
@@ -40,7 +40,7 @@ namespace System.Net
         public static System.Threading.Tasks.Task<System.Net.IPHostEntry> GetHostEntryAsync(string hostNameOrAddress, System.Net.Sockets.AddressFamily family, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static System.Threading.Tasks.Task<System.Net.IPHostEntry> GetHostEntryAsync(string hostNameOrAddress, System.Threading.CancellationToken cancellationToken) { throw null; }
         public static string GetHostName() { throw null; }
-        [System.ObsoleteAttribute("Resolve is obsoleted for this type, please use GetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Resolve has been deprecated. Use GetHostEntry.")]
         public static System.Net.IPHostEntry Resolve(string hostName) { throw null; }
     }
     public partial class IPHostEntry

--- a/src/libraries/System.Net.NameResolution/ref/System.Net.NameResolution.cs
+++ b/src/libraries/System.Net.NameResolution/ref/System.Net.NameResolution.cs
@@ -9,28 +9,28 @@ namespace System.Net
     public static partial class Dns
     {
         public static System.IAsyncResult BeginGetHostAddresses(string hostNameOrAddress, System.AsyncCallback? requestCallback, object? state) { throw null; }
-        [System.ObsoleteAttribute("BeginGetHostByName has been deprecated. Use BeginGetHostEntry.")]
+        [System.ObsoleteAttribute("BeginGetHostByName has been deprecated. Use BeginGetHostEntry instead.")]
         public static System.IAsyncResult BeginGetHostByName(string hostName, System.AsyncCallback? requestCallback, object? stateObject) { throw null; }
         public static System.IAsyncResult BeginGetHostEntry(System.Net.IPAddress address, System.AsyncCallback? requestCallback, object? stateObject) { throw null; }
         public static System.IAsyncResult BeginGetHostEntry(string hostNameOrAddress, System.AsyncCallback? requestCallback, object? stateObject) { throw null; }
-        [System.ObsoleteAttribute("BeginResolve has been deprecated. Use BeginGetHostEntry.")]
+        [System.ObsoleteAttribute("BeginResolve has been deprecated. Use BeginGetHostEntry instead.")]
         public static System.IAsyncResult BeginResolve(string hostName, System.AsyncCallback? requestCallback, object? stateObject) { throw null; }
         public static System.Net.IPAddress[] EndGetHostAddresses(System.IAsyncResult asyncResult) { throw null; }
-        [System.ObsoleteAttribute("EndGetHostByName has been deprecated. Use EndGetHostEntry.")]
+        [System.ObsoleteAttribute("EndGetHostByName has been deprecated. Use EndGetHostEntry instead.")]
         public static System.Net.IPHostEntry EndGetHostByName(System.IAsyncResult asyncResult) { throw null; }
         public static System.Net.IPHostEntry EndGetHostEntry(System.IAsyncResult asyncResult) { throw null; }
-        [System.ObsoleteAttribute("EndResolve has been deprecated. Use EndGetHostEntry.")]
+        [System.ObsoleteAttribute("EndResolve has been deprecated. Use EndGetHostEntry instead.")]
         public static System.Net.IPHostEntry EndResolve(System.IAsyncResult asyncResult) { throw null; }
         public static System.Net.IPAddress[] GetHostAddresses(string hostNameOrAddress) { throw null; }
         public static System.Net.IPAddress[] GetHostAddresses(string hostNameOrAddress, System.Net.Sockets.AddressFamily family) { throw null; }
         public static System.Threading.Tasks.Task<System.Net.IPAddress[]> GetHostAddressesAsync(string hostNameOrAddress) { throw null; }
         public static System.Threading.Tasks.Task<System.Net.IPAddress[]> GetHostAddressesAsync(string hostNameOrAddress, System.Net.Sockets.AddressFamily family, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static System.Threading.Tasks.Task<System.Net.IPAddress[]> GetHostAddressesAsync(string hostNameOrAddress, System.Threading.CancellationToken cancellationToken) { throw null; }
-        [System.ObsoleteAttribute("GetHostByAddress has been deprecated. Use GetHostEntry.")]
+        [System.ObsoleteAttribute("GetHostByAddress has been deprecated. Use GetHostEntry instead.")]
         public static System.Net.IPHostEntry GetHostByAddress(System.Net.IPAddress address) { throw null; }
-        [System.ObsoleteAttribute("GetHostByAddress has been deprecated. Use GetHostEntry.")]
+        [System.ObsoleteAttribute("GetHostByAddress has been deprecated. Use GetHostEntry instead.")]
         public static System.Net.IPHostEntry GetHostByAddress(string address) { throw null; }
-        [System.ObsoleteAttribute("GetHostByName has been deprecated. Use GetHostEntry.")]
+        [System.ObsoleteAttribute("GetHostByName has been deprecated. Use GetHostEntry instead.")]
         public static System.Net.IPHostEntry GetHostByName(string hostName) { throw null; }
         public static System.Net.IPHostEntry GetHostEntry(System.Net.IPAddress address) { throw null; }
         public static System.Net.IPHostEntry GetHostEntry(string hostNameOrAddress) { throw null; }
@@ -40,7 +40,7 @@ namespace System.Net
         public static System.Threading.Tasks.Task<System.Net.IPHostEntry> GetHostEntryAsync(string hostNameOrAddress, System.Net.Sockets.AddressFamily family, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static System.Threading.Tasks.Task<System.Net.IPHostEntry> GetHostEntryAsync(string hostNameOrAddress, System.Threading.CancellationToken cancellationToken) { throw null; }
         public static string GetHostName() { throw null; }
-        [System.ObsoleteAttribute("Resolve has been deprecated. Use GetHostEntry.")]
+        [System.ObsoleteAttribute("Resolve has been deprecated. Use GetHostEntry instead.")]
         public static System.Net.IPHostEntry Resolve(string hostName) { throw null; }
     }
     public partial class IPHostEntry

--- a/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
@@ -255,7 +255,7 @@ namespace System.Net
         public static IPAddress[] EndGetHostAddresses(IAsyncResult asyncResult) =>
             TaskToApm.End<IPAddress[]>(asyncResult ?? throw new ArgumentNullException(nameof(asyncResult)));
 
-        [Obsolete("GetHostByName is obsoleted for this type, please use GetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("GetHostByName has been deprecated. Use GetHostEntry.")]
         public static IPHostEntry GetHostByName(string hostName)
         {
             if (hostName is null)
@@ -271,15 +271,15 @@ namespace System.Net
             return GetHostEntryCore(hostName, AddressFamily.Unspecified);
         }
 
-        [Obsolete("BeginGetHostByName is obsoleted for this type, please use BeginGetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("BeginGetHostByName has been deprecated. Use BeginGetHostEntry.")]
         public static IAsyncResult BeginGetHostByName(string hostName, AsyncCallback? requestCallback, object? stateObject) =>
             TaskToApm.Begin(GetHostEntryCoreAsync(hostName, justReturnParsedIp: true, throwOnIIPAny: true, AddressFamily.Unspecified, CancellationToken.None), requestCallback, stateObject);
 
-        [Obsolete("EndGetHostByName is obsoleted for this type, please use EndGetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("EndGetHostByName has been deprecated. Use EndGetHostEntry.")]
         public static IPHostEntry EndGetHostByName(IAsyncResult asyncResult) =>
             TaskToApm.End<IPHostEntry>(asyncResult ?? throw new ArgumentNullException(nameof(asyncResult)));
 
-        [Obsolete("GetHostByAddress is obsoleted for this type, please use GetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("GetHostByAddress has been deprecated. Use GetHostEntry.")]
         public static IPHostEntry GetHostByAddress(string address)
         {
             if (address is null)
@@ -293,7 +293,7 @@ namespace System.Net
             return ipHostEntry;
         }
 
-        [Obsolete("GetHostByAddress is obsoleted for this type, please use GetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("GetHostByAddress has been deprecated. Use GetHostEntry.")]
         public static IPHostEntry GetHostByAddress(IPAddress address)
         {
             if (address is null)
@@ -307,7 +307,7 @@ namespace System.Net
             return ipHostEntry;
         }
 
-        [Obsolete("Resolve is obsoleted for this type, please use GetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("Resolve has been deprecated. Use GetHostEntry.")]
         public static IPHostEntry Resolve(string hostName)
         {
             if (hostName is null)
@@ -339,11 +339,11 @@ namespace System.Net
             return ipHostEntry;
         }
 
-        [Obsolete("BeginResolve is obsoleted for this type, please use BeginGetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("BeginResolve has been deprecated. Use BeginGetHostEntry.")]
         public static IAsyncResult BeginResolve(string hostName, AsyncCallback? requestCallback, object? stateObject) =>
             TaskToApm.Begin(GetHostEntryCoreAsync(hostName, justReturnParsedIp: false, throwOnIIPAny: false, AddressFamily.Unspecified, CancellationToken.None), requestCallback, stateObject);
 
-        [Obsolete("EndResolve is obsoleted for this type, please use EndGetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("EndResolve has been deprecated. Use EndGetHostEntry.")]
         public static IPHostEntry EndResolve(IAsyncResult asyncResult)
         {
             IPHostEntry ipHostEntry;

--- a/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
@@ -255,7 +255,7 @@ namespace System.Net
         public static IPAddress[] EndGetHostAddresses(IAsyncResult asyncResult) =>
             TaskToApm.End<IPAddress[]>(asyncResult ?? throw new ArgumentNullException(nameof(asyncResult)));
 
-        [Obsolete("GetHostByName has been deprecated. Use GetHostEntry.")]
+        [Obsolete("GetHostByName has been deprecated. Use GetHostEntry instead.")]
         public static IPHostEntry GetHostByName(string hostName)
         {
             if (hostName is null)
@@ -271,15 +271,15 @@ namespace System.Net
             return GetHostEntryCore(hostName, AddressFamily.Unspecified);
         }
 
-        [Obsolete("BeginGetHostByName has been deprecated. Use BeginGetHostEntry.")]
+        [Obsolete("BeginGetHostByName has been deprecated. Use BeginGetHostEntry instead.")]
         public static IAsyncResult BeginGetHostByName(string hostName, AsyncCallback? requestCallback, object? stateObject) =>
             TaskToApm.Begin(GetHostEntryCoreAsync(hostName, justReturnParsedIp: true, throwOnIIPAny: true, AddressFamily.Unspecified, CancellationToken.None), requestCallback, stateObject);
 
-        [Obsolete("EndGetHostByName has been deprecated. Use EndGetHostEntry.")]
+        [Obsolete("EndGetHostByName has been deprecated. Use EndGetHostEntry instead.")]
         public static IPHostEntry EndGetHostByName(IAsyncResult asyncResult) =>
             TaskToApm.End<IPHostEntry>(asyncResult ?? throw new ArgumentNullException(nameof(asyncResult)));
 
-        [Obsolete("GetHostByAddress has been deprecated. Use GetHostEntry.")]
+        [Obsolete("GetHostByAddress has been deprecated. Use GetHostEntry instead.")]
         public static IPHostEntry GetHostByAddress(string address)
         {
             if (address is null)
@@ -293,7 +293,7 @@ namespace System.Net
             return ipHostEntry;
         }
 
-        [Obsolete("GetHostByAddress has been deprecated. Use GetHostEntry.")]
+        [Obsolete("GetHostByAddress has been deprecated. Use GetHostEntry instead.")]
         public static IPHostEntry GetHostByAddress(IPAddress address)
         {
             if (address is null)
@@ -307,7 +307,7 @@ namespace System.Net
             return ipHostEntry;
         }
 
-        [Obsolete("Resolve has been deprecated. Use GetHostEntry.")]
+        [Obsolete("Resolve has been deprecated. Use GetHostEntry instead.")]
         public static IPHostEntry Resolve(string hostName)
         {
             if (hostName is null)
@@ -339,11 +339,11 @@ namespace System.Net
             return ipHostEntry;
         }
 
-        [Obsolete("BeginResolve has been deprecated. Use BeginGetHostEntry.")]
+        [Obsolete("BeginResolve has been deprecated. Use BeginGetHostEntry instead.")]
         public static IAsyncResult BeginResolve(string hostName, AsyncCallback? requestCallback, object? stateObject) =>
             TaskToApm.Begin(GetHostEntryCoreAsync(hostName, justReturnParsedIp: false, throwOnIIPAny: false, AddressFamily.Unspecified, CancellationToken.None), requestCallback, stateObject);
 
-        [Obsolete("EndResolve has been deprecated. Use EndGetHostEntry.")]
+        [Obsolete("EndResolve has been deprecated. Use EndGetHostEntry instead.")]
         public static IPHostEntry EndResolve(IAsyncResult asyncResult)
         {
             IPHostEntry ipHostEntry;

--- a/src/libraries/System.Net.Primitives/ref/System.Net.Primitives.cs
+++ b/src/libraries/System.Net.Primitives/ref/System.Net.Primitives.cs
@@ -232,7 +232,7 @@ namespace System.Net
         public IPAddress(long newAddress) { }
         public IPAddress(System.ReadOnlySpan<byte> address) { }
         public IPAddress(System.ReadOnlySpan<byte> address, long scopeid) { }
-        [System.ObsoleteAttribute("This property has been deprecated. It is address family dependent. Please use IPAddress.Equals method to perform comparisons. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("IPAddress.Address is address family dependent and has been deprecated. Use IPAddress.Equals to perform comparisons.")]
         public long Address { get { throw null; } set { } }
         public System.Net.Sockets.AddressFamily AddressFamily { get { throw null; } }
         public bool IsIPv4MappedToIPv6 { get { throw null; } }
@@ -512,12 +512,12 @@ namespace System.Security.Authentication
     public enum SslProtocols
     {
         None = 0,
-        [System.ObsoleteAttribute("This value has been deprecated.  It is no longer supported. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("SslProtocols.Ssl2 has been deprecated and is no longer supported.")]
         Ssl2 = 12,
-        [System.ObsoleteAttribute("This value has been deprecated.  It is no longer supported. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("SslProtocols.Ssl3 has been deprecated and is no longer supported.")]
         Ssl3 = 48,
         Tls = 192,
-        [System.ObsoleteAttribute("This value has been deprecated.  It is no longer supported. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("SslProtocols.Default has been deprecated and is no longer supported.")]
         Default = 240,
         Tls11 = 768,
         Tls12 = 3072,

--- a/src/libraries/System.Net.Primitives/ref/System.Net.Primitives.cs
+++ b/src/libraries/System.Net.Primitives/ref/System.Net.Primitives.cs
@@ -512,12 +512,12 @@ namespace System.Security.Authentication
     public enum SslProtocols
     {
         None = 0,
-        [System.ObsoleteAttribute("SslProtocols.Ssl2 has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("SslProtocols.Ssl2 has been deprecated and is not supported.")]
         Ssl2 = 12,
-        [System.ObsoleteAttribute("SslProtocols.Ssl3 has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("SslProtocols.Ssl3 has been deprecated and is not supported.")]
         Ssl3 = 48,
         Tls = 192,
-        [System.ObsoleteAttribute("SslProtocols.Default has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("SslProtocols.Default has been deprecated and is not supported.")]
         Default = 240,
         Tls11 = 768,
         Tls12 = 3072,

--- a/src/libraries/System.Net.Primitives/src/System/Net/IPAddress.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/IPAddress.cs
@@ -511,7 +511,7 @@ namespace System.Net
             }
         }
 
-        [Obsolete("IPAddress.Address is address family dependent and has been deprecated. Use IPAddress.Equals to perform comparisons.")]
+        [Obsolete("IPAddress.Address is address family dependent and has been deprecated. Use IPAddress.Equals to perform comparisons instead.")]
         public long Address
         {
             get

--- a/src/libraries/System.Net.Primitives/src/System/Net/IPAddress.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/IPAddress.cs
@@ -511,7 +511,7 @@ namespace System.Net
             }
         }
 
-        [Obsolete("This property has been deprecated. It is address family dependent. Please use IPAddress.Equals method to perform comparisons. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("IPAddress.Address is address family dependent and has been deprecated. Use IPAddress.Equals to perform comparisons.")]
         public long Address
         {
             get

--- a/src/libraries/System.Net.Requests/ref/System.Net.Requests.cs
+++ b/src/libraries/System.Net.Requests/ref/System.Net.Requests.cs
@@ -33,7 +33,7 @@ namespace System.Net
     }
     public partial class FileWebRequest : System.Net.WebRequest, System.Runtime.Serialization.ISerializable
     {
-        [System.ObsoleteAttribute("Serialization is obsoleted for this type. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Serialization has been deprecated for FileWebRequest.")]
         protected FileWebRequest(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public override string? ConnectionGroupName { get { throw null; } set { } }
         public override long ContentLength { get { throw null; } set { } }
@@ -60,7 +60,7 @@ namespace System.Net
     }
     public partial class FileWebResponse : System.Net.WebResponse, System.Runtime.Serialization.ISerializable
     {
-        [System.ObsoleteAttribute("Serialization is obsoleted for this type. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Serialization has been deprecated for FileWebResponse")]
         protected FileWebResponse(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public override long ContentLength { get { throw null; } }
         public override string ContentType { get { throw null; } }
@@ -162,7 +162,7 @@ namespace System.Net
         public override void Close() { }
         public override System.IO.Stream GetResponseStream() { throw null; }
     }
-    [System.ObsoleteAttribute("This class has been deprecated. Please use WebRequest.DefaultWebProxy instead to access and set the global default proxy. Use 'null' instead of GetEmptyWebProxy. https://go.microsoft.com/fwlink/?linkid=14202")]
+    [System.ObsoleteAttribute("GlobalProxySelection has been deprecated. Use WebRequest.DefaultWebProxy instead to access and set the global default proxy. Use 'null' instead of GetEmptyWebProxy.")]
     public partial class GlobalProxySelection
     {
         public GlobalProxySelection() { }
@@ -173,7 +173,7 @@ namespace System.Net
     public delegate void HttpContinueDelegate(int StatusCode, System.Net.WebHeaderCollection httpHeaders);
     public partial class HttpWebRequest : System.Net.WebRequest, System.Runtime.Serialization.ISerializable
     {
-        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         protected HttpWebRequest(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public string? Accept { get { throw null; } set { } }
         public System.Uri Address { get { throw null; } }
@@ -234,12 +234,12 @@ namespace System.Net
         public override System.IO.Stream EndGetRequestStream(System.IAsyncResult asyncResult) { throw null; }
         public System.IO.Stream EndGetRequestStream(System.IAsyncResult asyncResult, out System.Net.TransportContext? context) { throw null; }
         public override System.Net.WebResponse EndGetResponse(System.IAsyncResult asyncResult) { throw null; }
-        [System.ObsoleteAttribute("Serialization is obsoleted for this type.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Serialization has been deprecated for HttpWebRequest.")]
         protected override void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public override System.IO.Stream GetRequestStream() { throw null; }
         public System.IO.Stream GetRequestStream(out System.Net.TransportContext? context) { throw null; }
         public override System.Net.WebResponse GetResponse() { throw null; }
-        [System.ObsoleteAttribute("Serialization is obsoleted for this type.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Serialization has been deprecated for HttpWebRequest.")]
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
     }
     public partial class HttpWebResponse : System.Net.WebResponse, System.Runtime.Serialization.ISerializable
@@ -247,7 +247,7 @@ namespace System.Net
         [System.ObsoleteAttribute("This API supports the .NET infrastructure and is not intended to be used directly from your code.", true)]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public HttpWebResponse() { }
-        [System.ObsoleteAttribute("Serialization is obsoleted for this type.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Serialization has been deprecated for HttpWebResponse.")]
         protected HttpWebResponse(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public string? CharacterSet { get { throw null; } }
         public string ContentEncoding { get { throw null; } }
@@ -266,11 +266,11 @@ namespace System.Net
         public override bool SupportsHeaders { get { throw null; } }
         public override void Close() { }
         protected override void Dispose(bool disposing) { }
-        [System.ObsoleteAttribute("Serialization is obsoleted for this type.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Serialization has been deprecated for HttpWebResponse.")]
         protected override void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public string GetResponseHeader(string headerName) { throw null; }
         public override System.IO.Stream GetResponseStream() { throw null; }
-        [System.ObsoleteAttribute("Serialization is obsoleted for this type.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Serialization has been deprecated for HttpWebResponse.")]
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
     }
     public partial interface IAuthenticationModule
@@ -335,9 +335,9 @@ namespace System.Net
     }
     public abstract partial class WebRequest : System.MarshalByRefObject, System.Runtime.Serialization.ISerializable
     {
-        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         protected WebRequest() { }
-        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         protected WebRequest(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public System.Net.Security.AuthenticationLevel AuthenticationLevel { get { throw null; } set { } }
         public virtual System.Net.Cache.RequestCachePolicy? CachePolicy { get { throw null; } set { } }
@@ -359,15 +359,15 @@ namespace System.Net
         public virtual void Abort() { }
         public virtual System.IAsyncResult BeginGetRequestStream(System.AsyncCallback? callback, object? state) { throw null; }
         public virtual System.IAsyncResult BeginGetResponse(System.AsyncCallback? callback, object? state) { throw null; }
-        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.Net.WebRequest Create(string requestUriString) { throw null; }
-        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.Net.WebRequest Create(System.Uri requestUri) { throw null; }
-        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.Net.WebRequest CreateDefault(System.Uri requestUri) { throw null; }
-        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.Net.HttpWebRequest CreateHttp(string requestUriString) { throw null; }
-        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.Net.HttpWebRequest CreateHttp(System.Uri requestUri) { throw null; }
         public virtual System.IO.Stream EndGetRequestStream(System.IAsyncResult asyncResult) { throw null; }
         public virtual System.Net.WebResponse EndGetResponse(System.IAsyncResult asyncResult) { throw null; }

--- a/src/libraries/System.Net.Requests/ref/System.Net.Requests.cs
+++ b/src/libraries/System.Net.Requests/ref/System.Net.Requests.cs
@@ -60,7 +60,7 @@ namespace System.Net
     }
     public partial class FileWebResponse : System.Net.WebResponse, System.Runtime.Serialization.ISerializable
     {
-        [System.ObsoleteAttribute("Serialization has been deprecated for FileWebResponse")]
+        [System.ObsoleteAttribute("Serialization has been deprecated for FileWebResponse.")]
         protected FileWebResponse(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public override long ContentLength { get { throw null; } }
         public override string ContentType { get { throw null; } }
@@ -173,7 +173,7 @@ namespace System.Net
     public delegate void HttpContinueDelegate(int StatusCode, System.Net.WebHeaderCollection httpHeaders);
     public partial class HttpWebRequest : System.Net.WebRequest, System.Runtime.Serialization.ISerializable
     {
-        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         protected HttpWebRequest(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public string? Accept { get { throw null; } set { } }
         public System.Uri Address { get { throw null; } }
@@ -335,9 +335,9 @@ namespace System.Net
     }
     public abstract partial class WebRequest : System.MarshalByRefObject, System.Runtime.Serialization.ISerializable
     {
-        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         protected WebRequest() { }
-        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         protected WebRequest(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public System.Net.Security.AuthenticationLevel AuthenticationLevel { get { throw null; } set { } }
         public virtual System.Net.Cache.RequestCachePolicy? CachePolicy { get { throw null; } set { } }
@@ -359,15 +359,15 @@ namespace System.Net
         public virtual void Abort() { }
         public virtual System.IAsyncResult BeginGetRequestStream(System.AsyncCallback? callback, object? state) { throw null; }
         public virtual System.IAsyncResult BeginGetResponse(System.AsyncCallback? callback, object? state) { throw null; }
-        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.Net.WebRequest Create(string requestUriString) { throw null; }
-        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.Net.WebRequest Create(System.Uri requestUri) { throw null; }
-        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.Net.WebRequest CreateDefault(System.Uri requestUri) { throw null; }
-        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.Net.HttpWebRequest CreateHttp(string requestUriString) { throw null; }
-        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.Net.HttpWebRequest CreateHttp(System.Uri requestUri) { throw null; }
         public virtual System.IO.Stream EndGetRequestStream(System.IAsyncResult asyncResult) { throw null; }
         public virtual System.Net.WebResponse EndGetResponse(System.IAsyncResult asyncResult) { throw null; }

--- a/src/libraries/System.Net.Requests/src/System/Net/FileWebRequest.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/FileWebRequest.cs
@@ -35,7 +35,7 @@ namespace System.Net
             _uri = uri;
         }
 
-        [Obsolete("Serialization has been deprecated for FileWebRequest")]
+        [Obsolete("Serialization has been deprecated for FileWebRequest.")]
         protected FileWebRequest(SerializationInfo serializationInfo, StreamingContext streamingContext) : base(serializationInfo, streamingContext)
         {
             throw new PlatformNotSupportedException();

--- a/src/libraries/System.Net.Requests/src/System/Net/FileWebRequest.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/FileWebRequest.cs
@@ -35,7 +35,7 @@ namespace System.Net
             _uri = uri;
         }
 
-        [Obsolete("Serialization is obsoleted for this type. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("Serialization has been deprecated for FileWebRequest")]
         protected FileWebRequest(SerializationInfo serializationInfo, StreamingContext streamingContext) : base(serializationInfo, streamingContext)
         {
             throw new PlatformNotSupportedException();

--- a/src/libraries/System.Net.Requests/src/System/Net/FileWebResponse.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/FileWebResponse.cs
@@ -45,7 +45,7 @@ namespace System.Net
             }
         }
 
-        [Obsolete("Serialization has been deprecated for FileWebResponse")]
+        [Obsolete("Serialization has been deprecated for FileWebResponse.")]
         protected FileWebResponse(SerializationInfo serializationInfo, StreamingContext streamingContext) : base(serializationInfo, streamingContext)
         {
             throw new PlatformNotSupportedException();

--- a/src/libraries/System.Net.Requests/src/System/Net/FileWebResponse.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/FileWebResponse.cs
@@ -45,7 +45,7 @@ namespace System.Net
             }
         }
 
-        [Obsolete("Serialization is obsoleted for this type. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("Serialization has been deprecated for FileWebResponse")]
         protected FileWebResponse(SerializationInfo serializationInfo, StreamingContext streamingContext) : base(serializationInfo, streamingContext)
         {
             throw new PlatformNotSupportedException();

--- a/src/libraries/System.Net.Requests/src/System/Net/GlobalProxySelection.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/GlobalProxySelection.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace System.Net
 {
-    [Obsolete("This class has been deprecated. Please use WebRequest.DefaultWebProxy instead to access and set the global default proxy. Use 'null' instead of GetEmptyWebProxy.")]
+    [Obsolete("GlobalProxySelection has been deprecated. Use WebRequest.DefaultWebProxy instead to access and set the global default proxy. Use 'null' instead of GetEmptyWebProxy.")]
     public class GlobalProxySelection
     {
         // This defers to WebRequest.DefaultWebProxy, but returns EmptyWebProxy instead of null.

--- a/src/libraries/System.Net.Requests/src/System/Net/GlobalProxySelection.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/GlobalProxySelection.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace System.Net
 {
-    [Obsolete("This class has been deprecated. Please use WebRequest.DefaultWebProxy instead to access and set the global default proxy. Use 'null' instead of GetEmptyWebProxy. https://go.microsoft.com/fwlink/?linkid=14202")]
+    [Obsolete("This class has been deprecated. Please use WebRequest.DefaultWebProxy instead to access and set the global default proxy. Use 'null' instead of GetEmptyWebProxy.")]
     public class GlobalProxySelection
     {
         // This defers to WebRequest.DefaultWebProxy, but returns EmptyWebProxy instead of null.

--- a/src/libraries/System.Net.Requests/src/System/Net/HttpWebResponse.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/HttpWebResponse.cs
@@ -34,7 +34,7 @@ namespace System.Net
             _cookies = null!;
         }
 
-        [ObsoleteAttribute("Serialization is obsoleted for this type.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [ObsoleteAttribute("Serialization has been deprecated for HttpWebResponse")]
         protected HttpWebResponse(SerializationInfo serializationInfo, StreamingContext streamingContext) : base(serializationInfo, streamingContext)
         {
             throw new PlatformNotSupportedException();

--- a/src/libraries/System.Net.Requests/src/System/Net/HttpWebResponse.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/HttpWebResponse.cs
@@ -34,7 +34,7 @@ namespace System.Net
             _cookies = null!;
         }
 
-        [ObsoleteAttribute("Serialization has been deprecated for HttpWebResponse")]
+        [ObsoleteAttribute("Serialization has been deprecated for HttpWebResponse.")]
         protected HttpWebResponse(SerializationInfo serializationInfo, StreamingContext streamingContext) : base(serializationInfo, streamingContext)
         {
             throw new PlatformNotSupportedException();

--- a/src/libraries/System.Net.ServicePoint/ref/System.Net.ServicePoint.cs
+++ b/src/libraries/System.Net.ServicePoint/ref/System.Net.ServicePoint.cs
@@ -57,11 +57,11 @@ namespace System.Net
         public static System.Net.SecurityProtocolType SecurityProtocol { get { throw null; } set { } }
         public static System.Net.Security.RemoteCertificateValidationCallback? ServerCertificateValidationCallback { get { throw null; } set { } }
         public static bool UseNagleAlgorithm { get { throw null; } set { } }
-        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.Net.ServicePoint FindServicePoint(string uriString, System.Net.IWebProxy? proxy) { throw null; }
-        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.Net.ServicePoint FindServicePoint(System.Uri address) { throw null; }
-        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.Net.ServicePoint FindServicePoint(System.Uri address, System.Net.IWebProxy? proxy) { throw null; }
         public static void SetTcpKeepAlive(bool enabled, int keepAliveTime, int keepAliveInterval) { }
     }

--- a/src/libraries/System.Net.ServicePoint/ref/System.Net.ServicePoint.cs
+++ b/src/libraries/System.Net.ServicePoint/ref/System.Net.ServicePoint.cs
@@ -11,7 +11,7 @@ namespace System.Net
     public enum SecurityProtocolType
     {
         SystemDefault = 0,
-        [System.ObsoleteAttribute("SecurityProtocolType.Ssl3 has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("SecurityProtocolType.Ssl3 has been deprecated and is not supported.")]
         Ssl3 = 48,
         Tls = 192,
         Tls11 = 768,

--- a/src/libraries/System.Net.ServicePoint/ref/System.Net.ServicePoint.cs
+++ b/src/libraries/System.Net.ServicePoint/ref/System.Net.ServicePoint.cs
@@ -11,7 +11,7 @@ namespace System.Net
     public enum SecurityProtocolType
     {
         SystemDefault = 0,
-        [System.ObsoleteAttribute("This value has been deprecated.  It is no longer supported. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("SecurityProtocolType.Ssl3 has been deprecated and is no longer supported.")]
         Ssl3 = 48,
         Tls = 192,
         Tls11 = 768,
@@ -57,11 +57,11 @@ namespace System.Net
         public static System.Net.SecurityProtocolType SecurityProtocol { get { throw null; } set { } }
         public static System.Net.Security.RemoteCertificateValidationCallback? ServerCertificateValidationCallback { get { throw null; } set { } }
         public static bool UseNagleAlgorithm { get { throw null; } set { } }
-        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.Net.ServicePoint FindServicePoint(string uriString, System.Net.IWebProxy? proxy) { throw null; }
-        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.Net.ServicePoint FindServicePoint(System.Uri address) { throw null; }
-        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient.", DiagnosticId = "SYSLIB0014", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.Net.ServicePoint FindServicePoint(System.Uri address, System.Net.IWebProxy? proxy) { throw null; }
         public static void SetTcpKeepAlive(bool enabled, int keepAliveTime, int keepAliveInterval) { }
     }

--- a/src/libraries/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/libraries/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -287,9 +287,9 @@ namespace System.Net.Sockets
         public int SendBufferSize { get { throw null; } set { } }
         public int SendTimeout { get { throw null; } set { } }
         public System.Net.Sockets.SocketType SocketType { get { throw null; } }
-        [System.ObsoleteAttribute("SupportsIPv4 has been deprecated. Use OSSupportsIPv4.")]
+        [System.ObsoleteAttribute("SupportsIPv4 has been deprecated. Use OSSupportsIPv4 instead.")]
         public static bool SupportsIPv4 { get { throw null; } }
-        [System.ObsoleteAttribute("SupportsIPv6 has been deprecated. Use OSSupportsIPv6.")]
+        [System.ObsoleteAttribute("SupportsIPv6 has been deprecated. Use OSSupportsIPv6 instead.")]
         public static bool SupportsIPv6 { get { throw null; } }
         public short Ttl { get { throw null; } set { } }
         [System.ObsoleteAttribute("UseOnlyOverlappedIO has been deprecated and is not supported.")]
@@ -509,7 +509,7 @@ namespace System.Net.Sockets
         NonBlocking = 1,
         Connected = 2,
         Listening = 4,
-        [System.ObsoleteAttribute("This flag has no effect in .NET 5+ and .NET Core.")]
+        [System.ObsoleteAttribute("SocketInformationOptions.UseOnlyOverlappedIO has been deprecated and is not supported.")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         UseOnlyOverlappedIO = 8,
     }
@@ -683,7 +683,7 @@ namespace System.Net.Sockets
     }
     public partial class TcpListener
     {
-        [System.ObsoleteAttribute("This constructor has been deprecated. Use TcpListener(IPAddress localaddr, int port).")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use TcpListener(IPAddress localaddr, int port) instead.")]
         public TcpListener(int port) { }
         public TcpListener(System.Net.IPAddress localaddr, int port) { }
         public TcpListener(System.Net.IPEndPoint localEP) { }

--- a/src/libraries/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/libraries/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -287,12 +287,12 @@ namespace System.Net.Sockets
         public int SendBufferSize { get { throw null; } set { } }
         public int SendTimeout { get { throw null; } set { } }
         public System.Net.Sockets.SocketType SocketType { get { throw null; } }
-        [System.ObsoleteAttribute("SupportsIPv4 is obsoleted for this type, please use OSSupportsIPv4 instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("SupportsIPv4 has been deprecated. Use OSSupportsIPv4.")]
         public static bool SupportsIPv4 { get { throw null; } }
-        [System.ObsoleteAttribute("SupportsIPv6 is obsoleted for this type, please use OSSupportsIPv6 instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("SupportsIPv6 has been deprecated. Use OSSupportsIPv6.")]
         public static bool SupportsIPv6 { get { throw null; } }
         public short Ttl { get { throw null; } set { } }
-        [System.ObsoleteAttribute("This property has no effect in .NET 5+ and .NET Core.")]
+        [System.ObsoleteAttribute("UseOnlyOverlappedIO has been deprecated and is not supported.")]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public bool UseOnlyOverlappedIO { get { throw null; } set { } }
         public System.Net.Sockets.Socket Accept() { throw null; }
@@ -683,7 +683,7 @@ namespace System.Net.Sockets
     }
     public partial class TcpListener
     {
-        [System.ObsoleteAttribute("This method has been deprecated. Please use TcpListener(IPAddress localaddr, int port) instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use TcpListener(IPAddress localaddr, int port).")]
         public TcpListener(int port) { }
         public TcpListener(System.Net.IPAddress localaddr, int port) { }
         public TcpListener(System.Net.IPEndPoint localEP) { }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -242,9 +242,9 @@ namespace System.Net.Sockets
 
         // The CLR allows configuration of these properties, separately from whether the OS supports IPv4/6.  We
         // do not provide these config options, so SupportsIPvX === OSSupportsIPvX.
-        [Obsolete("SupportsIPv4 is obsoleted for this type, please use OSSupportsIPv4 instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("SupportsIPv4 has been deprecated. Use OSSupportsIPv4.")]
         public static bool SupportsIPv4 => OSSupportsIPv4;
-        [Obsolete("SupportsIPv6 is obsoleted for this type, please use OSSupportsIPv6 instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("SupportsIPv6 has been deprecated. Use OSSupportsIPv6.")]
         public static bool SupportsIPv6 => OSSupportsIPv6;
 
         public static bool OSSupportsIPv4 => SocketProtocolSupportPal.OSSupportsIPv4;
@@ -414,7 +414,7 @@ namespace System.Net.Sockets
         // allowing calls to DuplicateAndClose() even after performing asynchronous IO.
         // .NET (Core) Windows sockets are entirely IOCP-based, and the concept of "overlapped IO"
         // does not exist on other platforms, therefore UseOnlyOverlappedIO is a dummy, compat-only property.
-        [Obsolete("This property has no effect in .NET 5+ and .NET Core.")]
+        [Obsolete("UseOnlyOverlappedIO has been deprecated and is not supported.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool UseOnlyOverlappedIO
         {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -242,9 +242,9 @@ namespace System.Net.Sockets
 
         // The CLR allows configuration of these properties, separately from whether the OS supports IPv4/6.  We
         // do not provide these config options, so SupportsIPvX === OSSupportsIPvX.
-        [Obsolete("SupportsIPv4 has been deprecated. Use OSSupportsIPv4.")]
+        [Obsolete("SupportsIPv4 has been deprecated. Use OSSupportsIPv4 instead.")]
         public static bool SupportsIPv4 => OSSupportsIPv4;
-        [Obsolete("SupportsIPv6 has been deprecated. Use OSSupportsIPv6.")]
+        [Obsolete("SupportsIPv6 has been deprecated. Use OSSupportsIPv6 instead.")]
         public static bool SupportsIPv6 => OSSupportsIPv6;
 
         public static bool OSSupportsIPv4 => SocketProtocolSupportPal.OSSupportsIPv4;

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketInformationOptions.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketInformationOptions.cs
@@ -13,7 +13,7 @@ namespace System.Net.Sockets
         //disconnect doesn't update getpeername to return a failure.
         Connected = 0x2,
         Listening = 0x4,
-        [Obsolete("This flag has no effect in .NET 5+ and .NET Core.")]
+        [Obsolete("SocketInformationOptions.UseOnlyOverlappedIO has been deprecated and is not supported.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         UseOnlyOverlappedIO = 0x8,
     }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
@@ -52,7 +52,7 @@ namespace System.Net.Sockets
         }
 
         // Initiailizes a new instance of the TcpListener class that listens on the specified port.
-        [Obsolete("This constructor has been deprecated. Use TcpListener(IPAddress localaddr, int port).")]
+        [Obsolete("This constructor has been deprecated. Use TcpListener(IPAddress localaddr, int port) instead.")]
         public TcpListener(int port)
         {
             if (!TcpValidationHelpers.ValidatePortNumber(port))

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
@@ -52,7 +52,7 @@ namespace System.Net.Sockets
         }
 
         // Initiailizes a new instance of the TcpListener class that listens on the specified port.
-        [Obsolete("This method has been deprecated. Please use TcpListener(IPAddress localaddr, int port) instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("This constructor has been deprecated. Use TcpListener(IPAddress localaddr, int port).")]
         public TcpListener(int port)
         {
             if (!TcpValidationHelpers.ValidatePortNumber(port))

--- a/src/libraries/System.Net.WebProxy/ref/System.Net.WebProxy.cs
+++ b/src/libraries/System.Net.WebProxy/ref/System.Net.WebProxy.cs
@@ -32,7 +32,7 @@ namespace System.Net
         public bool BypassProxyOnLocal { get { throw null; } set { } }
         public System.Net.ICredentials? Credentials { get { throw null; } set { } }
         public bool UseDefaultCredentials { get { throw null; } set { } }
-        [System.ObsoleteAttribute("This method has been deprecated. Please use the proxy selected for you by default. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("WebProxy.GetDefaultProxy has been deprecated. Use the proxy selected for you by default.")]
         public static System.Net.WebProxy GetDefaultProxy() { throw null; }
         protected virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public System.Uri? GetProxy(System.Uri destination) { throw null; }

--- a/src/libraries/System.Net.WebProxy/src/System/Net/WebProxy.cs
+++ b/src/libraries/System.Net.WebProxy/src/System/Net/WebProxy.cs
@@ -181,7 +181,7 @@ namespace System.Net
         protected virtual void GetObjectData(SerializationInfo serializationInfo, StreamingContext streamingContext) =>
             throw new PlatformNotSupportedException();
 
-        [Obsolete("This method has been deprecated. Please use the proxy selected for you by default. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("WebProxy.GetDefaultProxy has been deprecated. Use the proxy selected for you by default.")]
         public static WebProxy GetDefaultProxy() =>
             // The .NET Framework here returns a proxy that fetches IE settings and
             // executes JavaScript to determine the correct proxy.

--- a/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
@@ -46,7 +46,7 @@ namespace System
 
         public string? DynamicDirectory => null;
 
-        [Obsolete("AppDomain.SetDynamicBase has been deprecated and is no longer supported.")]
+        [Obsolete("AppDomain.SetDynamicBase has been deprecated and is not supported.")]
         public void SetDynamicBase(string? path) { }
 
         public string FriendlyName
@@ -216,22 +216,22 @@ namespace System
 
         public bool ShadowCopyFiles => false;
 
-        [Obsolete("AppDomain.AppendPrivatePath has been deprecated and is no longer supported.")]
+        [Obsolete("AppDomain.AppendPrivatePath has been deprecated and is not supported.")]
         public void AppendPrivatePath(string? path) { }
 
-        [Obsolete("AppDomain.ClearPrivatePath has been deprecated and is no longer supported.")]
+        [Obsolete("AppDomain.ClearPrivatePath has been deprecated and is not supported.")]
         public void ClearPrivatePath() { }
 
-        [Obsolete("AppDomain.ClearShadowCopyPath has been deprecated and is no longer supported.")]
+        [Obsolete("AppDomain.ClearShadowCopyPath has been deprecated and is not supported.")]
         public void ClearShadowCopyPath() { }
 
-        [Obsolete("AppDomain.SetCachePath has been deprecated and is no longer supported.")]
+        [Obsolete("AppDomain.SetCachePath has been deprecated and is not supported.")]
         public void SetCachePath(string? path) { }
 
-        [Obsolete("AppDomain.SetShadowCopyFiles has been deprecated and is no longer supported.")]
+        [Obsolete("AppDomain.SetShadowCopyFiles has been deprecated and is not supported.")]
         public void SetShadowCopyFiles() { }
 
-        [Obsolete("AppDomain.SetShadowCopyPath has been deprecated and is no longer supported.")]
+        [Obsolete("AppDomain.SetShadowCopyPath has been deprecated and is not supported.")]
         public void SetShadowCopyPath(string? path) { }
 
         public Assembly[] GetAssemblies() => AssemblyLoadContext.GetLoadedAssemblies();

--- a/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
@@ -211,7 +211,7 @@ namespace System
 
         public long MonitoringTotalAllocatedMemorySize => GC.GetTotalAllocatedBytes(precise: false);
 
-        [Obsolete("AppDomain.GetCurrentThreadId has been deprecated because it does not provide a stable Id when managed threads are running on fibers (aka lightweight threads). To get a stable identifier for a managed thread, use the ManagedThreadId property on Thread.", false)]
+        [Obsolete("AppDomain.GetCurrentThreadId has been deprecated because it does not provide a stable Id when managed threads are running on fibers (aka lightweight threads). To get a stable identifier for a managed thread, use the ManagedThreadId property on Thread instead.", false)]
         public static int GetCurrentThreadId() => Environment.CurrentManagedThreadId;
 
         public bool ShadowCopyFiles => false;

--- a/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
@@ -211,7 +211,7 @@ namespace System
 
         public long MonitoringTotalAllocatedMemorySize => GC.GetTotalAllocatedBytes(precise: false);
 
-        [Obsolete("AppDomain.GetCurrentThreadId has been deprecated because it does not provide a stable Id when managed threads are running on fibers (aka lightweight threads). To get a stable identifier for a managed thread, use the ManagedThreadId property on Thread instead.", false)]
+        [Obsolete("AppDomain.GetCurrentThreadId has been deprecated because it does not provide a stable Id when managed threads are running on fibers (aka lightweight threads). To get a stable identifier for a managed thread, use the ManagedThreadId property on Thread instead.")]
         public static int GetCurrentThreadId() => Environment.CurrentManagedThreadId;
 
         public bool ShadowCopyFiles => false;

--- a/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
@@ -46,7 +46,7 @@ namespace System
 
         public string? DynamicDirectory => null;
 
-        [Obsolete("AppDomain.SetDynamicBase has been deprecated. Please investigate the use of AppDomainSetup.DynamicBase instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("AppDomain.SetDynamicBase has been deprecated and is no longer supported.")]
         public void SetDynamicBase(string? path) { }
 
         public string FriendlyName
@@ -211,27 +211,27 @@ namespace System
 
         public long MonitoringTotalAllocatedMemorySize => GC.GetTotalAllocatedBytes(precise: false);
 
-        [Obsolete("AppDomain.GetCurrentThreadId has been deprecated because it does not provide a stable Id when managed threads are running on fibers (aka lightweight threads). To get a stable identifier for a managed thread, use the ManagedThreadId property on Thread.  https://go.microsoft.com/fwlink/?linkid=14202", false)]
+        [Obsolete("AppDomain.GetCurrentThreadId has been deprecated because it does not provide a stable Id when managed threads are running on fibers (aka lightweight threads). To get a stable identifier for a managed thread, use the ManagedThreadId property on Thread.", false)]
         public static int GetCurrentThreadId() => Environment.CurrentManagedThreadId;
 
         public bool ShadowCopyFiles => false;
 
-        [Obsolete("AppDomain.AppendPrivatePath has been deprecated. Please investigate the use of AppDomainSetup.PrivateBinPath instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("AppDomain.AppendPrivatePath has been deprecated and is no longer supported.")]
         public void AppendPrivatePath(string? path) { }
 
-        [Obsolete("AppDomain.ClearPrivatePath has been deprecated. Please investigate the use of AppDomainSetup.PrivateBinPath instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("AppDomain.ClearPrivatePath has been deprecated and is no longer supported.")]
         public void ClearPrivatePath() { }
 
-        [Obsolete("AppDomain.ClearShadowCopyPath has been deprecated. Please investigate the use of AppDomainSetup.ShadowCopyDirectories instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("AppDomain.ClearShadowCopyPath has been deprecated and is no longer supported.")]
         public void ClearShadowCopyPath() { }
 
-        [Obsolete("AppDomain.SetCachePath has been deprecated. Please investigate the use of AppDomainSetup.CachePath instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("AppDomain.SetCachePath has been deprecated and is no longer supported.")]
         public void SetCachePath(string? path) { }
 
-        [Obsolete("AppDomain.SetShadowCopyFiles has been deprecated. Please investigate the use of AppDomainSetup.ShadowCopyFiles instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("AppDomain.SetShadowCopyFiles has been deprecated and is no longer supported.")]
         public void SetShadowCopyFiles() { }
 
-        [Obsolete("AppDomain.SetShadowCopyPath has been deprecated. Please investigate the use of AppDomainSetup.ShadowCopyDirectories instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("AppDomain.SetShadowCopyPath has been deprecated and is no longer supported.")]
         public void SetShadowCopyPath(string? path) { }
 
         public Assembly[] GetAssemblies() => AssemblyLoadContext.GetLoadedAssemblies();

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Hashtable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Hashtable.cs
@@ -149,7 +149,7 @@ namespace System.Collections
 
         private IEqualityComparer? _keycomparer;
 
-        [Obsolete("Please use EqualityComparer property.")]
+        [Obsolete("Hashtable.hcp has been deprecated. Use the EqualityComparer property instead.")]
         protected IHashCodeProvider? hcp
         {
             get
@@ -184,7 +184,7 @@ namespace System.Collections
             }
         }
 
-        [Obsolete("Please use KeyComparer properties.")]
+        [Obsolete("Hashtable.comparer has been deprecated. Use the KeyComparer properties instead.")]
         protected IComparer? comparer
         {
             get
@@ -284,7 +284,7 @@ namespace System.Collections
             _keycomparer = equalityComparer;
         }
 
-        [Obsolete("Please use Hashtable(IEqualityComparer) instead.")]
+        [Obsolete("This constructor has been deprecated. Use Hashtable(IEqualityComparer) instead.")]
         public Hashtable(IHashCodeProvider? hcp, IComparer? comparer)
             : this(0, 1.0f, hcp, comparer)
         {
@@ -294,7 +294,7 @@ namespace System.Collections
         {
         }
 
-        [Obsolete("Please use Hashtable(int, IEqualityComparer) instead.")]
+        [Obsolete("This constructor has been deprecated. Use Hashtable(int, IEqualityComparer) instead.")]
         public Hashtable(int capacity, IHashCodeProvider? hcp, IComparer? comparer)
             : this(capacity, 1.0f, hcp, comparer)
         {
@@ -320,7 +320,7 @@ namespace System.Collections
         {
         }
 
-        [Obsolete("Please use Hashtable(IDictionary, IEqualityComparer) instead.")]
+        [Obsolete("This constructor has been deprecated. Use Hashtable(IDictionary, IEqualityComparer) instead.")]
         public Hashtable(IDictionary d, IHashCodeProvider? hcp, IComparer? comparer)
             : this(d, 1.0f, hcp, comparer)
         {
@@ -331,7 +331,7 @@ namespace System.Collections
         {
         }
 
-        [Obsolete("Please use Hashtable(int, float, IEqualityComparer) instead.")]
+        [Obsolete("This constructor has been deprecated. Use Hashtable(int, float, IEqualityComparer) instead.")]
         public Hashtable(int capacity, float loadFactor, IHashCodeProvider? hcp, IComparer? comparer)
             : this(capacity, loadFactor)
         {
@@ -341,7 +341,7 @@ namespace System.Collections
             }
         }
 
-        [Obsolete("Please use Hashtable(IDictionary, float, IEqualityComparer) instead.")]
+        [Obsolete("This constructor has been deprecated. Use Hashtable(IDictionary, float, IEqualityComparer) instead.")]
         public Hashtable(IDictionary d, float loadFactor, IHashCodeProvider? hcp, IComparer? comparer)
             : this(d != null ? d.Count : 0, loadFactor, hcp, comparer)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/IHashCodeProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/IHashCodeProvider.cs
@@ -7,7 +7,7 @@ namespace System.Collections
     /// Provides a mechanism for a <see cref="Hashtable"/> user to override the default
     /// GetHashCode() function on Objects, providing their own hash function.
     /// </summary>
-    [Obsolete("Please use IEqualityComparer instead.")]
+    [Obsolete("IHashCodeProvider has been deprecated. Use IEqualityComparer instead.")]
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public interface IHashCodeProvider
     {

--- a/src/libraries/System.Private.CoreLib/src/System/CurrentSystemTimeZone.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/CurrentSystemTimeZone.cs
@@ -21,7 +21,7 @@ using System.Globalization;
 
 namespace System
 {
-    [Obsolete("System.CurrentSystemTimeZone has been deprecated.  Please investigate the use of System.TimeZoneInfo.Local instead.")]
+    [Obsolete("System.CurrentSystemTimeZone has been deprecated. Investigate the use of System.TimeZoneInfo.Local instead.")]
     internal sealed class CurrentSystemTimeZone : TimeZone
     {
         // Standard offset in ticks to the Universal time if

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -1202,7 +1202,7 @@ namespace System
         #endregion
 
         #region IFormattable
-        [Obsolete("The provider argument is not used. Please use ToString(String).")]
+        [Obsolete("The provider argument is not used. Use ToString(String) instead.")]
         public string ToString(string? format, IFormatProvider? provider)
         {
             return ToString(format);
@@ -1242,7 +1242,7 @@ namespace System
             throw new FormatException(SR.Format_InvalidEnumFormatSpecification);
         }
 
-        [Obsolete("The provider argument is not used. Please use ToString().")]
+        [Obsolete("The provider argument is not used. Use ToString() instead.")]
         public string ToString(IFormatProvider? provider)
         {
             return ToString();

--- a/src/libraries/System.Private.CoreLib/src/System/ExecutionEngineException.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ExecutionEngineException.cs
@@ -18,7 +18,7 @@ using System.Runtime.Serialization;
 
 namespace System
 {
-    [Obsolete("This type previously indicated an unspecified fatal error in the runtime. The runtime no longer raises this exception so this type is obsolete.")]
+    [Obsolete("ExecutionEngineException previously indicated an unspecified fatal error in the runtime. The runtime no longer raises this exception so this type is obsolete.")]
     [Serializable]
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed class ExecutionEngineException : SystemException

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureTypes.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureTypes.cs
@@ -18,9 +18,9 @@ namespace System.Globalization
 
         UserCustomCulture = 0x0008, // User defined custom culture
         ReplacementCultures = 0x0010, // User defined replacement custom culture.
-        [Obsolete("This value has been deprecated.  Please use other values in CultureTypes.")]
+        [Obsolete("CultureTypes.WindowsOnlyCultures has been deprecated. Use other values in CultureTypes instead.")]
         WindowsOnlyCultures = 0x0020, // this will always return empty list.
-        [Obsolete("This value has been deprecated.  Please use other values in CultureTypes.")]
+        [Obsolete("CultureTypes.FrameworkCultures has been deprecated. Use other values in CultureTypes instead.")]
         FrameworkCultures = 0x0040, // will return only the v2 cultures marked as Framework culture.
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
@@ -19,28 +19,28 @@ namespace System.IO
         private readonly FileStreamStrategy _strategy;
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("This constructor has been deprecated. Use new FileStream(SafeFileHandle handle, FileAccess access).")]
+        [Obsolete("This constructor has been deprecated. Use FileStream(SafeFileHandle handle, FileAccess access) instead.")]
         public FileStream(IntPtr handle, FileAccess access)
             : this(handle, access, true, DefaultBufferSize, DefaultIsAsync)
         {
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("This constructor has been deprecated. Use new FileStream(SafeFileHandle handle, FileAccess access) and optionally make a new SafeFileHandle with ownsHandle=false if needed.")]
+        [Obsolete("This constructor has been deprecated. Use FileStream(SafeFileHandle handle, FileAccess access) and optionally make a new SafeFileHandle with ownsHandle=false if needed instead.")]
         public FileStream(IntPtr handle, FileAccess access, bool ownsHandle)
             : this(handle, access, ownsHandle, DefaultBufferSize, DefaultIsAsync)
         {
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("This constructor has been deprecated. Use new FileStream(SafeFileHandle handle, FileAccess access, int bufferSize) and optionally make a new SafeFileHandle with ownsHandle=false if needed.")]
+        [Obsolete("This constructor has been deprecated. Use FileStream(SafeFileHandle handle, FileAccess access, int bufferSize) and optionally make a new SafeFileHandle with ownsHandle=false if needed instead.")]
         public FileStream(IntPtr handle, FileAccess access, bool ownsHandle, int bufferSize)
             : this(handle, access, ownsHandle, bufferSize, DefaultIsAsync)
         {
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("This constructor has been deprecated. Use new FileStream(SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync) and optionally make a new SafeFileHandle with ownsHandle=false if needed.")]
+        [Obsolete("This constructor has been deprecated. Use FileStream(SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync) and optionally make a new SafeFileHandle with ownsHandle=false if needed instead.")]
         public FileStream(IntPtr handle, FileAccess access, bool ownsHandle, int bufferSize, bool isAsync)
         {
             SafeFileHandle safeHandle = new SafeFileHandle(handle, ownsHandle: ownsHandle);
@@ -210,7 +210,7 @@ namespace System.IO
             _strategy = FileStreamHelpers.ChooseStrategy(this, path, mode, access, share, bufferSize, options, preallocationSize);
         }
 
-        [Obsolete("FileStream.Handle has been deprecated. Use FileStream's SafeFileHandle property.")]
+        [Obsolete("FileStream.Handle has been deprecated. Use FileStream's SafeFileHandle property instead.")]
         public virtual IntPtr Handle => _strategy.Handle;
 
         [UnsupportedOSPlatform("ios")]

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.cs
@@ -19,28 +19,28 @@ namespace System.IO
         private readonly FileStreamStrategy _strategy;
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("This constructor has been deprecated.  Please use new FileStream(SafeFileHandle handle, FileAccess access) instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("This constructor has been deprecated. Use new FileStream(SafeFileHandle handle, FileAccess access).")]
         public FileStream(IntPtr handle, FileAccess access)
             : this(handle, access, true, DefaultBufferSize, DefaultIsAsync)
         {
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("This constructor has been deprecated.  Please use new FileStream(SafeFileHandle handle, FileAccess access) instead, and optionally make a new SafeFileHandle with ownsHandle=false if needed.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("This constructor has been deprecated. Use new FileStream(SafeFileHandle handle, FileAccess access) and optionally make a new SafeFileHandle with ownsHandle=false if needed.")]
         public FileStream(IntPtr handle, FileAccess access, bool ownsHandle)
             : this(handle, access, ownsHandle, DefaultBufferSize, DefaultIsAsync)
         {
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("This constructor has been deprecated.  Please use new FileStream(SafeFileHandle handle, FileAccess access, int bufferSize) instead, and optionally make a new SafeFileHandle with ownsHandle=false if needed.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("This constructor has been deprecated. Use new FileStream(SafeFileHandle handle, FileAccess access, int bufferSize) and optionally make a new SafeFileHandle with ownsHandle=false if needed.")]
         public FileStream(IntPtr handle, FileAccess access, bool ownsHandle, int bufferSize)
             : this(handle, access, ownsHandle, bufferSize, DefaultIsAsync)
         {
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("This constructor has been deprecated.  Please use new FileStream(SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync) instead, and optionally make a new SafeFileHandle with ownsHandle=false if needed.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("This constructor has been deprecated. Use new FileStream(SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync) and optionally make a new SafeFileHandle with ownsHandle=false if needed.")]
         public FileStream(IntPtr handle, FileAccess access, bool ownsHandle, int bufferSize, bool isAsync)
         {
             SafeFileHandle safeHandle = new SafeFileHandle(handle, ownsHandle: ownsHandle);
@@ -210,7 +210,7 @@ namespace System.IO
             _strategy = FileStreamHelpers.ChooseStrategy(this, path, mode, access, share, bufferSize, options, preallocationSize);
         }
 
-        [Obsolete("This property has been deprecated.  Please use FileStream's SafeFileHandle property instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("FileStream.Handle has been deprecated. Use FileStream's SafeFileHandle property.")]
         public virtual IntPtr Handle => _strategy.Handle;
 
         [UnsupportedOSPlatform("ios")]

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
@@ -31,7 +31,7 @@ namespace System.IO
         // 8 random bytes provides 12 chars in our encoding for the 8.3 name.
         private const int KeyLength = 8;
 
-        [Obsolete("Please use GetInvalidPathChars or GetInvalidFileNameChars instead.")]
+        [Obsolete("Path.InvalidPathChars has been deprecated. Use GetInvalidPathChars or GetInvalidFileNameChars instead.")]
         public static readonly char[] InvalidPathChars = GetInvalidPathChars();
 
         // Changes the extension of a file path. The path parameter

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs
@@ -195,7 +195,7 @@ namespace System.IO
                 static state => ((Stream)state!).Flush(), this,
                 cancellationToken, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
 
-        [Obsolete("CreateWaitHandle has been deprecated. Use new ManualResetEvent(false) instead.")]
+        [Obsolete("CreateWaitHandle has been deprecated. Use the ManualResetEvent(false) constructor instead.")]
         protected virtual WaitHandle CreateWaitHandle() => new ManualResetEvent(false);
 
         public virtual IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state) =>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs
@@ -195,7 +195,7 @@ namespace System.IO
                 static state => ((Stream)state!).Flush(), this,
                 cancellationToken, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
 
-        [Obsolete("CreateWaitHandle will be removed eventually.  Please use \"new ManualResetEvent(false)\" instead.")]
+        [Obsolete("CreateWaitHandle has been deprecated. Use new ManualResetEvent(false) instead.")]
         protected virtual WaitHandle CreateWaitHandle() => new ManualResetEvent(false);
 
         public virtual IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state) =>

--- a/src/libraries/System.Private.CoreLib/src/System/LoaderOptimization.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/LoaderOptimization.cs
@@ -5,9 +5,9 @@ namespace System
 {
     public enum LoaderOptimization
     {
-        [System.ObsoleteAttribute("This method has been deprecated. Please use Assembly.Load() instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("LoaderOptimization.DisallowBindings has been deprecated and is no longer supported.")]
         DisallowBindings = 4,
-        [System.ObsoleteAttribute("This method has been deprecated. Please use Assembly.Load() instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("LoaderOptimization.DomainMask has been deprecated and is no longer supported.")]
         DomainMask = 3,
         MultiDomain = 2,
         MultiDomainHost = 3,

--- a/src/libraries/System.Private.CoreLib/src/System/LoaderOptimization.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/LoaderOptimization.cs
@@ -5,9 +5,9 @@ namespace System
 {
     public enum LoaderOptimization
     {
-        [System.ObsoleteAttribute("LoaderOptimization.DisallowBindings has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("LoaderOptimization.DisallowBindings has been deprecated and is not supported.")]
         DisallowBindings = 4,
-        [System.ObsoleteAttribute("LoaderOptimization.DomainMask has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("LoaderOptimization.DomainMask has been deprecated and is not supported.")]
         DomainMask = 3,
         MultiDomain = 2,
         MultiDomainHost = 3,

--- a/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
@@ -168,7 +168,7 @@ namespace System
         /// Always thrown by this method.
         /// </exception>
         /// </summary>
-        [Obsolete("Equals() on ReadOnlySpan will always throw an exception. Use == instead.")]
+        [Obsolete("Equals() on ReadOnlySpan has will always throw an exception. Use the == operator.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object? obj) =>
             throw new NotSupportedException(SR.NotSupported_CannotCallEqualsOnSpan);

--- a/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
@@ -168,7 +168,7 @@ namespace System
         /// Always thrown by this method.
         /// </exception>
         /// </summary>
-        [Obsolete("Equals() on ReadOnlySpan has will always throw an exception. Use the == operator.")]
+        [Obsolete("Equals() on ReadOnlySpan has will always throw an exception. Use the equality operator instead.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object? obj) =>
             throw new NotSupportedException(SR.NotSupported_CannotCallEqualsOnSpan);

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyFlagsAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyFlagsAttribute.cs
@@ -8,20 +8,20 @@ namespace System.Reflection
     {
         private readonly AssemblyNameFlags _flags;
 
-        [Obsolete("This constructor has been deprecated. Use AssemblyFlagsAttribute(AssemblyNameFlags).")]
+        [Obsolete("This constructor has been deprecated. Use AssemblyFlagsAttribute(AssemblyNameFlags) instead.")]
         [CLSCompliant(false)]
         public AssemblyFlagsAttribute(uint flags)
         {
             _flags = (AssemblyNameFlags)flags;
         }
 
-        [Obsolete("AssemblyFlagsAttribute.Flags has been deprecated. Use AssemblyFlags.")]
+        [Obsolete("AssemblyFlagsAttribute.Flags has been deprecated. Use AssemblyFlags instead.")]
         [CLSCompliant(false)]
         public uint Flags => (uint)_flags;
 
         public int AssemblyFlags => (int)_flags;
 
-        [Obsolete("This constructor has been deprecated. Use AssemblyFlagsAttribute(AssemblyNameFlags).")]
+        [Obsolete("This constructor has been deprecated. Use AssemblyFlagsAttribute(AssemblyNameFlags) instead.")]
         public AssemblyFlagsAttribute(int assemblyFlags)
         {
             _flags = (AssemblyNameFlags)assemblyFlags;

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyFlagsAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyFlagsAttribute.cs
@@ -8,20 +8,20 @@ namespace System.Reflection
     {
         private readonly AssemblyNameFlags _flags;
 
-        [Obsolete("This constructor has been deprecated. Please use AssemblyFlagsAttribute(AssemblyNameFlags) instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("This constructor has been deprecated. Use AssemblyFlagsAttribute(AssemblyNameFlags).")]
         [CLSCompliant(false)]
         public AssemblyFlagsAttribute(uint flags)
         {
             _flags = (AssemblyNameFlags)flags;
         }
 
-        [Obsolete("This property has been deprecated. Please use AssemblyFlags instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("AssemblyFlagsAttribute.Flags has been deprecated. Use AssemblyFlags.")]
         [CLSCompliant(false)]
         public uint Flags => (uint)_flags;
 
         public int AssemblyFlags => (int)_flags;
 
-        [Obsolete("This constructor has been deprecated. Please use AssemblyFlagsAttribute(AssemblyNameFlags) instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("This constructor has been deprecated. Use AssemblyFlagsAttribute(AssemblyNameFlags).")]
         public AssemblyFlagsAttribute(int assemblyFlags)
         {
             _flags = (AssemblyNameFlags)assemblyFlags;

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/FlowControl.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/FlowControl.cs
@@ -21,7 +21,7 @@ namespace System.Reflection.Emit
         Cond_Branch = 3,
         Meta = 4,
         Next = 5,
-        [Obsolete("FlowControl.Phi has been deprecated and is no longer supported.")]
+        [Obsolete("FlowControl.Phi has been deprecated and is not supported.")]
         Phi = 6,
         Return = 7,
         Throw = 8,

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/FlowControl.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/FlowControl.cs
@@ -21,7 +21,7 @@ namespace System.Reflection.Emit
         Cond_Branch = 3,
         Meta = 4,
         Next = 5,
-        [Obsolete("This API has been deprecated. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("FlowControl.Phi has been deprecated and is no longer supported.")]
         Phi = 6,
         Return = 7,
         Throw = 8,

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/OpCodeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/OpCodeType.cs
@@ -15,7 +15,7 @@ namespace System.Reflection.Emit
 {
     public enum OpCodeType
     {
-        [Obsolete("This API has been deprecated. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("OpCodeType.Annotation has been deprecated and is no longer supported.")]
         Annotation = 0,
         Macro = 1,
         Nternal = 2,

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/OpCodeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/OpCodeType.cs
@@ -15,7 +15,7 @@ namespace System.Reflection.Emit
 {
     public enum OpCodeType
     {
-        [Obsolete("OpCodeType.Annotation has been deprecated and is no longer supported.")]
+        [Obsolete("OpCodeType.Annotation has been deprecated and is not supported.")]
         Annotation = 0,
         Macro = 1,
         Nternal = 2,

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/OperandType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/OperandType.cs
@@ -21,7 +21,7 @@ namespace System.Reflection.Emit
         InlineI8 = 3,
         InlineMethod = 4,
         InlineNone = 5,
-        [Obsolete("This API has been deprecated. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("OperandType.InlinePhi has been deprecated and is no longer supported.")]
         InlinePhi = 6,
         InlineR = 7,
         InlineSig = 9,

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/OperandType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/OperandType.cs
@@ -21,7 +21,7 @@ namespace System.Reflection.Emit
         InlineI8 = 3,
         InlineMethod = 4,
         InlineNone = 5,
-        [Obsolete("OperandType.InlinePhi has been deprecated and is no longer supported.")]
+        [Obsolete("OperandType.InlinePhi has been deprecated and is not supported.")]
         InlinePhi = 6,
         InlineR = 7,
         InlineSig = 9,

--- a/src/libraries/System.Private.CoreLib/src/System/Security/SecurityTreatAsSafeAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Security/SecurityTreatAsSafeAttribute.cs
@@ -15,7 +15,7 @@ namespace System.Security
                     AttributeTargets.Delegate,
         AllowMultiple = false,
         Inherited = false)]
-    [Obsolete("SecurityTreatAsSafe is only used for .NET 2.0 transparency compatibility.  Please use the SecuritySafeCriticalAttribute instead.")]
+    [Obsolete("SecurityTreatAsSafe is only used for .NET 2.0 transparency compatibility. Use the SecuritySafeCriticalAttribute instead.")]
     public sealed class SecurityTreatAsSafeAttribute : Attribute
     {
         public SecurityTreatAsSafeAttribute() { }

--- a/src/libraries/System.Private.CoreLib/src/System/Span.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Span.cs
@@ -173,7 +173,7 @@ namespace System
         /// Always thrown by this method.
         /// </exception>
         /// </summary>
-        [Obsolete("Equals() on Span will always throw an exception. Use the == operator.")]
+        [Obsolete("Equals() on Span will always throw an exception. Use the equality operator instead.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object? obj) =>
             throw new NotSupportedException(SR.NotSupported_CannotCallEqualsOnSpan);

--- a/src/libraries/System.Private.CoreLib/src/System/Span.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Span.cs
@@ -173,7 +173,7 @@ namespace System
         /// Always thrown by this method.
         /// </exception>
         /// </summary>
-        [Obsolete("Equals() on Span will always throw an exception. Use == instead.")]
+        [Obsolete("Equals() on Span will always throw an exception. Use the == operator.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object? obj) =>
             throw new NotSupportedException(SR.NotSupported_CannotCallEqualsOnSpan);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -507,13 +507,13 @@ namespace System.Threading
             return SetApartmentStateUnchecked(state, throwOnError);
         }
 
-        [Obsolete("Thread.GetCompressedStack is no longer supported. Use the System.Threading.CompressedStack class instead.")]
+        [Obsolete("Thread.GetCompressedStack is not supported. Use the System.Threading.CompressedStack class instead.")]
         public CompressedStack GetCompressedStack()
         {
             throw new InvalidOperationException(SR.Thread_GetSetCompressedStack_NotSupported);
         }
 
-        [Obsolete("Thread.SetCompressedStack is no longer supported. Use the System.Threading.CompressedStack class instead.")]
+        [Obsolete("Thread.SetCompressedStack is not supported. Use the System.Threading.CompressedStack class instead.")]
         public void SetCompressedStack(CompressedStack stack)
         {
             throw new InvalidOperationException(SR.Thread_GetSetCompressedStack_NotSupported);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -507,13 +507,13 @@ namespace System.Threading
             return SetApartmentStateUnchecked(state, throwOnError);
         }
 
-        [Obsolete("Thread.GetCompressedStack is not supported. Use the System.Threading.CompressedStack class instead.")]
+        [Obsolete("Thread.GetCompressedStack has been deprecated. Use the System.Threading.CompressedStack class instead.")]
         public CompressedStack GetCompressedStack()
         {
             throw new InvalidOperationException(SR.Thread_GetSetCompressedStack_NotSupported);
         }
 
-        [Obsolete("Thread.SetCompressedStack is not supported. Use the System.Threading.CompressedStack class instead.")]
+        [Obsolete("Thread.SetCompressedStack has been deprecated. Use the System.Threading.CompressedStack class instead.")]
         public void SetCompressedStack(CompressedStack stack)
         {
             throw new InvalidOperationException(SR.Thread_GetSetCompressedStack_NotSupported);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -507,13 +507,13 @@ namespace System.Threading
             return SetApartmentStateUnchecked(state, throwOnError);
         }
 
-        [Obsolete("Thread.GetCompressedStack is no longer supported. Use the System.Threading.CompressedStack class")]
+        [Obsolete("Thread.GetCompressedStack is no longer supported. Use the System.Threading.CompressedStack class instead.")]
         public CompressedStack GetCompressedStack()
         {
             throw new InvalidOperationException(SR.Thread_GetSetCompressedStack_NotSupported);
         }
 
-        [Obsolete("Thread.SetCompressedStack is no longer supported. Use the System.Threading.CompressedStack class")]
+        [Obsolete("Thread.SetCompressedStack is no longer supported. Use the System.Threading.CompressedStack class instead.")]
         public void SetCompressedStack(CompressedStack stack)
         {
             throw new InvalidOperationException(SR.Thread_GetSetCompressedStack_NotSupported);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -447,13 +447,13 @@ namespace System.Threading
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_ThreadAbort);
         }
 
-        [Obsolete("Thread.Suspend has been deprecated.  Please use other classes in System.Threading, such as Monitor, Mutex, Event, and Semaphore, to synchronize Threads or protect resources.  https://go.microsoft.com/fwlink/?linkid=14202", false)]
+        [Obsolete("Thread.Suspend has been deprecated. Use other classes in System.Threading, such as Monitor, Mutex, Event, and Semaphore, to synchronize Threads or protect resources.", false)]
         public void Suspend()
         {
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_ThreadSuspend);
         }
 
-        [Obsolete("Thread.Resume has been deprecated.  Please use other classes in System.Threading, such as Monitor, Mutex, Event, and Semaphore, to synchronize Threads or protect resources.  https://go.microsoft.com/fwlink/?linkid=14202", false)]
+        [Obsolete("Thread.Resume has been deprecated. Use other classes in System.Threading, such as Monitor, Mutex, Event, and Semaphore, to synchronize Threads or protect resources.", false)]
         public void Resume()
         {
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_ThreadSuspend);
@@ -473,7 +473,7 @@ namespace System.Threading
         public static object? GetData(LocalDataStoreSlot slot) => LocalDataStore.GetData(slot);
         public static void SetData(LocalDataStoreSlot slot, object? data) => LocalDataStore.SetData(slot, data);
 
-        [Obsolete("The ApartmentState property has been deprecated.  Use GetApartmentState, SetApartmentState or TrySetApartmentState instead.", false)]
+        [Obsolete("The ApartmentState property has been deprecated. Use GetApartmentState, SetApartmentState or TrySetApartmentState.", false)]
         public ApartmentState ApartmentState
         {
             get => GetApartmentState();
@@ -507,13 +507,13 @@ namespace System.Threading
             return SetApartmentStateUnchecked(state, throwOnError);
         }
 
-        [Obsolete("Thread.GetCompressedStack is no longer supported. Please use the System.Threading.CompressedStack class")]
+        [Obsolete("Thread.GetCompressedStack is no longer supported. Use the System.Threading.CompressedStack class")]
         public CompressedStack GetCompressedStack()
         {
             throw new InvalidOperationException(SR.Thread_GetSetCompressedStack_NotSupported);
         }
 
-        [Obsolete("Thread.SetCompressedStack is no longer supported. Please use the System.Threading.CompressedStack class")]
+        [Obsolete("Thread.SetCompressedStack is no longer supported. Use the System.Threading.CompressedStack class")]
         public void SetCompressedStack(CompressedStack stack)
         {
             throw new InvalidOperationException(SR.Thread_GetSetCompressedStack_NotSupported);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -447,13 +447,13 @@ namespace System.Threading
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_ThreadAbort);
         }
 
-        [Obsolete("Thread.Suspend has been deprecated. Use other classes in System.Threading, such as Monitor, Mutex, Event, and Semaphore, to synchronize Threads or protect resources.", false)]
+        [Obsolete("Thread.Suspend has been deprecated. Use other classes in System.Threading, such as Monitor, Mutex, Event, and Semaphore, to synchronize Threads or protect resources.")]
         public void Suspend()
         {
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_ThreadSuspend);
         }
 
-        [Obsolete("Thread.Resume has been deprecated. Use other classes in System.Threading, such as Monitor, Mutex, Event, and Semaphore, to synchronize Threads or protect resources.", false)]
+        [Obsolete("Thread.Resume has been deprecated. Use other classes in System.Threading, such as Monitor, Mutex, Event, and Semaphore, to synchronize Threads or protect resources.")]
         public void Resume()
         {
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_ThreadSuspend);
@@ -473,7 +473,7 @@ namespace System.Threading
         public static object? GetData(LocalDataStoreSlot slot) => LocalDataStore.GetData(slot);
         public static void SetData(LocalDataStoreSlot slot, object? data) => LocalDataStore.SetData(slot, data);
 
-        [Obsolete("The ApartmentState property has been deprecated. Use GetApartmentState, SetApartmentState or TrySetApartmentState.", false)]
+        [Obsolete("The ApartmentState property has been deprecated. Use GetApartmentState, SetApartmentState or TrySetApartmentState.")]
         public ApartmentState ApartmentState
         {
             get => GetApartmentState();

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/WaitHandle.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/WaitHandle.cs
@@ -40,7 +40,7 @@ namespace System.Threading
         {
         }
 
-        [Obsolete("Use the SafeWaitHandle property instead.")]
+        [Obsolete("WaitHandleHandle has been deprecated. Use the SafeWaitHandle property instead.")]
         public virtual IntPtr Handle
         {
             get => _waitHandle == null ? InvalidHandle : _waitHandle.DangerousGetHandle();

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZone.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZone.cs
@@ -22,7 +22,7 @@ using System.Globalization;
 
 namespace System
 {
-    [Obsolete("System.TimeZone has been deprecated.  Please investigate the use of System.TimeZoneInfo instead.")]
+    [Obsolete("System.TimeZone has been deprecated. Investigate the use of System.TimeZoneInfo instead.")]
     public abstract class TimeZone
     {
         private static volatile TimeZone? currentTimeZone;

--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -369,7 +369,7 @@ namespace System
         //
         //  Uri constructor. Assumes that input string is canonically escaped
         //
-        [Obsolete("The constructor has been deprecated. Please use new Uri(string). The dontEscape parameter is deprecated and is always false. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("This constructor has been deprecated; the dontEscape parameter is always false. Use Uri(string).")]
         public Uri(string uriString, bool dontEscape)
         {
             if (uriString == null)
@@ -385,7 +385,7 @@ namespace System
         //  Uri combinatorial constructor. Do not perform character escaping if
         //  DontEscape is true
         //
-        [Obsolete("The constructor has been deprecated. Please new Uri(Uri, string). The dontEscape parameter is deprecated and is always false. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("This constructor has been deprecated; the dontEscape parameter is always false. Use Uri(Uri, string).")]
         public Uri(Uri baseUri, string? relativeUri, bool dontEscape)
         {
             if (baseUri is null)
@@ -5064,7 +5064,7 @@ namespace System
         // Throws:
         //  ArgumentNullException, InvalidOperationException
         //
-        [Obsolete("The method has been deprecated. Please use MakeRelativeUri(Uri uri). https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("Uri.MakeRelative has been deprecated. Use MakeRelativeUri(Uri uri).")]
         public string MakeRelative(Uri toUri)
         {
             if (toUri == null)
@@ -5080,7 +5080,7 @@ namespace System
         }
 
         /// <internalonly/>
-        [Obsolete("The method has been deprecated. It is not used by the system. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("Uri.Canonicalize has been deprecated and is no longer supported.")]
         protected virtual void Canonicalize()
         {
             // this method if suppressed by the derived class
@@ -5090,7 +5090,7 @@ namespace System
         }
 
         /// <internalonly/>
-        [Obsolete("The method has been deprecated. It is not used by the system. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("Uri.Parse has been deprecated and is no longer supported.")]
         protected virtual void Parse()
         {
             // this method if suppressed by the derived class
@@ -5100,7 +5100,7 @@ namespace System
         }
 
         /// <internalonly/>
-        [Obsolete("The method has been deprecated. It is not used by the system. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("Uri.Escape has been deprecated and is no longer supported.")]
         protected virtual void Escape()
         {
             // this method if suppressed by the derived class
@@ -5117,7 +5117,7 @@ namespace System
         //  UTF-8 sequences (e.g. %C4%D2 == 'Latin capital Ligature Ij')
         //
         /// <internalonly/>
-        [Obsolete("The method has been deprecated. Please use GetComponents() or static UnescapeDataString() to unescape a Uri component or a string. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("Uri.Unescape has been deprecated. Use GetComponents() or static UnescapeDataString() to unescape a Uri component or a string.")]
         protected virtual string Unescape(string path)
         {
             // This method is dangerous since it gives path unescaping control
@@ -5131,7 +5131,7 @@ namespace System
             return new string(dest, 0, count);
         }
 
-        [Obsolete("The method has been deprecated. Please use GetComponents() or static EscapeDataString() to escape a Uri component or a string. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("Uri.EscapeString has been deprecated. Use GetComponents() or Uri.EscapeDataString to escape a Uri component or a string.")]
         protected static string EscapeString(string? str) =>
             str is null ? string.Empty :
             UriHelper.EscapeString(str, checkExistingEscaped: true, UriHelper.UnreservedReservedTable, '?', '#');
@@ -5142,7 +5142,7 @@ namespace System
         //  Check for any invalid or problematic character sequences
         //
         /// <internalonly/>
-        [Obsolete("The method has been deprecated. It is not used by the system. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("Uri.CheckSecurity has been deprecated and is no longer supported.")]
         protected virtual void CheckSecurity()
         {
             // This method just does not make sense
@@ -5158,7 +5158,7 @@ namespace System
         //  true if <character> is reserved else false
         //
         /// <internalonly/>
-        [Obsolete("The method has been deprecated. It is not used by the system. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("Uri.IsReservedCharacter has been deprecated and is no longer supported.")]
         protected virtual bool IsReservedCharacter(char character)
         {
             // This method just does not make sense as protected virtual
@@ -5186,7 +5186,7 @@ namespace System
         //  true if <character> should be escaped else false
         //
         /// <internalonly/>
-        [Obsolete("The method has been deprecated. It is not used by the system. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("Uri.IsExcludedCharacter has been deprecated and is no longer supported.")]
         protected static bool IsExcludedCharacter(char character)
         {
             // This method just does not make sense as protected
@@ -5229,7 +5229,7 @@ namespace System
         //  true if <character> would be a treated as a bad file system character
         //  else false
         //
-        [Obsolete("The method has been deprecated. It is not used by the system. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("Uri.IsBadFileSystemCharacter has been deprecated and is no longer supported.")]
         protected virtual bool IsBadFileSystemCharacter(char character)
         {
             // This method just does not make sense as protected virtual

--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -5080,7 +5080,7 @@ namespace System
         }
 
         /// <internalonly/>
-        [Obsolete("Uri.Canonicalize has been deprecated and is no longer supported.")]
+        [Obsolete("Uri.Canonicalize has been deprecated and is not supported.")]
         protected virtual void Canonicalize()
         {
             // this method if suppressed by the derived class
@@ -5090,7 +5090,7 @@ namespace System
         }
 
         /// <internalonly/>
-        [Obsolete("Uri.Parse has been deprecated and is no longer supported.")]
+        [Obsolete("Uri.Parse has been deprecated and is not supported.")]
         protected virtual void Parse()
         {
             // this method if suppressed by the derived class
@@ -5100,7 +5100,7 @@ namespace System
         }
 
         /// <internalonly/>
-        [Obsolete("Uri.Escape has been deprecated and is no longer supported.")]
+        [Obsolete("Uri.Escape has been deprecated and is not supported.")]
         protected virtual void Escape()
         {
             // this method if suppressed by the derived class
@@ -5142,7 +5142,7 @@ namespace System
         //  Check for any invalid or problematic character sequences
         //
         /// <internalonly/>
-        [Obsolete("Uri.CheckSecurity has been deprecated and is no longer supported.")]
+        [Obsolete("Uri.CheckSecurity has been deprecated and is not supported.")]
         protected virtual void CheckSecurity()
         {
             // This method just does not make sense
@@ -5158,7 +5158,7 @@ namespace System
         //  true if <character> is reserved else false
         //
         /// <internalonly/>
-        [Obsolete("Uri.IsReservedCharacter has been deprecated and is no longer supported.")]
+        [Obsolete("Uri.IsReservedCharacter has been deprecated and is not supported.")]
         protected virtual bool IsReservedCharacter(char character)
         {
             // This method just does not make sense as protected virtual
@@ -5186,7 +5186,7 @@ namespace System
         //  true if <character> should be escaped else false
         //
         /// <internalonly/>
-        [Obsolete("Uri.IsExcludedCharacter has been deprecated and is no longer supported.")]
+        [Obsolete("Uri.IsExcludedCharacter has been deprecated and is not supported.")]
         protected static bool IsExcludedCharacter(char character)
         {
             // This method just does not make sense as protected
@@ -5229,7 +5229,7 @@ namespace System
         //  true if <character> would be a treated as a bad file system character
         //  else false
         //
-        [Obsolete("Uri.IsBadFileSystemCharacter has been deprecated and is no longer supported.")]
+        [Obsolete("Uri.IsBadFileSystemCharacter has been deprecated and is not supported.")]
         protected virtual bool IsBadFileSystemCharacter(char character)
         {
             // This method just does not make sense as protected virtual

--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -369,7 +369,7 @@ namespace System
         //
         //  Uri constructor. Assumes that input string is canonically escaped
         //
-        [Obsolete("This constructor has been deprecated; the dontEscape parameter is always false. Use Uri(string).")]
+        [Obsolete("This constructor has been deprecated; the dontEscape parameter is always false. Use Uri(string) instead.")]
         public Uri(string uriString, bool dontEscape)
         {
             if (uriString == null)
@@ -385,7 +385,7 @@ namespace System
         //  Uri combinatorial constructor. Do not perform character escaping if
         //  DontEscape is true
         //
-        [Obsolete("This constructor has been deprecated; the dontEscape parameter is always false. Use Uri(Uri, string).")]
+        [Obsolete("This constructor has been deprecated; the dontEscape parameter is always false. Use Uri(Uri, string) instead.")]
         public Uri(Uri baseUri, string? relativeUri, bool dontEscape)
         {
             if (baseUri is null)
@@ -5064,7 +5064,7 @@ namespace System
         // Throws:
         //  ArgumentNullException, InvalidOperationException
         //
-        [Obsolete("Uri.MakeRelative has been deprecated. Use MakeRelativeUri(Uri uri).")]
+        [Obsolete("Uri.MakeRelative has been deprecated. Use MakeRelativeUri(Uri uri) instead.")]
         public string MakeRelative(Uri toUri)
         {
             if (toUri == null)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/ValidationType.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/ValidationType.cs
@@ -19,7 +19,7 @@ namespace System.Xml
         // 4) If there is no <!DOCTYPE ...&> declaration and no XSD "schemaLocation" attribute but there are some namespaces
         //    using the MSXML "x-schema:" URN prefix, it will load and process those schemas and it will return any default
         //    attributes defined in those schemas.
-        [Obsolete("ValidationType.Auto has been deprecated.Use DTD or Schema instead.")]
+        [Obsolete("ValidationType.Auto has been deprecated. Use DTD or Schema instead.")]
         Auto,
 
         // Validate according to DTD.

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/ValidationType.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/ValidationType.cs
@@ -19,14 +19,14 @@ namespace System.Xml
         // 4) If there is no <!DOCTYPE ...&> declaration and no XSD "schemaLocation" attribute but there are some namespaces
         //    using the MSXML "x-schema:" URN prefix, it will load and process those schemas and it will return any default
         //    attributes defined in those schemas.
-        [Obsolete("Validation type should be specified as DTD or Schema.")]
+        [Obsolete("ValidationType.Auto has been deprecated.Use DTD or Schema instead.")]
         Auto,
 
         // Validate according to DTD.
         DTD,
 
         // Validate according to XDR.
-        [Obsolete("XDR Validation through XmlValidatingReader is obsoleted")]
+        [Obsolete("XDR Validation through XmlValidatingReader has been deprecated and is not supported.")]
         XDR,
 
         // Validate according to W3C XSD schemas, including inline schemas. An error is returned if both XDR and XSD schemas

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlReaderSettings.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlReaderSettings.cs
@@ -269,7 +269,7 @@ namespace System.Xml
             }
         }
 
-        [Obsolete("XmlReaderSettings.ProhibitDtd has been deprecated. Use the DtdProcessing property.")]
+        [Obsolete("XmlReaderSettings.ProhibitDtd has been deprecated. Use DtdProcessing instead.")]
         public bool ProhibitDtd
         {
             get

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlReaderSettings.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlReaderSettings.cs
@@ -269,7 +269,7 @@ namespace System.Xml
             }
         }
 
-        [Obsolete("Use XmlReaderSettings.DtdProcessing property instead.")]
+        [Obsolete("XmlReaderSettings.ProhibitDtd has been deprecated. Use the DtdProcessing property.")]
         public bool ProhibitDtd
         {
             get

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReader.cs
@@ -384,7 +384,7 @@ namespace System.Xml
             set { _impl.WhitespaceHandling = value; }
         }
 
-        [Obsolete("Use DtdProcessing property instead.")]
+        [Obsolete("XmlTextReader.ProhibitDtd has been deprecated. Use the DtdProcessing property.")]
         public bool ProhibitDtd
         {
             get { return _impl.DtdProcessing == DtdProcessing.Prohibit; }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReader.cs
@@ -384,7 +384,7 @@ namespace System.Xml
             set { _impl.WhitespaceHandling = value; }
         }
 
-        [Obsolete("XmlTextReader.ProhibitDtd has been deprecated. Use the DtdProcessing property.")]
+        [Obsolete("XmlTextReader.ProhibitDtd has been deprecated. Use DtdProcessing instead.")]
         public bool ProhibitDtd
         {
             get { return _impl.DtdProcessing == DtdProcessing.Prohibit; }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlValidatingReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlValidatingReader.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace System.Xml
 {
-    [Obsolete("XmlValidatingReader has been deprecated. Use XmlReader created by XmlReader.Create() method using appropriate XmlReaderSettings.")]
+    [Obsolete("XmlValidatingReader has been deprecated. Use XmlReader created by XmlReader.Create() method using appropriate XmlReaderSettings instead.")]
     public class XmlValidatingReader : XmlReader, IXmlLineInfo, IXmlNamespaceResolver
     {
         //

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlValidatingReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlValidatingReader.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace System.Xml
 {
-    [Obsolete("Use XmlReader created by XmlReader.Create() method using appropriate XmlReaderSettings instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+    [Obsolete("XmlValidatingReader has been deprecated. Use XmlReader created by XmlReader.Create() method using appropriate XmlReaderSettings.")]
     public class XmlValidatingReader : XmlReader, IXmlLineInfo, IXmlNamespaceResolver
     {
         //

--- a/src/libraries/System.Private.Xml/src/System/Xml/IApplicationResourceStreamResolver.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/IApplicationResourceStreamResolver.cs
@@ -8,7 +8,7 @@ using System.ComponentModel;
 namespace System.Xml
 {
     // we must specify the error flag as false so that we can typeforward this type without hitting a compile error.
-    [Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", false)]
+    [Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public interface IApplicationResourceStreamResolver
     {

--- a/src/libraries/System.Private.Xml/src/System/Xml/MTNameTable.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/MTNameTable.cs
@@ -219,7 +219,7 @@ namespace System.Xml {
 #else
 
     // XmlNameTable implemented as a multi-threaded splay tree.
-    [Obsolete("This class is going away")]
+    [Obsolete("MTNameTable has been deprecated and is not supported.")]
     public class MTNameTable : XmlNameTable {
         internal MTNameTableNode rootNode;
         internal ReaderWriterLock rwLock;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchema.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchema.cs
@@ -175,7 +175,7 @@ namespace System.Xml.Schema
             serializer.Serialize(writer, this, ns);
         }
 
-        [Obsolete("XmlSchema.Compile has been deprecated. Use System.Xml.Schema.XmlSchemaSet for schema compilation and validation.")]
+        [Obsolete("XmlSchema.Compile has been deprecated. Use System.Xml.Schema.XmlSchemaSet for schema compilation and validation instead.")]
         public void Compile(ValidationEventHandler? validationEventHandler)
         {
             SchemaInfo sInfo = new SchemaInfo();
@@ -183,7 +183,7 @@ namespace System.Xml.Schema
             CompileSchema(null, null, sInfo, null, validationEventHandler, NameTable, false);
         }
 
-        [Obsolete("XmlSchema.Compile has been deprecated. Use System.Xml.Schema.XmlSchemaSet for schema compilation and validation.")]
+        [Obsolete("XmlSchema.Compile has been deprecated. Use System.Xml.Schema.XmlSchemaSet for schema compilation and validation instead.")]
         public void Compile(ValidationEventHandler? validationEventHandler, XmlResolver? resolver)
         {
             SchemaInfo sInfo = new SchemaInfo();

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchema.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchema.cs
@@ -175,7 +175,7 @@ namespace System.Xml.Schema
             serializer.Serialize(writer, this, ns);
         }
 
-        [Obsolete("Use System.Xml.Schema.XmlSchemaSet for schema compilation and validation. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("XmlSchema.Compile has been deprecated. Use System.Xml.Schema.XmlSchemaSet for schema compilation and validation.")]
         public void Compile(ValidationEventHandler? validationEventHandler)
         {
             SchemaInfo sInfo = new SchemaInfo();
@@ -183,7 +183,7 @@ namespace System.Xml.Schema
             CompileSchema(null, null, sInfo, null, validationEventHandler, NameTable, false);
         }
 
-        [Obsolete("Use System.Xml.Schema.XmlSchemaSet for schema compilation and validation. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("XmlSchema.Compile has been deprecated. Use System.Xml.Schema.XmlSchemaSet for schema compilation and validation.")]
         public void Compile(ValidationEventHandler? validationEventHandler, XmlResolver? resolver)
         {
             SchemaInfo sInfo = new SchemaInfo();

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaAttribute.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaAttribute.cs
@@ -91,7 +91,7 @@ namespace System.Xml.Schema
         }
 
         [XmlIgnore]
-        [Obsolete("This property has been deprecated. Please use AttributeSchemaType property that returns a strongly typed attribute type. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("XmlSchemaAttribute.AttributeType has been deprecated. Use the AttributeSchemaType property that returns a strongly typed attribute type.")]
         public object? AttributeType
         {
             get

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaAttribute.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaAttribute.cs
@@ -91,7 +91,7 @@ namespace System.Xml.Schema
         }
 
         [XmlIgnore]
-        [Obsolete("XmlSchemaAttribute.AttributeType has been deprecated. Use the AttributeSchemaType property that returns a strongly typed attribute type.")]
+        [Obsolete("XmlSchemaAttribute.AttributeType has been deprecated. Use the AttributeSchemaType property that returns a strongly typed attribute type instead.")]
         public object? AttributeType
         {
             get

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaCollection.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaCollection.cs
@@ -19,7 +19,7 @@ namespace System.Xml.Schema
     /// The Validate method then uses this internal representation for
     /// efficient runtime validation of any given subtree.
     /// </summary>
-    [Obsolete("Use System.Xml.Schema.XmlSchemaSet for schema compilation and validation. https://go.microsoft.com/fwlink/?linkid=14202")]
+    [Obsolete("XmlSchemaCollection has been deprecated. Use System.Xml.Schema.XmlSchemaSet for schema compilation and validation.")]
     public sealed class XmlSchemaCollection : ICollection
     {
         private readonly Hashtable _collection;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaCollection.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaCollection.cs
@@ -19,7 +19,7 @@ namespace System.Xml.Schema
     /// The Validate method then uses this internal representation for
     /// efficient runtime validation of any given subtree.
     /// </summary>
-    [Obsolete("XmlSchemaCollection has been deprecated. Use System.Xml.Schema.XmlSchemaSet for schema compilation and validation.")]
+    [Obsolete("XmlSchemaCollection has been deprecated. Use System.Xml.Schema.XmlSchemaSet for schema compilation and validation instead.")]
     public sealed class XmlSchemaCollection : ICollection
     {
         private readonly Hashtable _collection;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaElement.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaElement.cs
@@ -164,7 +164,7 @@ namespace System.Xml.Schema
         }
 
         [XmlIgnore]
-        [Obsolete("XmlSchemaElement.ElementType has been deprecated. Use the ElementSchemaType property that returns a strongly typed element type.")]
+        [Obsolete("XmlSchemaElement.ElementType has been deprecated. Use the ElementSchemaType property that returns a strongly typed element type instead.")]
         public object? ElementType
         {
             get

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaElement.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaElement.cs
@@ -164,7 +164,7 @@ namespace System.Xml.Schema
         }
 
         [XmlIgnore]
-        [Obsolete("This property has been deprecated. Please use ElementSchemaType property that returns a strongly typed element type. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("XmlSchemaElement.ElementType has been deprecated. Use the ElementSchemaType property that returns a strongly typed element type.")]
         public object? ElementType
         {
             get

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaType.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaType.cs
@@ -125,7 +125,7 @@ namespace System.Xml.Schema
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
         [XmlIgnore]
-        [Obsolete("This property has been deprecated. Please use BaseXmlSchemaType property that returns a strongly typed base schema type. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("XmlSchemaType.BaseSchemaType has been deprecated. Use the BaseXmlSchemaType property that returns a strongly typed base schema type.")]
         public object? BaseSchemaType
         {
             get

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaType.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaType.cs
@@ -125,7 +125,7 @@ namespace System.Xml.Schema
         ///    <para>[To be supplied.]</para>
         /// </devdoc>
         [XmlIgnore]
-        [Obsolete("XmlSchemaType.BaseSchemaType has been deprecated. Use the BaseXmlSchemaType property that returns a strongly typed base schema type.")]
+        [Obsolete("XmlSchemaType.BaseSchemaType has been deprecated. Use the BaseXmlSchemaType property that returns a strongly typed base schema type instead.")]
         public object? BaseSchemaType
         {
             get

--- a/src/libraries/System.Private.Xml/src/System/Xml/XmlConvert.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XmlConvert.cs
@@ -751,7 +751,7 @@ namespace System.Xml
             return new XsdDuration(value).ToString();
         }
 
-        [Obsolete("Use XmlConvert.ToString() that takes in XmlDateTimeSerializationMode")]
+        [Obsolete("Use XmlConvert.ToString() that accepts an XmlDateTimeSerializationMode instead.")]
         public static string ToString(DateTime value)
         {
             return ToString(value, "yyyy-MM-ddTHH:mm:ss.fffffffzzzzzz");
@@ -1246,7 +1246,7 @@ namespace System.Xml
             }
         }
 
-        [Obsolete("Use XmlConvert.ToDateTime() that takes in XmlDateTimeSerializationMode")]
+        [Obsolete("Use XmlConvert.ToDateTime() that accepts an XmlDateTimeSerializationMode instead.")]
         public static DateTime ToDateTime(string s)
         {
             return ToDateTime(s, AllDateTimeFormats);

--- a/src/libraries/System.Reflection.Primitives/ref/System.Reflection.Primitives.cs
+++ b/src/libraries/System.Reflection.Primitives/ref/System.Reflection.Primitives.cs
@@ -14,7 +14,7 @@ namespace System.Reflection.Emit
         Cond_Branch = 3,
         Meta = 4,
         Next = 5,
-        [System.ObsoleteAttribute("FlowControl.Phi has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("FlowControl.Phi has been deprecated and is not supported.")]
         Phi = 6,
         Return = 7,
         Throw = 8,
@@ -270,7 +270,7 @@ namespace System.Reflection.Emit
     }
     public enum OpCodeType
     {
-        [System.ObsoleteAttribute("OpCodeType.Annotation has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("OpCodeType.Annotation has been deprecated and is not supported.")]
         Annotation = 0,
         Macro = 1,
         Nternal = 2,
@@ -286,7 +286,7 @@ namespace System.Reflection.Emit
         InlineI8 = 3,
         InlineMethod = 4,
         InlineNone = 5,
-        [System.ObsoleteAttribute("OperandType.InlinePhi has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("OperandType.InlinePhi has been deprecated and is not supported.")]
         InlinePhi = 6,
         InlineR = 7,
         InlineSig = 9,

--- a/src/libraries/System.Reflection.Primitives/ref/System.Reflection.Primitives.cs
+++ b/src/libraries/System.Reflection.Primitives/ref/System.Reflection.Primitives.cs
@@ -14,7 +14,7 @@ namespace System.Reflection.Emit
         Cond_Branch = 3,
         Meta = 4,
         Next = 5,
-        [System.ObsoleteAttribute("This API has been deprecated. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("FlowControl.Phi has been deprecated and is no longer supported.")]
         Phi = 6,
         Return = 7,
         Throw = 8,
@@ -270,7 +270,7 @@ namespace System.Reflection.Emit
     }
     public enum OpCodeType
     {
-        [System.ObsoleteAttribute("This API has been deprecated. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("OpCodeType.Annotation has been deprecated and is no longer supported.")]
         Annotation = 0,
         Macro = 1,
         Nternal = 2,
@@ -286,7 +286,7 @@ namespace System.Reflection.Emit
         InlineI8 = 3,
         InlineMethod = 4,
         InlineNone = 5,
-        [System.ObsoleteAttribute("This API has been deprecated. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("OperandType.InlinePhi has been deprecated and is no longer supported.")]
         InlinePhi = 6,
         InlineR = 7,
         InlineSig = 9,

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -1045,7 +1045,7 @@ namespace System.Runtime.InteropServices
         VariantBool = 37,
         FunctionPtr = 38,
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("Marshalling arbitrary types may be unavailable in future releases. Please specify the type you wish to marshal as.")]
+        [System.ObsoleteAttribute("Marshalling arbitrary types may be unavailable in future releases. Specify the type you wish to marshal as.")]
         AsAny = 40,
         LPArray = 42,
         LPStruct = 43,

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -854,13 +854,13 @@ namespace System.Runtime.InteropServices
     }
     public static partial class RuntimeEnvironment
     {
-        [System.ObsoleteAttribute("RuntimeEnvironment members SystemConfigurationFile, GetRuntimeInterfaceAsIntPtr, and GetRuntimeInterfaceAsObject are no longer supported and throw PlatformNotSupportedException.", DiagnosticId = "SYSLIB0019", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("RuntimeEnvironment members SystemConfigurationFile, GetRuntimeInterfaceAsIntPtr, and GetRuntimeInterfaceAsObject are not supported and throw PlatformNotSupportedException.", DiagnosticId = "SYSLIB0019", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static string SystemConfigurationFile { get { throw null; } }
         public static bool FromGlobalAccessCache(System.Reflection.Assembly a) { throw null; }
         public static string GetRuntimeDirectory() { throw null; }
-        [System.ObsoleteAttribute("RuntimeEnvironment members SystemConfigurationFile, GetRuntimeInterfaceAsIntPtr, and GetRuntimeInterfaceAsObject are no longer supported and throw PlatformNotSupportedException.", DiagnosticId = "SYSLIB0019", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("RuntimeEnvironment members SystemConfigurationFile, GetRuntimeInterfaceAsIntPtr, and GetRuntimeInterfaceAsObject are not supported and throw PlatformNotSupportedException.", DiagnosticId = "SYSLIB0019", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.IntPtr GetRuntimeInterfaceAsIntPtr(System.Guid clsid, System.Guid riid) { throw null; }
-        [System.ObsoleteAttribute("RuntimeEnvironment members SystemConfigurationFile, GetRuntimeInterfaceAsIntPtr, and GetRuntimeInterfaceAsObject are no longer supported and throw PlatformNotSupportedException.", DiagnosticId = "SYSLIB0019", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("RuntimeEnvironment members SystemConfigurationFile, GetRuntimeInterfaceAsIntPtr, and GetRuntimeInterfaceAsObject are not supported and throw PlatformNotSupportedException.", DiagnosticId = "SYSLIB0019", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static object GetRuntimeInterfaceAsObject(System.Guid clsid, System.Guid riid) { throw null; }
         public static string GetSystemVersion() { throw null; }
     }

--- a/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/IDispatchImplAttribute.cs
+++ b/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/IDispatchImplAttribute.cs
@@ -4,7 +4,7 @@
 namespace System.Runtime.InteropServices
 {
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly, Inherited = false)]
-    [Obsolete("IDispatchImplAttribute has deprecated and is not supported.", error: false)]
+    [Obsolete("IDispatchImplAttribute has been deprecated and is not supported.")]
     public sealed class IDispatchImplAttribute : Attribute
     {
         public IDispatchImplAttribute(short implType) : this((IDispatchImplType)implType)

--- a/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/IDispatchImplAttribute.cs
+++ b/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/IDispatchImplAttribute.cs
@@ -4,7 +4,7 @@
 namespace System.Runtime.InteropServices
 {
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly, Inherited = false)]
-    [Obsolete("This attribute is deprecated and will be removed in a future version.", error: false)]
+    [Obsolete("IDispatchImplAttribute has deprecated and is no longer supported.", error: false)]
     public sealed class IDispatchImplAttribute : Attribute
     {
         public IDispatchImplAttribute(short implType) : this((IDispatchImplType)implType)

--- a/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/IDispatchImplAttribute.cs
+++ b/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/IDispatchImplAttribute.cs
@@ -4,7 +4,7 @@
 namespace System.Runtime.InteropServices
 {
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Assembly, Inherited = false)]
-    [Obsolete("IDispatchImplAttribute has deprecated and is no longer supported.", error: false)]
+    [Obsolete("IDispatchImplAttribute has deprecated and is not supported.", error: false)]
     public sealed class IDispatchImplAttribute : Attribute
     {
         public IDispatchImplAttribute(short implType) : this((IDispatchImplType)implType)

--- a/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/IDispatchImplType.cs
+++ b/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/IDispatchImplType.cs
@@ -3,7 +3,7 @@
 
 namespace System.Runtime.InteropServices
 {
-    [Obsolete("IDispatchImplAttribute and IDispatchImplType have been deprecated and are no longer supported.", error: false)]
+    [Obsolete("IDispatchImplAttribute and IDispatchImplType have been deprecated and are no longer supported.")]
     public enum IDispatchImplType
     {
         CompatibleImpl = 2,

--- a/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/IDispatchImplType.cs
+++ b/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/IDispatchImplType.cs
@@ -3,7 +3,7 @@
 
 namespace System.Runtime.InteropServices
 {
-    [Obsolete("The IDispatchImplAttribute is deprecated.", error: false)]
+    [Obsolete("IDispatchImplAttribute and IDispatchImplType have been deprecated and are no longer supported.", error: false)]
     public enum IDispatchImplType
     {
         CompatibleImpl = 2,

--- a/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/IDispatchImplType.cs
+++ b/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/IDispatchImplType.cs
@@ -3,7 +3,7 @@
 
 namespace System.Runtime.InteropServices
 {
-    [Obsolete("IDispatchImplAttribute and IDispatchImplType have been deprecated and are no longer supported.")]
+    [Obsolete("IDispatchImplAttribute and IDispatchImplType have been deprecated and are not supported.")]
     public enum IDispatchImplType
     {
         CompatibleImpl = 2,

--- a/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/SetWin32ContextInIDispatchAttribute.cs
+++ b/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/SetWin32ContextInIDispatchAttribute.cs
@@ -3,7 +3,7 @@
 
 namespace System.Runtime.InteropServices
 {
-    [Obsolete("SetWin32ContextInIDispatchAttribute has been deprecated. Application Domains no longer respect Activation Context boundaries in IDispatch calls.", error: false)]
+    [Obsolete("SetWin32ContextInIDispatchAttribute has been deprecated. Application Domains no longer respect Activation Context boundaries in IDispatch calls.")]
     [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
     public sealed class SetWin32ContextInIDispatchAttribute : Attribute
     {

--- a/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/SetWin32ContextInIDispatchAttribute.cs
+++ b/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/SetWin32ContextInIDispatchAttribute.cs
@@ -3,7 +3,7 @@
 
 namespace System.Runtime.InteropServices
 {
-    [Obsolete("This attribute has been deprecated.  Application Domains no longer respect Activation Context boundaries in IDispatch calls.", error: false)]
+    [Obsolete("SetWin32ContextInIDispatchAttribute has been deprecated. Application Domains no longer respect Activation Context boundaries in IDispatch calls.", error: false)]
     [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
     public sealed class SetWin32ContextInIDispatchAttribute : Attribute
     {

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -2683,10 +2683,10 @@ namespace System
         [System.CLSCompliantAttribute(false)]
         public static object ToObject(System.Type enumType, ulong value) { throw null; }
         public override string ToString() { throw null; }
-        [System.ObsoleteAttribute("The provider argument is not used. Please use ToString().")]
+        [System.ObsoleteAttribute("The provider argument is not used. Use ToString() instead.")]
         public string ToString(System.IFormatProvider? provider) { throw null; }
         public string ToString(string? format) { throw null; }
-        [System.ObsoleteAttribute("The provider argument is not used. Please use ToString(String).")]
+        [System.ObsoleteAttribute("The provider argument is not used. Use ToString(String) instead.")]
         public string ToString(string? format, System.IFormatProvider? provider) { throw null; }
         public static bool TryParse(System.Type enumType, System.ReadOnlySpan<char> value, bool ignoreCase, out object? result) { throw null; }
         public static bool TryParse(System.Type enumType, System.ReadOnlySpan<char> value, out object? result) { throw null; }
@@ -2830,7 +2830,7 @@ namespace System
         public new System.Type GetType() { throw null; }
         public override string ToString() { throw null; }
     }
-    [System.ObsoleteAttribute("This type previously indicated an unspecified fatal error in the runtime. The runtime no longer raises this exception so this type is obsolete.")]
+    [System.ObsoleteAttribute("ExecutionEngineException previously indicated an unspecified fatal error in the runtime. The runtime no longer raises this exception so this type is obsolete.")]
     public sealed partial class ExecutionEngineException : System.SystemException
     {
         public ExecutionEngineException() { }
@@ -5121,7 +5121,7 @@ namespace System
         public int Length { get { throw null; } }
         public void CopyTo(System.Span<T> destination) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("Equals() on ReadOnlySpan will always throw an exception. Use the == operator.")]
+        [System.ObsoleteAttribute("Equals() on ReadOnlySpan will always throw an exception. Use the equality operator instead.")]
         public override bool Equals(object? obj) { throw null; }
         public System.ReadOnlySpan<T>.Enumerator GetEnumerator() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -5670,7 +5670,7 @@ namespace System
         public void Clear() { }
         public void CopyTo(System.Span<T> destination) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("Equals() on Span will always throw an exception. Use the == operator.")]
+        [System.ObsoleteAttribute("Equals() on Span will always throw an exception. Use the equality operator instead.")]
         public override bool Equals(object? obj) { throw null; }
         public void Fill(T value) { }
         public System.Span<T>.Enumerator GetEnumerator() { throw null; }
@@ -6230,7 +6230,7 @@ namespace System
         static System.TimeSpan IUnaryPlusOperators<System.TimeSpan, System.TimeSpan>.operator +(System.TimeSpan value) { throw null; }
 #endif // FEATURE_GENERIC_MATH
     }
-    [System.ObsoleteAttribute("System.TimeZone has been deprecated. Please investigate the use of System.TimeZoneInfo.")]
+    [System.ObsoleteAttribute("System.TimeZone has been deprecated. Investigate the use of System.TimeZoneInfo instead.")]
     public abstract partial class TimeZone
     {
         protected TimeZone() { }
@@ -7657,11 +7657,11 @@ namespace System
         public static readonly string UriSchemeWss;
         protected Uri(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public Uri(string uriString) { }
-        [System.ObsoleteAttribute("This constructor has been deprecated; the dontEscape parameter is always false. Use Uri(string).")]
+        [System.ObsoleteAttribute("This constructor has been deprecated; the dontEscape parameter is always false. Use Uri(string) instead.")]
         public Uri(string uriString, bool dontEscape) { }
         public Uri(string uriString, System.UriKind uriKind) { }
         public Uri(System.Uri baseUri, string? relativeUri) { }
-        [System.ObsoleteAttribute("This constructor has been deprecated; the dontEscape parameter is always false. Use Uri(Uri, string).")]
+        [System.ObsoleteAttribute("This constructor has been deprecated; the dontEscape parameter is always false. Use Uri(Uri, string) instead.")]
         public Uri(System.Uri baseUri, string? relativeUri, bool dontEscape) { }
         public Uri(System.Uri baseUri, System.Uri relativeUri) { }
         public string AbsolutePath { get { throw null; } }
@@ -8281,29 +8281,29 @@ namespace System.Collections
         public Hashtable() { }
         public Hashtable(System.Collections.IDictionary d) { }
         public Hashtable(System.Collections.IDictionary d, System.Collections.IEqualityComparer? equalityComparer) { }
-        [System.ObsoleteAttribute("This constructor has been deprecated. Use Hashtable(IDictionary, IEqualityComparer).")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use Hashtable(IDictionary, IEqualityComparer) instead.")]
         public Hashtable(System.Collections.IDictionary d, System.Collections.IHashCodeProvider? hcp, System.Collections.IComparer? comparer) { }
         public Hashtable(System.Collections.IDictionary d, float loadFactor) { }
         public Hashtable(System.Collections.IDictionary d, float loadFactor, System.Collections.IEqualityComparer? equalityComparer) { }
-        [System.ObsoleteAttribute("This constructor has been deprecated. Use Hashtable(IDictionary, float, IEqualityComparer).")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use Hashtable(IDictionary, float, IEqualityComparer) instead.")]
         public Hashtable(System.Collections.IDictionary d, float loadFactor, System.Collections.IHashCodeProvider? hcp, System.Collections.IComparer? comparer) { }
         public Hashtable(System.Collections.IEqualityComparer? equalityComparer) { }
         [System.ObsoleteAttribute("This constructor has been deprecated. Use Hashtable(IEqualityComparer).")]
         public Hashtable(System.Collections.IHashCodeProvider? hcp, System.Collections.IComparer? comparer) { }
         public Hashtable(int capacity) { }
         public Hashtable(int capacity, System.Collections.IEqualityComparer? equalityComparer) { }
-        [System.ObsoleteAttribute("This constructor has been deprecated. Use Hashtable(int, IEqualityComparer).")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use Hashtable(int, IEqualityComparer) instead.")]
         public Hashtable(int capacity, System.Collections.IHashCodeProvider? hcp, System.Collections.IComparer? comparer) { }
         public Hashtable(int capacity, float loadFactor) { }
         public Hashtable(int capacity, float loadFactor, System.Collections.IEqualityComparer? equalityComparer) { }
-        [System.ObsoleteAttribute("This constructor has been deprecated. Use Hashtable(int, float, IEqualityComparer).")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use Hashtable(int, float, IEqualityComparer) instead.")]
         public Hashtable(int capacity, float loadFactor, System.Collections.IHashCodeProvider? hcp, System.Collections.IComparer? comparer) { }
         protected Hashtable(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        [System.ObsoleteAttribute("Hashtable.comparer has been deprecated. Use the KeyComparer properties.")]
+        [System.ObsoleteAttribute("Hashtable.comparer has been deprecated. Use the KeyComparer properties instead.")]
         protected System.Collections.IComparer? comparer { get { throw null; } set { } }
         public virtual int Count { get { throw null; } }
         protected System.Collections.IEqualityComparer? EqualityComparer { get { throw null; } }
-        [System.ObsoleteAttribute("Hashtable.hcp has been deprecated. Use the EqualityComparer property.")]
+        [System.ObsoleteAttribute("Hashtable.hcp has been deprecated. Use the EqualityComparer property instead.")]
         protected System.Collections.IHashCodeProvider? hcp { get { throw null; } set { } }
         public virtual bool IsFixedSize { get { throw null; } }
         public virtual bool IsReadOnly { get { throw null; } }
@@ -8375,7 +8375,7 @@ namespace System.Collections
         bool Equals(object? x, object? y);
         int GetHashCode(object obj);
     }
-    [System.ObsoleteAttribute("IHashCodeProvider has been deprecated. Use IEqualityComparer.")]
+    [System.ObsoleteAttribute("IHashCodeProvider has been deprecated. Use IEqualityComparer instead.")]
     public partial interface IHashCodeProvider
     {
         int GetHashCode(object obj);
@@ -9290,9 +9290,9 @@ namespace System.Globalization
         AllCultures = 7,
         UserCustomCulture = 8,
         ReplacementCultures = 16,
-        [System.ObsoleteAttribute("This value has been deprecated.  Please use other values in CultureTypes.")]
+        [System.ObsoleteAttribute("CultureTypes.WindowsOnlyCultures has been deprecated. Use other values in CultureTypes instead.")]
         WindowsOnlyCultures = 32,
-        [System.ObsoleteAttribute("This value has been deprecated.  Please use other values in CultureTypes.")]
+        [System.ObsoleteAttribute("CultureTypes.FrameworkCultures has been deprecated. Use other values in CultureTypes instead.")]
         FrameworkCultures = 64,
     }
     public sealed partial class DateTimeFormatInfo : System.ICloneable, System.IFormatProvider
@@ -10164,16 +10164,16 @@ namespace System.IO
         public FileStream(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.IO.FileAccess access, int bufferSize) { }
         public FileStream(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.IO.FileAccess access, int bufferSize, bool isAsync) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("This constructor has been deprecated. Use new FileStream(SafeFileHandle handle, FileAccess access).")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use FileStream(SafeFileHandle handle, FileAccess access) instead.")]
         public FileStream(System.IntPtr handle, System.IO.FileAccess access) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("This constructor has been deprecated. Use new FileStream(SafeFileHandle handle, FileAccess access) and optionally make a new SafeFileHandle with ownsHandle=false if needed.")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use FileStream(SafeFileHandle handle, FileAccess access) and optionally make a new SafeFileHandle with ownsHandle=false if needed instead.")]
         public FileStream(System.IntPtr handle, System.IO.FileAccess access, bool ownsHandle) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("This constructor has been deprecated. Use new FileStream(SafeFileHandle handle, FileAccess access, int bufferSize) and optionally make a new SafeFileHandle with ownsHandle=false if needed.")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use FileStream(SafeFileHandle handle, FileAccess access, int bufferSize) and optionally make a new SafeFileHandle with ownsHandle=false if needed instead.")]
         public FileStream(System.IntPtr handle, System.IO.FileAccess access, bool ownsHandle, int bufferSize) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("This constructor has been deprecated. Use new FileStream(SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync) and optionally make a new SafeFileHandle with ownsHandle=false if needed.")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use FileStream(SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync) and optionally make a new SafeFileHandle with ownsHandle=false if needed instead.")]
         public FileStream(System.IntPtr handle, System.IO.FileAccess access, bool ownsHandle, int bufferSize, bool isAsync) { }
         public FileStream(string path, System.IO.FileMode mode) { }
         public FileStream(string path, System.IO.FileMode mode, System.IO.FileAccess access) { }
@@ -10185,7 +10185,7 @@ namespace System.IO
         public override bool CanRead { get { throw null; } }
         public override bool CanSeek { get { throw null; } }
         public override bool CanWrite { get { throw null; } }
-        [System.ObsoleteAttribute("FileStream.Handle has been deprecated. Use FileStream's SafeFileHandle property.")]
+        [System.ObsoleteAttribute("FileStream.Handle has been deprecated. Use FileStream's SafeFileHandle property instead.")]
         public virtual System.IntPtr Handle { get { throw null; } }
         public virtual bool IsAsync { get { throw null; } }
         public override long Length { get { throw null; } }
@@ -10540,7 +10540,7 @@ namespace System.IO
     {
         public static readonly char AltDirectorySeparatorChar;
         public static readonly char DirectorySeparatorChar;
-        [System.ObsoleteAttribute("Path.InvalidPathChars has been deprecated. Use GetInvalidPathChars or GetInvalidFileNameChars.")]
+        [System.ObsoleteAttribute("Path.InvalidPathChars has been deprecated. Use GetInvalidPathChars or GetInvalidFileNameChars instead.")]
         public static readonly char[] InvalidPathChars;
         public static readonly char PathSeparator;
         public static readonly char VolumeSeparatorChar;
@@ -10625,7 +10625,7 @@ namespace System.IO
         public System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, int bufferSize) { throw null; }
         public virtual System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, int bufferSize, System.Threading.CancellationToken cancellationToken) { throw null; }
         public System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, System.Threading.CancellationToken cancellationToken) { throw null; }
-        [System.ObsoleteAttribute("Stream.CreateWaitHandle has been deprecated. Use new ManualResetEvent(false).")]
+        [System.ObsoleteAttribute("Stream.CreateWaitHandle has been deprecated. Use new ManualResetEvent(false) instead.")]
         protected virtual System.Threading.WaitHandle CreateWaitHandle() { throw null; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
@@ -11150,7 +11150,7 @@ namespace System.Reflection
         public System.Reflection.Module LoadModule(string moduleName, byte[]? rawModule) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Types and members the loaded module depends on might be removed")]
         public virtual System.Reflection.Module LoadModule(string moduleName, byte[]? rawModule, byte[]? rawSymbolStore) { throw null; }
-        [System.ObsoleteAttribute("Assembly.LoadWithPartialName has been deprecated. Use Assembly.Load().")]
+        [System.ObsoleteAttribute("Assembly.LoadWithPartialName has been deprecated. Use Assembly.Load() instead.")]
         public static System.Reflection.Assembly? LoadWithPartialName(string partialName) { throw null; }
         public static bool operator ==(System.Reflection.Assembly? left, System.Reflection.Assembly? right) { throw null; }
         public static bool operator !=(System.Reflection.Assembly? left, System.Reflection.Assembly? right) { throw null; }
@@ -11232,15 +11232,15 @@ namespace System.Reflection
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly, Inherited=false)]
     public sealed partial class AssemblyFlagsAttribute : System.Attribute
     {
-        [System.ObsoleteAttribute("This constructor has been deprecated. Use AssemblyFlagsAttribute(AssemblyNameFlags).")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use AssemblyFlagsAttribute(AssemblyNameFlags) instead.")]
         public AssemblyFlagsAttribute(int assemblyFlags) { }
         public AssemblyFlagsAttribute(System.Reflection.AssemblyNameFlags assemblyFlags) { }
         [System.CLSCompliantAttribute(false)]
-        [System.ObsoleteAttribute("This constructor has been deprecated. Use AssemblyFlagsAttribute(AssemblyNameFlags).")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use AssemblyFlagsAttribute(AssemblyNameFlags) instead.")]
         public AssemblyFlagsAttribute(uint flags) { }
         public int AssemblyFlags { get { throw null; } }
         [System.CLSCompliantAttribute(false)]
-        [System.ObsoleteAttribute("This property has been deprecated. Use AssemblyFlags.")]
+        [System.ObsoleteAttribute("AssemblyFlagsAttribute.Flags has been deprecated. Use AssemblyFlags instead.")]
         public uint Flags { get { throw null; } }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly, Inherited=false)]
@@ -13022,7 +13022,7 @@ namespace System.Runtime.CompilerServices
     }
     public static partial class RuntimeHelpers
     {
-        [System.ObsoleteAttribute("OffsetToStringData has been deprecated. Use string.GetPinnableReference().")]
+        [System.ObsoleteAttribute("OffsetToStringData has been deprecated. Use string.GetPinnableReference() instead.")]
         public static int OffsetToStringData { get { throw null; } }
         public static System.IntPtr AllocateTypeAssociatedMemory(System.Type type, int size) { throw null; }
         public static void EnsureSufficientExecutionStack() { }
@@ -14173,7 +14173,7 @@ namespace System.Text
         public virtual System.ReadOnlySpan<byte> Preamble { get { throw null; } }
         public static System.Text.Encoding Unicode { get { throw null; } }
         public static System.Text.Encoding UTF32 { get { throw null; } }
-        [System.ObsoleteAttribute("The UTF-7 encoding is insecure and should not be used. Consider using UTF-8.", DiagnosticId = "SYSLIB0001", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("The UTF-7 encoding is insecure and should not be used. Consider using UTF-8 instead.", DiagnosticId = "SYSLIB0001", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.Text.Encoding UTF7 { get { throw null; } }
         public static System.Text.Encoding UTF8 { get { throw null; } }
         public virtual string WebName { get { throw null; } }
@@ -14576,7 +14576,7 @@ namespace System.Threading
         protected static readonly System.IntPtr InvalidHandle;
         public const int WaitTimeout = 258;
         protected WaitHandle() { }
-        [System.ObsoleteAttribute("WaitHandle.Handle has been deprecated. Use the SafeWaitHandle property.")]
+        [System.ObsoleteAttribute("WaitHandle.Handle has been deprecated. Use the SafeWaitHandle property instead.")]
         public virtual System.IntPtr Handle { get { throw null; } set { } }
         [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
         public Microsoft.Win32.SafeHandles.SafeWaitHandle SafeWaitHandle { get { throw null; } set { } }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -144,12 +144,12 @@ namespace System
         public event System.ResolveEventHandler? ResourceResolve { add { } remove { } }
         public event System.ResolveEventHandler? TypeResolve { add { } remove { } }
         public event System.UnhandledExceptionEventHandler? UnhandledException { add { } remove { } }
-        [System.ObsoleteAttribute("AppDomain.AppendPrivatePath has been deprecated. Please investigate the use of AppDomainSetup.PrivateBinPath instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("AppDomain.AppendPrivatePath has been deprecated and is no longer supported.")]
         public void AppendPrivatePath(string? path) { }
         public string ApplyPolicy(string assemblyName) { throw null; }
-        [System.ObsoleteAttribute("AppDomain.ClearPrivatePath has been deprecated. Please investigate the use of AppDomainSetup.PrivateBinPath instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("AppDomain.ClearPrivatePath has been deprecated and is no longer supported.")]
         public void ClearPrivatePath() { }
-        [System.ObsoleteAttribute("AppDomain.ClearShadowCopyPath has been deprecated. Please investigate the use of AppDomainSetup.ShadowCopyDirectories instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("AppDomain.ClearShadowCopyPath has been deprecated and is no longer supported.")]
         public void ClearShadowCopyPath() { }
         [System.ObsoleteAttribute("Creating and unloading AppDomains is not supported and throws an exception.", DiagnosticId = "SYSLIB0024", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.AppDomain CreateDomain(string friendlyName) { throw null; }
@@ -188,7 +188,7 @@ namespace System
         public int ExecuteAssemblyByName(string assemblyName) { throw null; }
         public int ExecuteAssemblyByName(string assemblyName, params string?[]? args) { throw null; }
         public System.Reflection.Assembly[] GetAssemblies() { throw null; }
-        [System.ObsoleteAttribute("AppDomain.GetCurrentThreadId has been deprecated because it does not provide a stable Id when managed threads are running on fibers (aka lightweight threads). To get a stable identifier for a managed thread, use the ManagedThreadId property on Thread.  https://go.microsoft.com/fwlink/?linkid=14202", false)]
+        [System.ObsoleteAttribute("AppDomain.GetCurrentThreadId has been deprecated because it does not provide a stable Id when managed threads are running on fibers (aka lightweight threads). To get a stable identifier for a managed thread, use the ManagedThreadId property on Thread.", false)]
         public static int GetCurrentThreadId() { throw null; }
         public object? GetData(string name) { throw null; }
         public bool? IsCompatibilitySwitchSet(string value) { throw null; }
@@ -201,15 +201,15 @@ namespace System
         public System.Reflection.Assembly Load(System.Reflection.AssemblyName assemblyRef) { throw null; }
         public System.Reflection.Assembly Load(string assemblyString) { throw null; }
         public System.Reflection.Assembly[] ReflectionOnlyGetAssemblies() { throw null; }
-        [System.ObsoleteAttribute("AppDomain.SetCachePath has been deprecated. Please investigate the use of AppDomainSetup.CachePath instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("AppDomain.SetCachePath has been deprecated and is no longer supported.")]
         public void SetCachePath(string? path) { }
         public void SetData(string name, object? data) { }
-        [System.ObsoleteAttribute("AppDomain.SetDynamicBase has been deprecated. Please investigate the use of AppDomainSetup.DynamicBase instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("AppDomain.SetDynamicBase has been deprecated and is no longer supported.")]
         public void SetDynamicBase(string? path) { }
         public void SetPrincipalPolicy(System.Security.Principal.PrincipalPolicy policy) { }
-        [System.ObsoleteAttribute("AppDomain.SetShadowCopyFiles has been deprecated. Please investigate the use of AppDomainSetup.ShadowCopyFiles instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("AppDomain.SetShadowCopyFiles has been deprecated and is no longer supported.")]
         public void SetShadowCopyFiles() { }
-        [System.ObsoleteAttribute("AppDomain.SetShadowCopyPath has been deprecated. Please investigate the use of AppDomainSetup.ShadowCopyDirectories instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("AppDomain.SetShadowCopyPath has been deprecated and is no longer supported.")]
         public void SetShadowCopyPath(string? path) { }
         public void SetThreadPrincipal(System.Security.Principal.IPrincipal principal) { }
         public override string ToString() { throw null; }
@@ -4491,10 +4491,10 @@ namespace System
         NotSpecified = 0,
         SingleDomain = 1,
         MultiDomain = 2,
-        [System.ObsoleteAttribute("This method has been deprecated. Please use Assembly.Load() instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("LoaderOptimization.DomainMask has been deprecated and is no longer supported.")]
         DomainMask = 3,
         MultiDomainHost = 3,
-        [System.ObsoleteAttribute("This method has been deprecated. Please use Assembly.Load() instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("LoaderOptimization.DisallowBindings has been deprecated and is no longer supported.")]
         DisallowBindings = 4,
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Method)]
@@ -5121,7 +5121,7 @@ namespace System
         public int Length { get { throw null; } }
         public void CopyTo(System.Span<T> destination) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("Equals() on ReadOnlySpan will always throw an exception. Use == instead.")]
+        [System.ObsoleteAttribute("Equals() on ReadOnlySpan will always throw an exception. Use the == operator.")]
         public override bool Equals(object? obj) { throw null; }
         public System.ReadOnlySpan<T>.Enumerator GetEnumerator() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
@@ -5670,7 +5670,7 @@ namespace System
         public void Clear() { }
         public void CopyTo(System.Span<T> destination) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("Equals() on Span will always throw an exception. Use == instead.")]
+        [System.ObsoleteAttribute("Equals() on Span will always throw an exception. Use the == operator.")]
         public override bool Equals(object? obj) { throw null; }
         public void Fill(T value) { }
         public System.Span<T>.Enumerator GetEnumerator() { throw null; }
@@ -6230,7 +6230,7 @@ namespace System
         static System.TimeSpan IUnaryPlusOperators<System.TimeSpan, System.TimeSpan>.operator +(System.TimeSpan value) { throw null; }
 #endif // FEATURE_GENERIC_MATH
     }
-    [System.ObsoleteAttribute("System.TimeZone has been deprecated.  Please investigate the use of System.TimeZoneInfo instead.")]
+    [System.ObsoleteAttribute("System.TimeZone has been deprecated. Please investigate the use of System.TimeZoneInfo.")]
     public abstract partial class TimeZone
     {
         protected TimeZone() { }
@@ -7657,11 +7657,11 @@ namespace System
         public static readonly string UriSchemeWss;
         protected Uri(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public Uri(string uriString) { }
-        [System.ObsoleteAttribute("The constructor has been deprecated. Please use new Uri(string). The dontEscape parameter is deprecated and is always false. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("This constructor has been deprecated; the dontEscape parameter is always false. Use Uri(string).")]
         public Uri(string uriString, bool dontEscape) { }
         public Uri(string uriString, System.UriKind uriKind) { }
         public Uri(System.Uri baseUri, string? relativeUri) { }
-        [System.ObsoleteAttribute("The constructor has been deprecated. Please new Uri(Uri, string). The dontEscape parameter is deprecated and is always false. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("This constructor has been deprecated; the dontEscape parameter is always false. Use Uri(Uri, string).")]
         public Uri(System.Uri baseUri, string? relativeUri, bool dontEscape) { }
         public Uri(System.Uri baseUri, System.Uri relativeUri) { }
         public string AbsolutePath { get { throw null; } }
@@ -7686,20 +7686,20 @@ namespace System
         public string[] Segments { get { throw null; } }
         public bool UserEscaped { get { throw null; } }
         public string UserInfo { get { throw null; } }
-        [System.ObsoleteAttribute("The method has been deprecated. It is not used by the system. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Uri.Canonicalize has been deprecated and is no longer supported.")]
         protected virtual void Canonicalize() { }
         public static System.UriHostNameType CheckHostName(string? name) { throw null; }
         public static bool CheckSchemeName([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? schemeName) { throw null; }
-        [System.ObsoleteAttribute("The method has been deprecated. It is not used by the system. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Uri.CheckSecurity has been deprecated and is no longer supported.")]
         protected virtual void CheckSecurity() { }
         public static int Compare(System.Uri? uri1, System.Uri? uri2, System.UriComponents partsToCompare, System.UriFormat compareFormat, System.StringComparison comparisonType) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? comparand) { throw null; }
-        [System.ObsoleteAttribute("The method has been deprecated. It is not used by the system. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Uri.Escape has been deprecated and is no longer supported.")]
         protected virtual void Escape() { }
         public static string EscapeDataString(string stringToEscape) { throw null; }
-        [System.ObsoleteAttribute("The method has been deprecated. Please use GetComponents() or static EscapeDataString() to escape a Uri component or a string. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Uri.EscapeString has been deprecated. Use GetComponents() or static EscapeDataString() to escape a Uri component or a string.")]
         protected static string EscapeString(string? str) { throw null; }
-        [System.ObsoleteAttribute("Uri.EscapeUriString can corrupt the Uri string in some cases. Consider using Uri.EscapeDataString for query string components instead.", DiagnosticId = "SYSLIB0013", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("Uri.EscapeUriString can corrupt the Uri string in some cases. Consider using Uri.EscapeDataString for query string components.", DiagnosticId = "SYSLIB0013", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static string EscapeUriString(string stringToEscape) { throw null; }
         public static int FromHex(char digit) { throw null; }
         public string GetComponents(System.UriComponents components, System.UriFormat format) { throw null; }
@@ -7708,30 +7708,30 @@ namespace System
         protected void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public static string HexEscape(char character) { throw null; }
         public static char HexUnescape(string pattern, ref int index) { throw null; }
-        [System.ObsoleteAttribute("The method has been deprecated. It is not used by the system. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Uri.IsBadFileSystemCharacter has been deprecated and is no longer supported.")]
         protected virtual bool IsBadFileSystemCharacter(char character) { throw null; }
         public bool IsBaseOf(System.Uri uri) { throw null; }
-        [System.ObsoleteAttribute("The method has been deprecated. It is not used by the system. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Uri.IsExcludedCharacter has been deprecated and is no longer supported.")]
         protected static bool IsExcludedCharacter(char character) { throw null; }
         public static bool IsHexDigit(char character) { throw null; }
         public static bool IsHexEncoding(string pattern, int index) { throw null; }
-        [System.ObsoleteAttribute("The method has been deprecated. It is not used by the system. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Uri.IsReservedCharacter has been deprecated and is no longer supported.")]
         protected virtual bool IsReservedCharacter(char character) { throw null; }
         public bool IsWellFormedOriginalString() { throw null; }
         public static bool IsWellFormedUriString([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? uriString, System.UriKind uriKind) { throw null; }
-        [System.ObsoleteAttribute("The method has been deprecated. Please use MakeRelativeUri(Uri uri). https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Uri.MakeRelative has been deprecated. Use MakeRelativeUri(Uri uri).")]
         public string MakeRelative(System.Uri toUri) { throw null; }
         public System.Uri MakeRelativeUri(System.Uri uri) { throw null; }
         public static bool operator ==(System.Uri? uri1, System.Uri? uri2) { throw null; }
         public static bool operator !=(System.Uri? uri1, System.Uri? uri2) { throw null; }
-        [System.ObsoleteAttribute("The method has been deprecated. It is not used by the system. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Uri.Parse has been deprecated and is no longer supported.")]
         protected virtual void Parse() { }
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public override string ToString() { throw null; }
         public static bool TryCreate([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? uriString, System.UriKind uriKind, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Uri? result) { throw null; }
         public static bool TryCreate(System.Uri? baseUri, string? relativeUri, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Uri? result) { throw null; }
         public static bool TryCreate(System.Uri? baseUri, System.Uri? relativeUri, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Uri? result) { throw null; }
-        [System.ObsoleteAttribute("The method has been deprecated. Please use GetComponents() or static UnescapeDataString() to unescape a Uri component or a string. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Uri.Unescape has been deprecated. Use GetComponents() or Uri.UnescapeDataString() to unescape a Uri component or a string.")]
         protected virtual string Unescape(string path) { throw null; }
         public static string UnescapeDataString(string stringToUnescape) { throw null; }
     }
@@ -8281,29 +8281,29 @@ namespace System.Collections
         public Hashtable() { }
         public Hashtable(System.Collections.IDictionary d) { }
         public Hashtable(System.Collections.IDictionary d, System.Collections.IEqualityComparer? equalityComparer) { }
-        [System.ObsoleteAttribute("Please use Hashtable(IDictionary, IEqualityComparer) instead.")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use Hashtable(IDictionary, IEqualityComparer).")]
         public Hashtable(System.Collections.IDictionary d, System.Collections.IHashCodeProvider? hcp, System.Collections.IComparer? comparer) { }
         public Hashtable(System.Collections.IDictionary d, float loadFactor) { }
         public Hashtable(System.Collections.IDictionary d, float loadFactor, System.Collections.IEqualityComparer? equalityComparer) { }
-        [System.ObsoleteAttribute("Please use Hashtable(IDictionary, float, IEqualityComparer) instead.")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use Hashtable(IDictionary, float, IEqualityComparer).")]
         public Hashtable(System.Collections.IDictionary d, float loadFactor, System.Collections.IHashCodeProvider? hcp, System.Collections.IComparer? comparer) { }
         public Hashtable(System.Collections.IEqualityComparer? equalityComparer) { }
-        [System.ObsoleteAttribute("Please use Hashtable(IEqualityComparer) instead.")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use Hashtable(IEqualityComparer).")]
         public Hashtable(System.Collections.IHashCodeProvider? hcp, System.Collections.IComparer? comparer) { }
         public Hashtable(int capacity) { }
         public Hashtable(int capacity, System.Collections.IEqualityComparer? equalityComparer) { }
-        [System.ObsoleteAttribute("Please use Hashtable(int, IEqualityComparer) instead.")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use Hashtable(int, IEqualityComparer).")]
         public Hashtable(int capacity, System.Collections.IHashCodeProvider? hcp, System.Collections.IComparer? comparer) { }
         public Hashtable(int capacity, float loadFactor) { }
         public Hashtable(int capacity, float loadFactor, System.Collections.IEqualityComparer? equalityComparer) { }
-        [System.ObsoleteAttribute("Please use Hashtable(int, float, IEqualityComparer) instead.")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use Hashtable(int, float, IEqualityComparer).")]
         public Hashtable(int capacity, float loadFactor, System.Collections.IHashCodeProvider? hcp, System.Collections.IComparer? comparer) { }
         protected Hashtable(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        [System.ObsoleteAttribute("Please use KeyComparer properties.")]
+        [System.ObsoleteAttribute("Hashtable.comparer has been deprecated. Use the KeyComparer properties.")]
         protected System.Collections.IComparer? comparer { get { throw null; } set { } }
         public virtual int Count { get { throw null; } }
         protected System.Collections.IEqualityComparer? EqualityComparer { get { throw null; } }
-        [System.ObsoleteAttribute("Please use EqualityComparer property.")]
+        [System.ObsoleteAttribute("Hashtable.hcp has been deprecated. Use the EqualityComparer property.")]
         protected System.Collections.IHashCodeProvider? hcp { get { throw null; } set { } }
         public virtual bool IsFixedSize { get { throw null; } }
         public virtual bool IsReadOnly { get { throw null; } }
@@ -8375,7 +8375,7 @@ namespace System.Collections
         bool Equals(object? x, object? y);
         int GetHashCode(object obj);
     }
-    [System.ObsoleteAttribute("Please use IEqualityComparer instead.")]
+    [System.ObsoleteAttribute("IHashCodeProvider has been deprecated. Use IEqualityComparer.")]
     public partial interface IHashCodeProvider
     {
         int GetHashCode(object obj);
@@ -10164,16 +10164,16 @@ namespace System.IO
         public FileStream(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.IO.FileAccess access, int bufferSize) { }
         public FileStream(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.IO.FileAccess access, int bufferSize, bool isAsync) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("This constructor has been deprecated.  Please use new FileStream(SafeFileHandle handle, FileAccess access) instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use new FileStream(SafeFileHandle handle, FileAccess access).")]
         public FileStream(System.IntPtr handle, System.IO.FileAccess access) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("This constructor has been deprecated.  Please use new FileStream(SafeFileHandle handle, FileAccess access) instead, and optionally make a new SafeFileHandle with ownsHandle=false if needed.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use new FileStream(SafeFileHandle handle, FileAccess access) and optionally make a new SafeFileHandle with ownsHandle=false if needed.")]
         public FileStream(System.IntPtr handle, System.IO.FileAccess access, bool ownsHandle) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("This constructor has been deprecated.  Please use new FileStream(SafeFileHandle handle, FileAccess access, int bufferSize) instead, and optionally make a new SafeFileHandle with ownsHandle=false if needed.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use new FileStream(SafeFileHandle handle, FileAccess access, int bufferSize) and optionally make a new SafeFileHandle with ownsHandle=false if needed.")]
         public FileStream(System.IntPtr handle, System.IO.FileAccess access, bool ownsHandle, int bufferSize) { }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        [System.ObsoleteAttribute("This constructor has been deprecated.  Please use new FileStream(SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync) instead, and optionally make a new SafeFileHandle with ownsHandle=false if needed.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use new FileStream(SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync) and optionally make a new SafeFileHandle with ownsHandle=false if needed.")]
         public FileStream(System.IntPtr handle, System.IO.FileAccess access, bool ownsHandle, int bufferSize, bool isAsync) { }
         public FileStream(string path, System.IO.FileMode mode) { }
         public FileStream(string path, System.IO.FileMode mode, System.IO.FileAccess access) { }
@@ -10185,7 +10185,7 @@ namespace System.IO
         public override bool CanRead { get { throw null; } }
         public override bool CanSeek { get { throw null; } }
         public override bool CanWrite { get { throw null; } }
-        [System.ObsoleteAttribute("This property has been deprecated.  Please use FileStream's SafeFileHandle property instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("FileStream.Handle has been deprecated. Use FileStream's SafeFileHandle property.")]
         public virtual System.IntPtr Handle { get { throw null; } }
         public virtual bool IsAsync { get { throw null; } }
         public override long Length { get { throw null; } }
@@ -10540,7 +10540,7 @@ namespace System.IO
     {
         public static readonly char AltDirectorySeparatorChar;
         public static readonly char DirectorySeparatorChar;
-        [System.ObsoleteAttribute("Please use GetInvalidPathChars or GetInvalidFileNameChars instead.")]
+        [System.ObsoleteAttribute("Path.InvalidPathChars has been deprecated. Use GetInvalidPathChars or GetInvalidFileNameChars.")]
         public static readonly char[] InvalidPathChars;
         public static readonly char PathSeparator;
         public static readonly char VolumeSeparatorChar;
@@ -10625,7 +10625,7 @@ namespace System.IO
         public System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, int bufferSize) { throw null; }
         public virtual System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, int bufferSize, System.Threading.CancellationToken cancellationToken) { throw null; }
         public System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, System.Threading.CancellationToken cancellationToken) { throw null; }
-        [System.ObsoleteAttribute("CreateWaitHandle will be removed eventually.  Please use \"new ManualResetEvent(false)\" instead.")]
+        [System.ObsoleteAttribute("Stream.CreateWaitHandle has been deprecated. Use new ManualResetEvent(false).")]
         protected virtual System.Threading.WaitHandle CreateWaitHandle() { throw null; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
@@ -11059,13 +11059,13 @@ namespace System.Reflection
     public abstract partial class Assembly : System.Reflection.ICustomAttributeProvider, System.Runtime.Serialization.ISerializable
     {
         protected Assembly() { }
-        [System.ObsoleteAttribute("Assembly.CodeBase and Assembly.EscapedCodeBase are only included for .NET Framework compatibility. Use Assembly.Location instead.", DiagnosticId = "SYSLIB0012", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("Assembly.CodeBase and Assembly.EscapedCodeBase are only included for .NET Framework compatibility. Use Assembly.Location.", DiagnosticId = "SYSLIB0012", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         [System.Diagnostics.CodeAnalysis.RequiresAssemblyFilesAttribute("This member throws an exception for assemblies embedded in a single-file app")]
         public virtual string? CodeBase { get { throw null; } }
         public virtual System.Collections.Generic.IEnumerable<System.Reflection.CustomAttributeData> CustomAttributes { get { throw null; } }
         public virtual System.Collections.Generic.IEnumerable<System.Reflection.TypeInfo> DefinedTypes { [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Types might be removed")] get { throw null; } }
         public virtual System.Reflection.MethodInfo? EntryPoint { get { throw null; } }
-        [System.ObsoleteAttribute("Assembly.CodeBase and Assembly.EscapedCodeBase are only included for .NET Framework compatibility. Use Assembly.Location instead.", DiagnosticId = "SYSLIB0012", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("Assembly.CodeBase and Assembly.EscapedCodeBase are only included for .NET Framework compatibility. Use Assembly.Location.", DiagnosticId = "SYSLIB0012", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         [System.Diagnostics.CodeAnalysis.RequiresAssemblyFilesAttribute("This member throws an exception for assemblies embedded in a single-file app")]
         public virtual string EscapedCodeBase { get { throw null; } }
         public virtual System.Collections.Generic.IEnumerable<System.Type> ExportedTypes { [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Types might be removed")] get { throw null; } }
@@ -11083,11 +11083,11 @@ namespace System.Reflection
         public virtual bool ReflectionOnly { get { throw null; } }
         public virtual System.Security.SecurityRuleSet SecurityRuleSet { get { throw null; } }
         public virtual event System.Reflection.ModuleResolveEventHandler? ModuleResolve { add { } remove { } }
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Assembly.CreateInstance is not supported with trimming. Use Type.GetType instead.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Assembly.CreateInstance is not supported with trimming. Use Type.GetType.")]
         public object? CreateInstance(string typeName) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Assembly.CreateInstance is not supported with trimming. Use Type.GetType instead.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Assembly.CreateInstance is not supported with trimming. Use Type.GetType.")]
         public object? CreateInstance(string typeName, bool ignoreCase) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Assembly.CreateInstance is not supported with trimming. Use Type.GetType instead.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Assembly.CreateInstance is not supported with trimming. Use Type.GetType.")]
         public virtual object? CreateInstance(string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, object[]? args, System.Globalization.CultureInfo? culture, object[]? activationAttributes) { throw null; }
         public static string CreateQualifiedName(string? assemblyName, string? typeName) { throw null; }
         public override bool Equals(object? o) { throw null; }
@@ -11150,7 +11150,7 @@ namespace System.Reflection
         public System.Reflection.Module LoadModule(string moduleName, byte[]? rawModule) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Types and members the loaded module depends on might be removed")]
         public virtual System.Reflection.Module LoadModule(string moduleName, byte[]? rawModule, byte[]? rawSymbolStore) { throw null; }
-        [System.ObsoleteAttribute("This method has been deprecated. Please use Assembly.Load() instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Assembly.LoadWithPartialName has been deprecated. Use Assembly.Load().")]
         public static System.Reflection.Assembly? LoadWithPartialName(string partialName) { throw null; }
         public static bool operator ==(System.Reflection.Assembly? left, System.Reflection.Assembly? right) { throw null; }
         public static bool operator !=(System.Reflection.Assembly? left, System.Reflection.Assembly? right) { throw null; }
@@ -11232,15 +11232,15 @@ namespace System.Reflection
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly, Inherited=false)]
     public sealed partial class AssemblyFlagsAttribute : System.Attribute
     {
-        [System.ObsoleteAttribute("This constructor has been deprecated. Please use AssemblyFlagsAttribute(AssemblyNameFlags) instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use AssemblyFlagsAttribute(AssemblyNameFlags).")]
         public AssemblyFlagsAttribute(int assemblyFlags) { }
         public AssemblyFlagsAttribute(System.Reflection.AssemblyNameFlags assemblyFlags) { }
         [System.CLSCompliantAttribute(false)]
-        [System.ObsoleteAttribute("This constructor has been deprecated. Please use AssemblyFlagsAttribute(AssemblyNameFlags) instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("This constructor has been deprecated. Use AssemblyFlagsAttribute(AssemblyNameFlags).")]
         public AssemblyFlagsAttribute(uint flags) { }
         public int AssemblyFlags { get { throw null; } }
         [System.CLSCompliantAttribute(false)]
-        [System.ObsoleteAttribute("This property has been deprecated. Please use AssemblyFlags instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("This property has been deprecated. Use AssemblyFlags.")]
         public uint Flags { get { throw null; } }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly, Inherited=false)]
@@ -13022,7 +13022,7 @@ namespace System.Runtime.CompilerServices
     }
     public static partial class RuntimeHelpers
     {
-        [System.ObsoleteAttribute("OffsetToStringData is obsolete. Use string.GetPinnableReference() instead.")]
+        [System.ObsoleteAttribute("OffsetToStringData has been deprecated. Use string.GetPinnableReference().")]
         public static int OffsetToStringData { get { throw null; } }
         public static System.IntPtr AllocateTypeAssociatedMemory(System.Type type, int size) { throw null; }
         public static void EnsureSufficientExecutionStack() { }
@@ -13837,7 +13837,7 @@ namespace System.Security
         public SecurityTransparentAttribute() { }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Delegate | System.AttributeTargets.Enum | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=false, Inherited=false)]
-    [System.ObsoleteAttribute("SecurityTreatAsSafe is only used for .NET 2.0 transparency compatibility.  Please use the SecuritySafeCriticalAttribute instead.")]
+    [System.ObsoleteAttribute("SecurityTreatAsSafe is only used for .NET 2.0 transparency compatibility. Use SecuritySafeCriticalAttribute.")]
     public sealed partial class SecurityTreatAsSafeAttribute : System.Attribute
     {
         public SecurityTreatAsSafeAttribute() { }
@@ -14173,7 +14173,7 @@ namespace System.Text
         public virtual System.ReadOnlySpan<byte> Preamble { get { throw null; } }
         public static System.Text.Encoding Unicode { get { throw null; } }
         public static System.Text.Encoding UTF32 { get { throw null; } }
-        [System.ObsoleteAttribute("The UTF-7 encoding is insecure and should not be used. Consider using UTF-8 instead.", DiagnosticId = "SYSLIB0001", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("The UTF-7 encoding is insecure and should not be used. Consider using UTF-8.", DiagnosticId = "SYSLIB0001", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.Text.Encoding UTF7 { get { throw null; } }
         public static System.Text.Encoding UTF8 { get { throw null; } }
         public virtual string WebName { get { throw null; } }
@@ -14576,7 +14576,7 @@ namespace System.Threading
         protected static readonly System.IntPtr InvalidHandle;
         public const int WaitTimeout = 258;
         protected WaitHandle() { }
-        [System.ObsoleteAttribute("Use the SafeWaitHandle property instead.")]
+        [System.ObsoleteAttribute("WaitHandle.Handle has been deprecated. Use the SafeWaitHandle property.")]
         public virtual System.IntPtr Handle { get { throw null; } set { } }
         [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
         public Microsoft.Win32.SafeHandles.SafeWaitHandle SafeWaitHandle { get { throw null; } set { } }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -13837,7 +13837,7 @@ namespace System.Security
         public SecurityTransparentAttribute() { }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Delegate | System.AttributeTargets.Enum | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=false, Inherited=false)]
-    [System.ObsoleteAttribute("SecurityTreatAsSafe is only used for .NET 2.0 transparency compatibility. Use SecuritySafeCriticalAttribute.")]
+    [System.ObsoleteAttribute("SecurityTreatAsSafe is only used for .NET 2.0 transparency compatibility. Use SecuritySafeCriticalAttribute instead.")]
     public sealed partial class SecurityTreatAsSafeAttribute : System.Attribute
     {
         public SecurityTreatAsSafeAttribute() { }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -11083,11 +11083,11 @@ namespace System.Reflection
         public virtual bool ReflectionOnly { get { throw null; } }
         public virtual System.Security.SecurityRuleSet SecurityRuleSet { get { throw null; } }
         public virtual event System.Reflection.ModuleResolveEventHandler? ModuleResolve { add { } remove { } }
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Assembly.CreateInstance is not supported with trimming. Use Type.GetType.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Assembly.CreateInstance is not supported with trimming. Use Type.GetType instead.")]
         public object? CreateInstance(string typeName) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Assembly.CreateInstance is not supported with trimming. Use Type.GetType.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Assembly.CreateInstance is not supported with trimming. Use Type.GetType instead.")]
         public object? CreateInstance(string typeName, bool ignoreCase) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Assembly.CreateInstance is not supported with trimming. Use Type.GetType.")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Assembly.CreateInstance is not supported with trimming. Use Type.GetType instead.")]
         public virtual object? CreateInstance(string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, object[]? args, System.Globalization.CultureInfo? culture, object[]? activationAttributes) { throw null; }
         public static string CreateQualifiedName(string? assemblyName, string? typeName) { throw null; }
         public override bool Equals(object? o) { throw null; }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -144,12 +144,12 @@ namespace System
         public event System.ResolveEventHandler? ResourceResolve { add { } remove { } }
         public event System.ResolveEventHandler? TypeResolve { add { } remove { } }
         public event System.UnhandledExceptionEventHandler? UnhandledException { add { } remove { } }
-        [System.ObsoleteAttribute("AppDomain.AppendPrivatePath has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("AppDomain.AppendPrivatePath has been deprecated and is not supported.")]
         public void AppendPrivatePath(string? path) { }
         public string ApplyPolicy(string assemblyName) { throw null; }
-        [System.ObsoleteAttribute("AppDomain.ClearPrivatePath has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("AppDomain.ClearPrivatePath has been deprecated and is not supported.")]
         public void ClearPrivatePath() { }
-        [System.ObsoleteAttribute("AppDomain.ClearShadowCopyPath has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("AppDomain.ClearShadowCopyPath has been deprecated and is not supported.")]
         public void ClearShadowCopyPath() { }
         [System.ObsoleteAttribute("Creating and unloading AppDomains is not supported and throws an exception.", DiagnosticId = "SYSLIB0024", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static System.AppDomain CreateDomain(string friendlyName) { throw null; }
@@ -201,15 +201,15 @@ namespace System
         public System.Reflection.Assembly Load(System.Reflection.AssemblyName assemblyRef) { throw null; }
         public System.Reflection.Assembly Load(string assemblyString) { throw null; }
         public System.Reflection.Assembly[] ReflectionOnlyGetAssemblies() { throw null; }
-        [System.ObsoleteAttribute("AppDomain.SetCachePath has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("AppDomain.SetCachePath has been deprecated and is not supported.")]
         public void SetCachePath(string? path) { }
         public void SetData(string name, object? data) { }
-        [System.ObsoleteAttribute("AppDomain.SetDynamicBase has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("AppDomain.SetDynamicBase has been deprecated and is not supported.")]
         public void SetDynamicBase(string? path) { }
         public void SetPrincipalPolicy(System.Security.Principal.PrincipalPolicy policy) { }
-        [System.ObsoleteAttribute("AppDomain.SetShadowCopyFiles has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("AppDomain.SetShadowCopyFiles has been deprecated and is not supported.")]
         public void SetShadowCopyFiles() { }
-        [System.ObsoleteAttribute("AppDomain.SetShadowCopyPath has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("AppDomain.SetShadowCopyPath has been deprecated and is not supported.")]
         public void SetShadowCopyPath(string? path) { }
         public void SetThreadPrincipal(System.Security.Principal.IPrincipal principal) { }
         public override string ToString() { throw null; }
@@ -4491,10 +4491,10 @@ namespace System
         NotSpecified = 0,
         SingleDomain = 1,
         MultiDomain = 2,
-        [System.ObsoleteAttribute("LoaderOptimization.DomainMask has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("LoaderOptimization.DomainMask has been deprecated and is not supported.")]
         DomainMask = 3,
         MultiDomainHost = 3,
-        [System.ObsoleteAttribute("LoaderOptimization.DisallowBindings has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("LoaderOptimization.DisallowBindings has been deprecated and is not supported.")]
         DisallowBindings = 4,
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Method)]
@@ -7686,15 +7686,15 @@ namespace System
         public string[] Segments { get { throw null; } }
         public bool UserEscaped { get { throw null; } }
         public string UserInfo { get { throw null; } }
-        [System.ObsoleteAttribute("Uri.Canonicalize has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("Uri.Canonicalize has been deprecated and is not supported.")]
         protected virtual void Canonicalize() { }
         public static System.UriHostNameType CheckHostName(string? name) { throw null; }
         public static bool CheckSchemeName([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? schemeName) { throw null; }
-        [System.ObsoleteAttribute("Uri.CheckSecurity has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("Uri.CheckSecurity has been deprecated and is not supported.")]
         protected virtual void CheckSecurity() { }
         public static int Compare(System.Uri? uri1, System.Uri? uri2, System.UriComponents partsToCompare, System.UriFormat compareFormat, System.StringComparison comparisonType) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? comparand) { throw null; }
-        [System.ObsoleteAttribute("Uri.Escape has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("Uri.Escape has been deprecated and is not supported.")]
         protected virtual void Escape() { }
         public static string EscapeDataString(string stringToEscape) { throw null; }
         [System.ObsoleteAttribute("Uri.EscapeString has been deprecated. Use GetComponents() or static EscapeDataString() to escape a Uri component or a string.")]
@@ -7708,14 +7708,14 @@ namespace System
         protected void GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public static string HexEscape(char character) { throw null; }
         public static char HexUnescape(string pattern, ref int index) { throw null; }
-        [System.ObsoleteAttribute("Uri.IsBadFileSystemCharacter has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("Uri.IsBadFileSystemCharacter has been deprecated and is not supported.")]
         protected virtual bool IsBadFileSystemCharacter(char character) { throw null; }
         public bool IsBaseOf(System.Uri uri) { throw null; }
-        [System.ObsoleteAttribute("Uri.IsExcludedCharacter has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("Uri.IsExcludedCharacter has been deprecated and is not supported.")]
         protected static bool IsExcludedCharacter(char character) { throw null; }
         public static bool IsHexDigit(char character) { throw null; }
         public static bool IsHexEncoding(string pattern, int index) { throw null; }
-        [System.ObsoleteAttribute("Uri.IsReservedCharacter has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("Uri.IsReservedCharacter has been deprecated and is not supported.")]
         protected virtual bool IsReservedCharacter(char character) { throw null; }
         public bool IsWellFormedOriginalString() { throw null; }
         public static bool IsWellFormedUriString([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? uriString, System.UriKind uriKind) { throw null; }
@@ -7724,7 +7724,7 @@ namespace System
         public System.Uri MakeRelativeUri(System.Uri uri) { throw null; }
         public static bool operator ==(System.Uri? uri1, System.Uri? uri2) { throw null; }
         public static bool operator !=(System.Uri? uri1, System.Uri? uri2) { throw null; }
-        [System.ObsoleteAttribute("Uri.Parse has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("Uri.Parse has been deprecated and is not supported.")]
         protected virtual void Parse() { }
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public override string ToString() { throw null; }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -10625,7 +10625,7 @@ namespace System.IO
         public System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, int bufferSize) { throw null; }
         public virtual System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, int bufferSize, System.Threading.CancellationToken cancellationToken) { throw null; }
         public System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, System.Threading.CancellationToken cancellationToken) { throw null; }
-        [System.ObsoleteAttribute("Stream.CreateWaitHandle has been deprecated. Use new ManualResetEvent(false) instead.")]
+        [System.ObsoleteAttribute("Stream.CreateWaitHandle has been deprecated. Use the ManualResetEvent(false) constructor instead.")]
         protected virtual System.Threading.WaitHandle CreateWaitHandle() { throw null; }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -188,7 +188,7 @@ namespace System
         public int ExecuteAssemblyByName(string assemblyName) { throw null; }
         public int ExecuteAssemblyByName(string assemblyName, params string?[]? args) { throw null; }
         public System.Reflection.Assembly[] GetAssemblies() { throw null; }
-        [System.ObsoleteAttribute("AppDomain.GetCurrentThreadId has been deprecated because it does not provide a stable Id when managed threads are running on fibers (aka lightweight threads). To get a stable identifier for a managed thread, use the ManagedThreadId property on Thread.", false)]
+        [System.ObsoleteAttribute("AppDomain.GetCurrentThreadId has been deprecated because it does not provide a stable Id when managed threads are running on fibers (aka lightweight threads). To get a stable identifier for a managed thread, use the ManagedThreadId property on Thread.")]
         public static int GetCurrentThreadId() { throw null; }
         public object? GetData(string name) { throw null; }
         public bool? IsCompatibilitySwitchSet(string value) { throw null; }

--- a/src/libraries/System.Security.AccessControl/ref/System.Security.AccessControl.Evidence.cs
+++ b/src/libraries/System.Security.AccessControl/ref/System.Security.AccessControl.Evidence.cs
@@ -11,29 +11,29 @@ namespace System.Security.Policy
     public sealed partial class Evidence : System.Collections.ICollection, System.Collections.IEnumerable
     {
         public Evidence() { }
-        [System.ObsoleteAttribute("This constructor is obsolete. Please use the constructor which takes arrays of EvidenceBase instead.")]
+        [System.ObsoleteAttribute("This constructor is obsolete. Use the constructor which accepts arrays of EvidenceBase instead.")]
         public Evidence(object[] hostEvidence, object[] assemblyEvidence) { }
         public Evidence(System.Security.Policy.Evidence evidence) { }
         public Evidence(System.Security.Policy.EvidenceBase[] hostEvidence, System.Security.Policy.EvidenceBase[] assemblyEvidence) { }
-        [System.ObsoleteAttribute("Evidence should not be treated as an ICollection. Please use GetHostEnumerator and GetAssemblyEnumerator to iterate over the evidence to collect a count.")]
+        [System.ObsoleteAttribute("Evidence should not be treated as an ICollection. Use GetHostEnumerator and GetAssemblyEnumerator to iterate over the evidence to collect a count.")]
         public int Count { get { throw null; } }
         public bool IsReadOnly { get { throw null; } }
         public bool IsSynchronized { get { throw null; } }
         public bool Locked { get { throw null; } set { } }
         public object SyncRoot { get { throw null; } }
-        [System.ObsoleteAttribute("This method is obsolete. Please use AddAssemblyEvidence instead.")]
+        [System.ObsoleteAttribute("Evidence.AddAssembly has been deprecated. Use AddAssemblyEvidence instead.")]
         public void AddAssembly(object id) { }
         public void AddAssemblyEvidence<T>(T evidence) where T : System.Security.Policy.EvidenceBase { }
-        [System.ObsoleteAttribute("This method is obsolete. Please use AddHostEvidence instead.")]
+        [System.ObsoleteAttribute("Evidence.AddHost has been deprecated. Use AddHostEvidence instead.")]
         public void AddHost(object id) { }
         public void AddHostEvidence<T>(T evidence) where T : System.Security.Policy.EvidenceBase { }
         public void Clear() { }
         public System.Security.Policy.Evidence? Clone() { throw null; }
-        [System.ObsoleteAttribute("Evidence should not be treated as an ICollection. Please use the GetHostEnumerator and GetAssemblyEnumerator methods rather than using CopyTo.")]
+        [System.ObsoleteAttribute("Evidence should not be treated as an ICollection. Use the GetHostEnumerator and GetAssemblyEnumerator methods rather than using CopyTo.")]
         public void CopyTo(System.Array array, int index) { }
         public System.Collections.IEnumerator GetAssemblyEnumerator() { throw null; }
         public T? GetAssemblyEvidence<T>() where T : System.Security.Policy.EvidenceBase { throw null; }
-        [System.ObsoleteAttribute("GetEnumerator is obsolete. Please use GetAssemblyEnumerator and GetHostEnumerator instead.")]
+        [System.ObsoleteAttribute("GetEnumerator is obsolete. Use GetAssemblyEnumerator and GetHostEnumerator instead.")]
         public System.Collections.IEnumerator GetEnumerator() { throw null; }
         public System.Collections.IEnumerator GetHostEnumerator() { throw null; }
         public T? GetHostEvidence<T>() where T : System.Security.Policy.EvidenceBase { throw null; }

--- a/src/libraries/System.Security.AccessControl/src/System/Security/Policy/Evidence.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/Policy/Evidence.cs
@@ -10,30 +10,30 @@ namespace System.Security.Policy
     public sealed partial class Evidence : ICollection, IEnumerable
     {
         public Evidence() { }
-        [Obsolete("This constructor is obsolete. Please use the constructor which takes arrays of EvidenceBase instead.")]
+        [Obsolete("This constructor is obsolete. Use the constructor which accepts arrays of EvidenceBase instead.")]
         public Evidence(object[] hostEvidence, object[] assemblyEvidence) { }
         public Evidence(Evidence evidence) { }
         public Evidence(EvidenceBase[] hostEvidence, EvidenceBase[] assemblyEvidence) { }
-        [Obsolete("Evidence should not be treated as an ICollection. Please use GetHostEnumerator and GetAssemblyEnumerator to iterate over the evidence to collect a count.")]
+        [Obsolete("Evidence should not be treated as an ICollection. Use GetHostEnumerator and GetAssemblyEnumerator to iterate over the evidence to collect a count.")]
         public int Count { get { return 0; } }
         public bool IsReadOnly { get { return false; } }
         public bool IsSynchronized { get { return false; } }
         public bool Locked { get; set; }
         public object SyncRoot { get { return false; } }
-        [Obsolete("This method is obsolete. Please use AddAssemblyEvidence instead.")]
+        [Obsolete("Evidence.AddAssembly has been deprecated. Use AddAssemblyEvidence instead.")]
         public void AddAssembly(object id) { }
         public void AddAssemblyEvidence<T>(T evidence) where T : EvidenceBase { }
         public void AddHostEvidence<T>(T evidence) where T : EvidenceBase { }
         public T? GetAssemblyEvidence<T>() where T : EvidenceBase { return default(T); }
         public T? GetHostEvidence<T>() where T : EvidenceBase { return default(T); }
-        [Obsolete("This method is obsolete. Please use AddHostEvidence instead.")]
+        [Obsolete("Evidence.AddHost has been deprecated. Use AddHostEvidence instead.")]
         public void AddHost(object id) { }
         public void Clear() { }
         public Evidence? Clone() { return default(Evidence); }
-        [Obsolete("Evidence should not be treated as an ICollection. Please use the GetHostEnumerator and GetAssemblyEnumerator methods rather than using CopyTo.")]
+        [Obsolete("Evidence should not be treated as an ICollection. Use the GetHostEnumerator and GetAssemblyEnumerator methods rather than using CopyTo.")]
         public void CopyTo(Array array, int index) { }
         public IEnumerator GetAssemblyEnumerator() { return Array.Empty<object>().GetEnumerator(); }
-        [Obsolete("GetEnumerator is obsolete. Please use GetAssemblyEnumerator and GetHostEnumerator instead.")]
+        [Obsolete("GetEnumerator is obsolete. Use GetAssemblyEnumerator and GetHostEnumerator instead.")]
         public IEnumerator GetEnumerator() { return Array.Empty<object>().GetEnumerator(); }
         public IEnumerator GetHostEnumerator() { return Array.Empty<object>().GetEnumerator(); }
         public void Merge(Evidence evidence) { }

--- a/src/libraries/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
@@ -521,7 +521,7 @@ namespace System.Security.Cryptography
         public HMACSHA384() { }
         public HMACSHA384(byte[] key) { }
         public override byte[] Key { get { throw null; } set { } }
-        [System.ObsoleteAttribute("ProduceLegacyHmacValues is obsolete. Producing legacy HMAC values is no longer supported.", DiagnosticId = "SYSLIB0029", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("ProduceLegacyHmacValues is obsolete. Producing legacy HMAC values is not supported.", DiagnosticId = "SYSLIB0029", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public bool ProduceLegacyHmacValues { get { throw null; } set { } }
         protected override void Dispose(bool disposing) { }
         protected override void HashCore(byte[] rgb, int ib, int cb) { }
@@ -540,7 +540,7 @@ namespace System.Security.Cryptography
         public HMACSHA512() { }
         public HMACSHA512(byte[] key) { }
         public override byte[] Key { get { throw null; } set { } }
-        [System.ObsoleteAttribute("ProduceLegacyHmacValues is obsolete. Producing legacy HMAC values is no longer supported.", DiagnosticId = "SYSLIB0029", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("ProduceLegacyHmacValues is obsolete. Producing legacy HMAC values is not supported.", DiagnosticId = "SYSLIB0029", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public bool ProduceLegacyHmacValues { get { throw null; } set { } }
         protected override void Dispose(bool disposing) { }
         protected override void HashCore(byte[] rgb, int ib, int cb) { }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.cs
@@ -189,12 +189,12 @@ namespace System.Security.Cryptography.X509Certificates
         public virtual string GetExpirationDateString() { throw null; }
         public virtual string GetFormat() { throw null; }
         public override int GetHashCode() { throw null; }
-        [System.ObsoleteAttribute("This method has been deprecated.  Please use the Issuer property instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("X509Certificate.GetIssuerName has been deprecated. Use the Issuer property.")]
         public virtual string GetIssuerName() { throw null; }
         public virtual string GetKeyAlgorithm() { throw null; }
         public virtual byte[] GetKeyAlgorithmParameters() { throw null; }
         public virtual string GetKeyAlgorithmParametersString() { throw null; }
-        [System.ObsoleteAttribute("This method has been deprecated.  Please use the Subject property instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("X509Certificate.GetName has been deprecated. Use the Subject property.")]
         public virtual string GetName() { throw null; }
         public virtual byte[] GetPublicKey() { throw null; }
         public virtual string GetPublicKeyString() { throw null; }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.cs
@@ -189,12 +189,12 @@ namespace System.Security.Cryptography.X509Certificates
         public virtual string GetExpirationDateString() { throw null; }
         public virtual string GetFormat() { throw null; }
         public override int GetHashCode() { throw null; }
-        [System.ObsoleteAttribute("X509Certificate.GetIssuerName has been deprecated. Use the Issuer property.")]
+        [System.ObsoleteAttribute("X509Certificate.GetIssuerName has been deprecated. Use the Issuer property instead.")]
         public virtual string GetIssuerName() { throw null; }
         public virtual string GetKeyAlgorithm() { throw null; }
         public virtual byte[] GetKeyAlgorithmParameters() { throw null; }
         public virtual string GetKeyAlgorithmParametersString() { throw null; }
-        [System.ObsoleteAttribute("X509Certificate.GetName has been deprecated. Use the Subject property.")]
+        [System.ObsoleteAttribute("X509Certificate.GetName has been deprecated. Use the Subject property instead.")]
         public virtual string GetName() { throw null; }
         public virtual byte[] GetPublicKey() { throw null; }
         public virtual string GetPublicKeyString() { throw null; }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs
@@ -507,14 +507,14 @@ namespace System.Security.Cryptography.X509Certificates
             return _lazySerialNumber ?? (_lazySerialNumber = Pal!.SerialNumber);
         }
 
-        [Obsolete("X509Certificate.GetName has been deprecated. Use the Subject property.")]
+        [Obsolete("X509Certificate.GetName has been deprecated. Use the Subject property instead.")]
         public virtual string GetName()
         {
             ThrowIfInvalid();
             return Pal!.LegacySubject;
         }
 
-        [Obsolete("X509Certificate.GetIssuerName has been deprecated. Use the Issuer property.")]
+        [Obsolete("X509Certificate.GetIssuerName has been deprecated. Use the Issuer property instead.")]
         public virtual string GetIssuerName()
         {
             ThrowIfInvalid();

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs
@@ -507,14 +507,14 @@ namespace System.Security.Cryptography.X509Certificates
             return _lazySerialNumber ?? (_lazySerialNumber = Pal!.SerialNumber);
         }
 
-        [Obsolete("This method has been deprecated.  Please use the Subject property instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("X509Certificate.GetName has been deprecated. Use the Subject property.")]
         public virtual string GetName()
         {
             ThrowIfInvalid();
             return Pal!.LegacySubject;
         }
 
-        [Obsolete("This method has been deprecated.  Please use the Issuer property instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("X509Certificate.GetIssuerName has been deprecated. Use the Issuer property.")]
         public virtual string GetIssuerName()
         {
             ThrowIfInvalid();

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermissionAttribute.cs
@@ -12,10 +12,10 @@ namespace System.Security.Permissions
         public ReflectionPermissionAttribute(SecurityAction action) : base(default(SecurityAction)) { }
         public ReflectionPermissionFlag Flags { get; set; }
         public bool MemberAccess { get; set; }
-        [Obsolete("This permission is no longer used by the CLR.")]
+        [Obsolete("ReflectionPermissionAttribute.ReflectionEmit has been deprecated and is no longer supported.")]
         public bool ReflectionEmit { get; set; }
         public bool RestrictedMemberAccess { get; set; }
-        [Obsolete("This API has been deprecated. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("ReflectionPermissionAttribute.TypeInformation has been deprecated and is no longer supported.")]
         public bool TypeInformation { get; set; }
         public override IPermission CreatePermission() { return default(IPermission); }
     }

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermissionAttribute.cs
@@ -12,10 +12,10 @@ namespace System.Security.Permissions
         public ReflectionPermissionAttribute(SecurityAction action) : base(default(SecurityAction)) { }
         public ReflectionPermissionFlag Flags { get; set; }
         public bool MemberAccess { get; set; }
-        [Obsolete("ReflectionPermissionAttribute.ReflectionEmit has been deprecated and is no longer supported.")]
+        [Obsolete("ReflectionPermissionAttribute.ReflectionEmit has been deprecated and is not supported.")]
         public bool ReflectionEmit { get; set; }
         public bool RestrictedMemberAccess { get; set; }
-        [Obsolete("ReflectionPermissionAttribute.TypeInformation has been deprecated and is no longer supported.")]
+        [Obsolete("ReflectionPermissionAttribute.TypeInformation has been deprecated and is not supported.")]
         public bool TypeInformation { get; set; }
         public override IPermission CreatePermission() { return default(IPermission); }
     }

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermissionFlag.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermissionFlag.cs
@@ -13,10 +13,10 @@ namespace System.Security.Permissions
         AllFlags = 7,
         MemberAccess = 2,
         NoFlags = 0,
-        [Obsolete("ReflectionPermissionFlag.ReflectionEmit  has been deprecated and is no longer supported.")]
+        [Obsolete("ReflectionPermissionFlag.ReflectionEmit  has been deprecated and is not supported.")]
         ReflectionEmit = 4,
         RestrictedMemberAccess = 8,
-        [Obsolete("ReflectionPermissionFlag.TypeInformation has been deprecated and is no longer supported.")]
+        [Obsolete("ReflectionPermissionFlag.TypeInformation has been deprecated and is not supported.")]
         TypeInformation = 1,
     }
 }

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermissionFlag.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/ReflectionPermissionFlag.cs
@@ -9,14 +9,14 @@ namespace System.Security.Permissions
     [Flags]
     public enum ReflectionPermissionFlag
     {
-        [Obsolete("This permission has been deprecated. Use PermissionState.Unrestricted to get full access.")]
+        [Obsolete("ReflectionPermissionFlag.AllFlags has been deprecated. Use PermissionState.Unrestricted to get full access.")]
         AllFlags = 7,
         MemberAccess = 2,
         NoFlags = 0,
-        [Obsolete("This permission is no longer used by the CLR.")]
+        [Obsolete("ReflectionPermissionFlag.ReflectionEmit  has been deprecated and is no longer supported.")]
         ReflectionEmit = 4,
         RestrictedMemberAccess = 8,
-        [Obsolete("This API has been deprecated. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("ReflectionPermissionFlag.TypeInformation has been deprecated and is no longer supported.")]
         TypeInformation = 1,
     }
 }

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/RegistryPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/RegistryPermissionAttribute.cs
@@ -10,7 +10,7 @@ namespace System.Security.Permissions
     public sealed partial class RegistryPermissionAttribute : CodeAccessSecurityAttribute
     {
         public RegistryPermissionAttribute(SecurityAction action) : base(default(SecurityAction)) { }
-        [Obsolete("Please use the ViewAndModify property instead.")]
+        [Obsolete("RegistryPermissionAttribute.Add has been deprecated. Use ViewAndModify instead.")]
         public string All { get; set; }
         public string ChangeAccessControl { get; set; }
         public string Create { get; set; }

--- a/src/libraries/System.Security.Permissions/src/System/Security/Policy/FirstMatchCodeGroup.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Policy/FirstMatchCodeGroup.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Policy
 {
-    [Obsolete("This type is obsolete. See https://go.microsoft.com/fwlink/?LinkID=155570 for more information.")]
+    [Obsolete("Code Access Security is not supported or honored by the runtime.")]
     public sealed partial class FirstMatchCodeGroup : CodeGroup
     {
         public FirstMatchCodeGroup(IMembershipCondition membershipCondition, PolicyStatement policy) : base(default(IMembershipCondition), default(PolicyStatement)) { }

--- a/src/libraries/System.Security.Permissions/src/System/Security/Policy/PermissionRequestEvidence.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Policy/PermissionRequestEvidence.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Policy
 {
-    [Obsolete("This type is obsolete. See https://go.microsoft.com/fwlink/?LinkID=155570 for more information.")]
+    [Obsolete("Code Access Security is not supported or honored by the runtime.")]
     public sealed partial class PermissionRequestEvidence : EvidenceBase
     {
         public PermissionRequestEvidence(PermissionSet request, PermissionSet optional, PermissionSet denied) { }

--- a/src/libraries/System.Security.Permissions/src/System/Security/Policy/PolicyLevel.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Policy/PolicyLevel.cs
@@ -27,7 +27,7 @@ namespace System.Security.Policy
     [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 #endif
         public NamedPermissionSet ChangeNamedPermissionSet(string name, PermissionSet pSet) { return default(NamedPermissionSet); }
-        [Obsolete("AppDomain policy levels are obsolete. See https://go.microsoft.com/fwlink/?LinkID=155570 for more information.")]
+        [Obsolete("Code Access Security is not supported or honored by the runtime.")]
         public static PolicyLevel CreateAppDomainLevel() { return default(PolicyLevel); }
         public void FromXml(SecurityElement e) { }
 #if NET5_0_OR_GREATER

--- a/src/libraries/System.Security.Permissions/src/System/Security/Policy/UnionCodeGroup.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Policy/UnionCodeGroup.cs
@@ -3,7 +3,7 @@
 
 namespace System.Security.Policy
 {
-    [Obsolete("This type is obsolete. See https://go.microsoft.com/fwlink/?LinkID=155570 for more information.")]
+    [Obsolete("Code Access Security is not supported or honored by the runtime.")]
     public sealed partial class UnionCodeGroup : CodeGroup
     {
         public UnionCodeGroup(IMembershipCondition membershipCondition, PolicyStatement policy) : base(default(IMembershipCondition), default(PolicyStatement)) { }

--- a/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/OptimizedInboxTextEncoder.cs
+++ b/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/OptimizedInboxTextEncoder.cs
@@ -73,14 +73,14 @@ namespace System.Text.Encodings.Web
             _allowedAsciiCodePoints.PopulateAllowedCodePoints(_allowedBmpCodePoints);
         }
 
-        [Obsolete("Greenfield code shouldn't call this. It should only be used by the TextEncoder adapter.")]
+        [Obsolete("FindFirstCharacterToEncode has been deprecated. It should only be used by the TextEncoder adapter.")]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe int FindFirstCharacterToEncode(char* text, int textLength)
         {
             return GetIndexOfFirstCharToEncode(new ReadOnlySpan<char>(text, textLength)); // performs bounds checking
         }
 
-        [Obsolete("Greenfield code shouldn't call this. It should only be used by the TextEncoder adapter.")]
+        [Obsolete("TryEncodeUnicodeScalar has been deprecated. It should only be used by the TextEncoder adapter.")]
         public unsafe bool TryEncodeUnicodeScalar(int unicodeScalar, char* buffer, int bufferLength, out int numberOfCharactersWritten)
         {
             Span<char> destination = new Span<char>(buffer, bufferLength);

--- a/src/libraries/System.Threading.Overlapped/ref/System.Threading.Overlapped.cs
+++ b/src/libraries/System.Threading.Overlapped/ref/System.Threading.Overlapped.cs
@@ -19,11 +19,11 @@ namespace System.Threading
     public partial class Overlapped
     {
         public Overlapped() { }
-        [System.ObsoleteAttribute("This constructor is not 64-bit compatible and has been deprecated. Use the constructor that accepts an IntPtr for the event handle.")]
+        [System.ObsoleteAttribute("This constructor is not 64-bit compatible and has been deprecated. Use the constructor that accepts an IntPtr for the event handle instead.")]
         public Overlapped(int offsetLo, int offsetHi, int hEvent, System.IAsyncResult? ar) { }
         public Overlapped(int offsetLo, int offsetHi, System.IntPtr hEvent, System.IAsyncResult? ar) { }
         public System.IAsyncResult? AsyncResult { get { throw null; } set { } }
-        [System.ObsoleteAttribute("Overlapped.EventHandle is not 64-bit compatible and has been deprecated. Use EventHandleIntPtr.")]
+        [System.ObsoleteAttribute("Overlapped.EventHandle is not 64-bit compatible and has been deprecated. Use EventHandleIntPtr instead.")]
         public int EventHandle { get { throw null; } set { } }
         public System.IntPtr EventHandleIntPtr { get { throw null; } set { } }
         public int OffsetHigh { get { throw null; } set { } }
@@ -31,14 +31,14 @@ namespace System.Threading
         [System.CLSCompliantAttribute(false)]
         public unsafe static void Free(System.Threading.NativeOverlapped* nativeOverlappedPtr) { }
         [System.CLSCompliantAttribute(false)]
-        [System.ObsoleteAttribute("This overload is not safe and has been deprecated. Use Pack(IOCompletionCallback?, object?).")]
+        [System.ObsoleteAttribute("This overload is not safe and has been deprecated. Use Pack(IOCompletionCallback?, object?) instead.")]
         public unsafe System.Threading.NativeOverlapped* Pack(System.Threading.IOCompletionCallback? iocb) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public unsafe System.Threading.NativeOverlapped* Pack(System.Threading.IOCompletionCallback? iocb, object? userData) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public unsafe static System.Threading.Overlapped Unpack(System.Threading.NativeOverlapped* nativeOverlappedPtr) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.ObsoleteAttribute("This overload is not safe and has been deprecated. Use UnsafePack(IOCompletionCallback?, object?).")]
+        [System.ObsoleteAttribute("This overload is not safe and has been deprecated. Use UnsafePack(IOCompletionCallback?, object?) instead.")]
         public unsafe System.Threading.NativeOverlapped* UnsafePack(System.Threading.IOCompletionCallback? iocb) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public unsafe System.Threading.NativeOverlapped* UnsafePack(System.Threading.IOCompletionCallback? iocb, object? userData) { throw null; }

--- a/src/libraries/System.Threading.Overlapped/ref/System.Threading.Overlapped.cs
+++ b/src/libraries/System.Threading.Overlapped/ref/System.Threading.Overlapped.cs
@@ -19,11 +19,11 @@ namespace System.Threading
     public partial class Overlapped
     {
         public Overlapped() { }
-        [System.ObsoleteAttribute("This constructor is not 64-bit compatible.  Use the constructor that takes an IntPtr for the event handle.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("This constructor is not 64-bit compatible and has been deprecated. Use the constructor that accepts an IntPtr for the event handle.")]
         public Overlapped(int offsetLo, int offsetHi, int hEvent, System.IAsyncResult? ar) { }
         public Overlapped(int offsetLo, int offsetHi, System.IntPtr hEvent, System.IAsyncResult? ar) { }
         public System.IAsyncResult? AsyncResult { get { throw null; } set { } }
-        [System.ObsoleteAttribute("This property is not 64-bit compatible.  Use EventHandleIntPtr instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("Overlapped.EventHandle is not 64-bit compatible and has been deprecated. Use EventHandleIntPtr.")]
         public int EventHandle { get { throw null; } set { } }
         public System.IntPtr EventHandleIntPtr { get { throw null; } set { } }
         public int OffsetHigh { get { throw null; } set { } }
@@ -31,14 +31,14 @@ namespace System.Threading
         [System.CLSCompliantAttribute(false)]
         public unsafe static void Free(System.Threading.NativeOverlapped* nativeOverlappedPtr) { }
         [System.CLSCompliantAttribute(false)]
-        [System.ObsoleteAttribute("This method is not safe.  Use Pack (iocb, userData) instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("This overload is not safe and has been deprecated. Use Pack(IOCompletionCallback?, object?).")]
         public unsafe System.Threading.NativeOverlapped* Pack(System.Threading.IOCompletionCallback? iocb) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public unsafe System.Threading.NativeOverlapped* Pack(System.Threading.IOCompletionCallback? iocb, object? userData) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public unsafe static System.Threading.Overlapped Unpack(System.Threading.NativeOverlapped* nativeOverlappedPtr) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.ObsoleteAttribute("This method is not safe.  Use UnsafePack (iocb, userData) instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("This overload is not safe and has been deprecated. Use UnsafePack(IOCompletionCallback?, object?).")]
         public unsafe System.Threading.NativeOverlapped* UnsafePack(System.Threading.IOCompletionCallback? iocb) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public unsafe System.Threading.NativeOverlapped* UnsafePack(System.Threading.IOCompletionCallback? iocb, object? userData) { throw null; }

--- a/src/libraries/System.Threading.Thread/ref/System.Threading.Thread.cs
+++ b/src/libraries/System.Threading.Thread/ref/System.Threading.Thread.cs
@@ -36,7 +36,7 @@ namespace System.Threading
         public Thread(System.Threading.ParameterizedThreadStart start, int maxStackSize) { }
         public Thread(System.Threading.ThreadStart start) { }
         public Thread(System.Threading.ThreadStart start, int maxStackSize) { }
-        [System.ObsoleteAttribute("The ApartmentState property has been deprecated.  Use GetApartmentState, SetApartmentState or TrySetApartmentState instead.", false)]
+        [System.ObsoleteAttribute("The ApartmentState property has been deprecated.  Use GetApartmentState, SetApartmentState or TrySetApartmentState.", false)]
         public System.Threading.ApartmentState ApartmentState { get { throw null; } set { } }
         public System.Globalization.CultureInfo CurrentCulture { get { throw null; } set { } }
         public static System.Security.Principal.IPrincipal? CurrentPrincipal { get { throw null; } set { } }
@@ -79,11 +79,11 @@ namespace System.Threading
         public static void MemoryBarrier() { }
         [System.ObsoleteAttribute("Thread.ResetAbort is not supported and throws PlatformNotSupportedException.", DiagnosticId = "SYSLIB0006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static void ResetAbort() { }
-        [System.ObsoleteAttribute("Thread.Resume has been deprecated.  Please use other classes in System.Threading, such as Monitor, Mutex, Event, and Semaphore, to synchronize Threads or protect resources.  https://go.microsoft.com/fwlink/?linkid=14202", false)]
+        [System.ObsoleteAttribute("Thread.Resume has been deprecated. Use other classes in System.Threading, such as Monitor, Mutex, Event, and Semaphore, to synchronize Threads or protect resources.", false)]
         public void Resume() { }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public void SetApartmentState(System.Threading.ApartmentState state) { }
-        [System.ObsoleteAttribute("Thread.SetCompressedStack is no longer supported. Please use the System.Threading.CompressedStack class")]
+        [System.ObsoleteAttribute("Thread.SetCompressedStack has been deprecated and is no longer supported. Use the System.Threading.CompressedStack class.")]
         public void SetCompressedStack(System.Threading.CompressedStack stack) { }
         public static void SetData(System.LocalDataStoreSlot slot, object? data) { }
         public static void Sleep(int millisecondsTimeout) { }
@@ -93,7 +93,7 @@ namespace System.Threading
         public void Start() { }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public void Start(object? parameter) { }
-        [System.ObsoleteAttribute("Thread.Suspend has been deprecated.  Please use other classes in System.Threading, such as Monitor, Mutex, Event, and Semaphore, to synchronize Threads or protect resources.  https://go.microsoft.com/fwlink/?linkid=14202", false)]
+        [System.ObsoleteAttribute("Thread.Suspend has been deprecated. Use other classes in System.Threading, such as Monitor, Mutex, Event, and Semaphore, to synchronize Threads or protect resources.", false)]
         public void Suspend() { }
         public bool TrySetApartmentState(System.Threading.ApartmentState state) { throw null; }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]

--- a/src/libraries/System.Threading.Thread/ref/System.Threading.Thread.cs
+++ b/src/libraries/System.Threading.Thread/ref/System.Threading.Thread.cs
@@ -64,7 +64,7 @@ namespace System.Threading
         ~Thread() { }
         public static void FreeNamedDataSlot(string name) { }
         public System.Threading.ApartmentState GetApartmentState() { throw null; }
-        [System.ObsoleteAttribute("Thread.GetCompressedStack is no longer supported. Use the System.Threading.CompressedStack class instead.")]
+        [System.ObsoleteAttribute("Thread.GetCompressedStack is not supported. Use the System.Threading.CompressedStack class instead.")]
         public System.Threading.CompressedStack GetCompressedStack() { throw null; }
         public static int GetCurrentProcessorId() { throw null; }
         public static object? GetData(System.LocalDataStoreSlot slot) { throw null; }
@@ -83,7 +83,7 @@ namespace System.Threading
         public void Resume() { }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public void SetApartmentState(System.Threading.ApartmentState state) { }
-        [System.ObsoleteAttribute("Thread.SetCompressedStack has been deprecated and is no longer supported. Use the System.Threading.CompressedStack class instead.")]
+        [System.ObsoleteAttribute("Thread.SetCompressedStack has been deprecated and is not supported. Use the System.Threading.CompressedStack class instead.")]
         public void SetCompressedStack(System.Threading.CompressedStack stack) { }
         public static void SetData(System.LocalDataStoreSlot slot, object? data) { }
         public static void Sleep(int millisecondsTimeout) { }

--- a/src/libraries/System.Threading.Thread/ref/System.Threading.Thread.cs
+++ b/src/libraries/System.Threading.Thread/ref/System.Threading.Thread.cs
@@ -36,7 +36,7 @@ namespace System.Threading
         public Thread(System.Threading.ParameterizedThreadStart start, int maxStackSize) { }
         public Thread(System.Threading.ThreadStart start) { }
         public Thread(System.Threading.ThreadStart start, int maxStackSize) { }
-        [System.ObsoleteAttribute("The ApartmentState property has been deprecated.  Use GetApartmentState, SetApartmentState or TrySetApartmentState.", false)]
+        [System.ObsoleteAttribute("The ApartmentState property has been deprecated. Use GetApartmentState, SetApartmentState or TrySetApartmentState instead.", false)]
         public System.Threading.ApartmentState ApartmentState { get { throw null; } set { } }
         public System.Globalization.CultureInfo CurrentCulture { get { throw null; } set { } }
         public static System.Security.Principal.IPrincipal? CurrentPrincipal { get { throw null; } set { } }
@@ -64,7 +64,7 @@ namespace System.Threading
         ~Thread() { }
         public static void FreeNamedDataSlot(string name) { }
         public System.Threading.ApartmentState GetApartmentState() { throw null; }
-        [System.ObsoleteAttribute("Thread.GetCompressedStack is no longer supported. Please use the System.Threading.CompressedStack class")]
+        [System.ObsoleteAttribute("Thread.GetCompressedStack is no longer supported. Use the System.Threading.CompressedStack class instead.")]
         public System.Threading.CompressedStack GetCompressedStack() { throw null; }
         public static int GetCurrentProcessorId() { throw null; }
         public static object? GetData(System.LocalDataStoreSlot slot) { throw null; }
@@ -83,7 +83,7 @@ namespace System.Threading
         public void Resume() { }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public void SetApartmentState(System.Threading.ApartmentState state) { }
-        [System.ObsoleteAttribute("Thread.SetCompressedStack has been deprecated and is no longer supported. Use the System.Threading.CompressedStack class.")]
+        [System.ObsoleteAttribute("Thread.SetCompressedStack has been deprecated and is no longer supported. Use the System.Threading.CompressedStack class instead.")]
         public void SetCompressedStack(System.Threading.CompressedStack stack) { }
         public static void SetData(System.LocalDataStoreSlot slot, object? data) { }
         public static void Sleep(int millisecondsTimeout) { }

--- a/src/libraries/System.Threading.Thread/ref/System.Threading.Thread.cs
+++ b/src/libraries/System.Threading.Thread/ref/System.Threading.Thread.cs
@@ -64,7 +64,7 @@ namespace System.Threading
         ~Thread() { }
         public static void FreeNamedDataSlot(string name) { }
         public System.Threading.ApartmentState GetApartmentState() { throw null; }
-        [System.ObsoleteAttribute("Thread.GetCompressedStack is not supported. Use the System.Threading.CompressedStack class instead.")]
+        [System.ObsoleteAttribute("Thread.GetCompressedStack has been deprecated. Use the System.Threading.CompressedStack class instead.")]
         public System.Threading.CompressedStack GetCompressedStack() { throw null; }
         public static int GetCurrentProcessorId() { throw null; }
         public static object? GetData(System.LocalDataStoreSlot slot) { throw null; }
@@ -83,7 +83,7 @@ namespace System.Threading
         public void Resume() { }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public void SetApartmentState(System.Threading.ApartmentState state) { }
-        [System.ObsoleteAttribute("Thread.SetCompressedStack has been deprecated and is not supported. Use the System.Threading.CompressedStack class instead.")]
+        [System.ObsoleteAttribute("Thread.SetCompressedStack has been deprecated. Use the System.Threading.CompressedStack class instead.")]
         public void SetCompressedStack(System.Threading.CompressedStack stack) { }
         public static void SetData(System.LocalDataStoreSlot slot, object? data) { }
         public static void Sleep(int millisecondsTimeout) { }

--- a/src/libraries/System.Threading.Thread/ref/System.Threading.Thread.cs
+++ b/src/libraries/System.Threading.Thread/ref/System.Threading.Thread.cs
@@ -36,7 +36,7 @@ namespace System.Threading
         public Thread(System.Threading.ParameterizedThreadStart start, int maxStackSize) { }
         public Thread(System.Threading.ThreadStart start) { }
         public Thread(System.Threading.ThreadStart start, int maxStackSize) { }
-        [System.ObsoleteAttribute("The ApartmentState property has been deprecated. Use GetApartmentState, SetApartmentState or TrySetApartmentState instead.", false)]
+        [System.ObsoleteAttribute("The ApartmentState property has been deprecated. Use GetApartmentState, SetApartmentState or TrySetApartmentState instead.")]
         public System.Threading.ApartmentState ApartmentState { get { throw null; } set { } }
         public System.Globalization.CultureInfo CurrentCulture { get { throw null; } set { } }
         public static System.Security.Principal.IPrincipal? CurrentPrincipal { get { throw null; } set { } }
@@ -79,7 +79,7 @@ namespace System.Threading
         public static void MemoryBarrier() { }
         [System.ObsoleteAttribute("Thread.ResetAbort is not supported and throws PlatformNotSupportedException.", DiagnosticId = "SYSLIB0006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public static void ResetAbort() { }
-        [System.ObsoleteAttribute("Thread.Resume has been deprecated. Use other classes in System.Threading, such as Monitor, Mutex, Event, and Semaphore, to synchronize Threads or protect resources.", false)]
+        [System.ObsoleteAttribute("Thread.Resume has been deprecated. Use other classes in System.Threading, such as Monitor, Mutex, Event, and Semaphore, to synchronize Threads or protect resources.")]
         public void Resume() { }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public void SetApartmentState(System.Threading.ApartmentState state) { }
@@ -93,7 +93,7 @@ namespace System.Threading
         public void Start() { }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public void Start(object? parameter) { }
-        [System.ObsoleteAttribute("Thread.Suspend has been deprecated. Use other classes in System.Threading, such as Monitor, Mutex, Event, and Semaphore, to synchronize Threads or protect resources.", false)]
+        [System.ObsoleteAttribute("Thread.Suspend has been deprecated. Use other classes in System.Threading, such as Monitor, Mutex, Event, and Semaphore, to synchronize Threads or protect resources.")]
         public void Suspend() { }
         public bool TrySetApartmentState(System.Threading.ApartmentState state) { throw null; }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]

--- a/src/libraries/System.Threading.ThreadPool/ref/System.Threading.ThreadPool.cs
+++ b/src/libraries/System.Threading.ThreadPool/ref/System.Threading.ThreadPool.cs
@@ -21,7 +21,7 @@ namespace System.Threading
         public static long CompletedWorkItemCount { get { throw null; } }
         public static long PendingWorkItemCount { get { throw null; } }
         public static int ThreadCount { get { throw null; } }
-        [System.ObsoleteAttribute("ThreadPool.BindHandle(IntPtr) has been deprecated.  Please use ThreadPool.BindHandle(SafeHandle) instead.", false)]
+        [System.ObsoleteAttribute("ThreadPool.BindHandle(IntPtr) has been deprecated. Use ThreadPool.BindHandle(SafeHandle) instead.", false)]
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public static bool BindHandle(System.IntPtr osHandle) { throw null; }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]

--- a/src/libraries/System.Threading.ThreadPool/ref/System.Threading.ThreadPool.cs
+++ b/src/libraries/System.Threading.ThreadPool/ref/System.Threading.ThreadPool.cs
@@ -21,7 +21,7 @@ namespace System.Threading
         public static long CompletedWorkItemCount { get { throw null; } }
         public static long PendingWorkItemCount { get { throw null; } }
         public static int ThreadCount { get { throw null; } }
-        [System.ObsoleteAttribute("ThreadPool.BindHandle(IntPtr) has been deprecated. Use ThreadPool.BindHandle(SafeHandle) instead.", false)]
+        [System.ObsoleteAttribute("ThreadPool.BindHandle(IntPtr) has been deprecated. Use ThreadPool.BindHandle(SafeHandle) instead.")]
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public static bool BindHandle(System.IntPtr osHandle) { throw null; }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]

--- a/src/libraries/System.Xml.ReaderWriter/ref/System.Xml.ReaderWriter.cs
+++ b/src/libraries/System.Xml.ReaderWriter/ref/System.Xml.ReaderWriter.cs
@@ -83,10 +83,10 @@ namespace System.Xml
     public enum ValidationType
     {
         None = 0,
-        [System.ObsoleteAttribute("Validation type should be specified as DTD or Schema.")]
+        [System.ObsoleteAttribute("ValidationType.Auto has been deprecated. Use DTD or Schema instead.")]
         Auto = 1,
         DTD = 2,
-        [System.ObsoleteAttribute("XDR Validation through XmlValidatingReader is obsoleted")]
+        [System.ObsoleteAttribute("XDR Validation through XmlValidatingReader has been deprecated and is no longer supported.")]
         XDR = 3,
         Schema = 4,
     }
@@ -214,7 +214,7 @@ namespace System.Xml
         public static bool ToBoolean(string s) { throw null; }
         public static byte ToByte(string s) { throw null; }
         public static char ToChar(string s) { throw null; }
-        [System.ObsoleteAttribute("Use XmlConvert.ToDateTime() that takes in XmlDateTimeSerializationMode")]
+        [System.ObsoleteAttribute("Use XmlConvert.ToDateTime() that accepts an XmlDateTimeSerializationMode instead.")]
         public static System.DateTime ToDateTime(string s) { throw null; }
         public static System.DateTime ToDateTime(string s, string format) { throw null; }
         public static System.DateTime ToDateTime(string s, string[] formats) { throw null; }
@@ -234,7 +234,7 @@ namespace System.Xml
         public static string ToString(bool value) { throw null; }
         public static string ToString(byte value) { throw null; }
         public static string ToString(char value) { throw null; }
-        [System.ObsoleteAttribute("Use XmlConvert.ToString() that takes in XmlDateTimeSerializationMode")]
+        [System.ObsoleteAttribute("Use XmlConvert.ToString() that accepts an XmlDateTimeSerializationMode instead.")]
         public static string ToString(System.DateTime value) { throw null; }
         public static string ToString(System.DateTime value, string format) { throw null; }
         public static string ToString(System.DateTime value, System.Xml.XmlDateTimeSerializationMode dateTimeOption) { throw null; }
@@ -934,7 +934,7 @@ namespace System.Xml
         public long MaxCharactersFromEntities { get { throw null; } set { } }
         public long MaxCharactersInDocument { get { throw null; } set { } }
         public System.Xml.XmlNameTable? NameTable { get { throw null; } set { } }
-        [System.ObsoleteAttribute("XmlReaderSettings.ProhibitDtd has been deprecated. Use the DtdProcessing property.")]
+        [System.ObsoleteAttribute("XmlReaderSettings.ProhibitDtd has been deprecated. Use DtdProcessing instead.")]
         public bool ProhibitDtd { get { throw null; } set { } }
         public System.Xml.Schema.XmlSchemaSet Schemas { get { throw null; } set { } }
         public System.Xml.Schema.XmlSchemaValidationFlags ValidationFlags { get { throw null; } set { } }
@@ -1034,7 +1034,7 @@ namespace System.Xml
         public override System.Xml.XmlNodeType NodeType { get { throw null; } }
         public bool Normalization { get { throw null; } set { } }
         public override string Prefix { get { throw null; } }
-        [System.ObsoleteAttribute("XmlTextReader.ProhibitDtd has been deprecated. Use the DtdProcessing property.")]
+        [System.ObsoleteAttribute("XmlTextReader.ProhibitDtd has been deprecated. Use DtdProcessing instead.")]
         public bool ProhibitDtd { get { throw null; } set { } }
         public override char QuoteChar { get { throw null; } }
         public override System.Xml.ReadState ReadState { get { throw null; } }
@@ -1146,7 +1146,7 @@ namespace System.Xml
         public override System.Threading.Tasks.Task<object> GetEntityAsync(System.Uri absoluteUri, string? role, System.Type? ofObjectToReturn) { throw null; }
         public override System.Uri ResolveUri(System.Uri? baseUri, string? relativeUri) { throw null; }
     }
-    [System.ObsoleteAttribute("XmlValidatingReader has been deprecated. Use XmlReader created by XmlReader.Create() method using appropriate XmlReaderSettings.")]
+    [System.ObsoleteAttribute("XmlValidatingReader has been deprecated. Use XmlReader created by XmlReader.Create() method using appropriate XmlReaderSettings instead.")]
     public partial class XmlValidatingReader : System.Xml.XmlReader, System.Xml.IXmlLineInfo, System.Xml.IXmlNamespaceResolver
     {
         public XmlValidatingReader(System.IO.Stream xmlFragment, System.Xml.XmlNodeType fragType, System.Xml.XmlParserContext context) { }
@@ -1551,7 +1551,7 @@ namespace System.Xml.Schema
         public XmlSchemaAttribute() { }
         [System.Xml.Serialization.XmlIgnoreAttribute]
         public System.Xml.Schema.XmlSchemaSimpleType? AttributeSchemaType { get { throw null; } }
-        [System.ObsoleteAttribute("XmlSchemaAttribute.AttributeType has been deprecated. Use the AttributeSchemaType property that returns a strongly typed attribute type.")]
+        [System.ObsoleteAttribute("XmlSchemaAttribute.AttributeType has been deprecated. Use the AttributeSchemaType property that returns a strongly typed attribute type instead.")]
         [System.Xml.Serialization.XmlIgnoreAttribute]
         public object? AttributeType { get { throw null; } }
         [System.ComponentModel.DefaultValueAttribute(null)]
@@ -1820,7 +1820,7 @@ namespace System.Xml.Schema
         public string? DefaultValue { get { throw null; } set { } }
         [System.Xml.Serialization.XmlIgnoreAttribute]
         public System.Xml.Schema.XmlSchemaType? ElementSchemaType { get { throw null; } }
-        [System.ObsoleteAttribute("XmlSchemaElement.ElementType has been deprecated. Use the ElementSchemaType property that returns a strongly typed element type.")]
+        [System.ObsoleteAttribute("XmlSchemaElement.ElementType has been deprecated. Use the ElementSchemaType property that returns a strongly typed element type instead.")]
         [System.Xml.Serialization.XmlIgnoreAttribute]
         public object? ElementType { get { throw null; } }
         [System.ComponentModel.DefaultValueAttribute(System.Xml.Schema.XmlSchemaDerivationMethod.None)]
@@ -2272,7 +2272,7 @@ namespace System.Xml.Schema
     public partial class XmlSchemaType : System.Xml.Schema.XmlSchemaAnnotated
     {
         public XmlSchemaType() { }
-        [System.ObsoleteAttribute("XmlSchemaType.BaseSchemaType has been deprecated. Use the BaseXmlSchemaType property that returns a strongly typed base schema type.")]
+        [System.ObsoleteAttribute("XmlSchemaType.BaseSchemaType has been deprecated. Use the BaseXmlSchemaType property that returns a strongly typed base schema type instead.")]
         [System.Xml.Serialization.XmlIgnoreAttribute]
         public object? BaseSchemaType { get { throw null; } }
         [System.Xml.Serialization.XmlIgnoreAttribute]

--- a/src/libraries/System.Xml.ReaderWriter/ref/System.Xml.ReaderWriter.cs
+++ b/src/libraries/System.Xml.ReaderWriter/ref/System.Xml.ReaderWriter.cs
@@ -86,7 +86,7 @@ namespace System.Xml
         [System.ObsoleteAttribute("ValidationType.Auto has been deprecated. Use DTD or Schema instead.")]
         Auto = 1,
         DTD = 2,
-        [System.ObsoleteAttribute("XDR Validation through XmlValidatingReader has been deprecated and is no longer supported.")]
+        [System.ObsoleteAttribute("XDR Validation through XmlValidatingReader has been deprecated and is not supported.")]
         XDR = 3,
         Schema = 4,
     }

--- a/src/libraries/System.Xml.ReaderWriter/ref/System.Xml.ReaderWriter.cs
+++ b/src/libraries/System.Xml.ReaderWriter/ref/System.Xml.ReaderWriter.cs
@@ -934,7 +934,7 @@ namespace System.Xml
         public long MaxCharactersFromEntities { get { throw null; } set { } }
         public long MaxCharactersInDocument { get { throw null; } set { } }
         public System.Xml.XmlNameTable? NameTable { get { throw null; } set { } }
-        [System.ObsoleteAttribute("Use XmlReaderSettings.DtdProcessing property instead.")]
+        [System.ObsoleteAttribute("XmlReaderSettings.ProhibitDtd has been deprecated. Use the DtdProcessing property.")]
         public bool ProhibitDtd { get { throw null; } set { } }
         public System.Xml.Schema.XmlSchemaSet Schemas { get { throw null; } set { } }
         public System.Xml.Schema.XmlSchemaValidationFlags ValidationFlags { get { throw null; } set { } }
@@ -1034,7 +1034,7 @@ namespace System.Xml
         public override System.Xml.XmlNodeType NodeType { get { throw null; } }
         public bool Normalization { get { throw null; } set { } }
         public override string Prefix { get { throw null; } }
-        [System.ObsoleteAttribute("Use DtdProcessing property instead.")]
+        [System.ObsoleteAttribute("XmlTextReader.ProhibitDtd has been deprecated. Use the DtdProcessing property.")]
         public bool ProhibitDtd { get { throw null; } set { } }
         public override char QuoteChar { get { throw null; } }
         public override System.Xml.ReadState ReadState { get { throw null; } }
@@ -1146,7 +1146,7 @@ namespace System.Xml
         public override System.Threading.Tasks.Task<object> GetEntityAsync(System.Uri absoluteUri, string? role, System.Type? ofObjectToReturn) { throw null; }
         public override System.Uri ResolveUri(System.Uri? baseUri, string? relativeUri) { throw null; }
     }
-    [System.ObsoleteAttribute("Use XmlReader created by XmlReader.Create() method using appropriate XmlReaderSettings instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+    [System.ObsoleteAttribute("XmlValidatingReader has been deprecated. Use XmlReader created by XmlReader.Create() method using appropriate XmlReaderSettings.")]
     public partial class XmlValidatingReader : System.Xml.XmlReader, System.Xml.IXmlLineInfo, System.Xml.IXmlNamespaceResolver
     {
         public XmlValidatingReader(System.IO.Stream xmlFragment, System.Xml.XmlNodeType fragType, System.Xml.XmlParserContext context) { }
@@ -1472,9 +1472,9 @@ namespace System.Xml.Schema
         public System.Xml.XmlAttribute[]? UnhandledAttributes { get { throw null; } set { } }
         [System.Xml.Serialization.XmlAttributeAttribute("version", DataType="token")]
         public string? Version { get { throw null; } set { } }
-        [System.ObsoleteAttribute("Use System.Xml.Schema.XmlSchemaSet for schema compilation and validation. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("XmlSchema.Compile has been deprecated. Use System.Xml.Schema.XmlSchemaSet for schema compilation and validation.")]
         public void Compile(System.Xml.Schema.ValidationEventHandler? validationEventHandler) { }
-        [System.ObsoleteAttribute("Use System.Xml.Schema.XmlSchemaSet for schema compilation and validation. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("XmlSchema.Compile has been deprecated. Use System.Xml.Schema.XmlSchemaSet for schema compilation and validation.")]
         public void Compile(System.Xml.Schema.ValidationEventHandler? validationEventHandler, System.Xml.XmlResolver? resolver) { }
         public static System.Xml.Schema.XmlSchema? Read(System.IO.Stream stream, System.Xml.Schema.ValidationEventHandler? validationEventHandler) { throw null; }
         public static System.Xml.Schema.XmlSchema? Read(System.IO.TextReader reader, System.Xml.Schema.ValidationEventHandler? validationEventHandler) { throw null; }
@@ -1551,7 +1551,7 @@ namespace System.Xml.Schema
         public XmlSchemaAttribute() { }
         [System.Xml.Serialization.XmlIgnoreAttribute]
         public System.Xml.Schema.XmlSchemaSimpleType? AttributeSchemaType { get { throw null; } }
-        [System.ObsoleteAttribute("This property has been deprecated. Please use AttributeSchemaType property that returns a strongly typed attribute type. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("XmlSchemaAttribute.AttributeType has been deprecated. Use the AttributeSchemaType property that returns a strongly typed attribute type.")]
         [System.Xml.Serialization.XmlIgnoreAttribute]
         public object? AttributeType { get { throw null; } }
         [System.ComponentModel.DefaultValueAttribute(null)]
@@ -1609,7 +1609,7 @@ namespace System.Xml.Schema
         [System.Xml.Serialization.XmlElementAttribute("sequence", typeof(System.Xml.Schema.XmlSchemaSequence))]
         public override System.Xml.Schema.XmlSchemaObjectCollection Items { get { throw null; } }
     }
-    [System.ObsoleteAttribute("Use System.Xml.Schema.XmlSchemaSet for schema compilation and validation. https://go.microsoft.com/fwlink/?linkid=14202")]
+    [System.ObsoleteAttribute("XmlSchemaCollection has been deprecated. Use System.Xml.Schema.XmlSchemaSet for schema compilation and validation.")]
     public sealed partial class XmlSchemaCollection : System.Collections.ICollection, System.Collections.IEnumerable
     {
         public XmlSchemaCollection() { }
@@ -1820,7 +1820,7 @@ namespace System.Xml.Schema
         public string? DefaultValue { get { throw null; } set { } }
         [System.Xml.Serialization.XmlIgnoreAttribute]
         public System.Xml.Schema.XmlSchemaType? ElementSchemaType { get { throw null; } }
-        [System.ObsoleteAttribute("This property has been deprecated. Please use ElementSchemaType property that returns a strongly typed element type. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("XmlSchemaElement.ElementType has been deprecated. Use the ElementSchemaType property that returns a strongly typed element type.")]
         [System.Xml.Serialization.XmlIgnoreAttribute]
         public object? ElementType { get { throw null; } }
         [System.ComponentModel.DefaultValueAttribute(System.Xml.Schema.XmlSchemaDerivationMethod.None)]
@@ -2272,7 +2272,7 @@ namespace System.Xml.Schema
     public partial class XmlSchemaType : System.Xml.Schema.XmlSchemaAnnotated
     {
         public XmlSchemaType() { }
-        [System.ObsoleteAttribute("This property has been deprecated. Please use BaseXmlSchemaType property that returns a strongly typed base schema type. https://go.microsoft.com/fwlink/?linkid=14202")]
+        [System.ObsoleteAttribute("XmlSchemaType.BaseSchemaType has been deprecated. Use the BaseXmlSchemaType property that returns a strongly typed base schema type.")]
         [System.Xml.Serialization.XmlIgnoreAttribute]
         public object? BaseSchemaType { get { throw null; } }
         [System.Xml.Serialization.XmlIgnoreAttribute]

--- a/src/mono/System.Private.CoreLib/src/System/Threading/Overlapped.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Threading/Overlapped.cs
@@ -224,7 +224,7 @@ namespace System.Threading
             _overlappedData.AsyncResult = ar;
         }
 
-        [Obsolete("This constructor is not 64-bit compatible.  Use the constructor that takes an IntPtr for the event handle.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("This constructor is not 64-bit compatible and has been deprecated. Use the constructor that accepts an IntPtr for the event handle.")]
         public Overlapped(int offsetLo, int offsetHi, int hEvent, IAsyncResult? ar) : this(offsetLo, offsetHi, new IntPtr(hEvent), ar)
         {
         }
@@ -247,7 +247,7 @@ namespace System.Threading
             set { _overlappedData.OffsetHigh = value; }
         }
 
-        [Obsolete("This property is not 64-bit compatible.  Use EventHandleIntPtr instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("Overlapped.EventHandle is not 64-bit compatible and has been deprecated. Use EventHandleIntPtr.")]
         public int EventHandle
         {
             get { return EventHandleIntPtr.ToInt32(); }
@@ -265,7 +265,7 @@ namespace System.Threading
         *  Roots the iocb and stores it in the ReservedCOR field of native Overlapped
         *  Pins the native Overlapped struct and returns the pinned index.
         ====================================================================*/
-        [Obsolete("This method is not safe.  Use Pack (iocb, userData) instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("This overload is not safe and has been deprecated. Use Pack(IOCompletionCallback?, object?).")]
         [CLSCompliant(false)]
         public unsafe NativeOverlapped* Pack(IOCompletionCallback? iocb)
         {
@@ -278,7 +278,7 @@ namespace System.Threading
             return _overlappedData.Pack(iocb, userData);
         }
 
-        [Obsolete("This method is not safe.  Use UnsafePack (iocb, userData) instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+        [Obsolete("This overload is not safe and has been deprecated. Use UnsafePack(IOCompletionCallback?, object?).")]
         [CLSCompliant(false)]
         public unsafe NativeOverlapped* UnsafePack(IOCompletionCallback? iocb)
         {

--- a/src/mono/System.Private.CoreLib/src/System/Threading/Overlapped.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Threading/Overlapped.cs
@@ -224,7 +224,7 @@ namespace System.Threading
             _overlappedData.AsyncResult = ar;
         }
 
-        [Obsolete("This constructor is not 64-bit compatible and has been deprecated. Use the constructor that accepts an IntPtr for the event handle.")]
+        [Obsolete("This constructor is not 64-bit compatible and has been deprecated. Use the constructor that accepts an IntPtr for the event handle instead.")]
         public Overlapped(int offsetLo, int offsetHi, int hEvent, IAsyncResult? ar) : this(offsetLo, offsetHi, new IntPtr(hEvent), ar)
         {
         }
@@ -247,7 +247,7 @@ namespace System.Threading
             set { _overlappedData.OffsetHigh = value; }
         }
 
-        [Obsolete("Overlapped.EventHandle is not 64-bit compatible and has been deprecated. Use EventHandleIntPtr.")]
+        [Obsolete("Overlapped.EventHandle is not 64-bit compatible and has been deprecated. Use EventHandleIntPtr instead.")]
         public int EventHandle
         {
             get { return EventHandleIntPtr.ToInt32(); }
@@ -265,7 +265,7 @@ namespace System.Threading
         *  Roots the iocb and stores it in the ReservedCOR field of native Overlapped
         *  Pins the native Overlapped struct and returns the pinned index.
         ====================================================================*/
-        [Obsolete("This overload is not safe and has been deprecated. Use Pack(IOCompletionCallback?, object?).")]
+        [Obsolete("This overload is not safe and has been deprecated. Use Pack(IOCompletionCallback?, object?) instead.")]
         [CLSCompliant(false)]
         public unsafe NativeOverlapped* Pack(IOCompletionCallback? iocb)
         {
@@ -278,7 +278,7 @@ namespace System.Threading
             return _overlappedData.Pack(iocb, userData);
         }
 
-        [Obsolete("This overload is not safe and has been deprecated. Use UnsafePack(IOCompletionCallback?, object?).")]
+        [Obsolete("This overload is not safe and has been deprecated. Use UnsafePack(IOCompletionCallback?, object?) instead.")]
         [CLSCompliant(false)]
         public unsafe NativeOverlapped* UnsafePack(IOCompletionCallback? iocb)
         {

--- a/src/mono/System.Private.CoreLib/src/System/Threading/ThreadPool.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Threading/ThreadPool.Mono.cs
@@ -28,7 +28,7 @@ namespace System.Threading
             return UnsafeQueueUserWorkItem(NativeOverlappedCallback, (IntPtr)overlapped);
         }
 
-        [Obsolete("ThreadPool.BindHandle(IntPtr) has been deprecated.  Please use ThreadPool.BindHandle(SafeHandle) instead.", false)]
+        [Obsolete("ThreadPool.BindHandle(IntPtr) has been deprecated. Use ThreadPool.BindHandle(SafeHandle) instead.", false)]
         [SupportedOSPlatform("windows")]
         public static bool BindHandle(IntPtr osHandle)
         {


### PR DESCRIPTION
Fixes #47255.

Removes from all messages the unhelpful [fwlink](https://go.microsoft.com/fwlink/?linkid=14202) that points to a "What's obsolete in the .NET Framework class library" page.

Takes a pass through all `[Obsolete]` APIs and makes the messages more consistent throughout.

Does not attempt to utilize the new `UrlFormat` property on the `Obsolete` attribute, as we don't have dedicated diagnostic IDs or landing pages for the affected APIs. Spot-checking the APIs with web searches was resulting in good hits in our docs and other sites.