### PR TITLE
Remove `GTF_NO_CSE` on the first `FIELD_LIST` arg (x86 specific)

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -4190,7 +4190,7 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
                     if (fieldLclNum == varDsc->lvFieldLclStart)
                     {
                         lcl->SetLclNum(fieldLclNum);
-                        lcl->ChangeOper(GT_LCL_VAR);
+                        lcl->SetOperResetFlags(GT_LCL_VAR);
                         lcl->gtType = fieldVarDsc->TypeGet();
                         fieldLcl    = lcl;
                     }


### PR DESCRIPTION
The code constructing the list reuses the original local node for the first field. Such a node is likely to have come from an `OBJ(ADDR(LCL_VAR))` tree, thus having `GTF_NO_CSE` set on it, pessimizing handling of the promoted struct field, in particular, blocking global constant propagation.

Fix this by calling `SetOperResetFlags` instead of `ChangeOper`. This may lose some flags, but the other fields in the list did not have them set in any case.

Some pretty significant positive diffs for this change:

## benchmarks.run.windows.x86.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 143021
Total bytes of diff: 141337
Total bytes of delta: -1684 (-1.18% of base)
Total relative delta: -5.47
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          11 : 15734.dasm (0.32% of base)
          11 : 9575.dasm (0.75% of base)
           8 : 23210.dasm (0.56% of base)
           4 : 6037.dasm (2.90% of base)
           1 : 15630.dasm (1.12% of base)

Top file improvements (bytes):
        -142 : 22986.dasm (-7.53% of base)
        -117 : 19722.dasm (-8.53% of base)
         -52 : 11515.dasm (-7.66% of base)
         -52 : 12427.dasm (-13.20% of base)
         -39 : 12465.dasm (-2.33% of base)
         -36 : 5870.dasm (-3.35% of base)
         -32 : 18787.dasm (-1.63% of base)
         -30 : 14040.dasm (-5.50% of base)
         -29 : 21472.dasm (-1.76% of base)
         -28 : 13259.dasm (-4.66% of base)
         -26 : 14373.dasm (-18.57% of base)
         -26 : 10847.dasm (-1.57% of base)
         -26 : 21306.dasm (-4.68% of base)
         -26 : 21614.dasm (-1.65% of base)
         -26 : 17833.dasm (-0.81% of base)
         -24 : 16186.dasm (-0.87% of base)
         -24 : 14958.dasm (-1.00% of base)
         -22 : 14879.dasm (-13.41% of base)
         -21 : 9935.dasm (-2.12% of base)
         -21 : 11618.dasm (-1.23% of base)

246 total files with Code Size differences (241 improved, 5 regressed), 3 unchanged.

Top method regressions (bytes):
          11 ( 0.32% of base) : 15734.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SourceNamedTypeSymbol:MakeTypeParameters(Microsoft.CodeAnalysis.DiagnosticBag):System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.CSharp.Symbols.TypeParameterSymbol, Microsoft.CodeAnalysis.CSharp, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]:this
          11 ( 0.75% of base) : 9575.dasm - <ReceiveAsyncThenSendAsync_Task>d__5:MoveNext():this
           8 ( 0.56% of base) : 23210.dasm - <SendAsyncThenReceiveAsync_Task>d__4:MoveNext():this
           4 ( 2.90% of base) : 6037.dasm - System.Text.Json.Utf8JsonWriter:WriteBooleanValue(bool):this
           1 ( 1.12% of base) : 15630.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.TupleTypeSymbol:TransformToTupleIfCompatible(Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol):Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol

Top method improvements (bytes):
        -142 (-7.53% of base) : 22986.dasm - System.Text.Tests.Perf_StringBuilder:Append_ValueTypes():System.Text.StringBuilder:this
        -117 (-8.53% of base) : 19722.dasm - BenchmarksGame.RegexRedux_5:RunBench(int):int:this
         -52 (-7.66% of base) : 11515.dasm - System.Net.Dns:GetHostEntry(System.String,int):System.Net.IPHostEntry
         -52 (-13.20% of base) : 12427.dasm - System.Tests.Perf_DateTimeOffset:.ctor():this
         -39 (-2.33% of base) : 12465.dasm - System.Text.Json.Tests.Perf_Basic:WriteBasicUtf8():this
         -36 (-3.35% of base) : 5870.dasm - System.Text.Json.Utf8JsonReader:ConsumeValue(ubyte):bool:this
         -32 (-1.63% of base) : 18787.dasm - <<Setup>b__0>d:MoveNext():this
         -30 (-5.50% of base) : 14040.dasm - System.Net.Dns:GetHostAddresses(System.String,int):System.Net.IPAddress[]
         -29 (-1.76% of base) : 21472.dasm - <ConcurrentReadWriteLargeBuffer>d__36:MoveNext():this
         -28 (-4.66% of base) : 13259.dasm - BenchmarksGame.KNucleotide_9:count4(int,long,System.Func`2[[System.Collections.Generic.Dictionary`2[[System.Int64, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[BenchmarksGame.Wrapper, MicroBenchmarks, Version=42.42.42.42, Culture=neutral, PublicKeyToken=null]], System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]):System.Threading.Tasks.Task`1[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
         -26 (-18.57% of base) : 14373.dasm - System.Tests.Perf_DateTimeOffset:get_Values():System.Collections.Generic.IEnumerable`1[[System.Object, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
         -26 (-1.57% of base) : 10847.dasm - Newtonsoft.Json.Serialization.JsonSerializerInternalWriter:GetPropertyName(Newtonsoft.Json.JsonWriter,System.Object,Newtonsoft.Json.Serialization.JsonContract,byref):System.String:this
         -26 (-4.68% of base) : 21306.dasm - State:FillBuffer(int,byref,System.DateTime):ProtoBuf.Internal.ReadBuffer`1[DateTime]:this
         -26 (-1.65% of base) : 21614.dasm - System.Xml.Schema.XsdDateTime:op_Implicit(System.Xml.Schema.XsdDateTime):System.DateTimeOffset
         -26 (-0.81% of base) : 17833.dasm - Microsoft.CodeAnalysis.CSharp.SyntaxTreeSemanticModel:CreateMemberModel(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode):Microsoft.CodeAnalysis.CSharp.MemberSemanticModel:this
         -24 (-0.87% of base) : 16186.dasm - Microsoft.CodeAnalysis.CSharp.Binder:CheckValEscape(Microsoft.CodeAnalysis.SyntaxNode,Microsoft.CodeAnalysis.CSharp.BoundExpression,int,int,bool,Microsoft.CodeAnalysis.DiagnosticBag):bool
         -24 (-1.00% of base) : 14958.dasm - ReferenceManager:CreateAndSetSourceAssemblyFullBind(Microsoft.CodeAnalysis.CSharp.CSharpCompilation):bool:this
         -22 (-13.41% of base) : 14879.dasm - Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions:.ctor(int,bool,System.String,System.String,System.String,System.Collections.Generic.IEnumerable`1[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]],int,bool,bool,System.String,System.String,System.Collections.Immutable.ImmutableArray`1[Byte],System.Nullable`1[Boolean],int,int,int,System.Collections.Generic.IEnumerable`1[[System.Collections.Generic.KeyValuePair`2[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.CodeAnalysis.ReportDiagnostic, Microsoft.CodeAnalysis, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]], System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]],bool,bool,Microsoft.CodeAnalysis.XmlReferenceResolver,Microsoft.CodeAnalysis.SourceReferenceResolver,Microsoft.CodeAnalysis.MetadataReferenceResolver,Microsoft.CodeAnalysis.AssemblyIdentityComparer,Microsoft.CodeAnalysis.StrongNameProvider,bool,ubyte):this
         -21 (-2.12% of base) : 9935.dasm - BenchmarksGame.BinaryTrees_6:Bench(int,bool):int
         -21 (-1.23% of base) : 11618.dasm - System.Text.Json.Tests.Perf_Deep:WriteDeepUtf8():this

