### PR TITLE
WinHttp: Remove [SupportedOSPlatformAttribute] with specific Windows version

### DIFF
--- a/src/libraries/System.Net.Http.WinHttpHandler/ref/System.Net.Http.WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/ref/System.Net.Http.WinHttpHandler.cs
@@ -44,11 +44,8 @@ namespace System.Net.Http
         public System.Func<System.Net.Http.HttpRequestMessage, System.Security.Cryptography.X509Certificates.X509Certificate2, System.Security.Cryptography.X509Certificates.X509Chain, System.Net.Security.SslPolicyErrors, bool>? ServerCertificateValidationCallback { get { throw null; } set { } }
         public System.Net.ICredentials? ServerCredentials { get { throw null; } set { } }
         public System.Security.Authentication.SslProtocols SslProtocols { get { throw null; } set { } }
-        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows10.0.19041")]
         public bool TcpKeepAliveEnabled { get { throw null; } set { } }
-        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows10.0.19041")]
         public System.TimeSpan TcpKeepAliveTime { get { throw null; } set { } }
-        [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows10.0.19041")]
         public System.TimeSpan TcpKeepAliveInterval { get { throw null; } set { } }
         public System.Net.Http.WindowsProxyUsePolicy WindowsProxyUsePolicy { get { throw null; } set { } }
         protected override void Dispose(bool disposing) { }

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -423,7 +423,6 @@ namespace System.Net.Http
         /// If enabled, the values of <see cref="TcpKeepAliveInterval" /> and <see cref="TcpKeepAliveTime"/> will be forwarded
         /// to set WINHTTP_OPTION_TCP_KEEPALIVE, enabling and configuring TCP keep-alive for the backing TCP socket.
         /// </remarks>
-        [SupportedOSPlatform("windows10.0.19041")]
         public bool TcpKeepAliveEnabled
         {
             get
@@ -445,7 +444,6 @@ namespace System.Net.Http
         /// Has no effect if <see cref="TcpKeepAliveEnabled"/> is <see langword="false" />.
         /// The default value of this property is 2 hours.
         /// </remarks>
-        [SupportedOSPlatform("windows10.0.19041")]
         public TimeSpan TcpKeepAliveTime
         {
             get
@@ -468,7 +466,6 @@ namespace System.Net.Http
         /// Has no effect if <see cref="TcpKeepAliveEnabled"/> is <see langword="false" />.
         /// The default value of this property is 1 second.
         /// </remarks>
-        [SupportedOSPlatform("windows10.0.19041")]
         public TimeSpan TcpKeepAliveInterval
         {
             get


### PR DESCRIPTION
The WinHttp folks will likely backport the TCP KeepAlive feature to an arbitrary previous version, which will eventually outdate any code that relies on OS Version validation and the matching analyzers.

Theoretically, we could react and release a new NuGet package when such changes happen, but this is probably not the type of maintenance work we want to invest into, or at least not with WinHttpHandler.