### PR TITLE
Fix size regression in DependencyInjection

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ActivatorUtilities.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ActivatorUtilities.cs
@@ -396,9 +396,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     }
                 }
 
-#if NETCOREAPP
-                return _constructor.Invoke(BindingFlags.DoNotWrapExceptions, binder: null, parameters: _parameterValues, culture: null);
-#else
+#if NETFRAMEWORK || NETSTANDARD2_0
                 try
                 {
                     return _constructor.Invoke(_parameterValues);
@@ -409,6 +407,8 @@ namespace Microsoft.Extensions.DependencyInjection
                     // The above line will always throw, but the compiler requires we throw explicitly.
                     throw;
                 }
+#else
+                return _constructor.Invoke(BindingFlags.DoNotWrapExceptions, binder: null, parameters: _parameterValues, culture: null);
 #endif
             }
         }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteRuntimeResolver.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteRuntimeResolver.cs
@@ -53,9 +53,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 }
             }
 
-#if NETSTANDARD2_1
-            return constructorCallSite.ConstructorInfo.Invoke(BindingFlags.DoNotWrapExceptions, binder: null, parameters: parameterValues, culture: null);
-#else
+#if NETFRAMEWORK || NETSTANDARD2_0
             try
             {
                 return constructorCallSite.ConstructorInfo.Invoke(parameterValues);
@@ -66,6 +64,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 // The above line will always throw, but the compiler requires we throw explicitly.
                 throw;
             }
+#else
+            return constructorCallSite.ConstructorInfo.Invoke(BindingFlags.DoNotWrapExceptions, binder: null, parameters: parameterValues, culture: null);
 #endif
         }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
@@ -55,10 +55,10 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             // Only scope methods are cached
             if (callSite.Cache.Location == CallSiteResultCacheLocation.Scope)
             {
-#if NETSTANDARD2_1
-                return _scopeResolverCache.GetOrAdd(callSite.Cache.Key, _buildTypeDelegate, callSite);
-#else
+#if NETFRAMEWORK || NETSTANDARD2_0
                 return _scopeResolverCache.GetOrAdd(callSite.Cache.Key, key => _buildTypeDelegate(key, callSite));
+#else
+                return _scopeResolverCache.GetOrAdd(callSite.Cache.Key, _buildTypeDelegate, callSite);
 #endif
             }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
@@ -69,10 +69,10 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             // Only scope methods are cached
             if (callSite.Cache.Location == CallSiteResultCacheLocation.Scope)
             {
-#if NETSTANDARD2_1
-                return _scopeResolverCache.GetOrAdd(callSite.Cache.Key, _buildTypeDelegate, callSite);
-#else
+#if NETFRAMEWORK || NETSTANDARD2_0
                 return _scopeResolverCache.GetOrAdd(callSite.Cache.Key, key => _buildTypeDelegate(key, callSite));
+#else
+                return _scopeResolverCache.GetOrAdd(callSite.Cache.Key, _buildTypeDelegate, callSite);
 #endif
             }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             ServiceProviderEngine engine;
 
-#if !NETSTANDARD2_1
+#if NETFRAMEWORK || NETSTANDARD2_0
             engine = new DynamicServiceProviderEngine(this);
 #else
             if (RuntimeFeature.IsDynamicCodeCompiled)


### PR DESCRIPTION
With the new 6.0 TFM, we are no longer checking IsDynamicCodeCompiled to back to Reflection on Blazor WASM. Thus we are now using IL Ref Emit on WASM.

The issue was the #ifs were no longer correct for the new TFM. I've made the #ifs consistent across DI and DI.Abstractions such that the #ifs are for old TFMs and any new TFM will use the #else block.

Fix #56779