### PR TITLE
Allow folding of `LONG` nodes with field sequences

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11032,13 +11032,7 @@ GenTree* Compiler::fgMorphCommutative(GenTreeOp* tree)
 
     cns1->SetIconValue(foldedCns->IconValue());
     cns1->SetVNsFromNode(foldedCns);
-
-    if (oper == GT_ADD)
-    {
-        // Note that gtFoldExprConst doesn't maintain fieldSeq when folding constant
-        // trees of TYP_LONG.
-        cns1->gtFieldSeq = GetFieldSeqStore()->Append(cns1->gtFieldSeq, cns2->gtFieldSeq);
-    }
+    cns1->gtFieldSeq = foldedCns->gtFieldSeq;
 
     op1 = tree->gtGetOp1();
     op1->SetVNsFromNode(tree);


### PR DESCRIPTION
Apparently, such folding was disallowed, for unclear reasons likely pertaining to the fact that `gtFoldExprConst` is very old.

No SPMI diffs for `linux-arm` and `win-x86` (as expected).

Small positive diffs for `win-arm64` and `win-x64`, also as expected.

## coreclr_tests.pmi.windows.arm64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 2436
Total bytes of diff: 2340
Total bytes of delta: -96 (-3.94% of base)
Total relative delta: -0.28
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -32 : 251951.dasm (-6.78% of base)
         -32 : 80305.dasm (-17.39% of base)
         -16 : 246056.dasm (-2.74% of base)
         -16 : 249755.dasm (-1.34% of base)

