### PR TITLE
Remove AppDomain::IsCompilationDomain (always false)

### DIFF
--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -2142,18 +2142,6 @@ void AppDomain::Init()
     m_nativeImageLoadCrst.Init(CrstNativeImageLoad);
 } // AppDomain::Init
 
-
-/*********************************************************************/
-
-BOOL AppDomain::IsCompilationDomain()
-{
-    LIMITED_METHOD_CONTRACT;
-
-    BOOL isCompilationDomain = (m_dwFlags & COMPILATION_DOMAIN) != 0;
-    return isCompilationDomain;
-}
-
-
 void AppDomain::Stop()
 {
     CONTRACTL

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -38,7 +38,6 @@
 class BaseDomain;
 class SystemDomain;
 class AppDomain;
-class CompilationDomain;
 class GlobalStringLiteralMap;
 class StringLiteralMap;
 class MngStdInterfacesInfo;
@@ -1997,23 +1996,6 @@ public:
         return (m_dwFlags & IGNORE_UNHANDLED_EXCEPTIONS);
     }
 
-    void SetCompilationDomain()
-    {
-        LIMITED_METHOD_CONTRACT;
-
-        m_dwFlags |= COMPILATION_DOMAIN;
-    }
-
-    BOOL IsCompilationDomain();
-
-    PTR_CompilationDomain ToCompilationDomain()
-    {
-        LIMITED_METHOD_CONTRACT;
-
-        _ASSERTE(IsCompilationDomain());
-        return dac_cast<PTR_CompilationDomain>(this);
-    }
-
     static void ExceptionUnwind(Frame *pFrame);
 
 #ifdef _DEBUG
@@ -2309,7 +2291,7 @@ public:
 
     enum {
         CONTEXT_INITIALIZED =               0x0001,
-        COMPILATION_DOMAIN =                0x0400, // Are we ngenning?
+        // unused =                         0x0400,
         IGNORE_UNHANDLED_EXCEPTIONS =      0x10000, // AppDomain was created using the APPDOMAIN_IGNORE_UNHANDLED_EXCEPTIONS flag
     };
 

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -3089,9 +3089,9 @@ ILStubCache* Module::GetILStubCache()
     }
     CONTRACTL_END;
 
-    // Use per-LoaderAllocator cache for modules when not NGENing
+    // Use per-LoaderAllocator cache for modules
     BaseDomain *pDomain = GetDomain();
-    if (!IsSystem() && !pDomain->AsAppDomain()->IsCompilationDomain())
+    if (!IsSystem())
         return GetLoaderAllocator()->GetILStubCache();
 
     if (m_pILStubCache == NULL)
@@ -4660,13 +4660,6 @@ void Module::FixupVTables()
     }
 
     HINSTANCE hInstThis = GetFile()->GetIJWBase();
-
-    // <REVISIT_TODO>@todo: workaround!</REVISIT_TODO>
-    // If we are compiling in-process, we don't want to fixup the vtables - as it
-    // will have side effects on the other copy of the module!
-    if (SystemDomain::GetCurrentDomain()->IsCompilationDomain()) {
-        return;
-    }
 
     // Get vtable fixup data
     COUNT_T cFixupRecords;

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -57,7 +57,6 @@ class SigTypeContext;
 class Assembly;
 class BaseDomain;
 class AppDomain;
-class CompilationDomain;
 class DomainModule;
 struct DomainLocalModule;
 class SystemDomain;

--- a/src/coreclr/vm/common.h
+++ b/src/coreclr/vm/common.h
@@ -116,7 +116,6 @@ typedef DPTR(class AssemblyNameBaseObject) PTR_AssemblyNameBaseObject;
 typedef VPTR(class BaseDomain)          PTR_BaseDomain;
 typedef DPTR(class ClassLoader)         PTR_ClassLoader;
 typedef DPTR(class ComCallMethodDesc)   PTR_ComCallMethodDesc;
-typedef VPTR(class CompilationDomain)   PTR_CompilationDomain;
 typedef DPTR(class ComPlusCallMethodDesc) PTR_ComPlusCallMethodDesc;
 typedef VPTR(class DebugInterface)      PTR_DebugInterface;
 typedef DPTR(class Dictionary)          PTR_Dictionary;

