### PR TITLE
[MacCatalyst][libraries] Update MacCatalyst as Case Preserving for tests

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/Directory/Exists.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/Exists.cs
@@ -236,7 +236,6 @@ namespace System.IO.Tests
 
         [Fact]
         [PlatformSpecific(CaseSensitivePlatforms)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/52857", TestPlatforms.MacCatalyst)]
         public void DoesCaseSensitiveComparisons()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());

--- a/src/libraries/System.IO.FileSystem/tests/DirectoryInfo/Exists.cs
+++ b/src/libraries/System.IO.FileSystem/tests/DirectoryInfo/Exists.cs
@@ -77,7 +77,6 @@ namespace System.IO.Tests
 
         [Fact]
         [PlatformSpecific(CaseSensitivePlatforms)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/52857", TestPlatforms.MacCatalyst)]
         public void CaseSensitivity()
         {
             Assert.False(new DirectoryInfo(TestDirectory.ToUpperInvariant()).Exists);

--- a/src/libraries/System.IO.FileSystem/tests/File/Exists.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/Exists.cs
@@ -180,7 +180,6 @@ namespace System.IO.Tests
 
         [Fact]
         [PlatformSpecific(CaseSensitivePlatforms)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/52857", TestPlatforms.MacCatalyst)]
         public void DoesCaseSensitiveComparisons()
         {
             FileInfo testFile = new FileInfo(GetTestFilePath());

--- a/src/libraries/System.IO.FileSystem/tests/FileInfo/Exists.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileInfo/Exists.cs
@@ -63,7 +63,6 @@ namespace System.IO.Tests
 
         [Fact]
         [PlatformSpecific(CaseSensitivePlatforms)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/52857", TestPlatforms.MacCatalyst)]
         public void CaseSensitivity()
         {
             string path = GetTestFilePath();

--- a/src/libraries/System.IO.FileSystem/tests/FileSystemTest.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileSystemTest.cs
@@ -11,8 +11,8 @@ namespace System.IO.Tests
     {
         public static readonly byte[] TestBuffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
 
-        protected const TestPlatforms CaseInsensitivePlatforms = TestPlatforms.Windows | TestPlatforms.OSX;
-        protected const TestPlatforms CaseSensitivePlatforms = TestPlatforms.AnyUnix & ~TestPlatforms.OSX;
+        protected const TestPlatforms CaseInsensitivePlatforms = TestPlatforms.Windows | TestPlatforms.OSX | TestPlatforms.MacCatalyst;
+        protected const TestPlatforms CaseSensitivePlatforms = TestPlatforms.AnyUnix & ~TestPlatforms.OSX & ~TestPlatforms.MacCatalyst;
 
         public static bool AreAllLongPathsAvailable => PathFeatures.AreAllLongPathsAvailable();
 
@@ -72,7 +72,7 @@ namespace System.IO.Tests
             string prefix = Path.Combine(Path.GetTempPath(), "CoreFxPipe_");
             int availableLength = MinUdsPathLength - prefix.Length - 1; // 1 - for possible null terminator
             Assert.True(availableLength >= MinAvailableForSufficientRandomness, $"UDS prefix {prefix} length {prefix.Length} is too long");
-            
+
             return string.Create(availableLength, 0, (span, _) =>
             {
                 for (int i = 0; i < span.Length; i++)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/52857

On MacCatalyst x64, checking the values of `DoesCaseSensitiveComparisons` 
```
System.Exception : 
testDir.FullName: /var/folders/yq/rwgq0l0d1yxgz5wtk2bvw0ww0000gn/T/Directory_Exists_cwmz21ja.jq3/DoesCaseSensitiveComparisons_241_b48c73fe
testDir.FullName.ToUpperInvariant(): /VAR/FOLDERS/YQ/RWGQ0L0D1YXGZ5WTK2BVW0WW0000GN/T/DIRECTORY_EXISTS_CWMZ21JA.JQ3/DOESCASESENSITIVECOMPARISONS_241_B48C73FE
testDir.FullName.ToLowerInvariant(): /var/folders/yq/rwgq0l0d1yxgz5wtk2bvw0ww0000gn/t/directory_exists_cwmz21ja.jq3/doescasesensitivecomparisons_241_b48c73fe
```
asserts true for `testDir.FullName.ToUpperInvariant()`, which suggests that MacCatalyst is case preserving like OSX

As a result, this PR updates the `CaseInsensitivePlatforms` and `CaseSensitivePlatforms` to have MacCatalyst behave like OSX.