### PR TITLE
Add arch info in missing framework error

### DIFF
--- a/src/native/corehost/apphost/apphost.windows.cpp
+++ b/src/native/corehost/apphost/apphost.windows.cpp
@@ -82,7 +82,7 @@ namespace
         {
             // We don't have a great way of passing out different kinds of detailed error info across components, so
             // just match the expected error string. See fx_resolver.messages.cpp.
-            dialogMsg = pal::string_t(_X("To run this application, you must install .NET.\n\n"));
+            dialogMsg = pal::string_t(_X("To run this application, you must install missing frameworks for .NET.\n\n"));
             pal::string_t line;
             pal::stringstream_t ss(g_buffered_errors);
             while (std::getline(ss, line, _X('\n'))){

--- a/src/native/corehost/fxr/fx_resolver.messages.cpp
+++ b/src/native/corehost/fxr/fx_resolver.messages.cpp
@@ -112,11 +112,11 @@ void fx_resolver_t::display_missing_framework_error(
     // Display the error message about missing FX.
     if (fx_version.length())
     {
-        trace::error(_X("The framework '%s', version '%s' was not found."), fx_name.c_str(), fx_version.c_str());
+        trace::error(_X("The framework '%s', version '%s' (%s) was not found."), fx_name.c_str(), fx_version.c_str(), get_arch());
     }
     else
     {
-        trace::error(_X("The framework '%s' was not found."), fx_name.c_str());
+        trace::error(_X("The framework '%s' (%s) was not found."), fx_name.c_str(), get_arch());
     }
 
     if (framework_infos.size())


### PR DESCRIPTION
Adds the architecture information for missing framework errors.