### PR TITLE
Add Fedora 36 to the RID graph

### DIFF
--- a/src/libraries/Microsoft.NETCore.Platforms/readme.md
+++ b/src/libraries/Microsoft.NETCore.Platforms/readme.md
@@ -100,7 +100,7 @@ For example:
 
 This will create a new RID for `myLinuxDistro` where `myLinuxDistro` should be the string used for the `ID=` value in the `/etc/os-release` file.
 
-Whenever modifying the `runtimeGroups.props` you should rebuild the project with `/p:UpdateRuntimeFiles=true` so that your changes will be regenerated in the checked-in `runtime.json`.
+Whenever modifying the `runtimeGroups.props` you should rebuild the project with `/t:UpdateRuntimeJson /p:UpdateRuntimeFiles=true` so that your changes will be regenerated in the checked-in `runtime.json`.
 
 RuntimeGroup items have the following format:
 - `Identity`: the base string for the RID, without version architecture, or qualifiers.

--- a/src/libraries/Microsoft.NETCore.Platforms/readme.md
+++ b/src/libraries/Microsoft.NETCore.Platforms/readme.md
@@ -100,7 +100,7 @@ For example:
 
 This will create a new RID for `myLinuxDistro` where `myLinuxDistro` should be the string used for the `ID=` value in the `/etc/os-release` file.
 
-Whenever modifying the `runtimeGroups.props` you should rebuild the project with `/t:UpdateRuntimeJson /p:UpdateRuntimeFiles=true` so that your changes will be regenerated in the checked-in `runtime.json`.
+Whenever modifying the `runtimeGroups.props` make sure to pack the project via the `dotnet pack` command and inspect if the generated package contains the desired changes.
 
 RuntimeGroup items have the following format:
 - `Identity`: the base string for the RID, without version architecture, or qualifiers.

--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtime.compatibility.json
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtime.compatibility.json
@@ -2883,6 +2883,38 @@
     "any",
     "base"
   ],
+  "fedora.36": [
+    "fedora.36",
+    "fedora",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "fedora.36-arm64": [
+    "fedora.36-arm64",
+    "fedora.36",
+    "fedora-arm64",
+    "fedora",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "fedora.36-x64": [
+    "fedora.36-x64",
+    "fedora.36",
+    "fedora-x64",
+    "fedora",
+    "linux-x64",
+    "linux",
+    "unix-x64",
+    "unix",
+    "any",
+    "base"
+  ],
   "freebsd": [
     "freebsd",
     "unix",

--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json
@@ -1106,6 +1106,23 @@
         "fedora-x64"
       ]
     },
+    "fedora.36": {
+      "#import": [
+        "fedora"
+      ]
+    },
+    "fedora.36-arm64": {
+      "#import": [
+        "fedora.36",
+        "fedora-arm64"
+      ]
+    },
+    "fedora.36-x64": {
+      "#import": [
+        "fedora.36",
+        "fedora-x64"
+      ]
+    },
     "freebsd": {
       "#import": [
         "unix"

--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtimeGroups.props
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtimeGroups.props
@@ -72,7 +72,7 @@
     <RuntimeGroup Include="fedora">
       <Parent>linux</Parent>
       <Architectures>x64;arm64</Architectures>
-      <Versions>23;24;25;26;27;28;29;30;31;32;33;34;35</Versions>
+      <Versions>23;24;25;26;27;28;29;30;31;32;33;34;35;36</Versions>
       <TreatVersionsAsCompatible>false</TreatVersionsAsCompatible>
     </RuntimeGroup>
 


### PR DESCRIPTION
Fedora 36 is under development:

    $ podman run -it registry.fedoraproject.org/fedora:rawhide /bin/cat /etc/os-release
    NAME="Fedora Linux"
    VERSION="36 (Container Image Prerelease)"
    ID=fedora
    VERSION_ID=36
    VERSION_CODENAME=""
    PLATFORM_ID="platform:f36"
    PRETTY_NAME="Fedora Linux 36 (Container Image Prerelease)"
    ANSI_COLOR="0;38;2;60;110;180"
    LOGO=fedora-logo-icon
    CPE_NAME="cpe:/o:fedoraproject:fedora:36"
    HOME_URL="https://fedoraproject.org/"
    DOCUMENTATION_URL="https://docs.fedoraproject.org/en-US/fedora/rawhide/system-administrators-guide/"
    SUPPORT_URL="https://fedoraproject.org/wiki/Communicating_and_getting_help"
    BUG_REPORT_URL="https://bugzilla.redhat.com/"
    REDHAT_BUGZILLA_PRODUCT="Fedora"
    REDHAT_BUGZILLA_PRODUCT_VERSION=rawhide
    REDHAT_SUPPORT_PRODUCT="Fedora"
    REDHAT_SUPPORT_PRODUCT_VERSION=rawhide
    PRIVACY_POLICY_URL="https://fedoraproject.org/wiki/Legal:PrivacyPolicy"
    VARIANT="Container Image"
    VARIANT_ID=container

I couldn't get the changes runtime.json to show up until I built with a customtarget. I updated readme.md with that extra information too.