### PR TITLE
Setup retry for System.Net.* tests

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -3,6 +3,6 @@
   "defaultOnFailure": "fail",
   "localRerunCount": 2,
   "retryOnRules": [
-    {"testAssembly": {"wildcard": "System.Net.*"}}
+    { "testAssembly": { "wildcard": "System.Net.*" } }
   ]
 }

--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "defaultOnFailure": "fail",
+  "localRerunCount": 2,
+  "retryOnRules": [
+    {"testAssembly": {"wildcard": "System.Net.*"}}
+  ]
+}


### PR DESCRIPTION
The Helix SDK in arcade supports test retries in Helix by reading this file, "test-configuration.json" if it's present.

This sets up any test who's assembly name starts with System.Net.* to have 3 attempts (2 reruns) locally.