### PR TITLE
Enable Http2.SocketSendQueueFull_RequestCanceled_ThrowsOperationCanceled

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -3579,17 +3579,10 @@ namespace System.Net.Http.Functional.Tests
                 });
         }
         
-        public static IEnumerable<object[]> LongRunning()
-        {
-            return Enumerable.Repeat(true, 100).Select((b, i) => new object[] { i % 2 == 0 }).ToArray();
-        }
-
-        [ConditionalTheory(nameof(SupportsAlpn))]
-        [MemberData(nameof(LongRunning))]
+        [Fact]
         [OuterLoop("Uses Task.Delay")]
-        public async Task SocketSendQueueFull_RequestCanceled_ThrowsOperationCanceled(bool b)
+        public async Task SocketSendQueueFull_RequestCanceled_ThrowsOperationCanceled()
         {
-            Assert.Equal(b, b);
             TaskCompletionSource clientComplete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await Http2LoopbackServer.CreateClientAndServerAsync(

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -3578,11 +3578,18 @@ namespace System.Net.Http.Functional.Tests
                     }
                 });
         }
-
-        [Fact]
-        [OuterLoop("Uses Task.Delay")]
-        public async Task SocketSendQueueFull_RequestCanceled_ThrowsOperationCanceled()
+        
+        public static IEnumerable<object[]> LongRunning()
         {
+            return Enumerable.Repeat(true, 100).Select((b, i) => new object[] { i % 2 == 0 }).ToArray();
+        }
+
+        [ConditionalTheory(nameof(SupportsAlpn))]
+        [MemberData(nameof(LongRunning))]
+        [OuterLoop("Uses Task.Delay")]
+        public async Task SocketSendQueueFull_RequestCanceled_ThrowsOperationCanceled(bool b)
+        {
+            Assert.Equal(b, b);
             TaskCompletionSource clientComplete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await Http2LoopbackServer.CreateClientAndServerAsync(

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -3581,7 +3581,6 @@ namespace System.Net.Http.Functional.Tests
 
         [Fact]
         [OuterLoop("Uses Task.Delay")]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/44352", TestPlatforms.OSX)]
         public async Task SocketSendQueueFull_RequestCanceled_ThrowsOperationCanceled()
         {
             TaskCompletionSource clientComplete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -3578,7 +3578,7 @@ namespace System.Net.Http.Functional.Tests
                     }
                 });
         }
-        
+
         [Fact]
         [OuterLoop("Uses Task.Delay")]
         public async Task SocketSendQueueFull_RequestCanceled_ThrowsOperationCanceled()


### PR DESCRIPTION
The test should have been already fixed by #56552.

Fixes #44352