### PR TITLE
Add missing nullable ref annotation to SourceSwitch

### DIFF
--- a/src/libraries/System.Diagnostics.TraceSource/ref/System.Diagnostics.TraceSource.cs
+++ b/src/libraries/System.Diagnostics.TraceSource/ref/System.Diagnostics.TraceSource.cs
@@ -61,7 +61,7 @@ namespace System.Diagnostics
     public partial class SourceSwitch : System.Diagnostics.Switch
     {
         public SourceSwitch(string name) : base (default(string), default(string)) { }
-        public SourceSwitch(string displayName, string defaultSwitchValue) : base (default(string), default(string)) { }
+        public SourceSwitch(string displayName, string? defaultSwitchValue) : base (default(string), default(string)) { }
         public System.Diagnostics.SourceLevels Level { get { throw null; } set { } }
         protected override void OnValueChanged() { }
         public bool ShouldTrace(System.Diagnostics.TraceEventType eventType) { throw null; }

--- a/src/libraries/System.Diagnostics.TraceSource/src/System/Diagnostics/SourceSwitch.cs
+++ b/src/libraries/System.Diagnostics.TraceSource/src/System/Diagnostics/SourceSwitch.cs
@@ -10,7 +10,7 @@ namespace System.Diagnostics
     {
         public SourceSwitch(string name) : base(name, string.Empty) { }
 
-        public SourceSwitch(string displayName, string defaultSwitchValue)
+        public SourceSwitch(string displayName, string? defaultSwitchValue)
             : base(displayName, string.Empty, defaultSwitchValue)
         { }
 


### PR DESCRIPTION
The `Switch` base class that this value is passed to already is marked as allowing a null value here.