### PR TITLE
Dispose server connection after client has been disposed

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -2556,15 +2556,9 @@ namespace System.Net.Http.Functional.Tests
             await new[] { serverTask, clientTask }.WhenAllOrAnyFailed(60_000);
         }
 
-        public static IEnumerable<object[]> LongRunning()
-        {
-            return Enumerable.Repeat(true, 10000).Select((b, i) => new object[] { i % 2 == 0 }).ToArray();
-        }
-
         [ConditionalTheory(nameof(PlatformSupportsUnixDomainSockets))]
-        [MemberData(nameof(LongRunning))]
-        //[InlineData(true)]
-        //[InlineData(false)]
+        [InlineData(true)]
+        [InlineData(false)]
         public async Task ConnectCallback_UseUnixDomainSocket_Success(bool useSsl)
         {
             GenericLoopbackOptions options = new GenericLoopbackOptions() { UseSsl = useSsl };


### PR DESCRIPTION
There is a race condition in Http2Connection in processing of GOAWAY frame between disposing the client's SslStream (`_stream` field) together with shutting down Http2Connection and sending RST_STREAM for aborted Http2Streams. It could be that a stream put an outgoing `RST_STREAM` on `_writeChannel.Writer` queue, but then `_writeChannle.Writer` has got disposed before sending that `RST_STREAM `frame.

The above behavior can lead to test code gets hang if it calls `Http2LoopbackConnection.ShutdownIgnoringErrorsAsync` directly or as part of a Dispose call because this method first sends `GOAWAY` frame to client and then waits for any frame from client which can never arrive due to that race condition.

This PR changes the call order, so `Http2LoopbackConnection` is called after the HttpClient has been disposed.

Fixes #44183