### PR TITLE
Fix `StringSegment.Buffer` can be null

### DIFF
--- a/src/libraries/Microsoft.Extensions.Primitives/ref/Microsoft.Extensions.Primitives.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/ref/Microsoft.Extensions.Primitives.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Extensions.Primitives
         bool HasChanged { get; }
         System.IDisposable RegisterChangeCallback(System.Action<object?> callback, object? state);
     }
-    public readonly partial struct StringSegment : System.IEquatable<Microsoft.Extensions.Primitives.StringSegment>, System.IEquatable<string>
+    public readonly partial struct StringSegment : System.IEquatable<Microsoft.Extensions.Primitives.StringSegment>, System.IEquatable<string?>
     {
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
@@ -74,7 +74,7 @@ namespace Microsoft.Extensions.Primitives
         public static bool operator ==(Microsoft.Extensions.Primitives.StringSegment left, Microsoft.Extensions.Primitives.StringSegment right) { throw null; }
         public static implicit operator System.ReadOnlyMemory<char>(Microsoft.Extensions.Primitives.StringSegment segment) { throw null; }
         public static implicit operator System.ReadOnlySpan<char>(Microsoft.Extensions.Primitives.StringSegment segment) { throw null; }
-        public static implicit operator Microsoft.Extensions.Primitives.StringSegment(string value) { throw null; }
+        public static implicit operator Microsoft.Extensions.Primitives.StringSegment(string? value) { throw null; }
         public static bool operator !=(Microsoft.Extensions.Primitives.StringSegment left, Microsoft.Extensions.Primitives.StringSegment right) { throw null; }
         public Microsoft.Extensions.Primitives.StringTokenizer Split(char[] chars) { throw null; }
         public bool StartsWith(string text, System.StringComparison comparisonType) { throw null; }

--- a/src/libraries/Microsoft.Extensions.Primitives/ref/Microsoft.Extensions.Primitives.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/ref/Microsoft.Extensions.Primitives.cs
@@ -41,9 +41,9 @@ namespace Microsoft.Extensions.Primitives
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
         public static readonly Microsoft.Extensions.Primitives.StringSegment Empty;
-        public StringSegment(string buffer) { throw null; }
+        public StringSegment(string? buffer) { throw null; }
         public StringSegment(string buffer, int offset, int length) { throw null; }
-        public string Buffer { get { throw null; } }
+        public string? Buffer { get { throw null; } }
         [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, nameof(Buffer))]
         public bool HasValue { get { throw null; } }
         public char this[int index] { get { throw null; } }

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
@@ -257,7 +257,7 @@ namespace Microsoft.Extensions.Primitives
         {
             if (text == null)
             {
-                return false;
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.text);
             }
 
             if (!HasValue)

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.Primitives
     /// <summary>
     /// An optimized representation of a substring.
     /// </summary>
-    public readonly struct StringSegment : IEquatable<StringSegment>, IEquatable<string>
+    public readonly struct StringSegment : IEquatable<StringSegment>, IEquatable<string?>
     {
         /// <summary>
         /// A <see cref="StringSegment"/> for <see cref="string.Empty"/>.
@@ -233,20 +233,14 @@ namespace Microsoft.Extensions.Primitives
         /// <param name="b">The second <see cref="StringSegment"/> to compare.</param>
         /// <param name="comparisonType">One of the enumeration values that specifies the rules for the comparison.</param>
         /// <returns><see langword="true" /> if the objects are equal; otherwise, <see langword="false" />.</returns>
-        public static bool Equals(StringSegment a, StringSegment b, StringComparison comparisonType)
-        {
-            return a.Equals(b, comparisonType);
-        }
+        public static bool Equals(StringSegment a, StringSegment b, StringComparison comparisonType) => a.Equals(b, comparisonType);
 
         /// <summary>
         /// Checks if the specified <see cref="string"/> is equal to the current <see cref="StringSegment"/>.
         /// </summary>
         /// <param name="text">The <see cref="string"/> to compare with the current <see cref="StringSegment"/>.</param>
         /// <returns><see langword="true" /> if the specified <see cref="string"/> is equal to the current <see cref="StringSegment"/>; otherwise, <see langword="false" />.</returns>
-        public bool Equals([NotNullWhen(true)] string? text)
-        {
-            return Equals(text, StringComparison.Ordinal);
-        }
+        public bool Equals([NotNullWhen(true)] string? text) => Equals(text, StringComparison.Ordinal);
 
         /// <summary>
         /// Checks if the specified <see cref="string"/> is equal to the current <see cref="StringSegment"/>.
@@ -257,15 +251,10 @@ namespace Microsoft.Extensions.Primitives
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals([NotNullWhen(true)] string? text, StringComparison comparisonType)
         {
-            if (text == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.text);
-            }
-
             if (!HasValue)
             {
                 CheckStringComparison(comparisonType); // must arg check before returning
-                return false;
+                return text == null;
             }
 
             return AsSpan().Equals(text.AsSpan(), comparisonType);
@@ -313,7 +302,7 @@ namespace Microsoft.Extensions.Primitives
         /// Creates a new <see cref="StringSegment"/> from the given <see cref="string"/>.
         /// </summary>
         /// <param name="value">The <see cref="string"/> to convert to a <see cref="StringSegment"/></param>
-        public static implicit operator StringSegment(string value) => new StringSegment(value);
+        public static implicit operator StringSegment(string? value) => new StringSegment(value);
 
         /// <summary>
         /// Creates a see <see cref="ReadOnlySpan{T}"/> from the given <see cref="StringSegment"/>.
@@ -733,15 +722,6 @@ namespace Microsoft.Extensions.Primitives
 
                 return ThrowHelper.GetArgumentException(ExceptionResource.Argument_InvalidOffsetLengthStringSegment);
             }
