### PR TITLE
Fix the string search behavior when using ICU

### DIFF
--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
@@ -453,8 +453,7 @@ static const char* BreakIteratorRule = "$CR      = [\\p{Grapheme_Cluster_Break =
                                        "$LF      = [\\p{Grapheme_Cluster_Break = LF}]; \n"          \
                                        "$Control = [[\\p{Grapheme_Cluster_Break = Control}]]; \n"   \
                                        "$Extend  = [[\\p{Grapheme_Cluster_Break = Extend}]];  \n"   \
-                                       "$ZWJ     = [\\p{Grapheme_Cluster_Break = ZWJ}];       \n"   \
-                                       "[^$Control $CR $LF] ($Extend | $ZWJ); \n";
+                                       "[^$Control $CR $LF] ($Extend | [\\u200D]); \n";
 
 // When doing string search operations using ICU, it is internally using a break iterator which doesn't allow breaking between some characters according to
 // the Grapheme Cluster Boundary Rules specified in http://www.unicode.org/reports/tr29/#Grapheme_Cluster_Boundary_Rules.

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
@@ -449,6 +449,56 @@ ResultCode GlobalizationNative_GetSortHandle(const char* lpLocaleName, SortHandl
     return GetResultCode(err);
 }
 
+static const char* BreakIteratorRule = "$CR      = [\\p{Grapheme_Cluster_Break = CR}]; \n"          \
+                                       "$LF      = [\\p{Grapheme_Cluster_Break = LF}]; \n"          \
+                                       "$Control = [[\\p{Grapheme_Cluster_Break = Control}]]; \n"   \
+                                       "$Extend  = [[\\p{Grapheme_Cluster_Break = Extend}]];  \n"   \
+                                       "$ZWJ     = [\\p{Grapheme_Cluster_Break = ZWJ}];       \n"   \
+                                       "[^$Control $CR $LF] ($Extend | $ZWJ); \n";
+
+// When doing string search operations using ICU, it is internally using a break iterator which doesn't allow breaking between some characters according to
+// the Grapheme Cluster Boundary Rules specified in http://www.unicode.org/reports/tr29/#Grapheme_Cluster_Boundary_Rules.
+// Unfortunately, not all rules will have the desired behavior we need to get in .NET. For example, the rules don't allow breaking between CR '\r' and LF '\n' characters.
+// When searching for "\n" in a string like "\r\n", will get not found result.
+// We are customizing the break iterator to include only the rules which give the desired behavior. Mainly, we include the GB9 rule http://www.unicode.org/reports/tr29/#GB9
+// which doesn't allow breaking before the nonspace marks.
+// The general rules syntax explained in the doc https://unicode-org.github.io/icu/userguide/boundaryanalysis/break-rules.html.
+// The ICU rules definition exist here https://github.com/unicode-org/icu/blob/main/icu4c/source/data/brkitr/rules/char.txt.
+static UBreakIterator* CreateCustomizedBreakIterator()
+{
+    UChar uRule[400];
+    assert(strlen(BreakIteratorRule) < 400);
+    u_uastrcpy(uRule, BreakIteratorRule);
+
+    static UChar emptyString[1];
+    UErrorCode status = U_ZERO_ERROR;
+
+    UBreakIterator* breaker = ubrk_openRules(uRule, (int32_t)strlen(BreakIteratorRule), emptyString, 0, NULL, &status);
+
+    return U_FAILURE(status) ? NULL : breaker;
+}
+
+static void CloseSearchIterator(UStringSearch* pSearch)
+{
+    assert(pSearch != NULL);
+
+#if !defined(TARGET_WINDOWS)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
+    UBreakIterator* breakIterator = (UBreakIterator*)usearch_getBreakIterator(pSearch);
+#if !defined(TARGET_WINDOWS)
+#pragma GCC diagnostic pop
+#endif
+
+    usearch_close(pSearch);
+
+    if (breakIterator != NULL)
+    {
+        ubrk_close(breakIterator);
+    }
+}
+
 void GlobalizationNative_CloseSortHandle(SortHandle* pSortHandle)
 {
     for (int i = 0; i <= CompareOptionsMask; i++)
@@ -460,7 +510,7 @@ void GlobalizationNative_CloseSortHandle(SortHandle* pSortHandle)
             {
                 if (pSearch != USED_STRING_SEARCH)
                 {
-                    usearch_close(pSearch);
+                    CloseSearchIterator(pSearch);
                 }
                 pSortHandle->searchIteratorList[i].searchIterator = NULL;
                 SearchIteratorNode* pNext = pSortHandle->searchIteratorList[i].next;
@@ -470,7 +520,7 @@ void GlobalizationNative_CloseSortHandle(SortHandle* pSortHandle)
                 {
                     if (pNext->searchIterator != NULL && pNext->searchIterator != USED_STRING_SEARCH)
                     {
-                        usearch_close(pNext->searchIterator);
+                        CloseSearchIterator(pNext->searchIterator);
                     }
                     SearchIteratorNode* pCurrent = pNext;
                     pNext = pCurrent->next;
@@ -581,9 +631,14 @@ static int32_t GetSearchIteratorUsingCollator(
 
     if (*pSearchIterator == NULL)
     {
-        *pSearchIterator = usearch_openFromCollator(lpTarget, cwTargetLength, lpSource, cwSourceLength, pColl, NULL, &err);
+        UBreakIterator* breakIterator = CreateCustomizedBreakIterator();
+        *pSearchIterator = usearch_openFromCollator(lpTarget, cwTargetLength, lpSource, cwSourceLength, pColl, breakIterator, &err);
         if (!U_SUCCESS(err))
         {
+            if (breakIterator != NULL)
+            {
+                ubrk_close(breakIterator);
+            }
             assert(false && "Couldn't open the search iterator.");
             return -1;
         }
@@ -593,7 +648,7 @@ static int32_t GetSearchIteratorUsingCollator(
         {
             if (!CreateNewSearchNode(pSortHandle, options))
             {
-                usearch_close(*pSearchIterator);
+                CloseSearchIterator(*pSearchIterator);
                 return -1;
             }
         }
@@ -619,16 +674,22 @@ static int32_t GetSearchIteratorUsingCollator(
 
     if (*pSearchIterator == NULL) // Couldn't find any available handle to borrow then create a new one.
     {
-        *pSearchIterator = usearch_openFromCollator(lpTarget, cwTargetLength, lpSource, cwSourceLength, pColl, NULL, &err);
+        UBreakIterator* breakIterator = CreateCustomizedBreakIterator();
+        *pSearchIterator = usearch_openFromCollator(lpTarget, cwTargetLength, lpSource, cwSourceLength, pColl, breakIterator, &err);
         if (!U_SUCCESS(err))
         {
+            if (breakIterator != NULL)
+            {
+                ubrk_close(breakIterator);
+            }
+
             assert(false && "Couldn't open a new search iterator.");
             return -1;
         }
 
         if (!CreateNewSearchNode(pSortHandle, options))
         {
-            usearch_close(*pSearchIterator);
+            CloseSearchIterator(*pSearchIterator);
             return -1;
         }
 

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
@@ -540,7 +540,7 @@ static UBreakIterator* CreateCustomizedBreakIterator()
 
     int32_t breakIteratorRulesLength = newRulesLength > oldRulesLength ? newRulesLength : oldRulesLength;
 
-    UChar* rules = (UChar*)malloc((breakIteratorRulesLength + 1) * sizeof(UChar));
+    UChar* rules = (UChar*)malloc(((size_t)breakIteratorRulesLength + 1) * sizeof(UChar));
     if (rules == NULL)
     {
         return NULL;

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal.h
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal.h
@@ -73,6 +73,8 @@ U_CAPI int32_t U_EXPORT2 ucal_getWindowsTimeZoneID(const UChar* id, int32_t len,
     PER_FUNCTION_BLOCK(u_tolower, libicuuc, true) \
     PER_FUNCTION_BLOCK(u_toupper, libicuuc, true) \
     PER_FUNCTION_BLOCK(u_uastrcpy, libicuuc, true) \
+    PER_FUNCTION_BLOCK(ubrk_close, libicui18n, true) \
+    PER_FUNCTION_BLOCK(ubrk_openRules, libicui18n, true) \
     PER_FUNCTION_BLOCK(ucal_add, libicui18n, true) \
     PER_FUNCTION_BLOCK(ucal_close, libicui18n, true) \
     PER_FUNCTION_BLOCK(ucal_get, libicui18n, true) \
@@ -155,6 +157,7 @@ U_CAPI int32_t U_EXPORT2 ucal_getWindowsTimeZoneID(const UChar* id, int32_t len,
     PER_FUNCTION_BLOCK(ures_open, libicuuc, true) \
     PER_FUNCTION_BLOCK(usearch_close, libicui18n, true) \
     PER_FUNCTION_BLOCK(usearch_first, libicui18n, true) \
+    PER_FUNCTION_BLOCK(usearch_getBreakIterator, libicui18n, true) \
     PER_FUNCTION_BLOCK(usearch_getMatchedLength, libicui18n, true) \
     PER_FUNCTION_BLOCK(usearch_last, libicui18n, true) \
     PER_FUNCTION_BLOCK(usearch_openFromCollator, libicui18n, true) \
@@ -216,6 +219,8 @@ FOR_ALL_ICU_FUNCTIONS
 #define u_tolower(...) u_tolower_ptr(__VA_ARGS__)
 #define u_toupper(...) u_toupper_ptr(__VA_ARGS__)
 #define u_uastrcpy(...) u_uastrcpy_ptr(__VA_ARGS__)
+#define ubrk_close(...) ubrk_close_ptr(__VA_ARGS__)
+#define ubrk_openRules(...) ubrk_openRules_ptr(__VA_ARGS__)
 #define ucal_add(...) ucal_add_ptr(__VA_ARGS__)
 #define ucal_close(...) ucal_close_ptr(__VA_ARGS__)
 #define ucal_get(...) ucal_get_ptr(__VA_ARGS__)
@@ -310,6 +315,7 @@ FOR_ALL_ICU_FUNCTIONS
 #define ures_open(...) ures_open_ptr(__VA_ARGS__)
 #define usearch_close(...) usearch_close_ptr(__VA_ARGS__)
 #define usearch_first(...) usearch_first_ptr(__VA_ARGS__)
+#define usearch_getBreakIterator(...) usearch_getBreakIterator_ptr(__VA_ARGS__)
 #define usearch_getMatchedLength(...) usearch_getMatchedLength_ptr(__VA_ARGS__)
 #define usearch_last(...) usearch_last_ptr(__VA_ARGS__)
 #define usearch_openFromCollator(...) usearch_openFromCollator_ptr(__VA_ARGS__)

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal.h
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal.h
@@ -72,7 +72,7 @@ U_CAPI int32_t U_EXPORT2 ucal_getWindowsTimeZoneID(const UChar* id, int32_t len,
     PER_FUNCTION_BLOCK(u_strncpy, libicuuc, true) \
     PER_FUNCTION_BLOCK(u_tolower, libicuuc, true) \
     PER_FUNCTION_BLOCK(u_toupper, libicuuc, true) \
-    PER_FUNCTION_BLOCK(u_uastrcpy, libicuuc, true) \
+    PER_FUNCTION_BLOCK(u_uastrncpy, libicuuc, true) \
     PER_FUNCTION_BLOCK(ubrk_close, libicui18n, true) \
     PER_FUNCTION_BLOCK(ubrk_openRules, libicui18n, true) \
     PER_FUNCTION_BLOCK(ucal_add, libicui18n, true) \
@@ -218,7 +218,7 @@ FOR_ALL_ICU_FUNCTIONS
 #define u_strncpy(...) u_strncpy_ptr(__VA_ARGS__)
 #define u_tolower(...) u_tolower_ptr(__VA_ARGS__)
 #define u_toupper(...) u_toupper_ptr(__VA_ARGS__)
-#define u_uastrcpy(...) u_uastrcpy_ptr(__VA_ARGS__)
+#define u_uastrncpy(...) u_uastrncpy_ptr(__VA_ARGS__)
 #define ubrk_close(...) ubrk_close_ptr(__VA_ARGS__)
 #define ubrk_openRules(...) ubrk_openRules_ptr(__VA_ARGS__)
 #define ucal_add(...) ucal_add_ptr(__VA_ARGS__)

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal_android.h
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal_android.h
@@ -433,7 +433,6 @@ typedef struct UFieldPosition {
     int32_t endIndex;
 } UFieldPosition;
 
-
 void u_charsToUChars(const char * cs, UChar * us, int32_t length);
 void u_getVersion(UVersionInfo versionArray);
 int32_t u_strlen(const UChar * s);
@@ -443,6 +442,8 @@ UChar * u_strncpy(UChar * dst, const UChar * src, int32_t n);
 UChar32 u_tolower(UChar32 c);
 UChar32 u_toupper(UChar32 c);
 UChar* u_uastrcpy(UChar * dst, const char * src);
+void ubrk_close(UBreakIterator * bi);
+UBreakIterator* ubrk_openRules(const UChar * rules, int32_t rulesLength, const UChar * text, int32_t textLength, UParseError * parseErr, UErrorCode * status);
 void ucal_add(UCalendar * cal, UCalendarDateFields field, int32_t amount, UErrorCode * status);
 void ucal_close(UCalendar * cal);
 int32_t ucal_get(const UCalendar * cal, UCalendarDateFields field, UErrorCode * status);
@@ -532,6 +533,7 @@ const UChar * ures_getStringByIndex(const UResourceBundle * resourceBundle, int3
 UResourceBundle * ures_open(const char * packageName, const char * locale, UErrorCode * status);
 void usearch_close(UStringSearch * searchiter);
 int32_t usearch_first(UStringSearch * strsrch, UErrorCode * status);
+const UBreakIterator* usearch_getBreakIterator(const UStringSearch * strsrch);
 int32_t usearch_getMatchedLength(const UStringSearch * strsrch);
 int32_t usearch_last(UStringSearch * strsrch, UErrorCode * status);
 UStringSearch * usearch_openFromCollator(const UChar * pattern, int32_t patternlength, const UChar * text, int32_t textlength, const UCollator * collator, UBreakIterator * breakiter, UErrorCode * status);

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal_android.h
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal_android.h
@@ -441,7 +441,7 @@ UChar * u_strcpy(UChar * dst, const UChar * src);
 UChar * u_strncpy(UChar * dst, const UChar * src, int32_t n);
 UChar32 u_tolower(UChar32 c);
 UChar32 u_toupper(UChar32 c);
-UChar* u_uastrcpy(UChar * dst, const char * src);
+UChar* u_uastrncpy(UChar * dst, const char * src, int32_t n);
 void ubrk_close(UBreakIterator * bi);
 UBreakIterator* ubrk_openRules(const UChar * rules, int32_t rulesLength, const UChar * text, int32_t textLength, UParseError * parseErr, UErrorCode * status);
 void ucal_add(UCalendar * cal, UCalendarDateFields field, int32_t amount, UErrorCode * status);

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_timeZoneInfo.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_timeZoneInfo.c
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "pal_errors_internal.h"
 #include "pal_locale_internal.h"
@@ -223,7 +224,7 @@ static void FixupTimeZoneGenericDisplayName(const char* locale, const UChar* tim
         }
 
         // Make a UChar[] version of the test time zone id for use in the API calls.
-        u_uastrcpy(testTimeZoneId, testId);
+        u_uastrncpy(testTimeZoneId, testId, (int32_t)strlen(testId));
 
         // Get the standard name from the test time zone.
         GetTimeZoneDisplayName_FromCalendar(locale, testTimeZoneId, timestamp, UCAL_STANDARD, testDisplayName, DISPLAY_NAME_LENGTH, err);

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_timeZoneInfo.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_timeZoneInfo.c
@@ -5,7 +5,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include "pal_errors_internal.h"
 #include "pal_locale_internal.h"
@@ -224,7 +223,7 @@ static void FixupTimeZoneGenericDisplayName(const char* locale, const UChar* tim
         }
 
         // Make a UChar[] version of the test time zone id for use in the API calls.
-        u_uastrncpy(testTimeZoneId, testId, (int32_t)strlen(testId));
+        u_uastrncpy(testTimeZoneId, testId, TZID_LENGTH);
 
         // Get the standard name from the test time zone.
         GetTimeZoneDisplayName_FromCalendar(locale, testTimeZoneId, timestamp, UCAL_STANDARD, testDisplayName, DISPLAY_NAME_LENGTH, err);

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IndexOf.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IndexOf.cs
@@ -73,10 +73,6 @@ namespace System.Globalization.Tests
             yield return new object[] { s_invariantCompare, "TestFooBA\u0300R", "FooB\u00C0R", 0, 11, CompareOptions.IgnoreNonSpace, 4, 7 };
             yield return new object[] { s_invariantCompare, "o\u0308", "o", 0, 2, CompareOptions.None, -1, 0 };
             yield return new object[] { s_invariantCompare, "\r\n", "\n", 0, 2, CompareOptions.None, 1, 1 };
-            yield return new object[] { s_invariantCompare, "\u0600x", "x", 0, 2, CompareOptions.None, 1, 1 };
-            yield return new object[] { s_invariantCompare, "\u0601x", "x", 0, 2, CompareOptions.None, 1, 1 };
-            yield return new object[] { s_invariantCompare, "x\u0600", "x", 0, 2, CompareOptions.None, 0, 1 };
-            yield return new object[] { s_invariantCompare, "x\u0601", "x", 0, 2, CompareOptions.None, 0, 1 };
 
             // Weightless characters
             yield return new object[] { s_invariantCompare, "", "\u200d", 0, 0, CompareOptions.None, 0, 0 };

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IndexOf.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IndexOf.cs
@@ -72,6 +72,11 @@ namespace System.Globalization.Tests
             yield return new object[] { s_invariantCompare, "FooBar", "Foo\u0400Bar", 0, 6, CompareOptions.Ordinal, -1, 0 };
             yield return new object[] { s_invariantCompare, "TestFooBA\u0300R", "FooB\u00C0R", 0, 11, CompareOptions.IgnoreNonSpace, 4, 7 };
             yield return new object[] { s_invariantCompare, "o\u0308", "o", 0, 2, CompareOptions.None, -1, 0 };
+            yield return new object[] { s_invariantCompare, "\r\n", "\n", 0, 2, CompareOptions.None, 1, 1 };
+            yield return new object[] { s_invariantCompare, "\u0600x", "x", 0, 2, CompareOptions.None, 1, 1 };
+            yield return new object[] { s_invariantCompare, "\u0601x", "x", 0, 2, CompareOptions.None, 1, 1 };
+            yield return new object[] { s_invariantCompare, "x\u0600", "x", 0, 2, CompareOptions.None, 0, 1 };
+            yield return new object[] { s_invariantCompare, "x\u0601", "x", 0, 2, CompareOptions.None, 0, 1 };
 
             // Weightless characters
             yield return new object[] { s_invariantCompare, "", "\u200d", 0, 0, CompareOptions.None, 0, 0 };

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.LastIndexOf.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.LastIndexOf.cs
@@ -86,6 +86,11 @@ namespace System.Globalization.Tests
             yield return new object[] { s_invariantCompare, "FooBar", "Foo\u0400Bar", 5, 6, CompareOptions.Ordinal, -1, 0 };
             yield return new object[] { s_invariantCompare, "TestFooBA\u0300R", "FooB\u00C0R", 10, 11, CompareOptions.IgnoreNonSpace, 4, 7 };
             yield return new object[] { s_invariantCompare, "o\u0308", "o", 1, 2, CompareOptions.None, -1, 0 };
+            yield return new object[] { s_invariantCompare, "\r\n", "\n", 1, 2, CompareOptions.None, 1, 1 };
+            yield return new object[] { s_invariantCompare, "x\u0600", "x", 1, 2, CompareOptions.None, 0, 1 };
+            yield return new object[] { s_invariantCompare, "x\u0601", "x", 1, 2, CompareOptions.None, 0, 1 };
+            yield return new object[] { s_invariantCompare, "\u0600x", "x", 1, 2, CompareOptions.None, 1, 1 };
+            yield return new object[] { s_invariantCompare, "\u0601x", "x", 1, 2, CompareOptions.None, 1, 1 };
 
             // Weightless characters
             // NLS matches weightless characters at the end of the string

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.LastIndexOf.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.LastIndexOf.cs
@@ -87,10 +87,6 @@ namespace System.Globalization.Tests
             yield return new object[] { s_invariantCompare, "TestFooBA\u0300R", "FooB\u00C0R", 10, 11, CompareOptions.IgnoreNonSpace, 4, 7 };
             yield return new object[] { s_invariantCompare, "o\u0308", "o", 1, 2, CompareOptions.None, -1, 0 };
             yield return new object[] { s_invariantCompare, "\r\n", "\n", 1, 2, CompareOptions.None, 1, 1 };
-            yield return new object[] { s_invariantCompare, "x\u0600", "x", 1, 2, CompareOptions.None, 0, 1 };
-            yield return new object[] { s_invariantCompare, "x\u0601", "x", 1, 2, CompareOptions.None, 0, 1 };
-            yield return new object[] { s_invariantCompare, "\u0600x", "x", 1, 2, CompareOptions.None, 1, 1 };
-            yield return new object[] { s_invariantCompare, "\u0601x", "x", 1, 2, CompareOptions.None, 1, 1 };
 
             // Weightless characters
             // NLS matches weightless characters at the end of the string


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/43736

In .NET 5.0, we have switched to use the ICU library for Globalization support. We got some issues with the string search operations like `IndexOf, LastIndexOf, IsSuffix, and IsPrefix` APIs. The linked issues containing some details about such problems. One example, when searching for "\n" in the string "\r\n" get string not found as a result. 
The underlying cause of this behavior is ICU internally is using a break iterator which disallows breaking between some characters.
The provided solution here is we are customizing the break iterator to get the desired behavior.
