### PR TITLE
[wasm][debugger] Fixing async locals in nested ContinueWith blocks

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -1767,7 +1767,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
             if (await IsAsyncMethod(sessionId, method.DebuggerId, token))
             {
-                List<int> objectAlreadyRead = new List<int>();
+                List<int> objectAlreadyRead = new();
                 retDebuggerCmdReader = await SendDebuggerAgentCommand<CmdFrame>(sessionId, CmdFrame.GetThis, commandParams, token);
                 retDebuggerCmdReader.ReadByte(); //ignore type
                 var objectId = retDebuggerCmdReader.ReadInt32();

--- a/src/mono/wasm/debugger/DebuggerTestSuite/AsyncTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/AsyncTests.cs
@@ -19,14 +19,15 @@ namespace DebuggerTests
         // FIXME: check object properties..
 
         //FIXME: function name
-        [Fact] // Same as Instance case
-        public async Task AsyncLocalsInContinueWithStaticBlock() => await CheckInspectLocalsAtBreakpointSite(
-             "DebuggerTests.AsyncTests.ContinueWithTests", "ContinueWithStaticAsync", 5, "<ContinueWithStaticAsync>b__3_0",
+        [Theory]
+        [InlineData("ContinueWithStaticAsync", "<ContinueWithStaticAsync>b__3_0")]
+        [InlineData("ContinueWithInstanceAsync", "<ContinueWithInstanceAsync>b__5_0")]
+        public async Task AsyncLocalsInContinueWith(string method_name, string expected_method_name) => await CheckInspectLocalsAtBreakpointSite(
+             "DebuggerTests.AsyncTests.ContinueWithTests", method_name, 5, expected_method_name,
              "window.setTimeout(function() { invoke_static_method('[debugger-test] DebuggerTests.AsyncTests.ContinueWithTests:RunAsync'); })",
              wait_for_event_fn: async (pause_location) =>
              {
                 var frame_locals = await GetProperties(pause_location["callFrames"][0]["callFrameId"].Value<string>());
-                Console.WriteLine (frame_locals);
                 await CheckProps(frame_locals, new
                 {
                     t = TObject("System.Threading.Tasks.Task.DelayPromise"),
@@ -40,33 +41,12 @@ namespace DebuggerTests
              });
 
         [Fact]
-        public async Task AsyncLocalsInContinueWithInstanceBlock() => await CheckInspectLocalsAtBreakpointSite(
-             "DebuggerTests.AsyncTests.ContinueWithTests", "ContinueWithInstanceAsync", 5, "<ContinueWithInstanceAsync>b__5_0",
-             "window.setTimeout(function() { invoke_static_method('[debugger-test] DebuggerTests.AsyncTests.ContinueWithTests:RunAsync'); })",
-             wait_for_event_fn: async (pause_location) =>
-             {
-                var frame_locals = await GetProperties(pause_location["callFrames"][0]["callFrameId"].Value<string>());
-                await CheckProps(frame_locals, new
-                {
-                    t = TObject("System.Threading.Tasks.Task.DelayPromise"),
-                    code = TEnum("System.Threading.Tasks.TaskStatus", "RanToCompletion"),
-                    dt = TDateTime(new DateTime(4513, 4, 5, 6, 7, 8)),
-                    @this = TObject("DebuggerTests.AsyncTests.ContinueWithTests.<>c"),
-                }, "locals");
-
-                var res = await InvokeGetter(GetAndAssertObjectWithName(frame_locals, "t"), "Status");
-                await CheckValue(res.Value["result"], TEnum("System.Threading.Tasks.TaskStatus", "RanToCompletion"), "t.Status");
-             });
-
-
-        [Fact]
         public async Task AsyncLocalsInContinueWithInstanceUsingThisBlock() => await CheckInspectLocalsAtBreakpointSite(
              "DebuggerTests.AsyncTests.ContinueWithTests", "ContinueWithInstanceUsingThisAsync", 5, "<ContinueWithInstanceUsingThisAsync>b__6_0",
              "window.setTimeout(function() { invoke_static_method('[debugger-test] DebuggerTests.AsyncTests.ContinueWithTests:RunAsync'); })",
              wait_for_event_fn: async (pause_location) =>
              {
                 var frame_locals = await GetProperties(pause_location["callFrames"][0]["callFrameId"].Value<string>());
-                Console.WriteLine (frame_locals);
                 await CheckProps(frame_locals, new
                 {
                     t = TObject("System.Threading.Tasks.Task.DelayPromise"),
@@ -88,9 +68,7 @@ namespace DebuggerTests
               "window.setTimeout(function() { invoke_static_method('[debugger-test] DebuggerTests.AsyncTests.ContinueWithTests:RunAsync'); })",
               wait_for_event_fn: async (pause_location) =>
               {
-                 Console.WriteLine(pause_location["callFrames"][0]);
                  var frame_locals = await GetProperties(pause_location["callFrames"][0]["callFrameId"].Value<string>());
-                 Console.WriteLine (frame_locals);
                  await CheckProps(frame_locals, new
                  {
                      t = TObject("System.Threading.Tasks.Task.DelayPromise"),

--- a/src/mono/wasm/debugger/DebuggerTestSuite/AsyncTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/AsyncTests.cs
@@ -1,0 +1,103 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.WebAssembly.Diagnostics;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace DebuggerTests
+{
+    public class AsyncTests : DebuggerTestBase
+    {
+
+        // FIXME: method with multiple async blocks - so that we have two separate classes for that method!
+        // FIXME: nested blocks
+        // FIXME: Confirm the actual bp location
+        // FIXME: check object properties..
+
+        //FIXME: function name
+        [Fact] // Same as Instance case
+        public async Task AsyncLocalsInContinueWithStaticBlock() => await CheckInspectLocalsAtBreakpointSite(
+             "DebuggerTests.AsyncTests.ContinueWithTests", "ContinueWithStaticAsync", 5, "<ContinueWithStaticAsync>b__3_0",
+             "window.setTimeout(function() { invoke_static_method('[debugger-test] DebuggerTests.AsyncTests.ContinueWithTests:RunAsync'); })",
+             wait_for_event_fn: async (pause_location) =>
+             {
+                var frame_locals = await GetProperties(pause_location["callFrames"][0]["callFrameId"].Value<string>());
+                Console.WriteLine (frame_locals);
+                await CheckProps(frame_locals, new
+                {
+                    t = TObject("System.Threading.Tasks.Task.DelayPromise"),
+                    code = TEnum("System.Threading.Tasks.TaskStatus", "RanToCompletion"),
+                    dt = TDateTime(new DateTime(4513, 4, 5, 6, 7, 8))
+                }, "locals");
+
+                var res = await InvokeGetter(GetAndAssertObjectWithName(frame_locals, "t"), "Status");
+                await CheckValue(res.Value["result"], TEnum("System.Threading.Tasks.TaskStatus", "RanToCompletion"), "t.Status");
+             });
+
+        [Fact]
+        public async Task AsyncLocalsInContinueWithInstanceBlock() => await CheckInspectLocalsAtBreakpointSite(
+             "DebuggerTests.AsyncTests.ContinueWithTests", "ContinueWithInstanceAsync", 5, "<ContinueWithInstanceAsync>b__5_0",
+             "window.setTimeout(function() { invoke_static_method('[debugger-test] DebuggerTests.AsyncTests.ContinueWithTests:RunAsync'); })",
+             wait_for_event_fn: async (pause_location) =>
+             {
+                var frame_locals = await GetProperties(pause_location["callFrames"][0]["callFrameId"].Value<string>());
+                await CheckProps(frame_locals, new
+                {
+                    t = TObject("System.Threading.Tasks.Task.DelayPromise"),
+                    code = TEnum("System.Threading.Tasks.TaskStatus", "RanToCompletion"),
+                    dt = TDateTime(new DateTime(4513, 4, 5, 6, 7, 8)),
+                    @this = TObject("DebuggerTests.AsyncTests.ContinueWithTests.<>c"),
+                }, "locals");
+
+                var res = await InvokeGetter(GetAndAssertObjectWithName(frame_locals, "t"), "Status");
+                await CheckValue(res.Value["result"], TEnum("System.Threading.Tasks.TaskStatus", "RanToCompletion"), "t.Status");
+             });
+
+
+        [Fact]
+        public async Task AsyncLocalsInContinueWithInstanceUsingThisBlock() => await CheckInspectLocalsAtBreakpointSite(
+             "DebuggerTests.AsyncTests.ContinueWithTests", "ContinueWithInstanceUsingThisAsync", 5, "<ContinueWithInstanceUsingThisAsync>b__6_0",
+             "window.setTimeout(function() { invoke_static_method('[debugger-test] DebuggerTests.AsyncTests.ContinueWithTests:RunAsync'); })",
+             wait_for_event_fn: async (pause_location) =>
+             {
+                var frame_locals = await GetProperties(pause_location["callFrames"][0]["callFrameId"].Value<string>());
+                Console.WriteLine (frame_locals);
+                await CheckProps(frame_locals, new
+                {
+                    t = TObject("System.Threading.Tasks.Task.DelayPromise"),
+                    code = TEnum("System.Threading.Tasks.TaskStatus", "RanToCompletion"),
+                    dt = TDateTime(new DateTime(4513, 4, 5, 6, 7, 8)),
+                    @this = TObject("DebuggerTests.AsyncTests.ContinueWithTests")
+                }, "locals");
+
+                var res = await InvokeGetter(GetAndAssertObjectWithName(frame_locals, "t"), "Status");
+                await CheckValue(res.Value["result"], TEnum("System.Threading.Tasks.TaskStatus", "RanToCompletion"), "t.Status");
+
+                res = await InvokeGetter(GetAndAssertObjectWithName(frame_locals, "this"), "Date");
+                await CheckValue(res.Value["result"], TDateTime(new DateTime(2510, 1, 2, 3, 4, 5)), "this.Date");
+             });
+
+         [Fact] // NestedContinueWith
+         public async Task AsyncLocalsInNestedContinueWithStaticBlock() => await CheckInspectLocalsAtBreakpointSite(
+              "DebuggerTests.AsyncTests.ContinueWithTests", "NestedContinueWithStaticAsync", 5, "MoveNext",
+              "window.setTimeout(function() { invoke_static_method('[debugger-test] DebuggerTests.AsyncTests.ContinueWithTests:RunAsync'); })",
+              wait_for_event_fn: async (pause_location) =>
+              {
+                 Console.WriteLine(pause_location["callFrames"][0]);
+                 var frame_locals = await GetProperties(pause_location["callFrames"][0]["callFrameId"].Value<string>());
+                 Console.WriteLine (frame_locals);
+                 await CheckProps(frame_locals, new
+                 {
+                     t = TObject("System.Threading.Tasks.Task.DelayPromise"),
+                     code = TEnum("System.Threading.Tasks.TaskStatus", "RanToCompletion"),
+                     str = TString("foobar"),
+                     @this = TObject("DebuggerTests.AsyncTests.ContinueWithTests.<>c__DisplayClass4_0"),
+                     ncs_dt0 = TDateTime(new DateTime(3412, 4, 6, 8, 0, 2))
+                 }, "locals");
+              });
+    }
+}

--- a/src/mono/wasm/debugger/DebuggerTestSuite/AsyncTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/AsyncTests.cs
@@ -31,6 +31,7 @@ namespace DebuggerTests
                 {
                     t = TObject("System.Threading.Tasks.Task.DelayPromise"),
                     code = TEnum("System.Threading.Tasks.TaskStatus", "RanToCompletion"),
+                    @this = TObject("DebuggerTests.AsyncTests.ContinueWithTests.<>c"),
                     dt = TDateTime(new DateTime(4513, 4, 5, 6, 7, 8))
                 }, "locals");
 

--- a/src/mono/wasm/debugger/DebuggerTestSuite/GetPropertiesTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/GetPropertiesTests.cs
@@ -340,7 +340,7 @@ namespace DebuggerTests
         {
             var pause_location = await EvaluateAndCheck(
                "window.setTimeout(function() { invoke_static_method('[debugger-test] TestChild:TestWatchWithInheritance'); }, 1);",
-                "dotnet://debugger-test.dll/debugger-test2.cs", 125, 8,
+                "dotnet://debugger-test.dll/debugger-test2.cs", 127, 8,
                "TestWatchWithInheritance");
             var frame_id = pause_location["callFrames"][0]["callFrameId"].Value<string>();
             var frame_locals = await GetProperties(frame_id);

--- a/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
@@ -830,12 +830,13 @@ namespace DebuggerTests
         public async Task InspectTaskAtLocals() => await CheckInspectLocalsAtBreakpointSite(
             "InspectTask",
             "RunInspectTask",
-            7,
+            10,
             "<RunInspectTask>b__0" ,
             $"window.setTimeout(function() {{ invoke_static_method_async('[debugger-test] InspectTask:RunInspectTask'); }}, 1);",
             wait_for_event_fn: async (pause_location) =>
             {
                 var locals = await GetProperties(pause_location["callFrames"][0]["callFrameId"].Value<string>());
+                CheckNumber(locals, "a", 10);
 
                 var t_props = await GetObjectOnLocals(locals, "t");
                 await CheckProps(t_props, new

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-async-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-async-test.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+
+namespace DebuggerTests.AsyncTests
+{
+    public class ContinueWithTests
+    {
+        public DateTime Date => new DateTime(2510, 1, 2, 3, 4, 5);
+
+        public static async Task RunAsync()
+        {
+            await ContinueWithStaticAsync("foobar");
+            await new ContinueWithTests().ContinueWithInstanceAsync("foobar");
+
+            await NestedContinueWithStaticAsync("foobar");
+            await new ContinueWithTests().NestedContinueWithInstanceAsync("foobar");
+            await new ContinueWithTests().ContinueWithInstanceUsingThisAsync("foobar");
+
+        }
+
+        public static async Task ContinueWithStaticAsync(string str)
+        {
+            await Task.Delay(1000).ContinueWith(t =>
+            {
+                var code = t.Status;
+                var dt = new DateTime(4513, 4, 5, 6, 7, 8);
+                Console.WriteLine ($"First continueWith: {code}, {dt}"); //t, code, dt
+            });
+            Console.WriteLine ($"done with this method");
+        }
+
+        public static async Task NestedContinueWithStaticAsync(string str)
+        {
+            await Task.Delay(500).ContinueWith(async t =>
+            {
+                var code = t.Status;
+                var ncs_dt0 = new DateTime(3412, 4, 6, 8, 0, 2);
+                Console.WriteLine ($"First continueWith: {code}, {ncs_dt0}"); // t, code, str, dt0
+                await Task.Delay(300).ContinueWith(t2 =>
+                {
+                    var ncs_dt1 = new DateTime(4513, 4, 5, 6, 7, 8);
+                    Console.WriteLine ($"t2: {t2.Status}, str: {str}, {ncs_dt1}, {ncs_dt0}");//t2, dt1, str, dt0
+                });
+            });
+            Console.WriteLine ($"done with this method");
+        }
+
+        public async Task ContinueWithInstanceAsync(string str)
+        {
+            await Task.Delay(1000).ContinueWith(t =>
+            {
+                var code = t.Status;
+                var dt = new DateTime(4513, 4, 5, 6, 7, 8);
+                Console.WriteLine ($"First continueWith: {code}, {dt}");// t, code, dt
+            });
+            Console.WriteLine ($"done with this method");
+        }
+
+        public async Task ContinueWithInstanceUsingThisAsync(string str)
+        {
+            await Task.Delay(1000).ContinueWith(t =>
+            {
+                var code = t.Status;
+                var dt = new DateTime(4513, 4, 5, 6, 7, 8);
+                Console.WriteLine ($"First continueWith: {code}, {dt}, {this.Date}");
+            });
+            Console.WriteLine ($"done with this method");
+        }
+
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public async Task NestedContinueWithInstanceAsync(string str)
+        {
+            await Task.Delay(500).ContinueWith(async t =>
+            {
+                var code = t.Status;
+                var dt0 = new DateTime(3412, 4, 6, 8, 0, 2);
+                if (str == "oi")
+                {
+                    dt0 = new DateTime(3415, 4, 6, 8, 0, 2);
+                }
+                Console.WriteLine ($"First continueWith: {code}, {dt0}, {Date}");//this, t, code, str, dt0
+                await Task.Delay(300).ContinueWith(t2 =>
+                {
+                    var dt1 = new DateTime(4513, 4, 5, 6, 7, 8);
+                    Console.WriteLine ($"t2: {t2.Status}, str: {str}, {dt1}, {dt0}");//this, t2, dt1, str, dt0
+                });
+            });
+            Console.WriteLine ($"done with this metho d");
+        }
+
+    }
+
+}

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-async-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-async-test.cs
@@ -89,7 +89,7 @@ namespace DebuggerTests.AsyncTests
                     Console.WriteLine ($"t2: {t2.Status}, str: {str}, {dt1}, {dt0}");//this, t2, dt1, str, dt0
                 });
             });
-            Console.WriteLine ($"done with this metho d");
+            Console.WriteLine ($"done with this method");
         }
 
     }

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test2.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test2.cs
@@ -85,6 +85,8 @@ public class InspectTask
         {
             await getJsonTask.ContinueWith(t =>
                 {
+                    int a = 10;
+                    Console.WriteLine(a);
                     if (t.IsCompletedSuccessfully)
                         forecasts = t.Result;
 


### PR DESCRIPTION
- Adding test to close https://github.com/dotnet/runtime/issues/41984
- Adding a lot of old tests written by @radical 
- Fixing the behavior of getting async locals in nested ContinueWith blocks.