### PR TITLE
Check `EventSource.IsSupported` in code paths specific to thread pool worker tracking

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/ThreadPool.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/ThreadPool.CoreCLR.cs
@@ -177,7 +177,7 @@ namespace System.Threading
 
         // This needs to be initialized after UsePortableThreadPool above, as it may depend on UsePortableThreadPool and the
         // config initialization
-        internal static readonly bool EnableWorkerTracking = GetEnableWorkerTracking();
+        private static readonly bool IsWorkerTrackingEnabledInConfig = GetEnableWorkerTracking();
 
         private static unsafe bool InitializeConfigAndDetermineUsePortableThreadPool()
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Portable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Portable.cs
@@ -25,7 +25,7 @@ namespace System.Threading
         internal const bool SupportsTimeSensitiveWorkItems = true;
 
 #if CORERT
-        internal const bool EnableWorkerTracking = false;
+        private const bool IsWorkerTrackingEnabledInConfig = false;
 #else
         private static readonly bool IsWorkerTrackingEnabledInConfig =
             AppContextConfigHelper.GetBooleanConfig("System.Threading.ThreadPool.EnableWorkerTracking", false);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Portable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Portable.cs
@@ -27,7 +27,7 @@ namespace System.Threading
 #if CORERT
         internal const bool EnableWorkerTracking = false;
 #else
-        internal static readonly bool EnableWorkerTracking =
+        private static readonly bool IsWorkerTrackingEnabledInConfig =
             AppContextConfigHelper.GetBooleanConfig("System.Threading.ThreadPool.EnableWorkerTracking", false);
 #endif
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
@@ -1059,6 +1059,8 @@ namespace System.Threading
             box.MoveNext();
         };
 
+        internal static bool EnableWorkerTracking => IsWorkerTrackingEnabledInConfig && EventSource.IsSupported;
+
         [CLSCompliant(false)]
         [UnsupportedOSPlatform("browser")]
         public static RegisteredWaitHandle RegisterWaitForSingleObject(

--- a/src/mono/System.Private.CoreLib/src/System/Threading/ThreadPool.Browser.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Threading/ThreadPool.Browser.Mono.cs
@@ -32,7 +32,7 @@ namespace System.Threading
         // does not yield the thread and instead processes time-sensitive work items queued by specific APIs periodically.
         internal const bool SupportsTimeSensitiveWorkItems = false; // the timer currently doesn't queue time-sensitive work
 
-        internal const bool EnableWorkerTracking = false;
+        private const bool IsWorkerTrackingEnabledInConfig = false;
 
         private static bool _callbackQueued;
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/47871