### PR TITLE
Improve GUI error dialog when no runtime is installed

### DIFF
--- a/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
@@ -494,11 +494,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             }
         }
 
-        [Theory]
+        [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // GUI app host is only supported on Windows.
-        [InlineData(true)]
-        [InlineData(false)]
-        public void AppHost_GUI_FrameworkDependent_MissingRuntimeFramework_ErrorReportedInDialog(bool missingHostfxr)
+        public void AppHost_GUI_FrameworkDependent_MissingRuntimeFramework_ErrorReportedInDialog()
         {
             var fixture = sharedTestState.PortableAppFixture_Built
                 .Copy();
@@ -515,22 +513,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
                 string expectedErrorCode;
                 string expectedUrlQuery;
-                string expectedUrlParameter = null;
-                if (missingHostfxr)
-                {
-                    expectedErrorCode = Constants.ErrorCode.CoreHostLibMissingFailure.ToString("x");
-                    expectedUrlQuery = "missing_runtime=true&";
-                    expectedUrlParameter = $"&apphost_version={sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}";
-                }
-                else
-                {
-                    invalidDotNet = new DotNetBuilder(invalidDotNet, sharedTestState.RepoDirectories.BuiltDotnet, "missingFramework")
-                        .Build()
-                        .BinPath;
-                    expectedErrorCode = Constants.ErrorCode.FrameworkMissingFailure.ToString("x");
-                    expectedUrlQuery = $"framework={Constants.MicrosoftNETCoreApp}&framework_version={sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}";
-                }
+                invalidDotNet = new DotNetBuilder(invalidDotNet, sharedTestState.RepoDirectories.BuiltDotnet, "missingFramework")
+                    .Build()
+                    .BinPath;
 
+                expectedErrorCode = Constants.ErrorCode.FrameworkMissingFailure.ToString("x");
+                expectedUrlQuery = $"framework={Constants.MicrosoftNETCoreApp}&framework_version={sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}";
                 Command command = Command.Create(appExe)
                     .EnableTracingAndCaptureOutputs()
                     .DotNetRoot(invalidDotNet)
@@ -541,22 +529,16 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 command.Process.Kill();
 
                 var result = command.WaitForExit(true)
-                    .Should().Fail();
-
-                result.And.HaveStdErrContaining($"Showing error dialog for application: '{Path.GetFileName(appExe)}' - error code: 0x{expectedErrorCode}")
+                    .Should().Fail()
+                    .And.HaveStdErrContaining($"Showing error dialog for application: '{Path.GetFileName(appExe)}' - error code: 0x{expectedErrorCode}")
                     .And.HaveStdErrContaining($"url: 'https://aka.ms/dotnet-core-applaunch?{expectedUrlQuery}")
                     .And.HaveStdErrContaining("&gui=true");
-
-                if (expectedUrlParameter != null)
-                {
-                    result.And.HaveStdErrContaining(expectedUrlParameter);
-                }
             }
         }
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
-        public void AppHost_GUI_RuntimeMissing_PrintArchitectureAndRuntimeVersionOnDialog()
+        public void AppHost_GUI_MissingRuntime_ErrorReportedInDialog()
         {
             var fixture = sharedTestState.PortableAppFixture_Built
                 .Copy();
@@ -567,25 +549,26 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             AppHostExtensions.SetWindowsGraphicalUserInterfaceBit(appExe);
 
             string invalidDotNet = SharedFramework.CalculateUniqueTestDirectory(Path.Combine(TestArtifact.TestArtifactsPath, "guiErrors"));
-            Directory.CreateDirectory(invalidDotNet);
-            File.Copy(sharedTestState.BuiltDotNet.DotnetExecutablePath, Path.Combine(invalidDotNet, "dotnet.exe"), true);
+            using (new TestArtifact(invalidDotNet))
+            {
+                Directory.CreateDirectory(invalidDotNet);
+                var command = Command.Create(appExe)
+                    .EnableTracingAndCaptureOutputs()
+                    .DotNetRoot(invalidDotNet)
+                    .MultilevelLookup(false)
+                    .Start();
 
-            var command = Command.Create(appExe)
-                .EnableTracingAndCaptureOutputs()
-                .DotNetRoot(invalidDotNet)
-                .MultilevelLookup(false)
-                .Start();
+                WaitForPopupFromProcess(command.Process);
+                command.Process.Kill();
 
-            WaitForPopupFromProcess(command.Process);
-            command.Process.Kill();
-
-            var expectedErrorCode = Constants.ErrorCode.CoreHostLibMissingFailure.ToString("x");
-            var result = command.WaitForExit(true)
-                .Should().Fail()
-                .And.HaveStdErrContaining($"Showing error dialog for application: '{Path.GetFileName(appExe)}' - error code: 0x{expectedErrorCode}")
-                .And.HaveStdErrContaining($"url: 'https://aka.ms/dotnet-core-applaunch?missing_runtime=true")
-                .And.HaveStdErrContaining("gui=true")
-                .And.HaveStdErrContaining($"&apphost_version={sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}");
+                var expectedErrorCode = Constants.ErrorCode.CoreHostLibMissingFailure.ToString("x");
+                var result = command.WaitForExit(true)
+                    .Should().Fail()
+                    .And.HaveStdErrContaining($"Showing error dialog for application: '{Path.GetFileName(appExe)}' - error code: 0x{expectedErrorCode}")
+                    .And.HaveStdErrContaining($"url: 'https://aka.ms/dotnet-core-applaunch?missing_runtime=true")
+                    .And.HaveStdErrContaining("gui=true")
+                    .And.HaveStdErrContaining($"&apphost_version={sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}");
+            }
         }
 
         [Fact]

--- a/src/native/corehost/apphost/apphost.windows.cpp
+++ b/src/native/corehost/apphost/apphost.windows.cpp
@@ -61,11 +61,12 @@ namespace
         if (pal::getenv(_X("DOTNET_DISABLE_GUI_ERRORS"), &gui_errors_disabled) && pal::xtoi(gui_errors_disabled.c_str()) == 1)
             return;
 
-        pal::string_t dialogMsg = _X("To run this application, you must install .NET.\n\n");
+        pal::string_t dialogMsg;
         pal::string_t url;
         const pal::string_t url_prefix = _X("  - ") DOTNET_CORE_APPLAUNCH_URL _X("?");
         if (error_code == StatusCode::CoreHostLibMissingFailure)
         {
+            dialogMsg = pal::string_t(_X("To run this application, you must install .NET Desktop Runtime ")) + _STRINGIFY(COMMON_HOST_PKG_VER) + _X(" (") + get_arch() + _X(").\n\n");
             pal::string_t line;
             pal::stringstream_t ss(g_buffered_errors);
             while (std::getline(ss, line, _X('\n'))) {
@@ -81,6 +82,7 @@ namespace
         {
             // We don't have a great way of passing out different kinds of detailed error info across components, so
             // just match the expected error string. See fx_resolver.messages.cpp.
+            dialogMsg = pal::string_t(_X("To run this application, you must install .NET.\n\n"));
             pal::string_t line;
             pal::stringstream_t ss(g_buffered_errors);
             while (std::getline(ss, line, _X('\n'))){


### PR DESCRIPTION
This adds information about the runtime version and architecture that the user needs to install in order to execute the failing application. Related to #3816.

Here's an example of how the dialog would look like: 
![image](https://user-images.githubusercontent.com/3836488/128774746-03846ac8-7b77-49fd-b95a-822f628d8075.png)

This makes the implicit assumption that, because we are running a GUI app, the user needs to install desktop runtime.