### PR TITLE
[iOS] Make sure IPGlobalProperties and NetworkInterface.GetIsNetworkAvailable methods return the correct info

### DIFF
--- a/src/libraries/Native/Unix/Common/pal_config.h.in
+++ b/src/libraries/Native/Unix/Common/pal_config.h.in
@@ -78,6 +78,10 @@
 #cmakedefine01 HAVE_NETINET_IP_VAR_H
 #cmakedefine01 HAVE_NETINET_ICMP_VAR_H
 #cmakedefine01 HAVE_IOS_NET_ROUTE_H
+#cmakedefine01 HAVE_IOS_NETINET_IP_VAR_H
+#cmakedefine01 HAVE_IOS_NETINET_ICMP_VAR_H
+#cmakedefine01 HAVE_IOS_NETINET_TCPFSM_H
+#cmakedefine01 HAVE_IOS_NETINET_UDP_VAR_H
 #cmakedefine01 HAVE_RT_MSGHDR
 #cmakedefine01 HAVE_RT_MSGHDR2
 #cmakedefine01 HAVE_IF_MSGHDR2
@@ -88,6 +92,7 @@
 #cmakedefine01 HAVE_NET_IF_ARP_H
 #cmakedefine01 HAVE_SYS_MNTENT_H
 #cmakedefine01 HAVE_NET_IFMEDIA_H
+#cmakedefine01 HAVE_IOS_NET_IFMEDIA_H
 #cmakedefine01 HAVE_LINUX_RTNETLINK_H
 #cmakedefine01 HAVE_LINUX_CAN_H
 #cmakedefine01 HAVE_GETDOMAINNAME_SIZET

