### PR TITLE
Fix `ThreadPool.SetMinThreads` and `SetMaxThreads` to return false when they don't override the preconfigured value

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.cs
@@ -85,13 +85,13 @@ namespace System.Threading
 
         private PortableThreadPool()
         {
-            _minThreads = ForcedMinWorkerThreads > 0 ? ForcedMinWorkerThreads : (short)Environment.ProcessorCount;
+            _minThreads = HasForcedMinThreads ? ForcedMinWorkerThreads : (short)Environment.ProcessorCount;
             if (_minThreads > MaxPossibleThreadCount)
             {
                 _minThreads = MaxPossibleThreadCount;
             }
 
-            _maxThreads = ForcedMaxWorkerThreads > 0 ? ForcedMaxWorkerThreads : DefaultMaxWorkerThreadCount;
+            _maxThreads = HasForcedMaxThreads ? ForcedMaxWorkerThreads : DefaultMaxWorkerThreadCount;
             if (_maxThreads > MaxPossibleThreadCount)
             {
                 _maxThreads = MaxPossibleThreadCount;
@@ -103,6 +103,11 @@ namespace System.Threading
 
             _separated.counts.NumThreadsGoal = _minThreads;
         }
+
+        private static bool HasForcedMinThreads =>
+            ForcedMinWorkerThreads > 0 && (ForcedMaxWorkerThreads <= 0 || ForcedMinWorkerThreads <= ForcedMaxWorkerThreads);
+        private static bool HasForcedMaxThreads =>
+            ForcedMaxWorkerThreads > 0 && (ForcedMinWorkerThreads <= 0 || ForcedMinWorkerThreads <= ForcedMaxWorkerThreads);
 
         public bool SetMinThreads(int workerThreads, int ioCompletionThreads)
         {
@@ -124,9 +129,9 @@ namespace System.Threading
 
                 ThreadPool.SetMinIOCompletionThreads(ioCompletionThreads);
 
-                if (ForcedMinWorkerThreads != 0)
+                if (HasForcedMinThreads)
                 {
-                    return true;
+                    return workerThreads == ForcedMinWorkerThreads;
                 }
 
                 short newMinThreads = (short)Math.Max(1, Math.Min(workerThreads, MaxPossibleThreadCount));
@@ -184,9 +189,9 @@ namespace System.Threading
 
                 ThreadPool.SetMaxIOCompletionThreads(ioCompletionThreads);
 
-                if (ForcedMaxWorkerThreads != 0)
+                if (HasForcedMaxThreads)
                 {
-                    return true;
+                    return workerThreads == ForcedMaxWorkerThreads;
                 }
 
                 short newMaxThreads = (short)Math.Min(workerThreads, MaxPossibleThreadCount);

--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -183,6 +183,33 @@ namespace System.Threading.ThreadPools.Tests
                     Assert.True(ThreadPool.SetMinThreads(minw, minc));
                     VerifyMinThreads(minw, minc);
                 }
+
+                // Verify that SetMinThreads() and SetMaxThreads() return false when trying to set a different value from what
+                // is configured through config
+                try
+                {
+                    // The actual test process below will inherit the environment variables
+                    Environment.SetEnvironmentVariable("COMPlus_ThreadPool_ForceMinWorkerThreads", "1");
+                    Environment.SetEnvironmentVariable("COMPlus_ThreadPool_ForceMaxWorkerThreads", "2");
+
+                    RemoteExecutor.Invoke(() =>
+                    {
+                        int w, c;
+                        Assert.True(ThreadPool.GetMinThreads(out w, out c));
+                        Assert.Equal(1, w);
+                        Assert.True(ThreadPool.GetMaxThreads(out w, out c));
+                        Assert.Equal(2, w);
+                        Assert.True(ThreadPool.SetMinThreads(1, 1));
+                        Assert.True(ThreadPool.SetMaxThreads(2, 1));
+                        Assert.False(ThreadPool.SetMinThreads(2, 1));
+                        Assert.False(ThreadPool.SetMinThreads(1, 1));
+                    }).Dispose();
+                }
+                finally
+                {
+                    Environment.SetEnvironmentVariable("COMPlus_ThreadPool_ForceMinWorkerThreads", null);
+                    Environment.SetEnvironmentVariable("COMPlus_ThreadPool_ForceMaxWorkerThreads", null);
+                }
             }).Dispose();
         }
 

--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -183,25 +183,25 @@ namespace System.Threading.ThreadPools.Tests
                     Assert.True(ThreadPool.SetMinThreads(minw, minc));
                     VerifyMinThreads(minw, minc);
                 }
-
-                // Verify that SetMinThreads() and SetMaxThreads() return false when trying to set a different value from what
-                // is configured through config
-                var options = new RemoteInvokeOptions();
-                options.StartInfo.EnvironmentVariables.Add("COMPlus_ThreadPool_ForceMinWorkerThreads", "1");
-                options.StartInfo.EnvironmentVariables.Add("COMPlus_ThreadPool_ForceMaxWorkerThreads", "2");
-                RemoteExecutor.Invoke(() =>
-                {
-                    int w, c;
-                    ThreadPool.GetMinThreads(out w, out c);
-                    Assert.Equal(1, w);
-                    ThreadPool.GetMaxThreads(out w, out c);
-                    Assert.Equal(2, w);
-                    Assert.True(ThreadPool.SetMinThreads(1, 1));
-                    Assert.True(ThreadPool.SetMaxThreads(2, 1));
-                    Assert.False(ThreadPool.SetMinThreads(2, 1));
-                    Assert.False(ThreadPool.SetMaxThreads(1, 1));
-                }, options).Dispose();
             }).Dispose();
