### PR TITLE
Improve performance of, and reduce allocations in, UIHintAttribute

### DIFF
--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/UIHintAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/UIHintAttribute.cs
@@ -97,7 +97,7 @@ namespace System.ComponentModel.DataAnnotations
             // If the method throws (indicating that the input params are invalid) this property will throw
             // every time it's accessed.
             public Dictionary<string, object?> ControlParameters =>
-                _controlParameters ?? (_controlParameters = BuildControlParametersDictionary());
+                _controlParameters ??= BuildControlParametersDictionary();
 
             /// <summary>
             ///     Returns the hash code for this UIHintAttribute.
@@ -156,18 +156,19 @@ namespace System.ComponentModel.DataAnnotations
             /// </returns>
             private Dictionary<string, object?> BuildControlParametersDictionary()
             {
+                Dictionary<string, object?> controlParameters = new Dictionary<string, object?>();
+
                 object?[]? inputControlParameters = _inputControlParameters;
 
                 if (inputControlParameters == null || inputControlParameters.Length == 0)
                 {
-                    return new Dictionary<string, object?>();
+                    return controlParameters;
                 }
                 if (inputControlParameters.Length % 2 != 0)
                 {
                     throw new InvalidOperationException(SR.UIHintImplementation_NeedEvenNumberOfControlParameters);
                 }
 
-                Dictionary<string, object?> controlParameters = new Dictionary<string, object?>(inputControlParameters.Length / 2);
                 for (int i = 0; i < inputControlParameters.Length; i += 2)
                 {
                     object? key = inputControlParameters[i];
@@ -202,16 +203,12 @@ namespace System.ComponentModel.DataAnnotations
                     return false;
                 }
 
-                var comparer = EqualityComparer<object?>.Default;
+                EqualityComparer<object?> comparer = EqualityComparer<object?>.Default;
 
-                foreach (var leftEntry in left)
+                foreach (KeyValuePair<string, object?> leftEntry in left)
                 {
-                    if (!right.TryGetValue(leftEntry.Key, out object? rightValue))
-                    {
-                        return false;
-                    }
-
-                    if (!comparer.Equals(leftEntry.Value, rightValue))
+                    if (!right.TryGetValue(leftEntry.Key, out object? rightValue) ||
+                        !comparer.Equals(leftEntry.Value, rightValue))
                     {
                         return false;
                     }

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/UIHintAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/UIHintAttribute.cs
@@ -219,7 +219,6 @@ namespace System.ComponentModel.DataAnnotations
 
                 return true;
             }
-
         }
     }
 }


### PR DESCRIPTION
Improves performance of, and reduces allocations in, **System.ComponentModel.DataAnnotations.UIHintAttribute** by avoiding both **System.Linq** and interface calls. This affects the `Equals(object? obj)` method and the `ControlParameters` property.

This is also a first (small) step toward removing the use of **System.Linq** in **System.ComponentModel.Annotations**.

<details>
  <summary>Benchmark Results</summary>

|                                                      Method | Toolchain         |     Mean    |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------------------------------------------ |-------------------|------------:|----------:|----------:|-------:|------:|------:|----------:|
| Equals_HintAndPresentationLayerAndControlParametersAreEqual | \main\corerun.exe | 1,269.97 ns | 25.182 ns | 29.977 ns | 0.2842 |     - |     - |   1,192 B |
| Equals_HintAndPresentationLayerAndControlParametersAreEqual | \pr\corerun.exe   |    72.97 ns |  1.474 ns |  1.513 ns |      - |     - |     - |         - |
|                         Equals_ControlParametersAreNotEqual | \main\corerun.exe | 1,164.32 ns | 22.946 ns | 22.536 ns | 0.2842 |     - |     - |   1,192 B |
|                         Equals_ControlParametersAreNotEqual | \pr\corerun.exe   |    50.75 ns |  0.620 ns |  0.550 ns |      - |     - |     - |         - |
|                                     ControlParameters_Empty | \main\corerun.exe |    32.30 ns |  0.240 ns |  0.224 ns | 0.0421 |     - |     - |     176 B |
|                                     ControlParameters_Empty | \pr\corerun.exe   |    32.16 ns |  0.276 ns |  0.258 ns | 0.0421 |     - |     - |     176 B |
|                                     ControlParameters_Small | \main\corerun.exe |   129.92 ns |  0.649 ns |  0.507 ns | 0.0861 |     - |     - |     360 B |
|                                     ControlParameters_Small | \pr\corerun.exe   |   101.74 ns |  0.307 ns |  0.272 ns | 0.0861 |     - |     - |     360 B |
</details>

<details>
<summary>Benchmark Code</summary>

```c#
 [MemoryDiagnoser]
    public class UIHintAttributeBenchmarks
    {
        private UIHintAttribute _hint1;
        private UIHintAttribute _hint2;
        private UIHintAttribute _hint3;
        private object[] _controlParametersSmall;

        [GlobalSetup]
        public void GlobalSetup()
        {
            _hint1 = new UIHintAttribute("abc", "def", new object[] { "A", 1, "C", 3, "B", 2 });
            _hint2 = new UIHintAttribute("abc", "def", new object[] { "B", 2, "A", 1, "C", 3 });
            _hint3 = new UIHintAttribute("abc", "def", new object[] { "B", 2, "A", 1, "D", 4 });

            _controlParametersSmall = new object[] { "A", 1, "B", 2, "C", 3 };
        }

        [Benchmark]
        public bool Equals_HintAndPresentationLayerAndControlParametersAreEqual()
        {
            return _hint1.Equals(_hint2);
        }

        [Benchmark]
        public bool Equals_ControlParametersAreNotEqual()
        {
            return _hint1.Equals(_hint3);
        }

        [Benchmark]
        public System.Collections.Generic.IDictionary<string, object> ControlParameters_Empty()
        {
            var hint = new UIHintAttribute("abc", "def", Array.Empty<object>());
            return hint.ControlParameters;
        }

        [Benchmark]
        public System.Collections.Generic.IDictionary<string, object> ControlParameters_Small()
        {
            var hint = new UIHintAttribute("abc", "def", _controlParametersSmall);
            return hint.ControlParameters;
        }
    }```