### PR TITLE
Tool to stress tiered compilation (and PGO)

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -216,6 +216,7 @@
 
   <ItemGroup Condition="$(_subset.Contains('+clr.tools+'))">
     <ProjectToBuild Include="$(CoreClrProjectRoot)tools\runincontext\runincontext.csproj;
+                             $(CoreClrProjectRoot)tools\tieringtest\tieringtest.csproj;
                              $(CoreClrProjectRoot)tools\r2rdump\R2RDump.csproj;
                              $(CoreClrProjectRoot)tools\dotnet-pgo\dotnet-pgo.csproj;
                              $(CoreClrProjectRoot)tools\r2rtest\R2RTest.csproj" Category="clr" Condition="'$(DotNetBuildFromSource)' != 'true'"/>

--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -16,6 +16,7 @@ parameters:
   stagedBuild: false
   displayNameArgs: ''
   runInUnloadableContext: false
+  tieringTest: false
   runtimeVariant: ''
   variables: {}
   pool: ''
@@ -359,6 +360,7 @@ jobs:
 
         compositeBuildMode: ${{ parameters.compositeBuildMode }}
         runInUnloadableContext: ${{ parameters.runInUnloadableContext }}
+        tieringTest: ${{ parameters.tieringTest }}
 
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           # Access token variable for internal project from the

--- a/eng/pipelines/common/templates/runtimes/send-to-helix-step.yml
+++ b/eng/pipelines/common/templates/runtimes/send-to-helix-step.yml
@@ -21,6 +21,7 @@ parameters:
   compositeBuildMode: false
   helixProjectArguments: ''
   runInUnloadableContext: ''
+  tieringTest: ''
   longRunningGcTests: ''
   gcSimulatorTests: ''
   runtimeFlavorDisplayName: 'CoreCLR'
@@ -49,6 +50,7 @@ steps:
       _RunCrossGen2: ${{ parameters.runCrossGen2 }}
       _CompositeBuildMode: ${{ parameters.compositeBuildMode }}
       _RunInUnloadableContext: ${{ parameters.runInUnloadableContext }}
+      _TieringTest: ${{ parameters.runInUnloadableContext }}
       _LongRunningGcTests: ${{ parameters.longRunningGcTests }}
       _GcSimulatorTests: ${{ parameters.gcSimulatorTests }}
       _Scenarios: ${{ join(',', parameters.scenarios) }}

--- a/eng/pipelines/coreclr/tieringtest.yml
+++ b/eng/pipelines/coreclr/tieringtest.yml
@@ -1,0 +1,49 @@
+trigger: none
+
+schedules:
+- cron: "0 18 * * 6,0"
+  displayName: Sat and Sun at 10:00 AM (UTC-8:00)
+  branches:
+    include:
+    - main
+  always: true
+
+jobs:
+
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_x64
+    - windows_x64
+    - windows_x86
+    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+    jobParameters:
+      testGroup: outerloop
+
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+    buildConfig: checked
+    platforms:
+    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+    jobParameters:
+      testGroup: outerloop
+      liveLibrariesBuildConfig: Release
+
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_x64
+    - windows_x64
+    - windows_x86
+    helixQueueGroup: ci
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: outerloop
+      tieringTest: true
+      displayNameArgs: TieringTest
+      liveLibrariesBuildConfig: Release

