### PR TITLE
Fix System.Text.Json IAsyncEnumerator disposal on cancellation

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -47,9 +47,9 @@ namespace System.Text.Json
         public Task? PendingTask;
 
         /// <summary>
-        /// List of IAsyncDisposables that have been scheduled for disposal by converters.
+        /// List of completed IAsyncDisposables that have been scheduled for disposal by converters.
         /// </summary>
-        public List<IAsyncDisposable>? PendingAsyncDisposables;
+        public List<IAsyncDisposable>? CompletedAsyncDisposables;
 
         /// <summary>
         /// The amount of bytes to write before the underlying Stream should be flushed and the
@@ -196,14 +196,6 @@ namespace System.Text.Json
             {
                 Debug.Assert(_continuationCount == 0);
 
-                if (Current.AsyncEnumerator is not null)
-                {
-                    // we have completed serialization of an AsyncEnumerator,
-                    // pop from the stack and schedule for async disposal.
-                    PendingAsyncDisposables ??= new List<IAsyncDisposable>();
-                    PendingAsyncDisposables.Add(Current.AsyncEnumerator);
-                }
-
                 if (--_count > 0)
                 {
                     Current = _stack[_count - 1];
@@ -211,13 +203,16 @@ namespace System.Text.Json
             }
         }
 
+        public void AddCompletedAsyncDisposable(IAsyncDisposable asyncDisposable)
+            => (CompletedAsyncDisposables ??= new List<IAsyncDisposable>()).Add(asyncDisposable);
+
         // Asynchronously dispose of any AsyncDisposables that have been scheduled for disposal
-        public async ValueTask DisposePendingAsyncDisposables()
+        public async ValueTask DisposeCompletedAsyncDisposables()
         {
-            Debug.Assert(PendingAsyncDisposables?.Count > 0);
+            Debug.Assert(CompletedAsyncDisposables?.Count > 0);
             Exception? exception = null;
 
-            foreach (IAsyncDisposable asyncDisposable in PendingAsyncDisposables)
+            foreach (IAsyncDisposable asyncDisposable in CompletedAsyncDisposables)
             {
                 try
                 {
@@ -234,7 +229,7 @@ namespace System.Text.Json
                 ExceptionDispatchInfo.Capture(exception).Throw();
             }
 
-            PendingAsyncDisposables.Clear();
+            CompletedAsyncDisposables.Clear();
         }
 
         /// <summary>
@@ -245,13 +240,13 @@ namespace System.Text.Json
         {
             Exception? exception = null;
 
-            Debug.Assert(Current.AsyncEnumerator is null);
+            Debug.Assert(Current.AsyncDisposable is null);
             DisposeFrame(Current.CollectionEnumerator, ref exception);
 
             int stackSize = Math.Max(_count, _continuationCount);
             for (int i = 0; i < stackSize - 1; i++)
             {
-                Debug.Assert(_stack[i].AsyncEnumerator is null);
+                Debug.Assert(_stack[i].AsyncDisposable is null);
                 DisposeFrame(_stack[i].CollectionEnumerator, ref exception);
             }
 
@@ -284,12 +279,12 @@ namespace System.Text.Json
         {
             Exception? exception = null;
 
-            exception = await DisposeFrame(Current.CollectionEnumerator, Current.AsyncEnumerator, exception).ConfigureAwait(false);
+            exception = await DisposeFrame(Current.CollectionEnumerator, Current.AsyncDisposable, exception).ConfigureAwait(false);
 
             int stackSize = Math.Max(_count, _continuationCount);
             for (int i = 0; i < stackSize - 1; i++)
             {
-                exception = await DisposeFrame(_stack[i].CollectionEnumerator, _stack[i].AsyncEnumerator, exception).ConfigureAwait(false);
+                exception = await DisposeFrame(_stack[i].CollectionEnumerator, _stack[i].AsyncDisposable, exception).ConfigureAwait(false);
             }
 
             if (exception is not null)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
@@ -19,7 +19,7 @@ namespace System.Text.Json
         /// <summary>
         /// The enumerator for resumable async disposables.
         /// </summary>
-        public IAsyncDisposable? AsyncEnumerator;
+        public IAsyncDisposable? AsyncDisposable;
 
         /// <summary>
         /// The current stackframe has suspended serialization due to a pending task,

--- a/src/libraries/System.Text.Json/tests/Common/CollectionTests/CollectionTests.AsyncEnumerable.cs
+++ b/src/libraries/System.Text.Json/tests/Common/CollectionTests/CollectionTests.AsyncEnumerable.cs
@@ -74,8 +74,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(1, asyncEnumerable.TotalDisposedEnumerators);
         }
 
-        [OuterLoop]
-        [Theory]
+        [Theory, OuterLoop]
         [InlineData(5000, 1000, true)]
         [InlineData(5000, 1000, false)]
         [InlineData(1000, 10_000, true)]

--- a/src/libraries/System.Text.Json/tests/Common/CollectionTests/CollectionTests.AsyncEnumerable.cs
+++ b/src/libraries/System.Text.Json/tests/Common/CollectionTests/CollectionTests.AsyncEnumerable.cs
@@ -74,16 +74,25 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(1, asyncEnumerable.TotalDisposedEnumerators);
         }
 
-        [Fact, OuterLoop]
-        public async Task WriteAsyncEnumerable_LongRunningEnumeration_Cancellation()
+        [OuterLoop]
+        [Theory]
+        [InlineData(5000, 1000, true)]
+        [InlineData(5000, 1000, false)]
+        [InlineData(1000, 10_000, true)]
+        [InlineData(1000, 10_000, false)]
+        public async Task WriteAsyncEnumerable_LongRunningEnumeration_Cancellation(
+            int cancellationTokenSourceDelayMilliseconds,
+            int enumeratorDelayMilliseconds,
+            bool passCancellationTokenToDelayTask)
         {
             var longRunningEnumerable = new MockedAsyncEnumerable<int>(
-                source: Enumerable.Range(1, 100),
+                source: Enumerable.Range(1, 1000),
                 delayInterval: 1,
-                delay: TimeSpan.FromMinutes(1));
+                delay: TimeSpan.FromMilliseconds(enumeratorDelayMilliseconds),
+                passCancellationTokenToDelayTask);
 
             using var utf8Stream = new Utf8MemoryStream();
-            using var cts = new CancellationTokenSource(delay: TimeSpan.FromSeconds(5));
+            using var cts = new CancellationTokenSource(delay: TimeSpan.FromMilliseconds(cancellationTokenSourceDelayMilliseconds));
             await Assert.ThrowsAsync<TaskCanceledException>(async () =>
                 await JsonSerializer.SerializeAsync(utf8Stream, longRunningEnumerable, cancellationToken: cts.Token));
 
@@ -225,21 +234,42 @@ namespace System.Text.Json.Serialization.Tests
             static object[] WrapArgs<TSource>(IEnumerable<TSource> source, int delayInterval, int bufferSize) => new object[]{ source, delayInterval, bufferSize };
         }
 
