### PR TITLE
Update the (Get|Set)CompressedStack obsoletions to use SYSLIB0003

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -507,13 +507,13 @@ namespace System.Threading
             return SetApartmentStateUnchecked(state, throwOnError);
         }
 
-        [Obsolete("Thread.GetCompressedStack has been deprecated. Use the System.Threading.CompressedStack class instead.")]
+        [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public CompressedStack GetCompressedStack()
         {
             throw new InvalidOperationException(SR.Thread_GetSetCompressedStack_NotSupported);
         }
 
-        [Obsolete("Thread.SetCompressedStack has been deprecated. Use the System.Threading.CompressedStack class instead.")]
+        [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public void SetCompressedStack(CompressedStack stack)
         {
             throw new InvalidOperationException(SR.Thread_GetSetCompressedStack_NotSupported);

--- a/src/libraries/System.Threading.Thread/ref/System.Threading.Thread.cs
+++ b/src/libraries/System.Threading.Thread/ref/System.Threading.Thread.cs
@@ -64,7 +64,7 @@ namespace System.Threading
         ~Thread() { }
         public static void FreeNamedDataSlot(string name) { }
         public System.Threading.ApartmentState GetApartmentState() { throw null; }
-        [System.ObsoleteAttribute("Thread.GetCompressedStack has been deprecated. Use the System.Threading.CompressedStack class instead.")]
+        [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public System.Threading.CompressedStack GetCompressedStack() { throw null; }
         public static int GetCurrentProcessorId() { throw null; }
         public static object? GetData(System.LocalDataStoreSlot slot) { throw null; }
@@ -83,7 +83,7 @@ namespace System.Threading
         public void Resume() { }
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public void SetApartmentState(System.Threading.ApartmentState state) { }
-        [System.ObsoleteAttribute("Thread.SetCompressedStack has been deprecated. Use the System.Threading.CompressedStack class instead.")]
+        [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public void SetCompressedStack(System.Threading.CompressedStack stack) { }
         public static void SetData(System.LocalDataStoreSlot slot, object? data) { }
         public static void Sleep(int millisecondsTimeout) { }

--- a/src/libraries/System.Threading.Thread/tests/ThreadTests.cs
+++ b/src/libraries/System.Threading.Thread/tests/ThreadTests.cs
@@ -1149,10 +1149,10 @@ namespace System.Threading.Threads.Tests
             Thread.BeginThreadAffinity();
             Thread.EndThreadAffinity();
 
-#pragma warning disable 618 // obsolete members
+#pragma warning disable SYSLIB0003 // obsolete members
             Assert.Throws<InvalidOperationException>(() => Thread.CurrentThread.GetCompressedStack());
             Assert.Throws<InvalidOperationException>(() => Thread.CurrentThread.SetCompressedStack(CompressedStack.Capture()));
-#pragma warning restore 618 // obsolete members
+#pragma warning restore SYSLIB0003 // obsolete members
 
             Thread.MemoryBarrier();
 


### PR DESCRIPTION
Per feedback in https://github.com/dotnet/runtime/pull/56690#discussion_r682425599, we should use `SYSLIB0003` on this existing obsoletion as it's more accurate than the previous message--it's even more obsolete now than it used to me.

This is an exceptionally minor breaking change (which I'll log a breaking change documentation issue for). If someone was previously suppressing `CS0618`, this change will introduce a new warning for them under the diagnostic ID of `SYSLIB0003`.