### PR TITLE
Fix a small failure in stress test

### DIFF
--- a/src/libraries/System.Runtime/tests/System/Reflection/ModuleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/ModuleTests.cs
@@ -232,14 +232,14 @@ namespace System.Reflection.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/51912", typeof(PlatformDetection), nameof(PlatformDetection.IsBuiltWithAggressiveTrimming), nameof(PlatformDetection.IsBrowser))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50831")]
         public void GetMethods()
         {
             var methodNames = TestModule.GetMethods().Select(m => m.Name).ToArray();
             AssertExtensions.SequenceEqual(new[]{ "TestMethodFoo", "TestMethodFoo" }, methodNames );
 
             methodNames = TestModule.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static).Select(m => m.Name).ToArray();
-            AssertExtensions.SequenceEqual(new[]{ "TestMethodFoo", "TestMethodFoo", "TestMethodBar" }, methodNames );
+            Array.Sort<string>(methodNames);
+            AssertExtensions.SequenceEqual(new[]{ "TestMethodBar", "TestMethodFoo", "TestMethodFoo" }, methodNames );
         }
 
         public static IEnumerable<Type> Types => Module.GetTypes();


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/50831

As mentioned in the issue [comments](https://github.com/dotnet/runtime/issues/50831#issuecomment-815519906) `The GetMethods method does not return methods in a particular order, such as alphabetical or declaration order.` which causing the failure and suggested to just sort the list before verifying method names