### PR TITLE
see if GetArrayDataReference_NullInput_ThrowsNullRef  passes on tvOS now

### DIFF
--- a/src/libraries/System.Memory/tests/MemoryMarshal/GetArrayDataReference.cs
+++ b/src/libraries/System.Memory/tests/MemoryMarshal/GetArrayDataReference.cs
@@ -11,7 +11,6 @@ namespace System.SpanTests
     public static partial class MemoryMarshalTests
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36885", TestPlatforms.tvOS)]
         public static void GetArrayDataReference_NullInput_ThrowsNullRef()
         {
             Assert.Throws<NullReferenceException>(() => MemoryMarshal.GetArrayDataReference<object>((object[])null));


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/36885#issuecomment-633148806

https://github.com/dotnet/runtime/issues/36883#issuecomment-882910858

fixes #36885