### PR TITLE
Mark operands of non-RMW as delayFree 

### DIFF
--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -3141,7 +3141,7 @@ int LinearScan::BuildDelayFreeUses(GenTree* node, GenTree* rmwNode, regMaskTP ca
     if (use != nullptr)
     {
         // If node != rmwNode, then definitely node should be marked as "delayFree".
-        // However, if node == rmwNode, then we can mark node as "delayFree" only
+        // However, if node == rmwNode, then we can mark node as "delayFree" only if
         // none of the node/rmwNode are the last uses. If either of them are last use,
         // we can safely reuse the rmwNode as destination.
         if ((use->getInterval() != rmwInterval) || (!rmwIsLastUse && !use->lastUse))

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -2403,7 +2403,7 @@ int LinearScan::BuildHWIntrinsic(GenTreeHWIntrinsic* intrinsicTree)
 
                 // Any pair of the index, mask, or destination registers should be different
                 srcCount += BuildOperandUses(op1);
-                srcCount += BuildDelayFreeUses(op2, op1);
+                srcCount += BuildDelayFreeUses(op2);
 
                 // op3 should always be contained
                 assert(op3->isContained());
@@ -2428,9 +2428,9 @@ int LinearScan::BuildHWIntrinsic(GenTreeHWIntrinsic* intrinsicTree)
 
                 // Any pair of the index, mask, or destination registers should be different
                 srcCount += BuildOperandUses(op1);
-                srcCount += BuildDelayFreeUses(op2, op1);
-                srcCount += BuildDelayFreeUses(op3, op1);
-                srcCount += BuildDelayFreeUses(op4, op1);
+                srcCount += BuildDelayFreeUses(op2);
+                srcCount += BuildDelayFreeUses(op3);
+                srcCount += BuildDelayFreeUses(op4);
 
                 // op5 should always be contained
                 assert(argList->Rest()->Current()->isContained());

--- a/src/tests/JIT/Regression/JitBlue/Runtime_56967/Runtime_56967.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_56967/Runtime_56967.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+public class Program
+{
+    // 'vlu1' is source as well as destination and want to make sure that
+    // we do not allocate same register to the src/dest. We need to mark the
+    // src as 'delayFree'.
+    static unsafe int Main()
+    {
+        int* values = stackalloc int[256];
+        var vmsk = Vector256.Create(-1, -1, -1, 0, -1, -1, -1, 0);
+        var vlu1 = Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7);
+        var vlu2 = Vector256.Create(7, 6, 5, 4, 3, 2, 1, 0);
+
+        vlu1 = Avx2.GatherMaskVector256(vlu1, values, vlu1, vmsk, sizeof(int));
+        vlu2 = Avx2.GatherMaskVector256(vlu2, values, vlu2, vmsk, sizeof(int));
+
+        if (vlu1.GetElement(3) == 3 && vlu2.GetElement(3) == 4)
+        {
+            return 100;
+        }
+        return 1;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_56967/Runtime_56967.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_56967/Runtime_56967.cs
@@ -9,18 +9,22 @@ public class Program
     // src as 'delayFree'.
     static unsafe int Main()
     {
-        int* values = stackalloc int[256];
-        var vmsk = Vector256.Create(-1, -1, -1, 0, -1, -1, -1, 0);
-        var vlu1 = Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7);
-        var vlu2 = Vector256.Create(7, 6, 5, 4, 3, 2, 1, 0);
-
-        vlu1 = Avx2.GatherMaskVector256(vlu1, values, vlu1, vmsk, sizeof(int));
-        vlu2 = Avx2.GatherMaskVector256(vlu2, values, vlu2, vmsk, sizeof(int));
-
-        if (vlu1.GetElement(3) == 3 && vlu2.GetElement(3) == 4)
+        if (Avx2.IsSupported)
         {
-            return 100;
+            int* values = stackalloc int[256];
+            var vmsk = Vector256.Create(-1, -1, -1, 0, -1, -1, -1, 0);
+            var vlu1 = Vector256.Create(0, 1, 2, 3, 4, 5, 6, 7);
+            var vlu2 = Vector256.Create(7, 6, 5, 4, 3, 2, 1, 0);
+
+            vlu1 = Avx2.GatherMaskVector256(vlu1, values, vlu1, vmsk, sizeof(int));
+            vlu2 = Avx2.GatherMaskVector256(vlu2, values, vlu2, vmsk, sizeof(int));
+
+            if (vlu1.GetElement(3) != 3 || vlu2.GetElement(3) != 4)
+            {
+                return 1;
+            }
         }
-        return 1;
+
+        return 100;
     }
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_56967/Runtime_56967.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_56967/Runtime_56967.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
For non-RMW intrinsics like `NI_AVX2_GatherVector256` and `NI_AVX2_GatherMaskVector256`, there is no `rmwNode` involved and hence we should always mark the operand as `delayFree`. It was regressed by my change in https://github.com/dotnet/runtime/pull/53964.

No asm diffs

Fixes: https://github.com/dotnet/runtime/issues/56967