Top method regressions (percentages):
           4 ( 2.90% of base) : 6037.dasm - System.Text.Json.Utf8JsonWriter:WriteBooleanValue(bool):this
           1 ( 1.12% of base) : 15630.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.TupleTypeSymbol:TransformToTupleIfCompatible(Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol):Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol
          11 ( 0.75% of base) : 9575.dasm - <ReceiveAsyncThenSendAsync_Task>d__5:MoveNext():this
           8 ( 0.56% of base) : 23210.dasm - <SendAsyncThenReceiveAsync_Task>d__4:MoveNext():this
          11 ( 0.32% of base) : 15734.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SourceNamedTypeSymbol:MakeTypeParameters(Microsoft.CodeAnalysis.DiagnosticBag):System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.CSharp.Symbols.TypeParameterSymbol, Microsoft.CodeAnalysis.CSharp, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]:this

Top method improvements (percentages):
         -14 (-23.33% of base) : 7912.dasm - System.Globalization.Tests.Perf_DateTimeCultureInfo:ToString(System.Globalization.CultureInfo):System.String:this
         -14 (-22.58% of base) : 9646.dasm - System.Tests.Perf_DateTime:ToString(System.String):System.String:this
         -14 (-21.54% of base) : 23152.dasm - System.Globalization.Tests.Perf_DateTimeCultureInfo:ToStringHebrewIsrael():System.String:this
         -26 (-18.57% of base) : 14373.dasm - System.Tests.Perf_DateTimeOffset:get_Values():System.Collections.Generic.IEnumerable`1[[System.Object, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
         -16 (-15.09% of base) : 13417.dasm - BoundedChannelReader[__Canon][System.__Canon]:.ctor(System.Threading.Channels.BoundedChannel`1[__Canon]):this
         -16 (-14.68% of base) : 10718.dasm - BoundedChannelReader[Int32][System.Int32]:.ctor(System.Threading.Channels.BoundedChannel`1[Int32]):this
         -16 (-14.68% of base) : 12490.dasm - UnboundedChannelReader[Int32][System.Int32]:.ctor(System.Threading.Channels.SingleConsumerUnboundedChannel`1[Int32]):this
         -16 (-14.68% of base) : 14108.dasm - UnboundedChannelReader[Int32][System.Int32]:.ctor(System.Threading.Channels.UnboundedChannel`1[Int32]):this
         -22 (-13.41% of base) : 14879.dasm - Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions:.ctor(int,bool,System.String,System.String,System.String,System.Collections.Generic.IEnumerable`1[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]],int,bool,bool,System.String,System.String,System.Collections.Immutable.ImmutableArray`1[Byte],System.Nullable`1[Boolean],int,int,int,System.Collections.Generic.IEnumerable`1[[System.Collections.Generic.KeyValuePair`2[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.CodeAnalysis.ReportDiagnostic, Microsoft.CodeAnalysis, Version=2.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]], System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]],bool,bool,Microsoft.CodeAnalysis.XmlReferenceResolver,Microsoft.CodeAnalysis.SourceReferenceResolver,Microsoft.CodeAnalysis.MetadataReferenceResolver,Microsoft.CodeAnalysis.AssemblyIdentityComparer,Microsoft.CodeAnalysis.StrongNameProvider,bool,ubyte):this
         -52 (-13.20% of base) : 12427.dasm - System.Tests.Perf_DateTimeOffset:.ctor():this
         -14 (-12.17% of base) : 7201.dasm - System.Runtime.Serialization.Json.JsonWriterDelegator:WriteDateTime(System.DateTime):this
         -14 (-11.97% of base) : 19792.dasm - System.Xml.Serialization.XmlCustomFormatter:FromDateTime(System.DateTime):System.String
          -4 (-11.76% of base) : 21273.dasm - System.Threading.Tests.Perf_Lock:ReaderWriterLockSlimPerf():this
          -3 (-8.57% of base) : 4902.dasm - System.IO.Tests.Perf_File:WriteAllBytesAsync(int):System.Threading.Tasks.Task:this
        -117 (-8.53% of base) : 19722.dasm - BenchmarksGame.RegexRedux_5:RunBench(int):int:this
         -52 (-7.66% of base) : 11515.dasm - System.Net.Dns:GetHostEntry(System.String,int):System.Net.IPHostEntry
        -142 (-7.53% of base) : 22986.dasm - System.Text.Tests.Perf_StringBuilder:Append_ValueTypes():System.Text.StringBuilder:this
         -13 (-6.44% of base) : 9699.dasm - System.Text.Json.Document.Tests.Perf_ParseThenWrite:Setup():this
          -4 (-5.97% of base) : 16024.dasm - Microsoft.CodeAnalysis.CSharp.ClsComplianceChecker:IsSyntacticallyFilteredOut(Microsoft.CodeAnalysis.CSharp.Symbol):bool:this
          -6 (-5.94% of base) : 10509.dasm - System.Threading.Tasks.Task:Run(System.Action):System.Threading.Tasks.Task

246 total methods with Code Size differences (241 improved, 5 regressed), 3 unchanged.

