### PR TITLE
Only decommit parts of regions and the mark array when memory is low.

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -10879,7 +10879,9 @@ void gc_heap::clear_region_info (heap_segment* region)
     ::record_changed_seg ((uint8_t*)region, heap_segment_reserved (region),
                         settings.gc_index, current_bgc_state,
                         seg_deleted);
-    decommit_mark_array_by_seg (region);
+
+    if (g_low_memory_status)
+        decommit_mark_array_by_seg (region);
 #endif //BACKGROUND_GC
 }
 
@@ -11364,6 +11366,10 @@ void gc_heap::decommit_heap_segment_pages (heap_segment* seg,
 size_t gc_heap::decommit_heap_segment_pages_worker (heap_segment* seg,
                                                     uint8_t* new_committed)
 {
+#ifdef USE_REGIONS
+    if (!g_low_memory_status)
+        return 0;
+#endif
     assert (!use_large_pages_p);
     uint8_t* page_start = align_on_page (new_committed);
     size_t size = heap_segment_committed (seg) - page_start;
@@ -11393,6 +11399,11 @@ size_t gc_heap::decommit_heap_segment_pages_worker (heap_segment* seg,
 //decommit all pages except one or 2
 void gc_heap::decommit_heap_segment (heap_segment* seg)
 {
+#ifdef USE_REGIONS
+    if (!g_low_memory_status)
+        return;
+#endif
+
     uint8_t*  page_start = align_on_page (heap_segment_mem (seg));
 
     dprintf (3, ("Decommitting heap segment %Ix(%Ix)", (size_t)seg, heap_segment_mem (seg)));

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -10880,8 +10880,10 @@ void gc_heap::clear_region_info (heap_segment* region)
                         settings.gc_index, current_bgc_state,
                         seg_deleted);
 
-    if (g_low_memory_status)
+    if (settings.entry_memory_load >= high_memory_load_th || g_low_memory_status)
+    {
         decommit_mark_array_by_seg (region);
+    }
 #endif //BACKGROUND_GC
 }
 
@@ -11367,8 +11369,10 @@ size_t gc_heap::decommit_heap_segment_pages_worker (heap_segment* seg,
                                                     uint8_t* new_committed)
 {
 #ifdef USE_REGIONS
-    if (!g_low_memory_status)
+    if (settings.entry_memory_load < high_memory_load_th && !g_low_memory_status)
+    {
         return 0;
+    }
 #endif
     assert (!use_large_pages_p);
     uint8_t* page_start = align_on_page (new_committed);
@@ -11400,8 +11404,10 @@ size_t gc_heap::decommit_heap_segment_pages_worker (heap_segment* seg,
 void gc_heap::decommit_heap_segment (heap_segment* seg)
 {
 #ifdef USE_REGIONS
-    if (!g_low_memory_status)
+    if (settings.entry_memory_load < high_memory_load_th && !g_low_memory_status)
+    {
         return;
+    }
 #endif
 
     uint8_t*  page_start = align_on_page (heap_segment_mem (seg));


### PR DESCRIPTION
We'll decommit completely free regions if they exceed the budget, but as we'll use the available memory in regions not on the free list preferentially, it seems smarter to decommit only when memory is low.

In a simple GCPerfSim Scenario (-tc 10 -tagb 1000 -tlgb 1 on a 10-core box) this made about a 10% difference in run time, the time saved is mainly in the OS - VirtualFree, VirtualAlloc, and KiPageFault.
