### PR TITLE
Rename transport packages to follow convention

### DIFF
--- a/docs/coding-guidelines/libraries-packaging.md
+++ b/docs/coding-guidelines/libraries-packaging.md
@@ -22,15 +22,15 @@ Removing a library from the shared framework is a breaking change and should be 
 
 Transport packages are non-shipping packages that dotnet/runtime produces in order to share binaries with other repositories.
 
-### Microsoft.AspNetCore.Internal.Transport
+### Microsoft.Internal.Runtime.**TARGET**.Transport
 
-This package represents the set of libraries which are produced in dotnet/runtime and ship in the ASP.NETCore shared framework. We produce a transport package so that we can easily share reference assemblies and implementation configurations that might not be present in NuGet packages that also ship.
+Such transport packages represent the set of libraries which are produced in dotnet/runtime and ship in target repo's shared framework (i.e. Microsoft.AspNetCore.App and Microsoft.WindowsDesktop.App). We produce a transport package so that we can easily share reference, implementation and analyzer assemblies that might not be present in NuGet packages that also ship.
 
-To add a library to the ASP.NETCore shared framework, that library should be listed in the `AspNetCoreAppLibrary` section in `NetCoreAppLibrary.props`.
+To add a library to the target's shared framework, that library should be listed in the `AspNetCoreAppLibrary` or `WindowsDesktopAppLibrary` section in `NetCoreAppLibrary.props`.
 
