### PR TITLE
Enable JIT\SIMD\Vector3Interop_r

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -624,9 +624,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/opt/rngchk/RngchkStress3/*">
             <Issue>Needs Triage</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/SIMD/Vector3Interop_r/*">
-            <Issue>https://github.com/dotnet/runtime/issues/46347</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- The following are x64 Unix failures on CoreCLR. -->


### PR DESCRIPTION
JIT\SIMD\Vector3Interop_r no longer fails on arm64 with JitStress - enabling the test back.

Fixes #46347