### PR TITLE
React to Verify* task PackageTesting change

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -198,7 +198,7 @@
       <Uri>https://github.com/dotnet/xharness</Uri>
       <Sha>aa0da55569eaa42c2c735dd89abd2843fba4fe01</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.PackageTesting" Version="6.0.0-beta.21370.12">
+    <Dependency Name="Microsoft.DotNet.PackageTesting" Version="6.0.0-beta.21402.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>89806f0b9e93ad2bbe32c654412835c0801a2032</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -65,7 +65,7 @@
     <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>6.0.0-beta.21372.16</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
     <MicrosoftDotNetRemoteExecutorVersion>6.0.0-beta.21370.12</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetVersionToolsTasksVersion>6.0.0-beta.21370.12</MicrosoftDotNetVersionToolsTasksVersion>
-    <MicrosoftDotNetPackageTestingVersion>6.0.0-beta.21370.12</MicrosoftDotNetPackageTestingVersion>
+    <MicrosoftDotNetPackageTestingVersion>6.0.0-beta.21402.1</MicrosoftDotNetPackageTestingVersion>
     <!-- NuGet dependencies -->
     <NuGetBuildTasksPackVersion>6.0.0-preview.1.102</NuGetBuildTasksPackVersion>
     <!-- Installer dependencies -->

--- a/src/libraries/pkg/test/build/packageTest.targets
+++ b/src/libraries/pkg/test/build/packageTest.targets
@@ -1,16 +1,17 @@
 <Project>
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' != ''">
-    <_targetFrameworkIdentifier>$(TargetFrameworkIdentifier.Substring(1).ToLower())</_targetFrameworkIdentifier>
-  </PropertyGroup>
-
   <PropertyGroup>
+    <_targetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' != ''">$(TargetFrameworkIdentifier.Substring(1).ToLower())</_targetFrameworkIdentifier>
     <!-- Make sure the SDK raises the runtime items so that they are passed to conflict resolution -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <!-- Suppress any SYSLIB9000 errors, as in these cases restore/build would succeed, the failure would be at run-time -->
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
-  <Import Project="build\Packaging.common.targets" />
+  <ItemGroup>
+    <!-- Required for VerifyClosure and VerifyTypes tasks. -->
+    <PackageReference Include="Microsoft.DotNet.PackageTesting" Version="$(MicrosoftDotNetPackageTestingVersion)" />
+  </ItemGroup>
+
   <!-- Import framework settings. -->
   <Import Project="frameworkSettings\$(_targetFrameworkIdentifier)\*.targets"
           Condition="'$(_targetFrameworkIdentifier)' != ''"  />
@@ -28,7 +29,6 @@
     <!-- Type duplicated: https://github.com/dotnet/runtime/issues/34420 -->
     <IgnoredTypes Include="System.Collections.Generic.CollectionExtensions" />
   </ItemGroup>
-
   
   <Target Name="LogBeginTest"
           Condition="'$(TargetFramework)' != ''">

--- a/src/libraries/pkg/test/frameworkSettings/netcore50/settings.targets
+++ b/src/libraries/pkg/test/frameworkSettings/netcore50/settings.targets
@@ -1,5 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <TargetPlatformMinVersion>10.0.0</TargetPlatformMinVersion>
-  </PropertyGroup>
-</Project>

--- a/src/libraries/pkg/test/packageSettings/Microsoft.NETCore.Platforms/netcoreapp2.2/settings.targets
+++ b/src/libraries/pkg/test/packageSettings/Microsoft.NETCore.Platforms/netcoreapp2.2/settings.targets
@@ -1,8 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <!-- This package will generate validation issues since we usually try to consume same-day packages from corefx that will have a higher
-         version than locally built packages. Validation will assume incorrectly that you are downgrading the reference which is why this error is flagged.
-         Since it isn't really an error, we will supress it in order to unblock same-day package ingestion. -->
-    <NoWarn>$(NoWarn);NU1605</NoWarn>
-  </PropertyGroup>
-</Project>

--- a/src/libraries/pkg/test/project.csproj.template
+++ b/src/libraries/pkg/test/project.csproj.template
@@ -14,8 +14,6 @@
     <MicrosoftNetCoreAppFrameworkName>{MicrosoftNetCoreAppFrameworkName}</MicrosoftNetCoreAppFrameworkName>
     <MicrosoftNetCoreAppRefPackDir>{MicrosoftNetCoreAppRefPackDir}</MicrosoftNetCoreAppRefPackDir>
 
