### PR TITLE
Optimize string.join for IList<string> with char separator

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -676,11 +676,6 @@ namespace System
 
         private static string JoinCore<T>(ReadOnlySpan<char> separator, IEnumerable<T> values)
         {
-            if (values == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.values);
-            }
-
             if (typeof(T) == typeof(string))
             {
                 if (values is List<string?> valuesList)
@@ -692,6 +687,11 @@ namespace System
                 {
                     return JoinCore(separator, new ReadOnlySpan<string?>(valuesArray));
                 }
+            }
+
+            if (values == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.values);
             }
 
             using (IEnumerator<T> en = values.GetEnumerator())

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -681,6 +681,19 @@ namespace System
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.values);
             }
 
+            if (typeof(T) == typeof(string))
+            {
+                if (values is List<string?> valuesList)
+                {
+                    return JoinCore(separator, CollectionsMarshal.AsSpan(valuesList));
+                }
+
+                if (values is string?[] valuesArray)
+                {
+                    return JoinCore(separator, new ReadOnlySpan<string?>(valuesArray));
+                }
+            }
+
             using (IEnumerator<T> en = values.GetEnumerator())
             {
                 if (!en.MoveNext())


### PR DESCRIPTION
This is a followup to #44032 because changing from `string,join(",", myList)` to `string,join(',', myList)` could lead to a performance degradation.

The below benchmark includes StringJoinIntList to verify that performance doesn't degrade for joining lists of non-string types.
https://github.com/dotnet/performance/compare/main...johnthcall:StringJoinChar
|                Method |  Toolchain | Size |         Mean |      Error |     StdDev | Ratio | RatioSD | Allocated |
|---------------------- |----------- |----- |-------------:|-----------:|-----------:|------:|--------:|----------:|
|  StringJoinStringList |       main |    1 |     32.72 ns |   1.464 ns |   1.504 ns |  1.00 |    0.00 |      40 B |
|  StringJoinStringList |         pr |    1 |     16.43 ns |   0.500 ns |   0.555 ns |  0.50 |    0.03 |         - |
|                       |            |      |              |            |            |       |         |           |
| StringJoinStringArray |       main |    1 |     21.87 ns |   0.244 ns |   0.203 ns |  1.00 |    0.00 |      32 B |
| StringJoinStringArray |         pr |    1 |     10.76 ns |   0.257 ns |   0.214 ns |  0.49 |    0.01 |         - |
|                       |            |      |              |            |            |       |         |           |
|   StringJoinClassList |       main |    1 |     31.72 ns |   0.540 ns |   0.479 ns |  1.00 |    0.00 |      40 B |
|   StringJoinClassList |         pr |    1 |     31.87 ns |   0.712 ns |   0.595 ns |  1.01 |    0.03 |      40 B |
|                       |            |      |              |            |            |       |         |           |
|  StringJoinStringList |       main |   10 |    348.21 ns |   8.552 ns |   9.506 ns |  1.00 |    0.00 |     800 B |
|  StringJoinStringList |         pr |   10 |    112.41 ns |   0.977 ns |   0.816 ns |  0.32 |    0.01 |     760 B |
|                       |            |      |              |            |            |       |         |           |
| StringJoinStringArray |       main |   10 |    269.76 ns |   8.286 ns |   9.542 ns |  1.00 |    0.00 |     792 B |
| StringJoinStringArray |         pr |   10 |    111.54 ns |   3.982 ns |   4.426 ns |  0.41 |    0.03 |     760 B |
|                       |            |      |              |            |            |       |         |           |
|   StringJoinClassList |       main |   10 |    200.61 ns |   6.895 ns |   7.663 ns |  1.00 |    0.00 |     104 B |
|   StringJoinClassList |         pr |   10 |    206.18 ns |   5.896 ns |   6.789 ns |  1.03 |    0.05 |     104 B |
|                       |            |      |              |            |            |       |         |           |
|  StringJoinStringList |       main |  100 |  2,848.19 ns |  87.952 ns |  97.758 ns |  1.00 |    0.00 |   7,464 B |
|  StringJoinStringList |         pr |  100 |  1,028.36 ns |  45.673 ns |  48.869 ns |  0.36 |    0.02 |   7,424 B |
|                       |            |      |              |            |            |       |         |           |
| StringJoinStringArray |       main |  100 |  2,323.68 ns | 105.224 ns | 121.176 ns |  1.00 |    0.00 |   7,456 B |
| StringJoinStringArray |         pr |  100 |    978.01 ns |  28.820 ns |  29.596 ns |  0.42 |    0.03 |   7,424 B |
|                       |            |      |              |            |            |       |         |           |
|   StringJoinClassList |       main |  100 |  2,679.20 ns |  71.741 ns |  73.672 ns |  1.00 |    0.00 |   3,520 B |
|   StringJoinClassList |         pr |  100 |  2,771.61 ns |  64.748 ns |  74.563 ns |  1.03 |    0.05 |   3,520 B |
|                       |            |      |              |            |            |       |         |           |
|  StringJoinStringList |       main | 1000 | 26,825.18 ns | 754.355 ns | 838.464 ns |  1.00 |    0.00 |  74,064 B |
|  StringJoinStringList |         pr | 1000 | 10,222.33 ns | 192.169 ns | 160.470 ns |  0.38 |    0.01 |  74,024 B |
|                       |            |      |              |            |            |       |         |           |
| StringJoinStringArray |       main | 1000 | 22,658.73 ns | 447.658 ns | 478.989 ns |  1.00 |    0.00 |  74,056 B |
| StringJoinStringArray |         pr | 1000 | 10,379.12 ns | 219.172 ns | 234.512 ns |  0.46 |    0.02 |  74,024 B |
|                       |            |      |              |            |            |       |         |           |
|   StringJoinClassList |       main | 1000 | 28,373.95 ns | 754.749 ns | 807.573 ns |  1.00 |    0.00 |  39,520 B |
|   StringJoinClassList |         pr | 1000 | 27,968.16 ns | 671.178 ns | 772.929 ns |  0.99 |    0.03 |  39,520 B |