### PR TITLE
Align DCJS with 4.8 implementation.

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/DataContractJsonSerializer.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/DataContractJsonSerializer.cs
@@ -365,7 +365,6 @@ namespace System.Runtime.Serialization.Json
             return JsonDataContract.GetJsonDataContract(contract).ReadJsonValue(reader, context);
         }
 
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
         internal static void WriteJsonNull(XmlWriterDelegator writer)
         {
             writer.WriteAttributeString(null, JsonGlobals.typeString, null, JsonGlobals.nullString); //  prefix //  namespace

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/DataContractJsonSerializer.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/DataContractJsonSerializer.cs
@@ -20,30 +20,25 @@ namespace System.Runtime.Serialization.Json
 
     public sealed class DataContractJsonSerializer : XmlObjectSerializer
     {
-        private const char BACK_SLASH = '\\';
-        private const char FORWARD_SLASH = '/';
-        private const char HIGH_SURROGATE_START = (char)0xd800;
-        private const char LOW_SURROGATE_END = (char)0xdfff;
-        private const char MAX_CHAR = (char)0xfffe;
-        private const char WHITESPACE = ' ';
-
-
         internal IList<Type>? knownTypeList;
         internal DataContractDictionary? knownDataContracts;
-        private readonly EmitTypeInformation _emitTypeInformation;
+        private EmitTypeInformation _emitTypeInformation;
         private ReadOnlyCollection<Type>? _knownTypeCollection;
-        private readonly int _maxItemsInObjectGraph;
-        private readonly bool _serializeReadOnlyTypes;
-        private readonly DateTimeFormat? _dateTimeFormat;
-        private readonly bool _useSimpleDictionaryFormat;
+        private int _maxItemsInObjectGraph;
+        private bool _serializeReadOnlyTypes;
+        private DateTimeFormat? _dateTimeFormat;
+        private bool _useSimpleDictionaryFormat;
+        private bool _ignoreExtensionDataObject;
+        private DataContract? _rootContract; // post-surrogate
+        private XmlDictionaryString? _rootName;
+        private bool _rootNameRequiresMapping;
+        private Type _rootType;
 
-        private readonly DataContractJsonSerializerImpl _serializer;
-        private readonly bool _ignoreExtensionDataObject;
 
         [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
         public DataContractJsonSerializer(Type type)
+            : this(type, (IEnumerable<Type>?)null)
         {
-            _serializer = new DataContractJsonSerializerImpl(type);
         }
 
         [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
@@ -60,8 +55,8 @@ namespace System.Runtime.Serialization.Json
 
         [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
         public DataContractJsonSerializer(Type type, IEnumerable<Type>? knownTypes)
+            : this(type, null, knownTypes, int.MaxValue, false, false)
         {
-            _serializer = new DataContractJsonSerializerImpl(type, knownTypes);
         }
 
         [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
@@ -72,14 +67,33 @@ namespace System.Runtime.Serialization.Json
 
         [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
         public DataContractJsonSerializer(Type type, XmlDictionaryString? rootName, IEnumerable<Type>? knownTypes)
+            : this(type, rootName, knownTypes, int.MaxValue, false, false)
         {
-            _serializer = new DataContractJsonSerializerImpl(type, rootName, knownTypes);
         }
 
         [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
         public DataContractJsonSerializer(Type type, DataContractJsonSerializerSettings? settings)
         {
-            _serializer = new DataContractJsonSerializerImpl(type, settings);
+            if (settings == null)
+            {
+                settings = new DataContractJsonSerializerSettings();
+            }
+
+            XmlDictionaryString? rootName = (settings.RootName == null) ? null : new XmlDictionary(1).Add(settings.RootName);
+            Initialize(type, rootName, settings.KnownTypes, settings.MaxItemsInObjectGraph, settings.IgnoreExtensionDataObject,
+                settings.EmitTypeInformation, settings.SerializeReadOnlyTypes, settings.DateTimeFormat, settings.UseSimpleDictionaryFormat);
+        }
+
+        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
+        internal DataContractJsonSerializer(Type type,
+            XmlDictionaryString? rootName,
+            IEnumerable<Type>? knownTypes,
+            int maxItemsInObjectGraph,
+            bool ignoreExtensionDataObject,
+            bool alwaysEmitTypeInformation)
+        {
+            EmitTypeInformation emitTypeInformation = alwaysEmitTypeInformation ? EmitTypeInformation.Always : EmitTypeInformation.AsNeeded;
+            Initialize(type, rootName, knownTypes, maxItemsInObjectGraph, ignoreExtensionDataObject, emitTypeInformation, false, null, false);
         }
 
         public bool IgnoreExtensionDataObject
@@ -152,493 +166,6 @@ namespace System.Runtime.Serialization.Json
             }
         }
 
-
-        public bool UseSimpleDictionaryFormat
-        {
-            get
-            {
-                return _useSimpleDictionaryFormat;
-            }
-        }
-
-        internal static void CheckIfTypeIsReference(DataContract dataContract)
-        {
-            if (dataContract.IsReference)
-            {
-                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
-                    XmlObjectSerializer.CreateSerializationException(SR.Format(
-                        SR.JsonUnsupportedForIsReference,
-                        DataContract.GetClrTypeFullName(dataContract.UnderlyingType),
-                        dataContract.IsReference)));
-            }
-        }
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        internal static DataContract GetDataContract(DataContract declaredTypeContract, Type declaredType, Type objectType)
-        {
-            DataContract contract = DataContractSerializer.GetDataContract(declaredTypeContract, declaredType, objectType);
-            CheckIfTypeIsReference(contract);
-            return contract;
-        }
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        public override void WriteObject(Stream stream, object? graph)
-        {
-            _serializer.WriteObject(stream, graph);
-        }
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        public override void WriteObject(XmlWriter writer, object? graph)
-        {
-            _serializer.WriteObject(writer, graph);
-        }
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        public override void WriteObject(XmlDictionaryWriter writer, object? graph)
-        {
-            _serializer.WriteObject(writer, graph);
-        }
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        public override object? ReadObject(Stream stream)
-        {
-            return _serializer.ReadObject(stream);
-        }
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        public override object? ReadObject(XmlReader reader)
-        {
-            return _serializer.ReadObject(reader);
-        }
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        public override object? ReadObject(XmlReader reader, bool verifyObjectName)
-        {
-            return _serializer.ReadObject(reader, verifyObjectName);
-        }
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        public override object? ReadObject(XmlDictionaryReader reader)
-        {
-            return _serializer.ReadObject(reader);
-        }
-
-        private List<Type> GetKnownTypesFromContext(XmlObjectSerializerContext context, IList<Type>? serializerKnownTypeList)
-        {
-            List<Type> knownTypesList = new List<Type>();
-            if (context != null)
-            {
-                List<XmlQualifiedName> stableNames = new List<XmlQualifiedName>();
-                Dictionary<XmlQualifiedName, DataContract>[] entries = context.scopedKnownTypes.dataContractDictionaries;
-                if (entries != null)
-                {
-                    for (int i = 0; i < entries.Length; i++)
-                    {
-                        Dictionary<XmlQualifiedName, DataContract> entry = entries[i];
-                        if (entry != null)
-                        {
-                            foreach (KeyValuePair<XmlQualifiedName, DataContract> pair in entry)
-                            {
-                                if (!stableNames.Contains(pair.Key))
-                                {
-                                    stableNames.Add(pair.Key);
-                                    knownTypesList.Add(pair.Value.UnderlyingType);
-                                }
-                            }
-                        }
-                    }
-                }
-                if (serializerKnownTypeList != null)
-                {
-                    knownTypesList.AddRange(serializerKnownTypeList);
-                }
-            }
-            return knownTypesList;
-        }
-
-        internal static void InvokeOnSerializing(object value, DataContract contract, XmlObjectSerializerWriteContextComplexJson context)
-        {
-            if (contract is ClassDataContract classContract)
-            {
-                if (classContract.BaseContract != null)
-                    InvokeOnSerializing(value, classContract.BaseContract, context);
-                if (classContract.OnSerializing != null)
-                {
-                    bool memberAccessFlag = classContract.RequiresMemberAccessForWrite(null);
-                    try
-                    {
-                        classContract.OnSerializing.Invoke(value, new object[] { context.GetStreamingContext() });
-                    }
-                    catch (SecurityException securityException)
-                    {
-                        if (memberAccessFlag)
-                        {
-                            classContract.RequiresMemberAccessForWrite(securityException);
-                        }
-                        else
-                        {
-                            throw;
-                        }
-                    }
-                    catch (TargetInvocationException targetInvocationException)
-                    {
-                        if (targetInvocationException.InnerException == null)
-                            throw;
-                        //We are catching the TIE here and throws the inner exception only,
-                        //this is needed to have a consistent exception story in all serializers
-                        throw targetInvocationException.InnerException;
-                    }
-                }
-            }
-        }
-
-        internal static void InvokeOnSerialized(object value, DataContract contract, XmlObjectSerializerWriteContextComplexJson context)
-        {
-            if (contract is ClassDataContract classContract)
-            {
-                if (classContract.BaseContract != null)
-                    InvokeOnSerialized(value, classContract.BaseContract, context);
-                if (classContract.OnSerialized != null)
-                {
-                    bool memberAccessFlag = classContract.RequiresMemberAccessForWrite(null);
-                    try
-                    {
-                        classContract.OnSerialized.Invoke(value, new object[] { context.GetStreamingContext() });
-                    }
-                    catch (SecurityException securityException)
-                    {
-                        if (memberAccessFlag)
-                        {
-                            classContract.RequiresMemberAccessForWrite(securityException);
-                        }
-                        else
-                        {
-                            throw;
-                        }
-                    }
-                    catch (TargetInvocationException targetInvocationException)
-                    {
-                        if (targetInvocationException.InnerException == null)
-                            throw;
-                        //We are catching the TIE here and throws the inner exception only,
-                        //this is needed to have a consistent exception story in all serializers
-                        throw targetInvocationException.InnerException;
-                    }
-                }
-            }
-        }
-
-        internal static void InvokeOnDeserializing(object value, DataContract contract, XmlObjectSerializerReadContextComplexJson context)
-        {
-            if (contract is ClassDataContract classContract)
-            {
-                if (classContract.BaseContract != null)
-                    InvokeOnDeserializing(value, classContract.BaseContract, context);
-                if (classContract.OnDeserializing != null)
-                {
-                    bool memberAccessFlag = classContract.RequiresMemberAccessForRead(null);
-                    try
-                    {
-                        classContract.OnDeserializing.Invoke(value, new object[] { context.GetStreamingContext() });
-                    }
-                    catch (SecurityException securityException)
-                    {
-                        if (memberAccessFlag)
-                        {
-                            classContract.RequiresMemberAccessForRead(securityException);
-                        }
-                        else
-                        {
-                            throw;
-                        }
-                    }
-                    catch (TargetInvocationException targetInvocationException)
-                    {
-                        if (targetInvocationException.InnerException == null)
-                            throw;
-                        //We are catching the TIE here and throws the inner exception only,
-                        //this is needed to have a consistent exception story in all serializers
-                        throw targetInvocationException.InnerException;
-                    }
-                }
-            }
-        }
-
-        internal static void InvokeOnDeserialized(object value, DataContract contract, XmlObjectSerializerReadContextComplexJson context)
-        {
-            if (contract is ClassDataContract classContract)
-            {
-                if (classContract.BaseContract != null)
-                    InvokeOnDeserialized(value, classContract.BaseContract, context);
-                if (classContract.OnDeserialized != null)
-                {
-                    bool memberAccessFlag = classContract.RequiresMemberAccessForRead(null);
-                    try
-                    {
-                        classContract.OnDeserialized.Invoke(value, new object[] { context.GetStreamingContext() });
-                    }
-                    catch (SecurityException securityException)
-                    {
-                        if (memberAccessFlag)
-                        {
-                            classContract.RequiresMemberAccessForRead(securityException);
-                        }
-                        else
-                        {
-                            throw;
-                        }
-                    }
-                    catch (TargetInvocationException targetInvocationException)
-                    {
-                        if (targetInvocationException.InnerException == null)
-                            throw;
-                        //We are catching the TIE here and throws the inner exception only,
-                        //this is needed to have a consistent exception story in all serializers
-                        throw targetInvocationException.InnerException;
-                    }
-                }
-            }
-        }
-
-        internal static bool CharacterNeedsEscaping(char ch)
-        {
-            return (ch == FORWARD_SLASH || ch == JsonGlobals.QuoteChar || ch < WHITESPACE || ch == BACK_SLASH
-                || (ch >= HIGH_SURROGATE_START && (ch <= LOW_SURROGATE_END || ch >= MAX_CHAR)));
-        }
-
-        internal static bool CheckIfJsonNameRequiresMapping(string jsonName)
-        {
-            if (jsonName != null)
-            {
-                if (!DataContract.IsValidNCName(jsonName))
-                {
-                    return true;
-                }
-
-                for (int i = 0; i < jsonName.Length; i++)
-                {
-                    if (CharacterNeedsEscaping(jsonName[i]))
-                    {
-                        return true;
-                    }
-                }
-            }
-            return false;
-        }
-
-        internal static bool CheckIfJsonNameRequiresMapping(XmlDictionaryString jsonName)
-        {
-            return (jsonName == null) ? false : CheckIfJsonNameRequiresMapping(jsonName.Value);
-        }
-
-        internal static string ConvertXmlNameToJsonName(string xmlName)
-        {
-            return XmlConvert.DecodeName(xmlName);
-        }
-
-        internal static XmlDictionaryString? ConvertXmlNameToJsonName(XmlDictionaryString? xmlName)
-        {
-            return (xmlName == null) ? null : new XmlDictionary().Add(ConvertXmlNameToJsonName(xmlName.Value));
-        }
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        internal static object? ReadJsonValue(DataContract contract, XmlReaderDelegator reader, XmlObjectSerializerReadContextComplexJson context)
-        {
-            return JsonDataContract.GetJsonDataContract(contract).ReadJsonValue(reader, context);
-        }
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        internal static void WriteJsonValue(JsonDataContract contract, XmlWriterDelegator writer, object graph, XmlObjectSerializerWriteContextComplexJson context, RuntimeTypeHandle declaredTypeHandle)
-        {
-            contract.WriteJsonValue(writer, graph, context, declaredTypeHandle);
-        }
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        public override void WriteStartObject(XmlWriter writer, object? graph)
-        {
-            _serializer.WriteStartObject(writer, graph);
-        }
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        public override void WriteStartObject(XmlDictionaryWriter writer, object? graph)
-        {
-            _serializer.WriteStartObject(writer, graph);
-        }
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        public override void WriteObjectContent(XmlWriter writer, object? graph)
-        {
-            _serializer.WriteObjectContent(writer, graph);
-        }
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        public override void WriteObjectContent(XmlDictionaryWriter writer, object? graph)
-        {
-            _serializer.WriteObjectContent(writer, graph);
-        }
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        public override void WriteEndObject(XmlWriter writer)
-        {
-            _serializer.WriteEndObject(writer);
-        }
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        public override void WriteEndObject(XmlDictionaryWriter writer)
-        {
-            _serializer.WriteEndObject(writer);
-        }
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        public override object? ReadObject(XmlDictionaryReader reader, bool verifyObjectName)
-        {
-            return _serializer.ReadObject(reader, verifyObjectName);
-        }
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        public override bool IsStartObject(XmlReader reader)
-        {
-            return _serializer.IsStartObject(reader);
-        }
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        public override bool IsStartObject(XmlDictionaryReader reader)
-        {
-            return _serializer.IsStartObject(reader);
-        }
-    }
-
-    internal sealed class DataContractJsonSerializerImpl : XmlObjectSerializer
-    {
-        internal IList<Type>? knownTypeList;
-        internal DataContractDictionary? knownDataContracts;
-        private EmitTypeInformation _emitTypeInformation;
-        private bool _ignoreExtensionDataObject;
-        private ReadOnlyCollection<Type>? _knownTypeCollection;
-        private int _maxItemsInObjectGraph;
-        private DataContract? _rootContract; // post-surrogate
-        private XmlDictionaryString? _rootName;
-        private bool _rootNameRequiresMapping;
-        private Type _rootType;
-        private bool _serializeReadOnlyTypes;
-        private DateTimeFormat? _dateTimeFormat;
-        private bool _useSimpleDictionaryFormat;
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        public DataContractJsonSerializerImpl(Type type)
-            : this(type, (IEnumerable<Type>?)null)
-        {
-        }
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        public DataContractJsonSerializerImpl(Type type, IEnumerable<Type>? knownTypes)
-            : this(type, null, knownTypes, int.MaxValue, false, false)
-        {
-        }
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        public DataContractJsonSerializerImpl(Type type, XmlDictionaryString? rootName, IEnumerable<Type>? knownTypes)
-            : this(type, rootName, knownTypes, int.MaxValue, false, false)
-        {
-        }
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        internal DataContractJsonSerializerImpl(Type type,
-            XmlDictionaryString? rootName,
-            IEnumerable<Type>? knownTypes,
-            int maxItemsInObjectGraph,
-            bool ignoreExtensionDataObject,
-            bool alwaysEmitTypeInformation)
-        {
-            EmitTypeInformation emitTypeInformation = alwaysEmitTypeInformation ? EmitTypeInformation.Always : EmitTypeInformation.AsNeeded;
-            Initialize(type, rootName, knownTypes, maxItemsInObjectGraph, ignoreExtensionDataObject, emitTypeInformation, false, null, false);
-        }
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        public DataContractJsonSerializerImpl(Type type, DataContractJsonSerializerSettings? settings)
-        {
-            if (settings == null)
-            {
-                settings = new DataContractJsonSerializerSettings();
-            }
-
-            XmlDictionaryString? rootName = (settings.RootName == null) ? null : new XmlDictionary(1).Add(settings.RootName);
-            Initialize(type, rootName, settings.KnownTypes, settings.MaxItemsInObjectGraph, settings.IgnoreExtensionDataObject,
-                settings.EmitTypeInformation, settings.SerializeReadOnlyTypes, settings.DateTimeFormat, settings.UseSimpleDictionaryFormat);
-        }
-
-        public ReadOnlyCollection<Type> KnownTypes
-        {
-            get
-            {
-                if (_knownTypeCollection == null)
-                {
-                    if (knownTypeList != null)
-                    {
-                        _knownTypeCollection = new ReadOnlyCollection<Type>(knownTypeList);
-                    }
-                    else
-                    {
-                        _knownTypeCollection = new ReadOnlyCollection<Type>(Type.EmptyTypes);
-                    }
-                }
-                return _knownTypeCollection;
-            }
-        }
-
-        internal override DataContractDictionary? KnownDataContracts
-        {
-            [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-            get
-            {
-                if (this.knownDataContracts == null && this.knownTypeList != null)
-                {
-                    // This assignment may be performed concurrently and thus is a race condition.
-                    // It's safe, however, because at worse a new (and identical) dictionary of
-                    // data contracts will be created and re-assigned to this field.  Introduction
-                    // of a lock here could lead to deadlocks.
-                    this.knownDataContracts = XmlObjectSerializerContext.GetDataContractsForKnownTypes(this.knownTypeList);
-                }
-                return this.knownDataContracts;
-            }
-        }
-
-        internal int MaxItemsInObjectGraph
-        {
-            get { return _maxItemsInObjectGraph; }
-        }
-
-        internal bool AlwaysEmitTypeInformation
-        {
-            get
-            {
-                return _emitTypeInformation == EmitTypeInformation.Always;
-            }
-        }
-
-        public EmitTypeInformation EmitTypeInformation
-        {
-            get
-            {
-                return _emitTypeInformation;
-            }
-        }
-
-        public bool SerializeReadOnlyTypes
-        {
-            get
-            {
-                return _serializeReadOnlyTypes;
-            }
-        }
-
-        public DateTimeFormat? DateTimeFormat
-        {
-            get
-            {
-                return _dateTimeFormat;
-            }
-        }
 
         public bool UseSimpleDictionaryFormat
         {
@@ -838,6 +365,7 @@ namespace System.Runtime.Serialization.Json
             return JsonDataContract.GetJsonDataContract(contract).ReadJsonValue(reader, context);
         }
 
+        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
         internal static void WriteJsonNull(XmlWriterDelegator writer)
         {
             writer.WriteAttributeString(null, JsonGlobals.typeString, null, JsonGlobals.nullString); //  prefix //  namespace
@@ -893,7 +421,7 @@ namespace System.Runtime.Serialization.Json
             DataContract contract = RootContract;
             if (contract.IsPrimitive && object.ReferenceEquals(contract.UnderlyingType, _rootType))// handle Nullable<T> differently
             {
-                return DataContractJsonSerializerImpl.ReadJsonValue(contract, xmlReader, null);
+                return DataContractJsonSerializer.ReadJsonValue(contract, xmlReader, null);
             }
 
             XmlObjectSerializerReadContextComplexJson context = XmlObjectSerializerReadContextComplexJson.CreateContext(this, contract);
@@ -926,11 +454,6 @@ namespace System.Runtime.Serialization.Json
             Type declaredType = contract.UnderlyingType;
             Type graphType = (graph == null) ? declaredType : graph.GetType();
 
-            //if (dataContractSurrogate != null)
-            //{
-            //    graph = DataContractSerializer.SurrogateToDataContractType(dataContractSurrogate, graph, declaredType, ref graphType);
-            //}
-
             if (graph == null)
             {
                 WriteJsonNull(writer);
@@ -947,13 +470,13 @@ namespace System.Runtime.Serialization.Json
                     }
                     else
                     {
-                        DataContractJsonSerializerImpl.WriteJsonValue(JsonDataContract.GetJsonDataContract(contract), writer, graph, null, declaredType.TypeHandle); //  XmlObjectSerializerWriteContextComplexJson
+                        DataContractJsonSerializer.WriteJsonValue(JsonDataContract.GetJsonDataContract(contract), writer, graph, null, declaredType.TypeHandle); //  XmlObjectSerializerWriteContextComplexJson
                     }
                 }
                 else
                 {
                     XmlObjectSerializerWriteContextComplexJson context = XmlObjectSerializerWriteContextComplexJson.CreateContext(this, RootContract);
-                    contract = DataContractJsonSerializerImpl.GetDataContract(contract, declaredType, graphType);
+                    contract = DataContractJsonSerializer.GetDataContract(contract, declaredType, graphType);
                     if (contract.CanContainReferences)
                     {
                         context.OnHandleReference(writer, graph, true); //  canContainCyclicReference
@@ -1057,7 +580,11 @@ namespace System.Runtime.Serialization.Json
         {
             if (dataContract.IsReference)
             {
-                throw XmlObjectSerializer.CreateSerializationException(SR.Format(SR.JsonUnsupportedForIsReference, DataContract.GetClrTypeFullName(dataContract.UnderlyingType), dataContract.IsReference));
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(
+                    XmlObjectSerializer.CreateSerializationException(SR.Format(
+                        SR.JsonUnsupportedForIsReference,
+                        DataContract.GetClrTypeFullName(dataContract.UnderlyingType),
+                        dataContract.IsReference)));
             }
         }
 

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonClassDataContract.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonClassDataContract.cs
@@ -21,12 +21,6 @@ namespace System.Runtime.Serialization.Json
             _helper = (base.Helper as JsonClassDataContractCriticalHelper)!;
         }
 
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        private JsonFormatClassReaderDelegate CreateJsonFormatReaderDelegate()
-        {
-            return new ReflectionJsonClassReader(TraditionalClassDataContract).ReflectionReadClass;
-        }
-
         internal JsonFormatClassReaderDelegate JsonFormatReaderDelegate
         {
             [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
@@ -41,7 +35,7 @@ namespace System.Runtime.Serialization.Json
                             JsonFormatClassReaderDelegate tempDelegate;
                             if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
                             {
-                                tempDelegate = CreateJsonFormatReaderDelegate();
+                                tempDelegate = new ReflectionJsonClassReader(TraditionalClassDataContract).ReflectionReadClass;
                             }
                             else
                             {
@@ -55,12 +49,6 @@ namespace System.Runtime.Serialization.Json
                 }
                 return _helper.JsonFormatReaderDelegate;
             }
-        }
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        private JsonFormatClassWriterDelegate CreateJsonFormatWriterDelegate()
-        {
-            return new ReflectionJsonFormatWriter().ReflectionWriteClass;
         }
 
         internal JsonFormatClassWriterDelegate JsonFormatWriterDelegate
@@ -77,7 +65,7 @@ namespace System.Runtime.Serialization.Json
                             JsonFormatClassWriterDelegate tempDelegate;
                             if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
                             {
-                                tempDelegate = CreateJsonFormatWriterDelegate();
+                                tempDelegate = new ReflectionJsonFormatWriter().ReflectionWriteClass;
                             }
                             else
                             {
@@ -171,7 +159,7 @@ namespace System.Runtime.Serialization.Json
                         else
                         {
                             memberTable.Add(_traditionalClassDataContract.MemberNames[i].Value, null);
-                            decodedMemberNames[i] = DataContractJsonSerializerImpl.ConvertXmlNameToJsonName(_traditionalClassDataContract.MemberNames[i]);
+                            decodedMemberNames[i] = DataContractJsonSerializer.ConvertXmlNameToJsonName(_traditionalClassDataContract.MemberNames[i]);
                         }
                     }
                     _memberNames = decodedMemberNames;

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonCollectionDataContract.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonCollectionDataContract.cs
@@ -21,12 +21,6 @@ namespace System.Runtime.Serialization.Json
             _helper = (base.Helper as JsonCollectionDataContractCriticalHelper)!;
         }
 
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        private JsonFormatCollectionReaderDelegate CreateJsonFormatReaderDelegate()
-        {
-            return new ReflectionJsonCollectionReader().ReflectionReadCollection;
-        }
-
         internal JsonFormatCollectionReaderDelegate JsonFormatReaderDelegate
         {
             [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
@@ -41,7 +35,7 @@ namespace System.Runtime.Serialization.Json
                             JsonFormatCollectionReaderDelegate tempDelegate;
                             if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
                             {
-                                tempDelegate = CreateJsonFormatReaderDelegate();
+                                tempDelegate = new ReflectionJsonCollectionReader().ReflectionReadCollection;
                             }
                             else
                             {
@@ -55,12 +49,6 @@ namespace System.Runtime.Serialization.Json
                 }
                 return _helper.JsonFormatReaderDelegate;
             }
-        }
-
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        private JsonFormatGetOnlyCollectionReaderDelegate CreateJsonFormatGetOnlyReaderDelegate()
-        {
-            return new ReflectionJsonCollectionReader().ReflectionReadGetOnlyCollection;
         }
 
         internal JsonFormatGetOnlyCollectionReaderDelegate JsonFormatGetOnlyReaderDelegate
@@ -83,7 +71,7 @@ namespace System.Runtime.Serialization.Json
                             JsonFormatGetOnlyCollectionReaderDelegate tempDelegate;
                             if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
                             {
-                                tempDelegate = CreateJsonFormatGetOnlyReaderDelegate();
+                                tempDelegate = new ReflectionJsonCollectionReader().ReflectionReadGetOnlyCollection;
                             }
                             else
                             {
@@ -99,13 +87,6 @@ namespace System.Runtime.Serialization.Json
             }
         }
 
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
-        private JsonFormatCollectionWriterDelegate CreateJsonFormatWriterDelegate()
-        {
-            return new ReflectionJsonFormatWriter().ReflectionWriteCollection;
-        }
-
-
         internal JsonFormatCollectionWriterDelegate JsonFormatWriterDelegate
         {
             [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
@@ -120,7 +101,7 @@ namespace System.Runtime.Serialization.Json
                             JsonFormatCollectionWriterDelegate tempDelegate;
                             if (DataContractSerializer.Option == SerializationOption.ReflectionOnly)
                             {
-                                tempDelegate = CreateJsonFormatWriterDelegate();
+                                tempDelegate = new ReflectionJsonFormatWriter().ReflectionWriteCollection;
                             }
                             else
                             {

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonEncodingStreamWrapper.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonEncodingStreamWrapper.cs
@@ -439,8 +439,7 @@ namespace System.Runtime.Serialization.Json
         {
             try
             {
-                //this.stream = new BufferedStream(inputStream);
-                _stream = inputStream;
+                _stream = new BufferedStream(inputStream);
 
                 SupportedEncoding expectedEnc = GetSupportedEncoding(expectedEncoding);
                 SupportedEncoding dataEnc = ReadEncoding();
@@ -472,8 +471,7 @@ namespace System.Runtime.Serialization.Json
         private void InitForWriting(Stream outputStream, Encoding writeEncoding)
         {
             _encoding = writeEncoding;
-            //this.stream = new BufferedStream(outputStream);
-            _stream = outputStream;
+            _stream = new BufferedStream(outputStream);
 
             // Set the encoding code
             _encodingCode = GetSupportedEncoding(writeEncoding);

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatGeneratorStatics.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatGeneratorStatics.cs
@@ -13,6 +13,8 @@ namespace System.Runtime.Serialization
 {
     public static class JsonFormatGeneratorStatics
     {
+        private static MethodInfo? s_boxPointer;
+
         private static PropertyInfo? s_collectionItemNameProperty;
 
         private static ConstructorInfo? s_extensionDataObjectCtor;
@@ -59,6 +61,8 @@ namespace System.Runtime.Serialization
 
         private static PropertyInfo? s_typeHandleProperty;
 
+        private static MethodInfo? s_unboxPointer;
+
         private static PropertyInfo? s_useSimpleDictionaryFormatReadProperty;
 
         private static PropertyInfo? s_useSimpleDictionaryFormatWriteProperty;
@@ -80,6 +84,19 @@ namespace System.Runtime.Serialization
         private static MethodInfo? s_parseEnumMethod;
 
         private static MethodInfo? s_getJsonMemberNameMethod;
+
+        public static MethodInfo BoxPointer
+        {
+            get
+            {
+                if (s_boxPointer == null)
+                {
+                    s_boxPointer = typeof(Pointer).GetMethod("Box");
+                    Debug.Assert(s_boxPointer != null);
+                }
+                return s_boxPointer;
+            }
+        }
 
         public static PropertyInfo CollectionItemNameProperty
         {
@@ -347,6 +364,18 @@ namespace System.Runtime.Serialization
                     Debug.Assert(s_typeHandleProperty != null);
                 }
                 return s_typeHandleProperty;
+            }
+        }
+        public static MethodInfo UnboxPointer
+        {
+            get
+            {
+                if (s_unboxPointer == null)
+                {
+                    s_unboxPointer = typeof(Pointer).GetMethod("Unbox");
+                    Debug.Assert(s_unboxPointer != null);
+                }
+                return s_unboxPointer;
             }
         }
         public static PropertyInfo UseSimpleDictionaryFormatReadProperty

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatReaderGenerator.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatReaderGenerator.cs
@@ -563,7 +563,14 @@ namespace System.Runtime.Serialization.Json
                 _ilg.Load(string.Empty);
                 _ilg.Call(XmlFormatGeneratorStatics.InternalDeserializeMethod);
 
-                _ilg.ConvertValue(Globals.TypeOfObject, type);
+                if (type.IsPointer)
+                {
+                    _ilg.Call(JsonFormatGeneratorStatics.UnboxPointer);
+                }
+                else
+                {
+                    _ilg.ConvertValue(Globals.TypeOfObject, type);
+                }
                 _ilg.Stloc(value);
             }
 

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonObjectDataContract.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonObjectDataContract.cs
@@ -44,7 +44,7 @@ namespace System.Runtime.Serialization.Json
                     break;
                 case JsonGlobals.arrayString:
                     // Read as object array
-                    return DataContractJsonSerializerImpl.ReadJsonValue(DataContract.GetDataContract(Globals.TypeOfObjectArray), jsonReader, context);
+                    return DataContractJsonSerializer.ReadJsonValue(DataContract.GetDataContract(Globals.TypeOfObjectArray), jsonReader, context);
                 default:
                     throw XmlObjectSerializer.CreateSerializationException(SR.Format(SR.JsonUnexpectedAttributeValue, contentMode));
             }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/ReflectionJsonFormatWriter.cs
@@ -243,7 +243,7 @@ namespace System.Runtime.Serialization.Json
                     {
                         memberValue = ReflectionGetMemberValue(obj, member);
                     }
-                    bool requiresNameAttribute = DataContractJsonSerializerImpl.CheckIfXmlNameRequiresMapping(classContract.MemberNames![i]);
+                    bool requiresNameAttribute = DataContractJsonSerializer.CheckIfXmlNameRequiresMapping(classContract.MemberNames![i]);
                     PrimitiveDataContract? primitiveContract = member.MemberPrimitiveContract;
                     if (requiresNameAttribute || !ReflectionTryWritePrimitive(xmlWriter, context, memberType, memberValue, memberNames[i + childElementIndex] /*name*/, null/*ns*/, primitiveContract))
                     {

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonReader.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonReader.cs
@@ -339,7 +339,6 @@ namespace System.Runtime.Serialization.Json
 
         public override void Close()
         {
-            base.Close();
             OnXmlDictionaryReaderClose? onClose = _onReaderClose;
             _onReaderClose = null;
             ResetState();
@@ -354,6 +353,8 @@ namespace System.Runtime.Serialization.Json
                     throw new InvalidOperationException(SR.GenericCallbackException, e);
                 }
             }
+
+            base.Close();
         }
 
         public override void EndCanonicalization()

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonReader.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonReader.cs
@@ -337,8 +337,9 @@ namespace System.Runtime.Serialization.Json
             }
         }
 
-        protected override void Dispose(bool disposing)
+        public override void Close()
         {
+            base.Close();
             OnXmlDictionaryReaderClose? onClose = _onReaderClose;
             _onReaderClose = null;
             ResetState();
@@ -353,7 +354,6 @@ namespace System.Runtime.Serialization.Json
                     throw new InvalidOperationException(SR.GenericCallbackException, e);
                 }
             }
-            base.Dispose(disposing);
         }
 
         public override void EndCanonicalization()

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonWriter.cs
@@ -193,7 +193,7 @@ namespace System.Runtime.Serialization.Json
 
         private bool WrittenNameWithMapping => (_nameState & NameState.WrittenNameWithMapping) == NameState.WrittenNameWithMapping;
 
-        protected override void Dispose(bool disposing)
+        public override void Close()
         {
             if (!IsClosed)
             {
@@ -218,8 +218,6 @@ namespace System.Runtime.Serialization.Json
                     }
                 }
             }
-
-            base.Dispose(disposing);
         }
 
         public override void Flush()
@@ -262,21 +260,20 @@ namespace System.Runtime.Serialization.Json
             {
                 throw new ArgumentNullException(nameof(encoding));
             }
-            Encoding? tempEncoding = encoding;
-            if (tempEncoding.WebName != Encoding.UTF8.WebName)
+            if (encoding.WebName != Encoding.UTF8.WebName)
             {
-                stream = new JsonEncodingStreamWrapper(stream, tempEncoding, false);
+                stream = new JsonEncodingStreamWrapper(stream, encoding, false);
             }
             else
             {
-                tempEncoding = null;
+                encoding = null!;
             }
             if (_nodeWriter == null)
             {
                 _nodeWriter = new JsonNodeWriter();
             }
 
-            _nodeWriter.SetOutput(stream, ownsStream, tempEncoding);
+            _nodeWriter.SetOutput(stream, ownsStream, encoding);
             InitializeWriter();
         }
 

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlJsonWriter.cs
@@ -218,6 +218,8 @@ namespace System.Runtime.Serialization.Json
                     }
                 }
             }