--- a/src/libraries/Native/Unix/System.Native/ios/net/if_media.h
+++ b/src/libraries/Native/Unix/System.Native/ios/net/if_media.h
@@ -1,0 +1,589 @@
+/*
+ * Copyright (c) 2000-2019 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ *
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+/*	$NetBSD: if_media.h,v 1.3 1997/03/26 01:19:27 thorpej Exp $	*/
+/* $FreeBSD: src/sys/net/if_media.h,v 1.9.2.1 2001/07/04 00:12:38 brooks Exp $ */
+
+/*
+ * Copyright (c) 1997
+ *	Jonathan Stone and Jason R. Thorpe.  All rights reserved.
+ *
+ * This software is derived from information provided by Matt Thomas.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by Jonathan Stone
+ *	and Jason R. Thorpe for the NetBSD Project.
+ * 4. The names of the authors may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _NET_IF_MEDIA_H_
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-id-macro"
+#define _NET_IF_MEDIA_H_
+#pragma clang diagnostic pop
+#ifndef DRIVERKIT
+#include <sys/appleapiopts.h>
+#endif /* DRIVERKIT */
+
+/*
+ * Prototypes and definitions for BSD/OS-compatible network interface
+ * media selection.
+ *
+ * Where it is safe to do so, this code strays slightly from the BSD/OS
+ * design.  Software which uses the API (device drivers, basically)
+ * shouldn't notice any difference.
+ *
+ * Many thanks to Matt Thomas for providing the information necessary
+ * to implement this interface.
+ */
+
+#ifdef KERNEL_PRIVATE
+/* sigh; some modules are lazy and thus rely on this */
+#include <sys/queue.h>
+#endif /* KERNEL_PRIVATE */
+
+/*
+ * if_media Options word:
+ *	Bits	Use
+ *	----	-------
+ *	0-4	Media variant
+ *	5-7     Media type
+ *	8-15	Type specific options
+ *	16-19	Extended media variant bits
+ *	20-27	Shared (global) options
+ *	28-31	Instance
+ */
+
+/*
+ * Ethernet
+ *
+ * In order to use more than 31 subtypes, Ethernet uses the extended media
+ * variant bits
+ *
+ * The extended media variant bits are not backward compatible so they
+ * must not be used by kernel extensions like ifnet and drivers that
+ * are to be deployed on older system versions
+ */
+#define IFM_X(x) IFM_X_SUBTYPE(x)   /* internal shorthand */
+
+#define IFM_ETHER       0x00000020
+#define IFM_10_T        3               /* 10BaseT - RJ45 */
+#define IFM_10_2        4               /* 10Base2 - Thinnet */
+#define IFM_10_5        5               /* 10Base5 - AUI */
+#define IFM_100_TX      6               /* 100BaseTX - RJ45 */
+#define IFM_100_FX      7               /* 100BaseFX - Fiber */
+#define IFM_100_T4      8               /* 100BaseT4 - 4 pair cat 3 */
+#define IFM_100_VG      9               /* 100VG-AnyLAN */
+#define IFM_100_T2      10              /* 100BaseT2 */
+#define IFM_1000_SX     11              /* 1000BaseSX - multi-mode fiber */
+#define IFM_10_STP      12              /* 10BaseT over shielded TP */
+#define IFM_10_FL       13              /* 10baseFL - Fiber */
+#define IFM_1000_LX     14              /* 1000baseLX - single-mode fiber */
+#define IFM_1000_CX     15              /* 1000baseCX - 150ohm STP */
+#define IFM_1000_T      16              /* 1000baseT - 4 pair cat 5 */
+#ifdef PRIVATE
+#define IFM_1000_TX     IFM_1000_T      /* For compatibility */
+#endif /* PRIVATE */
+#define IFM_HPNA_1      17              /* HomePNA 1.0 (1Mb/s) */
+#define IFM_10G_SR      18              /* 10GbaseSR - multi-mode fiber */
+#define IFM_10G_LR      19              /* 10GbaseLR - single-mode fiber */
+#define IFM_10G_CX4     20              /* 10GbaseCX4 - copper */
+#define IFM_10G_T       21              /* 10GbaseT - 4 pair cat 6 */
+#define IFM_2500_T      22              /* 2500baseT - 4 pair cat 5 */
+#define IFM_5000_T      23              /* 5000baseT - 4 pair cat 5 */
+#define IFM_1000_CX_SGMII    24         /* 1000Base-CX-SGMII */
+#define IFM_1000_KX     25              /* 1000Base-KX backplane */
+#define IFM_10G_KX4     26              /* 10GBase-KX4 backplane */
+#define IFM_10G_KR      27              /* 10GBase-KR backplane */
+#define IFM_10G_CR1     28              /* 10GBase-CR1 Twinax splitter */
+#define IFM_10G_ER      29              /* 10GBase-ER */
+#define IFM_20G_KR2     30              /* 20GBase-KR2 backplane */
+#define IFM_OTHER       31              /* Other: one of the following */
+
+/* following types are not visible to old binaries using the low bits of IFM_TMASK */
+#define IFM_2500_SX     IFM_X(32)       /* 2500BaseSX - multi-mode fiber */
+#define IFM_10G_TWINAX  IFM_X(33)       /* 10GBase Twinax copper */
+#define IFM_10G_TWINAX_LONG     IFM_X(34)       /* 10GBase Twinax Long copper */
+#define IFM_10G_LRM     IFM_X(35)       /* 10GBase-LRM 850nm Multi-mode */
+#define IFM_2500_KX     IFM_X(36)       /* 2500Base-KX backplane */
+#define IFM_40G_CR4     IFM_X(37)       /* 40GBase-CR4 */
+#define IFM_40G_SR4     IFM_X(38)       /* 40GBase-SR4 */
+#define IFM_50G_PCIE    IFM_X(39)       /* 50G Ethernet over PCIE */
+#define IFM_25G_PCIE    IFM_X(40)       /* 25G Ethernet over PCIE */
+#define IFM_1000_SGMII  IFM_X(41)       /* 1G media interface */
+#define IFM_10G_SFI     IFM_X(42)       /* 10G media interface */
+#define IFM_40G_XLPPI   IFM_X(43)       /* 40G media interface */
+#define IFM_40G_LR4     IFM_X(44)       /* 40GBase-LR4 */
+#define IFM_40G_KR4     IFM_X(45)       /* 40GBase-KR4 */
+#define IFM_100G_CR4    IFM_X(47)       /* 100GBase-CR4 */
+#define IFM_100G_SR4    IFM_X(48)       /* 100GBase-SR4 */
+#define IFM_100G_KR4    IFM_X(49)       /* 100GBase-KR4 */
+#define IFM_100G_LR4    IFM_X(50)       /* 100GBase-LR4 */
+#define IFM_56G_R4      IFM_X(51)       /* 56GBase-R4 */
+#define IFM_100_T       IFM_X(52)       /* 100BaseT - RJ45 */
+#define IFM_25G_CR      IFM_X(53)       /* 25GBase-CR */
+#define IFM_25G_KR      IFM_X(54)       /* 25GBase-KR */
+#define IFM_25G_SR      IFM_X(55)       /* 25GBase-SR */
+#define IFM_50G_CR2     IFM_X(56)       /* 50GBase-CR2 */
+#define IFM_50G_KR2     IFM_X(57)       /* 50GBase-KR2 */
+#define IFM_25G_LR      IFM_X(58)       /* 25GBase-LR */
+#define IFM_10G_AOC     IFM_X(59)       /* 10G active optical cable */
+#define IFM_25G_ACC     IFM_X(60)       /* 25G active copper cable */
+#define IFM_25G_AOC     IFM_X(61)       /* 25G active optical cable */
+#define IFM_100_SGMII   IFM_X(62)       /* 100M media interface */
+#define IFM_2500_X      IFM_X(63)       /* 2500BaseX */
+#define IFM_5000_KR     IFM_X(64)       /* 5GBase-KR backplane */
+#define IFM_25G_T       IFM_X(65)       /* 25GBase-T - RJ45 */
+#define IFM_25G_CR_S    IFM_X(66)       /* 25GBase-CR (short) */
+#define IFM_25G_CR1     IFM_X(67)       /* 25GBase-CR1 DA cable */
+#define IFM_25G_KR_S    IFM_X(68)       /* 25GBase-KR (short) */
+#define IFM_5000_KR_S   IFM_X(69)       /* 5GBase-KR backplane (short) */
+#define IFM_5000_KR1    IFM_X(70)       /* 5GBase-KR backplane */
+#define IFM_25G_AUI     IFM_X(71)       /* 25G-AUI-C2C (chip to chip) */
+#define IFM_40G_XLAUI   IFM_X(72)       /* 40G-XLAUI */
+#define IFM_40G_XLAUI_AC IFM_X(73)      /* 40G active copper/optical */
+#define IFM_40G_ER4     IFM_X(74)       /* 40GBase-ER4 */
+#define IFM_50G_SR2     IFM_X(75)       /* 50GBase-SR2 */
+#define IFM_50G_LR2     IFM_X(76)       /* 50GBase-LR2 */
+#define IFM_50G_LAUI2_AC IFM_X(77)      /* 50G active copper/optical */
+#define IFM_50G_LAUI2   IFM_X(78)       /* 50G-LAUI2 */
+#define IFM_50G_AUI2_AC IFM_X(79)       /* 50G active copper/optical */
+#define IFM_50G_AUI2    IFM_X(80)       /* 50G-AUI2 */
+#define IFM_50G_CP      IFM_X(81)       /* 50GBase-CP */
+#define IFM_50G_SR      IFM_X(82)       /* 50GBase-SR */
+#define IFM_50G_LR      IFM_X(83)       /* 50GBase-LR */
+#define IFM_50G_FR      IFM_X(84)       /* 50GBase-FR */
+#define IFM_50G_KR_PAM4 IFM_X(85)       /* 50GBase-KR PAM4 */
+#define IFM_25G_KR1     IFM_X(86)       /* 25GBase-KR1 */
+#define IFM_50G_AUI1_AC IFM_X(87)       /* 50G active copper/optical */
+#define IFM_50G_AUI1    IFM_X(88)       /* 50G-AUI1 */
+#define IFM_100G_CAUI4_AC IFM_X(89)     /* 100G-CAUI4 active copper/optical */
+#define IFM_100G_CAUI4 IFM_X(90)        /* 100G-CAUI4 */
+#define IFM_100G_AUI4_AC IFM_X(91)      /* 100G-AUI4 active copper/optical */
+#define IFM_100G_AUI4   IFM_X(92)       /* 100G-AUI4 */
+#define IFM_100G_CR_PAM4 IFM_X(93)      /* 100GBase-CR PAM4 */
+#define IFM_100G_KR_PAM4 IFM_X(94)      /* 100GBase-CR PAM4 */
+#define IFM_100G_CP2    IFM_X(95)       /* 100GBase-CP2 */
+#define IFM_100G_SR2    IFM_X(96)       /* 100GBase-SR2 */
+#define IFM_100G_DR     IFM_X(97)       /* 100GBase-DR */
+#define IFM_100G_KR2_PAM4 IFM_X(98)     /* 100GBase-KR2 PAM4 */
+#define IFM_100G_CAUI2_AC IFM_X(99)     /* 100G-CAUI2 active copper/optical */
+#define IFM_100G_CAUI2  IFM_X(100)      /* 100G-CAUI2 */
+#define IFM_100G_AUI2_AC IFM_X(101)     /* 100G-AUI2 active copper/optical */
+#define IFM_100G_AUI2   IFM_X(102)      /* 100G-AUI2 */
+#define IFM_200G_CR4_PAM4 IFM_X(103)    /* 200GBase-CR4 PAM4 */
+#define IFM_200G_SR4    IFM_X(104)      /* 200GBase-SR4 */
+#define IFM_200G_FR4    IFM_X(105)      /* 200GBase-FR4 */
+#define IFM_200G_LR4    IFM_X(106)      /* 200GBase-LR4 */
+#define IFM_200G_DR4    IFM_X(107)      /* 200GBase-DR4 */
+#define IFM_200G_KR4_PAM4 IFM_X(108)    /* 200GBase-KR4 PAM4 */
+#define IFM_200G_AUI4_AC IFM_X(109)     /* 200G-AUI4 active copper/optical */
+#define IFM_200G_AUI4   IFM_X(110)      /* 200G-AUI4 */
+#define IFM_200G_AUI8_AC IFM_X(111)     /* 200G-AUI8 active copper/optical */
+#define IFM_200G_AUI8   IFM_X(112)      /* 200G-AUI8 */
+#define IFM_400G_FR8    IFM_X(113)      /* 400GBase-FR8 */
+#define IFM_400G_LR8    IFM_X(114)      /* 400GBase-LR8 */
+#define IFM_400G_DR4    IFM_X(115)      /* 400GBase-DR4 */
+#define IFM_400G_AUI8_AC IFM_X(116)     /* 400G-AUI8 active copper/optical */
+#define IFM_400G_AUI8   IFM_X(117)      /* 400G-AUI8 */
+
+/*
+ * Token ring
+ */
+#define IFM_TOKEN       0x00000040
+#define IFM_TOK_STP4    3               /* Shielded twisted pair 4m - DB9 */
+#define IFM_TOK_STP16   4               /* Shielded twisted pair 16m - DB9 */
+#define IFM_TOK_UTP4    5               /* Unshielded twisted pair 4m - RJ45 */
+#define IFM_TOK_UTP16   6               /* Unshielded twisted pair 16m - RJ45 */
+#define IFM_TOK_STP100  7               /* Shielded twisted pair 100m - DB9 */
+#define IFM_TOK_UTP100  8               /* Unshielded twisted pair 100m - RJ45 */
+#define IFM_TOK_ETR     0x00000200      /* Early token release */
+#define IFM_TOK_SRCRT   0x00000400      /* Enable source routing features */
+#define IFM_TOK_ALLR    0x00000800      /* All routes / Single route bcast */
+#define IFM_TOK_DTR     0x00002000      /* Dedicated token ring */
+#define IFM_TOK_CLASSIC 0x00004000      /* Classic token ring */
+#define IFM_TOK_AUTO    0x00008000      /* Automatic Dedicate/Classic token ring */
+
+/*
+ * FDDI
+ */
+#define IFM_FDDI        0x00000060
+#define IFM_FDDI_SMF    3               /* Single-mode fiber */
+#define IFM_FDDI_MMF    4               /* Multi-mode fiber */
+#define IFM_FDDI_UTP    5               /* CDDI / UTP */
+#define IFM_FDDI_DA     0x00000100      /* Dual attach / single attach */
+
+/*
+ * IEEE 802.11 Wireless
+ */
+#define IFM_IEEE80211   0x00000080
+#define IFM_IEEE80211_FH1       3       /* Frequency Hopping 1Mbps */
+#define IFM_IEEE80211_FH2       4       /* Frequency Hopping 2Mbps */
+#define IFM_IEEE80211_DS2       5       /* Direct Sequence 2Mbps */
+#define IFM_IEEE80211_DS5       6       /* Direct Sequence 5Mbps*/
+#define IFM_IEEE80211_DS11      7       /* Direct Sequence 11Mbps*/
+#define IFM_IEEE80211_DS1       8       /* Direct Sequence 1Mbps */
+#define IFM_IEEE80211_DS22      9       /* Direct Sequence 22Mbps */
+#define IFM_IEEE80211_ADHOC     0x00000100      /* Operate in Adhoc mode */
+
+/*
+ * Shared media sub-types
+ */
+#define IFM_AUTO        0               /* Autoselect best media */
+#define IFM_MANUAL      1               /* Jumper/dipswitch selects media */
+#define IFM_NONE        2               /* Deselect all media */
+
+/*
+ * Shared options
+ */
+#define IFM_FDX         0x00100000      /* Force full duplex */
+#define IFM_HDX         0x00200000      /* Force half duplex */
+#define IFM_FLOW        0x00400000      /* enable hardware flow control */
+#define IFM_EEE         0x00800000      /* Support energy efficient ethernet */
+#define IFM_FLAG0       0x01000000      /* Driver defined flag */
+#define IFM_FLAG1       0x02000000      /* Driver defined flag */
+#define IFM_FLAG2       0x04000000      /* Driver defined flag */
+#define IFM_LOOP        0x08000000      /* Put hardware in loopback */
+
+/*
+ * Macros to access bits of extended media sub-types (media variants)
+ */
+#define IFM_TMASK_COMPAT        0x0000001f      /* Lower bits of media sub-type */
+#define IFM_TMASK_EXT           0x000f0000      /* For extended media sub-type */
+#define IFM_TMASK_EXT_SHIFT     11              /* to extract high bits */
+#define IFM_X_SUBTYPE(x) (((x) & IFM_TMASK_COMPAT) | \
+	(((x) & (IFM_TMASK_EXT >> IFM_TMASK_EXT_SHIFT)) << IFM_TMASK_EXT_SHIFT))
+
+/*
+ * Masks
+ */
+#define IFM_NMASK       0x000000e0      /* Network type */
+#define IFM_TMASK       (IFM_TMASK_COMPAT|IFM_TMASK_EXT)    /* Media sub-type */
+#define IFM_IMASK       0xf0000000      /* Instance */
+#define IFM_ISHIFT      28              /* Instance shift */
+#define IFM_OMASK       0x0000ff00      /* Type specific options */
+#define IFM_GMASK       0x0ff00000      /* Global options */
+
+/*
+ * Status bits
+ */
+#define IFM_AVALID      0x00000001      /* Active bit valid */
+#define IFM_ACTIVE      0x00000002      /* Interface attached to working net */
+#define IFM_WAKESAMENET 0x00000004      /* No link transition while asleep */
+
+/*
+ * Macros to extract various bits of information from the media word.
+ */
+#define IFM_TYPE(x)         ((x) & IFM_NMASK)
+#define IFM_SUBTYPE(x)      ((x) & IFM_TMASK)
+#define IFM_TYPE_OPTIONS(x) ((x) & IFM_OMASK)
+#define IFM_INST(x)         (((x) & IFM_IMASK) >> IFM_ISHIFT)
+#define IFM_OPTIONS(x)  ((x) & (IFM_OMASK|IFM_GMASK))
+
+#define IFM_INST_MAX    IFM_INST(IFM_IMASK)
+
+/*
+ * Macro to create a media word.
+ */
+#define IFM_MAKEWORD(type, subtype, options, instance)                  \
+	((type) | (subtype) | (options) | ((instance) << IFM_ISHIFT))
+
+/*
+ * NetBSD extension not defined in the BSDI API.  This is used in various
+ * places to get the canonical description for a given type/subtype.
+ *
+ * NOTE: all but the top-level type descriptions must contain NO whitespace!
+ * Otherwise, parsing these in ifconfig(8) would be a nightmare.
+ */
+struct ifmedia_description {
+	int     ifmt_word;              /* word value; may be masked */
+	const char *ifmt_string;        /* description */
+};
+
+#define IFM_TYPE_DESCRIPTIONS {                     \
+    { IFM_ETHER,     "Ethernet"   },                \
+    { IFM_TOKEN,     "Token ring" },                \
+    { IFM_FDDI,      "FDDI"       },                \
+    { IFM_IEEE80211, "IEEE802.11" },                \
+    { 0, NULL },                                    \
+}
+
+#define IFM_SUBTYPE_ETHERNET_DESCRIPTIONS {         \
+    { IFM_10_T,     "10baseT/UTP" },                \
+    { IFM_10_2,     "10base2/BNC" },                \
+    { IFM_10_5,     "10base5/AUI" },                \
+    { IFM_100_TX,   "100baseTX"   },                \
+    { IFM_100_FX,   "100baseFX"   },                \
+    { IFM_100_T4,   "100baseT4"   },                \
+    { IFM_100_VG,   "100baseVG"   },                \
+    { IFM_100_T2,   "100baseT2"   },                \
+    { IFM_10_STP,   "10baseSTP"   },                \
+    { IFM_10_FL,    "10baseFL"    },                \
+    { IFM_1000_SX,              "1000baseSX" },                         \
+    { IFM_1000_LX,  "1000baseLX"  },                \
+    { IFM_1000_CX,  "1000baseCX"  },                \
+    { IFM_1000_T,   "1000baseT"   },                \
+    { IFM_HPNA_1,               "homePNA" },                            \
+    { IFM_10G_LR,               "10Gbase-LR" },                         \
+    { IFM_10G_SR,               "10Gbase-SR" },                         \
+    { IFM_10G_CX4,              "10Gbase-CX4" },                        \
+    { IFM_2500_SX,              "2500BaseSX" },                         \
+    { IFM_10G_LRM,              "10Gbase-LRM" },                        \
+    { IFM_10G_TWINAX,           "10Gbase-Twinax" },                     \
+    { IFM_10G_TWINAX_LONG,      "10Gbase-Twinax-Long" },                \
+    { IFM_10G_T,                "10Gbase-T" },                          \
+    { IFM_40G_CR4,              "40Gbase-CR4" },                        \
+    { IFM_40G_SR4,              "40Gbase-SR4" },                        \
+    { IFM_40G_LR4,              "40Gbase-LR4" },                        \
+    { IFM_1000_KX,  "1000Base-KX" },                \
+    { IFM_OTHER,                "Other" },                              \
+    { IFM_10G_KX4,  "10GBase-KX4" },                \
+    { IFM_10G_KR,   "10GBase-KR" },                 \
+    { IFM_10G_CR1,  "10GBase-CR1" },                \
+    { IFM_20G_KR2,              "20GBase-KR2" },                        \
+    { IFM_2500_KX,              "2500Base-KX" },                        \
+    { IFM_2500_T,               "2500Base-T" },                         \
+    { IFM_5000_T,               "5000Base-T" },                         \
+    { IFM_50G_PCIE,             "PCIExpress-50G" },                     \
+    { IFM_25G_PCIE,             "PCIExpress-25G" },                     \
+    { IFM_1000_SGMII,           "1000Base-SGMII" },                     \
+    { IFM_10G_SFI,              "10GBase-SFI" },                        \
+    { IFM_40G_XLPPI,            "40GBase-XLPPI" },                      \
+    { IFM_1000_CX_SGMII,        "1000Base-CX-SGMII" },                  \
+    { IFM_40G_KR4,              "40GBase-KR4" },                        \
+    { IFM_10G_ER,   "10GBase-ER" },                 \
+    { IFM_100G_CR4,             "100GBase-CR4" },                       \
+    { IFM_100G_SR4,             "100GBase-SR4" },                       \
+    { IFM_100G_KR4,             "100GBase-KR4" },                       \
+    { IFM_100G_LR4,             "100GBase-LR4" },                       \
+    { IFM_56G_R4,               "56GBase-R4" },                         \
+    { IFM_100_T,                "100BaseT" },                           \
+    { IFM_25G_CR,   "25GBase-CR" },                 \
+    { IFM_25G_KR,   "25GBase-KR" },                 \
+    { IFM_25G_SR,   "25GBase-SR" },                 \
+    { IFM_50G_CR2,  "50GBase-CR2" },                \
+    { IFM_50G_KR2,  "50GBase-KR2" },                \
+    { IFM_25G_LR,               "25GBase-LR" },                         \
+    { IFM_10G_AOC,              "10GBase-AOC" },                        \
+    { IFM_25G_ACC,              "25GBase-ACC" },                        \
+    { IFM_25G_AOC,              "25GBase-AOC" },                        \
+    { IFM_100_SGMII,            "100M-SGMII" },                         \
+    { IFM_2500_X,               "2500Base-X" },                         \
+    { IFM_5000_KR,              "5000Base-KR" },                        \
+    { IFM_25G_T,                "25GBase-T" },                          \
+    { IFM_25G_CR_S,             "25GBase-CR-S" },                       \
+    { IFM_25G_CR1,              "25GBase-CR1" },                        \
+    { IFM_25G_KR_S,             "25GBase-KR-S" },                       \
+    { IFM_5000_KR_S,            "5000Base-KR-S" },                      \
+    { IFM_5000_KR1,             "5000Base-KR1" },                       \
+    { IFM_25G_AUI,              "25G-AUI" },                            \
+    { IFM_40G_XLAUI,            "40G-XLAUI" },                          \
+    { IFM_40G_XLAUI_AC,         "40G-XLAUI-AC" },                       \
+    { IFM_40G_ER4,              "40GBase-ER4" },                        \
+    { IFM_50G_SR2,  "50GBase-SR2" },                \
+    { IFM_50G_LR2,  "50GBase-LR2" },                \
+    { IFM_50G_LAUI2_AC,         "50G-LAUI2-AC" },                       \
+    { IFM_50G_LAUI2,            "50G-LAUI2" },                          \
+    { IFM_50G_AUI2_AC,          "50G-AUI2-AC" },                        \
+    { IFM_50G_AUI2,             "50G-AUI2" },                           \
+    { IFM_50G_CP,               "50GBase-CP" },                         \
+    { IFM_50G_SR,               "50GBase-SR" },                         \
+    { IFM_50G_LR,               "50GBase-LR" },                         \
+    { IFM_50G_FR,               "50GBase-FR" },                         \
+    { IFM_50G_KR_PAM4,          "50GBase-KR-PAM4" },                    \
+    { IFM_25G_KR1,              "25GBase-KR1" },                        \
+    { IFM_50G_AUI1_AC,          "50G-AUI1-AC" },                        \
+    { IFM_50G_AUI1,             "50G-AUI1" },                           \
+    { IFM_100G_CAUI4_AC,        "100G-CAUI4-AC" },                      \
+    { IFM_100G_CAUI4,           "100G-CAUI4" },                         \
+    { IFM_100G_AUI4_AC,         "100G-AUI4-AC" },                       \
+    { IFM_100G_AUI4,            "100G-AUI4" },                          \
+    { IFM_100G_CR_PAM4,         "100GBase-CR-PAM4" },                   \
+    { IFM_100G_KR_PAM4,         "100GBase-KR-PAM4" },                   \
+    { IFM_100G_CP2,             "100GBase-CP2" },                       \
+    { IFM_100G_SR2,             "100GBase-SR2" },                       \
+    { IFM_100G_DR,              "100GBase-DR" },                        \
+    { IFM_100G_KR2_PAM4,        "100GBase-KR2-PAM4" },                  \
+    { IFM_100G_CAUI2_AC,        "100G-CAUI2-AC" },                      \
+    { IFM_100G_CAUI2,           "100G-CAUI2" },                         \
+    { IFM_100G_AUI2_AC,         "100G-AUI2-AC" },                       \
+    { IFM_100G_AUI2,            "100G-AUI2" },                          \
+    { IFM_200G_CR4_PAM4,        "200GBase-CR4-PAM4" },                  \
+    { IFM_200G_SR4,             "200GBase-SR4" },                       \
+    { IFM_200G_FR4,             "200GBase-FR4" },                       \
+    { IFM_200G_LR4,             "200GBase-LR4" },                       \
+    { IFM_200G_DR4,             "200GBase-DR4" },                       \
+    { IFM_200G_KR4_PAM4,        "200GBase-KR4-PAM4" },                  \
+    { IFM_200G_AUI4_AC,         "200G-AUI4-AC" },                       \
+    { IFM_200G_AUI4,            "200G-AUI4" },                          \
+    { IFM_200G_AUI8_AC,         "200G-AUI8-AC" },                       \
+    { IFM_200G_AUI8,            "200G-AUI8" },                          \
+    { IFM_400G_FR8,             "400GBase-FR8" },                       \
+    { IFM_400G_LR8,             "400GBase-LR8" },                       \
+    { IFM_400G_DR4,             "400GBase-DR4" },                       \
+    { IFM_400G_AUI8_AC,         "400G-AUI8-AC" },                       \
+    { IFM_400G_AUI8,            "400G-AUI8" },                          \
+    { 0, NULL },                                    \
+}
+
+#define IFM_SUBTYPE_ETHERNET_ALIASES {              \
+    { IFM_10_T,     "UTP"    },                     \
+    { IFM_10_T,     "10UTP"  },                     \
+    { IFM_10_2,     "BNC"    },                     \
+    { IFM_10_2,     "10BNC"  },                     \
+    { IFM_10_5,     "AUI"    },                     \
+    { IFM_10_5,     "10AUI"  },                     \
+    { IFM_100_TX,   "100TX"  },                     \
+    { IFM_100_FX,   "100FX"  },                     \
+    { IFM_100_T4,   "100T4"  },                     \
+    { IFM_100_VG,   "100VG"  },                     \
+    { IFM_100_T2,   "100T2"  },                     \
+    { IFM_1000_SX,  "1000SX" },                     \
+    { IFM_10_STP,   "STP"    },                     \
+    { IFM_10_STP,   "10STP"  },                     \
+    { IFM_10_FL,    "FL"     },                     \
+    { IFM_10_FL,    "10FL"   },                     \
+    { IFM_1000_LX,  "1000LX" },                     \
+    { IFM_1000_CX,  "1000CX" },                     \
+    { IFM_1000_T,   "1000T"  },                     \
+    { IFM_HPNA_1,   "HPNA1"  },                     \
+    { IFM_10G_SR,   "10GSR"  },                     \
+    { IFM_10G_LR,   "10GLR"  },                     \
+    { IFM_10G_CX4,  "10GCX4" },                     \
+    { IFM_10G_T,    "10GT"   },                     \
+    { 0, NULL },                                    \
+}
+
+#define IFM_SUBTYPE_ETHERNET_OPTION_DESCRIPTIONS {  \
+    { 0, NULL },                                    \
+}
+
+#define IFM_SUBTYPE_TOKENRING_DESCRIPTIONS {        \
+    { IFM_TOK_STP4,  "DB9/4Mbit" },                 \
+    { IFM_TOK_STP16, "DB9/16Mbit" },                \
+    { IFM_TOK_UTP4,  "UTP/4Mbit" },                 \
+    { IFM_TOK_UTP16, "UTP/16Mbit" },                \
+    { 0, NULL },                                    \
+}
+
+#define IFM_SUBTYPE_TOKENRING_ALIASES {             \
+    { IFM_TOK_STP4,  "4STP" },                      \
+    { IFM_TOK_STP16, "16STP" },                     \
+    { IFM_TOK_UTP4,  "4UTP" },                      \
+    { IFM_TOK_UTP16, "16UTP" },                     \
+    { 0, NULL },                                    \
+}
+
+#define IFM_SUBTYPE_TOKENRING_OPTION_DESCRIPTIONS { \
+    { IFM_TOK_ETR,   "EarlyTokenRelease" },         \
+    { IFM_TOK_SRCRT, "SourceRouting" },             \
+    { IFM_TOK_ALLR,  "AllRoutes" },                 \
+    { 0, NULL },                                    \
+}
+
+#define IFM_SUBTYPE_FDDI_DESCRIPTIONS {             \
+    { IFM_FDDI_SMF, "Single-mode" },                \
+    { IFM_FDDI_MMF, "Multi-mode" },                 \
+    { IFM_FDDI_UTP, "UTP" },                        \
+    { 0, NULL },                                    \
+}
+
+#define IFM_SUBTYPE_FDDI_ALIASES {                  \
+    { IFM_FDDI_SMF, "SMF" },                        \
+    { IFM_FDDI_MMF, "MMF" },                        \
+    { IFM_FDDI_UTP, "CDDI" },                       \
+    { 0, NULL },                                    \
+}
+
+#define IFM_SUBTYPE_FDDI_OPTION_DESCRIPTIONS {      \
+    { IFM_FDDI_DA,  "Dual-attach" },                \
+    { 0, NULL },                                    \
+}
+
+#define IFM_SUBTYPE_IEEE80211_DESCRIPTIONS {        \
+    { IFM_IEEE80211_FH1,  "FH1"  },                 \
+    { IFM_IEEE80211_FH2,  "FH2"  },                 \
+    { IFM_IEEE80211_DS1,  "DS1"  },                 \
+    { IFM_IEEE80211_DS2,  "DS2"  },                 \
+    { IFM_IEEE80211_DS5,  "DS5"  },                 \
+    { IFM_IEEE80211_DS11, "DS11" },                 \
+    { IFM_IEEE80211_DS22, "DS22" },                 \
+    { 0, NULL },                                    \
+}
+
+#define IFM_SUBTYPE_IEEE80211_OPTION_DESCRIPTIONS { \
+    { IFM_IEEE80211_ADHOC,  "adhoc" },              \
+    { 0, NULL },                                    \
+}
+
+#define IFM_SUBTYPE_SHARED_DESCRIPTIONS {           \
+    { IFM_AUTO,     "autoselect" },                 \
+    { IFM_MANUAL,   "manual" },                     \
+    { IFM_NONE,     "none" },                       \
+    { 0, NULL },                                    \
+}
+
+#define IFM_SUBTYPE_SHARED_ALIASES {                \
+    { IFM_AUTO,     "auto" },                       \
+    { 0, NULL },                                    \
+}
+
+#define IFM_SHARED_OPTION_DESCRIPTIONS {            \
+    { IFM_FDX,      "full-duplex" },                \
+    { IFM_HDX,      "half-duplex" },                \
+    { IFM_FLOW,     "flow-control" },               \
+    { IFM_EEE,	    "energy-efficient-ethernet" },  \
+    { IFM_FLAG0,    "flag0" },                      \
+    { IFM_FLAG1,    "flag1" },                      \
+    { IFM_FLAG2,    "flag2" },                      \
+    { IFM_LOOP,     "hw-loopback" },                \
+    { 0, NULL },                                    \
+}
+
+#endif  /* _NET_IF_MEDIA_H_ */

