### PR TITLE
Fix `FileProviders.Physical.GetLastWriteTimeUtc` crash

### DIFF
--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PollingFileChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PollingFileChangeToken.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
     public class PollingFileChangeToken : IPollingChangeToken
     {
         private readonly FileInfo _fileInfo;
-        private DateTime? _previousWriteTimeUtc;
+        private DateTime _previousWriteTimeUtc;
         private DateTime _lastCheckedTimeUtc;
         private bool _hasChanged;
         private CancellationTokenSource _tokenSource;
@@ -45,7 +45,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
         // Internal for unit testing
         internal static TimeSpan PollingInterval { get; set; } = PhysicalFilesWatcher.DefaultPollingInterval;
 
-        private DateTime? GetLastWriteTimeUtc()
+        private DateTime GetLastWriteTimeUtc()
         {
             _fileInfo.Refresh();
 
@@ -65,7 +65,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
                 catch (IOException) { } // https://github.com/dotnet/runtime/issues/57221
             }
 
-            return lastWriteTimeUtc;
+            return lastWriteTimeUtc ?? DateTime.MinValue;
         }
 
         /// <summary>
@@ -109,8 +109,8 @@ namespace Microsoft.Extensions.FileProviders.Physical
                     return _hasChanged;
                 }
 
-                DateTime? lastWriteTimeUtc = GetLastWriteTimeUtc();
-                if (lastWriteTimeUtc != null && _previousWriteTimeUtc != lastWriteTimeUtc)
+                DateTime lastWriteTimeUtc = GetLastWriteTimeUtc();
+                if (_previousWriteTimeUtc != lastWriteTimeUtc)
                 {
                     _previousWriteTimeUtc = lastWriteTimeUtc;
                     _hasChanged = true;

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PollingFileChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PollingFileChangeToken.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
     public class PollingFileChangeToken : IPollingChangeToken
     {
         private readonly FileInfo _fileInfo;
-        private DateTime _previousWriteTimeUtc;
+        private DateTime? _previousWriteTimeUtc;
         private DateTime _lastCheckedTimeUtc;
         private bool _hasChanged;
         private CancellationTokenSource _tokenSource;
@@ -45,7 +45,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
         // Internal for unit testing
         internal static TimeSpan PollingInterval { get; set; } = PhysicalFilesWatcher.DefaultPollingInterval;
 
-        private DateTime GetLastWriteTimeUtc()
+        private DateTime? GetLastWriteTimeUtc()
         {
             _fileInfo.Refresh();
 
@@ -65,7 +65,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
                 catch (IOException) { } // https://github.com/dotnet/runtime/issues/57221
             }
 
-            return lastWriteTimeUtc.Value;
+            return lastWriteTimeUtc;
         }
 
         /// <summary>
@@ -109,8 +109,8 @@ namespace Microsoft.Extensions.FileProviders.Physical
                     return _hasChanged;
                 }
 
-                DateTime lastWriteTimeUtc = GetLastWriteTimeUtc();
-                if (_previousWriteTimeUtc != lastWriteTimeUtc)
+                DateTime? lastWriteTimeUtc = GetLastWriteTimeUtc();
+                if (lastWriteTimeUtc != null && _previousWriteTimeUtc != lastWriteTimeUtc)
                 {
                     _previousWriteTimeUtc = lastWriteTimeUtc;
                     _hasChanged = true;


### PR DESCRIPTION
Some tests are failing because of a recent changes.
Example: [failing test](https://helixre8s23ayyeko0k025g8.blob.core.windows.net/dotnet-runtime-refs-pull-57395-merge-0f3646ab75284a6cb3/Microsoft.Extensions.FileProviders.Physical.Tests/1/console.29678691.log?sv=2019-07-07&se=2021-09-03T19%3A34%3A21Z&sr=c&sp=rl&sig=6WlTuWWS7AQohTGzb24%2BQAjaIIGcksFMs%2Bgzchsez3k%3D)

Updated the code, so there won't be an NRE