### PR TITLE
Mark new test as incompatible with GC

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_4781/Runtime_4781_1.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_4781/Runtime_4781_1.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
This test relies on triggering GC at an exact point.

Closes #56704.