### PR TITLE
don't run LongModuleFileNamesAreSupported test on x86 

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/Interop.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/Interop.Unix.cs
@@ -1,16 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Win32.SafeHandles;
-using System.ComponentModel;
 using System.Runtime.InteropServices;
-using System.Security.Principal;
 
-namespace System.Diagnostics.Tests
+internal static partial class Interop
 {
-    internal static partial class Interop
-    {
-        [DllImport("libc")]
-        internal static extern int getsid(int pid);
-    }
+    [DllImport("libc")]
+    internal static extern int getsid(int pid);
 }

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessModuleTests.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessModuleTests.Windows.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace System.Diagnostics.Tests
+{
+    public partial class ProcessModuleTests : ProcessTestBase
+    {
+        [ConditionalFact(typeof(PathFeatures), nameof(PathFeatures.AreAllLongPathsAvailable))]
+        public void LongModuleFileNamesAreSupported()
+        {
+            // To be able to test Long Path support for ProcessModule.FileName we need a .dll that has a path > 260 chars.
+            // Since Long Paths support can be disabled (see the ConditionalFact attribute usage above),
+            // we just copy "LongName.dll" from bin to a temp directory with a long name and load it from there.
+            // Loading from new path is possible because the type exposed by the assembly is not referenced in any explicit way.
+            const string libraryName = "LongPath.dll";
+            const int minPathLength = 261;
+
+            string testBinPath = Path.GetDirectoryName(typeof(ProcessModuleTests).Assembly.Location);
+            string libraryToCopy = Path.Combine(testBinPath, libraryName);
+            Assert.True(File.Exists(libraryToCopy), $"{libraryName} was not present in bin folder '{testBinPath}'");
+
+            string directoryWithLongName = Path.Combine(TestDirectory, new string('a', Math.Max(1, minPathLength - TestDirectory.Length)));
+            Directory.CreateDirectory(directoryWithLongName);
+
+            string longNamePath = Path.Combine(directoryWithLongName, libraryName);
+            Assert.True(longNamePath.Length > minPathLength);
+
+            File.Copy(libraryToCopy, longNamePath);
+            Assert.True(File.Exists(longNamePath));
+
+            IntPtr moduleHandle = Interop.Kernel32.LoadLibrary(longNamePath);
+            Assert.False(moduleHandle == IntPtr.Zero, $"LoadLibrary failed with {Marshal.GetLastWin32Error()}");
+
+            try
+            {
+                string[] modulePaths = Process.GetCurrentProcess().Modules.Cast<ProcessModule>().Select(module => module.FileName).ToArray();
+                Assert.Contains(longNamePath, modulePaths);
+            }
+            finally
+            {
+                Interop.Kernel32.FreeLibrary(moduleHandle);
+            }
+        }
+    }
+}

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessModuleTests.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessModuleTests.Windows.cs
@@ -34,7 +34,12 @@ namespace System.Diagnostics.Tests
             Assert.True(File.Exists(longNamePath));
 
             IntPtr moduleHandle = Interop.Kernel32.LoadLibrary(longNamePath);
-            Assert.False(moduleHandle == IntPtr.Zero, $"LoadLibrary failed with {Marshal.GetLastWin32Error()}");
+            if (moduleHandle == IntPtr.Zero)
+            {
+                Assert.Equal(126, Marshal.GetLastWin32Error()); // ERROR_MOD_NOT_FOUND
+                Assert.Equal(Architecture.X86, RuntimeInformation.ProcessArchitecture);
+                return; // we have failed to load the module on x86, we skip the rest of the test (it's best effort)
+            }
 
             try
             {

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessModuleTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessModuleTests.cs
@@ -1,16 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Runtime.InteropServices;
 using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
 namespace System.Diagnostics.Tests
 {
-    public class ProcessModuleTests : ProcessTestBase
+    public partial class ProcessModuleTests : ProcessTestBase
     {
         [Fact]
         public void TestModuleProperties()
@@ -91,42 +88,6 @@ namespace System.Diagnostics.Tests
 
             process.Dispose();
             Assert.Equal(expectedCount, disposedCount);
-        }
-
-        public static bool Is_LongModuleFileNamesAreSupported_TestEnabled
-            => OperatingSystem.IsWindows() // it's specific to Windows
-            && PathFeatures.AreAllLongPathsAvailable() // we want to test long paths
-            && !PlatformDetection.IsMonoRuntime // Assembly.LoadFile used the way this test is implemented fails on Mono
-            && RuntimeInformation.ProcessArchitecture != Architecture.X86; // for some reason it's flaky on x86
-
-        [ConditionalFact(typeof(ProcessModuleTests), nameof(Is_LongModuleFileNamesAreSupported_TestEnabled))]
-        public void LongModuleFileNamesAreSupported()
-        {
-            // To be able to test Long Path support for ProcessModule.FileName we need a .dll that has a path > 260 chars.
-            // Since Long Paths support can be disabled (see the ConditionalFact attribute usage above),
-            // we just copy "LongName.dll" from bin to a temp directory with a long name and load it from there.
-            // Loading from new path is possible because the type exposed by the assembly is not referenced in any explicit way.
-            const string libraryName = "LongPath.dll";
-            const int minPathLength = 261;
-
-            string testBinPath = Path.GetDirectoryName(typeof(ProcessModuleTests).Assembly.Location);
-            string libraryToCopy = Path.Combine(testBinPath, libraryName);
-            Assert.True(File.Exists(libraryToCopy), $"{libraryName} was not present in bin folder '{testBinPath}'");
-
-            string directoryWithLongName = Path.Combine(TestDirectory, new string('a', Math.Max(1, minPathLength - TestDirectory.Length)));
-            Directory.CreateDirectory(directoryWithLongName);
-
-            string longNamePath = Path.Combine(directoryWithLongName, libraryName);
-            Assert.True(longNamePath.Length > minPathLength);
-
-            File.Copy(libraryToCopy, longNamePath);
-            Assert.True(File.Exists(longNamePath));
-
-            Assembly loaded = Assembly.LoadFile(longNamePath);
-            Assert.Equal(longNamePath, loaded.Location);
-
-            string[] modulePaths = Process.GetCurrentProcess().Modules.Cast<ProcessModule>().Select(module => module.FileName).ToArray();
-            Assert.Contains(longNamePath, modulePaths);
         }
     }
 }

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessModuleTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessModuleTests.cs
@@ -4,6 +4,7 @@
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
@@ -96,7 +97,7 @@ namespace System.Diagnostics.Tests
             => OperatingSystem.IsWindows() // it's specific to Windows
             && PathFeatures.AreAllLongPathsAvailable() // we want to test long paths
             && !PlatformDetection.IsMonoRuntime // Assembly.LoadFile used the way this test is implemented fails on Mono
