### PR TITLE
System.Net.NetworkInformation UnsupportedOSPlatform attributes

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/ref/System.Net.NetworkInformation.cs
+++ b/src/libraries/System.Net.NetworkInformation/ref/System.Net.NetworkInformation.cs
@@ -138,6 +138,8 @@ namespace System.Net.NetworkInformation
         public abstract System.Net.IPEndPoint[] GetActiveUdpListeners();
         public abstract System.Net.NetworkInformation.IcmpV4Statistics GetIcmpV4Statistics();
         public abstract System.Net.NetworkInformation.IcmpV6Statistics GetIcmpV6Statistics();
+        [System.Runtime.Versioning.UnsupportedOSPlatform("illumos")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("solaris")]
         public static System.Net.NetworkInformation.IPGlobalProperties GetIPGlobalProperties() { throw null; }
         public abstract System.Net.NetworkInformation.IPGlobalStatistics GetIPv4GlobalStatistics();
         public abstract System.Net.NetworkInformation.IPGlobalStatistics GetIPv6GlobalStatistics();
@@ -310,10 +312,14 @@ namespace System.Net.NetworkInformation
         public virtual System.Net.NetworkInformation.OperationalStatus OperationalStatus { get { throw null; } }
         public virtual long Speed { get { throw null; } }
         public virtual bool SupportsMulticast { get { throw null; } }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("illumos")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("solaris")]
         public static System.Net.NetworkInformation.NetworkInterface[] GetAllNetworkInterfaces() { throw null; }
         public virtual System.Net.NetworkInformation.IPInterfaceProperties GetIPProperties() { throw null; }
         public virtual System.Net.NetworkInformation.IPInterfaceStatistics GetIPStatistics() { throw null; }
         public virtual System.Net.NetworkInformation.IPv4InterfaceStatistics GetIPv4Statistics() { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("illumos")]
+        [System.Runtime.Versioning.UnsupportedOSPlatform("solaris")]
         public static bool GetIsNetworkAvailable() { throw null; }
         public virtual System.Net.NetworkInformation.PhysicalAddress GetPhysicalAddress() { throw null; }
         public virtual bool Supports(System.Net.NetworkInformation.NetworkInterfaceComponent networkInterfaceComponent) { throw null; }

--- a/src/libraries/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
+++ b/src/libraries/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
@@ -187,6 +187,10 @@
     <Compile Include="System\Net\NetworkInformation\NetworkAddressChange.UnknownUnix.cs" />
   </ItemGroup>
   <ItemGroup>
