### PR TITLE
[tests] Set the EventSourceSupport feature switch

### DIFF
--- a/src/libraries/System.Net.Primitives/tests/FunctionalTests/System.Net.Primitives.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Primitives/tests/FunctionalTests/System.Net.Primitives.Functional.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)-Browser</TargetFrameworks>
+    <EventSourceSupport>true</EventSourceSupport>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CookieTest.cs" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/56847

The `EventSource_ExistsWithCorrectId` test requires the event source
switch be set to true to work correctly after aggressive linking.