### PR TITLE
Remove unused parameters from assembly binder

### DIFF
--- a/src/coreclr/binder/assembly.cpp
+++ b/src/coreclr/binder/assembly.cpp
@@ -28,7 +28,6 @@ namespace BINDER_SPACE
     {
         m_cRef = 1;
         m_pPEImage = NULL;
-        m_pNativePEImage = NULL;
         m_pAssemblyName = NULL;
         m_pMDImport = NULL;
         m_dwAssemblyFlags = FLAG_NONE;
@@ -50,7 +49,6 @@ namespace BINDER_SPACE
     HRESULT Assembly::Init(IMDInternalImport       *pIMetaDataAssemblyImport,
                            PEKIND                   PeKind,
                            PEImage                 *pPEImage,
-                           PEImage                 *pNativePEImage,
                            SString                 &assemblyPath,
                            BOOL                     fIsInTPA)
     {
@@ -72,7 +70,6 @@ namespace BINDER_SPACE
         kAssemblyArchitecture = pAssemblyName->GetArchitecture();
         SetIsInTPA(fIsInTPA);
         SetPEImage(pPEImage);
-        SetNativePEImage(pNativePEImage);
         pAssemblyName->SetIsDefinition(TRUE);
 
         // Now take ownership of assembly names

--- a/src/coreclr/binder/assemblybindercommon.cpp
+++ b/src/coreclr/binder/assemblybindercommon.cpp
@@ -245,17 +245,12 @@ namespace BINDER_SPACE
         return hr;
     }
 
-    // See code:BINDER_SPACE::AssemblyBinderCommon::GetAssembly for info on fNgenExplicitBind
-    // and fExplicitBindToNativeImage, and see code:CEECompileInfo::LoadAssemblyByPath
-    // for an example of how they're used.
     HRESULT AssemblyBinderCommon::BindAssembly(/* in */  AssemblyBinder      *pBinder,
-                                         /* in */  AssemblyName        *pAssemblyName,
-                                         /* in */  LPCWSTR              szCodeBase,
-                                         /* in */  PEAssembly          *pParentAssembly,
-                                         /* in */  BOOL                 fNgenExplicitBind,
-                                         /* in */  BOOL                 fExplicitBindToNativeImage,
-                                         /* in */  bool                 excludeAppPaths,
-                                         /* out */ Assembly           **ppAssembly)
+                                               /* in */  AssemblyName        *pAssemblyName,
+                                               /* in */  LPCWSTR              szCodeBase,
+                                               /* in */  PEAssembly          *pParentAssembly,
+                                               /* in */  bool                 excludeAppPaths,
+                                               /* out */ Assembly           **ppAssembly)
     {
         HRESULT hr = S_OK;
         LONG kContextVersion = 0;
@@ -286,18 +281,9 @@ namespace BINDER_SPACE
 
                 // Convert URL to full path and block HTTP downloads
                 IF_FAIL_GO(URLToFullPath(assemblyPath));
-                BOOL fDoNgenExplicitBind = fNgenExplicitBind;
-
-                // Only use explicit ngen binding in the new coreclr path-based binding model
-                if (!pApplicationContext->IsTpaListProvided())
-                {
-                    fDoNgenExplicitBind = FALSE;
-                }
 
                 IF_FAIL_GO(BindWhereRef(pApplicationContext,
                                         assemblyPath,
-                                        fDoNgenExplicitBind,
-                                        fExplicitBindToNativeImage,
                                         excludeAppPaths,
                                         &bindResult));
             }
@@ -338,7 +324,7 @@ namespace BINDER_SPACE
 
 #if !defined(DACCESS_COMPILE)
     /* static */
