### PR TITLE
Get better assert failure in flaky FlushAsync_ThrowsIfWriterReaderWithException test

### DIFF
--- a/src/libraries/System.IO.Pipelines/tests/FlushAsyncTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/FlushAsyncTests.cs
@@ -49,7 +49,7 @@ namespace System.IO.Pipelines.Tests
             Assert.Equal("Reader exception", invalidOperationException.Message);
             Assert.Contains("ThrowTestException", invalidOperationException.StackTrace);
 
-            Assert.Single(Regex.Matches(invalidOperationException.StackTrace, "Pipe.GetFlushResult"));
+            Assert.Contains("Pipe.GetFlushResult", invalidOperationException.StackTrace);
         }
 
         [Fact]


### PR DESCRIPTION
This should give us a test failure like the following:

```
    Assert.Contains() Failure
Not found: Pipe.GetFlushResult2
In value:     at System.IO.Pipelines.Tests.FlushAsyncTests.<FlushAsync_ThrowsIfWriterReaderWithException>g__ThrowTestException|1_0() in C:\dev\dotnet\runtime\src\libraries\System.IO.Pipelines\tests\FlushAsyncTests.cs:line 32
--- End of stack trace from previous location ---
   at System.IO.Pipelines.Pipe.GetFlushResult(FlushResult& result) in C:\dev\dotnet\runtime\src\libraries\System.IO.Pipelines\src\System\IO\Pipelines\Pipe.cs:line 1021
   at System.IO.Pipelines.Pipe.PrepareFlush(CompletionData& completionData, ValueTask`1& result, CancellationToken cancellationToken) in C:\dev\dotnet\runtime\src\libraries\System.IO.Pipelines\src\System\IO\Pipelines\Pipe.cs:line 369
   at System.IO.Pipelines.Pipe.FlushAsync(CancellationToken cancellationToken) in C:\dev\dotnet\runtime\src\libraries\System.IO.Pipelines\src\System\IO\Pipelines\Pipe.cs:line 350
   at System.IO.Pipelines.Pipe.DefaultPipeWriter.FlushAsync(CancellationToken cancellationToken) in C:\dev\dotnet\runtime\src\libraries\System.IO.Pipelines\src\System\IO\Pipelines\Pipe.DefaultPipeWriter.cs:line 32
   at System.IO.Pipelines.Tests.FlushAsyncTests.<FlushAsync_ThrowsIfWriterReaderWithException>b__1_2() in C:\dev\dotnet\runtime\src\libraries\System.IO.Pipelines\tests\FlushAsyncTests.cs:line 48
   at Xunit.Assert.RecordExceptionAsync(Func`1 testCode) in C:\Dev\xunit\xunit\src\xunit.assert\Asserts\Record.cs:line 81
```

Instead of

```
     System.IO.Pipelines.Tests.FlushAsyncTests.FlushAsync_ThrowsIfWriterReaderWithException [FAIL]
       The collection was expected to contain a single element, but it was empty.
       Stack Trace:
         C:\dev\dotnet\runtime\src\libraries\System.IO.Pipelines\tests\FlushAsyncTests.cs(52,0): at System.IO.Pipelines.Tests.FlushAsyncTests.FlushAsync_ThrowsIfWriterReaderWithException()
         --- End of stack trace from previous location ---
```

I'm hoping this helps with debugging.

This is to help investigate #55435