### PR TITLE
[MacCatalyst] Make AppleCryptoNative_SslSetEnabledCipherSuites check for 32 bit & 16 bit SSLCipherSuite

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
@@ -596,19 +596,19 @@ int32_t AppleCryptoNative_SslSetEnabledCipherSuites(SSLContextRef sslContext, co
     // Max numCipherSuites is 2^16 (all possible cipher suites)
     assert(numCipherSuites < (1 << 16));
 
-#if !defined(TARGET_MACCATALYST) && !defined(TARGET_IOS) && !defined(TARGET_TVOS)
+#if !defined(TARGET_IOS) && !defined(TARGET_TVOS)
     if (sizeof(SSLCipherSuite) == sizeof(uint32_t))
     {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        // macOS
+        // macOS & MacCatalyst x64
         return SSLSetEnabledCiphers(sslContext, (const SSLCipherSuite *)cipherSuites, (size_t)numCipherSuites);
 #pragma clang diagnostic pop   
     }
     else
 #endif
     {
-        // MacCatalyst, iOS, tvOS, watchOS
+        // MacCatalyst arm64, iOS, tvOS, watchOS
         SSLCipherSuite* cipherSuites16 = (SSLCipherSuite*)calloc((size_t)numCipherSuites, sizeof(SSLCipherSuite));
 
         if (cipherSuites16 == NULL)

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ssl.c
@@ -596,7 +596,7 @@ int32_t AppleCryptoNative_SslSetEnabledCipherSuites(SSLContextRef sslContext, co
     // Max numCipherSuites is 2^16 (all possible cipher suites)
     assert(numCipherSuites < (1 << 16));
 
-#if !defined(TARGET_IOS) && !defined(TARGET_TVOS)
+#if !defined(TARGET_ARM64) && !defined(TARGET_IOS) && !defined(TARGET_TVOS)
     if (sizeof(SSLCipherSuite) == sizeof(uint32_t))
     {
 #pragma clang diagnostic push


### PR DESCRIPTION
According to CipherSuites.h, SSLCipherSuite is a 16 bit value on iOS/tvOS x64 & arm64, but on MacCatalyst that is only true on arm64.  x64 is defined as 32 bit.

```
/* 16-bit value on iOS */
typedef uint16_t SSLCipherSuite;
/* 32-bit value elsewhere */
typedef uint32_t SSLCipherSuite;
```

Fixes https://github.com/dotnet/runtime/issues/53120