### PR TITLE
Include path in IOException in Unix

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/Interop.IOErrors.cs
+++ b/src/libraries/Common/src/Interop/Unix/Interop.IOErrors.cs
@@ -159,12 +159,14 @@ internal static partial class Interop
                 goto default;
 
             default:
-                return GetIOException(errorInfo);
+                return GetIOException(errorInfo, path);
         }
     }
 
-    internal static Exception GetIOException(Interop.ErrorInfo errorInfo)
+    internal static Exception GetIOException(Interop.ErrorInfo errorInfo, string? path = null)
     {
-        return new IOException(errorInfo.GetErrorMessage(), errorInfo.RawErrno);
+        string msg = errorInfo.GetErrorMessage();
+        return new IOException(
+            string.IsNullOrEmpty(path) ? msg : $"{msg} : '{path}'", errorInfo.RawErrno);
     }
 }


### PR DESCRIPTION
In #57221 there is an IOException for a file operation that does not include the path. For most IO related exceptions we include the path, but not in this case.

It turns out we include the path in Windows, but not in non Windows. Copy the same pattern:

https://github.com/dotnet/runtime/blob/4d992f1c43310048005fb29f1696394ad73eae0b/src/libraries/Common/src/System/IO/Win32Marshal.cs#L60-L63