### PR TITLE
Handle early wakeup of counter loop

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -23,7 +23,6 @@ namespace System.Diagnostics.Tracing
         private readonly EventSource _eventSource;
         private readonly List<DiagnosticCounter> _counters;
         private static readonly object s_counterGroupLock = new object();
-        private static readonly TimeSpan s_minimumPollingInterval = TimeSpan.FromSeconds(1);
 
         internal CounterGroup(EventSource eventSource)
         {
@@ -128,7 +127,7 @@ namespace System.Diagnostics.Tracing
             Debug.Assert(Monitor.IsEntered(s_counterGroupLock));
             if (pollingIntervalInSeconds <= 0)
             {
-                _pollingIntervalInMilliseconds = 0;
+                DisableTimer();
             }
             else if (_pollingIntervalInMilliseconds == 0 || pollingIntervalInSeconds * 1000 < _pollingIntervalInMilliseconds)
             {
@@ -253,7 +252,7 @@ namespace System.Diagnostics.Tracing
                 {
                     _timeStampSinceCollectionStarted = now;
                     TimeSpan delta = now - _nextPollingTimeStamp;
-                    delta = s_minimumPollingInterval > delta ? s_minimumPollingInterval : delta;
+                    delta = _pollingIntervalInMilliseconds > delta.TotalMilliseconds ? TimeSpan.FromMilliseconds(_pollingIntervalInMilliseconds) : delta;
                     if (_pollingIntervalInMilliseconds > 0)
                         _nextPollingTimeStamp += TimeSpan.FromMilliseconds(_pollingIntervalInMilliseconds * Math.Ceiling(delta.TotalMilliseconds / _pollingIntervalInMilliseconds));
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -23,6 +23,7 @@ namespace System.Diagnostics.Tracing
         private readonly EventSource _eventSource;
         private readonly List<DiagnosticCounter> _counters;
         private static readonly object s_counterGroupLock = new object();
+        private static readonly TimeSpan s_minimumPollingInterval = TimeSpan.FromSeconds(1);
 
         internal CounterGroup(EventSource eventSource)
         {
@@ -252,7 +253,8 @@ namespace System.Diagnostics.Tracing
                 {
                     _timeStampSinceCollectionStarted = now;
                     TimeSpan delta = now - _nextPollingTimeStamp;
-                    if (delta > TimeSpan.Zero && _pollingIntervalInMilliseconds > 0)
+                    delta = s_minimumPollingInterval > delta ? s_minimumPollingInterval : delta;
+                    if (_pollingIntervalInMilliseconds > 0)
                         _nextPollingTimeStamp += TimeSpan.FromMilliseconds(_pollingIntervalInMilliseconds * Math.Ceiling(delta.TotalMilliseconds / _pollingIntervalInMilliseconds));
                 }
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -187,6 +187,7 @@ namespace System.Diagnostics.Tracing
 
         private void DisableTimer()
         {
+            Debug.Assert(Monitor.IsEntered(s_counterGroupLock));
             _pollingIntervalInMilliseconds = 0;
             s_counterGroupEnabledList?.Remove(this);
         }


### PR DESCRIPTION
Fix #56695
* prevent a negative delta value

Copy of comment from #56695:

> I think I've worked out what happened.
> 
> The new logic:
> 
> ```cs
> TimeSpan delta = now - _nextPollingTimeStamp;
> if (delta > TimeSpan.Zero && _pollingIntervalInMilliseconds > 0)
> 	_nextPollingTimeStamp += TimeSpan.FromMilliseconds(_pollingIntervalInMilliseconds * Math.Ceiling(delta.TotalMilliseconds / _pollingIntervalInMilliseconds));
> ```
> 
> can have wonky behavior if the sleep in `CounterGroup.PollForValues` wakes up early.
> 
> `delta` can be negative, which will result in `_nextPollingTimeStamp` not being updated. This means that `sleepDurationInMilliseconds` will be set to `1` and the counter will fire again on the next loop because `_nextPollingTimeStamp < now + new TimeSpan.FromMilliseconds(1)` will be true.
> 
> https://github.com/dotnet/runtime/blob/4d26112c07391f563cb0ca46af1993635399007e/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs#L267-L306
> 
> A fix would be to switch to the following:
> 
> ```cs
> private const TimeSpan MinimumPollingInterval = TimeSpan.FromSeconds(1);
> 
> // ...
> 
> TimeSpan delta = now - _nextPollingTimeStamp;
> delta = MinimumPollingInterval > delta ? MinimumPollingInterval : delta;
> if (_pollingIntervalInMilliseconds > 0)
> 	_nextPollingTimeStamp += TimeSpan.FromMilliseconds(_pollingIntervalInMilliseconds * Math.Ceiling(delta.TotalMilliseconds / _pollingIntervalInMilliseconds));
> ```
> 
> The `now - _nextPollingTimeStamp` is calculating the difference between when the counter woke up (`now`) and when it was _supposed_ to wake up (`_nextPollingTimeStamp`). This is supposed to then increment `_nextPollingTimeStamp` to the next discrete increment of `_pollingIntervalInMillseconds` from the origin time. This prevents the interval from sliding if counters take sufficiently long amounts of time to calculate. This updated logic without the loop, however, only increments if `now > _nextPollingTimeStamp` (if the counter woke up _after_ the intended timestamp).


We'll need to backport these changes to 3.1 and 5.0 if they are approved.