+
+            // Verify that SetMinThreads() and SetMaxThreads() return false when trying to set a different value from what is
+            // configured through config
+            var options = new RemoteInvokeOptions();
+            options.RuntimeConfigurationOptions["System.Threading.ThreadPool.MinThreads"] = "1";
+            options.RuntimeConfigurationOptions["System.Threading.ThreadPool.MaxThreads"] = "2";
+            RemoteExecutor.Invoke(() =>
+            {
+                int w, c;
+                ThreadPool.GetMinThreads(out w, out c);
+                Assert.Equal(1, w);
+                ThreadPool.GetMaxThreads(out w, out c);
+                Assert.Equal(2, w);
+                Assert.True(ThreadPool.SetMinThreads(1, 1));
+                Assert.True(ThreadPool.SetMaxThreads(2, 1));
+                Assert.False(ThreadPool.SetMinThreads(2, 1));
+                Assert.False(ThreadPool.SetMaxThreads(1, 1));
+            }, options).Dispose();
         }
 
         private static void VerifyMinThreads(int expectedMinw, int expectedMinc)

--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -195,9 +195,9 @@ namespace System.Threading.ThreadPools.Tests
                     RemoteExecutor.Invoke(() =>
                     {
                         int w, c;
-                        Assert.True(ThreadPool.GetMinThreads(out w, out c));
+                        ThreadPool.GetMinThreads(out w, out c);
                         Assert.Equal(1, w);
-                        Assert.True(ThreadPool.GetMaxThreads(out w, out c));
+                        ThreadPool.GetMaxThreads(out w, out c);
                         Assert.Equal(2, w);
                         Assert.True(ThreadPool.SetMinThreads(1, 1));
                         Assert.True(ThreadPool.SetMaxThreads(2, 1));

--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -186,30 +186,21 @@ namespace System.Threading.ThreadPools.Tests
 
                 // Verify that SetMinThreads() and SetMaxThreads() return false when trying to set a different value from what
                 // is configured through config
-                try
+                var options = new RemoteInvokeOptions();
+                options.StartInfo.EnvironmentVariables.Add("COMPlus_ThreadPool_ForceMinWorkerThreads", "1");
+                options.StartInfo.EnvironmentVariables.Add("COMPlus_ThreadPool_ForceMaxWorkerThreads", "2");
+                RemoteExecutor.Invoke(() =>
                 {
-                    // The actual test process below will inherit the environment variables
-                    Environment.SetEnvironmentVariable("COMPlus_ThreadPool_ForceMinWorkerThreads", "1");
-                    Environment.SetEnvironmentVariable("COMPlus_ThreadPool_ForceMaxWorkerThreads", "2");
-
-                    RemoteExecutor.Invoke(() =>
-                    {
-                        int w, c;
-                        ThreadPool.GetMinThreads(out w, out c);
-                        Assert.Equal(1, w);
-                        ThreadPool.GetMaxThreads(out w, out c);
-                        Assert.Equal(2, w);
-                        Assert.True(ThreadPool.SetMinThreads(1, 1));
-                        Assert.True(ThreadPool.SetMaxThreads(2, 1));
-                        Assert.False(ThreadPool.SetMinThreads(2, 1));
-                        Assert.False(ThreadPool.SetMinThreads(1, 1));
-                    }).Dispose();
-                }
-                finally
-                {
-                    Environment.SetEnvironmentVariable("COMPlus_ThreadPool_ForceMinWorkerThreads", null);
-                    Environment.SetEnvironmentVariable("COMPlus_ThreadPool_ForceMaxWorkerThreads", null);
-                }
+                    int w, c;
+                    ThreadPool.GetMinThreads(out w, out c);
+                    Assert.Equal(1, w);
+                    ThreadPool.GetMaxThreads(out w, out c);
+                    Assert.Equal(2, w);
+                    Assert.True(ThreadPool.SetMinThreads(1, 1));
+                    Assert.True(ThreadPool.SetMaxThreads(2, 1));
+                    Assert.False(ThreadPool.SetMinThreads(2, 1));
+                    Assert.False(ThreadPool.SetMinThreads(1, 1));
+                }, options).Dispose();
             }).Dispose();
         }
 

--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -199,7 +199,7 @@ namespace System.Threading.ThreadPools.Tests
                     Assert.True(ThreadPool.SetMinThreads(1, 1));
                     Assert.True(ThreadPool.SetMaxThreads(2, 1));
                     Assert.False(ThreadPool.SetMinThreads(2, 1));
-                    Assert.False(ThreadPool.SetMinThreads(1, 1));
+                    Assert.False(ThreadPool.SetMaxThreads(1, 1));
                 }, options).Dispose();
             }).Dispose();
         }


### PR DESCRIPTION
- Also added validity checks for configured values

Fixes https://github.com/dotnet/runtime/issues/1872