-        }
-
-        /// <inheritdoc />
-        bool IEquatable<string>.Equals(string? other)
-        {
-            // Explicit interface implementation for IEquatable<string> because
-            // the interface's Equals method allows null strings, which we return
-            // as not-equal.
-            return other != null && Equals(other);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
@@ -102,7 +102,8 @@ namespace Microsoft.Extensions.Primitives
                     ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
                 }
 
-                return Buffer![Offset + index];
+                Debug.Assert(Buffer is not null);
+                return Buffer[Offset + index];
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Extensions.Primitives
         /// <param name="buffer">
         /// The original <see cref="string"/>. The <see cref="StringSegment"/> includes the whole <see cref="string"/>.
         /// </param>
-        public StringSegment(string buffer)
+        public StringSegment(string? buffer)
         {
             Buffer = buffer;
             Offset = 0;
@@ -62,7 +62,7 @@ namespace Microsoft.Extensions.Primitives
         /// <summary>
         /// Gets the <see cref="string"/> buffer for this <see cref="StringSegment"/>.
         /// </summary>
-        public string Buffer { get; }
+        public string? Buffer { get; }
 
         /// <summary>
         /// Gets the offset within the buffer for this <see cref="StringSegment"/>.
@@ -102,7 +102,7 @@ namespace Microsoft.Extensions.Primitives
                     ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
                 }
 
-                return Buffer[Offset + index];
+                return Buffer![Offset + index];
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
@@ -251,10 +251,10 @@ namespace Microsoft.Extensions.Primitives
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals([NotNullWhen(true)] string? text, StringComparison comparisonType)
         {
-            if (!HasValue)
+            if (!HasValue || text == null)
             {
                 CheckStringComparison(comparisonType); // must arg check before returning
-                return text == null;
+                return text == Buffer; // return true if both are null
             }
 
             return AsSpan().Equals(text.AsSpan(), comparisonType);

--- a/src/libraries/Microsoft.Extensions.Primitives/tests/StringSegmentTest.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/tests/StringSegmentTest.cs
@@ -318,26 +318,20 @@ namespace Microsoft.Extensions.Primitives
             Assert.Throws<ArgumentOutOfRangeException>(() => segment[index]);
         }
 
-        public static TheoryData<string, StringComparison, bool> EndsWithData
+        // candidate / comparer / expected result
+        public static TheoryData<string, StringComparison, bool> EndsWithData => new()
         {
-            get
-            {
-                // candidate / comparer / expected result
-                return new TheoryData<string, StringComparison, bool>()
-                {
-                    { "Hello", StringComparison.Ordinal, false },
-                    { "ello ", StringComparison.Ordinal, false },
-                    { "ll", StringComparison.Ordinal, false },
-                    { "ello", StringComparison.Ordinal, true },
-                    { "llo", StringComparison.Ordinal, true },
-                    { "lo", StringComparison.Ordinal, true },
-                    { "o", StringComparison.Ordinal, true },
-                    { string.Empty, StringComparison.Ordinal, true },
-                    { "eLLo", StringComparison.Ordinal, false },
-                    { "eLLo", StringComparison.OrdinalIgnoreCase, true },
-                };
-            }
-        }
+            { "Hello", StringComparison.Ordinal, false },
+            { "ello ", StringComparison.Ordinal, false },
+            { "ll", StringComparison.Ordinal, false },
+            { "ello", StringComparison.Ordinal, true },
+            { "llo", StringComparison.Ordinal, true },
+            { "lo", StringComparison.Ordinal, true },
+            { "o", StringComparison.Ordinal, true },
+            { string.Empty, StringComparison.Ordinal, true },
+            { "eLLo", StringComparison.Ordinal, false },
+            { "eLLo", StringComparison.OrdinalIgnoreCase, true },
+        };
 
         [Theory]
         [MemberData(nameof(EndsWithData))]
