### PR TITLE
[mono] Support RuntimeType.MakeGenericType with non-RuntimeType elements

### DIFF
--- a/src/libraries/System.Runtime/tests/System/Type/TypeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Type/TypeTests.cs
@@ -923,6 +923,16 @@ namespace System.Tests
             Assert.True(!typeof(ContextBoundClass).IsContextful);
         }
 
+        [Fact]
+        public void MakeGenericType_NonRuntimeType()
+        {
+            foreach (Type nonRuntimeType in Helpers.NonRuntimeTypes)
+            {
+                Type t = typeof(List<>).MakeGenericType(nonRuntimeType);
+                Assert.NotNull(t);
+            }
+        }
+
 #region GetInterfaceMap tests
         public static IEnumerable<object[]> GetInterfaceMap_TestData()
         {

--- a/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
@@ -1336,8 +1336,9 @@ namespace System
                     for (int iCopy = 0; iCopy < instantiation.Length; iCopy++)
                         instantiationCopy[iCopy] = instantiation[iCopy];
                     instantiation = instantiationCopy;
-
-                    throw new NotImplementedException();
+                    if (!RuntimeFeature.IsDynamicCodeSupported)
+                        throw new PlatformNotSupportedException();
+                    return System.Reflection.Emit.TypeBuilderInstantiation.MakeGenericType(this, instantiation);
                 }
 
                 instantiationRuntimeType[i] = rtInstantiationElem;


### PR DESCRIPTION
* Fixes https://github.com/dotnet/runtime/issues/58013