### PR TITLE
[release/5.0] Add Fedora 36 RID

### DIFF
--- a/eng/packaging.props
+++ b/eng/packaging.props
@@ -23,7 +23,7 @@
     <PackageVersion Condition="'$(PackageVersion)' == ''">$(ProductVersion)</PackageVersion>
     <!-- major.minor.release version of the platforms package we're currently building
          Pre-release will be appended during build -->
-    <PlatformPackageVersion>5.0.3</PlatformPackageVersion>
+    <PlatformPackageVersion>5.0.4</PlatformPackageVersion>
     <SkipValidatePackageTargetFramework>true</SkipValidatePackageTargetFramework>
     <SkipGenerationCheck>true</SkipGenerationCheck>
   </PropertyGroup>

--- a/src/libraries/libraries-packages.proj
+++ b/src/libraries/libraries-packages.proj
@@ -19,6 +19,7 @@
     <ProjectReference Include="$(MSBuildThisFileDirectory)*\pkg\**\*.pkgproj" Condition="('$(BuildAllConfigurations)' == 'true' or '$(DotNetBuildFromSource)' == 'true') And '$(BuildAllOOBPackages)' == 'true'" />
     <!-- If setting BuildAllOOBPackages to false, add bellow the individual OOB packages you want to continue to build -->
     <!-- This is merge marker 1 to help automerge -->
+    <ProjectReference Include="$(PkgDir)\Microsoft.NETCore.Platforms\Microsoft.NETCore.Platforms.proj" />
     <!-- This is merge marker 2 to help automerge --> 
     <!-- This is merge marker 3 to help automerge --> 
     <!-- This is merge marker 4 to help automerge --> 

--- a/src/libraries/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
+++ b/src/libraries/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
@@ -2583,6 +2583,38 @@
     "any",
     "base"
   ],
+  "fedora.36": [
+    "fedora.36",
+    "fedora",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "fedora.36-arm64": [
+    "fedora.36-arm64",
+    "fedora.36",
+    "fedora-arm64",
+    "fedora",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "fedora.36-x64": [
+    "fedora.36-x64",
+    "fedora.36",
+    "fedora-x64",
+    "fedora",
+    "linux-x64",
+    "linux",
+    "unix-x64",
+    "unix",
+    "any",
+    "base"
+  ],
   "freebsd": [
     "freebsd",
     "unix",

--- a/src/libraries/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/src/libraries/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -1037,6 +1037,23 @@
         "fedora-x64"
       ]
     },
+    "fedora.36": {
+      "#import": [
+        "fedora"
+      ]
+    },
+    "fedora.36-arm64": {
+      "#import": [
+        "fedora.36",
+        "fedora-arm64"
+      ]
+    },
+    "fedora.36-x64": {
+      "#import": [
+        "fedora.36",
+        "fedora-x64"
+      ]
+    },
     "freebsd": {
       "#import": [
         "unix"

--- a/src/libraries/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
+++ b/src/libraries/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
@@ -60,7 +60,7 @@
     <RuntimeGroup Include="fedora">
       <Parent>linux</Parent>
       <Architectures>x64;arm64</Architectures>
-      <Versions>23;24;25;26;27;28;29;30;31;32;33;34;35</Versions>
+      <Versions>23;24;25;26;27;28;29;30;31;32;33;34;35;36</Versions>
       <TreatVersionsAsCompatible>false</TreatVersionsAsCompatible>
     </RuntimeGroup>
 

--- a/src/libraries/pkg/baseline/packageIndex.json
+++ b/src/libraries/pkg/baseline/packageIndex.json
@@ -1110,9 +1110,10 @@
         "5.0.0",
         "5.0.1",
         "5.0.2",
-        "5.0.3"
+        "5.0.3",
+        "5.0.4"
       ],
-      "BaselineVersion": "5.0.3",
+      "BaselineVersion": "5.0.4",
       "InboxOn": {}
     },
     "Microsoft.NETCore.Targets": {


### PR DESCRIPTION
It's currently in development:

    $ podman run -it registry.fedoraproject.org/fedora:rawhide /bin/cat /etc/os-release
    NAME="Fedora Linux"
    VERSION="36 (Container Image Prerelease)"
    ID=fedora
    VERSION_ID=36
    VERSION_CODENAME=""
    PLATFORM_ID="platform:f36"
    PRETTY_NAME="Fedora Linux 36 (Container Image Prerelease)"
    ANSI_COLOR="0;38;2;60;110;180"
    LOGO=fedora-logo-icon
    CPE_NAME="cpe:/o:fedoraproject:fedora:36"
    HOME_URL="https://fedoraproject.org/"
    DOCUMENTATION_URL="https://docs.fedoraproject.org/en-US/fedora/rawhide/system-administrators-guide/"
    SUPPORT_URL="https://fedoraproject.org/wiki/Communicating_and_getting_help"
    BUG_REPORT_URL="https://bugzilla.redhat.com/"
    REDHAT_BUGZILLA_PRODUCT="Fedora"
    REDHAT_BUGZILLA_PRODUCT_VERSION=rawhide
    REDHAT_SUPPORT_PRODUCT="Fedora"
    REDHAT_SUPPORT_PRODUCT_VERSION=rawhide
    PRIVACY_POLICY_URL="https://fedoraproject.org/wiki/Legal:PrivacyPolicy"
    VARIANT="Container Image"
    VARIANT_ID=container