### PR TITLE
Allow configuration binder to bind single elements to array

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -21,6 +21,9 @@ namespace Microsoft.Extensions.Configuration
         private const string PropertyTrimmingWarningMessage = "Cannot statically analyze property.PropertyType so its members may be trimmed.";
         private const string BindSingleElementsToArraySwitch = "Microsoft.Extensions.Configuration.BindSingleElementsToArray";
 
+        // Enable this switch by default.
+        private static bool ShouldBindSingleElementsToArray { get; } = AppContext.TryGetSwitch(BindSingleElementsToArraySwitch, out bool verifyCanBindSingleElementsToArray) ? verifyCanBindSingleElementsToArray : true;
+
         /// <summary>
         /// Attempts to bind the configuration instance to a new instance of type T.
         /// If this configuration section has a value, that will be used.
@@ -363,7 +366,7 @@ namespace Microsoft.Extensions.Configuration
                 return convertedValue;
             }
 
-            if (config != null && (config.GetChildren().Any() || (configValue != null && ShouldBindSingleElementsToArray())))
+            if (config != null && (config.GetChildren().Any() || (configValue != null && ShouldBindSingleElementsToArray)))
             {
                 // If we don't have an instance, try to create one
                 if (instance == null)
@@ -706,7 +709,7 @@ namespace Microsoft.Extensions.Configuration
 
         private static IEnumerable<IConfigurationSection> GetChildrenOrSelf(IConfiguration config)
         {
-            if (!ShouldBindSingleElementsToArray())
+            if (!ShouldBindSingleElementsToArray)
             {
                 return config.GetChildren();
             }
@@ -723,17 +726,6 @@ namespace Microsoft.Extensions.Configuration
             }
 
             return children;
-        }
-
-        private static bool ShouldBindSingleElementsToArray()
-        {
-            if (AppContext.TryGetSwitch(BindSingleElementsToArraySwitch, out bool bindSingleElementsToArray))
-            {
-                return bindSingleElementsToArray;
-            }
-
-            // Enable this switch by default.
-            return true;
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
@@ -936,6 +936,58 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
                 exception.Message);
         }
 
+        [Fact]
+        public void CanBindSingleElementToCollection()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"MyString", "hello world"},
+                {"Nested:Integer", "11"},
+            };
+
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            IConfiguration config = configurationBuilder.Build();
+
+            var stringArr = config.GetSection("MyString").Get<string[]>();
+            Assert.Equal("hello world", stringArr[0]);
+            Assert.Equal(1, stringArr.Length);
+
+            var stringAsStr = config.GetSection("MyString").Get<string>();
+            Assert.Equal("hello world", stringAsStr);
+
+            var nested = config.GetSection("Nested").Get<NestedOptions>();
+            Assert.Equal(11, nested.Integer);
+
+            var nestedAsArray = config.GetSection("Nested").Get<NestedOptions[]>();
+            Assert.Equal(11, nestedAsArray[0].Integer);
+            Assert.Equal(1, nestedAsArray.Length);
+        }
+
+        [Fact]
+        public void CannotBindSingleElementToCollectionWhenSwitchSet()
+        {
+            AppContext.SetSwitch("Microsoft.Extensions.Configuration.BindSingleElementsToArray", false);
+
+            var dic = new Dictionary<string, string>
+            {
+                {"MyString", "hello world"},
+                {"Nested:Integer", "11"},
+            };
+
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            IConfiguration config = configurationBuilder.Build();
+
+            var stringArr = config.GetSection("MyString").Get<string[]>();
+            Assert.Null(stringArr);
+
+            var stringAsStr = config.GetSection("MyString").Get<string>();
+            Assert.Equal("hello world", stringAsStr);
+
+            AppContext.SetSwitch("Microsoft.Extensions.Configuration.BindSingleElementsToArray", true);
+        }
+
         private interface ISomeInterface
         {
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Microsoft.Extensions.Configuration.Binder.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Microsoft.Extensions.Configuration.Binder.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);net461</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
+    <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Backport approved by tactics offline for 6.0.

---

#### PR Content
1st PR: https://github.com/dotnet/runtime/pull/57204
2nd PR: https://github.com/dotnet/runtime/pull/57872 (applies leftover PR feedback from original)

#### Customer Impact
When trying to bind from an XML configuration provider, we now can allow to bind single elements to array rather than leaving them as null:

```xml
<TvShow>
  <Metadata>
    <Name>Prison Break</Name>
  </Metadata>
</TvShow>
```

This however would be breaking for other providers (like JSON configuration provider) where this is not expected. 
So for example, when binding to:
```c#
public class TvShow
{
  public Metadata[] Metadata { get; set; }
}

public class Metadata
{
  public string Name { get; set; }
}
```
Even if we change the below JSON:
```c#
{
   "tvshow": {
        "metadata": [
            {
               "name": "PrisonBreak"
            }
         ]
    }
}
```
so that tvshows is an object with a single metadata:
```c#
{
   "tvshow": {
        "metadata": {
            "name": "PrisonBreak"
          }
    }
}
```
would still bind properly even though json is not specifying an array.

#### Testing
Using the test that is part of the linked PRs.

#### Risk
Low – Might incur a little bit of perf cost when app context switch is set to true.

If a customer is not interested in this breaking change they can set the introduced app context switch `Microsoft.Extensions.Configuration.BindSingleElementsToArray` to false and get the old behavior back.

#### Regression?
No

#### More links
Visit https://github.com/dotnet/docs/issues/25779 for more information.
