### PR TITLE
Disable GetBitLengthLarge for 32 bit due to OOM

### DIFF
--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/GetBitLengthTests.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/GetBitLengthTests.cs
@@ -38,7 +38,7 @@ namespace System.Numerics.Tests
             VerifyLoopGetBitLength(random, false);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))] // OOM on 32 bit
         [SkipOnPlatform(TestPlatforms.Browser, "OOM on browser due to large array allocations")]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public static void RunGetBitLengthTestsLarge()


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/57109