### PR TITLE
Fix PerfScore inconcistencies

### DIFF
--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -1206,7 +1206,7 @@ float emitter::insEvaluateExecutionCost(instrDesc* id)
     assert(throughput >= 0.0);
     assert(latency >= 0.0);
 
-    if (memAccessKind == PERFSCORE_MEMORY_WRITE)
+    if (memAccessKind == PERFSCORE_MEMORY_WRITE || memAccessKind == PERFSCORE_MEMORY_READ_WRITE)
     {
         // We assume that we won't read back from memory for the next WR_GENERAL cycles
         // Thus we normally won't pay latency costs for writes.


### PR DESCRIPTION
* Hide write latency for `memAccessKind == PERFSCORE_MEMORY_READ_WRITE` like for `PERFSCORE_MEMORY_WRITE`.
* Fix memory access latencies for many instructions that previously didn't add the instruction latency to memory access latency or overwrote memory latency with register access latency.
* Adjust some instruction latencies for `YMM` register size.
* Fix latencies for a lot of instructions by using more precise uops.info data.

Fixes #49647