### PR TITLE
[mono] Allow RuntimeType arguments in CustomAttributeBuilder

### DIFF
--- a/src/libraries/System.Reflection.Emit.ILGeneration/tests/CustomAttributeBuilderTests.cs
+++ b/src/libraries/System.Reflection.Emit.ILGeneration/tests/CustomAttributeBuilderTests.cs
@@ -255,7 +255,6 @@ namespace System.Reflection.Emit.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/2383", TestRuntimes.Mono)]
         public static void Ctor_AllPrimitives()
         {
             ConstructorInfo con = typeof(Primitives).GetConstructors()[0];

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/CustomAttributeBuilder.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/CustomAttributeBuilder.Mono.cs
@@ -123,7 +123,7 @@ namespace System.Reflection.Emit
                 // depends on this
                 Enum.GetUnderlyingType(t);
             }
-            if (t.IsClass && !(t.IsArray || t == typeof(object) || t == typeof(Type) || t == typeof(string) || t.Assembly.GetName().Name == "mscorlib"))
+            if (t.IsClass && !(t.IsArray || t == typeof(object) || typeof(Type).IsAssignableFrom(t) || t == typeof(string) || t.Assembly.GetName().Name == "mscorlib"))
                 return false;
             if (t.IsValueType && !(t.IsPrimitive || t.IsEnum || ((t.Assembly is AssemblyBuilder) && t.Assembly.GetName().Name == "mscorlib")))
                 return false;
@@ -149,7 +149,7 @@ namespace System.Reflection.Emit
         {
             if (type.IsValueType && value == null)
                 return false;
-            if (type.IsArray && type.GetElementType()!.IsValueType)
+            if (type.IsArray && type.GetElementType()!.IsValueType && value != null)
             {
                 foreach (object? v in (Array)value!)
                 {


### PR DESCRIPTION
* Fixes https://github.com/dotnet/runtime/issues/58019