### PR TITLE
Add missing WindowsDesktop libraries

### DIFF
--- a/src/libraries/NetCoreAppLibrary.props
+++ b/src/libraries/NetCoreAppLibrary.props
@@ -184,6 +184,8 @@
       System.Security.Cryptography.Xml;
     </AspNetCoreAppLibrary>
     <WindowsDesktopCoreAppLibrary>
+      Microsoft.Win32.Registry.AccessControl;
+      Microsoft.Win32.SystemEvents;
       System.CodeDom;
       System.Configuration.ConfigurationManager;
       System.Diagnostics.EventLog;


### PR DESCRIPTION
These two libraries are exposed in WindowsDesktop's shared framework but are missing from the transport package.