### PR TITLE
More JSON xml updates

### DIFF
--- a/src/libraries/System.Text.Json/Common/JsonKnownNamingPolicy.cs
+++ b/src/libraries/System.Text.Json/Common/JsonKnownNamingPolicy.cs
@@ -4,7 +4,7 @@
 namespace System.Text.Json.Serialization
 {
     /// <summary>
-    /// The <see cref="Json.JsonNamingPolicy"/> to be used at run-time.
+    /// The <see cref="Json.JsonNamingPolicy"/> to be used at run time.
     /// </summary>
 #if BUILDING_SOURCE_GENERATOR
     internal

--- a/src/libraries/System.Text.Json/Common/JsonSourceGenerationOptionsAttribute.cs
+++ b/src/libraries/System.Text.Json/Common/JsonSourceGenerationOptionsAttribute.cs
@@ -5,7 +5,7 @@ namespace System.Text.Json.Serialization
 {
     /// <summary>
     /// Instructs the System.Text.Json source generator to assume the specified
-    /// options will be used at run-time via <see cref="JsonSerializerOptions"/>.
+    /// options will be used at run time via <see cref="JsonSerializerOptions"/>.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
 #if BUILDING_SOURCE_GENERATOR
@@ -31,7 +31,7 @@ namespace System.Text.Json.Serialization
         public bool IgnoreReadOnlyProperties { get; set; }
 
         /// <summary>
-        /// Specifies whether to ignore custom converters provided at run-time.
+        /// Specifies whether to ignore custom converters provided at run time.
         /// </summary>
         public bool IgnoreRuntimeCustomConverters { get; set; }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.Parse.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.Parse.cs
@@ -229,7 +229,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        ///   Parse text representing a single JSON value into a JsonDocument.
+        ///   Parses text representing a single JSON value into a JsonDocument.
         /// </summary>
         /// <remarks>
         ///   The <see cref="ReadOnlyMemory{T}"/> value may be used for the entire lifetime of the
@@ -298,7 +298,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        ///   Parse text representing a single JSON value into a JsonDocument.
+        ///   Parses text representing a single JSON value into a JsonDocument.
         /// </summary>
         /// <param name="json">JSON text to parse.</param>
         /// <param name="options">Options to control the reader behavior during parsing.</param>
@@ -340,7 +340,7 @@ namespace System.Text.Json
         ///   </para>
         ///
         ///   <para>
-        ///     Upon completion of this method <paramref name="reader"/> will be positioned at the
+        ///     Upon completion of this method, <paramref name="reader"/> will be positioned at the
         ///     final token in the JSON value.  If an exception is thrown, or <see langword="false"/>
         ///     is returned, the reader is reset to the state it was in when the method was called.
         ///   </para>
@@ -380,8 +380,8 @@ namespace System.Text.Json
         ///   </para>
         ///
         ///   <para>
-        ///     Upon completion of this method <paramref name="reader"/> will be positioned at the
-        ///     final token in the JSON value.  If an exception is thrown the reader is reset to
+        ///     Upon completion of this method, <paramref name="reader"/> will be positioned at the
+        ///     final token in the JSON value. If an exception is thrown, the reader is reset to
         ///     the state it was in when the method was called.
         ///   </para>
         ///

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.Parse.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.Parse.cs
@@ -25,8 +25,8 @@ namespace System.Text.Json
         ///   </para>
         ///
         ///   <para>
-        ///     Upon completion of this method <paramref name="reader"/> will be positioned at the
-        ///     final token in the JSON value.  If an exception is thrown the reader is reset to
+        ///     Upon completion of this method, <paramref name="reader"/> will be positioned at the
+        ///     final token in the JSON value. If an exception is thrown, the reader is reset to
         ///     the state it was in when the method was called.
         ///   </para>
         ///
@@ -90,7 +90,7 @@ namespace System.Text.Json
         ///   </para>
         ///
         ///   <para>
-        ///     Upon completion of this method <paramref name="reader"/> will be positioned at the
+        ///     Upon completion of this method, <paramref name="reader"/> will be positioned at the
         ///     final token in the JSON value.  If an exception is thrown, or <see langword="false"/>
         ///     is returned, the reader is reset to the state it was in when the method was called.
         ///   </para>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.Parse.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonNode.Parse.cs
@@ -24,7 +24,7 @@ namespace System.Text.Json.Nodes
         ///     the start of the value.
         ///   </para>
         ///   <para>
-        ///     Upon completion of this method <paramref name="reader"/> will be positioned at the
+        ///     Upon completion of this method, <paramref name="reader"/> will be positioned at the
         ///     final token in the JSON value.  If an exception is thrown, the reader is reset to the state it was in when the method was called.
         ///   </para>
         ///   <para>
@@ -50,7 +50,7 @@ namespace System.Text.Json.Nodes
         }
 
         /// <summary>
-        ///   Parse text representing a single JSON value.
+        ///   Parses text representing a single JSON value.
         /// </summary>
         /// <param name="json">JSON text to parse.</param>
         /// <param name="nodeOptions">Options to control the node behavior after parsing.</param>
@@ -79,7 +79,7 @@ namespace System.Text.Json.Nodes
         }
 
         /// <summary>
-        ///   Parse text representing a single JSON value.
+        ///   Parses text representing a single JSON value.
         /// </summary>
         /// <param name="utf8Json">JSON text to parse.</param>
         /// <param name="nodeOptions">Options to control the node behavior after parsing.</param>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
