### PR TITLE
Migrate LoggerMessageGenerator to IIncrementalGenerator

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -41,9 +41,9 @@
     <ProjectServicingConfiguration Include="Microsoft.NETCore.App.Ref" PatchVersion="0" />
   </ItemGroup>
   <PropertyGroup>
-    <!-- For source generator support we need to target a pinned version in order to be able to run on older versions of Roslyn -->
-    <MicrosoftCodeAnalysisCSharpWorkspacesVersion>3.9.0</MicrosoftCodeAnalysisCSharpWorkspacesVersion>
-    <MicrosoftCodeAnalysisVersion>3.9.0</MicrosoftCodeAnalysisVersion>
+    <!-- For source generator support we are targeting the latest version of Roslyn for now, until we can support multi-targeting -->
+    <MicrosoftCodeAnalysisCSharpWorkspacesVersion>4.0.0-2.final</MicrosoftCodeAnalysisCSharpWorkspacesVersion>
+    <MicrosoftCodeAnalysisVersion>4.0.0-2.final</MicrosoftCodeAnalysisVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Code analysis dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -42,8 +42,8 @@
   </ItemGroup>
   <PropertyGroup>
     <!-- For source generator support we are targeting the latest version of Roslyn for now, until we can support multi-targeting -->
-    <MicrosoftCodeAnalysisCSharpWorkspacesVersion>4.0.0-2.final</MicrosoftCodeAnalysisCSharpWorkspacesVersion>
-    <MicrosoftCodeAnalysisVersion>4.0.0-2.final</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesVersion>4.0.0-3.final</MicrosoftCodeAnalysisCSharpWorkspacesVersion>
+    <MicrosoftCodeAnalysisVersion>4.0.0-3.final</MicrosoftCodeAnalysisVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Code analysis dependencies -->