--- a/src/coreclr/vm/comtoclrcall.cpp
+++ b/src/coreclr/vm/comtoclrcall.cpp
@@ -940,11 +940,8 @@ void ComCallMethodDesc::InitMethod(MethodDesc *pMD, MethodDesc *pInterfaceMD)
     m_pwStubStackSlotOffsets = NULL;
 #endif // TARGET_X86
 
-    if (!SystemDomain::GetCurrentDomain()->IsCompilationDomain())
-    {
-        // Initialize the native type information size of native stack, native retval flags, etc).
-        InitNativeInfo();
-    }
+    // Initialize the native type information size of native stack, native retval flags, etc).
+    InitNativeInfo();
 
     if (pMD->IsEEImpl() && COMDelegate::IsDelegateInvokeMethod(pMD))
     {
@@ -972,11 +969,8 @@ void ComCallMethodDesc::InitField(FieldDesc* pFD, BOOL isGetter)
     m_flags = enum_IsFieldCall; // mark the attribute as a field
     m_flags |= isGetter ? enum_IsGetter : 0;
 
-    if (!SystemDomain::GetCurrentDomain()->IsCompilationDomain())
-    {
-        // Initialize the native type information size of native stack, native retval flags, etc).
-        InitNativeInfo();
-    }
+    // Initialize the native type information size of native stack, native retval flags, etc).
+    InitNativeInfo();
 };
 
 // Initialize the member's native type information (size of native stack, native retval flags, etc).

--- a/src/coreclr/vm/contractimpl.cpp
+++ b/src/coreclr/vm/contractimpl.cpp
@@ -131,8 +131,7 @@ UINT32 TypeIDMap::GetTypeID(PTR_MethodTable pMT)
         m_idMap.InsertValue((UPTR)id, (UPTR)pMT >> 1);
         m_mtMap.InsertValue((UPTR)pMT, (UPTR)id);
         m_entryCount++;
-        CONSISTENCY_CHECK(GetThread()->GetDomain()->IsCompilationDomain() ||
-                          (LookupType(id) == pMT));
+        CONSISTENCY_CHECK((LookupType(id) == pMT));
     }
 #else // DACCESS_COMPILE
     if (id == TypeIDProvider::INVALID_TYPE_ID)

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -3283,10 +3283,6 @@ BOOL NDirect::MarshalingRequired(
                 return TRUE;
 
             NDirectMethodDesc* pNMD = (NDirectMethodDesc*)pMD;
-            // Make sure running cctor can be handled by stub
-            if (pNMD->IsClassConstructorTriggeredByILStub())
-                return TRUE;
-
             InitializeSigInfoAndPopulateNDirectMethodDesc(pNMD, &sigInfo);
 
             // Pending exceptions are handled by stub
@@ -5436,11 +5432,6 @@ MethodDesc* NDirect::GetILStubMethodDesc(NDirectMethodDesc* pNMD, PInvokeStaticS
 
     if (!pNMD->IsVarArgs() || SF_IsForNumParamBytes(dwStubFlags))
     {
-        if (pNMD->IsClassConstructorTriggeredByILStub())
-        {
-            dwStubFlags |= NDIRECTSTUB_FL_TRIGGERCCTOR;
-        }
-
         pStubMD = CreateCLRToNativeILStub(
             pSigInfo,
             dwStubFlags & ~NDIRECTSTUB_FL_FOR_NUMPARAMBYTES,
@@ -6155,11 +6146,6 @@ PCODE GetILStubForCalli(VASigCookie *pVASigCookie, MethodDesc *pMD)
 
         // vararg P/Invoke must be cdecl
         unmgdCallConv = CorInfoCallConvExtension::C;
-
-        if (((NDirectMethodDesc *)pMD)->IsClassConstructorTriggeredByILStub())
-        {
-            dwStubFlags |= NDIRECTSTUB_FL_TRIGGERCCTOR;
-        }
     }
 
     mdMethodDef md;

--- a/src/coreclr/vm/ilstubcache.cpp
+++ b/src/coreclr/vm/ilstubcache.cpp
@@ -339,7 +339,7 @@ MethodTable* ILStubCache::GetOrCreateStubMethodTable(Module* pModule)
     CONTRACT_END;
 
 #ifdef _DEBUG
-    if (pModule->IsSystem() || pModule->GetDomain()->AsAppDomain()->IsCompilationDomain())
+    if (pModule->IsSystem())
     {
         // in the shared domain and compilation AD we are associated with the module
         CONSISTENCY_CHECK(pModule->GetILStubCache() == this);

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -3173,7 +3173,7 @@ public:
         WRAPPER_NO_CONTRACT;
 
         return (IsClassConstructorTriggeredAtLinkTime() &&
-                (IsZapped() || SystemDomain::GetCurrentDomain()->IsCompilationDomain()));
+                IsZapped());
     }
 #endif //!DACCESS_COMPILE
 };  //class NDirectMethodDesc

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -3151,9 +3151,8 @@ public:
     // In AppDomains, we can trigger declarer's cctor when we link the P/Invoke,
     // which takes care of inlined calls as well. See code:NDirect.NDirectLink.
     // Although the cctor is guaranteed to run in the shared domain before the
-    // target is invoked (code:IsClassConstructorTriggeredByILStub), we will
-    // trigger at it link time as well because linking may depend on it - the
-    // cctor may change the target DLL, change DLL search path etc.
+    // target is invoked, we will trigger it at link time as well because linking
+    // may depend on it - cctor may change the target DLL, DLL search path etc.
     BOOL IsClassConstructorTriggeredAtLinkTime()
     {
         LIMITED_METHOD_CONTRACT;
@@ -3163,21 +3162,7 @@ public:
             return FALSE;
         return !pMT->GetClass()->IsBeforeFieldInit();
     }
-
-#ifndef DACCESS_COMPILE
-    // In the shared domain and in NGENed code, we will trigger declarer's cctor
-    // in the marshaling stub by calling code:StubHelpers.InitDeclaringType. If
-    // this returns TRUE, the call must not be inlined.
-    BOOL IsClassConstructorTriggeredByILStub()
-    {
-        WRAPPER_NO_CONTRACT;
-
-        return (IsClassConstructorTriggeredAtLinkTime() &&
-                IsZapped());
-    }
-#endif //!DACCESS_COMPILE
 };  //class NDirectMethodDesc
