### PR TITLE
[wasm][debugger] Fixing assert while debugging.

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -2280,10 +2280,16 @@ namespace Microsoft.WebAssembly.Diagnostics
                             var assemblyNameArg = await GetFullAssemblyName(sessionId, assemblyIdArg, token);
                             var classNameArg = await GetTypeNameOriginal(sessionId, genericTypeArgs[k], token);
                             typeToSearch += classNameArg +", " + assemblyNameArg;
+                            if (k + 1 < genericTypeArgs.Count)
+                                typeToSearch += "], [";
+                            else
+                                typeToSearch += "]";
                         }
-                        typeToSearch += "]]";
+                        typeToSearch += "]";
                         typeToSearch +=  ", " + assemblyName;
                         var genericTypeId = await GetTypeByName(sessionId, typeToSearch, token);
+                        if (genericTypeId < 0)
+                            return null;
                         methodId = await GetMethodIdByName(sessionId, genericTypeId, ".ctor", token);
                     }
                     else

--- a/src/mono/wasm/debugger/DebuggerTestSuite/CustomViewTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/CustomViewTests.cs
@@ -34,7 +34,7 @@ namespace DebuggerTests
         [Fact]
         public async Task UsingDebuggerTypeProxy()
         {
-            var bp = await SetBreakpointInMethod("debugger-test.dll", "DebuggerTests.DebuggerCustomViewTest", "run", 6);
+            var bp = await SetBreakpointInMethod("debugger-test.dll", "DebuggerTests.DebuggerCustomViewTest", "run", 12);
             var pause_location = await EvaluateAndCheck(
                 "window.setTimeout(function() { invoke_static_method ('[debugger-test] DebuggerTests.DebuggerCustomViewTest:run'); }, 1);",
                 "dotnet://debugger-test.dll/debugger-custom-view-test.cs",
@@ -54,8 +54,13 @@ namespace DebuggerTests
             props = await GetObjectOnFrame(frame, "b");
             CheckString(props, "Val2", "one");
 
+            CheckObject(locals, "openWith", "System.Collections.Generic.Dictionary<string, string>", description: "Count = 3");
+            props = await GetObjectOnFrame(frame, "openWith");
+            Assert.Equal(1, props.Count());
+
             await EvaluateOnCallFrameAndCheck(frame["callFrameId"].Value<string>(),
                 ("listToTestToList.ToList()", TObject("System.Collections.Generic.List<int>", description: "Count = 11")));
+
         }
     }
 }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/CustomViewTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/CustomViewTests.cs
@@ -17,7 +17,7 @@ namespace DebuggerTests
         [Fact]
         public async Task UsingDebuggerDisplay()
         {
-            var bp = await SetBreakpointInMethod("debugger-test.dll", "DebuggerTests.DebuggerCustomViewTest", "run", 6);
+            var bp = await SetBreakpointInMethod("debugger-test.dll", "DebuggerTests.DebuggerCustomViewTest", "run", 12);
             var pause_location = await EvaluateAndCheck(
                 "window.setTimeout(function() { invoke_static_method ('[debugger-test] DebuggerTests.DebuggerCustomViewTest:run'); }, 1);",
                 "dotnet://debugger-test.dll/debugger-custom-view-test.cs",

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-custom-view-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-custom-view-test.cs
@@ -67,6 +67,14 @@ namespace DebuggerTests
             var c = new DebuggerDisplayMethodTest();
             List<int> myList = new List<int>{ 1, 2, 3, 4 };
             var listToTestToList = System.Linq.Enumerable.Range(1, 11);
+
+            Dictionary<string, string> openWith = new Dictionary<string, string>();
+
+            openWith.Add("txt", "notepad");
+            openWith.Add("bmp", "paint");
+            openWith.Add("dib", "paint");
+            Console.WriteLine("break here");
+
             Console.WriteLine("break here");
         }
     }


### PR DESCRIPTION
When trying to evaluate DebuggerProxyAttribute of a generic type <T, K>, it was working only for one parameter <K>.
Fixes https://github.com/dotnet/runtime/issues/58021

