### PR TITLE
commenting out an assert that could be triggered on Win7

### DIFF
--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -1985,7 +1985,9 @@ CONTEXT* AllocateOSContextHelper(BYTE** contextBuffer)
         pfnInitializeContext2(NULL, context, NULL, &contextSize, xStateCompactionMask) :
         InitializeContext(NULL, context, NULL, &contextSize);
 
-    _ASSERTE(!success && GetLastError() == ERROR_INSUFFICIENT_BUFFER);
+    // The following assert is valid, but gets triggered in some Win7 runs with no impact on functionality.
+    // commenting this out to reduce noise, as long as Win7 is supported.
+    // _ASSERTE(!success && GetLastError() == ERROR_INSUFFICIENT_BUFFER);
 
     // So now allocate a buffer of that size and call InitializeContext again
     BYTE* buffer = new (nothrow)BYTE[contextSize];


### PR DESCRIPTION
Fixes:https://github.com/dotnet/runtime/issues/57137

This is just a sanity assert to make sure we use the `InitializeContext` API correctly, which we do. 
However the assert seems to be triggered in some Win7 runs with no impact on actual functionality. The easiest way to deal with that is just to disable the assert.