### PR TITLE
[HTTP/3] Fixed H/3 stress server after the last Kestrel change.

### DIFF
--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
@@ -122,15 +122,6 @@ namespace HttpStress
                         }
                     }
                 });
-
-                if (configuration.HttpVersion == HttpVersion.Version30)
-                {
-                    host = host.UseQuic(options =>
-                    {
-                        options.Alpn = "h3";
-                        options.IdleTimeout = TimeSpan.FromMinutes(1);
-                    });
-                }
             };
 
             LoggerConfiguration loggerConfiguration = new LoggerConfiguration();


### PR DESCRIPTION
Note that the stress compiles, runs HTTP/3, but it's full of errors. I don't know if some of them are new after this change, I haven't had time to properly investigate.

Fixes #57351