### PR TITLE
Make sure rid specific libs projs get packaged

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -259,12 +259,6 @@
     <IsShippingAssembly Condition="$(IsExperimentalAssembly)">false</IsShippingAssembly>
     <!-- We don't want Private packages to be shipped to NuGet.org -->
     <IsShippingPackage Condition="$(MSBuildProjectName.Contains('Private')) or $(IsExperimentalAssembly)">false</IsShippingPackage>
-    <!-- A package isn't generated if in servicing or in runtimelab. Intended to be overridden at project level.
-         Excluding .sfxprojs as they have their own incremental servicing infra. -->
-    <GeneratePackage Condition="'$(GeneratePackage)' == ''">true</GeneratePackage>
-    <GeneratePackage Condition="(('$(PreReleaseVersionLabel)' == 'servicing' or
-                                  '$(GitHubRepositoryName)' == 'runtimelab') and
-                                 '$(MSBuildProjectExtension)' != '.sfxproj')">false</GeneratePackage>
     <PlaceholderFile>$(RepositoryEngineeringDir)_._</PlaceholderFile>
   </PropertyGroup>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,4 @@
-<Project InitialTargets="_OverridePackDependsOn">
+<Project>
   <PropertyGroup>
     <!--
     For non-SDK projects that import this file and then import Microsoft.Common.targets,
@@ -54,23 +54,7 @@
     <PackageDescription Condition="'$(PackageDescription)' == '' and '$(UseRuntimePackageDisclaimer)' == 'true'">$(RuntimePackageDisclaimer)</PackageDescription>
     <!-- Keep in sync as required by the Packaging SDK in Arcade. -->
     <Description>$(PackageDescription)</Description>
-    <GenerateNuspecDependsOn>ErrorForMissingPackageDescription;$(GenerateNuspecDependsOn)</GenerateNuspecDependsOn>
   </PropertyGroup>
-
-  <!-- Remove when https://github.com/NuGet/Home/issues/10405 is implemented and consumed. -->
-  <Target Name="ErrorForMissingPackageDescription"
-          Condition="'$(PackageDescription)' == ''">
-    <Error Text="Required property 'PackageDescription' is missing for $(MSBuildProjectName)." />
-  </Target>
-
-  <!-- <GeneratePackage /> controls if a package should be created by clearing out <PackDependsOn />. -->
-  <Target Name="_OverridePackDependsOn"
-          Condition="'$(IsPackable)' == 'true' and
-                     '$(GeneratePackage)' != 'true'">
-    <PropertyGroup>
-      <PackDependsOn />
-    </PropertyGroup>
-  </Target>
 
   <!--
     Arcade SDK versioning is defined by static properties in a targets file: work around this by

--- a/eng/packaging.props
+++ b/eng/packaging.props
@@ -1,9 +1,0 @@
-<Project>
-
-  <PropertyGroup>
-    <!-- Needs to be set in a props file when package referencing NuGet.Build.Tasks.Pack, as NuGet's targets file is imported before
-         packaging.targets and hence the BeforePack isn't respected. This can be moved back when the PackageReference is removed. -->
-    <BeforePack>AddNETStandardCompatErrorFileForPackaging;IncludeAnalyzersInPackage;$(BeforePack)</BeforePack>
-  </PropertyGroup>
-
-</Project>

--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -5,6 +5,10 @@
     <!-- Don't restore prebuilt packages during sourcebuild. -->
     <DisablePackageBaselineValidation Condition="'$(DotNetBuildFromSource)' == 'true'">true</DisablePackageBaselineValidation>
     <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == ''">$([MSBuild]::Subtract($(MajorVersion), 1)).0.0</PackageValidationBaselineVersion>
+    <!-- PackDependsOn is the right hook in a targets file if the NuGet.Build.Tasks.Pack nuget package is used, otherwise
+         BeforePack must be used. Setting both to ensure that we are always running before other targets. --> 
+    <PackDependsOn>AddNETStandardCompatErrorFileForPackaging;IncludeAnalyzersInPackage;$(PackDependsOn)</PackDependsOn>
+    <BeforePack>AddNETStandardCompatErrorFileForPackaging;IncludeAnalyzersInPackage;$(BeforePack)</BeforePack>
     <SymbolPackageOutputPath>$(PackageOutputPath)</SymbolPackageOutputPath>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddRuntimeSpecificFilesToPackage</TargetsForTfmSpecificContentInPackage>
     <TargetsForTfmSpecificDebugSymbolsInPackage>$(TargetsForTfmSpecificDebugSymbolsInPackage);AddRuntimeSpecificSymbolToPackage</TargetsForTfmSpecificDebugSymbolsInPackage>
@@ -12,8 +16,14 @@
     <!-- Don't include target platform specific dependencies, since we use the target platform to represent RIDs instead -->
     <SuppressDependenciesWhenPacking Condition="'$(ExcludeFromPackage)' == 'true' or ('$(TargetsAnyOS)' != 'true' and $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net5.0')))">true</SuppressDependenciesWhenPacking>
     <PackageDesignerMarkerFile>$(MSBuildThisFileDirectory)useSharedDesignerContext.txt</PackageDesignerMarkerFile>
