### PR TITLE
Print docker info in installers tests

### DIFF
--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -252,6 +252,7 @@ jobs:
       value: |
         set -x
         df -h
+        docker info
         $(RunArguments) $(BuildScript) $(BuildArguments)
 
   ###

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileSharedState.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/SingleFileSharedState.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using Microsoft.DotNet;
 using Microsoft.DotNet.CoreSetup.Test;
 using Xunit;
 using static AppHost.Bundle.Tests.BundleTestBase;
@@ -15,10 +16,17 @@ namespace AppHost.Bundle.Tests
 
         public SingleFileSharedState()
         {
-            // We include mockcoreclr in our project to test native binaries extraction.
-            string mockCoreClrPath = Path.Combine(RepoDirectories.Artifacts, "corehost_test",
-                RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("mockcoreclr"));
-            TestFixture = PreparePublishedSelfContainedTestProject("SingleFileApiTests", $"/p:AddFile={mockCoreClrPath}");
+            try
+            {
+                // We include mockcoreclr in our project to test native binaries extraction.
+                string mockCoreClrPath = Path.Combine(RepoDirectories.Artifacts, "corehost_test",
+                    RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("mockcoreclr"));
+                TestFixture = PreparePublishedSelfContainedTestProject("SingleFileApiTests", $"/p:AddFile={mockCoreClrPath}");
+            }
+            catch (Exception e) when (TestUtils.FailFast(e)) // Fail fast to gather a crash dump
+            {
+                throw;
+            }
         }
 
         public void Dispose()

--- a/src/installer/tests/TestUtils/TestUtils.cs
+++ b/src/installer/tests/TestUtils/TestUtils.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.DotNet
+{
+    public static class TestUtils
+    {
+        public static bool FailFast(Exception e)
+        {
+            if (Debugger.IsAttached)
+            {
+                Debugger.Break();
+            }
+
+            Environment.FailFast(e.ToString(), e);
+            // Should never happen
+            throw new InvalidOperationException();
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/53587 seems to only occur on Linux, and seems more likely to occur when run under docker (I managed to repro the issue once a couple months ago under docker, and never again). This change will print the docker info for the installer tests, which might help diagnose the problem.