+    <SupportedPlatform Include="illumos"/>
+    <SupportedPlatform Include="Solaris "/>
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="Microsoft.Win32.Primitives" />
     <Reference Include="System.Collections" />
     <Reference Include="System.Diagnostics.Tracing" />

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIPGlobalProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIPGlobalProperties.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Net.NetworkInformation
 {
     internal sealed class BsdIPGlobalProperties : UnixIPGlobalProperties
@@ -135,6 +137,10 @@ namespace System.Net.NetworkInformation
             return new BsdIPv4GlobalStatistics();
         }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override IPGlobalStatistics GetIPv6GlobalStatistics()
         {
             // Although there is a 'net.inet6.ip6.stats' sysctl variable, there

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIPv4GlobalStatistics.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIPv4GlobalStatistics.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace System.Net.NetworkInformation
 {
@@ -95,18 +96,38 @@ namespace System.Net.NetworkInformation
 
         public override long OutputPacketRequests { get { return _outboundPackets; } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override long OutputPacketRoutingDiscards { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override long OutputPacketsDiscarded { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         public override long OutputPacketsWithNoRoute { get { return _outputPacketsNoRoute; } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override long PacketFragmentFailures { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override long PacketReassembliesRequired { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         public override long PacketReassemblyFailures { get { return _cantFrags; } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override long PacketReassemblyTimeout { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         public override long PacketsFragmented { get { return _datagramsFragmented; } }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIPv4InterfaceProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIPv4InterfaceProperties.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Net.NetworkInformation
 {
     internal sealed class BsdIPv4InterfaceProperties : UnixIPv4InterfaceProperties
@@ -13,17 +15,37 @@ namespace System.Net.NetworkInformation
             _mtu = mtu;
         }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override bool IsAutomaticPrivateAddressingActive { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override bool IsAutomaticPrivateAddressingEnabled { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override bool IsDhcpEnabled { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         // Doesn't seem to be exposed on a per-interface basis.
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override bool IsForwardingEnabled { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         public override int Mtu { get { return _mtu; } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override bool UsesWins { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
     }
 }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIPv4InterfaceStatistics.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIPv4InterfaceStatistics.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Net.NetworkInformation
 {
     internal sealed class BsdIPv4InterfaceStatistics : IPv4InterfaceStatistics
@@ -26,6 +28,10 @@ namespace System.Net.NetworkInformation
 
         public override long NonUnicastPacketsSent => _statistics.NonUnicastPacketsSent;
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override long OutgoingPacketsDiscarded => _statistics.OutgoingPacketsDiscarded;
 
         public override long OutgoingPacketsWithErrors => _statistics.OutgoingPacketsWithErrors;

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIPv6InterfaceProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIPv6InterfaceProperties.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Net.NetworkInformation
 {
     internal sealed class BsdIPv6InterfaceProperties : UnixIPv6InterfaceProperties
@@ -15,6 +17,10 @@ namespace System.Net.NetworkInformation
 
         public override int Mtu { get { return _mtu; } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override long GetScopeId(ScopeLevel scopeLevel)
         {
             throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIcmpV4Statistics.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIcmpV4Statistics.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Net.NetworkInformation
 {
     internal sealed class BsdIcmpV4Statistics : IcmpV4Statistics
@@ -80,12 +82,28 @@ namespace System.Net.NetworkInformation
 
         public override long EchoRequestsSent { get { return _echoRequestsSent; } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override long ErrorsReceived { get { throw new PlatformNotSupportedException(); } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override long ErrorsSent { get { throw new PlatformNotSupportedException(); } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override long MessagesReceived { get { throw new PlatformNotSupportedException(); } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override long MessagesSent { get { throw new PlatformNotSupportedException(); } }
 
         public override long ParameterProblemsReceived { get { return _parameterProblemsReceived; } }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIcmpV6Statistics.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIcmpV6Statistics.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Net.NetworkInformation
 {
     internal sealed class BsdIcmpV6Statistics : IcmpV6Statistics
@@ -84,12 +86,28 @@ namespace System.Net.NetworkInformation
 
         public override long EchoRequestsSent { get { return _echoRequestsSent; } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override long ErrorsReceived { get { throw new PlatformNotSupportedException(); } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override long ErrorsSent { get { throw new PlatformNotSupportedException(); } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override long MessagesReceived { get { throw new PlatformNotSupportedException(); } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override long MessagesSent { get { throw new PlatformNotSupportedException(); } }
 
         public override long ParameterProblemsReceived { get { return _parameterProblemsReceived; } }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIpInterfaceProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIpInterfaceProperties.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace System.Net.NetworkInformation
 {
@@ -20,16 +21,36 @@ namespace System.Net.NetworkInformation
             _gatewayAddresses = GetGatewayAddresses(oni.Index);
         }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override IPAddressInformationCollection AnycastAddresses { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override IPAddressCollection DhcpServerAddresses { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         public override GatewayIPAddressInformationCollection GatewayAddresses { get { return _gatewayAddresses; } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override bool IsDnsEnabled { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override bool IsDynamicDnsEnabled { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override IPAddressCollection WinsServersAddresses { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         public override IPv4InterfaceProperties GetIPv4Properties()

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIpInterfaceStatistics.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdIpInterfaceStatistics.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Net.NetworkInformation
 {
     internal sealed class BsdIpInterfaceStatistics : IPInterfaceStatistics
@@ -52,6 +54,10 @@ namespace System.Net.NetworkInformation
 
         public override long NonUnicastPacketsSent { get { return _outNonUnicastPackets; } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override long OutgoingPacketsDiscarded { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         public override long OutgoingPacketsWithErrors { get { return _outErrors; } }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdTcpStatistics.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/BsdTcpStatistics.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Net.NetworkInformation
 {
     internal sealed class BsdTcpStatistics : TcpStatistics
@@ -46,14 +48,34 @@ namespace System.Net.NetworkInformation
 
         public override long FailedConnectionAttempts { get { return _failedConnectionAttempts; } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override long MaximumConnections { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override long MaximumTransmissionTimeout { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override long MinimumTransmissionTimeout { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override long ResetConnections { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public override long ResetsSent { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         public override long SegmentsReceived { get { return _segmentsReceived; } }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPGlobalProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPGlobalProperties.cs
@@ -12,6 +12,8 @@ namespace System.Net.NetworkInformation
     /// </summary>
     public abstract class IPGlobalProperties
     {
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public static IPGlobalProperties GetIPGlobalProperties()
         {
             return IPGlobalPropertiesPal.GetIPGlobalProperties();

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPGlobalPropertiesPal.UnknownUnix.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPGlobalPropertiesPal.UnknownUnix.cs
@@ -1,10 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Net.NetworkInformation
 {
     internal static class IPGlobalPropertiesPal
     {
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public static IPGlobalProperties GetIPGlobalProperties()
         {
             throw new PlatformNotSupportedException();

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPInterfaceStatistics.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPInterfaceStatistics.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Net.NetworkInformation
 {
     /// <summary>
@@ -47,6 +49,10 @@ namespace System.Net.NetworkInformation
         /// <summary>
         /// Gets the number of outgoing packets that were discarded.
         /// </summary>
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public abstract long OutgoingPacketsDiscarded { get; }
 
         /// <summary>

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/Ipv4InterfaceStatistics.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/Ipv4InterfaceStatistics.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Net.NetworkInformation
 {
     /// <summary>
@@ -16,6 +18,10 @@ namespace System.Net.NetworkInformation
         public abstract long IncomingUnknownProtocolPackets { get; }
         public abstract long NonUnicastPacketsReceived { get; }
         public abstract long NonUnicastPacketsSent { get; }
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
         public abstract long OutgoingPacketsDiscarded { get; }
         public abstract long OutgoingPacketsWithErrors { get; }
         public abstract long OutputQueueLength { get; }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPAddressInformation.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPAddressInformation.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Net.NetworkInformation
 {
     internal sealed class LinuxIPAddressInformation : IPAddressInformation
@@ -14,8 +16,10 @@ namespace System.Net.NetworkInformation
 
         public override IPAddress Address { get { return _address; } }
 
+        [UnsupportedOSPlatform("linux")]
         public override bool IsDnsEligible { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
+        [UnsupportedOSPlatform("linux")]
         public override bool IsTransient { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
     }
 }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPGlobalStatistics.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPGlobalStatistics.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace System.Net.NetworkInformation
 {
@@ -56,6 +57,7 @@ namespace System.Net.NetworkInformation
 
         public override long OutputPacketRequests { get { return _table.OutRequests; } }
 
+        [UnsupportedOSPlatform("linux")]
         public override long OutputPacketRoutingDiscards { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         public override long OutputPacketsDiscarded { get { return _table.OutDiscards; } }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPInterfaceProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPInterfaceProperties.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.Versioning;
 
 namespace System.Net.NetworkInformation
 {
@@ -28,8 +29,10 @@ namespace System.Net.NetworkInformation
             _ipv6Properties = new LinuxIPv6InterfaceProperties(lni);
         }
 
+        [UnsupportedOSPlatform("linux")]
         public override bool IsDynamicDnsEnabled { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
+        [UnsupportedOSPlatform("linux")]
         public override IPAddressInformationCollection AnycastAddresses { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         public override GatewayIPAddressInformationCollection GatewayAddresses { get { return _gatewayAddresses; } }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPInterfaceStatistics.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPInterfaceStatistics.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
+using System.Runtime.Versioning;
 
 namespace System.Net.NetworkInformation
 {
@@ -35,10 +36,12 @@ namespace System.Net.NetworkInformation
 
         public override long IncomingPacketsWithErrors { get { return _table.ErrorsReceived; } }
 
+        [UnsupportedOSPlatform("linux")]
         public override long IncomingUnknownProtocolPackets { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         public override long NonUnicastPacketsReceived { get { return _table.MulticastFramesReceived; } }
 
+        [UnsupportedOSPlatform("linux")]
         public override long NonUnicastPacketsSent { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         public override long OutgoingPacketsDiscarded { get { return _table.OutgoingPacketsDropped; } }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPv4InterfaceProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPv4InterfaceProperties.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
+using System.Runtime.Versioning;
 
 namespace System.Net.NetworkInformation
 {
@@ -17,10 +18,13 @@ namespace System.Net.NetworkInformation
             _isForwardingEnabled = GetIsForwardingEnabled();
         }
 
+        [UnsupportedOSPlatform("linux")]
         public override bool IsAutomaticPrivateAddressingActive { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
+        [UnsupportedOSPlatform("linux")]
         public override bool IsAutomaticPrivateAddressingEnabled { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
+        [UnsupportedOSPlatform("linux")]
         public override bool IsDhcpEnabled { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         public override bool IsForwardingEnabled { get { return _isForwardingEnabled; } }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPv4InterfaceStatistics.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPv4InterfaceStatistics.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Net.NetworkInformation
 {
     internal sealed class LinuxIPv4InterfaceStatistics : IPv4InterfaceStatistics
@@ -20,10 +22,12 @@ namespace System.Net.NetworkInformation
 
         public override long IncomingPacketsWithErrors => _statistics.IncomingPacketsWithErrors;
 
+        [UnsupportedOSPlatform("linux")]
         public override long IncomingUnknownProtocolPackets => _statistics.IncomingUnknownProtocolPackets;
 
         public override long NonUnicastPacketsReceived => _statistics.NonUnicastPacketsReceived;
 
+        [UnsupportedOSPlatform("linux")]
         public override long NonUnicastPacketsSent => _statistics.NonUnicastPacketsSent;
 
         public override long OutgoingPacketsDiscarded => _statistics.OutgoingPacketsDiscarded;

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxTcpStatistics.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxTcpStatistics.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
 
 namespace System.Net.NetworkInformation
 {
@@ -18,10 +19,13 @@ namespace System.Net.NetworkInformation
             _currentConnections = StringParsingHelpers.ParseNumSocketConnections(sockstatFile, protoName);
         }
 
+        [UnsupportedOSPlatform("linux")]
         public override long ConnectionsAccepted { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
+        [UnsupportedOSPlatform("linux")]
         public override long ConnectionsInitiated { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
+        [UnsupportedOSPlatform("linux")]
         public override long CumulativeConnections { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         public override long CurrentConnections { get { return _currentConnections; } }
@@ -32,12 +36,15 @@ namespace System.Net.NetworkInformation
 
         public override long MaximumConnections { get { return _table.MaxConn; } }
 
+        [UnsupportedOSPlatform("linux")]
         public override long MaximumTransmissionTimeout { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
+        [UnsupportedOSPlatform("linux")]
         public override long MinimumTransmissionTimeout { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         public override long ResetConnections { get { return _table.EstabResets; } }
 
+        [UnsupportedOSPlatform("linux")]
         public override long ResetsSent { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         public override long SegmentsReceived { get { return _table.InSegs; } }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxUdpStatistics.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxUdpStatistics.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
+using System.Runtime.Versioning;
 
 namespace System.Net.NetworkInformation
 {
@@ -28,6 +29,7 @@ namespace System.Net.NetworkInformation
 
         public override long DatagramsSent { get { return _table.OutDatagrams; } }
 
+        [UnsupportedOSPlatform("linux")]
         public override long IncomingDatagramsDiscarded { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         public override long IncomingDatagramsWithErrors { get { return _table.InErrors; } }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.UnknownUnix.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.UnknownUnix.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Threading;
+using System.Runtime.Versioning;
 
 namespace System.Net.NetworkInformation
 {
@@ -17,12 +18,16 @@ namespace System.Net.NetworkInformation
             ContextCallback callbackContext = s_runAddressChangedHandler != null ? s_runHandlerAvailable : s_runHandlerNotAvailable;
         }
 
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public static event NetworkAddressChangedEventHandler? NetworkAddressChanged
         {
             add { throw new PlatformNotSupportedException(); }
             remove { throw new PlatformNotSupportedException(); }
         }
 
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public static event NetworkAvailabilityChangedEventHandler? NetworkAvailabilityChanged
         {
             add { throw new PlatformNotSupportedException(); }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkInterface.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkInterface.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Net.NetworkInformation
 {
     public abstract class NetworkInterface
@@ -9,16 +11,22 @@ namespace System.Net.NetworkInformation
         /// Returns objects that describe the network interfaces on the local computer.
         /// </summary>
         /// <returns>An array of all network interfaces on the local computer.</returns>
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public static NetworkInterface[] GetAllNetworkInterfaces()
         {
             return NetworkInterfacePal.GetAllNetworkInterfaces();
         }
 
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public static bool GetIsNetworkAvailable()
         {
             return NetworkInterfacePal.GetIsNetworkAvailable();
         }
 
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public static int IPv6LoopbackInterfaceIndex
         {
             get
@@ -27,6 +35,8 @@ namespace System.Net.NetworkInformation
             }
         }
 
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public static int LoopbackInterfaceIndex
         {
             get

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkInterfacePal.UnknownUnix.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkInterfacePal.UnknownUnix.cs
@@ -1,26 +1,36 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Net.NetworkInformation
 {
     internal static class NetworkInterfacePal
     {
         /// Returns objects that describe the network interfaces on the local computer.
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public static NetworkInterface[] GetAllNetworkInterfaces()
         {
             throw new PlatformNotSupportedException();
         }
 
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public static bool GetIsNetworkAvailable()
         {
             throw new PlatformNotSupportedException();
         }
 
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public static int IPv6LoopbackInterfaceIndex
         {
             get { throw new PlatformNotSupportedException(); }
         }
 
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public static int LoopbackInterfaceIndex
         {
             get { throw new PlatformNotSupportedException(); }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPGlobalProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPGlobalProperties.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -11,12 +12,14 @@ namespace System.Net.NetworkInformation
 {
     internal abstract class UnixIPGlobalProperties : IPGlobalProperties
     {
+        [UnsupportedOSPlatform("unix")]
         public override string DhcpScopeName { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         public override string DomainName { get { return HostInformation.DomainName; } }
 
         public override string HostName { get { return HostInformation.HostName; } }
 
+        [UnsupportedOSPlatform("unix")]
         public override bool IsWinsProxy { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         public override NetBiosNodeType NodeType { get { return NetBiosNodeType.Unknown; } }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPGlobalProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPGlobalProperties.cs
@@ -12,14 +12,26 @@ namespace System.Net.NetworkInformation
 {
     internal abstract class UnixIPGlobalProperties : IPGlobalProperties
     {
-        [UnsupportedOSPlatform("unix")]
+        [UnsupportedOSPlatform("linux")]
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public override string DhcpScopeName { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         public override string DomainName { get { return HostInformation.DomainName; } }
 
         public override string HostName { get { return HostInformation.HostName; } }
 
-        [UnsupportedOSPlatform("unix")]
+        [UnsupportedOSPlatform("linux")]
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public override bool IsWinsProxy { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         public override NetBiosNodeType NodeType { get { return NetBiosNodeType.Unknown; } }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixMulticastIPAddressInformation.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixMulticastIPAddressInformation.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Versioning;
+
 namespace System.Net.NetworkInformation
 {
     internal sealed class UnixMulticastIPAddressInformation : MulticastIPAddressInformation
@@ -14,20 +16,28 @@ namespace System.Net.NetworkInformation
 
         public override IPAddress Address { get { return _address; } }
 
+        [UnsupportedOSPlatform("unix")]
         public override bool IsDnsEligible { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
+        [UnsupportedOSPlatform("unix")]
         public override bool IsTransient { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
+        [UnsupportedOSPlatform("unix")]
         public override long AddressPreferredLifetime { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
+        [UnsupportedOSPlatform("unix")]
         public override long AddressValidLifetime { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
+        [UnsupportedOSPlatform("unix")]
         public override long DhcpLeaseLifetime { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
+        [UnsupportedOSPlatform("unix")]
         public override DuplicateAddressDetectionState DuplicateAddressDetectionState { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
+        [UnsupportedOSPlatform("unix")]
         public override PrefixOrigin PrefixOrigin { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
+        [UnsupportedOSPlatform("unix")]
         public override SuffixOrigin SuffixOrigin { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
     }
 }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixMulticastIPAddressInformation.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixMulticastIPAddressInformation.cs
@@ -16,28 +16,76 @@ namespace System.Net.NetworkInformation
 
         public override IPAddress Address { get { return _address; } }
 
-        [UnsupportedOSPlatform("unix")]
+        [UnsupportedOSPlatform("linux")]
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public override bool IsDnsEligible { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
-        [UnsupportedOSPlatform("unix")]
+        [UnsupportedOSPlatform("linux")]
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public override bool IsTransient { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
-        [UnsupportedOSPlatform("unix")]
+        [UnsupportedOSPlatform("linux")]
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public override long AddressPreferredLifetime { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
-        [UnsupportedOSPlatform("unix")]
+        [UnsupportedOSPlatform("linux")]
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public override long AddressValidLifetime { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
-        [UnsupportedOSPlatform("unix")]
+        [UnsupportedOSPlatform("linux")]
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public override long DhcpLeaseLifetime { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
-        [UnsupportedOSPlatform("unix")]
+        [UnsupportedOSPlatform("linux")]
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public override DuplicateAddressDetectionState DuplicateAddressDetectionState { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
-        [UnsupportedOSPlatform("unix")]
+        [UnsupportedOSPlatform("linux")]
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public override PrefixOrigin PrefixOrigin { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
-        [UnsupportedOSPlatform("unix")]
+        [UnsupportedOSPlatform("linux")]
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public override SuffixOrigin SuffixOrigin { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
     }
 }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixUnicastIPAddressInformation.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixUnicastIPAddressInformation.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Net.Sockets;
+using System.Runtime.Versioning;
 
 namespace System.Net.NetworkInformation
 {
@@ -19,26 +21,35 @@ namespace System.Net.NetworkInformation
         public override IPAddress Address { get { return _address; } }
 
         /// Gets a bool value that indicates whether the Internet Protocol (IP) address is legal to appear in a Domain Name System (DNS) server database.
+        [UnsupportedOSPlatform("unix")]
         public override bool IsDnsEligible { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         /// Gets a bool value that indicates whether the Internet Protocol (IP) address is transient.
+        [UnsupportedOSPlatform("unix")]
         public override bool IsTransient { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         /// [To be supplied.]
+        [UnsupportedOSPlatform("unix")]
         public override long AddressPreferredLifetime { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         /// [To be supplied.]
+        [UnsupportedOSPlatform("unix")]
         public override long AddressValidLifetime { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         /// Specifies the amount of time remaining on the Dynamic Host Configuration Protocol (DHCP) lease for this IP address.
+        [UnsupportedOSPlatform("unix")]
         public override long DhcpLeaseLifetime { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         /// Gets a value that indicates the state of the duplicate address detection algorithm.
+        [UnsupportedOSPlatform("unix")]
         public override DuplicateAddressDetectionState DuplicateAddressDetectionState { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
+
         /// Gets a value that identifies the source of a unicast IP address prefix.
+        [UnsupportedOSPlatform("unix")]
         public override PrefixOrigin PrefixOrigin { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         /// Gets a value that identifies the source of a unicast IP address suffix.
+        [UnsupportedOSPlatform("unix")]
         public override SuffixOrigin SuffixOrigin { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         public override IPAddress IPv4Mask

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixUnicastIPAddressInformation.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixUnicastIPAddressInformation.cs
@@ -21,35 +21,83 @@ namespace System.Net.NetworkInformation
         public override IPAddress Address { get { return _address; } }
 
         /// Gets a bool value that indicates whether the Internet Protocol (IP) address is legal to appear in a Domain Name System (DNS) server database.
-        [UnsupportedOSPlatform("unix")]
+        [UnsupportedOSPlatform("linux")]
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public override bool IsDnsEligible { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         /// Gets a bool value that indicates whether the Internet Protocol (IP) address is transient.
-        [UnsupportedOSPlatform("unix")]
+        [UnsupportedOSPlatform("linux")]
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public override bool IsTransient { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         /// [To be supplied.]
-        [UnsupportedOSPlatform("unix")]
+        [UnsupportedOSPlatform("linux")]
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public override long AddressPreferredLifetime { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         /// [To be supplied.]
-        [UnsupportedOSPlatform("unix")]
+        [UnsupportedOSPlatform("linux")]
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public override long AddressValidLifetime { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         /// Specifies the amount of time remaining on the Dynamic Host Configuration Protocol (DHCP) lease for this IP address.
-        [UnsupportedOSPlatform("unix")]
+        [UnsupportedOSPlatform("linux")]
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public override long DhcpLeaseLifetime { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         /// Gets a value that indicates the state of the duplicate address detection algorithm.
-        [UnsupportedOSPlatform("unix")]
+        [UnsupportedOSPlatform("linux")]
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public override DuplicateAddressDetectionState DuplicateAddressDetectionState { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         /// Gets a value that identifies the source of a unicast IP address prefix.
-        [UnsupportedOSPlatform("unix")]
+        [UnsupportedOSPlatform("linux")]
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public override PrefixOrigin PrefixOrigin { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         /// Gets a value that identifies the source of a unicast IP address suffix.
-        [UnsupportedOSPlatform("unix")]
+        [UnsupportedOSPlatform("linux")]
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("freebsd")]
+        [UnsupportedOSPlatform("illumos")]
+        [UnsupportedOSPlatform("solaris")]
         public override SuffixOrigin SuffixOrigin { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
 
         public override IPAddress IPv4Mask


### PR DESCRIPTION
All methods/properties unconditionally throwing PNSE annotated. Also all the call sites that reported an compilation error afterwards are annotated as well.

Fixes #51301

cc @buyaa-n 