### PR TITLE
[HTTP/3] Abort response stream on dispose if content not finished

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs
@@ -20,10 +20,10 @@ namespace System.Net.Test.Common
         private const int MaximumVarIntBytes = 8;
         private const long VarIntMax = (1L << 62) - 1;
 
-        private const long DataFrame = 0x0;
-        private const long HeadersFrame = 0x1;
-        private const long SettingsFrame = 0x4;
-        private const long GoAwayFrame = 0x7;
+        public const long DataFrame = 0x0;
+        public const long HeadersFrame = 0x1;
+        public const long SettingsFrame = 0x4;
+        public const long GoAwayFrame = 0x7;
 
         public const long ControlStream = 0x0;
         public const long PushStream = 0x1;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -84,6 +84,7 @@ namespace System.Net.Http
             if (!_disposed)
             {
                 _disposed = true;
+                AbortStream();
                 _stream.Dispose();
                 DisposeSyncHelper();
             }
@@ -94,6 +95,7 @@ namespace System.Net.Http
             if (!_disposed)
             {
                 _disposed = true;
+                AbortStream();
                 await _stream.DisposeAsync().ConfigureAwait(false);
                 DisposeSyncHelper();
             }
@@ -364,6 +366,9 @@ namespace System.Net.Http
             {
                 await content.CopyToAsync(writeStream, null, cancellationToken).ConfigureAwait(false);
             }
+
+            // Set to 0 to recognize that the whole request body has been sent and therefore there's no need to abort write side in case of a premature disposal.
+            _requestContentLengthRemaining = 0;
 
             if (_sendBuffer.ActiveLength != 0)
             {
@@ -1217,6 +1222,25 @@ namespace System.Net.Http
         public void Trace(string message, [CallerMemberName] string? memberName = null) =>
             _connection.Trace(StreamId, message, memberName);
 
+        private void AbortStream()
+        {
+            // ToDo : locking??? we don't have any in H/3 stream, we don't have a sync root or anything.
+            // Check if the response body has been fully consumed.
+            bool requestBodyFinished = _requestContentLengthRemaining == 0; // -1 is used for unknown Content-Length, 0 for the end of content writing
+            bool responseBodyFinished = _responseDataPayloadRemaining == -1; // -1 is used for EOF, 0 for consumed DATA frame payload before the next read
+
+            // If the request body isn't completed, cancel it now.
+            if (!requestBodyFinished)
+            {
+                _stream.AbortWrite((long)Http3ErrorCode.RequestCancelled);
+            }
+            // If the response body isn't completed, cancel it now.
+            if (!responseBodyFinished)
+            {
+                _stream.AbortRead((long)Http3ErrorCode.RequestCancelled);
+            }
+        }
+
         // TODO: it may be possible for Http3RequestStream to implement Stream directly and avoid this allocation.
         private sealed class Http3ReadStream : HttpBaseStream
         {
@@ -1240,35 +1264,41 @@ namespace System.Net.Http
 
             protected override void Dispose(bool disposing)
             {
-                if (_stream != null)
+                Http3RequestStream? stream = Interlocked.Exchange(ref _stream, null);
+                if (stream is null)
                 {
-                    if (disposing)
-                    {
-                        // This will remove the stream from the connection properly.
-                        _stream.Dispose();
-                    }
-                    else
-                    {
-                        // We shouldn't be using a managed instance here, but don't have much choice -- we
-                        // need to remove the stream from the connection's GOAWAY collection.
-                        _stream._connection.RemoveStream(_stream._stream);
-                        _stream._connection = null!;
-                    }
-
-                    _stream = null;
-                    _response = null;
+                    return;
                 }
+
+                if (disposing)
+                {
+                    // This will remove the stream from the connection properly.
+                    stream.Dispose();
+                }
+                else
+                {
+                    // We shouldn't be using a managed instance here, but don't have much choice -- we
+                    // need to remove the stream from the connection's GOAWAY collection.
+                    stream._connection.RemoveStream(stream._stream);
+                    stream._connection = null!;
+                }
+
+                _response = null;
 
                 base.Dispose(disposing);
             }
 
             public override async ValueTask DisposeAsync()
             {
-                if (_stream != null)
+                Http3RequestStream? stream = Interlocked.Exchange(ref _stream, null);
+                if (stream is null)
                 {
-                    await _stream.DisposeAsync().ConfigureAwait(false);
-                    _stream = null!;
+                    return;
                 }
+
+                await stream.DisposeAsync().ConfigureAwait(false);
+
+                _response = null;
 
                 await base.DisposeAsync().ConfigureAwait(false);
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -1224,18 +1224,13 @@ namespace System.Net.Http
 
         private void AbortStream()
         {
-            // ToDo : locking??? we don't have any in H/3 stream, we don't have a sync root or anything.
-            // Check if the response body has been fully consumed.
-            bool requestBodyFinished = _requestContentLengthRemaining == 0; // -1 is used for unknown Content-Length, 0 for the end of content writing
-            bool responseBodyFinished = _responseDataPayloadRemaining == -1; // -1 is used for EOF, 0 for consumed DATA frame payload before the next read
-
             // If the request body isn't completed, cancel it now.
-            if (!requestBodyFinished)
+            if (_requestContentLengthRemaining != 0) // 0 is used for the end of content writing, -1 is used for unknown Content-Length
             {
                 _stream.AbortWrite((long)Http3ErrorCode.RequestCancelled);
             }
             // If the response body isn't completed, cancel it now.
-            if (!responseBodyFinished)
+            if (_responseDataPayloadRemaining != -1) // -1 is used for EOF, 0 for consumed DATA frame payload before the next read
             {
                 _stream.AbortRead((long)Http3ErrorCode.RequestCancelled);
             }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -335,7 +335,7 @@ namespace System.Net.Http.Functional.Tests
 
                 Stopwatch sw = Stopwatch.StartNew();
                 bool hasFailed = false;
-                while (sw.Elapsed < TestHelper.PassingTestTimeout)
+                while (sw.Elapsed < TimeSpan.FromSeconds(15))
                 {
                     try
                     {
@@ -371,6 +371,7 @@ namespace System.Net.Http.Functional.Tests
 
                 // We haven't finished reading the whole respose, but we're disposing it, which should turn into an exception on the server-side.
                 response.Dispose();
+                await serverTask;
             });
 
             await new[] { clientTask, serverTask }.WhenAllOrAnyFailed(20_000);
@@ -392,7 +393,7 @@ namespace System.Net.Http.Functional.Tests
 
                 Stopwatch sw = Stopwatch.StartNew();
                 bool hasFailed = false;
-                while (sw.Elapsed < TestHelper.PassingTestTimeout)
+                while (sw.Elapsed < TimeSpan.FromSeconds(15))
                 {
                     try
                     {
@@ -425,6 +426,7 @@ namespace System.Net.Http.Functional.Tests
 
                 // We haven't finished sending the whole request, but we're disposing the response, which should turn into an exception on the server-side.
                 response.Dispose();
+                await serverTask;
             });
 
             await new[] { clientTask, serverTask }.WhenAllOrAnyFailed(20_000);
@@ -996,7 +998,7 @@ namespace System.Net.Http.Functional.Tests
                 VersionPolicy = HttpVersionPolicy.RequestVersionExact
             };
             HttpResponseMessage response = await client.SendAsync(request).WaitAsync(TimeSpan.FromSeconds(10));
-            
+
             Assert.Equal(statusCode, response.StatusCode);
 
             await serverTask;


### PR DESCRIPTION
Sends abort read/write if H/3 stream is disposed before respective contents are finished.

Fixes #56129

cc: @CarnaViire 