### PR TITLE
[iOS][libraries] Throw PNSE for Exportable and PersistKeySet flags iOS

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.iOS/AppleCertificatePal.ImportExport.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.iOS/AppleCertificatePal.ImportExport.cs
@@ -114,14 +114,11 @@ namespace Internal.Cryptography.Pal
 
             if (contentType == X509ContentType.Pkcs12)
             {
-                // TODO:
-                // We ignore keyStorageFlags which is tracked in https://github.com/dotnet/runtime/issues/52434.
-                // The keys are always imported as ephemeral and never persisted. Exportability is ignored for
-                // the moment and it needs to be investigated how to map it to iOS keychain primitives.
                 if ((keyStorageFlags & X509KeyStorageFlags.Exportable) == X509KeyStorageFlags.Exportable)
                 {
                     throw new PlatformNotSupportedException(SR.Cryptography_X509_PKCS12_ExportableNotSupported);
                 }
+
                 if ((keyStorageFlags & X509KeyStorageFlags.PersistKeySet) == X509KeyStorageFlags.PersistKeySet)
                 {
                     throw new PlatformNotSupportedException(SR.Cryptography_X509_PKCS12_PersistKeySetNotSupported);

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.iOS/AppleCertificatePal.ImportExport.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.iOS/AppleCertificatePal.ImportExport.cs
@@ -118,6 +118,15 @@ namespace Internal.Cryptography.Pal
                 // We ignore keyStorageFlags which is tracked in https://github.com/dotnet/runtime/issues/52434.
                 // The keys are always imported as ephemeral and never persisted. Exportability is ignored for
                 // the moment and it needs to be investigated how to map it to iOS keychain primitives.
+                if ((keyStorageFlags & X509KeyStorageFlags.Exportable) == X509KeyStorageFlags.Exportable)
+                {
+                    throw new PlatformNotSupportedException(SR.Cryptography_X509_PKCS12_PersistKeySetNotSupported);
+                }
+                if ((keyStorageFlags & X509KeyStorageFlags.PersistKeySet) == X509KeyStorageFlags.PersistKeySet))
+                {
+                    throw new PlatformNotSupportedException(SR.Cryptography_X509_PKCS12_ExportableNotSupported);
+                }
+
                 return ImportPkcs12(rawData, password, ephemeralSpecified);
             }
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.iOS/AppleCertificatePal.ImportExport.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.iOS/AppleCertificatePal.ImportExport.cs
@@ -120,11 +120,11 @@ namespace Internal.Cryptography.Pal
                 // the moment and it needs to be investigated how to map it to iOS keychain primitives.
                 if ((keyStorageFlags & X509KeyStorageFlags.Exportable) == X509KeyStorageFlags.Exportable)
                 {
-                    throw new PlatformNotSupportedException(SR.Cryptography_X509_PKCS12_PersistKeySetNotSupported);
+                    throw new PlatformNotSupportedException(SR.Cryptography_X509_PKCS12_ExportableNotSupported);
                 }
                 if ((keyStorageFlags & X509KeyStorageFlags.PersistKeySet) == X509KeyStorageFlags.PersistKeySet)
                 {
-                    throw new PlatformNotSupportedException(SR.Cryptography_X509_PKCS12_ExportableNotSupported);
+                    throw new PlatformNotSupportedException(SR.Cryptography_X509_PKCS12_PersistKeySetNotSupported);
                 }
 
                 return ImportPkcs12(rawData, password, ephemeralSpecified);

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.iOS/AppleCertificatePal.ImportExport.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.iOS/AppleCertificatePal.ImportExport.cs
@@ -122,7 +122,7 @@ namespace Internal.Cryptography.Pal
                 {
                     throw new PlatformNotSupportedException(SR.Cryptography_X509_PKCS12_PersistKeySetNotSupported);
                 }
-                if ((keyStorageFlags & X509KeyStorageFlags.PersistKeySet) == X509KeyStorageFlags.PersistKeySet))
+                if ((keyStorageFlags & X509KeyStorageFlags.PersistKeySet) == X509KeyStorageFlags.PersistKeySet)
                 {
                     throw new PlatformNotSupportedException(SR.Cryptography_X509_PKCS12_ExportableNotSupported);
                 }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -296,10 +296,10 @@
     <value>PKCS#7 certificate format is not supported on this platform.</value>
   </data>
   <data name="Cryptography_X509_PKCS12_PersistKeySetNotSupported" xml:space="preserve">
-    <value>PKCS#12 persist key set flag is not supported on this iOS.</value>
+    <value>PKCS#12 persist key set flag is not supported on this platform.</value>
   </data>
   <data name="Cryptography_X509_PKCS12_ExportableNotSupported" xml:space="preserve">
-    <value>PKCS#12 exportable flag is not supported on this iOS.</value>
+    <value>PKCS#12 exportable flag is not supported on this platform.</value>
   </data>
   <data name="Cryptography_X509_StoreAddFailure" xml:space="preserve">
     <value>The X509 certificate could not be added to the store.</value>

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -296,10 +296,10 @@
     <value>PKCS#7 certificate format is not supported on this platform.</value>
   </data>
   <data name="Cryptography_X509_PKCS12_PersistKeySetNotSupported" xml:space="preserve">
-    <value>PKCS#12 persist key set flag is not supported on this platform.</value>
+    <value>The PKCS#12 PersistKeySet flag is not supported on this platform.</value>
   </data>
   <data name="Cryptography_X509_PKCS12_ExportableNotSupported" xml:space="preserve">
-    <value>PKCS#12 exportable flag is not supported on this platform.</value>
+    <value>The PKCS#12 Exportable flag is not supported on this platform.</value>
   </data>
   <data name="Cryptography_X509_StoreAddFailure" xml:space="preserve">
     <value>The X509 certificate could not be added to the store.</value>

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -295,6 +295,12 @@
   <data name="Cryptography_X509_PKCS7_Unsupported" xml:space="preserve">
     <value>PKCS#7 certificate format is not supported on this platform.</value>
   </data>
+  <data name="Cryptography_X509_PKCS12_PersistKeySetNotSupported" xml:space="preserve">
+    <value>PKCS#12 persist key set flag is not supported on this iOS.</value>
+  </data>
+  <data name="Cryptography_X509_PKCS12_ExportableNotSupported" xml:space="preserve">
+    <value>PKCS#12 exportable flag is not supported on this iOS.</value>
+  </data>
   <data name="Cryptography_X509_StoreAddFailure" xml:space="preserve">
     <value>The X509 certificate could not be added to the store.</value>
   </data>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/52434

Until support is added for iOS with regards to Exportable and PersistKeySet flags, throw PNSE on iOS.