### PR TITLE
P2P instead of binplacing aspnetcore transport pkg

### DIFF
--- a/docs/coding-guidelines/libraries-packaging.md
+++ b/docs/coding-guidelines/libraries-packaging.md
@@ -26,9 +26,9 @@ Transport packages are non-shipping packages that dotnet/runtime produces in ord
 
 This package represents the set of libraries which are produced in dotnet/runtime and ship in the ASP.NETCore shared framework. We produce a transport package so that we can easily share reference assemblies and implementation configurations that might not be present in NuGet packages that also ship.
 
-To add a library to the ASP.NETCore shared framework, that library should set the `IsAspNetCoreApp` property for its `ref` and `src` project. This is typically done in the library's `Directory.Build.props`, for example https://github.com/dotnet/runtime/blob/98ac23212e6017c615e7e855e676fc43c8e44cb8/src/libraries/Microsoft.Extensions.Logging.Abstractions/Directory.Build.props#L4.
+To add a library to the ASP.NETCore shared framework, that library should be listed in the `AspNetCoreAppLibrary` section in `NetCoreAppLibrary.props`.
 
-Source generators and analyzers can be included in the ASP.NETCore shared framework by specifying `IsAspNetCoreAppAnalyzer`.  These projects should specify `AnalyzerLanguage` as mentioned [below](#analyzers--source-generators).
+Source generators and analyzers can be included in the ASP.NETCore shared framework by adding them to the `Microsoft.AspNetCore.Internal.Transport.proj` as an AnalyzerReference. These projects should specify `AnalyzerLanguage` as mentioned [below](#analyzers--source-generators).
 
 Libraries included in this transport package should ensure all direct and transitive assembly references are also included in either the ASP.NETCore shared framework or the .NETCore shared framework. This is not validated in dotnet/runtime at the moment: https://github.com/dotnet/runtime/issues/52562
 

--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -10,7 +10,7 @@
     <PackDependsOn>AddNETStandardCompatErrorFileForPackaging;IncludeAnalyzersInPackage;$(PackDependsOn)</PackDependsOn>
     <BeforePack>AddNETStandardCompatErrorFileForPackaging;IncludeAnalyzersInPackage;$(BeforePack)</BeforePack>
     <SymbolPackageOutputPath>$(PackageOutputPath)</SymbolPackageOutputPath>
-    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddRuntimeSpecificFilesToPackage</TargetsForTfmSpecificContentInPackage>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddRuntimeSpecificFilesToPackage;IncludePrivateProjectReferencesWithPackAttributeInPackage</TargetsForTfmSpecificContentInPackage>
     <TargetsForTfmSpecificDebugSymbolsInPackage>$(TargetsForTfmSpecificDebugSymbolsInPackage);AddRuntimeSpecificSymbolToPackage</TargetsForTfmSpecificDebugSymbolsInPackage>
     <IncludeBuildOutput Condition="'$(TargetsAnyOS)' != 'true' or '$(ExcludeFromPackage)' == 'true'">false</IncludeBuildOutput>  
     <!-- Don't include target platform specific dependencies, since we use the target platform to represent RIDs instead -->
@@ -190,6 +190,33 @@
             PackagePath="buildTransitive\%(NETStandardCompatError.Supported)"
             Pack="true" />
       <FileWrites Include="$(_NETStandardCompatErrorFilePath)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="IncludePrivateProjectReferencesWithPackAttributeInPackage"
+          Condition="'@(ProjectReference->WithMetadataValue('PrivateAssets', 'all')->WithMetadataValue('Pack', 'true'))' != ''"
+          DependsOnTargets="BuildOnlySettings;ResolveReferences">
+    <ItemGroup>
+      <_projectReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('PrivateAssets', 'all')->WithMetadataValue('Pack', 'true'))" />
+      <TfmSpecificPackageFile Include="@(_projectReferenceCopyLocalPaths)"
+                              PackagePath="$([MSBuild]::ValueOrDefault('%(ReferenceCopyLocalPaths.PackagePath)', '$(BuildOutputTargetFolder)/$(TargetFramework)'))" />
+      <TfmSpecificDebugSymbolsFile Include="@(TfmSpecificPackageFile->WithMetadataValue('Extension', '.pdb'))"
+                                   TargetPath="/%(TfmSpecificPackageFile.PackagePath)/%(Filename)%(Extension)"
+                                   TargetFramework="$(TargetFramework)"
+                                   Condition="'$(IncludeSymbols)' == 'true'" />
+      <!-- Remove symbols from the non symbol package. -->
+      <TfmSpecificPackageFile Remove="@(TfmSpecificPackageFile->WithMetadataValue('Extension', '.pdb'))" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <_referenceAssemblyPaths Include="@(_projectReferenceCopyLocalPaths->WithMetadataValue('Extension', '.dll')->WithMetadataValue('IncludeReferenceAssemblyInPackage', 'true')->Metadata('ReferenceAssembly'))" />
+      <TfmSpecificPackageFile Include="@(_referenceAssemblyPaths)"
+                              PackagePath="ref/$(TargetFramework)" />
+      <_referenceSymbolPaths Include="$([System.IO.Path]::ChangeExtension('%(_referenceAssemblyPaths.Identity)', '.pdb'))" />
+      <TfmSpecificDebugSymbolsFile Include="@(_referenceSymbolPaths->Exists())"
+                                   TargetPath="/ref/$(TargetFramework)/%(Filename)%(Extension)"
+                                   TargetFramework="$(TargetFramework)"
+                                   Condition="'$(IncludeSymbols)' == 'true'" />
     </ItemGroup>
   </Target>
 

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -112,10 +112,6 @@
     <NetCoreAppCurrentRefPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'ref', '$(NetCoreAppCurrent)'))</NetCoreAppCurrentRefPath>
     <NetCoreAppCurrentRuntimePath>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'runtime', '$(NetCoreAppCurrent)-$(TargetOS)-$(Configuration)-$(TargetArchitecture)'))</NetCoreAppCurrentRuntimePath>
 
-    <ASPNETCoreAppPackageRootPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'pkg', 'aspnetcoreapp'))</ASPNETCoreAppPackageRootPath>
-    <ASPNETCoreAppPackageRefPath>$([MSBuild]::NormalizeDirectory('$(ASPNETCoreAppPackageRootPath)', 'ref'))</ASPNETCoreAppPackageRefPath>
-    <ASPNETCoreAppPackageRuntimePath>$([MSBuild]::NormalizeDirectory('$(ASPNETCoreAppPackageRootPath)', 'lib'))</ASPNETCoreAppPackageRuntimePath>
-
     <CommonPathRoot>$([MSBuild]::NormalizeDirectory('$(LibrariesProjectRoot)', 'Common'))</CommonPathRoot>
     <CommonPath>$([MSBuild]::NormalizeDirectory('$(CommonPathRoot)', 'src'))</CommonPath>
     <CommonTestPath>$([MSBuild]::NormalizeDirectory('$(CommonPathRoot)', 'tests'))</CommonTestPath>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -96,13 +96,6 @@
                                 '$(BinPlaceRuntime)' == 'true' and
                                 '$(ILLinkTrimAssembly)' == ''">ILLinkTrimAssembly=true</SetProperties>
     </BinPlaceTargetFrameworks>
-    <BinPlaceTargetFrameworks Include="$(NetCoreAppCurrent)"
-                              Condition="'$(IsAspNetCoreApp)' == 'true'">
-      <RuntimePath>$(ASPNETCoreAppPackageRuntimePath)</RuntimePath>
-      <RefPath>$(ASPNETCoreAppPackageRefPath)</RefPath>
-    </BinPlaceTargetFrameworks>
-    <BinPlaceDir Include="$(ASPNETCoreAppPackageRootPath)\analyzers\dotnet\$(AnalyzerLanguage)"
-                 Condition="'$(IsAspNetCoreAppAnalyzer)' == 'true'" />
     <BinPlaceDir Include="$(MicrosoftNetCoreAppRefPackDir)analyzers\dotnet\$(AnalyzerLanguage)"
                  Condition="'$(IsNETCoreAppAnalyzer)' == 'true'" />
 

