### PR TITLE
Respect AppContext.SetData with APP_CONFIG_FILE key

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/IO/FileCleanupTestBase.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/IO/FileCleanupTestBase.cs
@@ -18,9 +18,9 @@ namespace System.IO
         protected static bool IsProcessElevated => s_isElevated.Value;
 
         /// <summary>Initialize the test class base.  This creates the associated test directory.</summary>
-        protected FileCleanupTestBase(string cleanupRootDirectory = null)
+        protected FileCleanupTestBase(string tempDirectory = null)
         {
-            cleanupRootDirectory ??= Path.GetTempPath();
+            tempDirectory ??= Path.GetTempPath();
 
             // Use a unique test directory per test class.  The test directory lives in the user's temp directory,
             // and includes both the name of the test class and a random string.  The test class name is included
@@ -33,7 +33,7 @@ namespace System.IO
             string failure = string.Empty;
             for (int i = 0; i <= 2; i++)
             {
-                TestDirectory = Path.Combine(cleanupRootDirectory, GetType().Name + "_" + Path.GetRandomFileName());
+                TestDirectory = Path.Combine(tempDirectory, GetType().Name + "_" + Path.GetRandomFileName());
                 try
                 {
                     Directory.CreateDirectory(TestDirectory);

--- a/src/libraries/Common/tests/TestUtilities/System/IO/FileCleanupTestBase.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/IO/FileCleanupTestBase.cs
@@ -18,8 +18,10 @@ namespace System.IO
         protected static bool IsProcessElevated => s_isElevated.Value;
 
         /// <summary>Initialize the test class base.  This creates the associated test directory.</summary>
-        protected FileCleanupTestBase()
+        protected FileCleanupTestBase(string cleanupRootDirectory = null)
         {
+            cleanupRootDirectory ??= Path.GetTempPath();
+
             // Use a unique test directory per test class.  The test directory lives in the user's temp directory,
             // and includes both the name of the test class and a random string.  The test class name is included
             // so that it can be easily correlated if necessary, and the random string to helps avoid conflicts if
@@ -31,7 +33,7 @@ namespace System.IO
             string failure = string.Empty;
             for (int i = 0; i <= 2; i++)
             {
-                TestDirectory = Path.Combine(Path.GetTempPath(), GetType().Name + "_" + Path.GetRandomFileName());
+                TestDirectory = Path.Combine(cleanupRootDirectory, GetType().Name + "_" + Path.GetRandomFileName());
                 try
                 {
                     Directory.CreateDirectory(TestDirectory);

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
@@ -92,7 +92,23 @@ namespace System.Configuration
                 }
             }
 
-            if (!string.IsNullOrEmpty(ApplicationUri))
+            string externalConfigPath = AppDomain.CurrentDomain.GetData("APP_CONFIG_FILE") as string;
+            if (!string.IsNullOrEmpty(externalConfigPath))
+            {
+                if (Uri.IsWellFormedUriString(externalConfigPath, UriKind.Absolute))
+                {
+                    Uri externalConfigUri = new Uri(externalConfigPath);
+                    if (externalConfigUri.IsFile)
+                    {
+                        ApplicationConfigUri = externalConfigUri.LocalPath;
+                    }
+                }
+                else
+                {
+                    ApplicationConfigUri = Path.GetFullPath(externalConfigPath);
+                }
+            }
+            else if (!string.IsNullOrEmpty(ApplicationUri))
             {
                 string applicationPath = ApplicationUri;
                 if (isSingleFile)

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
@@ -107,11 +107,10 @@ namespace System.Configuration
                 {
                     // Uri constructor would throw for relative paths but full framework doesn't.
                     // We will mimic full framework behavior here.
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && externalConfigPath.Length >= 2 && externalConfigPath.StartsWith('\\') && externalConfigPath[1] != '\\')
-                    {
-                        // if path starts with a single backslash Path.Combine would combine with a root of BaseDirectory so we trim that character to avoid that
-                        externalConfigPath = externalConfigPath.Substring(0, externalConfigPath.Length - 1);
-                    }
+
+                    // If path starts with directory separator Path.Combine would combine with a root of BaseDirectory so we trim that character to avoid that
+                    // For absolute path we should already be covered by the other code path
+                    externalConfigPath = externalConfigPath.TrimStart(Path.DirectorySeparatorChar);
 
                     ApplicationConfigUri = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, externalConfigPath);
                 }

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
@@ -107,7 +107,13 @@ namespace System.Configuration
                 {
                     // Uri constructor would throw for relative paths but full framework doesn't.
                     // We will mimic full framework behavior here.
-                    ApplicationConfigUri = Path.GetFullPath(externalConfigPath, AppDomain.CurrentDomain.BaseDirectory);
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && externalConfigPath.Length >= 2 && externalConfigPath.StartsWith('\\') && externalConfigPath[1] != '\\')
+                    {
+                        // if path starts with a single backslash Path.Combine would combine with a root of BaseDirectory so we trim that character to avoid that
+                        externalConfigPath = externalConfigPath.Substring(0, externalConfigPath.Length - 1);
+                    }
+
+                    ApplicationConfigUri = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, externalConfigPath);
                 }
             }
             else if (!string.IsNullOrEmpty(ApplicationUri))

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
@@ -105,7 +105,9 @@ namespace System.Configuration
                 }
                 else
                 {
-                    ApplicationConfigUri = Path.GetFullPath(externalConfigPath);
+                    // Uri constructor would throw for relative paths but full framework doesn't.
+                    // We will mimic full framework behavior here.
+                    ApplicationConfigUri = Path.GetFullPath(externalConfigPath, AppDomain.CurrentDomain.BaseDirectory);
                 }
             }
             else if (!string.IsNullOrEmpty(ApplicationUri))

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
@@ -97,7 +97,7 @@ namespace System.Configuration
             {
                 if (Uri.IsWellFormedUriString(externalConfigPath, UriKind.Absolute))
                 {
-                    Uri externalConfigUri = new Uri(externalConfigPath);
+                    Uri externalConfigUri = new Uri(externalConfigPath, UriKind.Absolute);
                     if (externalConfigUri.IsFile)
                     {
                         ApplicationConfigUri = externalConfigUri.LocalPath;
@@ -105,14 +105,12 @@ namespace System.Configuration
                 }
                 else
                 {
-                    // Uri constructor would throw for relative paths but full framework doesn't.
-                    // We will mimic full framework behavior here.
+                    if (!Path.IsPathRooted(externalConfigPath))
+                    {
+                        externalConfigPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, externalConfigPath);
+                    }
 
-                    // If path starts with directory separator Path.Combine would combine with a root of BaseDirectory so we trim that character to avoid that
-                    // For absolute path we should already be covered by the other code path
-                    externalConfigPath = externalConfigPath.TrimStart(Path.DirectorySeparatorChar);
-
-                    ApplicationConfigUri = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, externalConfigPath);
+                    ApplicationConfigUri = Path.GetFullPath(externalConfigPath);
                 }
             }
             else if (!string.IsNullOrEmpty(ApplicationUri))

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
@@ -65,6 +65,7 @@
     <Compile Include="System\Configuration\ConfigurationElementCollectionTests.cs" />
     <Compile Include="System\Configuration\ConfigurationElementTests.cs" />
     <Compile Include="System\Configuration\ConfigurationPropertyAttributeTests.cs" />
