### PR TITLE
Remove Microsoft.DotNet.PackageValidation from global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -13,7 +13,6 @@
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "6.0.0-beta.21405.3",
-    "Microsoft.DotNet.PackageValidation": "1.0.0-preview.7.21352.4",
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21405.3",
     "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.21405.3",
     "Microsoft.DotNet.SharedFramework.Sdk": "6.0.0-beta.21405.3",


### PR DESCRIPTION
I incorrectly added it back while resolving merge conflicts in https://github.com/dotnet/runtime/pull/56719 but it was removed from global.json with https://github.com/dotnet/runtime/pull/56712