### PR TITLE
Fix ARM64 unsigned div by const perf regression

### DIFF
--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -1856,10 +1856,9 @@ void CodeGen::genCodeForBinary(GenTreeOp* treeNode)
     emitAttr attr = emitActualTypeSize(treeNode);
 
     // UMULL/SMULL is twice as fast for 32*32->64bit MUL
-    if (oper == GT_MUL && EA_SIZE(attr) == EA_8BYTE && !varTypeIsFloating(treeNode->TypeGet()) &&
-        EA_SIZE(emitActualTypeSize(op1)) == EA_4BYTE && EA_SIZE(emitActualTypeSize(op2)) == EA_4BYTE)
+    if ((oper == GT_MUL) && (targetType == TYP_LONG) && genActualTypeIsInt(op1) && genActualTypeIsInt(op2))
     {
-        ins  = (treeNode->gtFlags & GTF_UNSIGNED) ? INS_umull : INS_smull;
+        ins  = treeNode->IsUnsigned() ? INS_umull : INS_smull;
         attr = EA_4BYTE;
     }
 

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5254,7 +5254,11 @@ bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
             BlockRange().InsertBefore(divMod, preShiftBy, adjustedDividend);
             firstNode = preShiftBy;
         }
-        else if (type != TYP_I_IMPL)
+        else if (type != TYP_I_IMPL
+#ifdef TARGET_ARM64
+                 && !simpleMul
+#endif
+                 )
         {
             adjustedDividend = comp->gtNewCastNode(TYP_I_IMPL, adjustedDividend, true, TYP_U_IMPL);
             BlockRange().InsertBefore(divMod, adjustedDividend);
@@ -5268,7 +5272,7 @@ bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
             adjustedDividend->SetRegNum(REG_RAX);
 #endif
 
-        divisor->gtType = TYP_I_IMPL;
+        divisor->gtType = simpleMul ? TYP_INT : TYP_I_IMPL;
         divisor->AsIntCon()->SetIconValue(magic);
 
         if (isDiv && !postShift && type == TYP_I_IMPL)

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5256,7 +5256,7 @@ bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
         }
         else if (type != TYP_I_IMPL
 #ifdef TARGET_ARM64
-                 && !simpleMul
+                 && !simpleMul // On ARM64 we will use a 32x32->64 bit multiply as that's faster.
 #endif
                  )
         {
@@ -5272,7 +5272,15 @@ bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
             adjustedDividend->SetRegNum(REG_RAX);
 #endif
 
-        divisor->gtType = simpleMul ? TYP_INT : TYP_I_IMPL;
+        divisor->gtType = TYP_I_IMPL;
+
+#ifdef TARGET_ARM64
+        if (simpleMul)
+        {
+            divisor->gtType = TYP_INT;
+        }
+#endif
+
         divisor->AsIntCon()->SetIconValue(magic);
 
         if (isDiv && !postShift && type == TYP_I_IMPL)


### PR DESCRIPTION
This fixes #54166. This is the alternative version of #57372 that just improves `GT_MUL` codegen for arm64. Diffs are identical.

Diff: https://www.diffchecker.com/9mkVf4se
Diff with baseline (no #52893): https://www.diffchecker.com/x2SRZJvW

Unfortunately this doesn't yet solve #47490, probably because the operand nodes are extended to 64-bit earlier.

cc @AndyAyersMS @echesakovMSFT 