### PR TITLE
improve SNI handling when IP is passed in as DnsEndPoint to QuicListener

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicListener.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicListener.cs
@@ -76,6 +76,11 @@ namespace System.Net.Quic.Implementations.MsQuic
 
         internal MsQuicListener(QuicListenerOptions options)
         {
+            if (options.ListenEndPoint == null)
+            {
+                throw new ArgumentNullException(nameof(options.ListenEndPoint));
+            }
+
             _state = new State(options);
             _stateHandle = GCHandle.Alloc(_state);
             try


### PR DESCRIPTION
contributes to  #57169 when somebody is trying to bypass DNS. 
HttpClient will always use DnsEndPoint even if the URI is IP specific address. 

Since I bump to it while writing test, I added more validation to listener.
fixes #57091