### PR TITLE
JsonPath not using last frame during continuation

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -228,8 +228,8 @@ namespace System.Text.Json
         {
             StringBuilder sb = new StringBuilder("$");
 
-            // If a continuation, always report back full stack.
-            int count = Math.Max(_count, _continuationCount);
+            // If a continuation, always report back full stack which does not use Current for the last frame.
+            int count = Math.Max(_count, _continuationCount + 1);
 
             for (int i = 0; i < count - 1; i++)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -328,8 +328,8 @@ namespace System.Text.Json
         {
             StringBuilder sb = new StringBuilder("$");
 
-            // If a continuation, always report back full stack.
-            int count = Math.Max(_count, _continuationCount);
+            // If a continuation, always report back full stack which does not use Current for the last frame.
+            int count = Math.Max(_count, _continuationCount + 1);
 
             for (int i = 0; i < count - 1; i++)
             {

--- a/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.Exceptions.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.Exceptions.cs
@@ -196,18 +196,45 @@ namespace System.Text.Json.Serialization.Tests
             public ChildClass[] Children { get; set; }
         }
 
-        [Fact]
-        public async Task PathForChildListFails()
+        private const string PathForChildListFails_Json = @"{""Child"":{""MyIntArray"":[1, bad]}";
+
+        [Theory]
+        [MemberData(nameof(PathForChildDictionaryFails_TestData))]
+        public async Task PathForChildListFails(int bufferSize)
         {
-            JsonException e = await Assert.ThrowsAsync<JsonException>(() => JsonSerializerWrapperForString.DeserializeWrapper<RootClass>(@"{""Child"":{""MyIntArray"":[1, bad]}"));
+            JsonSerializerOptions options = new() { DefaultBufferSize = bufferSize };
+            JsonException e = await Assert.ThrowsAsync<JsonException>(() => JsonSerializerWrapperForString.DeserializeWrapper<RootClass>(PathForChildListFails_Json, options));
             Assert.Contains("$.Child.MyIntArray", e.Path);
         }
 
-        [Fact]
-        public async Task PathForChildDictionaryFails()
+        public static IEnumerable<object[]> PathForChildListFails_TestData()
         {
-            JsonException e = await Assert.ThrowsAsync<JsonException>(() => JsonSerializerWrapperForString.DeserializeWrapper<RootClass>(@"{""Child"":{""MyDictionary"":{""Key"": bad]"));
+            int maxBufferSize = PathForChildListFails_Json.Length * 2;
+            for (int i = 1; i <= maxBufferSize; i++)
+            {
+                yield return new object[] { i };
+            }
+        }
+
+        private const string PathForChildDictionaryFails_Json = @"{""Child"":{""MyDictionary"":{""Key"": bad]";
+
+        [Theory]
+        [MemberData(nameof(PathForChildDictionaryFails_TestData))]
+        public async Task PathForChildDictionaryFails(int bufferSize)
+        {
+            JsonSerializerOptions options = new() { DefaultBufferSize = bufferSize };
+            JsonException e = await Assert.ThrowsAsync<JsonException>(() => JsonSerializerWrapperForString.DeserializeWrapper<RootClass>(PathForChildDictionaryFails_Json, options));
             Assert.Equal("$.Child.MyDictionary.Key", e.Path);
+        }
+
+        public static IEnumerable<object[]> PathForChildDictionaryFails_TestData()
+        {
+            int maxBufferSize = PathForChildDictionaryFails_Json.Length * 2;
+
+            for (int i = 1; i <= maxBufferSize; i++)
+            {
+                yield return new object[] { i };
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/39055

The test failure reports in that issue reference `PathForChildDictionaryFails` however only for .NET framework 461. However, the refactored `PathForChildDictionaryFails` test now repros on net6 as well. I believe the 461 ArrayPool was returning just the right size pooled buffer from a previous test that caused the continuation issue, and net6 returned a larger pool (likely on a boundary).

This also occurs in 5.0.