### PR TITLE
Add Quic back to aspnetcore transport pack

### DIFF
--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -32,8 +32,9 @@
   <PropertyGroup Condition="'$(ServicingVersion)' != ''">
     <!-- Always update the package version in servicing. -->
     <PackageVersion>$(MajorVersion).$(MinorVersion).$(ServicingVersion)</PackageVersion>
-    <IsWindowsDesktop Condition="$(WindowsDesktopCoreAppLibrary.Contains('$(AssemblyName);'))">true</IsWindowsDesktop>
-    <_AssemblyInTargetingPack Condition="'$(IsNETCoreAppSrc)' == 'true' or '$(IsAspNetCoreApp)' == 'true' or '$(IsWindowsDesktop)' == 'true'">true</_AssemblyInTargetingPack>
+    <_IsWindowsDesktopApp Condition="$(WindowsDesktopCoreAppLibrary.Contains('$(AssemblyName);'))">true</_IsWindowsDesktopApp>
+    <_IsAspNetCoreApp Condition="$(AspNetCoreAppLibrary.Contains('$(AssemblyName);'))">true</_IsAspNetCoreApp>
+    <_AssemblyInTargetingPack Condition="'$(IsNETCoreAppSrc)' == 'true' or '$(_IsAspNetCoreApp)' == 'true' or '$(_IsWindowsDesktopApp)' == 'true'">true</_AssemblyInTargetingPack>
     <!-- Assembly version do not get updated in non-netfx ref pack assemblies. -->
     <AssemblyVersion Condition="'$(_AssemblyInTargetingPack)' != 'true' or '$(TargetFrameworkIdentifier)' == '.NETFramework'">$(MajorVersion).$(MinorVersion).0.$(ServicingVersion)</AssemblyVersion>
   </PropertyGroup>
@@ -206,6 +207,7 @@
           Condition="'@(ProjectReference->WithMetadataValue('PrivateAssets', 'all')->WithMetadataValue('Pack', 'true'))' != ''"
           DependsOnTargets="BuildOnlySettings;ResolveReferences">
     <ItemGroup>
+      <!-- Add ReferenceCopyLocalPaths for ProjectReferences which are flagged as Pack="true" into the package. -->
       <_projectReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('PrivateAssets', 'all')->WithMetadataValue('Pack', 'true'))" />
       <TfmSpecificPackageFile Include="@(_projectReferenceCopyLocalPaths)"
                               PackagePath="$([MSBuild]::ValueOrDefault('%(ReferenceCopyLocalPaths.PackagePath)', '$(BuildOutputTargetFolder)/$(TargetFramework)'))" />
@@ -213,19 +215,18 @@
                                    TargetPath="/%(TfmSpecificPackageFile.PackagePath)/%(Filename)%(Extension)"
                                    TargetFramework="$(TargetFramework)"
                                    Condition="'$(IncludeSymbols)' == 'true'" />
-      <!-- Remove symbols from the non symbol package. -->
+      <!-- Remove symbol from the non symbol package. -->
       <TfmSpecificPackageFile Remove="@(TfmSpecificPackageFile->WithMetadataValue('Extension', '.pdb'))" />
+      <!-- If the reference assembly is included, don't put the documentation file next to the lib assembly. -->
+      <TfmSpecificPackageFile Remove="@(_projectReferenceCopyLocalPaths->WithMetadataValue('Extension', '.xml')->WithMetadataValue('IncludeReferenceAssemblyInPackage', 'true'))" />
     </ItemGroup>
 
     <ItemGroup>
+      <!-- Include the reference assembly and put the documentation file next to it. -->
       <_referenceAssemblyPaths Include="@(_projectReferenceCopyLocalPaths->WithMetadataValue('Extension', '.dll')->WithMetadataValue('IncludeReferenceAssemblyInPackage', 'true')->Metadata('ReferenceAssembly'))" />
+      <_referenceAssemblyPaths Include="@(_projectReferenceCopyLocalPaths->WithMetadataValue('Extension', '.xml')->WithMetadataValue('IncludeReferenceAssemblyInPackage', 'true'))" />
       <TfmSpecificPackageFile Include="@(_referenceAssemblyPaths)"
                               PackagePath="ref/$(TargetFramework)" />
-      <_referenceSymbolPaths Include="$([System.IO.Path]::ChangeExtension('%(_referenceAssemblyPaths.Identity)', '.pdb'))" />
-      <TfmSpecificDebugSymbolsFile Include="@(_referenceSymbolPaths->Exists())"
-                                   TargetPath="/ref/$(TargetFramework)/%(Filename)%(Extension)"
-                                   TargetFramework="$(TargetFramework)"
-                                   Condition="'$(IncludeSymbols)' == 'true'" />
     </ItemGroup>
   </Target>
 

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -45,8 +45,6 @@
     <IsNETCoreAppRef Condition="'$(IsNETCoreAppRef)' == '' and
                                 '$(IsReferenceAssembly)' == 'true' and
                                 $(NetCoreAppLibrary.Contains('$(AssemblyName);'))">true</IsNETCoreAppRef>
-    <IsAspNetCoreApp Condition="$(AspNetCoreAppLibrary.Contains('$(AssemblyName);'))">true</IsAspNetCoreApp>
-
     <!-- By default, disable implicit framework references for NetCoreAppCurrent libraries. -->
     <DisableImplicitFrameworkReferences Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
                                                    $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '$(NETCoreAppCurrentVersion)')) and

--- a/src/libraries/NetCoreAppLibrary.props
+++ b/src/libraries/NetCoreAppLibrary.props
@@ -181,6 +181,7 @@
       Microsoft.Extensions.Primitives;
       System.Diagnostics.EventLog;
       System.IO.Pipelines;
+      System.Net.Quic;
       System.Security.Cryptography.Xml;
     </AspNetCoreAppLibrary>
     <WindowsDesktopCoreAppLibrary>


### PR DESCRIPTION
1. System.Net.Quic was accidentally dropped from aspnetcore transport
package with 4684a1dbab50ea759eaf970302fc9c1f7007bbc2. Reverting that.

2. Make sure that the documentation file is placed next to the
reference assembly if such is included as part of a ProjectReference.

3. Don't include pdbs for reference assemblies as those aren't needed
in the transport package.

4. Move the IsAspNetCore property into packaging.targets as it's not
needed by the binplacing system anymore.