### PR TITLE
[libraries] Skip FormKC and FormKD on iOS, tvOS, and MacCatalyst

### DIFF
--- a/src/libraries/Common/tests/Tests/System/StringTests.cs
+++ b/src/libraries/Common/tests/Tests/System/StringTests.cs
@@ -7336,7 +7336,6 @@ namespace System.Tests
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInvariantGlobalization))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34577", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/52072", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public static unsafe void NormalizationTest() // basic test; more tests in globalization tests
         {
             // U+0063  LATIN SMALL LETTER C

--- a/src/libraries/Common/tests/Tests/System/StringTests.cs
+++ b/src/libraries/Common/tests/Tests/System/StringTests.cs
@@ -7349,9 +7349,11 @@ namespace System.Tests
             Assert.False(s.IsNormalized(NormalizationForm.FormC), "String should be not normalized when checking with FormC");
             Assert.False(s.IsNormalized(NormalizationForm.FormD), "String should be not normalized when checking with FormD");
 
-            if (PlatformDetection.IsNotBrowser)
+            // Browser's, iOS's, MacCatalyst's, and tvOS's ICU do not support FormKC and FormKD
+            bool supportsKCKD = !PlatformDetection.IsBrowser && !PlatformDetection.IsiOS && !PlatformDetection.IsMacCatalyst && !PlatformDetection.IstvOS;
+
+            if (supportsKCKD)
             {
-                // Browser's ICU doesn't support FormKC and FormKD
                 Assert.False(s.IsNormalized(NormalizationForm.FormKC), "String should be not normalized when checking with FormKC");
                 Assert.False(s.IsNormalized(NormalizationForm.FormKD), "String should be not normalized when checking with FormKD");
             }
@@ -7367,9 +7369,8 @@ namespace System.Tests
             normalized = s.Normalize(NormalizationForm.FormD);
             Assert.True(normalized.IsNormalized(NormalizationForm.FormD), "Expected to have the normalized string with FormD");
 
-            if (PlatformDetection.IsNotBrowser)
+            if (supportsKCKD)
             {
-                // Browser's ICU doesn't support FormKC and FormKD
                 normalized = s.Normalize(NormalizationForm.FormKC);
                 Assert.True(normalized.IsNormalized(NormalizationForm.FormKC), "Expected to have the normalized string with FormKC");
 
@@ -7382,9 +7383,8 @@ namespace System.Tests
             Assert.True(s.IsNormalized(NormalizationForm.FormC));
             Assert.True(s.IsNormalized(NormalizationForm.FormD));
 
-            if (PlatformDetection.IsNotBrowser)
+            if (supportsKCKD)
             {
-                // Browser's ICU doesn't support FormKC and FormKD
                 Assert.True(s.IsNormalized(NormalizationForm.FormKC));
                 Assert.True(s.IsNormalized(NormalizationForm.FormKD));
             }
@@ -7393,9 +7393,8 @@ namespace System.Tests
             Assert.Same(s, s.Normalize(NormalizationForm.FormC));
             Assert.Same(s, s.Normalize(NormalizationForm.FormD));
 
-            if (PlatformDetection.IsNotBrowser)
+            if (supportsKCKD)
             {
-                // Browser's ICU doesn't support FormKC and FormKD
                 Assert.Same(s, s.Normalize(NormalizationForm.FormKC));
                 Assert.Same(s, s.Normalize(NormalizationForm.FormKD));
             }


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/52072

```
System.Tests.StringTests.NormalizationTest
    System.ArgumentException : String contains invalid Unicode code points. (Parameter 'strInput')
       at System.Globalization.Normalization.IcuIsNormalized(String strInput, NormalizationForm normalizationForm)
   at System.Globalization.Normalization.IsNormalized(String strInput, NormalizationForm normalizationForm)
   at System.String.IsNormalized(NormalizationForm normalizationForm)
   at System.Tests.StringTests.NormalizationTest()
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
```

Fails because https://github.com/dotnet/runtime/blob/b1b91ef9c4027574c031af68d42e6803572159e2/src/libraries/Common/tests/Tests/System/StringTests.cs#L7355-L7356 throw argument exception instead of returning false.

Upon further inspection, the string normalizes to empty when printed to console, which leads me to suspect that FormKC and FormKD are not supported by iOS, tvOS, or MacCatalyst ICU.
https://github.com/dotnet/runtime/blob/b1b91ef9c4027574c031af68d42e6803572159e2/src/libraries/Common/tests/Tests/System/StringTests.cs#L7346