### PR TITLE
add more validation to quic config

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/SafeMsQuicConfigurationHandle.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/SafeMsQuicConfigurationHandle.cs
@@ -36,20 +36,34 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         public static SafeMsQuicConfigurationHandle Create(QuicClientConnectionOptions options)
         {
             X509Certificate? certificate = null;
-            if (options.ClientAuthenticationOptions?.ClientCertificates != null)
+
+            if (options.ClientAuthenticationOptions != null)
             {
-                foreach (var cert in options.ClientAuthenticationOptions.ClientCertificates)
+                if (options.ClientAuthenticationOptions.CipherSuitesPolicy != null)
                 {
-                    try
+                    throw new PlatformNotSupportedException(SR.Format(SR.net_quic_ssl_option, nameof(options.ClientAuthenticationOptions.CipherSuitesPolicy)));
+                }
+
+                if (options.ClientAuthenticationOptions.EncryptionPolicy == EncryptionPolicy.NoEncryption)
+                {
+                    throw new PlatformNotSupportedException(SR.Format(SR.net_quic_ssl_option, nameof(options.ClientAuthenticationOptions.EncryptionPolicy)));
+                }
+
+                if (options.ClientAuthenticationOptions.ClientCertificates != null)
+                {
+                    foreach (var cert in options.ClientAuthenticationOptions.ClientCertificates)
                     {
-                        if (((X509Certificate2)cert).HasPrivateKey)
+                        try
                         {
-                            // Pick first certificate with private key.
-                            certificate = cert;
-                            break;
+                            if (((X509Certificate2)cert).HasPrivateKey)
+                            {
+                                // Pick first certificate with private key.
+                                certificate = cert;
+                                break;
+                            }
                         }
+                        catch { }
                     }
-                    catch { }
                 }
             }
 


### PR DESCRIPTION
update client config validation. This is essentially  #55877 without the `LocalCertificateSelectionCallback` check. 
It seems like HttpClient would _always_ set it and there is no easy way to get around it AFAIK. 

The server part sneaked back in (unintentionally) in  #55468 as part of merge resolve. 

fixes  #55759
