### PR TITLE
Bump timeout for workloads build job

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -373,7 +373,7 @@ stages:
       - Linux_x64
 
   #
-  # Build Blazor Workload
+  # Build Workloads
   #
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
@@ -383,6 +383,7 @@ stages:
       - windows_x64
       jobParameters:
         isOfficialBuild: ${{ variables.isOfficialBuild }}
+        timeoutInMinutes: 120
         dependsOn:
         - Build_Android_arm_release_AllSubsets_Mono
         - Build_Android_arm64_release_AllSubsets_Mono


### PR DESCRIPTION
We're seeing it sometimes timing out on official builds.