### PR TITLE
Allow ConfigBinder to bind arrays to Singular elements

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -713,7 +713,7 @@ namespace Microsoft.Extensions.Configuration
 
 
             IEnumerable<IConfigurationSection> children;
-            // If children contain an array, there will a number as the index
+            // If configuration's children is an array, the configuration key will be a number
             if (config.GetChildren().Any(a => long.TryParse(a.Key, out _)))
             {
                 children = config.GetChildren();

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Extensions.Configuration
         private const string TrimmingWarningMessage = "In case the type is non-primitive, the trimmer cannot statically analyze the object's type so its members may be trimmed.";
         private const string InstanceGetTypeTrimmingWarningMessage = "Cannot statically analyze the type of instance so its members may be trimmed";
         private const string PropertyTrimmingWarningMessage = "Cannot statically analyze property.PropertyType so its members may be trimmed.";
+        private const string BindSingleElementsToArraySwitch = "Microsoft.Extensions.Configuration.BindSingleElementsToArray";
 
         /// <summary>
         /// Attempts to bind the configuration instance to a new instance of type T.
@@ -362,7 +363,7 @@ namespace Microsoft.Extensions.Configuration
                 return convertedValue;
             }
 
-            if (config != null && (config.GetChildren().Any() || configValue != null))
+            if (config != null && (config.GetChildren().Any() || (configValue != null && ShouldBindSingleElementsToArray())))
             {
                 // If we don't have an instance, try to create one
                 if (instance == null)
@@ -495,17 +496,7 @@ namespace Microsoft.Extensions.Configuration
             Type itemType = collectionType.GenericTypeArguments[0];
             MethodInfo addMethod = collectionType.GetMethod("Add", DeclaredOnlyLookup);
 
-            IEnumerable<IConfigurationSection> children;
-            if (config.GetChildren().Any(a => long.TryParse(a.Key, out _)))
-            {
-                children = config.GetChildren();
-            }
-            else
-            {
-                children = new[] { config as IConfigurationSection };
-            }
-
-            foreach (IConfigurationSection section in children)
+            foreach (IConfigurationSection section in GetChildrenOrSelf(config))
             {
                 try
                 {
@@ -528,16 +519,7 @@ namespace Microsoft.Extensions.Configuration
         [RequiresUnreferencedCode("Cannot statically analyze what the element type is of the Array so its members may be trimmed.")]
         private static Array BindArray(Array source, IConfiguration config, BinderOptions options)
         {
-            IConfigurationSection[] children;
-            if (config.GetChildren().Any(a => long.TryParse(a.Key, out _)))
-            {
-                children = config.GetChildren().ToArray();
-            }
-            else
-            {
-                children = new[] { config as IConfigurationSection };
-            }
-
+            IConfigurationSection[] children = GetChildrenOrSelf(config).ToArray();
             int arrayLength = source.Length;
             Type elementType = source.GetType().GetElementType();
             var newArray = Array.CreateInstance(elementType, arrayLength + children.Length);
@@ -720,6 +702,39 @@ namespace Microsoft.Extensions.Configuration
             }
 
             return property.Name;
+        }
+
+        private static IEnumerable<IConfigurationSection> GetChildrenOrSelf(IConfiguration config)
+        {
+            if (!ShouldBindSingleElementsToArray())
+            {
+                return config.GetChildren();
+            }
+
+
+            IEnumerable<IConfigurationSection> children;
+            // If children contain an array, there will a number as the index
+            if (config.GetChildren().Any(a => long.TryParse(a.Key, out _)))
+            {
+                children = config.GetChildren();
+            }
+            else
+            {
+                children = new[] { config as IConfigurationSection };
+            }
+
+            return children;
+        }
+
+        private static bool ShouldBindSingleElementsToArray()
+        {
+            if (AppContext.TryGetSwitch(BindSingleElementsToArraySwitch, out bool bindSingleElementsToArray))
+            {
+                return bindSingleElementsToArray;
+            }
+
+            // Enable this switch by default.
+            return true;
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -711,7 +711,6 @@ namespace Microsoft.Extensions.Configuration
                 return config.GetChildren();
             }
 
-
             IEnumerable<IConfigurationSection> children;
             // If configuration's children is an array, the configuration key will be a number
             if (config.GetChildren().Any(a => long.TryParse(a.Key, out _)))

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
@@ -960,6 +960,14 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             var nestedAsArray = config.GetSection("Nested").Get<NestedOptions[]>();
             Assert.Equal(11, nestedAsArray[0].Integer);
             Assert.Equal(1, nestedAsArray.Length);
+
+            AppContext.SetSwitch("Microsoft.Extensions.Configuration.BindSingleElementsToArray", false);
+
+            stringArr = config.GetSection("MyString").Get<string[]>();
+            Assert.Null(stringArr);
+
+            stringAsStr = config.GetSection("MyString").Get<string>();
+            Assert.Equal("hello world", stringAsStr);
         }
 
         private interface ISomeInterface

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
@@ -960,14 +960,30 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             var nestedAsArray = config.GetSection("Nested").Get<NestedOptions[]>();
             Assert.Equal(11, nestedAsArray[0].Integer);
             Assert.Equal(1, nestedAsArray.Length);
+        }
 
