### PR TITLE
Fix regression in dictionary key serialization when registering custom primitive converters.

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
@@ -55,7 +55,7 @@ namespace System.Text.Json.Serialization.Converters
                 {
                     state.Current.PropertyState = StackFramePropertyState.Name;
                     TKey key = enumerator.Current.Key;
-                    _keyConverter.WriteWithQuotes(writer, key, options, ref state);
+                    _keyConverter.WriteToPropertyName(writer, key, options, ref state);
                 }
 
                 TValue element = enumerator.Current.Value;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
@@ -55,7 +55,7 @@ namespace System.Text.Json.Serialization.Converters
                 {
                     state.Current.PropertyState = StackFramePropertyState.Name;
                     TKey key = enumerator.Current.Key;
-                    _keyConverter.WriteToPropertyName(writer, key, options, ref state);
+                    _keyConverter.WriteAsPropertyName(writer, key, options, ref state);
                 }
 
                 TValue element = enumerator.Current.Value;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryOfTKeyTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryOfTKeyTValueConverter.cs
@@ -61,7 +61,7 @@ namespace System.Text.Json.Serialization.Converters
                 do
                 {
                     TKey key = enumerator.Current.Key;
-                    _keyConverter.WriteToPropertyName(writer, key, options, ref state);
+                    _keyConverter.WriteAsPropertyName(writer, key, options, ref state);
                     _valueConverter.Write(writer, enumerator.Current.Value, options);
                 } while (enumerator.MoveNext());
             }
@@ -80,7 +80,7 @@ namespace System.Text.Json.Serialization.Converters
                         state.Current.PropertyState = StackFramePropertyState.Name;
 
                         TKey key = enumerator.Current.Key;
-                        _keyConverter.WriteToPropertyName(writer, key, options, ref state);
+                        _keyConverter.WriteAsPropertyName(writer, key, options, ref state);
                     }
 
                     TValue element = enumerator.Current.Value;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryOfTKeyTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryOfTKeyTValueConverter.cs
@@ -61,7 +61,7 @@ namespace System.Text.Json.Serialization.Converters
                 do
                 {
                     TKey key = enumerator.Current.Key;
-                    _keyConverter.WriteWithQuotes(writer, key, options, ref state);
+                    _keyConverter.WriteToPropertyName(writer, key, options, ref state);
                     _valueConverter.Write(writer, enumerator.Current.Value, options);
                 } while (enumerator.MoveNext());
             }
@@ -80,7 +80,7 @@ namespace System.Text.Json.Serialization.Converters
                         state.Current.PropertyState = StackFramePropertyState.Name;
 
                         TKey key = enumerator.Current.Key;
-                        _keyConverter.WriteWithQuotes(writer, key, options, ref state);
+                        _keyConverter.WriteToPropertyName(writer, key, options, ref state);
                     }
 
                     TValue element = enumerator.Current.Value;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IDictionaryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IDictionaryConverter.cs
@@ -92,13 +92,13 @@ namespace System.Text.Json.Serialization.Converters
                     if (key is string keyString)
                     {
                         _keyConverter ??= GetConverter<string>(typeInfo.KeyTypeInfo!);
-                        _keyConverter.WriteWithQuotes(writer, keyString, options, ref state);
+                        _keyConverter.WriteToPropertyName(writer, keyString, options, ref state);
                     }
                     else
                     {
                         // IDictionary is a special case since it has polymorphic object semantics on serialization
                         // but needs to use JsonConverter<string> on deserialization.
-                        _valueConverter.WriteWithQuotes(writer, key, options, ref state);
+                        _valueConverter.WriteToPropertyName(writer, key, options, ref state);
                     }
                 }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IDictionaryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IDictionaryConverter.cs
@@ -92,13 +92,13 @@ namespace System.Text.Json.Serialization.Converters
                     if (key is string keyString)
                     {
                         _keyConverter ??= GetConverter<string>(typeInfo.KeyTypeInfo!);
-                        _keyConverter.WriteToPropertyName(writer, keyString, options, ref state);
+                        _keyConverter.WriteAsPropertyName(writer, keyString, options, ref state);
                     }
                     else
                     {
                         // IDictionary is a special case since it has polymorphic object semantics on serialization
                         // but needs to use JsonConverter<string> on deserialization.
-                        _valueConverter.WriteToPropertyName(writer, key, options, ref state);
+                        _valueConverter.WriteAsPropertyName(writer, key, options, ref state);
                     }
                 }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonDictionaryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonDictionaryConverter.cs
