### PR TITLE
Search native code in all R2R ni.dll in version bubble

### DIFF
--- a/src/coreclr/inc/dacvars.h
+++ b/src/coreclr/inc/dacvars.h
@@ -70,7 +70,9 @@
 
 #define UNKNOWN_POINTER_TYPE SIZE_T
 
-DEFINE_DACVAR(ULONG, PTR_RangeSection, ExecutionManager__m_CodeRangeList, ExecutionManager::m_CodeRangeList)
+DEFINE_DACVAR(ULONG, PTR_RangeSectionHandle, ExecutionManager__m_RangeSectionHandleArray, ExecutionManager::m_RangeSectionHandleArray)
+DEFINE_DACVAR(ULONG, LONG, ExecutionManager__m_RangeSectionArraySize, ExecutionManager::m_RangeSectionArraySize)
+DEFINE_DACVAR(ULONG, LONG, ExecutionManager__m_RangeSectionArrayCapacity, ExecutionManager::m_RangeSectionArrayCapacity)
 DEFINE_DACVAR(ULONG, PTR_EECodeManager, ExecutionManager__m_pDefaultCodeMan, ExecutionManager::m_pDefaultCodeMan)
 DEFINE_DACVAR(ULONG, LONG, ExecutionManager__m_dwReaderCount, ExecutionManager::m_dwReaderCount)
 DEFINE_DACVAR(ULONG, LONG, ExecutionManager__m_dwWriterLock, ExecutionManager::m_dwWriterLock)

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -4675,7 +4675,7 @@ void ExecutionManager::AddRangeSection(RangeSection *pRS)
         //reallocate array
 #ifdef _DEBUG
         m_RangeSectionArrayCapacity = (SIZE_T)m_RangeSectionArrayCapacity + RangeSectionHandleArrayIncrement;
-#elif //_DEBUG
+#else
         m_RangeSectionArrayCapacity = (SIZE_T)m_RangeSectionArrayCapacity * RangeSectionHandleArrayExpansionFactor;
 #endif //_DEBUG
         RangeSectionHandle *tmp = new RangeSectionHandle[m_RangeSectionArrayCapacity];

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -4216,10 +4216,10 @@ ExecutionManager::FindCodeRange(PCODE currentPC, ScanFlag scanFlag)
     if (currentPC == NULL)
         return NULL;
 
-    if (scanFlag == ScanReaderLock)
-        return FindCodeRangeWithLock(currentPC);
+    //if (scanFlag == ScanReaderLock)
+    return FindCodeRangeWithLock(currentPC);
 
-    return GetRangeSection(currentPC);
+    //return GetRangeSection(currentPC);
 }
 
 //**************************************************************************

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -4568,6 +4568,22 @@ PTR_Module ExecutionManager::FindModuleForGCRefMap(TADDR currentData)
     return dac_cast<PTR_Module>(pRS->pHeapListOrZapModule);
 }
 
