### PR TITLE
Fix source indexer failing official builds

### DIFF
--- a/eng/common/templates/job/source-index-stage1.yml
+++ b/eng/common/templates/job/source-index-stage1.yml
@@ -35,19 +35,14 @@ jobs:
       packageType: sdk
       version: 3.1.x
 
-  - task: UseDotNet@2
-    displayName: Use .NET Core sdk
-    inputs:
-      useGlobalJson: true
+  - script: ${{ parameters.sourceIndexBuildCommand }}
+    displayName: Build Repository
 
   - script: |
       dotnet tool install BinLogToSln --version $(SourceIndexPackageVersion) --add-source $(SourceIndexPackageSource) --tool-path .source-index/tools
       dotnet tool install UploadIndexStage1 --version $(SourceIndexPackageVersion) --add-source $(SourceIndexPackageSource) --tool-path .source-index/tools
       echo ##vso[task.prependpath]$(Build.SourcesDirectory)/.source-index/tools
     displayName: Download Tools
-
-  - script: ${{ parameters.sourceIndexBuildCommand }}
-    displayName: Build Repository
 
   - script: BinLogToSln -i $(BinlogPath) -r $(Build.SourcesDirectory) -n $(Build.Repository.Name) -o .source-index/stage1output
     displayName: Process Binlog into indexable sln


### PR DESCRIPTION
Works around https://github.com/dotnet/arcade/issues/7747 to unblock official builds.
This change will revert itself with the next Arcade update.

Tested with an official build: https://dnceng.visualstudio.com/internal/_build/results?buildId=1291865&view=logs&j=316d5c15-0c50-544e-8051-e6b14a1ab674&t=4e01507e-10cc-507d-f6d0-adc59e92bcb8.