### PR TITLE
Allow Multiple EventSources with same name (GUID)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -3886,8 +3886,20 @@ namespace System.Diagnostics.Tracing
         internal const string s_ActivityStartSuffix = "Start";
         internal const string s_ActivityStopSuffix = "Stop";
 
+        // This switch controls an opt-in, off-by-default mechanism for allowing multiple EventSources to have the same
+        // name and by extension GUID. This is not considered a mainline scenario and is explicitly intended as a release
+        // valve for users that make heavy use of AssemblyLoadContext and experience exceptions from EventSource.
+        // This does not solve any issues that might arise from this configuration. For instance:
+        //
+        // * If multiple manifest-mode EventSources have the same name/GUID, it is ambiguous which manifest should be used by an ETW parser.
+        //   This can result in events being incorrectly parse. The data will still be there, but EventTrace (or other libraries) won't
+        //   know how to parse it.
+        // * Potential issues in parsing self-describing EventSources that use the same name/GUID, event name, and payload type from the same AssemblyLoadContext
+        //   but have different event IDs set.
+        //
+        // Most users should not turn this on.
         internal const string DuplicateSourceNamesSwitch = "System.Diagnostics.Tracing.EventSource.AllowDuplicateSourceNames";
-        private static readonly bool AllowDuplicateSourceNames = AppContextConfigHelper.GetBooleanConfig(configName: DuplicateSourceNamesSwitch, defaultValue: false);
+        private static readonly bool AllowDuplicateSourceNames = AppContext.TryGetSwitch(DuplicateSourceNamesSwitch, out bool isEnabled) ? isEnabled : false;
 
         // WARNING: Do not depend upon initialized statics during creation of EventSources, as it is possible for creation of an EventSource to trigger
         // creation of yet another EventSource.  When this happens, these statics may not yet be initialized.

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -2823,7 +2823,7 @@ namespace System.Diagnostics.Tracing
                 Debug.Assert(m_eventData != null);
 
                 // TODO Enforce singleton pattern
-                if (!AllowMultipleEventSources)
+                if (!AllowDuplicateSourceNames)
                 {
                     Debug.Assert(EventListener.s_EventSources != null, "should be called within lock on EventListener.EventListenersLock which ensures s_EventSources to be initialized");
                     foreach (WeakReference<EventSource> eventSourceRef in EventListener.s_EventSources)
@@ -3886,14 +3886,8 @@ namespace System.Diagnostics.Tracing
         internal const string s_ActivityStartSuffix = "Start";
         internal const string s_ActivityStopSuffix = "Stop";
 
-        internal const string MultipleEventSourcesSwitch = "System.Diagnostics.Tracing.EventSource.AllowMultipleEventSources";
-        internal const string MultipleEventSourcesEnvironmentVariable = "DOTNET_" + MultipleEventSourcesSwitch;
-        private static readonly bool AllowMultipleEventSources =
-#if !ES_BUILD_STANDALONE
-            AppContextConfigHelper.GetBooleanConfig(switchName: MultipleEventSourcesSwitch, envVariable: MultipleEventSourcesEnvironmentVariable, defaultValue: false);
-#else
-            false;
-#endif // !ES_BUILD_STANDALONE
+        internal const string DuplicateSourceNamesSwitch = "System.Diagnostics.Tracing.EventSource.AllowDuplicateSourceNames";
+        private static readonly bool AllowDuplicateSourceNames = AppContextConfigHelper.GetBooleanConfig(configName: DuplicateSourceNamesSwitch, defaultValue: false);
 
         // WARNING: Do not depend upon initialized statics during creation of EventSources, as it is possible for creation of an EventSource to trigger
         // creation of yet another EventSource.  When this happens, these statics may not yet be initialized.


### PR DESCRIPTION
resolves #56052

This patch adds an opt-in feature to allow multiple `EventSource`s to have the same name (and by extension GUID) in the same process.

Historically, .net allowed for `EventSource`s to share a name/GUID so long as they were in different AppDomains. Modern .net has only one AppDomain, but allows for multiple `AssemblyLoadContext`s. This can result in multiple versions of the same `EventSource` being loaded into different contexts. The infrastructure for keeping track of this is global and has no notion of `AssemblyLoadContext`, so you can end up with an `EventSource` throwing on creation because it has been loaded in a different context.

These changes don't attempt to fully solve this problem, but rather just remove the requirement that there be one `EventSource` per name/GUID. This works well for self-describing `EventSource`s since they send their metadata with each event. Manifest based `EventSource`s can be tripped up if multiple exist with the same name. It is ambiguous in external systems, which source's manifest is correct. If they don't agree, then parsers like PerfView and Visual Studio may attempt to parse payloads incorrectly.

I imagine that a more robust solution that is on by default will be added to .net7.

CC @tommcdon @brianrob @noahfalk 