### PR TITLE
Ensure MetadataEnumResult is sufficiently updated by MetaDataImport::…

### DIFF
--- a/src/coreclr/vm/managedmdimport.cpp
+++ b/src/coreclr/vm/managedmdimport.cpp
@@ -163,6 +163,7 @@ static int * EnsureResultSize(MetadataEnumResult * pResult, ULONG length)
     else
     {
         ZeroMemory(pResult->smallResult, sizeof(pResult->smallResult));
+        pResult->largeResult = NULL;
         p = pResult->smallResult;
     }
 


### PR DESCRIPTION
…Enum

`MetadataEnumResult` has a fixed inline buffer for returning small results
and a pointer to allow it to return larger ones. The indexer for this
checks the pointer and if non-null assumes that's the current set of
values.

But if a `MetadataEnumResult` is re-used within a loop, values written to it
by `MetaDataImport::Enum` may bleed from one loop iteration to the next
if the iterations first get a large result and then a small one.

One case where this could happen was in libraries PGO tests, where PGO data
encouraged the jit to inline `MemberInfoCache<T>.PopulateProperties(Filter,...)`
into `MemberInfoCache<T>.PopulateProperties(Filter)`.

Note this also is a conseqeunce of skipping zero init locals; without that
the struct would have been zeroed each loop iteration.

Fixes #56655.