### PR TITLE
Remove MethodTable::IsPreRestored (always false)

### DIFF
--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -1047,8 +1047,7 @@ private:
     // For protecting additions to the heap
     CrstExplicitInit        m_LookupTableCrst;
 
-    #define TYPE_DEF_MAP_ALL_FLAGS                    ((TADDR)0x00000001)
-        #define ZAPPED_TYPE_NEEDS_NO_RESTORE          ((TADDR)0x00000001)
+    #define TYPE_DEF_MAP_ALL_FLAGS                    NO_MAP_FLAGS
 
     #define TYPE_REF_MAP_ALL_FLAGS                    NO_MAP_FLAGS
         // For type ref map, 0x1 cannot be used as a flag: reserved for FIXUP_POINTER_INDIRECTION bit
@@ -1064,8 +1063,7 @@ private:
 
     #define GENERIC_PARAM_MAP_ALL_FLAGS               NO_MAP_FLAGS
 
-    #define GENERIC_TYPE_DEF_MAP_ALL_FLAGS            ((TADDR)0x00000001)
-        #define ZAPPED_GENERIC_TYPE_NEEDS_NO_RESTORE  ((TADDR)0x00000001)
+    #define GENERIC_TYPE_DEF_MAP_ALL_FLAGS            NO_MAP_FLAGS
 
     #define FILE_REF_MAP_ALL_FLAGS                    NO_MAP_FLAGS
         // For file ref map, 0x1 cannot be used as a flag: reserved for FIXUP_POINTER_INDIRECTION bit
@@ -1706,18 +1704,7 @@ public:
 
         if (pLoadLevel && !th.IsNull())
         {
-            if (flags & ZAPPED_TYPE_NEEDS_NO_RESTORE)
-            {
-                // Make sure the flag is consistent with the target data and implies the load level we think it does
-                _ASSERTE(th.AsMethodTable()->IsPreRestored());
-                _ASSERTE(th.GetLoadLevel() == CLASS_LOADED);
-
-                *pLoadLevel = CLASS_LOADED;
-            }
-            else
-            {
-                *pLoadLevel = th.GetLoadLevel();
-            }
+            *pLoadLevel = th.GetLoadLevel();
         }
 
         return th;
@@ -1736,18 +1723,7 @@ public:
 
         if (pLoadLevel && !th.IsNull())
         {
-            if (flags & ZAPPED_GENERIC_TYPE_NEEDS_NO_RESTORE)
-            {
-                // Make sure the flag is consistent with the target data and implies the load level we think it does
-                _ASSERTE(th.AsMethodTable()->IsPreRestored());
-                _ASSERTE(th.GetLoadLevel() == CLASS_LOADED);
-
-                *pLoadLevel = CLASS_LOADED;
-            }
-            else
-            {
-                *pLoadLevel = th.GetLoadLevel();
-            }
+            *pLoadLevel = th.GetLoadLevel();
         }
 
         return th;

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -2411,14 +2411,6 @@ BOOL MethodDesc::MayHaveNativeCode()
     return TRUE;
 }
 
-#ifndef DACCESS_COMPILE
-
-void DynamicMethodDesc::Restore()
-{
-}
-
-#endif // !DACCESS_COMPILE
-
 //*******************************************************************************
 void MethodDesc::CheckRestore(ClassLoadLevel level)
 {
@@ -2457,9 +2449,6 @@ void MethodDesc::CheckRestore(ClassLoadLevel level)
             ClassLoader::EnsureLoaded(TypeHandle(GetMethodTable()), level);
 
 #ifndef DACCESS_COMPILE
-            PTR_DynamicMethodDesc pDynamicMD = AsDynamicMethodDesc();
-            pDynamicMD->Restore();
-
             if (ETW_PROVIDER_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER))
             {
                 ETW::MethodLog::MethodRestored(this);

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -2522,7 +2522,7 @@ protected:
         nomdStructMarshalStub        = 0x0080,
         nomdUnbreakable              = 0x0100,
         //unused                     = 0x0200,
-        nomdSignatureNeedsRestore    = 0x0400,
+        //unused                     = 0x0400,
         nomdStubNeedsCOMStarted      = 0x0800,  // EnsureComStarted must be called before executing the method
         nomdMulticastStub            = 0x1000,
         nomdUnboxingILStub           = 0x2000,
@@ -2586,15 +2586,6 @@ public:
         }
     }
 
