### PR TITLE
PhysicalFileProvider: Avoid NullRef if ResolveLinkTarget returns null 

### DIFF
--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Internal/FileSystemInfoHelper.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Internal/FileSystemInfoHelper.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
                 try
                 {
                     FileSystemInfo targetInfo = fileInfo.ResolveLinkTarget(returnFinalTarget: true);
-                    if (targetInfo.Exists)
+                    if (targetInfo != null && targetInfo.Exists)
                     {
                         return targetInfo.LastWriteTimeUtc;
                     }


### PR DESCRIPTION
Spotted the following exception in https://github.com/dotnet/runtime/pull/57229 ([helix log](https://helixre8s23ayyeko0k025g8.blob.core.windows.net/dotnet-runtime-refs-pull-57229-merge-4bc05735600349c981/Microsoft.Extensions.FileProviders.Physical.Tests/1/console.e7ee7e09.log?sv=2019-07-07&se=2021-08-31T19%3A43%3A52Z&sr=c&sp=rl&sig=NMXgQktfzbiSmEquLmFA8MLPgyEGpVekdBJ0r8Kwx4M%3D))

```
Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.Extensions.FileProviders.Physical.FileSystemInfoHelper.GetFileLinkTargetLastWriteTimeUtc(FileInfo fileInfo) in /_/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/Internal/FileSystemInfoHelper.cs:line 57
   at Microsoft.Extensions.FileProviders.Physical.PollingFileChangeToken.GetLastWriteTimeUtc() in /_/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PollingFileChangeToken.cs:line 57
   at Microsoft.Extensions.FileProviders.Physical.PollingFileChangeToken.get_HasChanged() in /_/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PollingFileChangeToken.cs:line 101
   at Microsoft.Extensions.FileProviders.Physical.PhysicalFilesWatcher.RaiseChangeEvents(Object state) in /_/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFilesWatcher.cs:line 455
   at System.Threading.TimerQueueTimer.Fire(Boolean isThreadPool) in /_/src/libraries/System.Private.CoreLib/src/System/Threading/Timer.cs:line 673
   at System.Threading.TimerQueue.FireNextTimers() in /_/src/libraries/System.Private.CoreLib/src/System/Threading/Timer.cs:line 326