### PR TITLE
Improve serializer performance

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/FSharp/FSharpTypeConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/FSharp/FSharpTypeConverterFactory.cs
@@ -8,7 +8,7 @@ using FSharpKind = System.Text.Json.Serialization.Metadata.FSharpCoreReflectionP
 
 namespace System.Text.Json.Serialization.Converters
 {
-    internal class FSharpTypeConverterFactory : JsonConverterFactory
+    internal sealed class FSharpTypeConverterFactory : JsonConverterFactory
     {
         // Temporary solution to account for not implemented support for type-level attributes
         // TODO remove once addressed https://github.com/mono/linker/issues/1742#issuecomment-875036480

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -16,6 +16,9 @@ namespace System.Text.Json.Serialization.Converters
     {
         internal override bool CanHaveIdMetadata => true;
 
+#if NET6_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
         internal override bool OnTryRead(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options, ref ReadStack state, [MaybeNullWhen(false)] out T value)
         {
             JsonTypeInfo jsonTypeInfo = state.Current.JsonTypeInfo;
@@ -246,6 +249,9 @@ namespace System.Text.Json.Serialization.Converters
             return true;
         }
 
+#if NET6_0_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
         internal sealed override bool OnTryWrite(
             Utf8JsonWriter writer,
             T value,
@@ -272,7 +278,7 @@ namespace System.Text.Json.Serialization.Converters
                     onSerializing.OnSerializing();
                 }
 
-                List<KeyValuePair<string, JsonPropertyInfo?>> properties = state.Current.JsonTypeInfo.PropertyCache!.List;
+                List<KeyValuePair<string, JsonPropertyInfo?>> properties = jsonTypeInfo.PropertyCache!.List;
                 for (int i = 0; i < properties.Count; i++)
                 {
                     JsonPropertyInfo jsonPropertyInfo = properties[i].Value!;
@@ -291,7 +297,7 @@ namespace System.Text.Json.Serialization.Converters
                 }
 
                 // Write extension data after the normal properties.
-                JsonPropertyInfo? dataExtensionProperty = state.Current.JsonTypeInfo.DataExtensionProperty;
+                JsonPropertyInfo? dataExtensionProperty = jsonTypeInfo.DataExtensionProperty;
                 if (dataExtensionProperty?.ShouldSerialize == true)
                 {
                     // Remember the current property for JsonPath support if an exception is thrown.
@@ -327,7 +333,7 @@ namespace System.Text.Json.Serialization.Converters
                     state.Current.ProcessedStartToken = true;
                 }
 
-                List<KeyValuePair<string, JsonPropertyInfo?>>? propertyList = state.Current.JsonTypeInfo.PropertyCache!.List!;
+                List<KeyValuePair<string, JsonPropertyInfo?>>? propertyList = jsonTypeInfo.PropertyCache!.List!;
                 while (state.Current.EnumeratorIndex < propertyList.Count)
                 {
                     JsonPropertyInfo? jsonPropertyInfo = propertyList![state.Current.EnumeratorIndex].Value;
@@ -362,7 +368,7 @@ namespace System.Text.Json.Serialization.Converters
                 // Write extension data after the normal properties.
                 if (state.Current.EnumeratorIndex == propertyList.Count)
                 {
-                    JsonPropertyInfo? dataExtensionProperty = state.Current.JsonTypeInfo.DataExtensionProperty;
+                    JsonPropertyInfo? dataExtensionProperty = jsonTypeInfo.DataExtensionProperty;
                     if (dataExtensionProperty?.ShouldSerialize == true)
                     {
                         // Remember the current property for JsonPath support if an exception is thrown.
@@ -407,7 +413,7 @@ namespace System.Text.Json.Serialization.Converters
 
         // AggressiveInlining since this method is only called from two locations and is on a hot path.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected void ReadPropertyValue(
+        protected static void ReadPropertyValue(
             object obj,
             ref ReadStack state,
             ref Utf8JsonReader reader,
@@ -438,7 +444,7 @@ namespace System.Text.Json.Serialization.Converters
             state.Current.EndProperty();
         }
 
-        protected bool ReadAheadPropertyValue(ref ReadStack state, ref Utf8JsonReader reader, JsonPropertyInfo jsonPropertyInfo)
+        protected static bool ReadAheadPropertyValue(ref ReadStack state, ref Utf8JsonReader reader, JsonPropertyInfo jsonPropertyInfo)
         {
             // Returning false below will cause the read-ahead functionality to finish the read.
             state.Current.PropertyState = StackFramePropertyState.ReadValue;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/NullableConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/NullableConverter.cs
@@ -70,8 +70,5 @@ namespace System.Text.Json.Serialization.Converters
                 _converter.WriteNumberWithCustomHandling(writer, value.Value, handling);
             }
         }
-
-        internal override bool IsNull(in T? value) => !value.HasValue;
-        internal override bool IsNullableOfT() => true;
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/NullableConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/NullableConverter.cs
@@ -72,5 +72,6 @@ namespace System.Text.Json.Serialization.Converters
         }
 
         internal override bool IsNull(in T? value) => !value.HasValue;
+        internal override bool IsNullableOfT() => true;
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -314,9 +314,11 @@ namespace System.Text.Json.Serialization
         }
 
         /// <summary>
-        /// Performance optimization. The 'in' modifier in TryWrite(in T Value) will cause boxing, so this helper method avoids that.
+        /// Performance optimization.
+        /// The 'in' modifier in 'TryWrite(in T Value)' causes boxing for Nullable{T}, so this helper avoids that.
+        /// TODO: Remove this work-around once #50915 is addressed.
         /// </summary>
-        internal bool IsNull(T value) => value is null;
+        private static bool IsNull(T value) => value is null;
 
 #if NET6_0_OR_GREATER
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Helpers.cs
@@ -15,6 +15,8 @@ namespace System.Text.Json
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
         private static JsonTypeInfo GetTypeInfo(JsonSerializerOptions? options, Type runtimeType)
         {
+            Debug.Assert(runtimeType != null);
+
             options ??= JsonSerializerOptions.s_defaultOptions;
             if (!options.IsInitializedForReflectionSerializer)
             {
@@ -30,7 +32,7 @@ namespace System.Text.Json
             Debug.Assert(type != null);
 
             JsonTypeInfo? info = context.GetTypeInfo(type);
-            if (info == null)
+            if (info is null)
             {
                 ThrowHelper.ThrowInvalidOperationException_NoMetadataForType(type);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Helpers.cs
@@ -13,10 +13,14 @@ namespace System.Text.Json
         internal const string SerializationUnreferencedCodeMessage = "JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.";
 
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
-        private static JsonTypeInfo GetTypeInfo(Type runtimeType, JsonSerializerOptions? options)
+        private static JsonTypeInfo GetTypeInfo(JsonSerializerOptions? options, Type runtimeType)
         {
             options ??= JsonSerializerOptions.s_defaultOptions;
-            options.RootBuiltInConvertersAndTypeInfoCreator();
+            if (!options.IsInitializedForReflectionSerializer)
+            {
+                options.InitializeForReflectionSerializer();
+            }
+
             return options.GetOrAddClassForRootType(runtimeType);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Document.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Document.cs
@@ -33,7 +33,8 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(document));
             }
 
-            return ReadUsingOptions<TValue>(document, typeof(TValue), options);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, typeof(TValue));
+            return ReadDocument<TValue>(document, jsonTypeInfo);
         }
 
         /// <summary>
@@ -66,7 +67,8 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(returnType));
             }
 
-            return ReadUsingOptions<object?>(document, returnType, options);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, returnType);
+            return ReadDocument<object?>(document, jsonTypeInfo);
         }
 
         /// <summary>
@@ -101,7 +103,7 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(jsonTypeInfo));
             }
 
-            return ReadUsingMetadata<TValue>(document, jsonTypeInfo);
+            return ReadDocument<TValue>(document, jsonTypeInfo);
         }
 
         /// <summary>
@@ -157,17 +159,14 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return ReadUsingMetadata<object?>(document, GetTypeInfo(context, returnType));
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(context, returnType);
+            return ReadDocument<object?>(document, jsonTypeInfo);
         }
 
