### PR TITLE
Fix race condition in Net.Security telemetry test

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TelemetryTest.cs
@@ -36,7 +36,17 @@ namespace System.Net.Security.Tests
                 listener.AddActivityTracking();
 
                 var events = new ConcurrentQueue<(EventWrittenEventArgs Event, Guid ActivityId)>();
-                await listener.RunWithCallbackAsync(e => events.Enqueue((e, e.ActivityId)), async () =>
+                await listener.RunWithCallbackAsync(e =>
+                {
+                    events.Enqueue((e, e.ActivityId));
+
+                    if (e.EventName == "HandshakeStart")
+                    {
+                        // Wait for a new counter group so that current-tls-handshakes is guaranteed a non-zero value
+                        WaitForEventCountersAsync(events).GetAwaiter().GetResult();
+                    }
+                },
+                async () =>
                 {
                     // Invoke tests that'll cause some events to be generated
                     var test = new SslStreamStreamToStreamTest_Async();
@@ -86,7 +96,17 @@ namespace System.Net.Security.Tests
                 listener.AddActivityTracking();
 
                 var events = new ConcurrentQueue<(EventWrittenEventArgs Event, Guid ActivityId)>();
-                await listener.RunWithCallbackAsync(e => events.Enqueue((e, e.ActivityId)), async () =>
+                await listener.RunWithCallbackAsync(e =>
+                {
+                    events.Enqueue((e, e.ActivityId));
+
+                    if (e.EventName == "HandshakeStart")
+                    {
+                        // Wait for a new counter group so that current-tls-handshakes is guaranteed a non-zero value
+                        WaitForEventCountersAsync(events).GetAwaiter().GetResult();
+                    }
+                },
+                async () =>
                 {
                     // Invoke tests that'll cause some events to be generated
                     var test = new SslStreamStreamToStreamTest_Async();


### PR DESCRIPTION
Seen by @aik-jahoda in https://github.com/dotnet/runtime/issues/42613#issuecomment-894294548.

If the handshake completes quickly, we may never log a counter with a non-zero value for the "current-tls-handshakes".
This PR adds a wait during the handshake to ensure a counter is logged.