### PR TITLE
Make noise if trying to use the cache after it's been disposed.

### DIFF
--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/ConfigUtil.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/Configuration/ConfigUtil.cs
@@ -15,6 +15,7 @@ namespace System.Runtime.Caching.Configuration
         internal const string PhysicalMemoryLimitPercentage = "physicalMemoryLimitPercentage";
         internal const string PollingInterval = "pollingInterval";
         internal const string UseMemoryCacheManager = "useMemoryCacheManager";
+        internal const string ThrowOnDisposed = "throwOnDisposed";
         internal const int DefaultPollingTimeMilliseconds = 120000;
 
         internal static int GetIntValue(NameValueCollection config, string valueName, int defaultValue, bool zeroAllowed, int maxValueAllowed)

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCache.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCache.cs
@@ -37,7 +37,8 @@ namespace System.Runtime.Caching
         private Counters _perfCounters;
         private readonly bool _configLess;
         private bool _useMemoryCacheManager = true;
-        private bool _throwOnDisposed;// = false;
+        private bool _throwOnDisposed;
+        private readonly string _disposedName;
         private EventHandler _onAppDomainUnload;
         private UnhandledExceptionEventHandler _onUnhandledException;
 #if NET5_0_OR_GREATER
@@ -345,6 +346,7 @@ namespace System.Runtime.Caching
         private MemoryCache()
         {
             _name = "Default";
+            _disposedName = typeof(MemoryCache).FullName + $"({_name})";
             Init(null);
         }
 
@@ -363,6 +365,7 @@ namespace System.Runtime.Caching
                 throw new ArgumentException(SR.Default_is_reserved, nameof(name));
             }
             _name = name;
+            _disposedName = typeof(MemoryCache).FullName + $"({_name})";
             Init(config);
         }
 
@@ -383,6 +386,7 @@ namespace System.Runtime.Caching
                 throw new ArgumentException(SR.Default_is_reserved, nameof(name));
             }
             _name = name;
+            _disposedName = typeof(MemoryCache).FullName + $"({_name})";
             _configLess = ignoreConfigSection;
             Init(config);
         }
@@ -438,7 +442,7 @@ namespace System.Runtime.Caching
 
                 if (_throwOnDisposed)
                 {
-                    throw new ObjectDisposedException(typeof(MemoryCache).FullName);
+                    throw new ObjectDisposedException(_disposedName);
                 }
 
                 return null;