@@ -387,26 +381,20 @@ namespace Microsoft.Extensions.Primitives
             Assert.Throws<ArgumentOutOfRangeException>("comparisonType", () => segment.EndsWith(string.Empty, (StringComparison)6));
         }
 
-        public static TheoryData<string, StringComparison, bool> StartsWithData
+        // candidate / comparer / expected result
+        public static TheoryData<string, StringComparison, bool> StartsWithData => new()
         {
-            get
-            {
-                // candidate / comparer / expected result
-                return new TheoryData<string, StringComparison, bool>()
-                {
-                    { "Hello", StringComparison.Ordinal, false },
-                    { "ello ", StringComparison.Ordinal, false },
-                    { "ll", StringComparison.Ordinal, false },
-                    { "ello", StringComparison.Ordinal, true },
-                    { "ell", StringComparison.Ordinal, true },
-                    { "el", StringComparison.Ordinal, true },
-                    { "e", StringComparison.Ordinal, true },
-                    { string.Empty, StringComparison.Ordinal, true },
-                    { "eLLo", StringComparison.Ordinal, false },
-                    { "eLLo", StringComparison.OrdinalIgnoreCase, true },
-                };
-            }
-        }
+            { "Hello", StringComparison.Ordinal, false },
+            { "ello ", StringComparison.Ordinal, false },
+            { "ll", StringComparison.Ordinal, false },
+            { "ello", StringComparison.Ordinal, true },
+            { "ell", StringComparison.Ordinal, true },
+            { "el", StringComparison.Ordinal, true },
+            { "e", StringComparison.Ordinal, true },
+            { string.Empty, StringComparison.Ordinal, true },
+            { "eLLo", StringComparison.Ordinal, false },
+            { "eLLo", StringComparison.OrdinalIgnoreCase, true },
+        };
 
         [Theory]
         [MemberData(nameof(StartsWithData))]
@@ -579,21 +567,15 @@ namespace Microsoft.Extensions.Primitives
             Assert.False(StringSegment.IsNullOrEmpty(new StringSegment("ABCDefg", 3, 2)));
         }
 
-        public static TheoryData GetHashCode_ReturnsSameValueForEqualSubstringsData
+        public static TheoryData GetHashCode_ReturnsSameValueForEqualSubstringsData => new TheoryData<StringSegment, StringSegment>
         {
-            get
-            {
-                return new TheoryData<StringSegment, StringSegment>
-                {
-                    { default(StringSegment), default(StringSegment) },
-                    { default(StringSegment), new StringSegment() },
-                    { new StringSegment("Test123", 0, 0), new StringSegment(string.Empty) },
-                    { new StringSegment("C`est si bon", 2, 3), new StringSegment("Yesterday", 1, 3) },
-                    { new StringSegment("Hello", 1, 4), new StringSegment("Hello world", 1, 4) },
-                    { new StringSegment("Hello"), new StringSegment("Hello", 0, 5) },
-                };
-            }
-        }
+            { default(StringSegment), default(StringSegment) },
+            { default(StringSegment), new StringSegment() },
+            { new StringSegment("Test123", 0, 0), new StringSegment(string.Empty) },
+            { new StringSegment("C`est si bon", 2, 3), new StringSegment("Yesterday", 1, 3) },
+            { new StringSegment("Hello", 1, 4), new StringSegment("Hello world", 1, 4) },
+            { new StringSegment("Hello"), new StringSegment("Hello", 0, 5) },
+        };
 
         [Theory]
         [MemberData(nameof(GetHashCode_ReturnsSameValueForEqualSubstringsData))]
@@ -649,18 +631,12 @@ namespace Microsoft.Extensions.Primitives
             Assert.False(result);
         }
 
-        public static TheoryData<StringSegment> DefaultStringSegmentEqualsStringSegmentData
+        // candidate
+        public static TheoryData<StringSegment> DefaultStringSegmentEqualsStringSegmentData => new()
         {
-            get
-            {
-                // candidate
-                return new TheoryData<StringSegment>()
-                {
-                    { default(StringSegment) },
-                    { new StringSegment() },
-                };
-            }
-        }
+            { default(StringSegment) },
+            { new StringSegment() },
+        };
 
         [Theory]
         [MemberData(nameof(DefaultStringSegmentEqualsStringSegmentData))]
@@ -676,19 +652,13 @@ namespace Microsoft.Extensions.Primitives
             Assert.True(result);
         }
 
