### PR TITLE
Do not run crossgen2 under GC stress in tests

### DIFF
--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -82,16 +82,6 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
         __ResponseFile="$__OutputFile.rsp"
         rm $__ResponseFile
 
-        # Suppress the GC stress COMPlus for the duration of Crossgen2 execution
-        local gcStressModeToRestore=$COMPlus_GCStress;
-        local heapVerifyModeToRestore=$COMPlus_HeapVerify;
-        local readyToRunModeToRestore=$COMPlus_ReadyToRun;
-        local gcstandaloneModeToRestore=$COMPlus_GCName;
-        unset COMPlus_GCStress
-        unset COMPlus_HeapVerify
-        unset COMPlus_ReadyToRun
-        unset COMPlus_GCName
-
         __Command=$_DebuggerFullPath
         # Tests run locally need __TestDotNetCmd (set by runtest.py) or a compatible 5.0 dotnet runtime in the path
         if [ ! -z ${__TestDotNetCmd+x} ] %3B then
@@ -115,14 +105,15 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
 
         echo "Response file: $__ResponseFile"
         cat $__ResponseFile
+
+        # Suppress some COMPlus variables for the duration of Crossgen2 execution
+        export -n COMPlus_GCName COMPlus_GCStress COMPlus_HeapVerify COMPlus_ReadyToRun
+
         echo "Running CrossGen2: $__Command"
         $__Command
         __cg2ExitCode=$?
 
-        export COMPlus_GCName=$gcstandaloneModeToRestore
-        export COMPlus_GCStress=$gcStressModeToRestore
-        export COMPlus_HeapVerify=$heapVerifyModeToRestore
-        export COMPlus_ReadyToRun=$readyToRunModeToRestore
+        export COMPlus_GCName COMPlus_GCStress COMPlus_HeapVerify COMPlus_ReadyToRun
       }
 
       if [ ! -z ${CompositeBuildMode+x} ]%3B then
