### PR TITLE
Request fewer threads in the thread pool

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
@@ -12,6 +12,17 @@ namespace System.Threading
         /// </summary>
         private static class WorkerThread
         {
+            private const int SemaphoreSpinCountDefaultBaseline = 70;
+#if !TARGET_ARM64 && !TARGET_ARM
+            private const int SemaphoreSpinCountDefault = SemaphoreSpinCountDefaultBaseline;
+#else
+            // On systems with ARM processors, more spin-waiting seems to be necessary to avoid perf regressions from incurring
+            // the full wait when work becomes available soon enough. This is more noticeable after reducing the number of
+            // thread requests made to the thread pool because otherwise the extra thread requests cause threads to do more
+            // busy-waiting instead and adding to contention in trying to look for work items, which is less preferable.
+            private const int SemaphoreSpinCountDefault = SemaphoreSpinCountDefaultBaseline * 4;
+#endif
+
             // This value represents an assumption of how much uncommited stack space a worker thread may use in the future.
             // Used in calculations to estimate when to throttle the rate of thread injection to reduce the possibility of
             // preexisting threads from running out of memory when using new stack space in low-memory situations.
@@ -24,7 +35,10 @@ namespace System.Threading
                 new LowLevelLifoSemaphore(
                     0,
                     MaxPossibleThreadCount,
-                    AppContextConfigHelper.GetInt32Config("System.Threading.ThreadPool.UnfairSemaphoreSpinLimit", 70, false),
+                    AppContextConfigHelper.GetInt32Config(
+                        "System.Threading.ThreadPool.UnfairSemaphoreSpinLimit",
+                        SemaphoreSpinCountDefault,
+                        false),
                     onWait: () =>
                     {
                         if (NativeRuntimeEventSource.Log.IsEnabled())


### PR DESCRIPTION
- Currently up to proc count thread requests are made, one when each work item is enqueued and one when each work item is dequeued. Some of the conditions for making a thread request are speculative, making it difficult to reduce the cap without running into issues (see https://github.com/dotnet/runtime/issues/8951#issuecomment-337107933).
- When the thread pool is not fully loaded, more threads are requested than necessary, causing more threads to wake up and compete for work items, and this shows a perf degradation at some point as load is decreased
- Fixed by using a similar solution to [this](https://github.com/dotnet/runtime/blob/50576e326d1015906608e3c06670344e335c3225/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs#L209). With this change, at most one thread is requested at a time. A thread pool thread requests another thread for parallelization of work after dequeuing the first work item and does not request any more threads, leaving it up to whichever thread services the new thread request to parallelize further.
- After this, there was a regression in ASP.NET benchmarks on arm64 with default number of connections, see https://github.com/dotnet/runtime/issues/39559 for more info. Increased the spin-waiting duration on thread pool worker threads to compensate. Spin-waiting longer is preferrable to busy-waiting and competing with other threads for work items, and hitting a full wait and waking up frequently.
- The change seems to solve the perf cliff seen at some point as load is decreased, especially on arm64. A portion of the perf improvements seen on arm64 at lower load is due to the increase in spin-waiting. On x64 at full load there's not much change in perf, maybe a small improvement in FortunesPlatform and Fortunes. On arm64 at full load there seem to be some improvements in Json/Fortunes-like benchmarks.

Fixes https://github.com/dotnet/runtime/issues/39559