```

</details>

--------------------------------------------------------------------------------

## coreclr_tests.pmi.windows.x86.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 1276214
Total bytes of diff: 1271530
Total bytes of delta: -4684 (-0.37% of base)
Total relative delta: -19.84
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          24 : 215436.dasm (9.76% of base)
          24 : 215439.dasm (9.76% of base)
          16 : 215433.dasm (7.21% of base)
          14 : 248592.dasm (3.37% of base)
           4 : 167060.dasm (0.12% of base)
           1 : 218807.dasm (0.11% of base)
           1 : 168690.dasm (0.04% of base)
           1 : 168694.dasm (0.04% of base)

Top file improvements (bytes):
        -358 : 218830.dasm (-4.21% of base)
        -289 : 223281.dasm (-6.07% of base)
        -157 : 170184.dasm (-58.80% of base)
        -152 : 170185.dasm (-53.33% of base)
        -152 : 170186.dasm (-41.87% of base)
        -152 : 170183.dasm (-53.71% of base)
        -117 : 136451.dasm (-5.09% of base)
         -80 : 252759.dasm (-21.16% of base)
         -68 : 170181.dasm (-47.22% of base)
         -68 : 170182.dasm (-37.78% of base)
         -67 : 170223.dasm (-45.89% of base)
         -67 : 170200.dasm (-45.89% of base)
         -52 : 170242.dasm (-14.81% of base)
         -52 : 170188.dasm (-6.97% of base)
         -52 : 170219.dasm (-14.81% of base)
         -52 : 242262.dasm (-4.01% of base)
         -51 : 250989.dasm (-12.98% of base)
         -50 : 170191.dasm (-6.70% of base)
         -49 : 170243.dasm (-11.84% of base)
         -49 : 170220.dasm (-11.89% of base)

623 total files with Code Size differences (615 improved, 8 regressed), 33 unchanged.

Top method regressions (bytes):
          24 ( 9.76% of base) : 215436.dasm - Mutual_recursion:fifth():int
          24 ( 9.76% of base) : 215439.dasm - Mutual_recursion:sixth():int
          16 ( 7.21% of base) : 215433.dasm - Mutual_recursion:fourth():int
          14 ( 3.37% of base) : 248592.dasm - GitHub_21915:Main():int
           4 ( 0.12% of base) : 167060.dasm - Internal.TypeSystem.Ecma.EcmaModule:ResolveMemberReference(System.Reflection.Metadata.MemberReferenceHandle):System.Object:this
           1 ( 0.11% of base) : 218807.dasm - structinreg.Program2:Main1():int
           1 ( 0.04% of base) : 168690.dasm - Managed:MarshalStructAsParam_AsSeqByValIn(int)
           1 ( 0.04% of base) : 168694.dasm - Managed:MarshalStructAsParam_AsSeqByValInOut(int)

Top method improvements (bytes):
        -358 (-4.21% of base) : 218830.dasm - structinreg.Program3:Main1():int
        -289 (-6.07% of base) : 223281.dasm - TestShufflingThunk.Test16833:Main(System.String[]):int
        -157 (-58.80% of base) : 170184.dasm - NativeVarargTest.VarArg:TestPassingTwoLongStructsWithIntAndLongNoVarargsManaged():bool
        -152 (-53.33% of base) : 170185.dasm - NativeVarargTest.VarArg:TestPassingTwoLongStructsAndIntNoVarargsManaged():bool
        -152 (-41.87% of base) : 170186.dasm - NativeVarargTest.VarArg:TestPassingFourLongStructsNoVarargsManaged():bool
        -152 (-53.71% of base) : 170183.dasm - NativeVarargTest.VarArg:TestPassingTwoLongStructsNoVarargsManaged():bool
        -117 (-5.09% of base) : 136451.dasm - BenchmarksGame.RegexRedux_5:Bench(System.IO.TextReader,bool):int
         -80 (-21.16% of base) : 252759.dasm - JitTest.superlong:Main():int
         -68 (-47.22% of base) : 170181.dasm - NativeVarargTest.VarArg:TestPassingTwoIntStructsNoVarargsManaged():bool
         -68 (-37.78% of base) : 170182.dasm - NativeVarargTest.VarArg:TestPassingFourIntStructsNoVarargsManaged():bool
         -67 (-45.89% of base) : 170223.dasm - NativeVarargTest.VarArg:TestFour16ByteStructsManaged():int
         -67 (-45.89% of base) : 170200.dasm - NativeVarargTest.VarArg:TestFour16ByteStructs():int
         -52 (-14.81% of base) : 170242.dasm - NativeVarargTest.VarArg:TestPassingEightByteStructs():int
         -52 (-6.97% of base) : 170188.dasm - NativeVarargTest.VarArg:TestPassingFourFloatStructsNoVarargsManaged():bool
         -52 (-14.81% of base) : 170219.dasm - NativeVarargTest.VarArg:TestPassingEightByteStructsManaged():int
         -52 (-4.01% of base) : 242262.dasm - FastTailCallCandidates:Tester(int):int
         -51 (-12.98% of base) : 250989.dasm - Program:Main(System.String[]):int
         -50 (-6.70% of base) : 170191.dasm - NativeVarargTest.VarArg:TestPassingFourDoubleStructsNoVarargsManaged():bool
         -49 (-11.84% of base) : 170243.dasm - NativeVarargTest.VarArg:TestPassingSixteenByteStructs():int
         -49 (-11.89% of base) : 170220.dasm - NativeVarargTest.VarArg:TestPassingSixteenByteStructsManaged():int

Top method regressions (percentages):
          24 ( 9.76% of base) : 215436.dasm - Mutual_recursion:fifth():int
          24 ( 9.76% of base) : 215439.dasm - Mutual_recursion:sixth():int
          16 ( 7.21% of base) : 215433.dasm - Mutual_recursion:fourth():int
          14 ( 3.37% of base) : 248592.dasm - GitHub_21915:Main():int
           4 ( 0.12% of base) : 167060.dasm - Internal.TypeSystem.Ecma.EcmaModule:ResolveMemberReference(System.Reflection.Metadata.MemberReferenceHandle):System.Object:this
           1 ( 0.11% of base) : 218807.dasm - structinreg.Program2:Main1():int
           1 ( 0.04% of base) : 168690.dasm - Managed:MarshalStructAsParam_AsSeqByValIn(int)
           1 ( 0.04% of base) : 168694.dasm - Managed:MarshalStructAsParam_AsSeqByValInOut(int)

Top method improvements (percentages):
        -157 (-58.80% of base) : 170184.dasm - NativeVarargTest.VarArg:TestPassingTwoLongStructsWithIntAndLongNoVarargsManaged():bool
        -152 (-53.71% of base) : 170183.dasm - NativeVarargTest.VarArg:TestPassingTwoLongStructsNoVarargsManaged():bool
        -152 (-53.33% of base) : 170185.dasm - NativeVarargTest.VarArg:TestPassingTwoLongStructsAndIntNoVarargsManaged():bool
         -68 (-47.22% of base) : 170181.dasm - NativeVarargTest.VarArg:TestPassingTwoIntStructsNoVarargsManaged():bool
         -67 (-45.89% of base) : 170223.dasm - NativeVarargTest.VarArg:TestFour16ByteStructsManaged():int
         -67 (-45.89% of base) : 170200.dasm - NativeVarargTest.VarArg:TestFour16ByteStructs():int
        -152 (-41.87% of base) : 170186.dasm - NativeVarargTest.VarArg:TestPassingFourLongStructsNoVarargsManaged():bool
         -24 (-41.38% of base) : 168284.dasm - <>c:<TestVector128C>b__56_3():this
         -24 (-41.38% of base) : 168280.dasm - <>c:<TestVector128B>b__55_3():this
         -18 (-40.91% of base) : 168232.dasm - <>c:<TestVector64L>b__71_3():this
         -18 (-40.91% of base) : 168224.dasm - <>c:<TestVector64D>b__69_3():this
         -18 (-40.91% of base) : 168228.dasm - <>c:<TestVector64F>b__70_3():this
         -18 (-40.91% of base) : 168216.dasm - <>c:<TestVector64B>b__67_3():this
         -18 (-40.91% of base) : 168220.dasm - <>c:<TestVector64C>b__68_3():this
         -18 (-40.91% of base) : 168180.dasm - <>c:<TestVector64U>b__72_3():this
         -68 (-37.78% of base) : 170182.dasm - NativeVarargTest.VarArg:TestPassingFourIntStructsNoVarargsManaged():bool
         -32 (-36.36% of base) : 86437.dasm - Test:Main():int
         -42 (-33.07% of base) : 86435.dasm - projs.GitHub_35821:Main(System.String[]):int
         -17 (-30.36% of base) : 86555.dasm - MyTest:Main():int
         -38 (-28.15% of base) : 170222.dasm - NativeVarargTest.VarArg:TestMany16ByteStructsManaged():int

623 total methods with Code Size differences (615 improved, 8 regressed), 33 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.crossgen2.windows.x86.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 105964
Total bytes of diff: 104506
Total bytes of delta: -1458 (-1.38% of base)
Total relative delta: -11.52
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          10 : 181642.dasm (1.03% of base)
           1 : 197097.dasm (0.08% of base)
           1 : 205020.dasm (0.42% of base)
           1 : 78721.dasm (0.08% of base)

Top file improvements (bytes):
         -69 : 29970.dasm (-14.29% of base)
         -66 : 29728.dasm (-7.96% of base)
         -56 : 26805.dasm (-6.44% of base)
         -56 : 186456.dasm (-11.45% of base)
         -56 : 186437.dasm (-17.34% of base)
         -52 : 30243.dasm (-3.98% of base)
         -35 : 30244.dasm (-5.38% of base)
         -32 : 186439.dasm (-20.51% of base)
         -32 : 186442.dasm (-23.36% of base)
         -32 : 26806.dasm (-5.08% of base)
         -32 : 186458.dasm (-8.04% of base)
         -32 : 186438.dasm (-21.62% of base)
         -30 : 186448.dasm (-6.82% of base)
         -28 : 33166.dasm (-7.55% of base)
         -24 : 42371.dasm (-4.86% of base)
         -20 : 29742.dasm (-30.77% of base)
         -20 : 29744.dasm (-40.00% of base)
         -18 : 181875.dasm (-5.03% of base)
         -16 : 189735.dasm (-6.64% of base)
         -15 : 22318.dasm (-1.99% of base)

310 total files with Code Size differences (306 improved, 4 regressed), 7 unchanged.

Top method regressions (bytes):
          10 ( 1.03% of base) : 181642.dasm - Internal.TypeSystem.Ecma.EcmaModule:ResolveMemberReference(System.Reflection.Metadata.MemberReferenceHandle):System.Object:this
           1 ( 0.08% of base) : 197097.dasm - System.DirectoryServices.AccountManagement.AuthZSet:.ctor(System.Byte[],System.DirectoryServices.AccountManagement.NetCred,int,System.String,System.DirectoryServices.AccountManagement.StoreCtx,System.Object):this
           1 ( 0.42% of base) : 205020.dasm - Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteValidator:VisitScopeCache(Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceCallSite,Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteValidator+CallSiteValidatorState):System.Type:this
           1 ( 0.08% of base) : 78721.dasm - Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.Parser:ParseSpecifierDeclaration(Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.SyntaxList`1[Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.AttributeListSyntax],Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.SyntaxList`1[Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.KeywordSyntax]):Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.StatementSyntax:this

Top method improvements (bytes):
         -69 (-14.29% of base) : 29970.dasm - System.DateTimeOffset:.cctor()
         -66 (-7.96% of base) : 29728.dasm - System.DateTimeFormat:GetAllDateTimes(System.DateTime,ushort,System.Globalization.DateTimeFormatInfo):System.String[]
         -56 (-6.44% of base) : 26805.dasm - System.TimeOnly:TryFormat(System.Span`1[System.Char],byref,System.ReadOnlySpan`1[System.Char],System.IFormatProvider):bool:this
         -56 (-11.45% of base) : 186456.dasm - System.Net.Dns:GetHostEntry(System.String,int):System.Net.IPHostEntry
         -56 (-17.34% of base) : 186437.dasm - System.Net.Dns:Resolve(System.String):System.Net.IPHostEntry
         -52 (-3.98% of base) : 30243.dasm - System.DateOnly:TryFormat(System.Span`1[System.Char],byref,System.ReadOnlySpan`1[System.Char],System.IFormatProvider):bool:this
         -35 (-5.38% of base) : 30244.dasm - System.DateOnly:ToString(System.String,System.IFormatProvider):System.String:this
         -32 (-20.51% of base) : 186439.dasm - System.Net.Dns:GetHostByAddress(System.String):System.Net.IPHostEntry
         -32 (-23.36% of base) : 186442.dasm - System.Net.Dns:GetHostByName(System.String):System.Net.IPHostEntry
         -32 (-5.08% of base) : 26806.dasm - System.TimeOnly:ToString(System.String,System.IFormatProvider):System.String:this
         -32 (-8.04% of base) : 186458.dasm - System.Net.Dns:GetHostEntry(System.Net.IPAddress):System.Net.IPHostEntry
         -32 (-21.62% of base) : 186438.dasm - System.Net.Dns:GetHostByAddress(System.Net.IPAddress):System.Net.IPHostEntry
         -30 (-6.82% of base) : 186448.dasm - System.Net.Dns:GetHostAddresses(System.String,int):System.Net.IPAddress[]
         -28 (-7.55% of base) : 33166.dasm - System.Text.ValueStringBuilder:AppendSpanFormattable(System.DateTime,System.String,System.IFormatProvider):this
         -24 (-4.86% of base) : 42371.dasm - System.Text.Json.Utf8JsonWriter:WriteRawValueCore(System.ReadOnlySpan`1[System.Byte],bool):this
         -20 (-30.77% of base) : 29742.dasm - System.DateTimeFormat:TryFormat(System.DateTime,System.Span`1[System.Char],byref,System.ReadOnlySpan`1[System.Char],System.IFormatProvider):bool
         -20 (-40.00% of base) : 29744.dasm - System.DateTimeFormat:Format(System.DateTime,System.String,System.IFormatProvider):System.String
         -18 (-5.03% of base) : 181875.dasm - Internal.TypeSystem.MethodSignature:ApplySubstitution(Internal.TypeSystem.Instantiation):Internal.TypeSystem.MethodSignature:this
         -16 (-6.64% of base) : 189735.dasm - ILCompiler.Reflection.ReadyToRun.x86.GcTransitionCall:.ctor(int,bool,int,int):this
         -15 (-1.99% of base) : 22318.dasm - System.Threading.Tasks.ConcurrentExclusiveSchedulerPair:ProcessAsyncIfNecessary(bool):this

