### PR TITLE
Use unsigned casts for array/Span indexers

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -4177,13 +4177,16 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                     GenTreeBoundsChk(GT_ARR_BOUNDS_CHECK, TYP_VOID, index, length, SCK_RNGCHK_FAIL);
 
                 // Element access
-                GenTree*             indexIntPtr = impImplicitIorI4Cast(indexClone, TYP_I_IMPL);
-                GenTree*             sizeofNode  = gtNewIconNode(elemSize);
-                GenTree*             mulNode     = gtNewOperNode(GT_MUL, TYP_I_IMPL, indexIntPtr, sizeofNode);
-                CORINFO_FIELD_HANDLE ptrHnd      = info.compCompHnd->getFieldInClass(clsHnd, 0);
-                const unsigned       ptrOffset   = info.compCompHnd->getFieldOffset(ptrHnd);
-                GenTree*             data        = gtNewFieldRef(TYP_BYREF, ptrHnd, ptrToSpanClone, ptrOffset);
-                GenTree*             result      = gtNewOperNode(GT_ADD, TYP_BYREF, data, mulNode);
+                index = impImplicitIorI4Cast(indexClone, TYP_I_IMPL);
+                if (elemSize != 1)
+                {
+                    GenTree* sizeofNode = gtNewIconNode(elemSize);
+                    index               = gtNewOperNode(GT_MUL, TYP_I_IMPL, index, sizeofNode);
+                }
+                CORINFO_FIELD_HANDLE ptrHnd    = info.compCompHnd->getFieldInClass(clsHnd, 0);
+                const unsigned       ptrOffset = info.compCompHnd->getFieldOffset(ptrHnd);
+                GenTree*             data      = gtNewFieldRef(TYP_BYREF, ptrHnd, ptrToSpanClone, ptrOffset);
+                GenTree*             result    = gtNewOperNode(GT_ADD, TYP_BYREF, data, index);
 
                 // Prepare result
                 var_types resultType = JITtype2varType(sig->retType);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5685,7 +5685,7 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
 
         if (bndsChkType != TYP_INT)
         {
-            arrLen = gtNewCastNode(bndsChkType, arrLen, false, bndsChkType);
+            arrLen = gtNewCastNode(bndsChkType, arrLen, true, bndsChkType);
         }
 
         GenTreeBoundsChk* arrBndsChk = new (this, GT_ARR_BOUNDS_CHECK)
@@ -5714,7 +5714,7 @@ GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
         }
         else
         {
-            index = gtNewCastNode(TYP_I_IMPL, index, false, TYP_I_IMPL);
+            index = gtNewCastNode(TYP_I_IMPL, index, true, TYP_I_IMPL);
         }
     }
 #endif // TARGET_64BIT


### PR DESCRIPTION
Array and Span length is never negative and after bounds checking index is also guaranteed to be non-negative. Unsigned casts get rid of quite a few `movsxd` instructions and replace the rest with cheaper `mov` variants.

PMI diffs for System.Private.CoreLib show only 8 regressions, of which only a couple are because of CSE misses, most are from loop alignment changes.

```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 5517665
Total bytes of diff: 5513593
Total bytes of delta: -4072 (-0,07% of base)
Total relative delta: -10,86
    diff is an improvement.
    relative diff is an improvement.
```
<details>
<summary>Detailed diffs for win-x64</summary>