--- a/src/coreclr/tools/tieringtest/tieringtest.cs
+++ b/src/coreclr/tools/tieringtest/tieringtest.cs
@@ -1,0 +1,223 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Threading;
+
+class Program
+{
+    // Normalybehavior is to not print anything on success.
+    //
+    static bool verbose = false;
+
+    // Repeatedly execute a test case's Main method so that methods jitted
+    // by the test can get rejitted at Tier1.
+    //
+    static int Main(string[] args)
+    {
+        string testAssemblyName = args[0];
+
+        // We'll stop iterating if total test time exceeds this value (in ms).
+        //
+        int timeout = 10_000;
+
+        // Some tests return zero for success.
+        //
+        int expectedResult = 100;
+
+        string[][] zeroReturnValuePatterns = {
+            new string[] { "JIT", "jit64", "regress", "vsw", "102754", "test1"},
+            new string[] { "JIT", "Regression", "CLR-x86-JIT", "V1-M09", "b16102", "b16102"},
+        };
+
+        foreach (string[] pattern in zeroReturnValuePatterns)
+        {
+            if (testAssemblyName.IndexOf(Path.Join(pattern)) > 0)
+            {
+                expectedResult = 0;
+                break;
+            }
+        }
+
+        // Exclude tests that seem to be incompatible.
+        // Todo: root cause these and fix tests if possible.
+        //
+        // With Full PGO:
+        // RngchkStress2_o can hit a jit assert: '!m_failedToConverge' in 'SimpleArray_01.Test:Test1()' during 'Profile incorporation'
+        // GitHub_25027 can hit a jit assert: 'verCurrentState.esStackDepth == 0' in 'X:Main():int' during 'Morph - Inlining'
+        //
+        string[][] exclusionPatterns = {
+            new string[] { "JIT", "jit64", "opt", "cse", "VolatileTest_op" },
+            new string[] { "JIT", "jit64", "opt", "rngchk", "ArrayWithThread_o" },
+            new string[] { "baseservices", "threading", "threadstatic", "ThreadStatic01" },
+            new string[] { "GC", "Scenarios", "ReflectObj", "reflectobj"},
+            new string[] { "baseservices", "threading", "mutex", "openexisting", "openmutexpos4"},
+            new string[] { "GC", "Scenarios", "NDPin", "ndpinfinal"},
+            new string[] { "JIT", "Regression", "JitBlue", "GitHub_4044", "GitHub_4044"},
+            new string[] { "JIT", "HardwareIntrinsics", "X86", "Regression", "GitHub_21666", "GitHub_21666_ro"},
+            new string[] { "Interop", "NativeLibrary", "API", "NativeLibraryTests"},
+            new string[] { "baseservices", "compilerservices", "FixedAddressValueType", "FixedAddressValueType"},
+            new string[] { "GC", "LargeMemory", "API", "gc", "gettotalmemory" },
+
+            new string[] { "JIT", "jit64", "opt", "rngchk", "RngchkStress2_o" },
+            new string[] { "JIT", "Regression", "JitBlue", "GitHub_25027", "GitHub_25027" },
+        };
+
+        foreach (string[] pattern in exclusionPatterns)
+        {
+            if (testAssemblyName.IndexOf(Path.Join(pattern)) > 0)
+            {
+                if (verbose)
+                {
+                    Console.WriteLine($"Test {Path.Join(pattern)} excluded; marked as incompatible");
+                }
+                return expectedResult;
+            }
+        }
+
+        AssemblyLoadContext alc = AssemblyLoadContext.Default;
+        Assembly testAssembly = alc.LoadFromAssemblyPath(testAssemblyName);
+        MethodInfo main = testAssembly.EntryPoint;
+
+        if (main == null)
+        {
+            Console.WriteLine($"Can't find entry point in {Path.GetFileName(args[0])}");
+            return -1;
+        }
+
+        string[] mainArgs = new string[args.Length - 1];
+        Array.Copy(args, 1, mainArgs, 0, mainArgs.Length);
+
+        // Console.WriteLine($"Found entry point {main.Name} in {Path.GetFileName(args[0])}");
+
+        // See if main wants any args.
+        //
+        var mainParams = main.GetParameters();
+
+        int result = 0;
+
+        // Repeatedly invoke main to get things to pass through Tier0 and rejit at Tier1
+        //
+        int warmup = 40;
+        int final = 5;
+        int total = warmup + final;
+        int i = 0;
+        int sleepInterval = 5;
+        Stopwatch s = new Stopwatch();
+        s.Start();
+
+        // We might decide to give up on this test, for reasons.
+        //
+        // If the test fails at iteration 0, assume it's incompatible with the way we're running it
+        // and don't report as a failure.
+        //
+        // If the test fails at iteration 1, assume it's got some bit of state that carries over
+        // from one call to main to the next, and so don't report it as failure.
+        //
+        // If the test takes too long, just give up on iterating it.
+        //
+        bool giveUp = false;
+
+        try
+        {
+
+            for (; i < warmup && !giveUp; i++)
+            {
+                if (mainParams.Length == 0)
+                {
+                    result = (int)main.Invoke(null, new object[] { });
+                }
+                else
+                {
+                    result = (int)main.Invoke(null, new object[] { mainArgs });
+                }
+
+                if (result != expectedResult)
+                {
+                    if (i < 2)
+                    {
+                        Console.WriteLine($"[tieringtest] test failed at iteration {i} with result {result}. Test is likely incompatible.");
+                        result = expectedResult;
+                    }
+                    else
+                    {
+                        Console.WriteLine($"[tieringtest] test failed at iteration {i}: {result} (expected {expectedResult})");
+                    }
+                    giveUp = true;
+                    break;
+                }
+
+                // Don't iterate if test is running long.
+                //
+                if (s.ElapsedMilliseconds > timeout)
+                {
+                    Console.WriteLine($"[tieringtest] test running long ({s.ElapsedMilliseconds / (i + 1)} ms/iteration). Giving up at iteration {i}");
+                    giveUp = true;
+                    break;
+                }
+
+                // Give TC a chance to jit some things.
+                //
+                Thread.Sleep(sleepInterval);
+            }
+
+            for (; i < total && !giveUp; i++)
+            {
+                if (mainParams.Length == 0)
+                {
+                    result = (int)main.Invoke(null, new object[] { });
+                }
+                else
+                {
+                    result = (int)main.Invoke(null, new object[] { mainArgs });
+                }
+
+                if (result != expectedResult)
+                {
+                    Console.WriteLine($"[tieringtest] failed at iteration {i}: {result} (expected {expectedResult})");
+                    giveUp = true;
+                    break;
+                }
+
+                // Don't iterate if test is running long.
+                //
+                if (s.ElapsedMilliseconds > timeout)
+                {
+                    Console.WriteLine($"[tieringtest] test running long ({s.ElapsedMilliseconds / (i + 1)} ms/iteration). Giving up at iteration {i}");
+                    giveUp = true;
+                    break;
+                }
+            }
+
+            if (result == expectedResult)
+            {
+                if (verbose)
+                {
+                    Console.WriteLine($"[tieringtest] ran {total} test iterations sucessfully");
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            if (i < 2)
+            {
+                if (verbose)
+                {
+                    Console.WriteLine($"[tieringtest] test failed at iteration {i} with exception {e.Message}. Test is likely incompatible.");
+                }
+                result = expectedResult;
+            }
+            else
+            {
+                Console.WriteLine($"[tieringtest] test failed at iteration {i} with exception {e.Message}");
+                result = -1;
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/coreclr/tools/tieringtest/tieringtest.csproj
+++ b/src/coreclr/tools/tieringtest/tieringtest.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
+    <RuntimeFrameworkVersion>$(MicrosoftNETCoreAppVersion)</RuntimeFrameworkVersion>
+    <UseAppHost>false</UseAppHost>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <OutputPath>$(RuntimeBinDir)</OutputPath>
+  </PropertyGroup>
+</Project>

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -31,6 +31,7 @@
         LongRunningGCTests=$(_LongRunningGCTests);
         GcSimulatorTests=$(_GcSimulatorTests);
         RunInUnloadableContext=$(_RunInUnloadableContext);
+        TieringTest=$(_TieringTest);
         TimeoutPerTestCollectionInMinutes=$(_TimeoutPerTestCollectionInMinutes);
         TimeoutPerTestInMinutes=$(_TimeoutPerTestInMinutes);
         RuntimeVariant=$(_RuntimeVariant);
@@ -197,6 +198,8 @@
     <Copy SourceFiles="@(_XUnitConsoleRunnerFiles)" DestinationFolder="$(CoreRootDirectory)\xunit" />
     <Copy SourceFiles="$(MSBuildThisFileDirectory)scripts\runincontext.cmd" DestinationFolder="$(CoreRootDirectory)" Condition=" '$(TestWrapperTargetsWindows)' == 'true' and '$(_RunInUnloadableContext)' == 'true'" />
     <Copy SourceFiles="$(MSBuildThisFileDirectory)scripts/runincontext.sh" DestinationFolder="$(CoreRootDirectory)" Condition=" '$(TestWrapperTargetsWindows)' != 'true' and '$(_RunInUnloadableContext)' == 'true'" />
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)scripts\tieringtest.cmd" DestinationFolder="$(CoreRootDirectory)" Condition=" '$(TestWrapperTargetsWindows)' == 'true' and '$(_TieringTest)' == 'true'" />
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)scripts/tieringtest.sh" DestinationFolder="$(CoreRootDirectory)" Condition=" '$(TestWrapperTargetsWindows)' != 'true' and '$(_TieringTest)' == 'true'" />
   </Target>
 
   <Target Name="CreateTestEnvFiles">
@@ -273,6 +276,7 @@
     <HelixPreCommand Include="set RunningGCSimulatorTests=1" Condition=" '$(GcSimulatorTests)' == 'true' " />
     <HelixPreCommand Include="set RunInUnloadableContext=1" Condition=" '$(RunInUnloadableContext)' == 'true' " />
     <HelixPreCommand Include="set CLRCustomTestLauncher=%HELIX_CORRELATION_PAYLOAD%\runincontext.cmd" Condition=" '$(RunInUnloadableContext)' == 'true' " />
+    <HelixPreCommand Include="set CLRCustomTestLauncher=%HELIX_CORRELATION_PAYLOAD%\tieringtest.cmd" Condition=" '$(TieringTest)' == 'true' " />
     <HelixPreCommand Include="set __TestEnv=%HELIX_WORKITEM_PAYLOAD%\$(TestEnvFileName)" />
     <HelixPreCommand Include="set __TestTimeout=$(TimeoutPerTestInMilliseconds)" Condition=" '$(TimeoutPerTestInMilliseconds)' != '' " />
     <HelixPreCommand Include="set __CollectDumps=1" />
@@ -293,6 +297,7 @@
     <HelixPreCommand Include="export RunningGCSimulatorTests=1" Condition=" '$(GcSimulatorTests)' == 'true' " />
     <HelixPreCommand Include="export RunInUnloadableContext=1" Condition=" '$(RunInUnloadableContext)' == 'true' " />
     <HelixPreCommand Include="export CLRCustomTestLauncher=$HELIX_CORRELATION_PAYLOAD/runincontext.sh" Condition=" '$(RunInUnloadableContext)' == 'true' " />
+    <HelixPreCommand Include="export CLRCustomTestLauncher=$HELIX_CORRELATION_PAYLOAD/tieringtest.sh" Condition=" '$(TieringTest)' == 'true' " />
     <HelixPreCommand Include="export __TestEnv=$HELIX_WORKITEM_PAYLOAD/$(TestEnvFileName)" />
     <HelixPreCommand Include="export __TestTimeout=$(TimeoutPerTestInMilliseconds)" Condition=" '$(TimeoutPerTestInMilliseconds)' != '' " />
     <HelixPreCommand Include="export __CollectDumps=1" />

--- a/src/tests/Common/scripts/tieringtest.cmd
+++ b/src/tests/Common/scripts/tieringtest.cmd
@@ -1,0 +1,8 @@
+@rem This script is a bridge that allows .cmd files of individual tests to run repeatedly so methods
+@rem can tier up.
+@rem
+@rem To use this script, set the CLRCustomTestLauncher environment variable to the full path of this script.
+
+set CORE_LIBRARIES=%1
+%_DebuggerFullPath% "%CORE_ROOT%\corerun.exe" "%CORE_ROOT%\tieringtest.dll" %1%2 %3 %4 %5 %6 %7 %8 %9
+

--- a/src/tests/Common/scripts/tieringtest.sh
+++ b/src/tests/Common/scripts/tieringtest.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# This script is a bridge that allows .cmd files of individual tests to run the respective test executables
+# repeatedly so that more methods get rejitted at Tier1
+#
+# To use this script, set the CLRCustomTestLauncher environment variable to the full path of this script.
+
+export CORE_LIBRARIES=$1
+$_DebuggerFullPath "$CORE_ROOT/corerun" "$CORE_ROOT/tieringtest.dll" $1$2 "${@:3}"

--- a/src/tests/run.cmd
+++ b/src/tests/run.cmd
@@ -28,6 +28,7 @@ set __GCSimulatorTests=
 set __IlasmRoundTrip=
 set __PrintLastResultsOnly=
 set RunInUnloadableContext=
+set TieringTest=
 
 :Arg_Loop
 if "%1" == "" goto ArgsDone
@@ -70,6 +71,7 @@ REM change it to COMPlus_GCStress when we stop using xunit harness
 if /i "%1" == "gcstresslevel"                           (set COMPlus_GCStress=%2&set __TestTimeout=1800000&shift&shift&goto Arg_Loop)
 
 if /i "%1" == "runincontext"                            (set RunInUnloadableContext=1&shift&goto Arg_Loop)
+if /i "%1" == "tieringtest"                             (set TieringTest=1&shift&goto Arg_Loop)
 
 if /i not "%1" == "msbuildargs" goto SkipMsbuildArgs
 :: All the rest of the args will be collected and passed directly to msbuild.
@@ -143,6 +145,10 @@ if defined __PrintLastResultsOnly (
 
 if defined RunInUnloadableContext (
     set __RuntestPyArgs=%__RuntestPyArgs% --run_in_context
+)
+
+if defined TieringTest (
+    set __RuntestPyArgs=%__RuntestPyArgs% --tiering_test
 )
 
 REM Find python and set it to the variable PYTHON

--- a/src/tests/run.py
+++ b/src/tests/run.py
@@ -100,6 +100,7 @@ parser.add_argument("--analyze_results_only", dest="analyze_results_only", actio
 parser.add_argument("--verbose", dest="verbose", action="store_true", default=False)
 parser.add_argument("--limited_core_dumps", dest="limited_core_dumps", action="store_true", default=False)
 parser.add_argument("--run_in_context", dest="run_in_context", action="store_true", default=False)
+parser.add_argument("--tiering_test", dest="tiering_test", action="store_true", default=False)
 
 ################################################################################
 # Globals
@@ -885,6 +886,10 @@ def run_tests(args,
         os.environ["RunInUnloadableContext"] = "1";
         per_test_timeout = 20*60*1000
 
+    if args.tiering_test:
+        print("Running test repeatedly to promote methods to tier1")
+        os.environ["CLRCustomTestLauncher"] = args.tieringtest_script_path
+
     # Set __TestTimeout environment variable, which is the per-test timeout in milliseconds.
     # This is read by the test wrapper invoker, in src\tests\Common\Coreclr.TestWrapper\CoreclrTestWrapperLib.cs.
     print("Setting __TestTimeout=%s" % str(per_test_timeout))
@@ -1011,6 +1016,11 @@ def setup_args(args):
                               lambda arg: True,
                               "Error setting run_in_context")
 
+    coreclr_setup_args.verify(args,
+                              "tiering_test",
+                              lambda arg: True,
+                              "Error setting tiering_test")
+
     print("host_os                  : %s" % coreclr_setup_args.host_os)
     print("arch                     : %s" % coreclr_setup_args.arch)
     print("build_type               : %s" % coreclr_setup_args.build_type)
@@ -1023,6 +1033,7 @@ def setup_args(args):
     coreclr_setup_args.coreclr_tests_dir = os.path.join(coreclr_setup_args.coreclr_dir, "tests")
     coreclr_setup_args.coreclr_tests_src_dir = os.path.join(coreclr_setup_args.runtime_repo_location, "src", "tests")
     coreclr_setup_args.runincontext_script_path = os.path.join(coreclr_setup_args.coreclr_tests_src_dir, "Common", "scripts", "runincontext%s" % (".cmd" if coreclr_setup_args.host_os == "windows" else ".sh"))
+    coreclr_setup_args.tieringtest_script_path = os.path.join(coreclr_setup_args.coreclr_tests_src_dir, "Common", "scripts", "tieringtest%s" % (".cmd" if coreclr_setup_args.host_os == "windows" else ".sh"))
     coreclr_setup_args.logs_dir = os.path.join(coreclr_setup_args.artifacts_location, "log")
 
     return coreclr_setup_args

--- a/src/tests/run.sh
+++ b/src/tests/run.sh
@@ -34,6 +34,7 @@ function print_usage {
     echo '  --link <ILlink>                  : Runs the tests after linking via ILlink'
     echo '  --printLastResultsOnly           : Print the results of the last run'
     echo '  --runincontext                   : Run each tests in an unloadable AssemblyLoadContext'
+    echo '  --tieringtest                    : Run each test to encourage tier1 rejitting'
     echo '  --limitedDumpGeneration          : '
 }
 
@@ -96,6 +97,7 @@ ilasmroundtrip=
 printLastResultsOnly=
 runSequential=0
 runincontext=0
+tieringtest=0
 
 for i in "$@"
 do
@@ -192,6 +194,9 @@ do
         --runincontext)
             runincontext=1
             ;;
+        --tieringtest)
+            tieringtest=1
+            ;;
         *)
             echo "Unknown switch: $i"
             print_usage
@@ -283,6 +288,11 @@ fi
 if [[ ! "$runincontext" -eq 0 ]]; then
     echo "Running in an unloadable AssemblyLoadContext"
     runtestPyArguments+=("--run_in_context")
+fi
+
+if [[ ! "$tieringtest" -eq 0 ]]; then
+    echo "Running to encourage tier1 rejitting"
+   runtestPyArguments+=("--tieringtest")
 fi
 
 # Default to python3 if it is installed


### PR DESCRIPTION
Add a test wrapper that repeatedly executes a test's `Main` method so that more methods are
able to reach Tier1. In particular this is useful in trying to increase test coverage for dynamic PGO.

Uses various tricks to tolerate tests that are not amenable to being run in this manner:
* failures on the first or second iteration are ignored
* long running tests are run for fewer iterations
* some tests that become flaky after 2 iterations are excluded

Also add support for running tests in this mode to various CI scripts.