@@ -541,7 +545,7 @@ namespace System.Runtime.Caching
             {
                 if (_throwOnDisposed)
                 {
-                    throw new ObjectDisposedException(typeof(MemoryCache).FullName);
+                    throw new ObjectDisposedException(_disposedName);
                 }
 
                 return null;
@@ -557,7 +561,7 @@ namespace System.Runtime.Caching
 
             if (IsDisposed && _throwOnDisposed)
             {
-                throw new ObjectDisposedException(typeof(MemoryCache).FullName);
+                throw new ObjectDisposedException(_disposedName);
             }
 
             if (!IsDisposed)
@@ -576,7 +580,7 @@ namespace System.Runtime.Caching
 
             if (IsDisposed && _throwOnDisposed)
             {
-                throw new ObjectDisposedException(typeof(MemoryCache).FullName);
+                throw new ObjectDisposedException(_disposedName);
             }
 
             if (!IsDisposed)
@@ -600,7 +604,7 @@ namespace System.Runtime.Caching
         {
             if (IsDisposed && _throwOnDisposed)
             {
-                throw new ObjectDisposedException(typeof(MemoryCache).FullName);
+                throw new ObjectDisposedException(_disposedName);
             }
 
             if (percent > 100)
@@ -747,7 +751,7 @@ namespace System.Runtime.Caching
 
                 if (_throwOnDisposed)
                 {
-                    throw new ObjectDisposedException(typeof(MemoryCache).FullName);
+                    throw new ObjectDisposedException(_disposedName);
                 }
 
                 return;
@@ -793,7 +797,7 @@ namespace System.Runtime.Caching
 
                 if (_throwOnDisposed)
                 {
-                    throw new ObjectDisposedException(typeof(MemoryCache).FullName);
+                    throw new ObjectDisposedException(_disposedName);
                 }
 
                 return;
@@ -854,7 +858,7 @@ namespace System.Runtime.Caching
             {
                 if (_throwOnDisposed)
                 {
-                    throw new ObjectDisposedException(typeof(MemoryCache).FullName);
+                    throw new ObjectDisposedException(_disposedName);
                 }
 
                 return null;
@@ -872,7 +876,7 @@ namespace System.Runtime.Caching
 
             if (IsDisposed && _throwOnDisposed)
             {
-                throw new ObjectDisposedException(typeof(MemoryCache).FullName);
+                throw new ObjectDisposedException(_disposedName);
             }
 
             long count = 0;
@@ -908,7 +912,7 @@ namespace System.Runtime.Caching
             }
             if (IsDisposed && _throwOnDisposed)
             {
-                throw new ObjectDisposedException(typeof(MemoryCache).FullName);
+                throw new ObjectDisposedException(_disposedName);
             }
 
             Dictionary<string, object> values = null;

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCache.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCache.cs
@@ -37,6 +37,7 @@ namespace System.Runtime.Caching
         private Counters _perfCounters;
         private readonly bool _configLess;
         private bool _useMemoryCacheManager = true;
+        private bool _throwOnDisposed;// = false;
         private EventHandler _onAppDomainUnload;
         private UnhandledExceptionEventHandler _onUnhandledException;
 #if NET5_0_OR_GREATER
@@ -393,6 +394,7 @@ namespace System.Runtime.Caching
             if (config != null)
             {
                 _useMemoryCacheManager = ConfigUtil.GetBooleanValue(config, ConfigUtil.UseMemoryCacheManager, true);
+                _throwOnDisposed = ConfigUtil.GetBooleanValue(config, ConfigUtil.ThrowOnDisposed, false);
             }
             InitDisposableMembers(config);
         }
@@ -433,6 +435,12 @@ namespace System.Runtime.Caching
                         }
                     }
                 }
+
+                if (_throwOnDisposed)
+                {
+                    throw new ObjectDisposedException(typeof(MemoryCache).FullName);
+                }
+
                 return null;
             }
             MemoryCacheKey cacheKey = new MemoryCacheKey(key);
@@ -531,6 +539,11 @@ namespace System.Runtime.Caching
         {
             if (IsDisposed)
             {
+                if (_throwOnDisposed)
+                {
+                    throw new ObjectDisposedException(typeof(MemoryCache).FullName);
+                }
+
                 return null;
             }
             MemoryCacheKey cacheKey = new MemoryCacheKey(key);
@@ -541,6 +554,12 @@ namespace System.Runtime.Caching
         IEnumerator IEnumerable.GetEnumerator()
         {
             Hashtable h = new Hashtable();
+
+            if (IsDisposed && _throwOnDisposed)
+            {
+                throw new ObjectDisposedException(typeof(MemoryCache).FullName);
+            }
+
             if (!IsDisposed)
             {
                 foreach (var storeRef in _storeRefs)
@@ -554,6 +573,12 @@ namespace System.Runtime.Caching
         protected override IEnumerator<KeyValuePair<string, object>> GetEnumerator()
         {
             Dictionary<string, object> h = new Dictionary<string, object>();
+
+            if (IsDisposed && _throwOnDisposed)
+            {
+                throw new ObjectDisposedException(typeof(MemoryCache).FullName);
+            }
+
             if (!IsDisposed)
             {
                 foreach (var storeRef in _storeRefs)
@@ -573,12 +598,17 @@ namespace System.Runtime.Caching
 
         public long Trim(int percent)
         {
+            if (IsDisposed && _throwOnDisposed)
+            {
+                throw new ObjectDisposedException(typeof(MemoryCache).FullName);
+            }
+
             if (percent > 100)
             {
                 percent = 100;
             }
             long trimmed = 0;
-            if (_disposed == 0)
+            if (!IsDisposed)
             {
                 foreach (var storeRef in _storeRefs)
                 {
@@ -714,6 +744,12 @@ namespace System.Runtime.Caching
                         }
                     }
                 }
+
+                if (_throwOnDisposed)
+                {
+                    throw new ObjectDisposedException(typeof(MemoryCache).FullName);
+                }
+
                 return;
             }
             MemoryCacheKey cacheKey = new MemoryCacheKey(key);
@@ -754,6 +790,12 @@ namespace System.Runtime.Caching
                         }
                     }
                 }
+
+                if (_throwOnDisposed)
+                {
+                    throw new ObjectDisposedException(typeof(MemoryCache).FullName);
+                }
+
                 return;
             }
             // Insert updatable cache entry
