### PR TITLE
Make SendFile_NonParallel<T> abstract

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
@@ -468,7 +468,7 @@ namespace System.Net.Sockets.Tests
     // Running all cases of GreaterThan2GBFile_SendsAllBytes in parallel may attempt to allocate Min(ProcessorCount, Subclass_Count) * 2GB of disk space
     // in extreme cases. Some CI machines may run out of disk space if this happens.
     [Collection(nameof(NoParallelTests))]
-    public class SendFile_NonParallel<T> : SocketTestHelperBase<T> where T : SocketHelperBase, new()
+    public abstract class SendFile_NonParallel<T> : SocketTestHelperBase<T> where T : SocketHelperBase, new()
     {
         protected SendFile_NonParallel(ITestOutputHelper output) : base(output)
         {


### PR DESCRIPTION
Minor, but important addition to #57946, test base class should have been made abstract, without that tests are failing.

Fixes #57907

/cc @ManickaP