### PR TITLE
Move runtime-coreclr macOS x64 test jobs to 10.14 Helix queue

### DIFF
--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -113,13 +113,9 @@ jobs:
 
     # OSX x64
     - ${{ if eq(parameters.platform, 'OSX_x64') }}:
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.jobParameters.helixQueueGroup, 'pr', 'ci', 'libraries')) }}:
-        - OSX.1013.Amd64.Open
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), notIn(parameters.jobParameters.helixQueueGroup, 'pr', 'ci', 'libraries')) }}:
-        - OSX.1013.Amd64.Open
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
         - OSX.1014.Amd64.Open
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        - OSX.1013.Amd64
         - OSX.1014.Amd64
         - OSX.1015.Amd64
 


### PR DESCRIPTION
Move runtime-coreclr macOS x64 test jobs to 10.14 Helix queue (10.13 causes 'No space left on device' issues since their work catalog is mounted to a small disk).