### PR TITLE
Remove workaroudn for linker issue in Http3RequestStream

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -127,13 +127,6 @@ namespace System.Net.Http
 
             try
             {
-                // Works around linker issue where it tries to eliminate QuicStreamAbortedException
-                // https://github.com/dotnet/runtime/issues/57010
-                #if TARGET_MOBILE
-                if (string.Empty.Length > 0)
-                    throw new QuicStreamAbortedException("", 0);
-                #endif
-
                 BufferHeaders(_request);
 
                 // If using Expect 100 Continue, setup a TCS to wait to send content until we get a response.


### PR DESCRIPTION
Part of the linker issue https://github.com/mono/linker/issues/2181 has been fixed in https://github.com/mono/linker/pull/2205. This part was the one affecting Http3RequestStream.

This change simple reverts the workaround since it's not needed anymore.