### PR TITLE
Fix loading app local ICU

### DIFF
--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal.h
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal.h
@@ -73,8 +73,8 @@ U_CAPI int32_t U_EXPORT2 ucal_getWindowsTimeZoneID(const UChar* id, int32_t len,
     PER_FUNCTION_BLOCK(u_tolower, libicuuc, true) \
     PER_FUNCTION_BLOCK(u_toupper, libicuuc, true) \
     PER_FUNCTION_BLOCK(u_uastrncpy, libicuuc, true) \
-    PER_FUNCTION_BLOCK(ubrk_close, libicui18n, true) \
-    PER_FUNCTION_BLOCK(ubrk_openRules, libicui18n, true) \
+    PER_FUNCTION_BLOCK(ubrk_close, libicuuc, true) \
+    PER_FUNCTION_BLOCK(ubrk_openRules, libicuuc, true) \
     PER_FUNCTION_BLOCK(ucal_add, libicui18n, true) \
     PER_FUNCTION_BLOCK(ucal_close, libicui18n, true) \
     PER_FUNCTION_BLOCK(ucal_get, libicui18n, true) \


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/57942

.NET runtime is using the ICU library for globalization. We have started using a couple of new APIs (e.g., `ubrk_close` and `ubrk_openRules`) that we didn't use before. During runtime we get the pointer to such API dynamically from the ICU library `libicui18n` which works fine when using whatever installed ICU version on the system. The problem occurs when using app-local version (which the app decides to use ICU version installed from NuGet package). The runtime will not be able to resolve the API against `libicui18n` because NuGet package libraries export these APIs from different library. 
The fix here is to use `libicuuc` instead of `libicui18n` which guarantees to have API exports in all environments (system installed ICU or app-local ICU).