+
+            base.Close();
         }
 
         public override void Flush()

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerReadContextComplexJson.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerReadContextComplexJson.cs
@@ -7,8 +7,6 @@ using System.Text;
 using System.Reflection;
 using System.Xml;
 using System.Runtime.Serialization;
-using DataContractDictionary = System.Collections.Generic.Dictionary<System.Xml.XmlQualifiedName, System.Runtime.Serialization.DataContract>;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 namespace System.Runtime.Serialization.Json
@@ -19,8 +17,8 @@ namespace System.Runtime.Serialization.Json
         private readonly DateTimeFormat? _dateTimeFormat;
         private readonly bool _useSimpleDictionaryFormat;
 
-        internal XmlObjectSerializerReadContextComplexJson(DataContractJsonSerializerImpl serializer, DataContract rootTypeDataContract)
-            : base(serializer, serializer.MaxItemsInObjectGraph, default(StreamingContext), false)
+        internal XmlObjectSerializerReadContextComplexJson(DataContractJsonSerializer serializer, DataContract rootTypeDataContract)
+            : base(serializer, serializer.MaxItemsInObjectGraph, new StreamingContext(StreamingContextStates.All), serializer.IgnoreExtensionDataObject)
         {
             this.rootTypeDataContract = rootTypeDataContract;
             this.serializerKnownTypeList = serializer.knownTypeList;
@@ -28,7 +26,7 @@ namespace System.Runtime.Serialization.Json
             _useSimpleDictionaryFormat = serializer.UseSimpleDictionaryFormat;
         }
 