-        public static TheoryData<StringSegment> DefaultStringSegmentDoesNotEqualStringSegmentData
+        // candidate
+        public static TheoryData<StringSegment> DefaultStringSegmentDoesNotEqualStringSegmentData => new()
         {
-            get
-            {
-                // candidate
-                return new TheoryData<StringSegment>()
-                {
-                    { new StringSegment("Hello, World!", 1, 4) },
-                    { new StringSegment("Hello", 1, 0) },
-                    { new StringSegment(string.Empty) },
-                };
-            }
-        }
+            { new StringSegment("Hello, World!", 1, 4) },
+            { new StringSegment("Hello", 1, 0) },
+            { new StringSegment(string.Empty) },
+        };
 
         [Theory]
         [MemberData(nameof(DefaultStringSegmentDoesNotEqualStringSegmentData))]
@@ -704,18 +674,12 @@ namespace Microsoft.Extensions.Primitives
             Assert.False(result);
         }
 
-        public static TheoryData<string> DefaultStringSegmentDoesNotEqualStringData
+        // candidate
+        public static TheoryData<string> DefaultStringSegmentDoesNotEqualStringData => new()
         {
-            get
-            {
-                // candidate
-                return new TheoryData<string>()
-                {
-                    { string.Empty },
-                    { "Hello, World!" },
-                };
-            }
-        }
+            { string.Empty },
+            { "Hello, World!" },
+        };
 
         [Theory]
         [MemberData(nameof(DefaultStringSegmentDoesNotEqualStringData))]
@@ -731,22 +695,16 @@ namespace Microsoft.Extensions.Primitives
             Assert.False(result);
         }
 
-        public static TheoryData<StringSegment, StringComparison, bool> EqualsStringSegmentData
+        // candidate / comparer / expected result
+        public static TheoryData<StringSegment, StringComparison, bool> EqualsStringSegmentData => new()
         {
-            get
-            {
-                // candidate / comparer / expected result
-                return new TheoryData<StringSegment, StringComparison, bool>()
-                {
-                    { new StringSegment("Hello, World!", 1, 4), StringComparison.Ordinal, true },
-                    { new StringSegment("HELlo, World!", 1, 4), StringComparison.Ordinal, false },
-                    { new StringSegment("HELlo, World!", 1, 4), StringComparison.OrdinalIgnoreCase, true },
-                    { new StringSegment("ello, World!", 0, 4), StringComparison.Ordinal, true },
-                    { new StringSegment("ello, World!", 0, 3), StringComparison.Ordinal, false },
-                    { new StringSegment("ello, World!", 1, 3), StringComparison.Ordinal, false },
-                };
-            }
-        }
+            { new StringSegment("Hello, World!", 1, 4), StringComparison.Ordinal, true },
+            { new StringSegment("HELlo, World!", 1, 4), StringComparison.Ordinal, false },
+            { new StringSegment("HELlo, World!", 1, 4), StringComparison.OrdinalIgnoreCase, true },
+            { new StringSegment("ello, World!", 0, 4), StringComparison.Ordinal, true },
+            { new StringSegment("ello, World!", 0, 3), StringComparison.Ordinal, false },
+            { new StringSegment("ello, World!", 1, 3), StringComparison.Ordinal, false },
+        };
 
         [Theory]
         [MemberData(nameof(EqualsStringSegmentData))]
@@ -960,19 +918,13 @@ namespace Microsoft.Extensions.Primitives
             Assert.Contains("bounds", exception.Message);
         }
 
-        public static TheoryData<StringSegment, StringSegmentComparer> CompareLesserData
+        // candidate / comparer
+        public static TheoryData<StringSegment, StringSegmentComparer> CompareLesserData => new()
         {
-            get
-            {
-                // candidate / comparer
-                return new TheoryData<StringSegment, StringSegmentComparer>()
-                {
-                    { new StringSegment("abcdef", 1, 4), StringSegmentComparer.Ordinal },
-                    { new StringSegment("abcdef", 1, 5), StringSegmentComparer.OrdinalIgnoreCase },
-                    { new StringSegment("ABCDEF", 2, 2), StringSegmentComparer.OrdinalIgnoreCase },
-                };
-            }
-        }
+            { new StringSegment("abcdef", 1, 4), StringSegmentComparer.Ordinal },
+            { new StringSegment("abcdef", 1, 5), StringSegmentComparer.OrdinalIgnoreCase },
+            { new StringSegment("ABCDEF", 2, 2), StringSegmentComparer.OrdinalIgnoreCase },
+        };
 
         [Theory]
         [MemberData(nameof(CompareLesserData))]
@@ -988,20 +940,14 @@ namespace Microsoft.Extensions.Primitives
             Assert.True(result < 0, $"{segment} should be less than {candidate}");
         }
 
