### PR TITLE
Removed '-r2r' shorthand flag due to conflicts with '-r'

### DIFF
--- a/src/coreclr/tools/r2rtest/CommandLineOptions.cs
+++ b/src/coreclr/tools/r2rtest/CommandLineOptions.cs
@@ -278,7 +278,7 @@ namespace R2RTest
                 new Option<int>(new[] { "--execution-timeout-minutes", "-et" }, "Execution timeout (minutes)");
 
             Option R2RDumpPath() =>
-                new Option<FileInfo>(new[] { "--r2r-dump-path", "-r2r" }, "Path to R2RDump.exe/dll").ExistingOnly();
+                new Option<FileInfo>(new[] { "--r2r-dump-path" }, "Path to R2RDump.exe/dll").ExistingOnly();
 
             Option MeasurePerf() =>
                 new Option<bool>(new[] { "--measure-perf" }, "Print out compilation time");


### PR DESCRIPTION
*R2RTest* has several command line options for different optional parameters that can be passed to the tool. Some of these have both, short `(-)` and long `(--)` flags, while others only have long ones. All this is handled by the [Command Line API](https://github.com/dotnet/command-line-api).

However, due to a bug in their codebase, there was a conflict between two flags here:
- `--reference-path` has `-r` as its shorthand flag.
- `--r2r-dump-path` has `-r2r` as its shorthand flag.

Or so was the expected behavior. In reality, issuing `-r2r` resulted in an error saying `2r` directory could not be found. The bug caused the API to interpret `-r2r` as `-r 2r`, thus conflicting with the R2RDump one.

After discussion with Tomas, it was decided that the best course of action was to simply remove `-r2r` and just leave the long flag. This PR submits this fix.