### PR TITLE
Fix handling of new connection in MsQuicListener

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicListener.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicListener.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Net.Quic.Implementations.MsQuic.Internal;
 using System.Net.Security;
@@ -25,7 +26,7 @@ namespace System.Net.Quic.Implementations.MsQuic
 
         private readonly IPEndPoint _listenEndPoint;
 
-        private sealed class State
+        internal sealed class State
         {
             // set immediately in ctor, but we need a GCHandle to State in order to create the handle.
             public SafeMsQuicListenerHandle Handle = null!;
@@ -33,6 +34,7 @@ namespace System.Net.Quic.Implementations.MsQuic
 
             public readonly SafeMsQuicConfigurationHandle? ConnectionConfiguration;
             public readonly Channel<MsQuicConnection> AcceptConnectionQueue;
+            public readonly ConcurrentDictionary<IntPtr, MsQuicConnection> PendingConnections;
 
             public QuicOptions ConnectionOptions = new QuicOptions();
             public SslServerAuthenticationOptions AuthenticationOptions = new SslServerAuthenticationOptions();
@@ -66,6 +68,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                     ConnectionConfiguration = SafeMsQuicConfigurationHandle.Create(options, options.ServerAuthenticationOptions);
                 }
 
+                PendingConnections = new ConcurrentDictionary<IntPtr, MsQuicConnection>();
                 AcceptConnectionQueue = Channel.CreateBounded<MsQuicConnection>(new BoundedChannelOptions(options.ListenBacklog)
                 {
                     SingleReader = true,
@@ -229,7 +232,6 @@ namespace System.Net.Quic.Implementations.MsQuic
 
             SafeMsQuicConnectionHandle? connectionHandle = null;
             MsQuicConnection? msQuicConnection = null;
-
             try
             {
                 ref NewConnectionInfo connectionInfo = ref *evt.Data.NewConnection.Info;
@@ -273,13 +275,15 @@ namespace System.Net.Quic.Implementations.MsQuic
                 uint status = MsQuicApi.Api.ConnectionSetConfigurationDelegate(connectionHandle, connectionConfiguration);
                 if (MsQuicStatusHelper.SuccessfulStatusCode(status))
                 {
-                    msQuicConnection = new MsQuicConnection(localEndPoint, remoteEndPoint, connectionHandle, state.AuthenticationOptions.ClientCertificateRequired, state.AuthenticationOptions.CertificateRevocationCheckMode, state.AuthenticationOptions.RemoteCertificateValidationCallback);
+                    msQuicConnection = new MsQuicConnection(localEndPoint, remoteEndPoint, state, connectionHandle, state.AuthenticationOptions.ClientCertificateRequired, state.AuthenticationOptions.CertificateRevocationCheckMode, state.AuthenticationOptions.RemoteCertificateValidationCallback);
                     msQuicConnection.SetNegotiatedAlpn(connectionInfo.NegotiatedAlpn, connectionInfo.NegotiatedAlpnLength);
 
-                    if (state.AcceptConnectionQueue.Writer.TryWrite(msQuicConnection))
+                    if (!state.PendingConnections.TryAdd(connectionHandle.DangerousGetHandle(), msQuicConnection))
                     {
-                        return MsQuicStatusCodes.Success;
+                        msQuicConnection.Dispose();
                     }
+
+                    return MsQuicStatusCodes.Success;
                 }
 
                 // If we fall-through here something wrong happened.

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -304,7 +304,7 @@ namespace System.Net.Quic.Tests
         [Theory]
         [PlatformSpecific(TestPlatforms.Windows)]
         [InlineData(true)]
-        // [InlineData(false)] ActiveIssue("https://github.com/dotnet/runtime/issues/57308")
+        // [InlineData(false)] [ActiveIssue("https://github.com/dotnet/runtime/issues/57308")]
         public async Task ConnectWithClientCertificate(bool sendCerttificate)
         {
             bool clientCertificateOK = false;
@@ -315,7 +315,6 @@ namespace System.Net.Quic.Tests
             listenerOptions.ServerAuthenticationOptions.ClientCertificateRequired = true;
             listenerOptions.ServerAuthenticationOptions.RemoteCertificateValidationCallback = (sender, cert, chain, errors) =>
             {
-                Console.WriteLine("RemoteCertificateValidationCallback called!!!");
                 if (sendCerttificate)
                 {
                     _output.WriteLine("client certificate {0}", cert);


### PR DESCRIPTION
I'm still testing but this is somewhat invasive change so I would like to get any early feedback.
As noted in  #57246, part of the problem is that now we hand out QuicConnection before it is ready. 
To fix that, this change adds another holding container, and it waits to either get CONNECTED event and then it jumps on old path to add connection to the Channel and that wakes the AcceptConnectionAsync.
If the connection does not get connected wit would get SHUTDOEN_COMPLETED and we would dispose and remove connection in the handler.

Since the vents are coming on the Connection we need relation back to the listener.  So  until one of the events come, we would hold reference to the ListenerState - similar to the Connection - Stream relation.

The second part is the validation handling. While on client we want to throw and propagate details to the caller there is nowhere to pass the exception on server. I updated the code to simple return failure instead of throwing.  (that will clean the connection) 

Added new test as well updated few existing one as failing handshake will no longer produce connection. 


fixes  #57246