### PR TITLE
[release/6.0-rc1] Give tvOS a special value for Personal/MyDocuments

### DIFF
--- a/src/libraries/Common/src/Interop/OSX/System.Native/Interop.SearchPath.iOS.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Native/Interop.SearchPath.iOS.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SearchPath_TempDirectory")]
+        internal static extern string SearchPathTempDirectory();
+    }
+}

--- a/src/libraries/Native/Unix/System.Native/entrypoints.c
+++ b/src/libraries/Native/Unix/System.Native/entrypoints.c
@@ -218,6 +218,7 @@ static const Entry s_sysNative[] =
     DllImportEntry(SystemNative_GetOSArchitecture)
     DllImportEntry(SystemNative_GetProcessArchitecture)
     DllImportEntry(SystemNative_SearchPath)
+    DllImportEntry(SystemNative_SearchPath_TempDirectory)
     DllImportEntry(SystemNative_RegisterForSigChld)
     DllImportEntry(SystemNative_SetDelayedSigChildConsoleConfigurationHandler)
     DllImportEntry(SystemNative_SetTerminalInvalidationHandler)

--- a/src/libraries/Native/Unix/System.Native/pal_searchpath.c
+++ b/src/libraries/Native/Unix/System.Native/pal_searchpath.c
@@ -10,3 +10,9 @@ const char* SystemNative_SearchPath(int32_t folderId)
     __builtin_unreachable();
     return NULL;
 }
+
+const char* SystemNative_SearchPath_TempDirectory()
+{
+    __builtin_unreachable();
+    return NULL;
+}

--- a/src/libraries/Native/Unix/System.Native/pal_searchpath.h
+++ b/src/libraries/Native/Unix/System.Native/pal_searchpath.h
@@ -7,3 +7,5 @@
 #include "pal_types.h"
 
 PALEXPORT const char* SystemNative_SearchPath(int32_t folderId);
+
+PALEXPORT const char* SystemNative_SearchPath_TempDirectory(void);

--- a/src/libraries/Native/Unix/System.Native/pal_searchpath.m
+++ b/src/libraries/Native/Unix/System.Native/pal_searchpath.m
@@ -11,3 +11,10 @@ const char* SystemNative_SearchPath(int32_t folderId)
     const char* path = [[url path] UTF8String];
     return path == NULL ? NULL : strdup (path);
 }
+
+const char* SystemNative_SearchPath_TempDirectory()
+{
+    NSString* tempPath = NSTemporaryDirectory();
+    const char *path = [tempPath UTF8String];
+    return path == NULL ? NULL : strdup (path);
+}

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -2112,6 +2112,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\FileSystem.Exists.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\FileSystemInfo.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\Path.Unix.cs" />
+    <Compile Condition="'$(IsiOSLike)' == 'true'" Include="$(MSBuildThisFileDirectory)System\IO\Path.Unix.iOS.cs" />
+    <Compile Condition="'$(IsiOSLike)' != 'true'" Include="$(MSBuildThisFileDirectory)System\IO\Path.Unix.NoniOS.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\PathInternal.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\PersistedFiles.Names.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\RandomAccess.Unix.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.NoniOS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.NoniOS.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.IO
+{
+    public static partial class Path
+    {
+        private static string DefaultTempPath => "/tmp/";
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
@@ -80,7 +80,6 @@ namespace System.IO
         public static string GetTempPath()
         {
             const string TempEnvVar = "TMPDIR";
-            const string DefaultTempPath = "/tmp/";
 
             // Get the temp path from the TMPDIR environment variable.
             // If it's not set, just return the default path.

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.iOS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.iOS.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace System.IO
+{
+    public static partial class Path
+    {
+        private static string? s_defaultTempPath;
+
+        private static string DefaultTempPath =>
+            s_defaultTempPath ?? (s_defaultTempPath = Interop.Sys.SearchPathTempDirectory()) ??
+            throw new InvalidOperationException();
+    }
+}

--- a/src/libraries/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -331,6 +331,13 @@ namespace System.Tests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix | TestPlatforms.Browser)]
+        public void GetFolderPath_Unix_PersonalExists()
+        {
+            Assert.True(Directory.Exists(Environment.GetFolderPath(Environment.SpecialFolder.Personal)));
+        }
+
+        [Fact]
         [PlatformSpecific(TestPlatforms.AnyUnix | TestPlatforms.Browser)]  // Tests OS-specific environment
         public void GetFolderPath_Unix_PersonalIsHomeAndUserProfile()
         {
@@ -339,7 +346,11 @@ namespace System.Tests
                 Assert.Equal(Environment.GetEnvironmentVariable("HOME"), Environment.GetFolderPath(Environment.SpecialFolder.Personal));
                 Assert.Equal(Environment.GetEnvironmentVariable("HOME"), Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments));
             }
