### PR TITLE
Create WindowsDesktop transport package

### DIFF
--- a/src/libraries/Microsoft.WindowsDesktop.Internal.Transport/src/Microsoft.WindowsDesktop.Internal.Transport.proj
+++ b/src/libraries/Microsoft.WindowsDesktop.Internal.Transport/src/Microsoft.WindowsDesktop.Internal.Transport.proj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <IsShipping>false</IsShipping>
+    <!-- Reference the outputs to have them available as build outputs. -->
+    <NoTargetsDoNotReferenceOutputAssemblies>false</NoTargetsDoNotReferenceOutputAssemblies>
+    <IsPackable>true</IsPackable>
+    <IncludeBuildOutput>true</IncludeBuildOutput>
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>none</DebugType>
+    <!-- This is non-shipping package. -->
+    <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
+    <PackageDescription>Internal transport package to provide windowsdesktop with the assemblies that make up the Microsoft.WindowsDesktop.App shared framework.</PackageDescription>
+    <!-- Reference elements are missing from the nuspec: https://github.com/NuGet/Home/issues/8684. -->
+    <NoWarn>$(NoWarn);NU5131</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Requires Private=true to calculate ReferenceCopyLocalPaths items. -->
+    <ProjectReference Include="@(WindowsDesktopCoreAppLibrary->'$(LibrariesProjectRoot)%(Identity)\src\%(Identity).csproj')" PrivateAssets="all" Pack="true" Private="true" IncludeReferenceAssemblyInPackage="true" />
+  </ItemGroup>
+</Project>

--- a/src/libraries/src.proj
+++ b/src/libraries/src.proj
@@ -9,8 +9,9 @@
              Exclude="@(ProjectExclusions);
                       $(MSBuildThisFileDirectory)*\src\**\*.shproj" />
     <!-- Build these packages which reference many other projects in the allconfigurations leg only. -->
-    <_allSrc Remove="$(MSBuildThisFileDirectory)Microsoft.Windows.Compatibility\src\Microsoft.Windows.Compatibility.csproj;
-                     $(MSBuildThisFileDirectory)Microsoft.AspNetCore.Internal.Transport\src\Microsoft.AspNetCore.Internal.Transport.proj"
+    <_allSrc Remove="Microsoft.AspNetCore.Internal.Transport\src\Microsoft.AspNetCore.Internal.Transport.proj;
+                     Microsoft.Windows.Compatibility\src\Microsoft.Windows.Compatibility.csproj;
+                     Microsoft.WindowsDesktop.Internal.Transport\src\Microsoft.WindowsDesktop.Internal.Transport.proj"
              Condition="'$(BuildAllConfigurations)' != 'true'" />
 
     <NonNetCoreAppProject Include="@(_allSrc)"


### PR DESCRIPTION
As we don't include reference assemblies in our packages anymore, we
need a transport package for WindowsDesktop which contains the necessary
reference assemblies. Using the same layout as aspnetcore's package
which worked well in the past.