### PR TITLE
[Wasm] Ensure debugger is disabled

### DIFF
--- a/src/mono/mono/component/mini-wasm-debugger.c
+++ b/src/mono/mono/component/mini-wasm-debugger.c
@@ -144,8 +144,10 @@ static void
 mono_wasm_enable_debugging_internal (int debug_level)
 {
 	log_level = debug_level;
-	PRINT_DEBUG_MSG (1, "DEBUGGING ENABLED\n");
-	debugger_enabled = TRUE;
+	if (debug_level != 0) {
+		PRINT_DEBUG_MSG (1, "DEBUGGING ENABLED\n");
+		debugger_enabled = TRUE;
+	}
 }
 
 static void


### PR DESCRIPTION
fixes https://github.com/dotnet/runtime/issues/56884

Takes `debug_level` into account to disable the debugger in interp-only build, and avoid introducing a performance regression.