### PR TITLE
Additional statistics when a ServiceProvider is created

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/DependencyInjectionEventSourceTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/DependencyInjectionEventSourceTests.cs
@@ -241,14 +241,18 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             serviceCollection.AddScoped<IFakeMultipleService, FakeDisposableCallbackInnerService>();
             serviceCollection.AddTransient<IFakeMultipleService, FakeDisposableCallbackInnerService>();
             serviceCollection.AddSingleton<IFakeService, FakeDisposableCallbackInnerService>();
+            serviceCollection.AddScoped(typeof(IFakeOpenGenericService<>), typeof(FakeOpenGenericService<>));
+            serviceCollection.AddTransient<IFakeOpenGenericService<PocoClass>, FakeOpenGenericService<PocoClass>>();
 
             using ServiceProvider provider = serviceCollection.BuildServiceProvider();
 
             EventWrittenEventArgs serviceProviderBuiltEvent = _listener.EventData.Single(e => e.EventName == "ServiceProviderBuilt");
             GetProperty<int>(serviceProviderBuiltEvent, "serviceProviderHashCode"); // assert hashcode exists as an int
             Assert.Equal(4, GetProperty<int>(serviceProviderBuiltEvent, "singletonServices"));
-            Assert.Equal(1, GetProperty<int>(serviceProviderBuiltEvent, "scopedServices"));
-            Assert.Equal(2, GetProperty<int>(serviceProviderBuiltEvent, "transientServices"));
+            Assert.Equal(2, GetProperty<int>(serviceProviderBuiltEvent, "scopedServices"));
+            Assert.Equal(3, GetProperty<int>(serviceProviderBuiltEvent, "transientServices"));
+            Assert.Equal(1, GetProperty<int>(serviceProviderBuiltEvent, "closedGenericsServices"));
+            Assert.Equal(1, GetProperty<int>(serviceProviderBuiltEvent, "openGenericsServices"));
             Assert.Equal(7, serviceProviderBuiltEvent.EventId);
 
             EventWrittenEventArgs serviceProviderDescriptorsEvent = _listener.EventData.Single(e => e.EventName == "ServiceProviderDescriptors");
@@ -290,6 +294,16 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
                 "      \"serviceType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeService\",",
                 "      \"lifetime\": \"Singleton\",",
                 "      \"implementationType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeDisposableCallbackInnerService\"",
+                "    },",
+                "    {",
+                "      \"serviceType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeOpenGenericService`1[TValue]\",",
+                "      \"lifetime\": \"Scoped\",",
+                "      \"implementationType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeOpenGenericService`1[TVal]\"",
+                "    },",
+                "    {",
+                "      \"serviceType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeOpenGenericService`1[Microsoft.Extensions.DependencyInjection.Specification.Fakes.PocoClass]\",",
+                "      \"lifetime\": \"Transient\",",
+                "      \"implementationType\": \"Microsoft.Extensions.DependencyInjection.Specification.Fakes.FakeOpenGenericService`1[Microsoft.Extensions.DependencyInjection.Specification.Fakes.PocoClass]\"",
                 "    }",
                 "  ]",
                 "}"),


### PR DESCRIPTION
Adds the following statistics to the existing `ServiceProviderBuilt` event:
* Number of open generics
* Number of closed generics

fix #52364