### PR TITLE
Remove some unnecessary parameters/fields from interop helpers

### DIFF
--- a/src/coreclr/vm/cominterfacemarshaler.h
+++ b/src/coreclr/vm/cominterfacemarshaler.h
@@ -25,15 +25,12 @@ public:
 
     VOID Init(IUnknown* pUnk, MethodTable* pClassMT, Thread *pThread, DWORD flags = 0); // see RCW::CreationFlags
 
-    OBJECTREF FindOrCreateObjectRef(IUnknown **ppIncomingIP, MethodTable *pIncomingItfMT = NULL);
-    OBJECTREF FindOrCreateObjectRef(IUnknown *pIncomingIP, MethodTable *pIncomingItfMT = NULL);
-
-    VOID InitializeExistingComObject(OBJECTREF *pComObj, IUnknown **ppIncomingIP);
+    OBJECTREF FindOrCreateObjectRef(IUnknown *pIncomingIP);
 
 private:
     VOID InitializeObjectClass(IUnknown *pIncomingIP);
-    OBJECTREF FindOrCreateObjectRefInternal(IUnknown **ppIncomingIP, MethodTable *pIncomingItfMT, bool bIncomingIPAddRefed);
-    VOID      CreateObjectRef(BOOL fDuplicate, OBJECTREF *pComObj, IUnknown **ppIncomingIP, MethodTable *pIncomingItfMT, bool bIncomingIPAddRefed);
+    OBJECTREF FindOrCreateObjectRefInternal(IUnknown **ppIncomingIP);
+    VOID      CreateObjectRef(BOOL fDuplicate, OBJECTREF *pComObj, IUnknown **ppIncomingIP);
     static VOID      EnsureCOMInterfacesSupported(OBJECTREF oref, MethodTable* pClassMT);
 
     inline bool NeedUniqueObject();
@@ -42,7 +39,6 @@ private:
     IUnknown*               m_pUnknown;         // NOT AddRef'ed
     IUnknown*               m_pIdentity;        // NOT AddRef'ed
     TypeHandle              m_typeHandle;       // inited and computed if inited value is NULL.  Need to represent all array information too.
-    TypeHandle              m_itfTypeHandle;    // an interface supported by the object as returned from GetRuntimeClassName
     Thread*                 m_pThread;          // Current thread - avoid calling GetThread multiple times
     DWORD                   m_flags;
 };

--- a/src/coreclr/vm/dispparammarshaler.cpp
+++ b/src/coreclr/vm/dispparammarshaler.cpp
@@ -192,7 +192,7 @@ void DispParamInterfaceMarshaler::MarshalNativeToManaged(VARIANT *pSrcVar, OBJEC
     IUnknown *pUnk = bByref ? *V_UNKNOWNREF(pSrcVar) : V_UNKNOWN(pSrcVar);
 
     // Convert the IP to an OBJECTREF.
-    GetObjectRefFromComIP(pDestObj, pUnk, m_pClassMT, /* pItfMT = */ NULL, m_bClassIsHint ? ObjFromComIP::CLASS_IS_HINT : ObjFromComIP::NONE);
+    GetObjectRefFromComIP(pDestObj, pUnk, m_pClassMT, m_bClassIsHint ? ObjFromComIP::CLASS_IS_HINT : ObjFromComIP::NONE);
 }
 
 void DispParamInterfaceMarshaler::MarshalManagedToNative(OBJECTREF *pSrcObj, VARIANT *pDestVar)

--- a/src/coreclr/vm/interopconverter.cpp
+++ b/src/coreclr/vm/interopconverter.cpp
@@ -375,7 +375,7 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, REFIID iid, bool throwIfNoComI
 // pMTClass : specifies the type of instance to be returned
 // NOTE:**  As per COM Rules, the IUnknown passed in shouldn't be AddRef'ed
 //+----------------------------------------------------------------------------
