### PR TITLE
Fix COM test failures on Windows Nano Server

### DIFF
--- a/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstance.Marshalling.cs
+++ b/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstance.Marshalling.cs
@@ -47,7 +47,8 @@ namespace ComWrappersTests.GlobalInstance
                     ValidatePInvokes(validateUseRegistered: false);
                 }
 
-                if(!builtInComDisabled)
+                // RegFree COM is not supported on Windows Nano Server
+                if(!builtInComDisabled && !Utilities.IsWindowsNanoServer)
                 {
                     // This calls ValidateNativeServerActivation which calls Marshal.GetTypeFromCLSID that is not supported
                     ValidateComActivation(validateUseRegistered: true);

--- a/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstance.TrackerSupport.cs
+++ b/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstance.TrackerSupport.cs
@@ -33,7 +33,7 @@ namespace ComWrappersTests.GlobalInstance
                 ValidateRegisterForTrackerSupport();
 #if Windows
                 ValidateNotRegisteredForMarshalling();
-#endif                
+#endif
 
                 IntPtr trackerObjRaw = MockReferenceTrackerRuntime.CreateTrackerObject();
                 var trackerObj = GlobalComWrappers.Instance.GetOrCreateObjectForComInstance(trackerObjRaw, CreateObjectFlags.TrackerObject);
@@ -50,8 +50,12 @@ namespace ComWrappersTests.GlobalInstance
                 ValidatePInvokes(validateUseRegistered: true);
                 ValidatePInvokes(validateUseRegistered: false);
 
-                ValidateComActivation(validateUseRegistered: true);
-                ValidateComActivation(validateUseRegistered: false);
+                // RegFree COM is not supported on Windows Nano Server
+                if (!Utilities.IsWindowsNanoServer)
+                {
+                    ValidateComActivation(validateUseRegistered: true);
+                    ValidateComActivation(validateUseRegistered: false);
+                }
 #endif
                 ValidateNotifyEndOfReferenceTrackingOnThread();
             }


### PR DESCRIPTION
Failures seen when re-enabling outerloop Windows test legs on various different Windows versions and flavors (#57068)

Fixes issues around STA support and Reg-Free COM usage, both of which are unsupported on Nano Server.