### PR TITLE
Try to fix and enable a ThreadPool.CompletedWorkItemCount test and add more info about failures

### DIFF
--- a/src/libraries/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_IntegrationTests.cs
+++ b/src/libraries/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_IntegrationTests.cs
@@ -47,13 +47,14 @@ public partial class ThreadPoolBoundHandleTests
         Assert.Equal(DATA_SIZE, result.BytesWritten);
     }
 
-    [Fact]
+    [Theory]
+    [InlineData(nameof(MultipleOperationsOverSingleHandle))]
     [PlatformSpecific(TestPlatforms.Windows)] // ThreadPoolBoundHandle.BindHandle is not supported on Unix
-    public unsafe void MultipleOperationsOverSingleHandle()
+    public unsafe void MultipleOperationsOverSingleHandle(string tempFileNamePrefix)
     {
         const int DATA_SIZE = 2;
 
-        SafeHandle handle = HandleFactory.CreateAsyncFileHandleForWrite(Path.Combine(TestDirectory, @"MultipleOperationsOverSingleHandle.tmp"));
+        SafeHandle handle = HandleFactory.CreateAsyncFileHandleForWrite(Path.Combine(TestDirectory, $"{tempFileNamePrefix}.tmp"));
         ThreadPoolBoundHandle boundHandle = ThreadPoolBoundHandle.BindHandle(handle);
 
         OverlappedContext result1 = new OverlappedContext();

--- a/src/libraries/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_IntegrationTests.cs
+++ b/src/libraries/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_IntegrationTests.cs
@@ -47,14 +47,13 @@ public partial class ThreadPoolBoundHandleTests
         Assert.Equal(DATA_SIZE, result.BytesWritten);
     }
 
-    [Theory]
-    [InlineData(nameof(MultipleOperationsOverSingleHandle))]
+    [Fact]
     [PlatformSpecific(TestPlatforms.Windows)] // ThreadPoolBoundHandle.BindHandle is not supported on Unix
-    public unsafe void MultipleOperationsOverSingleHandle(string tempFileNamePrefix)
+    public unsafe void MultipleOperationsOverSingleHandle()
     {
         const int DATA_SIZE = 2;
 
-        SafeHandle handle = HandleFactory.CreateAsyncFileHandleForWrite(Path.Combine(TestDirectory, $"{tempFileNamePrefix}.tmp"));
+        SafeHandle handle = HandleFactory.CreateAsyncFileHandleForWrite(Path.Combine(TestDirectory, @"MultipleOperationsOverSingleHandle.tmp"));
         ThreadPoolBoundHandle boundHandle = ThreadPoolBoundHandle.BindHandle(handle);
 
         OverlappedContext result1 = new OverlappedContext();

--- a/src/libraries/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_IntegrationTests.netcoreapp.cs
+++ b/src/libraries/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_IntegrationTests.netcoreapp.cs
@@ -13,7 +13,7 @@ public partial class ThreadPoolBoundHandleTests
     public unsafe void MultipleOperationsOverSingleHandle_CompletedWorkItemCountTest()
     {
         long initialCompletedWorkItemCount = ThreadPool.CompletedWorkItemCount;
-        MultipleOperationsOverSingleHandle(nameof(MultipleOperationsOverSingleHandle_CompletedWorkItemCountTest));
+        MultipleOperationsOverSingleHandle();
         long changeInCompletedWorkItemCount = 0;
         try
         {

--- a/src/libraries/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_IntegrationTests.netcoreapp.cs
+++ b/src/libraries/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_IntegrationTests.netcoreapp.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Threading;
 using System.Threading.Tests;
 using Xunit;
@@ -9,11 +10,23 @@ public partial class ThreadPoolBoundHandleTests
 {
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)] // ThreadPoolBoundHandle.BindHandle is not supported on Unix
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/49700")]
     public unsafe void MultipleOperationsOverSingleHandle_CompletedWorkItemCountTest()
     {
         long initialCompletedWorkItemCount = ThreadPool.CompletedWorkItemCount;
-        MultipleOperationsOverMultipleHandles();
-        ThreadTestHelpers.WaitForCondition(() => ThreadPool.CompletedWorkItemCount - initialCompletedWorkItemCount >= 2);
+        MultipleOperationsOverSingleHandle(nameof(MultipleOperationsOverSingleHandle_CompletedWorkItemCountTest));
+        long changeInCompletedWorkItemCount = 0;
+        try
+        {
+            ThreadTestHelpers.WaitForCondition(() =>
+            {
+                changeInCompletedWorkItemCount = ThreadPool.CompletedWorkItemCount - initialCompletedWorkItemCount;
+                return changeInCompletedWorkItemCount >= 2;
+            });
+        }
+        catch (Exception ex)
+        {
+            // Test likely timed out, include the change for more information
+            throw new AggregateException($"changeInCompletedWorkItemCount: {changeInCompletedWorkItemCount}", ex);
+        }
     }
 }


### PR DESCRIPTION
- Not sure why it would be failing. The test seems to be calling a different sub-test method than intended. Fixed that and added more info if it happens to fail again.
- Closes https://github.com/dotnet/runtime/issues/47979
- Closes https://github.com/dotnet/runtime/issues/49700