### PR TITLE
disable token info in traces.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/LocalAppContextSwitches.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/LocalAppContextSwitches.cs
@@ -54,7 +54,7 @@ namespace System
             if (s_showILOffset < 0) return false;
             if (s_showILOffset > 0) return true;
 
-            // Disabled by default. 
+            // Disabled by default.
             bool isSwitchEnabled = AppContextConfigHelper.GetBooleanConfig("Switch.System.Diagnostics.StackTrace.ShowILOffsets", false);
             s_showILOffset = isSwitchEnabled ? 1 : -1;
 

--- a/src/libraries/System.Private.CoreLib/src/System/LocalAppContextSwitches.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/LocalAppContextSwitches.cs
@@ -54,7 +54,8 @@ namespace System
             if (s_showILOffset < 0) return false;
             if (s_showILOffset > 0) return true;
 
-            bool isSwitchEnabled = AppContextConfigHelper.GetBooleanConfig("Switch.System.Diagnostics.StackTrace.ShowILOffsets", true);
+            // Disabled by default. 
+            bool isSwitchEnabled = AppContextConfigHelper.GetBooleanConfig("Switch.System.Diagnostics.StackTrace.ShowILOffsets", false);
             s_showILOffset = isSwitchEnabled ? 1 : -1;
 
             return isSwitchEnabled;


### PR DESCRIPTION
Though token+offset is useful for certain scenarios, they might not be usable for majority of scenarios. So disabling them by default. It was enabled by default in https://github.com/dotnet/runtime/pull/44013