### PR TITLE
Harvest signatures of methods being compiled by the token resolver

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
@@ -143,6 +143,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 AddModuleTokenForType(owningType, new ModuleToken(token.Module, owningTypeHandle));
                 memberRef.DecodeMethodSignature<DummyTypeInfo, ModuleTokenResolver>(new TokenResolverProvider(this, token.Module), this);
             }
+            if (token.TokenType == CorTokenType.mdtMethodDef)
+            {
+                MethodDefinition methodDef = token.MetadataReader.GetMethodDefinition((MethodDefinitionHandle)token.Handle);
+                methodDef.DecodeSignature<DummyTypeInfo, ModuleTokenResolver>(new TokenResolverProvider(this, token.Module), this);
+            }
         }
 
         private void AddModuleTokenForFieldReference(TypeDesc owningType, ModuleToken token)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -471,6 +471,12 @@ namespace Internal.JitInterface
                     {
                         if (!FunctionJustThrows(methodIL))
                         {
+                            if (MethodBeingCompiled.GetTypicalMethodDefinition() is EcmaMethod ecmaMethod)
+                            {
+                                // Harvest the method being compiled for the purpose of populating the type resolver
+                                var resolver = _compilation.NodeFactory.Resolver;
+                                resolver.AddModuleTokenForMethod(MethodBeingCompiled, new ModuleToken(ecmaMethod.Module, ecmaMethod.Handle));
+                            }
                             CompileMethodInternal(methodCodeNodeNeedingCode, methodIL);
                             codeGotPublished = true;
                         }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/56971

I believe this is the primary fix for the issue; when a type only
ever occurs in method signatures in an assembly, never in the
implementation IL, JIT never calls resolveToken for it and so it
doesn't make it to the module token resolver table.

My investigation revealed additional potential problems in the
product around exported type resolution and the IL linker;
I described them in the issue thread but I believe this to be
both the most appropriate and the safest primary fix.

Thanks

Tomas

/cc @dotnet/crossgen-contrib 