### PR TITLE
Remove unNeccessat package downloads and package reference

### DIFF
--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -41,15 +41,6 @@
 
   <ItemGroup Condition="'$(EnablePackageValidation)' == 'true'">
     <PackageReference Include="Microsoft.DotNet.PackageValidation" Version="$(MicrosoftDotNetPackageValidationVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
-    <!-- TODO: Remove when the SDK is upgraded to RC1. -->
-    <PackageDownload Include="$([MSBuild]::ValueOrDefault('$(PackageValidationBaselineName)', '$(PackageId)'))"
-                     Version="[$(PackageValidationBaselineVersion)]"
-                     Condition="'$(DisablePackageBaselineValidation)' != 'true' and '$(PackageValidationBaselinePath)' == '' and '$(PackageValidationBaselineVersion)' != ''" />
-  </ItemGroup>
-
-  <!-- TODO: Remove when all required nuget pack features are part of the consumed SDK. -->
-  <ItemGroup>
-    <PackageReference Include="NuGet.Build.Tasks.Pack" Version="$(NuGetBuildTasksPackVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We are using the lastest rc1 sdk package which contains the latest nuget pack and packagevalidation targets file