### PR TITLE
Fix Enum.Parse's parse failure exception to include value in error message

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -879,6 +879,8 @@ namespace System
 
         private static bool TryParseByName(RuntimeType enumType, ReadOnlySpan<char> value, bool ignoreCase, bool throwOnFailure, out ulong result)
         {
+            ReadOnlySpan<char> originalValue = value;
+
             // Find the field. Let's assume that these are always static classes because the class is an enum.
             EnumInfo enumInfo = GetEnumInfo(enumType);
             string[] enumNames = enumInfo.Names;
@@ -952,7 +954,7 @@ namespace System
 
             if (throwOnFailure)
             {
-                throw new ArgumentException(SR.Format(SR.Arg_EnumValueNotFound, value.ToString()));
+                throw new ArgumentException(SR.Format(SR.Arg_EnumValueNotFound, originalValue.ToString()));
             }
 
             result = 0;

--- a/src/libraries/System.Runtime/tests/System/EnumTests.cs
+++ b/src/libraries/System.Runtime/tests/System/EnumTests.cs
@@ -288,6 +288,15 @@ namespace System.Tests
         }
 
         [Theory]
+        [InlineData("Yellow")]
+        [InlineData("Yellow,Orange")]
+        public static void Parse_NonExistentValue_IncludedInErrorMessage(string value)
+        {
+            ArgumentException e = Assert.Throws<ArgumentException>(() => Enum.Parse(typeof(SimpleEnum), value));
+            Assert.Contains(value, e.Message);
+        }
+
+        [Theory]
         [InlineData(SByteEnum.Min, "Min")]
         [InlineData(SByteEnum.One, "One")]
         [InlineData(SByteEnum.Two, "Two")]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/57939