### PR TITLE
Remove FOREACH_REGISTER_FILE macro

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -14,14 +14,6 @@
 #include "regset.h"
 #include "jitgcinfo.h"
 
-#if defined(TARGET_AMD64) || defined(TARGET_ARM64) || defined(TARGET_ARM)
-#define FOREACH_REGISTER_FILE(file)                                                                                    \
-    for ((file) = &(this->intRegState); (file) != NULL;                                                                \
-         (file) = ((file) == &(this->intRegState)) ? &(this->floatRegState) : NULL)
-#else
-#define FOREACH_REGISTER_FILE(file) (file) = &(this->intRegState);
-#endif
-
 class CodeGen final : public CodeGenInterface
 {
     friend class emitter;

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -7562,8 +7562,6 @@ void CodeGen::genFnProlog()
      * Take care of register arguments first
      */
 
-    RegState* regState;
-
     // Update the arg initial register locations.
     compiler->lvaUpdateArgsWithInitialReg();
 
@@ -7572,8 +7570,7 @@ void CodeGen::genFnProlog()
     //
     if (!compiler->opts.IsOSR())
     {
-        FOREACH_REGISTER_FILE(regState)
-        {
+        auto assignIncomingRegisterArgs = [this, initReg, &initRegZeroed](RegState* regState) {
             if (regState->rsCalleeRegArgMaskLiveIn)
             {
                 // If we need an extra register to shuffle around the incoming registers
@@ -7600,7 +7597,14 @@ void CodeGen::genFnProlog()
                     initRegZeroed = false;
                 }
             }
-        }
+        };
+
+#if defined(TARGET_AMD64) || defined(TARGET_ARM64) || defined(TARGET_ARM)
+        assignIncomingRegisterArgs(&intRegState);
+        assignIncomingRegisterArgs(&floatRegState);
+#else
+        assignIncomingRegisterArgs(&intRegState);
+#endif
     }
 
     // Home the incoming arguments.

--- a/src/coreclr/jit/cpp.hint
+++ b/src/coreclr/jit/cpp.hint
@@ -7,8 +7,6 @@
 // See the article on hints in MSDN for more information on their necessity and use:
 //    http://msdn.microsoft.com/en-us/library/dd997977.aspx
 
-#define FOREACH_REGISTER_FILE(file) for (;;)
-
 // From jit.h
 
 #define INDEBUG(x)          x


### PR DESCRIPTION
Replace `FOREACH_REGISTER_FILE ` macro with lambda.