### PR TITLE
Check for OpenSSL availability for OpenSsl asymmetric primitives

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/DSAOpenSsl.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/DSAOpenSsl.cs
@@ -41,6 +41,7 @@ namespace System.Security.Cryptography
 
             public DSAOpenSsl(int keySize)
             {
+                ThrowIfNotSupported();
                 LegalKeySizesValue = s_legalKeySizes;
                 base.KeySize = keySize;
                 _key = new Lazy<SafeDsaHandle>(GenerateKey);
@@ -415,6 +416,8 @@ namespace System.Security.Cryptography
 
                 _key = new Lazy<SafeDsaHandle>(newKey);
             }
+
+            private static partial void ThrowIfNotSupported();
 
             private static readonly KeySizes[] s_legalKeySizes = new KeySizes[] { new KeySizes(minSize: 512, maxSize: 3072, skipSize: 64) };
         }

--- a/src/libraries/Common/src/System/Security/Cryptography/DSAOpenSsl.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/DSAOpenSsl.cs
@@ -417,7 +417,7 @@ namespace System.Security.Cryptography
                 _key = new Lazy<SafeDsaHandle>(newKey);
             }
 
-            private static partial void ThrowIfNotSupported();
+            static partial void ThrowIfNotSupported();
 
             private static readonly KeySizes[] s_legalKeySizes = new KeySizes[] { new KeySizes(minSize: 512, maxSize: 3072, skipSize: 64) };
         }

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanOpenSsl.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanOpenSsl.cs
@@ -15,6 +15,7 @@ namespace System.Security.Cryptography
 
             public ECDiffieHellmanOpenSsl(ECCurve curve)
             {
+                ThrowIfNotSupported();
                 _key = new ECOpenSsl(curve);
                 KeySizeValue = _key.KeySize;
             }
@@ -26,6 +27,7 @@ namespace System.Security.Cryptography
 
             public ECDiffieHellmanOpenSsl(int keySize)
             {
+                ThrowIfNotSupported();
                 base.KeySize = keySize;
                 _key = new ECOpenSsl(this);
             }
@@ -133,6 +135,8 @@ namespace System.Security.Cryptography
                 ThrowIfDisposed();
                 return _key.Value;
             }
+
+            private static partial void ThrowIfNotSupported();
         }
 #if INTERNAL_ASYMMETRIC_IMPLEMENTATIONS
     }

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanOpenSsl.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanOpenSsl.cs
@@ -136,7 +136,7 @@ namespace System.Security.Cryptography
                 return _key.Value;
             }
 
-            private static partial void ThrowIfNotSupported();
+            static partial void ThrowIfNotSupported();
         }
 #if INTERNAL_ASYMMETRIC_IMPLEMENTATIONS
     }

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDsaOpenSsl.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDsaOpenSsl.cs
@@ -363,7 +363,7 @@ namespace System.Security.Cryptography
                 }
             }
 
-            private static partial void ThrowIfNotSupported();
+            static partial void ThrowIfNotSupported();
         }
 #if INTERNAL_ASYMMETRIC_IMPLEMENTATIONS
     }

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDsaOpenSsl.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDsaOpenSsl.cs
@@ -26,6 +26,7 @@ namespace System.Security.Cryptography
             /// <exception cref="ArgumentNullException">if <paramref name="curve" /> is null.</exception>
             public ECDsaOpenSsl(ECCurve curve)
             {
+                ThrowIfNotSupported();
                 _key = new ECOpenSsl(curve);
                 ForceSetKeySize(_key.KeySize);
             }
@@ -44,6 +45,7 @@ namespace System.Security.Cryptography
             /// <param name="keySize">Size of the key to generate, in bits.</param>
             public ECDsaOpenSsl(int keySize)
             {
+                ThrowIfNotSupported();
                 // Use the base setter to get the validation and field assignment without the
                 // side effect of dereferencing _key.
                 base.KeySize = keySize;
@@ -360,6 +362,8 @@ namespace System.Security.Cryptography
                     );
                 }
             }
+
+            private static partial void ThrowIfNotSupported();
         }
 #if INTERNAL_ASYMMETRIC_IMPLEMENTATIONS
     }

--- a/src/libraries/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -33,6 +33,7 @@ namespace System.Security.Cryptography
 
         public RSAOpenSsl(int keySize)
         {
+            ThrowIfNotSupported();
             base.KeySize = keySize;
             _key = new Lazy<SafeEvpPKeyHandle>(GenerateKey);
         }
@@ -945,6 +946,8 @@ namespace System.Security.Cryptography
                 throw PaddingModeNotSupported();
             }
         }
+
+        private static partial void ThrowIfNotSupported();
 
         private static Exception PaddingModeNotSupported() =>
             new CryptographicException(SR.Cryptography_InvalidPaddingMode);

--- a/src/libraries/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -947,7 +947,7 @@ namespace System.Security.Cryptography
             }
         }
 
