### PR TITLE
[wasm][debugger] Fixing DebuggerDisplayAttribute when using utf16 characters

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -17,6 +17,7 @@ using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp;
 using System.Reflection;
+using System.Text;
 
 namespace Microsoft.WebAssembly.Diagnostics
 {
@@ -397,9 +398,10 @@ namespace Microsoft.WebAssembly.Diagnostics
         public override string ReadString()
         {
             var valueLen = ReadInt32();
-            char[] value = new char[valueLen];
+            byte[] value = new byte[valueLen];
             Read(value, 0, valueLen);
-            return new string(value);
+
+            return new string(Encoding.UTF8.GetChars(value, 0, valueLen));
         }
         public unsafe long ReadLong()
         {

--- a/src/mono/wasm/debugger/DebuggerTestSuite/CustomViewTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/CustomViewTests.cs
@@ -17,7 +17,7 @@ namespace DebuggerTests
         [Fact]
         public async Task UsingDebuggerDisplay()
         {
-            var bp = await SetBreakpointInMethod("debugger-test.dll", "DebuggerTests.DebuggerCustomViewTest", "run", 12);
+            var bp = await SetBreakpointInMethod("debugger-test.dll", "DebuggerTests.DebuggerCustomViewTest", "run", 15);
             var pause_location = await EvaluateAndCheck(
                 "window.setTimeout(function() { invoke_static_method ('[debugger-test] DebuggerTests.DebuggerCustomViewTest:run'); }, 1);",
                 "dotnet://debugger-test.dll/debugger-custom-view-test.cs",
@@ -29,12 +29,14 @@ namespace DebuggerTests
             CheckObject(locals, "a", "DebuggerTests.WithDisplayString", description:"Some one Value 2 End");
             CheckObject(locals, "c", "DebuggerTests.DebuggerDisplayMethodTest", description: "First Int:32 Second Int:43");
             CheckObject(locals, "myList", "System.Collections.Generic.List<int>", description: "Count = 4");
+            CheckObject(locals, "person1", "DebuggerTests.Person", description: "FirstName: Anton, SurName: Mueller, Age: 44");
+            CheckObject(locals, "person2", "DebuggerTests.Person", description: "FirstName: Lisa, SurName: Müller, Age: 41");
         }
 
         [Fact]
         public async Task UsingDebuggerTypeProxy()
         {
-            var bp = await SetBreakpointInMethod("debugger-test.dll", "DebuggerTests.DebuggerCustomViewTest", "run", 12);
+            var bp = await SetBreakpointInMethod("debugger-test.dll", "DebuggerTests.DebuggerCustomViewTest", "run", 15);
             var pause_location = await EvaluateAndCheck(
                 "window.setTimeout(function() { invoke_static_method ('[debugger-test] DebuggerTests.DebuggerCustomViewTest:run'); }, 1);",
                 "dotnet://debugger-test.dll/debugger-custom-view-test.cs",

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-custom-view-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-custom-view-test.cs
@@ -58,6 +58,13 @@ namespace DebuggerTests
         }
     }
 
+    [DebuggerDisplay("FirstName: {FirstName}, SurName: {SurName}, Age: {Age}")]
+    public class Person {
+        public string FirstName { get; set; }
+        public string SurName { get; set; }
+        public int Age { get; set; }
+    }
+
     class DebuggerCustomViewTest
     {
         public static void run()
@@ -73,6 +80,9 @@ namespace DebuggerTests
             openWith.Add("txt", "notepad");
             openWith.Add("bmp", "paint");
             openWith.Add("dib", "paint");
+            var person1 = new Person { FirstName = "Anton", SurName="Mueller", Age = 44};
+            var person2 = new Person { FirstName = "Lisa", SurName="Müller", Age = 41};
+
             Console.WriteLine("break here");
 
             Console.WriteLine("break here");


### PR DESCRIPTION
Fixing viewing DebuggerDisplayAttribute content with utf16 characters.
Using the same method used on debugger-libs to read string from buffer: https://github.com/mono/debugger-libs/blob/03850bfd42eb17d6425f03ee03114f9dc471db6c/Mono.Debugger.Soft/Mono.Debugger.Soft/Connection.cs#L865

Fixes https://github.com/dotnet/runtime/issues/58046