### PR TITLE
Build rid specific pkgs under condition and -s390x

### DIFF
--- a/src/libraries/System.IO.Ports/pkg/runtime.linux-s390.runtime.native.System.IO.Ports.proj
+++ b/src/libraries/System.IO.Ports/pkg/runtime.linux-s390.runtime.native.System.IO.Ports.proj
@@ -1,8 +1,0 @@
-<Project>
-  <Import Project="runtime.native.System.IO.Ports.props" />
-
-  <PropertyGroup>
-    <!-- TODO: Remove when the package shipped. -->
-    <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
-  </PropertyGroup>
-</Project>

--- a/src/libraries/libraries-packages.proj
+++ b/src/libraries/libraries-packages.proj
@@ -11,10 +11,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Build the identity package in the allconfigurations build. -->
-    <ProjectReference Include="$(MSBuildThisFileDirectory)*\pkg\runtime.native.*.proj" Condition="'$(BuildAllConfigurations)' == 'true'" />
-    <!-- Build the runtime specific package matching the current RID, outside of an allconfigurations build. -->
-    <ProjectReference Include="$(MSBuildThisFileDirectory)*\pkg\runtime.$(OutputRid).*.proj" Condition="'$(BuildAllConfigurations)' != 'true'" />
+    <!-- During an official build, build the identity package only in the allconfigurations build, otherwise always. -->
+    <ProjectReference Include="$(MSBuildThisFileDirectory)*\pkg\runtime.native.*.proj" Condition="'$(BuildingAnOfficialBuildLeg)' != 'true' or '$(BuildAllConfigurations)' == 'true'" />
+    <!-- During an official Build, build the rid specific package matching the OutputRid only outside of an allconfigurations build and only when targeting the CoreCLR runtime.
+         The limitation on the CoreCLR runtime is entirely artificial but avoids duplicate assets being publish. -->
+    <ProjectReference Include="$(MSBuildThisFileDirectory)*\pkg\runtime.$(OutputRid).*.proj" Condition="'$(BuildingAnOfficialBuildLeg)' != 'true' or
+                                                                                                        ('$(BuildAllConfigurations)' != 'true' and '$(RuntimeFlavor)' == '$(PrimaryRuntimeFlavor)')" />
   </ItemGroup>
 
   <!-- Need the PackageIndexFile file property from baseline.props -->


### PR DESCRIPTION
Build rid specific packages under libraries only when targeting the
primary runtime flavor to avoid duplicate packages being published.

Remove the runtime.native.System.IO.Ports s390x variant as that one
isn't built in official builds and causes the restore of the
meta package runtime.native.System.IO.Ports to fail because of its
missing dependency.