-    <!-- Generate packages in the allconfigurations build. -->
-    <GeneratePackageOnBuild Condition="'$(BuildAllConfigurations)' == 'true'">true</GeneratePackageOnBuild>
+    <!-- Generate packages for rid specific projects or for allconfigurations during build. -->
+    <!-- A package isn't generated if in servicing or in runtimelab. Intended to be overridden at project level. -->
+    <IsRIDSpecificProject Condition="$(MSBuildProjectName.StartsWith('runtime.')) and
+                                     !$(MSBuildProjectName.StartsWith('runtime.native'))">true</IsRIDSpecificProject>
+    <GeneratePackageOnBuild Condition="('$(BuildAllConfigurations)' == 'true' or
+                                       '$(IsRIDSpecificProject)' == 'true') and
+                                       '$(PreReleaseVersionLabel)' != 'servicing' and
+                                       '$(GitHubRepositoryName)' != 'runtimelab'">true</GeneratePackageOnBuild>
     <!-- Search for the documentation file in the intellisense package and otherwise pick up the generated one. -->
     <LibIntellisenseDocumentationFilePath>$(XmlDocFileRoot)1033\$(AssemblyName).xml</LibIntellisenseDocumentationFilePath>
     <UseIntellisenseDocumentationFile Condition="'$(UseIntellisenseDocumentationFile)' == '' and Exists('$(LibIntellisenseDocumentationFilePath)')">true</UseIntellisenseDocumentationFile>

--- a/global.json
+++ b/global.json
@@ -16,7 +16,7 @@
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21405.3",
     "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.21405.3",
     "Microsoft.DotNet.SharedFramework.Sdk": "6.0.0-beta.21405.3",
-    "Microsoft.Build.NoTargets": "3.0.4",
+    "Microsoft.Build.NoTargets": "3.1.0",
     "Microsoft.Build.Traversal": "3.0.23",
     "Microsoft.NET.Sdk.IL": "6.0.0-rc.1.21401.3"
   }

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -60,7 +60,6 @@
   </ItemGroup>
 
   <Import Project="NetCoreAppLibrary.props" />
-  <Import Project="$(RepositoryEngineeringDir)packaging.props" Condition="'$(IsSourceProject)' == 'true'" />
   <Import Project="$(RepositoryEngineeringDir)referenceAssemblies.props" Condition="'$(IsReferenceAssembly)' == 'true'" />
   <Import Project="$(RepositoryEngineeringDir)targetframeworksuffix.props" Condition="'$(DesignTimeBuild)' != 'true'" />
 

--- a/src/libraries/System.IO.Ports/pkg/runtime.native.System.IO.Ports.props
+++ b/src/libraries/System.IO.Ports/pkg/runtime.native.System.IO.Ports.props
@@ -6,6 +6,7 @@
     <IncludeBuildOutput>true</IncludeBuildOutput>
     <DebugSymbols>false</DebugSymbols>
     <DebugType>none</DebugType>
+    <IsPackable>true</IsPackable>
     <AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>$(SymbolsSuffix)</AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>
     <TargetsForTfmSpecificDebugSymbolsInPackage>$(TargetsForTfmSpecificDebugSymbolsInPackage);AddRuntimeSpecificNativeSymbolToPackage</TargetsForTfmSpecificDebugSymbolsInPackage>
     <UseRuntimePackageDisclaimer>true</UseRuntimePackageDisclaimer>

--- a/src/libraries/System.IO.Ports/pkg/runtime.native.System.IO.Ports.props
+++ b/src/libraries/System.IO.Ports/pkg/runtime.native.System.IO.Ports.props
@@ -26,12 +26,4 @@
                                    TargetFramework="$(TargetFramework)" />
     </ItemGroup>
   </Target>
-
-  <!-- This is necessary as NuGet reads from this item when IncludeBuildOutput is set to true.
-       Remove when https://github.com/microsoft/MSBuildSdks/pull/276 is merged and a new version is consumed. -->
-  <Target Name="ClearBuiltProjectOutputGroupKeyOutput" BeforeTargets="_WalkEachTargetPerFramework;BuiltProjectOutputGroup">
-    <ItemGroup>
-      <BuiltProjectOutputGroupKeyOutput Remove="@(BuiltProjectOutputGroupKeyOutput)" />
-    </ItemGroup>
-  </Target>
 </Project>


### PR DESCRIPTION
**Make sure rid specific libs projs get packaged …**

RID specific runtime.*.runtime.native.System.IO.Ports projects weren't
packaged because the GeneratePackageOnBuild property wasn't set to true
for them. The property was only true during an allconfigurations build.
As these projects are only built outside of an allconfigurations build,
the GeneratePackageOnBuild property needs to account for such as well.

Also updating the NoTargets Sdk to clean the rid specific package up.

Moving the GeneratePackageOnBuild logic into a props file and set it to
false during servicing (or runtimelab) so that devs can set the property
during servicing directly in the project file if a project should be
packaged.

**Remove the GeneratePackage property …**

That property was intended to enabled incremental servicing but with
now using the NuGet Pack task we can just make use of the publicly
available GeneratePackageOnBuild property.