### PR TITLE
Move UpdateRuntimeJson out of props file into Microsoft.NETCore.Platforms project file

### DIFF
--- a/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
@@ -16,7 +16,11 @@
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <NoWarn>$(NoWarn);NU5128</NoWarn> <!-- No Dependencies-->
     <PackageDescription>Provides runtime information required to resolve target framework, platform, and runtime specific implementations of .NETCore packages.</PackageDescription>
+    <BeforePack>GenerateRuntimeJson;UpdateRuntimeJson;$(BeforePack)</BeforePack>
     
+    <_generateRuntimeGraphTargetFramework Condition="'$(MSBuildRuntimeType)' == 'core'">$(NetCoreAppToolCurrent)</_generateRuntimeGraphTargetFramework>
+    <_generateRuntimeGraphTargetFramework Condition="'$(MSBuildRuntimeType)' != 'core'">net472</_generateRuntimeGraphTargetFramework>
+    <_generateRuntimeGraphTask>$([MSBuild]::NormalizePath('$(BaseOutputPath)', '$(_generateRuntimeGraphTargetFramework)-$(Configuration)', '$(AssemblyName).dll'))</_generateRuntimeGraphTask>
     <!-- When building from source, ensure the RID we're building for is part of the RID graph -->
     <AdditionalRuntimeIdentifiers Condition="'$(DotNetBuildFromSource)' == 'true'">$(AdditionalRuntimeIdentifiers);$(OutputRID)</AdditionalRuntimeIdentifiers>
   </PropertyGroup>
@@ -48,14 +52,28 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(RefOnlyMicrosoftBuildTasksCoreVersion)" />
     <PackageReference Include="NuGet.ProjectModel" Version="$(RefOnlyNugetProjectModelVersion)" />
   </ItemGroup>
+  
+  <UsingTask TaskName="GenerateRuntimeGraph" AssemblyFile="$(_generateRuntimeGraphTask)"/>
 
-  <Target Name="GenerateRuntimeJson" Condition="'$(AdditionalRuntimeIdentifiers)' != ''" BeforeTargets="GenerateNuspec">
+  <Target Name="GenerateRuntimeJson" Condition="'$(AdditionalRuntimeIdentifiers)' != ''">
     <MakeDir Directories="$(IntermediateOutputPath)" />
     <GenerateRuntimeGraph RuntimeGroups="@(RuntimeGroupWithQualifiers)"
                           AdditionalRuntimeIdentifiers="$(AdditionalRuntimeIdentifiers)"
                           AdditionalRuntimeIdentifierParent="$(AdditionalRuntimeIdentifierParent)"
                           RuntimeJson="$(IntermediateOutputPath)runtime.json"
                           UpdateRuntimeFiles="True" />
+  </Target>
+
+  <Target Name="UpdateRuntimeJson">
+    <!-- Generates a Runtime graph using RuntimeGroups and diffs it with the graph described by runtime.json and runtime.compatibility.json
+         Specifying UpdateRuntimeFiles=true skips the diff and updates those files.
+         The graph can be visualized using the generated dmgl -->
+    <MakeDir Directories="$(OutputPath)" />
+    <GenerateRuntimeGraph RuntimeGroups="@(RuntimeGroupWithQualifiers)"
+                          RuntimeJson="runtime.json"
+                          CompatibilityMap="runtime.compatibility.json"
+                          RuntimeDirectedGraph="$(OutputPath)runtime.json.dgml"
+                          UpdateRuntimeFiles="$(UpdateRuntimeFiles)" />
   </Target>
   
   <Import Project="runtimeGroups.props" />

--- a/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
@@ -53,6 +53,8 @@
     <PackageReference Include="NuGet.ProjectModel" Version="$(RefOnlyNugetProjectModelVersion)" />
   </ItemGroup>
   
+  <Import Project="runtimeGroups.props" />
+  
   <UsingTask TaskName="GenerateRuntimeGraph" AssemblyFile="$(_generateRuntimeGraphTask)"/>
 
   <Target Name="GenerateRuntimeJson" Condition="'$(AdditionalRuntimeIdentifiers)' != ''">
@@ -75,6 +77,5 @@
                           RuntimeDirectedGraph="$(OutputPath)runtime.json.dgml"
                           UpdateRuntimeFiles="$(UpdateRuntimeFiles)" />
   </Target>
-  
-  <Import Project="runtimeGroups.props" />
+
 </Project>

--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtimeGroups.props
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtimeGroups.props
@@ -1,4 +1,5 @@
-﻿<Project>
+<Project>
+
   <ItemGroup>
     <RuntimeGroup Include="unix">
       <Parent>any</Parent>
@@ -262,22 +263,4 @@
     </RuntimeGroupWithQualifiers>
   </ItemGroup>
 
-  <PropertyGroup>
-    <_generateRuntimeGraphTargetFramework Condition="'$(MSBuildRuntimeType)' == 'core'">$(NetCoreAppToolCurrent)</_generateRuntimeGraphTargetFramework>
-    <_generateRuntimeGraphTargetFramework Condition="'$(MSBuildRuntimeType)' != 'core'">net472</_generateRuntimeGraphTargetFramework>
-    <_generateRuntimeGraphTask>$([MSBuild]::NormalizePath('$(BaseOutputPath)', '$(_generateRuntimeGraphTargetFramework)-$(Configuration)', '$(AssemblyName).dll'))</_generateRuntimeGraphTask>
-  </PropertyGroup>
-  <UsingTask TaskName="GenerateRuntimeGraph" AssemblyFile="$(_generateRuntimeGraphTask)"/>
-
-  <Target Name="UpdateRuntimeJson" BeforeTargets="Pack">
-    <!-- Generates a Runtime graph using RuntimeGroups and diffs it with the graph described by runtime.json and runtime.compatibility.json
-         Specifying UpdateRuntimeFiles=true skips the diff and updates those files.
-         The graph can be visualized using the generated dmgl -->
-    <MakeDir Directories="$(OutputPath)" />
-    <GenerateRuntimeGraph RuntimeGroups="@(RuntimeGroupWithQualifiers)"
-                          RuntimeJson="runtime.json"
-                          CompatibilityMap="runtime.compatibility.json"
-                          RuntimeDirectedGraph="$(OutputPath)runtime.json.dgml"
-                          UpdateRuntimeFiles="$(UpdateRuntimeFiles)" />
-  </Target>
 </Project>


### PR DESCRIPTION
It's not common to have a target inside a props file. Also as one target related to the runtime.json file already exists in the project's file, moving them together.