### PR TITLE
Disable formatter test on Mono

### DIFF
--- a/src/libraries/System.Runtime.Serialization.Formatters/tests/FormatterServicesTests.Windows.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/tests/FormatterServicesTests.Windows.cs
@@ -11,7 +11,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
     public partial class FormatterServicesTests
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/39704", TestRuntimes.Mono)]
+        [SkipOnMono("COM support is disabled on Mono runtime. Refer to issue #39704.")]
         public void GetUninitializedObject_COMObject_ThrowsNotSupportedException()
         {
             Type comObjectType = typeof(COMObject);


### PR DESCRIPTION
Disable formatter test on Mono.

This particular test is using a COM object, but COM support is
disabled on Mono runtime.

Fixes #39704