### PR TITLE
Enable global constant propagation for small types

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -2667,8 +2667,17 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
                         unreached();
                         break;
 
+                    case TYP_BOOL:
+                    case TYP_BYTE:
+                    case TYP_UBYTE:
+                    case TYP_SHORT:
+                    case TYP_USHORT:
+                        assert(FitsIn(tree->TypeGet(), value));
+                        conValTree = gtNewIconNode(value);
+                        break;
+
                     default:
-                        // Do not support (e.g. bool(const int)).
+                        // Do not support (e.g. byref(const int)).
                         break;
                 }
             }

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -2648,17 +2648,17 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
                     case TYP_REF:
                     case TYP_INT:
                         // Same type no conversion required
-                        conValTree = gtNewIconNode(static_cast<int>(value));
+                        conValTree = gtNewIconNode(value);
                         break;
 
                     case TYP_LONG:
                         // Implicit assignment conversion to larger integer
-                        conValTree = gtNewLconNode(static_cast<int>(value));
+                        conValTree = gtNewLconNode(value);
                         break;
 
                     case TYP_FLOAT:
                         // Same sized reinterpretation of bits to float
-                        conValTree = gtNewDconNode(*(reinterpret_cast<float*>(&value)), TYP_FLOAT);
+                        conValTree = gtNewDconNode(*reinterpret_cast<float*>(&value), TYP_FLOAT);
                         break;
 
                     case TYP_DOUBLE:

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -6034,7 +6034,7 @@ void CodeGen::genCompareInt(GenTree* treeNode)
 #ifdef TARGET_X86
             (!op1->isUsedFromReg() || isByteReg(op1->GetRegNum())) &&
 #endif
-            (op2->IsCnsIntOrI() && genSmallTypeCanRepresentValue(TYP_UBYTE, op2->AsIntCon()->IconValue())))
+            (op2->IsCnsIntOrI() && FitsIn<uint8_t>(op2->AsIntCon()->IconValue())))
         {
             type = TYP_UBYTE;
         }
@@ -6104,8 +6104,7 @@ void CodeGen::genCompareInt(GenTree* treeNode)
         // If op2 is smaller then it cannot be in memory, we're probably missing a cast
         assert((genTypeSize(op2Type) >= genTypeSize(type)) || !op2->isUsedFromMemory());
         // If we ended up with a small type and op2 is a constant then make sure we don't lose constant bits
-        assert(!op2->IsCnsIntOrI() || !varTypeIsSmall(type) ||
-               genSmallTypeCanRepresentValue(type, op2->AsIntCon()->IconValue()));
+        assert(!op2->IsCnsIntOrI() || !varTypeIsSmall(type) || FitsIn(type, op2->AsIntCon()->IconValue()));
     }
 
     // The type cannot be larger than the machine word size

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -533,34 +533,6 @@ inline regNumber genRegNumFromMask(regMaskTP mask)
     return regNum;
 }
 
