### PR TITLE
[wasm] Skip tests for ExpectContinue HTTP header

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.RemoteServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.RemoteServer.cs
@@ -607,7 +607,7 @@ namespace System.Net.Http.Functional.Tests
         [OuterLoop("Uses external servers", typeof(PlatformDetection), nameof(PlatformDetection.LocalEchoServerIsNotAvailable))]
         [Theory]
         [MemberData(nameof(ExpectContinueVersion))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/53876", TestPlatforms.Browser)]
+        [SkipOnPlatform(TestPlatforms.Browser, "ExpectContinue not supported on Browser")]
         public async Task PostAsync_ExpectContinue_Success(bool? expectContinue, Version version)
         {
             // Sync API supported only up to HTTP/1.1

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -429,10 +429,10 @@ namespace System.Net.Http.Functional.Tests
                     if (PlatformDetection.IsNotBrowser)
                     {
                         request.Content.Headers.ContentMD5 = MD5.Create().ComputeHash(contentArray);
+                        request.Headers.Expect.Add(new NameValueWithParametersHeaderValue("100-continue"));
                     }
                     request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/x-www-form-urlencoded");
                     request.Headers.Date = DateTimeOffset.Parse("Tue, 15 Nov 1994 08:12:31 GMT");
-                    request.Headers.Expect.Add(new NameValueWithParametersHeaderValue("100-continue"));
                     request.Headers.Add("Forwarded", "for=192.0.2.60;proto=http;by=203.0.113.43");
                     request.Headers.Add("From", "User Name <user@example.com>");
                     request.Headers.Host = "en.wikipedia.org:8080";
@@ -1369,7 +1369,7 @@ namespace System.Net.Http.Functional.Tests
 #region Post Methods Tests
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/53876", TestPlatforms.Browser)]
+        [SkipOnPlatform(TestPlatforms.Browser, "ExpectContinue not supported on Browser")]
         public async Task GetAsync_ExpectContinueTrue_NoContent_StillSendsHeader()
         {
             if (IsWinHttpHandler && UseVersion >= HttpVersion20.Value)
@@ -1547,6 +1547,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "ExpectContinue not supported on Browser")]
         public async Task SendAsync_MultipleExpected100Responses_ReceivesCorrectResponse()
         {
             if (IsWinHttpHandler && UseVersion >= HttpVersion20.Value)
@@ -1642,6 +1643,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "ExpectContinue not supported on Browser")]
         public async Task SendAsync_No100ContinueReceived_RequestBodySentEventually()
         {
             if (IsWinHttpHandler && UseVersion >= HttpVersion20.Value)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpRequestHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpRequestHeaders.cs
@@ -19,11 +19,8 @@ namespace System.Net.Http.Headers
 
         private object[]? _specialCollectionsSlots;
         private HttpGeneralHeaders? _generalHeaders;
-
-#if !TARGET_BROWSER
         private HttpHeaderValueCollection<NameValueWithParametersHeaderValue>? _expect;
         private bool _expectContinueSet;
-#endif
 
         #region Request Headers
 
@@ -54,21 +51,6 @@ namespace System.Net.Http.Headers
             set { SetOrRemoveParsedValue(KnownHeaders.Authorization.Descriptor, value); }
         }
 
-#if TARGET_BROWSER
-        public HttpHeaderValueCollection<NameValueWithParametersHeaderValue> Expect
-        {
-            get => throw new PlatformNotSupportedException();
-        }
-
-        public bool? ExpectContinue
-        {
-            get => false;
-            set
-            {
-                if (value ?? false) { throw new PlatformNotSupportedException();}
-            }
-        }
-#else
         public HttpHeaderValueCollection<NameValueWithParametersHeaderValue> Expect
         {
             get { return ExpectCore; }
@@ -107,7 +89,6 @@ namespace System.Net.Http.Headers
                 }
             }
         }
