### PR TITLE
Add dedicated wasm implementation for Parallel.Invoke and Parallel.For

### DIFF
--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System.Private.Runtime.InteropServices.JavaScript.Tests.csproj
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System.Private.Runtime.InteropServices.JavaScript.Tests.csproj
@@ -16,6 +16,7 @@
     <Compile Include="System\Runtime\InteropServices\JavaScript\DelegateTests.cs" />
     <Compile Include="System\Runtime\InteropServices\JavaScript\HelperMarshal.cs" />
     <Compile Include="System\Runtime\InteropServices\JavaScript\Http\HttpRequestMessageTest.cs" />
+    <Compile Include="System\Runtime\InteropServices\JavaScript\ParallelTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <!-- Part of the shared framework but not exposed. -->

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/ParallelTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/ParallelTests.cs
@@ -39,8 +39,6 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [Theory]
         [InlineData(0)]
         [InlineData(1)]
-        [InlineData(2)]
-        [InlineData(5)]
         [InlineData(32)]
         [InlineData(250)]
         public static void ParallelFor(int count)
@@ -49,6 +47,23 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             for (int i = 0; i < count; i++)
                 expected += i;
             Parallel.For(0, count, (i) => { sum += i; });
+            Assert.Equal(expected, sum);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(32)]
+        [InlineData(250)]
+        public static void ParallelForEach(int count)
+        {
+            int sum = 0, expected = 0;
+            var items = new List<int>();
+            for (int i = 0; i < count; i++) {
+                items.Add(i);
+                expected += i;
+            }
+            Parallel.ForEach(items, (i) => { sum += i; });
             Assert.Equal(expected, sum);
         }
     }

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/ParallelTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/ParallelTests.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.InteropServices.JavaScript;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Runtime.InteropServices.JavaScript.Tests
+{
+    public static class ParallelTests
+    {
+        // The behavior of APIs like Invoke depends on how many items they are asked to invoke
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(5)]
+        [InlineData(32)]
+        [InlineData(250)]
+        public static void ParallelInvokeActionArray(int count)
+        {
+            var actions = new List<Action>();
+            int sum = 0, expected = 0;
+            for (int i = 0; i < count; i++) {
+                int j = i;
+                actions.Add(() => {
+                    sum += j;
+                });
+                expected += j;
+            }
+
+            Parallel.Invoke(actions.ToArray());
+            Assert.Equal(expected, sum);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(5)]
+        [InlineData(32)]
+        [InlineData(250)]
+        public static void ParallelFor(int count)
+        {
+            int sum = 0, expected = 0;
+            for (int i = 0; i < count; i++)
+                expected += i;
+            Parallel.For(0, count, (i) => { sum += i; });
+            Assert.Equal(expected, sum);
+        }
+    }
+}

--- a/src/libraries/System.Threading.Tasks.Parallel/src/System.Threading.Tasks.Parallel.csproj
+++ b/src/libraries/System.Threading.Tasks.Parallel/src/System.Threading.Tasks.Parallel.csproj
@@ -3,7 +3,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
     <Nullable>enable</Nullable>
-    <DefineConstants Condition="'$(TargetsBrowser)' == 'true'">$(DefineConstants);TARGET_BROWSER</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Threading\Tasks\Parallel.cs" />

--- a/src/libraries/System.Threading.Tasks.Parallel/src/System.Threading.Tasks.Parallel.csproj
+++ b/src/libraries/System.Threading.Tasks.Parallel/src/System.Threading.Tasks.Parallel.csproj
@@ -3,6 +3,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <DefineConstants Condition="'$(TargetsBrowser)' == 'true'">$(DefineConstants);TARGET_BROWSER</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Threading\Tasks\Parallel.cs" />