-//------------------------------------------------------------------------------
-// genSmallTypeCanRepresentValue: Checks if a value can be represented by a given small type.
-//
-// Arguments:
-//    value - the value to check
-//    type  - the type
-//
-// Return Value:
-//    True if the value is representable, false otherwise.
-
-inline bool genSmallTypeCanRepresentValue(var_types type, ssize_t value)
-{
-    switch (type)
-    {
-        case TYP_UBYTE:
-        case TYP_BOOL:
-            return FitsIn<UINT8>(value);
-        case TYP_BYTE:
-            return FitsIn<INT8>(value);
-        case TYP_USHORT:
-            return FitsIn<UINT16>(value);
-        case TYP_SHORT:
-            return FitsIn<INT16>(value);
-        default:
-            unreached();
-    }
-}
-
 /*****************************************************************************
  *
  *  Return the size in bytes of the given type.

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -2481,7 +2481,7 @@ GenTree* Lowering::OptimizeConstCompare(GenTree* cmp)
 
 #ifdef TARGET_XARCH
     var_types op1Type = op1->TypeGet();
-    if (IsContainableMemoryOp(op1) && varTypeIsSmall(op1Type) && genSmallTypeCanRepresentValue(op1Type, op2Value))
+    if (IsContainableMemoryOp(op1) && varTypeIsSmall(op1Type) && FitsIn(op1Type, op2Value))
     {
         //
         // If op1's type is small then try to narrow op2 so it has the same type as op1.

--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -2592,24 +2592,21 @@ bool CastFromIntOverflows(int32_t fromValue, var_types toType, bool fromUnsigned
 {
     switch (toType)
     {
-        case TYP_BYTE:
-            return ((int8_t)fromValue != fromValue) || (fromUnsigned && fromValue < 0);
         case TYP_BOOL:
+        case TYP_BYTE:
         case TYP_UBYTE:
-            return (uint8_t)fromValue != fromValue;
         case TYP_SHORT:
-            return ((int16_t)fromValue != fromValue) || (fromUnsigned && fromValue < 0);
         case TYP_USHORT:
-            return (uint16_t)fromValue != fromValue;
         case TYP_INT:
-            return fromUnsigned && (fromValue < 0);
         case TYP_UINT:
-        case TYP_ULONG:
-            return !fromUnsigned && (fromValue < 0);
         case TYP_LONG:
+        case TYP_ULONG:
+            return fromUnsigned ? !FitsIn(toType, static_cast<uint32_t>(fromValue)) : !FitsIn(toType, fromValue);
+
         case TYP_FLOAT:
         case TYP_DOUBLE:
             return false;
+
         default:
             unreached();
     }
@@ -2619,26 +2616,21 @@ bool CastFromLongOverflows(int64_t fromValue, var_types toType, bool fromUnsigne
 {
     switch (toType)
     {
-        case TYP_BYTE:
-            return ((int8_t)fromValue != fromValue) || (fromUnsigned && fromValue < 0);
         case TYP_BOOL:
+        case TYP_BYTE:
         case TYP_UBYTE:
-            return (uint8_t)fromValue != fromValue;
         case TYP_SHORT:
-            return ((int16_t)fromValue != fromValue) || (fromUnsigned && fromValue < 0);
         case TYP_USHORT:
-            return (uint16_t)fromValue != fromValue;
         case TYP_INT:
-            return ((int32_t)fromValue != fromValue) || (fromUnsigned && fromValue < 0);
         case TYP_UINT:
-            return (uint32_t)fromValue != fromValue;
         case TYP_LONG:
-            return fromUnsigned && (fromValue < 0);
         case TYP_ULONG:
-            return !fromUnsigned && (fromValue < 0);
+            return fromUnsigned ? !FitsIn(toType, static_cast<uint64_t>(fromValue)) : !FitsIn(toType, fromValue);
+
         case TYP_FLOAT:
         case TYP_DOUBLE:
             return false;
+
         default:
             unreached();
     }

--- a/src/coreclr/jit/utils.h
+++ b/src/coreclr/jit/utils.h
@@ -776,6 +776,36 @@ int64_t GetSigned64Magic(int64_t d, int* shift /*out*/);
 
 double CachedCyclesPerSecond();
 
+template <typename T>
+bool FitsIn(var_types type, T value)
+{
+    static_assert_no_msg((std::is_same<T, int32_t>::value || std::is_same<T, int64_t>::value ||
+                          std::is_same<T, uint32_t>::value || std::is_same<T, uint64_t>::value));
+
+    switch (type)
+    {
+        case TYP_BYTE:
+            return FitsIn<int8_t>(value);
+        case TYP_BOOL:
+        case TYP_UBYTE:
+            return FitsIn<uint8_t>(value);
+        case TYP_SHORT:
+            return FitsIn<int16_t>(value);
+        case TYP_USHORT:
+            return FitsIn<uint16_t>(value);
+        case TYP_INT:
+            return FitsIn<int32_t>(value);
+        case TYP_UINT:
+            return FitsIn<uint32_t>(value);
+        case TYP_LONG:
+            return FitsIn<int64_t>(value);
+        case TYP_ULONG:
+            return FitsIn<uint64_t>(value);
+        default:
+            unreached();
+    }
+}
+
 namespace CheckedOps
 {
 const bool Unsigned = true;


### PR DESCRIPTION
Just as the title says - remove the restriction that we do not propagate constants for small-typed trees. It is safe because VN [adds](https://github.com/dotnet/runtime/blob/b75e55beb1628df8f704a3014b9acd1b98d4f445/src/coreclr/jit/valuenum.cpp#L7719-L7731) the necessary truncating casts when evaluating the assignment.

Now, small-typed nodes themselves are a bit rare, but one scenario where they come up is in field-by-field copying and initialization of promoted structs, which is where practically all the diffs for this change come from.

The substantial code here is only in the third commit, the rest is miscellaneous cleanup.

Some nice diffs for this change: [`win-x64`](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-57726/win-x64.md), [`win-arm64`](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-57726/win-arm64.md), [`win-x86`](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-57726/win-x86.md)

Small regressions here and there are due to slightly different register allocation and the fact that sometimes containing a constant is not profitable size-wise.

Because this is an impactful change, I think stress testing is warranted for this PR. SPMI replay already revealed one bug (#57450), there may be more.