### PR TITLE
Remove unnecessary llvmParameter from installer build job

### DIFF
--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -110,7 +110,6 @@ jobs:
         /p:PortableBuild=true
         /p:SkipTests=$(SkipTests)
         /p:RuntimeFlavor=${{ parameters.runtimeFlavor }}
-        $(llvmParameter)
         $(OfficialBuildArg)
     - name: MsbuildSigningArguments
       value: >-
@@ -138,7 +137,6 @@ jobs:
         /p:RuntimeFlavor=${{ parameters.runtimeFlavor }}
         /p:TargetArchitecture=${{ parameters.archType }}
         /p:CrossBuild=${{ parameters.crossBuild }}
-        $(llvmParameter)
 
     - name: BaseJobBuildCommand
       value: >-
@@ -156,7 +154,6 @@ jobs:
       value: >-
         /p:PortableBuild=true
         /p:SkipTests=$(SkipTests)
-        $(llvmParameter)
 
     - name: BaseJobBuildCommand
       value: >-
@@ -207,7 +204,6 @@ jobs:
         /p:TargetArchitecture=${{ parameters.archType }}
         /p:RuntimeFlavor=${{ parameters.runtimeFlavor }}
         $(OfficialBuildArg)
-        $(llvmParameter)
 
     - name: _PortableBuild
       value: ${{ eq(parameters.osSubgroup, '') }}


### PR DESCRIPTION
`llvmParameter` is never set, so it just results in a bunch of noise/warning in all installer legs. For example:
```
llvmParameter : The term 'llvmParameter' is not recognized as the name of a cmdlet, function, script file, or operable 
program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At line:1 char:327
+ ... e /p:SkipTests=False /p:RuntimeFlavor=coreclr $(llvmParameter) /p:Cer ...
+                                                     ~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (llvmParameter:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
```
```
++ llvmParameter
/datadisks/disk1/workspace/_work/_temp/8f3a8148-13a3-48b7-9604-8741f30bca2a.sh: line 3: llvmParameter: command not found
```