### PR TITLE
Forbid fgMorphCommutative during optValnumCSE_phase

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13093,7 +13093,8 @@ DONE_MORPHING_CHILDREN:
                 op2  = tree->AsOp()->gtOp2;
             }
 
-            if (varTypeIsIntegralOrI(tree->TypeGet()) && tree->OperIs(GT_ADD, GT_MUL, GT_AND, GT_OR, GT_XOR))
+            if (varTypeIsIntegralOrI(tree->TypeGet()) && tree->OperIs(GT_ADD, GT_MUL, GT_AND, GT_OR, GT_XOR) &&
+                !optValnumCSE_phase)
             {
                 GenTree* foldedTree = fgMorphCommutative(tree->AsOp());
                 if (foldedTree != nullptr)

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -10988,7 +10988,7 @@ GenTree* Compiler::fgMorphCommutative(GenTreeOp* tree)
     }
 
     cns1->gtIconVal = foldedCns->AsIntCon()->IconValue();
-    if ((oper == GT_ADD) && foldedCns->IsCnsIntOrI())
+    if (oper == GT_ADD)
     {
         cns1->AsIntCon()->gtFieldSeq =
             GetFieldSeqStore()->Append(cns1->AsIntCon()->gtFieldSeq, cns2->AsIntCon()->gtFieldSeq);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11011,11 +11011,13 @@ GenTree* Compiler::fgMorphCommutative(GenTreeOp* tree)
 
     auto foldedCns = folded->AsIntCon();
 
-    cns1->SetIconValue(foldedCns->gtIconVal);
+    cns1->SetIconValue(foldedCns->IconValue());
     cns1->SetVNsFromNode(foldedCns);
 
     if (oper == GT_ADD)
     {
+        // Note that gtFoldExprConst doesn't maintain fieldSeq when folding constant
+        // trees of TYP_LONG.
         cns1->gtFieldSeq = GetFieldSeqStore()->Append(cns1->gtFieldSeq, cns2->gtFieldSeq);
     }
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_56935/Runtime_56935.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_56935/Runtime_56935.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Runtime_56935
+{
+    public class Program
+    {
+        static int clsFld;
+
+        public static int Main()
+        {
+            int zeroVal = 0;
+
+            // The rhs of the following statement on Arm64 will be transformed into the following tree
+            //
+            // N012 ( 27, 14) [000009] ---X--------  *  ADD       int    $42
+            // N010 ( 25, 11) [000029] ---X--------  +--*  ADD       int    $40
+            // N008 ( 23,  8) [000032] ---X--------  |  +--*  NEG       int    $41
+            // N007 ( 22,  7) [000008] ---X--------  |  |  \--*  DIV       int    $42
+            // N003 (  1,  2) [000004] ------------  |  |     +--*  CNS_INT   int    1 $42
+            // N006 (  1,  2) [000024] ------------  |  |     \--*  COMMA     int    $42
+            // N004 (  0,  0) [000022] ------------  |  |        +--*  NOP       void   $100
+            // N005 (  1,  2) [000023] ------------  |  |        \--*  CNS_INT   int    1 $42
+            // N009 (  1,  2) [000028] ------------  |  \--*  CNS_INT   int    1 $42
+            // N011 (  1,  2) [000003] ------------  \--*  CNS_INT   int    1 $42
+            //
+            // Then, during optValnumCSE() the tree is transformed even further by fgMorphCommutative()
+            //
+            // N014 ( 25, 11) [000029] ---X--------  *  ADD       int    $40
+            // N012 ( 23,  8) [000032] ---X--------  +--*  NEG       int    $41
+            // N011 ( 22,  7) [000008] ---X--------  |  \--*  DIV       int    $42
+            // N007 (  1,  2) [000004] ------------  |     +--*  CNS_INT   int    1 $42
+            // N010 (  1,  2) [000024] ------------  |     \--*  COMMA     int    $42
+            // N008 (  0,  0) [000022] ------------  |        +--*  NOP       void   $100
+            // N009 (  1,  2) [000023] ------------  |        \--*  CNS_INT   int    1 $42
+            // N013 (  1,  2) [000028] ------------  \--*  CNS_INT   int    2 $42
+            //
+            // The issue is that VN for [000028] has not been updated ($42 corresponds to CnsInt(1)).
+            // As a result, during optVNAssertionPropCurStmt() the whole tree is **incorrecly** folded to
+            //
+            // After constant propagation on [000029]:
+            // N007 (  1,  2) [000040] ------------  *  CNS_INT   int    0 $40
+
+            clsFld = 1 + (1 % (zeroVal + 1));
+            return (clsFld == 1) ? 100 : 0;
+        }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_56935/Runtime_56935.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_56935/Runtime_56935.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
During `fgMorphCommutative` we don't update a VN of modified trees properly and, as a result, in #56935 the JIT made wrong decision during `optVNAssertionPropCurStmt`. (You can find out what exactly happens in the comments for the regression test).

The fix is to not allow running `fgMorphCommutative` during `optValnumCSE_phase` (as we do for similar optimizations).
The change is conservative and results in some regressions (I will post the results later), but there nothing major as far as I can tell, so I am open for suggestions whether we can do anything that is better and still safe.

@dotnet/jit-contrib PTAL

Fixes #56935