### PR TITLE
Fix codegen on ARM in NativeAOT

### DIFF
--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -2480,7 +2480,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
     }
     else if (call->IsR2ROrVirtualStubRelativeIndir())
     {
-        // Generate a direct call to a non-virtual user defined or helper method
+        // Generate a indirect call to a virtual user defined function or helper method
         assert(callType == CT_HELPER || callType == CT_USER_FUNC);
 #ifdef FEATURE_READYTORUN_COMPILER
         assert(((call->IsR2RRelativeIndir()) && (call->gtEntryPoint.accessType == IAT_PVALUE)) ||
@@ -2490,7 +2490,9 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
         assert(!call->IsTailCall());
 
         regNumber tmpReg = call->GetSingleTempReg();
-        GetEmitter()->emitIns_R_R(ins_Load(TYP_I_IMPL), emitActualTypeSize(TYP_I_IMPL), tmpReg, REG_R2R_INDIRECT_PARAM);
+        regNumber callAddrReg =
+            call->IsVirtualStubRelativeIndir() ? compiler->virtualStubParamInfo->GetReg() : REG_R2R_INDIRECT_PARAM;
+        GetEmitter()->emitIns_R_R(ins_Load(TYP_I_IMPL), emitActualTypeSize(TYP_I_IMPL), tmpReg, callAddrReg);
 
         // We have now generated code for gtControlExpr evaluating it into `tmpReg`.
         // We just need to emit "call tmpReg" in this case.


### PR DESCRIPTION
NativeAOT has different ABI, so it produce Relative Indirection Virtual Stub when invoke virtual methods on generic interface. Appears that this is affects ARM in NativeAOT context, and not affected in runtime repo, because it probably never generate relative indirect stubs.

Actual idea by @SingleAccretion, I do just troubleshooting.
See https://github.com/dotnet/runtimelab/issues/1426 for a bit more contex and how issue appears..