### PR TITLE
Move Select_AcceptNonBlocking_Success to non-parallel collection

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SelectTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SelectTest.cs
@@ -275,7 +275,11 @@ namespace System.Net.Sockets.Tests
                 Assert.True(pair.Value.SafeHandle.IsClosed);
             }
         }
+    }
 
+    [Collection(nameof(NoParallelTests))]
+    public class SelectTest_NonParallel
+    {
         [OuterLoop]
         [Fact]
         public static async Task Select_AcceptNonBlocking_Success()


### PR DESCRIPTION
On Unix, this test seems to be prone to IPv4-IPv6 port collision. Windows failures can be likely explained by timing issues on CI (5 seconds can be strict with heavy parallel workloads). Serialization should help with both problems.

Fixes #41579