@@ -102,7 +102,7 @@ namespace System.Text.Json
         /// <seealso cref="TokenType" />
         /// </exception>
         /// <exception cref="FormatException">
-        /// Thrown when the JSON string contains data outside of the expected Base64 range, or if it contains invalid/more than two padding characters,
+        /// The JSON string contains data outside of the expected Base64 range, or if it contains invalid/more than two padding characters,
         /// or is incomplete (i.e. the JSON string length is not a multiple of 4).
         /// </exception>
         public byte[] GetBytesFromBase64()

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Span.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Span.cs
@@ -10,13 +10,13 @@ namespace System.Text.Json
     public static partial class JsonSerializer
     {
         /// <summary>
-        /// Parse the UTF-8 encoded text representing a single JSON value into a <typeparamref name="TValue"/>.
+        /// Parses the UTF-8 encoded text representing a single JSON value into a <typeparamref name="TValue"/>.
         /// </summary>
         /// <returns>A <typeparamref name="TValue"/> representation of the JSON value.</returns>
         /// <param name="utf8Json">JSON text to parse.</param>
         /// <param name="options">Options to control the behavior during parsing.</param>
         /// <exception cref="JsonException">
-        /// Thrown when the JSON is invalid,
+        /// The JSON is invalid,
         /// <typeparamref name="TValue"/> is not compatible with the JSON,
         /// or when there is remaining data in the Stream.
         /// </exception>
@@ -29,7 +29,7 @@ namespace System.Text.Json
             => ReadUsingOptions<TValue>(utf8Json, typeof(TValue), options);
 
         /// <summary>
-        /// Parse the UTF-8 encoded text representing a single JSON value into a <paramref name="returnType"/>.
+        /// Parses the UTF-8 encoded text representing a single JSON value into a <paramref name="returnType"/>.
         /// </summary>
         /// <returns>A <paramref name="returnType"/> representation of the JSON value.</returns>
         /// <param name="utf8Json">JSON text to parse.</param>
@@ -39,7 +39,7 @@ namespace System.Text.Json
         /// <paramref name="returnType"/> is <see langword="null"/>.
         /// </exception>
         /// <exception cref="JsonException">
-        /// Thrown when the JSON is invalid,
+        /// The JSON is invalid,
         /// <paramref name="returnType"/> is not compatible with the JSON,
         /// or when there is remaining data in the Stream.
         /// </exception>
@@ -59,13 +59,13 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Parse the UTF-8 encoded text representing a single JSON value into a <typeparamref name="TValue"/>.
+        /// Parses the UTF-8 encoded text representing a single JSON value into a <typeparamref name="TValue"/>.
         /// </summary>
         /// <returns>A <typeparamref name="TValue"/> representation of the JSON value.</returns>
         /// <param name="utf8Json">JSON text to parse.</param>
         /// <param name="jsonTypeInfo">Metadata about the type to convert.</param>
         /// <exception cref="JsonException">
-        /// Thrown when the JSON is invalid,
+        /// The JSON is invalid,
         /// <typeparamref name="TValue"/> is not compatible with the JSON,
         /// or when there is remaining data in the Stream.
         /// </exception>
@@ -84,7 +84,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Parse the UTF-8 encoded text representing a single JSON value into a <paramref name="returnType"/>.
+        /// Parses the UTF-8 encoded text representing a single JSON value into a <paramref name="returnType"/>.
         /// </summary>
         /// <returns>A <paramref name="returnType"/> representation of the JSON value.</returns>
         /// <param name="utf8Json">JSON text to parse.</param>
@@ -94,7 +94,7 @@ namespace System.Text.Json
         /// <paramref name="returnType"/> is <see langword="null"/>.
         /// </exception>
         /// <exception cref="JsonException">
-        /// Thrown when the JSON is invalid,
+        /// The JSON is invalid,
         /// <paramref name="returnType"/> is not compatible with the JSON,
         /// or when there is remaining data in the Stream.
         /// </exception>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -18,20 +18,20 @@ namespace System.Text.Json
     public static partial class JsonSerializer
     {
         /// <summary>
-        /// Read the UTF-8 encoded text representing a single JSON value into a <typeparamref name="TValue"/>.
+        /// Reads the UTF-8 encoded text representing a single JSON value into a <typeparamref name="TValue"/>.
         /// The Stream will be read to completion.
         /// </summary>
         /// <returns>A <typeparamref name="TValue"/> representation of the JSON value.</returns>
         /// <param name="utf8Json">JSON data to parse.</param>
         /// <param name="options">Options to control the behavior during reading.</param>
         /// <param name="cancellationToken">
-        /// The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the read operation.
+        /// The <see cref="System.Threading.CancellationToken"/> that can be used to cancel the read operation.
         /// </param>
         /// <exception cref="System.ArgumentNullException">
         /// <paramref name="utf8Json"/> is <see langword="null"/>.
         /// </exception>
         /// <exception cref="JsonException">
-        /// Thrown when the JSON is invalid,
+        /// The JSON is invalid,
         /// <typeparamref name="TValue"/> is not compatible with the JSON,
         /// or when there is remaining data in the Stream.
         /// </exception>
@@ -54,7 +54,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Read the UTF-8 encoded text representing a single JSON value into a <typeparamref name="TValue"/>.
+        /// Reads the UTF-8 encoded text representing a single JSON value into a <typeparamref name="TValue"/>.
         /// The Stream will be read to completion.
         /// </summary>
         /// <returns>A <typeparamref name="TValue"/> representation of the JSON value.</returns>
@@ -64,7 +64,7 @@ namespace System.Text.Json
         /// <paramref name="utf8Json"/> is <see langword="null"/>.
         /// </exception>
         /// <exception cref="JsonException">
-        /// Thrown when the JSON is invalid,
+        /// The JSON is invalid,
         /// <typeparamref name="TValue"/> is not compatible with the JSON,
         /// or when there is remaining data in the Stream.
         /// </exception>
@@ -86,7 +86,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Read the UTF-8 encoded text representing a single JSON value into a <paramref name="returnType"/>.
+        /// Reads the UTF-8 encoded text representing a single JSON value into a <paramref name="returnType"/>.
         /// The Stream will be read to completion.
         /// </summary>
         /// <returns>A <paramref name="returnType"/> representation of the JSON value.</returns>
@@ -94,13 +94,13 @@ namespace System.Text.Json
         /// <param name="returnType">The type of the object to convert to and return.</param>
         /// <param name="options">Options to control the behavior during reading.</param>
         /// <param name="cancellationToken">
-        /// The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the read operation.
+        /// The <see cref="System.Threading.CancellationToken"/> that can be used to cancel the read operation.
         /// </param>
         /// <exception cref="System.ArgumentNullException">
         /// <paramref name="utf8Json"/> or <paramref name="returnType"/> is <see langword="null"/>.
         /// </exception>
         /// <exception cref="JsonException">
-        /// Thrown when the JSON is invalid,
+        /// The JSON is invalid,
         /// the <paramref name="returnType"/> is not compatible with the JSON,
         /// or when there is remaining data in the Stream.
         /// </exception>
@@ -129,7 +129,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Read the UTF-8 encoded text representing a single JSON value into a <paramref name="returnType"/>.
+        /// Reads the UTF-8 encoded text representing a single JSON value into a <paramref name="returnType"/>.
         /// The Stream will be read to completion.
         /// </summary>
         /// <returns>A <paramref name="returnType"/> representation of the JSON value.</returns>
@@ -140,7 +140,7 @@ namespace System.Text.Json
         /// <paramref name="utf8Json"/> or <paramref name="returnType"/> is <see langword="null"/>.
         /// </exception>
         /// <exception cref="JsonException">
-        /// Thrown when the JSON is invalid,
+        /// The JSON is invalid,
         /// the <paramref name="returnType"/> is not compatible with the JSON,
         /// or when there is remaining data in the Stream.
         /// </exception>
@@ -168,20 +168,20 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Read the UTF-8 encoded text representing a single JSON value into a <typeparamref name="TValue"/>.
+        /// Reads the UTF-8 encoded text representing a single JSON value into a <typeparamref name="TValue"/>.
         /// The Stream will be read to completion.
         /// </summary>
         /// <returns>A <typeparamref name="TValue"/> representation of the JSON value.</returns>
         /// <param name="utf8Json">JSON data to parse.</param>
         /// <param name="jsonTypeInfo">Metadata about the type to convert.</param>
         /// <param name="cancellationToken">
-        /// The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the read operation.
+        /// The <see cref="System.Threading.CancellationToken"/> that can be used to cancel the read operation.
         /// </param>
         /// <exception cref="System.ArgumentNullException">
         /// <paramref name="utf8Json"/> or <paramref name="jsonTypeInfo"/> is <see langword="null"/>.
         /// </exception>
         /// <exception cref="JsonException">
-        /// Thrown when the JSON is invalid,
+        /// The JSON is invalid,
         /// <typeparamref name="TValue"/> is not compatible with the JSON,
         /// or when there is remaining data in the Stream.
         /// </exception>
@@ -208,7 +208,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Read the UTF-8 encoded text representing a single JSON value into a <typeparamref name="TValue"/>.
+        /// Reads the UTF-8 encoded text representing a single JSON value into a <typeparamref name="TValue"/>.
         /// The Stream will be read to completion.
         /// </summary>
         /// <returns>A <typeparamref name="TValue"/> representation of the JSON value.</returns>
@@ -218,7 +218,7 @@ namespace System.Text.Json
         /// <paramref name="utf8Json"/> or <paramref name="jsonTypeInfo"/> is <see langword="null"/>.
         /// </exception>
         /// <exception cref="JsonException">
-        /// Thrown when the JSON is invalid,
+        /// The JSON is invalid,
         /// <typeparamref name="TValue"/> is not compatible with the JSON,
         /// or when there is remaining data in the Stream.
         /// </exception>
@@ -244,7 +244,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Read the UTF-8 encoded text representing a single JSON value into a <paramref name="returnType"/>.
+        /// Reads the UTF-8 encoded text representing a single JSON value into a <paramref name="returnType"/>.
         /// The Stream will be read to completion.
         /// </summary>
         /// <returns>A <paramref name="returnType"/> representation of the JSON value.</returns>
@@ -252,13 +252,13 @@ namespace System.Text.Json
         /// <param name="returnType">The type of the object to convert to and return.</param>
         /// <param name="context">A metadata provider for serializable types.</param>
         /// <param name="cancellationToken">
-        /// The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the read operation.
+        /// The <see cref="System.Threading.CancellationToken"/> that can be used to cancel the read operation.
         /// </param>
         /// <exception cref="System.ArgumentNullException">
         /// <paramref name="utf8Json"/>, <paramref name="returnType"/>, or <paramref name="context"/> is <see langword="null"/>.
         /// </exception>
         /// <exception cref="JsonException">
-        /// Thrown when the JSON is invalid,
+        /// The JSON is invalid,
         /// the <paramref name="returnType"/> is not compatible with the JSON,
         /// or when there is remaining data in the Stream.
         /// </exception>
@@ -295,7 +295,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Read the UTF-8 encoded text representing a single JSON value into a <paramref name="returnType"/>.
+        /// Reads the UTF-8 encoded text representing a single JSON value into a <paramref name="returnType"/>.
         /// The Stream will be read to completion.
         /// </summary>
         /// <returns>A <paramref name="returnType"/> representation of the JSON value.</returns>
@@ -306,7 +306,7 @@ namespace System.Text.Json
         /// <paramref name="utf8Json"/>, <paramref name="returnType"/>, or <paramref name="context"/> is <see langword="null"/>.
         /// </exception>
         /// <exception cref="JsonException">
-        /// Thrown when the JSON is invalid,
+        /// The JSON is invalid,
         /// the <paramref name="returnType"/> is not compatible with the JSON,
         /// or when there is remaining data in the Stream.
         /// </exception>
@@ -348,7 +348,7 @@ namespace System.Text.Json
         /// <returns>An <see cref="IAsyncEnumerable{TValue}" /> representation of the provided JSON array.</returns>
         /// <param name="utf8Json">JSON data to parse.</param>
         /// <param name="options">Options to control the behavior during reading.</param>
-        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the read operation.</param>
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> that can be used to cancel the read operation.</param>
         /// <returns>An <typeparamref name="TValue"/> representation of the JSON value.</returns>
         /// <exception cref="System.ArgumentNullException">
         /// <paramref name="utf8Json"/> is <see langword="null"/>.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
@@ -15,7 +15,7 @@ namespace System.Text.Json
     public static partial class JsonSerializer
     {
         /// <summary>
-        /// Parse the text representing a single JSON value into a <typeparamref name="TValue"/>.
+        /// Parses the text representing a single JSON value into a <typeparamref name="TValue"/>.
         /// </summary>
         /// <returns>A <typeparamref name="TValue"/> representation of the JSON value.</returns>
         /// <param name="json">JSON text to parse.</param>
@@ -83,7 +83,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Parse the text representing a single JSON value into a <paramref name="returnType"/>.
+        /// Parses the text representing a single JSON value into a <paramref name="returnType"/>.
         /// </summary>
         /// <returns>A <paramref name="returnType"/> representation of the JSON value.</returns>
         /// <param name="json">JSON text to parse.</param>
@@ -126,7 +126,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Parse the text representing a single JSON value into an instance of a specified type.
+        /// Parses the text representing a single JSON value into an instance of a specified type.
         /// </summary>
         /// <returns>A <paramref name="returnType"/> representation of the JSON value.</returns>
         /// <param name="json">The JSON text to parse.</param>
@@ -166,7 +166,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Parse the text representing a single JSON value into a <typeparamref name="TValue"/>.
+        /// Parses the text representing a single JSON value into a <typeparamref name="TValue"/>.
         /// </summary>
         /// <returns>A <typeparamref name="TValue"/> representation of the JSON value.</returns>
         /// <param name="json">JSON text to parse.</param>
@@ -213,7 +213,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Parse the text representing a single JSON value into a <typeparamref name="TValue"/>.
+        /// Parses the text representing a single JSON value into a <typeparamref name="TValue"/>.
         /// </summary>
         /// <returns>A <typeparamref name="TValue"/> representation of the JSON value.</returns>
         /// <param name="json">JSON text to parse.</param>
@@ -255,7 +255,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Parse the text representing a single JSON value into a <paramref name="returnType"/>.
+        /// Parses the text representing a single JSON value into a <paramref name="returnType"/>.
         /// </summary>
         /// <returns>A <paramref name="returnType"/> representation of the JSON value.</returns>
         /// <param name="json">JSON text to parse.</param>
@@ -300,7 +300,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Parse the text representing a single JSON value into a <paramref name="returnType"/>.
+        /// Parses the text representing a single JSON value into a <paramref name="returnType"/>.
         /// </summary>
         /// <returns>A <paramref name="returnType"/> representation of the JSON value.</returns>
         /// <param name="json">JSON text to parse.</param>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Utf8JsonReader.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Utf8JsonReader.cs
@@ -18,7 +18,7 @@ namespace System.Text.Json
         /// <param name="reader">The reader to read.</param>
         /// <param name="options">Options to control the serializer behavior during reading.</param>
         /// <exception cref="JsonException">
-        /// Thrown when the JSON is invalid,
+        /// The JSON is invalid,
         /// <typeparamref name="TValue"/> is not compatible with the JSON,
         /// or a value could not be read from the reader.
         /// </exception>
@@ -38,8 +38,8 @@ namespace System.Text.Json
         ///   </para>
         ///
         ///   <para>
-        ///     Upon completion of this method <paramref name="reader"/> will be positioned at the
-        ///     final token in the JSON value.  If an exception is thrown the reader is reset to
+        ///     Upon completion of this method, <paramref name="reader"/> will be positioned at the
+        ///     final token in the JSON value. If an exception is thrown, the reader is reset to
         ///     the state it was in when the method was called.
         ///   </para>
         ///
@@ -68,7 +68,7 @@ namespace System.Text.Json
         /// <paramref name="returnType"/> is <see langword="null"/>.
         /// </exception>
         /// <exception cref="JsonException">
-        /// Thrown when the JSON is invalid,
+        /// The JSON is invalid,
         /// <paramref name="returnType"/> is not compatible with the JSON,
         /// or a value could not be read from the reader.
         /// </exception>
@@ -88,8 +88,8 @@ namespace System.Text.Json
         ///   </para>
         ///
         ///   <para>
-        ///     Upon completion of this method <paramref name="reader"/> will be positioned at the
-        ///     final token in the JSON value.  If an exception is thrown the reader is reset to
+        ///     Upon completion of this method, <paramref name="reader"/> will be positioned at the
+        ///     final token in the JSON value. If an exception is thrown, the reader is reset to
         ///     the state it was in when the method was called.
         ///   </para>
         ///
@@ -120,7 +120,7 @@ namespace System.Text.Json
         /// <param name="reader">The reader to read.</param>
         /// <param name="jsonTypeInfo">Metadata about the type to convert.</param>
         /// <exception cref="JsonException">
-        /// Thrown when the JSON is invalid,
+        /// The JSON is invalid,
         /// <typeparamref name="TValue"/> is not compatible with the JSON,
         /// or a value could not be read from the reader.
         /// </exception>
@@ -140,8 +140,8 @@ namespace System.Text.Json
         ///   </para>
         ///
         ///   <para>
-        ///     Upon completion of this method <paramref name="reader"/> will be positioned at the
-        ///     final token in the JSON value.  If an exception is thrown the reader is reset to
+        ///     Upon completion of this method, <paramref name="reader"/> will be positioned at the
+        ///     final token in the JSON value. If an exception is thrown, the reader is reset to
         ///     the state it was in when the method was called.
         ///   </para>
         ///
@@ -176,7 +176,7 @@ namespace System.Text.Json
         /// <paramref name="returnType"/> or <paramref name="context"/> is <see langword="null"/>.
         /// </exception>
         /// <exception cref="JsonException">
-        /// Thrown when the JSON is invalid,
+        /// The JSON is invalid,
         /// <paramref name="returnType"/> is not compatible with the JSON,
         /// or a value could not be read from the reader.
         /// </exception>
@@ -200,8 +200,8 @@ namespace System.Text.Json
         ///   </para>
         ///
         ///   <para>
-        ///     Upon completion of this method <paramref name="reader"/> will be positioned at the
-        ///     final token in the JSON value.  If an exception is thrown the reader is reset to
+        ///     Upon completion of this method, <paramref name="reader"/> will be positioned at the
+        ///     final token in the JSON value. If an exception is thrown, the reader is reset to
         ///     the state it was in when the method was called.
         ///   </para>
         ///

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.ByteArray.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.ByteArray.cs
@@ -10,7 +10,7 @@ namespace System.Text.Json
     public static partial class JsonSerializer
     {
         /// <summary>
-        /// Convert the provided value into a <see cref="byte"/> array.
+        /// Converts the provided value into a <see cref="byte"/> array.
         /// </summary>
         /// <returns>A UTF-8 representation of the value.</returns>
         /// <param name="value">The value to convert.</param>
@@ -28,7 +28,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Convert the provided value into a <see cref="byte"/> array.
+        /// Converts the provided value into a <see cref="byte"/> array.
         /// </summary>
         /// <returns>A UTF-8 representation of the value.</returns>
         /// <param name="value">The value to convert.</param>
@@ -57,7 +57,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Convert the provided value into a <see cref="byte"/> array.
+        /// Converts the provided value into a <see cref="byte"/> array.
         /// </summary>
         /// <returns>A UTF-8 representation of the value.</returns>
         /// <param name="value">The value to convert.</param>
@@ -80,7 +80,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Convert the provided value into a <see cref="byte"/> array.
+        /// Converts the provided value into a <see cref="byte"/> array.
         /// </summary>
         /// <returns>A UTF-8 representation of the value.</returns>
         /// <param name="value">The value to convert.</param>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Document.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Document.cs
@@ -11,7 +11,7 @@ namespace System.Text.Json
     public static partial class JsonSerializer
     {
         /// <summary>
-        /// Convert the provided value into a <see cref="JsonDocument"/>.
+        /// Converts the provided value into a <see cref="JsonDocument"/>.
         /// </summary>
         /// <returns>A <see cref="JsonDocument"/> representation of the JSON value.</returns>
         /// <param name="value">The value to convert.</param>
@@ -25,7 +25,7 @@ namespace System.Text.Json
             WriteDocument(value, GetRuntimeType(value), options);
 
         /// <summary>
-        /// Convert the provided value into a <see cref="JsonDocument"/>.
+        /// Converts the provided value into a <see cref="JsonDocument"/>.
         /// </summary>
         /// <returns>A <see cref="JsonDocument"/> representation of the value.</returns>
         /// <param name="value">The value to convert.</param>
@@ -49,7 +49,7 @@ namespace System.Text.Json
                 options);
 
         /// <summary>
-        /// Convert the provided value into a <see cref="JsonDocument"/>.
+        /// Converts the provided value into a <see cref="JsonDocument"/>.
         /// </summary>
         /// <returns>A <see cref="JsonDocument"/> representation of the value.</returns>
         /// <param name="value">The value to convert.</param>
@@ -72,7 +72,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Convert the provided value into a <see cref="JsonDocument"/>.
+        /// Converts the provided value into a <see cref="JsonDocument"/>.
         /// </summary>
         /// <returns>A <see cref="JsonDocument"/> representation of the value.</returns>
         /// <param name="value">The value to convert.</param>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Element.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Element.cs
@@ -11,7 +11,7 @@ namespace System.Text.Json
     public static partial class JsonSerializer
     {
         /// <summary>
-        /// Convert the provided value into a <see cref="JsonDocument"/>.
+        /// Converts the provided value into a <see cref="JsonDocument"/>.
         /// </summary>
         /// <returns>A <see cref="JsonDocument"/> representation of the JSON value.</returns>
         /// <param name="value">The value to convert.</param>
@@ -25,7 +25,7 @@ namespace System.Text.Json
             WriteElement(value, GetRuntimeType(value), options);
 
         /// <summary>
-        /// Convert the provided value into a <see cref="JsonDocument"/>.
+        /// Converts the provided value into a <see cref="JsonDocument"/>.
         /// </summary>
         /// <returns>A <see cref="JsonDocument"/> representation of the value.</returns>
         /// <param name="value">The value to convert.</param>
@@ -49,7 +49,7 @@ namespace System.Text.Json
                 options);
 
         /// <summary>
-        /// Convert the provided value into a <see cref="JsonDocument"/>.
+        /// Converts the provided value into a <see cref="JsonDocument"/>.
         /// </summary>
         /// <returns>A <see cref="JsonDocument"/> representation of the value.</returns>
         /// <param name="value">The value to convert.</param>
@@ -72,7 +72,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Convert the provided value into a <see cref="JsonDocument"/>.
+        /// Converts the provided value into a <see cref="JsonDocument"/>.
         /// </summary>
         /// <returns>A <see cref="JsonDocument"/> representation of the value.</returns>
         /// <param name="value">The value to convert.</param>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Node.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Node.cs
@@ -12,7 +12,7 @@ namespace System.Text.Json
     public static partial class JsonSerializer
     {
         /// <summary>
-        /// Convert the provided value into a <see cref="JsonNode"/>.
+        /// Converts the provided value into a <see cref="JsonNode"/>.
         /// </summary>
         /// <returns>A <see cref="JsonNode"/> representation of the JSON value.</returns>
         /// <param name="value">The value to convert.</param>
@@ -26,7 +26,7 @@ namespace System.Text.Json
             WriteNode(value, GetRuntimeType(value), options);
 
         /// <summary>
-        /// Convert the provided value into a <see cref="JsonNode"/>.
+        /// Converts the provided value into a <see cref="JsonNode"/>.
         /// </summary>
         /// <returns>A <see cref="JsonNode"/> representation of the value.</returns>
         /// <param name="value">The value to convert.</param>
@@ -50,7 +50,7 @@ namespace System.Text.Json
                 options);
 
         /// <summary>
-        /// Convert the provided value into a <see cref="JsonNode"/>.
+        /// Converts the provided value into a <see cref="JsonNode"/>.
         /// </summary>
         /// <returns>A <see cref="JsonNode"/> representation of the value.</returns>
         /// <param name="value">The value to convert.</param>
@@ -73,7 +73,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Convert the provided value into a <see cref="JsonNode"/>.
+        /// Converts the provided value into a <see cref="JsonNode"/>.
         /// </summary>
         /// <returns>A <see cref="JsonNode"/> representation of the value.</returns>
         /// <param name="value">The value to convert.</param>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -22,13 +22,13 @@ namespace System.Text.Json
         private const float FlushThreshold = .9f;
 
         /// <summary>
-        /// Convert the provided value to UTF-8 encoded JSON text and write it to the <see cref="System.IO.Stream"/>.
+        /// Converts the provided value to UTF-8 encoded JSON text and write it to the <see cref="System.IO.Stream"/>.
         /// </summary>
         /// <returns>A task that represents the asynchronous write operation.</returns>
         /// <param name="utf8Json">The UTF-8 <see cref="System.IO.Stream"/> to write to.</param>
         /// <param name="value">The value to convert.</param>
         /// <param name="options">Options to control the conversion behavior.</param>
-        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the write operation.</param>
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> that can be used to cancel the write operation.</param>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="utf8Json"/> is <see langword="null"/>.
         /// </exception>
@@ -58,7 +58,7 @@ namespace System.Text.Json
 
 
         /// <summary>
-        /// Convert the provided value to UTF-8 encoded JSON text and write it to the <see cref="System.IO.Stream"/>.
+        /// Converts the provided value to UTF-8 encoded JSON text and write it to the <see cref="System.IO.Stream"/>.
         /// </summary>
         /// <param name="utf8Json">The UTF-8 <see cref="System.IO.Stream"/> to write to.</param>
         /// <param name="value">The value to convert.</param>
@@ -89,14 +89,14 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Convert the provided value to UTF-8 encoded JSON text and write it to the <see cref="System.IO.Stream"/>.
+        /// Converts the provided value to UTF-8 encoded JSON text and write it to the <see cref="System.IO.Stream"/>.
         /// </summary>
         /// <returns>A task that represents the asynchronous write operation.</returns>
         /// <param name="utf8Json">The UTF-8 <see cref="System.IO.Stream"/> to write to.</param>
         /// <param name="value">The value to convert.</param>
         /// <param name="inputType">The type of the <paramref name="value"/> to convert.</param>
         /// <param name="options">Options to control the conversion behavior.</param>
-        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the write operation.</param>
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> that can be used to cancel the write operation.</param>
         /// <exception cref="ArgumentException">
         /// <paramref name="inputType"/> is not compatible with <paramref name="value"/>.
         /// </exception>
@@ -129,7 +129,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Convert the provided value to UTF-8 encoded JSON text and write it to the <see cref="System.IO.Stream"/>.
+        /// Converts the provided value to UTF-8 encoded JSON text and write it to the <see cref="System.IO.Stream"/>.
         /// </summary>
         /// <param name="utf8Json">The UTF-8 <see cref="System.IO.Stream"/> to write to.</param>
         /// <param name="value">The value to convert.</param>
@@ -165,13 +165,13 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Convert the provided value to UTF-8 encoded JSON text and write it to the <see cref="System.IO.Stream"/>.
+        /// Converts the provided value to UTF-8 encoded JSON text and write it to the <see cref="System.IO.Stream"/>.
         /// </summary>
         /// <returns>A task that represents the asynchronous write operation.</returns>
         /// <param name="utf8Json">The UTF-8 <see cref="System.IO.Stream"/> to write to.</param>
         /// <param name="value">The value to convert.</param>
         /// <param name="jsonTypeInfo">Metadata about the type to convert.</param>
-        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the write operation.</param>
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> that can be used to cancel the write operation.</param>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="utf8Json"/> is <see langword="null"/>.
         /// </exception>
@@ -199,7 +199,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Convert the provided value to UTF-8 encoded JSON text and write it to the <see cref="System.IO.Stream"/>.
+        /// Converts the provided value to UTF-8 encoded JSON text and write it to the <see cref="System.IO.Stream"/>.
         /// </summary>
         /// <param name="utf8Json">The UTF-8 <see cref="System.IO.Stream"/> to write to.</param>
         /// <param name="value">The value to convert.</param>
@@ -230,19 +230,19 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Convert the provided value to UTF-8 encoded JSON text and write it to the <see cref="System.IO.Stream"/>.
+        /// Converts the provided value to UTF-8 encoded JSON text and write it to the <see cref="System.IO.Stream"/>.
         /// </summary>
         /// <returns>A task that represents the asynchronous write operation.</returns>
         /// <param name="utf8Json">The UTF-8 <see cref="System.IO.Stream"/> to write to.</param>
         /// <param name="value">The value to convert.</param>
         /// <param name="inputType">The type of the <paramref name="value"/> to convert.</param>
         /// <param name="context">A metadata provider for serializable types.</param>
-        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the write operation.</param>
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> that can be used to cancel the write operation.</param>
         /// <exception cref="ArgumentException">
         /// <paramref name="inputType"/> is not compatible with <paramref name="value"/>.
         /// </exception>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="utf8Json"/>, <paramref name="inputType"/> or <paramref name="context"/> is <see langword="null"/>.
+        /// <paramref name="utf8Json"/>, <paramref name="inputType"/>, or <paramref name="context"/> is <see langword="null"/>.
         /// </exception>
         /// <exception cref="NotSupportedException">
         /// There is no compatible <see cref="System.Text.Json.Serialization.JsonConverter"/>
@@ -274,7 +274,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Convert the provided value to UTF-8 encoded JSON text and write it to the <see cref="System.IO.Stream"/>.
+        /// Converts the provided value to UTF-8 encoded JSON text and write it to the <see cref="System.IO.Stream"/>.
         /// </summary>
         /// <param name="utf8Json">The UTF-8 <see cref="System.IO.Stream"/> to write to.</param>
         /// <param name="value">The value to convert.</param>
@@ -284,7 +284,7 @@ namespace System.Text.Json
         /// <paramref name="inputType"/> is not compatible with <paramref name="value"/>.
         /// </exception>
         /// <exception cref="ArgumentNullException">
-        /// <paramref name="utf8Json"/>, <paramref name="inputType"/> or <paramref name="context"/> is <see langword="null"/>.
+        /// <paramref name="utf8Json"/>, <paramref name="inputType"/>, or <paramref name="context"/> is <see langword="null"/>.
         /// </exception>
         /// <exception cref="NotSupportedException">
         /// There is no compatible <see cref="System.Text.Json.Serialization.JsonConverter"/>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.String.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.String.cs
@@ -10,7 +10,7 @@ namespace System.Text.Json
     public static partial class JsonSerializer
     {
         /// <summary>
-        /// Convert the provided value into a <see cref="string"/>.
+        /// Converts the provided value into a <see cref="string"/>.
         /// </summary>
         /// <returns>A <see cref="string"/> representation of the value.</returns>
         /// <param name="value">The value to convert.</param>
@@ -30,7 +30,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Convert the provided value into a <see cref="string"/>.
+        /// Converts the provided value into a <see cref="string"/>.
         /// </summary>
         /// <returns>A <see cref="string"/> representation of the value.</returns>
         /// <param name="value">The value to convert.</param>
@@ -63,7 +63,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Convert the provided value into a <see cref="string"/>.
+        /// Converts the provided value into a <see cref="string"/>.
         /// </summary>
         /// <returns>A <see cref="string"/> representation of the value.</returns>
         /// <param name="value">The value to convert.</param>
@@ -85,7 +85,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Convert the provided value into a <see cref="string"/>.
+        /// Converts the provided value into a <see cref="string"/>.
         /// </summary>
         /// <returns>A <see cref="string"/> representation of the value.</returns>
         /// <param name="value">The value to convert.</param>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Utf8JsonWriter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Utf8JsonWriter.cs
@@ -10,7 +10,7 @@ namespace System.Text.Json
     public static partial class JsonSerializer
     {
         /// <summary>
-        /// Write one JSON value (including objects or arrays) to the provided writer.
+        /// Writes one JSON value (including objects or arrays) to the provided writer.
         /// </summary>
         /// <param name="writer">The writer to write.</param>
         /// <param name="value">The value to convert and write.</param>
@@ -32,7 +32,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Write one JSON value (including objects or arrays) to the provided writer.
+        /// Writes one JSON value (including objects or arrays) to the provided writer.
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="value">The value to convert and write.</param>
@@ -63,7 +63,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Write one JSON value (including objects or arrays) to the provided writer.
+        /// Writes one JSON value (including objects or arrays) to the provided writer.
         /// </summary>
         /// <param name="writer">The writer to write.</param>
         /// <param name="value">The value to convert and write.</param>
@@ -91,7 +91,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Write one JSON value (including objects or arrays) to the provided writer.
+        /// Writes one JSON value (including objects or arrays) to the provided writer.
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="value">The value to convert and write.</param>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerContext.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerContext.cs
@@ -19,7 +19,7 @@ namespace System.Text.Json.Serialization
 
         /// <summary>
         /// Indicates whether pre-generated serialization logic for types in the context
-        /// is compatible with the run-time specified <see cref="JsonSerializerOptions"/>.
+        /// is compatible with the run time specified <see cref="JsonSerializerOptions"/>.
         /// </summary>
         internal bool CanUseSerializationLogic
         {
@@ -61,7 +61,7 @@ namespace System.Text.Json.Serialization
         }
 
         /// <summary>
-        /// Gets the run-time specified options of the context. If no options were passed
+        /// Gets the run time specified options of the context. If no options were passed
         /// when instanciating the context, then a new instance is bound and returned.
         /// </summary>
         /// <remarks>
@@ -84,8 +84,8 @@ namespace System.Text.Json.Serialization
         /// <summary>
         /// Creates an instance of <see cref="JsonSerializerContext"/> and binds it with the indicated <see cref="JsonSerializerOptions"/>.
         /// </summary>
-        /// <param name="instanceOptions">The run-time provided options for the context instance.</param>
-        /// <param name="defaultOptions">The default run-time options for the context. It's values are defined at design-time via <see cref="JsonSourceGenerationOptionsAttribute"/>.</param>
+        /// <param name="instanceOptions">The run time provided options for the context instance.</param>
+        /// <param name="defaultOptions">The default run time options for the context. Its values are defined at design-time via <see cref="JsonSourceGenerationOptionsAttribute"/>.</param>
         /// <remarks>
         /// If no instance options are passed, then no options are set until the context is bound using <see cref="JsonSerializerOptions.AddContext{TContext}"/>,
         /// or until <see cref="Options"/> is called, where a new options instance is created and bound.
@@ -110,7 +110,7 @@ namespace System.Text.Json.Serialization
         /// Returns a <see cref="JsonTypeInfo"/> instance representing the given type.
         /// </summary>
         /// <param name="type">The type to fetch metadata about.</param>
-        /// <returns>Should return null if the context has no metadata for the type.</returns>
+        /// <returns>The metadata for the specified type, or <see langword="null" /> if the context has no metadata for the type.</returns>
         public abstract JsonTypeInfo? GetTypeInfo(Type type);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonParameterInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonParameterInfo.cs
@@ -67,7 +67,7 @@ namespace System.Text.Json.Serialization.Metadata
             NumberHandling = matchingProperty.NumberHandling;
         }
 
-        // Create a parameter that is ignored at run-time. It uses the same type (typeof(sbyte)) to help
+        // Create a parameter that is ignored at run time. It uses the same type (typeof(sbyte)) to help
         // prevent issues with unsupported types and helps ensure we don't accidently (de)serialize it.
         public static JsonParameterInfo CreateIgnoredParameterPlaceholder(JsonPropertyInfo matchingProperty)
         {


### PR DESCRIPTION
Relates to https://github.com/dotnet/dotnet-api-docs/pull/6963

Pulling back more comments from docs.

In this process I'm learning
1. how unsustainable it is to maintain the text in two places
2. the port tool does not want to overwrite existing content - somehow I need to tell it that this library is the source of truth
3. due to 1 and 2, for code to be the source of truth, we are either going to have to ask docs folks to review xml docs in code PR's to match docs style, or have engineers learn to write docs style, or learn to tolerate a less consistent voice and style in the docs. probably a combination of the latter two.