### PR TITLE
Upgrade SDK to 6.0.100-rc.1.21411.13

### DIFF
--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -54,7 +54,7 @@
              AssemblyFile="$(RuntimeConfigParserTasksAssemblyPath)"
              Condition="'$(RuntimeConfigParserTasksAssemblyPath)' != ''" />
 
-  <Target Name="GenerateRuntimeConfig" Condition="'$(OutputType)' != 'library' and '$(TargetOS)' != 'Browser'">
+  <Target Name="GenerateRuntimeConfig">
     <PropertyGroup>
       <RuntimeConfigFilePath>$(PublishDir)$(AssemblyName).runtimeconfig.json</RuntimeConfigFilePath>
       <ParsedRuntimeConfigFilePath>$(PublishDir)runtimeconfig.bin</ParsedRuntimeConfigFilePath>

--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -54,7 +54,7 @@
              AssemblyFile="$(RuntimeConfigParserTasksAssemblyPath)"
              Condition="'$(RuntimeConfigParserTasksAssemblyPath)' != ''" />
 
-  <Target Name="GenerateRuntimeConfig">
+  <Target Name="GenerateRuntimeConfig" Condition="'$(TargetOS)' != 'Browser'">
     <PropertyGroup>
       <RuntimeConfigFilePath>$(PublishDir)$(AssemblyName).runtimeconfig.json</RuntimeConfigFilePath>
       <ParsedRuntimeConfigFilePath>$(PublishDir)runtimeconfig.bin</ParsedRuntimeConfigFilePath>

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "6.0.100-rc.1.21411.13",
+    "version": "6.0.100-rc.1.21411.28",
     "allowPrerelease": true,
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "6.0.100-rc.1.21411.13"
+    "dotnet": "6.0.100-rc.1.21411.28"
   },
   "native-tools": {
     "cmake": "3.16.4",

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "6.0.100-preview.6.21355.2",
+    "version": "6.0.100-rc.1.21379.2",
     "allowPrerelease": true,
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "6.0.100-preview.6.21355.2"
+    "dotnet": "6.0.100-rc.1.21379.2"
   },
   "native-tools": {
     "cmake": "3.16.4",

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "6.0.100-rc.1.21379.2",
+    "version": "6.0.100-rc.1.21411.13",
     "allowPrerelease": true,
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "6.0.100-rc.1.21379.2"
+    "dotnet": "6.0.100-rc.1.21411.13"
   },
   "native-tools": {
     "cmake": "3.16.4",

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
@@ -192,28 +192,6 @@ namespace Microsoft.NET.HostModel.Tests
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.Windows, "Creating symbolic links requires administrative privilege on Windows, so skip test.")]
-        public void Put_app_directory_behind_symlink_and_use_dotnet_run()
-        {
-            var fixture = sharedTestState.StandaloneAppFixture_Published
-                .Copy();
-
-            var dotnet = fixture.SdkDotnet;
-            var binDir = fixture.TestProject.OutputDirectory;
-            var binDirNewPath = Path.Combine(Directory.GetParent(fixture.TestProject.Location).ToString(), "PutTheBinDirSomewhereElse");
-            Directory.Move(binDir, binDirNewPath);
-
-            using var symlink = new SymLink(binDir, binDirNewPath);
-            dotnet.Exec("run")
-                .WorkingDirectory(fixture.TestProject.Location)
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .Execute()
-                .Should().Pass()
-                .And.HaveStdOutContaining("Hello World");
-        }
-
-        [Fact]
         // If enabled, this tests will need to set the console code page to output unicode characters: Command.Create("chcp 65001").Execute();
         [SkipOnPlatform(TestPlatforms.Windows, "Creating symbolic links requires administrative privilege on Windows, so skip test.")]
         public void Put_satellite_assembly_behind_symlink()

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundleAndRun.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundleAndRun.cs
@@ -100,6 +100,7 @@ namespace Microsoft.NET.HostModel.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/57242", TestPlatforms.OSX)]
         public void TestWithAbsolutePaths()
         {
             var fixture = sharedTestState.TestFixture.Copy();
@@ -108,6 +109,7 @@ namespace Microsoft.NET.HostModel.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/57242", TestPlatforms.OSX)]
         public void TestWithRelativePaths()
         {
             var fixture = sharedTestState.TestFixture.Copy();
@@ -116,6 +118,7 @@ namespace Microsoft.NET.HostModel.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/57242", TestPlatforms.OSX)]
         public void TestWithRelativePathsDirSeparator()
         {
             var fixture = sharedTestState.TestFixture.Copy();

--- a/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/NetCoreServer.csproj
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/NetCoreServer.csproj
@@ -5,6 +5,7 @@
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <OutputType>Exe</OutputType>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/Common/tests/System/Net/Prerequisites/RemoteLoopServer/RemoteLoopServer.csproj
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/RemoteLoopServer/RemoteLoopServer.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>$(AspNetCoreAppCurrent)</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <OutputType>Exe</OutputType>
+    <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/HttpStress.csproj
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/HttpStress.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -223,12 +223,5 @@ namespace System.Reflection.Metadata
             bool result = MetadataUpdater.IsSupported;
             Assert.False(result);
         }
-
-        [ConditionalFact(typeof(ApplyUpdateUtil), nameof(ApplyUpdateUtil.TestUsingLaunchEnvironment))]
-        public static void IsSupported2()
-        {
-            bool result = MetadataUpdater.IsSupported;
-            Assert.True(result);
-        }
     }
 }

