### PR TITLE
[release/6.0] Don't regress SkipLocalsInit optimization on < 6.0 .NETCoreApp assets

### DIFF
--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -229,9 +229,11 @@
       <PropertyGroup >
         <!-- This is needed to use the SkipLocalsInitAttribute. -->
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <IncludeSkipLocalsInitAttribute Condition="'$(IncludeSkipLocalsInitAttribute)' == '' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '5.0'))">true</IncludeSkipLocalsInitAttribute>
       </PropertyGroup>
 
       <ItemGroup>
+        <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\SkipLocalsInitAttribute.cs" Link="System\Runtime\CompilerServices\SkipLocalsInitAttribute.cs" Condition="'$(IncludeSkipLocalsInitAttribute)' == 'true'" />
         <Compile Include="$(CommonPath)SkipLocalsInit.cs" Link="Common\SkipLocalsInit.cs" />
       </ItemGroup>
     </When>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -218,8 +218,9 @@
     </When>
   </Choose>
 
+  <!-- Enable the SkipLocalsInit feature for any source project that is part of the .NETCoreApp shared framework. -->
   <PropertyGroup>
-    <SkipLocalsInit Condition="'$(SkipLocalsInit)' == '' and '$(MSBuildProjectExtension)' == '.csproj' and '$(IsNETCoreAppSrc)' == 'true' and ($([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', '$(NetCoreAppCurrent)')))">true</SkipLocalsInit>
+    <SkipLocalsInit Condition="'$(SkipLocalsInit)' == '' and '$(MSBuildProjectExtension)' == '.csproj' and '$(IsNETCoreAppSrc)' == 'true' and $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net5.0'))">true</SkipLocalsInit>
   </PropertyGroup>
 
   <!--Instructs compiler not to emit .locals init, using SkipLocalsInitAttribute.-->

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -220,7 +220,7 @@
 
   <!-- Enable the SkipLocalsInit feature for any source project that is part of the .NETCoreApp shared framework. -->
   <PropertyGroup>
-    <SkipLocalsInit Condition="'$(SkipLocalsInit)' == '' and '$(MSBuildProjectExtension)' == '.csproj' and '$(IsNETCoreAppSrc)' == 'true' and $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net5.0'))">true</SkipLocalsInit>
+    <SkipLocalsInit Condition="'$(SkipLocalsInit)' == '' and '$(MSBuildProjectExtension)' == '.csproj' and '$(IsNETCoreAppSrc)' == 'true' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">true</SkipLocalsInit>
   </PropertyGroup>
 
   <!--Instructs compiler not to emit .locals init, using SkipLocalsInitAttribute.-->

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/SkipLocalsInitAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/SkipLocalsInitAttribute.cs
@@ -25,7 +25,12 @@ namespace System.Runtime.CompilerServices
         | AttributeTargets.Method
         | AttributeTargets.Property
         | AttributeTargets.Event, Inherited = false)]
-    public sealed class SkipLocalsInitAttribute : Attribute
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+    sealed class SkipLocalsInitAttribute : Attribute
     {
         public SkipLocalsInitAttribute()
         {


### PR DESCRIPTION
## Customer Impact
netcoreapp3.1 and net5.0 assets which are part of the Microsoft.NETCore.App shared framework and ship inside a package need to keep the SkipLocalsInit optimization to avoid regressing perf. This would happen when referencing one of the 6.0 packages but consuming either the netcoreapp3.1 or net5.0 asset in it. The higher assembly version of the netcoreapp3.1/net5.0 asset would win over the same asset in the shared framework and without this fix, the SkipLocalsInit optimization would be lost.

## Testing
Manually tested. Made sure that the optimization is correctly applied to netcoreapp3.1 or net5.0 assets which are part of the shared framework when producing the 6.0 package.

## Risk
Low. This impacts 6.0 packages which contain netcoreapp3.1 or net5.0 assets that are part of the shared framework.




Contributes to https://github.com/dotnet/runtime/issues/54964