### PR TITLE
Remove IsZapped and GetZappedModule functions

### DIFF
--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -1607,7 +1607,7 @@ void DacDbiInterfaceImpl::ComputeFieldData(PTR_FieldDesc pFD,
             {
                 // RVA statics are relative to a base module address
                 DWORD offset = pFD->GetOffset();
-                PTR_VOID addr = pFD->GetModule()->GetRvaField(offset, pFD->IsZapped());
+                PTR_VOID addr = pFD->GetModule()->GetRvaField(offset);
                 if (pCurrentFieldData->OkToGetOrSetStaticAddress())
                 {
                     pCurrentFieldData->SetStaticAddress(PTR_TO_TADDR(addr));

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -205,7 +205,7 @@ BOOL DacValidateMD(MethodDesc * pMD)
             retval = FALSE;
         }
 
-        if (retval && pMD->HasTemporaryEntryPoint())
+        if (retval)
         {
             MethodDesc *pMDCheck = MethodDesc::GetMethodDescFromStubAddr(pMD->GetTemporaryEntryPoint(), TRUE);
 

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -2544,7 +2544,7 @@ void Module::FreeClassTables()
                 if (!th.IsTypeDesc())
                 {
                     MethodTable * pMT = th.AsMethodTable();
-                    if (pMT->IsCanonicalMethodTable() && (!pMT->IsZapped() || pMT->GetZapModule() == this))
+                    if (pMT->IsCanonicalMethodTable())
                         pMT->GetClass()->Destruct(pMT);
                 }
             }
@@ -3261,7 +3261,7 @@ TADDR Module::GetIL(DWORD target)
     return m_file->GetIL(target);
 }
 
-PTR_VOID Module::GetRvaField(DWORD rva, BOOL fZapped)
+PTR_VOID Module::GetRvaField(DWORD rva)
 {
     WRAPPER_NO_CONTRACT;
     SUPPORTS_DAC;
@@ -7657,9 +7657,8 @@ TADDR ReflectionModule::GetIL(RVA il) // virtual
 #endif // DACCESS_COMPILE
 }
 
-PTR_VOID ReflectionModule::GetRvaField(RVA field, BOOL fZapped) // virtual
+PTR_VOID ReflectionModule::GetRvaField(RVA field) // virtual
 {
-    _ASSERTE(!fZapped);
 #ifndef DACCESS_COMPILE
     WRAPPER_NO_CONTRACT;
     // This function should be call only if the target is a field or a field with RVA.

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -2079,7 +2079,7 @@ public:
     // These are overridden by reflection modules
     virtual TADDR GetIL(RVA il);
 
-    virtual PTR_VOID GetRvaField(RVA field, BOOL fZapped);
+    virtual PTR_VOID GetRvaField(RVA field);
     CHECK CheckRvaField(RVA field);
     CHECK CheckRvaField(RVA field, COUNT_T size);
 
@@ -2538,7 +2538,7 @@ public:
 
     // Overrides functions to access sections
     virtual TADDR GetIL(RVA target);
-    virtual PTR_VOID GetRvaField(RVA rva, BOOL fZapped);
+    virtual PTR_VOID GetRvaField(RVA rva);
 
     Assembly* GetCreatingAssembly( void )
     {

--- a/src/coreclr/vm/class.cpp
+++ b/src/coreclr/vm/class.cpp
@@ -171,7 +171,7 @@ void EEClass::Destruct(MethodTable * pOwningMT)
     }
 
 #ifdef FEATURE_COMINTEROP
-    if (GetSparseCOMInteropVTableMap() != NULL && !pOwningMT->IsZapped())
+    if (GetSparseCOMInteropVTableMap() != NULL)
         delete GetSparseCOMInteropVTableMap();
 #endif // FEATURE_COMINTEROP
 

--- a/src/coreclr/vm/comutilnative.cpp
+++ b/src/coreclr/vm/comutilnative.cpp
@@ -1718,14 +1718,11 @@ static BOOL HasOverriddenMethod(MethodTable* mt, MethodTable* classMT, WORD meth
         return FALSE;
     }
 
-    if (!classMT->IsZapped())
+    // If CoreLib is JITed, the slots can be patched and thus we need to compare the actual MethodDescs
+    // to detect match reliably
+    if (MethodTable::GetMethodDescForSlotAddress(actual) == MethodTable::GetMethodDescForSlotAddress(base))
     {
-        // If CoreLib is JITed, the slots can be patched and thus we need to compare the actual MethodDescs
-        // to detect match reliably
-        if (MethodTable::GetMethodDescForSlotAddress(actual) == MethodTable::GetMethodDescForSlotAddress(base))
-        {
-            return FALSE;
-        }
+        return FALSE;
     }
 
     return TRUE;
@@ -2084,13 +2081,10 @@ static bool HasOverriddenStreamMethod(MethodTable * pMT, WORD slot)
     if (actual == base)
         return false;
 
-    if (!g_pStreamMT->IsZapped())
-    {
-        // If CoreLib is JITed, the slots can be patched and thus we need to compare the actual MethodDescs
-        // to detect match reliably
-        if (MethodTable::GetMethodDescForSlotAddress(actual) == MethodTable::GetMethodDescForSlotAddress(base))
-            return false;
-    }
+    // If CoreLib is JITed, the slots can be patched and thus we need to compare the actual MethodDescs
+    // to detect match reliably
+    if (MethodTable::GetMethodDescForSlotAddress(actual) == MethodTable::GetMethodDescForSlotAddress(base))
+        return false;
 
     return true;
 }

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -5949,12 +5949,9 @@ EXTERN_C LPVOID STDCALL NDirectImportWorker(NDirectMethodDesc* pMD)
 
     if (pMD->IsEarlyBound())
     {
-        if (!pMD->IsZapped())
-        {
-            // we need the MD to be populated in case we decide to build an intercept
-            // stub to wrap the target in InitEarlyBoundNDirectTarget
-            NDirect::PopulateNDirectMethodDesc(pMD);
-        }
+        // we need the MD to be populated in case we decide to build an intercept
+        // stub to wrap the target in InitEarlyBoundNDirectTarget
+        NDirect::PopulateNDirectMethodDesc(pMD);
 
         pMD->InitEarlyBoundNDirectTarget();
     }
@@ -5973,16 +5970,7 @@ EXTERN_C LPVOID STDCALL NDirectImportWorker(NDirectMethodDesc* pMD)
             // With IL stubs, we don't have to do anything but ensure the DLL is loaded.
             //
 
-            if (!pMD->IsZapped())
-            {
-                NDirect::PopulateNDirectMethodDesc(pMD);
-            }
-            else
-            {
-                // must have been populated at NGEN time
-                _ASSERTE(pMD->GetLibName() != NULL);
-            }
-
+            NDirect::PopulateNDirectMethodDesc(pMD);
             pMD->CheckRestore();
 
             NDirectLink(pMD);

--- a/src/coreclr/vm/ecall.cpp
+++ b/src/coreclr/vm/ecall.cpp
@@ -317,9 +317,6 @@ DWORD ECall::GetIDForMethod(MethodDesc *pMD)
     }
     CONTRACTL_END;
 
