### PR TITLE
HTTP3: Dispose HTTP3 connection when HttpClientHandler is disposed

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/Http3LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http3LoopbackConnection.cs
@@ -195,7 +195,7 @@ namespace System.Net.Test.Common
         }
 
         // Wait for the client to close the connection, e.g. after we send a GOAWAY, or after the HttpClient is disposed.
-        public async Task WaitForClientDisconnectAsync()
+        public async Task WaitForClientDisconnectAsync(bool refuseNewRequests = true)
         {
             while (true)
             {
@@ -204,6 +204,11 @@ namespace System.Net.Test.Common
                 try
                 {
                     stream = await AcceptRequestStreamAsync().ConfigureAwait(false);
+
+                    if (!refuseNewRequests)
+                    {
+                        throw new Exception("Unexpected request stream received while waiting for client disconnect");
+                    }
                 }
                 catch (QuicConnectionAbortedException abortException) when (abortException.ErrorCode == H3_NO_ERROR)
                 {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1942,6 +1942,12 @@ namespace System.Net.Http
                     _associatedHttp2ConnectionCount -= (_availableHttp2Connections?.Count ?? 0);
                     _availableHttp2Connections?.Clear();
 
+                    if (_http3Connection is not null)
+                    {
+                        toDispose.Add(_http3Connection);
+                        _http3Connection = null;
+                    }
+
                     if (_authorityExpireTimer != null)
                     {
                         _authorityExpireTimer.Dispose();


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/pull/56785