-        [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
-        private static TValue? ReadUsingOptions<TValue>(JsonDocument document, Type returnType, JsonSerializerOptions? options) =>
-            ReadUsingMetadata<TValue>(document, GetTypeInfo(returnType, options));
-
-        private static TValue? ReadUsingMetadata<TValue>(JsonDocument document, JsonTypeInfo jsonTypeInfo)
+        private static TValue? ReadDocument<TValue>(JsonDocument document, JsonTypeInfo jsonTypeInfo)
         {
             ReadOnlySpan<byte> utf8Json = document.GetRootRawValue().Span;
-            return ReadUsingMetadata<TValue>(utf8Json, jsonTypeInfo);
+            return ReadSpan<TValue>(utf8Json, jsonTypeInfo);
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Document.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Document.cs
@@ -166,7 +166,7 @@ namespace System.Text.Json
         private static TValue? ReadDocument<TValue>(JsonDocument document, JsonTypeInfo jsonTypeInfo)
         {
             ReadOnlySpan<byte> utf8Json = document.GetRootRawValue().Span;
-            return ReadSpan<TValue>(utf8Json, jsonTypeInfo);
+            return ReadFromSpan<TValue>(utf8Json, jsonTypeInfo);
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Element.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Element.cs
@@ -135,7 +135,7 @@ namespace System.Text.Json
         private static TValue? ReadUsingMetadata<TValue>(JsonElement element, JsonTypeInfo jsonTypeInfo)
         {
             ReadOnlySpan<byte> utf8Json = element.GetRawValue().Span;
-            return ReadSpan<TValue>(utf8Json, jsonTypeInfo);
+            return ReadFromSpan<TValue>(utf8Json, jsonTypeInfo);
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Element.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Element.cs
@@ -23,8 +23,11 @@ namespace System.Text.Json
         /// for <typeparamref name="TValue"/> or its serializable members.
         /// </exception>
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
-        public static TValue? Deserialize<TValue>(this JsonElement element, JsonSerializerOptions? options = null) =>
-            ReadUsingOptions<TValue>(element, typeof(TValue), options);
+        public static TValue? Deserialize<TValue>(this JsonElement element, JsonSerializerOptions? options = null)
+        {
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, typeof(TValue));
+            return ReadUsingMetadata<TValue>(element, jsonTypeInfo);
+        }
 
         /// <summary>
         /// Converts the <see cref="JsonElement"/> representing a single JSON value into a <paramref name="returnType"/>.
@@ -51,7 +54,8 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(returnType));
             }
 
-            return ReadUsingOptions<object?>(element, returnType, options);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, returnType);
+            return ReadUsingMetadata<object?>(element, jsonTypeInfo);
         }
 
         /// <summary>
@@ -124,17 +128,14 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return ReadUsingMetadata<object?>(element, GetTypeInfo(context, returnType));
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(context, returnType);
+            return ReadUsingMetadata<object?>(element, jsonTypeInfo);
         }
-
-        [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
-        private static TValue? ReadUsingOptions<TValue>(JsonElement element, Type returnType, JsonSerializerOptions? options) =>
-            ReadUsingMetadata<TValue>(element, GetTypeInfo(returnType, options));
 
         private static TValue? ReadUsingMetadata<TValue>(JsonElement element, JsonTypeInfo jsonTypeInfo)
         {
             ReadOnlySpan<byte> utf8Json = element.GetRawValue().Span;
-            return ReadUsingMetadata<TValue>(utf8Json, jsonTypeInfo);
+            return ReadSpan<TValue>(utf8Json, jsonTypeInfo);
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Helpers.cs
@@ -23,7 +23,7 @@ namespace System.Text.Json
             return (TValue?)value;
         }
 
-        private static TValue? ReadSpan<TValue>(ReadOnlySpan<byte> utf8Json, JsonTypeInfo jsonTypeInfo, int? actualByteCount = null)
+        private static TValue? ReadFromSpan<TValue>(ReadOnlySpan<byte> utf8Json, JsonTypeInfo jsonTypeInfo, int? actualByteCount = null)
         {
             JsonSerializerOptions options = jsonTypeInfo.Options;
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Helpers.cs
@@ -20,10 +20,10 @@ namespace System.Text.Json
             // The non-generic API was called or we have a polymorphic case where TValue is not equal to the T in JsonConverter<T>.
             object? value = jsonConverter.ReadCoreAsObject(ref reader, options, ref state);
             Debug.Assert(value == null || value is TValue);
-            return (TValue)value!;
+            return (TValue?)value;
         }
 
-        private static TValue? ReadUsingMetadata<TValue>(ReadOnlySpan<byte> utf8Json, JsonTypeInfo jsonTypeInfo, int? actualByteCount = null)
+        private static TValue? ReadSpan<TValue>(ReadOnlySpan<byte> utf8Json, JsonTypeInfo jsonTypeInfo, int? actualByteCount = null)
         {
             JsonSerializerOptions options = jsonTypeInfo.Options;
 
@@ -33,7 +33,22 @@ namespace System.Text.Json
             ReadStack state = default;
             state.Initialize(jsonTypeInfo);
 
-            TValue? value = ReadCore<TValue>(jsonTypeInfo.PropertyInfoForTypeInfo.ConverterBase, ref reader, options, ref state);
+            TValue? value;
+            JsonConverter jsonConverter = jsonTypeInfo.PropertyInfoForTypeInfo.ConverterBase;
+
+            // For performance, the code below is a lifted ReadCore() above.
+            if (jsonConverter is JsonConverter<TValue> converter)
+            {
+                // Call the strongly-typed ReadCore that will not box structs.
+                value = converter.ReadCore(ref reader, options, ref state);
+            }
+            else
+            {
+                // The non-generic API was called or we have a polymorphic case where TValue is not equal to the T in JsonConverter<T>.
+                object? objValue = jsonConverter.ReadCoreAsObject(ref reader, options, ref state);
+                Debug.Assert(objValue == null || objValue is TValue);
+                value = (TValue?)objValue;
+            }
 
             // The reader should have thrown if we have remaining bytes.
             Debug.Assert(reader.BytesConsumed == (actualByteCount ?? utf8Json.Length));

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Node.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Node.cs
@@ -27,7 +27,8 @@ namespace System.Text.Json
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
         public static TValue? Deserialize<TValue>(this JsonNode? node, JsonSerializerOptions? options = null)
         {
-            return ReadUsingOptions<TValue>(node, typeof(TValue), options);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, typeof(TValue));
+            return ReadNode<TValue>(node, jsonTypeInfo);
         }
 
         /// <summary>
@@ -52,7 +53,8 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(returnType));
             }
 
-            return ReadUsingOptions<object?>(node, returnType, options);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, returnType);
+            return ReadNode<object?>(node, jsonTypeInfo);
         }
 
         /// <summary>
@@ -78,7 +80,7 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(jsonTypeInfo));
             }
 
-            return ReadUsingMetadata<TValue>(node, jsonTypeInfo);
+            return ReadNode<TValue>(node, jsonTypeInfo);
         }
 
         /// <summary>
@@ -125,17 +127,13 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return ReadUsingMetadata<object?>(node, GetTypeInfo(context, returnType));
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(context, returnType);
+            return ReadNode<object?>(node, jsonTypeInfo);
         }
 
-        [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
-        private static TValue? ReadUsingOptions<TValue>(JsonNode? node, Type returnType, JsonSerializerOptions? options) =>
-            ReadUsingMetadata<TValue>(node, GetTypeInfo(returnType, options));
-
-        private static TValue? ReadUsingMetadata<TValue>(JsonNode? node, JsonTypeInfo jsonTypeInfo)
+        private static TValue? ReadNode<TValue>(JsonNode? node, JsonTypeInfo jsonTypeInfo)
         {
             JsonSerializerOptions options = jsonTypeInfo.Options;
-            Debug.Assert(options != null);
 
             // For performance, share the same buffer across serialization and deserialization.
             using var output = new PooledByteBufferWriter(options.DefaultBufferSize);
@@ -151,7 +149,7 @@ namespace System.Text.Json
                 }
             }
 
-            return ReadUsingMetadata<TValue>(output.WrittenMemory.Span, jsonTypeInfo);
+            return ReadSpan<TValue>(output.WrittenMemory.Span, jsonTypeInfo);
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Node.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Node.cs
@@ -149,7 +149,7 @@ namespace System.Text.Json
                 }
             }
 
-            return ReadSpan<TValue>(output.WrittenMemory.Span, jsonTypeInfo);
+            return ReadFromSpan<TValue>(output.WrittenMemory.Span, jsonTypeInfo);
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Span.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Span.cs
@@ -28,7 +28,7 @@ namespace System.Text.Json
         public static TValue? Deserialize<TValue>(ReadOnlySpan<byte> utf8Json, JsonSerializerOptions? options = null)
         {
             JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, typeof(TValue));
-            return ReadSpan<TValue>(utf8Json, jsonTypeInfo);
+            return ReadFromSpan<TValue>(utf8Json, jsonTypeInfo);
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace System.Text.Json
             }
 
             JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, returnType);
-            return ReadSpan<object>(utf8Json, jsonTypeInfo);
+            return ReadFromSpan<object>(utf8Json, jsonTypeInfo);
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(jsonTypeInfo));
             }
 
-            return ReadSpan<TValue>(utf8Json, jsonTypeInfo);
+            return ReadFromSpan<TValue>(utf8Json, jsonTypeInfo);
         }
 
         /// <summary>
@@ -122,7 +122,7 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return ReadSpan<object?>(utf8Json, GetTypeInfo(context, returnType));
+            return ReadFromSpan<object?>(utf8Json, GetTypeInfo(context, returnType));
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Span.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Span.cs
@@ -26,7 +26,10 @@ namespace System.Text.Json
         /// </exception>
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
         public static TValue? Deserialize<TValue>(ReadOnlySpan<byte> utf8Json, JsonSerializerOptions? options = null)
-            => ReadUsingOptions<TValue>(utf8Json, typeof(TValue), options);
+        {
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, typeof(TValue));
+            return ReadSpan<TValue>(utf8Json, jsonTypeInfo);
+        }
 
         /// <summary>
         /// Parses the UTF-8 encoded text representing a single JSON value into a <paramref name="returnType"/>.
@@ -55,7 +58,8 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(returnType));
             }
 
