### PR TITLE
Update pinned compiler version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -270,6 +270,8 @@
     <!-- Enables Strict mode for Roslyn compiler -->
     <Features>strict;nullablePublicOnly</Features>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Warnings to always disable -->
+    <NoWarn>$(NoWarn),CS8969</NoWarn>
     <!-- Always pass portable to override arcade sdk which uses embedded for local builds -->
     <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,7 +19,7 @@
     <!-- Opt-in/out repo features -->
     <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
     <!-- TODO: Upgrade compiler version to enable Static Abstracts in Interfaces, interpolated string handlers, and caller arg expressions; remove this once the employed SDK uses a new enough version. -->
-    <MicrosoftNetCompilersToolsetVersion>4.0.0-3.21376.12</MicrosoftNetCompilersToolsetVersion>
+    <MicrosoftNetCompilersToolsetVersion>4.0.0-4.21416.10</MicrosoftNetCompilersToolsetVersion>
     <UsingToolMicrosoftNetILLinkTasks>true</UsingToolMicrosoftNetILLinkTasks>
     <UsingToolIbcOptimization>false</UsingToolIbcOptimization>
     <UsingToolXliff>false</UsingToolXliff>

--- a/src/libraries/System.Dynamic.Runtime/tests/Dynamic.DynamicType/Conformance.dynamic.dynamicType.basic.cs
+++ b/src/libraries/System.Dynamic.Runtime/tests/Dynamic.DynamicType/Conformance.dynamic.dynamicType.basic.cs
@@ -3392,7 +3392,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.dynamicType.basic.impli
             }
 
             ;
-            if (d.GetType() != typeof(dynamic[]))
+            if (d.GetType() != typeof(object[]))
                 return 1;
             return 0;
         }
@@ -3420,7 +3420,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.dynamicType.basic.impli
             }
 
             ;
-            if (d.GetType() != typeof(dynamic[]))
+            if (d.GetType() != typeof(object[]))
                 return 1;
             return 0;
         }
@@ -3456,7 +3456,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.dynamicType.basic.impli
             }
 
             ;
-            if (d.GetType() != typeof(dynamic[]))
+            if (d.GetType() != typeof(object[]))
                 return 1;
             return 0;
         }

--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -5,7 +5,7 @@
     <!-- Workaround for overriding the XML comments related warnings that are being supressed repo wide (within arcade): -->
     <!-- https://github.com/dotnet/arcade/blob/ea6addfdc65e5df1b2c036f11614a5f922e36267/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props#L90 -->
     <!-- For this project, we want warnings if there are public APIs/types without properly formatted XML comments (particularly CS1591). -->
-    <NoWarn />
+    <NoWarn>CS8969</NoWarn>
     <Nullable>enable</Nullable>
     <IncludeInternalObsoleteAttribute>true</IncludeInternalObsoleteAttribute>
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
The version that flows in automatically appears to still be old.  We need to fix that, but in the meantime, we're a month out of date on the compiler.