### PR TITLE
[mono] Check for additional implemented variant interfaces

### DIFF
--- a/src/mono/mono/metadata/class-setup-vtable.c
+++ b/src/mono/mono/metadata/class-setup-vtable.c
@@ -369,8 +369,8 @@ mono_class_setup_interface_offsets (MonoClass *klass)
 }
 
 
-#define DEBUG_INTERFACE_VTABLE_CODE 1
-#define TRACE_INTERFACE_VTABLE_CODE 1
+#define DEBUG_INTERFACE_VTABLE_CODE 0
+#define TRACE_INTERFACE_VTABLE_CODE 0
 #define VERIFY_INTERFACE_VTABLE_CODE 0
 #define VTABLE_SELECTOR (1)
 


### PR DESCRIPTION
If a class implements a variant interface, consider whether it is explicitly implementing (as opposed to obtaining by being a subclass of some base class) some variant interfaces.

Two examples:
```
public interface IFactory<out T> { T Get(); }
public class Foo {}
public class Bar : Foo {}
public class FooFactory : IFactory<Foo> { public Foo Get() => new Foo(); }
public class BarFactory : FooFactory, IFactory<Bar> { public new Bar Get() => new Bar(); }
```

In this case, `BarFactory` explicitly implements `IFactory<Bar>` and also `IFactory<Foo>`.

Conversely for contravariant gparams:
```
interface ITaker<in T> { string Consume (T x); }
class Foo {}
class Bar : Foo {}
class BarTaker : ITaker<Bar> { public string Consume (Bar x) => "consumed Bar"; }
class FooTaker : BarTaker, ITaker<Foo> { public string Consume (Foo x) => "consumed Foo"; }
```

In this case `FooTaker` implements `ITaker<Foo>` but also`ITaker<Bar>`.

When this happens, the signature of the implementing method `'Bar BarFactory:Get()'` doesn't match the signature of the implemented interface method `'Foo IFactory<Foo>:Get()'`.

We should check the signature parameters of the candidate method and the implemented method, but I think the interface setup code already checks this for us.

Fixes https://github.com/dotnet/runtime/issues/48512