### PR TITLE
Additional Diagnostics in Dependency Injection

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/DependencyInjectionEventSource.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/DependencyInjectionEventSource.cs
@@ -184,6 +184,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
         }
 
+        [NonEvent]
         private static void AppendServiceDescriptor(StringBuilder builder, ServiceDescriptor descriptor)
         {
             builder.Append("{ \"serviceType\": \"");

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/DependencyInjectionEventSource.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/DependencyInjectionEventSource.cs
@@ -16,6 +16,11 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static readonly DependencyInjectionEventSource Log = new DependencyInjectionEventSource();
 
+        public static class Keywords
+        {
+            public const EventKeywords ServiceProviderInitialized = (EventKeywords)0x1;
+        }
+
         // Event source doesn't support large payloads so we chunk large payloads like formatted call site tree and descriptors
         private const int MaxChunkSize = 10 * 1024;
 
@@ -73,7 +78,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
             Justification = "Parameters to this method are primitive and are trimmer safe.")]
-        [Event(7, Level = EventLevel.Verbose)]
+        [Event(7, Level = EventLevel.Informational, Keywords = Keywords.ServiceProviderInitialized)]
         private void ServiceProviderBuilt(int serviceProviderHashCode, int singletonServices, int scopedServices, int transientServices)
         {
             WriteEvent(7, serviceProviderHashCode, singletonServices, scopedServices, transientServices);
@@ -81,7 +86,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
             Justification = "Parameters to this method are primitive and are trimmer safe.")]
-        [Event(8, Level = EventLevel.Verbose)]
+        [Event(8, Level = EventLevel.Informational, Keywords = Keywords.ServiceProviderInitialized)]
         private void ServiceProviderDescriptors(int serviceProviderHashCode, string descriptors, int chunkIndex, int chunkCount)
         {
             WriteEvent(8, serviceProviderHashCode, descriptors, chunkIndex, chunkCount);
@@ -156,7 +161,7 @@ namespace Microsoft.Extensions.DependencyInjection
         [NonEvent]
         private void WriteServiceProviderBuilt(ServiceProvider provider)
         {
-            if (IsEnabled(EventLevel.Verbose, EventKeywords.All))
+            if (IsEnabled(EventLevel.Informational, Keywords.ServiceProviderInitialized))
             {
                 int singletonServices = 0;
                 int scopedServices = 0;

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             Populate();
         }
 
+        internal ServiceDescriptor[] Descriptors => _descriptors;
+
         private void Populate()
         {
             foreach (ServiceDescriptor descriptor in _descriptors)

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/DynamicServiceProviderEngine.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/DynamicServiceProviderEngine.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                         }
                         catch (Exception ex)
                         {
-                            DependencyInjectionEventSource.Log.ServiceRealizationFailed(ex);
+                            DependencyInjectionEventSource.Log.ServiceRealizationFailed(ex, _serviceProvider.GetHashCode());
 
                             Debug.Fail($"We should never get exceptions from the background compilation.{Environment.NewLine}{ex}");
                         }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         public Func<ServiceProviderEngineScope, object> BuildNoCache(ServiceCallSite callSite)
         {
             Expression<Func<ServiceProviderEngineScope, object>> expression = BuildExpression(callSite);
-            DependencyInjectionEventSource.Log.ExpressionTreeGenerated(callSite.ServiceType, expression);
+            DependencyInjectionEventSource.Log.ExpressionTreeGenerated(_rootScope.RootProvider, callSite.ServiceType, expression);
             return expression.Compile();
         }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             type.CreateTypeInfo();
             assembly.Save(assemblyName + ".dll");
 #endif
-            DependencyInjectionEventSource.Log.DynamicMethodBuilt(callSite.ServiceType, ilGenerator.ILOffset);
+            DependencyInjectionEventSource.Log.DynamicMethodBuilt(_rootScope.RootProvider, callSite.ServiceType, ilGenerator.ILOffset);
 
             return new GeneratedMethod()
             {

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
@@ -88,15 +88,21 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <inheritdoc />
         public void Dispose()
         {
-            _disposed = true;
+            DisposeCore();
             Root.Dispose();
         }
 
         /// <inheritdoc/>
         public ValueTask DisposeAsync()
         {
-            _disposed = true;
+            DisposeCore();
             return Root.DisposeAsync();
+        }
+
+        private void DisposeCore()
+        {
+            _disposed = true;
+            DependencyInjectionEventSource.Log.ServiceProviderDisposed(this);
         }
 
         private void OnCreate(ServiceCallSite callSite)

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             Func<ServiceProviderEngineScope, object> realizedService = _realizedServices.GetOrAdd(serviceType, _createServiceAccessor);
             OnResolve(serviceType, serviceProviderEngineScope);
-            DependencyInjectionEventSource.Log.ServiceResolved(serviceType);
+            DependencyInjectionEventSource.Log.ServiceResolved(this, serviceType);
             var result = realizedService.Invoke(serviceProviderEngineScope);
             System.Diagnostics.Debug.Assert(result is null || CallSiteFactory.IsService(serviceType));
             return result;
@@ -150,7 +150,7 @@ namespace Microsoft.Extensions.DependencyInjection
             ServiceCallSite callSite = CallSiteFactory.GetCallSite(serviceType, new CallSiteChain());
             if (callSite != null)
             {
-                DependencyInjectionEventSource.Log.CallSiteBuilt(serviceType, callSite);
+                DependencyInjectionEventSource.Log.CallSiteBuilt(this, serviceType, callSite);
                 OnCreate(callSite);
 
                 // Optimize singleton case

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
@@ -75,6 +75,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 }
             }
 
+            DependencyInjectionEventSource.Log.ServiceProviderBuilt(this);
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/DependencyInjectionEventSourceTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/DependencyInjectionEventSourceTests.cs
@@ -214,12 +214,13 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         public void EmitsServiceRealizationFailedEvent()
         {
             var exception = new Exception("Test error.");
-            DependencyInjectionEventSource.Log.ServiceRealizationFailed(exception);
+            DependencyInjectionEventSource.Log.ServiceRealizationFailed(exception, 1234);
 
             var eventName = nameof(DependencyInjectionEventSource.Log.ServiceRealizationFailed);
             var serviceRealizationFailedEvent = _listener.EventData.Single(e => e.EventName == eventName);
 
             Assert.Equal("System.Exception: Test error.", GetProperty<string>(serviceRealizationFailedEvent, "exceptionMessage"));
+            Assert.Equal(1234, GetProperty<int>(serviceRealizationFailedEvent, "serviceProviderHashCode"));
             Assert.Equal(6, serviceRealizationFailedEvent.EventId);
         }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/DependencyInjectionEventSourceTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/DependencyInjectionEventSourceTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         {
             // clear the provider list in between tests
             typeof(DependencyInjectionEventSource).GetField("_providers", BindingFlags.NonPublic | BindingFlags.Instance)
-                .SetValue(DependencyInjectionEventSource.Log, new List<ServiceProvider>());
+                .SetValue(DependencyInjectionEventSource.Log, new List<WeakReference<ServiceProvider>>());
 
             _listener.EnableEvents(DependencyInjectionEventSource.Log, EventLevel.Verbose);
         }


### PR DESCRIPTION
Log events when a ServiceProvider is created:

* How many singleton, scoped, transient services?
* Log the list of registrations

Fix #56313

Of the list in #56313, I left out `How many container instances are in the processes?` because this can be determined from the number of `ServiceProviderBuilt` events that have occurred in the process.