### PR TITLE
make use of ports in SPN optional

### DIFF
--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/EnterpriseTestConfiguration.cs
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/EnterpriseTestConfiguration.cs
@@ -7,6 +7,7 @@ namespace System.Net.Test.Common
     {
         public const string Realm = "LINUX.CONTOSO.COM";
         public const string NegotiateAuthWebServer = "http://apacheweb.linux.contoso.com/auth/kerberos/";
+        public const string NegotiateAuthWebServerNotDefaultPort = "http://apacheweb.linux.contoso.com:8081/auth/kerberos/";
         public const string AlternativeService = "http://altweb.linux.contoso.com:8080/auth/kerberos/";
         public const string NtlmAuthWebServer = "http://apacheweb.linux.contoso.com:8080/auth/ntlm/";
         public const string DigestAuthWebServer = "http://apacheweb.linux.contoso.com/auth/digest/";

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/apacheweb/apache2.conf
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/apacheweb/apache2.conf
@@ -54,6 +54,7 @@ Listen 8080
 </IfDefine>
 <IfDefine !ALTPORT>
 Listen 80
+Listen 8081
 </IfDefine>
 
 #
@@ -238,7 +239,7 @@ Group daemon
 # e-mailed.  This address appears on some server-generated pages, such
 # as error documents.  e.g. admin@your-domain.com
 #
-ServerAdmin you@example.com
+ServerAdmin webmaster@contoso.com
 
 #
 # ServerName gives the name and port that the server uses to identify itself.
@@ -583,11 +584,18 @@ SSLRandomSeed startup builtin
 SSLRandomSeed connect builtin
 </IfModule>
 
+<IfDefine ALTPORT>
 <VirtualHost *:8080>
-  ServerAdmin webmaster@contoso.com
   DocumentRoot "/setup/altdocs"
   ServerName altservice.contoso.com:8080
 </VirtualHost>
+</IfDefine>
+
+<IfDefine !ALTSPN>
+<VirtualHost *:8081>
+  DocumentRoot "/setup/htdocs"
+</VirtualHost>
+</IfDefine>
 
 
 <IFDefine NTLM>

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/apacheweb/run.sh
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/apacheweb/run.sh
@@ -11,6 +11,7 @@ if [ "$1" == "-debug" ]; then
 fi
 
 if [ "$1" == "-DNTLM" ]; then
+  # NTLM/Winbind is aggressive and eats Negotiate so it cannot be combined with Kerberos
   ./setup-pdc.sh
   /usr/sbin/apache2 -DALTPORT "$@"
   shift

--- a/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/docker-compose.yml
+++ b/src/libraries/Common/tests/System/Net/EnterpriseTests/setup/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     hostname: altweb
     domainname: linux.contoso.com
     dns_search: linux.contoso.com
-    command: -DALTPORT
+    command: "-DALTPORT -DALTSPN"
     volumes:
       - shared-volume:/SHARED
     networks:

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
@@ -27,20 +27,20 @@ namespace System.Net.Http
                 {
                     return usePortInSpn != 0;
                 }
-                
+
                 // First check for the AppContext switch, giving it priority over the environment variable.
-                if (AppContext.TryGetSwitch(UsePortInSpnCtxSwitch, out bool disabled))
+                if (AppContext.TryGetSwitch(UsePortInSpnCtxSwitch, out bool value))
                 {
-                    s_usePortInSpn = disabled;
+                    s_usePortInSpn = value ? 1 : 0;
                 }
                 else
                 {
                     // AppContext switch wasn't used. Check the environment variable.
                    s_usePortInSpn =
                        Environment.GetEnvironmentVariable(UsePortInSpnEnvironmentVariable) is string envVar &&
-                       (envVar == "1" || envVar.Equals("true", StringComparison.OrdinalIgnoreCase);
+                       (envVar == "1" || envVar.Equals("true", StringComparison.OrdinalIgnoreCase)) ? 1 : 0;
                 }
-                
+
                 return s_usePortInSpn != 0;
             }
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
@@ -16,26 +16,26 @@ namespace System.Net.Http
         private const string UsePortInSpnCtxSwitch = "System.Net.Http.UsePortInSpn";
         private const string UsePortInSpnEnvironmentVariable = "DOTNET_SYSTEM_NET_HTTP_USEPORTINSPN";
 
-        private static bool UsePortInSpn
+        private static bool UsePortInSpn => s_UsePortInSpn.Value;
+        private static readonly Lazy<bool> s_UsePortInSpn = new Lazy<bool>(GetUsePortInSpn);
+
+        private static bool GetUsePortInSpn()
         {
-            get
+            // First check for the AppContext switch, giving it priority over the environment variable.
+            if (AppContext.TryGetSwitch(UsePortInSpnCtxSwitch, out bool disabled))
             {
-                // First check for the AppContext switch, giving it priority over the environment variable.
-                if (AppContext.TryGetSwitch(UsePortInSpnCtxSwitch, out bool disabled))
-                {
-                    return disabled;
-                }
+                return disabled;
+            }
 
-                // AppContext switch wasn't used. Check the environment variable.
-                string? envVar = Environment.GetEnvironmentVariable(UsePortInSpnEnvironmentVariable);
+            // AppContext switch wasn't used. Check the environment variable.
+            string? envVar = Environment.GetEnvironmentVariable(UsePortInSpnEnvironmentVariable);
 
-                if (envVar is not null)
-                {
-                    return envVar == "1" || envVar.Equals("true", StringComparison.OrdinalIgnoreCase);
-                }
+            if (envVar is not null)
+            {
+                return envVar == "1" || envVar.Equals("true", StringComparison.OrdinalIgnoreCase);
+            }
 
-                return false;
-             }
+            return false;
         }
 
         private static Task<HttpResponseMessage> InnerSendAsync(HttpRequestMessage request, bool async, bool isProxyAuth, HttpConnectionPool pool, HttpConnection connection, CancellationToken cancellationToken)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
