### PR TITLE
Define timeout for CreateSocket.Ctor_SafeHandle_Listening_Success

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/CreateSocketTests.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/CreateSocketTests.cs
@@ -447,7 +447,6 @@ namespace System.Net.Sockets.Tests
         [InlineData(false)]
         [InlineData(true)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/52124", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
-
         public async Task Ctor_SafeHandle_Listening_Success(bool shareSafeHandle)
         {
             await Task.Run(async () =>
@@ -481,7 +480,7 @@ namespace System.Net.Sockets.Tests
                         }
                     }
                 }
-            }).WaitAsync(TimeSpan.FromSeconds(30)); 
+            }).WaitAsync(TestSettings.PassingTestTimeout); 
         }
 
         [DllImport("libc")]

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/CreateSocketTests.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/CreateSocketTests.cs
@@ -447,37 +447,41 @@ namespace System.Net.Sockets.Tests
         [InlineData(false)]
         [InlineData(true)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/52124", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
+
         public async Task Ctor_SafeHandle_Listening_Success(bool shareSafeHandle)
         {
-            using var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
-            listener.Listen();
-
-            using var listenerCopy = new Socket(shareSafeHandle ? listener.SafeHandle : new SafeSocketHandle(listener.Handle, ownsHandle: false));
-            Assert.False(listenerCopy.Connected);
-            // This will throw if _isListening is set internally. (before reaching any real code)
-            Assert.Throws<InvalidOperationException>(() => listenerCopy.Connect(new IPEndPoint(IPAddress.Loopback,0)));
-
-            Assert.Equal(listener.AddressFamily, listenerCopy.AddressFamily);
-            Assert.Equal(listener.Handle, listenerCopy.Handle);
-            Assert.Equal(listener.IsBound, listenerCopy.IsBound);
-            Assert.Equal(listener.LocalEndPoint, listenerCopy.LocalEndPoint);
-            Assert.Equal(listener.ProtocolType, listenerCopy.ProtocolType);
-            Assert.Equal(listener.SocketType, listenerCopy.SocketType);
-
-            foreach (Socket listenerSocket in new[] { listener, listenerCopy })
+            await Task.Run(async () =>
             {
-                using (var client1 = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+                using var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                listener.Listen();
+
+                using var listenerCopy = new Socket(shareSafeHandle ? listener.SafeHandle : new SafeSocketHandle(listener.Handle, ownsHandle: false));
+                Assert.False(listenerCopy.Connected);
+                // This will throw if _isListening is set internally. (before reaching any real code)
+                Assert.Throws<InvalidOperationException>(() => listenerCopy.Connect(new IPEndPoint(IPAddress.Loopback, 0)));
+
+                Assert.Equal(listener.AddressFamily, listenerCopy.AddressFamily);
+                Assert.Equal(listener.Handle, listenerCopy.Handle);
+                Assert.Equal(listener.IsBound, listenerCopy.IsBound);
+                Assert.Equal(listener.LocalEndPoint, listenerCopy.LocalEndPoint);
+                Assert.Equal(listener.ProtocolType, listenerCopy.ProtocolType);
+                Assert.Equal(listener.SocketType, listenerCopy.SocketType);
+
+                foreach (Socket listenerSocket in new[] { listener, listenerCopy })
                 {
-                    Task connect1 = client1.ConnectAsync(listenerSocket.LocalEndPoint);
-                    using (Socket server1 = listenerSocket.Accept())
+                    using (var client1 = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
                     {
-                        await connect1;
-                        server1.Send(new byte[] { 42 });
-                        Assert.Equal(1, client1.Receive(new byte[1]));
+                        Task connect1 = client1.ConnectAsync(listenerSocket.LocalEndPoint);
+                        using (Socket server1 = listenerSocket.Accept())
+                        {
+                            await connect1;
+                            server1.Send(new byte[] { 42 });
+                            Assert.Equal(1, client1.Receive(new byte[1]));
+                        }
                     }
                 }
-            }
+            }).WaitAsync(TimeSpan.FromSeconds(30)); 
         }
 
         [DllImport("libc")]


### PR DESCRIPTION
Contributes to #56666. The test uses sync API-s which I didn't want to change so I wrapped the code with `Task.Run(...).WaitAsync(...)`.