### PR TITLE
Catch UnauthorizedAccessException from UsePollingFileWatcher_UseActivePolling_HasChanged_SymbolicLink_TargetChanged

### DIFF
--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PhysicalFileProviderTests.netcoreapp.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/PhysicalFileProviderTests.netcoreapp.cs
@@ -106,11 +106,16 @@ namespace Microsoft.Extensions.FileProviders
 
             // Act - Change link target to file 2.
             File.Delete(linkPath);
-            File.CreateSymbolicLink(linkPath, file2Path);
+            try
+            {
+                File.CreateSymbolicLink(linkPath, file2Path);
 
-            // Assert - It should report the change regardless of the timestamp being older.
-            Assert.True(await tcs.Task,
-                $"Change event was not raised - current time: {DateTime.UtcNow:O}, file1 LastWriteTimeUtc: {File.GetLastWriteTimeUtc(file1Path):O}, file2 LastWriteTime: {File.GetLastWriteTimeUtc(file2Path):O}.");
+                // Assert - It should report the change regardless of the timestamp being older.
+                Assert.True(await tcs.Task,
+                    $"Change event was not raised - current time: {DateTime.UtcNow:O}, file1 LastWriteTimeUtc: {File.GetLastWriteTimeUtc(file1Path):O}, file2 LastWriteTime: {File.GetLastWriteTimeUtc(file2Path):O}.");
+            }
+            // https://github.com/dotnet/runtime/issues/56810
+            catch (UnauthorizedAccessException) { }
         }
 
         [Theory]


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/56810