-        public static TheoryData<StringSegment, StringSegmentComparer> CompareEqualData
+        // candidate / comparer
+        public static TheoryData<StringSegment, StringSegmentComparer> CompareEqualData => new()
         {
-            get
-            {
-                // candidate / comparer
-                return new TheoryData<StringSegment, StringSegmentComparer>()
-                {
-                    { new StringSegment("abcdef", 1, 4), StringSegmentComparer.Ordinal },
-                    { new StringSegment("ABCDEF", 1, 4), StringSegmentComparer.OrdinalIgnoreCase },
-                    { new StringSegment("bcde", 0, 4), StringSegmentComparer.Ordinal },
-                    { new StringSegment("BcDeF", 0, 4), StringSegmentComparer.OrdinalIgnoreCase },
-                };
-            }
-        }
+            { new StringSegment("abcdef", 1, 4), StringSegmentComparer.Ordinal },
+            { new StringSegment("ABCDEF", 1, 4), StringSegmentComparer.OrdinalIgnoreCase },
+            { new StringSegment("bcde", 0, 4), StringSegmentComparer.Ordinal },
+            { new StringSegment("BcDeF", 0, 4), StringSegmentComparer.OrdinalIgnoreCase },
+        };
 
         [Theory]
         [MemberData(nameof(CompareEqualData))]
@@ -1017,19 +963,13 @@ namespace Microsoft.Extensions.Primitives
             Assert.True(result == 0, $"{segment} should equal {candidate}");
         }
 
-        public static TheoryData<StringSegment, StringSegmentComparer> CompareGreaterData
+        // candidate / comparer
+        public static TheoryData<StringSegment, StringSegmentComparer> CompareGreaterData => new()
         {
-            get
-            {
-                // candidate / comparer
-                return new TheoryData<StringSegment, StringSegmentComparer>()
-                {
-                    { new StringSegment("ABCDEF", 1, 4), StringSegmentComparer.Ordinal },
-                    { new StringSegment("ABCDEF", 0, 6), StringSegmentComparer.OrdinalIgnoreCase },
-                    { new StringSegment("abcdef", 0, 3), StringSegmentComparer.Ordinal },
-                };
-            }
-        }
+            { new StringSegment("ABCDEF", 1, 4), StringSegmentComparer.Ordinal },
+            { new StringSegment("ABCDEF", 0, 6), StringSegmentComparer.OrdinalIgnoreCase },
+            { new StringSegment("abcdef", 0, 3), StringSegmentComparer.Ordinal },
+        };
 
         [Theory]
         [MemberData(nameof(CompareGreaterData))]
@@ -1429,28 +1369,22 @@ namespace Microsoft.Extensions.Primitives
             Assert.Equal(expected, actual.Value);
         }
 
-        public static TheoryData<string, string, StringComparison, int> GlobalizationCompareTestData
+        public static TheoryData<string, string, StringComparison, int> GlobalizationCompareTestData => new()
         {
-            get
-            {
-                return new()
-                {
-                    { null, string.Empty, StringComparison.Ordinal, -1 }, // null always compares before non-null
-                    { null, string.Empty, StringComparison.InvariantCultureIgnoreCase, -1 }, // null always compares before non-null
-                    { null, null, StringComparison.Ordinal, 0 },
-                    { null, null, StringComparison.InvariantCultureIgnoreCase, 0 },
-                    { string.Empty, null, StringComparison.Ordinal, 1 },
-                    { string.Empty, null, StringComparison.InvariantCultureIgnoreCase, 1 },
-                    { "x\u00E9y", "xE\u0301y", StringComparison.InvariantCulture,
-                    PlatformDetection.IsInvariantGlobalization ? 1 : -1 }, // linguistic: lowercase sorts before uppercase
-                    { "x\u00E9y", "xE\u0301y", StringComparison.InvariantCultureIgnoreCase,
-                    PlatformDetection.IsInvariantGlobalization ? 1 : 0 }, // equal (linguistic, one is normalized)
-                    { "Hello", "HELLO", StringComparison.InvariantCulture,
-                    PlatformDetection.IsInvariantGlobalization ? 1 : -1 }, // linguistic: lowercase sorts before uppercase
-                    { "Hello", "HELLO", StringComparison.InvariantCultureIgnoreCase, 0 },
-                };
-            }
-        }
+            { null, string.Empty, StringComparison.Ordinal, -1 }, // null always compares before non-null
+            { null, string.Empty, StringComparison.InvariantCultureIgnoreCase, -1 }, // null always compares before non-null
+            { null, null, StringComparison.Ordinal, 0 },
+            { null, null, StringComparison.InvariantCultureIgnoreCase, 0 },
+            { string.Empty, null, StringComparison.Ordinal, 1 },
+            { string.Empty, null, StringComparison.InvariantCultureIgnoreCase, 1 },
+            { "x\u00E9y", "xE\u0301y", StringComparison.InvariantCulture,
+            PlatformDetection.IsInvariantGlobalization ? 1 : -1 }, // linguistic: lowercase sorts before uppercase
+            { "x\u00E9y", "xE\u0301y", StringComparison.InvariantCultureIgnoreCase,
+            PlatformDetection.IsInvariantGlobalization ? 1 : 0 }, // equal (linguistic, one is normalized)
+            { "Hello", "HELLO", StringComparison.InvariantCulture,
+            PlatformDetection.IsInvariantGlobalization ? 1 : -1 }, // linguistic: lowercase sorts before uppercase
+            { "Hello", "HELLO", StringComparison.InvariantCultureIgnoreCase, 0 },
+        };
 
         [Theory]
         [MemberData(nameof(GlobalizationCompareTestData))]
