### PR TITLE
Initialize compCurBB during fgInsertGCPoll

### DIFF
--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -93,6 +93,8 @@ PhaseStatus Compiler::fgInsertGCPolls()
     // Walk through the blocks and hunt for a block that needs a GC Poll
     for (block = fgFirstBB; block != nullptr; block = block->bbNext)
     {
+        compCurBB = block;
+
         // When optimizations are enabled, we can't rely on BBF_HAS_SUPPRESSGC_CALL flag:
         // the call could've been moved, e.g., hoisted from a loop, CSE'd, etc.
         if (opts.OptimizationDisabled() ? ((block->bbFlags & BBF_HAS_SUPPRESSGC_CALL) == 0) : !blockNeedsGCPoll(block))

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -88,8 +88,10 @@ PhaseStatus Compiler::fgInsertGCPolls()
     }
 #endif // DEBUG
 
+    BasicBlock* block;
+
     // Walk through the blocks and hunt for a block that needs a GC Poll
-    for (BasicBlock* block : Blocks())
+    for (block = fgFirstBB; block != nullptr; block = block->bbNext)
     {
         compCurBB = block;
 

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -88,10 +88,8 @@ PhaseStatus Compiler::fgInsertGCPolls()
     }
 #endif // DEBUG
 
-    BasicBlock* block;
-
     // Walk through the blocks and hunt for a block that needs a GC Poll
-    for (BasicBlock* const block : Blocks())
+    for (BasicBlock* block : Blocks())
     {
         compCurBB = block;
 

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -91,7 +91,7 @@ PhaseStatus Compiler::fgInsertGCPolls()
     BasicBlock* block;
 
     // Walk through the blocks and hunt for a block that needs a GC Poll
-    for (block = fgFirstBB; block != nullptr; block = block->bbNext)
+    for (BasicBlock* const block : Blocks())
     {
         compCurBB = block;
 

--- a/src/tests/JIT/Directed/coverage/flowgraph/gcpoll.cs
+++ b/src/tests/JIT/Directed/coverage/flowgraph/gcpoll.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.using System;
+using System;
+
+public class TestClass13
+{
+    // With below flags, we were using uninitialized compCurBB during insertGCPolls()
+    // COMPlus_JitDoAssertionProp=0
+    // COMPlus_JitNoCSE=1
+    public void Method0()
+    {
+        Console.WriteLine();
+    }
+    public static void Main(string[] args)
+    {
+        TestClass13 objTestClass13 = new TestClass13();
+        objTestClass13.Method0();
+    }
+}

--- a/src/tests/JIT/Directed/coverage/flowgraph/gcpoll.cs
+++ b/src/tests/JIT/Directed/coverage/flowgraph/gcpoll.cs
@@ -11,9 +11,10 @@ public class TestClass13
     {
         Console.WriteLine();
     }
-    public static void Main(string[] args)
+    public static int Main(string[] args)
     {
         TestClass13 objTestClass13 = new TestClass13();
         objTestClass13.Method0();
+        return 100;
     }
 }

--- a/src/tests/JIT/Directed/coverage/flowgraph/gcpoll.csproj
+++ b/src/tests/JIT/Directed/coverage/flowgraph/gcpoll.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+   <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_JitDoAssertionProp=0
+set COMPlus_JitNoCSE=1
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_JitDoAssertionProp=0
+export COMPlus_JitNoCSE=1
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
I found a small issue where we would access uninitialized `compCurBB` .