### PR TITLE
Fix build with Xcode 13 / MacOSX12.0.sdk

### DIFF
--- a/src/libraries/Native/Unix/System.Globalization.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.Globalization.Native/CMakeLists.txt
@@ -19,9 +19,9 @@ if(CLR_CMAKE_TARGET_UNIX)
             set(ICU_HOMEBREW_INC_PATH "${brew_prefix}/opt/icu4c/include")
         endif()
 
-        find_path(UTYPES_H "unicode/utypes.h" PATHS ${ICU_HOMEBREW_INC_PATH})
-        if(UTYPES_H STREQUAL UTYPES_H-NOTFOUND)
-            message(FATAL_ERROR "Cannot find utypes.h, try installing libicu-dev (or the appropriate package for your platform)")
+        find_path(UCURR_H "unicode/ucurr.h" PATHS ${ICU_HOMEBREW_INC_PATH})
+        if(UCURR_H STREQUAL UCURR_H-NOTFOUND)
+            message(FATAL_ERROR "Cannot find ucurr.h, try installing libicu-dev (or the appropriate package for your platform)")
             return()
         endif()
 
@@ -42,7 +42,7 @@ if(CLR_CMAKE_TARGET_UNIX)
             endif()
         endif()
 
-        include_directories(${UTYPES_H})
+        include_directories(${UCURR_H})
     endif()
 endif()
 

--- a/src/libraries/Native/Unix/System.Globalization.Native/configure.cmake
+++ b/src/libraries/Native/Unix/System.Globalization.Native/configure.cmake
@@ -6,7 +6,7 @@ else()
     include(CheckSymbolExists)
 
     if (CLR_CMAKE_TARGET_UNIX)
-        set(CMAKE_REQUIRED_INCLUDES ${UTYPES_H} ${ICU_HOMEBREW_INC_PATH})
+        set(CMAKE_REQUIRED_INCLUDES ${UCURR_H} ${ICU_HOMEBREW_INC_PATH})
 
         CHECK_C_SOURCE_COMPILES("
             #include <unicode/udat.h>


### PR DESCRIPTION
The macOS 12 SDK bundled in Xcode 13 seems to contain a subset of icu headers now which means we're finding utypes.h in `Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.0.sdk/usr/include/unicode` now.

![image](https://user-images.githubusercontent.com/1376924/128185756-ee13553c-104c-471c-b15a-2e975f410907.png)


When compiling System.Globalization.Native however we run into this error because ucurr.h isn't included in MacOSX12.0.sdk:

```
  In file included from /Users/alexander/dev/runtime/src/libraries/Native/Unix/System.Globalization.Native/pal_casing.c:9:
  /Users/alexander/dev/runtime/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal.h:22:10: fatal error: 'unicode/ucurr.h' file not found
  #include <unicode/ucurr.h>
           ^~~~~~~~~~~~~~~~~
  1 error generated.
```

To workaround this check for ucurr.h in CMakeLists.txt instead so we continue to find ICU headers from Homebrew like before.