@@ -1516,29 +1450,23 @@ namespace Microsoft.Extensions.Primitives
             }
         }
 
-        public static TheoryData<string, string, StringComparison, bool> GlobalizationStartsWithData
+        public static TheoryData<string, string, StringComparison, bool> GlobalizationStartsWithData => new()
         {
-            get
-            {
-                return new()
-                {
-                    { null, "\u200d", StringComparison.Ordinal, false }, // null never starts with anything
-                    { null, "\u200d", StringComparison.InvariantCulture, false }, // null never starts with anything
-                    { null, string.Empty, StringComparison.Ordinal, false }, // null never starts with anything
-                    { string.Empty, string.Empty, StringComparison.Ordinal, true }, // not char-for-char equivalent
-                    { string.Empty, "\u200d", StringComparison.Ordinal, false }, // not char-for-char equivalent
-                    { string.Empty, "\u200d", StringComparison.InvariantCulture,
-                    PlatformDetection.IsInvariantGlobalization ? false : true }, // linguistic: ZWJ is zero-weight, occurs at all indices
-                    { "\u200d", string.Empty, StringComparison.Ordinal, true }, // all strings trivially start with the empty string
-                    { "\u200d", "\u200d\u200d", StringComparison.InvariantCulture,
-                    PlatformDetection.IsInvariantGlobalization ? false : true }, // linguistic: ZWJ is zero-weight
-                    { "Hello", "h", StringComparison.Ordinal, false },
-                    { "Hello", "h", StringComparison.OrdinalIgnoreCase, true },
-                    { "Hello", "hi", StringComparison.Ordinal, false },
-                    { "Hello", "hi", StringComparison.OrdinalIgnoreCase, false },
-                };
-            }
-        }
+            { null, "\u200d", StringComparison.Ordinal, false }, // null never starts with anything
+            { null, "\u200d", StringComparison.InvariantCulture, false }, // null never starts with anything
+            { null, string.Empty, StringComparison.Ordinal, false }, // null never starts with anything
+            { string.Empty, string.Empty, StringComparison.Ordinal, true }, // not char-for-char equivalent
+            { string.Empty, "\u200d", StringComparison.Ordinal, false }, // not char-for-char equivalent
+            { string.Empty, "\u200d", StringComparison.InvariantCulture,
+            PlatformDetection.IsInvariantGlobalization ? false : true }, // linguistic: ZWJ is zero-weight, occurs at all indices
+            { "\u200d", string.Empty, StringComparison.Ordinal, true }, // all strings trivially start with the empty string
+            { "\u200d", "\u200d\u200d", StringComparison.InvariantCulture,
+            PlatformDetection.IsInvariantGlobalization ? false : true }, // linguistic: ZWJ is zero-weight
+            { "Hello", "h", StringComparison.Ordinal, false },
+            { "Hello", "h", StringComparison.OrdinalIgnoreCase, true },
+            { "Hello", "hi", StringComparison.Ordinal, false },
+            { "Hello", "hi", StringComparison.OrdinalIgnoreCase, false },
+        };
 
         [Theory]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "netfx has some IsPrefix / IsSuffix globalization bugs.")]
@@ -1561,29 +1489,23 @@ namespace Microsoft.Extensions.Primitives
             Assert.Equal(expectedResult, actualResult);
         }
 