```
Top method regressions (bytes):
          20 ( 1,56% of base) : System.Private.CoreLib.dasm - PathHelper:TryExpandShortFileName(byref,String):String
           9 ( 1,29% of base) : System.Private.CoreLib.dasm - GregorianCalendarHelper:GetYearOffset(int,int,bool):int:this
           5 ( 0,90% of base) : System.Private.CoreLib.dasm - Encoder:GetBytes(long,int,long,int,bool):int:this
           4 ( 0,71% of base) : System.Private.CoreLib.dasm - Decoder:GetChars(long,int,long,int,bool):int:this
           3 ( 0,78% of base) : System.Private.CoreLib.dasm - String:<GetNonRandomizedHashCodeOrdinalIgnoreCase>g__GetNonRandomizedHashCodeOrdinalIgnoreCaseSlow|47_0(String):int
           1 ( 0,27% of base) : System.Private.CoreLib.dasm - Decoder:GetCharCount(long,int,bool):int:this
           1 ( 0,26% of base) : System.Private.CoreLib.dasm - Encoder:GetByteCount(long,int,bool):int:this
           1 ( 0,16% of base) : System.Private.CoreLib.dasm - RuntimeModule:ResolveSignature(int):ref:this

Top method improvements (bytes):
        -112 (-1,08% of base) : System.Private.CoreLib.dasm - List`1:ConvertAll(Converter`2):List`1:this (64 methods)
         -70 (-0,64% of base) : System.Private.CoreLib.dasm - DefaultBinder:BindToMethod(int,ref,byref,ref,CultureInfo,ref,byref):MethodBase:this
         -60 (-0,66% of base) : System.Private.CoreLib.dasm - HashSet`1:SymmetricExceptWithEnumerable(IEnumerable`1):this (8 methods)
         -55 (-1,13% of base) : System.Private.CoreLib.dasm - Dictionary`2:Resize(int,bool):this (10 methods)
         -42 (-0,55% of base) : System.Private.CoreLib.dasm - Enumerator:MoveNext():bool:this (74 methods)
         -37 (-1,09% of base) : System.Private.CoreLib.dasm - HashSet`1:Resize(int,bool):this (8 methods)
         -35 (-3,43% of base) : System.Private.CoreLib.dasm - ArraySortHelper`1:SwapIfGreater(Span`1,Comparison`1,int,int) (9 methods)
         -32 (-1,47% of base) : System.Private.CoreLib.dasm - ArraySortHelper`1:DownHeap(Span`1,int,int,Comparison`1) (8 methods)
         -32 (-0,44% of base) : System.Private.CoreLib.dasm - Dictionary`2:OnDeserialization(Object):this (8 methods)
         -31 (-0,41% of base) : System.Private.CoreLib.dasm - HashSet`1:OnDeserialization(Object):this (8 methods)
         -31 (-1,66% of base) : System.Private.CoreLib.dasm - List`1:RemoveAll(Predicate`1):int:this (8 methods)
         -30 (-0,82% of base) : System.Private.CoreLib.dasm - ArraySortHelper`2:DownHeap(Span`1,Span`1,int,int,IComparer`1) (8 methods)
         -30 (-0,50% of base) : System.Private.CoreLib.dasm - ArraySortHelper`2:PickPivotAndPartition(Span`1,Span`1,IComparer`1):int (8 methods)
         -30 (-0,77% of base) : System.Private.CoreLib.dasm - Vector128`1:ToString():String:this (6 methods)
         -30 (-0,77% of base) : System.Private.CoreLib.dasm - Vector256`1:ToString():String:this (6 methods)
         -29 (-0,35% of base) : System.Private.CoreLib.dasm - TlsOverPerCoreLockedStacksArrayPool`1:Rent(int):ref:this (10 methods)
         -28 (-0,46% of base) : System.Private.CoreLib.dasm - HashSet`1:IntersectWithEnumerable(IEnumerable`1):this (8 methods)
         -28 (-1,42% of base) : System.Private.CoreLib.dasm - PerCoreLockedStacks:TryPop():ref:this (8 methods)
         -28 (-0,76% of base) : System.Private.CoreLib.dasm - Vector64`1:ToString():String:this (6 methods)
         -24 (-0,54% of base) : System.Private.CoreLib.dasm - ConfigurableArrayPool`1:Rent(int):ref:this (8 methods)

Top method regressions (percentages):
          20 ( 1,56% of base) : System.Private.CoreLib.dasm - PathHelper:TryExpandShortFileName(byref,String):String
           9 ( 1,29% of base) : System.Private.CoreLib.dasm - GregorianCalendarHelper:GetYearOffset(int,int,bool):int:this
           5 ( 0,90% of base) : System.Private.CoreLib.dasm - Encoder:GetBytes(long,int,long,int,bool):int:this
           3 ( 0,78% of base) : System.Private.CoreLib.dasm - String:<GetNonRandomizedHashCodeOrdinalIgnoreCase>g__GetNonRandomizedHashCodeOrdinalIgnoreCaseSlow|47_0(String):int
           4 ( 0,71% of base) : System.Private.CoreLib.dasm - Decoder:GetChars(long,int,long,int,bool):int:this
           1 ( 0,27% of base) : System.Private.CoreLib.dasm - Decoder:GetCharCount(long,int,bool):int:this
           1 ( 0,26% of base) : System.Private.CoreLib.dasm - Encoder:GetByteCount(long,int,bool):int:this
           1 ( 0,16% of base) : System.Private.CoreLib.dasm - RuntimeModule:ResolveSignature(int):ref:this

Top method improvements (percentages):
         -16 (-8,60% of base) : System.Private.CoreLib.dasm - String:TrimHelper(long,int,int):String:this
         -19 (-6,09% of base) : System.Private.CoreLib.dasm - Utf8Parser:TryParseByteX(ReadOnlySpan`1,byref,byref):bool
         -24 (-5,80% of base) : System.Private.CoreLib.dasm - Path:Populate83FileNameFromRandomBytes(long,int,Span`1)
         -10 (-5,03% of base) : System.Private.CoreLib.dasm - <GetEnumerator>d__17:MoveNext():bool:this
         -14 (-3,98% of base) : System.Private.CoreLib.dasm - Utf8Parser:TryParseUInt64X(ReadOnlySpan`1,byref,byref):bool
          -8 (-3,79% of base) : System.Private.CoreLib.dasm - TraceLoggingDataCollector:EndBufferedArray(int,int)
         -24 (-3,51% of base) : System.Private.CoreLib.dasm - TimeSpanTokenizer:GetNextToken():TimeSpanToken:this
          -1 (-3,45% of base) : System.Private.CoreLib.dasm - TimeSpanTokenizer:get_NextChar():ushort:this
         -35 (-3,43% of base) : System.Private.CoreLib.dasm - ArraySortHelper`1:SwapIfGreater(Span`1,Comparison`1,int,int) (9 methods)
          -6 (-3,41% of base) : System.Private.CoreLib.dasm - List`1:FindLast(Predicate`1):Vector`1:this
          -1 (-3,23% of base) : System.Private.CoreLib.dasm - ParameterModifier:get_Item(int):bool:this
          -1 (-3,23% of base) : System.Private.CoreLib.dasm - ParameterModifier:set_Item(int,bool):this
          -1 (-3,23% of base) : System.Private.CoreLib.dasm - StackFrameHelper:GetILOffset(int):int:this
          -1 (-3,23% of base) : System.Private.CoreLib.dasm - StackFrameHelper:GetOffset(int):int:this
          -1 (-3,12% of base) : System.Private.CoreLib.dasm - ConcreteFormattableString:GetArgument(int):Object:this
          -1 (-3,12% of base) : System.Private.CoreLib.dasm - SZArrayHelper:get_Item(int):int:this
         -16 (-3,08% of base) : System.Private.CoreLib.dasm - Enumerator:get_Current():byref:this (16 methods)
          -1 (-3,03% of base) : System.Private.CoreLib.dasm - DTSubString:get_Item(int):ushort:this
          -1 (-3,03% of base) : System.Private.CoreLib.dasm - SZArrayHelper:get_Item(int):long:this
          -1 (-3,03% of base) : System.Private.CoreLib.dasm - SZArrayHelper:get_Item(int):Nullable`1:this

1334 total methods with Code Size differences (1326 improved, 8 regressed), 24492 unchanged.
```
</details>