### PR TITLE
Ignore IOException in PollingFileChangeToken

### DIFF
--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PollingFileChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PollingFileChangeToken.cs
@@ -54,7 +54,18 @@ namespace Microsoft.Extensions.FileProviders.Physical
                 return DateTime.MinValue;
             }
 
-            return FileSystemInfoHelper.GetFileLinkTargetLastWriteTimeUtc(_fileInfo) ?? _fileInfo.LastWriteTimeUtc;
+            DateTime? lastWriteTimeUtc = FileSystemInfoHelper.GetFileLinkTargetLastWriteTimeUtc(_fileInfo);
+
+            if (lastWriteTimeUtc == null)
+            {
+                try
+                {
+                    lastWriteTimeUtc = _fileInfo.LastWriteTimeUtc;
+                }
+                catch (IOException) { } // https://github.com/dotnet/runtime/issues/57221
+            }
+
+            return lastWriteTimeUtc.Value;
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStatus.Unix.cs
@@ -402,20 +402,18 @@ namespace System.IO
         // Throws if any of the caches has an error number saved in it
         private void ThrowOnCacheInitializationError(ReadOnlySpan<char> path)
         {
-            int errno = 0;
-
             // Lstat should always be initialized by Refresh
             if (_initializedFileCache != 0)
             {
-                errno = _initializedFileCache;
+                Throw(_initializedFileCache);
             }
             // Stat is optionally initialized when Refresh detects object is a symbolic link
             else if (_initializedSymlinkCache != 0 && _initializedSymlinkCache != -1)
             {
-                errno = _initializedSymlinkCache;
+                Throw(_initializedSymlinkCache);
             }
 
-            if (errno != 0)
+            void Throw(int errno)
             {
                 InvalidateCaches();
                 throw Interop.GetExceptionForIoErrno(new Interop.ErrorInfo(errno), new string(path));

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStatus.Unix.cs
@@ -405,18 +405,14 @@ namespace System.IO
             // Lstat should always be initialized by Refresh
             if (_initializedFileCache != 0)
             {
-                Throw(_initializedFileCache);
+                InvalidateCaches();
+                throw Interop.GetExceptionForIoErrno(new Interop.ErrorInfo(_initializedFileCache), new string(path));
             }
             // Stat is optionally initialized when Refresh detects object is a symbolic link
             else if (_initializedSymlinkCache != 0 && _initializedSymlinkCache != -1)
             {
-                Throw(_initializedSymlinkCache);
-            }
-
-            void Throw(int errno)
-            {
                 InvalidateCaches();
-                throw Interop.GetExceptionForIoErrno(new Interop.ErrorInfo(errno), new string(path));
+                throw Interop.GetExceptionForIoErrno(new Interop.ErrorInfo(_initializedSymlinkCache), new string(path));
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStatus.Unix.cs
@@ -402,17 +402,20 @@ namespace System.IO
         // Throws if any of the caches has an error number saved in it
         private void ThrowOnCacheInitializationError(ReadOnlySpan<char> path)
         {
+            int errno;
             // Lstat should always be initialized by Refresh
             if (_initializedFileCache != 0)
             {
+                errno = _initializedFileCache;
                 InvalidateCaches();
-                throw Interop.GetExceptionForIoErrno(new Interop.ErrorInfo(_initializedFileCache), new string(path));
+                throw Interop.GetExceptionForIoErrno(new Interop.ErrorInfo(errno), new string(path));
             }
             // Stat is optionally initialized when Refresh detects object is a symbolic link
             else if (_initializedSymlinkCache != 0 && _initializedSymlinkCache != -1)
             {
+                errno = _initializedSymlinkCache;
                 InvalidateCaches();
-                throw Interop.GetExceptionForIoErrno(new Interop.ErrorInfo(_initializedSymlinkCache), new string(path));
+                throw Interop.GetExceptionForIoErrno(new Interop.ErrorInfo(errno), new string(path));
             }
         }
 


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/57221, ignores the exception to unblock clean CI.
I've also split `throw` calls to one per `stat`/`lstat` to identify which is the one throwing EINVAL.