-            && PlatformDetection.Is64BitProcess; // for some reason it's flaky on x86
+            && RuntimeInformation.ProcessArchitecture != Architecture.X86; // for some reason it's flaky on x86
 
         [ConditionalFact(typeof(ProcessModuleTests), nameof(Is_LongModuleFileNamesAreSupported_TestEnabled))]
         public void LongModuleFileNamesAreSupported()

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessModuleTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessModuleTests.cs
@@ -93,9 +93,10 @@ namespace System.Diagnostics.Tests
         }
 
         public static bool Is_LongModuleFileNamesAreSupported_TestEnabled
-            => PathFeatures.AreAllLongPathsAvailable() // we want to test long paths
+            => OperatingSystem.IsWindows() // it's specific to Windows
+            && PathFeatures.AreAllLongPathsAvailable() // we want to test long paths
             && !PlatformDetection.IsMonoRuntime // Assembly.LoadFile used the way this test is implemented fails on Mono
-            && OperatingSystem.IsWindowsVersionAtLeast(8); // it's specific to Windows and does not work on Windows 7
+            && PlatformDetection.Is64BitProcess; // for some reason it's flaky on x86
 
         [ConditionalFact(typeof(ProcessModuleTests), nameof(Is_LongModuleFileNamesAreSupported_TestEnabled))]
         public void LongModuleFileNamesAreSupported()

--- a/src/libraries/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
+++ b/src/libraries/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants Condition="'$(TargetsWindows)' == 'true'">$(DefineConstants);TargetsWindows</DefineConstants>
@@ -37,10 +37,17 @@
     <Compile Include="AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
+    <Compile Include="ProcessModuleTests.Windows.cs" />
     <Compile Include="ProcessTests.Windows.cs" />
     <Compile Include="ProcessThreadTests.Windows.cs" />
     <Compile Include="$(CoreLibSharedDir)System\PasteArguments.Windows.cs"
              Link="System\PasteArguments.Windows.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Interop.Libraries.cs"
+         Link="Common\Interop\Windows\Interop.Libraries.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.LoadLibrary.cs"
+         Link="Common\Interop\Windows\Kernel32\Interop.LoadLibrary.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\Kernel32\Interop.FreeLibrary.cs"
+             Link="Common\Interop\Windows\Kernel32\Interop.FreeLibrary.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true' or '$(TargetsBrowser)' == 'true'">
     <Compile Include="Interop.Unix.cs" />


### PR DESCRIPTION
This particular tests uses `Assembly.LoadFile(path)` to load a test assembly:

https://github.com/dotnet/runtime/blob/80392a9aa7a8cc8760e85003f2efd6beb3f081d7/src/libraries/System.Diagnostics.Process/tests/ProcessModuleTests.cs#L101-L107

for some reason it's flaky on x86. I've tried to repro it on two Windows machines and failed. Since I don't have better idea, I think it's just OK not to run this test on x86.

The previous check of Windows version (`OperatingSystem.IsWindowsVersionAtLeast(8)`) can be removed as in the past this test was failing only on Windows 7 x86.

fixes #57452