4 total files with Code Size differences (4 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -32 (-6.78% of base) : 251951.dasm - DefaultNamespace.ArrCpy:Main(System.String[]):int
         -32 (-17.39% of base) : 80305.dasm - Default.q:func(int,int,System.Byte[],System.Int32[]):int
         -16 (-2.74% of base) : 246056.dasm - DefaultNamespace.GC_Base1:runTest(int,int):bool:this
         -16 (-1.34% of base) : 249755.dasm - Threading.Tests.OSThreadId:Main(System.String[]):int

Top method improvements (percentages):
         -32 (-17.39% of base) : 80305.dasm - Default.q:func(int,int,System.Byte[],System.Int32[]):int
         -32 (-6.78% of base) : 251951.dasm - DefaultNamespace.ArrCpy:Main(System.String[]):int
         -16 (-2.74% of base) : 246056.dasm - DefaultNamespace.GC_Base1:runTest(int,int):bool:this
         -16 (-1.34% of base) : 249755.dasm - Threading.Tests.OSThreadId:Main(System.String[]):int

4 total methods with Code Size differences (4 improved, 0 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.crossgen2.windows.arm64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 2616
Total bytes of diff: 2544
Total bytes of delta: -72 (-2.75% of base)
Total relative delta: -0.14
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -16 : 126499.dasm (-2.41% of base)
         -16 : 102247.dasm (-3.36% of base)
         -16 : 144760.dasm (-2.92% of base)
         -12 : 2511.dasm (-3.00% of base)
         -12 : 2328.dasm (-2.27% of base)

5 total files with Code Size differences (5 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -16 (-2.41% of base) : 126499.dasm - ItemType:Create(int,System.Xml.Xsl.XmlQualifiedNameTest,System.Xml.Schema.XmlSchemaType,bool):System.Xml.Xsl.XmlQueryType
         -16 (-3.36% of base) : 102247.dasm - Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC:GetUserAllocated(System.Collections.Generic.List`1[Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC],Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC,int):double
         -16 (-2.92% of base) : 144760.dasm - System.Data.SqlTypes.SqlDecimal:CalculatePrecision():ubyte:this
         -12 (-3.00% of base) : 2511.dasm - Newtonsoft.Json.Utilities.EnumUtils:InternalFlagsFormat(Newtonsoft.Json.Utilities.EnumInfo,long):System.String
         -12 (-2.27% of base) : 2328.dasm - Newtonsoft.Json.Utilities.StringUtils:ToCamelCase(System.String):System.String

Top method improvements (percentages):
         -16 (-3.36% of base) : 102247.dasm - Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC:GetUserAllocated(System.Collections.Generic.List`1[Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC],Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC,int):double
         -12 (-3.00% of base) : 2511.dasm - Newtonsoft.Json.Utilities.EnumUtils:InternalFlagsFormat(Newtonsoft.Json.Utilities.EnumInfo,long):System.String
         -16 (-2.92% of base) : 144760.dasm - System.Data.SqlTypes.SqlDecimal:CalculatePrecision():ubyte:this
         -16 (-2.41% of base) : 126499.dasm - ItemType:Create(int,System.Xml.Xsl.XmlQualifiedNameTest,System.Xml.Schema.XmlSchemaType,bool):System.Xml.Xsl.XmlQueryType
         -12 (-2.27% of base) : 2328.dasm - Newtonsoft.Json.Utilities.StringUtils:ToCamelCase(System.String):System.String

5 total methods with Code Size differences (5 improved, 0 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.pmi.windows.arm64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3272
Total bytes of diff: 3184
Total bytes of delta: -88 (-2.69% of base)
Total relative delta: -0.17
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -16 : 111614.dasm (-2.72% of base)
         -16 : 131278.dasm (-2.78% of base)
         -16 : 102766.dasm (-4.44% of base)
         -16 : 102769.dasm (-2.37% of base)
         -12 : 105160.dasm (-3.06% of base)
         -12 : 105356.dasm (-1.76% of base)

6 total files with Code Size differences (6 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -16 (-2.72% of base) : 111614.dasm - System.Data.SqlTypes.SqlDecimal:CalculatePrecision():ubyte:this
         -16 (-2.78% of base) : 131278.dasm - ItemType:Create(int,System.Xml.Xsl.XmlQualifiedNameTest,System.Xml.Schema.XmlSchemaType,bool):System.Xml.Xsl.XmlQueryType
         -16 (-4.44% of base) : 102766.dasm - Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC:GetUserAllocated(System.Collections.Generic.List`1[[Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC,int):double
         -16 (-2.37% of base) : 102769.dasm - Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC:GetUserAllocatedPerHeap(System.Collections.Generic.List`1[[Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC,int,int):double
         -12 (-3.06% of base) : 105160.dasm - Newtonsoft.Json.Utilities.EnumUtils:InternalFlagsFormat(Newtonsoft.Json.Utilities.EnumInfo,long):System.String
         -12 (-1.76% of base) : 105356.dasm - Newtonsoft.Json.Utilities.StringUtils:ToCamelCase(System.String):System.String

Top method improvements (percentages):
         -16 (-4.44% of base) : 102766.dasm - Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC:GetUserAllocated(System.Collections.Generic.List`1[[Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC,int):double
         -12 (-3.06% of base) : 105160.dasm - Newtonsoft.Json.Utilities.EnumUtils:InternalFlagsFormat(Newtonsoft.Json.Utilities.EnumInfo,long):System.String
         -16 (-2.78% of base) : 131278.dasm - ItemType:Create(int,System.Xml.Xsl.XmlQualifiedNameTest,System.Xml.Schema.XmlSchemaType,bool):System.Xml.Xsl.XmlQueryType
         -16 (-2.72% of base) : 111614.dasm - System.Data.SqlTypes.SqlDecimal:CalculatePrecision():ubyte:this
         -16 (-2.37% of base) : 102769.dasm - Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC:GetUserAllocatedPerHeap(System.Collections.Generic.List`1[[Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC,int,int):double
         -12 (-1.76% of base) : 105356.dasm - Newtonsoft.Json.Utilities.StringUtils:ToCamelCase(System.String):System.String

6 total methods with Code Size differences (6 improved, 0 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries_tests.pmi.windows.arm64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 4684
Total bytes of diff: 4544
Total bytes of delta: -140 (-2.99% of base)
Total relative delta: -0.24
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -32 : 243544.dasm (-3.96% of base)
         -24 : 11185.dasm (-3.35% of base)
         -24 : 240941.dasm (-5.94% of base)
         -24 : 236667.dasm (-5.94% of base)
         -20 : 82373.dasm (-1.05% of base)
         -16 : 120798.dasm (-3.51% of base)

6 total files with Code Size differences (6 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -32 (-3.96% of base) : 243544.dasm - WebData.BaseLib.StringGen:GetIllegalXmlStringWithSeed(int,bool,int):System.String
         -24 (-3.35% of base) : 11185.dasm - Builder:Add(Microsoft.CodeAnalysis.Text.TextSpan,int):this
         -24 (-5.94% of base) : 240941.dasm - System.Data.SqlClient.TdsParser:TryProcessTableName(int,System.Data.SqlClient.TdsParserStateObject,byref):bool:this
         -24 (-5.94% of base) : 236667.dasm - System.Data.SqlClient.TdsParser:TryProcessTableName(int,System.Data.SqlClient.TdsParserStateObject,byref):bool:this
         -20 (-1.05% of base) : 82373.dasm - System.Text.Encodings.Web.Tests.UnicodeHelpersTests:ReadListOfDefinedCharacters():System.Boolean[]
         -16 (-3.51% of base) : 120798.dasm - Microsoft.Build.Graph.GraphBuilder:FormatCircularDependencyError(System.Collections.Generic.List`1[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]):System.String

Top method improvements (percentages):
         -24 (-5.94% of base) : 240941.dasm - System.Data.SqlClient.TdsParser:TryProcessTableName(int,System.Data.SqlClient.TdsParserStateObject,byref):bool:this
         -24 (-5.94% of base) : 236667.dasm - System.Data.SqlClient.TdsParser:TryProcessTableName(int,System.Data.SqlClient.TdsParserStateObject,byref):bool:this
         -32 (-3.96% of base) : 243544.dasm - WebData.BaseLib.StringGen:GetIllegalXmlStringWithSeed(int,bool,int):System.String
         -16 (-3.51% of base) : 120798.dasm - Microsoft.Build.Graph.GraphBuilder:FormatCircularDependencyError(System.Collections.Generic.List`1[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]):System.String
         -24 (-3.35% of base) : 11185.dasm - Builder:Add(Microsoft.CodeAnalysis.Text.TextSpan,int):this
         -20 (-1.05% of base) : 82373.dasm - System.Text.Encodings.Web.Tests.UnicodeHelpersTests:ReadListOfDefinedCharacters():System.Boolean[]

6 total methods with Code Size differences (6 improved, 0 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## coreclr_tests.pmi.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 2166
Total bytes of diff: 2117
Total bytes of delta: -49 (-2.26% of base)
Total relative delta: -0.22
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -19 : 252655.dasm (-4.74% of base)
         -18 : 80606.dasm (-15.38% of base)
          -6 : 246802.dasm (-1.32% of base)
          -6 : 250440.dasm (-0.50% of base)

4 total files with Code Size differences (4 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -19 (-4.74% of base) : 252655.dasm - DefaultNamespace.ArrCpy:Main(System.String[]):int
         -18 (-15.38% of base) : 80606.dasm - Default.q:func(int,int,System.Byte[],System.Int32[]):int
          -6 (-1.32% of base) : 246802.dasm - DefaultNamespace.GC_Base1:runTest(int,int):bool:this
          -6 (-0.50% of base) : 250440.dasm - Threading.Tests.OSThreadId:Main(System.String[]):int

Top method improvements (percentages):
         -18 (-15.38% of base) : 80606.dasm - Default.q:func(int,int,System.Byte[],System.Int32[]):int
         -19 (-4.74% of base) : 252655.dasm - DefaultNamespace.ArrCpy:Main(System.String[]):int
          -6 (-1.32% of base) : 246802.dasm - DefaultNamespace.GC_Base1:runTest(int,int):bool:this
          -6 (-0.50% of base) : 250440.dasm - Threading.Tests.OSThreadId:Main(System.String[]):int

4 total methods with Code Size differences (4 improved, 0 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.crossgen2.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 2145
Total bytes of diff: 2091
Total bytes of delta: -54 (-2.52% of base)
Total relative delta: -0.15
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -13 : 97469.dasm (-3.04% of base)
         -11 : 109084.dasm (-3.86% of base)
          -9 : 69754.dasm (-1.99% of base)
          -9 : 108903.dasm (-2.91% of base)
          -6 : 69757.dasm (-1.71% of base)
          -6 : 116381.dasm (-1.86% of base)

6 total files with Code Size differences (6 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -13 (-3.04% of base) : 97469.dasm - ItemType:Create(int,System.Xml.Xsl.XmlQualifiedNameTest,System.Xml.Schema.XmlSchemaType,bool):System.Xml.Xsl.XmlQueryType
         -11 (-3.86% of base) : 109084.dasm - Newtonsoft.Json.Utilities.EnumUtils:InternalFlagsFormat(Newtonsoft.Json.Utilities.EnumInfo,long):System.String
          -9 (-1.99% of base) : 69754.dasm - Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC:GetUserAllocatedPerHeap(System.Collections.Generic.List`1[Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC],Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC,int,int):double
          -9 (-2.91% of base) : 108903.dasm - Newtonsoft.Json.Utilities.StringUtils:ToCamelCase(System.String):System.String
          -6 (-1.71% of base) : 69757.dasm - Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC:GetUserAllocated(System.Collections.Generic.List`1[Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC],Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC,int):double
          -6 (-1.86% of base) : 116381.dasm - System.Data.SqlTypes.SqlDecimal:CalculatePrecision():ubyte:this

Top method improvements (percentages):
         -11 (-3.86% of base) : 109084.dasm - Newtonsoft.Json.Utilities.EnumUtils:InternalFlagsFormat(Newtonsoft.Json.Utilities.EnumInfo,long):System.String
         -13 (-3.04% of base) : 97469.dasm - ItemType:Create(int,System.Xml.Xsl.XmlQualifiedNameTest,System.Xml.Schema.XmlSchemaType,bool):System.Xml.Xsl.XmlQueryType
          -9 (-2.91% of base) : 108903.dasm - Newtonsoft.Json.Utilities.StringUtils:ToCamelCase(System.String):System.String
          -9 (-1.99% of base) : 69754.dasm - Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC:GetUserAllocatedPerHeap(System.Collections.Generic.List`1[Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC],Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC,int,int):double
          -6 (-1.86% of base) : 116381.dasm - System.Data.SqlTypes.SqlDecimal:CalculatePrecision():ubyte:this
          -6 (-1.71% of base) : 69757.dasm - Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC:GetUserAllocated(System.Collections.Generic.List`1[Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC],Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC,int):double

6 total methods with Code Size differences (6 improved, 0 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.pmi.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 2664
Total bytes of diff: 2618
Total bytes of delta: -46 (-1.73% of base)
Total relative delta: -0.11
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
          -9 : 102673.dasm (-1.79% of base)
          -9 : 140495.dasm (-1.65% of base)
          -9 : 107133.dasm (-1.46% of base)
          -7 : 106937.dasm (-2.36% of base)
          -6 : 113423.dasm (-1.49% of base)
          -6 : 102670.dasm (-1.99% of base)

6 total files with Code Size differences (6 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
          -9 (-1.79% of base) : 102673.dasm - Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC:GetUserAllocatedPerHeap(System.Collections.Generic.List`1[[Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC,int,int):double
          -9 (-1.65% of base) : 140495.dasm - ItemType:Create(int,System.Xml.Xsl.XmlQualifiedNameTest,System.Xml.Schema.XmlSchemaType,bool):System.Xml.Xsl.XmlQueryType
          -9 (-1.46% of base) : 107133.dasm - Newtonsoft.Json.Utilities.StringUtils:ToCamelCase(System.String):System.String
          -7 (-2.36% of base) : 106937.dasm - Newtonsoft.Json.Utilities.EnumUtils:InternalFlagsFormat(Newtonsoft.Json.Utilities.EnumInfo,long):System.String
          -6 (-1.49% of base) : 113423.dasm - System.Data.SqlTypes.SqlDecimal:CalculatePrecision():ubyte:this
          -6 (-1.99% of base) : 102670.dasm - Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC:GetUserAllocated(System.Collections.Generic.List`1[[Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC,int):double

Top method improvements (percentages):
          -7 (-2.36% of base) : 106937.dasm - Newtonsoft.Json.Utilities.EnumUtils:InternalFlagsFormat(Newtonsoft.Json.Utilities.EnumInfo,long):System.String
          -6 (-1.99% of base) : 102670.dasm - Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC:GetUserAllocated(System.Collections.Generic.List`1[[Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC,int):double
          -9 (-1.79% of base) : 102673.dasm - Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC:GetUserAllocatedPerHeap(System.Collections.Generic.List`1[[Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.65.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC,int,int):double
          -9 (-1.65% of base) : 140495.dasm - ItemType:Create(int,System.Xml.Xsl.XmlQualifiedNameTest,System.Xml.Schema.XmlSchemaType,bool):System.Xml.Xsl.XmlQueryType
          -6 (-1.49% of base) : 113423.dasm - System.Data.SqlTypes.SqlDecimal:CalculatePrecision():ubyte:this
          -9 (-1.46% of base) : 107133.dasm - Newtonsoft.Json.Utilities.StringUtils:ToCamelCase(System.String):System.String

6 total methods with Code Size differences (6 improved, 0 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries_tests.pmi.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 4900
Total bytes of diff: 4841
Total bytes of delta: -59 (-1.20% of base)
Total relative delta: -0.11
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -14 : 244487.dasm (-2.07% of base)
         -10 : 121541.dasm (-2.58% of base)
         -10 : 11268.dasm (-1.30% of base)
          -9 : 241873.dasm (-2.37% of base)
          -9 : 237595.dasm (-2.37% of base)
          -7 : 82962.dasm (-0.30% of base)

6 total files with Code Size differences (6 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -14 (-2.07% of base) : 244487.dasm - WebData.BaseLib.StringGen:GetIllegalXmlStringWithSeed(int,bool,int):System.String
         -10 (-2.58% of base) : 121541.dasm - Microsoft.Build.Graph.GraphBuilder:FormatCircularDependencyError(System.Collections.Generic.List`1[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]):System.String
         -10 (-1.30% of base) : 11268.dasm - Builder:Add(Microsoft.CodeAnalysis.Text.TextSpan,int):this
          -9 (-2.37% of base) : 241873.dasm - System.Data.SqlClient.TdsParser:TryProcessTableName(int,System.Data.SqlClient.TdsParserStateObject,byref):bool:this
          -9 (-2.37% of base) : 237595.dasm - System.Data.SqlClient.TdsParser:TryProcessTableName(int,System.Data.SqlClient.TdsParserStateObject,byref):bool:this
          -7 (-0.30% of base) : 82962.dasm - System.Text.Encodings.Web.Tests.UnicodeHelpersTests:ReadListOfDefinedCharacters():System.Boolean[]

Top method improvements (percentages):
         -10 (-2.58% of base) : 121541.dasm - Microsoft.Build.Graph.GraphBuilder:FormatCircularDependencyError(System.Collections.Generic.List`1[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]):System.String
          -9 (-2.37% of base) : 241873.dasm - System.Data.SqlClient.TdsParser:TryProcessTableName(int,System.Data.SqlClient.TdsParserStateObject,byref):bool:this
          -9 (-2.37% of base) : 237595.dasm - System.Data.SqlClient.TdsParser:TryProcessTableName(int,System.Data.SqlClient.TdsParserStateObject,byref):bool:this
         -14 (-2.07% of base) : 244487.dasm - WebData.BaseLib.StringGen:GetIllegalXmlStringWithSeed(int,bool,int):System.String
         -10 (-1.30% of base) : 11268.dasm - Builder:Add(Microsoft.CodeAnalysis.Text.TextSpan,int):this
          -7 (-0.30% of base) : 82962.dasm - System.Text.Encodings.Web.Tests.UnicodeHelpersTests:ReadListOfDefinedCharacters():System.Boolean[]

6 total methods with Code Size differences (6 improved, 0 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

The usual pattern that is being optimized now is array access with constant offsets:
```diff
-            mov     w4, #3
-            sxtw    x4, w4
-            lsl     x4, x4, #2
-            add     x4, x4, #16
-            ldr     w4, [x3, x4]
+            ldr     w4, [x3,#28]
```
