### PR TITLE
Fix ExplicitLayoutValidator build on older C# compilers

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/ExplicitLayoutValidator.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/ExplicitLayoutValidator.cs
@@ -53,7 +53,7 @@ namespace Internal.TypeSystem
 
         // Represent field layout bits as as a series of intervals to prevent pathological bad behavior
         // involving excessively large explicit layout structures.
-        private readonly List<FieldLayoutInterval> _fieldLayout = new List<FieldLayoutInterval>();
+        private readonly List<FieldLayoutInterval> _fieldLayout;
 
         private readonly MetadataType _typeBeingValidated;
 
@@ -61,6 +61,7 @@ namespace Internal.TypeSystem
         {
             _typeBeingValidated = type;
             _pointerSize = type.Context.Target.PointerSize;
+            _fieldLayout = new List<FieldLayoutInterval>();
         }
 
         public static void Validate(MetadataType type, ComputedInstanceFieldLayout layout)


### PR DESCRIPTION
Outerloop builds are failing with
```
/__w/1/s/src/coreclr/tools/Common/TypeSystem/Common/ExplicitLayoutValidator.cs(56,52): error CS0573: 'ExplicitLayoutValidator': cannot have instance property or field initializers in structs [/__w/1/s/src/tests/ilverify/ILVerification.Tests.csproj]
```

Looks like the test build is using an older version of the C# compiler that does not have https://github.com/dotnet/roslyn/pull/55042.

cc @davidwrighton