### PR TITLE
JIT: don't clone loops where init or limit is a cast local

### DIFF
--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -969,7 +969,7 @@ bool Compiler::optDeriveLoopCloningConditions(unsigned loopNum, LoopCloneContext
         {
             // initVar >= 0
             const unsigned initLcl = loop->lpVarInit;
-            if (!genActualTypeIsInt(lvaGetDesc(initLcl)->lvType))
+            if (!genActualTypeIsInt(lvaGetDesc(initLcl)))
             {
                 JITDUMP("> Init var V%02u not compatible with TYP_INT\n", initLcl);
                 return false;
@@ -1000,7 +1000,7 @@ bool Compiler::optDeriveLoopCloningConditions(unsigned loopNum, LoopCloneContext
         else if (loop->lpFlags & LPFLG_VAR_LIMIT)
         {
             const unsigned limitLcl = loop->lpVarLimit();
-            if (!genActualTypeIsInt(lvaGetDesc(limitLcl)->lvType))
+            if (!genActualTypeIsInt(lvaGetDesc(limitLcl)))
             {
                 JITDUMP("> Limit var V%02u not compatible with TYP_INT\n", limitLcl);
                 return false;

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -968,7 +968,14 @@ bool Compiler::optDeriveLoopCloningConditions(unsigned loopNum, LoopCloneContext
         else if (loop->lpFlags & LPFLG_VAR_INIT)
         {
             // initVar >= 0
-            LC_Condition geZero(GT_GE, LC_Expr(LC_Ident(loop->lpVarInit, LC_Ident::Var)),
+            const unsigned initLcl = loop->lpVarInit;
+            if (!genActualTypeIsInt(lvaGetDesc(initLcl)->lvType))
+            {
+                JITDUMP("> Init var V%02u not compatible with TYP_INT\n", initLcl);
+                return false;
+            }
+
+            LC_Condition geZero(GT_GE, LC_Expr(LC_Ident(initLcl, LC_Ident::Var)),
                                 LC_Expr(LC_Ident(0, LC_Ident::Const)));
             context->EnsureConditions(loopNum)->Push(geZero);
         }
@@ -992,9 +999,14 @@ bool Compiler::optDeriveLoopCloningConditions(unsigned loopNum, LoopCloneContext
         }
         else if (loop->lpFlags & LPFLG_VAR_LIMIT)
         {
-            unsigned limitLcl = loop->lpVarLimit();
-            ident             = LC_Ident(limitLcl, LC_Ident::Var);
+            const unsigned limitLcl = loop->lpVarLimit();
+            if (!genActualTypeIsInt(lvaGetDesc(limitLcl)->lvType))
+            {
+                JITDUMP("> Limit var V%02u not compatible with TYP_INT\n", limitLcl);
+                return false;
+            }
 
+            ident = LC_Ident(limitLcl, LC_Ident::Var);
             LC_Condition geZero(GT_GE, LC_Expr(ident), LC_Expr(LC_Ident(0, LC_Ident::Const)));
 
             context->EnsureConditions(loopNum)->Push(geZero);

--- a/src/tests/JIT/Regression/JitBlue/Runtime_57535/Runtime_57535.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_57535/Runtime_57535.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Runtime.CompilerServices;
+
+class Runtime_57535
+{
+    static long z;
+
+    public static int Main()
+    {
+        z = 10;
+        int[] a = F();
+        long zz = z;
+        int result = 0;
+        for (int i = 0; i < (int) zz; i++)        
+        {
+            result += a[i];
+        }
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int[] F()
+    {
+       int[] result = new int[100];
+       result[3] = 100;
+       return result;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_57535/Runtime_57535.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_57535/Runtime_57535.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_57535/Runtime_57535_1.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_57535/Runtime_57535_1.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Runtime.CompilerServices;
+
+class Runtime_57535_1
+{
+    static long z;
+
+    public static int Main()
+    {
+        z = 2;
+        int[] a = F();
+        long zz = z;
+        int result = 0;
+        for (int i = (int) zz; i < a.Length; i++)
+        {
+            result += a[i];
+        }
+        Bar(zz);
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int[] F()
+    {
+       int[] result = new int[100];
+       result[3] = 100;
+       return result;
+    }
+
+    static void Bar(long z) {}
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_57535/Runtime_57535_1.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_57535/Runtime_57535_1.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The loop cloner assumes all computations it introduces are compatible
with TYP_INT, so don't allow cloning when the initial or final value
are variables with incompatible types.

Fixes #57535.