### PR TITLE
Zero upper 4 bytes of the second operand of Vector3.Dot

### DIFF
--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -1190,6 +1190,17 @@ void Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
         op1 = comp->gtNewSimdAsHWIntrinsicNode(simdType, op1, idx, tmp1, NI_AdvSimd_Insert, simdBaseJitType, simdSize);
         BlockRange().InsertAfter(tmp1, op1);
         LowerNode(op1);
+
+        idx = comp->gtNewIconNode(0x03, TYP_INT);
+        BlockRange().InsertAfter(op2, idx);
+
+        tmp2 = comp->gtNewZeroConNode(TYP_FLOAT);
+        BlockRange().InsertAfter(idx, tmp2);
+        LowerNode(tmp2);
+
+        op2 = comp->gtNewSimdAsHWIntrinsicNode(simdType, op2, idx, tmp2, NI_AdvSimd_Insert, simdBaseJitType, simdSize);
+        BlockRange().InsertAfter(tmp2, op2);
+        LowerNode(op2);
     }
 
     // We will be constructing the following parts:


### PR DESCRIPTION
In #53838 during ReversePIinvoke Vector3 (SIMD12) value is passed on the stack as an argument to a managed method.

When we read from such location there is no guarantee that upper 4 bytes are zero, hence the lower inserts a sequence of LIR nodes that insert a zero value (of type `float32`) into `op1[3]`. The generation of similar instruction sequence for zeroing `op2[3]` is omitted in lower making the result of `Vector3.Dot` operation depending on the value of this field (and if the field value is `NaN` then the operation result becomes `NaN`).

Unfortunately, I don't think I would be able reproduce the issue in a regression test (I can not control what C++ compiler generates), so for validation I will rely on the fact that Vector3Interop_r and Vector3Interop_ro tests fail reliable in runtime-coreclr pgo CI pipeline.

@AndyAyersMS @dotnet/jit-contrib PTAL
cc @tannergooding 

Fixes #53838