### PR TITLE
Fix hanging HTTP cancelation test.

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -425,12 +425,8 @@ namespace System.Net.Http.Functional.Tests
                 {
                     await server.AcceptConnectionAsync(async connection =>
                     {
+                        await Task.Delay(10);
                         cts.Cancel();
-                        try
-                        {
-                            await connection.ReadRequestHeaderAndSendResponseAsync();
-                        }
-                        catch { }
                     });
                 });
         }
@@ -592,12 +588,8 @@ namespace System.Net.Http.Functional.Tests
                 {
                     await server.AcceptConnectionAsync(async connection =>
                     {
+                        await Task.Delay(10);
                         cts.Cancel();
-                        try
-                        {
-                            await connection.ReadRequestHeaderAndSendResponseAsync();
-                        }
-                        catch { }
                     });
                 });
         }
@@ -666,12 +658,8 @@ namespace System.Net.Http.Functional.Tests
                 {
                     await server.AcceptConnectionAsync(async connection =>
                     {
+                        await Task.Delay(10);
                         cts.Cancel();
-                        try
-                        {
-                            await connection.ReadRequestHeaderAndSendResponseAsync();
-                        }
-                        catch { }
                     });
                 });
         }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -425,7 +425,11 @@ namespace System.Net.Http.Functional.Tests
                 {
                     await server.AcceptConnectionAsync(async connection =>
                     {
-                        await Task.Delay(10);
+                        try
+                        {
+                            await connection.ReadRequestHeaderAsync();
+                        }
+                        catch { }
                         cts.Cancel();
                     });
                 });
@@ -588,7 +592,11 @@ namespace System.Net.Http.Functional.Tests
                 {
                     await server.AcceptConnectionAsync(async connection =>
                     {
-                        await Task.Delay(10);
+                        try
+                        {
+                            await connection.ReadRequestHeaderAsync();
+                        }
+                        catch { }
                         cts.Cancel();
                     });
                 });
@@ -658,7 +666,11 @@ namespace System.Net.Http.Functional.Tests
                 {
                     await server.AcceptConnectionAsync(async connection =>
                     {
-                        await Task.Delay(10);
+                        try
+                        {
+                            await connection.ReadRequestHeaderAsync();
+                        }
+                        catch { }
                         cts.Cancel();
                     });
                 });


### PR DESCRIPTION
On wasm, the loopback can be slower.
The client may get abort before sending the headers and the server would hang waiting forever.
I can reproduce it in 1/50 runs of System.Net.Http.Functional.Tests on windows/chrome.