@@ -261,7 +261,7 @@ namespace System.Text.Json.Serialization
                 else
                 {
                     _keyConverter ??= GetConverter<TKey>(state.Current.JsonTypeInfo.KeyTypeInfo!);
-                    key = _keyConverter.ReadFromPropertyName(ref reader, typeToConvert, options);
+                    key = _keyConverter.ReadAsPropertyName(ref reader, typeToConvert, options);
                     unescapedPropertyNameAsString = reader.GetString()!;
                 }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonDictionaryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonDictionaryConverter.cs
@@ -261,7 +261,7 @@ namespace System.Text.Json.Serialization
                 else
                 {
                     _keyConverter ??= GetConverter<TKey>(state.Current.JsonTypeInfo.KeyTypeInfo!);
-                    key = _keyConverter.ReadWithQuotes(ref reader);
+                    key = _keyConverter.ReadFromPropertyName(ref reader, typeToConvert, options);
                     unescapedPropertyNameAsString = reader.GetString()!;
                 }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/BooleanConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/BooleanConverter.cs
@@ -17,7 +17,7 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteBooleanValue(value);
         }
 
-        internal override bool ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        internal override bool ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             ReadOnlySpan<byte> propertyName = reader.GetSpan();
             if (Utf8Parser.TryParse(propertyName, out bool value, out int bytesConsumed)
@@ -29,7 +29,7 @@ namespace System.Text.Json.Serialization.Converters
             throw ThrowHelper.GetFormatException(DataType.Boolean);
         }
 
