### PR TITLE
This fixes a perf bug in revisit_written_pages for regions

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -33410,7 +33410,7 @@ void gc_heap::revisit_written_pages (BOOL concurrent_p, BOOL reset_only_p)
             seg = heap_segment_next_rw (seg);
         }
 
-        if (i < loh_generation)
+        if (i == soh_gen2)
         {
             if (!reset_only_p)
             {


### PR DESCRIPTION
If we are called with concurrent_p == FALSE, we start iterating at gen 0. This causes the small_object_segments to be set to FALSE when we are done with gen 0. This is of course incorrect, we should set this flag when we are done with gen 2. Fix is to modify the if-condition to test for the end of gen 2.