--- a/src/libraries/Native/Unix/System.Native/ios/netinet/icmp_var.h
+++ b/src/libraries/Native/Unix/System.Native/ios/netinet/icmp_var.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2000-2013 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ *
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+/*
+ * Copyright (c) 1982, 1986, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)icmp_var.h	8.1 (Berkeley) 6/10/93
+ * $FreeBSD: src/sys/netinet/icmp_var.h,v 1.15.2.1 2001/02/24 21:35:18 bmilekic Exp $
+ */
+
+#ifndef _NETINET_ICMP_VAR_H_
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-id-macro"
+#define _NETINET_ICMP_VAR_H_
+#pragma clang diagnostic pop
+#include <sys/appleapiopts.h>
+
+/*
+ * Variables related to this implementation
+ * of the internet control message protocol.
+ */
+struct  icmpstat {
+/* statistics related to icmp packets generated */
+	u_int32_t       icps_error;     /* # of calls to icmp_error */
+	u_int32_t       icps_oldshort;  /* no error 'cuz old ip too short */
+	u_int32_t       icps_oldicmp;   /* no error 'cuz old was icmp */
+	u_int32_t       icps_outhist[ICMP_MAXTYPE + 1];
+/* statistics related to input messages processed */
+	u_int32_t       icps_badcode;   /* icmp_code out of range */
+	u_int32_t       icps_tooshort;  /* packet < ICMP_MINLEN */
+	u_int32_t       icps_checksum;  /* bad checksum */
+	u_int32_t       icps_badlen;    /* calculated bound mismatch */
+	u_int32_t       icps_reflect;   /* number of responses */
+	u_int32_t       icps_inhist[ICMP_MAXTYPE + 1];
+	u_int32_t       icps_bmcastecho;/* b/mcast echo requests dropped */
+	u_int32_t       icps_bmcasttstamp; /* b/mcast tstamp requests dropped */
+};
+
+/*
+ * Names for ICMP sysctl objects
+ */
+#define ICMPCTL_MASKREPL        1       /* allow replies to netmask requests */
+#define ICMPCTL_STATS           2       /* statistics (read-only) */
+#define ICMPCTL_ICMPLIM         3
+#define ICMPCTL_TIMESTAMP       4       /* allow replies to time stamp requests */
+#define ICMPCTL_MAXID           5
+
+#ifdef BSD_KERNEL_PRIVATE
+#define ICMPCTL_NAMES { \
+	{ 0, 0 }, \
+	{ "maskrepl", CTLTYPE_INT }, \
+	{ "stats", CTLTYPE_STRUCT }, \
+	{ "icmplim", CTLTYPE_INT }, \
+	{ "icmptimestamp", CTLTYPE_INT }, \
+}
+
+SYSCTL_DECL(_net_inet_icmp);
+#ifdef ICMP_BANDLIM
+extern boolean_t badport_bandlim(int which);
+#endif
+#define BANDLIM_ICMP_UNREACH 0
+#define BANDLIM_ICMP_ECHO 1
+#define BANDLIM_ICMP_TSTAMP 2
+#define BANDLIM_MAX 4
+
+extern struct   icmpstat icmpstat;
+#endif /* BSD_KERNEL_PRIVATE */
+#endif /* _NETINET_ICMP_VAR_H_ */

