### PR TITLE
Corrected terminology in SequencePosition documentation

### DIFF
--- a/src/libraries/System.Memory/src/System/SequencePosition.cs
+++ b/src/libraries/System.Memory/src/System/SequencePosition.cs
@@ -8,7 +8,7 @@ namespace System
 {
     /// <summary>
     /// Represents position in non-contiguous set of memory.
-    /// Properties of this type should not be interpreted by anything but the type that created it.
+    /// Parts of this type should not be interpreted by anything but the type that created it.
     /// </summary>
     public readonly struct SequencePosition : IEquatable<SequencePosition>
     {


### PR DESCRIPTION
`SequencePosition` does not use properties to access its fields, so the documentation for the type should use a different term. The documentation for the getter methods uses "parts", so I used that here too.