### PR TITLE
Remove GTF_CALL_POP_ARGS option

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -9316,7 +9316,7 @@ void cTreeFlags(Compiler* comp, GenTree* tree)
                 {
                     chars += printf("[CALL_NULLCHECK]");
                 }
-                if (tree->gtFlags & GTF_CALL_POP_ARGS)
+                if (tree->AsCall()->CallerPop())
                 {
                     chars += printf("[CALL_POP_ARGS]");
                 }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6412,9 +6412,6 @@ GenTreeCall* Compiler::gtNewCallNode(
     GenTreeCall* node = new (this, GT_CALL) GenTreeCall(genActualType(type));
 
     node->gtFlags |= (GTF_CALL | GTF_GLOB_REF);
-#ifdef UNIX_X86_ABI
-    node->gtFlags |= GTF_CALL_POP_ARGS;
-#endif // UNIX_X86_ABI
     for (GenTreeCall::Use& use : GenTreeCall::UseList(args))
     {
         node->gtFlags |= (use.GetNode()->gtFlags & GTF_ALL_EFFECT);
@@ -10077,7 +10074,7 @@ void Compiler::gtDispNodeName(GenTree* tree)
         {
             char* gtfTypeBufWalk = gtfTypeBuf;
             gtfTypeBufWalk += SimpleSprintf_s(gtfTypeBufWalk, gtfTypeBuf, sizeof(gtfTypeBuf), " unman");
-            if (tree->gtFlags & GTF_CALL_POP_ARGS)
+            if (tree->AsCall()->CallerPop())
             {
                 gtfTypeBufWalk += SimpleSprintf_s(gtfTypeBufWalk, gtfTypeBuf, sizeof(gtfTypeBuf), " popargs");
             }

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -482,7 +482,7 @@ enum GenTreeFlags : unsigned int
     GTF_CALL_VIRT_VTABLE        = 0x20000000, // GT_CALL -- a  vtable-based virtual call
 
     GTF_CALL_NULLCHECK          = 0x08000000, // GT_CALL -- must check instance pointer for null
-    GTF_CALL_POP_ARGS           = 0x04000000, // GT_CALL -- caller pop arguments?
+//    GTF_CALL_POP_ARGS           = 0x04000000, // GT_CALL -- caller pop arguments? Deprecated
     GTF_CALL_HOISTABLE          = 0x02000000, // GT_CALL -- call is hoistable
 
     GTF_MEMORYBARRIER_LOAD      = 0x40000000, // GT_MEMORYBARRIER -- Load barrier
@@ -4404,7 +4404,11 @@ struct GenTreeCall final : public GenTree
     }
     bool CallerPop() const
     {
-        return (gtFlags & GTF_CALL_POP_ARGS) != 0;
+#ifdef TARGET_X86
+        return IsCallerPop(GetUnmanagedCallConv());
+#else
+        return false;
+#endif
     }
     bool IsVirtual() const
     {

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4405,7 +4405,7 @@ struct GenTreeCall final : public GenTree
     bool CallerPop() const
     {
 #ifdef TARGET_X86
-        return IsCallerPop(GetUnmanagedCallConv());
+        return IsCallerPop(GetUnmanagedCallConv()) || (gtCallMoreFlags & GTF_CALL_M_VARARGS);
 #else
         return false;
 #endif

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -482,7 +482,7 @@ enum GenTreeFlags : unsigned int
     GTF_CALL_VIRT_VTABLE        = 0x20000000, // GT_CALL -- a  vtable-based virtual call
 
     GTF_CALL_NULLCHECK          = 0x08000000, // GT_CALL -- must check instance pointer for null
-//    GTF_CALL_POP_ARGS           = 0x04000000, // GT_CALL -- caller pop arguments? Deprecated
+//    unused                      = 0x04000000,
     GTF_CALL_HOISTABLE          = 0x02000000, // GT_CALL -- call is hoistable
 
     GTF_MEMORYBARRIER_LOAD      = 0x40000000, // GT_MEMORYBARRIER -- Load barrier

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -74,9 +74,6 @@ GenTree* Compiler::fgMorphIntoHelperCall(GenTree* tree, int helper, GenTreeCall:
     call->gtCallMoreFlags       = GTF_CALL_M_EMPTY;
     call->gtInlineCandidateInfo = nullptr;
     call->gtControlExpr         = nullptr;
-#ifdef UNIX_X86_ABI
-    call->gtFlags |= GTF_CALL_POP_ARGS;
-#endif // UNIX_X86_ABI
 
 #if DEBUG
     // Helper calls are never candidates.
@@ -2901,7 +2898,7 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
 // For X86 we handle the varargs and unmanaged calling conventions
 
 #ifndef UNIX_X86_ABI
-    if (call->gtFlags & GTF_CALL_POP_ARGS)
+    if (call->CallerPop())
     {
         noway_assert(intArgRegNum < MAX_REG_ARG);
         // No more register arguments for varargs (CALL_POP_ARGS)
@@ -8790,7 +8787,6 @@ void Compiler::fgMorphTailCallViaJitHelper(GenTreeCall* call)
 
     // It is now a varargs tail call.
     call->gtCallMoreFlags |= GTF_CALL_M_VARARGS;
-    call->gtFlags &= ~GTF_CALL_POP_ARGS;
 
     // The function is responsible for doing explicit null check when it is necessary.
     assert(!call->NeedsNullCheck());


### PR DESCRIPTION
Caller/callee pop args should be decided by calling convention: Try to remove GTF_CALL_POP_ARGS flag.