### PR TITLE
Add special Mac Catalyst values for mtriple to MonoAOTCompiler.props

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -191,9 +191,6 @@
     <!-- Crashes on CI but passes locally https://github.com/dotnet/runtime/issues/52615 -->
     <ProjectExclusions Include="$(RepoRoot)\src\tests\FunctionalTests\iOS\Simulator\Interpreter\iOS.Simulator.Interpreter.Test.csproj" />
     <ProjectExclusions Include="$(RepoRoot)\src\tests\FunctionalTests\iOS\Simulator\InvariantCultureOnlyMode\iOS.Simulator.InvariantCultureOnlyMode.Test.csproj" />
-
-    <!-- No current support for AOT+LLVM on catalyst, so skip functional test -->
-    <ProjectExclusions Include="$(RepoRoot)\src\tests\FunctionalTests\iOS\Simulator\AOT-LLVM\**\*.Test.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'MacCatalyst' and '$(TargetArchitecture)' == 'arm64' and '$(RunDisablediOSTests)' != 'true'">

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.props
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.props
@@ -1,8 +1,10 @@
 <Project>
   <ItemGroup Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'iOSSimulator' or '$(TargetOS)' == 'tvOS' or '$(TargetOS)' == 'tvOSSimulator' or '$(TargetOS)' == 'MacCatalyst'">
-    <MonoAOTCompilerDefaultAotArguments Condition="'$(TargetArchitecture)' == 'arm64'" Include="mtriple=arm64-ios" />
+    <MonoAOTCompilerDefaultAotArguments Condition="'$(TargetArchitecture)' == 'arm64' and '$(TargetOS)' != 'MacCatalyst'" Include="mtriple=arm64-ios" />
+    <MonoAOTCompilerDefaultAotArguments Condition="'$(TargetArchitecture)' == 'arm64' and '$(TargetOS)' == 'MacCatalyst'" Include="mtriple=arm64-apple-ios14.2-macabi" />
     <MonoAOTCompilerDefaultAotArguments Condition="'$(TargetArchitecture)' == 'arm'" Include="mtriple=armv7-ios" />
-    <MonoAOTCompilerDefaultAotArguments Condition="'$(TargetArchitecture)' == 'x64'" Include="mtriple=x86_64-ios" />
+    <MonoAOTCompilerDefaultAotArguments Condition="'$(TargetArchitecture)' == 'x64' and '$(TargetOS)' != 'MacCatalyst'" Include="mtriple=x86_64-ios" />
+    <MonoAOTCompilerDefaultAotArguments Condition="'$(TargetArchitecture)' == 'x64' and '$(TargetOS)' == 'MacCatalyst'" Include="mtriple=x86_64-apple-ios13.5-macabi" />
     <MonoAOTCompilerDefaultAotArguments Condition="'$(TargetArchitecture)' == 'x86'" Include="mtriple=i386-ios" />
     <MonoAOTCompilerDefaultAotArguments Include="static" />
     <MonoAOTCompilerDefaultAotArguments Include="dwarfdebug" />


### PR DESCRIPTION
Effectively, we are correctly saying "build a Mac Catalyst app from runtime and these `-llvm.o` files, but the `-llvm.o` files are not correctly being built in a Mac Catalyst compatible way, resulting in the error

```
  ld: building for Mac Catalyst, but linking in object file built for , file '/Users/filipnavara/Projects/llvmbug/obj/Debug/net6.0-maccatalyst/maccatalyst-arm64/nativelibraries/aot-output/arm64/llvmbug.dll.llvm.o'
```

The target platform parameter gets passed around a LOT - `src/tasks/AotCompilerTask/MonoAOTCompiler.props` specifies `<MonoAOTCompilerDefaultAotArguments Condition="'$(TargetArchitecture)' == 'arm64'" Include="mtriple=arm64-ios" />` which passes through to MonoAOTCompiler.cs task which passes through to the `mono --aot=llvmopts=mtriple=arm64-ios` flag, which is processed by `src/mono/mono/mini/aot-compiler.c` and eventually regurgitated as `llc -mtriple=arm64-ios -march=aarch64`, which results in .o files which lack the required annotations to be considered Catalyst compatible.

Thankfully, it seems that `llc` accepts `clang`'s `-target` triplet values as valid for `-mtriple`, so passing through Catalyst specific values for `mtriple` in `MonoAOTCompiler.props` results in .o files which are correctly linked later by `clang` during the AppleAppBuilder task.

It's slow though! 🙀

Fixes https://github.com/dotnet/runtime/issues/57589