### PR TITLE
Fix timeouts in coreroot_determinism test in GC stress mode

### DIFF
--- a/src/coreclr/tools/r2rtest/Crossgen2Runner.cs
+++ b/src/coreclr/tools/r2rtest/Crossgen2Runner.cs
@@ -65,6 +65,10 @@ namespace R2RTest
         {
             ProcessParameters processParameters = base.CompilationProcess(outputFileName, inputAssemblyFileNames);
             processParameters.Arguments = $"{Crossgen2Path} {processParameters.Arguments}";
+            processParameters.EnvironmentOverrides["COMPlus_GCStress"] = "";
+            processParameters.EnvironmentOverrides["COMPlus_HeapVerify"] = "";
+            processParameters.EnvironmentOverrides["COMPlus_ReadyToRun"] = "";
+            processParameters.EnvironmentOverrides["COMPlus_GCName"] = "";
             return processParameters;
         }
 

--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -87,9 +87,9 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
         local heapVerifyModeToRestore=$COMPlus_HeapVerify;
         local readyToRunModeToRestore=$COMPlus_ReadyToRun;
         local gcstandaloneModeToRestore=$COMPlus_GCName;
-        export COMPlus_GCStress=
-        export COMPlus_HeapVerify=
-        export COMPlus_ReadyToRun=
+        unset COMPlus_GCStress
+        unset COMPlus_HeapVerify
+        unset COMPlus_ReadyToRun
         unset COMPlus_GCName
 
         __Command=$_DebuggerFullPath


### PR DESCRIPTION
I have found two deficiencies in our CoreCLR test infrastructure
related to running Crossgen2 in GC stress mode; this change should
fix both:

1) In the Unix (bash) variant of Execute.Crossgen.targets we weren't
properly unsetting the GC stress-related COMPlus environment
variables.

2) In the particular case of the coreroot_determinism test this
needed fixing in r2rtest that is internally used by the test
implementation (on both Windows and Unix).

Thanks

Tomas

Fixes: https://github.com/dotnet/runtime/issues/50704

/cc @dotnet/crossgen-contrib, @dotnet/runtime-infrastructure