### PR TITLE
[libraries] Reenable System.Diagnostics.DiagnosticSorce.Switches.Tests on mobile

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/TestWithConfigSwitches/ActivityTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/TestWithConfigSwitches/ActivityTests.cs
@@ -6,8 +6,6 @@ using Xunit;
 
 namespace System.Diagnostics.Tests
 {
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/37073", TestPlatforms.Android)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/51376", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
     public class ActivityTests : IDisposable
     {
         [Fact]


### PR DESCRIPTION
Fixes #37073

After running locally on iOS/tvOS, MacCatalyst, and Android, this suite no longer fails.