### PR TITLE
Temporarily disable test `ThreadPoolBoundHandleTests.MultipleOperationsOverSingleHandle_CompletedWorkItemCountTest`

### DIFF
--- a/src/libraries/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_IntegrationTests.netcoreapp.cs
+++ b/src/libraries/System.Threading.Overlapped/tests/ThreadPoolBoundHandle_IntegrationTests.netcoreapp.cs
@@ -10,6 +10,7 @@ public partial class ThreadPoolBoundHandleTests
 {
     [Fact]
     [PlatformSpecific(TestPlatforms.Windows)] // ThreadPoolBoundHandle.BindHandle is not supported on Unix
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/49700")]
     public unsafe void MultipleOperationsOverSingleHandle_CompletedWorkItemCountTest()
     {
         long initialCompletedWorkItemCount = ThreadPool.CompletedWorkItemCount;


### PR DESCRIPTION
- Not sure what would be causing it, disabling until it's figured out
- Latest failure: https://github.com/dotnet/runtime/issues/49700#issuecomment-901952809