### PR TITLE
Fix building CoreCLR for x86 with the Windows 10.0.20348.0 SDK

### DIFF
--- a/src/coreclr/inc/crosscomp.h
+++ b/src/coreclr/inc/crosscomp.h
@@ -41,7 +41,9 @@
 #define ARM_MAX_BREAKPOINTS     8
 #define ARM_MAX_WATCHPOINTS     1
 
+#ifndef CONTEXT_UNWOUND_TO_CALL
 #define CONTEXT_UNWOUND_TO_CALL 0x20000000
+#endif
 
 #if !defined(HOST_ARM64)
 typedef struct _NEON128 {


### PR DESCRIPTION
The SDK now defines CONTEXT_UNWOUND_TO_CALL in more cases, so we get a macro redefinition error. Since the SDK defines it to the same value as we do, just skip our definition if it's already defined.