### PR TITLE
Move to 6.0 only for release runs

### DIFF
--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -3,7 +3,7 @@ trigger:
   branches:
     include:
     - main
-    - release/*
+    - release/6.0
   paths:
     include:
     - '*'


### PR DESCRIPTION
We need to remove the trigger for both the release/6.0 branch and the release/6.0-rc1 branch as we do not have lab capacity to run both. This sets us up to run just release/6.0.