-            return ReadUsingOptions<object>(utf8Json, returnType, options);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, returnType);
+            return ReadSpan<object>(utf8Json, jsonTypeInfo);
         }
 
         /// <summary>
@@ -80,7 +84,7 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(jsonTypeInfo));
             }
 
-            return ReadUsingMetadata<TValue>(utf8Json, jsonTypeInfo);
+            return ReadSpan<TValue>(utf8Json, jsonTypeInfo);
         }
 
         /// <summary>
@@ -118,14 +122,7 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return ReadUsingMetadata<object?>(utf8Json, GetTypeInfo(context, returnType));
-        }
-
-        [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
-        private static TValue? ReadUsingOptions<TValue>(ReadOnlySpan<byte> utf8Json, Type returnType, JsonSerializerOptions? options)
-        {
-            JsonTypeInfo jsonTypeInfo = GetTypeInfo(returnType, options);
-            return ReadUsingMetadata<TValue>(utf8Json, jsonTypeInfo);
+            return ReadSpan<object?>(utf8Json, GetTypeInfo(context, returnType));
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -50,7 +50,8 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(utf8Json));
             }
 
-            return ReadAllUsingOptionsAsync<TValue>(utf8Json, typeof(TValue), options, cancellationToken);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, typeof(TValue));
+            return ReadAllAsync<TValue>(utf8Json, jsonTypeInfo, cancellationToken);
         }
 
         /// <summary>
@@ -125,7 +126,8 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(returnType));
             }
 
-            return ReadAllUsingOptionsAsync<object>(utf8Json, returnType, options, cancellationToken);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, returnType);
+            return ReadAllAsync<object?>(utf8Json, jsonTypeInfo, cancellationToken);
         }
 
         /// <summary>
@@ -365,7 +367,10 @@ namespace System.Text.Json
             }
 
             options ??= JsonSerializerOptions.s_defaultOptions;
-            options.RootBuiltInConvertersAndTypeInfoCreator();
+            if (!options.IsInitializedForReflectionSerializer)
+            {
+                options.InitializeForReflectionSerializer();
+            }
 
             return CreateAsyncEnumerableDeserializer(utf8Json, options, cancellationToken);
 
@@ -617,23 +622,12 @@ namespace System.Text.Json
         }
 
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
-        private static ValueTask<TValue?> ReadAllUsingOptionsAsync<TValue>(
-            Stream utf8Json,
-            Type returnType,
-            JsonSerializerOptions? options,
-            CancellationToken cancellationToken)
-        {
-            JsonTypeInfo jsonTypeInfo = GetTypeInfo(returnType, options);
-            return ReadAllAsync<TValue>(utf8Json, jsonTypeInfo, cancellationToken);
-        }
-
-        [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
         private static TValue? ReadAllUsingOptions<TValue>(
             Stream utf8Json,
             Type returnType,
             JsonSerializerOptions? options)
         {
-            JsonTypeInfo jsonTypeInfo = GetTypeInfo(returnType, options);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, returnType);
             return ReadAll<TValue>(utf8Json, jsonTypeInfo);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
@@ -49,7 +49,7 @@ namespace System.Text.Json
             }
 
             JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, typeof(TValue));
-            return ReadSpan<TValue>(json.AsSpan(), jsonTypeInfo);
+            return ReadFromSpan<TValue>(json.AsSpan(), jsonTypeInfo);
         }
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace System.Text.Json
             // default/null span is treated as empty
 
             JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, typeof(TValue));
-            return ReadSpan<TValue>(json, jsonTypeInfo);
+            return ReadFromSpan<TValue>(json, jsonTypeInfo);
         }
 
         /// <summary>
@@ -125,7 +125,7 @@ namespace System.Text.Json
             }
 
             JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, returnType);
-            return ReadSpan<object?>(json.AsSpan(), jsonTypeInfo)!;
+            return ReadFromSpan<object?>(json.AsSpan(), jsonTypeInfo)!;
         }
 
         /// <summary>
@@ -171,7 +171,7 @@ namespace System.Text.Json
             }
 
             JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, returnType);
-            return ReadSpan<object?>(json, jsonTypeInfo)!;
+            return ReadFromSpan<object?>(json, jsonTypeInfo)!;
         }
 
         /// <summary>
@@ -218,7 +218,7 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(jsonTypeInfo));
             }
 
-            return ReadSpan<TValue?>(json.AsSpan(), jsonTypeInfo);
+            return ReadFromSpan<TValue?>(json.AsSpan(), jsonTypeInfo);
         }
 
         /// <summary>
@@ -260,7 +260,7 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(jsonTypeInfo));
             }
 
-            return ReadSpan<TValue?>(json, jsonTypeInfo);
+            return ReadFromSpan<TValue?>(json, jsonTypeInfo);
         }
 
         /// <summary>
@@ -316,7 +316,7 @@ namespace System.Text.Json
             }
 
             JsonTypeInfo jsonTypeInfo = GetTypeInfo(context, returnType);
-            return ReadSpan<object?>(json.AsSpan(), jsonTypeInfo);
+            return ReadFromSpan<object?>(json.AsSpan(), jsonTypeInfo);
         }
 
         /// <summary>
@@ -367,10 +367,10 @@ namespace System.Text.Json
             }
 
             JsonTypeInfo jsonTypeInfo = GetTypeInfo(context, returnType);
-            return ReadSpan<object?>(json, jsonTypeInfo);
+            return ReadFromSpan<object?>(json, jsonTypeInfo);
         }
 
-        private static TValue? ReadSpan<TValue>(ReadOnlySpan<char> json, JsonTypeInfo jsonTypeInfo)
+        private static TValue? ReadFromSpan<TValue>(ReadOnlySpan<char> json, JsonTypeInfo jsonTypeInfo)
         {
             byte[]? tempArray = null;
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
@@ -386,7 +386,7 @@ namespace System.Text.Json
             {
                 int actualByteCount = JsonReaderHelper.GetUtf8FromText(json, utf8);
                 utf8 = utf8.Slice(0, actualByteCount);
-                return ReadSpan<TValue>(utf8, jsonTypeInfo, actualByteCount);
+                return ReadFromSpan<TValue>(utf8, jsonTypeInfo, actualByteCount);
             }
             finally
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
@@ -48,7 +48,8 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(json));
             }
 
-            return ReadUsingOptions<TValue>(json.AsSpan(), typeof(TValue), options);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, typeof(TValue));
+            return ReadSpan<TValue>(json.AsSpan(), jsonTypeInfo);
         }
 
         /// <summary>
@@ -79,7 +80,8 @@ namespace System.Text.Json
         {
             // default/null span is treated as empty
 
-            return ReadUsingOptions<TValue>(json, typeof(TValue), options);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, typeof(TValue));
+            return ReadSpan<TValue>(json, jsonTypeInfo);
         }
 
         /// <summary>
@@ -122,7 +124,8 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(returnType));
             }
 
-            return ReadUsingOptions<object?>(json.AsSpan(), returnType, options)!;
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, returnType);
+            return ReadSpan<object?>(json.AsSpan(), jsonTypeInfo)!;
         }
 
         /// <summary>
@@ -162,7 +165,13 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(returnType));
             }
 
-            return ReadUsingOptions<object?>(json, returnType, options)!;
+            if (returnType == null)
+            {
+                throw new ArgumentNullException(nameof(returnType));
+            }
+
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, returnType);
+            return ReadSpan<object?>(json, jsonTypeInfo)!;
         }
 
         /// <summary>
@@ -209,7 +218,7 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(jsonTypeInfo));
             }
 
-            return ReadUsingMetadata<TValue?>(json.AsSpan(), jsonTypeInfo);
+            return ReadSpan<TValue?>(json.AsSpan(), jsonTypeInfo);
         }
 
         /// <summary>
@@ -251,7 +260,7 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(jsonTypeInfo));
             }
 
-            return ReadUsingMetadata<TValue?>(json, jsonTypeInfo);
+            return ReadSpan<TValue?>(json, jsonTypeInfo);
         }
 
         /// <summary>
@@ -296,7 +305,18 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(json));
             }
 
-            return Deserialize(json.AsSpan(), returnType, context);
+            if (returnType == null)
+            {
+                throw new ArgumentNullException(nameof(returnType));
+            }
+
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(context, returnType);
+            return ReadSpan<object?>(json.AsSpan(), jsonTypeInfo);
         }
 
         /// <summary>
@@ -346,14 +366,11 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return ReadUsingMetadata<object?>(json, GetTypeInfo(context, returnType));
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(context, returnType);
+            return ReadSpan<object?>(json, jsonTypeInfo);
         }
 
