### PR TITLE
Add --make-repro-path option to crossgen2

### DIFF
--- a/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
@@ -357,4 +357,7 @@
   <data name="InstructionSetHelp" xml:space="preserve">
     <value>The allowable values for the --instruction-set option are described in the table below. Each architecture has a different set of valid instruction sets, and multiple instruction sets may be specified by separating the instructions sets by a ','. For example 'avx2,bmi,lzcnt'</value>
   </data>
+  <data name="MakeReproPathHelp" xml:space="preserve">
+    <value>Make a repro zip file in the specified path. This is used for sending error reports to the .NET team.</value>
+  </data>
 </root>


### PR DESCRIPTION
- This is used to create repro packages for customer discovered issues with CrossGen2
- Customers will use this by setting the `PublishCrossGen2ExtraArgs` property to something like `--make-repro-path:c:\repro\crossgen2repro`
- Then the build will run, and produce zip files in the specified directory, one for each crossgen2 run that occurs during that build.
- Hopefully, then it is straightforward to package the failure up and send it in.

In addition, this tech can be used to transfer a full set of repro details from a Unix to Windows machine for easier debugging.