### PR TITLE
Improve AppendLiteral for short literals

### DIFF
--- a/src/libraries/System.CodeDom/tests/System/CodeDom/Compiler/CSharpCodeGeneratorTests.cs
+++ b/src/libraries/System.CodeDom/tests/System/CodeDom/Compiler/CSharpCodeGeneratorTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace System.CodeDom.Compiler.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/57363", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoInterpreter))]
     public class CSharpCodeGeneratorTests
     {
         private static IEnumerable<string> Identifier_TestData()

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -1963,7 +1963,46 @@ namespace System
             /// <summary>Writes the specified string to the handler.</summary>
             /// <param name="value">The string to write.</param>
             /// <returns>true if the value could be formatted to the span; otherwise, false.</returns>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public bool AppendLiteral(string value)
+            {
+                // See comment on inlining and special-casing in DefaultInterpolatedStringHandler.AppendLiteral.
+
+                if (value.Length == 1)
+                {
+                    Span<char> destination = _destination;
+                    int pos = _pos;
+                    if ((uint)pos < (uint)destination.Length)
+                    {
+                        destination[pos] = value[0];
+                        _pos = pos + 1;
+                        return true;
+                    }
+
+                    return Fail();
+                }
+
+                if (value.Length == 2)
+                {
+                    Span<char> destination = _destination;
+                    int pos = _pos;
+                    if ((uint)(pos + 1) < (uint)destination.Length)
+                    {
+                        Unsafe.As<char, int>(ref MemoryMarshal.GetReference(destination)) = Unsafe.As<char, int>(ref value.GetRawStringData());
+                        _pos = pos + 2;
+                        return true;
+                    }
+
+                    return Fail();
+                }
+
+                return AppendStringDirect(value);
+            }
+
+            /// <summary>Writes the specified string to the handler.</summary>
+            /// <param name="value">The string to write.</param>
+            /// <returns>true if the value could be appended to the span; otherwise, false.</returns>
+            private bool AppendStringDirect(string value)
             {
                 if (value.TryCopyTo(_destination.Slice(_pos)))
                 {
@@ -2023,7 +2062,7 @@ namespace System
                     s = value?.ToString();
                 }
 
-                return s is null || AppendLiteral(s); // use AppendLiteral to avoid going back through this method recursively
+                return s is null || AppendStringDirect(s);
             }
 
             /// <summary>Writes the specified value to the handler.</summary>
@@ -2067,7 +2106,7 @@ namespace System
                     s = value?.ToString();
                 }
 
-                return s is null || AppendLiteral(s); // use AppendLiteral to avoid going back through this method recursively
+                return s is null || AppendStringDirect(s);
             }
 
             /// <summary>Writes the specified value to the handler.</summary>
