### PR TITLE
JIT: fix morph tail call copy opt alias analysis

### DIFF
--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -1184,7 +1184,7 @@ private:
 
         if (isArgToCall)
         {
-            JITDUMP("LocalAddressVisitor incrementing weighted ref count from %d to %d"
+            JITDUMP("LocalAddressVisitor incrementing weighted ref count from " FMT_WT " to " FMT_WT
                     " for implicit by-ref V%02d arg passed to call\n",
                     varDsc->lvRefCntWtd(RCS_EARLY), varDsc->lvRefCntWtd(RCS_EARLY) + 1, lclNum);
             varDsc->incLvRefCntWtd(1, RCS_EARLY);

--- a/src/tests/JIT/Regression/JitBlue/Runtime_56743/Runtime_56743_0.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_56743/Runtime_56743_0.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+class Runtime_56743_0
+{
+    [MethodImpl(MethodImplOptions.NoOptimization)]
+    static int Main()
+    {
+        int result = Foo(default, default);
+        return result == 0 ? 100 : -1;
+    }
+
+    static int Foo(S s, Span<S> span)
+    {
+        span = MemoryMarshal.CreateSpan(ref s, 1);
+        return Bar(s, span);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Bar(S h, Span<S> s)
+    {
+        s[0].A = 10;
+        return h.A;
+    }
+
+    struct S
+    {
+        public int A, B, C, D;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_56743/Runtime_56743_0.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_56743/Runtime_56743_0.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_56743/Runtime_56743_1.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_56743/Runtime_56743_1.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+unsafe class Runtime_56743_1
+{
+    [MethodImpl(MethodImplOptions.NoOptimization)]
+    static int Main()
+    {
+        int result = Foo(default);
+        return result == 0 ? 100 : -1;
+    }
+
+    static S* s_s;
+    static int Foo(S s)
+    {
+        s_s = &s;
+        return Bar(s);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Bar(S h)
+    {
+        s_s->A = 10;
+        return h.A;
+    }
+
+    struct S
+    {
+        public int A, B, C, D;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_56743/Runtime_56743_1.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_56743/Runtime_56743_1.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_56743/Runtime_56743_2.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_56743/Runtime_56743_2.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+unsafe class Runtime_56743_2
+{
+    [MethodImpl(MethodImplOptions.NoOptimization)]
+    static int Main()
+    {
+        int result = Foo(default);
+        return result == 0 ? 100 : -1;
+    }
+
+    static int Foo(S h)
+    {
+        h.H = &h;
+        return Bar(h);
+    }
+    
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Bar(S h)
+    {
+        h.H->A = 10;
+        return h.A;
+    }
+    
+    unsafe struct S
+    {
+        public int A, B;
+        public S* H;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_56743/Runtime_56743_2.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_56743/Runtime_56743_2.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
If there are non-call references to an implicit byref local, disqualify
that local from morph tail call copy optimization.

The fix is conservative in that "harmless" non-call references like field
accesses will also disqualify the opt. This can be improved on with extra
analysis in local morph.

Closes #56743.