-#endif
 
         public string? From
         {
@@ -208,10 +189,8 @@ namespace System.Net.Http.Headers
         public HttpHeaderValueCollection<ProductInfoHeaderValue> UserAgent =>
             GetSpecializedCollection(UserAgentSlot, static thisRef => new HttpHeaderValueCollection<ProductInfoHeaderValue>(KnownHeaders.UserAgent.Descriptor, thisRef));
 
-#if !TARGET_BROWSER
         private HttpHeaderValueCollection<NameValueWithParametersHeaderValue> ExpectCore =>
             _expect ??= new HttpHeaderValueCollection<NameValueWithParametersHeaderValue>(KnownHeaders.Expect.Descriptor, this, HeaderUtilities.ExpectContinue);
-#endif
 
         #endregion
 
@@ -295,13 +274,11 @@ namespace System.Net.Http.Headers
                 GeneralHeaders.AddSpecialsFrom(sourceRequestHeaders._generalHeaders);
             }
 
-#if !TARGET_BROWSER
             bool? expectContinue = ExpectContinue;
             if (!expectContinue.HasValue)
             {
                 ExpectContinue = sourceRequestHeaders.ExpectContinue;
             }
-#endif
         }
 
         private HttpGeneralHeaders GeneralHeaders => _generalHeaders ?? (_generalHeaders = new HttpGeneralHeaders(this));

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpRequestHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpRequestHeaders.cs
@@ -19,8 +19,11 @@ namespace System.Net.Http.Headers
 
         private object[]? _specialCollectionsSlots;
         private HttpGeneralHeaders? _generalHeaders;
+
+#if !TARGET_BROWSER
         private HttpHeaderValueCollection<NameValueWithParametersHeaderValue>? _expect;
         private bool _expectContinueSet;
+#endif
 
         #region Request Headers
 
@@ -51,6 +54,21 @@ namespace System.Net.Http.Headers
             set { SetOrRemoveParsedValue(KnownHeaders.Authorization.Descriptor, value); }
         }
 
+#if TARGET_BROWSER
+        public HttpHeaderValueCollection<NameValueWithParametersHeaderValue> Expect
+        {
+            get => throw new PlatformNotSupportedException();
+        }
+
+        public bool? ExpectContinue
+        {
+            get => false;
+            set
+            {
+                if (value ?? false) { throw new PlatformNotSupportedException();}
+            }
+        }
+#else
         public HttpHeaderValueCollection<NameValueWithParametersHeaderValue> Expect
         {
             get { return ExpectCore; }
@@ -89,6 +107,7 @@ namespace System.Net.Http.Headers
                 }
             }
         }
+#endif
 
         public string? From
         {
@@ -189,8 +208,10 @@ namespace System.Net.Http.Headers
         public HttpHeaderValueCollection<ProductInfoHeaderValue> UserAgent =>
             GetSpecializedCollection(UserAgentSlot, static thisRef => new HttpHeaderValueCollection<ProductInfoHeaderValue>(KnownHeaders.UserAgent.Descriptor, thisRef));
 
+#if !TARGET_BROWSER
         private HttpHeaderValueCollection<NameValueWithParametersHeaderValue> ExpectCore =>
             _expect ??= new HttpHeaderValueCollection<NameValueWithParametersHeaderValue>(KnownHeaders.Expect.Descriptor, this, HeaderUtilities.ExpectContinue);
+#endif
 
         #endregion
 
@@ -274,11 +295,13 @@ namespace System.Net.Http.Headers
                 GeneralHeaders.AddSpecialsFrom(sourceRequestHeaders._generalHeaders);
             }
 
+#if !TARGET_BROWSER
             bool? expectContinue = ExpectContinue;
             if (!expectContinue.HasValue)
             {
                 ExpectContinue = sourceRequestHeaders.ExpectContinue;
             }
+#endif
         }
 
         private HttpGeneralHeaders GeneralHeaders => _generalHeaders ?? (_generalHeaders = new HttpGeneralHeaders(this));


### PR DESCRIPTION
[Expect:](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expect
) `100-continue` header is not supported by any of the normal browsers.

See
[Gecko issue](https://bugzilla.mozilla.org/show_bug.cgi?id=803673)
[Chromium issue](https://bugs.chromium.org/p/chromium/issues/detail?id=174906) 

Skip related tests fixes https://github.com/dotnet/runtime/issues/53876