--- a/src/libraries/Common/tests/SourceGenerators/RoslynTestUtils.cs
+++ b/src/libraries/Common/tests/SourceGenerators/RoslynTestUtils.cs
@@ -141,10 +141,9 @@ namespace SourceGenerators.Tests
         /// Runs a Roslyn generator over a set of source files.
         /// </summary>
         public static async Task<(ImmutableArray<Diagnostic>, ImmutableArray<GeneratedSourceResult>)> RunGenerator(
-            ISourceGenerator generator,
+            IIncrementalGenerator generator,
             IEnumerable<Assembly>? references,
             IEnumerable<string> sources,
-            AnalyzerConfigOptionsProvider? optionsProvider = null,
             bool includeBaseReferences = true,
             CancellationToken cancellationToken = default)
         {
@@ -156,7 +155,9 @@ namespace SourceGenerators.Tests
 
             Compilation? comp = await proj!.GetCompilationAsync(CancellationToken.None).ConfigureAwait(false);
 
-            CSharpGeneratorDriver cgd = CSharpGeneratorDriver.Create(new[] { generator }, optionsProvider: optionsProvider);
+            // workaround https://github.com/dotnet/roslyn/pull/55866. We can remove "LangVersion=Preview" when we get a Roslyn build with that change.
+            CSharpParseOptions options = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview);
+            CSharpGeneratorDriver cgd = CSharpGeneratorDriver.Create(new[] { generator.AsSourceGenerator() }, parseOptions: options);
             GeneratorDriver gd = cgd.RunGenerators(comp!, cancellationToken);
 
             GeneratorDriverRunResult r = gd.GetRunResult();

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Extensions.Logging.Generators
     {
         internal class Parser
         {
+            private const string LoggerMessageAttribute = "Microsoft.Extensions.Logging.LoggerMessageAttribute";
+
             private readonly CancellationToken _cancellationToken;
             private readonly Compilation _compilation;
             private readonly Action<Diagnostic> _reportDiagnostic;
@@ -28,13 +30,42 @@ namespace Microsoft.Extensions.Logging.Generators
                 _reportDiagnostic = reportDiagnostic;
             }
 
+            internal static bool IsSyntaxTargetForGeneration(SyntaxNode node) =>
+                node is MethodDeclarationSyntax m && m.AttributeLists.Count > 0;
+
+            internal static ClassDeclarationSyntax? GetSemanticTargetForGeneration(GeneratorSyntaxContext context)
+            {
+                var methodDeclarationSyntax = (MethodDeclarationSyntax)context.Node;
+
+                foreach (AttributeListSyntax attributeListSyntax in methodDeclarationSyntax.AttributeLists)
+                {
+                    foreach (var attributeSyntax in attributeListSyntax.Attributes)
+                    {
+                        IMethodSymbol attributeSymbol = context.SemanticModel.GetSymbolInfo(attributeSyntax).Symbol as IMethodSymbol;
+                        if (attributeSymbol == null)
+                        {
+                            continue;
+                        }
+
+                        INamedTypeSymbol attributeContainingTypeSymbol = attributeSymbol.ContainingType;
+                        string fullName = attributeContainingTypeSymbol.ToDisplayString();
+
+                        if (fullName == LoggerMessageAttribute)
+                        {
+                            return methodDeclarationSyntax.Parent as ClassDeclarationSyntax;
+                        }
+                    }
+
+                }
+
+                return null;
+            }
+
             /// <summary>
             /// Gets the set of logging classes containing methods to output.
             /// </summary>
             public IReadOnlyList<LoggerClass> GetLogClasses(IEnumerable<ClassDeclarationSyntax> classes)
             {
-                const string LoggerMessageAttribute = "Microsoft.Extensions.Logging.LoggerMessageAttribute";
-
                 INamedTypeSymbol loggerMessageAttribute = _compilation.GetTypeByMetadataName(LoggerMessageAttribute);
                 if (loggerMessageAttribute == null)
                 {
@@ -442,11 +473,11 @@ namespace Microsoft.Extensions.Logging.Generators
                                             LoggerClass currentLoggerClass = lc;
                                             var parentLoggerClass = (classDec.Parent as TypeDeclarationSyntax);
 
-                                            bool IsAllowedKind(SyntaxKind kind) => 
+                                            bool IsAllowedKind(SyntaxKind kind) =>
                                                 kind == SyntaxKind.ClassDeclaration ||
                                                 kind == SyntaxKind.StructDeclaration ||
                                                 kind == SyntaxKind.RecordDeclaration;
-                                            
+
                                             while (parentLoggerClass != null && IsAllowedKind(parentLoggerClass.Kind()))
                                             {
                                                 currentLoggerClass.ParentClass = new LoggerClass

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Extensions.Logging.Generators
 
                 foreach (AttributeListSyntax attributeListSyntax in methodDeclarationSyntax.AttributeLists)
                 {
-                    foreach (var attributeSyntax in attributeListSyntax.Attributes)
+                    foreach (AttributeSyntax attributeSyntax in attributeListSyntax.Attributes)
                     {
                         IMethodSymbol attributeSymbol = context.SemanticModel.GetSymbolInfo(attributeSyntax).Symbol as IMethodSymbol;
                         if (attributeSymbol == null)
@@ -55,7 +55,6 @@ namespace Microsoft.Extensions.Logging.Generators
                             return methodDeclarationSyntax.Parent as ClassDeclarationSyntax;
                         }
                     }
-
                 }
 
                 return null;

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.cs
@@ -23,16 +23,16 @@ namespace Microsoft.Extensions.Logging.Generators
         public void Initialize(IncrementalGeneratorInitializationContext context)
         {
             IncrementalValuesProvider<ClassDeclarationSyntax> classDeclarations = context.SyntaxProvider
-                .CreateSyntaxProvider((s, _) => Parser.IsSyntaxTargetForGeneration(s), (ctx, _) => Parser.GetSemanticTargetForGeneration(ctx))
-                .Where(m => m is not null);
+                .CreateSyntaxProvider(static (s, _) => Parser.IsSyntaxTargetForGeneration(s), static (ctx, _) => Parser.GetSemanticTargetForGeneration(ctx))
+                .Where(static m => m is not null);
 
             IncrementalValueProvider<(Compilation, ImmutableArray<ClassDeclarationSyntax>)> compilationAndClasses =
                 context.CompilationProvider.Combine(classDeclarations.Collect());
 
-            context.RegisterSourceOutput(compilationAndClasses, (spc, source) => Execute(source.Item1, source.Item2, spc));
+            context.RegisterSourceOutput(compilationAndClasses, static (spc, source) => Execute(source.Item1, source.Item2, spc));
         }
 
-        private void Execute(Compilation compilation, ImmutableArray<ClassDeclarationSyntax> classes, SourceProductionContext context)
+        private static void Execute(Compilation compilation, ImmutableArray<ClassDeclarationSyntax> classes, SourceProductionContext context)
         {
             if (classes.IsDefaultOrEmpty)
             {

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.cs
@@ -3,7 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Tracing;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -15,50 +18,38 @@ using Microsoft.CodeAnalysis.Text;
 namespace Microsoft.Extensions.Logging.Generators
 {
     [Generator]
-    public partial class LoggerMessageGenerator : ISourceGenerator
+    public partial class LoggerMessageGenerator : IIncrementalGenerator
     {
-        [ExcludeFromCodeCoverage]
-        public void Initialize(GeneratorInitializationContext context)
+        public void Initialize(IncrementalGeneratorInitializationContext context)
         {
-            context.RegisterForSyntaxNotifications(SyntaxReceiver.Create);
+            IncrementalValuesProvider<ClassDeclarationSyntax> classDeclarations = context.SyntaxProvider
+                .CreateSyntaxProvider((s, _) => Parser.IsSyntaxTargetForGeneration(s), (ctx, _) => Parser.GetSemanticTargetForGeneration(ctx))
+                .Where(m => m is not null);
+
+            IncrementalValueProvider<(Compilation, ImmutableArray<ClassDeclarationSyntax>)> compilationAndClasses =
+                context.CompilationProvider.Combine(classDeclarations.Collect());
+
+            context.RegisterSourceOutput(compilationAndClasses, (spc, source) => Execute(source.Item1, source.Item2, spc));
         }
 
-        [ExcludeFromCodeCoverage]
-        public void Execute(GeneratorExecutionContext context)
+        private void Execute(Compilation compilation, ImmutableArray<ClassDeclarationSyntax> classes, SourceProductionContext context)
         {
-            if (context.SyntaxReceiver is not SyntaxReceiver receiver || receiver.ClassDeclarations.Count == 0)
+            if (classes.IsDefaultOrEmpty)
             {
                 // nothing to do yet
                 return;
             }
 
-            var p = new Parser(context.Compilation, context.ReportDiagnostic, context.CancellationToken);
-            IReadOnlyList<LoggerClass> logClasses = p.GetLogClasses(receiver.ClassDeclarations);
+            IEnumerable<ClassDeclarationSyntax> distinctClasses = classes.Distinct();
+
+            var p = new Parser(compilation, context.ReportDiagnostic, context.CancellationToken);
+            IReadOnlyList<LoggerClass> logClasses = p.GetLogClasses(distinctClasses);
             if (logClasses.Count > 0)
             {
                 var e = new Emitter();
                 string result = e.Emit(logClasses, context.CancellationToken);
-    
+
                 context.AddSource("LoggerMessage.g.cs", SourceText.From(result, Encoding.UTF8));
-            }
-        }
-
-        [ExcludeFromCodeCoverage]
-        private sealed class SyntaxReceiver : ISyntaxReceiver
-        {
-            internal static ISyntaxReceiver Create()
-            {
-                return new SyntaxReceiver();
-            }
-
-            public List<ClassDeclarationSyntax> ClassDeclarations { get; } = new ();
-
-            public void OnVisitSyntaxNode(SyntaxNode syntaxNode)
-            {
-                if (syntaxNode is ClassDeclarationSyntax classSyntax)
-                {
-                    ClassDeclarations.Add(classSyntax);
-                }
             }
         }
     }

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorParserTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorParserTests.cs
@@ -380,6 +380,7 @@ namespace Microsoft.Extensions.Logging.Generators.Tests
                     public class Void {}
                     public class String {}
                     public struct DateTime {}
+                    public abstract class Attribute {}
                 }
                 namespace System.Collections
                 {
@@ -392,10 +393,12 @@ namespace Microsoft.Extensions.Logging.Generators.Tests
                 }
                 namespace Microsoft.Extensions.Logging
                 {
-                    public class LoggerMessageAttribute {}
+                    public class LoggerMessageAttribute : System.Attribute {}
                 }
                 partial class C
                 {
+                    [Microsoft.Extensions.Logging.LoggerMessage]
+                    public static partial void Log(ILogger logger);
                 }
             ", false, includeBaseReferences: false, includeLoggingReferences: false);
 


### PR DESCRIPTION
This reduces the time spent in the background in VS running the source generator, since we only need to respond to methods that have the LoggerMessageAttribute on them.

Contributes to #56702

Note: The current plan is to enable multi-targeting in a separate PR, once the design for how to multi-target Roslyn Components is solidified. We are considering using the IIncrementalGenerator for RC1 in order to get feedback before doing the multi-targeting work.

cc @jaredpar 