--- a/src/libraries/Native/Unix/System.Native/ios/netinet/ip_var.h
+++ b/src/libraries/Native/Unix/System.Native/ios/netinet/ip_var.h
@@ -1,0 +1,371 @@
+/*
+ * Copyright (c) 2000-2020 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ *
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+/*
+ * Copyright (c) 1982, 1986, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)ip_var.h	8.2 (Berkeley) 1/9/95
+ */
+/*
+ * NOTICE: This file was modified by SPARTA, Inc. in 2007 to introduce
+ * support for mandatory and extensible security protections.  This notice
+ * is included in support of clause 2.2 (b) of the Apple Public License,
+ * Version 2.0.
+ */
+
+#ifndef _NETINET_IP_VAR_H_
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-id-macro"
+#define _NETINET_IP_VAR_H_
+#pragma clang diagnostic pop
+#include <sys/appleapiopts.h>
+
+/*
+ * Overlay for ip header used by other protocols (tcp, udp).
+ */
+struct ipovly {
+	u_char  ih_x1[9];               /* (unused) */
+	u_char  ih_pr;                  /* protocol */
+	u_short ih_len;                 /* protocol length */
+	struct  in_addr ih_src;         /* source internet address */
+	struct  in_addr ih_dst;         /* destination internet address */
+};
+
+#ifdef BSD_KERNEL_PRIVATE
+/*
+ * Ip reassembly queue structure.  Each fragment
+ * being reassembled is attached to one of these structures.
+ * They are timed out after ipq_ttl drops to 0, and may also
+ * be reclaimed if memory becomes tight.
+ */
+struct ipq {
+	TAILQ_ENTRY(ipq) ipq_list;      /* to other reass headers */
+	struct mbuf *ipq_frags;         /* to ip headers of fragments */
+	u_char  ipq_ttl;                /* time for reass q to live */
+	u_char  ipq_p;                  /* protocol of this fragment */
+	u_short ipq_id;                 /* sequence id for reassembly */
+	struct  in_addr ipq_src, ipq_dst;
+	u_int32_t       ipq_nfrags;     /* # frags in this packet */
+	uint32_t ipq_csum_flags;        /* checksum flags */
+	uint32_t ipq_csum;              /* partial checksum value */
+};
+
+/*
+ * Structure stored in mbuf in inpcb.ip_options
+ * and passed to ip_output when ip options are in use.
+ * The actual length of the options (including ipopt_dst)
+ * is in m_len.
+ */
+#endif /* BSD_KERNEL_PRIVATE */
+#define MAX_IPOPTLEN    40
+#ifdef BSD_KERNEL_PRIVATE
+struct ipoption {
+	struct  in_addr ipopt_dst;      /* first-hop dst if source routed */
+	char    ipopt_list[MAX_IPOPTLEN];       /* options proper */
+};
+
+/*
+ * Structure attached to inpcb.ip_moptions and
+ * passed to ip_output when IP multicast options are in use.
+ */
+struct ip_moptions {
+	decl_lck_mtx_data(, imo_lock);
+	uint32_t imo_refcnt;            /* ref count */
+	uint32_t imo_debug;             /* see ifa_debug flags */
+	struct  ifnet *imo_multicast_ifp; /* ifp for outgoing multicasts */
+	u_char  imo_multicast_ttl;      /* TTL for outgoing multicasts */
+	u_char  imo_multicast_loop;     /* 1 => hear sends if a member */
+	u_short imo_num_memberships;    /* no. memberships this socket */
+	u_short imo_max_memberships;    /* max memberships this socket */
+	struct  in_multi **imo_membership;      /* group memberships */
+	struct  in_mfilter *imo_mfilters;       /* source filters */
+	u_int32_t imo_multicast_vif;    /* vif num outgoing multicasts */
+	struct  in_addr imo_multicast_addr; /* ifindex/addr on MULTICAST_IF */
+	void (*imo_trace)               /* callback fn for tracing refs */
+	(struct ip_moptions *, int);
+};
+
+#define IMO_LOCK_ASSERT_HELD(_imo)                                      \
+	LCK_MTX_ASSERT(&(_imo)->imo_lock, LCK_MTX_ASSERT_OWNED)
+
+#define IMO_LOCK_ASSERT_NOTHELD(_imo)                                   \
+	LCK_MTX_ASSERT(&(_imo)->imo_lock, LCK_MTX_ASSERT_NOTOWNED)
+
+#define IMO_LOCK(_imo)                                                  \
+	lck_mtx_lock(&(_imo)->imo_lock)
+
+#define IMO_LOCK_SPIN(_imo)                                             \
+	lck_mtx_lock_spin(&(_imo)->imo_lock)
+
+#define IMO_CONVERT_LOCK(_imo) do {                                     \
+	IMO_LOCK_ASSERT_HELD(_imo);                                     \
+	lck_mtx_convert_spin(&(_imo)->imo_lock);                        \
+} while (0)
+
+#define IMO_UNLOCK(_imo)                                                \
+	lck_mtx_unlock(&(_imo)->imo_lock)
+
+#define IMO_ADDREF(_imo)                                                \
+	imo_addref(_imo, 0)
+
+#define IMO_ADDREF_LOCKED(_imo)                                         \
+	imo_addref(_imo, 1)
+
+#define IMO_REMREF(_imo)                                                \
+	imo_remref(_imo)
+
+/* mbuf tag for ip_forwarding info */
+struct ip_fwd_tag {
+	struct sockaddr_in *next_hop;   /* next_hop */
+};
+#endif /* BSD_KERNEL_PRIVATE */
+
+struct  ipstat {
+	u_int32_t ips_total;            /* total packets received */
+	u_int32_t ips_badsum;           /* checksum bad */
+	u_int32_t ips_tooshort;         /* packet too short */
+	u_int32_t ips_toosmall;         /* not enough data */
+	u_int32_t ips_badhlen;          /* ip header length < data size */
+	u_int32_t ips_badlen;           /* ip length < ip header length */
+	u_int32_t ips_fragments;        /* fragments received */
+	u_int32_t ips_fragdropped;      /* frags dropped (dups, out of space) */
+	u_int32_t ips_fragtimeout;      /* fragments timed out */
+	u_int32_t ips_forward;          /* packets forwarded */
+	u_int32_t ips_fastforward;      /* packets fast forwarded */
+	u_int32_t ips_cantforward;      /* packets rcvd for unreachable dest */
+	u_int32_t ips_redirectsent;     /* packets forwarded on same net */
+	u_int32_t ips_noproto;          /* unknown or unsupported protocol */
+	u_int32_t ips_delivered;        /* datagrams delivered to upper level */
+	u_int32_t ips_localout;         /* total ip packets generated here */
+	u_int32_t ips_odropped;         /* lost packets due to nobufs, etc. */
+	u_int32_t ips_reassembled;      /* total packets reassembled ok */
+	u_int32_t ips_fragmented;       /* datagrams successfully fragmented */
+	u_int32_t ips_ofragments;       /* output fragments created */
+	u_int32_t ips_cantfrag;         /* don't fragment flag was set, etc. */
+	u_int32_t ips_badoptions;       /* error in option processing */
+	u_int32_t ips_noroute;          /* packets discarded due to no route */
+	u_int32_t ips_badvers;          /* ip version != 4 */
+	u_int32_t ips_rawout;           /* total raw ip packets generated */
+	u_int32_t ips_toolong;          /* ip length > max ip packet size */
+	u_int32_t ips_notmember;        /* multicasts for unregistered grps */
+	u_int32_t ips_nogif;            /* no match gif found */
+	u_int32_t ips_badaddr;          /* invalid address on header */
+	u_int32_t ips_pktdropcntrl;     /* pkt dropped, no mbufs for ctl data */
+	u_int32_t ips_rcv_swcsum;       /* ip hdr swcksum (inbound), packets */
+	u_int32_t ips_rcv_swcsum_bytes; /* ip hdr swcksum (inbound), bytes */
+	u_int32_t ips_snd_swcsum;       /* ip hdr swcksum (outbound), packets */
+	u_int32_t ips_snd_swcsum_bytes; /* ip hdr swcksum (outbound), bytes */
+	u_int32_t ips_adj;              /* total packets trimmed/adjusted */
+	u_int32_t ips_adj_hwcsum_clr;   /* hwcksum discarded during adj */
+	u_int32_t ips_rxc_collisions;   /* rx chaining collisions */
+	u_int32_t ips_rxc_chained;      /* rx chains */
+	u_int32_t ips_rxc_notchain;     /* rx bypassed chaining */
+	u_int32_t ips_rxc_chainsz_gt2;  /* rx chain size greater than 2 */
+	u_int32_t ips_rxc_chainsz_gt4;  /* rx chain size greater than 4 */
+	u_int32_t ips_rxc_notlist;      /* count of pkts through ip_input */
+	u_int32_t ips_raw_sappend_fail; /* sock append failed */
+	u_int32_t ips_necp_policy_drop; /* NECP policy related drop */
+	u_int32_t ips_rcv_if_weak_match; /* packets whose receive interface that passed the Weak ES address check */
+	u_int32_t ips_rcv_if_no_match;  /* packets whose receive interface did not pass the address check */
+};
+
+struct ip_linklocal_stat {
+	u_int32_t       iplls_in_total;
+	u_int32_t       iplls_in_badttl;
+	u_int32_t       iplls_out_total;
+	u_int32_t       iplls_out_badttl;
+};
+
+#ifdef KERNEL_PRIVATE
+/* forward declarations for ip_output() */
+struct ip_out_args;
+struct ip_moptions;
+#endif /* KERNEL_PRIVATE */
+
+#ifdef BSD_KERNEL_PRIVATE
+/* flags passed to ip_output as last parameter */
+#define IP_FORWARDING   0x1             /* most of ip header exists */
+#define IP_RAWOUTPUT    0x2             /* raw ip header exists */
+#define IP_NOIPSEC      0x4             /* No IPsec processing */
+#define IP_ROUTETOIF    SO_DONTROUTE    /* bypass routing tables (0x0010) */
+#define IP_ALLOWBROADCAST SO_BROADCAST  /* can send broadcast pkts (0x0020) */
+#define IP_OUTARGS      0x100           /* has ancillary output info */
+
+#define IP_HDR_ALIGNED_P(_ip)   ((((uintptr_t)(_ip)) & ((uintptr_t)3)) == 0)
+#define IP_OFF_IS_ATOMIC(_ip_off) ((_ip_off & (IP_DF | IP_MF | IP_OFFMASK)) == IP_DF)
+
+/*
+ * On platforms which require strict alignment (currently for anything but
+ * i386 or x86_64), this macro checks whether the pointer to the IP header
+ * is 32-bit aligned, and assert otherwise.
+ */
+#if defined(__i386__) || defined(__x86_64__)
+#define IP_HDR_STRICT_ALIGNMENT_CHECK(_ip) do { } while (0)
+#else /* !__i386__ && !__x86_64__ */
+#define IP_HDR_STRICT_ALIGNMENT_CHECK(_ip) do {                         \
+	if (!IP_HDR_ALIGNED_P(_ip)) {                                   \
+	        panic_plain("\n%s: Unaligned IP header %p\n",           \
+	            __func__, _ip);                                     \
+	}                                                               \
+} while (0)
+#endif /* !__i386__ && !__x86_64__ */
+
+struct ip;
+struct inpcb;
+struct route;
+struct sockopt;
+
+#include <kern/zalloc.h>
+#include <net/flowadv.h>
+
+/*
+ * Extra information passed to ip_output when IP_OUTARGS is set.
+ *
+ * Upon returning an error to the caller, ip_output may indicate through
+ * ipoa_retflags any additional information regarding the error.
+ */
+struct ip_out_args {
+	unsigned int    ipoa_boundif;   /* boundif interface index */
+	struct flowadv  ipoa_flowadv;   /* flow advisory code */
+	u_int32_t       ipoa_flags;     /* IPOAF output flags (see below) */
+#define IPOAF_SELECT_SRCIF      0x00000001      /* src interface selection */
+#define IPOAF_BOUND_IF          0x00000002      /* boundif value is valid */
+#define IPOAF_BOUND_SRCADDR     0x00000004      /* bound to src address */
+#define IPOAF_NO_CELLULAR       0x00000010      /* skip IFT_CELLULAR */
+#define IPOAF_NO_EXPENSIVE      0x00000020      /* skip IFT_EXPENSIVE */
+#define IPOAF_AWDL_UNRESTRICTED 0x00000040      /* can send over
+	                                         *  AWDL_RESTRICTED */
+#define IPOAF_QOSMARKING_ALLOWED        0x00000080      /* policy allows Fastlane DSCP marking */
+#define IPOAF_NO_CONSTRAINED    0x00000100      /* skip IFXF_CONSTRAINED */
+#define IPOAF_REDO_QOSMARKING_POLICY    0x00000200      /* Re-evaluate QOS marking policy */
+	u_int32_t       ipoa_retflags;  /* IPOARF return flags (see below) */
+#define IPOARF_IFDENIED 0x00000001      /* denied access to interface */
+	int             ipoa_sotc;      /* traffic class for Fastlane DSCP mapping */
+	int             ipoa_netsvctype; /* network service type */
+	int32_t         qos_marking_gencount;
+};
+
+extern struct ipstat ipstat;
+extern int ip_use_randomid;
+extern u_short ip_id;                   /* ip packet ctr, for ids */
+extern int ip_defttl;                   /* default IP ttl */
+extern int ipforwarding;                /* ip forwarding */
+extern int rfc6864;
+extern struct protosw *ip_protox[];
+extern struct pr_usrreqs rip_usrreqs;
+
+extern void ip_moptions_init(void);
+extern struct ip_moptions *ip_allocmoptions(zalloc_flags_t);
+extern int inp_getmoptions(struct inpcb *, struct sockopt *);
+extern int inp_setmoptions(struct inpcb *, struct sockopt *);
+extern void imo_addref(struct ip_moptions *, int);
+extern void imo_remref(struct ip_moptions *);
+
+struct protosw;
+struct domain;
+
+extern int ip_checkrouteralert(struct mbuf *);
+extern int ip_ctloutput(struct socket *, struct sockopt *sopt);
+extern void ip_drain(void);
+extern void ip_init(struct protosw *, struct domain *);
+extern int ip_output(struct mbuf *, struct mbuf *, struct route *, int,
+    struct ip_moptions *, struct ip_out_args *);
+extern int ip_output_list(struct mbuf *, int, struct mbuf *, struct route *,
+    int, struct ip_moptions *, struct ip_out_args *);
+extern void ip_output_checksum(struct ifnet *, struct mbuf *, int, int,
+    uint32_t *);
+extern struct in_ifaddr *ip_rtaddr(struct in_addr);
+extern int ip_savecontrol(struct inpcb *, struct mbuf **, struct ip *,
+    struct mbuf *);
+extern struct mbuf *ip_srcroute(void);
+extern void  ip_stripoptions(struct mbuf *);
+extern void ip_initid(void);
+extern u_int16_t ip_randomid(void);
+extern int ip_fragment(struct mbuf *, struct ifnet *, uint32_t, int);
+
+extern void ip_setsrcifaddr_info(struct mbuf *, uint32_t, struct in_ifaddr *);
+extern void ip_setdstifaddr_info(struct mbuf *, uint32_t, struct in_ifaddr *);
+extern int ip_getsrcifaddr_info(struct mbuf *, uint32_t *, uint32_t *);
+extern int ip_getdstifaddr_info(struct mbuf *, uint32_t *, uint32_t *);
+
+extern int rip_ctloutput(struct socket *, struct sockopt *);
+extern void rip_ctlinput(int, struct sockaddr *, void *, struct ifnet *);
+extern void rip_init(struct protosw *, struct domain *);
+extern void rip_input(struct mbuf *, int);
+extern int rip_output(struct mbuf *, struct socket *, u_int32_t, struct mbuf *);
+extern int rip_unlock(struct socket *, int, void *);
+extern int rip_send(struct socket *, int, struct mbuf *, struct sockaddr *,
+    struct mbuf *, struct proc *);
+
+extern void tcp_in_cksum_stats(u_int32_t);
+extern void tcp_out_cksum_stats(u_int32_t);
+
+extern void udp_in_cksum_stats(u_int32_t);
+extern void udp_out_cksum_stats(u_int32_t);
+
+extern void tcp_in6_cksum_stats(u_int32_t);
+extern void tcp_out6_cksum_stats(u_int32_t);
+
+extern void udp_in6_cksum_stats(u_int32_t);
+extern void udp_out6_cksum_stats(u_int32_t);
+#endif /* BSD_KERNEL_PRIVATE */
+#ifdef KERNEL_PRIVATE
+/* for PPP/PPTP */
+extern int ip_gre_output(struct mbuf *);
+typedef struct mbuf *(*gre_input_func_t)(struct mbuf *, int, int);
+extern int ip_gre_register_input(gre_input_func_t);
+#endif /* KERNEL_PRIVATE */
+#endif /* !_NETINET_IP_VAR_H_ */

