### PR TITLE
Implement DefType.IsUnsafeValueType

### DIFF
--- a/src/coreclr/tools/Common/Compiler/VectorFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/Compiler/VectorFieldLayoutAlgorithm.cs
@@ -90,6 +90,12 @@ namespace ILCompiler
             return false;
         }
 
+        public override bool ComputeIsUnsafeValueType(DefType type)
+        {
+            Debug.Assert(!_fallbackAlgorithm.ComputeIsUnsafeValueType(type));
+            return false;
+        }
+
         public override ValueTypeShapeCharacteristics ComputeValueTypeShapeCharacteristics(DefType type)
         {
             if (type.Context.Target.Architecture == TargetArchitecture.ARM64 &&

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1875,9 +1875,8 @@ namespace Internal.JitInterface
                 if (metadataType.IsExplicitLayout || (metadataType.IsSequentialLayout && metadataType.GetClassLayout().Size != 0) || metadataType.IsWellKnownType(WellKnownType.TypedReference))
                     result |= CorInfoFlag.CORINFO_FLG_CUSTOMLAYOUT;
 
-                // TODO
-                // if (type.IsUnsafeValueType)
-                //    result |= CorInfoFlag.CORINFO_FLG_UNSAFE_VALUECLASS;
+                if (metadataType.IsUnsafeValueType)
+                    result |= CorInfoFlag.CORINFO_FLG_UNSAFE_VALUECLASS;
             }
 
             if (type.IsCanonicalSubtype(CanonicalFormKind.Any))

--- a/src/coreclr/tools/Common/TypeSystem/Common/DefType.FieldLayout.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/DefType.FieldLayout.cs
@@ -53,6 +53,16 @@ namespace Internal.TypeSystem
             /// True if the layout of the type is not stable for use in the ABI
             /// </summary>
             public const int ComputedInstanceLayoutAbiUnstable = 0x80;
+
+            /// <summary>
+            /// True if IsUnsafeValueType has been computed
+            /// </summary>
+            public const int ComputedIsUnsafeValueType = 0x100;
+
+            /// <summary>
+            /// True if type transitively has UnsafeValueTypeAttribute
+            /// </summary>
+            public const int IsUnsafeValueType = 0x200;
         }
 
         private class StaticBlockInfo
@@ -89,6 +99,22 @@ namespace Internal.TypeSystem
                 return _fieldLayoutFlags.HasFlags(FieldLayoutFlags.ContainsGCPointers);
             }
         }
+
+        /// <summary>
+        /// Does a type transitively have any fields which are marked with System.Runtime.CompilerServices.UnsafeValueTypeAttribute
+        /// </summary>
+        public bool IsUnsafeValueType
+        {
+            get
+            {
+                if (!_fieldLayoutFlags.HasFlags(FieldLayoutFlags.ComputedIsUnsafeValueType))
+                {
+                    ComputeIsUnsafeValueType();
+                }
+                return _fieldLayoutFlags.HasFlags(FieldLayoutFlags.IsUnsafeValueType);
+            }
+        }
+
 
         /// <summary>
         /// The number of bytes required to hold a field of this type
@@ -445,6 +471,21 @@ namespace Internal.TypeSystem
             if (this.Context.GetLayoutAlgorithmForType(this).ComputeContainsGCPointers(this))
             {
                 flagsToAdd |= FieldLayoutFlags.ContainsGCPointers;
+            }
+
+            _fieldLayoutFlags.AddFlags(flagsToAdd);
+        }
+
+        public void ComputeIsUnsafeValueType()
+        {
+            if (_fieldLayoutFlags.HasFlags(FieldLayoutFlags.ComputedIsUnsafeValueType))
+                return;
+
+            int flagsToAdd = FieldLayoutFlags.ComputedIsUnsafeValueType;
+
+            if (this.Context.GetLayoutAlgorithmForType(this).ComputeIsUnsafeValueType(this))
+            {
+                flagsToAdd |= FieldLayoutFlags.IsUnsafeValueType;
             }
 
             _fieldLayoutFlags.AddFlags(flagsToAdd);

--- a/src/coreclr/tools/Common/TypeSystem/Common/FieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/FieldLayoutAlgorithm.cs
@@ -32,6 +32,11 @@ namespace Internal.TypeSystem
         public abstract bool ComputeContainsGCPointers(DefType type);
 
         /// <summary>
+        /// Compute whether the specified type is a value type that transitively has UnsafeValueTypeAttribute
+        /// </summary>
+        public abstract bool ComputeIsUnsafeValueType(DefType type);
+
+        /// <summary>
         /// Compute the shape of a value type. The shape information is used to control code generation and allocation
         /// (such as vectorization, passing the value type by value across method calls, or boxing alignment).
         /// </summary>

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -1025,16 +1025,14 @@ namespace Internal.TypeSystem
 
             foreach (FieldDesc field in metadataType.GetFields())
             {
-                if (field.IsStatic || field.IsLiteral)
+                if (field.IsStatic)
                     continue;
 
-                if (field.FieldType is not DefType fieldType)
+                TypeDesc fieldType = field.FieldType;
+                if (!fieldType.IsValueType || fieldType.IsPrimitive)
                     continue;
 
-                if (fieldType.IsPrimitive)
-                    continue;
-
-                if (fieldType.IsUnsafeValueType)
+                if ((DefType)fieldType).IsUnsafeValueType)
                     return true;
             }
 

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -1032,7 +1032,7 @@ namespace Internal.TypeSystem
                 if (!fieldType.IsValueType || fieldType.IsPrimitive)
                     continue;
 