-        [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
-        private static TValue? ReadUsingOptions<TValue>(ReadOnlySpan<char> json, Type returnType, JsonSerializerOptions? options)
-            => ReadUsingMetadata<TValue>(json, GetTypeInfo(returnType, options));
-
-        private static TValue? ReadUsingMetadata<TValue>(ReadOnlySpan<char> json, JsonTypeInfo jsonTypeInfo)
+        private static TValue? ReadSpan<TValue>(ReadOnlySpan<char> json, JsonTypeInfo jsonTypeInfo)
         {
             byte[]? tempArray = null;
 
@@ -369,7 +386,7 @@ namespace System.Text.Json
             {
                 int actualByteCount = JsonReaderHelper.GetUtf8FromText(json, utf8);
                 utf8 = utf8.Slice(0, actualByteCount);
-                return ReadUsingMetadata<TValue>(utf8, jsonTypeInfo, actualByteCount);
+                return ReadSpan<TValue>(utf8, jsonTypeInfo, actualByteCount);
             }
             finally
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Utf8JsonReader.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Utf8JsonReader.cs
@@ -55,7 +55,10 @@ namespace System.Text.Json
         /// </remarks>
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
         public static TValue? Deserialize<TValue>(ref Utf8JsonReader reader, JsonSerializerOptions? options = null)
-            => ReadUsingOptions<TValue>(ref reader, typeof(TValue), options);
+        {
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, typeof(TValue));
+            return Read<TValue>(ref reader, jsonTypeInfo);
+        }
 
         /// <summary>
         /// Reads one JSON value (including objects or arrays) from the provided reader into a <paramref name="returnType"/>.
@@ -110,7 +113,8 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(returnType));
             }
 
-            return ReadUsingOptions<object?>(ref reader, returnType, options);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, returnType);
+            return Read<object?>(ref reader, jsonTypeInfo);
         }
 
         /// <summary>
@@ -162,7 +166,7 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(jsonTypeInfo));
             }
 
-            return ReadUsingMetadata<TValue>(ref reader, jsonTypeInfo);
+            return Read<TValue>(ref reader, jsonTypeInfo);
         }
 
         /// <summary>
@@ -226,17 +230,10 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return ReadUsingMetadata<object>(ref reader, GetTypeInfo(context, returnType));
+            return Read<object>(ref reader, GetTypeInfo(context, returnType));
         }
 
-        [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
-        private static TValue? ReadUsingOptions<TValue>(ref Utf8JsonReader reader, Type returnType, JsonSerializerOptions? options)
-        {
-            JsonTypeInfo jsonTypeInfo = GetTypeInfo(returnType, options);
-            return ReadUsingMetadata<TValue>(ref reader, jsonTypeInfo);
-        }
-
-        private static TValue? ReadUsingMetadata<TValue>(ref Utf8JsonReader reader, JsonTypeInfo jsonTypeInfo)
+        private static TValue? Read<TValue>(ref Utf8JsonReader reader, JsonTypeInfo jsonTypeInfo)
         {
             ReadStack state = default;
             state.Initialize(jsonTypeInfo);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.ByteArray.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.ByteArray.cs
@@ -24,7 +24,8 @@ namespace System.Text.Json
             TValue value,
             JsonSerializerOptions? options = null)
         {
-            return WriteCoreBytes(value, GetRuntimeType(value), options);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, typeof(TValue));
+            return WriteBytesUsingSerializer(value, jsonTypeInfo);
         }
 
         /// <summary>
@@ -50,10 +51,9 @@ namespace System.Text.Json
             Type inputType,
             JsonSerializerOptions? options = null)
         {
-            return WriteCoreBytes(
-                value!,
-                GetRuntimeTypeAndValidateInputType(value, inputType),
-                options);
+            Type runtimeType = GetRuntimeTypeAndValidateInputType(value, inputType);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, runtimeType);
+            return WriteBytesUsingSerializer(value, jsonTypeInfo);
         }
 
         /// <summary>
@@ -108,14 +108,8 @@ namespace System.Text.Json
             }
 
             Type runtimeType = GetRuntimeTypeAndValidateInputType(value, inputType);
-            return WriteBytesUsingGeneratedSerializer(value!, GetTypeInfo(context, runtimeType));
-        }
-
-        [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
-        private static byte[] WriteCoreBytes<TValue>(in TValue value, Type runtimeType, JsonSerializerOptions? options)
-        {
-            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, runtimeType);
-            return WriteBytesUsingSerializer(value, jsonTypeInfo);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(context, runtimeType);
+            return WriteBytesUsingGeneratedSerializer(value!, jsonTypeInfo);
         }
 
         private static byte[] WriteBytesUsingGeneratedSerializer<TValue>(in TValue value, JsonTypeInfo jsonTypeInfo)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.ByteArray.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.ByteArray.cs
@@ -24,7 +24,8 @@ namespace System.Text.Json
             TValue value,
             JsonSerializerOptions? options = null)
         {
-            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, typeof(TValue));
+            Type runtimeType = GetRuntimeType(value);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, runtimeType);
             return WriteBytesUsingSerializer(value, jsonTypeInfo);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.ByteArray.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.ByteArray.cs
@@ -76,7 +76,7 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(jsonTypeInfo));
             }
 
-            return WriteCoreBytes(value, jsonTypeInfo);
+            return WriteBytesUsingGeneratedSerializer(value, jsonTypeInfo);
         }
 
         /// <summary>
@@ -108,24 +108,37 @@ namespace System.Text.Json
             }
 
             Type runtimeType = GetRuntimeTypeAndValidateInputType(value, inputType);
-            return WriteCoreBytes(value!, GetTypeInfo(context, runtimeType));
+            return WriteBytesUsingGeneratedSerializer(value!, GetTypeInfo(context, runtimeType));
         }
 
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
         private static byte[] WriteCoreBytes<TValue>(in TValue value, Type runtimeType, JsonSerializerOptions? options)
         {
-            JsonTypeInfo jsonTypeInfo = GetTypeInfo(runtimeType, options);
-            return WriteCoreBytes(value, jsonTypeInfo);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, runtimeType);
+            return WriteBytesUsingSerializer(value, jsonTypeInfo);
         }
 
-        private static byte[] WriteCoreBytes<TValue>(in TValue value, JsonTypeInfo jsonTypeInfo)
+        private static byte[] WriteBytesUsingGeneratedSerializer<TValue>(in TValue value, JsonTypeInfo jsonTypeInfo)
         {
             JsonSerializerOptions options = jsonTypeInfo.Options;
 
             using var output = new PooledByteBufferWriter(options.DefaultBufferSize);
             using (var writer = new Utf8JsonWriter(output, options.GetWriterOptions()))
             {
-                WriteUsingMetadata(writer, value, jsonTypeInfo);
+                WriteUsingGeneratedSerializer(writer, value, jsonTypeInfo);
+            }
+
+            return output.WrittenMemory.ToArray();
+        }
+
+        private static byte[] WriteBytesUsingSerializer<TValue>(in TValue value, JsonTypeInfo jsonTypeInfo)
+        {
+            JsonSerializerOptions options = jsonTypeInfo.Options;
+
+            using var output = new PooledByteBufferWriter(options.DefaultBufferSize);
+            using (var writer = new Utf8JsonWriter(output, options.GetWriterOptions()))
+            {
+                WriteUsingSerializer(writer, value, jsonTypeInfo);
             }
 
             return output.WrittenMemory.ToArray();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Element.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Element.cs
@@ -21,8 +21,12 @@ namespace System.Text.Json
         /// for <typeparamref name="TValue"/> or its serializable members.
         /// </exception>
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
-        public static JsonElement SerializeToElement<TValue>(TValue value, JsonSerializerOptions? options = null) =>
-            WriteElement(value, GetRuntimeType(value), options);
+        public static JsonElement SerializeToElement<TValue>(TValue value, JsonSerializerOptions? options = null)
+        {
+            Type runtimeType = GetRuntimeType(value);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, runtimeType);
+            return WriteElementUsingSerializer(value, jsonTypeInfo);
+        }
 
         /// <summary>
         /// Converts the provided value into a <see cref="JsonDocument"/>.
@@ -42,11 +46,12 @@ namespace System.Text.Json
         /// for <paramref name="inputType"/>  or its serializable members.
         /// </exception>
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
-        public static JsonElement SerializeToElement(object? value, Type inputType, JsonSerializerOptions? options = null) =>
-            WriteElement(
-                value,
-                GetRuntimeTypeAndValidateInputType(value, inputType),
-                options);
+        public static JsonElement SerializeToElement(object? value, Type inputType, JsonSerializerOptions? options = null)
+        {
+            Type type = GetRuntimeTypeAndValidateInputType(value, inputType);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, type);
+            return WriteElementUsingSerializer(value, jsonTypeInfo);
+        }
 
         /// <summary>
         /// Converts the provided value into a <see cref="JsonDocument"/>.
@@ -68,7 +73,7 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(jsonTypeInfo));
             }
 
-            return WriteElement(value, jsonTypeInfo);
+            return WriteElementUsingGeneratedSerializer(value, jsonTypeInfo);
         }
 
         /// <summary>
@@ -96,18 +101,12 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(context));
             }
 
-            Type runtimeType = GetRuntimeTypeAndValidateInputType(value, inputType);
-            return WriteElement(value, GetTypeInfo(context, runtimeType));
+            Type type = GetRuntimeTypeAndValidateInputType(value, inputType);
+            JsonTypeInfo typeInfo = GetTypeInfo(context, type);
+            return WriteElementUsingGeneratedSerializer(value, typeInfo);
         }
 