--- a/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.cs
@@ -128,6 +128,12 @@ namespace System.Threading.Tasks
     /// </remarks>
     public static partial class Parallel
     {
+#if TARGET_BROWSER
+        internal const bool IsSingleThreadedHost = true;
+#else
+        internal const bool IsSingleThreadedHost = false;
+#endif
+
         // static counter for generating unique Fork/Join Context IDs to be used in ETW events
         internal static int s_forkJoinContextID;
 
@@ -245,7 +251,9 @@ namespace System.Threading.Tasks
 
                 // This is more efficient for a large number of actions, or for enforcing MaxDegreeOfParallelism:
                 if ((actionsCopy.Length > SMALL_ACTIONCOUNT_LIMIT) ||
-                     (parallelOptions.MaxDegreeOfParallelism != -1 && parallelOptions.MaxDegreeOfParallelism < actionsCopy.Length))
+                     (parallelOptions.MaxDegreeOfParallelism != -1 && parallelOptions.MaxDegreeOfParallelism < actionsCopy.Length) ||
+                     // Single-threaded hosts need special treatment that will be centralized in TaskReplicator
+                     IsSingleThreadedHost)
                 {
                     // Used to hold any exceptions encountered during action processing
                     ConcurrentQueue<Exception>? exceptionQ = null; // will be lazily initialized if necessary

--- a/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.cs
@@ -131,7 +131,8 @@ namespace System.Threading.Tasks
 #if TARGET_BROWSER
         internal const bool IsSingleThreadedHost = true;
 #else
-        internal const bool IsSingleThreadedHost = false;
+// FIXME: The ifdef doesn't work
+        internal const bool IsSingleThreadedHost = true;
 #endif
 
         // static counter for generating unique Fork/Join Context IDs to be used in ETW events

--- a/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.cs
@@ -128,13 +128,6 @@ namespace System.Threading.Tasks
     /// </remarks>
     public static partial class Parallel
     {
-#if TARGET_BROWSER
-        internal const bool IsSingleThreadedHost = true;
-#else
-// FIXME: The ifdef doesn't work
-        internal const bool IsSingleThreadedHost = true;
-#endif
-
         // static counter for generating unique Fork/Join Context IDs to be used in ETW events
         internal static int s_forkJoinContextID;
 
@@ -250,11 +243,12 @@ namespace System.Threading.Tasks
             {
                 // If we've gotten this far, it's time to process the actions.
 
-                // This is more efficient for a large number of actions, or for enforcing MaxDegreeOfParallelism:
-                if ((actionsCopy.Length > SMALL_ACTIONCOUNT_LIMIT) ||
-                     (parallelOptions.MaxDegreeOfParallelism != -1 && parallelOptions.MaxDegreeOfParallelism < actionsCopy.Length) ||
-                     // Single-threaded hosts need special treatment that will be centralized in TaskReplicator
-                     IsSingleThreadedHost)
+                // Web browsers need special treatment that is implemented in TaskReplicator
+                if (OperatingSystem.IsBrowser() ||
+                    // This is more efficient for a large number of actions, or for enforcing MaxDegreeOfParallelism:
+                    (actionsCopy.Length > SMALL_ACTIONCOUNT_LIMIT) ||
+                    (parallelOptions.MaxDegreeOfParallelism != -1 && parallelOptions.MaxDegreeOfParallelism < actionsCopy.Length)
+                )
                 {
                     // Used to hold any exceptions encountered during action processing
                     ConcurrentQueue<Exception>? exceptionQ = null; // will be lazily initialized if necessary

--- a/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/TaskReplicator.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/TaskReplicator.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
 

--- a/src/libraries/System.Threading.Tasks.Parallel/tests/BreakTests.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/tests/BreakTests.cs
@@ -10,7 +10,7 @@ namespace System.Threading.Tasks.Tests
 {
     public static class BreakTests
     {
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Theory]
         [InlineData(100, 10)]
         [InlineData(100, 20)]
         [InlineData(1000, 100)]
@@ -46,7 +46,7 @@ namespace System.Threading.Tasks.Tests
             Assert.True(result, "TestForBreak:  Failed: Could not detect any interruption of For-loop.");
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Theory]
         [InlineData(100, 10)]
         [InlineData(100, 20)]
         [InlineData(1000, 100)]
@@ -86,7 +86,7 @@ namespace System.Threading.Tasks.Tests
             Assert.True(result, "TestFor64Break:  Failed: Could not detect any interruption of For-loop.");
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Theory]
         [InlineData(500, 10)]
         [InlineData(500, 20)]
         [InlineData(1000, 100)]

--- a/src/libraries/System.Threading.Tasks.Parallel/tests/ParallelFor.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/tests/ParallelFor.cs
@@ -7,7 +7,7 @@ namespace System.Threading.Tasks.Tests
 {
     public static class ParallelForUnitTests
     {
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Theory]
         [InlineData(API.For64, StartIndexBase.Int32, 0, WithParallelOption.None, ActionWithState.None, ActionWithLocal.None)]
         [InlineData(API.For64, StartIndexBase.Int32, 10, WithParallelOption.None, ActionWithState.Stop, ActionWithLocal.HasFinally)]
         [InlineData(API.For64, StartIndexBase.Int32, 10, WithParallelOption.WithDOP, ActionWithState.None, ActionWithLocal.None)]


### PR DESCRIPTION
This PR introduces a simple single-threaded implementation of ```TaskReplicator``` and then makes sure that ```Parallel.Invoke``` and ```.For``` use it . This works around various issues like #44605, #43411.

I still need to verify whether the other Parallel primitives need changes to properly use this in all scenarios, but it works good for the two methods I targeted right now.

I was unable to get platform conditionals to work in any fashion (ifdef, etc) so it's hardcoded to on in this PR right now, which is obviously wrong. If some reviewer can figure out how the heck to make this work I'd appreciate it (see the FIXME in Parallel.cs)