### PR TITLE
Enable SocketHttpHandler to decompress zlib or deflate

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Decompression.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Decompression.cs
@@ -60,13 +60,13 @@ namespace System.Net.Http.Functional.Tests
                     compress = s => new BrotliStream(s, CompressionLevel.Optimal, leaveOpen: true);
                     methods = all ? DecompressionMethods.Brotli : _all;
                     break;
-#endif
 
                 case "zlib":
                     compress = s => new ZLibStream(s, CompressionLevel.Optimal, leaveOpen: true);
                     methods = all ? DecompressionMethods.Deflate : _all;
                     encodingName = "deflate";
                     break;
+#endif
 
                 case "deflate":
                     compress = s => new DeflateStream(s, CompressionLevel.Optimal, leaveOpen: true);

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.RemoteServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.RemoteServer.cs
@@ -1237,8 +1237,9 @@ namespace System.Net.Http.Functional.Tests
             {
                 yield return new object[] { remoteServer, remoteServer.GZipUri };
 
-                // Remote deflate endpoint isn't correctly following the deflate protocol.
-                //yield return new object[] { remoteServer, remoteServer.DeflateUri };
+                // Remote deflate endpoint isn't correctly following the deflate protocol,
+                // but SocketsHttpHandler makes it work, anyway.
+                yield return new object[] { remoteServer, remoteServer.DeflateUri };
             }
         }
 
@@ -1271,10 +1272,6 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        // The remote server endpoint was written to use DeflateStream, which isn't actually a correct
-        // implementation of the deflate protocol (the deflate protocol requires the zlib wrapper around
-        // deflate).  Until we can get that updated (and deal with previous releases still testing it
-        // via a DeflateStream-based implementation), we utilize httpbin.org to help validate behavior.
         [OuterLoop("Uses external servers")]
         [Theory]
         [InlineData("http://httpbin.org/deflate", "\"deflated\": true")]

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTestBase.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTestBase.cs
@@ -199,6 +199,7 @@ namespace System.Net.Http.Functional.Tests
 
         public static Task<byte[]> GetByteArrayAsync(this HttpClient client, bool async, bool useCopyTo, Uri uri)
         {
+#if NETCOREAPP
             return Task.Run(async () =>
             {
                 var m = new HttpRequestMessage(HttpMethod.Get, uri);
@@ -232,6 +233,10 @@ namespace System.Net.Http.Functional.Tests
                 }
                 return result.ToArray();
             });
