### PR TITLE
Define dependencies for aspnetcore transport pkg

### DIFF
--- a/src/libraries/Microsoft.AspNetCore.Internal.Transport/src/Microsoft.AspNetCore.Internal.Transport.proj
+++ b/src/libraries/Microsoft.AspNetCore.Internal.Transport/src/Microsoft.AspNetCore.Internal.Transport.proj
@@ -9,8 +9,9 @@
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <PackageDescription>Internal transport package to provide aspnetcore with the assemblies that make up the Microsoft.ASPNetCore.App shared framework.</PackageDescription>
-    <!-- Reference elements are missing from the nuspec: https://github.com/NuGet/Home/issues/8684. -->
-    <NoWarn>$(NoWarn);NU5131</NoWarn>
+    <!-- NU5131: Reference elements are missing from the nuspec: https://github.com/NuGet/Home/issues/8684.
+         NU5128: Don't list dependencies as this is a mega and not meta package. -->
+    <NoWarn>$(NoWarn);NU5131;NU5128</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/Microsoft.AspNetCore.Internal.Transport/src/Microsoft.AspNetCore.Internal.Transport.proj
+++ b/src/libraries/Microsoft.AspNetCore.Internal.Transport/src/Microsoft.AspNetCore.Internal.Transport.proj
@@ -1,14 +1,21 @@
 ﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
-    <IsPackable>true</IsPackable>
     <IsShipping>false</IsShipping>
+    <!-- Reference the outputs to have them available as build outputs. -->
+    <NoTargetsDoNotReferenceOutputAssemblies>false</NoTargetsDoNotReferenceOutputAssemblies>
+    <IsPackable>true</IsPackable>
     <!-- This is non-shipping package. -->
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <PackageDescription>Internal transport package to provide aspnetcore with the assemblies that make up the Microsoft.ASPNetCore.App shared framework.</PackageDescription>
     <!-- Reference elements are missing from the nuspec: https://github.com/NuGet/Home/issues/8684. -->
     <NoWarn>$(NoWarn);NU5131</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="@(AspNetCoreAppLibrary->'$(LibrariesProjectRoot)%(Identity)\src\%(Identity).csproj')" />
+  </ItemGroup>
   
   <ItemGroup>
     <_analyzer Include="$(ASPNETCoreAppPackageRootPath)\analyzers\**\*.*" />

--- a/src/libraries/NetCoreAppLibrary.props
+++ b/src/libraries/NetCoreAppLibrary.props
@@ -145,9 +145,48 @@
       System.Xml.XPath;
       System.Xml.XPath.XDocument;
     </NetCoreAppLibrary>
+    <AspNetCoreAppLibrary>
+      Microsoft.Extensions.Caching.Abstractions;
+      Microsoft.Extensions.Caching.Memory;
+      Microsoft.Extensions.Configuration;
+      Microsoft.Extensions.Configuration.Abstractions;
+      Microsoft.Extensions.Configuration.Binder;
+      Microsoft.Extensions.Configuration.CommandLine;
+      Microsoft.Extensions.Configuration.EnvironmentVariables;
+      Microsoft.Extensions.Configuration.FileExtensions;
+      Microsoft.Extensions.Configuration.Ini;
+      Microsoft.Extensions.Configuration.Json;
+      Microsoft.Extensions.Configuration.UserSecrets;
+      Microsoft.Extensions.Configuration.Xml;
+      Microsoft.Extensions.DependencyInjection;
+      Microsoft.Extensions.DependencyInjection.Abstractions;
+      Microsoft.Extensions.FileProviders.Abstractions;
+      Microsoft.Extensions.FileProviders.Composite;
+      Microsoft.Extensions.FileProviders.Physical;
+      Microsoft.Extensions.FileSystemGlobbing;
+      Microsoft.Extensions.Hosting;
+      Microsoft.Extensions.Hosting.Abstractions;
+      Microsoft.Extensions.Http;
+      Microsoft.Extensions.Logging;
+      Microsoft.Extensions.Logging.Abstractions;
+      Microsoft.Extensions.Logging.Configuration;
+      Microsoft.Extensions.Logging.Console;
+      Microsoft.Extensions.Logging.Debug;
+      Microsoft.Extensions.Logging.EventLog;
+      Microsoft.Extensions.Logging.EventSource;
+      Microsoft.Extensions.Logging.TraceSource;
+      Microsoft.Extensions.Options;
+      Microsoft.Extensions.Options.ConfigurationExtensions;
+      Microsoft.Extensions.Options.DataAnnotations;
+      Microsoft.Extensions.Primitives;
+      System.Diagnostics.EventLog;
+      System.IO.Pipelines;
+      System.Security.Cryptography.Xml;
+    </AspNetCoreAppLibrary>
   </PropertyGroup>
   <!-- Make NetCoreAppLibrary available as an item. -->
   <ItemGroup>
     <NetCoreAppLibrary Include="$(NetCoreAppLibrary)" />
+    <AspNetCoreAppLibrary Include="$(AspNetCoreAppLibrary)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/src.proj
+++ b/src/libraries/src.proj
@@ -8,8 +8,9 @@
     <_allSrc Include="$(MSBuildThisFileDirectory)*\src\*.*proj"
              Exclude="@(ProjectExclusions);
                       $(MSBuildThisFileDirectory)*\src\**\*.shproj" />
-    <!-- Only build the compat pack in the allconfigurations leg. -->
-    <_allSrc Remove="$(MSBuildThisFileDirectory)Microsoft.Windows.Compatibility\src\Microsoft.Windows.Compatibility.csproj"
+    <!-- Build these packages which reference many other projects in the allconfigurations leg only. -->
+    <_allSrc Remove="$(MSBuildThisFileDirectory)Microsoft.Windows.Compatibility\src\Microsoft.Windows.Compatibility.csproj;
+                     $(MSBuildThisFileDirectory)Microsoft.AspNetCore.Internal.Transport\src\Microsoft.AspNetCore.Internal.Transport.proj"
              Condition="'$(BuildAllConfigurations)' != 'true'" />
 
     <NonNetCoreAppProject Include="@(_allSrc)"


### PR DESCRIPTION
The AspNetCoreApp internal transport packages relies on a set of
projects already being built. This was working well before when
the transport package was built after src.proj run.

Adding dependencies via ProjectReferences to the transport package
so that those are always built in before.

In a subsequent change, the output from these P2Ps should be used
instead of relying on binplacing.

Fixes the regression observed in https://github.com/dotnet/aspnetcore/pull/35138#issuecomment-897015633.