### PR TITLE
Disable test: ConstructorTests.PathForChildDictionaryFails()

### DIFF
--- a/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.Exceptions.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.Exceptions.cs
@@ -204,6 +204,7 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/39055 (already fixed in main)")]
         public async Task PathForChildDictionaryFails()
         {
             JsonException e = await Assert.ThrowsAsync<JsonException>(() => JsonSerializerWrapperForString.DeserializeWrapper<RootClass>(@"{""Child"":{""MyDictionary"":{""Key"": bad]"));


### PR DESCRIPTION
Now fixed in main(), but fix is not ported to 6.0 so this disables the test to avoid CI issues.

Original issue: https://github.com/dotnet/runtime/issues/39055