-        private static partial void ThrowIfNotSupported();
+        static partial void ThrowIfNotSupported();
 
         private static Exception PaddingModeNotSupported() =>
             new CryptographicException(SR.Cryptography_InvalidPaddingMode);

--- a/src/libraries/System.Security.Cryptography.OpenSsl/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/src/Resources/Strings.resx
@@ -1,16 +1,16 @@
 ﻿<root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -25,36 +25,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -232,6 +232,9 @@
   </data>
   <data name="Cryptography_NotValidPublicOrPrivateKey" xml:space="preserve">
     <value>Key is not a valid public or private key.</value>
+  </data>
+  <data name="Cryptography_AlgorithmNotSupported" xml:space="preserve">
+    <value>Algorithm '{0}' is not supported on this platform.</value>
   </data>
   <data name="PlatformNotSupported_CryptographyOpenSSL" xml:space="preserve">
     <value>OpenSSL is not supported on this platform.</value>

--- a/src/libraries/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
@@ -55,6 +55,8 @@
              Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslVersion.cs"
              Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslVersion.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslAvailable.cs"
+             Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslAvailable.cs" />
     <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs"
              Link="Common\Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs" />
     <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeBignumHandle.Unix.cs"

--- a/src/libraries/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/DSAOpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/DSAOpenSsl.cs
@@ -93,7 +93,7 @@ namespace System.Security.Cryptography
             }
         }
 