@@ -810,6 +852,11 @@ namespace System.Runtime.Caching
             }
             if (IsDisposed)
             {
+                if (_throwOnDisposed)
+                {
+                    throw new ObjectDisposedException(typeof(MemoryCache).FullName);
+                }
+
                 return null;
             }
             MemoryCacheEntry entry = RemoveEntry(key, null, reason);
@@ -822,6 +869,12 @@ namespace System.Runtime.Caching
             {
                 throw new NotSupportedException(SR.RegionName_not_supported);
             }
+
+            if (IsDisposed && _throwOnDisposed)
+            {
+                throw new ObjectDisposedException(typeof(MemoryCache).FullName);
+            }
+
             long count = 0;
             if (!IsDisposed)
             {
@@ -853,6 +906,11 @@ namespace System.Runtime.Caching
             {
                 throw new ArgumentNullException(nameof(keys));
             }
+            if (IsDisposed && _throwOnDisposed)
+            {
+                throw new ObjectDisposedException(typeof(MemoryCache).FullName);
+            }
+
             Dictionary<string, object> values = null;
             if (!IsDisposed)
             {

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCache.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCache.cs
@@ -916,7 +916,7 @@ namespace System.Runtime.Caching
 
             if (_throwOnDisposed)
             {
-                string cacheName = this.GetType().FullName + $"({_name})";
+                string cacheName = $"{this.GetType().FullName}({_name})";
                 throw new ObjectDisposedException(cacheName);
             }
 

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCacheEntry.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCacheEntry.cs
@@ -240,7 +240,11 @@ namespace System.Runtime.Caching
         {
             if (State == EntryState.AddedToCache)
             {
-                _fields._cache.RemoveEntry(this.Key, this, CacheEntryRemovedReason.ChangeMonitorChanged);
+                try
+                {
+                    _fields._cache.RemoveEntry(this.Key, this, CacheEntryRemovedReason.ChangeMonitorChanged);
+                }
+                catch (ObjectDisposedException) { }
             }
         }
 

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCacheEntry.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCacheEntry.cs
@@ -240,11 +240,11 @@ namespace System.Runtime.Caching
         {
             if (State == EntryState.AddedToCache)
             {
-                try
-                {
-                    _fields._cache.RemoveEntry(this.Key, this, CacheEntryRemovedReason.ChangeMonitorChanged);
-                }
-                catch (ObjectDisposedException) { }
+                // This is a callback - not directly called by the user. We don't want
+                // to throw potentially unhandled "disposed" exceptions in this case.
+                // However, RemoveEntry sidesteps 'throwOnDispose' so we don't need to
+                // worry about a try/catch here.
+                _fields._cache.RemoveEntry(this.Key, this, CacheEntryRemovedReason.ChangeMonitorChanged);
             }
         }
 

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCacheStatistics.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCacheStatistics.cs
@@ -319,6 +319,12 @@ namespace System.Runtime.Caching
 #endif
                 return trimmedOrExpired;
             }
+            catch (ObjectDisposedException)
+            {
+                // There is a small window for _memoryCache to be disposed after we check our own
+                // disposed bit. No big deal.
+                return 0;
+            }
             finally
             {
                 Interlocked.Exchange(ref _inCacheManagerThread, 0);

--- a/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
+++ b/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
@@ -69,6 +69,19 @@ namespace MonoTests.System.Runtime.Caching
         }
         public static bool DoesNotSupportPhysicalMemoryMonitor => !SupportsPhysicalMemoryMonitor;
 
+        private bool IsFullFramework = RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
+
+        private PokerMemoryCache CreatePokerMemoryCache(string name, string throwOnDisposed)
+        {
+            if (throwOnDisposed == null)
+            {
+                return new PokerMemoryCache(name);
+            }
+
+            var config = new NameValueCollection();
+            config.Add("throwOnDisposed", throwOnDisposed);
+            return new PokerMemoryCache("MyCache", config);
+        }
 
         [Fact]
         public void ConstructorParameters()
@@ -196,6 +209,10 @@ namespace MonoTests.System.Runtime.Caching
                 DefaultCacheCapabilities.CacheEntryRemovedCallback |
                 DefaultCacheCapabilities.CacheEntryUpdateCallback,
                 mc.DefaultCacheCapabilities);