-        public static TheoryData<string, string, StringComparison, bool> GlobalizationEndsWithData
+        public static TheoryData<string, string, StringComparison, bool> GlobalizationEndsWithData => new()
         {
-            get
-            {
-                return new()
-                {
-                    { null, "\u200d", StringComparison.Ordinal, false }, // null never ends with anything
-                    { null, "\u200d", StringComparison.InvariantCulture, false }, // null never ends with anything
-                    { null, string.Empty, StringComparison.Ordinal, false }, // null never ends with anything
-                    { string.Empty, string.Empty, StringComparison.Ordinal, true }, // not char-for-char equivalent
-                    { string.Empty, "\u200d", StringComparison.Ordinal, false }, // not char-for-char equivalent
-                    { string.Empty, "\u200d", StringComparison.InvariantCulture,
-                    PlatformDetection.IsInvariantGlobalization ? false : true }, // linguistic: ZWJ is zero-weight, occurs at all indices
-                    { "\u200d", string.Empty, StringComparison.Ordinal, true }, // all strings trivially ends with the empty string
-                    { "\u200d", "\u200d\u200d", StringComparison.InvariantCulture,
-                    PlatformDetection.IsInvariantGlobalization ? false : true }, // linguistic: ZWJ is zero-weight
-                    { "HELLO", "o", StringComparison.Ordinal, false },
-                    { "HELLO", "o", StringComparison.OrdinalIgnoreCase, true },
-                    { "HELLO", "illo", StringComparison.Ordinal, false },
-                    { "HELLO", "illo", StringComparison.OrdinalIgnoreCase, false },
-                };
-            }
-        }
+            { null, "\u200d", StringComparison.Ordinal, false }, // null never ends with anything
+            { null, "\u200d", StringComparison.InvariantCulture, false }, // null never ends with anything
+            { null, string.Empty, StringComparison.Ordinal, false }, // null never ends with anything
+            { string.Empty, string.Empty, StringComparison.Ordinal, true }, // not char-for-char equivalent
+            { string.Empty, "\u200d", StringComparison.Ordinal, false }, // not char-for-char equivalent
+            { string.Empty, "\u200d", StringComparison.InvariantCulture,
+            PlatformDetection.IsInvariantGlobalization ? false : true }, // linguistic: ZWJ is zero-weight, occurs at all indices
+            { "\u200d", string.Empty, StringComparison.Ordinal, true }, // all strings trivially ends with the empty string
+            { "\u200d", "\u200d\u200d", StringComparison.InvariantCulture,
+            PlatformDetection.IsInvariantGlobalization ? false : true }, // linguistic: ZWJ is zero-weight
+            { "HELLO", "o", StringComparison.Ordinal, false },
+            { "HELLO", "o", StringComparison.OrdinalIgnoreCase, true },
+            { "HELLO", "illo", StringComparison.Ordinal, false },
+            { "HELLO", "illo", StringComparison.OrdinalIgnoreCase, false },
+        };
 
         [Theory]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "netfx has some IsPrefix / IsSuffix globalization bugs.")]

--- a/src/libraries/Microsoft.Extensions.Primitives/tests/StringSegmentTest.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/tests/StringSegmentTest.cs
@@ -170,6 +170,9 @@ namespace Microsoft.Extensions.Primitives
             Assert.False(segment.HasValue);
             Assert.Equal(0, segment.Offset);
             Assert.Equal(0, segment.Length);
+            Assert.Null(segment.Buffer);
+            Assert.Null(segment.Value);
+            Assert.Throws<ArgumentOutOfRangeException>(() => segment[0]);
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Primitives/tests/StringSegmentTest.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/tests/StringSegmentTest.cs
@@ -472,6 +472,7 @@ namespace Microsoft.Extensions.Primitives
             { null, StringComparison.OrdinalIgnoreCase, true },
             { null, StringComparison.Ordinal, true },
             { "eLLo", StringComparison.Ordinal, false },
+            { string.Empty, StringComparison.Ordinal, false },
         };
 
         [Theory]
@@ -1523,7 +1524,7 @@ namespace Microsoft.Extensions.Primitives
 
         private static StringSegment MakePaddedStringSegment(string input)
         {
-            return (input is null) ? new StringSegment() : new StringSegment("xx" + input + "zzz", 2, input.Length);
+            return (input is null) ? new StringSegment(null) : new StringSegment("xx" + input + "zzz", 2, input.Length);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Primitives/tests/StringSegmentTest.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/tests/StringSegmentTest.cs
@@ -1429,23 +1429,16 @@ namespace Microsoft.Extensions.Primitives
 
             // StringSegment.Equals(string, ...) and IEquatable<string>.Equals
             {
-                if (b == null)
+                bool areEqual = sa.Equals(b, comparisonType);
+                Assert.Equal(expectedCompareToSign == 0, areEqual);
+
+                if (comparisonType == StringComparison.Ordinal)
                 {
-                    Assert.False(((IEquatable<string>)sa).Equals(b)); // null string never equal, not even to null StringSegment
-                }
-                else
-                {
-                    bool areEqual = sa.Equals(b, comparisonType);
+                    areEqual = sa.Equals(b);
                     Assert.Equal(expectedCompareToSign == 0, areEqual);
 
-                    if (comparisonType == StringComparison.Ordinal)
-                    {
-                        areEqual = sa.Equals(b);
-                        Assert.Equal(expectedCompareToSign == 0, areEqual);
-
-                        areEqual = ((IEquatable<string>)sa).Equals(b);
-                        Assert.Equal(expectedCompareToSign == 0, areEqual);
-                    }
+                    areEqual = ((IEquatable<string>)sa).Equals(b);
+                    Assert.Equal(expectedCompareToSign == 0, areEqual);
                 }
             }
         }

