### PR TITLE
Add CodeSign to HostModel.AppHost

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/AppHost/CodeSign.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/AppHost/CodeSign.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.NET.HostModel.AppHost
+{
+    public static class CodeSign
+    {
+        private const string CodeSignPath = @"/usr/bin/codesign";
+
+        /// <summary>
+        /// Sign the app binary using codesign with an anonymous certificate.
+        /// </summary>
+        public static void CodeSignAppHost(string appHostPath)
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
+            if (!File.Exists(CodeSignPath))
+                return;
+
+            var psi = new ProcessStartInfo()
+            {
+                Arguments = $"-s - \"{appHostPath}\"",
+                FileName = CodeSignPath,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+
+            using (var p = Process.Start(psi))
+            {
+                p.WaitForExit();
+                if (p.ExitCode != 0)
+                    throw new AppHostSigningException(p.ExitCode, p.StandardError.ReadToEnd());
+            }
+        }
+    }
+}

--- a/src/installer/managed/Microsoft.NET.HostModel/AppHost/HostWriter.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/AppHost/HostWriter.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.IO;
 using System.IO.MemoryMappedFiles;
 using System.Runtime.InteropServices;
@@ -31,14 +30,12 @@ namespace Microsoft.NET.HostModel.AppHost
         /// <param name="appBinaryFilePath">Full path to app binary or relative path to the result apphost file</param>
         /// <param name="windowsGraphicalUserInterface">Specify whether to set the subsystem to GUI. Only valid for PE apphosts.</param>
         /// <param name="assemblyToCopyResorcesFrom">Path to the intermediate assembly, used for copying resources to PE apphosts.</param>
-        /// <param name="enableMacOSCodeSign">Sign the app binary using codesign with an anonymous certificate.</param>
         public static void CreateAppHost(
             string appHostSourceFilePath,
             string appHostDestinationFilePath,
             string appBinaryFilePath,
             bool windowsGraphicalUserInterface = false,
-            string assemblyToCopyResorcesFrom = null,
-            bool enableMacOSCodeSign = false)
+            string assemblyToCopyResorcesFrom = null)
         {
             var bytesToWrite = Encoding.UTF8.GetBytes(appBinaryFilePath);
             if (bytesToWrite.Length > 1024)
@@ -143,9 +140,6 @@ namespace Microsoft.NET.HostModel.AppHost
                     {
                         throw new Win32Exception(Marshal.GetLastWin32Error(), $"Could not set file permission {filePermissionOctal} for {appHostDestinationFilePath}.");
                     }
-
-                    if (enableMacOSCodeSign && RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                        CodeSign(appHostDestinationFilePath);
                 }
             }
             catch (Exception ex)
@@ -237,29 +231,6 @@ namespace Microsoft.NET.HostModel.AppHost
             bundleHeaderOffset = headerOffset;
 
             return headerOffset != 0;
-        }
-
-        private static void CodeSign(string appHostPath)
-        {
-            Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.OSX));
-            const string codesign = @"/usr/bin/codesign";
-            if (!File.Exists(codesign))
-                return;
-
-            var psi = new ProcessStartInfo()
-            {
-                Arguments = $"-s - \"{appHostPath}\"",
-                FileName = codesign,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-            };
-
-            using (var p = Process.Start(psi))
-            {
-                p.WaitForExit();
-                if (p.ExitCode != 0)
-                    throw new AppHostSigningException(p.ExitCode, p.StandardError.ReadToEnd());
-            }
         }
 
         [DllImport("libc", SetLastError = true)]

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUpdateTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUpdateTests.cs
@@ -237,12 +237,14 @@ namespace Microsoft.NET.HostModel.Tests
                    sourceAppHostMock,
                    destinationFilePath,
                    appBinaryFilePath,
-                   windowsGraphicalUserInterface: false,
-                   enableMacOSCodeSign: true);
+                   windowsGraphicalUserInterface: false);
 
+                CodeSign.CodeSignAppHost(destinationFilePath);
                 const string codesign = @"/usr/bin/codesign";
                 var psi = new ProcessStartInfo()
                 {
+                    // Display contents. If used on an unsigned binary f, it will print
+                    // f: code object not signed at all.
                     Arguments = $"-d \"{destinationFilePath}\"",
                     FileName = codesign,
                     RedirectStandardError = true,
@@ -308,18 +310,13 @@ namespace Microsoft.NET.HostModel.Tests
                    sourceAppHostMock,
                    destinationFilePath,
                    appBinaryFilePath,
-                   windowsGraphicalUserInterface: false,
-                   enableMacOSCodeSign: true);
+                   windowsGraphicalUserInterface: false);
 
-                // Run CreateAppHost again to sign the apphost a second time,
-                // causing codesign to fail.
+                CodeSign.CodeSignAppHost(destinationFilePath);
+                // Run CodeSignAppHost a second time causing codesign to fail.
                 var exception = Assert.Throws<AppHostSigningException>(() =>
-                    HostWriter.CreateAppHost(
-                    sourceAppHostMock,
-                    destinationFilePath,
-                    appBinaryFilePath,
-                    windowsGraphicalUserInterface: false,
-                    enableMacOSCodeSign: true));
+                    CodeSign.CodeSignAppHost(destinationFilePath));
+
                 Assert.Contains($"{destinationFilePath}: is already signed", exception.Message);
             }
         }


### PR DESCRIPTION
In preparation for changes necessary for #57242, move codesigning in macOS out of `HostWriter`, so that the SDK can call it independently of creating an apphost.