### PR TITLE
Disable 2 memory heavy array tests for 2 distros

### DIFF
--- a/src/libraries/System.Runtime/tests/System/ArrayTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ArrayTests.cs
@@ -4746,7 +4746,14 @@ namespace System.Tests
             // If this test is run in a 32-bit process, the large allocation will fail.
             if (IntPtr.Size != sizeof(long))
             {
-                return;
+                throw new SkipTestException("Unable to allocate enough memory");
+            }
+
+            if (PlatformDetection.IsUbuntu1804 || PlatformDetection.IsSLES)
+            {
+                // On these platforms, occasionally the OOM Killer will terminate the
+                // tests when they're using ~1GB, before they complete.
+                throw new SkipTestException("Unable to allocate enough memory");
             }
 
             short[,] a = AllocateLargeMDArray(2, 2_000_000_000);
@@ -4765,7 +4772,14 @@ namespace System.Tests
             // If this test is run in a 32-bit process, the large allocation will fail.
             if (IntPtr.Size != sizeof(long))
             {
-                return;
+                throw new SkipTestException("Unable to allocate enough memory");
+            }
+
+            if (PlatformDetection.IsUbuntu1804 || PlatformDetection.IsSLES)
+            {
+                // On these platforms, occasionally the OOM Killer will terminate the
+                // tests when they're using ~1GB, before they complete.
+                throw new SkipTestException("Unable to allocate enough memory");
             }
 
             short[,] a = AllocateLargeMDArray(2, 2_000_000_000);

--- a/src/libraries/System.Runtime/tests/System/ArrayTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ArrayTests.cs
@@ -4753,7 +4753,7 @@ namespace System.Tests
             {
                 // On these platforms, occasionally the OOM Killer will terminate the
                 // tests when they're using ~1GB, before they complete.
-                throw new SkipTestException("Unable to allocate enough memory");
+                throw new SkipTestException("Prone to OOM killer");
             }
 
             short[,] a = AllocateLargeMDArray(2, 2_000_000_000);
@@ -4779,7 +4779,7 @@ namespace System.Tests
             {
                 // On these platforms, occasionally the OOM Killer will terminate the
                 // tests when they're using ~1GB, before they complete.
-                throw new SkipTestException("Unable to allocate enough memory");
+                throw new SkipTestException("Prone to OOM killer");
             }
 
             short[,] a = AllocateLargeMDArray(2, 2_000_000_000);


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/56567

We know System.Runtime OuterLoop tests began failing regularly but sporadically on Ubuntu 18.04 and SLES 15 starting the day after this change added a new such test in April
https://github.com/dotnet/runtime/pull/51548/files?diff=unified&w=1

There is already a test that allocates 1GB, which apparently was passing OK, but perhaps adding a 2nd running immediately afterwards is causing the GC to allocate more pages than it did when there was just one. My assumption is that these two distros are configured to be more aggressive with the OOM killer, or are configured with different memory, and the difference is not interesting. So, disabling the two tests for those distros.