### PR TITLE
[HTTP/3] Stress fixes

### DIFF
--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
@@ -10,9 +10,9 @@ COPY . .
 # Pulling the msquic Debian package from msquic-ci public pipeline and from a hardcoded build.
 # Note that this is a temporary solution until we have properly published Linux packages.
 # Also note that in order to update to a newer msquic build, you have update this link.
-ARG MSQUIC_PACKAGE=libmsquic_1.5.0_amd64.deb
+ARG MSQUIC_PACKAGE=libmsquic_1.6.0_amd64.deb
 ARG PACKAGES_DIR=LinuxPackages
-RUN wget 'https://dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_apis/build/builds/1223883/artifacts?artifactName=LinuxPackages&api-version=6.0&%24format=zip' -O "$PACKAGES_DIR".zip
+RUN wget 'https://dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_apis/build/builds/1266893/artifacts?artifactName=LinuxPackages&api-version=6.0&%24format=zip' -O "$PACKAGES_DIR".zip
 RUN apt-get update
 RUN apt-get install unzip
 RUN unzip $PACKAGES_DIR.zip


### PR DESCRIPTION
Just updated msquic package in the stress docker image.

There'll be another update like this a day or two later.