### PR TITLE
[mono][debugger] Fix watch of local variable values

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -9282,16 +9282,14 @@ frame_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 				pos = - pos - 1;
 				cmd_stack_frame_get_parameter (frame, sig, pos, buf, jit);
 			} else {
-				MonoDebugLocalsInfo *locals;
-
-				locals = mono_debug_lookup_locals (frame->de.method);
-				if (locals) { 
-					if (!CHECK_PROTOCOL_VERSION (2, 59)) //from newer protocol versions it's sent the pdb index
-					{
+				if (!CHECK_PROTOCOL_VERSION (2, 59)) { //from newer protocol versions it's sent the pdb index
+					MonoDebugLocalsInfo *locals;
+					locals = mono_debug_lookup_locals (frame->de.method);
+					if (locals) {
 						g_assert (pos < locals->num_locals);
 						pos = locals->locals [pos].index;
+						mono_debug_free_locals (locals);
 					}
-					mono_debug_free_locals (locals);
 				}
 
 				PRINT_DEBUG_MSG (4, "[dbg]   send local %d.\n", pos);
@@ -9339,16 +9337,14 @@ frame_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 				var = &jit->params [pos];
 				is_arg = TRUE;
 			} else {
-				MonoDebugLocalsInfo *locals;
-
-				locals = mono_debug_lookup_locals (frame->de.method);
-				if (locals) {
-					if (!CHECK_PROTOCOL_VERSION (2, 59)) //from newer protocol versions it's sent the pdb index
-					{
+				if (!CHECK_PROTOCOL_VERSION (2, 59)) { //from newer protocol versions it's sent the pdb index
+					MonoDebugLocalsInfo *locals;
+					locals = mono_debug_lookup_locals (frame->de.method);
+					if (locals) {
 						g_assert (pos < locals->num_locals);
 						pos = locals->locals [pos].index;
+						mono_debug_free_locals (locals);
 					}
-					mono_debug_free_locals (locals);
 				}
 				g_assert (pos >= 0 && pos < jit->num_locals);
 

--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -9286,7 +9286,7 @@ frame_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 
 				locals = mono_debug_lookup_locals (frame->de.method);
 				if (locals) { 
-					if (CHECK_ICORDBG (FALSE)) //on icordbg the index value is correct, we don't need to fix it.
+					if (!CHECK_PROTOCOL_VERSION (2, 59)) //from newer protocol versions it's sent the pdb index
 					{
 						g_assert (pos < locals->num_locals);
 						pos = locals->locals [pos].index;
@@ -9343,7 +9343,7 @@ frame_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 
 				locals = mono_debug_lookup_locals (frame->de.method);
 				if (locals) {
-					if (CHECK_ICORDBG (FALSE))
+					if (!CHECK_PROTOCOL_VERSION (2, 59)) //from newer protocol versions it's sent the pdb index
 					{
 						g_assert (pos < locals->num_locals);
 						pos = locals->locals [pos].index;

--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -8565,7 +8565,7 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 			return ERR_INVALID_ARGUMENT;
 		}
 
-		locals = mono_debug_lookup_locals (method, FALSE);
+		locals = mono_debug_lookup_locals (method);
 		if (!locals) {
 			if (CHECK_PROTOCOL_VERSION (2, 43)) {
 				/* Scopes */
@@ -9284,8 +9284,8 @@ frame_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 			} else {
 				MonoDebugLocalsInfo *locals;
 
-				locals = mono_debug_lookup_locals (frame->de.method, TRUE);
-				if (locals) {
+				locals = mono_debug_lookup_locals (frame->de.method);
+				if (locals && CHECK_ICORDBG (FALSE)) { //on icordbg the index value is correct, we don't need to fix it.
 					g_assert (pos < locals->num_locals);
 					pos = locals->locals [pos].index;
 					mono_debug_free_locals (locals);
@@ -9338,8 +9338,8 @@ frame_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 			} else {
 				MonoDebugLocalsInfo *locals;
 
-				locals = mono_debug_lookup_locals (frame->de.method, TRUE);
-				if (locals) {
+				locals = mono_debug_lookup_locals (frame->de.method);
+				if (locals && CHECK_ICORDBG (FALSE)) {
 					g_assert (pos < locals->num_locals);
 					pos = locals->locals [pos].index;
 					mono_debug_free_locals (locals);

--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -9285,9 +9285,12 @@ frame_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 				MonoDebugLocalsInfo *locals;
 
 				locals = mono_debug_lookup_locals (frame->de.method);
-				if (locals && CHECK_ICORDBG (FALSE)) { //on icordbg the index value is correct, we don't need to fix it.
-					g_assert (pos < locals->num_locals);
-					pos = locals->locals [pos].index;
+				if (locals) { 
+					if (CHECK_ICORDBG (FALSE)) //on icordbg the index value is correct, we don't need to fix it.
+					{
+						g_assert (pos < locals->num_locals);
+						pos = locals->locals [pos].index;
+					}
 					mono_debug_free_locals (locals);
 				}
 
@@ -9339,9 +9342,12 @@ frame_commands (int command, guint8 *p, guint8 *end, Buffer *buf)
 				MonoDebugLocalsInfo *locals;
 
 				locals = mono_debug_lookup_locals (frame->de.method);
-				if (locals && CHECK_ICORDBG (FALSE)) {
-					g_assert (pos < locals->num_locals);
-					pos = locals->locals [pos].index;
+				if (locals) {
+					if (CHECK_ICORDBG (FALSE))
+					{
+						g_assert (pos < locals->num_locals);
+						pos = locals->locals [pos].index;
+					}
 					mono_debug_free_locals (locals);
 				}
 				g_assert (pos >= 0 && pos < jit->num_locals);

--- a/src/mono/mono/metadata/mono-debug.c
+++ b/src/mono/mono/metadata/mono-debug.c
@@ -867,7 +867,7 @@ mono_debug_method_lookup_location (MonoDebugMethodInfo *minfo, int il_offset)
  * The result should be freed using mono_debug_free_locals ().
  */
 MonoDebugLocalsInfo*
-mono_debug_lookup_locals (MonoMethod *method, mono_bool ignore_pdb)
+mono_debug_lookup_locals (MonoMethod *method)
 {
 	MonoDebugMethodInfo *minfo;
 	MonoDebugLocalsInfo *res;
@@ -893,18 +893,16 @@ mono_debug_lookup_locals (MonoMethod *method, mono_bool ignore_pdb)
 		return NULL;
 	}
 
-	if (ignore_pdb)
-		res = mono_debug_symfile_lookup_locals (minfo);
-	else {
-		if (minfo->handle->ppdb) {
-			res = mono_ppdb_lookup_locals (minfo);
-		} else {
-			if (!minfo->handle->symfile || !mono_debug_symfile_is_loaded (minfo->handle->symfile))
-				res = NULL;
-			else
-				res = mono_debug_symfile_lookup_locals (minfo);
-		}
+
+	if (minfo->handle->ppdb) {
+		res = mono_ppdb_lookup_locals (minfo);
+	} else {
+		if (!minfo->handle->symfile || !mono_debug_symfile_is_loaded (minfo->handle->symfile))
+			res = NULL;
+		else
+			res = mono_debug_symfile_lookup_locals (minfo);
 	}
+
 	mono_debugger_unlock ();
 
 	return res;

--- a/src/mono/mono/metadata/mono-debug.h
+++ b/src/mono/mono/metadata/mono-debug.h
@@ -189,7 +189,7 @@ MONO_API void
 mono_debug_add_delegate_trampoline (void* code, int size);
 
 MONO_API MonoDebugLocalsInfo*
-mono_debug_lookup_locals (MonoMethod *method, mono_bool ignore_pdb);
+mono_debug_lookup_locals (MonoMethod *method);
 
 MONO_API MonoDebugMethodAsyncInfo*
 mono_debug_lookup_method_async_debug_info (MonoMethod *method);

--- a/src/mono/mono/mini/dwarfwriter.c
+++ b/src/mono/mono/mini/dwarfwriter.c
@@ -1899,7 +1899,7 @@ mono_dwarf_writer_emit_method (MonoDwarfWriter *w, MonoCompile *cfg, MonoMethod 
 	g_free (names);
 
 	/* Locals */
-	locals_info = mono_debug_lookup_locals (method, FALSE);
+	locals_info = mono_debug_lookup_locals (method);
 
 	for (i = 0; i < header->num_locals; ++i) {
 		MonoInst *ins = locals [i];

--- a/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/Tests.cs
@@ -845,6 +845,21 @@ namespace DebuggerTests
                     }, "t_props", num_fields: 53);
             });
 
+
+        [Fact]
+        public async Task InspectLocalsWithIndexAndPositionWithDifferentValues() //https://github.com/xamarin/xamarin-android/issues/6161
+        {
+            await EvaluateAndCheck(
+                "window.setTimeout(function() { invoke_static_method('[debugger-test] MainPage:CallSetValue'); }, 1);",
+                "dotnet://debugger-test.dll/debugger-test.cs", 758, 16,
+                "set_SomeValue",
+                locals_fn: (locals) =>
+                {
+                    CheckNumber(locals, "view", 150);
+                }
+            );
+        }
+
         //TODO add tests covering basic stepping behavior as step in/out/over
     }
 }

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -725,5 +725,48 @@ public class Foo
         Console.WriteLine($"time for await");
         return true;
     }
+
+}
+
+public class MainPage
+{
+    public MainPage()
+    {
+    }
+
+    int count = 0;
+    private int someValue;
+
+    public int SomeValue
+    {
+        get
+        {
+            return someValue;
+        }
+        set
+        {
+            someValue = value;
+            count++;
+
+            if (count == 10)
+            {
+                var view = 150;
+
+                if (view != 50)
+                {
+
+                }
+                System.Diagnostics.Debugger.Break();
+            }
+
+            SomeValue = count;
+        }
+    }
+
+    public static void CallSetValue()
+    {
+        var mainPage = new MainPage();
+        mainPage.SomeValue = 10;
+    }
 }
 


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-android/issues/6161

This was a side-effect of icordbg support implementation.

In this case the index that come from debugger-libs is 0 but the correct index after reading pdb info is 1. That is why it was showing wrong variable value.

The index that comes from icordbg is already the correct one read from pdb we don't need to "fix" it on runtime side.