### PR TITLE
[mono][debugger] Fix deadlock when debugging AOTed class

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -4081,6 +4081,13 @@ jit_end (MonoProfiler *prof, MonoMethod *method, MonoJitInfo *jinfo)
 		}
 	}
 
+	// only send typeload from AOTed classes if has .cctor when .cctor emit jit_end 
+	// to avoid deadlock while trying to set a breakpoint in a class that was not fully initialized
+	if (jinfo->from_aot && m_class_has_cctor(method->klass) && (!(method->flags & METHOD_ATTRIBUTE_SPECIAL_NAME) || strcmp (method->name, ".cctor")))
+	{
+		return;
+	}
+
 	send_type_load (method->klass);
 
 	if (m_class_get_image(method->klass)->has_updates) {

--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -4081,7 +4081,7 @@ jit_end (MonoProfiler *prof, MonoMethod *method, MonoJitInfo *jinfo)
 		}
 	}
 
-	// only send typeload from AOTed classes if has .cctor when .cctor emit jit_end 
+	// only send typeload from AOTed classes if has .cctor when .cctor emits jit_end 
 	// to avoid deadlock while trying to set a breakpoint in a class that was not fully initialized
 	if (jinfo->from_aot && m_class_has_cctor(method->klass) && (!(method->flags & METHOD_ATTRIBUTE_SPECIAL_NAME) || strcmp (method->name, ".cctor")))
 	{


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/48753

Code sample:

```
using System;

public static partial class TestClass
{
        private static readonly int[] s_primes =
        {
            3, 7, 11, 17, 23, 29, 37, 47, 59, 71, 89, 107, 131, 163, 197, 239, 293, 353, 431, 521, 631, 761, 919,
            1103, 1327, 1597, 1931, 2333, 2801, 3371, 4049, 4861, 5839, 7013, 8419, 10103, 12143, 14591,
            17519, 21023, 25229, 30293, 36353, 43627, 52361, 62851, 75431, 90523, 108631, 130363, 156437,
            187751, 225307, 270371, 324449, 389357, 467237, 560689, 672827, 807403, 968897, 1162687, 1395263,
            1674319, 2009191, 2411033, 2893249, 3471899, 4166287, 4999559, 5999471, 7199369
        };

        public static int GetPrime(int min)
        {
            return min;
        }
}

public static class Program
{
    public static int Main(string[] args)
    {
        Console.WriteLine("Hello, Android! " + TestClass.GetPrime(5)); // logcat
        return 42;
    }
}
```