### PR TITLE
Disable failing arm64 win10 Graphics.FromHdc tests 

### DIFF
--- a/src/libraries/System.Drawing.Common/tests/GraphicsTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/GraphicsTests.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.Drawing.Text;
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.Drawing.Tests
@@ -102,6 +103,12 @@ namespace System.Drawing.Tests
         [MemberData(nameof(FromHdc_TestData))]
         public void FromHdc_ValidHdc_ReturnsExpected(IntPtr hdc)
         {
+            if (PlatformDetection.IsArm64Process && OperatingSystem.IsWindows())
+            {
+                // ActiveIssue: 51097
+                throw new SkipTestException("Visible clipping region is not empty.");
+            }
+
             using (Graphics graphics = Graphics.FromHdc(hdc))
             {
                 Rectangle expected = Helpers.GetWindowDCRect(hdc);
@@ -114,6 +121,12 @@ namespace System.Drawing.Tests
         [MemberData(nameof(FromHdc_TestData))]
         public void FromHdc_ValidHdcWithContext_ReturnsExpected(IntPtr hdc)
         {
+            if (PlatformDetection.IsArm64Process && OperatingSystem.IsWindows())
+            {
+                // ActiveIssue: 51097
+                throw new SkipTestException("Visible clipping region is not empty.");
+            }
+
             using (Graphics graphics = Graphics.FromHdc(hdc, IntPtr.Zero))
             {
                 Rectangle expected = Helpers.GetWindowDCRect(hdc);
@@ -126,6 +139,12 @@ namespace System.Drawing.Tests
         [MemberData(nameof(FromHdc_TestData))]
         public void FromHdcInternal_GetDC_ReturnsExpected(IntPtr hdc)
         {
+            if (PlatformDetection.IsArm64Process && OperatingSystem.IsWindows())
+            {
+                // ActiveIssue: 51097
+                throw new SkipTestException("Visible clipping region is not empty.");
+            }
+
             using (Graphics graphics = Graphics.FromHdcInternal(hdc))
             {
                 Rectangle expected = Helpers.GetWindowDCRect(hdc);
@@ -262,6 +281,12 @@ namespace System.Drawing.Tests
         [MemberData(nameof(Hwnd_TestData))]
         public void FromHwnd_ValidHwnd_ReturnsExpected(IntPtr hWnd)
         {
+            if (PlatformDetection.IsArm64Process && OperatingSystem.IsWindows ())
+            {
+                // ActiveIssue: 51097
+                throw new SkipTestException("Visible clipping region is not empty.");
+            }
+
             using (Graphics graphics = Graphics.FromHwnd(hWnd))
             {
                 Rectangle expected = Helpers.GetHWndRect(hWnd);
@@ -274,6 +299,12 @@ namespace System.Drawing.Tests
         [MemberData(nameof(Hwnd_TestData))]
         public void FromHwndInternal_ValidHwnd_ReturnsExpected(IntPtr hWnd)
         {
+            if (PlatformDetection.IsArm64Process && OperatingSystem.IsWindows())
+            {
+                // ActiveIssue: 51097
+                throw new SkipTestException("Visible clipping region is not empty.");
+            }
+
             using (Graphics graphics = Graphics.FromHwnd(hWnd))
             {
                 Rectangle expected = Helpers.GetHWndRect(hWnd);

--- a/src/libraries/System.Drawing.Common/tests/GraphicsTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/GraphicsTests.cs
@@ -6,7 +6,6 @@ using System.ComponentModel;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.Drawing.Text;
-using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.Drawing.Tests
@@ -99,16 +98,11 @@ namespace System.Drawing.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/51097", typeof(PlatformDetection), nameof(PlatformDetection.IsArm64Process), nameof(PlatformDetection.IsWindows10OrLater))]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(FromHdc_TestData))]
         public void FromHdc_ValidHdc_ReturnsExpected(IntPtr hdc)
         {
-            if (PlatformDetection.IsArm64Process && OperatingSystem.IsWindows())
-            {
-                // ActiveIssue: 51097
-                throw new SkipTestException("Visible clipping region is not empty.");
-            }
-
             using (Graphics graphics = Graphics.FromHdc(hdc))
             {
                 Rectangle expected = Helpers.GetWindowDCRect(hdc);
@@ -117,16 +111,11 @@ namespace System.Drawing.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/51097", typeof(PlatformDetection), nameof(PlatformDetection.IsArm64Process), nameof(PlatformDetection.IsWindows10OrLater))]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(FromHdc_TestData))]
         public void FromHdc_ValidHdcWithContext_ReturnsExpected(IntPtr hdc)
         {
-            if (PlatformDetection.IsArm64Process && OperatingSystem.IsWindows())
-            {
-                // ActiveIssue: 51097
-                throw new SkipTestException("Visible clipping region is not empty.");
-            }
-
             using (Graphics graphics = Graphics.FromHdc(hdc, IntPtr.Zero))
             {
                 Rectangle expected = Helpers.GetWindowDCRect(hdc);
@@ -135,16 +124,11 @@ namespace System.Drawing.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/51097", typeof(PlatformDetection), nameof(PlatformDetection.IsArm64Process), nameof(PlatformDetection.IsWindows10OrLater))]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(FromHdc_TestData))]
         public void FromHdcInternal_GetDC_ReturnsExpected(IntPtr hdc)
         {
-            if (PlatformDetection.IsArm64Process && OperatingSystem.IsWindows())
-            {
-                // ActiveIssue: 51097
-                throw new SkipTestException("Visible clipping region is not empty.");
-            }
-
             using (Graphics graphics = Graphics.FromHdcInternal(hdc))
             {
                 Rectangle expected = Helpers.GetWindowDCRect(hdc);
@@ -277,16 +261,11 @@ namespace System.Drawing.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/51097", typeof(PlatformDetection), nameof(PlatformDetection.IsArm64Process), nameof(PlatformDetection.IsWindows10OrLater))]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Hwnd_TestData))]
         public void FromHwnd_ValidHwnd_ReturnsExpected(IntPtr hWnd)
         {
-            if (PlatformDetection.IsArm64Process && OperatingSystem.IsWindows ())
-            {
-                // ActiveIssue: 51097
-                throw new SkipTestException("Visible clipping region is not empty.");
-            }
-
             using (Graphics graphics = Graphics.FromHwnd(hWnd))
             {
                 Rectangle expected = Helpers.GetHWndRect(hWnd);
@@ -295,16 +274,11 @@ namespace System.Drawing.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/51097", typeof(PlatformDetection), nameof(PlatformDetection.IsArm64Process), nameof(PlatformDetection.IsWindows10OrLater))]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Hwnd_TestData))]
         public void FromHwndInternal_ValidHwnd_ReturnsExpected(IntPtr hWnd)
         {
-            if (PlatformDetection.IsArm64Process && OperatingSystem.IsWindows())
-            {
-                // ActiveIssue: 51097
-                throw new SkipTestException("Visible clipping region is not empty.");
-            }
-
             using (Graphics graphics = Graphics.FromHwnd(hWnd))
             {
                 Rectangle expected = Helpers.GetHWndRect(hWnd);


### PR DESCRIPTION
These tests have been failing on win10 arm64 builds and are blocking a clean CI.

See dotnet/winforms#8829.

/cc @BruceForstall @hoyosjs 