### PR TITLE
XmlSerializer: Add GenerateSerializer overload with defaultNamespace argument

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -633,6 +633,14 @@ namespace System.Xml.Serialization
             Justification = "Code is used on diagnostics so we fallback to print assembly.FullName if assembly.Location is empty")]
         internal static bool GenerateSerializer(Type[]? types, XmlMapping[] mappings, Stream stream)
         {
+            return GenerateSerializer(types, mappings, null, stream);
+        }
+
+        [RequiresUnreferencedCode("calls GenerateSerializerToStream")]
+        [UnconditionalSuppressMessage("SingleFile", "IL3000: Avoid accessing Assembly file path when publishing as a single file",
+            Justification = "Code is used on diagnostics so we fallback to print assembly.FullName if assembly.Location is empty")]
+        internal static bool GenerateSerializer(Type[]? types, XmlMapping[] mappings, string defaultNamespace, Stream stream)
+        {
             if (types == null || types.Length == 0)
                 return false;
 
@@ -669,7 +677,7 @@ namespace System.Xml.Serialization
                 }
             }
 
-            return TempAssembly.GenerateSerializerToStream(mappings, types, null, assembly, new Hashtable(), stream);
+            return TempAssembly.GenerateSerializerToStream(mappings, types, defaultNamespace, assembly, new Hashtable(), stream);
         }
 
         [RequiresUnreferencedCode("calls Contract")]

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -633,13 +633,13 @@ namespace System.Xml.Serialization
             Justification = "Code is used on diagnostics so we fallback to print assembly.FullName if assembly.Location is empty")]
         internal static bool GenerateSerializer(Type[]? types, XmlMapping[] mappings, Stream stream)
         {
-            return GenerateSerializer(types, mappings, null!, stream);
+            return GenerateSerializer(types, mappings, null, stream);
         }
 
         [RequiresUnreferencedCode("calls GenerateSerializerToStream")]
         [UnconditionalSuppressMessage("SingleFile", "IL3000: Avoid accessing Assembly file path when publishing as a single file",
             Justification = "Code is used on diagnostics so we fallback to print assembly.FullName if assembly.Location is empty")]
-        internal static bool GenerateSerializer(Type[]? types, XmlMapping[] mappings, string defaultNamespace, Stream stream)
+        internal static bool GenerateSerializer(Type[]? types, XmlMapping[] mappings, string? defaultNamespace, Stream stream)
         {
             if (types == null || types.Length == 0)
                 return false;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -633,7 +633,7 @@ namespace System.Xml.Serialization
             Justification = "Code is used on diagnostics so we fallback to print assembly.FullName if assembly.Location is empty")]
         internal static bool GenerateSerializer(Type[]? types, XmlMapping[] mappings, Stream stream)
         {
-            return GenerateSerializer(types, mappings, null, stream);
+            return GenerateSerializer(types, mappings, null!, stream);
         }
 
         [RequiresUnreferencedCode("calls GenerateSerializerToStream")]


### PR DESCRIPTION
Motivation: In PR #46500 we called GenerateSerializerToStream directly because a GenerateSerializer overload with the defaultNamespace argument was not available, this change is proposed in order to correct that.