-        [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
-        private static JsonElement WriteElement<TValue>(in TValue value, Type runtimeType, JsonSerializerOptions? options)
-        {
-            JsonTypeInfo typeInfo = GetTypeInfo(runtimeType, options);
-            return WriteElement(value, typeInfo);
-        }
-
-        private static JsonElement WriteElement<TValue>(in TValue value, JsonTypeInfo jsonTypeInfo)
+        private static JsonElement WriteElementUsingGeneratedSerializer<TValue>(in TValue value, JsonTypeInfo jsonTypeInfo)
         {
             JsonSerializerOptions options = jsonTypeInfo.Options;
             Debug.Assert(options != null);
@@ -116,7 +115,22 @@ namespace System.Text.Json
             using var output = new PooledByteBufferWriter(options.DefaultBufferSize);
             using (var writer = new Utf8JsonWriter(output, options.GetWriterOptions()))
             {
-                WriteUsingMetadata(writer, value, jsonTypeInfo);
+                WriteUsingGeneratedSerializer(writer, value, jsonTypeInfo);
+            }
+
+            return JsonElement.ParseValue(output.WrittenMemory.Span, options.GetDocumentOptions());
+        }
+
+        private static JsonElement WriteElementUsingSerializer<TValue>(in TValue value, JsonTypeInfo jsonTypeInfo)
+        {
+            JsonSerializerOptions options = jsonTypeInfo.Options;
+            Debug.Assert(options != null);
+
+            // For performance, share the same buffer across serialization and deserialization.
+            using var output = new PooledByteBufferWriter(options.DefaultBufferSize);
+            using (var writer = new Utf8JsonWriter(output, options.GetWriterOptions()))
+            {
+                WriteUsingSerializer(writer, value, jsonTypeInfo);
             }
 
             return JsonElement.ParseValue(output.WrittenMemory.Span, options.GetDocumentOptions());

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Element.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Element.cs
@@ -48,8 +48,8 @@ namespace System.Text.Json
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
         public static JsonElement SerializeToElement(object? value, Type inputType, JsonSerializerOptions? options = null)
         {
-            Type type = GetRuntimeTypeAndValidateInputType(value, inputType);
-            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, type);
+            Type runtimeType = GetRuntimeTypeAndValidateInputType(value, inputType);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, runtimeType);
             return WriteElementUsingSerializer(value, jsonTypeInfo);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
@@ -98,12 +98,12 @@ namespace System.Text.Json
 
         private static Type GetRuntimeTypeAndValidateInputType(object? value, Type inputType)
         {
-            if (inputType == null)
+            if (inputType is null)
             {
                 throw new ArgumentNullException(nameof(inputType));
             }
 
-            if (value != null)
+            if (value is not null)
             {
                 Type runtimeType = value.GetType();
                 if (!inputType.IsAssignableFrom(runtimeType))

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
@@ -58,7 +58,10 @@ namespace System.Text.Json
             Debug.Assert(writer != null);
 
             Debug.Assert(!jsonTypeInfo.HasSerialize ||
-                jsonTypeInfo is not JsonTypeInfo<TValue>, "Incorrect method called.");
+                jsonTypeInfo is not JsonTypeInfo<TValue> ||
+                jsonTypeInfo.Options._context == null ||
+                !jsonTypeInfo.Options._context.CanUseSerializationLogic,
+                "Incorrect method called. WriteUsingGeneratedSerializer() should have been called instead.");
 
             WriteStack state = default;
             state.Initialize(jsonTypeInfo, supportContinuation: false);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
@@ -37,6 +37,8 @@ namespace System.Text.Json
 
         private static void WriteUsingGeneratedSerializer<TValue>(Utf8JsonWriter writer, in TValue value, JsonTypeInfo jsonTypeInfo)
         {
+            Debug.Assert(writer != null);
+
             if (jsonTypeInfo.HasSerialize &&
                 jsonTypeInfo is JsonTypeInfo<TValue> typedInfo &&
                 typedInfo.Options._context?.CanUseSerializationLogic == true)
@@ -53,7 +55,10 @@ namespace System.Text.Json
 
         private static void WriteUsingSerializer<TValue>(Utf8JsonWriter writer, in TValue value, JsonTypeInfo jsonTypeInfo)
         {
-            Debug.Assert(jsonTypeInfo is not JsonTypeInfo<TValue>, "Incorrect method called.");
+            Debug.Assert(writer != null);
+
+            Debug.Assert(!jsonTypeInfo.HasSerialize ||
+                jsonTypeInfo is not JsonTypeInfo<TValue>, "Incorrect method called.");
 
             WriteStack state = default;
             state.Initialize(jsonTypeInfo, supportContinuation: false);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 
@@ -36,37 +35,57 @@ namespace System.Text.Json
             return success;
         }
 
-        private static void WriteUsingMetadata<TValue>(Utf8JsonWriter writer, in TValue value, JsonTypeInfo jsonTypeInfo)
+        private static void WriteUsingGeneratedSerializer<TValue>(Utf8JsonWriter writer, in TValue value, JsonTypeInfo jsonTypeInfo)
         {
-            if (jsonTypeInfo is JsonTypeInfo<TValue> typedInfo &&
-                typedInfo.Serialize != null &&
+            if (jsonTypeInfo.HasSerialize &&
+                jsonTypeInfo is JsonTypeInfo<TValue> typedInfo &&
                 typedInfo.Options._context?.CanUseSerializationLogic == true)
             {
+                Debug.Assert(typedInfo.Serialize != null);
                 typedInfo.Serialize(writer, value);
                 writer.Flush();
             }
             else
             {
-                WriteStack state = default;
-                state.Initialize(jsonTypeInfo, supportContinuation: false);
-
-                JsonConverter converter = jsonTypeInfo.PropertyInfoForTypeInfo.ConverterBase;
-                Debug.Assert(converter != null);
-
-                Debug.Assert(jsonTypeInfo.Options != null);
-
-                WriteCore(converter, writer, value, jsonTypeInfo.Options, ref state);
+                WriteUsingSerializer(writer, value, jsonTypeInfo);
             }
+        }
+
+        private static void WriteUsingSerializer<TValue>(Utf8JsonWriter writer, in TValue value, JsonTypeInfo jsonTypeInfo)
+        {
+            Debug.Assert(jsonTypeInfo is not JsonTypeInfo<TValue>, "Incorrect method called.");
+
+            WriteStack state = default;
+            state.Initialize(jsonTypeInfo, supportContinuation: false);
+
+            JsonConverter converter = jsonTypeInfo.PropertyInfoForTypeInfo.ConverterBase;
+            Debug.Assert(converter != null);
+            Debug.Assert(jsonTypeInfo.Options != null);
+
+            // For performance, the code below is a lifted WriteCore() above.
+            if (converter is JsonConverter<TValue> typedConverter)
+            {
+                // Call the strongly-typed WriteCore that will not box structs.
+                typedConverter.WriteCore(writer, value, jsonTypeInfo.Options, ref state);
+            }
+            else
+            {
+                // The non-generic API was called or we have a polymorphic case where TValue is not equal to the T in JsonConverter<T>.
+                converter.WriteCoreAsObject(writer, value, jsonTypeInfo.Options, ref state);
+            }
+
+            writer.Flush();
         }
 
         private static Type GetRuntimeType<TValue>(in TValue value)
         {
-            if (typeof(TValue) == typeof(object) && value != null)
+            Type type = typeof(TValue);
+            if (type == JsonTypeInfo.ObjectType && value is not null)
             {
-                return value.GetType();
+                type = value.GetType();
             }
 
-            return typeof(TValue);
+            return type;
         }
 
         private static Type GetRuntimeTypeAndValidateInputType(object? value, Type inputType)
@@ -84,7 +103,7 @@ namespace System.Text.Json
                     ThrowHelper.ThrowArgumentException_DeserializeWrongType(inputType, value);
                 }
 
-                if (inputType == typeof(object))
+                if (inputType == JsonTypeInfo.ObjectType)
                 {
                     return runtimeType;
                 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Node.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Node.cs
@@ -22,8 +22,12 @@ namespace System.Text.Json
         /// for <typeparamref name="TValue"/> or its serializable members.
         /// </exception>
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
-        public static JsonNode? SerializeToNode<TValue>(TValue value, JsonSerializerOptions? options = null) =>
-            WriteNode(value, GetRuntimeType(value), options);
+        public static JsonNode? SerializeToNode<TValue>(TValue value, JsonSerializerOptions? options = null)
+        {
+            Type runtimeType = GetRuntimeType(value);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, runtimeType);
+            return WriteNodeUsingSerializer(value, jsonTypeInfo);
+        }
 
         /// <summary>
         /// Converts the provided value into a <see cref="JsonNode"/>.
@@ -43,11 +47,12 @@ namespace System.Text.Json
         /// for <paramref name="inputType"/>  or its serializable members.
         /// </exception>
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
-        public static JsonNode? SerializeToNode(object? value, Type inputType, JsonSerializerOptions? options = null) =>
-            WriteNode(
-                value,
-                GetRuntimeTypeAndValidateInputType(value, inputType),
-                options);
+        public static JsonNode? SerializeToNode(object? value, Type inputType, JsonSerializerOptions? options = null)
+        {
+            Type runtimeType = GetRuntimeTypeAndValidateInputType(value, inputType);
+            JsonTypeInfo typeInfo = GetTypeInfo(options, runtimeType);
+            return WriteNodeUsingSerializer(value, typeInfo);
+        }
 
         /// <summary>
         /// Converts the provided value into a <see cref="JsonNode"/>.
@@ -69,7 +74,7 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(jsonTypeInfo));
             }
 
-            return WriteNode(value, jsonTypeInfo);
+            return WriteNodeUsingGeneratedSerializer(value, jsonTypeInfo);
         }
 
         /// <summary>
