### PR TITLE
Fixing update issue with multivalued properties #34267

### DIFF
--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx_LoadStore.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx_LoadStore.cs
@@ -1361,7 +1361,7 @@ namespace System.DirectoryServices.AccountManagement
                         // directly. This allows us to override all existing elements without using Clear() and then Add(),
                         // as that order sends a Clear operation and then a number of Append operations, which will fail.
                         // Instead, setting the new list all at once will send a Clear operation and then an Update operation.
-                        var values = new List<object>();
+                        var propertyValueList = new List<object>();
 
                         foreach (object oVal in valueCollection)
                         {
@@ -1379,10 +1379,10 @@ namespace System.DirectoryServices.AccountManagement
                             if (p.unpersisted && null == oVal)
                                 continue;
 
-                            values.Add(oVal);
+                            propertyValueList.Add(oVal);
                         }
 
-                        de.Properties[kvp.Key].Value = values.ToArray();
+                        de.Properties[kvp.Key].Value = propertyValueList.ToArray();
 
                         GlobalDebug.WriteLineIf(GlobalDebug.Info, "ADStoreCtx", "ExtensionCacheToLdapConverter - Collection complete");
                     }

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx_LoadStore.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx_LoadStore.cs
@@ -1357,6 +1357,12 @@ namespace System.DirectoryServices.AccountManagement
                             valueCollection = (ICollection)kvp.Value.Value;
                         }
 
+                        // We make a local copy of all elements to set, instead of adding them to the real property
+                        // directly. This allows us to override all existing elements without using Clear() and then Add(),
+                        // as that order sends a Clear operation and then a number of Append operations, which will fail.
+                        // Instead, setting the new list all at once will send a Clear operation and then an Update operation.
+                        var values = new List<object>();
+
                         foreach (object oVal in valueCollection)
                         {
                             if (null != oVal)
@@ -1373,8 +1379,11 @@ namespace System.DirectoryServices.AccountManagement
                             if (p.unpersisted && null == oVal)
                                 continue;
 
-                            de.Properties[kvp.Key].Add(oVal);
+                            values.Add(oVal);
                         }
+
+                        de.Properties[kvp.Key].Value = values.ToArray();
+
                         GlobalDebug.WriteLineIf(GlobalDebug.Info, "ADStoreCtx", "ExtensionCacheToLdapConverter - Collection complete");
                     }
                     else

--- a/src/libraries/System.DirectoryServices.AccountManagement/tests/AccountManagementTests.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/tests/AccountManagementTests.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.DirectoryServices.Tests;
 using System.Linq;
 using Xunit;
+using System.Collections.Generic;
 
 namespace System.DirectoryServices.AccountManagement.Tests
 {
@@ -325,6 +326,7 @@ namespace System.DirectoryServices.AccountManagement.Tests
                     using (GroupPrincipal gp = FindGroup(g1.Name, context)) { Assert.Equal(group.DisplayName, gp.DisplayName); }
 
                     user.DisplayName = "Updated CoreFx Test Child User 4";
+                    
                     user.Save();
                     group.DisplayName = "Updated CoreFX Test Group Container 4";
                     group.Save();
@@ -362,6 +364,38 @@ namespace System.DirectoryServices.AccountManagement.Tests
             finally
             {
                 DeleteUser(u1.Name);
+            }
+        }
+
+        [ConditionalFact(nameof(IsActiveDirectoryServer))]
+        public void TestCustomUserAttributes()
+        {
+            var userData = CustomUserData.GenerateUserData("CustomCoreFxUser1");
+
+            DeleteUser(userData.Name);
+
+            try
+            {
+                using var context = DomainContext;
+                using (var principal = CreateCustomUser(context, userData))
+                {
+                    Assert.NotNull(principal);
+                    ValidateRecentAddedUser(context, userData);
+                    ValidateUserUsingPrincipal(context, principal);
+
+                    using var foundPrincipal = FindCustomUser(userData.Name, context);
+                    Assert.NotNull(foundPrincipal);
+
+                    Assert.Equal(userData.PostalCode, foundPrincipal.PostalCode);
+                    Assert.Equal(principal.PostalCode, foundPrincipal.PostalCode);
+
+                    Assert.Equal(userData.PostalAddress, foundPrincipal.PostalAddress);
+                    Assert.Equal(principal.PostalAddress, foundPrincipal.PostalAddress);
+                }
+            }
+            finally
+            {
+                DeleteUser(userData.Name);
             }
         }
 
@@ -440,6 +474,20 @@ namespace System.DirectoryServices.AccountManagement.Tests
             return user;
         }
 
