### PR TITLE
update and enable ReadOutstanding_ReadAborted_Throws test

### DIFF
--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
@@ -504,7 +504,6 @@ namespace System.Net.Quic.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/55948")]
         public async Task ReadOutstanding_ReadAborted_Throws()
         {
             // aborting doesn't work properly on mock
@@ -513,27 +512,31 @@ namespace System.Net.Quic.Tests
                 return;
             }
 
-            const int ExpectedErrorCode = 0xfffffff;
+            (QuicConnection clientConnection, QuicConnection serverConnection) = await CreateConnectedQuicConnection();
+            using (clientConnection)
+            using (serverConnection)
+            {
+                byte[] buffer = new byte[1] { 42 };
+                const int ExpectedErrorCode = 0xfffffff;
 
-            using SemaphoreSlim sem = new SemaphoreSlim(0);
+                QuicStream clientStream = clientConnection.OpenBidirectionalStream();
+                Task<QuicStream> t = serverConnection.AcceptStreamAsync().AsTask();
+                await TaskTimeoutExtensions.WhenAllOrAnyFailed(clientStream.WriteAsync(buffer).AsTask(), t, PassingTestTimeoutMilliseconds);
+                QuicStream serverStream = t.Result;
+                Assert.Equal(1, await serverStream.ReadAsync(buffer));
 
-            await RunBidirectionalClientServer(
-                async clientStream =>
-                {
-                    await sem.WaitAsync();
-                },
-                async serverStream =>
+                // streams are new established and in good shape.
+                using (clientStream)
+                using (serverStream)
                 {
                     Task exTask = Assert.ThrowsAsync<QuicOperationAbortedException>(() => serverStream.ReadAsync(new byte[1]).AsTask());
-
                     Assert.False(exTask.IsCompleted);
 
                     serverStream.AbortRead(ExpectedErrorCode);
 
                     await exTask;
-
-                    sem.Release();
-                });
+                }
+            }
         }
 
         [Fact]


### PR DESCRIPTION
I don't think it is safe to use RunClientServer in this case (tried to explain in #56347) 
So I updated test not to use it as well as there are no semaphores any more. 
Did few hundreds runs over night without sign of problem.
I may update the stream establishment to helper function if we end up using that pattern more. 


Fixes #55948