-
 
 //-----------------------------------------------------------------------
 // Operations specific to EEImplCall methods. We use a derived class to get

--- a/src/coreclr/vm/pefile.cpp
+++ b/src/coreclr/vm/pefile.cpp
@@ -228,9 +228,7 @@ void PEFile::LoadLibrary(BOOL allowNativeSkip/*=TRUE*/) // if allowNativeSkip==F
 
     // Since we couldn't call LoadLibrary, we must be an IL only image
     // or the image may still contain unfixed up stuff
-    // Note that we make an exception for CompilationDomains, since PEImage
-    // will map non-ILOnly images in a compilation domain.
-    if (!GetILimage()->IsILOnly() && !GetAppDomain()->IsCompilationDomain())
+    if (!GetILimage()->IsILOnly())
     {
         if (!GetILimage()->HasV1Metadata())
             ThrowHR(COR_E_FIXUPSINEXE); // <TODO>@todo: better error</TODO>

--- a/src/coreclr/vm/peimage.cpp
+++ b/src/coreclr/vm/peimage.cpp
@@ -75,19 +75,7 @@ CHECK PEImage::CheckLayoutFormat(PEDecoder *pe)
     }
     CONTRACT_CHECK_END;
 
-    // If we are in a compilation domain, we will allow
-    // non-IL only files to be treated as IL only
-
-    // <TODO>@todo: this is not really the right model here.  This is a per-app domain
-    // choice, but an image created this way would become available globally.
-    // (Also, this call prevents us from moving peimage into utilcode.)</TODO>
-
-    if (GetAppDomain() == NULL ||
-        (!GetAppDomain()->IsCompilationDomain()))
-    {
-        CHECK(pe->IsILOnly());
-    }
-
+    CHECK(pe->IsILOnly());
     CHECK(!pe->HasNativeHeader());
     CHECK_OK;
 }


### PR DESCRIPTION
Remove
- `AppDomain::IsCompilationDomain` (always false)
- `NDirectMethodDesc::IsClassConstructorTriggeredByILStub` (always false)

Contributes to #54129

cc @AaronRobinsonMSFT @jkoritzinsky @vitek-karas 