### PR TITLE
Fix duplicate license files in msi packages

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -39,7 +39,7 @@
     <None Include="$(LicenseFile)"
           PackagePath="$([System.IO.Path]::GetFileName('$(LicenseFile)'))"
           Pack="true"
-          Condition="'$(MSBuildProjectExtension)' != '.sfxproj'" />
+          Condition="'$(MSBuildProjectExtension)' != '.sfxproj' and '$(MSBuildProjectFile)' != 'msi.csproj'" />
     <None Include="$(PackageThirdPartyNoticesFile)"
           PackagePath="$([System.IO.Path]::GetFileName('$(PackageThirdPartyNoticesFile)'))"
           Pack="true" />


### PR DESCRIPTION
It appears when we added the workloads subset, the msi projects contained a step to add a License.txt file to the packages it creates. This resulted in a conflict as the runtime build will also add one.

To fix, we'll skip adding the extra License.txt file when the project is 'msi.csproj'.

Note: A better fix might be to give msi.csproj a different extension, but unsure of the implications.

Fixes https://github.com/dotnet/runtime/issues/56516