### PR TITLE
Fix .NET 5 FileStream compat detection in the test utility project

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -286,7 +286,7 @@ namespace System
                               version & 0xFF);
         }
 
-        private static readonly Lazy<bool> _net5CompatFileStream = new Lazy<bool>(() => GetStaticNonPublicBooleanPropertyValue("System.IO.FileStreamHelpers", "UseNet5CompatStrategy"));
+        private static readonly Lazy<bool> _net5CompatFileStream = new Lazy<bool>(() => GetStaticNonPublicBooleanPropertyValue("System.IO.Strategies.FileStreamHelpers", "UseNet5CompatStrategy"));
 
         public static bool IsNet5CompatFileStreamEnabled => _net5CompatFileStream.Value;
 

--- a/src/libraries/System.IO.FileSystem/tests/Net5CompatTests/Net5CompatSwitchTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Net5CompatTests/Net5CompatSwitchTests.cs
@@ -11,6 +11,8 @@ namespace System.IO.Tests
         [Fact]
         public static void LegacySwitchIsHonored()
         {
+            Assert.True(PlatformDetection.IsNet5CompatFileStreamEnabled);
+
             string filePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
 
             using (FileStream fileStream = File.Create(filePath))


### PR DESCRIPTION
`FileStreamHelpers` was moved from `System.IO` to `System.IO.Strategies` namespace

https://github.com/dotnet/runtime/blob/a4894885a534c3c9091fd7dedae18d2686c6b844/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.cs#L7-L9