### PR TITLE
Fix C++ compile error in pal_io_common.h

### DIFF
--- a/src/libraries/Native/Unix/Common/pal_io_common.h
+++ b/src/libraries/Native/Unix/Common/pal_io_common.h
@@ -90,7 +90,7 @@ inline static int32_t Common_Poll(PollEvent* pollEvents, uint32_t eventCount, in
     }
     else
     {
-        pollfds = calloc(eventCount, sizeof(*pollfds));
+        pollfds = (struct pollfd*) calloc(eventCount, sizeof(*pollfds));
         if (pollfds == NULL)
         {
             return Error_ENOMEM;

--- a/src/libraries/Native/Unix/Common/pal_io_common.h
+++ b/src/libraries/Native/Unix/Common/pal_io_common.h
@@ -90,7 +90,7 @@ inline static int32_t Common_Poll(PollEvent* pollEvents, uint32_t eventCount, in
     }
     else
     {
-        pollfds = (struct pollfd*) calloc(eventCount, sizeof(*pollfds));
+        pollfds = (struct pollfd*)calloc(eventCount, sizeof(*pollfds));
         if (pollfds == NULL)
         {
             return Error_ENOMEM;


### PR DESCRIPTION
This cast fixes a compilation error when compiling `pal_io_common.h` as C++. I'm porting the runtime to an exotic platform whose compiler toolchain requires compiling System.Native in C++ mode instead of C, thus requiring the cast.

cc: @RalfKornmannEnvision, I saw you were running into this as well with your PS5 work.