### PR TITLE
Generate proper DWARF reg num for ARM32

### DIFF
--- a/src/coreclr/jit/unwind.cpp
+++ b/src/coreclr/jit/unwind.cpp
@@ -187,7 +187,12 @@ void Compiler::unwindPushPopMaskCFI(regMaskTP regMask, bool isFloat)
     regMaskTP regBit = isFloat ? genRegMask(REG_FP_FIRST) : 1;
 
     for (regNumber regNum = isFloat ? REG_FP_FIRST : REG_FIRST; regNum < REG_COUNT;
-         regNum           = REG_NEXT(regNum), regBit <<= 1)
+#if TARGET_ARM
+         regNum = isFloat ? REG_NEXT(REG_NEXT(regNum)) : REG_NEXT(regNum), regBit <<= isFloat ? 2 : 1
+#else
+         regNum = REG_NEXT(regNum), regBit <<= 1
+#endif
+         )
     {
         if (regBit > regMask)
         {

--- a/src/coreclr/jit/unwind.cpp
+++ b/src/coreclr/jit/unwind.cpp
@@ -187,7 +187,7 @@ void Compiler::unwindPushPopMaskCFI(regMaskTP regMask, bool isFloat)
     regMaskTP regBit = isFloat ? genRegMask(REG_FP_FIRST) : 1;
 
     regNumber regNum = isFloat ? REG_FP_FIRST : REG_FIRST;
-    for (; regNum < REG_COUNT; )
+    for (; regNum < REG_COUNT;)
     {
         if (regBit > regMask)
         {

--- a/src/coreclr/jit/unwind.cpp
+++ b/src/coreclr/jit/unwind.cpp
@@ -186,13 +186,8 @@ void Compiler::unwindPushPopMaskCFI(regMaskTP regMask, bool isFloat)
 {
     regMaskTP regBit = isFloat ? genRegMask(REG_FP_FIRST) : 1;
 
-    for (regNumber regNum = isFloat ? REG_FP_FIRST : REG_FIRST; regNum < REG_COUNT;
-#if TARGET_ARM
-         regNum = isFloat ? REG_NEXT(REG_NEXT(regNum)) : REG_NEXT(regNum), regBit <<= isFloat ? 2 : 1
-#else
-         regNum = REG_NEXT(regNum), regBit <<= 1
-#endif
-         )
+    regNumber regNum = isFloat ? REG_FP_FIRST : REG_FIRST;
+    for (; regNum < REG_COUNT; )
     {
         if (regBit > regMask)
         {
@@ -203,6 +198,19 @@ void Compiler::unwindPushPopMaskCFI(regMaskTP regMask, bool isFloat)
         {
             unwindPushPopCFI(regNum);
         }
+
+#if TARGET_ARM
+        // JIT for ARM emit local variables in S0-S31 registers,
+        // which cannot be emitted to DWARF when using LLVM,
+        // because LLVM only know about D0-D31.
+        // As such pairs Sx,Sx+1 are referenced as D0-D15 registers in DWARF
+        // For that we process registers in pairs.
+        regNum = isFloat ? REG_NEXT(REG_NEXT(regNum)) : REG_NEXT(regNum);
+        regBit <<= isFloat ? 2 : 1;
+#else
+        regNum = REG_NEXT(regNum);
+        regBit <<= 1;
+#endif
     }
 }
 

--- a/src/coreclr/jit/unwindarm.cpp
+++ b/src/coreclr/jit/unwindarm.cpp
@@ -71,100 +71,52 @@ short Compiler::mapRegNumToDwarfReg(regNumber reg)
             dwarfReg = 15;
             break;
         case REG_F0:
-            dwarfReg = 64;
-            break;
-        case REG_F1:
-            dwarfReg = 65;
+            dwarfReg = 256;
             break;
         case REG_F2:
-            dwarfReg = 66;
-            break;
-        case REG_F3:
-            dwarfReg = 67;
+            dwarfReg = 257;
             break;
         case REG_F4:
-            dwarfReg = 68;
-            break;
-        case REG_F5:
-            dwarfReg = 69;
+            dwarfReg = 258;
             break;
         case REG_F6:
-            dwarfReg = 70;
-            break;
-        case REG_F7:
-            dwarfReg = 71;
+            dwarfReg = 259;
             break;
         case REG_F8:
-            dwarfReg = 72;
-            break;
-        case REG_F9:
-            dwarfReg = 73;
+            dwarfReg = 260;
             break;
         case REG_F10:
-            dwarfReg = 74;
-            break;
-        case REG_F11:
-            dwarfReg = 75;
+            dwarfReg = 261;
             break;
         case REG_F12:
-            dwarfReg = 76;
-            break;
-        case REG_F13:
-            dwarfReg = 77;
+            dwarfReg = 262;
             break;
         case REG_F14:
-            dwarfReg = 78;
-            break;
-        case REG_F15:
-            dwarfReg = 79;
+            dwarfReg = 263;
             break;
         case REG_F16:
-            dwarfReg = 80;
-            break;
-        case REG_F17:
-            dwarfReg = 81;
+            dwarfReg = 264;
             break;
         case REG_F18:
-            dwarfReg = 82;
-            break;
-        case REG_F19:
-            dwarfReg = 83;
+            dwarfReg = 265;
             break;
         case REG_F20:
-            dwarfReg = 84;
-            break;
-        case REG_F21:
-            dwarfReg = 85;
+            dwarfReg = 266;
             break;
         case REG_F22:
-            dwarfReg = 86;
-            break;
-        case REG_F23:
-            dwarfReg = 87;
+            dwarfReg = 267;
             break;
         case REG_F24:
-            dwarfReg = 88;
-            break;
-        case REG_F25:
-            dwarfReg = 89;
+            dwarfReg = 268;
             break;
         case REG_F26:
-            dwarfReg = 90;
-            break;
-        case REG_F27:
-            dwarfReg = 91;
+            dwarfReg = 269;
             break;
         case REG_F28:
-            dwarfReg = 92;
-            break;
-        case REG_F29:
-            dwarfReg = 93;
+            dwarfReg = 270;
             break;
         case REG_F30:
-            dwarfReg = 94;
-            break;
-        case REG_F31:
-            dwarfReg = 95;
+            dwarfReg = 271;
             break;
         default:
             noway_assert(!"unexpected REG_NUM");


### PR DESCRIPTION
After introduction of VFP-v3 ARM S0-S31 no longer can be generated using LLVM because  numbering of registers to start from 256 and only D0-D31 are used.
So this change encode S0 as D0, S2 as D1, etc. Also use reg nums for DXX registers.
This change fix generation of CFI codes,
which trigger issue with generation of DWARF using LLVM in NativeAOT
See https://developer.arm.com/documentation/ihi0040/c/?lang=en#dwarf-register-names
See https://github.com/dotnet/runtimelab/issues/1388