--- a/src/libraries/Native/Unix/System.Native/ios/netinet/tcp_fsm.h
+++ b/src/libraries/Native/Unix/System.Native/ios/netinet/tcp_fsm.h
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2000 Apple Computer, Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ *
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+/*
+ * Copyright (c) 1982, 1986, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)tcp_fsm.h	8.1 (Berkeley) 6/10/93
+ * $FreeBSD: src/sys/netinet/tcp_fsm.h,v 1.14 1999/11/07 04:18:30 jlemon Exp $
+ */
+
+#ifndef _NETINET_TCP_FSM_H_
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-id-macro"
+#define _NETINET_TCP_FSM_H_
+#pragma clang diagnostic pop
+#include <sys/appleapiopts.h>
+
+/*
+ * TCP FSM state definitions.
+ * Per RFC793, September, 1981.
+ */
+
+#define TCP_NSTATES     11
+
+#define TCPS_CLOSED             0       /* closed */
+#define TCPS_LISTEN             1       /* listening for connection */
+#define TCPS_SYN_SENT           2       /* active, have sent syn */
+#define TCPS_SYN_RECEIVED       3       /* have send and received syn */
+/* states < TCPS_ESTABLISHED are those where connections not established */
+#define TCPS_ESTABLISHED        4       /* established */
+#define TCPS_CLOSE_WAIT         5       /* rcvd fin, waiting for close */
+/* states > TCPS_CLOSE_WAIT are those where user has closed */
+#define TCPS_FIN_WAIT_1         6       /* have closed, sent fin */
+#define TCPS_CLOSING            7       /* closed xchd FIN; await FIN ACK */
+#define TCPS_LAST_ACK           8       /* had fin and close; await FIN ACK */
+/* states > TCPS_CLOSE_WAIT && < TCPS_FIN_WAIT_2 await ACK of FIN */
+#define TCPS_FIN_WAIT_2         9       /* have closed, fin is acked */
+#define TCPS_TIME_WAIT          10      /* in 2*msl quiet wait after close */
+
+/* for KAME src sync over BSD*'s */
+#define TCP6_NSTATES            TCP_NSTATES
+#define TCP6S_CLOSED            TCPS_CLOSED
+#define TCP6S_LISTEN            TCPS_LISTEN
+#define TCP6S_SYN_SENT          TCPS_SYN_SENT
+#define TCP6S_SYN_RECEIVED      TCPS_SYN_RECEIVED
+#define TCP6S_ESTABLISHED       TCPS_ESTABLISHED
+#define TCP6S_CLOSE_WAIT        TCPS_CLOSE_WAIT
+#define TCP6S_FIN_WAIT_1        TCPS_FIN_WAIT_1
+#define TCP6S_CLOSING           TCPS_CLOSING
+#define TCP6S_LAST_ACK          TCPS_LAST_ACK
+#define TCP6S_FIN_WAIT_2        TCPS_FIN_WAIT_2
+#define TCP6S_TIME_WAIT         TCPS_TIME_WAIT
+
+#define TCPS_HAVERCVDSYN(s)     ((s) >= TCPS_SYN_RECEIVED)
+#define TCPS_HAVEESTABLISHED(s) ((s) >= TCPS_ESTABLISHED)
+#define TCPS_HAVERCVDFIN(s)     ((s) >= TCPS_TIME_WAIT)
+#define TCPS_HAVERCVDFIN2(s)    ((s) == TCPS_CLOSE_WAIT ||                      \
+	                         (s) == TCPS_CLOSING ||                         \
+	                         (s) == TCPS_LAST_ACK ||                        \
+	                         (s) == TCPS_TIME_WAIT)
+
+#ifdef KERNEL_PRIVATE
+#ifdef  TCPOUTFLAGS
+/*
+ * Flags used when sending segments in tcp_output.
+ * Basic flags (TH_RST,TH_ACK,TH_SYN,TH_FIN) are totally
+ * determined by state, with the proviso that TH_FIN is sent only
+ * if all data queued for output is included in the segment.
+ */
+static u_char   tcp_outflags[TCP_NSTATES] = {
+	TH_RST | TH_ACK,          /* 0, CLOSED */
+	0,                      /* 1, LISTEN */
+	TH_SYN,                 /* 2, SYN_SENT */
+	TH_SYN | TH_ACK,          /* 3, SYN_RECEIVED */
+	TH_ACK,                 /* 4, ESTABLISHED */
+	TH_ACK,                 /* 5, CLOSE_WAIT */
+	TH_FIN | TH_ACK,          /* 6, FIN_WAIT_1 */
+	TH_FIN | TH_ACK,          /* 7, CLOSING */
+	TH_FIN | TH_ACK,          /* 8, LAST_ACK */
+	TH_ACK,                 /* 9, FIN_WAIT_2 */
+	TH_ACK,                 /* 10, TIME_WAIT */
+};
+#endif
+#endif /* KERNEL_PRIVATE */
+
+#if KPROF
+#ifdef KERNEL_PRIVATE
+int     tcp_acounts[TCP_NSTATES][PRU_NREQ];
+#endif /* KERNEL_PRIVATE */
+#endif
+
+#ifdef  TCPSTATES
+char *tcpstates[] = {
+	"CLOSED", "LISTEN", "SYN_SENT", "SYN_RCVD",
+	"ESTABLISHED", "CLOSE_WAIT", "FIN_WAIT_1", "CLOSING",
+	"LAST_ACK", "FIN_WAIT_2", "TIME_WAIT"
+};
+#endif
+
+#endif

