### PR TITLE
Remove support for the `APP_NI_PATHS` property

### DIFF
--- a/src/coreclr/binder/applicationcontext.cpp
+++ b/src/coreclr/binder/applicationcontext.cpp
@@ -82,7 +82,6 @@ namespace BINDER_SPACE
     HRESULT ApplicationContext::SetupBindingPaths(SString &sTrustedPlatformAssemblies,
                                                   SString &sPlatformResourceRoots,
                                                   SString &sAppPaths,
-                                                  SString &sAppNiPaths,
                                                   BOOL     fAcquireLock)
     {
         HRESULT hr = S_OK;
@@ -217,31 +216,6 @@ namespace BINDER_SPACE
 #endif
 
             m_appPaths.Append(pathName);
-        }
-
-        //
-        // Parse AppNiPaths
-        //
-        sAppNiPaths.Normalize();
-        for (SString::Iterator i = sAppNiPaths.Begin(); i != sAppNiPaths.End(); )
-        {
-            SString pathName;
-            HRESULT pathResult = S_OK;
-
-            IF_FAIL_GO(pathResult = GetNextPath(sAppNiPaths, i, pathName));
-            if (pathResult == S_FALSE)
-            {
-                break;
-            }
-
-#ifndef CROSSGEN_COMPILE
-            if (Path::IsRelative(pathName))
-            {
-                GO_WITH_HRESULT(E_INVALIDARG);
-            }
-#endif
-
-            m_appNiPaths.Append(pathName);
         }
 
     Exit:

--- a/src/coreclr/binder/defaultassemblybinder.cpp
+++ b/src/coreclr/binder/defaultassemblybinder.cpp
@@ -189,14 +189,13 @@ Exit:;
 
 HRESULT DefaultAssemblyBinder::SetupBindingPaths(SString  &sTrustedPlatformAssemblies,
                                                 SString  &sPlatformResourceRoots,
-                                                SString  &sAppPaths,
-                                                SString  &sAppNiPaths)
+                                                SString  &sAppPaths)
 {
     HRESULT hr = S_OK;
 
     EX_TRY
     {
-        hr = GetAppContext()->SetupBindingPaths(sTrustedPlatformAssemblies, sPlatformResourceRoots, sAppPaths, sAppNiPaths, TRUE /* fAcquireLock */);
+        hr = GetAppContext()->SetupBindingPaths(sTrustedPlatformAssemblies, sPlatformResourceRoots, sAppPaths, TRUE /* fAcquireLock */);
     }
     EX_CATCH_HRESULT(hr);
     return hr;

--- a/src/coreclr/binder/inc/applicationcontext.hpp
+++ b/src/coreclr/binder/inc/applicationcontext.hpp
@@ -92,7 +92,6 @@ namespace BINDER_SPACE
         HRESULT SetupBindingPaths(/* in */ SString &sTrustedPlatformAssemblies,
                                   /* in */ SString &sPlatformResourceRoots,
                                   /* in */ SString &sAppPaths,
-                                  /* in */ SString &sAppNiPaths,
                                   /* in */ BOOL     fAcquireLock);
 
         HRESULT GetAssemblyIdentity(/* in */ LPCSTR                szTextualIdentity,
@@ -106,7 +105,6 @@ namespace BINDER_SPACE
         inline StringArrayList *GetAppPaths();
         inline SimpleNameToFileNameMap *GetTpaList();
         inline StringArrayList *GetPlatformResourceRoots();
-        inline StringArrayList *GetAppNiPaths();
 
         // Using a host-configured Trusted Platform Assembly list
         bool IsTpaListProvided();
@@ -125,7 +123,6 @@ namespace BINDER_SPACE
 
         StringArrayList    m_platformResourceRoots;
         StringArrayList    m_appPaths;
-        StringArrayList    m_appNiPaths;
 
         SimpleNameToFileNameMap * m_pTrustedPlatformAssemblyMap;
     };

--- a/src/coreclr/binder/inc/applicationcontext.inl
+++ b/src/coreclr/binder/inc/applicationcontext.inl
@@ -63,11 +63,6 @@ StringArrayList * ApplicationContext::GetPlatformResourceRoots()
     return &m_platformResourceRoots;
 }
 
