### PR TITLE
Avoid dereferencing target pointer

### DIFF
--- a/src/coreclr/debug/daccess/request_svr.cpp
+++ b/src/coreclr/debug/daccess/request_svr.cpp
@@ -134,7 +134,7 @@ ClrDataAccess::ServerGCHeapDetails(CLRDATA_ADDRESS heapAddr, DacpGcHeapDetails *
     if (pHeap->saved_sweep_ephemeral_seg.IsValid())
     {
         detailsData->saved_sweep_ephemeral_seg = (CLRDATA_ADDRESS)dac_cast<TADDR>(pHeap->saved_sweep_ephemeral_seg);
-        detailsData->saved_sweep_ephemeral_start = (CLRDATA_ADDRESS)*pHeap->saved_sweep_ephemeral_start;
+        detailsData->saved_sweep_ephemeral_start = (CLRDATA_ADDRESS)pHeap->saved_sweep_ephemeral_start;
     }
     else
     {


### PR DESCRIPTION
I had a typo in https://github.com/dotnet/runtime/pull/56056, we shouldn't be dereferencing target pointers in DAC, this change fixed it.