--- a/src/libraries/Microsoft.Extensions.Primitives/tests/StringSegmentTest.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/tests/StringSegmentTest.cs
@@ -456,18 +456,13 @@ namespace Microsoft.Extensions.Primitives
             Assert.Throws<ArgumentOutOfRangeException>("comparisonType", () => segment.StartsWith(string.Empty, (StringComparison)6));
         }
 
-        public static TheoryData<string, StringComparison, bool> EqualsStringData
+        // candidate / comparer / expected result
+        public static TheoryData<string, StringComparison, bool> EqualsStringData =>new()
         {
-            get
-            {
-                // candidate / comparer / expected result
-                return new TheoryData<string, StringComparison, bool>()
-                {
-                    { "eLLo", StringComparison.OrdinalIgnoreCase, true },
-                    { "eLLo", StringComparison.Ordinal, false },
-                };
-            }
-        }
+            { "eLLo", StringComparison.OrdinalIgnoreCase, true },
+            { "eLLo", StringComparison.Ordinal, false },
+            { null, StringComparison.Ordinal, false },
+        };
 
         [Theory]
         [MemberData(nameof(EqualsStringData))]
@@ -483,15 +478,26 @@ namespace Microsoft.Extensions.Primitives
             Assert.Equal(expectedResult, result);
         }
 
-        [Fact]
-        public void StringSegment_Equals_NullString_Throws()
+        // candidate / comparer / expected result
+        public static TheoryData<string, StringComparison, bool> NullEqualsStringData => new()
+        {
+            { null, StringComparison.OrdinalIgnoreCase, true },
+            { null, StringComparison.Ordinal, true },
+            { "eLLo", StringComparison.Ordinal, false },
+        };
+
+        [Theory]
+        [MemberData(nameof(NullEqualsStringData))]
+        public void StringSegment_Equals_NullString_Valid(string candidate, StringComparison comparison, bool expectedResult)
         {
             // Arrange
-            var segment = new StringSegment();
+            var segment = new StringSegment(null);
+
+            // Act
+            bool result = segment.Equals(candidate, comparison);
 
             // Act & assert
-            Assert.Throws<ArgumentNullException>("text", () => segment.Equals((string)null));
-            Assert.Throws<ArgumentNullException>("text", () => segment.Equals((string)null, StringComparison.Ordinal));
+            Assert.Equal(expectedResult, result);
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Primitives/tests/StringSegmentTest.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/tests/StringSegmentTest.cs
@@ -462,8 +462,6 @@ namespace Microsoft.Extensions.Primitives
                 {
                     { "eLLo", StringComparison.OrdinalIgnoreCase, true },
                     { "eLLo", StringComparison.Ordinal, false },
-                    { null, StringComparison.OrdinalIgnoreCase, false },
-                    { null, StringComparison.Ordinal, false },
                 };
             }
         }
@@ -480,6 +478,17 @@ namespace Microsoft.Extensions.Primitives
 
             // Assert
             Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void StringSegment_Equals_NullString_Throws()
+        {
+            // Arrange
+            var segment = new StringSegment();
+
+            // Act & assert
+            Assert.Throws<ArgumentNullException>("text", () => segment.Equals((string)null));
+            Assert.Throws<ArgumentNullException>("text", () => segment.Equals((string)null, StringComparison.Ordinal));
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Primitives/tests/StringSegmentTest.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/tests/StringSegmentTest.cs
@@ -449,6 +449,7 @@ namespace Microsoft.Extensions.Primitives
         {
             { "eLLo", StringComparison.OrdinalIgnoreCase, true },
             { "eLLo", StringComparison.Ordinal, false },
+            { null, StringComparison.OrdinalIgnoreCase, false },
             { null, StringComparison.Ordinal, false },
         };
 
@@ -471,7 +472,9 @@ namespace Microsoft.Extensions.Primitives
         {
             { null, StringComparison.OrdinalIgnoreCase, true },
             { null, StringComparison.Ordinal, true },
+            { "eLLo", StringComparison.OrdinalIgnoreCase, false },
             { "eLLo", StringComparison.Ordinal, false },
+            { string.Empty, StringComparison.OrdinalIgnoreCase, false },
             { string.Empty, StringComparison.Ordinal, false },
         };
 
@@ -1524,7 +1527,7 @@ namespace Microsoft.Extensions.Primitives
 
         private static StringSegment MakePaddedStringSegment(string input)
         {
-            return (input is null) ? new StringSegment(null) : new StringSegment("xx" + input + "zzz", 2, input.Length);
+            return (input is null) ? new StringSegment() : new StringSegment("xx" + input + "zzz", 2, input.Length);
         }
     }
 }


### PR DESCRIPTION
Addresses: https://github.com/dotnet/runtime/pull/57395#issuecomment-902859880

- Made `Buffer` nullable
- `Equals(text)` returns `true` if both `Buffer` and `text` are null