--- a/src/libraries/System.Text.Encoding/tests/Directory.Build.targets
+++ b/src/libraries/System.Text.Encoding/tests/Directory.Build.targets
@@ -1,7 +1,0 @@
-﻿<Project>
-  <Import Project="..\..\Directory.Build.targets" />
-  <PropertyGroup>
-    <!-- workaround https://github.com/dotnet/sdk/pull/19677. This can be removed when we get an SDK that has that fix. -->
-    <EnableUnsafeUTF7Encoding>true</EnableUnsafeUTF7Encoding>
-  </PropertyGroup>
-</Project>

--- a/src/libraries/System.Text.Encoding/tests/Directory.Build.targets
+++ b/src/libraries/System.Text.Encoding/tests/Directory.Build.targets
@@ -1,0 +1,7 @@
+﻿<Project>
+  <Import Project="..\..\Directory.Build.targets" />
+  <PropertyGroup>
+    <!-- workaround https://github.com/dotnet/sdk/pull/19677. This can be removed when we get an SDK that has that fix. -->
+    <EnableUnsafeUTF7Encoding>true</EnableUnsafeUTF7Encoding>
+  </PropertyGroup>
+</Project>

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj
@@ -8,6 +8,8 @@
     <!-- these tests depend on the pdb files. Causes test failures like:
           [FAIL] System.Text.Json.Tests.DebuggerTests.DefaultJsonElement -->
     <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and '$(TargetOS)' == 'Browser'">true</DebuggerSupport>
+    <!-- Needed for JsonSerializerOptionsUpdateHandler tests -->
+    <MetadataUpdaterSupport Condition="'$(MetadataUpdaterSupport)' == '' and '$(TargetOS)' == 'Browser'">true</MetadataUpdaterSupport>
     <WasmXHarnessArgs>$(WasmXHarnessArgs) --timeout=1800</WasmXHarnessArgs>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->

--- a/src/mono/wasm/debugger/BrowserDebugHost/BrowserDebugHost.csproj
+++ b/src/mono/wasm/debugger/BrowserDebugHost/BrowserDebugHost.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
+    <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
     <TargetFramework>$(AspNetCoreAppCurrent)</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <NoWarn>$(NoWarn),CA2007</NoWarn>

--- a/src/tests/tracing/eventpipe/processinfo/processinfo.cs
+++ b/src/tests/tracing/eventpipe/processinfo/processinfo.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Diagnostics.Tools.RuntimeClient;
@@ -55,10 +56,31 @@ namespace Tracing.Tests.ProcessInfoValidation
                 }
             }
 
-            string normalizedCommandLine = parts
-                .Where(part => !string.IsNullOrWhiteSpace(part))
-                .Select(part => (new FileInfo(part)).FullName)
-                .Aggregate((s1, s2) => string.Join(' ', s1, s2));
+            StringBuilder sb = new();
+            bool isArgument = false;
+            for (int i = 0; i < parts.Count; i++)
+            {
+                if (string.IsNullOrEmpty(parts[i]))
+                    continue;
+                else if (parts[i].StartsWith('-'))
+                {
+                    // if we see '-', then assume it's a '-option argument' pair
+                    sb.Append(parts[i] + " ");
+                    isArgument = true;
+                }
+                else if (isArgument)
+                {
+                    sb.Append(parts[i] + " ");
+                    isArgument = false;
+                }
+                else
+                {
+                    // assume anything else is a file/executable so get the full path
+                    sb.Append((new FileInfo(parts[i])).FullName + " ");
+                }
+            }
+
+            string normalizedCommandLine = sb.ToString().Trim();
 
             // Tests are run out of /tmp on Mac and linux, but on Mac /tmp is actually a symlink that points to /private/tmp.
             // This isn't represented in the output from FileInfo.FullName unfortunately, so we'll fake that completion in that case.

