### PR TITLE
Stop using ERR_GET_FUNC, since it has been removed in OSSL3 Beta2.

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/openssl.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/openssl.c
@@ -1068,27 +1068,30 @@ int32_t CryptoNative_LookupFriendlyNameByOid(const char* oidValue, const char** 
         return -2;
     }
 
+    // First, check if oidValue parses as a dotted decimal OID. If not, we'll
+    // return not-found and let the system cache that.
+    int asnRet = a2d_ASN1_OBJECT(NULL, 0, oidValue, -1);
+
+    if (asnRet <= 0)
+    {
+        return 0;
+    }
+
     // Do a lookup with no_name set. The purpose of this function is to map only the
     // dotted decimal to the friendly name. "sha1" in should not result in "sha1" out.
     oid = OBJ_txt2obj(oidValue, 1);
 
-    if (!oid)
+    if (oid == NULL)
     {
-        unsigned long err = ERR_peek_last_error();
-
-        // If the most recent error pushed onto the error queue is NOT from OID parsing
-        // then signal for an exception to be thrown.
-        if (err != 0 && ERR_GET_FUNC(err) != ASN1_F_A2D_ASN1_OBJECT)
-        {
-            return -1;
-        }
-
-        return 0;
+        // We know that the OID parsed (unless it underwent concurrent modification,
+        // which is unsupported), so any error in this stage should be an exception.
+        return -1;
     }
 
     // Look in the predefined, and late-registered, OIDs list to get the lookup table
     // identifier for this OID.  The OBJ_txt2obj object will not have ln set.
     nid = OBJ_obj2nid(oid);
+    ASN1_OBJECT_free(oid);
 
     if (nid == NID_undef)
     {

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -159,6 +159,7 @@ const EVP_CIPHER* EVP_chacha20_poly1305(void);
 // that needs to be added.
 
 #define FOR_ALL_OPENSSL_FUNCTIONS \
+    REQUIRED_FUNCTION(a2d_ASN1_OBJECT) \
     REQUIRED_FUNCTION(ASN1_BIT_STRING_free) \
     REQUIRED_FUNCTION(ASN1_d2i_bio) \
     REQUIRED_FUNCTION(ASN1_i2d_bio) \
@@ -607,6 +608,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 
 // Redefine all calls to OpenSSL functions as calls through pointers that are set
 // to the functions from the libssl.so selected by the shim.
+#define a2d_ASN1_OBJECT a2d_ASN1_OBJECT_ptr
 #define ASN1_BIT_STRING_free ASN1_BIT_STRING_free_ptr
 #define ASN1_GENERALIZEDTIME_free ASN1_GENERALIZEDTIME_free_ptr
 #define ASN1_d2i_bio ASN1_d2i_bio_ptr


### PR DESCRIPTION
Restructure CryptoNative_LookupFriendlyNameByOid to not depend on the so-deprecated-its-removed ERR_GET_FUNC.

This approach calls a2d_ASN1_OBJECT directly, rather than looking for it having been the source of the error.
While that does make for double work on success, it's just a state walker for a short string, so it's not too bad.

While noodling around in the function, I noticed that there was a small memory leak, so now that's fixed, too.

Fixes #57674 (in main).