### PR TITLE
disable a failing stress test.

### DIFF
--- a/src/tests/Regressions/coreclr/GitHub_34094/Test34094.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_34094/Test34094.csproj
@@ -4,6 +4,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test34094.cs" />


### PR DESCRIPTION
Reenable when https://github.com/dotnet/runtime/issues/57458 is fixed.