### PR TITLE
Make implicit function declaration an error

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -319,6 +319,7 @@ if (CLR_CMAKE_HOST_UNIX)
     endif()
   endif(CLR_CMAKE_HOST_OSX OR CLR_CMAKE_HOST_MACCATALYST)
 
+  add_compile_options(-Werror=implicit-function-declaration)
   # Suppress warnings-as-errors in release branches to reduce servicing churn
   if (PRERELEASE)
     add_compile_options(-Werror)


### PR DESCRIPTION
Implicit function declaration is a warning (not an error) by default, which can lead to issues like https://github.com/dotnet/runtime/issues/57674