### PR TITLE
make Quic AcceptStreamAsync concurrent safe

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -74,7 +74,6 @@ namespace System.Net.Quic.Implementations.MsQuic
             // Backlog limit is managed by MsQuic so it can be unbounded here.
             public readonly Channel<MsQuicStream> AcceptQueue = Channel.CreateUnbounded<MsQuicStream>(new UnboundedChannelOptions()
             {
-                SingleReader = true,
                 SingleWriter = true,
             });
 

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
@@ -171,12 +171,12 @@ namespace System.Net.Quic.Tests
             {
                 for (int i = 0; i < count; i++)
                 {
-                    tasks[i] = makeStreams(clientConnection, serverConnection);
+                    tasks[i] = MakeStreams(clientConnection, serverConnection);
                 }
                 await tasks.WhenAllOrAnyFailed(PassingTestTimeoutMilliseconds);
             }
 
-            static async Task makeStreams(QuicConnection clientConnection, QuicConnection serverConnection)
+            static async Task MakeStreams(QuicConnection clientConnection, QuicConnection serverConnection)
             {
                 byte[] buffer = new byte[64];
                 QuicStream clientStream = clientConnection.OpenBidirectionalStream();

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
@@ -160,6 +160,35 @@ namespace System.Net.Quic.Tests
         }
 
         [Fact]
+        public async Task MultipleConcurrentStreamsOnSingleConnection()
+        {
+            const int count = 100;
+            Task[] tasks = new Task[count];
+
+            (QuicConnection clientConnection, QuicConnection serverConnection) = await CreateConnectedQuicConnection();
+            using (clientConnection)
+            using (serverConnection)
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    tasks[i] = makeStreams(clientConnection, serverConnection);
+                }
+                await tasks.WhenAllOrAnyFailed(PassingTestTimeoutMilliseconds);
+            }
+
+            static async Task makeStreams(QuicConnection clientConnection, QuicConnection serverConnection)
+            {
+                byte[] buffer = new byte[64];
+                QuicStream clientStream = clientConnection.OpenBidirectionalStream();
+                ValueTask writeTask = clientStream.WriteAsync(Encoding.UTF8.GetBytes("PING"), endStream: true);
+                ValueTask<QuicStream> acceptTask = serverConnection.AcceptStreamAsync();
+                await new Task[] { writeTask.AsTask(), acceptTask.AsTask()}.WhenAllOrAnyFailed(PassingTestTimeoutMilliseconds);
+                QuicStream serverStream = acceptTask.Result;
+                await serverStream.ReadAsync(buffer);
+            }
+        }
+
+        [Fact]
         public async Task GetStreamIdWithoutStartWorks()
         {
             using QuicListener listener = CreateQuicListener();


### PR DESCRIPTION
I found this while investigating #55249
While I could rarely reproduce the reported issue, I would often see strange timeout. 
With the current code, running `AcceptStreamAsync` in parallel is not safe. 
Thanks to @stephentoub who pointed the right place when we would throw `OperationCancelledException` without token expiring. 
With the change, I'm yet to see the `InvalidOperationException`. (not really sure why)

contributes to  #55249
I'm not sure if this really matters to runtime tests but the local runs seems happier. (not enough samples yet) 

cc: @JamesNK