### PR TITLE
[HTTP/3] Enable IncompleteResponseStream_ResponseDropped_CancelsRequestToServer

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Finalization.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Finalization.cs
@@ -27,12 +27,6 @@ namespace System.Net.Http.Functional.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
         public async Task IncompleteResponseStream_ResponseDropped_CancelsRequestToServer()
         {
-            if (UseVersion == HttpVersion30)
-            {
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/53089")]
-                return;
-            }
-
             using (HttpClient client = CreateHttpClient())
             {
                 bool stopGCs = false;


### PR DESCRIPTION
No failure in ~500 local runs
Most possibly fixed by https://github.com/dotnet/runtime/pull/57156

Fixes #53089