### PR TITLE
[HTTP/3] Reenable interop tests

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -1142,6 +1142,11 @@ namespace System.Net.Http
                 switch (frameType)
                 {
                     case Http3FrameType.Data:
+                        // Ignore DATA frames with 0 length.
+                        if (payloadLength == 0)
+                        {
+                            continue;
+                        }
                         _responseDataPayloadRemaining = payloadLength;
                         return true;
                     case Http3FrameType.Headers:

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -403,6 +403,30 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop]
         [ConditionalTheory(nameof(IsMsQuicSupported))]
+        [MemberData(nameof(InteropUrisWithContent))]
+        public async Task Public_Interop_ExactVersion_BufferContent_Success(string uri)
+        {
+            if (UseQuicImplementationProvider == QuicImplementationProviders.Mock)
+            {
+                return;
+            }
+
+            using HttpClient client = CreateHttpClient();
+            using HttpRequestMessage request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Get,
+                RequestUri = new Uri(uri, UriKind.Absolute),
+                Version = HttpVersion.Version30,
+                VersionPolicy = HttpVersionPolicy.RequestVersionExact
+            };
+            using HttpResponseMessage response = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead).WaitAsync(TimeSpan.FromSeconds(20));
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(3, response.Version.Major);
+        }
+
+        [OuterLoop]
+        [ConditionalTheory(nameof(IsMsQuicSupported))]
         [MemberData(nameof(InteropUris))]
         public async Task Public_Interop_Upgrade_Success(string uri)
         {
@@ -419,7 +443,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 Method = HttpMethod.Get,
                 RequestUri = new Uri(uri, UriKind.Absolute),
-                Version = HttpVersion.Version30,
+                Version = HttpVersion.Version20,
                 VersionPolicy = HttpVersionPolicy.RequestVersionOrLower
             })
             {
@@ -441,7 +465,7 @@ namespace System.Net.Http.Functional.Tests
                 using HttpResponseMessage responseB = await client.SendAsync(requestB).WaitAsync(TimeSpan.FromSeconds(20));
 
                 Assert.Equal(HttpStatusCode.OK, responseB.StatusCode);
-                Assert.NotEqual(3, responseB.Version.Major);
+                Assert.Equal(3, responseB.Version.Major);
             }
         }
 
@@ -752,14 +776,26 @@ namespace System.Net.Http.Functional.Tests
 
         /// <summary>
         /// These are public interop test servers for various QUIC and HTTP/3 implementations,
-        /// taken from https://github.com/quicwg/base-drafts/wiki/Implementations
+        /// taken from https://github.com/quicwg/base-drafts/wiki/Implementations and https://bagder.github.io/HTTP3-test/.
         /// </summary>
         public static TheoryData<string> InteropUris() =>
             new TheoryData<string>
             {
-                { "https://quic.rocks:4433/" }, // Chromium
-                { "https://http3-test.litespeedtech.com:4433/" }, // LiteSpeed
-                { "https://quic.tech:8443/" } // Cloudflare
+                { "https://www.litespeedtech.com/" }, // LiteSpeed
+                { "https://quic.tech:8443/" }, // Cloudflare
+                { "https://quic.aiortc.org:443/" }, // aioquic
+                { "https://h2o.examp1e.net/" } // h2o/quicly
+            };
+
+        /// <summary>
+        /// These are public interop test servers for various QUIC and HTTP/3 implementations,
+        /// taken from https://github.com/quicwg/base-drafts/wiki/Implementations and https://bagder.github.io/HTTP3-test/.
+        /// </summary>
+        public static TheoryData<string> InteropUrisWithContent() =>
+            new TheoryData<string>
+            {
+                { "https://cloudflare-quic.com/" }, // Cloudflare with content
+                { "https://pgjones.dev/" }, // aioquic with content
             };
     }
 }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -380,7 +380,6 @@ namespace System.Net.Http.Functional.Tests
         [OuterLoop]
         [ConditionalTheory(nameof(IsMsQuicSupported))]
         [MemberData(nameof(InteropUris))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/54726")]
         public async Task Public_Interop_ExactVersion_Success(string uri)
         {
             if (UseQuicImplementationProvider == QuicImplementationProviders.Mock)
@@ -405,7 +404,6 @@ namespace System.Net.Http.Functional.Tests
         [OuterLoop]
         [ConditionalTheory(nameof(IsMsQuicSupported))]
         [MemberData(nameof(InteropUris))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/54726")]
         public async Task Public_Interop_Upgrade_Success(string uri)
         {
             if (UseQuicImplementationProvider == QuicImplementationProviders.Mock)


### PR DESCRIPTION
Re-enabled interop tests. Added some more external servers.
Added tests which also buffer the content and fixed handling of 0-byte length DATA frame.

https://quic.rocks:4433/ was randomly reporting as UNREACHABLE, so I removed it.

Fixes #54726