--- a/src/libraries/Native/Unix/System.Native/ios/netinet/udp_var.h
+++ b/src/libraries/Native/Unix/System.Native/ios/netinet/udp_var.h
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2008-2016 Apple Inc. All rights reserved.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. The rights granted to you under the License
+ * may not be used to create, or enable the creation or redistribution of,
+ * unlawful or unlicensed copies of an Apple operating system, or to
+ * circumvent, violate, or enable the circumvention or violation of, any
+ * terms of an Apple operating system software license agreement.
+ *
+ * Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPLE_OSREFERENCE_LICENSE_HEADER_END@
+ */
+/*
+ * Copyright (c) 1982, 1986, 1989, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)udp_var.h	8.1 (Berkeley) 6/10/93
+ */
+
+#ifndef _NETINET_UDP_VAR_H_
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-id-macro"
+#define _NETINET_UDP_VAR_H_
+#pragma clang diagnostic pop
+
+#include <sys/appleapiopts.h>
+#include <sys/sysctl.h>
+
+/*
+ * UDP kernel structures and variables.
+ */
+struct  udpiphdr {
+	struct  ipovly ui_i;            /* overlaid ip structure */
+	struct  udphdr ui_u;            /* udp header */
+};
+#define ui_x1           ui_i.ih_x1
+#define ui_pr           ui_i.ih_pr
+#define ui_len          ui_i.ih_len
+#define ui_src          ui_i.ih_src
+#define ui_dst          ui_i.ih_dst
+#define ui_sport        ui_u.uh_sport
+#define ui_dport        ui_u.uh_dport
+#define ui_ulen         ui_u.uh_ulen
+#define ui_sum          ui_u.uh_sum
+#define ui_next         ui_i.ih_next
+#define ui_prev         ui_i.ih_prev
+
+struct  udpstat {
+	/* input statistics: */
+	u_int32_t udps_ipackets;        /* total input packets */
+	u_int32_t udps_hdrops;          /* packet shorter than header */
+	u_int32_t udps_badsum;          /* checksum error */
+	u_int32_t udps_badlen;          /* data length larger than packet */
+	u_int32_t udps_noport;          /* no socket on port */
+	u_int32_t udps_noportbcast;     /* of above, arrived as broadcast */
+	u_int32_t udps_fullsock;        /* not delivered, input socket full */
+	u_int32_t udpps_pcbcachemiss;   /* input packets missing pcb cache */
+	u_int32_t udpps_pcbhashmiss;    /* input packets not for hashed pcb */
+	/* output statistics: */
+	u_int32_t udps_opackets;        /* total output packets */
+	u_int32_t udps_fastout;         /* output packets on fast path */
+	u_int32_t udps_nosum;           /* no checksum */
+	u_int32_t udps_noportmcast;     /* of no socket on port, multicast */
+	u_int32_t udps_filtermcast;     /* blocked by multicast filter */
+	/* checksum statistics: */
+	u_int32_t udps_rcv_swcsum;        /* udp swcksum (inbound), packets */
+	u_int32_t udps_rcv_swcsum_bytes;  /* udp swcksum (inbound), bytes */
+	u_int32_t udps_rcv6_swcsum;       /* udp6 swcksum (inbound), packets */
+	u_int32_t udps_rcv6_swcsum_bytes; /* udp6 swcksum (inbound), bytes */
+	u_int32_t udps_snd_swcsum;        /* udp swcksum (outbound), packets */
+	u_int32_t udps_snd_swcsum_bytes;  /* udp swcksum (outbound), bytes */
+	u_int32_t udps_snd6_swcsum;       /* udp6 swcksum (outbound), packets */
+	u_int32_t udps_snd6_swcsum_bytes; /* udp6 swcksum (outbound), bytes */
+};
+
+/*
+ * Names for UDP sysctl objects
+ */
+#define UDPCTL_CHECKSUM         1       /* checksum UDP packets */
+#define UDPCTL_STATS            2       /* statistics (read-only) */
+#define UDPCTL_MAXDGRAM         3       /* max datagram size */
+#define UDPCTL_RECVSPACE        4       /* default receive buffer space */
+#define UDPCTL_PCBLIST          5       /* list of PCBs for UDP sockets */
+#define UDPCTL_MAXID            6
+
+#ifdef BSD_KERNEL_PRIVATE
+#include <kern/locks.h>
+#include <sys/bitstring.h>
+
+#define UDPCTL_NAMES {                                                  \
+	{ 0, 0 },                                                       \
+	{ "checksum", CTLTYPE_INT },                                    \
+	{ "stats", CTLTYPE_STRUCT },                                    \
+	{ "maxdgram", CTLTYPE_INT },                                    \
+	{ "recvspace", CTLTYPE_INT },                                   \
+	{ "pcblist", CTLTYPE_STRUCT },                                  \
+}
+
+#define udp6stat        udpstat
+#define udp6s_opackets  udps_opackets
+
+SYSCTL_DECL(_net_inet_udp);
+
+struct udpstat_local {
+	u_int64_t       port_unreach;
+	u_int64_t       faithprefix;    /* deprecated */
+	u_int64_t       port0;
+	u_int64_t       badlength;
+	u_int64_t       badchksum;
+	u_int64_t       badmcast;
+	u_int64_t       cleanup;
+	u_int64_t       badipsec;
+};
+
+extern struct pr_usrreqs udp_usrreqs;
+extern struct inpcbhead udb;
+extern struct inpcbinfo udbinfo;
+extern u_int32_t udp_sendspace;
+extern u_int32_t udp_recvspace;
+extern struct udpstat udpstat;
+extern int udp_log_in_vain;
+
+__BEGIN_DECLS
+extern void udp_ctlinput(int, struct sockaddr *, void *, struct ifnet *);
+extern int udp_ctloutput(struct socket *, struct sockopt *);
+extern void udp_init(struct protosw *, struct domain *);
+extern void udp_input(struct mbuf *, int);
+extern int udp_connectx_common(struct socket *, int, struct sockaddr *,
+    struct sockaddr *, struct proc *, uint32_t, sae_associd_t,
+    sae_connid_t *, uint32_t, void *, uint32_t, struct uio*, user_ssize_t *);
+extern void udp_notify(struct inpcb *inp, int errno);
+extern int udp_shutdown(struct socket *so);
+extern int udp_lock(struct socket *, int, void *);
+extern int udp_unlock(struct socket *, int, void *);
+extern lck_mtx_t *udp_getlock(struct socket *, int);
+extern void udp_get_ports_used(u_int32_t, int, u_int32_t, bitstr_t *);
+extern uint32_t udp_count_opportunistic(unsigned int, u_int32_t);
+extern uint32_t udp_find_anypcb_byaddr(struct ifaddr *);
+
+extern void udp_fill_keepalive_offload_frames(struct ifnet *,
+    struct ifnet_keepalive_offload_frame *, u_int32_t, size_t, u_int32_t *);
+
+__END_DECLS
+#endif /* BSD_KERNEL_PRIVATE */
+#endif /* _NETINET_UDP_VAR_H_ */