-    // We should not go here for NGened methods
-    _ASSERTE(!pMD->IsZapped());
-
     INT ImplsIndex = FindImplsIndexForClass(pMD->GetMethodTable());
     if (ImplsIndex < 0)
         return 0;

--- a/src/coreclr/vm/field.cpp
+++ b/src/coreclr/vm/field.cpp
@@ -306,7 +306,7 @@ PTR_VOID FieldDesc::GetStaticAddressHandle(PTR_VOID base)
     if (IsRVA())
     {
         Module* pModule = GetModule();
-        PTR_VOID ret = pModule->GetRvaField(GetOffset(), IsZapped());
+        PTR_VOID ret = pModule->GetRvaField(GetOffset());
 
         _ASSERTE(!pModule->IsPEFile() || !pModule->IsRvaFieldTls(GetOffset()));
 

--- a/src/coreclr/vm/field.h
+++ b/src/coreclr/vm/field.h
@@ -586,15 +586,6 @@ public:
         return GetApproxEnclosingMethodTable()->GetModule();
     }
 
-    BOOL IsZapped()
-    {
-        WRAPPER_NO_CONTRACT;
-
-        // Field Desc's are currently always saved into the same module as their
-        // corresponding method table.
-        return GetApproxEnclosingMethodTable()->IsZapped();
-    }
-
     Module *GetLoaderModule()
     {
         WRAPPER_NO_CONTRACT;

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -1516,7 +1516,7 @@ void CEEInfo::getFieldInfo (CORINFO_RESOLVED_TOKEN * pResolvedToken,
                 fieldAccessor = intrinsicAccessor;
             }
             else
-            if (m_pMethodBeingCompiled->IsZapped() || IsCompilingForNGen() ||
+            if (IsCompilingForNGen() ||
                 // Static fields are not pinned in collectible types. We will always access
                 // them using a helper since the address cannot be embeded into the code.
                 pFieldMT->Collectible() ||
@@ -3816,7 +3816,7 @@ CorInfoInitClassResult CEEInfo::initClass(
 
     MethodDesc *methodBeingCompiled = m_pMethodBeingCompiled;
 
-    BOOL fMethodZappedOrNGen = methodBeingCompiled->IsZapped() || IsCompilingForNGen();
+    BOOL fMethodZappedOrNGen = IsCompilingForNGen();
 
     MethodTable *pTypeToInitMT = typeToInitTH.AsMethodTable();
 

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -1400,21 +1400,6 @@ DWORD MethodDesc::GetImplAttrs()
 }
 
 //*******************************************************************************
-Module* MethodDesc::GetZapModule()
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-        FORBID_FAULT;
-        SUPPORTS_DAC;
-    }
-    CONTRACTL_END
-
-    return NULL;
-}
-
-//*******************************************************************************
 Module* MethodDesc::GetLoaderModule()
 {
     CONTRACTL

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -2978,8 +2978,6 @@ PCODE MethodDescChunk::GetTemporaryEntryPoint(int index)
 {
     LIMITED_METHOD_CONTRACT;
 
-    _ASSERTE(HasTemporaryEntryPoints());
-
 #ifdef HAS_COMPACT_ENTRYPOINTS
     if (HasCompactEntryPoints())
     {
@@ -3013,8 +3011,6 @@ PCODE MethodDesc::GetTemporaryEntryPoint()
     CONTRACTL_END;
 
     MethodDescChunk* pChunk = GetMethodDescChunk();
-    _ASSERTE(pChunk->HasTemporaryEntryPoints());
-
     int lo = 0, hi = pChunk->GetCount() - 1;
 
     // Find the temporary entrypoint in the chunk by binary search
@@ -4061,23 +4057,20 @@ MethodDescChunk::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
         pMT->EnumMemoryRegions(flags);
     }
 
-    if (HasTemporaryEntryPoints())
-    {
-        SIZE_T size;
+    SIZE_T size;
 
 #ifdef HAS_COMPACT_ENTRYPOINTS
-        if (HasCompactEntryPoints())
-        {
-            size = SizeOfCompactEntryPoints(GetCount());
-        }
-        else
-#endif // HAS_COMPACT_ENTRYPOINTS
-        {
-            size = Precode::SizeOfTemporaryEntryPoints(GetTemporaryEntryPoints(), GetCount());
-        }
-
-        DacEnumMemoryRegion(GetTemporaryEntryPoints(), size);
+    if (HasCompactEntryPoints())
+    {
+        size = SizeOfCompactEntryPoints(GetCount());
     }
+    else
+#endif // HAS_COMPACT_ENTRYPOINTS
+    {
+        size = Precode::SizeOfTemporaryEntryPoints(GetTemporaryEntryPoints(), GetCount());
+    }
+
+    DacEnumMemoryRegion(GetTemporaryEntryPoints(), size);
 
     MethodDesc * pMD = GetFirstMethodDesc();
     MethodDesc * pOldMD = NULL;

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -518,9 +518,6 @@ public:
 
     Module* GetZapModule();
 
-    // Does this immediate item live in an NGEN module?
-    BOOL IsZapped();
-
     // Strip off method and class instantiation if present and replace by the typical instantiation
     // e.g. C<int>.m<string> -> C<T>.m<U>.  Does not modify the MethodDesc, but returns
     // the appropriate stripped MethodDesc.
@@ -1695,7 +1692,7 @@ public:
     void PrepareForUseAsADependencyOfANativeImage()
     {
         WRAPPER_NO_CONTRACT;
-        if (!IsZapped() && !HaveValueTypeParametersBeenWalked())
+        if (!HaveValueTypeParametersBeenWalked())
             PrepareForUseAsADependencyOfANativeImageWorker();
     }
 
@@ -1712,7 +1709,7 @@ protected:
                                                                       // These are seperate to allow the flags space available and used to be obvious here
                                                                       // and for the logic that splits the token to be algorithmically generated based on the
                                                                       // #define
-        enum_flag3_HasForwardedValuetypeParameter           = 0x4000, // Indicates that a type-forwarded type is used as a valuetype parameter (this flag is only valid for ngenned items)
+        // unused                                           = 0x4000,
         enum_flag3_ValueTypeParametersWalked                = 0x4000, // Indicates that all typeref's in the signature of the method have been resolved to typedefs (or that process failed) (this flag is only valid for non-ngenned methods)
         enum_flag3_DoesNotHaveEquivalentValuetypeParameters = 0x8000, // Indicates that we have verified that there are no equivalent valuetype parameters for this method
     };
@@ -1842,26 +1839,12 @@ public:
     }
 #endif // FEATURE_TYPEEQUIVALENCE
 
-    inline BOOL HasForwardedValuetypeParameter()
-    {
-        LIMITED_METHOD_DAC_CONTRACT;
-        // This should only be asked of Zapped MethodDescs
-        _ASSERTE(IsZapped());
-        return (m_wFlags3AndTokenRemainder & enum_flag3_HasForwardedValuetypeParameter) != 0;
-    }
-
-    inline void SetHasForwardedValuetypeParameter()
-    {
-        LIMITED_METHOD_CONTRACT;
-        InterlockedUpdateFlags3(enum_flag3_HasForwardedValuetypeParameter, TRUE);
-    }
-
     inline BOOL HaveValueTypeParametersBeenWalked()
     {
         LIMITED_METHOD_DAC_CONTRACT;
 
         // This should only be asked of non-Zapped MethodDescs, and only during execution (not compilation)
-        _ASSERTE(!IsZapped() && !IsCompilationProcess());
+        _ASSERTE(!IsCompilationProcess());
 
         return (m_wFlags3AndTokenRemainder & enum_flag3_ValueTypeParametersWalked) != 0;
     }
@@ -1870,7 +1853,7 @@ public:
     {
         LIMITED_METHOD_CONTRACT;
 
-        _ASSERTE(!IsZapped() && !IsCompilationProcess());
+        _ASSERTE(!IsCompilationProcess());
 
         InterlockedUpdateFlags3(enum_flag3_ValueTypeParametersWalked, TRUE);
     }

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -516,8 +516,6 @@ public:
 
     Module* GetLoaderModule();
 
-    Module* GetZapModule();
-
     // Strip off method and class instantiation if present and replace by the typical instantiation
     // e.g. C<int>.m<string> -> C<T>.m<U>.  Does not modify the MethodDesc, but returns
     // the appropriate stripped MethodDesc.

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -252,7 +252,6 @@ public:
     void SetMethodEntryPoint(PCODE addr);
     BOOL SetStableEntryPointInterlocked(PCODE addr);
 
-    BOOL HasTemporaryEntryPoint();
     PCODE GetTemporaryEntryPoint();
 
     void SetTemporaryEntryPoint(LoaderAllocator *pLoaderAllocator, AllocMemTracker *pamTracker);
@@ -2228,7 +2227,7 @@ class MethodDescChunk
                                                                      // and for the logic that splits the token to be algorithmically generated based on the
                                                                      // #define
         enum_flag_HasCompactEntrypoints                    = 0x4000, // Compact temporary entry points
-        enum_flag_IsZapped                                 = 0x8000, // This chunk lives in NGen module
+        // unused                                          = 0x8000,
     };
 
 public:
@@ -2244,16 +2243,9 @@ public:
                                         MethodTable *initialMT,
                                         class AllocMemTracker *pamTracker);
 
