### PR TITLE
DO NOT MERGE: Add client IP address to build log

### DIFF
--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -149,7 +149,7 @@ try {
   if ($restore) {
     InitializeNativeTools
   }
-
+  Try-LogClientIpAddress
   Build
 }
 catch {

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -187,6 +187,7 @@ function InitializeCustomToolset {
 }
 
 function Build {
+  LogClientIp
   InitializeToolset
   InitializeCustomToolset
 
@@ -226,7 +227,6 @@ if [[ "$clean" == true ]]; then
 fi
 
 if [[ "$restore" == true ]]; then
-  LogClientIp
   InitializeNativeTools
 fi
 

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -226,6 +226,7 @@ if [[ "$clean" == true ]]; then
 fi
 
 if [[ "$restore" == true ]]; then
+  LogClientIp
   InitializeNativeTools
 fi
 

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -83,6 +83,7 @@ try {
   }
 
   if ($restore) {
+    Try-LogClientIpAddress
     Build 'Restore'
   }
 

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -872,3 +872,19 @@ if (!$disableConfigureToolsetImport) {
     }
   }
 }
+
+function Try-LogClientIpAddress()
+{
+    Write-Host "Attempting to log this client's IP for Azure Package feed telemetry purposes"
+    try
+    {
+        $result = Invoke-WebRequest -Uri "http://co1.msedge.net/fdv2/diagnostics.aspx"
+        $lines = $result.Content.Split([Environment]::NewLine) 
+        Write-Host $lines | Select-String -Pattern "^Socket IP:.*"
+        Write-Host $lines | Select-String -Pattern "^Client IP:.*"
+    }
+    catch
+    {
+        Write-Host "Unable to get this machine's effective IP address for logging"
+    }
+}

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -399,6 +399,14 @@ function StopProcesses {
   return 0
 }
 
+function LogClientIp () {
+  echo 'Attempting to log this client''s IP for Azure Package feed telemetry purposes'
+  echo
+  if command -v curl > /dev/null; then
+    curl -s 'http://co1.msedge.net/fdv2/diagnostics.aspx' | grep ' IP: '
+  fi
+}
+
 function MSBuild {
   local args=$@
   if [[ "$pipelines_log" == true ]]; then


### PR DESCRIPTION
Testing script changes for using the Azure Edge diagnostic endpoint to log reported the build machine's IP address, needed for Azure Front Door investigation of package feed 'hangups'