-    HRESULT AssemblyBinderCommon::BindToSystem(BINDER_SPACE::Assembly** ppSystemAssembly, bool fBindToNativeImage)
+    HRESULT AssemblyBinderCommon::BindToSystem(BINDER_SPACE::Assembly** ppSystemAssembly)
     {
         HRESULT hr = S_OK;
         _ASSERTE(ppSystemAssembly != NULL);
@@ -347,7 +333,7 @@ namespace BINDER_SPACE
         {
             ReleaseHolder<BINDER_SPACE::Assembly> pAsm;
             StackSString systemPath(SystemDomain::System()->SystemDirectory());
-            hr = AssemblyBinderCommon::BindToSystem(systemPath, &pAsm, fBindToNativeImage);
+            hr = AssemblyBinderCommon::BindToSystem(systemPath, &pAsm);
             if (SUCCEEDED(hr))
             {
                 _ASSERTE(pAsm != NULL);
@@ -362,8 +348,7 @@ namespace BINDER_SPACE
 
     /* static */
     HRESULT AssemblyBinderCommon::BindToSystem(SString   &systemDirectory,
-                                         Assembly **ppSystemAssembly,
-                                         bool       fBindToNativeImage)
+                                               Assembly **ppSystemAssembly)
     {
         HRESULT hr = S_OK;
 
@@ -394,7 +379,6 @@ namespace BINDER_SPACE
 
         hr = AssemblyBinderCommon::GetAssembly(sCoreLib,
                                          TRUE /* fIsInTPA */,
-                                         fBindToNativeImage,
                                          &pSystemAssembly,
                                          NULL /* szMDAssemblyPath */,
                                          bundleFileLocation);
@@ -435,7 +419,6 @@ namespace BINDER_SPACE
 
             hr = AssemblyBinderCommon::GetAssembly(sCoreLib,
                 TRUE /* fIsInTPA */,
-                fBindToNativeImage,
                 &pSystemAssembly,
                 NULL /* szMDAssemblyPath */,
                 bundleFileLocation);
@@ -494,7 +477,6 @@ namespace BINDER_SPACE
         ReleaseHolder<Assembly> pSystemAssembly;
         IF_FAIL_GO(AssemblyBinderCommon::GetAssembly(sCoreLibSatellite,
                                                TRUE /* fIsInTPA */,
-                                               FALSE /* fExplicitBindToNativeImage */,
                                                &pSystemAssembly,
                                                NULL /* szMDAssemblyPath */,
                                                bundleFileLocation));
@@ -582,13 +564,8 @@ namespace BINDER_SPACE
     }
 
     /* static */
-    // See code:BINDER_SPACE::AssemblyBinderCommon::GetAssembly for info on fNgenExplicitBind
-    // and fExplicitBindToNativeImage, and see code:CEECompileInfo::LoadAssemblyByPath
-    // for an example of how they're used.
     HRESULT AssemblyBinderCommon::BindWhereRef(ApplicationContext *pApplicationContext,
                                          PathString         &assemblyPath,
-                                         BOOL                fNgenExplicitBind,
-                                         BOOL                fExplicitBindToNativeImage,
                                          bool                excludeAppPaths,
                                          BindResult         *pBindResult)
     {
@@ -609,12 +586,6 @@ namespace BINDER_SPACE
         // Security team did not see any security concern with interpreting the version information.
         IF_FAIL_GO(GetAssembly(assemblyPath,
                                FALSE /* fIsInTPA */,
-
-                               // Pass through caller's intent of whether to bind to the
-                               // NI using an explicit path to the NI that was
-                               // specified.  Generally only NGEN PDB generation has
-                               // this TRUE.
-                               fExplicitBindToNativeImage,
                                &pAssembly,
                                NULL /* szMDAssemblyPath */,
                                Bundle::ProbeAppBundle(assemblyPath)));
@@ -622,18 +593,15 @@ namespace BINDER_SPACE
         AssemblyName *pAssemblyName;
         pAssemblyName = pAssembly->GetAssemblyName();
 
-        if (!fNgenExplicitBind)
+        IF_FAIL_GO(BindLocked(pApplicationContext,
+                                pAssemblyName,
+                                false, // skipVersionCompatibilityCheck
+                                excludeAppPaths,
+                                &lockedBindResult));
+        if (lockedBindResult.HaveResult())
         {
-            IF_FAIL_GO(BindLocked(pApplicationContext,
-                                  pAssemblyName,
-                                  false, // skipVersionCompatibilityCheck
-                                  excludeAppPaths,
-                                  &lockedBindResult));
-            if (lockedBindResult.HaveResult())
-            {
-                pBindResult->SetResult(&lockedBindResult);
-                GO_WITH_HRESULT(S_OK);
-            }
+            pBindResult->SetResult(&lockedBindResult);
+            GO_WITH_HRESULT(S_OK);
         }
 
         hr = S_OK;
@@ -794,7 +762,6 @@ namespace BINDER_SPACE
             ReleaseHolder<Assembly> pAssembly;
             hr = AssemblyBinderCommon::GetAssembly(relativePath,
                                              FALSE /* fIsInTPA */,
-                                             FALSE /* fExplicitBindToNativeImage */,
                                              &pAssembly,
                                              NULL,  // szMDAssemblyPath
                                              bundleFileLocation);
@@ -844,7 +811,6 @@ namespace BINDER_SPACE
 
                 hr = AssemblyBinderCommon::GetAssembly(fileName,
                                                  FALSE /* fIsInTPA */,
-                                                 FALSE /* fExplicitBindToNativeImage */,
                                                  &pAssembly);
                 BinderTracing::PathProbed(fileName, pathSource, hr);
 
@@ -952,7 +918,6 @@ namespace BINDER_SPACE
                 fileName.Append(W(".dll"));
                 hr = AssemblyBinderCommon::GetAssembly(fileName,
                                                  FALSE, // fIsInTPA
-                                                 FALSE, // fExplicitBindToNativeImage
                                                  &pAssembly);
                 BinderTracing::PathProbed(fileName, pathSource, hr);
 
@@ -962,7 +927,6 @@ namespace BINDER_SPACE
                     fileName.Append(W(".exe"));
                     hr = AssemblyBinderCommon::GetAssembly(fileName,
                                                      FALSE, // fIsInTPA
-                                                     FALSE, // fExplicitBindToNativeImage
                                                      &pAssembly);
                     BinderTracing::PathProbed(fileName, pathSource, hr);
                 }
@@ -1059,7 +1023,6 @@ namespace BINDER_SPACE
                     {
                         hr = GetAssembly(assemblyFilePath,
                                          TRUE,  // fIsInTPA
-                                         FALSE, // fExplicitBindToNativeImage
                                          &pTPAAssembly,
                                          NULL,  // szMDAssemblyPath
                                          bundleFileLocation);
@@ -1094,7 +1057,6 @@ namespace BINDER_SPACE
 
                     hr = GetAssembly(fileName,
                                      TRUE,  // fIsInTPA
-                                     TRUE,  // fExplicitBindToNativeImage
                                      &pTPAAssembly);
                     BinderTracing::PathProbed(fileName, BinderTracing::PathSource::ApplicationAssemblies, hr);
                 }
@@ -1105,7 +1067,6 @@ namespace BINDER_SPACE
 
                     hr = GetAssembly(fileName,
                                      TRUE,  // fIsInTPA
-                                     FALSE, // fExplicitBindToNativeImage
                                      &pTPAAssembly);
                     BinderTracing::PathProbed(fileName, BinderTracing::PathSource::ApplicationAssemblies, hr);
                 }
@@ -1191,20 +1152,13 @@ namespace BINDER_SPACE
 
     /* static */
     HRESULT AssemblyBinderCommon::GetAssembly(SString            &assemblyPath,
-                                        BOOL               fIsInTPA,
-
-                                        // When binding to the native image, should we
-                                        // assume assemblyPath explicitly specifies that
-                                        // NI?  (If not, infer the path to the NI
-                                        // implicitly.)
-                                        BOOL               fExplicitBindToNativeImage,
-
-                                        Assembly           **ppAssembly,
-
-                                        // If assemblyPath refers to a native image without metadata,
-                                        // szMDAssemblyPath gives the alternative file to get metadata.
-                                        LPCTSTR            szMDAssemblyPath,
-                                        BundleFileLocation bundleFileLocation)
+                                              BOOL               fIsInTPA,
+                                              Assembly           **ppAssembly,
+  
+                                              // If assemblyPath refers to a native image without metadata,
+                                              // szMDAssemblyPath gives the alternative file to get metadata.
+                                              LPCTSTR            szMDAssemblyPath,
+                                              BundleFileLocation bundleFileLocation)
     {
         HRESULT hr = S_OK;
 
@@ -1224,37 +1178,11 @@ namespace BINDER_SPACE
         {
             LPCTSTR szAssemblyPath = const_cast<LPCTSTR>(assemblyPath.GetUnicode());
 
-            hr = BinderAcquirePEImage(szAssemblyPath, &pPEImage, &pNativePEImage, fExplicitBindToNativeImage, bundleFileLocation);
+            hr = BinderAcquirePEImage(szAssemblyPath, &pPEImage, bundleFileLocation);
             IF_FAIL_GO(hr);
 
-            // If we found a native image, it might be an MSIL assembly masquerading as an native image
-            // as a fallback mechanism for when the Triton tool chain wasn't able to generate a native image.
-            // In that case it will not have a native header, so just treat it like the MSIL assembly it is.
-            if (pNativePEImage)
-            {
-                BOOL hasHeader = TRUE;
-                IF_FAIL_GO(BinderHasNativeHeader(pNativePEImage, &hasHeader));
-                if (!hasHeader)
-                {
-                    BinderReleasePEImage(pPEImage);
-                    BinderReleasePEImage(pNativePEImage);
-
-                    hr = BinderAcquirePEImage(szAssemblyPath, &pPEImage, &pNativePEImage, false, bundleFileLocation);
-                    IF_FAIL_GO(hr);
-                }
-            }
-
-            if (pNativePEImage)
-                hr = BinderAcquireImport(pNativePEImage, &pIMetaDataAssemblyImport, dwPAFlags, TRUE);
-            else
-                hr = BinderAcquireImport(pPEImage, &pIMetaDataAssemblyImport, dwPAFlags, FALSE);
-
+            hr = BinderAcquireImport(pPEImage, &pIMetaDataAssemblyImport, dwPAFlags, FALSE);
             IF_FAIL_GO(hr);
-
-            if (pIMetaDataAssemblyImport == NULL && pNativePEImage != NULL)
-            {
-                IF_FAIL_GO(HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND));
-            }
 
             IF_FAIL_GO(TranslatePEToArchitectureType(dwPAFlags, &PeKind));
         }

--- a/src/coreclr/binder/assemblybindercommon.cpp
+++ b/src/coreclr/binder/assemblybindercommon.cpp
@@ -1181,7 +1181,7 @@ namespace BINDER_SPACE
             hr = BinderAcquirePEImage(szAssemblyPath, &pPEImage, bundleFileLocation);
             IF_FAIL_GO(hr);
 