-            Assert.Equal(Environment.GetEnvironmentVariable("HOME"), Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
+            // tvOS effectively doesn't have a HOME
+            if (!PlatformDetection.IstvOS)
+            {
+                Assert.Equal(Environment.GetEnvironmentVariable("HOME"), Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
+            }
         }
 
         [Theory]

--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -294,7 +294,7 @@
         <TestTarget>$(AppleTestTarget)</TestTarget>
       </XHarnessAppBundleToTest>
       <!-- Create work items for run-only apps -->
-      <XHarnessAppBundleToTest Condition="Exists('$(TestArchiveRoot)runonly')" Include="$([System.IO.Directory]::GetDirectories('$(TestArchiveRoot)runonly', '*.app', System.IO.SearchOption.AllDirectories))" >
+      <XHarnessAppBundleToTest Condition="Exists('$(TestArchiveRoot)runonly') and '$(TargetOS)' != 'tvOS'" Include="$([System.IO.Directory]::GetDirectories('$(TestArchiveRoot)runonly', '*.app', System.IO.SearchOption.AllDirectories))" >
         <!-- The sample app doesn't need test runner -->
         <IncludesTestRunner>false</IncludesTestRunner>
         <!-- The sample's C# Main method returns 42 so it should be considered by xharness as a success -->

--- a/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -271,6 +271,9 @@
       <Compile Include="$(CommonPath)Interop\OSX\System.Native\Interop.SearchPath.cs">
         <Link>Common\Interop\OSX\Interop.SearchPath.cs</Link>
       </Compile>
+      <Compile Include="$(CommonPath)Interop\OSX\System.Native\Interop.SearchPath.iOS.cs">
+        <Link>Common\Interop\OSX\Interop.SearchPath.iOS.cs</Link>
+      </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsBrowser)' == 'true'">
       <Compile Include="$(BclSourcesRoot)\System\Threading\TimerQueue.Browser.Mono.cs" />

--- a/src/mono/System.Private.CoreLib/src/System/Environment.iOS.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Environment.iOS.cs
@@ -36,18 +36,14 @@ namespace System
         {
             switch (folder)
             {
-                // TODO: fix for tvOS (https://github.com/dotnet/runtime/issues/34007)
-                // The "normal" NSDocumentDirectory is a read-only directory on tvOS
-                // and that breaks a lot of assumptions in the runtime and the BCL
-
                 case SpecialFolder.Personal:
                 case SpecialFolder.LocalApplicationData:
-                    return Interop.Sys.SearchPath(NSSearchPathDirectory.NSDocumentDirectory);
+                    return CombineDocumentDirectory(string.Empty);
 
                 case SpecialFolder.ApplicationData:
                     // note: at first glance that looked like a good place to return NSLibraryDirectory
                     // but it would break isolated storage for existing applications
-                    return CombineSearchPath(NSSearchPathDirectory.NSDocumentDirectory, ".config");
+                    return CombineDocumentDirectory(".config");
 
                 case SpecialFolder.Resources:
                     return Interop.Sys.SearchPath(NSSearchPathDirectory.NSLibraryDirectory); // older (8.2 and previous) would return String.Empty
@@ -63,7 +59,7 @@ namespace System
                     return Path.Combine(GetFolderPathCore(SpecialFolder.Personal, SpecialFolderOption.None), "Pictures");
 
                 case SpecialFolder.Templates:
-                    return CombineSearchPath(NSSearchPathDirectory.NSDocumentDirectory, "Templates");
+                    return CombineDocumentDirectory("Templates");
 
                 case SpecialFolder.MyVideos:
                     return Path.Combine(GetFolderPathCore(SpecialFolder.Personal, SpecialFolderOption.None), "Videos");
@@ -72,7 +68,7 @@ namespace System
                     return "/usr/share/templates";
 
                 case SpecialFolder.Fonts:
-                    return CombineSearchPath(NSSearchPathDirectory.NSDocumentDirectory, ".fonts");
+                    return CombineDocumentDirectory(".fonts");
 
                 case SpecialFolder.Favorites:
                     return CombineSearchPath(NSSearchPathDirectory.NSLibraryDirectory, "Favorites");
@@ -99,6 +95,23 @@ namespace System
                 return path != null ?
                     Path.Combine(path, subdirectory) :
                     string.Empty;
+            }
+
+            static string CombineDocumentDirectory(string subdirectory)
+            {
+#if TARGET_TVOS
+                string? path = CombineSearchPath(NSSearchPathDirectory.NSLibraryDirectory, Path.Combine("Caches", "Documents", subdirectory));
+                // Special version of CombineSearchPath which creates the path if needed.
+                // This isn't needed for "real" search paths which always exist, but on tvOS
+                // the base path is really a subdirectory we define rather than an OS directory.
+                // In order to not treat Directory.Exists(SpecialFolder.ApplicationData) differently
+                // on tvOS, guarantee that it exists by creating it here
+                if (!Directory.Exists (path))
+                    Directory.CreateDirectory (path);
+#else
+                string? path = CombineSearchPath(NSSearchPathDirectory.NSDocumentDirectory, subdirectory);
+#endif
+                return path;
             }
         }
     }


### PR DESCRIPTION
Backport of #57508 to release/6.0-rc1

/cc @directhex

## Customer Impact

Fixes two issues where tvOS devices have read-only directories which are read-write on other Apple platforms; SpecialFolders.Personal (and subdirectories thereof), and TMP.

## Testing

Manual testing on Helix & local device

## Risk

Low - makes minor changes to how temp folders are calculated on all iOS-like targets, which should be more futureproof if Apple stops allowing /tmp or TMP in an OS update

Fixes #34007
Fixes #57638

Backport of https://github.com/dotnet/runtime/pull/57508 to release/6.0-rc1
