### PR TITLE
[HTTP/3] Re-enable GetAsync_LargeHeader_Success

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
@@ -214,12 +214,6 @@ namespace System.Net.Http.Functional.Tests
         [InlineData("RandomCustomHeader", 12345)]
         public async Task GetAsync_LargeHeader_Success(string headerName, int headerValueLength)
         {
-            if (UseVersion == HttpVersion.Version30)
-            {
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/55508")]
-                return;
-            }
-
             var rand = new Random(42);
             string headerValue = string.Concat(Enumerable.Range(0, headerValueLength).Select(_ => (char)('A' + rand.Next(26))));
 


### PR DESCRIPTION
Root cause was fixed in #56134. ~500 local runs of System.Net.Http.Functional.Tests in a tight loop (and with parallelism enabled) didn't show the failure.

Fixes #55508