### PR TITLE
Ensure Category attribute works well when UseSystemResourceKeys feature is turned on

### DIFF
--- a/src/libraries/System.ComponentModel.Primitives/src/System.ComponentModel.Primitives.csproj
+++ b/src/libraries/System.ComponentModel.Primitives/src/System.ComponentModel.Primitives.csproj
@@ -1,6 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <!--
+      Since many resource strings in this library are shown to an end-user,
+      always generate default resource string values which will be used when UseSystemResourceKeys is true in trimmed apps.
+    -->
+    <GenerateResxSourceIncludeDefaultValues>true</GenerateResxSourceIncludeDefaultValues>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/src/libraries/System.ComponentModel.Primitives/src/System/ComponentModel/CategoryAttribute.cs
+++ b/src/libraries/System.ComponentModel.Primitives/src/System/ComponentModel/CategoryAttribute.cs
@@ -222,7 +222,7 @@ namespace System.ComponentModel
             "Scale" => SR.PropertyCategoryScale,
             "Text" => SR.PropertyCategoryText,
             "WindowStyle" => SR.PropertyCategoryWindowStyle,
-            _ => SR.GetResourceString("PropertyCategory" + value, value)
+            _ => null
         };
 
         public override bool IsDefaultAttribute() => Category == Default.Category;

--- a/src/libraries/System.ComponentModel.Primitives/src/System/ComponentModel/CategoryAttribute.cs
+++ b/src/libraries/System.ComponentModel.Primitives/src/System/ComponentModel/CategoryAttribute.cs
@@ -199,7 +199,31 @@ namespace System.ComponentModel
         /// <summary>
         /// Looks up the localized name of a given category.
         /// </summary>
-        protected virtual string? GetLocalizedString(string value) => SR.GetResourceString("PropertyCategory" + value);
+        protected virtual string? GetLocalizedString(string value) => value switch
+        {
+            "Action" => SR.PropertyCategoryAction,
+            "Appearance" => SR.PropertyCategoryAppearance,
+            "Asynchronous" => SR.PropertyCategoryAsynchronous,
+            "Behavior" => SR.PropertyCategoryBehavior,
+            "Config" => SR.PropertyCategoryConfig,
+            "Data" => SR.PropertyCategoryData,
+            "DDE" => SR.PropertyCategoryDDE,
+            "Default" => SR.PropertyCategoryDefault,
+            "Design" => SR.PropertyCategoryDesign,
+            "DragDrop" => SR.PropertyCategoryDragDrop,
+            "Focus" => SR.PropertyCategoryFocus,
+            "Font" => SR.PropertyCategoryFont,
+            "Format" => SR.PropertyCategoryFormat,
+            "Key" => SR.PropertyCategoryKey,
+            "Layout" => SR.PropertyCategoryLayout,
+            "List" => SR.PropertyCategoryList,
+            "Mouse" => SR.PropertyCategoryMouse,
+            "Position" => SR.PropertyCategoryPosition,
+            "Scale" => SR.PropertyCategoryScale,
+            "Text" => SR.PropertyCategoryText,
+            "WindowStyle" => SR.PropertyCategoryWindowStyle,
+            _ => SR.GetResourceString("PropertyCategory" + value, value)
+        };
 
         public override bool IsDefaultAttribute() => Category == Default.Category;
     }

--- a/src/libraries/System.ComponentModel.Primitives/tests/TrimmingTests/System.ComponentModel.Primitives.TrimmingTests.proj
+++ b/src/libraries/System.ComponentModel.Primitives/tests/TrimmingTests/System.ComponentModel.Primitives.TrimmingTests.proj
@@ -4,7 +4,7 @@
   <ItemGroup>
     <TestConsoleAppSourceFiles Include="VerifyCategoryNamesDontGetTrimmed.cs">
       <!-- Setting the Trimming feature switch to make sure that the Resources get trimmed by the linker
