### PR TITLE
Ignore inherit param for ParameterInfo.GetCustomAttributes

### DIFF
--- a/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeParameterInfo.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeParameterInfo.cs
@@ -181,14 +181,20 @@ namespace System.Reflection
         override
         object[] GetCustomAttributes(bool inherit)
         {
-            return CustomAttribute.GetCustomAttributes(this, inherit);
+            // It is documented that the inherit flag is ignored.
+            // Attribute.GetCustomAttributes is to be used to search
+            // inheritance chain.
+            return CustomAttribute.GetCustomAttributes(this, false);
         }
 
         public
         override
         object[] GetCustomAttributes(Type attributeType, bool inherit)
         {
-            return CustomAttribute.GetCustomAttributes(this, attributeType, inherit);
+            // It is documented that the inherit flag is ignored.
+            // Attribute.GetCustomAttributes is to be used to search
+            // inheritance chain.
+            return CustomAttribute.GetCustomAttributes(this, attributeType, false);
         }
 
         internal static object? GetDefaultValueImpl(ParameterInfo pinfo)


### PR DESCRIPTION
It is documented that the inherit flag is ignored.
Attribute.GetCustomAttributes is to be used to search
inheritance chain.

This change is only for the Mono classlib implementation.
CoreCLR already has this behavior.

Adding a test to verify behavior.