Top method regressions (percentages):
          10 ( 1.03% of base) : 181642.dasm - Internal.TypeSystem.Ecma.EcmaModule:ResolveMemberReference(System.Reflection.Metadata.MemberReferenceHandle):System.Object:this
           1 ( 0.42% of base) : 205020.dasm - Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteValidator:VisitScopeCache(Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceCallSite,Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteValidator+CallSiteValidatorState):System.Type:this
           1 ( 0.08% of base) : 197097.dasm - System.DirectoryServices.AccountManagement.AuthZSet:.ctor(System.Byte[],System.DirectoryServices.AccountManagement.NetCred,int,System.String,System.DirectoryServices.AccountManagement.StoreCtx,System.Object):this
           1 ( 0.08% of base) : 78721.dasm - Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.Parser:ParseSpecifierDeclaration(Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.SyntaxList`1[Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.AttributeListSyntax],Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.SyntaxList`1[Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.KeywordSyntax]):Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.StatementSyntax:this

Top method improvements (percentages):
         -20 (-40.00% of base) : 29744.dasm - System.DateTimeFormat:Format(System.DateTime,System.String,System.IFormatProvider):System.String
         -20 (-30.77% of base) : 29742.dasm - System.DateTimeFormat:TryFormat(System.DateTime,System.Span`1[System.Char],byref,System.ReadOnlySpan`1[System.Char],System.IFormatProvider):bool
         -14 (-24.14% of base) : 30134.dasm - System.DateTime:ToString(System.IFormatProvider):System.String:this
         -32 (-23.36% of base) : 186442.dasm - System.Net.Dns:GetHostByName(System.String):System.Net.IPHostEntry
         -14 (-23.33% of base) : 30135.dasm - System.DateTime:ToString(System.String):System.String:this
         -14 (-23.33% of base) : 30136.dasm - System.DateTime:ToString():System.String:this
         -14 (-22.22% of base) : 30133.dasm - System.DateTime:ToString(System.String,System.IFormatProvider):System.String:this
         -32 (-21.62% of base) : 186438.dasm - System.Net.Dns:GetHostByAddress(System.Net.IPAddress):System.Net.IPHostEntry
         -14 (-21.21% of base) : 30137.dasm - System.DateTime:ToShortTimeString():System.String:this
         -14 (-21.21% of base) : 30138.dasm - System.DateTime:ToShortDateString():System.String:this
         -14 (-21.21% of base) : 30139.dasm - System.DateTime:ToLongTimeString():System.String:this
         -14 (-21.21% of base) : 30140.dasm - System.DateTime:ToLongDateString():System.String:this
         -32 (-20.51% of base) : 186439.dasm - System.Net.Dns:GetHostByAddress(System.String):System.Net.IPHostEntry
         -14 (-20.29% of base) : 30355.dasm - System.Convert:ToString(System.DateTime):System.String
         -14 (-18.92% of base) : 30354.dasm - System.Convert:ToString(System.DateTime,System.IFormatProvider):System.String
         -56 (-17.34% of base) : 186437.dasm - System.Net.Dns:Resolve(System.String):System.Net.IPHostEntry
         -14 (-14.89% of base) : 30132.dasm - System.DateTime:TryFormat(System.Span`1[System.Char],byref,System.ReadOnlySpan`1[System.Char],System.IFormatProvider):bool:this
          -3 (-14.29% of base) : 22250.dasm - System.Threading.Tasks.Task`1:ContinueWith(System.Action`1[System.Threading.Tasks.Task`1[System.__Canon]],System.Threading.Tasks.TaskScheduler):System.Threading.Tasks.Task:this
          -3 (-14.29% of base) : 33445.dasm - System.Threading.Tasks.Task`1:ContinueWith(System.Action`1[System.Threading.Tasks.Task`1[System.Boolean]],System.Threading.Tasks.TaskScheduler):System.Threading.Tasks.Task:this
          -3 (-14.29% of base) : 21987.dasm - System.Threading.Tasks.Task:ContinueWith(System.Action`1[System.Threading.Tasks.Task],System.Threading.Tasks.TaskScheduler):System.Threading.Tasks.Task:this

310 total methods with Code Size differences (306 improved, 4 regressed), 7 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.pmi.windows.x86.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 981662
Total bytes of diff: 971911
Total bytes of delta: -9751 (-0.99% of base)
Total relative delta: -49.23
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          20 : 28055.dasm (0.98% of base)
          18 : 42788.dasm (0.60% of base)
          18 : 28076.dasm (1.65% of base)
          10 : 192079.dasm (0.47% of base)
           8 : 156354.dasm (3.32% of base)
           7 : 55132.dasm (0.37% of base)
           5 : 48951.dasm (0.26% of base)
           4 : 156223.dasm (1.42% of base)
           4 : 156229.dasm (1.42% of base)
           4 : 156237.dasm (2.90% of base)
           4 : 162623.dasm (0.12% of base)
           3 : 52913.dasm (0.88% of base)
           3 : 156349.dasm (0.44% of base)
           3 : 28035.dasm (0.35% of base)
           3 : 28045.dasm (0.71% of base)
           2 : 48943.dasm (0.09% of base)
           2 : 28048.dasm (0.20% of base)
           2 : 44833.dasm (0.49% of base)
           2 : 83683.dasm (1.06% of base)
           1 : 57062.dasm (0.09% of base)

Top file improvements (bytes):
        -373 : 203557.dasm (-44.35% of base)
        -224 : 104584.dasm (-9.42% of base)
        -172 : 116877.dasm (-4.82% of base)
        -137 : 49441.dasm (-3.32% of base)
        -118 : 55895.dasm (-1.49% of base)
         -84 : 180394.dasm (-4.97% of base)
         -82 : 167672.dasm (-14.72% of base)
         -82 : 106046.dasm (-14.44% of base)
         -64 : 28049.dasm (-2.37% of base)
         -61 : 229499.dasm (-2.61% of base)
         -60 : 147243.dasm (-2.37% of base)
         -59 : 203715.dasm (-15.53% of base)
         -56 : 77401.dasm (-7.85% of base)
         -52 : 203696.dasm (-7.66% of base)
         -52 : 84201.dasm (-1.53% of base)
         -51 : 127075.dasm (-1.21% of base)
         -48 : 80559.dasm (-2.31% of base)
         -47 : 79693.dasm (-5.91% of base)
         -46 : 189429.dasm (-1.64% of base)
         -42 : 71514.dasm (-14.00% of base)

1765 total files with Code Size differences (1738 improved, 27 regressed), 71 unchanged.

Top method regressions (bytes):
          20 ( 0.98% of base) : 28055.dasm - Microsoft.CodeAnalysis.CSharp.ExpressionLambdaRewriter:VisitObjectCreationExpressionInternal(Microsoft.CodeAnalysis.CSharp.BoundObjectCreationExpression):Microsoft.CodeAnalysis.CSharp.BoundExpression:this
          18 ( 0.60% of base) : 42788.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SourceNamedTypeSymbol:MakeTypeParameters(Microsoft.CodeAnalysis.DiagnosticBag):System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.CSharp.Symbols.TypeParameterSymbol, Microsoft.CodeAnalysis.CSharp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]:this
          18 ( 1.65% of base) : 28076.dasm - Microsoft.CodeAnalysis.CSharp.ExpressionLambdaRewriter:VisitArrayCreation(Microsoft.CodeAnalysis.CSharp.BoundArrayCreation):Microsoft.CodeAnalysis.CSharp.BoundExpression:this
          10 ( 0.47% of base) : 192079.dasm - System.Security.AccessControl.DirectoryObjectSecurity:GetRules(bool,bool,bool,System.Type):System.Security.AccessControl.AuthorizationRuleCollection:this
           8 ( 3.32% of base) : 156354.dasm - System.Text.Json.Utf8JsonWriter:WriteBoolean(System.Text.Json.JsonEncodedText,bool):this
           7 ( 0.37% of base) : 55132.dasm - Microsoft.CodeAnalysis.VisualBasic.MethodCompiler:GenerateMethodBody(Microsoft.CodeAnalysis.VisualBasic.Emit.PEModuleBuilder,Microsoft.CodeAnalysis.VisualBasic.Symbols.MethodSymbol,int,Microsoft.CodeAnalysis.VisualBasic.BoundStatement,System.Collections.Immutable.ImmutableArray`1[LambdaDebugInfo],System.Collections.Immutable.ImmutableArray`1[ClosureDebugInfo],Microsoft.CodeAnalysis.VisualBasic.StateMachineTypeSymbol,Microsoft.CodeAnalysis.CodeGen.VariableSlotAllocator,Microsoft.CodeAnalysis.CodeGen.DebugDocumentProvider,Microsoft.CodeAnalysis.DiagnosticBag,bool):Microsoft.CodeAnalysis.CodeGen.MethodBody
           5 ( 0.26% of base) : 48951.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindXmlAttribute(Microsoft.CodeAnalysis.VisualBasic.Syntax.XmlAttributeSyntax,XmlElementRootInfo,byref,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundXmlAttribute:this
           4 ( 1.42% of base) : 156223.dasm - System.Text.Json.Utf8JsonWriter:WriteFloatingPointConstant(double):this
           4 ( 1.42% of base) : 156229.dasm - System.Text.Json.Utf8JsonWriter:WriteFloatingPointConstant(float):this
           4 ( 2.90% of base) : 156237.dasm - System.Text.Json.Utf8JsonWriter:WriteBooleanValue(bool):this
           4 ( 0.12% of base) : 162623.dasm - Internal.TypeSystem.Ecma.EcmaModule:ResolveMemberReference(System.Reflection.Metadata.MemberReferenceHandle):System.Object:this
           3 ( 0.88% of base) : 52913.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.SourceMemberContainerTypeSymbol:GenerateVarianceDiagnosticsForConstraints(System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.VisualBasic.Symbols.TypeParameterSymbol, Microsoft.CodeAnalysis.VisualBasic, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],byref,byref):this
           3 ( 0.44% of base) : 156349.dasm - System.Text.Json.Utf8JsonWriter:WriteNullSection(System.ReadOnlySpan`1[Byte]):this
           3 ( 0.35% of base) : 28035.dasm - Microsoft.CodeAnalysis.CSharp.ExpressionLambdaRewriter:VisitCall(Microsoft.CodeAnalysis.CSharp.BoundCall):Microsoft.CodeAnalysis.CSharp.BoundExpression:this
           3 ( 0.71% of base) : 28045.dasm - Microsoft.CodeAnalysis.CSharp.ExpressionLambdaRewriter:VisitLambda(Microsoft.CodeAnalysis.CSharp.BoundLambda):Microsoft.CodeAnalysis.CSharp.BoundExpression:this
           2 ( 0.09% of base) : 48943.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindXmlElementWithoutAddingNamespaces(Microsoft.CodeAnalysis.VisualBasic.Syntax.XmlNodeSyntax,Microsoft.CodeAnalysis.VisualBasic.Syntax.XmlNodeSyntax,byref,Microsoft.CodeAnalysis.ArrayBuilder`1[[Microsoft.CodeAnalysis.VisualBasic.BoundXmlAttribute, Microsoft.CodeAnalysis.VisualBasic, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],Microsoft.CodeAnalysis.ArrayBuilder`1[[Microsoft.CodeAnalysis.VisualBasic.Syntax.XmlNodeSyntax, Microsoft.CodeAnalysis.VisualBasic, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],Microsoft.CodeAnalysis.SyntaxList`1[[Microsoft.CodeAnalysis.VisualBasic.Syntax.XmlNodeSyntax, Microsoft.CodeAnalysis.VisualBasic, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],XmlElementRootInfo,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundExpression:this
           2 ( 0.20% of base) : 28048.dasm - Microsoft.CodeAnalysis.CSharp.ExpressionLambdaRewriter:VisitNullCoalescingOperator(Microsoft.CodeAnalysis.CSharp.BoundNullCoalescingOperator):Microsoft.CodeAnalysis.CSharp.BoundExpression:this
           2 ( 0.49% of base) : 44833.dasm - AttributeExpressionVisitor:VisitTypeOfExpression(Microsoft.CodeAnalysis.CSharp.BoundTypeOfOperator,Microsoft.CodeAnalysis.DiagnosticBag,byref,bool):Microsoft.CodeAnalysis.TypedConstant
           2 ( 1.06% of base) : 83683.dasm - Microsoft.Diagnostics.Symbols.SymbolPath:ComputerNameExists(System.String,int):bool
           1 ( 0.09% of base) : 57062.dasm - Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.Parser:ParseSpecifierDeclaration(Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.SyntaxList`1[[Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.AttributeListSyntax, Microsoft.CodeAnalysis.VisualBasic, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.SyntaxList`1[[Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.KeywordSyntax, Microsoft.CodeAnalysis.VisualBasic, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]):Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.StatementSyntax:this

Top method improvements (bytes):
        -373 (-44.35% of base) : 203557.dasm - System.Net.Mime.SmtpDateTime:InitializeShortHandLookups():System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.TimeSpan, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
        -224 (-9.42% of base) : 104584.dasm - Microsoft.VisualBasic.Strings:FormatNamed(System.Object,System.String,byref):bool
        -172 (-4.82% of base) : 116877.dasm - System.Data.Common.SqlDecimalStorage:Aggregate(System.Int32[],int):System.Object:this
        -137 (-3.32% of base) : 49441.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindAttribute(Microsoft.CodeAnalysis.VisualBasic.Syntax.AttributeSyntax,Microsoft.CodeAnalysis.VisualBasic.Symbols.NamedTypeSymbol,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundAttribute:this
        -118 (-1.49% of base) : 55895.dasm - Microsoft.CodeAnalysis.VisualBasic.IteratorRewriter:GenerateMethodImplementations():this
         -84 (-4.97% of base) : 180394.dasm - System.ComponentModel.DateTimeConverter:ConvertTo(System.ComponentModel.ITypeDescriptorContext,System.Globalization.CultureInfo,System.Object,System.Type):System.Object:this
         -82 (-14.72% of base) : 167672.dasm - Newtonsoft.Json.Bson.Utilities.DateTimeUtils:TryParseDateTimeOffsetMicrosoft(System.String,byref):bool
         -82 (-14.44% of base) : 106046.dasm - Newtonsoft.Json.Utilities.DateTimeUtils:TryParseDateTimeOffsetMicrosoft(Newtonsoft.Json.Utilities.StringReference,byref):bool
         -64 (-2.37% of base) : 28049.dasm - Microsoft.CodeAnalysis.CSharp.ExpressionLambdaRewriter:MakeConversionLambda(Microsoft.CodeAnalysis.CSharp.Conversion,Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol,Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol):Microsoft.CodeAnalysis.CSharp.BoundExpression:this
         -61 (-2.61% of base) : 229499.dasm - <CreateTestRun>d__20:MoveNext():this
         -60 (-2.37% of base) : 147243.dasm - System.Xml.Serialization.ReflectionXmlSerializationWriter:WritePrimitiveValue(System.Xml.Serialization.TypeDesc,System.Object,bool,byref):bool:this
         -59 (-15.53% of base) : 203715.dasm - System.Net.Dns:Resolve(System.String):System.Net.IPHostEntry
         -56 (-7.85% of base) : 77401.dasm - Microsoft.CodeAnalysis.TypeNameDecoder`2[__Canon,__Canon][System.__Canon,System.__Canon]:GetTypeSymbol(AssemblyQualifiedTypeName,byref):System.__Canon:this
         -52 (-7.66% of base) : 203696.dasm - System.Net.Dns:GetHostEntry(System.String,int):System.Net.IPHostEntry
         -52 (-1.53% of base) : 84201.dasm - Microsoft.Diagnostics.Tracing.TraceEvent:PayloadString(int,System.IFormatProvider):System.String:this
         -51 (-1.21% of base) : 127075.dasm - <ProcessServerStreamAsync>d__42:MoveNext():this
         -48 (-2.31% of base) : 80559.dasm - Microsoft.CodeAnalysis.CodeGen.SwitchIntegralJumpTableEmitter:EmitSwitchBucketsLinearLeaf(System.Collections.Immutable.ImmutableArray`1[SwitchBucket],int,int):this
         -47 (-5.91% of base) : 79693.dasm - Microsoft.CodeAnalysis.Diagnostics.AnalysisResult:StoreAnalysisResult(Microsoft.CodeAnalysis.Diagnostics.AnalysisScope,Microsoft.CodeAnalysis.Diagnostics.AnalyzerDriver,Microsoft.CodeAnalysis.Compilation):this
         -46 (-1.64% of base) : 189429.dasm - System.DirectoryServices.AccountManagement.ADStoreCtx:GetGroupsMemberOf(System.DirectoryServices.AccountManagement.Principal,System.DirectoryServices.AccountManagement.StoreCtx):System.DirectoryServices.AccountManagement.ResultSet:this
         -42 (-14.00% of base) : 71514.dasm - Microsoft.VisualBasic.CompilerServices.Conversions:ToString(System.DateTime):System.String

Top method regressions (percentages):
           8 ( 3.32% of base) : 156354.dasm - System.Text.Json.Utf8JsonWriter:WriteBoolean(System.Text.Json.JsonEncodedText,bool):this
           4 ( 2.90% of base) : 156237.dasm - System.Text.Json.Utf8JsonWriter:WriteBooleanValue(bool):this
          18 ( 1.65% of base) : 28076.dasm - Microsoft.CodeAnalysis.CSharp.ExpressionLambdaRewriter:VisitArrayCreation(Microsoft.CodeAnalysis.CSharp.BoundArrayCreation):Microsoft.CodeAnalysis.CSharp.BoundExpression:this
           4 ( 1.42% of base) : 156223.dasm - System.Text.Json.Utf8JsonWriter:WriteFloatingPointConstant(double):this
           4 ( 1.42% of base) : 156229.dasm - System.Text.Json.Utf8JsonWriter:WriteFloatingPointConstant(float):this
           1 ( 1.35% of base) : 156236.dasm - System.Text.Json.Utf8JsonWriter:WriteNullValue():this
           2 ( 1.06% of base) : 83683.dasm - Microsoft.Diagnostics.Symbols.SymbolPath:ComputerNameExists(System.String,int):bool
          20 ( 0.98% of base) : 28055.dasm - Microsoft.CodeAnalysis.CSharp.ExpressionLambdaRewriter:VisitObjectCreationExpressionInternal(Microsoft.CodeAnalysis.CSharp.BoundObjectCreationExpression):Microsoft.CodeAnalysis.CSharp.BoundExpression:this
           3 ( 0.88% of base) : 52913.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.SourceMemberContainerTypeSymbol:GenerateVarianceDiagnosticsForConstraints(System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.VisualBasic.Symbols.TypeParameterSymbol, Microsoft.CodeAnalysis.VisualBasic, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],byref,byref):this
           3 ( 0.71% of base) : 28045.dasm - Microsoft.CodeAnalysis.CSharp.ExpressionLambdaRewriter:VisitLambda(Microsoft.CodeAnalysis.CSharp.BoundLambda):Microsoft.CodeAnalysis.CSharp.BoundExpression:this
          18 ( 0.60% of base) : 42788.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SourceNamedTypeSymbol:MakeTypeParameters(Microsoft.CodeAnalysis.DiagnosticBag):System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.CSharp.Symbols.TypeParameterSymbol, Microsoft.CodeAnalysis.CSharp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]:this
           2 ( 0.49% of base) : 44833.dasm - AttributeExpressionVisitor:VisitTypeOfExpression(Microsoft.CodeAnalysis.CSharp.BoundTypeOfOperator,Microsoft.CodeAnalysis.DiagnosticBag,byref,bool):Microsoft.CodeAnalysis.TypedConstant
          10 ( 0.47% of base) : 192079.dasm - System.Security.AccessControl.DirectoryObjectSecurity:GetRules(bool,bool,bool,System.Type):System.Security.AccessControl.AuthorizationRuleCollection:this
           3 ( 0.44% of base) : 156349.dasm - System.Text.Json.Utf8JsonWriter:WriteNullSection(System.ReadOnlySpan`1[Byte]):this
           7 ( 0.37% of base) : 55132.dasm - Microsoft.CodeAnalysis.VisualBasic.MethodCompiler:GenerateMethodBody(Microsoft.CodeAnalysis.VisualBasic.Emit.PEModuleBuilder,Microsoft.CodeAnalysis.VisualBasic.Symbols.MethodSymbol,int,Microsoft.CodeAnalysis.VisualBasic.BoundStatement,System.Collections.Immutable.ImmutableArray`1[LambdaDebugInfo],System.Collections.Immutable.ImmutableArray`1[ClosureDebugInfo],Microsoft.CodeAnalysis.VisualBasic.StateMachineTypeSymbol,Microsoft.CodeAnalysis.CodeGen.VariableSlotAllocator,Microsoft.CodeAnalysis.CodeGen.DebugDocumentProvider,Microsoft.CodeAnalysis.DiagnosticBag,bool):Microsoft.CodeAnalysis.CodeGen.MethodBody
           3 ( 0.35% of base) : 28035.dasm - Microsoft.CodeAnalysis.CSharp.ExpressionLambdaRewriter:VisitCall(Microsoft.CodeAnalysis.CSharp.BoundCall):Microsoft.CodeAnalysis.CSharp.BoundExpression:this
           5 ( 0.26% of base) : 48951.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindXmlAttribute(Microsoft.CodeAnalysis.VisualBasic.Syntax.XmlAttributeSyntax,XmlElementRootInfo,byref,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundXmlAttribute:this
           1 ( 0.26% of base) : 57285.dasm - Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.Blender:.ctor(Microsoft.CodeAnalysis.Text.SourceText,Microsoft.CodeAnalysis.Text.TextChangeRange[],Microsoft.CodeAnalysis.SyntaxTree,Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions):this
           2 ( 0.20% of base) : 28048.dasm - Microsoft.CodeAnalysis.CSharp.ExpressionLambdaRewriter:VisitNullCoalescingOperator(Microsoft.CodeAnalysis.CSharp.BoundNullCoalescingOperator):Microsoft.CodeAnalysis.CSharp.BoundExpression:this
           1 ( 0.16% of base) : 118933.dasm - System.Drawing.BufferedGraphicsContext:CreateCompatibleDIB(int,int,int,int,byref):int:this

Top method improvements (percentages):
        -373 (-44.35% of base) : 203557.dasm - System.Net.Mime.SmtpDateTime:InitializeShortHandLookups():System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.TimeSpan, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
         -29 (-32.58% of base) : 189560.dasm - System.DirectoryServices.AccountManagement.SDSUtils:ConstructSearcher(System.DirectoryServices.DirectoryEntry):System.DirectoryServices.DirectorySearcher
         -40 (-29.20% of base) : 79691.dasm - Microsoft.CodeAnalysis.Diagnostics.AnalysisResult:CreateAnalyzerExecutionTimeMap(System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer, Microsoft.CodeAnalysis, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]):System.Collections.Generic.Dictionary`2[[Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer, Microsoft.CodeAnalysis, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35],[System.TimeSpan, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
         -14 (-20.59% of base) : 219458.dasm - System.Security.Cryptography.X509Certificates.X509Certificate:GetEffectiveDateString():System.String:this
         -14 (-20.59% of base) : 219459.dasm - System.Security.Cryptography.X509Certificates.X509Certificate:GetExpirationDateString():System.String:this
         -14 (-19.72% of base) : 203562.dasm - System.Net.Mime.SmtpDateTime:FormatDate(System.DateTime):System.String:this
         -14 (-19.72% of base) : 67862.dasm - Microsoft.CodeAnalysis.VisualBasic.ObjectDisplay.ObjectDisplay:FormatLiteral(System.DateTime):System.String
         -32 (-19.63% of base) : 203711.dasm - System.Net.Dns:GetHostByName(System.String):System.Net.IPHostEntry
         -14 (-19.44% of base) : 136208.dasm - System.Xml.XmlConvert:ToString(System.DateTime,System.String):System.String
         -36 (-19.35% of base) : 203713.dasm - System.Net.Dns:GetHostByAddress(System.String):System.Net.IPHostEntry
          -5 (-18.52% of base) : 173772.dasm - System.Collections.Immutable.ImmutableInterlocked:InterlockedInitialize(byref,System.Collections.Immutable.ImmutableArray`1[Byte]):bool
         -32 (-18.29% of base) : 203714.dasm - System.Net.Dns:GetHostByAddress(System.Net.IPAddress):System.Net.IPHostEntry
          -4 (-17.39% of base) : 214184.dasm - System.Security.AccessControl.ObjectSecurity:WriteLock():this
          -4 (-17.39% of base) : 214182.dasm - System.Security.AccessControl.ObjectSecurity:ReadLock():this
          -4 (-17.39% of base) : 179654.dasm - Microsoft.Internal.Lock:EnterReadLock():this
          -4 (-17.39% of base) : 179655.dasm - Microsoft.Internal.Lock:EnterWriteLock():this
          -4 (-17.39% of base) : 178210.dasm - System.Threading.Lock:EnterReadLock():this
          -4 (-17.39% of base) : 178211.dasm - System.Threading.Lock:EnterWriteLock():this
         -14 (-16.87% of base) : 136207.dasm - System.Xml.XmlConvert:ToString(System.DateTime):System.String
         -14 (-16.87% of base) : 147627.dasm - System.Xml.Serialization.XmlCustomFormatter:FromDate(System.DateTime):System.String

1765 total methods with Code Size differences (1738 improved, 27 regressed), 71 unchanged.

```

</details>

--------------------------------------------------------------------------------

The larger diffs come from `long` fields being constant propagated:
```diff
-       xor      ecx, ecx
-       mov      edx, 0xD1FFAB1E
-       mov      dword ptr [ebp-18H], ecx
-       mov      dword ptr [ebp-14H], edx
        mov      ecx, dword ptr [ebp-10H]
        mov      edx, dword ptr [ebp-0CH]
        push     edx
        push     ecx
-       mov      ecx, dword ptr [ebp-18H]
-       mov      edx, dword ptr [ebp-14H]
-       push     edx
-       push     ecx
+       push     0xD1FFAB1E
+       push     0
```

The regressions are cases where constant propagation results in larger code (a few cases in `coreclr_tests` with floats), minor CSE and register allocation differences.