-      as this test will ensure Category names will use default values whe the switch is on. -->
+      as this test will ensure Category names will use default values when the switch is on. -->
       <EnabledFeatureSwitches>System.Resources.UseSystemResourceKeys</EnabledFeatureSwitches>
     </TestConsoleAppSourceFiles>
   </ItemGroup>

--- a/src/libraries/System.ComponentModel.Primitives/tests/TrimmingTests/System.ComponentModel.Primitives.TrimmingTests.proj
+++ b/src/libraries/System.ComponentModel.Primitives/tests/TrimmingTests/System.ComponentModel.Primitives.TrimmingTests.proj
@@ -1,0 +1,13 @@
+<Project DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
+
+  <ItemGroup>
+    <TestConsoleAppSourceFiles Include="VerifyCategoryNamesDontGetTrimmed.cs">
+      <!-- Setting the Trimming feature switch to make sure that the Resources get trimmed by the linker
+      as this test will ensure Category names will use default values whe the switch is on. -->
+      <EnabledFeatureSwitches>System.Resources.UseSystemResourceKeys</EnabledFeatureSwitches>
+    </TestConsoleAppSourceFiles>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
+</Project>

--- a/src/libraries/System.ComponentModel.Primitives/tests/TrimmingTests/VerifyCategoryNamesDontGetTrimmed.cs
+++ b/src/libraries/System.ComponentModel.Primitives/tests/TrimmingTests/VerifyCategoryNamesDontGetTrimmed.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.ComponentModel;
+
+namespace Test
+{
+    /// <summary>
+    /// When UseSystemResourceStrings feature switch is on, we want to validate that getting the resource string of
+    /// a category attribute won't result in having "PropertyCategory" appended to the beginning of the resulting string.
+    /// This test ensures that both built-in categories as well as custom categories get the right Category when the
+    /// feature switch is on.
+    /// </summary>
+    public class Program
+    {
+        public static int Main()
+        {
+            if (GetEnumCategory(AnEnum.Action) == "Action" && GetEnumCategory(AnEnum.Something) == "Something")
+            {
+                return 100;
+            }
+            return -1;
+        }
+
+        public static string GetEnumCategory<T>(T enumValue)
+            where T : struct, IConvertible
+        {
+            if (!typeof(T).IsEnum)
+                return null;
+            var enumCategory = enumValue.ToString();
+            var fieldInfo = enumValue.GetType().GetField(enumValue.ToString());
+            if (fieldInfo != null)
+            {
+                var attrs = fieldInfo.GetCustomAttributes(typeof(CategoryAttribute), false);
+                if (attrs != null && attrs.Length > 0)
+                {
+                    enumCategory = ((CategoryAttribute)attrs[0]).Category;
+                }
+            }
+            return enumCategory;
+        }
+    }
+
+    public enum AnEnum
+    {
+        [Category("Action")] // Built-in category
+        Action = 1,
+
+        [Category("Something")] // Custom category
+        Something = 2
+    }
+}

--- a/src/libraries/System.ComponentModel.Primitives/tests/TrimmingTests/VerifyCategoryNamesDontGetTrimmed.cs
+++ b/src/libraries/System.ComponentModel.Primitives/tests/TrimmingTests/VerifyCategoryNamesDontGetTrimmed.cs
@@ -16,7 +16,7 @@ namespace Test
     {
         public static int Main()
         {
-            if (GetEnumCategory(AnEnum.Action) == "Action" && GetEnumCategory(AnEnum.Something) == "Something")
+            if (GetEnumCategory(AnEnum.Action) == "Action" && GetEnumCategory(AnEnum.Something) == "Something" && GetEnumCategory(AnEnum.WindowStyle) == "Window Style")
             {
                 return 100;
             }
@@ -48,6 +48,9 @@ namespace Test
         Action = 1,
 
         [Category("Something")] // Custom category
-        Something = 2
+        Something = 2,
+
+        [Category("WindowStyle")] // Built-in category with localized string different than category name.
+        WindowStyle = 3,
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/49554

These changes will make it so that Category attribute will not append a "PropertyCategory" as a suffix of the Category when UseSystemResourceKeys feature switch is turned on (in a trimmed application).