+#else
+            // For WinHttpHandler on .NET Framework, we fall back to ignoring async and useCopyTo.
+            return client.GetByteArrayAsync(uri);
+#endif
         }
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/DecompressionHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/DecompressionHandler.cs
@@ -330,7 +330,7 @@ namespace System.Net.Http
 
                     public int PeekFirstByte()
                     {
-                        Debug.Assert(_firstByteStatus == 0);
+                        Debug.Assert(_firstByteStatus == FirstByteStatus.None);
 
                         int value = _stream.ReadByte();
                         if (value == -1)
@@ -346,7 +346,7 @@ namespace System.Net.Http
 
                     public async ValueTask<int> PeekFirstByteAsync(CancellationToken cancellationToken)
                     {
-                        Debug.Assert(_firstByteStatus == 0);
+                        Debug.Assert(_firstByteStatus == FirstByteStatus.None);
 
                         var buffer = new byte[1];
 
@@ -354,7 +354,7 @@ namespace System.Net.Http
                         if (bytesRead == 0)
                         {
                             _firstByteStatus = FirstByteStatus.Consumed;
-                            return 0;
+                            return -1;
                         }
 
                         _firstByte = buffer[0];
@@ -400,7 +400,7 @@ namespace System.Net.Http
 
                     public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
                     {
-                        Debug.Assert(_firstByteStatus != 0);
+                        Debug.Assert(_firstByteStatus != FirstByteStatus.None);
 
                         ValidateCopyToArguments(destination, bufferSize);
                         if (_firstByteStatus == FirstByteStatus.Available)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/DecompressionHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/DecompressionHandler.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Net.Http.Headers;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -224,12 +223,203 @@ namespace System.Net.Http
             { }
 
             protected override Stream GetDecompressedStream(Stream originalStream) =>
-                // As described in RFC 2616, the deflate content-coding is actually
-                // the "zlib" format (RFC 1950) in combination with the "deflate"
-                // compression algrithm (RFC 1951).  So while potentially
-                // counterintuitive based on naming, this needs to use ZLibStream
-                // rather than DeflateStream.
-                new ZLibStream(originalStream, CompressionMode.Decompress);
+                new ZLibOrDeflateStream(originalStream);
+
+            /// <summary>Stream that wraps either <see cref="ZLibStream"/> or <see cref="DeflateStream"/> for decompression.</summary>
+            private sealed class ZLibOrDeflateStream : HttpBaseStream
+            {
+                // As described in RFC 2616, the deflate content-coding is the "zlib" format (RFC 1950) in combination with
+                // the "deflate" compression algrithm (RFC 1951). Thus, the right stream to use here is ZLibStream.  However,
+                // some servers incorrectly interpret "deflate" to mean the raw, unwrapped deflate protocol.  To account for
+                // that, this switches between using ZLibStream (correct) and DeflateStream (incorrect) in order to maximize
+                // compatibility with servers.
+
+                private readonly PeekFirstByteReadStream _stream;
+                private Stream? _decompressionStream;
+
+                public ZLibOrDeflateStream(Stream stream) => _stream = new PeekFirstByteReadStream(stream);
+
+                protected override void Dispose(bool disposing)
+                {
+                    if (disposing)
+                    {
+                        _decompressionStream?.Dispose();
+                        _stream.Dispose();
+                    }
+                    base.Dispose(disposing);
+                }
+
+                public override bool CanRead => true;
+                public override bool CanWrite => false;
+                public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken) => throw new NotSupportedException();
+
+                // On the first read request, peek at the first nibble of the response. If it's an 8, use ZLibStream, otherwise
+                // use DeflateStream. This heuristic works because we're deciding only between raw deflate and zlib wrapped around
+                // deflate, in which case the first nibble will always be 8 for zlib and never be 8 for deflate.
+                // https://stackoverflow.com/a/37528114 provides an explanation for why.
+
+                public override int Read(Span<byte> buffer)
+                {
+                    if (_decompressionStream is null)
+                    {
+                        int firstByte = _stream.PeekFirstByte();
+                        _decompressionStream = CreateDecompressionStream(firstByte, _stream);
+                    }
+
+                    return _decompressionStream.Read(buffer);
+                }
+
+                public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+                {
+                    if (_decompressionStream is null)
+                    {
+                        return CreateAndReadAsync(this, buffer, cancellationToken);
+
+                        static async ValueTask<int> CreateAndReadAsync(ZLibOrDeflateStream thisRef, Memory<byte> buffer, CancellationToken cancellationToken)
+                        {
+                            int firstByte = await thisRef._stream.PeekFirstByteAsync(cancellationToken).ConfigureAwait(false);
+                            thisRef._decompressionStream = CreateDecompressionStream(firstByte, thisRef._stream);
+                            return await thisRef._decompressionStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+                        }
+                    }
+
+                    return _decompressionStream.ReadAsync(buffer, cancellationToken);
+                }
+
+                public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+                {
+                    ValidateCopyToArguments(destination, bufferSize);
+                    return Core(destination, bufferSize, cancellationToken);
+                    async Task Core(Stream destination, int bufferSize, CancellationToken cancellationToken)
+                    {
+                        if (_decompressionStream is null)
+                        {
+                            int firstByte = await _stream.PeekFirstByteAsync(cancellationToken).ConfigureAwait(false);
+                            _decompressionStream = CreateDecompressionStream(firstByte, _stream);
+                        }
+
+                        await _decompressionStream.CopyToAsync(destination, bufferSize, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+
+                private static Stream CreateDecompressionStream(int firstByte, Stream stream) =>
+                    (firstByte & 0xF) == 8 ?
+                        new ZLibStream(stream, CompressionMode.Decompress) :
+                        new DeflateStream(stream, CompressionMode.Decompress);
+
+                private sealed class PeekFirstByteReadStream : HttpBaseStream
+                {
+                    private readonly Stream _stream;
+                    private byte _firstByte;
+                    private FirstByteStatus _firstByteStatus;
+
+                    public PeekFirstByteReadStream(Stream stream) => _stream = stream;
+
+                    protected override void Dispose(bool disposing)
+                    {
+                        if (disposing)
+                        {
+                            _stream.Dispose();
+                        }
+                        base.Dispose(disposing);
+                    }
+
+                    public override bool CanRead => true;
+                    public override bool CanWrite => false;
+                    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken) => throw new NotSupportedException();
+
+                    public int PeekFirstByte()
+                    {
+                        Debug.Assert(_firstByteStatus == 0);
+
+                        int value = _stream.ReadByte();
+                        if (value == -1)
+                        {
+                            _firstByteStatus = FirstByteStatus.Consumed;
+                            return -1;
+                        }
+
+                        _firstByte = (byte)value;
+                        _firstByteStatus = FirstByteStatus.Available;
+                        return value;
+                    }
+
+                    public async ValueTask<int> PeekFirstByteAsync(CancellationToken cancellationToken)
+                    {
+                        Debug.Assert(_firstByteStatus == 0);
+
+                        var buffer = new byte[1];
+
+                        int bytesRead = await _stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+                        if (bytesRead == 0)
+                        {
+                            _firstByteStatus = FirstByteStatus.Consumed;
+                            return 0;
+                        }
+
+                        _firstByte = buffer[0];
+                        _firstByteStatus = FirstByteStatus.Available;
+                        return buffer[0];
+                    }
+
+                    public override int Read(Span<byte> buffer)
+                    {
+                        if (_firstByteStatus == FirstByteStatus.Available)
+                        {
+                            if (buffer.Length != 0)
+                            {
+                                buffer[0] = _firstByte;
+                                _firstByteStatus = FirstByteStatus.Consumed;
+                                return 1;
+                            }
+
+                            return 0;
+                        }
+
+                        Debug.Assert(_firstByteStatus == FirstByteStatus.Consumed);
+                        return _stream.Read(buffer);
+                    }
+
+                    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+                    {
+                        if (_firstByteStatus == FirstByteStatus.Available)
+                        {
+                            if (buffer.Length != 0)
+                            {
+                                buffer.Span[0] = _firstByte;
+                                _firstByteStatus = FirstByteStatus.Consumed;
+                                return new ValueTask<int>(1);
+                            }
+
+                            return new ValueTask<int>(0);
+                        }
+
+                        Debug.Assert(_firstByteStatus == FirstByteStatus.Consumed);
+                        return _stream.ReadAsync(buffer, cancellationToken);
+                    }
+
+                    public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+                    {
+                        Debug.Assert(_firstByteStatus != 0);
+
+                        ValidateCopyToArguments(destination, bufferSize);
+                        if (_firstByteStatus == FirstByteStatus.Available)
+                        {
+                            await destination.WriteAsync(new byte[] { _firstByte }, cancellationToken).ConfigureAwait(false);
+                            _firstByteStatus = FirstByteStatus.Consumed;
+                        }
+
+                        await _stream.CopyToAsync(destination, bufferSize, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    private enum FirstByteStatus : byte
+                    {
+                        None = 0,
+                        Available = 1,
+                        Consumed = 2
+                    }
+                }
+            }
         }
 
         private sealed class BrotliDecompressedContent : DecompressedContent


### PR DESCRIPTION
Some servers incorrectly implement the deflate content-coding with the raw deflate algorithm rather than with deflate wrapped with a zlib header/footer.  Auto-detect whether to use ZLibStream or DeflateStream in order to accomodate both kinds of responses.

Fixes #57604