### PR TITLE
reenable a disabled test

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -8,9 +8,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/GitHub_22888/test22888/*">
             <Issue>https://github.com/dotnet/runtime/issues/13703</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/GitHub_45929/test45929/*">
-            <Issue>https://github.com/dotnet/runtime/issues/49881</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- All OS/Arch CoreCLR excludes -->


### PR DESCRIPTION
Now that a few intermittent issues have been fixed enabling this again. Fixes https://github.com/dotnet/runtime/issues/49881