+/*********************************************************************/
+// This function returns coded index: a number to be converted 
+// to an actual index of RangeSectionHandleArray. Coded index uses
+// non-negative values to store actual index of an element already
+// existed in the array or it uses negative values to code an index
+// to be used for placing a new element to the array. If value
+// returned from FindRangeSectionHandleHelper is not negative, it can
+// be immediately used to read an existing element like this:
+// pRS = RangeSectionHandleArray[non_negative].pRS;
+// If the value becomes negative then there is no element with
+// requested TADDR in the RangeSectionHandleArray, and the value
+// might be decoded to an actual index of RangeSectionHandleArray cell
+// to place new RangeSectionHandle (if intended).
+// The function to decode is DecodeRangeSectionIndex that takes
+// negative coded index and returns an actual index.
+//
 int ExecutionManager::FindRangeSectionHandleHelper(TADDR addr)
 {
     CONTRACTL {

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -4686,7 +4686,7 @@ void ExecutionManager::AddRangeSection(RangeSection *pRS)
 
     //where to add?
     SIZE_T size = m_RangeSectionArraySize;
-    if (pRS->LowAddress >= m_RangeSectionHandleArray[size - 1].HighAddress)
+    if ((size == 0) || (pRS->LowAddress >= m_RangeSectionHandleArray[size - 1].HighAddress))
     {
         m_RangeSectionHandleArray[size].LowAddress = pRS->LowAddress;
         m_RangeSectionHandleArray[size].HighAddress = pRS->HighAddress;

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -4657,7 +4657,11 @@ void ExecutionManager::AddRangeSection(RangeSection *pRS)
     if (m_RangeSectionArraySize == m_RangeSectionArrayCapacity)
     {
         //reallocate array
+#ifdef _DEBUG
+        m_RangeSectionArrayCapacity = (SIZE_T)m_RangeSectionArrayCapacity + RangeSectionHandleArrayIncrement;
+#elif //_DEBUG
         m_RangeSectionArrayCapacity = (SIZE_T)m_RangeSectionArrayCapacity * RangeSectionHandleArrayExpansionFactor;
+#endif //_DEBUG
         RangeSectionHandle *tmp = new RangeSectionHandle[m_RangeSectionArrayCapacity];
         memcpy(tmp, m_RangeSectionHandleArray, m_RangeSectionArraySize*sizeof(RangeSectionHandle));
         delete[] m_RangeSectionHandleArray;

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -4461,7 +4461,7 @@ RangeSection* ExecutionManager::GetRangeSection(TADDR addr)
     }
 #endif
 
-    ReaderLockHolder rlh;
+    ReaderLockHolder rlh(HostCallPreference::NoHostCalls);
 
 #ifndef DACCESS_COMPILE
     //negative case

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -4456,8 +4456,11 @@ RangeSection* ExecutionManager::GetRangeSection(TADDR addr)
 
         //negative case
         if ((m_LastUsedRSIndex != 0)
-            && ((addr < LowAddress) && ((LastUsedRSIndex == 0)
-                || (addr >= m_RangeSectionHandleArray[LastUsedRSIndex - 1].pRS->HighAddress))))
+            && (addr < LowAddress)
+            && (addr >= m_RangeSectionHandleArray[LastUsedRSIndex - 1].pRS->HighAddress))
+                return NULL;
+
+        if ((addr < LowAddress) && (LastUsedRSIndex == 0))
             return NULL;
     }
 #endif

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -4464,6 +4464,7 @@ RangeSection* ExecutionManager::GetRangeSection(TADDR addr)
     ReaderLockHolder rlh(HostCallPreference::NoHostCalls);
 
 #ifndef DACCESS_COMPILE
+    while (!rlh.Acquired()); // rlh con did not yield and we have HOST_NOCALLS limitation
     //negative case
     LastUsedRSIndex = (int)m_LastUsedRSIndex;
     if ((LastUsedRSIndex > 0)

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -1181,6 +1181,9 @@ class ExecutionManager
     {
         RangeSectionHandleArrayInitialSize = 100,
         RangeSectionHandleArrayExpansionFactor = 2
+#ifdef _DEBUG
+	,RangeSectionHandleArrayIncrement = 1
+#endif //(_DEBUG)
     };
 
     static int EncodeRangeSectionIndex(int index)

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -1186,6 +1186,8 @@ class ExecutionManager
 #endif //(_DEBUG)
     };
 
+    static int FindRangeSectionHandleHelper(TADDR addr);
+
     static int EncodeRangeSectionIndex(int index)
     {
         return -(index+1);
@@ -1292,8 +1294,6 @@ public:
     static void           AddNativeImageRange(TADDR StartRange,
                                               SIZE_T Size,
                                               Module * pModule);
-
-    static int            FindRangeSectionHandleHelper(TADDR addr);
 
 #ifndef DACCESS_COMPILE
     static void            AddRangeSection(RangeSection *pRS);

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -613,13 +613,11 @@ typedef DPTR(struct RangeSectionHandle) PTR_RangeSectionHandle;
 struct RangeSectionHandle
 {
     TADDR LowAddress;
-    TADDR  HighAddress;
     PTR_RangeSection pRS;
 
     RangeSectionHandle()
     {
         LowAddress = 0;
-        HighAddress = 0;
         pRS = NULL;
     }
 };

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -1175,10 +1175,12 @@ class ExecutionManager
 
     enum
     {
+#ifndef _DEBUG
         RangeSectionHandleArrayInitialSize = 100,
         RangeSectionHandleArrayExpansionFactor = 2
-#ifdef _DEBUG
-	,RangeSectionHandleArrayIncrement = 1
+#else
+        RangeSectionHandleArrayInitialSize = 8,
+	RangeSectionHandleArrayIncrement = 1
 #endif //(_DEBUG)
     };
 

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -614,11 +614,7 @@ struct RangeSectionHandle
 {
     TADDR LowAddress;
     TADDR  HighAddress;
-#ifndef DACCESS_COMPILE
-    Volatile<RangeSection *> pRS;
-#else
     PTR_RangeSection pRS;
-#endif
 
     RangeSectionHandle()
     {

--- a/src/coreclr/vm/codeversion.cpp
+++ b/src/coreclr/vm/codeversion.cpp
@@ -1637,7 +1637,8 @@ PCODE CodeVersionManager::PublishVersionableCodeIfNecessary(
     MethodDesc* pMethodDesc,
     CallerGCMode callerGCMode,
     bool *doBackpatchRef,
-    bool *doFullBackpatchRef)
+    bool *doFullBackpatchRef,
+    Module* pModule)
 {
     STANDARD_VM_CONTRACT;
     _ASSERTE(!IsLockOwnedByCurrentThread());
@@ -1698,7 +1699,7 @@ PCODE CodeVersionManager::PublishVersionableCodeIfNecessary(
 
             // Record the caller's GC mode.
             config->SetCallerGCMode(callerGCMode);
-            pCode = pMethodDesc->PrepareCode(config);
+            pCode = pMethodDesc->PrepareCode(config, pModule);
 
         #ifdef FEATURE_CODE_VERSIONING
             if (config->ProfilerMayHaveActivatedNonDefaultCodeVersion())

--- a/src/coreclr/vm/codeversion.h
+++ b/src/coreclr/vm/codeversion.h
@@ -594,7 +594,8 @@ public:
         MethodDesc* pMethodDesc,
         CallerGCMode callerGCMode,
         bool *doBackpatchRef,
-        bool *doFullBackpatchRef);
+        bool *doFullBackpatchRef,
+        Module* pModule = NULL);
     HRESULT PublishNativeCodeVersion(MethodDesc* pMethodDesc, NativeCodeVersion nativeCodeVersion);
     HRESULT GetOrCreateMethodDescVersioningState(MethodDesc* pMethod, MethodDescVersioningState** ppMethodDescVersioningState);
     HRESULT GetOrCreateILCodeVersioningState(Module* pModule, mdMethodDef methodDef, ILCodeVersioningState** ppILCodeVersioningState);

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1645,7 +1645,7 @@ public:
     //
     PCODE DoBackpatch(MethodTable * pMT, MethodTable * pDispatchingMT, BOOL fFullBackPatch);
 
-    PCODE DoPrestub(MethodTable *pDispatchingMT, CallerGCMode callerGCMode = CallerGCMode::Unknown);
+    PCODE DoPrestub(MethodTable *pDispatchingMT, CallerGCMode callerGCMode = CallerGCMode::Unknown, Module* pModule = NULL);
 
     VOID GetMethodInfo(SString &namespaceOrClassName, SString &methodName, SString &methodSignature);
     VOID GetMethodInfoWithNewSig(SString &namespaceOrClassName, SString &methodName, SString &methodSignature);
@@ -1846,12 +1846,12 @@ public:
 #ifndef DACCESS_COMPILE
 public:
     PCODE PrepareInitialCode(CallerGCMode callerGCMode = CallerGCMode::Unknown);
-    PCODE PrepareCode(PrepareCodeConfig* pConfig);
+    PCODE PrepareCode(PrepareCodeConfig* pConfig, Module* pModule = NULL);
 
 private:
-    PCODE PrepareILBasedCode(PrepareCodeConfig* pConfig);
-    PCODE GetPrecompiledCode(PrepareCodeConfig* pConfig, bool shouldTier);
-    PCODE GetPrecompiledR2RCode(PrepareCodeConfig* pConfig);
+    PCODE PrepareILBasedCode(PrepareCodeConfig* pConfig, Module* pModule = NULL);
+    PCODE GetPrecompiledCode(PrepareCodeConfig* pConfig, bool shouldTier, Module* pModule = NULL);
+    PCODE GetPrecompiledR2RCode(PrepareCodeConfig* pConfig, Module* pModule_probe = NULL);
     PCODE GetMulticoreJitCode(PrepareCodeConfig* pConfig, bool* pWasTier0);
     COR_ILMETHOD_DECODER* GetAndVerifyILHeader(PrepareCodeConfig* pConfig, COR_ILMETHOD_DECODER* pIlDecoderMemory);
     COR_ILMETHOD_DECODER* GetAndVerifyMetadataILHeader(PrepareCodeConfig* pConfig, COR_ILMETHOD_DECODER* pIlDecoderMemory);

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -1860,12 +1860,12 @@ extern "C" PCODE STDCALL PreStubWorker(TransitionBlock* pTransitionBlock, Method
 {
     PCODE pbRetVal = NULL;
 
-    Module* pModule = NULL;
-    FrameWithCookie<ExternalMethodFrame> frame(pTransitionBlock);
-    ExternalMethodFrame * pEMFrame = &frame;
-    pModule = ExecutionManager::FindReadyToRunModule((TADDR)(((BYTE*)pEMFrame->GetReturnAddress())-1));
-
     BEGIN_PRESERVE_LAST_ERROR;
+
+    TADDR pRetAddr = dac_cast<TADDR>(pTransitionBlock) + TransitionBlock::GetOffsetOfReturnAddress();
+    TADDR retAddr = (pRetAddr != NULL) ? *PTR_PCODE(pRetAddr) : NULL;
+    Module* pModule = NULL;
+    pModule = ExecutionManager::FindReadyToRunModule((TADDR)(((BYTE*)retAddr)-1));
 
     STATIC_CONTRACT_THROWS;
     STATIC_CONTRACT_GC_TRIGGERS;


### PR DESCRIPTION
This PR fixes part of #44948 and fixes #46160.

This code simply traverses through assemblies in the application
domain. For each assembly (module) it realizes is it Ready To Run and is
it in the same bubble with (does it deliberately bubbling the) module
from which generic function originates. If so, it makes request for code
is Ready To Run and hopes there is some in the module. If the request
succeeds it proceeds with found pointer to the bare native code.

```
Generic instantiations like System.Collections.Concurrent.ConcurrentDictionary`2[System.Int32,System.__Canon] contained within same version bubble are either a bug in crossgen2 or should be taken care of by having PGO data.
```
Now such methods use their Ready To Run code.

We have got significant performance gain on startup: 7% average on our representative set on Tizen.

This PR worked out notices in PR below:
https://github.com/dotnet/runtime/pull/47269
about linear search through the set of RangeSections. In this new PR we propose storing of RangeSections in sorted array (with number of optimizations inspired by prior linked list based solution).

We have extensively tested this PR on armel/Tizen platform so in this case we are confident in reliability and profitability of the solution.

Dear colleagues @jkotas @alpencolt @gbalykov @t-mustafin, please take a look.