+        [Fact]
+        public void CannotBindSingleElementToCollectionWhenSwitchSet()
+        {
             AppContext.SetSwitch("Microsoft.Extensions.Configuration.BindSingleElementsToArray", false);
 
-            stringArr = config.GetSection("MyString").Get<string[]>();
+            var dic = new Dictionary<string, string>
+            {
+                {"MyString", "hello world"},
+                {"Nested:Integer", "11"},
+            };
+
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            var config = configurationBuilder.Build();
+
+            var stringArr = config.GetSection("MyString").Get<string[]>();
             Assert.Null(stringArr);
 
-            stringAsStr = config.GetSection("MyString").Get<string>();
+            var stringAsStr = config.GetSection("MyString").Get<string>();
             Assert.Equal("hello world", stringAsStr);
+
+            AppContext.SetSwitch("Microsoft.Extensions.Configuration.BindSingleElementsToArray", true);
         }
 
         private interface ISomeInterface

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
@@ -934,6 +934,34 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
                 exception.Message);
         }
 
+        [Fact]
+        public void CanBindSingleElementToCollection()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"MyString", "hello world"},
+                {"Nested:Integer", "11"},
+            };
+
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            var config = configurationBuilder.Build();
+
+            var stringArr = config.GetSection("MyString").Get<string[]>();
+            Assert.Equal("hello world", stringArr[0]);
+            Assert.Equal(1, stringArr.Length);
+
+            var stringAsStr = config.GetSection("MyString").Get<string>();
+            Assert.Equal("hello world", stringAsStr);
+
+            var nested = config.GetSection("Nested").Get<NestedOptions>();
+            Assert.Equal(11, nested.Integer);
+
+            var nestedAsArray = config.GetSection("Nested").Get<NestedOptions[]>();
+            Assert.Equal(11, nestedAsArray[0].Integer);
+            Assert.Equal(1, nestedAsArray.Length);
+        }
+
         private interface ISomeInterface
         {
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
@@ -945,7 +945,7 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             var configurationBuilder = new ConfigurationBuilder();
             configurationBuilder.AddInMemoryCollection(dic);
-            var config = configurationBuilder.Build();
+            IConfiguration config = configurationBuilder.Build();
 
             var stringArr = config.GetSection("MyString").Get<string[]>();
             Assert.Equal("hello world", stringArr[0]);
@@ -975,7 +975,7 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
 
             var configurationBuilder = new ConfigurationBuilder();
             configurationBuilder.AddInMemoryCollection(dic);
-            var config = configurationBuilder.Build();
+            IConfiguration config = configurationBuilder.Build();
 
             var stringArr = config.GetSection("MyString").Get<string[]>();
             Assert.Null(stringArr);


### PR DESCRIPTION
When trying to bind a collection of type `T`, ConfigBinder will now try to bind to the current object instead of children objects when the provided configuration doesn't contain an array.

This change allows elements that are not arrays to be bound to arrays. For example, a type string[] can now be bound to "key" in case "key:0" doesn't exist.