-    <!-- Turn off end of life target framework checks as we intentionally build older .NETCoreApp configurations. -->
-    <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <NETCoreAppMaximumVersion>$(NetCoreAppCurrentVersion)</NETCoreAppMaximumVersion>
   </PropertyGroup>
 

--- a/src/libraries/pkg/test/testPackages.proj
+++ b/src/libraries/pkg/test/testPackages.proj
@@ -1,13 +1,7 @@
 <Project Sdk="Microsoft.Build.NoTargets">
 
-  <UsingTask TaskName="GetCompatiblePackageTargetFrameworks"
-             AssemblyFile="$(DotNetPackageTestingAssembly)"
-             Condition="'$(DotNetPackageTestingAssembly)' != ''" />
-
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.PackageTesting" Version="$(MicrosoftDotNetPackageTestingVersion)" />
-    <!-- Needed by packageTest.targets, could be moved into PackageTesting: https://github.com/dotnet/arcade/issues/7474. -->
-    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Packaging" Version="$(MicrosoftDotNetBuildTasksPackagingVersion)" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -38,11 +32,6 @@
     <ExcludePackages Condition="'$(PackagesToTest)' != ''" Include="@(AllPackages)" Exclude="@(PackagesToTest)" />
     <TestPackages Include="@(AllPackages)" Exclude="@(ExcludePackages)" />
     <TestPackagesPath Include="@(TestPackages->'%(PackagePath)')" />
-
-    <!-- no targeting pack was ever shipped for net463 -->
-    <TargetFrameworksToExclude Include="net463" />
-    <TargetFrameworksToExclude Include="net47" />
-    <TargetFrameworksToExclude Include="netcoreapp2.2" />
   </ItemGroup>
 
   <ItemGroup>
@@ -59,9 +48,6 @@
                               build\Directory.Build.props;
                               build\Directory.Build.targets"
                      DestinationFolder="$(TestDir)" />
-    <TestSupportFile Include="$(PackagingTaskDir)..\..\**\*.*"
-                     Exclude="$(PackagingTaskDir)..\..\*.*"
-                     DestinationFolder="$(TestDir)%(RecursiveDir)" />
     <!-- frameworksettings and packagesettings -->
     <TestSupportFile Include="frameworkSettings\**\*"
                      DestinationFolder="$(TestDir)frameworkSettings\%(RecursiveDir)" />
@@ -77,7 +63,14 @@
   </Target>
 
   <Target Name="GetSupportedPackages">
-    <GetCompatiblePackageTargetFrameworks PackagePaths="@(TestPackagesPath)" SupportedTestFrameworks="@(SupportedTestFramework)">
+    <!-- Adding NetCoreAppCurrent to the supported test frameworks list to avoid a test gap when
+         the repository retargets NetCoreAppCurrent to the next major version. -->
+    <ItemGroup>
+      <SupportedTestFramework Include="$(NetCoreAppCurrent)" />
+    </ItemGroup>
+
+    <GetCompatiblePackageTargetFrameworks PackagePaths="@(TestPackagesPath)"
+                                          SupportedTestFrameworks="@(SupportedTestFramework)">
       <Output TaskParameter="TestProjects" ItemName="SupportedPackage" />
     </GetCompatiblePackageTargetFrameworks>
 
@@ -98,7 +91,7 @@
       </_supportedPackageByTargetFramework>
 
       <_supportedPackageByTargetFrameworkToRemove Include="@(_supportedPackageByTargetFramework)" Exclude="@(TargetFrameworksToInclude)" Condition="'@(TargetFrameworksToInclude)' != ''" />
-      <_filteredSupportedPackageByTargetFramework Include="@(_supportedPackageByTargetFramework)" Exclude="@(TargetFrameworksToExclude);@(_supportedPackageByTargetFrameworkToRemove)" />
+      <_filteredSupportedPackageByTargetFramework Include="@(_supportedPackageByTargetFramework)" Exclude="@(_supportedPackageByTargetFrameworkToRemove)" />
 
       <SupportedPackage Remove="@(SupportedPackage)" />
       <SupportedPackage Include="@(_filteredSupportedPackageByTargetFramework->'%(Original)')" />


### PR DESCRIPTION
Depends on https://github.com/dotnet/arcade/pull/7692

Removing the dependency on the Packaging assembly in favor of the
PackageTesting assembly which now contains the VerifyClosure and
VerifyTypes tasks that are required for package testing.

Also removing some obsolete properties and files.