+
+            // throwOnDisposed is false
+            mc.Dispose();
+            mc.Trim(0);
         }
 
         [Fact]
@@ -212,6 +229,10 @@ namespace MonoTests.System.Runtime.Caching
                 DefaultCacheCapabilities.CacheEntryRemovedCallback |
                 DefaultCacheCapabilities.CacheEntryUpdateCallback,
                 mc.DefaultCacheCapabilities);
+
+            // throwOnDisposed is false
+            mc.Dispose();
+            mc.Trim(0);
         }
 
         [ConditionalFact(nameof(SupportsPhysicalMemoryMonitor))]
@@ -236,10 +257,10 @@ namespace MonoTests.System.Runtime.Caching
             Assert.Equal(TimeSpan.FromMinutes(70), mc.PollingInterval);
         }
 
-        [Fact]
-        public void Indexer()
+        [Theory, InlineData("true"), InlineData("false"), InlineData(null)]
+        public void Indexer(string throwOnDisposed)
         {
-            var mc = new PokerMemoryCache("MyCache");
+            var mc = CreatePokerMemoryCache("MyCache", throwOnDisposed);
 
             Assert.Throws<ArgumentNullException>(() =>
             {
@@ -269,13 +290,23 @@ namespace MonoTests.System.Runtime.Caching
             Assert.Equal(1, mc.Calls.Count);
             Assert.Equal("get_this [string key]", mc.Calls[0]);
             Assert.Equal("value", value);
+
+            mc.Dispose();
+            if (throwOnDisposed == "true" && !IsFullFramework)  // Noisy when disposed is a Core-only feature.
+            {
+                Assert.Throws<ObjectDisposedException>(() => { var val = mc["key"]; });
+            }
+            else
+            {
+                Assert.Null(mc["key"]);
+            }
         }
 
-        [Fact]
+        [Theory, InlineData("true"), InlineData("false"), InlineData(null)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/1429")]
-        public void Contains()
+        public void Contains(string throwOnDisposed)
         {
-            var mc = new PokerMemoryCache("MyCache");
+            var mc = CreatePokerMemoryCache("MyCache", throwOnDisposed);
 
             Assert.Throws<ArgumentNullException>(() =>
             {
@@ -301,6 +332,17 @@ namespace MonoTests.System.Runtime.Caching
 
             // Attempt to retrieve an expired entry
             Assert.False(mc.Contains("key"));
+
+            // Contains throws when disposed
+            mc.Dispose();
+            if (throwOnDisposed == "true" && !IsFullFramework)  // Noisy when disposed is a Core-only feature.
+            {
+                Assert.Throws<ObjectDisposedException>(() => { mc.Contains("key"); });
+            }
+            else
+            {
+                Assert.False(mc.Contains("key"));
+            }
         }
 
         [Fact]
@@ -353,10 +395,10 @@ namespace MonoTests.System.Runtime.Caching
             Assert.True (monitor.HasChanged);
         }
 
-        [Fact]
-        public void AddOrGetExisting_String_Object_DateTimeOffset_String()
+        [Theory, InlineData("true"), InlineData("false"), InlineData(null)]
+        public void AddOrGetExisting_String_Object_DateTimeOffset_String(string throwOnDisposed)
         {
-            var mc = new PokerMemoryCache("MyCache");
+            var mc = CreatePokerMemoryCache("MyCache", throwOnDisposed);
 
             Assert.Throws<ArgumentNullException>(() =>
             {
@@ -388,6 +430,23 @@ namespace MonoTests.System.Runtime.Caching
             value = mc.AddOrGetExisting("key_expired", "value", DateTimeOffset.MinValue);
             Assert.False(mc.Contains("key_expired"));
             Assert.Null(value);
+
+            // Throws when disposed
+            mc.Dispose();
+            if (throwOnDisposed == "true" && !IsFullFramework)  // Noisy when disposed is a Core-only feature.
+            {
+                Assert.Throws<ObjectDisposedException>(() => {
+                    value = mc.AddOrGetExisting("key3_A2-1", "value3", DateTimeOffset.Now.AddMinutes(1));
+                });
+                Assert.Throws<ObjectDisposedException>(() => {
+                    value = mc.AddOrGetExisting("not-key3_A2-1", "value4", DateTimeOffset.Now.AddMinutes(1));
+                });
+            }
+            else
+            {
+                Assert.Null(mc.AddOrGetExisting("key3_A2-1", "value3", DateTimeOffset.Now.AddMinutes(1)));
+                Assert.Null(mc.AddOrGetExisting("not-key3_A2-1", "value4", DateTimeOffset.Now.AddMinutes(1)));
+            }
         }
 
         [Fact]
@@ -610,10 +669,10 @@ namespace MonoTests.System.Runtime.Caching
             Assert.Equal("AddOrGetExisting (CacheItem item, CacheItemPolicy policy)", mc.Calls[0]);
         }
 
-        [Fact]
-        public void Set_String_Object_CacheItemPolicy_String()
+        [Theory, InlineData("true"), InlineData("false"), InlineData(null)]
+        public void Set_String_Object_CacheItemPolicy_String(string throwOnDisposed)
         {
-            var mc = new PokerMemoryCache("MyCache");
+            var mc = CreatePokerMemoryCache("MyCache", throwOnDisposed);
 
             Assert.Throws<NotSupportedException>(() =>
             {
@@ -691,6 +750,22 @@ namespace MonoTests.System.Runtime.Caching
             Assert.True(mc.Contains("key_A5"));
             Assert.Equal(2, mc.Calls.Count);
             Assert.Equal("Set (string key, object value, CacheItemPolicy policy, string regionName = null)", mc.Calls[0]);
+
+            // Throws when disposed
+            mc.Dispose();
+            if (throwOnDisposed == "true" && !IsFullFramework)  // Noisy when disposed is a Core-only feature.
+            {
+                cip = new CacheItemPolicy();
+                cip.AbsoluteExpiration = DateTimeOffset.MaxValue;
+                Assert.Throws<ObjectDisposedException>(() => { mc.Set("key_A6", "value_A6", cip); });
+            }
+            else
+            {
+                cip = new CacheItemPolicy();
+                cip.AbsoluteExpiration = DateTimeOffset.MaxValue;
+                mc.Set("key_A6", "value_A6", cip);
+                Assert.Null(mc["key_A6"]);
+            }
         }
 
         [Fact]
@@ -820,10 +895,10 @@ namespace MonoTests.System.Runtime.Caching
             Assert.Equal("Set (string key, object value, CacheItemPolicy policy, string regionName = null)", mc.Calls[1]);
         }
 
-        [Fact]
-        public void Remove()
+        [Theory, InlineData("true"), InlineData("false"), InlineData(null)]
+        public void Remove(string throwOnDisposed)
         {
-            var mc = new PokerMemoryCache("MyCache");
+            var mc = CreatePokerMemoryCache("MyCache", throwOnDisposed);
 
             Assert.Throws<NotSupportedException>(() =>
             {
@@ -904,12 +979,35 @@ namespace MonoTests.System.Runtime.Caching
             value = mc.Remove("key");
             Assert.NotNull(value);
             Assert.False(callbackInvoked);
+
+            // Throws when disposed
+            cip = new CacheItemPolicy();
+            cip.UpdateCallback = (CacheEntryUpdateArguments args) =>
+            {
+                callbackInvoked = true;
+                reason = args.RemovedReason;
+                throw new ApplicationException("test");
+            };
+            mc.Set("key", "value", cip);
+            callbackInvoked = false;
+            reason = (CacheEntryRemovedReason)1000;
+            mc.Dispose();
+            if (throwOnDisposed == "true" && !IsFullFramework)  // Noisy when disposed is a Core-only feature.
+            {
+                Assert.Throws<ObjectDisposedException>(() => { value = mc.Remove("key"); });
+            }
+            else
+            {
+                value = mc.Remove("key");
+                Assert.Null(value);
+                Assert.False(callbackInvoked);
+            }
         }
 
-        [Fact]
-        public void GetValues()
+        [Theory, InlineData("true"), InlineData("false"), InlineData(null)]
+        public void GetValues(string throwOnDisposed)
         {
-            var mc = new PokerMemoryCache("MyCache");
+            var mc = CreatePokerMemoryCache("MyCache", throwOnDisposed);
 
             Assert.Throws<ArgumentNullException>(() =>
             {
@@ -953,6 +1051,18 @@ namespace MonoTests.System.Runtime.Caching
             Assert.Equal("value1", value["key1"]);
             Assert.Equal("value3", value["key3"]);
             Assert.False(value.ContainsKey("Key1"));
+
+            // Throws when disposed
+            mc.Dispose();
+            if (throwOnDisposed == "true" && !IsFullFramework)  // Noisy when disposed is a Core-only feature.
+            {
+                Assert.Throws<ObjectDisposedException>(() => { mc.GetValues(new string[] { "key1", "key3" }); });
+            }
+            else
+            {
+                value = mc.GetValues(new string[] { "key1", "key3" });
+                Assert.Null(value);
+            }
         }
 
         [Fact]
@@ -995,11 +1105,14 @@ namespace MonoTests.System.Runtime.Caching
 
         // Due to internal implementation details Trim has very few easily verifiable scenarios
         // ActiveIssue: https://github.com/dotnet/runtime/issues/36488
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))]
-        public void Trim()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))]
+        [InlineData("true"), InlineData("false"), InlineData(null)]
+        public void Trim(string throwOnDisposed)
         {
             var config = new NameValueCollection();
             config["__MonoEmulateOneCPU"] = "true";
+            if (throwOnDisposed != null)
+                config["throwOnDisposed"] = throwOnDisposed;
             var mc = new MemoryCache("MyCache", config);
 
             var numCpuCores = Environment.ProcessorCount;
@@ -1029,6 +1142,18 @@ namespace MonoTests.System.Runtime.Caching
             Assert.Equal(11, mc.GetCount());
             trimmed = mc.Trim(50);
             Assert.Equal(11, mc.GetCount());
+
+            // Trim should throw if the cache is disposed
+            // Throws when disposed
+            mc.Dispose();
+            if (throwOnDisposed == "true" && !IsFullFramework)  // Noisy when disposed is a Core-only feature.
+            {
+                Assert.Throws<ObjectDisposedException>(() => { mc.Trim(50); });
+            }
+            else
+            {
+                Assert.Equal(0, mc.Trim(50));
+            }
         }
 
         [ConditionalFact(nameof(SupportsPhysicalMemoryMonitor))]


### PR DESCRIPTION
SRC.MemoryCache silently fails to add after Dispose().

With this PR, you can set an option when creating a cache
that will tell the cache to be more vocal when trying to use
a cache that has been disposed.

Fixes #1424