### PR TITLE
Use temporary ni.dll.tmp files with crossgen2 pipeline mode in order to not interfere with crossgen2 itself

### DIFF
--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -499,6 +499,19 @@ namespace ILCompiler
 
                     RunSingleCompilation(singleCompilationInputFilePaths, instructionSetSupport, compositeRootPath, unrootedInputFilePaths, singleCompilationVersionBubbleModulesHash, typeSystemContext);
                 }
+
+                // In case of inputbubble ni.dll are created as ni.dll.tmp in order to not interfere with crossgen2, move them all to ni.dll
+                // See https://github.com/dotnet/runtime/issues/55663#issuecomment-898161751 for more details
+                if (_commandLineOptions.InputBubble)
+                {
+                    foreach (var inputFile in inputFilePaths)
+                    {
+                        var tmpOutFile = inputFile.Value.Replace(".dll", ".ni.dll.tmp");
+                        var outFile = inputFile.Value.Replace(".dll", ".ni.dll");
+                        Console.WriteLine($@"Moving R2R PE file: {tmpOutFile} to {outFile}");
+                        System.IO.File.Move(tmpOutFile, outFile);
+                    }
+                }
             }
             else
             {
@@ -513,7 +526,8 @@ namespace ILCompiler
             //
             // Initialize output filename
             //
-            var outFile = _commandLineOptions.OutNearInput ? inFilePaths.First().Value.Replace(".dll", ".ni.dll") : _commandLineOptions.OutputFilePath;
+            var suffixStr = _commandLineOptions.SingleFileCompilation && _commandLineOptions.InputBubble ? ".ni.dll.tmp" : ".ni.dll";
+            var outFile = _commandLineOptions.OutNearInput ? inFilePaths.First().Value.Replace(".dll", suffixStr) : _commandLineOptions.OutputFilePath;
 
             using (PerfEventSource.StartStopEvents.CompilationEvents())
             {

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -325,6 +325,9 @@ namespace ILCompiler
             if (_commandLineOptions.OutputFilePath == null && !_commandLineOptions.OutNearInput)
                 throw new CommandLineException(SR.MissingOutputFile);
 
+            if (_commandLineOptions.SingleFileCompilation && !_commandLineOptions.OutNearInput)
+                throw new CommandLineException(SR.MissingOutNearInput);
+
             ConfigureTarget();
             InstructionSetSupport instructionSetSupport = ConfigureInstructionSetSupport();
 

--- a/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
@@ -195,6 +195,9 @@
   <data name="MissingOutputFile" xml:space="preserve">
     <value>Output filename must be specified (--out &lt;file&gt;)</value>
   </data>
+  <data name="MissingOutNearInput" xml:space="preserve">
+    <value>Single file compilation mode requires --out-near-input option</value>
+  </data>
   <data name="InputWasNotLoadable" xml:space="preserve">
     <value>No input files are loadable</value>
   </data>

--- a/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
@@ -132,6 +132,9 @@
   <data name="EmittingPEFile" xml:space="preserve">
     <value>Emitting R2R PE file: {0}</value>
   </data>
+  <data name="MovingPEFile" xml:space="preserve">
+    <value>Moving R2R PE file: {0} to {1}</value>
+  </data>
   <data name="EnableOptimizationsOption" xml:space="preserve">
     <value>Enable optimizations</value>
   </data>

--- a/src/coreclr/tools/r2rtest/Buckets.cs
+++ b/src/coreclr/tools/r2rtest/Buckets.cs
@@ -112,6 +112,7 @@ namespace R2RTest
                         line.StartsWith("EXEC : warning") ||
                         line.StartsWith("To repro,") ||
                         line.StartsWith("Emitting R2R PE file") ||
+                        line.StartsWith("Moving R2R PE file") ||
                         line.StartsWith("Warning: ") ||
                         line.StartsWith("Info: ") ||
                         line == "Assertion Failed")


### PR DESCRIPTION
This is required, because all inputbubble ni.dlls should be used all at once, otherwise type layout issues may arise.

See https://github.com/dotnet/runtime/issues/55663#issuecomment-898161751 for more details.

cc @davidwrighton @alpencolt 