### PR TITLE
Update helix version

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -18,9 +18,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>0bb1ae8e4c33203b81c9ed24e418a2b70f3c17ab</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="6.0.0-beta.21405.3">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="6.0.0-beta.21407.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>0bb1ae8e4c33203b81c9ed24e418a2b70f3c17ab</Sha>
+      <Sha>7a04201a936a34bb070145302fa3f0af2a018508</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.ApiCompat" Version="6.0.0-beta.21405.3">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/global.json
+++ b/global.json
@@ -14,7 +14,7 @@
   "msbuild-sdks": {
     "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "6.0.0-beta.21405.3",
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21405.3",
-    "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.21405.3",
+    "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.21407.1",
     "Microsoft.DotNet.SharedFramework.Sdk": "6.0.0-beta.21405.3",
     "Microsoft.Build.NoTargets": "3.0.4",
     "Microsoft.Build.Traversal": "3.0.23",


### PR DESCRIPTION
Update helix to pick up https://github.com/dotnet/arcade/pull/7723. Currently superpmi collection pipeline is failing because of this.