@@ -97,18 +102,11 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(context));
             }
 
-            Type runtimeType = GetRuntimeTypeAndValidateInputType(value, inputType);
-            return WriteNode(value, GetTypeInfo(context, runtimeType));
+            Type type = GetRuntimeTypeAndValidateInputType(value, inputType);
+            return WriteNodeUsingGeneratedSerializer(value, GetTypeInfo(context, type));
         }
 
-        [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
-        private static JsonNode? WriteNode<TValue>(in TValue value, Type runtimeType, JsonSerializerOptions? options)
-        {
-            JsonTypeInfo typeInfo = GetTypeInfo(runtimeType, options);
-            return WriteNode(value, typeInfo);
-        }
-
-        private static JsonNode? WriteNode<TValue>(in TValue value, JsonTypeInfo jsonTypeInfo)
+        private static JsonNode? WriteNodeUsingGeneratedSerializer<TValue>(in TValue value, JsonTypeInfo jsonTypeInfo)
         {
             JsonSerializerOptions options = jsonTypeInfo.Options;
             Debug.Assert(options != null);
@@ -117,7 +115,22 @@ namespace System.Text.Json
             using var output = new PooledByteBufferWriter(options.DefaultBufferSize);
             using (var writer = new Utf8JsonWriter(output, options.GetWriterOptions()))
             {
-                WriteUsingMetadata(writer, value, jsonTypeInfo);
+                WriteUsingGeneratedSerializer(writer, value, jsonTypeInfo);
+            }
+
+            return JsonNode.Parse(output.WrittenMemory.Span, options.GetNodeOptions());
+        }
+
+        private static JsonNode? WriteNodeUsingSerializer<TValue>(in TValue value, JsonTypeInfo jsonTypeInfo)
+        {
+            JsonSerializerOptions options = jsonTypeInfo.Options;
+            Debug.Assert(options != null);
+
+            // For performance, share the same buffer across serialization and deserialization.
+            using var output = new PooledByteBufferWriter(options.DefaultBufferSize);
+            using (var writer = new Utf8JsonWriter(output, options.GetWriterOptions()))
+            {
+                WriteUsingSerializer(writer, value, jsonTypeInfo);
             }
 
             return JsonNode.Parse(output.WrittenMemory.Span, options.GetNodeOptions());

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Node.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Node.cs
@@ -103,7 +103,8 @@ namespace System.Text.Json
             }
 
             Type runtimeType = GetRuntimeTypeAndValidateInputType(value, inputType);
-            return WriteNodeUsingGeneratedSerializer(value, GetTypeInfo(context, runtimeType));
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(context, runtimeType);
+            return WriteNodeUsingGeneratedSerializer(value, jsonTypeInfo);
         }
 
         private static JsonNode? WriteNodeUsingGeneratedSerializer<TValue>(in TValue value, JsonTypeInfo jsonTypeInfo)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Node.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Node.cs
@@ -102,8 +102,8 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(context));
             }
 
-            Type type = GetRuntimeTypeAndValidateInputType(value, inputType);
-            return WriteNodeUsingGeneratedSerializer(value, GetTypeInfo(context, type));
+            Type runtimeType = GetRuntimeTypeAndValidateInputType(value, inputType);
+            return WriteNodeUsingGeneratedSerializer(value, GetTypeInfo(context, runtimeType));
         }
 
         private static JsonNode? WriteNodeUsingGeneratedSerializer<TValue>(in TValue value, JsonTypeInfo jsonTypeInfo)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -184,7 +184,7 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(jsonTypeInfo));
             }
 
-            return WriteAsyncCore(utf8Json, value, jsonTypeInfo, cancellationToken);
+            return WriteStreamAsync(utf8Json, value, jsonTypeInfo, cancellationToken);
         }
 
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -318,7 +318,7 @@ namespace System.Text.Json
             JsonSerializerOptions? options,
             CancellationToken cancellationToken)
         {
-            JsonTypeInfo jsonTypeInfo = GetTypeInfo(runtimeType, options);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, runtimeType);
             return WriteAsyncCore(utf8Json, value!, jsonTypeInfo, cancellationToken);
         }
 
@@ -329,7 +329,7 @@ namespace System.Text.Json
             Type runtimeType,
             JsonSerializerOptions? options)
         {
-            JsonTypeInfo jsonTypeInfo = GetTypeInfo(runtimeType, options);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, runtimeType);
             WriteCore(utf8Json, value!, jsonTypeInfo);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -48,14 +48,10 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(utf8Json));
             }
 
-            return WriteAsync(
-                utf8Json,
-                value,
-                GetRuntimeType(value),
-                options,
-                cancellationToken);
+            Type runtimeType = GetRuntimeType(value);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, runtimeType);
+            return WriteStreamAsync(utf8Json, value!, jsonTypeInfo, cancellationToken);
         }
-
 
         /// <summary>
         /// Converts the provided value to UTF-8 encoded JSON text and write it to the <see cref="System.IO.Stream"/>.
@@ -81,11 +77,9 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(utf8Json));
             }
 
-            Write(
-                utf8Json,
-                value,
-                GetRuntimeType(value),
-                options);
+            Type runtimeType = GetRuntimeType(value);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, runtimeType);
+            WriteStream(utf8Json, value!, jsonTypeInfo);
         }
 
         /// <summary>
@@ -120,12 +114,9 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(utf8Json));
             }
 
-            return WriteAsync<object?>(
-                utf8Json,
-                value!,
-                GetRuntimeTypeAndValidateInputType(value, inputType),
-                options,
-                cancellationToken);
+            Type runtimeType = GetRuntimeTypeAndValidateInputType(value, inputType);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, runtimeType);
+            return WriteStreamAsync(utf8Json, value!, jsonTypeInfo, cancellationToken);
         }
 
         /// <summary>
@@ -157,11 +148,9 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(utf8Json));
             }
 
-            Write<object?>(
-                utf8Json,
-                value!,
-                GetRuntimeTypeAndValidateInputType(value, inputType),
-                options);
+            Type runtimeType = GetRuntimeTypeAndValidateInputType(value, inputType);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, runtimeType);
+            WriteStream(utf8Json, value!, jsonTypeInfo);
         }
 
         /// <summary>
@@ -226,7 +215,7 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(jsonTypeInfo));
             }
 
-            WriteCore(utf8Json, value, jsonTypeInfo);
+            WriteStream(utf8Json, value, jsonTypeInfo);
         }
 
         /// <summary>
@@ -266,7 +255,7 @@ namespace System.Text.Json
             }
 
             Type runtimeType = GetRuntimeTypeAndValidateInputType(value, inputType);
-            return WriteAsyncCore(
+            return WriteStreamAsync(
                 utf8Json,
                 value!,
                 GetTypeInfo(context, runtimeType),
@@ -307,33 +296,10 @@ namespace System.Text.Json
             }
 
             Type runtimeType = GetRuntimeTypeAndValidateInputType(value, inputType);
-            WriteCore(utf8Json, value!, GetTypeInfo(context, runtimeType));
+            WriteStream(utf8Json, value!, GetTypeInfo(context, runtimeType));
         }
 
-        [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
-        private static Task WriteAsync<TValue>(
-            Stream utf8Json,
-            in TValue value,
-            Type runtimeType,
-            JsonSerializerOptions? options,
-            CancellationToken cancellationToken)
-        {
-            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, runtimeType);
-            return WriteAsyncCore(utf8Json, value!, jsonTypeInfo, cancellationToken);
-        }
-
-        [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
-        private static void Write<TValue>(
-            Stream utf8Json,
-            in TValue value,
-            Type runtimeType,
-            JsonSerializerOptions? options)
-        {
-            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, runtimeType);
-            WriteCore(utf8Json, value!, jsonTypeInfo);
-        }
-
-        private static async Task WriteAsyncCore<TValue>(
+        private static async Task WriteStreamAsync<TValue>(
             Stream utf8Json,
             TValue value,
             JsonTypeInfo jsonTypeInfo,
@@ -394,7 +360,7 @@ namespace System.Text.Json
             }
         }
 
-        private static void WriteCore<TValue>(
+        private static void WriteStream<TValue>(
             Stream utf8Json,
             in TValue value,
             JsonTypeInfo jsonTypeInfo)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Utf8JsonWriter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Utf8JsonWriter.cs
@@ -28,7 +28,14 @@ namespace System.Text.Json
             TValue value,
             JsonSerializerOptions? options = null)
         {
-            Serialize(writer, value, GetRuntimeType(value), options);
+            if (writer == null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
+            Type runtimeType = GetRuntimeType(value);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, runtimeType);
+            WriteUsingSerializer(writer, value, jsonTypeInfo);
         }
 
         /// <summary>
@@ -55,11 +62,14 @@ namespace System.Text.Json
             Type inputType,
             JsonSerializerOptions? options = null)
         {
-            Serialize<object?>(
-                writer,
-                value,
-                GetRuntimeTypeAndValidateInputType(value, inputType),
-                options);
+            if (writer == null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
+            Type runtimeType = GetRuntimeTypeAndValidateInputType(value, inputType);
+            JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, runtimeType);
+            WriteUsingSerializer(writer, value, jsonTypeInfo);
         }
 
         /// <summary>