+    <Compile Include="System\Configuration\ConfigurationPathTests.cs" />
     <Compile Include="System\Configuration\CustomHostTests.cs" />
     <Compile Include="System\Configuration\ConfigurationPropertyTests.cs" />
     <Compile Include="System\Configuration\ConfigurationTests.cs" />

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/ConfigurationPathTests.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/ConfigurationPathTests.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Configuration;
+using System.IO;
+using Microsoft.DotNet.RemoteExecutor;
+using Xunit;
+
+namespace System.ConfigurationTests
+{
+    public class ConfigurationPathTests
+    {
+        private const string ConfigName = "APP_CONFIG_FILE";
+
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void CustomAppConfigIsUsedWhenSpecifiedAsRelativePath()
+        {
+            const string SettingName = "test_CustomAppConfigIsUsedWhenSpecified";
+            string expectedSettingValue = Guid.NewGuid().ToString();
+            string configFilePath = CreateAppConfigFileWithSetting(SettingName, expectedSettingValue);
+
+            RemoteExecutor.Invoke((string configFilePath, string expectedSettingValue) => {
+                AppDomain.CurrentDomain.SetData(ConfigName, configFilePath);
+                Assert.Equal(expectedSettingValue, ConfigurationManager.AppSettings[SettingName]);
+            }, configFilePath, expectedSettingValue).Dispose();
+        }
+
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void CustomAppConfigIsUsedWhenSpecifiedAsAbsolutePath()
+        {
+            const string SettingName = "test_CustomAppConfigIsUsedWhenSpecified";
+            string expectedSettingValue = Guid.NewGuid().ToString();
+            string configFilePath = Path.GetFullPath(CreateAppConfigFileWithSetting(SettingName, expectedSettingValue));
+
+            RemoteExecutor.Invoke((string configFilePath, string expectedSettingValue) => {
+                AppDomain.CurrentDomain.SetData(ConfigName, configFilePath);
+                Assert.Equal(expectedSettingValue, ConfigurationManager.AppSettings[SettingName]);
+            }, configFilePath, expectedSettingValue).Dispose();
+        }
+
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void CustomAppConfigIsUsedWhenSpecifiedAsAbsoluteUri()
+        {
+            const string SettingName = "test_CustomAppConfigIsUsedWhenSpecified";
+            string expectedSettingValue = Guid.NewGuid().ToString();
+            string configFilePath = new Uri(Path.GetFullPath(CreateAppConfigFileWithSetting(SettingName, expectedSettingValue))).ToString();
+
+            RemoteExecutor.Invoke((string configFilePath, string expectedSettingValue) => {
+                AppDomain.CurrentDomain.SetData(ConfigName, configFilePath);
+                Assert.Equal(expectedSettingValue, ConfigurationManager.AppSettings[SettingName]);
+            }, configFilePath, expectedSettingValue).Dispose();
+        }
+
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void NoErrorWhenCustomAppConfigIsSpecifiedAndItDoesNotExist()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                AppDomain.CurrentDomain.SetData(ConfigName, "non-existing-file.config");
+                Assert.Null(ConfigurationManager.AppSettings["AnySetting"]);
+            }).Dispose();
+        }
+
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void MalformedAppConfigCausesException()
+        {
+            const string SettingName = "AnySetting";
+
+            // Following will cause malformed config file
+            string configFilePath = CreateAppConfigFileWithSetting(SettingName, "\"");
+
+            RemoteExecutor.Invoke((string configFilePath) => {
+                AppDomain.CurrentDomain.SetData(ConfigName, configFilePath);
+                Assert.Throws<ConfigurationErrorsException>(() => ConfigurationManager.AppSettings[SettingName]);
+            }, configFilePath).Dispose();
+        }
+
+        private static string CreateAppConfigFileWithSetting(string key, string rawUnquotedValue)
+        {
+            string fileName = Path.GetRandomFileName() + ".config";
+            File.WriteAllText(fileName,
+                @$"<?xml version=""1.0"" encoding=""utf-8"" ?>
+<configuration>
+  <appSettings>
+    <add key=""{key}"" value=""{rawUnquotedValue}""/>
+  </appSettings>
+</configuration>");
+
+            return fileName;
+        }
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/931

Full framework works with following path types:
- relative path, i.e.: `myconfig.config`
- absolute path
- file URI, i.e.: `file:///c:/myconfig.config`

additionally:
- when file doesn't exists there is no error and all settings read as null
- when file is malformed you get an error