### PR TITLE
STJ: Fix deserialization of UInt16 properties

### DIFF
--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
@@ -1051,7 +1051,7 @@ namespace System.Text.Json.SourceGeneration
                 _numberTypes.Add(ResolveType(SpecialType.System_Int32));
                 _numberTypes.Add(ResolveType(SpecialType.System_Int64));
                 _numberTypes.Add(ResolveType(SpecialType.System_Single));
-                _numberTypes.Add(ResolveType(SpecialType.System_UInt64));
+                _numberTypes.Add(ResolveType(SpecialType.System_UInt16));
                 _numberTypes.Add(ResolveType(SpecialType.System_UInt32));
                 _numberTypes.Add(ResolveType(SpecialType.System_UInt64));
             }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/ContextClasses.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/ContextClasses.cs
@@ -10,6 +10,7 @@ namespace System.Text.Json.SourceGeneration.Tests
     public interface ITestContext
     {
         public JsonTypeInfo<Location> Location { get; }
+        public JsonTypeInfo<NumberTypes> NumberTypes { get; }
         public JsonTypeInfo<RepeatedTypes.Location> RepeatedLocation { get; }
         public JsonTypeInfo<ActiveOrUpcomingEvent> ActiveOrUpcomingEvent { get; }
         public JsonTypeInfo<CampaignSummaryViewModel> CampaignSummaryViewModel { get; }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/MetadataAndSerializationContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/MetadataAndSerializationContextTests.cs
@@ -8,6 +8,7 @@ namespace System.Text.Json.SourceGeneration.Tests
 {
     [JsonSerializable(typeof(Location))]
     [JsonSerializable(typeof(RepeatedTypes.Location), TypeInfoPropertyName = "RepeatedLocation")]
+    [JsonSerializable(typeof(NumberTypes))]
     [JsonSerializable(typeof(ActiveOrUpcomingEvent))]
     [JsonSerializable(typeof(CampaignSummaryViewModel))]
     [JsonSerializable(typeof(IndexViewModel))]
@@ -38,6 +39,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         public override void EnsureFastPathGeneratedAsExpected()
         {
             Assert.NotNull(MetadataAndSerializationContext.Default.Location.Serialize);
+            Assert.NotNull(MetadataAndSerializationContext.Default.NumberTypes.Serialize);
             Assert.NotNull(MetadataAndSerializationContext.Default.RepeatedLocation.Serialize);
             Assert.NotNull(MetadataAndSerializationContext.Default.ActiveOrUpcomingEvent.Serialize);
             Assert.NotNull(MetadataAndSerializationContext.Default.CampaignSummaryViewModel.Serialize);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/MetadataContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/MetadataContextTests.cs
@@ -8,6 +8,7 @@ namespace System.Text.Json.SourceGeneration.Tests
 {
     [JsonSerializable(typeof(Location), GenerationMode = JsonSourceGenerationMode.Metadata)]
     [JsonSerializable(typeof(RepeatedTypes.Location), TypeInfoPropertyName = "RepeatedLocation", GenerationMode = JsonSourceGenerationMode.Metadata)]
+    [JsonSerializable(typeof(NumberTypes), GenerationMode = JsonSourceGenerationMode.Metadata)]
     [JsonSerializable(typeof(ActiveOrUpcomingEvent), GenerationMode = JsonSourceGenerationMode.Metadata)]
     [JsonSerializable(typeof(CampaignSummaryViewModel), GenerationMode = JsonSourceGenerationMode.Metadata)]
     [JsonSerializable(typeof(IndexViewModel), GenerationMode = JsonSourceGenerationMode.Metadata)]
@@ -38,6 +39,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         {
             Assert.Null(MetadataWithPerTypeAttributeContext.Default.Location.Serialize);
             Assert.Null(MetadataWithPerTypeAttributeContext.Default.RepeatedLocation.Serialize);
+            Assert.Null(MetadataWithPerTypeAttributeContext.Default.NumberTypes.Serialize);
             Assert.Null(MetadataWithPerTypeAttributeContext.Default.ActiveOrUpcomingEvent.Serialize);
             Assert.Null(MetadataWithPerTypeAttributeContext.Default.CampaignSummaryViewModel.Serialize);
             Assert.Null(MetadataWithPerTypeAttributeContext.Default.IndexViewModel.Serialize);
@@ -59,6 +61,7 @@ namespace System.Text.Json.SourceGeneration.Tests
     [JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Metadata)]
     [JsonSerializable(typeof(Location))]
     [JsonSerializable(typeof(RepeatedTypes.Location), TypeInfoPropertyName = "RepeatedLocation")]
+    [JsonSerializable(typeof(NumberTypes))]
     [JsonSerializable(typeof(ActiveOrUpcomingEvent))]
     [JsonSerializable(typeof(CampaignSummaryViewModel))]
     [JsonSerializable(typeof(IndexViewModel))]
@@ -89,6 +92,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         {
             Assert.Null(MetadataContext.Default.Location.Serialize);
             Assert.Null(MetadataContext.Default.RepeatedLocation.Serialize);
+            Assert.Null(MetadataContext.Default.NumberTypes.Serialize);
             Assert.Null(MetadataContext.Default.ActiveOrUpcomingEvent.Serialize);
             Assert.Null(MetadataContext.Default.CampaignSummaryViewModel.Serialize);
             Assert.Null(MetadataContext.Default.IndexViewModel.Serialize);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/MixedModeContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/MixedModeContextTests.cs
@@ -8,6 +8,7 @@ namespace System.Text.Json.SourceGeneration.Tests
 {
     [JsonSerializable(typeof(Location), GenerationMode = JsonSourceGenerationMode.Metadata)]
     [JsonSerializable(typeof(RepeatedTypes.Location), TypeInfoPropertyName = "RepeatedLocation", GenerationMode = JsonSourceGenerationMode.Serialization)]
+    [JsonSerializable(typeof(NumberTypes), GenerationMode = JsonSourceGenerationMode.Metadata)]
     [JsonSerializable(typeof(ActiveOrUpcomingEvent), GenerationMode = JsonSourceGenerationMode.Metadata)]
     [JsonSerializable(typeof(CampaignSummaryViewModel), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(IndexViewModel), GenerationMode = JsonSourceGenerationMode.Metadata)]
@@ -38,6 +39,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         {
             Assert.Null(MixedModeContext.Default.Location.Serialize);
             Assert.NotNull(MixedModeContext.Default.RepeatedLocation.Serialize);
+            Assert.Null(MixedModeContext.Default.NumberTypes.Serialize);
             Assert.NotNull(MixedModeContext.Default.CampaignSummaryViewModel.Serialize);
             Assert.Null(MixedModeContext.Default.IndexViewModel.Serialize);
             Assert.Null(MixedModeContext.Default.WeatherForecastWithPOCOs.Serialize);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/RealWorldContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/RealWorldContextTests.cs
@@ -34,6 +34,17 @@ namespace System.Text.Json.SourceGeneration.Tests
         }
 
         [Fact]
+        public virtual void RoundTripNumberTypes()
+        {
+            NumberTypes expected = CreateNumberTypes();
+
+            string json = JsonSerializer.Serialize(expected, DefaultContext.NumberTypes);
+            NumberTypes obj = JsonSerializer.Deserialize(json, DefaultContext.NumberTypes);
+            VerifyNumberTypes(expected, obj);
+        }
+
+
+        [Fact]
         public virtual void RoundTripIndexViewModel()
         {
             IndexViewModel expected = CreateIndexViewModel();
@@ -125,6 +136,39 @@ namespace System.Text.Json.SourceGeneration.Tests
             Assert.Equal(expected.Name, obj.Name);
             Assert.Equal(expected.PhoneNumber, obj.PhoneNumber);
             Assert.Equal(expected.Country, obj.Country);
+        }
+
+        protected static NumberTypes CreateNumberTypes()
+        {
+            return new NumberTypes
+            {
+                Single = 1.1f,
+                Double = 2.2d,
+                Decimal = 3.3m,
+                SByte = -1,
+                Byte = 1,
+                UShort = 2,
+                Short = -2,
+                UInt = 3,
+                Int = -3,
+                ULong = 4,
+                Long = -4,
+            };
+        }
+
+        protected static void VerifyNumberTypes(NumberTypes expected, NumberTypes obj)
+        {
+            Assert.Equal(expected.Single, obj.Single);
+            Assert.Equal(expected.Double, obj.Double);
+            Assert.Equal(expected.Decimal, obj.Decimal);
+            Assert.Equal(expected.SByte, obj.SByte);
+            Assert.Equal(expected.Byte, obj.Byte);
+            Assert.Equal(expected.UShort, obj.UShort);
+            Assert.Equal(expected.Short, obj.Short);
+            Assert.Equal(expected.UInt, obj.UInt);
+            Assert.Equal(expected.Int, obj.Int);
+            Assert.Equal(expected.ULong, obj.ULong);
+            Assert.Equal(expected.Long, obj.Long);
         }
 
         protected static ActiveOrUpcomingEvent CreateActiveOrUpcomingEvent()

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/SerializationContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/SerializationContextTests.cs
@@ -9,6 +9,7 @@ namespace System.Text.Json.SourceGeneration.Tests
     [JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(Location))]
     [JsonSerializable(typeof(RepeatedTypes.Location), TypeInfoPropertyName = "RepeatedLocation")]
+    [JsonSerializable(typeof(NumberTypes))]
     [JsonSerializable(typeof(ActiveOrUpcomingEvent))]
     [JsonSerializable(typeof(CampaignSummaryViewModel))]
     [JsonSerializable(typeof(IndexViewModel))]
@@ -32,6 +33,7 @@ namespace System.Text.Json.SourceGeneration.Tests
 
     [JsonSerializable(typeof(Location), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(RepeatedTypes.Location), GenerationMode = JsonSourceGenerationMode.Serialization, TypeInfoPropertyName = "RepeatedLocation")]
+    [JsonSerializable(typeof(NumberTypes), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(ActiveOrUpcomingEvent), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(CampaignSummaryViewModel), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(IndexViewModel), GenerationMode = JsonSourceGenerationMode.Serialization)]
@@ -56,6 +58,7 @@ namespace System.Text.Json.SourceGeneration.Tests
     [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
     [JsonSerializable(typeof(Location), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(RepeatedTypes.Location), GenerationMode = JsonSourceGenerationMode.Serialization, TypeInfoPropertyName = "RepeatedLocation")]
+    [JsonSerializable(typeof(NumberTypes), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(ActiveOrUpcomingEvent), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(CampaignSummaryViewModel), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(IndexViewModel), GenerationMode = JsonSourceGenerationMode.Serialization)]
@@ -91,6 +94,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         {
             Assert.NotNull(SerializationContext.Default.Location.Serialize);
             Assert.NotNull(SerializationContext.Default.RepeatedLocation.Serialize);
+            Assert.NotNull(SerializationContext.Default.NumberTypes.Serialize);
             Assert.NotNull(SerializationContext.Default.ActiveOrUpcomingEvent.Serialize);
             Assert.NotNull(SerializationContext.Default.CampaignSummaryViewModel.Serialize);
             Assert.NotNull(SerializationContext.Default.IndexViewModel.Serialize);
@@ -122,6 +126,20 @@ namespace System.Text.Json.SourceGeneration.Tests
             VerifyLocation(expected, obj);
 
             AssertFastPathLogicCorrect(json, obj, DefaultContext.Location);
+        }
+
+        [Fact]
+        public override void RoundTripNumberTypes()
+        {
+            NumberTypes expected = CreateNumberTypes();
+
+            string json = JsonSerializer.Serialize(expected, DefaultContext.NumberTypes);
+            JsonTestHelper.AssertThrows_PropMetadataInit(() => JsonSerializer.Deserialize(json, DefaultContext.NumberTypes), typeof(NumberTypes));
+
+            NumberTypes obj = JsonSerializer.Deserialize(json, ((ITestContext)MetadataWithPerTypeAttributeContext.Default).NumberTypes);
+            VerifyNumberTypes(expected, obj);
+
+            AssertFastPathLogicCorrect(json, obj, DefaultContext.NumberTypes);
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/TestClasses.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/TestClasses.cs
@@ -35,6 +35,21 @@ namespace System.Text.Json.SourceGeneration.Tests
         public string Country { get; set; }
     }
 
+    public class NumberTypes
+    {
+        public float Single { get; set; }
+        public double Double { get; set; }
+        public decimal Decimal { get; set; }
+        public sbyte SByte { get; set; }
+        public byte Byte { get; set; }
+        public ushort UShort { get; set; }
+        public short Short { get; set; }
+        public uint UInt { get; set; }
+        public int Int { get; set; }
+        public ulong ULong { get; set; }
+        public long Long { get; set; }
+    }
+
     public class ActiveOrUpcomingEvent
     {
         public int Id { get; set; }


### PR DESCRIPTION
Fixes source generation for properties of type `System.UInt16` #56792

I added tests to ensure that numeric types can be serialized/deserialized successfully. I'm don't think that all those tests are necessary, but I tried to follow the pattern of existing tests.