@@ -87,7 +97,7 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(jsonTypeInfo));
             }
 
-            WriteUsingMetadata(writer, value, jsonTypeInfo);
+            WriteUsingGeneratedSerializer(writer, value, jsonTypeInfo);
         }
 
         /// <summary>
@@ -124,19 +134,7 @@ namespace System.Text.Json
             }
 
             Type runtimeType = GetRuntimeTypeAndValidateInputType(value, inputType);
-            WriteUsingMetadata(writer, value, GetTypeInfo(context, runtimeType));
-        }
-
-        [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
-        private static void Serialize<TValue>(Utf8JsonWriter writer, in TValue value, Type runtimeType, JsonSerializerOptions? options)
-        {
-            if (writer == null)
-            {
-                throw new ArgumentNullException(nameof(writer));
-            }
-
-            JsonTypeInfo typeInfo = GetTypeInfo(runtimeType, options);
-            WriteUsingMetadata(writer, value, typeInfo);
+            WriteUsingGeneratedSerializer(writer, value, GetTypeInfo(context, runtimeType));
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -30,8 +30,8 @@ namespace System.Text.Json
         [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
         private void RootBuiltInConverters()
         {
-            s_defaultSimpleConverters ??= GetDefaultSimpleConverters();
-            s_defaultFactoryConverters ??= new JsonConverter[]
+            s_defaultSimpleConverters = GetDefaultSimpleConverters();
+            s_defaultFactoryConverters = new JsonConverter[]
             {
                 // Check for disallowed types.
                 new DisallowedTypeConverterFactory(),

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -247,8 +247,6 @@ namespace System.Text.Json
             }
         }
 
-        internal bool IsInitializedForReflectionSerializer { get; set; }
-
         /// <summary>
         /// Determines whether null values are ignored during serialization and deserialization.
         /// The default value is false.
@@ -577,6 +575,15 @@ namespace System.Text.Json
             }
         }
 
+        /// <summary>
+        /// Whether <see cref="InitializeForReflectionSerializer()"/> needs to be called.
+        /// </summary>
+        internal bool IsInitializedForReflectionSerializer { get; set; }
+
+        /// <summary>
+        /// Initializes the converters for the reflection-based serializer.
+        /// <seealso cref="InitializeForReflectionSerializer"/> must be checked before calling.
+        /// </summary>
         [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
         internal void InitializeForReflectionSerializer()
         {
@@ -624,6 +631,7 @@ namespace System.Text.Json
         /// Return the TypeInfo for root API calls.
         /// This has a LRU cache that is intended only for public API calls that specify the root type.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal JsonTypeInfo GetOrAddClassForRootType(Type type)
         {
             JsonTypeInfo? jsonTypeInfo = _lastClass;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -247,6 +247,8 @@ namespace System.Text.Json
             }
         }
 
+        internal bool IsInitializedForReflectionSerializer { get; set; }
+
         /// <summary>
         /// Determines whether null values are ignored during serialization and deserialization.
         /// The default value is false.
@@ -576,10 +578,12 @@ namespace System.Text.Json
         }
 
         [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
-        internal void RootBuiltInConvertersAndTypeInfoCreator()
+        internal void InitializeForReflectionSerializer()
         {
+            // For threading cases, the state that is set here can be overwritten.
             RootBuiltInConverters();
-            _typeInfoCreationFunc ??= CreateJsonTypeInfo;
+            _typeInfoCreationFunc = CreateJsonTypeInfo;
+            IsInitializedForReflectionSerializer = true;
 
             [RequiresUnreferencedCode(JsonSerializer.SerializationUnreferencedCodeMessage)]
             static JsonTypeInfo CreateJsonTypeInfo(Type type, JsonSerializerOptions options) => new JsonTypeInfo(type, options);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -33,6 +33,9 @@ namespace System.Text.Json.Serialization.Metadata
         // If enumerable or dictionary, the JsonTypeInfo for the element type.
         private JsonTypeInfo? _elementTypeInfo;
 
+        // Avoids having to perform an expensive cast to JsonTypeInfo<T> to check if there is a Serialize method.
+        internal bool HasSerialize { get; set; }
+
         /// <summary>
         /// Return the JsonTypeInfo for the element type, or null if the type is not an enumerable or dictionary.
         /// </summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.cs
@@ -13,6 +13,8 @@ namespace System.Text.Json.Serialization.Metadata
     [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class JsonTypeInfo<T> : JsonTypeInfo
     {
+        private Action<Utf8JsonWriter, T>? _serialize;
+
         internal JsonTypeInfo(Type type, JsonSerializerOptions options, ConverterStrategy converterStrategy) :
             base(type, options, converterStrategy)
         { }
@@ -26,6 +28,17 @@ namespace System.Text.Json.Serialization.Metadata
         /// A method that serializes an instance of <typeparamref name="T"/> using
         /// <see cref="JsonSourceGenerationOptionsAttribute"/> values specified at design time.
         /// </summary>
-        public Action<Utf8JsonWriter, T>? Serialize { get; private protected set; }
+        public Action<Utf8JsonWriter, T>? Serialize
+        {
+            get
+            {
+                return _serialize;
+            }
+            private protected set
+            {
+                _serialize = value;
+                HasSerialize = value != null;
+            }
+        }
     }
 }


### PR DESCRIPTION
Primarily addresses serializer overhead of a given call, but there are general gains throughout.

Changes include:
- Manual inlinining \ lifting of serializer calls. This avoids some `if` statements and the smaller size appears to help the jitter.
- Avoids a cast against `JsonTypeInfo<T>` in unnecessary cases during serialization; this is expected to help perf for source-gen when falling back to the serializer.
- Use of `[MethodImplOptions.AggressiveOptimization]` in hot, looping methods.
- Optimized check for `null` when serializing either `Nullable<T>` and non-`Nullable<T>`.
- Misc others, including some consistency changes for variable and method names.

It primarily resolves this issue with overhead:
resolves https://github.com/dotnet/runtime/issues/56993
<details>
  <summary>Overhead</summary>

A class with no members:

5.0
|      Method |      Mean |    Error |   StdDev |  Gen 0 | Allocated |
|------------ |----------:|---------:|---------:|-------:|----------:|
|   Serialize |  85.53 ns | 0.375 ns | 0.351 ns |      - |         - |
| Deserialize | 268.87 ns | 1.627 ns | 1.522 ns | 0.0049 |      32 B |

6.0 before this PR
|      Method |     Mean |   Error |  StdDev |  Gen 0 | Allocated |
|------------ |---------:|--------:|--------:|-------:|----------:|
|   Serialize | 106.5 ns | 0.55 ns | 0.49 ns |      - |         - |
| Deserialize | 267.9 ns | 0.55 ns | 0.49 ns | 0.0049 |      32 B |

6.0 with this PR
|      Method |      Mean |    Error |   StdDev |  Gen 0 | Allocated |
|------------ |----------:|---------:|---------:|-------:|----------:|
|   Serialize |  85.88 ns | 0.527 ns | 0.493 ns |      - |         - |
| Deserialize | 263.78 ns | 2.824 ns | 2.503 ns | 0.0049 |      32 B |

Serialize overhead: 1.24x faster
Deserialize overhead: 1.015x faster

Also, if this test is changed to add 2 String properties:

5.0
|      Method |     Mean |   Error |  StdDev |  Gen 0 | Allocated |
|------------ |---------:|--------:|--------:|-------:|----------:|
|   Serialize | 196.3 ns | 1.31 ns | 1.16 ns |      - |         - |
| Deserialize | 341.1 ns | 0.74 ns | 0.70 ns | 0.0161 |     104 B |

6.0 before this PR
|      Method |     Mean |   Error |  StdDev |  Gen 0 | Allocated |
|------------ |---------:|--------:|--------:|-------:|----------:|
|   Serialize | 218.2 ns | 1.06 ns | 0.94 ns |      - |         - |
| Deserialize | 334.5 ns | 0.71 ns | 0.63 ns | 0.0161 |     104 B |

6.0 before this PR
|      Method |     Mean |   Error |  StdDev |  Gen 0 | Allocated |
|------------ |---------:|--------:|--------:|-------:|----------:|
|   Serialize | 198.4 ns | 2.19 ns | 2.05 ns |      - |         - |
| Deserialize | 324.2 ns | 2.35 ns | 2.08 ns | 0.0161 |     104 B |

Serialize: 1.1x faster compared to before this PR
Deserialize: 1.03x faster compared to before this PR
</details>

but also should resolve these (verification needed for some):

resolves https://github.com/dotnet/runtime/issues/57093
resolves https://github.com/dotnet/runtime/issues/52640
resolves https://github.com/dotnet/runtime/issues/52311
resolves https://github.com/dotnet/runtime/issues/43413

<details>
  <summary>Improvements in benchmarks with this PR</summary>

```
note: threshold is 2%
summary:
better: 31, geomean: 1.057
worse: 2, geomean: 1.071
total diff: 33
```

| Slower                                                                           | diff/base | Base Median (ns) | Diff Median (ns) | Modality|
| -------------------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| -------- |
| System.Text.Json.Serialization.Tests.ReadJson<Location>.DeserializeFromStream    |      1.11 |          1386.49 |          1540.57 | bimodal |
| System.Text.Json.Serialization.Tests.WriteJson<MyEventsListerViewModel>.Serializ |      1.03 |        377918.23 |        390056.88 |         |

| Faster                                                                           | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| -------------------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Text.Json.Serialization.Tests.WriteJson<Int32>.SerializeToUtf8Bytes       |      1.19 |           119.98 |           100.69 |         |
| System.Text.Json.Serialization.Tests.WriteJson<Int32>.SerializeToString          |      1.16 |           137.06 |           117.90 |         |
| System.Text.Json.Serialization.Tests.WriteJson<Int32>.SerializeObjectProperty    |      1.09 |           246.90 |           225.56 |         |
| System.Text.Json.Serialization.Tests.WriteJson<LoginViewModel>.SerializeObjectPr |      1.09 |           505.15 |           462.27 |         |
| System.Text.Json.Serialization.Tests.WriteJson<ArrayList>.SerializeToString      |      1.08 |          7678.84 |          7140.75 |         |
| System.Text.Json.Serialization.Tests.WriteJson<SimpleStructWithProperties>.Seria |      1.07 |           251.04 |           234.99 |         |
| System.Text.Json.Serialization.Tests.WriteJson<LargeStructWithProperties>.Serial |      1.06 |           622.98 |           586.76 |         |
| System.Text.Json.Serialization.Tests.WriteJson<LoginViewModel>.SerializeToUtf8By |      1.06 |           303.54 |           286.05 |         |
| System.Text.Json.Serialization.Tests.ReadJson<LoginViewModel>.DeserializeFromUtf |      1.06 |           393.55 |           371.04 |         |
| System.Text.Json.Serialization.Tests.WriteJson<SimpleStructWithProperties>.Seria |      1.06 |           412.13 |           388.94 |         |
| System.Text.Json.Serialization.Tests.WriteJson<LargeStructWithProperties>.Serial |      1.06 |           862.66 |           815.38 |         |
| System.Text.Json.Serialization.Tests.ReadJson<Int32>.DeserializeFromString       |      1.06 |           124.69 |           118.10 |         |
| System.Text.Json.Serialization.Tests.ReadJson<SimpleStructWithProperties>.Deseri |      1.05 |           559.86 |           530.84 |         |
| System.Text.Json.Serialization.Tests.WriteJson<LoginViewModel>.SerializeToString |      1.05 |           331.31 |           314.80 |         |
| System.Text.Json.Serialization.Tests.WriteJson<SimpleStructWithProperties>.Seria |      1.05 |           225.08 |           214.83 |         |
| System.Text.Json.Serialization.Tests.WriteJson<Location>.SerializeToString       |      1.05 |           810.09 |           774.23 |         |
| System.Text.Json.Serialization.Tests.WriteJson<ArrayList>.SerializeToUtf8Bytes   |      1.05 |          7249.32 |          6936.89 |         |
| System.Text.Json.Serialization.Tests.ReadJson<SimpleStructWithProperties>.Deseri |      1.04 |           334.56 |           320.96 |         |
| System.Text.Json.Serialization.Tests.WriteJson<BinaryData>.SerializeToUtf8Bytes  |      1.04 |           390.61 |           374.94 |         |
| System.Text.Json.Serialization.Tests.ReadJson<LoginViewModel>.DeserializeFromStr |      1.04 |           729.07 |           700.01 |         |
| System.Text.Json.Serialization.Tests.ReadJson<Location>.DeserializeFromUtf8Bytes |      1.04 |          1076.71 |          1035.66 |         |
| System.Text.Json.Serialization.Tests.WriteJson<Location>.SerializeToUtf8Bytes    |      1.04 |           779.50 |           750.04 |         |
| System.Text.Json.Serialization.Tests.WriteJson<BinaryData>.SerializeToString     |      1.04 |           543.79 |           523.71 |         |
| System.Text.Json.Serialization.Tests.WriteJson<LargeStructWithProperties>.Serial |      1.04 |           658.87 |           636.45 |         |
| System.Text.Json.Serialization.Tests.ReadJson<Int32>.DeserializeFromUtf8Bytes    |      1.03 |            74.08 |            71.59 |         |
| System.Text.Json.Serialization.Tests.WriteJson<LargeStructWithProperties>.Serial |      1.03 |           774.83 |           748.87 |         |
| System.Text.Json.Serialization.Tests.WriteJson<MyEventsListerViewModel>.Serializ |      1.03 |        379279.76 |        367081.10 |         |
| System.Text.Json.Serialization.Tests.ReadJson<LargeStructWithProperties>.Deseria |      1.03 |          1145.78 |          1114.74 |         |
| System.Text.Json.Serialization.Tests.ReadJson<LargeStructWithProperties>.Deseria |      1.03 |          1556.95 |          1515.01 |         |
| System.Text.Json.Serialization.Tests.ReadJson<Int32>.DeserializeFromStream       |      1.03 |           298.83 |           290.81 |         |
| System.Text.Json.Serialization.Tests.WriteJson<HashSet<String>>.SerializeToStrin |      1.03 |          6444.12 |          6282.43 |         |
</details>


<details>
  <summary>6.0 status (with this PR) of benchmarks compared to 5.0 </summary>

```
note: threshold is 2%
summary:
better: 22, geomean: 1.268
worse: 2, geomean: 1.065
total diff: 24
```

| Slower                                                                           | diff/base | Base Median (ns) | Diff Median (ns) | Modality|
| -------------------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Text.Json.Serialization.Tests.ReadJson<SimpleStructWithProperties>.Deseri |      1.10 |           482.68 |           530.03 |         |
| System.Text.Json.Serialization.Tests.ReadJson<LoginViewModel>.DeserializeFromStr |      1.03 |           668.86 |           690.92 |         |

| Faster                                                                           | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| -------------------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Text.Json.Serialization.Tests.ReadJson<ArrayList>.DeserializeFromString   |      2.13 |         47511.77 |         22281.48 |         |
| System.Text.Json.Serialization.Tests.ReadJson<ArrayList>.DeserializeFromStream   |      2.10 |         47456.53 |         22649.40 |         |
| System.Text.Json.Serialization.Tests.ReadJson<ArrayList>.DeserializeFromUtf8Byte |      2.07 |         46860.63 |         22584.86 |         |
| System.Text.Json.Serialization.Tests.ReadJson<Hashtable>.DeserializeFromString   |      1.88 |         67083.49 |         35639.60 |         |
| System.Text.Json.Serialization.Tests.ReadJson<Hashtable>.DeserializeFromUtf8Byte |      1.76 |         63251.21 |         35890.00 |         |
| System.Text.Json.Serialization.Tests.ReadJson<Hashtable>.DeserializeFromStream   |      1.74 |         63594.48 |         36651.60 |         |
| System.Text.Json.Serialization.Tests.ReadJson<ImmutableDictionary<String, String |      1.14 |         45314.11 |         39891.80 |         |
| System.Text.Json.Serialization.Tests.ReadJson<ImmutableDictionary<String, String |      1.12 |         45394.56 |         40385.56 |         |
| System.Text.Json.Serialization.Tests.ReadJson<HashSet<String>>.DeserializeFromUt |      1.11 |         11901.75 |         10722.24 |         |
| System.Text.Json.Serialization.Tests.ReadJson<Dictionary<String, String>>.Deseri |      1.11 |         21191.19 |         19168.64 |         |
| System.Text.Json.Serialization.Tests.ReadJson<HashSet<String>>.DeserializeFromSt |      1.10 |         12139.81 |         11039.48 |         |
| System.Text.Json.Serialization.Tests.ReadJson<ImmutableSortedDictionary<String,  |      1.10 |         75880.24 |         69099.21 |         |
| System.Text.Json.Serialization.Tests.ReadJson<ImmutableDictionary<String, String |      1.09 |         47138.25 |         43118.00 |         |
| System.Text.Json.Serialization.Tests.ReadJson<IndexViewModel>.DeserializeFromStr |      1.09 |         29213.97 |         26797.27 |         |
| System.Text.Json.Serialization.Tests.ReadJson<Dictionary<String, String>>.Deseri |      1.08 |         20351.18 |         18857.99 |         |
| System.Text.Json.Serialization.Tests.ReadJson<IndexViewModel>.DeserializeFromUtf |      1.07 |         27666.04 |         25944.15 |         |
| System.Text.Json.Serialization.Tests.ReadJson<Dictionary<String, String>>.Deseri |      1.07 |         22345.68 |         20956.26 |         |
| System.Text.Json.Serialization.Tests.ReadJson<Location>.DeserializeFromUtf8Bytes |      1.06 |          1105.41 |          1039.88 |         |
| System.Text.Json.Serialization.Tests.ReadJson<Location>.DeserializeFromString    |      1.06 |          1178.27 |          1113.83 |         |
| System.Text.Json.Serialization.Tests.ReadJson<ImmutableSortedDictionary<String,  |      1.05 |         75538.87 |         72250.75 |         |
| System.Text.Json.Serialization.Tests.ReadJson<BinaryData>.DeserializeFromString  |      1.04 |           587.58 |           564.27 |         |
| System.Text.Json.Serialization.Tests.ReadJson<HashSet<String>>.DeserializeFromSt |      1.03 |         12883.77 |         12530.95 |         |

</summary>