-        private static partial void ThrowIfNotSupported()
+        static partial void ThrowIfNotSupported()
         {
             if (!Interop.OpenSslNoInit.OpenSslIsAvailable)
             {

--- a/src/libraries/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/DSAOpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/DSAOpenSsl.cs
@@ -9,6 +9,7 @@ namespace System.Security.Cryptography
     {
         public DSAOpenSsl(DSAParameters parameters)
         {
+            ThrowIfNotSupported();
             // Make _key be non-null before calling ImportParameters
             _key = new Lazy<SafeDsaHandle>();
             ImportParameters(parameters);
@@ -31,6 +32,7 @@ namespace System.Security.Cryptography
             if (pkeyHandle.IsInvalid)
                 throw new ArgumentException(SR.Cryptography_OpenInvalidHandle, nameof(pkeyHandle));
 
+            ThrowIfNotSupported();
             // If dsa is valid it has already been up-ref'd, so we can just use this handle as-is.
             SafeDsaHandle key = Interop.Crypto.EvpPkeyGetDsa(pkeyHandle);
             if (key.IsInvalid)
@@ -57,6 +59,7 @@ namespace System.Security.Cryptography
             if (handle == IntPtr.Zero)
                 throw new ArgumentException(SR.Cryptography_OpenInvalidHandle, nameof(handle));
 
+            ThrowIfNotSupported();
             SafeDsaHandle ecKeyHandle = SafeDsaHandle.DuplicateHandle(handle);
             SetKey(ecKeyHandle);
         }
@@ -87,6 +90,14 @@ namespace System.Security.Cryptography
             {
                 pkeyHandle.Dispose();
                 throw;
+            }
+        }
+
+        private static partial void ThrowIfNotSupported()
+        {
+            if (!Interop.OpenSslNoInit.OpenSslIsAvailable)
+            {
+                throw new PlatformNotSupportedException(SR.Format(SR.Cryptography_AlgorithmNotSupported, nameof(DSAOpenSsl)));
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/ECDiffieHellmanOpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/ECDiffieHellmanOpenSsl.cs
@@ -86,7 +86,7 @@ namespace System.Security.Cryptography
             }
         }
 
-        private static partial void ThrowIfNotSupported()
+        static partial void ThrowIfNotSupported()
         {
             if (!Interop.OpenSslNoInit.OpenSslIsAvailable)
             {

--- a/src/libraries/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/ECDiffieHellmanOpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/ECDiffieHellmanOpenSsl.cs
@@ -23,6 +23,7 @@ namespace System.Security.Cryptography
             if (pkeyHandle.IsInvalid)
                 throw new ArgumentException(SR.Cryptography_OpenInvalidHandle, nameof(pkeyHandle));
 
+            ThrowIfNotSupported();
             // If ecKey is valid it has already been up-ref'd, so we can just use this handle as-is.
             SafeEcKeyHandle key = Interop.Crypto.EvpPkeyGetEcKey(pkeyHandle);
             if (key.IsInvalid)
@@ -50,6 +51,7 @@ namespace System.Security.Cryptography
             if (handle == IntPtr.Zero)
                 throw new ArgumentException(SR.Cryptography_OpenInvalidHandle, nameof(handle));
 
+            ThrowIfNotSupported();
             SafeEcKeyHandle ecKeyHandle = SafeEcKeyHandle.DuplicateHandle(handle);
             _key = new ECOpenSsl(ecKeyHandle);
             KeySizeValue = _key.KeySize;
@@ -81,6 +83,14 @@ namespace System.Security.Cryptography
             {
                 pkeyHandle.Dispose();
                 throw;
+            }
+        }
+
+        private static partial void ThrowIfNotSupported()
+        {
+            if (!Interop.OpenSslNoInit.OpenSslIsAvailable)
+            {
+                throw new PlatformNotSupportedException(SR.Format(SR.Cryptography_AlgorithmNotSupported, nameof(ECDiffieHellmanOpenSsl)));
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/ECDsaOpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/ECDsaOpenSsl.cs
@@ -86,7 +86,7 @@ namespace System.Security.Cryptography
             }
         }
 
-        private static partial void ThrowIfNotSupported()
+        static partial void ThrowIfNotSupported()
         {
             if (!Interop.OpenSslNoInit.OpenSslIsAvailable)
             {

--- a/src/libraries/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/ECDsaOpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/ECDsaOpenSsl.cs
@@ -23,6 +23,7 @@ namespace System.Security.Cryptography
             if (pkeyHandle.IsInvalid)
                 throw new ArgumentException(SR.Cryptography_OpenInvalidHandle, nameof(pkeyHandle));
 
+            ThrowIfNotSupported();
             // If ecKey is valid it has already been up-ref'd, so we can just use this handle as-is.
             SafeEcKeyHandle key = Interop.Crypto.EvpPkeyGetEcKey(pkeyHandle);
             if (key.IsInvalid)
@@ -50,6 +51,7 @@ namespace System.Security.Cryptography
             if (handle == IntPtr.Zero)
                 throw new ArgumentException(SR.Cryptography_OpenInvalidHandle, nameof(handle));
 
+            ThrowIfNotSupported();
             SafeEcKeyHandle ecKeyHandle = SafeEcKeyHandle.DuplicateHandle(handle);
             _key = new ECOpenSsl(ecKeyHandle);
             KeySizeValue = _key.KeySize;
@@ -81,6 +83,14 @@ namespace System.Security.Cryptography
             {
                 pkeyHandle.Dispose();
                 throw;
+            }
+        }
+
+        private static partial void ThrowIfNotSupported()
+        {
+            if (!Interop.OpenSslNoInit.OpenSslIsAvailable)
+            {
+                throw new PlatformNotSupportedException(SR.Format(SR.Cryptography_AlgorithmNotSupported, nameof(ECDsaOpenSsl)));
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -10,6 +10,8 @@ namespace System.Security.Cryptography
     {
         public RSAOpenSsl(RSAParameters parameters)
         {
+            ThrowIfNotSupported();
+
             // Make _key be non-null before calling ImportParameters
             _key = new Lazy<SafeEvpPKeyHandle>();
             ImportParameters(parameters);
@@ -30,6 +32,7 @@ namespace System.Security.Cryptography
             if (handle == IntPtr.Zero)
                 throw new ArgumentException(SR.Cryptography_OpenInvalidHandle, nameof(handle));
 
+            ThrowIfNotSupported();
             SafeEvpPKeyHandle pkey = Interop.Crypto.EvpPKeyCreateRsa(handle);
             Debug.Assert(!pkey.IsInvalid);
 
@@ -53,6 +56,7 @@ namespace System.Security.Cryptography
             if (pkeyHandle.IsInvalid)
                 throw new ArgumentException(SR.Cryptography_OpenInvalidHandle, nameof(pkeyHandle));
 
+            ThrowIfNotSupported();
             SafeEvpPKeyHandle newKey = Interop.Crypto.EvpPKeyDuplicate(
                 pkeyHandle,
                 Interop.Crypto.EvpAlgorithmId.RSA);
@@ -68,6 +72,14 @@ namespace System.Security.Cryptography
         public SafeEvpPKeyHandle DuplicateKeyHandle()
         {
             return Interop.Crypto.EvpPKeyDuplicate(GetKey(), Interop.Crypto.EvpAlgorithmId.RSA);
+        }
+
+        private static partial void ThrowIfNotSupported()
+        {
+            if (!Interop.OpenSslNoInit.OpenSslIsAvailable)
+            {
+                throw new PlatformNotSupportedException(SR.Format(SR.Cryptography_AlgorithmNotSupported, nameof(RSAOpenSsl)));
+            }
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -74,7 +74,7 @@ namespace System.Security.Cryptography
             return Interop.Crypto.EvpPKeyDuplicate(GetKey(), Interop.Crypto.EvpAlgorithmId.RSA);
         }
 
-        private static partial void ThrowIfNotSupported()
+        static partial void ThrowIfNotSupported()
         {
             if (!Interop.OpenSslNoInit.OpenSslIsAvailable)
             {


### PR DESCRIPTION
If you attempt to use any of the `*OpenSsl` primitives on macOS, this will currently abort the whole process. This changes them to check for OpenSSL's presence and throw an appropriate exception instead of aborting.

When used as an internal implementation, the aborting behavior remains.