### PR TITLE
[MonoAOTCompiler] accept more than one AotProfilePath

### DIFF
--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -225,7 +225,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
             {
                 if (!File.Exists(path))
                 {
-                    Log.LogError($"'{path}' doesn't exist.");
+                    Log.LogError($"AotProfilePath '{path}' doesn't exist.");
                     return false;
                 }
             }

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -111,7 +111,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
     /// <summary>
     /// File to use for profile-guided optimization, *only* the methods described in the file will be AOT compiled.
     /// </summary>
-    public string? AotProfilePath { get; set; }
+    public string[]? AotProfilePath { get; set; }
 
     /// <summary>
     /// List of profilers to use.
@@ -219,10 +219,16 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
             return false;
         }
 
-        if (!string.IsNullOrEmpty(AotProfilePath) && !File.Exists(AotProfilePath))
+        if (AotProfilePath != null)
         {
-            Log.LogError($"'{AotProfilePath}' doesn't exist.", nameof(AotProfilePath));
-            return false;
+            foreach (var path in AotProfilePath)
+            {
+                if (!File.Exists(path))
+                {
+                    Log.LogError($"'{path}' doesn't exist.");
+                    return false;
+                }
+            }
         }
 
         if (UseLLVM)
@@ -491,9 +497,13 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
             aotAssembly.SetMetadata("AotDataFile", aotDataFile);
         }
 
-        if (!string.IsNullOrEmpty(AotProfilePath))
+        if (AotProfilePath?.Length > 0)
         {
-            aotArgs.Add($"profile={AotProfilePath},profile-only");
+            aotArgs.Add("profile-only");
+            foreach (var path in AotProfilePath)
+            {
+                aotArgs.Add($"profile={path}");
+            }
         }
 
         // we need to quote the entire --aot arguments here to make sure it is parsed


### PR DESCRIPTION
Fixes part of: https://github.com/dotnet/runtime/issues/56989

The Android workload needs to be able to pass in multiple AOT profiles
to the `<MonoAOTCompiler/>` MSBuild task. We plan on shipping a
default profile in the Android workload, as well as the MAUI workload.
.NET MAUI would have two profiles when using profiled AOT.

Adding `profile-only`, and then multiple `profile` arguments is
currently working in legacy Xamarin.Android:

https://github.com/xamarin/xamarin-android/blob/77895e2a03ed91fdf3729cde54501f91e7d1a36f/src/Xamarin.Android.Build.Tasks/Tasks/GetAotArguments.cs#L256-L260

Either a single property or item group can be passed in for
`AotProfilePath` now. I avoided changing the name, as it looks like it
might be used by wasm.