### PR TITLE
Disable X509Certificates test assembly on Mariner

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/AssemblyInfo.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+  
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Xunit;
+
+[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/57810", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsMariner))]

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
   <Import Project="$(CommonPath)System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" />
   <ItemGroup>
+    <Compile Include="AssemblyInfo.cs" />
     <Compile Include="$(CommonPath)System\Memory\PointerMemoryManager.cs"
              Link="Common\System\Memory\PointerMemoryManager.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\CryptoPool.cs"


### PR DESCRIPTION
Tracking issue https://github.com/dotnet/runtime/issues/57810