### PR TITLE
More Extensions doc updates

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/AsyncServiceScope.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/AsyncServiceScope.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
-    /// A <see cref="IServiceScope" /> implementation that implements <see cref="IAsyncDisposable" />.
+    /// An <see cref="IServiceScope" /> implementation that implements <see cref="IAsyncDisposable" />.
     /// </summary>
     public readonly struct AsyncServiceScope : IServiceScope, IAsyncDisposable
     {
@@ -16,8 +16,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Initializes a new instance of the <see cref="AsyncServiceScope"/> struct.
         /// Wraps an instance of <see cref="IServiceScope" />.
-        /// <param name="serviceScope">The <see cref="IServiceScope"/> instance to wrap.</param>
         /// </summary>
+        /// <param name="serviceScope">The <see cref="IServiceScope"/> instance to wrap.</param>
         public AsyncServiceScope(IServiceScope serviceScope)
         {
             _serviceScope = serviceScope ?? throw new ArgumentNullException(nameof(serviceScope));

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceProviderServiceExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceProviderServiceExtensions.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Creates a new <see cref="AsyncServiceScope"/> that can be used to resolve scoped services.
         /// </summary>
         /// <param name="provider">The <see cref="IServiceProvider"/> to create the scope from.</param>
-        /// <returns>A <see cref="AsyncServiceScope"/> that can be used to resolve scoped services.</returns>
+        /// <returns>An <see cref="AsyncServiceScope"/> that can be used to resolve scoped services.</returns>
         public static AsyncServiceScope CreateAsyncScope(this IServiceProvider provider)
         {
             return new AsyncServiceScope(provider.CreateScope());
@@ -140,7 +140,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Creates a new <see cref="AsyncServiceScope"/> that can be used to resolve scoped services.
         /// </summary>
         /// <param name="serviceScopeFactory">The <see cref="IServiceScopeFactory"/> to create the scope from.</param>
-        /// <returns>A <see cref="AsyncServiceScope"/> that can be used to resolve scoped services.</returns>
+        /// <returns>An <see cref="AsyncServiceScope"/> that can be used to resolve scoped services.</returns>
         public static AsyncServiceScope CreateAsyncScope(this IServiceScopeFactory serviceScopeFactory)
         {
             return new AsyncServiceScope(serviceScopeFactory.CreateScope());

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
@@ -118,8 +118,7 @@ namespace Microsoft.Extensions.Hosting
         }
 
         /// <summary>
-        /// Adds a delegate for configuring the <see cref="HostOptions"/> of the <see cref="IHost"/> instance
-        /// related to th.
+        /// Adds a delegate for configuring the <see cref="HostOptions"/> of the <see cref="IHost"/>.
         /// </summary>
         /// <param name="hostBuilder">The <see cref="IHostBuilder" /> to configure.</param>
         /// <param name="configureOptions">The delegate for configuring the <see cref="HostOptions"/>.</param>


### PR DESCRIPTION
Per https://github.com/dotnet/dotnet-api-docs/pull/6959

Clearly, we want to get to a point where all spelling, grammar etc is caught in code review of implementation not in porting to docs repo. Plus, the quicker one place (implementation) is source of truth the better.