### PR TITLE
Fix ServiceController test

### DIFF
--- a/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceController.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceController.cs
@@ -283,7 +283,7 @@ namespace System.ServiceProcess
         }
 
         /// <summary>
-        /// A set of services on which the given service object is depend upon.
+        /// A set of services on which the given service object is dependent upon.
         /// </summary>
         public unsafe ServiceController[] ServicesDependedOn
         {

--- a/src/libraries/System.ServiceProcess.ServiceController/tests/ServiceBaseTests.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/tests/ServiceBaseTests.cs
@@ -183,7 +183,7 @@ namespace System.ServiceProcess.Tests
         public void LogWritten()
         {
             string serviceName = Guid.NewGuid().ToString();
-            // If the username is null, then the service is created under LocalSystem Account which have access to EventLog.
+            // If the username is null, then the service is created under LocalSystem Account which has access to EventLog.
             var testService = new TestServiceProvider(serviceName);
             Assert.True(EventLog.SourceExists(serviceName));
             testService.DeleteTestServices();

--- a/src/libraries/System.ServiceProcess.ServiceController/tests/ServiceControllerTests.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/tests/ServiceControllerTests.cs
@@ -148,18 +148,16 @@ namespace System.ServiceProcess.Tests
         [ConditionalFact(nameof(IsProcessElevated))]
         public void Dependencies()
         {
-            // The test service creates a number of dependent services, each of which is depended on
-            // by all the services created after it.
             var controller = new ServiceController(_testService.TestServiceName);
             Assert.Equal(0, controller.DependentServices.Length);
             Assert.Equal(1, controller.ServicesDependedOn.Length);
 
-            var dependentController = new ServiceController(_testService.TestServiceName + ".Dependent");
-            Assert.Equal(1, dependentController.DependentServices.Length);
-            Assert.Equal(0, dependentController.ServicesDependedOn.Length);
+            var prerequisiteServiceController = new ServiceController(_testService.TestServiceName + ".Prerequisite");
+            Assert.Equal(1, prerequisiteServiceController.DependentServices.Length);
+            Assert.Equal(0, prerequisiteServiceController.ServicesDependedOn.Length);
 
-            Assert.Equal(controller.ServicesDependedOn[0].ServiceName, dependentController.ServiceName);
-            Assert.Equal(dependentController.DependentServices[0].ServiceName, controller.ServiceName);
+            Assert.Equal(controller.ServicesDependedOn[0].ServiceName, prerequisiteServiceController.ServiceName);
+            Assert.Equal(prerequisiteServiceController.DependentServices[0].ServiceName, controller.ServiceName);
         }
 
         [ConditionalFact(nameof(IsProcessElevated))]
@@ -168,7 +166,7 @@ namespace System.ServiceProcess.Tests
             var controller = new ServiceController(_testService.TestServiceName);
             Assert.Equal(ServiceStartMode.Manual, controller.StartType);
 
-            // Check for the startType of the dependent services.
+            // Check for the startType of the services that depend on the test service
             for (int i = 0; i < controller.DependentServices.Length; i++)
             {
                 Assert.Equal(ServiceStartMode.Disabled, controller.DependentServices[i].StartType);

--- a/src/libraries/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/TestService.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/TestService.cs
@@ -12,7 +12,7 @@ namespace System.ServiceProcess.Tests
         // To view tracing, use DbgView from sysinternals.com;
         // run it elevated, check "Capture>Global Win32" and "Capture>Win32",
         // and filter to just messages beginning with "##"
-        internal const bool DebugTracing = false;
+        internal const bool DebugTracing = false; // toggle in TestServiceProvider.cs as well
 
         private bool _disposed;
         private Task _waitClientConnect;

--- a/src/libraries/System.ServiceProcess.ServiceController/tests/TestServiceProvider.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/tests/TestServiceProvider.cs
@@ -13,7 +13,7 @@ namespace System.ServiceProcess.Tests
         // To view tracing, use DbgView from sysinternals.com;
         // run it elevated, check "Capture>Global Win32" and "Capture>Win32",
         // and filter to just messages beginning with "##"
-        internal const bool DebugTracing = false;
+        internal const bool DebugTracing = false; // toggle in TestService.cs as well
 
         private const int readTimeout = 60000;
 
@@ -56,7 +56,9 @@ namespace System.ServiceProcess.Tests
         public readonly string TestServiceName;
         public readonly string TestServiceDisplayName;
 
-        private readonly TestServiceProvider _dependentServices;
+        private readonly TestServiceProvider _prerequisiteServices;
+
+        // Creates a test service with a prerequisite service
         public TestServiceProvider()
         {
             TestMachineName = ".";
@@ -64,19 +66,20 @@ namespace System.ServiceProcess.Tests
             TestServiceName = Guid.NewGuid().ToString();
             TestServiceDisplayName = "Test Service " + TestServiceName;
 
-            _dependentServices = new TestServiceProvider(TestServiceName + ".Dependent");
+            _prerequisiteServices = new TestServiceProvider(TestServiceName + ".Prerequisite");
 
             // Create the service
             CreateTestServices();
         }
 
+        // Creates a test service with no prerequisite services
         public TestServiceProvider(string serviceName)
         {
             TestMachineName = ".";
             ControlTimeout = TimeSpan.FromSeconds(120);
             TestServiceName = serviceName;
             TestServiceDisplayName = "Test Service " + TestServiceName;
-            
+
             // Create the service
             CreateTestServices();
         }
@@ -94,6 +97,7 @@ namespace System.ServiceProcess.Tests
 
         private void CreateTestServices()
         {
+            DebugTrace($"TestServiceProvider: Creating test service {TestServiceName}");
             TestServiceInstaller testServiceInstaller = new TestServiceInstaller();
 
             testServiceInstaller.ServiceName = TestServiceName;
@@ -101,9 +105,10 @@ namespace System.ServiceProcess.Tests
             testServiceInstaller.Description = "__Dummy Test Service__";
             testServiceInstaller.Username = null;
 
-            if (_dependentServices != null)
+            if (_prerequisiteServices != null)
             {
-                testServiceInstaller.ServicesDependedOn = new string[] { _dependentServices.TestServiceName };
+                DebugTrace($"TestServiceProvider: .. with prequisite services {_prerequisiteServices.TestServiceName}");
+                testServiceInstaller.ServicesDependedOn = new string[] { _prerequisiteServices.TestServiceName };
             }
 
             string processName = Process.GetCurrentProcess().MainModule.FileName;
@@ -122,8 +127,9 @@ namespace System.ServiceProcess.Tests
             }
 
             testServiceInstaller.ServiceCommandLine = $"\"{processName}\" {arguments}";
-
+            DebugTrace($"TestServiceProvider: Executing {testServiceInstaller.ServiceCommandLine}");
             testServiceInstaller.Install();
+            DebugTrace("TestServiceProvider: Completed install of test service");
         }
 
         public void DeleteTestServices()
@@ -140,14 +146,16 @@ namespace System.ServiceProcess.Tests
                 TestServiceInstaller testServiceInstaller = new TestServiceInstaller();
                 testServiceInstaller.ServiceName = TestServiceName;
                 testServiceInstaller.RemoveService();
+                DebugTrace("TestServiceProvider: Removed test service");
             }
             finally
             {
-                // Lets be sure to try and clean up dependenct services even if something goes
+                // Lets be sure to try and clean up prerequisite services even if something goes
                 // wrong with the full removal of the other service.
-                if (_dependentServices != null)
+                if (_prerequisiteServices != null)
                 {
-                    _dependentServices.DeleteTestServices();
+                    _prerequisiteServices.DeleteTestServices();
+                    DebugTrace("TestServiceProvider: Deleted test services");
                 }
             }
         }


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/57115

This outer loop test has apparently never passed as it was written backwards: it was intended to test that if you have a service A depending on (requiring) service B, then a call `serviceControllerForB.Stop(stopDependentServices: false))` will throw IOE. Instead it was stopping service A, which of course works fine. 

The confusion was likely because the word **dependency** is overloaded in that it can mean both depended-on and depending-on. When we created a test service XYZ that depends on another test service, we named the latter XYZ.Dependency (ie XYZ ---> XYZ.Dependency). On the Win32 SCM API, services you depend on are named "dependencies". Nevertheless in everyday English, "dependency" is often used to mean the reverse -- "the thing depending on another".  On ServiceController, the API is clearer: DependentServices are those that depend on YOU, and ServicesDependedOn are those you depend on; the method `Stop(bool stopDependentServices)` has a boolean to first stop services that depend on you (to which you are a prerequisite).

Renamed the test service that's depended on to be XYZ.Prerequisite.
Fixed test to attempt to stop that instead.
Added more of the handy off-by-default tracing in the tests.

Note these tests only run in Windows+OuterLoop+Elevated, which may be one reason it wasn't noticed.