### PR TITLE
Obsolete System.Security.SecurityContext

### DIFF
--- a/src/libraries/System.Security.Permissions/ref/System.Security.Permissions.cs
+++ b/src/libraries/System.Security.Permissions/ref/System.Security.Permissions.cs
@@ -745,6 +745,9 @@ namespace System.Security
         Enterprise = 2,
         AppDomain = 3,
     }
+#if NET6_0_OR_GREATER
+    [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+#endif
     public sealed partial class SecurityContext : System.IDisposable
     {
         internal SecurityContext() { }

--- a/src/libraries/System.Security.Permissions/src/System/Security/SecurityContext.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/SecurityContext.cs
@@ -5,6 +5,9 @@ using System.Threading;
 
 namespace System.Security
 {
+#if NET6_0_OR_GREATER
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
     public sealed partial class SecurityContext : System.IDisposable
     {
         internal SecurityContext() { }


### PR DESCRIPTION
This obsoletes the type `System.Security.SecurityContext` conditionally for .NET 6+.

* All public members on this type throw `PlatformNotSupportedException`, and it is sealed.
* Skipping API Review and setting for 6.0 per #50528 (comment).