--- a/src/tests/tracing/eventpipe/processinfo/processinfo.cs
+++ b/src/tests/tracing/eventpipe/processinfo/processinfo.cs
@@ -64,13 +64,11 @@ namespace Tracing.Tests.ProcessInfoValidation
                     continue;
                 else if (parts[i].StartsWith('-'))
                 {
-                    // if we see '-', then assume it's a '-option argument' pair
-                    sb.Append(parts[i] + " ");
+                    // if we see '-', then assume it's a '-option argument' pair and remove
                     isArgument = true;
                 }
                 else if (isArgument)
                 {
-                    sb.Append(parts[i] + " ");
                     isArgument = false;
                 }
                 else

--- a/src/tests/tracing/eventpipe/processinfo2/processinfo2.cs
+++ b/src/tests/tracing/eventpipe/processinfo2/processinfo2.cs
@@ -65,13 +65,11 @@ namespace Tracing.Tests.ProcessInfoValidation
                     continue;
                 else if (parts[i].StartsWith('-'))
                 {
-                    // if we see '-', then assume it's a '-option argument' pair
-                    sb.Append(parts[i] + " ");
+                    // if we see '-', then assume it's a '-option argument' pair and remove
                     isArgument = true;
                 }
                 else if (isArgument)
                 {
-                    sb.Append(parts[i] + " ");
                     isArgument = false;
                 }
                 else

--- a/src/tests/tracing/eventpipe/processinfo2/processinfo2.cs
+++ b/src/tests/tracing/eventpipe/processinfo2/processinfo2.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Reflection;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Diagnostics.Tools.RuntimeClient;
@@ -56,10 +57,31 @@ namespace Tracing.Tests.ProcessInfoValidation
                 }
             }
 
-            string normalizedCommandLine = parts
-                .Where(part => !string.IsNullOrWhiteSpace(part))
-                .Select(part => (new FileInfo(part)).FullName)
-                .Aggregate((s1, s2) => string.Join(' ', s1, s2));
+            StringBuilder sb = new();
+            bool isArgument = false;
+            for (int i = 0; i < parts.Count; i++)
+            {
+                if (string.IsNullOrEmpty(parts[i]))
+                    continue;
+                else if (parts[i].StartsWith('-'))
+                {
+                    // if we see '-', then assume it's a '-option argument' pair
+                    sb.Append(parts[i] + " ");
+                    isArgument = true;
+                }
+                else if (isArgument)
+                {
+                    sb.Append(parts[i] + " ");
+                    isArgument = false;
+                }
+                else
+                {
+                    // assume anything else is a file/executable so get the full path
+                    sb.Append((new FileInfo(parts[i])).FullName + " ");
+                }
+            }
+
+            string normalizedCommandLine = sb.ToString().Trim();
 
             // Tests are run out of /tmp on Mac and linux, but on Mac /tmp is actually a symlink that points to /private/tmp.
             // This isn't represented in the output from FileInfo.FullName unfortunately, so we'll fake that completion in that case.


### PR DESCRIPTION
Both the AzDO and the Core-Eng team believe believe that the issue is on our side and was caused by a thread pool regression. The assumption stands that we need to update to a newer SDK which contains the fix for the thread pool hang.

Pros:
-	AzDO and Core-Eng believe that this will mitigate the AzDO feed restore issues.
Cons:
-	We will upgrade to an unsigned SDK build. Arcade and other repos already did the same to workaround the issue.
-	That SDK build isn’t officially released and won’t until RC 1 ships. This means that developers need to install that build via the nightly channel (from https://github.com/dotnet/installer) if they want to use their globally installed SDK in combination with dotnet/runtime.
-	Even though this is a breaking change, we can’t wait for the next monthly infrastructure rollout.