@@ -16,24 +16,27 @@ namespace System.Net.Http
         private const string UsePortInSpnCtxSwitch = "System.Net.Http.UsePortInSpn";
         private const string UsePortInSpnEnvironmentVariable = "DOTNET_SYSTEM_NET_HTTP_USEPORTINSPN";
 
-        private static bool UsePortInSpn()
+        private static bool UsePortInSpn
         {
-            // First check for the AppContext switch, giving it priority over the environment variable.
-            if (AppContext.TryGetSwitch(UsePortInSpnCtxSwitch, out bool disabled))
+            get
             {
-                return disabled;
-            }
+                // First check for the AppContext switch, giving it priority over the environment variable.
+                if (AppContext.TryGetSwitch(UsePortInSpnCtxSwitch, out bool disabled))
+                {
+                    return disabled;
+                }
 
-            // AppContext switch wasn't used. Check the environment variable.
-            string? envVar = Environment.GetEnvironmentVariable(UsePortInSpnEnvironmentVariable);
+                // AppContext switch wasn't used. Check the environment variable.
+                string? envVar = Environment.GetEnvironmentVariable(UsePortInSpnEnvironmentVariable);
 
-            if (envVar is not null)
-            {
-                return envVar == "1" || envVar.Equals("true", StringComparison.OrdinalIgnoreCase);
-            }
+                if (envVar is not null)
+                {
+                    return envVar == "1" || envVar.Equals("true", StringComparison.OrdinalIgnoreCase);
+                }
 
-            return false;
-         }
+                return false;
+             }
+        }
 
         private static Task<HttpResponseMessage> InnerSendAsync(HttpRequestMessage request, bool async, bool isProxyAuth, HttpConnectionPool pool, HttpConnection connection, CancellationToken cancellationToken)
         {

--- a/src/libraries/System.Net.Http/tests/EnterpriseTests/HttpClientAuthenticationTest.cs
+++ b/src/libraries/System.Net.Http/tests/EnterpriseTests/HttpClientAuthenticationTest.cs
@@ -11,14 +11,19 @@ namespace System.Net.Http.Enterprise.Tests
     [ConditionalClass(typeof(EnterpriseTestConfiguration), nameof(EnterpriseTestConfiguration.Enabled))]
     public class HttpClientAuthenticationTest
     {
+        private const string AppContextSettingName = "System.Net.Http.UsePortInSpn";
+
         [Theory]
         [InlineData(EnterpriseTestConfiguration.NegotiateAuthWebServer, false)]
-        [InlineData(EnterpriseTestConfiguration.AlternativeService, false)]
+        [InlineData(EnterpriseTestConfiguration.NegotiateAuthWebServerNotDefaultPort, false)]
+        [InlineData(EnterpriseTestConfiguration.AlternativeService, false, true)]
         [InlineData(EnterpriseTestConfiguration.DigestAuthWebServer, true)]
         [InlineData(EnterpriseTestConfiguration.DigestAuthWebServer, false)]
         [InlineData(EnterpriseTestConfiguration.NtlmAuthWebServer, true)]
-        public async Task HttpClient_ValidAuthentication_Success(string url, bool useDomain)
+        public async Task HttpClient_ValidAuthentication_Success(string url, bool useDomain, bool useAltPort = false)
         {
+            // This is safe as we have no parallel tests
+            AppContext.SetSwitch(AppContextSettingName, useAltPort);
             using var handler = new HttpClientHandler();
             handler.Credentials = useDomain ? EnterpriseTestConfiguration.ValidDomainNetworkCredentials : EnterpriseTestConfiguration.ValidNetworkCredentials;
             using var client = new HttpClient(handler);

--- a/src/libraries/System.Net.Http/tests/EnterpriseTests/System.Net.Http.Enterprise.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/EnterpriseTests/System.Net.Http.Enterprise.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)-Browser</TargetFrameworks>
+    <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="HttpClientAuthenticationTest.cs" />


### PR DESCRIPTION
This is regression caused by #40860. There is some ambiguity if port should be used for contracting SPN when it is not default port. We did not do that up to 5.0 and we do since. However that change can have negative impact on existing services. 
Since there is no API for developers to control the SPN (#25320), I added ENV & AppContext switch so control this and choose old or new behavior globally. 

I did some more testing with IIS can 4.7/4.8 It seems like when configure server on custom ports, client connects to it without specifying port in SPN. 
For that reason I'm leaving this off by default as we did prior to 5.0.


fixes #53193
fixes #51701