### PR TITLE
Sgen: Update GetTempAssemblyName according to #46499

### DIFF
--- a/src/libraries/Microsoft.XmlSerializer.Generator/src/Microsoft.XmlSerializer.Generator.csproj
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/src/Microsoft.XmlSerializer.Generator.csproj
@@ -20,6 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Reference Include="System.Memory" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="build\prefercliruntime"
           PackagePath="/"
           Pack="true" />

--- a/src/libraries/Microsoft.XmlSerializer.Generator/src/Microsoft.XmlSerializer.Generator.csproj
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/src/Microsoft.XmlSerializer.Generator.csproj
@@ -20,10 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="System.Memory" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Include="build\prefercliruntime"
           PackagePath="/"
           Pack="true" />

--- a/src/libraries/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -562,7 +562,7 @@ namespace Microsoft.XmlSerializer.Generator
         private static uint GetPersistentHashCode(string value)
         {
             byte[] valueBytes = Encoding.UTF8.GetBytes(value);
-            byte[] hash = SHA512.HashData(valueBytes);
+            byte[] hash = SHA512.Create().ComputeHash(valueBytes);
             return ReadUInt32BigEndian(hash);
         }
 

--- a/src/libraries/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -1,12 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
+using System.Buffers.Binary;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -555,7 +557,14 @@ namespace Microsoft.XmlSerializer.Generator
 
         private static string GetTempAssemblyName(AssemblyName parent, string ns)
         {
-            return parent.Name + ".XmlSerializers" + (ns == null || ns.Length == 0 ? "" : "." + ns.GetHashCode());
+            return parent.Name + ".XmlSerializers" + (string.IsNullOrEmpty(ns) ? "" : $".{GetPersistentHashCode(ns)}");
+        }
+
+        private static uint GetPersistentHashCode(string value)
+        {
+            byte[] valueBytes = Encoding.UTF8.GetBytes(value);
+            byte[] hash = SHA512.HashData(valueBytes);
+            return BinaryPrimitives.ReadUInt32BigEndian(hash);
         }
 
         private static void ParseReferences()

--- a/src/libraries/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
-using System.Buffers.Binary;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
@@ -564,7 +563,12 @@ namespace Microsoft.XmlSerializer.Generator
         {
             byte[] valueBytes = Encoding.UTF8.GetBytes(value);
             byte[] hash = SHA512.HashData(valueBytes);
-            return BinaryPrimitives.ReadUInt32BigEndian(hash);
+            return ReadUInt32BigEndian(hash);
+        }
+
+        private static uint ReadUInt32BigEndian(byte[] value)
+        {
+            return (uint)(value[0] << 24 | value[1] << 16 | value[2] << 8 | value[3]);
         }
 
         private static void ParseReferences()


### PR DESCRIPTION
In #46499 we corrected Compilation.GetTempAssemblyName in order for it to be not deterministic under .NET Core.
In this PR we update the generated filename to match the new logic.