### PR TITLE
[metadata] Generic params in covariant return checking is ok

### DIFF
--- a/src/mono/mono/metadata/class-setup-vtable.c
+++ b/src/mono/mono/metadata/class-setup-vtable.c
@@ -1386,7 +1386,7 @@ is_ok_for_covariant_ret (MonoType *type_impl, MonoType *type_decl)
 	MonoClass *class_impl = mono_class_from_mono_type_internal (type_impl);
 
 	/* method declared to return an interface, impl returns a value type that implements the interface */
-	if (m_class_is_valuetype (type_impl) && mono_type_is_reference (type_decl))
+	if (m_class_is_valuetype (class_impl) && mono_type_is_reference (type_decl))
 		return FALSE;
 
 

--- a/src/mono/mono/metadata/class-setup-vtable.c
+++ b/src/mono/mono/metadata/class-setup-vtable.c
@@ -1382,8 +1382,11 @@ is_ok_for_covariant_ret (MonoType *type_impl, MonoType *type_decl)
 	if (type_impl->byref) {
 		return mono_byref_type_is_assignable_from (type_decl, type_impl, TRUE);
 	}
+
+	MonoClass *class_impl = mono_class_from_mono_type_internal (type_impl);
+
 	/* method declared to return an interface, impl returns a value type that implements the interface */
-	if (!mono_type_is_reference (type_impl) && mono_type_is_reference (type_decl))
+	if (m_class_is_valuetype (type_impl) && mono_type_is_reference (type_decl))
 		return FALSE;
 
 
@@ -1395,7 +1398,6 @@ is_ok_for_covariant_ret (MonoType *type_impl, MonoType *type_decl)
 			g_free (impl_str);
 		} while (0));
 
-	MonoClass *class_impl = mono_class_from_mono_type_internal (type_impl);
 	MonoClass *class_decl = mono_class_from_mono_type_internal (type_decl);
 
 	/* Also disallow overriding a Nullable<T> return with an impl that


### PR DESCRIPTION
The issue is that `mono_type_is_reference` does not look at whether a generic parameter has a constraint that would make it a reference type (there is a big comment near `mono_type_is_reference` that making it do so would break generic
sharing).

The issue is if you have something like:

```csharp
class BaseClass {}

public class C {
       public virtual BaseClass SomeCovariantFunction() => ...
}

public class G<T> : C where T : BaseClass {
       public override T SomeCovariantFunction() => ...
}
```

Here when setting up `G<T>` we do a check that the override of `SomeCovariantFunction` that returns T is a valid, which boils down to checking that `T` is ok for a covariant return from `BaseClass`.  This is mostly the same as `BaseClass` is-assignable-from `T`, except we also need to check that `T` is not a valuetype that implements interface `BaseClass`.  That check was wrong.  The fix is to check for `is_valuetype`, not `!is_reference` on `T`.

Fixes https://github.com/dotnet/runtime/issues/49731