### PR TITLE
[libraries][Android] Skip OffsetOfTests on Android x86

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/OffsetOfTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/OffsetOfTests.cs
@@ -33,14 +33,10 @@ namespace System.Runtime.InteropServices.Tests
             Assert.Equal(new IntPtr(4), Marshal.OffsetOf(typeof(MyPoint), nameof(MyPoint.y)));
         }
 
-        [ConditionalFact]
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/49872", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroid), nameof(PlatformDetection.Is32BitProcess))]
         public void OffsetOf_ExplicitLayout_ReturnsExpected()
         {
-            if (OperatingSystem.IsAndroid() && RuntimeInformation.ProcessArchitecture == Architecture.X86)
-            {
-                throw new SkipTestException("https://github.com/dotnet/runtime/issues/49872 Test fails on Android x86 with -- Expected: 56, Actual: 52");
-            }
-
             Type t = typeof(ExplicitLayoutTest);
             Assert.Equal(56, Marshal.SizeOf(t));
             Assert.Equal(new IntPtr(0), Marshal.OffsetOf(t, nameof(ExplicitLayoutTest.m_short1)));
@@ -110,14 +106,10 @@ namespace System.Runtime.InteropServices.Tests
             }
         }
 
-        [ConditionalFact]
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/49872", typeof(PlatformDetection), nameof(PlatformDetection.IsAndroid), nameof(PlatformDetection.Is32BitProcess))]
         public void OffsetOf_Decimal_ReturnsExpected()
         {
-            if (OperatingSystem.IsAndroid() && RuntimeInformation.ProcessArchitecture == Architecture.X86)
-            {
-                throw new SkipTestException("https://github.com/dotnet/runtime/issues/49872 Test fails on Android x86 with -- Expected: 88, Actual: 72");
-            }
-
             Type t = typeof(FieldAlignmentTest_Decimal);
 
             if (OperatingSystem.IsWindows() || (RuntimeInformation.ProcessArchitecture != Architecture.X86 && RuntimeInformation.ProcessArchitecture != Architecture.Wasm))

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/OffsetOfTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/OffsetOfTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
 using System.Reflection.Emit;
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.Runtime.InteropServices.Tests
@@ -35,7 +36,7 @@ namespace System.Runtime.InteropServices.Tests
         [ConditionalFact]
         public void OffsetOf_ExplicitLayout_ReturnsExpected()
         {
-            if (OperatingSystem.IsAndroid() && RuntimeInformation.ProcessArchitecture == Architecture.x86)
+            if (OperatingSystem.IsAndroid() && RuntimeInformation.ProcessArchitecture == Architecture.X86)
             {
                 throw new SkipTestException("https://github.com/dotnet/runtime/issues/49872 Test fails on Android x86 with -- Expected: 56, Actual: 52");
             }
@@ -112,7 +113,7 @@ namespace System.Runtime.InteropServices.Tests
         [ConditionalFact]
         public void OffsetOf_Decimal_ReturnsExpected()
         {
-            if (OperatingSystem.IsAndroid() && RuntimeInformation.ProcessArchitecture == Architecture.x86)
+            if (OperatingSystem.IsAndroid() && RuntimeInformation.ProcessArchitecture == Architecture.X86)
             {
                 throw new SkipTestException("https://github.com/dotnet/runtime/issues/49872 Test fails on Android x86 with -- Expected: 88, Actual: 72");
             }

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/OffsetOfTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/OffsetOfTests.cs
@@ -32,9 +32,14 @@ namespace System.Runtime.InteropServices.Tests
             Assert.Equal(new IntPtr(4), Marshal.OffsetOf(typeof(MyPoint), nameof(MyPoint.y)));
         }
 
-        [Fact]
+        [ConditionalFact]
         public void OffsetOf_ExplicitLayout_ReturnsExpected()
         {
+            if (OperatingSystem.IsAndroid() && RuntimeInformation.ProcessArchitecture == Architecture.x86)
+            {
+                throw new SkipTestException("https://github.com/dotnet/runtime/issues/49872 Test fails on Android x86 with -- Expected: 56, Actual: 52");
+            }
+
             Type t = typeof(ExplicitLayoutTest);
             Assert.Equal(56, Marshal.SizeOf(t));
             Assert.Equal(new IntPtr(0), Marshal.OffsetOf(t, nameof(ExplicitLayoutTest.m_short1)));
@@ -104,9 +109,14 @@ namespace System.Runtime.InteropServices.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public void OffsetOf_Decimal_ReturnsExpected()
         {
+            if (OperatingSystem.IsAndroid() && RuntimeInformation.ProcessArchitecture == Architecture.x86)
+            {
+                throw new SkipTestException("https://github.com/dotnet/runtime/issues/49872 Test fails on Android x86 with -- Expected: 88, Actual: 72");
+            }
+
             Type t = typeof(FieldAlignmentTest_Decimal);
 
             if (OperatingSystem.IsWindows() || (RuntimeInformation.ProcessArchitecture != Architecture.X86 && RuntimeInformation.ProcessArchitecture != Architecture.Wasm))


### PR DESCRIPTION
Continuation of https://github.com/dotnet/runtime/issues/49872

The test passes on x64 but doesnt pass on x86.