### PR TITLE
Add a forgotten `fgMorphInitBlock` to fix jitstress issue.

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -16169,6 +16169,10 @@ void Compiler::fgMergeBlockReturn(BasicBlock* block)
             {
                 tree = fgMorphCopyBlock(tree);
             }
+            else if (tree->OperIsInitBlkOp())
+            {
+                tree = fgMorphInitBlock(tree);
+            }
 
             if (pAfterStatement == lastStmt)
             {

--- a/src/tests/Interop/PInvoke/Vector2_3_4/Vector2_3_4.csproj
+++ b/src/tests/Interop/PInvoke/Vector2_3_4/Vector2_3_4.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <!-- https://github.com/dotnet/runtime/issues/49189 -->
-    <JitOptimizationSensitive Condition="'$(TargetArchitecture)' == 'x86'">true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="*.cs" />

--- a/src/tests/JIT/Methodical/xxobj/ldobj/_il_relldobj_V.ilproj
+++ b/src/tests/JIT/Methodical/xxobj/ldobj/_il_relldobj_V.ilproj
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
-    <!-- https://github.com/dotnet/runtime/issues/49189 -->
-    <JitOptimizationSensitive Condition="'$(TargetArchitecture)' == 'x86'">true</JitOptimizationSensitive>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>


### PR DESCRIPTION
Fixes #49189.

No asm diffs.

With `STRESS_PROMOTE_FEWER_STRUCTS` we were ending up with:
```
***** BB01
STMT00005 (IL 0x01D...  ???)
               [000037] IA----------              *  ASG       struct (init)
               [000036] D------N----              +--*  LCL_VAR   struct<JitTest.ValueClass, 4>(P) V04 tmp2
                                                  +--*    ref    V04.arr (offs=0x00) -> V06 tmp4
               [000025] -----+------              \--*  CNS_INT   int    0

------------ BB02 [???..???) (return), preds={BB01} succs={}

***** BB02
STMT00007 (IL   ???...  ???)
               [000031] -----+------              *  RETURN    struct
               [000030] -----+-N----              \--*  LCL_VAR   ref    V06 tmp4
```

and because `V04` was marked as independently promoted we were later deleting the asg and ended with incorrect IR that was triggering an assert.