### PR TITLE
disable TestConvertFromIntegral on arm with stress.

### DIFF
--- a/src/tests/JIT/IL_Conformance/Convert/TestConvertFromIntegral.csproj
+++ b/src/tests/JIT/IL_Conformance/Convert/TestConvertFromIntegral.csproj
@@ -6,6 +6,8 @@
   <PropertyGroup>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
+    <!-- https://github.com/dotnet/runtime/issues/57040 -->
+    <JitOptimizationSensitive Condition="'$(TargetArchitecture)' == 'arm' And '$(TargetOS)' != 'Windows'">true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
Revert when https://github.com/dotnet/runtime/issues/57040 is fixed.