-Source generators and analyzers can be included in the ASP.NETCore shared framework by adding them to the `Microsoft.AspNetCore.Internal.Transport.proj` as an AnalyzerReference. These projects should specify `AnalyzerLanguage` as mentioned [below](#analyzers--source-generators).
+Source generators and analyzers can be included in the package by adding them to the `Microsoft.Internal.Runtime.**TARGET**.Transport.proj` as an AnalyzerReference. The analyzer projects should specify `AnalyzerLanguage` as mentioned [below](#analyzers--source-generators).
 
-Libraries included in this transport package should ensure all direct and transitive assembly references are also included in either the ASP.NETCore shared framework or the .NETCore shared framework. This is not validated in dotnet/runtime at the moment: https://github.com/dotnet/runtime/issues/52562
+Libraries included in this transport package should ensure all direct and transitive assembly references are also included in either the target's shared framework or the Microsoft.NETCore.App shared framework. This is not validated in dotnet/runtime at the moment: https://github.com/dotnet/runtime/issues/52562
 
 Removing a library from this transport package is a breaking change and should be avoided.
 

--- a/src/libraries/Microsoft.Internal.Runtime.AspNetCore.Transport/src/Microsoft.Internal.Runtime.AspNetCore.Transport.proj
+++ b/src/libraries/Microsoft.Internal.Runtime.AspNetCore.Transport/src/Microsoft.Internal.Runtime.AspNetCore.Transport.proj
@@ -8,16 +8,17 @@
     <IncludeBuildOutput>true</IncludeBuildOutput>
     <DebugSymbols>false</DebugSymbols>
     <DebugType>none</DebugType>
-    <!-- This is non-shipping package. -->
+    <!-- Enable when the package shipped with NET6. -->
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
-    <PackageDescription>Internal transport package to provide aspnetcore with the assemblies that make up the Microsoft.ASPNetCore.App shared framework.</PackageDescription>
+    <PackageDescription>Internal transport package to provide aspnetcore with the assemblies from dotnet/runtime that make up the Microsoft.AspNetCore.App shared framework.</PackageDescription>
     <!-- Reference elements are missing from the nuspec: https://github.com/NuGet/Home/issues/8684. -->
     <NoWarn>$(NoWarn);NU5131</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Requires Private=true to calculate ReferenceCopyLocalPaths items. -->
-    <ProjectReference Include="@(AspNetCoreAppLibrary->'$(LibrariesProjectRoot)%(Identity)\src\%(Identity).csproj')" PrivateAssets="all" Pack="true" Private="true" IncludeReferenceAssemblyInPackage="true" />
+    <!-- Requires Private=true to calculate ReferenceCopyLocalPaths items. Also share System.Net.Quic which isn't part of aspnetcore's shared framework but which is needed by them. -->
+    <ProjectReference Include="@(AspNetCoreAppLibrary->'$(LibrariesProjectRoot)%(Identity)\src\%(Identity).csproj');
+                               $(LibrariesProjectRoot)System.Net.Quic\src\System.Net.Quic.csproj" PrivateAssets="all" Pack="true" Private="true" IncludeReferenceAssemblyInPackage="true" />
     <!-- TODO: Find a better way to include source generators without hardcoding them. -->
     <AnalyzerReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.Logging.Abstractions\gen\Microsoft.Extensions.Logging.Generators.csproj" />
   </ItemGroup>

--- a/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj
+++ b/src/libraries/Microsoft.Internal.Runtime.WindowsDesktop.Transport/src/Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj
@@ -8,9 +8,9 @@
     <IncludeBuildOutput>true</IncludeBuildOutput>
     <DebugSymbols>false</DebugSymbols>
     <DebugType>none</DebugType>
-    <!-- This is non-shipping package. -->
+    <!-- Enable when the package shipped with NET6. -->
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
-    <PackageDescription>Internal transport package to provide windowsdesktop with the assemblies that make up the Microsoft.WindowsDesktop.App shared framework.</PackageDescription>
+    <PackageDescription>Internal transport package to provide windowsdesktop with the assemblies from dotnet/runtime that make up the Microsoft.WindowsDesktop.App shared framework.</PackageDescription>
     <!-- Reference elements are missing from the nuspec: https://github.com/NuGet/Home/issues/8684. -->
     <NoWarn>$(NoWarn);NU5131</NoWarn>
   </PropertyGroup>

--- a/src/libraries/NetCoreAppLibrary.props
+++ b/src/libraries/NetCoreAppLibrary.props
@@ -181,7 +181,6 @@
       Microsoft.Extensions.Primitives;
       System.Diagnostics.EventLog;
       System.IO.Pipelines;
-      System.Net.Quic;
       System.Security.Cryptography.Xml;
     </AspNetCoreAppLibrary>
     <WindowsDesktopCoreAppLibrary>

--- a/src/libraries/src.proj
+++ b/src/libraries/src.proj
@@ -10,8 +10,8 @@
                       $(MSBuildThisFileDirectory)*\src\**\*.shproj" />
     <!-- Build these packages which reference many other projects in the allconfigurations leg only. -->
     <_allSrc Remove="Microsoft.AspNetCore.Internal.Transport\src\Microsoft.AspNetCore.Internal.Transport.proj;
-                     Microsoft.Windows.Compatibility\src\Microsoft.Windows.Compatibility.csproj;
-                     Microsoft.WindowsDesktop.Internal.Transport\src\Microsoft.WindowsDesktop.Internal.Transport.proj"
+                     Microsoft.Internal.Runtime.AspNetCore.Transport\src\Microsoft.Internal.Runtime.AspNetCore.Transport.proj;
+                     Microsoft.Internal.Runtime.WindowsDesktop.Transport\src\Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj"
              Condition="'$(BuildAllConfigurations)' != 'true'" />
 
     <NonNetCoreAppProject Include="@(_allSrc)"

--- a/src/libraries/src.proj
+++ b/src/libraries/src.proj
@@ -9,9 +9,9 @@
              Exclude="@(ProjectExclusions);
                       $(MSBuildThisFileDirectory)*\src\**\*.shproj" />
     <!-- Build these packages which reference many other projects in the allconfigurations leg only. -->
-    <_allSrc Remove="Microsoft.AspNetCore.Internal.Transport\src\Microsoft.AspNetCore.Internal.Transport.proj;
-                     Microsoft.Internal.Runtime.AspNetCore.Transport\src\Microsoft.Internal.Runtime.AspNetCore.Transport.proj;
-                     Microsoft.Internal.Runtime.WindowsDesktop.Transport\src\Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj"
+    <_allSrc Remove="Microsoft.Internal.Runtime.AspNetCore.Transport\src\Microsoft.Internal.Runtime.AspNetCore.Transport.proj;
+                     Microsoft.Internal.Runtime.WindowsDesktop.Transport\src\Microsoft.Internal.Runtime.WindowsDesktop.Transport.proj;
+                     Microsoft.Windows.Compatibility\src\Microsoft.Windows.Compatibility.csproj"
              Condition="'$(BuildAllConfigurations)' != 'true'" />
 
     <NonNetCoreAppProject Include="@(_allSrc)"


### PR DESCRIPTION
As agreed on in https://github.com/dotnet/windowsdesktop/pull/1936, we
want to follow a common schema when naming our transport packages.

Also updating the docs to reflect the name changes and to also
accomodate for the WindowsDesktop transport package.

@Anipik I also addressed your feedback regarding System.Net.Quic.