### PR TITLE
Fix explicit layout validator memory alloc problems

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/ExplicitLayoutValidator.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/ExplicitLayoutValidator.cs
@@ -9,7 +9,14 @@ namespace Internal.TypeSystem
 {
     public struct ExplicitLayoutValidator
     {
-        struct FieldLayoutInterval : IComparable<FieldLayoutInterval>
+        private enum FieldLayoutTag : byte
+        {
+            Empty,
+            NonORef,
+            ORef,
+        }
+
+        private struct FieldLayoutInterval : IComparable<FieldLayoutInterval>
         {
             public FieldLayoutInterval(int start, int size, FieldLayoutTag tag)
             {
@@ -46,13 +53,6 @@ namespace Internal.TypeSystem
                 
                 return 1;
             }
-        }
-
-        private enum FieldLayoutTag : byte
-        {
-            Empty,
-            NonORef,
-            ORef,
         }
 
         private readonly int _pointerSize;
@@ -218,7 +218,7 @@ namespace Internal.TypeSystem
                 int newIntervalLocation = ~binarySearchIndex;
 
                 // Check for previous interval overlaps cases
-                if ((newIntervalLocation - 1) > 0)
+                if (newIntervalLocation > 0)
                 {
                     var previousInterval = fieldLayoutInterval[newIntervalLocation - 1];
                     bool tagMatches = previousInterval.Tag == tag;

--- a/src/coreclr/tools/Common/TypeSystem/Common/ExplicitLayoutValidator.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/ExplicitLayoutValidator.cs
@@ -45,13 +45,7 @@ namespace Internal.TypeSystem
 
             public int CompareTo(FieldLayoutInterval other)
             {
-                if (other.Start == Start)
-                    return 0;
-                
-                if (Start < other.Start )
-                    return -1;
-                
-                return 1;
+                return Start.CompareTo(other.Start);
             }
         }
 
@@ -186,7 +180,7 @@ namespace Internal.TypeSystem
 
             var newInterval = new FieldLayoutInterval(offset, count, tag);
 
-            int binarySearchIndex = fieldLayoutInterval.BinarySearch(new FieldLayoutInterval(offset, 0, FieldLayoutTag.Empty));
+            int binarySearchIndex = fieldLayoutInterval.BinarySearch(newInterval);
 
             if (binarySearchIndex >= 0)
             {


### PR DESCRIPTION
The ExplicitLayoutValidator currently used an array of bytes one to one with the size of the layout of the class. However, we have some test cases for outrageously large explicit layout structures and classes which cause this approach to OOM in crossgen2.

The fix is to move to a data structure defined in terms of intervals. This is probably a bit slower, but it requires vastly less memory for pathological situations.

Fixes #55164
Fixes #53559