### PR TITLE
Fix analyzer, docs file packaging and don't overbuild runtime.native IO.Ports packages.

### DIFF
--- a/eng/packaging.props
+++ b/eng/packaging.props
@@ -1,20 +1,9 @@
 <Project>
 
   <PropertyGroup>
-    <DefaultAllowedOutputExtensionsInPackageBuildOutputFolder>.dll;.exe;.winmd;.json;.pri;</DefaultAllowedOutputExtensionsInPackageBuildOutputFolder>
+    <!-- Needs to be set in a props file when package referencing NuGet.Build.Tasks.Pack, as NuGet's targets file is imported before
+         packaging.targets and hence the BeforePack isn't respected. This can be moved back when the PackageReference is removed. -->
+    <BeforePack>AddNETStandardCompatErrorFileForPackaging;IncludeAnalyzersInPackage;$(BeforePack)</BeforePack>
   </PropertyGroup>
-
-  <ItemGroup>
-    <!-- Add a marker to help the designer optimize & share .NET Core packages -->
-    <None Include="$(PackageDesignerMarkerFile)"
-          PackagePath="$([System.IO.Path]::GetFileName('$(PackageDesignerMarkerFile)'))"
-          Pack="true"
-          Condition="'$(IncludeDesignerMarker)' != 'false'" />
-  </ItemGroup>
-
-  <!-- TODO: Remove when all required nuget pack features are part of the consumed SDK. -->
-  <ItemGroup>
-    <PackageReference Include="NuGet.Build.Tasks.Pack" Version="$(NuGetBuildTasksPackVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
-  </ItemGroup>
 
 </Project>

--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -12,7 +12,6 @@
     <!-- Don't include target platform specific dependencies, since we use the target platform to represent RIDs instead -->
     <SuppressDependenciesWhenPacking Condition="'$(ExcludeFromPackage)' == 'true' or ('$(TargetsAnyOS)' != 'true' and $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net5.0')))">true</SuppressDependenciesWhenPacking>
     <PackageDesignerMarkerFile>$(MSBuildThisFileDirectory)useSharedDesignerContext.txt</PackageDesignerMarkerFile>
-    <BeforePack>AddNETStandardCompatErrorFileForPackaging;IncludeAnalyzersInPackage;$(BeforePack)</BeforePack>
     <!-- Generate packages in the allconfigurations build. -->
     <GeneratePackageOnBuild Condition="'$(BuildAllConfigurations)' == 'true'">true</GeneratePackageOnBuild>
     <!-- Search for the documentation file in the intellisense package and otherwise pick up the generated one. -->
@@ -26,6 +25,19 @@
     <PackageDownload Include="$([MSBuild]::ValueOrDefault('$(PackageValidationBaselineName)', '$(PackageId)'))"
                      Version="[$(PackageValidationBaselineVersion)]"
                      Condition="'$(DisablePackageBaselineValidation)' != 'true' and '$(PackageValidationBaselinePath)' == '' and '$(PackageValidationBaselineVersion)' != ''" />
+  </ItemGroup>
+
+  <!-- TODO: Remove when all required nuget pack features are part of the consumed SDK. -->
+  <ItemGroup>
+    <PackageReference Include="NuGet.Build.Tasks.Pack" Version="$(NuGetBuildTasksPackVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Add a marker to help the designer optimize & share .NET Core packages -->
+    <None Include="$(PackageDesignerMarkerFile)"
+          PackagePath="$([System.IO.Path]::GetFileName('$(PackageDesignerMarkerFile)'))"
+          Pack="true"
+          Condition="'$(IncludeDesignerMarker)' != 'false'" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(AddNETFrameworkAssemblyReferenceToPackage)' == 'true'">

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <Import Project="NetCoreAppLibrary.props" />
-  <Import Project="$(RepositoryEngineeringDir)packaging.props" Condition="'$(IsPackable)' == 'true'" />
+  <Import Project="$(RepositoryEngineeringDir)packaging.props" Condition="'$(IsSourceProject)' == 'true'" />
   <Import Project="$(RepositoryEngineeringDir)referenceAssemblies.props" Condition="'$(IsReferenceAssembly)' == 'true'" />
   <Import Project="$(RepositoryEngineeringDir)targetframeworksuffix.props" Condition="'$(DesignTimeBuild)' != 'true'" />
 

--- a/src/libraries/System.IO.Ports/src/System.IO.Ports.csproj
+++ b/src/libraries/System.IO.Ports/src/System.IO.Ports.csproj
@@ -153,10 +153,10 @@ System.IO.Ports.SerialPort</PackageDescription>
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
-    <!-- Just reference the runtime meta package but don't build it to avoid unintentional Build/Pack invocations. -->
-    <ProjectReference Include="..\pkg\runtime.native.$(MSBuildProjectName).proj" />
+    <!-- Just reference the runtime packages but don't build them in order to avoid unintentional Build/Pack invocations. -->
+    <ProjectReference Include="..\pkg\runtime.native.$(MSBuildProjectName).proj" BuildReference="false" />
     <!-- Make the runtime specific packages non transitive so that they aren't flowing into other projects. -->
-    <ProjectReference Include="..\pkg\runtime.*.runtime.native.$(MSBuildProjectName).proj" PrivateAssets="all" />
+    <ProjectReference Include="..\pkg\runtime.*.runtime.native.$(MSBuildProjectName).proj" BuildReference="false" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">


### PR DESCRIPTION
This commit fixes analyzers which were dropped from the package during
the clean-up of pkgprojs and missing documentation files.

1. Analyzers were dropped from the package because the BeforePack
   hook wasn't respected. This happens when the NuGet Pack nuget package
   is referenced which then gets imported before the packaging.targets
   file. The BeforePack property needs to be set in a props file if
   NuGet's targets file isn't used from the SDK but from its package.
2. Documentation files were dropped as the
   DefaultAllowedOutputExtensionsInPackageBuildOutputFolder property
   didn't include the .xml extension.
3. runtime.native.System.IO.Ports.csproj is referenced both in the src.proj
    traversal project and in System.IO.Ports.csproj. The latter reference is
    necessary in order to make it appear as a dependency in the
    System.IO.Ports nuget package. The ProjectReference was missing the
    `BuildReferences=false` attribute and hence the
    runtime.native.System.IO.Ports project was built twice which resulted
    in multiple concurrent builds likely with different global properties.