-    BOOL HasTemporaryEntryPoints()
-    {
-        LIMITED_METHOD_CONTRACT;
-        return !IsZapped();
-    }
-
     TADDR GetTemporaryEntryPoints()
     {
         LIMITED_METHOD_CONTRACT;
-        _ASSERTE(HasTemporaryEntryPoints());
         return *(dac_cast<DPTR(TADDR)>(this) - 1);
     }
 
@@ -2354,12 +2346,6 @@ public:
         return m_count + 1;
     }
 
-    BOOL IsZapped()
-    {
-        LIMITED_METHOD_DAC_CONTRACT;
-        return FALSE;
-    }
-
     inline BOOL HasCompactEntryPoints()
     {
         LIMITED_METHOD_DAC_CONTRACT;
@@ -2397,12 +2383,6 @@ public:
 #endif
 
 private:
-    void SetIsZapped()
-    {
-        LIMITED_METHOD_CONTRACT;
-        m_flagsAndTokenRange |= enum_flag_IsZapped;
-    }
-
     void SetHasCompactEntryPoints()
     {
         LIMITED_METHOD_CONTRACT;

--- a/src/coreclr/vm/method.inl
+++ b/src/coreclr/vm/method.inl
@@ -15,12 +15,6 @@ inline InstantiatedMethodDesc* MethodDesc::AsInstantiatedMethodDesc() const
     return dac_cast<PTR_InstantiatedMethodDesc>(this);
 }
 
-inline BOOL MethodDesc::IsZapped()
-{
-    WRAPPER_NO_CONTRACT;
-    return FALSE;
-}
-
 inline PTR_DynamicResolver DynamicMethodDesc::GetResolver()
 {
     LIMITED_METHOD_CONTRACT;

--- a/src/coreclr/vm/method.inl
+++ b/src/coreclr/vm/method.inl
@@ -6,12 +6,6 @@
 #ifndef _METHOD_INL_
 #define _METHOD_INL_
 
-inline BOOL MethodDesc::HasTemporaryEntryPoint()
-{
-    WRAPPER_NO_CONTRACT;
-    return GetMethodDescChunk()->HasTemporaryEntryPoints();
-}
-
 inline InstantiatedMethodDesc* MethodDesc::AsInstantiatedMethodDesc() const
 {
     WRAPPER_NO_CONTRACT;

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -4034,27 +4034,6 @@ static void CheckForTypeForwardedTypeRefParameter(
         pLocals->fDependsOnEquivalentOrForwardedStructs = TRUE;
 }
 
-// Callback for code:MethodDesc::WalkValueTypeParameters (of type code:WalkValueTypeParameterFnPtr)
-static void LoadTypeDefOrRefAssembly(
-    Module *         pModule,
-    mdToken          token,
-    Module *         pDefModule,
-    mdToken          defToken,
-    const SigParser *ptr,
-    SigTypeContext * pTypeContext,
-    void *           pData)
-{
-    STANDARD_VM_CONTRACT;
-
-    DoFullyLoadLocals * pLocals = (DoFullyLoadLocals *)pData;
-
-    CheckForTypeForwardedTypeRefParameterLocals locals;
-    locals.pModule = pModule;
-    locals.pfTypeForwarderFound = NULL; // By passing NULL here, we simply resolve the token to TypeDef.
-
-    WalkValueTypeTypeDefOrRefs(ptr, CheckForTypeForwardedTypeRef, &locals);
-}
-
 #endif //!DACCESS_COMPILE
 
 void MethodTable::DoFullyLoad(Generics::RecursionGraph * const pVisited,  const ClassLoadLevel level, DFLPendingList * const pPending,
@@ -4304,15 +4283,6 @@ void MethodTable::DoFullyLoad(Generics::RecursionGraph * const pVisited,  const 
                 {
                 }
                 EX_END_CATCH(RethrowTerminalExceptions);
-
-                // This marks the class as needing restore.
-                if (locals.fHasTypeForwarderDependentStructParameter && !pMD->IsZapped())
-                    pMD->SetHasForwardedValuetypeParameter();
-            }
-            else if (pMD->IsZapped() && pMD->HasForwardedValuetypeParameter())
-            {
-                pMD->WalkValueTypeParameters(this, LoadTypeDefOrRefAssembly, NULL);
-                locals.fDependsOnEquivalentOrForwardedStructs = TRUE;
             }
 
 #ifdef FEATURE_TYPEEQUIVALENCE

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -592,9 +592,6 @@ public:
     // then they will all belong to the same domain.
     PTR_BaseDomain GetDomain();
 
-    // Does this immediate item live in an NGEN module?
-    BOOL IsZapped();
-
     // For types that are part of an ngen-ed assembly this gets the
     // Module* that contains this methodtable.
     PTR_Module GetZapModule();
@@ -1259,11 +1256,7 @@ public:
         {
             return VTableIndir2_t::GetValueMaybeNullAtPtr(pSlot);
         }
-        else if (IsZapped() && slotNumber >= GetNumVirtuals())
-        {
-            // Non-virtual slots in NGened images are relative pointers
-            return RelativePointer<PCODE>::GetValueAtPtr(pSlot);
-        }
+
         return *dac_cast<PTR_PCODE>(pSlot);
     }
 
@@ -1314,10 +1307,6 @@ public:
     TADDR GetSlotPtr(UINT32 slotNum)
     {
         WRAPPER_NO_CONTRACT;
-
-        // Slots in NGened images are relative pointers
-        CONSISTENCY_CHECK(!IsZapped());
-
         return GetSlotPtrRaw(slotNum);
     }
 
@@ -3619,10 +3608,8 @@ private:
         enum_flag_HasNonVirtualSlots        = 0x0008,
         enum_flag_HasModuleOverride         = 0x0010,
 
-        enum_flag_IsZapped                  = 0x0020, // This could be fetched from m_pLoaderModule if we run out of flags
-
-        enum_flag_IsPreRestored             = 0x0040, // Class does not need restore
-                                                      // This flag is set only for NGENed classes (IsZapped is true)
+        // unused                           = 0x0020,
+        // unused                           = 0x0040,
 
         enum_flag_HasModuleDependencies     = 0x0080,
 

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -592,10 +592,6 @@ public:
     // then they will all belong to the same domain.
     PTR_BaseDomain GetDomain();
 
-    // For types that are part of an ngen-ed assembly this gets the
-    // Module* that contains this methodtable.
-    PTR_Module GetZapModule();
-
     // For regular, non-constructed types, GetLoaderModule() == GetModule()
     // For constructed types (e.g. int[], Dict<int[], C>) the hash table through which a type
     // is accessed lives in a "loader module". The rule for determining the loader module must ensure

--- a/src/coreclr/vm/methodtable.inl
+++ b/src/coreclr/vm/methodtable.inl
@@ -112,28 +112,12 @@ inline BOOL MethodTable::IsClassPointerValid()
 }
 
 //==========================================================================================
-// Does this immediate item live in an NGEN module?
-inline BOOL MethodTable::IsZapped()
-{
-    LIMITED_METHOD_DAC_CONTRACT;
-
-    return FALSE;
-}
-
-//==========================================================================================
 // For types that are part of an ngen-ed assembly this gets the
 // Module* that contains this methodtable.
 inline PTR_Module MethodTable::GetZapModule()
 {
     LIMITED_METHOD_DAC_CONTRACT;
-
-    PTR_Module zapModule = NULL;
-    if (IsZapped())
-    {
-        zapModule = ReadPointer(this, &MethodTable::m_pLoaderModule);
-    }
-
-    return zapModule;
+    return NULL;
 }
 
 //==========================================================================================

--- a/src/coreclr/vm/methodtable.inl
+++ b/src/coreclr/vm/methodtable.inl
@@ -112,15 +112,6 @@ inline BOOL MethodTable::IsClassPointerValid()
 }
 
 //==========================================================================================
-// For types that are part of an ngen-ed assembly this gets the
-// Module* that contains this methodtable.
-inline PTR_Module MethodTable::GetZapModule()
-{
-    LIMITED_METHOD_DAC_CONTRACT;
-    return NULL;
-}
-
-//==========================================================================================
 inline PTR_Module MethodTable::GetLoaderModule()
 {
     LIMITED_METHOD_DAC_CONTRACT;

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -8912,9 +8912,6 @@ void MethodTableBuilder::CopyExactParentSlots(MethodTable *pMT, MethodTable *pAp
     }
     CONTRACTL_END;
 
-    if (pMT->IsZapped())
-        return;
-
     DWORD nParentVirtuals = pMT->GetNumParentVirtuals();
     if (nParentVirtuals == 0)
         return;

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -126,9 +126,6 @@ PCODE MethodDesc::DoBackpatch(MethodTable * pMT, MethodTable *pDispatchingMT, BO
     {
         _ASSERTE(pTarget == GetStableEntryPoint());
 
-        if (!HasTemporaryEntryPoint())
-            return pTarget;
-
         pExpected = GetTemporaryEntryPoint();
         if (pExpected == pTarget)
             return pTarget;

--- a/src/coreclr/vm/typedesc.cpp
+++ b/src/coreclr/vm/typedesc.cpp
@@ -92,14 +92,6 @@ PTR_Module TypeDesc::GetLoaderModule()
     }
 }
 
-
-PTR_Module TypeDesc::GetZapModule()
-{
-    WRAPPER_NO_CONTRACT;
-    SUPPORTS_DAC;
-    return ExecutionManager::FindZapModule(dac_cast<TADDR>(this));
-}
-
 PTR_BaseDomain TypeDesc::GetDomain()
 {
     CONTRACTL

--- a/src/coreclr/vm/typedesc.h
+++ b/src/coreclr/vm/typedesc.h
@@ -159,9 +159,6 @@ public:
     // The module that defined the underlying type
     PTR_Module GetModule();
 
-    // The ngen'ed module where this type-desc lives
-    PTR_Module GetZapModule();
-
     // The module where this type lives for the purposes of loading and prejitting
     // See ComputeLoaderModule for more information
     PTR_Module GetLoaderModule();

--- a/src/coreclr/vm/typehandle.cpp
+++ b/src/coreclr/vm/typehandle.cpp
@@ -297,16 +297,6 @@ PTR_Module TypeHandle::GetLoaderModule() const
         return AsMethodTable()->GetLoaderModule();
 }
 
-PTR_Module TypeHandle::GetZapModule() const
-{
-    LIMITED_METHOD_DAC_CONTRACT;
-
-    if (IsTypeDesc())
-        return AsTypeDesc()->GetZapModule();
-    else
-        return AsMethodTable()->GetZapModule();
-}
-
 PTR_BaseDomain TypeHandle::GetDomain() const
 {
     LIMITED_METHOD_DAC_CONTRACT;

--- a/src/coreclr/vm/typehandle.h
+++ b/src/coreclr/vm/typehandle.h
@@ -423,12 +423,6 @@ public:
     // (First strip off array/ptr qualifiers and generic type arguments)
     PTR_Module GetModule() const;
 
-    // The ngen'ed module where this type lives
-    PTR_Module GetZapModule() const;
-
-    // Does this immediate item live in an NGEN module?
-    BOOL IsZapped() const;
-
     // The module where this type lives for the purposes of loading and prejitting
     // Note: NGen time result might differ from runtime result for parametrized types (generics, arrays, etc.)
     // See code:ClassLoader::ComputeLoaderModule or file:clsload.hpp#LoaderModule for more information

--- a/src/coreclr/vm/typehandle.inl
+++ b/src/coreclr/vm/typehandle.inl
@@ -66,13 +66,6 @@ inline unsigned int TypeHandle::GetRank() const
     return AsMethodTable()->GetRank();
 }
 
-inline BOOL TypeHandle::IsZapped() const
-{
-    LIMITED_METHOD_DAC_CONTRACT;
-
-    return FALSE;
-}
-
 // Methods to allow you get get a the two possible representations
 inline PTR_MethodTable TypeHandle::AsMethodTable() const
 {


### PR DESCRIPTION
Remove
- `IsZapped` from `FieldDesc`, `MethodDesc`, `MethodTable`, `TypeHandle` (always false)
- `GetZapModule` from `MethodDesc`, `MethodTable`, `TypeDesc`, `TypeHandle` (always null)

This frees up two method table flags (`enum_flag_IsZapped`, `enum_flag_IsPreRestored`).

cc @AaronRobinsonMSFT @jkoritzinsky @davidwrighton