### PR TITLE
Fix HttpStress build

### DIFF
--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
@@ -127,7 +127,7 @@ namespace HttpStress
                 {
                     host = host.UseQuic(options =>
                     {
-                        options.Alpn = SslApplicationProtocol.Http3.ToString();
+                        options.Alpn = "h3";
                         options.IdleTimeout = TimeSpan.FromMinutes(1);
                     });
                 }


### PR DESCRIPTION
#56775 broke HttpStress.

Instead of including `System.Net.Security`, I'm reverting this to the old stringly-typed code, so it keeps building with official preview SDK-s, not only docker / locally-built one.