### PR TITLE
Fix a few gcc warnings in jit

### DIFF
--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -4,8 +4,7 @@ include_directories("./jitstd")
 include_directories("../inc")
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fpermissive>)
-  add_compile_options(-Wno-error)
+  add_compile_options(-Wno-error) # tracked by https://github.com/dotnet/runtime/issues/33541
 endif()
 
 function(create_standalone_jit)

--- a/src/coreclr/jit/bitsetasshortlong.h
+++ b/src/coreclr/jit/bitsetasshortlong.h
@@ -345,7 +345,7 @@ public:
     {
         if (IsShort(env))
         {
-            (size_t&)out = (size_t)out & ((size_t)gen | (size_t)in);
+            (size_t&)(int&) out = (size_t)out & ((size_t)gen | (size_t)in);
         }
         else
         {
@@ -361,7 +361,7 @@ public:
     {
         if (IsShort(env))
         {
-            (size_t&)in = (size_t)use | ((size_t)out & ~(size_t)def);
+            (size_t&)(int&) in = (size_t)use | ((size_t)out & ~(size_t)def);
         }
         else
         {

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -79,7 +79,7 @@ void CodeGen::genSetGSSecurityCookie(regNumber initReg, bool* pInitRegZeroed)
     {
         noway_assert(compiler->gsGlobalSecurityCookieVal != 0);
 #ifdef TARGET_AMD64
-        if ((int)compiler->gsGlobalSecurityCookieVal != compiler->gsGlobalSecurityCookieVal)
+        if ((size_t)(int)compiler->gsGlobalSecurityCookieVal != compiler->gsGlobalSecurityCookieVal)
         {
             // initReg = #GlobalSecurityCookieVal64; [frame.GSSecurityCookie] = initReg
             genSetRegToIcon(initReg, compiler->gsGlobalSecurityCookieVal, TYP_I_IMPL);
@@ -2511,7 +2511,7 @@ void CodeGen::genLclHeap(GenTree* tree)
             amount /= STACK_ALIGN;
         }
 
-        genSetRegToIcon(regCnt, amount, ((int)amount == amount) ? TYP_INT : TYP_LONG);
+        genSetRegToIcon(regCnt, amount, ((size_t)(int)amount == amount) ? TYP_INT : TYP_LONG);
     }
 
     if (compiler->info.compInitMem)

--- a/src/coreclr/jit/emitarm.cpp
+++ b/src/coreclr/jit/emitarm.cpp
@@ -6790,7 +6790,7 @@ void emitter::emitDispImm(int imm, bool addComma, bool alwaysHex /* =false */)
         printf("%d", imm);
     else if ((imm > 0) ||
              (imm == -imm) || // -0x80000000 == 0x80000000. So we don't want to add an extra "-" at the beginning.
-             (emitComp->opts.disDiffable && (imm == 0xD1FFAB1E))) // Don't display this as negative
+             (emitComp->opts.disDiffable && (imm == (int)0xD1FFAB1E))) // Don't display this as negative
         printf("0x%02x", imm);
     else // val <= -1000
         printf("-0x%02x", -imm);

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -7624,7 +7624,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
                         // An absolute indir address that doesn't need reloc should fit within 32-bits
                         // to be encoded as offset relative to zero.  This addr mode requires an extra
                         // SIB byte
-                        noway_assert(static_cast<int>(reinterpret_cast<intptr_t>(addr)) == (size_t)addr);
+                        noway_assert((size_t) static_cast<int>(reinterpret_cast<intptr_t>(addr)) == (size_t)addr);
                         sz++;
                     }
 #endif // TARGET_AMD64
@@ -7660,7 +7660,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
             // An absolute indir address that doesn't need reloc should fit within 32-bits
             // to be encoded as offset relative to zero.  This addr mode requires an extra
             // SIB byte
-            noway_assert(static_cast<int>(reinterpret_cast<intptr_t>(addr)) == (size_t)addr);
+            noway_assert((size_t) static_cast<int>(reinterpret_cast<intptr_t>(addr)) == (size_t)addr);
             sz++;
         }
 #endif // TARGET_AMD64

--- a/src/coreclr/jit/gcencode.cpp
+++ b/src/coreclr/jit/gcencode.cpp
@@ -1672,7 +1672,7 @@ size_t GCInfo::gcInfoBlockHdrSave(
 #if REGEN_SHORTCUTS
             regenLog(headerEncoding, header, &state);
 #endif
-            _ASSERTE(codeSet == 1 || codeSet == 2 && "Encoding must correspond to InfoHdrAdjust or InfoHdrAdjust2");
+            _ASSERTE((codeSet == 1 || codeSet == 2) && "Encoding must correspond to InfoHdrAdjust or InfoHdrAdjust2");
             if (codeSet == 2)
             {
                 *dest++ = NEXT_OPCODE | MORE_BYTES_TO_FOLLOW;

--- a/src/coreclr/jit/inlinepolicy.h
+++ b/src/coreclr/jit/inlinepolicy.h
@@ -185,7 +185,7 @@ protected:
 class ExtendedDefaultPolicy : public DefaultPolicy
 {
 public:
-    ExtendedDefaultPolicy::ExtendedDefaultPolicy(Compiler* compiler, bool isPrejitRoot)
+    ExtendedDefaultPolicy(Compiler* compiler, bool isPrejitRoot)
         : DefaultPolicy(compiler, isPrejitRoot)
         , m_ProfileFrequency(0.0)
         , m_BinaryExprWithCns(0)

--- a/src/coreclr/jit/lir.h
+++ b/src/coreclr/jit/lir.h
@@ -298,7 +298,7 @@ public:
 
 public:
     static Range& AsRange(BasicBlock* block);
-    static const LIR::Range& LIR::AsRange(const BasicBlock* block);
+    static const Range& AsRange(const BasicBlock* block);
 
     static Range EmptyRange();
     static Range SeqTree(Compiler* compiler, GenTree* tree);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -3394,7 +3394,7 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
                     if (callIsVararg)
                     {
                         // Override the decision and force a split.
-                        isRegArg = isRegArg = (intArgRegNum + (size - 1)) <= maxRegArgs;
+                        isRegArg = (intArgRegNum + (size - 1)) <= maxRegArgs;
                     }
                     else
 #endif // defined(TARGET_WINDOWS)


### PR DESCRIPTION
Fixes #57861

Cleans up 1045 occurrences of warning from gcc debug build logs. Remaining one compiler warning related to 'bit field width overflow', which has 2565 occurrences, is tracked by #33541.