### PR TITLE
Remove exception filters from Http3RequestStream

### DIFF
--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -9,6 +9,9 @@
   <PropertyGroup Condition=" '$(TargetsOSX)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true' or '$(TargetsMacCatalyst)' == 'true'">
     <DefineConstants>$(DefineConstants);SYSNETHTTP_NO_OPENSSL</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetsAndroid)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetsMacCatalyst)' == 'true' or '$(TargetsTVOS)' == 'true'">
+    <DefineConstants>$(DefineConstants);TARGET_MOBILE</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(TargetsBrowser)' == 'true'">
     <DefineConstants>$(DefineConstants);TARGET_BROWSER</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
I've updated the description as I understand it to be more accurate:

The type of exception filters used cause the linker to generate invalid IL when building the AOT functional tests for iOS.  This in turn causes the mono aot compiler to issue a warning about the invalid IL AND fails the build.

Addresses https://github.com/dotnet/runtime/issues/57010 and unblocks failing builds on CI