### PR TITLE
Do not drain HttpContentReadStream if the connection is disposed

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
@@ -425,7 +425,9 @@ namespace System.Net.Http
                 Done
             }
 
-            public override bool NeedsDrain => (_connection != null);
+            // _connection == null typically means that we have finished reading the response.
+            // Cancellation may lead to a state where a disposed _connection is not null.
+            public override bool NeedsDrain => _connection != null && _connection._disposed != Status_Disposed;
 
             public override async ValueTask<bool> DrainAsync(int maxDrainBytes)
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
@@ -425,7 +425,7 @@ namespace System.Net.Http
                 Done
             }
 
-            public override bool NeedsDrain => IsConnectionAlive;
+            public override bool NeedsDrain => CanReadFromConnection;
 
             public override async ValueTask<bool> DrainAsync(int maxDrainBytes)
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
@@ -425,9 +425,7 @@ namespace System.Net.Http
                 Done
             }
 
-            // _connection == null typically means that we have finished reading the response.
-            // Cancellation may lead to a state where a disposed _connection is not null.
-            public override bool NeedsDrain => _connection != null && _connection._disposed != Status_Disposed;
+            public override bool NeedsDrain => IsConnectionAlive;
 
             public override async ValueTask<bool> DrainAsync(int maxDrainBytes)
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
@@ -190,9 +190,7 @@ namespace System.Net.Http
                 return connectionBuffer.Slice(0, bytesToConsume);
             }
 
-            // _connection == null typically means that we have finished reading the response.
-            // Cancellation may lead to a state where a disposed _connection is not null.
-            public override bool NeedsDrain => _connection != null && _connection._disposed != Status_Disposed;
+            public override bool NeedsDrain => IsConnectionAlive;
 
             public override async ValueTask<bool> DrainAsync(int maxDrainBytes)
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
@@ -190,7 +190,7 @@ namespace System.Net.Http
                 return connectionBuffer.Slice(0, bytesToConsume);
             }
 
-            public override bool NeedsDrain => IsConnectionAlive;
+            public override bool NeedsDrain => CanReadFromConnection;
 
             public override async ValueTask<bool> DrainAsync(int maxDrainBytes)
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
@@ -190,7 +190,9 @@ namespace System.Net.Http
                 return connectionBuffer.Slice(0, bytesToConsume);
             }
 
-            public override bool NeedsDrain => (_connection != null);
+            // _connection == null typically means that we have finished reading the response.
+            // Cancellation may lead to a state where a disposed _connection is not null.
+            public override bool NeedsDrain => _connection != null && _connection._disposed != Status_Disposed;
 
             public override async ValueTask<bool> DrainAsync(int maxDrainBytes)
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentReadStream.cs
@@ -28,6 +28,17 @@ namespace System.Net.Http
 
             protected bool IsDisposed => _disposed == 1;
 
+            protected bool IsConnectionAlive
+            {
+                get
+                {
+                    // _connection == null typically means that we have finished reading the response.
+                    // Cancellation may lead to a state where a disposed _connection is not null.
+                    HttpConnection? connection = _connection;
+                    return connection != null && connection._disposed != Status_Disposed;
+                }
+            }
+
             public virtual ValueTask<bool> DrainAsync(int maxDrainBytes)
             {
                 Debug.Fail($"DrainAsync should not be called for this response stream: {GetType()}");

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentReadStream.cs
@@ -46,7 +46,8 @@ namespace System.Net.Http
                     return;
                 }
 
-                if (disposing && NeedsDrain)
+                // The connection might be disposed because of cancellation. We should not drain the response in this case.
+                if (disposing && NeedsDrain && _connection?._disposed != Status_Disposed)
                 {
                     // Start the asynchronous drain.
                     // It may complete synchronously, in which case the connection will be put back in the pool synchronously.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentReadStream.cs
@@ -46,8 +46,7 @@ namespace System.Net.Http
                     return;
                 }
 
-                // The connection might be disposed because of cancellation. We should not drain the response in this case.
-                if (disposing && NeedsDrain && _connection?._disposed != Status_Disposed)
+                if (disposing && NeedsDrain)
                 {
                     // Start the asynchronous drain.
                     // It may complete synchronously, in which case the connection will be put back in the pool synchronously.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentReadStream.cs
@@ -28,7 +28,7 @@ namespace System.Net.Http
 
             protected bool IsDisposed => _disposed == 1;
 
-            protected bool IsConnectionAlive
+            protected bool CanReadFromConnection
             {
                 get
                 {


### PR DESCRIPTION
See https://github.com/dotnet/runtime/issues/56159#issuecomment-897680702 for more details.

Fixes #56159