### PR TITLE
[release/5.0] Fix ReadOnlySequence created out of sliced Memory owned by MemoryManager

### DIFF
--- a/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -150,7 +150,7 @@ namespace System.Buffers
                 _startObject = manager;
                 _endObject = manager;
                 _startInteger = ReadOnlySequence.MemoryManagerToSequenceStart(index);
-                _endInteger = ReadOnlySequence.MemoryManagerToSequenceEnd(length);
+                _endInteger = ReadOnlySequence.MemoryManagerToSequenceEnd(index + length);
             }
             else if (MemoryMarshal.TryGetArray(memory, out ArraySegment<T> segment))
             {

--- a/src/libraries/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceFactory.byte.cs
+++ b/src/libraries/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceFactory.byte.cs
@@ -4,6 +4,8 @@
 using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.Memory.Tests
 {
@@ -11,6 +13,7 @@ namespace System.Memory.Tests
     {
         public static ReadOnlySequenceFactory<T> ArrayFactory { get; } = new ArrayTestSequenceFactory();
         public static ReadOnlySequenceFactory<T> MemoryFactory { get; } = new MemoryTestSequenceFactory();
+        public static ReadOnlySequenceFactory<T> MemoryManagerFactory { get; } = new MemoryManagerTestSequenceFactory();
         public static ReadOnlySequenceFactory<T> SingleSegmentFactory { get; } = new SingleSegmentTestSequenceFactory();
         public static ReadOnlySequenceFactory<T> SegmentPerItemFactory { get; } = new BytePerSegmentTestSequenceFactory();
         public static ReadOnlySequenceFactory<T> SplitInThree { get; } = new SegmentsTestSequenceFactory(3);
@@ -109,6 +112,49 @@ namespace System.Memory.Tests
                 }
 
                 return CreateSegments(segments.ToArray());
+            }
+        }
+
+        internal class MemoryManagerTestSequenceFactory : ReadOnlySequenceFactory<T>
+        {
+            public override ReadOnlySequence<T> CreateOfSize(int size)
+            {
+#if DEBUG
+                return new ReadOnlySequence<T>(new CustomMemoryManager(size + 1).Memory.Slice(1));
+#else
+                return new ReadOnlySequence<T>(new CustomMemoryManager(size).Memory);
+#endif
+            }
+
+            public override ReadOnlySequence<T> CreateWithContent(T[] data)
+            {
+                return new ReadOnlySequence<T>(new CustomMemoryManager(data).Memory);
+            }
+
+            private unsafe class CustomMemoryManager : MemoryManager<T>
+            {
+                private readonly T[] _buffer;
+
+                public CustomMemoryManager(int size) => _buffer = new T[size];
+
+                public CustomMemoryManager(T[] content) => _buffer = content;
+
+                public unsafe override Span<T> GetSpan() => _buffer;
+
+                public override unsafe MemoryHandle Pin(int elementIndex = 0)
+                {
+                    if ((uint)elementIndex > (uint)_buffer.Length)
+                    {
+                        throw new ArgumentOutOfRangeException(nameof(elementIndex));
+                    }
+
+                    var handle = GCHandle.Alloc(_buffer, GCHandleType.Pinned);
+                    return new MemoryHandle(Unsafe.Add<T>((void*)handle.AddrOfPinnedObject(), elementIndex), handle, this);
+                }
+
+                public override void Unpin() { }
+
+                protected override void Dispose(bool disposing) { }
             }
         }
 

--- a/src/libraries/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.byte.cs
+++ b/src/libraries/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.byte.cs
@@ -20,6 +20,11 @@ namespace System.Memory.Tests
             public Memory() : base(ReadOnlySequenceFactory<byte>.MemoryFactory) { }
         }
 
+        public class MemoryManager : ReadOnlySequenceTestsByte
+        {
+            public MemoryManager() : base(ReadOnlySequenceFactory<byte>.MemoryManagerFactory) { }
+        }
+
         public class SingleSegment : ReadOnlySequenceTestsByte
         {
             public SingleSegment() : base(ReadOnlySequenceFactory<byte>.SingleSegmentFactory) { }


### PR DESCRIPTION
Port #57479 to release/5.0

## Customer Impact

Customers who create `ReadOnlySequence<T>` out of sliced `Memory` owned by any `MemoryManager` are seeing invalid end position and length. This issue was reported by a customer and the fix was provided by them as well.

Depending on the input (how many elements of the original `Memory` were sliced) iteration over `ReadOnlySequence<T>` can result in returning incomplete data or throwing `ArgumentOutOfRangeException`. These conditions can lead to data loss or data corruption that would be difficult to diagnose in a production application.

```cs
using System;
using System.Buffers;
using System.Runtime.CompilerServices;
using System.Runtime.InteropServices;

public class Program
{
    public static void Main()
    {
        MemoryManager<byte> memoryManager = new CustomMemoryManager<byte>(4);
        ReadOnlySequence<byte> ros = new ReadOnlySequence<byte>(memoryManager.Memory.Slice(1));
        Console.WriteLine(ros.Length); // prints 2 instead of 3

        foreach (var item in ros)
        {
            Console.WriteLine(item.Length); // prints 2 instead of 3
        }

        memoryManager = new CustomMemoryManager<byte>(3);
        ros = new ReadOnlySequence<byte>(memoryManager.Memory.Slice(2));
        Console.WriteLine(ros.Length); // prints -1 instead of 1

        foreach (var item in ros) // throws System.ArgumentOutOfRangeException
        {
            Console.WriteLine(item.Length); // never gets printed
        }
    }
}

public unsafe class CustomMemoryManager<T> : MemoryManager<T>
{
    private readonly T[] _buffer;

    public CustomMemoryManager(int size) => _buffer = new T[size];

    public unsafe override Span<T> GetSpan() => _buffer;

    public override unsafe MemoryHandle Pin(int elementIndex = 0)
    {
        if ((uint)elementIndex > (uint)_buffer.Length)
        {
            throw new ArgumentOutOfRangeException(nameof(elementIndex));
        }

        var handle = GCHandle.Alloc(_buffer, GCHandleType.Pinned);
        return new MemoryHandle(Unsafe.Add<T>((void*)handle.AddrOfPinnedObject(), elementIndex), handle, this);
    }

    public override void Unpin() { }

    protected override void Dispose(bool disposing) { }
}
```

## Testing

Failing test has been added in this PR.

![image](https://user-images.githubusercontent.com/6011991/129708309-90a15871-bbda-4ac1-b1bf-8c6818202869.png)


## Risk

Low, as the change is very simple and obvious when you look at `ReadOnlySequence<T>` ctor that accepts `ReadOnlyMemory<T>` :

https://github.com/dotnet/runtime/blob/54b37c976b503368d28e945ff426eaf59e133c25/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequence.cs#L162

https://github.com/dotnet/runtime/blob/54b37c976b503368d28e945ff426eaf59e133c25/src/libraries/System.Memory/src/System/Buffers/ReadOnlySequence.cs#L172

## Regression

This is not a regression.