### PR TITLE
Fix Microsoft.NETCore.Platforms builds on Unix

### DIFF
--- a/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.SDK">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppToolCurrent);net472</TargetFrameworks>
     <!-- This project should not build against the live built .NETCoreApp targeting pack as it contributes to the build itself. -->


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/57702

The casing of the SDK imported via the Sdk attribute was wrong which lead to:

`Microsoft.NETCore.Platforms.csproj : error MSB4236: The SDK 'Microsoft.NET.SDK' specified could not be found.`

We should probably backport this into release/6.0-rc1.