### PR TITLE
Set the cmake policy for CMP0066 and CMP0067

### DIFF
--- a/src/coreclr/CMakeLists.txt
+++ b/src/coreclr/CMakeLists.txt
@@ -1,8 +1,15 @@
 cmake_minimum_required(VERSION 3.6.2)
 
-cmake_policy(SET CMP0042 NEW)
+cmake_policy(SET CMP0042 NEW) # MACOSX_RPATH is enabled by default.
+
+if (CMAKE_VERSION VERSION_GREATER 3.7 OR CMAKE_VERSION VERSION_EQUAL 3.7)
+  cmake_policy(SET CMP0066 NEW) # Honor per-config flags in try_compile() source-file signature.
+endif()
+if (CMAKE_VERSION VERSION_GREATER 3.8 OR CMAKE_VERSION VERSION_EQUAL 3.8)
+  cmake_policy(SET CMP0067 NEW) # Honor language standard in try_compile() source-file signature
+endif()
 if (CMAKE_VERSION VERSION_GREATER 3.15 OR CMAKE_VERSION VERSION_EQUAL 3.15)
-  cmake_policy(SET CMP0091 NEW)
+  cmake_policy(SET CMP0091 NEW) # MSVC runtime library flags are selected by an abstraction.
 endif()
 
 # Set the project name


### PR DESCRIPTION
As per https://cmake.org/cmake/help/v3.21/policy/CMP0066.html and https://cmake.org/cmake/help/v3.21/policy/CMP0067.html, the default policy for these is `OLD` meaning that `try_compile` checks (such as is done for `check_c_source_compiles`) will not respect `CMAKE_<LANG>_FLAGS`, `CMAKE_<LANG>_STANDARD`, `CMAKE_<LANG>_STANDARD_REQUIRED`, and `CMAKE_<LANG>_EXTENSIONS` variables.

The net effect of this is that certain header or other checks may be misreported between the test and what we ultimately compile our source with and may cause less efficient code or other downstream failures such as https://github.com/dotnet/runtime/issues/56746.

This resolves https://github.com/dotnet/runtime/issues/56746 by ensuring that these policies are explicitly set to `NEW` so that the cmake tests match our source compilation configuration and are accurate.