-            hr = BinderAcquireImport(pPEImage, &pIMetaDataAssemblyImport, dwPAFlags, FALSE);
+            hr = BinderAcquireImport(pPEImage, &pIMetaDataAssemblyImport, dwPAFlags);
             IF_FAIL_GO(hr);
 
             IF_FAIL_GO(TranslatePEToArchitectureType(dwPAFlags, &PeKind));

--- a/src/coreclr/binder/assemblybindercommon.cpp
+++ b/src/coreclr/binder/assemblybindercommon.cpp
@@ -157,7 +157,6 @@ namespace BINDER_SPACE
         HRESULT CreateImageAssembly(IMDInternalImport       *pIMetaDataAssemblyImport,
                                     PEKIND                   PeKind,
                                     PEImage                 *pPEImage,
-                                    PEImage                 *pNativePEImage,
                                     BindResult              *pBindResult)
         {
             HRESULT hr = S_OK;
@@ -168,7 +167,6 @@ namespace BINDER_SPACE
             IF_FAIL_GO(pAssembly->Init(pIMetaDataAssemblyImport,
                                        PeKind,
                                        pPEImage,
-                                       pNativePEImage,
                                        asesmblyPath,
                                        FALSE /* fIsInTPA */));
 
@@ -1169,7 +1167,6 @@ namespace BINDER_SPACE
         DWORD dwPAFlags[2];
         PEKIND PeKind = peNone;
         PEImage *pPEImage = NULL;
-        PEImage *pNativePEImage = NULL;
 
         // Allocate assembly object
         SAFE_NEW(pAssembly, Assembly);
@@ -1191,7 +1188,6 @@ namespace BINDER_SPACE
         IF_FAIL_GO(pAssembly->Init(pIMetaDataAssemblyImport,
                                    PeKind,
                                    pPEImage,
-                                   pNativePEImage,
                                    assemblyPath,
                                    fIsInTPA));
 
@@ -1201,7 +1197,6 @@ namespace BINDER_SPACE
     Exit:
 
         BinderReleasePEImage(pPEImage);
-        BinderReleasePEImage(pNativePEImage);
 
         // Normalize file not found
         if ((FAILED(hr)) && IsFileNotFound(hr))
@@ -1393,7 +1388,6 @@ Retry:
             IF_FAIL_GO(CreateImageAssembly(pIMetaDataAssemblyImport,
                                            peKind,
                                            pPEImage,
-                                           NULL,
                                            &bindResult));
         }
         else if (hr == S_OK)

