### PR TITLE
EnvironmentVariables config add missing prefix POSTGRESQLCONNSTR_

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
     public class EnvironmentVariablesConfigurationProvider : ConfigurationProvider
     {
         private const string MySqlServerPrefix = "MYSQLCONNSTR_";
+        private const string PostgreSqlServerPrefix = "POSTGRESQLCONNSTR_";
         private const string SqlAzureServerPrefix = "SQLAZURECONNSTR_";
         private const string SqlServerPrefix = "SQLCONNSTR_";
         private const string CustomPrefix = "CUSTOMCONNSTR_";
@@ -63,6 +64,11 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
                     {
                         prefix = MySqlServerPrefix;
                         provider = "MySql.Data.MySqlClient";
+                    }
+                    else if (key.StartsWith(PostgreSqlServerPrefix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        prefix = PostgreSqlServerPrefix;
+                        provider = "Npgsql";
                     }
                     else if (key.StartsWith(SqlAzureServerPrefix, StringComparison.OrdinalIgnoreCase))
                     {

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
                     else if (key.StartsWith(PostgreSqlServerPrefix, StringComparison.OrdinalIgnoreCase))
                     {
                         prefix = PostgreSqlServerPrefix;
-                        provider = "Npgsql";
+                        provider = "Postgres";
                     }
                     else if (key.StartsWith(SqlAzureServerPrefix, StringComparison.OrdinalIgnoreCase))
                     {

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/tests/EnvironmentVariablesTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/tests/EnvironmentVariablesTest.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
                     {"MYSQLCONNSTR_db3", "MySQLConnStr"},
                     {"SQLAZURECONNSTR_db4", "SQLAzureConnStr"},
                     {"CommonEnv", "CommonEnvValue"},
+                    {"POSTGRESQLCONNSTR_db5", "PostgreSQLConnStr"},
                 };
             var envConfigSrc = new EnvironmentVariablesConfigurationProvider();
 
@@ -80,6 +81,8 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
             Assert.Equal("SQLAzureConnStr", envConfigSrc.Get("ConnectionStrings:db4"));
             Assert.Equal("System.Data.SqlClient", envConfigSrc.Get("ConnectionStrings:db4_ProviderName"));
             Assert.Equal("CommonEnvValue", envConfigSrc.Get("CommonEnv"));
+            Assert.Equal("PostgreSQLConnStr", envConfigSrc.Get("ConnectionStrings:db5"));
+            Assert.Equal("Npgsql", envConfigSrc.Get("ConnectionStrings:db5_ProviderName"));
         }
 
         [Fact]
@@ -92,6 +95,7 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
                 {"MYSQLCONNSTR_db3", "MySQLConnStr"},
                 {"SQLAZURECONNSTR_db4", "SQLAzureConnStr"},
                 {"CommonEnv", "CommonEnvValue"},
+                {"POSTGRESQLCONNSTR_db5", "PostgreSQLConnStr"},
             };
             var envConfigSrc = new EnvironmentVariablesConfigurationProvider("ConnectionStrings:");
 
@@ -104,6 +108,8 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
             Assert.Equal("MySql.Data.MySqlClient", envConfigSrc.Get("db3_ProviderName"));
             Assert.Equal("SQLAzureConnStr", envConfigSrc.Get("db4"));
             Assert.Equal("System.Data.SqlClient", envConfigSrc.Get("db4_ProviderName"));
+            Assert.Equal("PostgreSQLConnStr", envConfigSrc.Get("db5"));
+            Assert.Equal("Npgsql", envConfigSrc.Get("db5_ProviderName"));
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/tests/EnvironmentVariablesTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/tests/EnvironmentVariablesTest.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
             Assert.Equal("System.Data.SqlClient", envConfigSrc.Get("ConnectionStrings:db4_ProviderName"));
             Assert.Equal("CommonEnvValue", envConfigSrc.Get("CommonEnv"));
             Assert.Equal("PostgreSQLConnStr", envConfigSrc.Get("ConnectionStrings:db5"));
-            Assert.Equal("Npgsql", envConfigSrc.Get("ConnectionStrings:db5_ProviderName"));
+            Assert.Equal("Postgres", envConfigSrc.Get("ConnectionStrings:db5_ProviderName"));
         }
 
         [Fact]
@@ -109,7 +109,7 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
             Assert.Equal("SQLAzureConnStr", envConfigSrc.Get("db4"));
             Assert.Equal("System.Data.SqlClient", envConfigSrc.Get("db4_ProviderName"));
             Assert.Equal("PostgreSQLConnStr", envConfigSrc.Get("db5"));
-            Assert.Equal("Npgsql", envConfigSrc.Get("db5_ProviderName"));
+            Assert.Equal("Postgres", envConfigSrc.Get("db5_ProviderName"));
         }
 
         [Fact]


### PR DESCRIPTION
Add missing connection string prefix POSTGRESQLCONNSTR_ for EnvironmentVariablesConfigurationProvider

To fix #57545 