-StringArrayList * ApplicationContext::GetAppNiPaths()
-{
-    return &m_appNiPaths;
-}
-
 CRITSEC_COOKIE ApplicationContext::GetCriticalSectionCookie()
 {
     return m_contextCS;

--- a/src/coreclr/binder/inc/bindertracing.h
+++ b/src/coreclr/binder/inc/bindertracing.h
@@ -176,7 +176,7 @@ namespace BinderTracing
     enum PathSource
     {
         ApplicationAssemblies,
-        AppNativeImagePaths,
+        Unused,
         AppPaths,
         PlatformResourceRoots,
         SatelliteSubdirectory,

--- a/src/coreclr/binder/inc/defaultassemblybinder.h
+++ b/src/coreclr/binder/inc/defaultassemblybinder.h
@@ -35,8 +35,7 @@ public:
 
     HRESULT SetupBindingPaths(SString  &sTrustedPlatformAssemblies,
                               SString  &sPlatformResourceRoots,
-                              SString  &sAppPaths,
-                              SString  &sAppNiPaths);
+                              SString  &sAppPaths);
 
     HRESULT Bind(LPCWSTR      wszCodeBase,
                  PEAssembly  *pParentAssembly,

--- a/src/coreclr/hosts/corerun/corerun.cpp
+++ b/src/coreclr/hosts/corerun/corerun.cpp
@@ -217,12 +217,6 @@ static int run(const configuration& config)
         pal::ensure_trailing_delimiter(app_path);
     }
 
-    // Define the NI app_path.
-    string_t app_path_ni = app_path + W("NI");
-    pal::ensure_trailing_delimiter(app_path_ni);
-    app_path_ni.append(1, pal::env_path_delim);
-    app_path_ni.append(app_path);
-
     // Accumulate path for native search path.
     pal::stringstream_t native_search_dirs;
     native_search_dirs << app_path << pal::env_path_delim;
@@ -291,7 +285,6 @@ static int run(const configuration& config)
     // Construct CoreCLR properties.
     pal::string_utf8_t tpa_list_utf8 = pal::convert_to_utf8(std::move(tpa_list));
     pal::string_utf8_t app_path_utf8 = pal::convert_to_utf8(std::move(app_path));
-    pal::string_utf8_t app_path_ni_utf8 = pal::convert_to_utf8(std::move(app_path_ni));
     pal::string_utf8_t native_search_dirs_utf8 = pal::convert_to_utf8(native_search_dirs.str());
 
     std::vector<pal::string_utf8_t> user_defined_keys_utf8;
@@ -314,11 +307,6 @@ static int run(const configuration& config)
     // - The list of paths which will be probed by the assembly loader
     propertyKeys.push_back("APP_PATHS");
     propertyValues.push_back(app_path_utf8.c_str());
-
-    // APP_NI_PATHS
-    // - The list of additional paths that the assembly loader will probe for ngen images
-    propertyKeys.push_back("APP_NI_PATHS");
-    propertyValues.push_back(app_path_ni_utf8.c_str());
 
     // NATIVE_DLL_SEARCH_DIRECTORIES
     // - The list of paths that will be probed for native DLLs called by PInvoke

--- a/src/coreclr/vm/ClrEtwAll.man
+++ b/src/coreclr/vm/ClrEtwAll.man
@@ -537,7 +537,7 @@
                     </valueMap>
                     <valueMap name="KnownPathSourceMap">
                         <map value="0x0" message="$(string.RuntimePublisher.KnownPathSource.ApplicationAssembliesMessage)"/>
-                        <map value="0x1" message="$(string.RuntimePublisher.KnownPathSource.AppNativeImagePathsMessage)"/>
+                        <map value="0x1" message="$(string.RuntimePublisher.KnownPathSource.UnusedMessage)"/>
                         <map value="0x2" message="$(string.RuntimePublisher.KnownPathSource.AppPathsMessage)"/>
                         <map value="0x3" message="$(string.RuntimePublisher.KnownPathSource.PlatformResourceRootsMessage)"/>
                         <map value="0x4" message="$(string.RuntimePublisher.KnownPathSource.SatelliteSubdirectoryMessage)"/>
@@ -8730,7 +8730,7 @@
                 <string id="RuntimePublisher.TieredCompilationSettingsFlags.QuickJitMapMessage" value="QuickJit" />
                 <string id="RuntimePublisher.TieredCompilationSettingsFlags.QuickJitForLoopsMapMessage" value="QuickJitForLoops" />
                 <string id="RuntimePublisher.KnownPathSource.ApplicationAssembliesMessage" value="ApplicationAssemblies" />
-                <string id="RuntimePublisher.KnownPathSource.AppNativeImagePathsMessage" value="AppNativeImagePaths" />
+                <string id="RuntimePublisher.KnownPathSource.UnusedMessage" value="Unused" />
                 <string id="RuntimePublisher.KnownPathSource.AppPathsMessage" value="AppPaths" />
                 <string id="RuntimePublisher.KnownPathSource.PlatformResourceRootsMessage" value="PlatformResourceRoots" />
                 <string id="RuntimePublisher.KnownPathSource.SatelliteSubdirectoryMessage" value="SatelliteSubdirectory" />

--- a/src/coreclr/vm/corhost.cpp
+++ b/src/coreclr/vm/corhost.cpp
@@ -631,7 +631,6 @@ HRESULT CorHost2::CreateAppDomainWithManager(
     LPCWSTR pwzTrustedPlatformAssemblies = NULL;
     LPCWSTR pwzPlatformResourceRoots = NULL;
     LPCWSTR pwzAppPaths = NULL;
-    LPCWSTR pwzAppNiPaths = NULL;
 
     for (int i = 0; i < nProperties; i++)
     {
@@ -655,11 +654,6 @@ HRESULT CorHost2::CreateAppDomainWithManager(
             pwzAppPaths = pPropertyValues[i];
         }
         else
-        if (wcscmp(pPropertyNames[i], W("APP_NI_PATHS")) == 0)
-        {
-            pwzAppNiPaths = pPropertyValues[i];
-        }
-        else
         if (wcscmp(pPropertyNames[i], W("DEFAULT_STACK_SIZE")) == 0)
         {
             extern void ParseDefaultStackSize(LPCWSTR value);
@@ -679,15 +673,13 @@ HRESULT CorHost2::CreateAppDomainWithManager(
         SString sTrustedPlatformAssemblies(pwzTrustedPlatformAssemblies);
         SString sPlatformResourceRoots(pwzPlatformResourceRoots);
         SString sAppPaths(pwzAppPaths);
-        SString sAppNiPaths(pwzAppNiPaths);
 
         DefaultAssemblyBinder *pBinder = pDomain->GetTPABinderContext();
         _ASSERTE(pBinder != NULL);
         IfFailThrow(pBinder->SetupBindingPaths(
             sTrustedPlatformAssemblies,
             sPlatformResourceRoots,
-            sAppPaths,
-            sAppNiPaths));
+            sAppPaths));
     }
 
     *pAppDomainID=DefaultADID;

--- a/src/mono/mono/mini/monovm.c
+++ b/src/mono/mono/mini/monovm.c
@@ -16,7 +16,6 @@
 static MonoCoreTrustedPlatformAssemblies *trusted_platform_assemblies;
 static MonoCoreLookupPaths *native_lib_paths;
 static MonoCoreLookupPaths *app_paths;
-static MonoCoreLookupPaths *app_ni_paths;
 static MonoCoreLookupPaths *platform_resource_roots;
 
 static void
@@ -163,8 +162,6 @@ parse_properties (int propertyCount, const char **propertyKeys, const char **pro
 			parse_trusted_platform_assemblies (propertyValues[i]);
 		} else if (prop_len == 9 && !strncmp (propertyKeys [i], "APP_PATHS", 9)) {
 			app_paths = parse_lookup_paths (propertyValues [i]);
-		} else if (prop_len == 12 && !strncmp (propertyKeys [i], "APP_NI_PATHS", 12)) {
-			app_ni_paths = parse_lookup_paths (propertyValues [i]);
 		} else if (prop_len == 23 && !strncmp (propertyKeys [i], "PLATFORM_RESOURCE_ROOTS", 23)) {
 			platform_resource_roots = parse_lookup_paths (propertyValues [i]);
 		} else if (prop_len == 29 && !strncmp (propertyKeys [i], "NATIVE_DLL_SEARCH_DIRECTORIES", 29)) {

--- a/src/native/corehost/hostpolicy/coreclr.cpp
+++ b/src/native/corehost/hostpolicy/coreclr.cpp
@@ -145,7 +145,6 @@ namespace
         _X("PROBING_DIRECTORIES"),
         _X("STARTUP_HOOKS"),
         _X("APP_PATHS"),
-        _X("APP_NI_PATHS"),
         _X("RUNTIME_IDENTIFIER"),
         _X("BUNDLE_PROBE"),
         _X("HOSTPOLICY_EMBEDDED"),

--- a/src/native/corehost/hostpolicy/coreclr.h
+++ b/src/native/corehost/hostpolicy/coreclr.h
@@ -63,7 +63,6 @@ enum class common_property
     ProbingDirectories,
     StartUpHooks,
     AppPaths,
-    AppNIPaths,
     RuntimeIdentifier,
     BundleProbe,
     HostPolicyEmbedded,

--- a/src/native/corehost/hostpolicy/hostpolicy_context.cpp
+++ b/src/native/corehost/hostpolicy/hostpolicy_context.cpp
@@ -247,7 +247,7 @@ int hostpolicy_context_t::initialize(hostpolicy_init_t &hostpolicy_init, const a
         }
     }
 
-    // App paths and App NI paths.
+    // App paths.
     // Note: Keep this check outside of the loop above since the _last_ key wins
     // and that could indicate the app paths shouldn't be set.
     if (set_app_paths)
@@ -255,12 +255,6 @@ int hostpolicy_context_t::initialize(hostpolicy_init_t &hostpolicy_init, const a
         if (!coreclr_properties.add(common_property::AppPaths, app_base.c_str()))
         {
             log_duplicate_property_error(coreclr_property_bag_t::common_property_to_string(common_property::AppPaths));
-            return StatusCode::LibHostDuplicateProperty;
-        }
-
-        if (!coreclr_properties.add(common_property::AppNIPaths, app_base.c_str()))
-        {
-            log_duplicate_property_error(coreclr_property_bag_t::common_property_to_string(common_property::AppNIPaths));
             return StatusCode::LibHostDuplicateProperty;
         }
     }

--- a/src/tests/Loader/binding/tracing/BinderEventListener.cs
+++ b/src/tests/Loader/binding/tracing/BinderEventListener.cs
@@ -140,7 +140,7 @@ namespace BinderTracingTests
         public enum PathSource : ushort
         {
             ApplicationAssemblies,
-            AppNativeImagePaths,
+            Unused,
             AppPaths,
             PlatformResourceRoots,
             SatelliteSubdirectory

--- a/src/tests/Loader/binding/tracing/BinderTracingTest.DefaultProbing.cs
+++ b/src/tests/Loader/binding/tracing/BinderTracingTest.DefaultProbing.cs
@@ -18,10 +18,8 @@ namespace BinderTracingTests
     partial class BinderTracingTest
     {
         // Assembly found in app path:
-        //   KnownPathProbed : AppNativeImagePaths  (DLL)   [COR_E_FILENOTFOUND]
-        //   KnownPathProbed : AppNativeImagePaths  (EXE)   [COR_E_FILENOTFOUND]
         //   KnownPathProbed : AppPaths             (DLL)   [S_OK]
-        // Note: corerun always sets APP_PATH and APP_NI_PATH. In regular use cases,
+        // Note: corerun always sets APP_PATH. In regular use cases,
         // the customer would have to explicitly configure the app to set those.
         [BinderTest]
         public static BindOperation AssemblyInAppPath()
@@ -42,18 +40,6 @@ namespace BinderTracingTests
                 {
                     new ProbedPath()
                     {
-                        FilePath = Helpers.GetProbingFilePath(ProbedPath.PathSource.AppNativeImagePaths, assemblyName.Name, isExe: false),
-                        Source = ProbedPath.PathSource.AppNativeImagePaths,
-                        Result = COR_E_FILENOTFOUND
-                    },
-                    new ProbedPath()
-                    {
-                        FilePath = Helpers.GetProbingFilePath(ProbedPath.PathSource.AppNativeImagePaths, assemblyName.Name, isExe: true),
-                        Source = ProbedPath.PathSource.AppNativeImagePaths,
-                        Result = COR_E_FILENOTFOUND
-                    },
-                    new ProbedPath()
-                    {
                         FilePath = Helpers.GetProbingFilePath(ProbedPath.PathSource.AppPaths, assemblyName.Name, isExe: false),
                         Source = ProbedPath.PathSource.AppPaths,
                         Result = S_OK
@@ -63,11 +49,9 @@ namespace BinderTracingTests
         }
 
         // Assembly not found:
-        //   KnownPathProbed : AppNativeImagePaths  (DLL)   [COR_E_FILENOTFOUND]
-        //   KnownPathProbed : AppNativeImagePaths  (EXE)   [COR_E_FILENOTFOUND]
         //   KnownPathProbed : AppPaths             (DLL)   [COR_E_FILENOTFOUND]
         //   KnownPathProbed : AppPaths             (EXE)   [COR_E_FILENOTFOUND]
-        // Note: corerun always sets APP_PATH and APP_NI_PATH. In regular use cases,
+        // Note: corerun always sets APP_PATH. In regular use cases,
         // the customer would have to explicitly configure the app to set those.
         [BinderTest(additionalLoadsToTrack: new string[] { "DoesNotExist" })]
         public static BindOperation NonExistentAssembly()
@@ -91,18 +75,6 @@ namespace BinderTracingTests
                 {
                     new ProbedPath()
                     {
-                        FilePath = Helpers.GetProbingFilePath(ProbedPath.PathSource.AppNativeImagePaths, assemblyName, isExe: false),
-                        Source = ProbedPath.PathSource.AppNativeImagePaths,
-                        Result = COR_E_FILENOTFOUND
-                    },
-                    new ProbedPath()
-                    {
-                        FilePath = Helpers.GetProbingFilePath(ProbedPath.PathSource.AppNativeImagePaths, assemblyName, isExe: true),
-                        Source = ProbedPath.PathSource.AppNativeImagePaths,
-                        Result = COR_E_FILENOTFOUND
-                    },
-                    new ProbedPath()
-                    {
                         FilePath = Helpers.GetProbingFilePath(ProbedPath.PathSource.AppPaths, assemblyName, isExe: false),
                         Source = ProbedPath.PathSource.AppPaths,
                         Result = COR_E_FILENOTFOUND
@@ -119,7 +91,7 @@ namespace BinderTracingTests
 
         // Satellite assembly found in app path:
         //   KnownPathProbed : AppPaths             (DLL)   [S_OK]
-        // Note: corerun always sets APP_PATH and APP_NI_PATH. In regular use cases,
+        // Note: corerun always sets APP_PATH. In regular use cases,
         // the customer would have to explicitly configure the app to set those.
         [BinderTest(isolate: true)]
         public static BindOperation SatelliteAssembly_AppPath()
@@ -182,7 +154,7 @@ namespace BinderTracingTests
         // Satellite assembly found in culture subdirectory (default ALC):
         //   KnownPathProbed : AppPaths                 [COR_E_FILENOTFOUND]
         //   KnownPathProbed : SatelliteSubdirectory    [S_OK]
-        // Note: corerun always sets APP_PATH and APP_NI_PATH. In regular use cases,
+        // Note: corerun always sets APP_PATH. In regular use cases,
         // the customer would have to explicitly configure the app to set those.
         [BinderTest(isolate: true)]
         public static BindOperation SatelliteAssembly_CultureSubdirectory_DefaultALC()

--- a/src/tests/Loader/binding/tracing/Helpers.cs
+++ b/src/tests/Loader/binding/tracing/Helpers.cs
@@ -75,8 +75,6 @@ namespace BinderTracingTests
             string extension = isExe ? "exe" : "dll";
             switch (pathSource)
             {
-                case ProbedPath.PathSource.AppNativeImagePaths:
-                    return Path.Combine(baseDirectory, $"{assemblyName}.ni.{extension}");
                 case ProbedPath.PathSource.AppPaths:
                 case ProbedPath.PathSource.SatelliteSubdirectory:
                     return Path.Combine(baseDirectory, $"{assemblyName}.{extension}");


### PR DESCRIPTION
This property is no longer relevant. Remove uses and all testing.