@@ -2228,7 +2267,7 @@ namespace System
 
                 if (formatter is not null && formatter.Format(format, value, _provider) is string customFormatted)
                 {
-                    return AppendLiteral(customFormatted);
+                    return AppendStringDirect(customFormatted);
                 }
 
                 return true;

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -1986,9 +1986,11 @@ namespace System
                 {
                     Span<char> destination = _destination;
                     int pos = _pos;
-                    if ((uint)(pos + 1) < (uint)destination.Length)
+                    if ((uint)pos < destination.Length - 1)
                     {
-                        Unsafe.As<char, int>(ref MemoryMarshal.GetReference(destination)) = Unsafe.As<char, int>(ref value.GetRawStringData());
+                        Unsafe.WriteUnaligned(
+                            ref Unsafe.As<char, byte>(ref Unsafe.Add(ref MemoryMarshal.GetReference(destination), pos)),
+                            Unsafe.ReadUnaligned<int>(ref Unsafe.As<char, byte>(ref value.GetRawStringData())));
                         _pos = pos + 2;
                         return true;
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/DefaultInterpolatedStringHandler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/DefaultInterpolatedStringHandler.cs
@@ -173,9 +173,11 @@ namespace System.Runtime.CompilerServices
             {
                 Span<char> chars = _chars;
                 int pos = _pos;
-                if ((uint)(pos + 1) < (uint)chars.Length)
+                if ((uint)pos < chars.Length - 1)
                 {
-                    Unsafe.As<char, int>(ref MemoryMarshal.GetReference(chars)) = Unsafe.As<char, int>(ref value.GetRawStringData());
+                    Unsafe.WriteUnaligned(
+                        ref Unsafe.As<char, byte>(ref Unsafe.Add(ref MemoryMarshal.GetReference(chars), pos)),
+                        Unsafe.ReadUnaligned<int>(ref Unsafe.As<char, byte>(ref value.GetRawStringData())));
                     _pos = pos + 2;
                 }
                 else

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/DefaultInterpolatedStringHandler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/DefaultInterpolatedStringHandler.cs
@@ -4,6 +4,8 @@
 using System.Buffers;
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.InteropServices;
+using Internal.Runtime.CompilerServices;
 
 namespace System.Runtime.CompilerServices
 {
@@ -130,7 +132,65 @@ namespace System.Runtime.CompilerServices
 
         /// <summary>Writes the specified string to the handler.</summary>
         /// <param name="value">The string to write.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void AppendLiteral(string value)
+        {
+            // AppendLiteral is expected to always be called by compiler-generated code with a literal string.
+            // By inlining it, the method body is exposed to the constant length of that literal, allowing the JIT to
+            // prune away the irrelevant cases.  This effectively enables multiple implementations of AppendLiteral,
+            // special-cased on and optimized for the literal's length.  We special-case lengths 1 and 2 because
+            // they're very common, e.g.
+            //     1: ' ', '.', '-', '\t', etc.
+            //     2: ", ", "0x", "=>", ": ", etc.
+            // but we refrain from adding more because, in the rare case where AppendLiteral is called with a non-literal,
+            // there is a lot of code here to be inlined.
+
+            // TODO: https://github.com/dotnet/runtime/issues/41692#issuecomment-685192193
+            // What we really want here is to be able to add a bunch of additional special-cases based on length,
+            // e.g. a switch with a case for each length <= 8, not mark the method as AggressiveInlining, and have
+            // it inlined when provided with a string literal such that all the other cases evaporate but not inlined
+            // if called directly with something that doesn't enable pruning.  Even better, if "literal".TryCopyTo
+            // could be unrolled based on the literal, ala https://github.com/dotnet/runtime/pull/46392, we might
+            // be able to remove all special-casing here.
+
+            if (value.Length == 1)
+            {
+                Span<char> chars = _chars;
+                int pos = _pos;
+                if ((uint)pos < (uint)chars.Length)
+                {
+                    chars[pos] = value[0];
+                    _pos = pos + 1;
+                }
+                else
+                {
+                    GrowThenCopyString(value);
+                }
+                return;
+            }
+
+            if (value.Length == 2)
+            {
+                Span<char> chars = _chars;
+                int pos = _pos;
+                if ((uint)(pos + 1) < (uint)chars.Length)
+                {
+                    Unsafe.As<char, int>(ref MemoryMarshal.GetReference(chars)) = Unsafe.As<char, int>(ref value.GetRawStringData());
+                    _pos = pos + 2;
+                }
+                else
+                {
+                    GrowThenCopyString(value);
+                }
+                return;
+            }
+
+            AppendStringDirect(value);
+        }
+
+        /// <summary>Writes the specified string to the handler.</summary>
+        /// <param name="value">The string to write.</param>
+        private void AppendStringDirect(string value)
         {
             if (value.TryCopyTo(_chars.Slice(_pos)))
             {
@@ -265,7 +325,7 @@ namespace System.Runtime.CompilerServices
 
             if (s is not null)
             {
-                AppendLiteral(s);
+                AppendStringDirect(s);
             }
         }
         /// <summary>Writes the specified value to the handler.</summary>
@@ -312,7 +372,7 @@ namespace System.Runtime.CompilerServices
 
             if (s is not null)
             {
-                AppendLiteral(s);
+                AppendStringDirect(s);
             }
         }
 
@@ -493,7 +553,7 @@ namespace System.Runtime.CompilerServices
 
             if (formatter is not null && formatter.Format(format, value, _provider) is string customFormatted)
             {
-                AppendLiteral(customFormatted);
+                AppendStringDirect(customFormatted);
             }
         }
 
@@ -543,7 +603,7 @@ namespace System.Runtime.CompilerServices
             }
         }
 
-        /// <summary>Fallback for fast path in <see cref="AppendLiteral"/> when there's not enough space in the destination.</summary>
+        /// <summary>Fallback for fast path in <see cref="AppendStringDirect"/> when there's not enough space in the destination.</summary>
         /// <param name="value">The string to write.</param>
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void GrowThenCopyString(string value)


### PR DESCRIPTION
DefaultInterpolatedStringHandler.AppendLiteral is special, in that the 99.9% use case is it's called as part of string interpolation by compiler-generated code where the argument is always a literal.  That means when the method is inlined, the JIT can specialize the implementation based on knowing the literal's Length is a constant.  Which means we can provide specialized implementations for common lengths, resulting in faster and smaller code.  This does so for strings of length 1 and 2, as they're quite common in code bases examined, and it does so for both the default handler and also the handler used to format into a span.  Just as one data point, a quick-and-dirty search through dotnet/aspnetcore suggests that ~15% of literals are 1-character long.

The exact same code as before gets generated by the JIT for literals of length > 2 (well, at least for the default handler; for the TryWrite one, there's a few more instructions getting generated now for reasons I'm unsure of).  The main downside here is if someone does manually call this CompilerServices method with a variable, the call site will end up bloated with the special cases.

|        Method |         Toolchain |     Mean |    Error |   StdDev | Ratio | Allocated | Code Size |
|-------------- |------------------ |---------:|---------:|---------:|------:|----------:|----------:|
|    DefaultOne | \main\corerun.exe | 66.08 ns | 0.983 ns | 0.920 ns |  1.00 |      40 B |     513 B |
|    DefaultOne |   \pr\corerun.exe | 61.63 ns | 0.177 ns | 0.157 ns |  0.93 |      40 B |     378 B |
|               |                   |          |          |          |       |           |           |
|    DefaultTwo | \main\corerun.exe | 63.90 ns | 0.266 ns | 0.249 ns |  1.00 |      48 B |     516 B |
|    DefaultTwo |   \pr\corerun.exe | 55.60 ns | 0.082 ns | 0.073 ns |  0.87 |      48 B |     390 B |
|               |                   |          |          |          |       |           |           |
|  DefaultThree | \main\corerun.exe | 63.72 ns | 0.354 ns | 0.314 ns |  1.00 |      48 B |     516 B |
|  DefaultThree |   \pr\corerun.exe | 62.17 ns | 0.616 ns | 0.546 ns |  0.98 |      48 B |     516 B |
|               |                   |          |          |          |       |           |           |
|   TryWriteOne | \main\corerun.exe | 35.81 ns | 0.057 ns | 0.054 ns |  1.00 |         - |     506 B |
|   TryWriteOne |   \pr\corerun.exe | 28.60 ns | 0.053 ns | 0.047 ns |  0.80 |         - |     371 B |
|               |                   |          |          |          |       |           |           |
|   TryWriteTwo | \main\corerun.exe | 34.94 ns | 0.121 ns | 0.101 ns |  1.00 |         - |     509 B |
|   TryWriteTwo |   \pr\corerun.exe | 29.30 ns | 0.011 ns | 0.009 ns |  0.84 |         - |     429 B |
|               |                   |          |          |          |       |           |           |
| TryWriteThree | \main\corerun.exe | 35.19 ns | 0.187 ns | 0.175 ns |  1.00 |         - |     509 B |
| TryWriteThree |   \pr\corerun.exe | 35.09 ns | 0.380 ns | 0.337 ns |  1.00 |         - |     545 B |

```C#
private char[] _buffer = new char[100];

[Benchmark]
[Arguments(1, 2, 3, 4)]
public string DefaultOne(uint a, uint b, uint c, uint d) => $"{a}.{b}.{c}.{d}";

[Benchmark]
[Arguments(1, 2, 3, 4)]
public string DefaultTwo(uint a, uint b, uint c, uint d) => $"{a}, {b}, {c}, {d}";

[Benchmark]
[Arguments(1, 2, 3, 4)]
public string DefaultThree(uint a, uint b, uint c, uint d) => $"{a} : {b} : {c} : {d}";

[Benchmark]
[Arguments(1, 2, 3, 4)]
public bool TryWriteOne(uint a, uint b, uint c, uint d) => _buffer.AsSpan().TryWrite($"{a}.{b}.{c}.{d}", out _);

[Benchmark]
[Arguments(1, 2, 3, 4)]
public bool TryWriteTwo(uint a, uint b, uint c, uint d) => _buffer.AsSpan().TryWrite($"{a}, {b}, {c}, {d}", out _);

[Benchmark]
[Arguments(1, 2, 3, 4)]
public bool TryWriteThree(uint a, uint b, uint c, uint d) => _buffer.AsSpan().TryWrite($"{a} : {b} : {c} : {d}", out _);
```

cc: @GrabYourPitchforks, @EgorBo 