### PR TITLE
Throw NotSupportedException when serializing Date/TimeOnly types

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DisallowedTypeConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DisallowedTypeConverterFactory.cs
@@ -23,7 +23,13 @@ namespace System.Text.Json.Serialization.Converters
                 // Invoking such ctors is not safe when used with untrusted user input.
                 type == typeof(SerializationInfo) ||
                 type == typeof(IntPtr) ||
-                type == typeof(UIntPtr);
+                type == typeof(UIntPtr) ||
+                // To be added in future releases; guard against invalid object-based serializations.
+                // https://github.com/dotnet/runtime/issues/53539
+                IsDateOnlyOrTimeOnly(type);
+
+            static bool IsDateOnlyOrTimeOnly(Type type)
+                => type.Assembly == typeof(int).Assembly && type.FullName is "System.DateOnly" or "System.TimeOnly";
         }
 
         public override JsonConverter CreateConverter(Type type, JsonSerializerOptions options)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DisallowedTypeConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DisallowedTypeConverterFactory.cs
@@ -24,12 +24,19 @@ namespace System.Text.Json.Serialization.Converters
                 type == typeof(SerializationInfo) ||
                 type == typeof(IntPtr) ||
                 type == typeof(UIntPtr) ||
-                // To be added in future releases; guard against invalid object-based serializations.
-                // https://github.com/dotnet/runtime/issues/53539
-                IsDateOnlyOrTimeOnly(type);
-
-            static bool IsDateOnlyOrTimeOnly(Type type)
-                => type.Assembly == typeof(int).Assembly && type.FullName is "System.DateOnly" or "System.TimeOnly";
+                // DateOnly/TimeOnly support to be added in future releases;
+                // guard against invalid object-based serializations for now.
+                // cf. https://github.com/dotnet/runtime/issues/53539
+                //
+                // For simplicity we elide equivalent checks for targets
+                // that are older than net6.0, since they do not include
+                // DateOnly or TimeOnly.
+#if NET6_0_OR_GREATER
+                type == typeof(DateOnly) ||
+                type == typeof(TimeOnly);
+#else
+                false;
+#endif
         }
 
         public override JsonConverter CreateConverter(Type type, JsonSerializerOptions options)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/ExceptionTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/ExceptionTests.cs
@@ -522,6 +522,10 @@ namespace System.Text.Json.Serialization.Tests
             RunTest<SerializationInfo>(json);
             RunTest<IntPtr>(json);
             RunTest<UIntPtr>(json);
+#if NETCOREAPP
+            RunTest<DateOnly>(json);
+            RunTest<TimeOnly>(json);
+#endif
 
             void RunTest<T>(string json)
             {
@@ -553,10 +557,14 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void SerializeUnsupportedType()
         {
-            RunTest<Type>(typeof(int));
-            RunTest<SerializationInfo>(new SerializationInfo(typeof(Type), new FormatterConverter()));
-            RunTest<IntPtr>((IntPtr)123);
-            RunTest<UIntPtr>((UIntPtr)123);
+            RunTest(typeof(int));
+            RunTest(new SerializationInfo(typeof(Type), new FormatterConverter()));
+            RunTest((IntPtr)123);
+            RunTest((UIntPtr)123);
+#if NETCOREAPP
+            RunTest(DateOnly.MaxValue);
+            RunTest(TimeOnly.MinValue);
+#endif
 
             void RunTest<T>(T value)
             {


### PR DESCRIPTION
To prevent invalid object-based serialization until full support is implemented. Contributes to #53539.