### PR TITLE
Don't consider classes that do not have any attributes or base classes

### DIFF
--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.cs
@@ -67,7 +67,7 @@ namespace System.Text.Json.SourceGeneration
 
             public void OnVisitSyntaxNode(SyntaxNode syntaxNode)
             {
-                if (syntaxNode is ClassDeclarationSyntax cds)
+                if (syntaxNode is ClassDeclarationSyntax { AttributeLists.Count: > 0, BaseList.Types.Count: > 0 } cds)
                 {
                     (ClassDeclarationSyntaxList ??= new List<ClassDeclarationSyntax>()).Add(cds);
                 }


### PR DESCRIPTION
The generator will ignore any class without a matching attribute or base class. We can thus not ever consider them for binding, short circuiting in the vast majority of cases.