-        internal static XmlObjectSerializerReadContextComplexJson CreateContext(DataContractJsonSerializerImpl serializer, DataContract rootTypeDataContract)
+        internal static XmlObjectSerializerReadContextComplexJson CreateContext(DataContractJsonSerializer serializer, DataContract rootTypeDataContract)
         {
             return new XmlObjectSerializerReadContextComplexJson(serializer, rootTypeDataContract);
         }
@@ -36,7 +34,7 @@ namespace System.Runtime.Serialization.Json
         [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
         protected override object? ReadDataContractValue(DataContract dataContract, XmlReaderDelegator reader)
         {
-            return DataContractJsonSerializerImpl.ReadJsonValue(dataContract, reader, this);
+            return DataContractJsonSerializer.ReadJsonValue(dataContract, reader, this);
         }
 
         [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
@@ -133,6 +131,11 @@ namespace System.Runtime.Serialization.Json
                 TypeCode.Decimal => new DataNode<decimal>((decimal)numericalValue),
                 _ => throw new InvalidOperationException(SR.ParseJsonNumberReturnInvalidNumber),
             };
+        }
+
+        internal override int GetArraySize()
+        {
+            return -1;
         }
 
         internal override void ReadAttributes(XmlReaderDelegator xmlReader)
@@ -239,6 +242,24 @@ namespace System.Runtime.Serialization.Json
         }
 
         [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
+        protected override bool IsReadingCollectionExtensionData(XmlReaderDelegator xmlReader)
+        {
+            return xmlReader.GetAttribute(JsonGlobals.typeString) == JsonGlobals.arrayString;
+        }
+
+        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
+        protected override bool IsReadingClassExtensionData(XmlReaderDelegator xmlReader)
+        {
+            return xmlReader.GetAttribute(JsonGlobals.typeString) == JsonGlobals.objectString;
+        }
+
+        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
+        protected override XmlReaderDelegator CreateReaderDelegatorForReader(XmlReader xmlReader)
+        {
+            return new JsonReaderDelegator(xmlReader, this._dateTimeFormat);
+        }
+
+        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
         internal override DataContract GetDataContract(RuntimeTypeHandle typeHandle, Type? type)
         {
             DataContract dataContract = base.GetDataContract(typeHandle, type);
@@ -322,6 +343,11 @@ namespace System.Runtime.Serialization.Json
         private static bool IsBitSet(byte[] bytes, int bitIndex)
         {
             return BitFlagsGenerator.IsBitSet(bytes, bitIndex);
+        }
+
+        protected override DataContract? ResolveDataContractFromRootDataContract(XmlQualifiedName typeQName)
+        {
+            return XmlObjectSerializerWriteContextComplexJson.ResolveJsonDataContractFromRootDataContract(this, typeQName, rootTypeDataContract!);
         }
     }
 }

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerReadContextComplexJson.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerReadContextComplexJson.cs
@@ -241,19 +241,16 @@ namespace System.Runtime.Serialization.Json
             return new XmlQualifiedName(name, ns);
         }
 
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
         protected override bool IsReadingCollectionExtensionData(XmlReaderDelegator xmlReader)
         {
             return xmlReader.GetAttribute(JsonGlobals.typeString) == JsonGlobals.arrayString;
         }
 
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
         protected override bool IsReadingClassExtensionData(XmlReaderDelegator xmlReader)
         {
             return xmlReader.GetAttribute(JsonGlobals.typeString) == JsonGlobals.objectString;
         }
 