+        private CustomUserPrincipal CreateCustomUser(PrincipalContext context, CustomUserData userData)
+        {
+            CustomUserPrincipal user = new CustomUserPrincipal(context, userData.Name, userData.Password, true);
+
+            // assign some properties to the custom user principal
+            user.GivenName = userData.FirstName;
+            user.Surname = userData.LastName;
+            user.DisplayName = userData.DisplayName;
+            user.PostalCode = userData.PostalCode;
+            user.PostalAddress = userData.PostalAddress;
+            user.Save();
+            return user;
+        }
+
         private GroupPrincipal CreateGroup(PrincipalContext context, GroupData groupData)
         {
             GroupPrincipal group = new GroupPrincipal(context, groupData.Name);
@@ -493,6 +541,11 @@ namespace System.DirectoryServices.AccountManagement.Tests
             return UserPrincipal.FindByIdentity(context, IdentityType.Name, userName);
         }
 
+        private CustomUserPrincipal FindCustomUser(string userName, PrincipalContext context)
+        {
+            return CustomUserPrincipal.FindByIdentity(context, IdentityType.SamAccountName, userName);
+        }
+
         private UserPrincipal FindUserUsingFilter(string userName, PrincipalContext context)
         {
             CustomUserPrincipal userPrincipal = new CustomUserPrincipal(context);
@@ -528,6 +581,23 @@ namespace System.DirectoryServices.AccountManagement.Tests
         internal string DisplayName { get; set; }
     }
 
+    internal class CustomUserData : UserData
+    {
+        internal static new CustomUserData GenerateUserData(string name) => new CustomUserData
+        {
+            Name = name,
+            Password = Guid.NewGuid().ToString() + "#1aZ",
+            FirstName = "First " + name,
+            LastName = "Last " + name,
+            DisplayName = "Display " + name,
+            PostalAddress = new List<string> { "Postal Address " + name },
+            PostalCode = "Code " + name
+        };
+
+        internal string PostalCode { get; set; }
+        internal List<string> PostalAddress { get; set; }
+    }
+
     internal class GroupData
     {
         internal static GroupData GenerateGroupData(string name)
@@ -545,11 +615,14 @@ namespace System.DirectoryServices.AccountManagement.Tests
     }
 
     [DirectoryObjectClass("user")]
+    [DirectoryRdnPrefix("CN")]
     public class CustomUserPrincipal : UserPrincipal
     {
         private CustomFilter _customFilter;
 
         public CustomUserPrincipal(PrincipalContext context) : base(context) { }
+        public CustomUserPrincipal(PrincipalContext context, string samAccountName, string password, bool enabled)
+            : base(context, samAccountName, password, enabled) { }
 
         public void SetUserNameFilter(string name)
         {
@@ -567,6 +640,27 @@ namespace System.DirectoryServices.AccountManagement.Tests
 
                 return _customFilter;
             }
+        }
+
+        // Custom properties
+        [DirectoryProperty("postalCode")]
+        public string PostalCode
+        {
+            get => ExtensionGet("postalCode").FirstOrDefault() as string;
+            set => ExtensionSet("postalCode", value);
+        }
+
+        [DirectoryProperty("postalAddress")]
+        public List<string> PostalAddress
+        {
+            get => ExtensionGet("postalAddress").OfType<string>().ToList();
+            set => ExtensionSet("postalAddress", value == null || value?.Count == 0 ? null : value.ToArray());
+        }
+
+        // Method overrides
+        public new static CustomUserPrincipal FindByIdentity(PrincipalContext context, IdentityType identityType, string identityValue)
+        {
+            return FindByIdentityWithType(context, typeof(CustomUserPrincipal), identityType, identityValue) as CustomUserPrincipal;
         }
     }
 


### PR DESCRIPTION
Fixes Issue #34267

# Description
This PR fixes the issue linked. Updating a multivalued property would only add new values, but not remove old values. Only in the case 0 or 1 items were remaining, a different code path did remove all other values.

This has been solved in this PR by recreating the entire array of properties. My proposed solution in the issue (clearing the list and re-adding all values) did not work properly, as it would cause an error when creating a new principal. My best guess for a cause is that such a solution would only send Clear and Append operations to `IADs::PutEx`, while for a newly-created object it requires/expects an Update operation. To circumvent this, I construct the new list of values locally, and then set the array all at once. This invokes a different codepath in `PropertyValueCollection` which does send an Update.

# Customer Impact
The current issue causes unexpected behaviour that is hard to catch, as it only occurs when removing values but keeping at least 2 values remaining.

# Regression
As far as I can see, this issue has been present for years.

# Testing
Added a unit test demonstrating the issue first, before attempting to solve it. The unit test now passes.

# Risk
There might be some risk involved, as this technically changes behaviour. However, I don't believe the old behaviour was documented to be correct anywhere, and it was inconsistent (dependent on the number of items in the list). 