@@ -220,16 +211,6 @@ if defined RunCrossGen2 (
     set __ResponseFile=!__OutputFile!.rsp
     del /Q !__ResponseFile!
 
-    REM Suppress GC stress mode for the duration of Crossgen2 execution
-    set __gcStressModeToRestore=!COMPlus_GCStress!
-    set COMPlus_GCStress=
-    set __heapVerifyModeToRestore=!COMPlus_HeapVerify!
-    set COMPlus_HeapVerify=
-    set __readyToRunModeToRestore=!COMPlus_ReadyToRun!
-    set COMPlus_ReadyToRun=
-    set __gcStandaloneModeToRestore=!COMPlus_GCName!
-    set COMPlus_GCName=
-
     set __Command=!_DebuggerFullPath!
     REM Tests run locally need __TestDotNetCmd (set by runtest.py) or a compatible 5.0 dotnet runtime in the path
     if defined __TestDotNetCmd (
@@ -257,14 +238,16 @@ if defined RunCrossGen2 (
     echo Response file: !__ResponseFile!
     type !__ResponseFile!
 
+    REM Suppress some COMPlus variables for the duration of Crossgen2 execution
+    setlocal
+    set "COMPlus_GCName="
+    set "COMPlus_GCStress="
+    set "COMPlus_HeapVerify="
+    set "COMPlus_ReadyToRun="
+
     echo "!__Command!"
     call !__Command!
-    set CrossGen2Status=!ERRORLEVEL!
-    set COMPlus_GCStress=!__gcStressModeToRestore!
-    set COMPlus_HeapVerify=!__heapVerifyModeToRestore!
-    set COMPlus_ReadyToRun=!__readyToRunModeToRestore!
-    set COMPlus_GCName=!__gcStandaloneModeToRestore!
-
+    endlocal & set CrossGen2Status=%ERRORLEVEL%
     Exit /b 0
 
 :DoneCrossgen2Operations

--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -247,7 +247,8 @@ if defined RunCrossGen2 (
 
     echo "!__Command!"
     call !__Command!
-    endlocal & set CrossGen2Status=%ERRORLEVEL%
+    endlocal
+    set CrossGen2Status=!ERRORLEVEL!
     Exit /b 0
 
 :DoneCrossgen2Operations

--- a/src/tests/baseservices/TieredCompilation/BasicTestWithMcj.csproj
+++ b/src/tests/baseservices/TieredCompilation/BasicTestWithMcj.csproj
@@ -4,8 +4,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>
     <CLRTestPriority>0</CLRTestPriority>
-    <!-- Disable test for GCStress. Tracking: https://github.com/dotnet/runtime/issues/54203 -->
-    <GCStressIncompatible>true</GCStressIncompatible>
     <!-- Generated shell script and corresponding assembly have different names -->
     <CLRTestTargetUnsupported Condition="'$(TargetOS)' == 'Android'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
@@ -24,13 +22,29 @@
     <CLRTestBatchPreCommands><![CDATA[
 $(CLRTestBatchPreCommands)
 mkdir r2r
+
+REM Suppress some COMPlus variables for the duration of Crossgen2 execution
+setlocal
+set "COMPlus_GCName="
+set "COMPlus_GCStress="
+set "COMPlus_HeapVerify="
+set "COMPlus_ReadyToRun="
+
 "%CORE_ROOT%\corerun" %CORE_ROOT%\crossgen2\crossgen2.dll --out r2r\$(MSBuildProjectName).dll $(MSBuildProjectName).dll -r %CORE_ROOT%\*.dll
+
+endlocal
 set CLRCustomTestLauncher=RunBasicTestWithMcj.cmd --runCustomTest
 ]]></CLRTestBatchPreCommands>
     <BashCLRTestPreCommands><![CDATA[
 $(BashCLRTestPreCommands)
 mkdir r2r
+
+# Suppress some COMPlus variables for the duration of Crossgen2 execution
+export -n COMPlus_GCName COMPlus_GCStress COMPlus_HeapVerify COMPlus_ReadyToRun
+
 "$CORE_ROOT/corerun" $CORE_ROOT/crossgen2/crossgen2.dll --out r2r/$(MSBuildProjectName).dll $(MSBuildProjectName).dll -r $CORE_ROOT/*.dll
+
+export COMPlus_GCName COMPlus_GCStress COMPlus_HeapVerify COMPlus_ReadyToRun
 chmod +x ./RunBasicTestWithMcj.sh
 export CLRCustomTestLauncher="./RunBasicTestWithMcj.sh --runCustomTest"
 ]]></BashCLRTestPreCommands>

--- a/src/tests/readytorun/coreroot_determinism/coreroot_determinism.csproj
+++ b/src/tests/readytorun/coreroot_determinism/coreroot_determinism.csproj
@@ -4,8 +4,6 @@
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' != 'coreclr'">true</CLRTestTargetUnsupported>
-    <!-- See https://github.com/dotnet/runtime/issues/50704 -->
-    <GCStressIncompatible>true</GCStressIncompatible>
     <!-- This is an explicit crossgen test -->
     <CrossGenTest>false</CrossGenTest>
     <OldToolsVersion>2.0</OldToolsVersion>

--- a/src/tests/readytorun/determinism/crossgen2determinism.csproj
+++ b/src/tests/readytorun/determinism/crossgen2determinism.csproj
@@ -4,7 +4,7 @@
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' != 'coreclr'">true</CLRTestTargetUnsupported>
-    <!-- Known not to work with GCStress for now: https://github.com/dotnet/runtime/issues/13394 -->
+    <!-- Running Crossgen2 under GCStress takes too long -->
     <GCStressIncompatible>true</GCStressIncompatible>
     <!-- This is an explicit crossgen test -->
     <CrossGenTest>false</CrossGenTest>

--- a/src/tests/readytorun/multifolder/multifolder.csproj
+++ b/src/tests/readytorun/multifolder/multifolder.csproj
@@ -2,7 +2,8 @@
   <PropertyGroup>
     <OutputType>exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
-    <GCStressIncompatible>true</GCStressIncompatible> <!-- https://github.com/dotnet/runtime/issues/39933 -->
+    <!-- Running Crossgen2 under GCStress takes too long -->
+    <GCStressIncompatible>true</GCStressIncompatible>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
 

--- a/src/tests/readytorun/tests/mainv1.csproj
+++ b/src/tests/readytorun/tests/mainv1.csproj
@@ -3,8 +3,6 @@
     <OutputType>exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CrossGenTest>false</CrossGenTest>
-    <!-- Disabled under GCStress. Tracking issue: https://github.com/dotnet/runtime/issues/54203 -->
-    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="fieldgetter.ilproj" />
@@ -19,6 +17,14 @@
   <PropertyGroup>
     <CLRTestBatchPreCommands><![CDATA[
 $(CLRTestBatchPreCommands)
+
+REM Suppress some COMPlus variables for the duration of Crossgen2 execution
+setlocal
+set "COMPlus_GCName="
+set "COMPlus_GCStress="
+set "COMPlus_HeapVerify="
+set "COMPlus_ReadyToRun="
+
 DEL test.dll
 if exist test.dll (
     echo FAILED to delete test.dll
@@ -65,9 +71,15 @@ if not exist mainv1.ni.dll (
     echo FAILED to build mainv1.ni.dll
     exit /b 1
 )
+
+endlocal
 ]]></CLRTestBatchPreCommands>
     <BashCLRTestPreCommands><![CDATA[
 $(BashCLRTestPreCommands)
+
+# Suppress some COMPlus variables for the duration of Crossgen2 execution
+export -n COMPlus_GCName COMPlus_GCStress COMPlus_HeapVerify COMPlus_ReadyToRun
+
 rm -f test.dll
 if [ -f test.dll ]
 then
@@ -121,6 +133,8 @@ then
   echo Failed to build mainv1.ni.dll
   exit 1
 fi
+
+export COMPlus_GCName COMPlus_GCStress COMPlus_HeapVerify COMPlus_ReadyToRun
 ]]></BashCLRTestPreCommands>
   </PropertyGroup>
 </Project>

--- a/src/tests/readytorun/tests/mainv2.csproj
+++ b/src/tests/readytorun/tests/mainv2.csproj
@@ -3,8 +3,6 @@
     <OutputType>exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CrossGenTest>false</CrossGenTest>
-    <!-- Disabled under GCStress. Tracking issue: https://github.com/dotnet/runtime/issues/54203 -->
-    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="fieldgetter.ilproj" />
@@ -17,6 +15,14 @@
   <PropertyGroup>
     <CLRTestBatchPreCommands><![CDATA[
 $(CLRTestBatchPreCommands)
+
+REM Suppress some COMPlus variables for the duration of Crossgen2 execution
+setlocal
+set "COMPlus_GCName="
+set "COMPlus_GCStress="
+set "COMPlus_HeapVerify="
+set "COMPlus_ReadyToRun="
+
 DEL test.dll
 if exist test.dll (
     echo FAILED to delete test.dll
@@ -73,9 +79,15 @@ if not exist test.ni.dll (
     echo FAILED to build test.ni.dll
     exit /b 1
 )
+
+endlocal
 ]]></CLRTestBatchPreCommands>
     <BashCLRTestPreCommands><![CDATA[
 $(BashCLRTestPreCommands)
+
+# Suppress some COMPlus variables for the duration of Crossgen2 execution
+export -n COMPlus_GCName COMPlus_GCStress COMPlus_HeapVerify COMPlus_ReadyToRun
+
 rm -f test.dll
 if [ -f test.dll ]
 then
@@ -142,6 +154,8 @@ then
   echo Failed to build test.ni.dll
   exit 1
 fi
+
+export COMPlus_GCName COMPlus_GCStress COMPlus_HeapVerify COMPlus_ReadyToRun
 ]]></BashCLRTestPreCommands>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Unset `COMPlus_GCName`, `COMPlus_GCStress`, `COMPlus_HeapVerify`, and `COMPlus_ReadyToRun` environment variables before running `crossgen2` for `mainv1`, `mainv2`, and `BasicTestWithMcj` tests as we already do for other tests. Use `setlocal` / `endlocal` and `export -n` / `export` commands to simplify saving and restoring original variable values.

Fixes #54203. @dotnet/crossgen-contrib