### PR TITLE
Fix RuntimeTypeHandle.IsComObject check for __ComObject type

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -463,8 +463,9 @@ namespace System
         internal static bool IsComObject(RuntimeType type, bool isGenericCOM)
         {
 #if FEATURE_COMINTEROP
+            // We need to check the type handle values - not the instances - to determine if the runtime type is a ComOjbect.
             if (isGenericCOM)
-                return type == typeof(__ComObject);
+                return type.TypeHandle.Value == typeof(__ComObject).TypeHandle.Value;
 
             return RuntimeTypeHandle.CanCastTo(type, (RuntimeType)typeof(__ComObject));
 #else

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -463,7 +463,7 @@ namespace System
         internal static bool IsComObject(RuntimeType type, bool isGenericCOM)
         {
 #if FEATURE_COMINTEROP
-            // We need to check the type handle values - not the instances - to determine if the runtime type is a ComOjbect.
+            // We need to check the type handle values - not the instances - to determine if the runtime type is a ComObject.
             if (isGenericCOM)
                 return type.TypeHandle.Value == typeof(__ComObject).TypeHandle.Value;
 

--- a/src/tests/Interop/COM/NETClients/ConsumeNETServer/Program.cs
+++ b/src/tests/Interop/COM/NETClients/ConsumeNETServer/Program.cs
@@ -29,6 +29,23 @@ namespace NetClient
             Assert.IsTrue(Marshal.IsComObject(test));
         }
 
+        static void Validate_Activation_CreateInstance()
+        {
+            Console.WriteLine($"{nameof(Validate_Activation_CreateInstance)}...");
+
+            Type t = Type.GetTypeFromCLSID(Guid.Parse(Guids.ConsumeNETServerTesting));
+            Assert.IsTrue(t.IsCOMObject);
+
+            // Use the overload that takes constructor arguments. This tests the path where the runtime searches for the
+            // constructor to use (which has some special-casing for COM) instead of just always using the default.
+            object obj = Activator.CreateInstance(t, Array.Empty<object>());
+
+            var test = (CoClass.ConsumeNETServerTesting)obj;
+            test.ReleaseResources();
+
+            Assert.IsTrue(Marshal.IsComObject(test));
+        }
+
         static void Validate_CCW_Wasnt_Unwrapped()
         {
             Console.WriteLine($"{nameof(Validate_CCW_Wasnt_Unwrapped)}...");
@@ -102,6 +119,7 @@ namespace NetClient
                     string.Empty))
                 {
                     Validate_Activation();
+                    Validate_Activation_CreateInstance();
                     Validate_CCW_Wasnt_Unwrapped();
                     Validate_Client_CCW_RCW();
                     Validate_Server_CCW_RCW();

--- a/src/tests/Interop/COM/NETClients/ConsumeNETServer/Program.cs
+++ b/src/tests/Interop/COM/NETClients/ConsumeNETServer/Program.cs
@@ -36,11 +36,16 @@ namespace NetClient
             Type t = Type.GetTypeFromCLSID(Guid.Parse(Guids.ConsumeNETServerTesting));
             Assert.IsTrue(t.IsCOMObject);
 
+            object obj = Activator.CreateInstance(t);
+            var test = (CoClass.ConsumeNETServerTesting)obj;
+            test.ReleaseResources();
+            
+            Assert.IsTrue(Marshal.IsComObject(test));
+
             // Use the overload that takes constructor arguments. This tests the path where the runtime searches for the
             // constructor to use (which has some special-casing for COM) instead of just always using the default.
-            object obj = Activator.CreateInstance(t, Array.Empty<object>());
-
-            var test = (CoClass.ConsumeNETServerTesting)obj;
+            obj = Activator.CreateInstance(t, Array.Empty<object>());
+            test = (CoClass.ConsumeNETServerTesting)obj;
             test.ReleaseResources();
 
             Assert.IsTrue(Marshal.IsComObject(test));


### PR DESCRIPTION
Fixes #57107

cc @AaronRobinsonMSFT @jkoritzinsky 