-void GetObjectRefFromComIP(OBJECTREF* pObjOut, IUnknown **ppUnk, MethodTable *pMTClass, MethodTable *pItfMT, DWORD dwFlags)
+void GetObjectRefFromComIP(OBJECTREF* pObjOut, IUnknown **ppUnk, MethodTable *pMTClass, DWORD dwFlags)
 {
     CONTRACTL
     {
@@ -386,7 +386,6 @@ void GetObjectRefFromComIP(OBJECTREF* pObjOut, IUnknown **ppUnk, MethodTable *pM
         PRECONDITION(CheckPointer(*ppUnk, NULL_OK));
         PRECONDITION(CheckPointer(pMTClass, NULL_OK));
         PRECONDITION(IsProtectedByGCFrame(pObjOut));
-        PRECONDITION(pItfMT == NULL || pItfMT->IsInterface());
     }
     CONTRACTL_END;
 
@@ -457,7 +456,7 @@ void GetObjectRefFromComIP(OBJECTREF* pObjOut, IUnknown **ppUnk, MethodTable *pM
             COMInterfaceMarshaler marshaler;
 
             marshaler.Init(pOuter, pComClassMT, pThread, flags);
-            *pObjOut = marshaler.FindOrCreateObjectRef(pUnk, pItfMT);
+            *pObjOut = marshaler.FindOrCreateObjectRef(pUnk);
         }
     }
 

--- a/src/coreclr/vm/interopconverter.h
+++ b/src/coreclr/vm/interopconverter.h
@@ -122,15 +122,15 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, REFIID iid, bool throwIfNoComI
 // GetObjectRefFromComIP(IUnknown **ppUnk, MethodTable *pMTClass, ...)
 // Converts a COM IP to ObjectRef, pMTClass is the desired RCW type. If bSuppressAddRef and a new RCW is created,
 // *ppUnk will be assigned NULL to signal to the caller that it is no longer responsible for releasing the IP.
-void GetObjectRefFromComIP(OBJECTREF* pObjOut, IUnknown **ppUnk, MethodTable *pMTClass, MethodTable *pItfMT, DWORD dwFlags); // ObjFromComIP::flags
+void GetObjectRefFromComIP(OBJECTREF* pObjOut, IUnknown **ppUnk, MethodTable *pMTClass, DWORD dwFlags); // ObjFromComIP::flags
 
 //--------------------------------------------------------------------------------
 // GetObjectRefFromComIP(IUnknown *pUnk, MethodTable *pMTClass, ...)
 // Converts a COM IP to ObjectRef, pMTClass is the desired RCW type.
-inline void GetObjectRefFromComIP(OBJECTREF* pObjOut, IUnknown *pUnk, MethodTable *pMTClass = NULL, MethodTable *pItfMT = NULL, DWORD dwFlags = ObjFromComIP::NONE)
+inline void GetObjectRefFromComIP(OBJECTREF* pObjOut, IUnknown *pUnk, MethodTable *pMTClass = NULL, DWORD dwFlags = ObjFromComIP::NONE)
 {
     WRAPPER_NO_CONTRACT;
-    return GetObjectRefFromComIP(pObjOut, &pUnk, pMTClass, pItfMT, dwFlags);
+    return GetObjectRefFromComIP(pObjOut, &pUnk, pMTClass, dwFlags);
 }
 
 #endif // FEATURE_COMINTEROP

--- a/src/coreclr/vm/interoputil.cpp
+++ b/src/coreclr/vm/interoputil.cpp
@@ -4226,20 +4226,18 @@ void UnmarshalObjectFromInterface(OBJECTREF *ppObjectDest, IUnknown **ppUnkSrc, 
 
     _ASSERTE(!pClassMT || !pClassMT->IsInterface());
 
-    bool fIsInterface = (pItfMT != NULL && pItfMT->IsInterface());
-
     DWORD dwObjFromComIPFlags = ObjFromComIP::FromItfMarshalInfoFlags(dwFlags);
     GetObjectRefFromComIP(
         ppObjectDest,                  // Object
         ppUnkSrc,                      // Interface pointer
         pClassMT,                      // Class type
-        fIsInterface ? pItfMT : NULL,  // Interface type - used to cache the incoming interface pointer
         dwObjFromComIPFlags            // Flags
         );
 
     // Make sure the interface is supported.
     _ASSERTE(!pItfMT || pItfMT->IsInterface() || pItfMT->GetComClassInterfaceType() != clsIfNone);
 
+    bool fIsInterface = (pItfMT != NULL && pItfMT->IsInterface());
     if (fIsInterface)
     {
         // We only verify that the object supports the interface for non-WinRT scenarios because we

--- a/src/coreclr/vm/marshalnative.cpp
+++ b/src/coreclr/vm/marshalnative.cpp
@@ -809,7 +809,7 @@ FCIMPL1(Object*, MarshalNative::GetUniqueObjectForIUnknownNative, IUnknown* pUnk
     // Ensure COM is started up.
     EnsureComStarted();
 
-    GetObjectRefFromComIP(&oref, pUnk, NULL, NULL, ObjFromComIP::UNIQUE_OBJECT);
+    GetObjectRefFromComIP(&oref, pUnk, NULL, ObjFromComIP::UNIQUE_OBJECT);
 
     HELPER_METHOD_FRAME_END();
     return OBJECTREFToObject(oref);


### PR DESCRIPTION
Built-in WinRT support remnants, I believe.

cc @AaronRobinsonMSFT @jkoritzinsky 