### PR TITLE
[android] build and ship libmono-profiler-aot.so

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -206,6 +206,7 @@
     <PlatformManifestFileEntry Include="libmono-icall-table.a" IsNative="true" />
     <PlatformManifestFileEntry Include="libmono-ilgen.a" IsNative="true" />
     <PlatformManifestFileEntry Include="libmono-profiler-aot.a" IsNative="true" />
+    <PlatformManifestFileEntry Include="libmono-profiler-aot.so" IsNative="true" />
     <PlatformManifestFileEntry Include="System.Private.Runtime.InteropServices.Javascript.dll" />
     <PlatformManifestFileEntry Include="dotnet.js" IsNative="true" />
     <PlatformManifestFileEntry Include="dotnet.wasm" IsNative="true" />

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -831,8 +831,11 @@
       <_MonoRuntimeArtifacts Condition="'$(_MonoIncludeInterpStaticFiles)' == 'true'" Include="$(MonoObjDir)out\lib\libmono-ilgen.a">
         <Destination>$(RuntimeBinDir)libmono-ilgen.a</Destination>
       </_MonoRuntimeArtifacts>
-      <_MonoRuntimeArtifacts Condition="'$(TargetsBrowser)' == 'true' and '$(BuildMonoAOTCrossCompilerOnly)' != 'true'" Include="$(MonoObjDir)out\lib\libmono-profiler-aot.a">
+      <_MonoRuntimeArtifacts Condition="('$(TargetsBrowser)' == 'true' or '$(TargetsAndroid)' == 'true') and '$(BuildMonoAOTCrossCompilerOnly)' != 'true'" Include="$(MonoObjDir)out\lib\libmono-profiler-aot.a">
         <Destination>$(RuntimeBinDir)libmono-profiler-aot.a</Destination>
+      </_MonoRuntimeArtifacts>
+      <_MonoRuntimeArtifacts Condition="'$(TargetsAndroid)' == 'true' and '$(BuildMonoAOTCrossCompilerOnly)' != 'true'" Include="$(MonoObjDir)out\lib\libmono-profiler-aot$(SharedLibExt)">
+        <Destination>$(RuntimeBinDir)libmono-profiler-aot$(SharedLibExt)</Destination>
       </_MonoRuntimeArtifacts>
       <_MonoICorDebugArtifacts Condition="'$(MonoMsCorDbi)' == 'true'" Include="$(MonoObjDir)out\lib\$(LibPrefix)dbgshim$(SharedLibExt)">
         <Destination>$(RuntimeBinDir)$(LibPrefix)dbgshim$(SharedLibExt)</Destination>

--- a/src/mono/mono/profiler/CMakeLists.txt
+++ b/src/mono/mono/profiler/CMakeLists.txt
@@ -24,6 +24,13 @@ if(NOT DISABLE_LIBS)
     install(TARGETS mono-profiler-log-static LIBRARY)
   endif()
 
+  if(HOST_ANDROID)
+    add_library(mono-profiler-aot SHARED aot.c helper.c)
+    target_compile_definitions(mono-profiler-aot PRIVATE -DMONO_DLL_EXPORT)
+    target_link_libraries(mono-profiler-aot monosgen-shared eglib_objects log)
+    install(TARGETS mono-profiler-aot LIBRARY)
+  endif()
+
   add_library(mono-profiler-aot-static STATIC aot.c helper.c)
   set_target_properties(mono-profiler-aot-static PROPERTIES OUTPUT_NAME mono-profiler-aot)
   install(TARGETS mono-profiler-aot-static LIBRARY)


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/6171
Fixes: https://github.com/dotnet/runtime/issues/56989

In order for the Android workload to be able to record
`.aotprof`/`.aotprofile` files, we need `libmono-profiler-aot.so`
to be available. Down the road this feature could be provided by the
Mono diagnostics component, but will probably not happen in .NET 6.

These changes build `libmono-profiler-aot.so` for Android, and includes
it in the `Microsoft.NETCore.App.Runtime.Mono.android-*` runtime packs.
In the Android workload's MSBuild targets we exclude this native library
unless the app is configured to record an AOT profile.

I also included in `CMakeLists.txt`:

    target_compile_definitions(mono-profiler-aot PRIVATE -DMONO_DLL_EXPORT)

Otherwise, the AOT profiler cannot be loaded:

    08-12 16:01:39.817  3003  3003 I monodroid-assembly: Trying to load shared library '/data/app/com.microsoft.net6.helloandroid-4u8tNHoPAh4zSZMaf2FsnA==/lib/x86_64/libmono-profiler-aot.so'
    08-12 16:01:39.818  3003  3003 W monodroid: Looking for profiler init symbol 'mono_profiler_init_aot'? 0x0
    08-12 16:01:39.818  3003  3003 W monodroid: The 'aot' profiler wasn't found in the main executable nor could it be loaded from 'libmono-profiler-aot.so'.

With these changes, I can successfully record an AOT profile on Android:

    Reading from '127.0.0.1:9999'...
    Read 4096 bytes...
    ...
    Read 2671 bytes...
    Read total 72303 bytes...
    Summary:
            Modules:          8
            Types:          197
            Methods:        910
    Going to write the profile to 'custom.aprof'

When using the profile, I get improved startup times:

    08-12 16:56:33.940  1624  1874 I ActivityTaskManager: Displayed com.microsoft.net6.helloandroid/crc6490bfc84a0f5dff7a.MainActivity: +217ms