--- a/src/libraries/Microsoft.AspNetCore.Internal.Transport/src/Microsoft.AspNetCore.Internal.Transport.proj
+++ b/src/libraries/Microsoft.AspNetCore.Internal.Transport/src/Microsoft.AspNetCore.Internal.Transport.proj
@@ -5,33 +5,20 @@
     <!-- Reference the outputs to have them available as build outputs. -->
     <NoTargetsDoNotReferenceOutputAssemblies>false</NoTargetsDoNotReferenceOutputAssemblies>
     <IsPackable>true</IsPackable>
+    <IncludeBuildOutput>true</IncludeBuildOutput>
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>none</DebugType>
     <!-- This is non-shipping package. -->
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
-    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <PackageDescription>Internal transport package to provide aspnetcore with the assemblies that make up the Microsoft.ASPNetCore.App shared framework.</PackageDescription>
-    <!-- NU5131: Reference elements are missing from the nuspec: https://github.com/NuGet/Home/issues/8684.
-         NU5128: Don't list dependencies as this is a mega and not meta package. -->
-    <NoWarn>$(NoWarn);NU5131;NU5128</NoWarn>
+    <!-- Reference elements are missing from the nuspec: https://github.com/NuGet/Home/issues/8684. -->
+    <NoWarn>$(NoWarn);NU5131</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="@(AspNetCoreAppLibrary->'$(LibrariesProjectRoot)%(Identity)\src\%(Identity).csproj')" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <_analyzer Include="$(ASPNETCoreAppPackageRootPath)\analyzers\**\*.*" />
-    <_libDoc Include="$(ASPNETCoreAppPackageRuntimePath)\*.xml" />
-
-    <Content Include="@(_analyzer)"
-             Pack="true"
-             PackagePath="analyzers" />
-    <Content Include="$(ASPNETCoreAppPackageRefPath)\*.*;
-                      @(_libDoc)"
-             Pack="true"
-             PackagePath="ref\$(NetCoreAppCurrent)" />
-    <Content Include="$(ASPNETCoreAppPackageRuntimePath)\*.*"
-             Exclude="@(_libDoc)"
-             Pack="true"
-             PackagePath="lib\$(NetCoreAppCurrent)" />
+    <!-- Requires Private=true to calculate ReferenceCopyLocalPaths items. -->
+    <ProjectReference Include="@(AspNetCoreAppLibrary->'$(LibrariesProjectRoot)%(Identity)\src\%(Identity).csproj')" PrivateAssets="all" Pack="true" Private="true" IncludeReferenceAssemblyInPackage="true" />
+    <!-- TODO: Find a better way to include source generators without hardcoding them. -->
+    <AnalyzerReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.Logging.Abstractions\gen\Microsoft.Extensions.Logging.Generators.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Microsoft.Extensions.Logging.Generators.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/Microsoft.Extensions.Logging.Generators.csproj
@@ -8,7 +8,6 @@
     <UsingToolXliff>true</UsingToolXliff>
     <CLSCompliant>false</CLSCompliant>
     <IsPackable>false</IsPackable>
-    <IsAspNetCoreAppAnalyzer>true</IsAspNetCoreAppAnalyzer>
     <AnalyzerLanguage>cs</AnalyzerLanguage>
   </PropertyGroup>
 


### PR DESCRIPTION
Use ProjectReferences to compose the aspnetcore tranport package.
Avoid binplacing and with that unnecessary copies which overall
simplifies the infrastructure and allows to add additional transport
packages without creating a binplace configuration for each.

This also makes sure that the dependencies are compatible with the
package's tfm.