### PR TITLE
Fix thread pool completed work item counter to remove finalized nodes

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadInt64PersistentCounter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadInt64PersistentCounter.cs
@@ -75,7 +75,7 @@ namespace System.Threading
             }
         }
 
-        private sealed class ThreadLocalNode : IDisposable
+        private sealed class ThreadLocalNode
         {
             private uint _count;
             private readonly ThreadInt64PersistentCounter _counter;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadInt64PersistentCounter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadInt64PersistentCounter.cs
@@ -83,6 +83,7 @@ namespace System.Threading
                 try
                 {
                     counter._overflowCount += _count;
+                    counter._nodes.Remove(this);
                 }
                 finally
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadInt64PersistentCounter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadInt64PersistentCounter.cs
@@ -29,11 +29,7 @@ namespace System.Threading
         {
             var node = new ThreadLocalNode(this);
 
-            List<ThreadLocalNodeFinalizationHelper>? nodeFinalizationHelpers = t_nodeFinalizationHelpers;
-            if (nodeFinalizationHelpers == null)
-            {
-                t_nodeFinalizationHelpers = nodeFinalizationHelpers = new List<ThreadLocalNodeFinalizationHelper>(1);
-            }
+            List<ThreadLocalNodeFinalizationHelper>? nodeFinalizationHelpers = t_nodeFinalizationHelpers ??= new List<ThreadLocalNodeFinalizationHelper>(1);
             nodeFinalizationHelpers.Add(new ThreadLocalNodeFinalizationHelper(node));
 
             s_lock.Acquire();

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadInt64PersistentCounter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadInt64PersistentCounter.cs
@@ -13,7 +13,7 @@ namespace System.Threading
         private static readonly LowLevelLock s_lock = new LowLevelLock();
 
         [ThreadStatic]
-        private static List<ThreadLocalNodeFinalizationHelper> t_nodeFinalizationHelpers;
+        private static List<ThreadLocalNodeFinalizationHelper>? t_nodeFinalizationHelpers;
 
         private long _overflowCount;
         private HashSet<ThreadLocalNode> _nodes = new HashSet<ThreadLocalNode>();
@@ -29,7 +29,7 @@ namespace System.Threading
         {
             var node = new ThreadLocalNode(this);
 
-            List<ThreadLocalNodeFinalizationHelper> nodeFinalizationHelpers = t_nodeFinalizationHelpers;
+            List<ThreadLocalNodeFinalizationHelper>? nodeFinalizationHelpers = t_nodeFinalizationHelpers;
             if (nodeFinalizationHelpers == null)
             {
                 t_nodeFinalizationHelpers = nodeFinalizationHelpers = new List<ThreadLocalNodeFinalizationHelper>(1);


### PR DESCRIPTION
- New nodes are being added to the set but finalized ones were not being removed
- The node was also not made finalizable, fixed by adding a finalization helper with the appropriate lifetime for each node