### PR TITLE
Fix stack overflow reporting from native code

### DIFF
--- a/src/coreclr/vm/eepolicy.cpp
+++ b/src/coreclr/vm/eepolicy.cpp
@@ -629,7 +629,7 @@ void DECLSPEC_NORETURN EEPolicy::HandleFatalStackOverflow(EXCEPTION_POINTERS *pE
     if (pExceptionInfo && pExceptionInfo->ContextRecord)
     {
         GCX_COOP();
-        AdjustContextForJITHelpers(pExceptionInfo->ExceptionRecord, pExceptionInfo->ContextRecord);
+        Thread::VirtualUnwindToFirstManagedCallFrame(pExceptionInfo->ContextRecord);
         fef.InitAndLink(pExceptionInfo->ContextRecord);
     }
 

--- a/src/coreclr/vm/eepolicy.cpp
+++ b/src/coreclr/vm/eepolicy.cpp
@@ -629,7 +629,13 @@ void DECLSPEC_NORETURN EEPolicy::HandleFatalStackOverflow(EXCEPTION_POINTERS *pE
     if (pExceptionInfo && pExceptionInfo->ContextRecord)
     {
         GCX_COOP();
+#if defined(TARGET_X86) && defined(TARGET_WINDOWS)
+        // For Windows x86, we don't have a reliable method to unwind to the first managed call frame,
+        // so we handle at least the cases when the stack overflow happens in JIT helpers
+        AdjustContextForJITHelpers(pExceptionInfo->ExceptionRecord, pExceptionInfo->ContextRecord);
+#else
         Thread::VirtualUnwindToFirstManagedCallFrame(pExceptionInfo->ContextRecord);
+#endif
         fef.InitAndLink(pExceptionInfo->ContextRecord);
     }
 


### PR DESCRIPTION
When stack overflow happens in native code, the stack walker is unable
to walk the stack and we end up reporting no call stack at all.
This issue was occurring on Windows only, Linux exception handling 
unwinds the context to the first managed frame in the HandleHardwareException.

This change fixes it by first unwinding the exception context to the first
managed frame and then letting the stack walker to walk the frames.

Close #46279