-    void SetSignatureNeedsRestore(bool value)
-    {
-        LIMITED_METHOD_CONTRACT;
-        if (value)
-        {
-            m_dwExtendedFlags |= nomdSignatureNeedsRestore;
-        }
-    }
-
     void SetStubNeedsCOMStarted(bool value)
     {
         LIMITED_METHOD_CONTRACT;
@@ -2608,17 +2599,6 @@ public:
     {
         LIMITED_METHOD_CONTRACT;
 
-        if (IsSignatureNeedsRestore())
-        {
-            // Since we don't update the signatreNeedsRestore bit when we actually
-            // restore the signature, the bit will have a stall value.  The signature
-            // bit in the metadata will always contain the correct, up-to-date
-            // information.
-            Volatile<BYTE> *pVolatileSig = (Volatile<BYTE> *)GetStoredMethodSig();
-            if ((*pVolatileSig & IMAGE_CEE_CS_CALLCONV_NEEDSRESTORE) != 0)
-                return false;
-        }
-
         return true;
     }
 
@@ -2630,7 +2610,6 @@ public:
     bool IsCOMToCLRStub()    { LIMITED_METHOD_CONTRACT; _ASSERTE(IsILStub()); return ((0 == (m_dwExtendedFlags & mdStatic)) &&  IsReverseStub()); }
     bool IsPInvokeStub()     { LIMITED_METHOD_CONTRACT; _ASSERTE(IsILStub()); return ((0 != (m_dwExtendedFlags & mdStatic)) && !IsReverseStub() && !IsCALLIStub() && !IsStructMarshalStub()); }
     bool IsUnbreakable()     { LIMITED_METHOD_CONTRACT; _ASSERTE(IsILStub()); return (0 != (m_dwExtendedFlags & nomdUnbreakable));  }
-    bool IsSignatureNeedsRestore() { LIMITED_METHOD_CONTRACT; _ASSERTE(IsILStub()); return (0 != (m_dwExtendedFlags & nomdSignatureNeedsRestore)); }
     bool IsStubNeedsCOMStarted()   { LIMITED_METHOD_CONTRACT; _ASSERTE(IsILStub()); return (0 != (m_dwExtendedFlags & nomdStubNeedsCOMStarted)); }
     bool IsStructMarshalStub()   { LIMITED_METHOD_CONTRACT; _ASSERTE(IsILStub()); return (0 != (m_dwExtendedFlags & nomdStructMarshalStub)); }
 #ifdef FEATURE_MULTICASTSTUB_AS_IL

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -2639,7 +2639,6 @@ public:
         return IsCLRToCOMStub() || IsPInvokeStub();
     }
 
-    void Restore();
     //
     // following implementations defined in DynamicMethod.cpp
     //

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -877,8 +877,7 @@ public:
     {
         LIMITED_METHOD_DAC_CONTRACT;
 
-        return !IsPreRestored() &&
-            (GetWriteableData()->m_dwFlags & MethodTableWriteableData::enum_flag_UnrestoredTypeKey) != 0;
+        return (GetWriteableData()->m_dwFlags & MethodTableWriteableData::enum_flag_UnrestoredTypeKey) != 0;
     }
 
     // Actually do the restore actions on the method table
@@ -890,11 +889,6 @@ public:
     {
         LIMITED_METHOD_DAC_CONTRACT;
 
-        // If we are prerestored then we are considered a restored methodtable.
-        // Note that IsPreRestored is always false for jitted code.
-        if (IsPreRestored())
-            return TRUE;
-
         return !(GetWriteableData_NoLogging()->m_dwFlags & MethodTableWriteableData::enum_flag_Unrestored);
     }
     inline BOOL IsRestored()
@@ -902,11 +896,6 @@ public:
         LIMITED_METHOD_DAC_CONTRACT;
 
         g_IBCLogger.LogMethodTableAccess(this);
-
-        // If we are prerestored then we are considered a restored methodtable.
-        // Note that IsPreRestored is always false for jitted code.
-        if (IsPreRestored())
-            return TRUE;
 
         return !(GetWriteableData()->m_dwFlags & MethodTableWriteableData::enum_flag_Unrestored);
     }
@@ -944,8 +933,7 @@ public:
     {
         WRAPPER_NO_CONTRACT;
 
-        return (IsPreRestored())
-            || (GetWriteableData()->m_dwFlags & MethodTableWriteableData::enum_flag_IsNotFullyLoaded) == 0;
+        return (GetWriteableData()->m_dwFlags & MethodTableWriteableData::enum_flag_IsNotFullyLoaded) == 0;
     }
 
     inline BOOL CanCompareBitsOrUseFastGetHashCode()
@@ -1004,10 +992,6 @@ public:
         LIMITED_METHOD_DAC_CONTRACT;
 
         g_IBCLogger.LogMethodTableAccess(this);
-
-        // Fast path for zapped images
-        if (IsPreRestored())
-            return CLASS_LOADED;
 
         DWORD dwFlags = GetWriteableData()->m_dwFlags;
 
@@ -2770,13 +2754,6 @@ public:
     inline DWORD GetAttrClass();
 
     inline BOOL HasFieldsWhichMustBeInited();
-
-    inline BOOL IsPreRestored() const
-    {
-        LIMITED_METHOD_DAC_CONTRACT;
-
-        return FALSE;
-    }
 
     //-------------------------------------------------------------------
     // THE EXPOSED CLASS OBJECT

--- a/src/coreclr/vm/typedesc.h
+++ b/src/coreclr/vm/typedesc.h
@@ -191,8 +191,8 @@ public:
     // See methodtable.h for details of the flags with the same name there
     enum
     {
-        enum_flag_NeedsRestore           = 0x00000100, // Only used during ngen
-        enum_flag_PreRestored            = 0x00000200, // Only used during ngen
+        // unused                        = 0x00000100,
+        // unused                        = 0x00000200,
         enum_flag_Unrestored             = 0x00000400,
         enum_flag_UnrestoredTypeKey      = 0x00000800,
         enum_flag_IsNotFullyLoaded       = 0x00001000,


### PR DESCRIPTION
Remove
- `DynamicMethodDesc::Restore` (does nothing)
- `DynamicMethodDesc::SetSignatureNeedsRestore` (never used) and `DynamicMethodDesc::IsSignatureNeedsRestore` (always false)
- `MethodTable::IsPreRestored` (always false)
- `ZAPPED_TYPE_NEEDS_NO_RESTORE` and `ZAPPED_GENERIC_TYPE_NEEDS_NO_RESTORE` (never set)

cc @AaronRobinsonMSFT @davidwrighton @jkoritzinsky