--- a/src/libraries/Native/Unix/System.Native/pal_interfaceaddresses.c
+++ b/src/libraries/Native/Unix/System.Native/pal_interfaceaddresses.c
@@ -29,6 +29,8 @@
 #endif
 #if HAVE_NET_IFMEDIA_H
 #include <net/if_media.h>
+#elif HAVE_IOS_NET_IFMEDIA_H
+#include "ios/net/if_media.h"
 #endif
 
 #if defined(AF_PACKET)
@@ -203,7 +205,7 @@ int32_t SystemNative_EnumerateInterfaceAddresses(void* context,
                 lla.NumAddressBytes = sadl->sdl_alen;
                 lla.HardwareType = MapHardwareType(sadl->sdl_type);
 
-#if HAVE_NET_IFMEDIA_H
+#if HAVE_NET_IFMEDIA_H || HAVE_IOS_NET_IFMEDIA_H
                 if (lla.HardwareType == NetworkInterfaceType_Ethernet)
                 {
                     // WI-FI and Ethernet have same address type so we can try to distinguish more

--- a/src/libraries/Native/Unix/System.Native/pal_networkstatistics.c
+++ b/src/libraries/Native/Unix/System.Native/pal_networkstatistics.c
@@ -36,6 +36,9 @@
 #if HAVE_NET_IFMEDIA_H
 #include <net/if_media.h>
 #include <sys/ioctl.h>
+#elif HAVE_IOS_NET_IFMEDIA_H
+#include "ios/net/if_media.h"
+#include <sys/ioctl.h>
 #endif
 #include <sys/socketvar.h>
 #include <netinet/in.h>
@@ -44,6 +47,8 @@
 #include <netinet/ip_icmp.h>
 #if HAVE_NETINET_IP_VAR_H
 #include <netinet/ip_var.h>
+#elif HAVE_IOS_NETINET_IP_VAR_H
+#include "ios/netinet/ip_var.h"
 #endif
 #include <netinet/tcp.h>
 #if HAVE_TCP_FSM_H
@@ -53,10 +58,14 @@
 #include <netinet/udp.h>
 #if HAVE_NETINET_UDP_VAR_H
 #include <netinet/udp_var.h>
+#elif HAVE_IOS_NETINET_UDP_VAR_H
+#include "ios/netinet/udp_var.h"
 #endif
 #include <netinet/icmp6.h>
 #if HAVE_NETINET_ICMP_VAR_H
 #include <netinet/icmp_var.h>
+#elif HAVE_IOS_NETINET_ICMP_VAR_H
+#include "ios/netinet/icmp_var.h"
 #endif
 
 static _Atomic(int) icmp6statSize = sizeof(struct icmp6stat);
@@ -105,7 +114,7 @@ int32_t SystemNative_GetTcpGlobalStatistics(TcpGlobalStatistics* retStats)
 
 int32_t SystemNative_GetIPv4GlobalStatistics(IPv4GlobalStatistics* retStats)
 {
-#if HAVE_NETINET_IP_VAR_H
+#if HAVE_NETINET_IP_VAR_H || HAVE_IOS_NETINET_IP_VAR_H
     size_t oldlenp;
 
     assert(retStats != NULL);
@@ -154,7 +163,7 @@ int32_t SystemNative_GetIPv4GlobalStatistics(IPv4GlobalStatistics* retStats)
 
 int32_t SystemNative_GetUdpGlobalStatistics(UdpGlobalStatistics* retStats)
 {
-#if HAVE_NETINET_UDP_VAR_H
+#if HAVE_NETINET_UDP_VAR_H || HAVE_IOS_NETINET_UDP_VAR_H
     size_t oldlenp;
 
     assert(retStats != NULL);
@@ -194,7 +203,7 @@ int32_t SystemNative_GetUdpGlobalStatistics(UdpGlobalStatistics* retStats)
 
 int32_t SystemNative_GetIcmpv4GlobalStatistics(Icmpv4GlobalStatistics* retStats)
 {
-#if HAVE_NETINET_ICMP_VAR_H
+#if HAVE_NETINET_ICMP_VAR_H || HAVE_IOS_NETINET_ICMP_VAR_H
     size_t oldlenp;
 
     assert(retStats != NULL);
@@ -587,7 +596,7 @@ int32_t SystemNative_GetNativeIPInterfaceStatistics(char* interfaceName, NativeI
             if (ifHdr->ifm_flags & IFF_UP)
             {
                 retStats->Flags |= InterfaceUp;
-#if HAVE_NET_IFMEDIA_H
+#if HAVE_NET_IFMEDIA_H || HAVE_IOS_NET_IFMEDIA_H
                 int fd =  socket(AF_INET, SOCK_DGRAM, 0);
                 if (fd < 0) {
                     retStats->Flags |= InterfaceError;

--- a/src/libraries/Native/Unix/System.Native/pal_tcpstate.c
+++ b/src/libraries/Native/Unix/System.Native/pal_tcpstate.c
@@ -7,6 +7,8 @@
 
 #if HAVE_TCP_FSM_H
 #include <netinet/tcp_fsm.h>
+#elif HAVE_IOS_NETINET_TCPFSM_H
+#include "ios/netinet/tcp_fsm.h"
 #elif HAVE_TCP_H_TCPSTATE_ENUM
 #include <netinet/tcp.h>
 #endif
@@ -15,7 +17,7 @@ int32_t SystemNative_MapTcpState(int32_t tcpState)
 {
     switch (tcpState)
     {
-#if HAVE_TCP_FSM_H
+#if HAVE_TCP_FSM_H || HAVE_IOS_NETINET_TCPFSM_H
         case TCPS_CLOSED:
             return TcpState_Closed;
         case TCPS_LISTEN:

--- a/src/libraries/Native/Unix/configure.cmake
+++ b/src/libraries/Native/Unix/configure.cmake
@@ -879,7 +879,20 @@ check_symbol_exists(
 
 if(CLR_CMAKE_TARGET_MACCATALYST OR CLR_CMAKE_TARGET_IOS OR CLR_CMAKE_TARGET_TVOS)
     set(HAVE_IOS_NET_ROUTE_H 1)
-    set(CMAKE_EXTRA_INCLUDE_FILES sys/types.h "${CMAKE_CURRENT_SOURCE_DIR}/System.Native/ios/net/route.h")
+    set(HAVE_IOS_NET_IFMEDIA_H 1)
+    set(HAVE_IOS_NETINET_TCPFSM_H 1)
+    set(HAVE_IOS_NETINET_IP_VAR_H 1)
+    set(HAVE_IOS_NETINET_ICMP_VAR_H 1)
+    set(HAVE_IOS_NETINET_UDP_VAR_H 1)
+    set(CMAKE_EXTRA_INCLUDE_FILES 
+        sys/types.h 
+        "${CMAKE_CURRENT_SOURCE_DIR}/System.Native/ios/net/route.h"
+        "${CMAKE_CURRENT_SOURCE_DIR}/System.Native/ios/net/route.h"
+        "${CMAKE_CURRENT_SOURCE_DIR}/System.Native/ios/netinet/icmp_var.h"
+        "${CMAKE_CURRENT_SOURCE_DIR}/System.Native/ios/netinet/ip_var.h"
+        "${CMAKE_CURRENT_SOURCE_DIR}/System.Native/ios/netinet/tcp_fsm.h"
+        "${CMAKE_CURRENT_SOURCE_DIR}/System.Native/ios/netinet/udp_var.h"
+    )
 else()
     set(CMAKE_EXTRA_INCLUDE_FILES sys/types.h net/if.h net/route.h)
 endif()

--- a/src/libraries/Native/Unix/configure.cmake
+++ b/src/libraries/Native/Unix/configure.cmake
@@ -887,11 +887,6 @@ if(CLR_CMAKE_TARGET_MACCATALYST OR CLR_CMAKE_TARGET_IOS OR CLR_CMAKE_TARGET_TVOS
     set(CMAKE_EXTRA_INCLUDE_FILES 
         sys/types.h 
         "${CMAKE_CURRENT_SOURCE_DIR}/System.Native/ios/net/route.h"
-        "${CMAKE_CURRENT_SOURCE_DIR}/System.Native/ios/net/route.h"
-        "${CMAKE_CURRENT_SOURCE_DIR}/System.Native/ios/netinet/icmp_var.h"
-        "${CMAKE_CURRENT_SOURCE_DIR}/System.Native/ios/netinet/ip_var.h"
-        "${CMAKE_CURRENT_SOURCE_DIR}/System.Native/ios/netinet/tcp_fsm.h"
-        "${CMAKE_CURRENT_SOURCE_DIR}/System.Native/ios/netinet/udp_var.h"
     )
 else()
     set(CMAKE_EXTRA_INCLUDE_FILES sys/types.h net/if.h net/route.h)

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
@@ -26,7 +26,6 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void IPGlobalProperties_AccessAllMethods_NoErrors()
         {
             IPGlobalProperties gp = IPGlobalProperties.GetIPGlobalProperties();
@@ -36,7 +35,7 @@ namespace System.Net.NetworkInformation.Tests
             Assert.NotNull(gp.GetActiveUdpListeners());
 
             Assert.NotNull(gp.GetIPv4GlobalStatistics());
-            if (!OperatingSystem.IsMacOS() && !OperatingSystem.IsFreeBSD())
+            if (!OperatingSystem.IsMacOS() && !OperatingSystem.IsIOS() && !OperatingSystem.IsTvOS() && !OperatingSystem.IsFreeBSD())
             {
                 // OSX and FreeBSD do not provide IPv6  stats.
                 Assert.NotNull(gp.GetIPv6GlobalStatistics());
@@ -52,7 +51,6 @@ namespace System.Net.NetworkInformation.Tests
 
         [Theory]
         [MemberData(nameof(Loopbacks))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void IPGlobalProperties_TcpListeners_Succeed(IPAddress address)
         {
             using (var server = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp))
@@ -78,7 +76,6 @@ namespace System.Net.NetworkInformation.Tests
 
         [Theory]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34690", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         [MemberData(nameof(Loopbacks))]
         public async Task IPGlobalProperties_TcpActiveConnections_Succeed(IPAddress address)
         {

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -273,7 +273,6 @@ namespace System.Net.NetworkInformation.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/50567", TestPlatforms.Android)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void BasicTest_GetIsNetworkAvailable_Success()
         {
             Assert.True(NetworkInterface.GetIsNetworkAvailable());


### PR DESCRIPTION
This change makes sure some of the IPGlobalProperties stop throwing exceptions and return the correct values.

- GetIPv4GlobalStatistics, GetIcmpV4Statistics, GetTcpIPv4Statistics, GetUdpIPv4Statistics no longer throw NetworkInformationException.

- GetActiveTcpConnections no longer returns TcpConnectionInformation instances only with the State of Unknown.

- GetActiveTcpListeners return the correct IPEndPoint details for the IPV6 loopback.

- NetworkInterface.GetIsNetworkAvailable no longer returns false for every call.

The reason these methods were behaving incorrectly on iOS is due to Apple not including the public headers for icmp_var.h, ip_var.h, tcp_fsm.h, if_media.h, and udp_var.h in the iOS SDK.  This would lead to, for example, pal_tcpstate.c always returning TcpState_Unknown even if the underlying native value was TCPS_ESTABLISHED. This change includes the missing public headers in our build.

Fixes https://github.com/dotnet/runtime/issues/36890