-        internal override void WriteToPropertyName(Utf8JsonWriter writer, bool value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteAsPropertyName(Utf8JsonWriter writer, bool value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/BooleanConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/BooleanConverter.cs
@@ -17,7 +17,7 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteBooleanValue(value);
         }
 
-        internal override bool ReadWithQuotes(ref Utf8JsonReader reader)
+        internal override bool ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             ReadOnlySpan<byte> propertyName = reader.GetSpan();
             if (Utf8Parser.TryParse(propertyName, out bool value, out int bytesConsumed)
@@ -29,7 +29,7 @@ namespace System.Text.Json.Serialization.Converters
             throw ThrowHelper.GetFormatException(DataType.Boolean);
         }
 
-        internal override void WriteWithQuotes(Utf8JsonWriter writer, bool value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteToPropertyName(Utf8JsonWriter writer, bool value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ByteConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ByteConverter.cs
@@ -20,12 +20,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        internal override byte ReadWithQuotes(ref Utf8JsonReader reader)
+        internal override byte ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetByteWithQuotes();
         }
 
-        internal override void WriteWithQuotes(Utf8JsonWriter writer, byte value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteToPropertyName(Utf8JsonWriter writer, byte value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ByteConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ByteConverter.cs
@@ -20,12 +20,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        internal override byte ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        internal override byte ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetByteWithQuotes();
         }
 
-        internal override void WriteToPropertyName(Utf8JsonWriter writer, byte value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteAsPropertyName(Utf8JsonWriter writer, byte value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/CharConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/CharConverter.cs
@@ -28,10 +28,10 @@ namespace System.Text.Json.Serialization.Converters
                 );
         }
 
-        internal override char ReadWithQuotes(ref Utf8JsonReader reader)
-            => Read(ref reader, default!, default!);
+        internal override char ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            => Read(ref reader, typeToConvert, options);
 
-        internal override void WriteWithQuotes(Utf8JsonWriter writer, char value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteToPropertyName(Utf8JsonWriter writer, char value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(
 #if BUILDING_INBOX_LIBRARY

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/CharConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/CharConverter.cs
@@ -28,10 +28,10 @@ namespace System.Text.Json.Serialization.Converters
                 );
         }
 
-        internal override char ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        internal override char ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             => Read(ref reader, typeToConvert, options);
 
-        internal override void WriteToPropertyName(Utf8JsonWriter writer, char value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteAsPropertyName(Utf8JsonWriter writer, char value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(
 #if BUILDING_INBOX_LIBRARY

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DateTimeConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DateTimeConverter.cs
@@ -15,12 +15,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteStringValue(value);
         }
 
-        internal override DateTime ReadWithQuotes(ref Utf8JsonReader reader)
+        internal override DateTime ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetDateTimeNoValidation();
         }
 
-        internal override void WriteWithQuotes(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteToPropertyName(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DateTimeConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DateTimeConverter.cs
@@ -15,12 +15,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteStringValue(value);
         }
 
-        internal override DateTime ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        internal override DateTime ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetDateTimeNoValidation();
         }
 
-        internal override void WriteToPropertyName(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteAsPropertyName(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DateTimeOffsetConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DateTimeOffsetConverter.cs
@@ -15,12 +15,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteStringValue(value);
         }
 
-        internal override DateTimeOffset ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        internal override DateTimeOffset ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetDateTimeOffsetNoValidation();
         }
 
-        internal override void WriteToPropertyName(Utf8JsonWriter writer, DateTimeOffset value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteAsPropertyName(Utf8JsonWriter writer, DateTimeOffset value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DateTimeOffsetConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DateTimeOffsetConverter.cs
@@ -15,12 +15,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteStringValue(value);
         }
 
-        internal override DateTimeOffset ReadWithQuotes(ref Utf8JsonReader reader)
+        internal override DateTimeOffset ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetDateTimeOffsetNoValidation();
         }
 
-        internal override void WriteWithQuotes(Utf8JsonWriter writer, DateTimeOffset value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteToPropertyName(Utf8JsonWriter writer, DateTimeOffset value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DecimalConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DecimalConverter.cs
@@ -20,12 +20,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        internal override decimal ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        internal override decimal ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetDecimalWithQuotes();
         }
 
-        internal override void WriteToPropertyName(Utf8JsonWriter writer, decimal value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteAsPropertyName(Utf8JsonWriter writer, decimal value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DecimalConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DecimalConverter.cs
@@ -20,12 +20,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        internal override decimal ReadWithQuotes(ref Utf8JsonReader reader)
+        internal override decimal ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetDecimalWithQuotes();
         }
 
-        internal override void WriteWithQuotes(Utf8JsonWriter writer, decimal value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteToPropertyName(Utf8JsonWriter writer, decimal value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DoubleConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DoubleConverter.cs
@@ -20,12 +20,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        internal override double ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        internal override double ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetDoubleWithQuotes();
         }
 
-        internal override void WriteToPropertyName(Utf8JsonWriter writer, double value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteAsPropertyName(Utf8JsonWriter writer, double value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DoubleConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DoubleConverter.cs
@@ -20,12 +20,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        internal override double ReadWithQuotes(ref Utf8JsonReader reader)
+        internal override double ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetDoubleWithQuotes();
         }
 
-        internal override void WriteWithQuotes(Utf8JsonWriter writer, double value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteToPropertyName(Utf8JsonWriter writer, double value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
@@ -330,6 +330,8 @@ namespace System.Text.Json.Serialization.Converters
             // Try to obtain values from caches
             if (options.DictionaryKeyPolicy != null)
             {
+                Debug.Assert(!state.Current.IgnoreDictionaryKeyPolicy);
+
                 if (_dictionaryKeyPolicyCache != null && _dictionaryKeyPolicyCache.TryGetValue(key, out JsonEncodedText formatted))
                 {
                     writer.WritePropertyName(formatted);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
@@ -84,7 +84,7 @@ namespace System.Text.Json.Serialization.Converters
                     return default;
                 }
 
-                return ReadWithQuotes(ref reader);
+                return ReadFromPropertyName(ref reader, typeToConvert, options);
             }
 
             if (token != JsonTokenType.Number || !_converterOptions.HasFlag(EnumConverterOptions.AllowNumbers))
@@ -304,7 +304,7 @@ namespace System.Text.Json.Serialization.Converters
             return converted;
         }
 
-        internal override T ReadWithQuotes(ref Utf8JsonReader reader)
+        internal override T ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             string? enumString = reader.GetString();
 
@@ -318,7 +318,7 @@ namespace System.Text.Json.Serialization.Converters
             return value;
         }
 
-        internal override void WriteWithQuotes(Utf8JsonWriter writer, T value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteToPropertyName(Utf8JsonWriter writer, T value, JsonSerializerOptions options, ref WriteStack state)
         {
             // An EnumConverter that invokes this method
             // can only be created by JsonSerializerOptions.GetDictionaryKeyConverter
@@ -330,8 +330,6 @@ namespace System.Text.Json.Serialization.Converters
             // Try to obtain values from caches
             if (options.DictionaryKeyPolicy != null)
             {
-                Debug.Assert(!state.Current.IgnoreDictionaryKeyPolicy);
-
                 if (_dictionaryKeyPolicyCache != null && _dictionaryKeyPolicyCache.TryGetValue(key, out JsonEncodedText formatted))
                 {
                     writer.WritePropertyName(formatted);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
@@ -84,7 +84,7 @@ namespace System.Text.Json.Serialization.Converters
                     return default;
                 }
 
-                return ReadFromPropertyName(ref reader, typeToConvert, options);
+                return ReadAsPropertyName(ref reader, typeToConvert, options);
             }
 
             if (token != JsonTokenType.Number || !_converterOptions.HasFlag(EnumConverterOptions.AllowNumbers))
@@ -304,7 +304,7 @@ namespace System.Text.Json.Serialization.Converters
             return converted;
         }
 
-        internal override T ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        internal override T ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             string? enumString = reader.GetString();
 
@@ -318,7 +318,7 @@ namespace System.Text.Json.Serialization.Converters
             return value;
         }
 
-        internal override void WriteToPropertyName(Utf8JsonWriter writer, T value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteAsPropertyName(Utf8JsonWriter writer, T value, JsonSerializerOptions options, ref WriteStack state)
         {
             // An EnumConverter that invokes this method
             // can only be created by JsonSerializerOptions.GetDictionaryKeyConverter

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/GuidConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/GuidConverter.cs
@@ -15,12 +15,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteStringValue(value);
         }
 
-        internal override Guid ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        internal override Guid ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetGuidNoValidation();
         }
 
-        internal override void WriteToPropertyName(Utf8JsonWriter writer, Guid value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteAsPropertyName(Utf8JsonWriter writer, Guid value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/GuidConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/GuidConverter.cs
@@ -15,12 +15,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteStringValue(value);
         }
 
-        internal override Guid ReadWithQuotes(ref Utf8JsonReader reader)
+        internal override Guid ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetGuidNoValidation();
         }
 
-        internal override void WriteWithQuotes(Utf8JsonWriter writer, Guid value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteToPropertyName(Utf8JsonWriter writer, Guid value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int16Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int16Converter.cs
@@ -21,12 +21,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue((long)value);
         }
 
-        internal override short ReadWithQuotes(ref Utf8JsonReader reader)
+        internal override short ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetInt16WithQuotes();
         }
 
-        internal override void WriteWithQuotes(Utf8JsonWriter writer, short value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteToPropertyName(Utf8JsonWriter writer, short value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int16Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int16Converter.cs
@@ -21,12 +21,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue((long)value);
         }
 
-        internal override short ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        internal override short ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetInt16WithQuotes();
         }
 
-        internal override void WriteToPropertyName(Utf8JsonWriter writer, short value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteAsPropertyName(Utf8JsonWriter writer, short value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int32Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int32Converter.cs
@@ -21,12 +21,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue((long)value);
         }
 
-        internal override int ReadWithQuotes(ref Utf8JsonReader reader)
+        internal override int ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetInt32WithQuotes();
         }
 
-        internal override void WriteWithQuotes(Utf8JsonWriter writer, int value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteToPropertyName(Utf8JsonWriter writer, int value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int32Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int32Converter.cs
@@ -21,12 +21,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue((long)value);
         }
 
-        internal override int ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        internal override int ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetInt32WithQuotes();
         }
 
-        internal override void WriteToPropertyName(Utf8JsonWriter writer, int value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteAsPropertyName(Utf8JsonWriter writer, int value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int64Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int64Converter.cs
@@ -20,12 +20,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        internal override long ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        internal override long ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetInt64WithQuotes();
         }
 
-        internal override void WriteToPropertyName(Utf8JsonWriter writer, long value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteAsPropertyName(Utf8JsonWriter writer, long value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int64Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int64Converter.cs
@@ -20,12 +20,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        internal override long ReadWithQuotes(ref Utf8JsonReader reader)
+        internal override long ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetInt64WithQuotes();
         }
 
-        internal override void WriteWithQuotes(Utf8JsonWriter writer, long value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteToPropertyName(Utf8JsonWriter writer, long value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ObjectConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ObjectConverter.cs
@@ -30,13 +30,13 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteEndObject();
         }
 
-        internal override object ReadWithQuotes(ref Utf8JsonReader reader)
+        internal override object ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             ThrowHelper.ThrowNotSupportedException_DictionaryKeyTypeNotSupported(TypeToConvert, this);
             return null!;
         }
 
-        internal override void WriteWithQuotes(Utf8JsonWriter writer, object? value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteToPropertyName(Utf8JsonWriter writer, object? value, JsonSerializerOptions options, ref WriteStack state)
         {
             // This converter does not handle nulls.
             Debug.Assert(value != null);
@@ -48,7 +48,7 @@ namespace System.Text.Json.Serialization.Converters
                 ThrowHelper.ThrowNotSupportedException_DictionaryKeyTypeNotSupported(runtimeType, this);
             }
 
-            runtimeConverter.WriteWithQuotesAsObject(writer, value, options, ref state);
+            runtimeConverter.WriteToPropertyNameAsObject(writer, value, options, ref state);
         }
 
         internal override object? ReadNumberWithCustomHandling(ref Utf8JsonReader reader, JsonNumberHandling handling, JsonSerializerOptions options)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ObjectConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ObjectConverter.cs
@@ -30,13 +30,13 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteEndObject();
         }
 
-        internal override object ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        internal override object ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             ThrowHelper.ThrowNotSupportedException_DictionaryKeyTypeNotSupported(TypeToConvert, this);
             return null!;
         }
 
-        internal override void WriteToPropertyName(Utf8JsonWriter writer, object? value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteAsPropertyName(Utf8JsonWriter writer, object? value, JsonSerializerOptions options, ref WriteStack state)
         {
             // This converter does not handle nulls.
             Debug.Assert(value != null);
@@ -48,7 +48,7 @@ namespace System.Text.Json.Serialization.Converters
                 ThrowHelper.ThrowNotSupportedException_DictionaryKeyTypeNotSupported(runtimeType, this);
             }
 
-            runtimeConverter.WriteToPropertyNameAsObject(writer, value, options, ref state);
+            runtimeConverter.WriteAsPropertyNameAsObject(writer, value, options, ref state);
         }
 
         internal override object? ReadNumberWithCustomHandling(ref Utf8JsonReader reader, JsonNumberHandling handling, JsonSerializerOptions options)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/SByteConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/SByteConverter.cs
@@ -20,12 +20,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        internal override sbyte ReadWithQuotes(ref Utf8JsonReader reader)
+        internal override sbyte ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetSByteWithQuotes();
         }
 
-        internal override void WriteWithQuotes(Utf8JsonWriter writer, sbyte value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteToPropertyName(Utf8JsonWriter writer, sbyte value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/SByteConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/SByteConverter.cs
@@ -20,12 +20,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        internal override sbyte ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        internal override sbyte ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetSByteWithQuotes();
         }
 
-        internal override void WriteToPropertyName(Utf8JsonWriter writer, sbyte value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteAsPropertyName(Utf8JsonWriter writer, sbyte value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/SingleConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/SingleConverter.cs
@@ -21,12 +21,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        internal override float ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        internal override float ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetSingleWithQuotes();
         }
 
-        internal override void WriteToPropertyName(Utf8JsonWriter writer, float value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteAsPropertyName(Utf8JsonWriter writer, float value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/SingleConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/SingleConverter.cs
@@ -21,12 +21,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        internal override float ReadWithQuotes(ref Utf8JsonReader reader)
+        internal override float ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetSingleWithQuotes();
         }
 
-        internal override void WriteWithQuotes(Utf8JsonWriter writer, float value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteToPropertyName(Utf8JsonWriter writer, float value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/StringConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/StringConverter.cs
@@ -23,12 +23,12 @@ namespace System.Text.Json.Serialization.Converters
             }
         }
 
-        internal override string ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        internal override string ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetString()!;
         }
 
-        internal override void WriteToPropertyName(Utf8JsonWriter writer, string value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteAsPropertyName(Utf8JsonWriter writer, string value, JsonSerializerOptions options, ref WriteStack state)
         {
             if (options.DictionaryKeyPolicy != null && !state.Current.IgnoreDictionaryKeyPolicy)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/StringConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/StringConverter.cs
@@ -23,12 +23,12 @@ namespace System.Text.Json.Serialization.Converters
             }
         }
 
-        internal override string ReadWithQuotes(ref Utf8JsonReader reader)
+        internal override string ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetString()!;
         }
 
-        internal override void WriteWithQuotes(Utf8JsonWriter writer, string value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteToPropertyName(Utf8JsonWriter writer, string value, JsonSerializerOptions options, ref WriteStack state)
         {
             if (options.DictionaryKeyPolicy != null && !state.Current.IgnoreDictionaryKeyPolicy)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt16Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt16Converter.cs
@@ -21,12 +21,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue((long)value);
         }
 
-        internal override ushort ReadWithQuotes(ref Utf8JsonReader reader)
+        internal override ushort ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetUInt16WithQuotes();
         }
 
-        internal override void WriteWithQuotes(Utf8JsonWriter writer, ushort value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteToPropertyName(Utf8JsonWriter writer, ushort value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt16Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt16Converter.cs
@@ -21,12 +21,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue((long)value);
         }
 
-        internal override ushort ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        internal override ushort ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetUInt16WithQuotes();
         }
 
-        internal override void WriteToPropertyName(Utf8JsonWriter writer, ushort value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteAsPropertyName(Utf8JsonWriter writer, ushort value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt32Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt32Converter.cs
@@ -21,12 +21,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue((ulong)value);
         }
 
-        internal override uint ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        internal override uint ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetUInt32WithQuotes();
         }
 
-        internal override void WriteToPropertyName(Utf8JsonWriter writer, uint value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteAsPropertyName(Utf8JsonWriter writer, uint value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt32Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt32Converter.cs
@@ -21,12 +21,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue((ulong)value);
         }
 
-        internal override uint ReadWithQuotes(ref Utf8JsonReader reader)
+        internal override uint ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetUInt32WithQuotes();
         }
 
-        internal override void WriteWithQuotes(Utf8JsonWriter writer, uint value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteToPropertyName(Utf8JsonWriter writer, uint value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt64Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt64Converter.cs
@@ -20,12 +20,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        internal override ulong ReadWithQuotes(ref Utf8JsonReader reader)
+        internal override ulong ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetUInt64WithQuotes();
         }
 
-        internal override void WriteWithQuotes(Utf8JsonWriter writer, ulong value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteToPropertyName(Utf8JsonWriter writer, ulong value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt64Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt64Converter.cs
@@ -20,12 +20,12 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        internal override ulong ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        internal override ulong ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetUInt64WithQuotes();
         }
 
-        internal override void WriteToPropertyName(Utf8JsonWriter writer, ulong value, JsonSerializerOptions options, ref WriteStack state)
+        internal override void WriteAsPropertyName(Utf8JsonWriter writer, ulong value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -105,9 +105,9 @@ namespace System.Text.Json.Serialization
         internal abstract bool WriteCoreAsObject(Utf8JsonWriter writer, object? value, JsonSerializerOptions options, ref WriteStack state);
 
         /// <summary>
-        /// Loosely-typed WriteWithQuotes() that forwards to strongly-typed WriteWithQuotes().
+        /// Loosely-typed WriteToPropertyName() that forwards to strongly-typed WriteToPropertyName().
         /// </summary>
-        internal abstract void WriteWithQuotesAsObject(Utf8JsonWriter writer, object value, JsonSerializerOptions options, ref WriteStack state);
+        internal abstract void WriteToPropertyNameAsObject(Utf8JsonWriter writer, object value, JsonSerializerOptions options, ref WriteStack state);
 
         // Whether a type (ConverterStrategy.Object) is deserialized using a parameterized constructor.
         internal virtual bool ConstructorIsParameterized { get; }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -107,7 +107,7 @@ namespace System.Text.Json.Serialization
         /// <summary>
         /// Loosely-typed WriteToPropertyName() that forwards to strongly-typed WriteToPropertyName().
         /// </summary>
-        internal abstract void WriteToPropertyNameAsObject(Utf8JsonWriter writer, object value, JsonSerializerOptions options, ref WriteStack state);
+        internal abstract void WriteAsPropertyNameAsObject(Utf8JsonWriter writer, object value, JsonSerializerOptions options, ref WriteStack state);
 
         // Whether a type (ConverterStrategy.Object) is deserialized using a parameterized constructor.
         internal virtual bool ConstructorIsParameterized { get; }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
@@ -119,7 +119,7 @@ namespace System.Text.Json.Serialization
             throw new InvalidOperationException();
         }
 
-        internal sealed override void WriteToPropertyNameAsObject(
+        internal sealed override void WriteAsPropertyNameAsObject(
             Utf8JsonWriter writer, object value,
             JsonSerializerOptions options,
             ref WriteStack state)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
@@ -119,7 +119,7 @@ namespace System.Text.Json.Serialization
             throw new InvalidOperationException();
         }
 
-        internal sealed override void WriteWithQuotesAsObject(
+        internal sealed override void WriteToPropertyNameAsObject(
             Utf8JsonWriter writer, object value,
             JsonSerializerOptions options,
             ref WriteStack state)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -607,34 +607,34 @@ namespace System.Text.Json.Serialization
 #nullable restore
             JsonSerializerOptions options);
 
-        internal virtual T ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        internal virtual T ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             if (!IsInternalConverter && options.TryGetDefaultSimpleConverter(TypeToConvert, out JsonConverter? defaultConverter))
             {
                 // .NET 5 backward compatibility: hardcode the default converter for primitive key serialization.
                 Debug.Assert(defaultConverter.IsInternalConverter && defaultConverter is JsonConverter<T>);
-                return ((JsonConverter<T>)defaultConverter).ReadFromPropertyName(ref reader, TypeToConvert, options);
+                return ((JsonConverter<T>)defaultConverter).ReadAsPropertyName(ref reader, TypeToConvert, options);
             }
 
             ThrowHelper.ThrowNotSupportedException_DictionaryKeyTypeNotSupported(TypeToConvert, this);
             return default;
         }
 
-        internal virtual void WriteToPropertyName(Utf8JsonWriter writer, T value, JsonSerializerOptions options, ref WriteStack state)
+        internal virtual void WriteAsPropertyName(Utf8JsonWriter writer, T value, JsonSerializerOptions options, ref WriteStack state)
         {
             if (!IsInternalConverter && options.TryGetDefaultSimpleConverter(TypeToConvert, out JsonConverter? defaultConverter))
             {
                 // .NET 5 backward compatibility: hardcode the default converter for primitive key serialization.
                 Debug.Assert(defaultConverter.IsInternalConverter && defaultConverter is JsonConverter<T>);
-                ((JsonConverter<T>)defaultConverter).WriteToPropertyName(writer, value, options, ref state);
+                ((JsonConverter<T>)defaultConverter).WriteAsPropertyName(writer, value, options, ref state);
                 return;
             }
 
             ThrowHelper.ThrowNotSupportedException_DictionaryKeyTypeNotSupported(TypeToConvert, this);
         }
 
-        internal sealed override void WriteToPropertyNameAsObject(Utf8JsonWriter writer, object value, JsonSerializerOptions options, ref WriteStack state)
-            => WriteToPropertyName(writer, (T)value, options, ref state);
+        internal sealed override void WriteAsPropertyNameAsObject(Utf8JsonWriter writer, object value, JsonSerializerOptions options, ref WriteStack state)
+            => WriteAsPropertyName(writer, (T)value, options, ref state);
 
         internal virtual T ReadNumberWithCustomHandling(ref Utf8JsonReader reader, JsonNumberHandling handling, JsonSerializerOptions options)
             => throw new InvalidOperationException();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -607,17 +607,34 @@ namespace System.Text.Json.Serialization
 #nullable restore
             JsonSerializerOptions options);
 
-        internal virtual T ReadWithQuotes(ref Utf8JsonReader reader)
+        internal virtual T ReadFromPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (!IsInternalConverter && options.TryGetDefaultSimpleConverter(TypeToConvert, out JsonConverter? defaultConverter))
+            {
+                // .NET 5 backward compatibility: hardcode the default converter for primitive key serialization.
+                Debug.Assert(defaultConverter.IsInternalConverter && defaultConverter is JsonConverter<T>);
+                return ((JsonConverter<T>)defaultConverter).ReadFromPropertyName(ref reader, TypeToConvert, options);
+            }
+
             ThrowHelper.ThrowNotSupportedException_DictionaryKeyTypeNotSupported(TypeToConvert, this);
             return default;
         }
 
-        internal virtual void WriteWithQuotes(Utf8JsonWriter writer, [DisallowNull] T value, JsonSerializerOptions options, ref WriteStack state)
-            => ThrowHelper.ThrowNotSupportedException_DictionaryKeyTypeNotSupported(TypeToConvert, this);
+        internal virtual void WriteToPropertyName(Utf8JsonWriter writer, T value, JsonSerializerOptions options, ref WriteStack state)
+        {
+            if (!IsInternalConverter && options.TryGetDefaultSimpleConverter(TypeToConvert, out JsonConverter? defaultConverter))
+            {
+                // .NET 5 backward compatibility: hardcode the default converter for primitive key serialization.
+                Debug.Assert(defaultConverter.IsInternalConverter && defaultConverter is JsonConverter<T>);
+                ((JsonConverter<T>)defaultConverter).WriteToPropertyName(writer, value, options, ref state);
+                return;
+            }
 
-        internal sealed override void WriteWithQuotesAsObject(Utf8JsonWriter writer, object value, JsonSerializerOptions options, ref WriteStack state)
-            => WriteWithQuotes(writer, (T)value, options, ref state);
+            ThrowHelper.ThrowNotSupportedException_DictionaryKeyTypeNotSupported(TypeToConvert, this);
+        }
+
+        internal sealed override void WriteToPropertyNameAsObject(Utf8JsonWriter writer, object value, JsonSerializerOptions options, ref WriteStack state)
+            => WriteToPropertyName(writer, (T)value, options, ref state);
 
         internal virtual T ReadNumberWithCustomHandling(ref Utf8JsonReader reader, JsonNumberHandling handling, JsonSerializerOptions options)
             => throw new InvalidOperationException();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -224,7 +224,6 @@ namespace System.Text.Json
 
                 if (s_defaultSimpleConverters.TryGetValue(typeToConvert, out JsonConverter? foundConverter))
                 {
-                    Debug.Assert(foundConverter != null);
                     converter = foundConverter;
                 }
                 else
@@ -316,6 +315,21 @@ namespace System.Text.Json
             }
 
             return converter;
+        }
+
+        internal bool TryGetDefaultSimpleConverter(Type typeToConvert, [NotNullWhen(true)] out JsonConverter? converter)
+        {
+            if (_context == null && // For consistency do not return any default converters for
+                                    // options instances linked to a JsonSerializerContext,
+                                    // even if the default converters might have been rooted.
+                s_defaultSimpleConverters != null &&
+                s_defaultSimpleConverters.TryGetValue(typeToConvert, out converter))
+            {
+                return true;
+            }
+
+            converter = null;
+            return false;
         }
 
         private static Attribute? GetAttributeThatCanHaveMultiple(Type classType, Type attributeType, MemberInfo memberInfo)


### PR DESCRIPTION
Reverts a breaking change intentionally introduced in #50074: when users register a custom converter for a primitive type in the reflection-based serializer, the key serialization logic for that type will fall back to the default converter, assuming it has been rooted by the current application.

Fixes #53241.