-        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
         protected override XmlReaderDelegator CreateReaderDelegatorForReader(XmlReader xmlReader)
         {
             return new JsonReaderDelegator(xmlReader, this._dateTimeFormat);
@@ -345,6 +342,7 @@ namespace System.Runtime.Serialization.Json
             return BitFlagsGenerator.IsBitSet(bytes, bitIndex);
         }
 
+        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
         protected override DataContract? ResolveDataContractFromRootDataContract(XmlQualifiedName typeQName)
         {
             return XmlObjectSerializerWriteContextComplexJson.ResolveJsonDataContractFromRootDataContract(this, typeQName, rootTypeDataContract!);

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerContext.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerContext.cs
@@ -281,22 +281,26 @@ namespace System.Runtime.Serialization
                     if (rootTypeDataContract.StableName == qname)
                         dataContract = rootTypeDataContract;
                     else
-                    {
-                        CollectionDataContract? collectionContract = rootTypeDataContract as CollectionDataContract;
-                        while (collectionContract != null)
-                        {
-                            DataContract itemContract = GetDataContract(GetSurrogatedType(collectionContract.ItemType));
-                            if (itemContract.StableName == qname)
-                            {
-                                dataContract = itemContract;
-                                break;
-                            }
-                            collectionContract = itemContract as CollectionDataContract;
-                        }
-                    }
+                        dataContract = ResolveDataContractFromRootDataContract(qname);
                 }
             }
             return dataContract;
