### PR TITLE
Fix contract violation in debugger func eval

### DIFF
--- a/src/coreclr/debug/ee/debugger.h
+++ b/src/coreclr/debug/ee/debugger.h
@@ -3452,7 +3452,7 @@ public:
     TypeHandle                         m_ownerTypeHandle;
     DebuggerEvalBreakpointInfoSegment* m_bpInfoSegment;
 
-    DebuggerEval(T_CONTEXT * pContext, DebuggerIPCE_FuncEvalInfo * pEvalInfo, bool fInException);
+    DebuggerEval(T_CONTEXT * pContext, DebuggerIPCE_FuncEvalInfo * pEvalInfo, bool fInException, DebuggerEvalBreakpointInfoSegment* bpInfoSegmentRX);
 
     bool Init()
     {


### PR DESCRIPTION
`DebuggerEval::DebuggerEval` is called from `Debugger::FuncEvalSetup` which is a NOTHROW function. As the `GetInteropSafeExecutableHeap` and associated `Alloc` functions can fail with an OOM, move the allocation out of the constructor to the caller where we can safely return `E_OUTOFMEMORY`.

This contract violation prevents debugging on chk and debug builds of the runtime.

Fixes #54504