### PR TITLE
Re-enable NameResolution tests on SLES, Debian 9 and Ubuntu 16.04

### DIFF
--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostByNameTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostByNameTest.cs
@@ -108,12 +108,6 @@ namespace System.Net.NameResolution.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/51377", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void DnsObsoleteGetHostByName_EmptyString_ReturnsHostName()
         {
-            if (PlatformDetection.IsSLES || // [ActiveIssue("https://github.com/dotnet/runtime/issues/55271")]
-                PlatformDetection.IsUbuntu1604 || PlatformDetection.IsDebian9) // [ActiveIssue("https://github.com/dotnet/runtime/issues/56295")]
-            {
-                throw new SkipTestException("Test environment is not configured for this test to work.");
-            }
-
             IPHostEntry entry = Dns.GetHostByName("");
 
             // DNS labels should be compared as case insensitive for ASCII characters. See RFC 4343.
@@ -125,12 +119,6 @@ namespace System.Net.NameResolution.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/51377", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void DnsObsoleteBeginEndGetHostByName_EmptyString_ReturnsHostName()
         {
-            if (PlatformDetection.IsSLES || // [ActiveIssue("https://github.com/dotnet/runtime/issues/55271")]
-                PlatformDetection.IsUbuntu1604 || PlatformDetection.IsDebian9) // [ActiveIssue("https://github.com/dotnet/runtime/issues/56295")]
-            {
-                throw new SkipTestException("Test environment is not configured for this test to work.");
-            }
-
             IPHostEntry entry = Dns.EndGetHostByName(Dns.BeginGetHostByName("", null, null));
 
             // DNS labels should be compared as case insensitive for ASCII characters. See RFC 4343.

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
@@ -28,11 +28,7 @@ namespace System.Net.NameResolution.Tests
             // [ActiveIssue("https://github.com/dotnet/runtime/issues/1488", TestPlatforms.OSX)]
             !PlatformDetection.IsOSX &&
             // [ActiveIssue("https://github.com/dotnet/runtime/issues/51377", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
-            !PlatformDetection.IsiOS && !PlatformDetection.IstvOS && !PlatformDetection.IsMacCatalyst &&
-            // [ActiveIssue("https://github.com/dotnet/runtime/issues/55271")]
-            !PlatformDetection.IsSLES &&
-            // [ActiveIssue("https://github.com/dotnet/runtime/issues/56295")]
-            !PlatformDetection.IsUbuntu1604 && !PlatformDetection.IsDebian9;
+            !PlatformDetection.IsiOS && !PlatformDetection.IstvOS && !PlatformDetection.IsMacCatalyst;
 
         [ConditionalTheory(nameof(GetHostEntryWorks))]
         [InlineData("")]


### PR DESCRIPTION
The underlying infrastructure issue was addressed in https://github.com/dotnet/core-eng/issues/13889

Fixes #55271
Fixes #56295