-        private class MockedAsyncEnumerable<TElement> : IAsyncEnumerable<TElement>, IEnumerable<TElement>
+        [Fact]
+        public async Task RegressionTest_DisposingEnumeratorOnPendingMoveNextAsyncOperation()
+        {
+            // Regression test for https://github.com/dotnet/runtime/issues/57360
+            using var stream = new Utf8MemoryStream();
+            using var cts = new CancellationTokenSource(millisecondsDelay: 1000);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await JsonSerializer.SerializeAsync(stream, GetNumbersAsync(), cancellationToken: cts.Token));
+
+            static async IAsyncEnumerable<int> GetNumbersAsync()
+            {
+                int i = 0;
+                while (true)
+                {
+                    await Task.Delay(100);
+                    yield return i++;
+                }
+            }
+        }
+
+        public class MockedAsyncEnumerable<TElement> : IAsyncEnumerable<TElement>, IEnumerable<TElement>
         {
             private readonly IEnumerable<TElement> _source;
             private readonly TimeSpan _delay;
             private readonly int _delayInterval;
+            private readonly bool _passCancellationTokenToDelayTask;
 
-            internal int TotalCreatedEnumerators { get; private set; }
-            internal int TotalDisposedEnumerators { get; private set; }
-            internal int TotalEnumeratedElements { get; private set; }
+            public int TotalCreatedEnumerators { get; private set; }
+            public int TotalDisposedEnumerators { get; private set; }
+            public int TotalEnumeratedElements { get; private set; }
 
-            public MockedAsyncEnumerable(IEnumerable<TElement> source, int delayInterval = 0, TimeSpan? delay = null)
+            public MockedAsyncEnumerable(IEnumerable<TElement> source, int delayInterval = 0, TimeSpan? delay = null, bool passCancellationTokenToDelayTask = true)
             {
                 _source = source;
                 _delay = delay ?? TimeSpan.FromMilliseconds(20);
                 _delayInterval = delayInterval;
+                _passCancellationTokenToDelayTask = passCancellationTokenToDelayTask;
             }
 
             public IAsyncEnumerator<TElement> GetAsyncEnumerator(CancellationToken cancellationToken = default)
@@ -277,7 +307,7 @@ namespace System.Text.Json.Serialization.Tests
                 {
                     if (i > 0 && _delayInterval > 0 && i % _delayInterval == 0)
                     {
-                        await Task.Delay(_delay, cancellationToken);
+                        await Task.Delay(_delay, _passCancellationTokenToDelayTask ? cancellationToken : default);
                     }
 
                     if (cancellationToken.IsCancellationRequested)


### PR DESCRIPTION
Addresses an issue in System.Text.Json IAsyncEnumerable serialization where, in the event of a user-thrown exception, the serializer will attempt to dispose the IAsyncEnumerator instance without making sure that there are no pending `MoveNextAsync()` operations. In the case of compiler-generated IAsyncEnumerables, this can result in a `NotSupportedException` being thrown, see https://github.com/dotnet/runtime/issues/51176.  This issue will most typically manifest in cases where the ambient cancellation token has fired, but authors of the serialized IAsyncEnumerable are not passing that cancellation token to nested async operations.

This PR changes the IAsyncEnumerable implementation to wait on any pending `MoveNextAsync()` operations even if an exception has been thrown. This should not have any impact on latency provided that users take care to pass the IAsyncEnumerator cancellation token to any underlying dependencies. It also fixes an unrelated issue where in certain exceptional conditions the serializer would try to dispose the IAsyncEnumerator twice.

Fix #57360.

cc @davidfowl