--- a/src/coreclr/binder/customassemblybinder.cpp
+++ b/src/coreclr/binder/customassemblybinder.cpp
@@ -26,13 +26,11 @@ HRESULT CustomAssemblyBinder::BindAssemblyByNameWorker(BINDER_SPACE::AssemblyNam
 
     // Do we have the assembly already loaded in the context of the current binder?
     hr = AssemblyBinderCommon::BindAssembly(this,
-                                      pAssemblyName,
-                                      NULL,
-                                      NULL,
-                                      FALSE, //fNgenExplicitBind,
-                                      FALSE, //fExplicitBindToNativeImage,
-                                      false, //excludeAppPaths,
-                                      ppCoreCLRFoundAssembly);
+                                            pAssemblyName,
+                                            NULL,  // szCodeBase
+                                            NULL,  // pParentAssembly
+                                            false, //excludeAppPaths,
+                                            ppCoreCLRFoundAssembly);
     if (!FAILED(hr))
     {
         _ASSERTE(*ppCoreCLRFoundAssembly != NULL);

--- a/src/coreclr/binder/customassemblybinder.cpp
+++ b/src/coreclr/binder/customassemblybinder.cpp
@@ -103,8 +103,7 @@ Exit:;
 }
 
 HRESULT CustomAssemblyBinder::BindUsingPEImage( /* in */ PEImage *pPEImage,
-                                                            /* in */ BOOL fIsNativeImage,
-                                                            /* [retval][out] */ BINDER_SPACE::Assembly **ppAssembly)
+                                                /* [retval][out] */ BINDER_SPACE::Assembly **ppAssembly)
 {
     HRESULT hr = S_OK;
 
@@ -118,7 +117,7 @@ HRESULT CustomAssemblyBinder::BindUsingPEImage( /* in */ PEImage *pPEImage,
 
         // Get the Metadata interface
         DWORD dwPAFlags[2];
-        IF_FAIL_GO(BinderAcquireImport(pPEImage, &pIMetaDataAssemblyImport, dwPAFlags, fIsNativeImage));
+        IF_FAIL_GO(BinderAcquireImport(pPEImage, &pIMetaDataAssemblyImport, dwPAFlags));
         IF_FAIL_GO(AssemblyBinderCommon::TranslatePEToArchitectureType(dwPAFlags, &PeKind));
 
         _ASSERTE(pIMetaDataAssemblyImport != NULL);

--- a/src/coreclr/binder/defaultassemblybinder.cpp
+++ b/src/coreclr/binder/defaultassemblybinder.cpp
@@ -113,8 +113,7 @@ Exit:;
 
 #if !defined(DACCESS_COMPILE)
 HRESULT DefaultAssemblyBinder::BindUsingPEImage( /* in */ PEImage *pPEImage,
-                                                /* in */ BOOL fIsNativeImage,
-                                                /* [retval][out] */ BINDER_SPACE::Assembly **ppAssembly)
+                                                 /* [retval][out] */ BINDER_SPACE::Assembly **ppAssembly)
 {
     HRESULT hr = S_OK;
 
@@ -128,7 +127,7 @@ HRESULT DefaultAssemblyBinder::BindUsingPEImage( /* in */ PEImage *pPEImage,
 
         // Get the Metadata interface
         DWORD dwPAFlags[2];
-        IF_FAIL_GO(BinderAcquireImport(pPEImage, &pIMetaDataAssemblyImport, dwPAFlags, fIsNativeImage));
+        IF_FAIL_GO(BinderAcquireImport(pPEImage, &pIMetaDataAssemblyImport, dwPAFlags));
         IF_FAIL_GO(AssemblyBinderCommon::TranslatePEToArchitectureType(dwPAFlags, &PeKind));
 
         _ASSERTE(pIMetaDataAssemblyImport != NULL);

--- a/src/coreclr/binder/defaultassemblybinder.cpp
+++ b/src/coreclr/binder/defaultassemblybinder.cpp
@@ -24,13 +24,11 @@ HRESULT DefaultAssemblyBinder::BindAssemblyByNameWorker(BINDER_SPACE::AssemblyNa
 #endif
 
     hr = AssemblyBinderCommon::BindAssembly(this,
-                                      pAssemblyName,
-                                      NULL,
-                                      NULL,
-                                      FALSE, //fNgenExplicitBind,
-                                      FALSE, //fExplicitBindToNativeImage,
-                                      excludeAppPaths,
-                                      ppCoreCLRFoundAssembly);
+                                            pAssemblyName,
+                                            NULL, // szCodeBase
+                                            NULL, // pParentAssembly
+                                            excludeAppPaths,
+                                            ppCoreCLRFoundAssembly);
     if (!FAILED(hr))
     {
         (*ppCoreCLRFoundAssembly)->SetBinder(this);
@@ -201,14 +199,9 @@ HRESULT DefaultAssemblyBinder::SetupBindingPaths(SString  &sTrustedPlatformAssem
     return hr;
 }
 
-// See code:BINDER_SPACE::AssemblyBinderCommon::GetAssembly for info on fNgenExplicitBind
-// and fExplicitBindToNativeImage, and see code:CEECompileInfo::LoadAssemblyByPath
-// for an example of how they're used.
-HRESULT DefaultAssemblyBinder::Bind(LPCWSTR            wszCodeBase,
-                                   PEAssembly        *pParentAssembly,
-                                   BOOL               fNgenExplicitBind,
-                                   BOOL               fExplicitBindToNativeImage,
-                                   BINDER_SPACE::Assembly **ppAssembly)
+HRESULT DefaultAssemblyBinder::Bind(LPCWSTR                  wszCodeBase,
+                                    PEAssembly              *pParentAssembly,
+                                    BINDER_SPACE::Assembly **ppAssembly)
 {
     HRESULT hr = S_OK;
     VALIDATE_ARG_RET(wszCodeBase != NULL && ppAssembly != NULL);
@@ -217,13 +210,11 @@ HRESULT DefaultAssemblyBinder::Bind(LPCWSTR            wszCodeBase,
     {
         ReleaseHolder<BINDER_SPACE::Assembly> pAsm;
         hr = AssemblyBinderCommon::BindAssembly(this,
-                                          NULL,
-                                          wszCodeBase,
-                                          pParentAssembly,
-                                          fNgenExplicitBind,
-                                          fExplicitBindToNativeImage,
-                                          false, // excludeAppPaths
-                                          &pAsm);
+                                                NULL, // pAssemblyName
+                                                wszCodeBase,
+                                                pParentAssembly,
+                                                false, // excludeAppPaths
+                                                &pAsm);
         if(SUCCEEDED(hr))
         {
             _ASSERTE(pAsm != NULL);

--- a/src/coreclr/binder/inc/assembly.hpp
+++ b/src/coreclr/binder/inc/assembly.hpp
@@ -29,8 +29,6 @@
 
 STDAPI BinderAcquirePEImage(LPCTSTR            szAssemblyPath,
                             PEImage          **ppPEImage,
-                            PEImage          **ppNativeImage,
-                            BOOL               fExplicitBindToNativeImage,
                             BundleFileLocation bundleFileLocation);
 
 STDAPI BinderAcquireImport(PEImage            *pPEImage,

--- a/src/coreclr/binder/inc/assembly.hpp
+++ b/src/coreclr/binder/inc/assembly.hpp
@@ -33,11 +33,7 @@ STDAPI BinderAcquirePEImage(LPCTSTR            szAssemblyPath,
 
 STDAPI BinderAcquireImport(PEImage            *pPEImage,
                            IMDInternalImport **pIMetaDataAssemblyImport,
-                           DWORD              *pdwPAFlags,
-                           BOOL                bNativeImage);
-
-STDAPI BinderHasNativeHeader(PEImage *pPEImage,
-                             BOOL    *result);
+                           DWORD              *pdwPAFlags);
 
 STDAPI BinderReleasePEImage(PEImage *pPEImage);
 

--- a/src/coreclr/binder/inc/assembly.hpp
+++ b/src/coreclr/binder/inc/assembly.hpp
@@ -65,7 +65,6 @@ namespace BINDER_SPACE
         HRESULT Init(/* in */ IMDInternalImport       *pIMetaDataAssemblyImport,
                      /* in */ PEKIND                   PeKind,
                      /* in */ PEImage                 *pPEImage,
-                     /* in */ PEImage                 *pPENativeImage,
                      /* in */ SString                 &assemblyPath,
                      /* in */ BOOL                     fIsInTPA);
 
@@ -75,8 +74,6 @@ namespace BINDER_SPACE
         inline SString &GetPath();
 
         inline PEImage *GetPEImage(BOOL fAddRef = FALSE);
-        inline PEImage *GetNativePEImage(BOOL fAddRef = FALSE);
-        inline PEImage *GetNativeOrILPEImage(BOOL fAddRef = FALSE);
 
         HRESULT GetMVID(GUID *pMVID);
 
@@ -99,7 +96,6 @@ namespace BINDER_SPACE
         };
 
         inline void SetPEImage(PEImage *pPEImage);
-        inline void SetNativePEImage(PEImage *pNativePEImage);
 
         inline void SetAssemblyName(AssemblyName *pAssemblyName,
                                     BOOL          fAddRef = TRUE);
@@ -110,7 +106,6 @@ namespace BINDER_SPACE
 
         LONG                     m_cRef;
         PEImage                 *m_pPEImage;
-        PEImage                 *m_pNativePEImage;
         IMDInternalImport       *m_pMDImport;
         AssemblyName            *m_pAssemblyName;
         SString                  m_assemblyPath;

--- a/src/coreclr/binder/inc/assembly.inl
+++ b/src/coreclr/binder/inc/assembly.inl
@@ -43,36 +43,10 @@ PEImage *Assembly::GetPEImage(BOOL fAddRef /* = FALSE */)
     return pPEImage;
 }
 
-PEImage *Assembly::GetNativePEImage(BOOL fAddRef /* = FALSE */)
-{
-    PEImage *pNativePEImage = m_pNativePEImage;
-
-    if (fAddRef)
-    {
-        BinderAddRefPEImage(pNativePEImage);
-    }
-
-    return pNativePEImage;
-}
-
-PEImage *Assembly::GetNativeOrILPEImage(BOOL fAddRef /* = FALSE */)
-{
-    PEImage* pPEImage = GetNativePEImage(fAddRef);
-    if (pPEImage == NULL)
-        pPEImage = GetPEImage(fAddRef);
-    return pPEImage;
-}
-
 void Assembly::SetPEImage(PEImage *pPEImage)
 {
     BinderAddRefPEImage(pPEImage);
     m_pPEImage = pPEImage;
-}
-
-void Assembly::SetNativePEImage(PEImage *pNativePEImage)
-{
-    BinderAddRefPEImage(pNativePEImage);
-    m_pNativePEImage = pNativePEImage;
 }
 
 AssemblyName *Assembly::GetAssemblyName(BOOL fAddRef /* = FALSE */)

--- a/src/coreclr/binder/inc/assemblybindercommon.hpp
+++ b/src/coreclr/binder/inc/assemblybindercommon.hpp
@@ -30,23 +30,17 @@ namespace BINDER_SPACE
     class AssemblyBinderCommon
     {
     public:
-        // See code:BINDER_SPACE::AssemblyBinderCommon::GetAssembly for info on fNgenExplicitBind
-        // and fExplicitBindToNativeImage, and see code:CEECompileInfo::LoadAssemblyByPath
-        // for an example of how they're used.
         static HRESULT BindAssembly(/* in */  AssemblyBinder      *pBinder, 
                                     /* in */  AssemblyName        *pAssemblyName,
                                     /* in */  LPCWSTR              szCodeBase,
                                     /* in */  PEAssembly          *pParentAssembly,
-                                    /* in */  BOOL                 fNgenExplicitBind,
-                                    /* in */  BOOL                 fExplicitBindToNativeImage,
                                     /* in */  bool                 excludeAppPaths,
                                     /* out */ Assembly           **ppAssembly);
 
-        static HRESULT BindToSystem(BINDER_SPACE::Assembly** ppSystemAssembly, bool fBindToNativeImage);
+        static HRESULT BindToSystem(BINDER_SPACE::Assembly** ppSystemAssembly);
 
         static HRESULT BindToSystem(/* in */ SString    &systemDirectory,
-                                    /* out */ Assembly **ppSystemAssembly,
-                                    /* in */ bool fBindToNativeImage);
+                                    /* out */ Assembly **ppSystemAssembly);
 
         static HRESULT BindToSystemSatellite(/* in */ SString   &systemDirectory,
                                              /* in */ SString   &simpleName,
@@ -55,7 +49,6 @@ namespace BINDER_SPACE
 
         static HRESULT GetAssembly(/* in */  SString     &assemblyPath,
                                    /* in */  BOOL         fIsInTPA,
-                                   /* in */  BOOL         fExplicitBindToNativeImage,
                                    /* out */ Assembly   **ppAssembly,
                                    /* in */  LPCTSTR      szMDAssemblyPath = NULL,
                                    /* in */  BundleFileLocation bundleFileLocation = BundleFileLocation::Invalid());
@@ -93,13 +86,8 @@ namespace BINDER_SPACE
                                   /* in */  bool                excludeAppPaths,
                                   /* out */ BindResult         *pBindResult);
 
-        // See code:BINDER_SPACE::AssemblyBinderCommon::GetAssembly for info on fNgenExplicitBind
-        // and fExplicitBindToNativeImage, and see code:CEECompileInfo::LoadAssemblyByPath
-        // for an example of how they're used.
         static HRESULT BindWhereRef(/* in */  ApplicationContext *pApplicationContext,
                                     /* in */  PathString         &assemblyPath,
-                                    /* in */  BOOL                fNgenExplicitBind,
-                                    /* in */  BOOL                fExplicitBindToNativeImage,
                                     /* in */  bool                excludeAppPaths,
                                     /* out */ BindResult         *pBindResult);
 

--- a/src/coreclr/binder/inc/customassemblybinder.h
+++ b/src/coreclr/binder/inc/customassemblybinder.h
@@ -21,7 +21,6 @@ public:
     // AssemblyBinder functions
     //-------------------------------------------------------------------------
     HRESULT BindUsingPEImage(PEImage* pPEImage,
-        BOOL fIsNativeImage,
         BINDER_SPACE::Assembly** ppAssembly);
 
     HRESULT BindUsingAssemblyName(BINDER_SPACE::AssemblyName* pAssemblyName,

--- a/src/coreclr/binder/inc/defaultassemblybinder.h
+++ b/src/coreclr/binder/inc/defaultassemblybinder.h
@@ -19,7 +19,6 @@ public:
     //-------------------------------------------------------------------------
 
     HRESULT BindUsingPEImage(PEImage* pPEImage,
-        BOOL fIsNativeImage,
         BINDER_SPACE::Assembly** ppAssembly);
 
     HRESULT BindUsingAssemblyName(BINDER_SPACE::AssemblyName* pAssemblyName,

--- a/src/coreclr/binder/inc/defaultassemblybinder.h
+++ b/src/coreclr/binder/inc/defaultassemblybinder.h
@@ -39,8 +39,6 @@ public:
 
     HRESULT Bind(LPCWSTR      wszCodeBase,
                  PEAssembly  *pParentAssembly,
-                 BOOL         fNgenExplicitBind,
-                 BOOL         fExplicitBindToNativeImage,
                  BINDER_SPACE::Assembly **ppAssembly);
 
 private:

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -3829,7 +3829,7 @@ PEAssembly * AppDomain::BindAssemblySpec(
                 // Use CoreClr's fusion alternative
                 CoreBindResult bindResult;
 
-                pSpec->Bind(this, FALSE /* fThrowOnFileNotFound */, &bindResult, FALSE /* fNgenExplicitBind */, FALSE /* fExplicitBindToNativeImage */);
+                pSpec->Bind(this, FALSE /* fThrowOnFileNotFound */, &bindResult);
                 hrBindResult = bindResult.GetHRBindResult();
 
                 if (bindResult.Found())

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -1322,7 +1322,7 @@ void SystemDomain::LoadBaseSystemClasses()
     ETWOnStartup(LdSysBases_V1, LdSysBasesEnd_V1);
 
     {
-        m_pSystemFile = PEAssembly::OpenSystem(NULL);
+        m_pSystemFile = PEAssembly::OpenSystem();
     }
     // Only partially load the system assembly. Other parts of the code will want to access
     // the globals in this function before finishing the load.

--- a/src/coreclr/vm/assembly.cpp
+++ b/src/coreclr/vm/assembly.cpp
@@ -61,33 +61,7 @@
 
 #ifndef DACCESS_COMPILE
 
-// This value is to make it easier to diagnose Assembly Loader "grant set" crashes.
-// See Dev11 bug 358184 for more details.
-
-// This value is not thread safe and is not intended to be. It is just a best
-// effort to collect more data on the problem. Is is possible, though unlikely,
-// that thread A would record a reason for an upcoming crash,
-// thread B would then record a different reason, and we would then
-// crash on thread A, thus ending up with the recorded reason not matching
-// the thread we crash in. Be aware of this when using this value
-// to help your debugging.
-DWORD g_dwLoaderReasonForNotSharing = 0; // See code:DomainFile::m_dwReasonForRejectingNativeImage for a similar variable.
-
 volatile uint32_t g_cAssemblies = 0;
-
-// These will sometimes result in a crash with error code 0x80131401 SECURITY_E_INCOMPATIBLE_SHARE
-// "Loading this assembly would produce a different grant set from other instances."
-enum ReasonForNotSharing
-{
-    ReasonForNotSharing_NoInfoRecorded = 0x1,
-    ReasonForNotSharing_NullDomainassembly = 0x2,
-    ReasonForNotSharing_DebuggerFlagMismatch = 0x3,
-    ReasonForNotSharing_NullPeassembly = 0x4,
-    ReasonForNotSharing_MissingAssemblyClosure1 = 0x5,
-    ReasonForNotSharing_MissingAssemblyClosure2 = 0x6,
-    ReasonForNotSharing_MissingDependenciesResolved = 0x7,
-    ReasonForNotSharing_ClosureComparisonFailed = 0x8,
-};
 
 static CrstStatic g_friendAssembliesCrst;
 

--- a/src/coreclr/vm/assemblybinder.h
+++ b/src/coreclr/vm/assemblybinder.h
@@ -16,7 +16,6 @@ public:
         BINDER_SPACE::Assembly** ppAssembly);
 
     virtual HRESULT BindUsingPEImage(PEImage* pPEImage,
-        BOOL fIsNativeImage,
         BINDER_SPACE::Assembly** ppAssembly) = 0;
 
     virtual HRESULT BindUsingAssemblyName(BINDER_SPACE::AssemblyName* pAssemblyName,

--- a/src/coreclr/vm/assemblynative.cpp
+++ b/src/coreclr/vm/assemblynative.cpp
@@ -127,12 +127,13 @@ void QCALLTYPE AssemblyNative::InternalLoad(QCall::ObjectHandleOnStack assemblyN
 }
 
 /* static */
-Assembly* AssemblyNative::LoadFromPEImage(AssemblyBinder* pBinderContext, PEImage *pILImage, PEImage *pNIImage)
+Assembly* AssemblyNative::LoadFromPEImage(AssemblyBinder* pBinderContext, PEImage *pImage)
 {
     CONTRACT(Assembly*)
     {
         STANDARD_VM_CHECK;
         PRECONDITION(CheckPointer(pBinderContext));
+        PRECONDITION(pImage != NULL);
         POSTCONDITION(CheckPointer(RETVAL));
     }
     CONTRACT_END;
@@ -140,19 +141,6 @@ Assembly* AssemblyNative::LoadFromPEImage(AssemblyBinder* pBinderContext, PEImag
     Assembly *pLoadedAssembly = NULL;
 
     ReleaseHolder<BINDER_SPACE::Assembly> pAssembly;
-
-    // Get the correct PEImage to work with.
-    BOOL fIsNativeImage = TRUE;
-    PEImage *pImage = pNIImage;
-    if (pNIImage == NULL)
-    {
-        // Since we do not have a NI image, we are working with IL assembly
-        pImage = pILImage;
-        fIsNativeImage = FALSE;
-    }
-    _ASSERTE(pImage != NULL);
-
-    BOOL fHadLoadFailure = FALSE;
 
     // Force the image to be loaded and mapped so that subsequent loads do not
     // map a duplicate copy.
@@ -181,7 +169,7 @@ Assembly* AssemblyNative::LoadFromPEImage(AssemblyBinder* pBinderContext, PEImag
     HRESULT hr = S_OK;
     PTR_AppDomain pCurDomain = GetAppDomain();
     DefaultAssemblyBinder *pTPABinder = pCurDomain->GetTPABinderContext();
-    hr = pBinderContext->BindUsingPEImage(pImage, fIsNativeImage, &pAssembly);
+    hr = pBinderContext->BindUsingPEImage(pImage, &pAssembly);
 
     if (hr != S_OK)
     {
@@ -216,9 +204,9 @@ void QCALLTYPE AssemblyNative::LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext
     AssemblyBinder *pBinderContext = reinterpret_cast<AssemblyBinder*>(ptrNativeAssemblyLoadContext);
     _ASSERTE(pBinderContext != NULL);
 
-    // Form the PEImage for the ILAssembly. Incase of an exception, the holders will ensure
+    // Form the PEImage for the ILAssembly. Incase of an exception, the holder will ensure
     // the release of the image.
-    PEImageHolder pILImage, pNIImage;
+    PEImageHolder pILImage;
 
     if (pwzILPath != NULL)
     {
@@ -238,7 +226,7 @@ void QCALLTYPE AssemblyNative::LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext
         }
     }
 
-    Assembly *pLoadedAssembly = AssemblyNative::LoadFromPEImage(pBinderContext, pILImage, pNIImage);
+    Assembly *pLoadedAssembly = AssemblyNative::LoadFromPEImage(pBinderContext, pILImage);
 
     {
         GCX_COOP();
@@ -286,8 +274,8 @@ void QCALLTYPE AssemblyNative::LoadFromStream(INT_PTR ptrNativeAssemblyLoadConte
         ThrowHR(COR_E_BADIMAGEFORMAT, BFA_IJW_IN_COLLECTIBLE_ALC);
     }
 
-    // Pass the stream based assembly as IL and NI in an attempt to bind and load it
-    Assembly* pLoadedAssembly = AssemblyNative::LoadFromPEImage(pBinderContext, pILImage, NULL);
+    // Pass the stream based assembly as IL in an attempt to bind and load it
+    Assembly* pLoadedAssembly = AssemblyNative::LoadFromPEImage(pBinderContext, pILImage);
     {
         GCX_COOP();
         retLoadedAssembly.Set(pLoadedAssembly->GetExposedObject());
@@ -343,7 +331,7 @@ void QCALLTYPE AssemblyNative::LoadFromInMemoryModule(INT_PTR ptrNativeAssemblyL
     AssemblyBinder *pBinderContext = reinterpret_cast<AssemblyBinder*>(ptrNativeAssemblyLoadContext);
 
     // Pass the in memory module as IL in an attempt to bind and load it
-    Assembly* pLoadedAssembly = AssemblyNative::LoadFromPEImage(pBinderContext, pILImage, NULL);
+    Assembly* pLoadedAssembly = AssemblyNative::LoadFromPEImage(pBinderContext, pILImage);
     {
         GCX_COOP();
         retLoadedAssembly.Set(pLoadedAssembly->GetExposedObject());

--- a/src/coreclr/vm/assemblynative.cpp
+++ b/src/coreclr/vm/assemblynative.cpp
@@ -184,7 +184,7 @@ Assembly* AssemblyNative::LoadFromPEImage(AssemblyBinder* pBinderContext, PEImag
         COMPlusThrowHR(COR_E_FILELOAD, dwMessageID, name);
     }
 
-    PEAssemblyHolder pPEAssembly(PEAssembly::Open(pParentAssembly, pAssembly->GetPEImage(), NULL, pAssembly));
+    PEAssemblyHolder pPEAssembly(PEAssembly::Open(pParentAssembly, pAssembly->GetPEImage(), pAssembly));
     bindOperation.SetResult(pPEAssembly.GetValue());
 
     DomainAssembly *pDomainAssembly = pCurDomain->LoadDomainAssembly(&spec, pPEAssembly, FILE_LOADED);

--- a/src/coreclr/vm/assemblynative.cpp
+++ b/src/coreclr/vm/assemblynative.cpp
@@ -184,7 +184,7 @@ Assembly* AssemblyNative::LoadFromPEImage(AssemblyBinder* pBinderContext, PEImag
         COMPlusThrowHR(COR_E_FILELOAD, dwMessageID, name);
     }
 
-    PEAssemblyHolder pPEAssembly(PEAssembly::Open(pParentAssembly, pAssembly->GetPEImage(), pAssembly->GetNativePEImage(), pAssembly));
+    PEAssemblyHolder pPEAssembly(PEAssembly::Open(pParentAssembly, pAssembly->GetPEImage(), NULL, pAssembly));
     bindOperation.SetResult(pPEAssembly.GetValue());
 
     DomainAssembly *pDomainAssembly = pCurDomain->LoadDomainAssembly(&spec, pPEAssembly, FILE_LOADED);

--- a/src/coreclr/vm/assemblynative.hpp
+++ b/src/coreclr/vm/assemblynative.hpp
@@ -119,7 +119,7 @@ public:
 #ifndef TARGET_UNIX
     static void QCALLTYPE LoadFromInMemoryModule(INT_PTR ptrNativeAssemblyLoadContext, INT_PTR hModule, QCall::ObjectHandleOnStack retLoadedAssembly);
 #endif
-    static Assembly* LoadFromPEImage(AssemblyBinder* pBinderContext, PEImage *pILImage, PEImage *pNIImage);
+    static Assembly* LoadFromPEImage(AssemblyBinder* pBinderContext, PEImage *pImage);
     static INT_PTR QCALLTYPE GetLoadContextForAssembly(QCall::AssemblyHandle pAssembly);
 
     static BOOL QCALLTYPE InternalTryGetRawMetadata(QCall::AssemblyHandle assembly, UINT8 **blobRef, INT32 *lengthRef);

--- a/src/coreclr/vm/assemblyspec.hpp
+++ b/src/coreclr/vm/assemblyspec.hpp
@@ -188,9 +188,7 @@ class AssemblySpec  : public BaseAssemblySpec
     VOID Bind(
         AppDomain* pAppDomain,
         BOOL fThrowOnFileNotFound,
-        CoreBindResult* pBindResult,
-        BOOL fNgenExplicitBind = FALSE,
-        BOOL fExplicitBindToNativeImage = FALSE);
+        CoreBindResult* pBindResult);
 
     Assembly *LoadAssembly(FileLoadLevel targetLevel,
                            BOOL fThrowOnFileNotFound = TRUE);

--- a/src/coreclr/vm/coreassemblyspec.cpp
+++ b/src/coreclr/vm/coreassemblyspec.cpp
@@ -68,14 +68,9 @@ static VOID ThrowLoadError(AssemblySpec * pSpec, HRESULT hr)
     EEFileLoadException::Throw(name, hr);
 }
 
-// See code:BINDER_SPACE::AssemblyBinderCommon::GetAssembly for info on fNgenExplicitBind
-// and fExplicitBindToNativeImage, and see code:CEECompileInfo::LoadAssemblyByPath
-// for an example of how they're used.
 VOID  AssemblySpec::Bind(AppDomain      *pAppDomain,
                          BOOL            fThrowOnFileNotFound,
-                         CoreBindResult *pResult,
-                         BOOL fNgenExplicitBind /* = FALSE */,
-                         BOOL fExplicitBindToNativeImage /* = FALSE */)
+                         CoreBindResult *pResult)
 {
     CONTRACTL
     {
@@ -122,8 +117,6 @@ VOID  AssemblySpec::Bind(AppDomain      *pAppDomain,
     }
     else if (m_wszCodeBase == NULL)
     {
-        // For name based binding these arguments shouldn't have been changed from default
-        _ASSERTE(!fNgenExplicitBind && !fExplicitBindToNativeImage);
         AssemblyNameData assemblyNameData = { 0 };
         PopulateAssemblyNameData(assemblyNameData);
         hr = pBinder->BindAssemblyByName(&assemblyNameData, &pPrivAsm);
@@ -132,8 +125,6 @@ VOID  AssemblySpec::Bind(AppDomain      *pAppDomain,
     {
         hr = pTPABinder->Bind(m_wszCodeBase,
                               GetParentAssembly() ? GetParentAssembly()->GetFile() : NULL,
-                              fNgenExplicitBind,
-                              fExplicitBindToNativeImage,
                               &pPrivAsm);
     }
 
@@ -156,8 +147,6 @@ VOID  AssemblySpec::Bind(AppDomain      *pAppDomain,
 
 STDAPI BinderAcquirePEImage(LPCWSTR             wszAssemblyPath,
                             PEImage           **ppPEImage,
-                            PEImage           **ppNativeImage,
-                            BOOL                fExplicitBindToNativeImage,
                             BundleFileLocation  bundleFileLocation)
 {
     HRESULT hr = S_OK;
@@ -166,10 +155,7 @@ STDAPI BinderAcquirePEImage(LPCWSTR             wszAssemblyPath,
 
     EX_TRY
     {
-        PEImageHolder pImage = NULL;
-        PEImageHolder pNativeImage = NULL;
-
-        pImage = PEImage::OpenImage(wszAssemblyPath, MDInternalImport_Default, bundleFileLocation);
+        PEImageHolder pImage = PEImage::OpenImage(wszAssemblyPath, MDInternalImport_Default, bundleFileLocation);
 
         // Make sure that the IL image can be opened if the native image is not available.
         hr=pImage->TryOpenFile();
@@ -180,9 +166,6 @@ STDAPI BinderAcquirePEImage(LPCWSTR             wszAssemblyPath,
 
         if (pImage)
             *ppPEImage = pImage.Extract();
-
-        if (ppNativeImage)
-            *ppNativeImage = pNativeImage.Extract();
     }
     EX_CATCH_HRESULT(hr);
 

--- a/src/coreclr/vm/coreassemblyspec.cpp
+++ b/src/coreclr/vm/coreassemblyspec.cpp
@@ -173,40 +173,9 @@ STDAPI BinderAcquirePEImage(LPCWSTR             wszAssemblyPath,
     return hr;
 }
 
-STDAPI BinderHasNativeHeader(PEImage *pPEImage, BOOL* result)
-{
-    HRESULT hr = S_OK;
-
-    _ASSERTE(pPEImage != NULL);
-    _ASSERTE(result != NULL);
-
-    EX_TRY
-    {
-        *result = pPEImage->HasNativeHeader();
-    }
-    EX_CATCH_HRESULT(hr);
-
-    if (FAILED(hr))
-    {
-        *result = false;
-
-#if defined(TARGET_UNIX)
-        // PAL_LOADLoadPEFile may fail while loading IL masquerading as NI.
-        // This will result in a ThrowHR(E_FAIL).  Suppress the error.
-        if(hr == E_FAIL)
-        {
-            hr = S_OK;
-        }
-#endif // defined(TARGET_UNIX)
-    }
-
-    return hr;
-}
-
 STDAPI BinderAcquireImport(PEImage                  *pPEImage,
                            IMDInternalImport       **ppIAssemblyMetaDataImport,
-                           DWORD                    *pdwPAFlags,
-                           BOOL                      bNativeImage)
+                           DWORD                    *pdwPAFlags)
 {
     HRESULT hr = S_OK;
 
@@ -230,9 +199,7 @@ STDAPI BinderAcquireImport(PEImage                  *pPEImage,
         *ppIAssemblyMetaDataImport = pPEImage->GetMDImport();
         if (!*ppIAssemblyMetaDataImport)
         {
-            // Some native images don't contain metadata, to reduce size
-            if (!bNativeImage)
-                IfFailGo(COR_E_BADIMAGEFORMAT);
+            IfFailGo(COR_E_BADIMAGEFORMAT);
         }
         else
             (*ppIAssemblyMetaDataImport)->AddRef();

--- a/src/coreclr/vm/coreclr/corebindresult.h
+++ b/src/coreclr/vm/coreclr/corebindresult.h
@@ -42,8 +42,6 @@ public:
     PEImage* GetPEImage();
     BOOL IsCoreLib();
     void GetBindAssembly(BINDER_SPACE::Assembly** ppAssembly);
-    BOOL HasNativeImage() { return FALSE; }
-    PEImage* GetNativeImage() { return NULL; }
 
     void SetHRBindResult(HRESULT hrBindResult);
     HRESULT GetHRBindResult();

--- a/src/coreclr/vm/coreclr/corebindresult.inl
+++ b/src/coreclr/vm/coreclr/corebindresult.inl
@@ -50,7 +50,7 @@ inline PEImage* CoreBindResult::GetPEImage()
 {
     WRAPPER_NO_CONTRACT;
     return m_pAssembly ?
-        m_pAssembly->GetNativeOrILPEImage() :
+        m_pAssembly->GetPEImage() :
         NULL;
 };
 

--- a/src/coreclr/vm/domainfile.cpp
+++ b/src/coreclr/vm/domainfile.cpp
@@ -41,8 +41,7 @@ DomainFile::DomainFile(AppDomain *pDomain, PEFile *pFile)
     m_loading(TRUE),
     m_pDynamicMethodTable(NULL),
     m_pUMThunkHash(NULL),
-    m_bDisableActivationCheck(FALSE),
-    m_dwReasonForRejectingNativeImage(0)
+    m_bDisableActivationCheck(FALSE)
 {
     CONTRACTL
     {

--- a/src/coreclr/vm/domainfile.h
+++ b/src/coreclr/vm/domainfile.h
@@ -394,11 +394,6 @@ class DomainFile
     DynamicMethodTable          *m_pDynamicMethodTable;
     class UMThunkHash *m_pUMThunkHash;
     BOOL m_bDisableActivationCheck;
-
-    // This value is to make it easier to diagnose Assembly Loader "rejected native image" crashes.
-    // See Dev11 bug 358184 for more details
-public:
-    DWORD m_dwReasonForRejectingNativeImage; // See code:g_dwLoaderReasonForNotSharing in Assembly.cpp for a similar variable.
 };
 
 // These will sometimes result in a crash with error code 0x80131506 COR_E_EXECUTIONENGINE

--- a/src/coreclr/vm/pefile.cpp
+++ b/src/coreclr/vm/pefile.cpp
@@ -1139,7 +1139,7 @@ PEAssembly *PEAssembly::DoOpenSystem(IUnknown * pAppCtx)
     ETWOnStartup (FusionBinding_V1, FusionBindingEnd_V1);
     CoreBindResult bindResult;
     ReleaseHolder<BINDER_SPACE::Assembly> pPrivAsm;
-    IfFailThrow(BINDER_SPACE::AssemblyBinderCommon::BindToSystem(&pPrivAsm, true));
+    IfFailThrow(BINDER_SPACE::AssemblyBinderCommon::BindToSystem(&pPrivAsm));
     if(pPrivAsm != NULL)
     {
         bindResult.Init(pPrivAsm);

--- a/src/coreclr/vm/pefile.cpp
+++ b/src/coreclr/vm/pefile.cpp
@@ -986,12 +986,10 @@ PEAssembly::PEAssembly(
                 PEFile *creator,
                 BOOL system,
                 PEImage * pPEImageIL /*= NULL*/,
-                PEImage * pPEImageNI /*= NULL*/,
                 BINDER_SPACE::Assembly * pHostAssembly /*= NULL*/)
 
-  : PEFile(pBindResultInfo ? (pBindResultInfo->GetPEImage() ? pBindResultInfo->GetPEImage() :
-                                                              (pBindResultInfo->HasNativeImage() ? pBindResultInfo->GetNativeImage() : NULL)
-                              ): pPEImageIL? pPEImageIL:(pPEImageNI? pPEImageNI:NULL)),
+  : PEFile(pBindResultInfo ? pBindResultInfo->GetPEImage()
+                           : pPEImageIL),
     m_creator(clr::SafeAddRef(creator))
 {
     CONTRACTL
@@ -999,7 +997,7 @@ PEAssembly::PEAssembly(
         CONSTRUCTOR_CHECK;
         PRECONDITION(CheckPointer(pEmit, NULL_OK));
         PRECONDITION(CheckPointer(creator, NULL_OK));
-        PRECONDITION(pBindResultInfo == NULL || (pPEImageIL == NULL && pPEImageNI == NULL));
+        PRECONDITION(pBindResultInfo == NULL || pPEImageIL == NULL);
         STANDARD_VM_CHECK;
     }
     CONTRACTL_END;
@@ -1066,7 +1064,6 @@ PEAssembly::PEAssembly(
 PEAssembly *PEAssembly::Open(
     PEAssembly *       pParent,
     PEImage *          pPEImageIL,
-    PEImage *          pPEImageNI,
     BINDER_SPACE::Assembly * pHostAssembly)
 {
     STANDARD_VM_CONTRACT;
@@ -1077,7 +1074,6 @@ PEAssembly *PEAssembly::Open(
         pParent,        // PEFile creator
         FALSE,          // isSystem
         pPEImageIL,
-        pPEImageNI,
         pHostAssembly);
 
     return pPEAssembly;
@@ -1102,7 +1098,7 @@ PEAssembly::~PEAssembly()
 }
 
 /* static */
-PEAssembly *PEAssembly::OpenSystem(IUnknown * pAppCtx)
+PEAssembly *PEAssembly::OpenSystem()
 {
     STANDARD_VM_CONTRACT;
 
@@ -1110,7 +1106,7 @@ PEAssembly *PEAssembly::OpenSystem(IUnknown * pAppCtx)
 
     EX_TRY
     {
-        result = DoOpenSystem(pAppCtx);
+        result = DoOpenSystem();
     }
     EX_HOOK
     {
@@ -1127,7 +1123,7 @@ PEAssembly *PEAssembly::OpenSystem(IUnknown * pAppCtx)
 }
 
 /* static */
-PEAssembly *PEAssembly::DoOpenSystem(IUnknown * pAppCtx)
+PEAssembly *PEAssembly::DoOpenSystem()
 {
     CONTRACT(PEAssembly *)
     {
@@ -1145,7 +1141,7 @@ PEAssembly *PEAssembly::DoOpenSystem(IUnknown * pAppCtx)
         bindResult.Init(pPrivAsm);
     }
 
-    RETURN new PEAssembly(&bindResult, NULL, NULL, TRUE, FALSE);
+    RETURN new PEAssembly(&bindResult, NULL, NULL, TRUE);
 }
 
 PEAssembly* PEAssembly::Open(CoreBindResult* pBindResult,

--- a/src/coreclr/vm/pefile.h
+++ b/src/coreclr/vm/pefile.h
@@ -559,11 +559,10 @@ class PEAssembly : public PEFile
     static PEAssembly * Open(
         PEAssembly *       pParent,
         PEImage *          pPEImageIL,
-        PEImage *          pPEImageNI,
         BINDER_SPACE::Assembly * pHostAssembly);
 
     // This opens the canonical System.Private.CoreLib.dll
-    static PEAssembly *OpenSystem(IUnknown *pAppCtx);
+    static PEAssembly *OpenSystem();
 #ifdef DACCESS_COMPILE
     virtual void EnumMemoryRegions(CLRDataEnumMemoryFlags flags);
 #endif
@@ -578,7 +577,7 @@ class PEAssembly : public PEFile
 
   private:
     // Private helpers for crufty exception handling reasons
-    static PEAssembly *DoOpenSystem(IUnknown *pAppCtx);
+    static PEAssembly *DoOpenSystem();
 
   public:
 
@@ -627,7 +626,6 @@ class PEAssembly : public PEFile
         PEFile *creator,
         BOOL system,
         PEImage * pPEImageIL = NULL,
-        PEImage * pPEImageNI = NULL,
         BINDER_SPACE::Assembly * pHostAssembly = NULL
         );
     virtual ~PEAssembly();


### PR DESCRIPTION
Remove some parameters and fields that are no longer needed/used now that crossgen1 is removed.
- `fNgenExplicitBind` and `fExplicitBindToNativeImage` (always false) from
  - `AssemblyBinderCommon::BindAssembly`
  - `AssemblySpec::Bind` 
  - `BinderAcquirePEImage`
  - `DefaultAssemblyBinder::Bind` 
- `fIsNativeImage` (always false) from
  - `AssemblyBinder::BindUsingPEImage`
  - `BinderAcquireImport`
- `BINDER_SPACE::Assembly::m_pNativePEImage` (always null)
- `pPEImageNI` (always null) from `PEAssembly` constructor

cc @vitek-karas @VSadov @AaronRobinsonMSFT @jkoritzinsky 