### PR TITLE
imul instruction size misprediction

### DIFF
--- a/src/coreclr/jit/clrjit.natvis
+++ b/src/coreclr/jit/clrjit.natvis
@@ -175,8 +175,8 @@ Documentation for VS debugger format specifiers: https://docs.microsoft.com/en-u
 
   <!-- Emitter -->
   <Type Name="insGroup">
-    <DisplayString Condition="igFlags &amp; 0x200">IG{igNum,d} [extend]</DisplayString>
-    <DisplayString>IG{igNum,d}</DisplayString>
+    <DisplayString Condition="igFlags &amp; 0x200">IG{igNum,d}, size={igSize,d}, offset={igOffs,d} [extend]</DisplayString>
+    <DisplayString>IG{igNum,d}, size={igSize,d}, offset={igOffs,d}</DisplayString>
   </Type>
 
   <Type Name="emitter::instrDesc">

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -885,17 +885,6 @@ protected:
         void idCodeSize(unsigned sz)
         {
             assert(sz <= 15); // Intel decoder limit.
-            if (sz > 15)
-            {
-                // This is a temporary workaround for non-precise instr size
-                // estimator on XARCH. It often overestimates sizes and can
-                // return value more than 15 that doesn't fit in 4 bits _idCodeSize.
-                // If somehow we generate instruction that needs more than 15 bytes we
-                // will fail on another assert in emit.cpp: noway_assert(id->idCodeSize() >= csz).
-                // Issue https://github.com/dotnet/runtime/issues/12840.
-                sz = 15;
-            }
-            assert(sz <= 15); // Intel decoder limit.
             _idCodeSize = sz;
             assert(sz == _idCodeSize);
         }

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -884,6 +884,7 @@ protected:
         }
         void idCodeSize(unsigned sz)
         {
+            assert(sz <= 15); // Intel decoder limit.
             if (sz > 15)
             {
                 // This is a temporary workaround for non-precise instr size

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -2639,6 +2639,7 @@ inline UNATIVE_OFFSET emitter::emitInsSizeCV(instrDesc* id, code_t code, int val
     }
     else
     {
+        assert((ins == INS_mov) || (valSize < 8));
         assert(!IsSSEOrAVXInstruction(ins));
     }
 

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -2635,7 +2635,14 @@ inline UNATIVE_OFFSET emitter::emitInsSizeCV(instrDesc* id, code_t code, int val
     UNATIVE_OFFSET valSize   = EA_SIZE_IN_BYTES(id->idOpSize());
     bool           valInByte = ((signed char)val == val) && (ins != INS_mov) && (ins != INS_test);
 
-#ifndef TARGET_AMD64
+#ifdef TARGET_AMD64
+    // 64-bit immediates are only supported on mov r64, imm64
+    // As per manual:
+    // Support for 64-bit immediate operands is accomplished by expanding
+    // the semantics of the existing move (MOV reg, imm16/32) instructions.
+    if ((valSize > sizeof(INT32)) && (ins != INS_mov))
+        valSize = sizeof(INT32);
+#else
     // occasionally longs get here on x86
     if (valSize > sizeof(INT32))
         valSize = sizeof(INT32);

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -2639,7 +2639,7 @@ inline UNATIVE_OFFSET emitter::emitInsSizeCV(instrDesc* id, code_t code, int val
     }
     else
     {
-        assert((ins == INS_mov) || (valSize < 8));
+        //assert((ins == INS_mov) || (valSize < 8));
         assert(!IsSSEOrAVXInstruction(ins));
     }
 

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -1177,15 +1177,22 @@ unsigned emitter::emitGetAdjustedSize(instruction ins, emitAttr attr, code_t cod
     return adjustedSize;
 }
 
-// Get size of rex or vex prefix emitted in code
-unsigned emitter::emitGetPrefixSize(code_t code)
+// 
+//------------------------------------------------------------------------
+// emitGetPrefixSize: Get size of rex or vex prefix emitted in code
+//
+// Arguments:
+//    code                  -- The current opcode and any known prefixes
+//    includeRexPrefixSize  -- If Rex Prefix size should be included or not
+//
+unsigned emitter::emitGetPrefixSize(code_t code, bool includeRexPrefixSize)
 {
     if (hasVexPrefix(code))
     {
         return 3;
     }
 
-    if (hasRexPrefix(code))
+    if (includeRexPrefixSize && hasRexPrefix(code))
     {
         return 1;
     }
@@ -1946,16 +1953,18 @@ bool emitter::emitVerifyEncodable(instruction ins, emitAttr size, regNumber reg1
     return true;
 }
 
-/*****************************************************************************
- *
- *  Estimate the size (in bytes of generated code) of the given instruction.
- */
-
-inline UNATIVE_OFFSET emitter::emitInsSize(code_t code)
+//------------------------------------------------------------------------
+// emitInsSize: Estimate the size (in bytes of generated code) of the given instruction.
+//
+// Arguments:
+//    code  -- The current opcode and any known prefixes
+//    includeRexPrefixSize  -- If Rex Prefix size should be included or not
+//
+inline UNATIVE_OFFSET emitter::emitInsSize(code_t code, bool includeRexPrefixSize)
 {
     UNATIVE_OFFSET size = (code & 0xFF000000) ? 4 : (code & 0x00FF0000) ? 3 : 2;
 #ifdef TARGET_AMD64
-    size += emitGetPrefixSize(code);
+    size += emitGetPrefixSize(code, includeRexPrefixSize);
 #endif
     return size;
 }
@@ -1973,16 +1982,18 @@ inline UNATIVE_OFFSET emitter::emitInsSizeRR(instrDesc* id, code_t code)
     instruction ins  = id->idIns();
     emitAttr    attr = id->idOpSize();
 
-    UNATIVE_OFFSET sz = emitInsSize(code);
+    UNATIVE_OFFSET sz = emitGetAdjustedSize(ins, attr, code);
 
-    sz += emitGetAdjustedSize(ins, attr, code);
-
+    bool includeRexPrefixSize = true;
     // REX prefix
     if (TakesRexWPrefix(ins, attr) || IsExtendedReg(id->idReg1(), attr) || IsExtendedReg(id->idReg2(), attr) ||
         (!id->idIsSmallDsc() && (IsExtendedReg(id->idReg3(), attr) || IsExtendedReg(id->idReg4(), attr))))
     {
         sz += emitGetRexPrefixSize(ins);
+        includeRexPrefixSize = !IsAVXInstruction(ins);
     }
+
+    sz += emitInsSize(code, includeRexPrefixSize);
 
     return sz;
 }
@@ -2034,24 +2045,14 @@ inline UNATIVE_OFFSET emitter::emitInsSizeRR(instruction ins, regNumber reg1, re
 {
     emitAttr size = EA_SIZE(attr);
 
-    UNATIVE_OFFSET sz;
-
     // If Byte 4 (which is 0xFF00) is zero, that's where the RM encoding goes.
     // Otherwise, it will be placed after the 4 byte encoding, making the total 5 bytes.
     // This would probably be better expressed as a different format or something?
     code_t code = insCodeRM(ins);
 
-    if ((code & 0xFF00) != 0)
-    {
-        sz = IsSSEOrAVXInstruction(ins) ? emitInsSize(code) : 5;
-    }
-    else
-    {
-        sz = emitInsSize(insEncodeRMreg(ins, code));
-    }
+    UNATIVE_OFFSET sz = emitGetAdjustedSize(ins, size, insCodeRM(ins));
 
-    sz += emitGetAdjustedSize(ins, size, insCodeRM(ins));
-
+    bool includeRexPrefixSize = true;
     // REX prefix
     if (!hasRexPrefix(code))
     {
@@ -2059,7 +2060,17 @@ inline UNATIVE_OFFSET emitter::emitInsSizeRR(instruction ins, regNumber reg1, re
             IsExtendedReg(reg2, attr))
         {
             sz += emitGetRexPrefixSize(ins);
+            includeRexPrefixSize = false;
         }
+    }
+
+    if ((code & 0xFF00) != 0)
+    {
+        sz += IsSSEOrAVXInstruction(ins) ? emitInsSize(code, includeRexPrefixSize) : 5;
+    }
+    else
+    {
+        sz += emitInsSize(insEncodeRMreg(ins, code), includeRexPrefixSize);
     }
 
     return sz;
@@ -2069,7 +2080,7 @@ inline UNATIVE_OFFSET emitter::emitInsSizeRR(instruction ins, regNumber reg1, re
 
 inline UNATIVE_OFFSET emitter::emitInsSizeSV(code_t code, int var, int dsp)
 {
-    UNATIVE_OFFSET size = emitInsSize(code);
+    UNATIVE_OFFSET size = emitInsSize(code, /* includeRexPrefixSize */ true);
     UNATIVE_OFFSET offs;
     bool           offsIsUpperBound = true;
     bool           EBPbased         = true;
@@ -2605,14 +2616,17 @@ inline UNATIVE_OFFSET emitter::emitInsSizeCV(instrDesc* id, code_t code)
 
     size += emitGetAdjustedSize(ins, attrSize, code);
 
+    bool includeRexPrefixSize = true;
+
     // 64-bit operand instructions will need a REX.W prefix
     if (TakesRexWPrefix(ins, attrSize) || IsExtendedReg(id->idReg1(), attrSize) ||
         IsExtendedReg(id->idReg2(), attrSize))
     {
         size += emitGetRexPrefixSize(ins);
+        includeRexPrefixSize = false;
     }
 
-    return size + emitInsSize(code);
+    return size + emitInsSize(code, includeRexPrefixSize);
 }
 
 inline UNATIVE_OFFSET emitter::emitInsSizeCV(instrDesc* id, code_t code, int val)
@@ -4036,7 +4050,15 @@ void emitter::emitIns_R_I(instruction ins, emitAttr attr, regNumber reg, ssize_t
             {
                 if (IsSSEOrAVXInstruction(ins))
                 {
-                    sz = emitInsSize(insCodeMI(ins));
+                    bool includeRexPrefixSize = true;
+                    // Do not get the RexSize() but just decide if it will be included down further and if yes,
+                    // do not include it again.
+                    if (IsExtendedReg(reg, attr) || TakesRexWPrefix(ins, size) || instrIsExtendedReg3opImul(ins))
+                    {
+                        includeRexPrefixSize = false;
+                    }
+
+                    sz = emitInsSize(insCodeMI(ins), includeRexPrefixSize);
                     sz += 1;
                 }
                 else if (size == EA_1BYTE && reg == REG_EAX && !instrIs3opImul(ins))

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -1177,7 +1177,7 @@ unsigned emitter::emitGetAdjustedSize(instruction ins, emitAttr attr, code_t cod
     return adjustedSize;
 }
 
-// 
+//
 //------------------------------------------------------------------------
 // emitGetPrefixSize: Get size of rex or vex prefix emitted in code
 //
@@ -2660,7 +2660,6 @@ inline UNATIVE_OFFSET emitter::emitInsSizeCV(instrDesc* id, code_t code, int val
     }
     else
     {
-        //assert((ins == INS_mov) || (valSize < 8));
         assert(!IsSSEOrAVXInstruction(ins));
     }
 

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -38,7 +38,7 @@ struct CnsVal
     bool    cnsReloc;
 };
 
-UNATIVE_OFFSET emitInsSize(code_t code);
+UNATIVE_OFFSET emitInsSize(code_t code, bool includeRexPrefixSize);
 UNATIVE_OFFSET emitInsSizeSV(code_t code, int var, int dsp);
 UNATIVE_OFFSET emitInsSizeSV(instrDesc* id, code_t code, int var, int dsp);
 UNATIVE_OFFSET emitInsSizeSV(instrDesc* id, code_t code, int var, int dsp, int val);
@@ -67,7 +67,7 @@ BYTE* emitOutputLJ(insGroup* ig, BYTE* dst, instrDesc* id);
 unsigned emitOutputRexOrVexPrefixIfNeeded(instruction ins, BYTE* dst, code_t& code);
 unsigned emitGetRexPrefixSize(instruction ins);
 unsigned emitGetVexPrefixSize(instruction ins, emitAttr attr);
-unsigned emitGetPrefixSize(code_t code);
+unsigned emitGetPrefixSize(code_t code, bool includeRexPrefixSize);
 unsigned emitGetAdjustedSize(instruction ins, emitAttr attr, code_t code);
 
 unsigned insEncodeReg012(instruction ins, regNumber reg, emitAttr size, code_t* code);


### PR DESCRIPTION
During emitting `imul`, we wrongly predict the size of instruction as `16 bytes` whereas it should be just `15 bytes` (which is debatable, see below) comprising of 1 byte `REX prefix` + 1 byte `opcode` + 1 byte `modR/M` + 4 bytes `RIP-relative displacement` + 4 bytes of `immediate`. Last row in https://www.felixcloutier.com/x86/imul table.

Now as per Intel docs:

```
RIP-relative addressing allows specific ModR/M modes to address memory relative to the 64-bit RIP using a signed
32-bit displacement. 
```
which means the RIP immediate above should be just 4-bytes and the instruction size should be just `11 bytes`. But in `emitInsSizeCV()` we have it calculated as `valSize == 8`.

When calculating the size, it seems that we double calculate the `REX prefix size`, once in https://github.com/dotnet/runtime/blob/53a1ddc4af2cb7592125aa80e4f812f2a3a3fde3/src/coreclr/jit/emitxarch.cpp#L2612

and then further in `emitInsSize() -> emitGetPrefixSize()` in https://github.com/dotnet/runtime/blob/53a1ddc4af2cb7592125aa80e4f812f2a3a3fde3/src/coreclr/jit/emitxarch.cpp#L1188-L1191


Because of above conditions, we end up with size of `16 bytes` but when we save the size in `instrDesc`, we cap it to `15 bytes` because of #12840.

https://github.com/dotnet/runtime/blob/d20606c23a985a5906324d9eef992c225afb29c8/src/coreclr/jit/emit.h#L887-L896


Further, we account the wrong size of instruction `16 bytes` instead of the one we have in `id->CodeSize()` of `15 bytes`. 

https://github.com/dotnet/runtime/blob/53a1ddc4af2cb7592125aa80e4f812f2a3a3fde3/src/coreclr/jit/emitxarch.cpp#L5596-L5601

Due to this, the `emitCurIGSize` and hence `ig->igOffs` becomes off by 1 byte and during emitting, we think that we just over-estimated the instruction by 4 bytes = 15 (`id->CodeSize()`) - 11 (`actual encoding size`) but the offsets were calculated assuming the instruction size of `16 bytes`. That difference of 1 byte leads to an assert in https://github.com/dotnet/runtime/issues/57041.

To summarize, there are 3 problems:
1. Double counting of REX prefix which happens at multiple places.

This is fixed by tracking if we have already counted REX prefix size and if yes, do not include it in `emitGetPrefixSize()`.

2. Why is `valSize > 4` for RIP-immediate . I have added an assert in this draft PR to see if there are any instructions other than `mov` for which we get `valSize > 4` other wise, we should just update [this code ](https://github.com/dotnet/runtime/blob/53a1ddc4af2cb7592125aa80e4f812f2a3a3fde3/src/coreclr/jit/emitxarch.cpp#L2624-L2628) to cap `valSize` to 4 bytes.

This is fixed by making sure we cap `valSize` to 4 bytes for all instructions except `mov`.

3. There are multiple places that has code like this:
```c++
sz = calculateSize();
id->idCodeSize(sz);
emitCurIGsize += sz; // This can be wrong for sz >= 15.
```

This problem should never arise because I have removed the code that caps `sz` to 15 bytes and added an assert for `sz <= 15`. With that, it will be safe to use `emitCurIGsize += sz`.

Thanks @tannergooding for pointing me to manuals.

Fixes: #12840, #57041