### PR TITLE
Fix stack overflow handling issue in GC stress

### DIFF
--- a/src/coreclr/vm/eepolicy.cpp
+++ b/src/coreclr/vm/eepolicy.cpp
@@ -616,6 +616,10 @@ void DECLSPEC_NORETURN EEPolicy::HandleFatalStackOverflow(EXCEPTION_POINTERS *pE
 
     WRAPPER_NO_CONTRACT;
 
+    // Disable GC stress triggering GC at this point, we don't want the GC to start running
+    // on this thread when we have only a very limited space left on the stack
+    GCStressPolicy::InhibitHolder iholder;
+
     STRESS_LOG0(LF_EH, LL_INFO100, "In EEPolicy::HandleFatalStackOverflow\n");
 
     FrameWithCookie<FaultingExceptionFrame> fef;


### PR DESCRIPTION
This change fixes a problem when in GC stress mode 3, GC started to run
on the thread that hit stack overflow due to the GCX_PREEMP in
DebuggerRCThread::DoFavor that is called from the
EEPolicy::HandleFatalStackOverflow. It was causing failures in the CI.
The issue is GC stress specific, the GCX_PREEMP would not start running
GC on the current thread in regular cases.

The fix is to inhibit GC stress in the HandleFatalStackOverflow.