-                if ((DefType)fieldType).IsUnsafeValueType)
+                if (((DefType)fieldType).IsUnsafeValueType)
                     return true;
             }
 

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -1014,6 +1014,33 @@ namespace Internal.TypeSystem
             return NotHA;
         }
 
+        public override bool ComputeIsUnsafeValueType(DefType type)
+        {
+            if (!type.IsValueType)
+                return false;
+
+            MetadataType metadataType = (MetadataType)type;
+            if (metadataType.HasCustomAttribute("System.Runtime.CompilerServices", "UnsafeValueTypeAttribute"))
+                return true;
+
+            foreach (FieldDesc field in metadataType.GetFields())
+            {
+                if (field.IsStatic || field.IsLiteral)
+                    continue;
+
+                if (field.FieldType is not DefType fieldType)
+                    continue;
+
+                if (fieldType.IsPrimitive)
+                    continue;
+
+                if (fieldType.IsUnsafeValueType)
+                    return true;
+            }
+
+            return false;
+        }
+
         private struct SizeAndAlignment
         {
             public LayoutInt Size;

--- a/src/coreclr/tools/Common/TypeSystem/Common/UniversalCanonLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/UniversalCanonLayoutAlgorithm.cs
@@ -34,6 +34,11 @@ namespace Internal.TypeSystem
             };
         }
 
+        public override bool ComputeIsUnsafeValueType(DefType type)
+        {
+            throw new NotSupportedException();
+        }
+
         public override ComputedStaticFieldLayout ComputeStaticFieldLayout(DefType type, StaticLayoutKind layoutKind)
         {
             return new ComputedStaticFieldLayout()

--- a/src/coreclr/tools/Common/TypeSystem/RuntimeDetermined/RuntimeDeterminedFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/RuntimeDetermined/RuntimeDeterminedFieldLayoutAlgorithm.cs
@@ -58,5 +58,13 @@ namespace Internal.TypeSystem
 
             return canonicalType.ValueTypeShapeCharacteristics;
         }
+
+        public override bool ComputeIsUnsafeValueType(DefType type)
+        {
+            RuntimeDeterminedType runtimeDeterminedType = (RuntimeDeterminedType)type;
+            DefType canonicalType = runtimeDeterminedType.CanonicalType;
+
+            return canonicalType.IsUnsafeValueType;
+        }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
@@ -154,6 +154,11 @@ namespace ILCompiler
             return false;
         }
 
+        public override bool ComputeIsUnsafeValueType(DefType type)
+        {
+            return false;
+        }
+
         public override ComputedInstanceFieldLayout ComputeInstanceLayout(DefType type, InstanceLayoutKind layoutKind)
         {
             DefType similarSpecifiedVector = GetSimilarVector(type);

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/SystemObjectFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/SystemObjectFieldLayoutAlgorithm.cs
@@ -50,6 +50,11 @@ namespace ILCompiler
             return false;
         }
 
+        public override bool ComputeIsUnsafeValueType(DefType type)
+        {
+            return false;
+        }
+
         public override ValueTypeShapeCharacteristics ComputeValueTypeShapeCharacteristics(DefType type)
         {
             return _fallbackAlgorithm.ComputeValueTypeShapeCharacteristics(type);


### PR DESCRIPTION
I ran into a test failure while working on #56669 because we did an unexpected tailcall. In the test (TailcallVerifyWithPrefix `TailcallVerify.Condition17.Test1`) we expect not to do a fast tailcall because there is an unsafe value type and we expect to do a GS cookie check before exit, but because of this TODO we didn't.

cc @dotnet/crossgen-contrib 