+        }
+
+        [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]
+        protected virtual DataContract? ResolveDataContractFromRootDataContract(XmlQualifiedName typeQName)
+        {
+            CollectionDataContract? collectionContract = rootTypeDataContract as CollectionDataContract;
+            while (collectionContract != null)
+            {
+                DataContract itemContract = GetDataContract(GetSurrogatedType(collectionContract.ItemType));
+                if (itemContract.StableName == typeQName)
+                {
+                    return itemContract;
+                }
+                collectionContract = itemContract as CollectionDataContract;
+            }
+            return null;
         }
 
         [RequiresUnreferencedCode(DataContract.SerializerTrimmerWarning)]

--- a/src/libraries/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/libraries/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -2384,6 +2384,38 @@ public static partial class DataContractJsonSerializerTests
         }
     }
 
+    [Fact]
+    public static void DCJS_ExtensionDataObjectTest2()
+    {
+        SerializeThenDeserialize(new ContractExtended { Item = new Item { Id = 1, Code = 2 } });
+        SerializeThenDeserialize(new ContractExtended { Item = new Item { Id = 1 } });
+    }
+
+    private static void SerializeThenDeserialize(ContractExtended extendedData)
+    {
+        string extendedContractJson;
+        using (var memoryStream = new MemoryStream())
+        {
+            new DataContractJsonSerializer(typeof(ContractExtended)).WriteObject(memoryStream, extendedData);
+            extendedContractJson = Encoding.UTF8.GetString(memoryStream.ToArray());
+        }
+
+        ContractGeneric reducedData;
+        using (var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(extendedContractJson)))
+        {
+            reducedData = (ContractGeneric)new DataContractJsonSerializer(typeof(ContractGeneric)).ReadObject(memoryStream);
+        }
+
+        string reducedContractJson;
+        using (var memoryStream = new MemoryStream())
+        {
+            new DataContractJsonSerializer(typeof(ContractGeneric)).WriteObject(memoryStream, reducedData);
+            reducedContractJson = Encoding.UTF8.GetString(memoryStream.ToArray());
+        }
+
+        Assert.Equal(extendedContractJson, reducedContractJson);
+    }
+
     private static string ConstructorWithRootNameTestHelper(TypeForRootNameTest value, DataContractJsonSerializer serializer)
     {
         using (var ms = new MemoryStream())

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.RuntimeOnly.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.RuntimeOnly.cs
@@ -4334,6 +4334,29 @@ public class NativeJsonTestData
     public Func<object> Instantiate { get; set; }
 }
 
+[DataContract]
+public class ContractGeneric : IExtensibleDataObject
+{
+    public ExtensionDataObject ExtensionData { get; set; }
+}
+
+[DataContract(Name = "ContractGeneric")]
+public class ContractExtended
+{
+    [DataMember(Name = "item", Order = 1)]
+    public Item Item;
+}
+
+[DataContract]
+public class Item
+{
+    [DataMember(Name = "id", Order = 1, EmitDefaultValue = false)]
+    public long? Id;
+
+    [DataMember(Name = "code", Order = 2, EmitDefaultValue = false)]
+    public long? Code;
+}
+
 public class TypeWithCollectionAndDateTimeOffset
 {
     public TypeWithCollectionAndDateTimeOffset()


### PR DESCRIPTION
Align DCJS with 4.8 implementation.

DCJS in .Net Core (and previously, going back to the days of
Silverlight) has been a wild evolution of features being cut
and added back and morphed as the features and concepts
of the associated runtimes have changed. This PR should
finally bring DCJS back inline with the current .Net 4.8
implementation.

In the process of doing so, this PR also corrects a couple of
places where DCJS was mis-stepping to cause the bug described
in #55270, which is a regression from NetFx.

Fixes #55270