### PR TITLE
add Http3LoopbackConnection.ShutdownAsync and use in AcceptConnectionAsync

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/Http3LoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http3LoopbackServer.cs
@@ -52,7 +52,7 @@ namespace System.Net.Test.Common
             _cert.Dispose();
         }
 
-        public override async Task<GenericLoopbackConnection> EstablishGenericConnectionAsync()
+        private async Task<Http3LoopbackConnection> EstablishHttp3ConnectionAsync()
         {
             QuicConnection con = await _listener.AcceptConnectionAsync().ConfigureAwait(false);
             Http3LoopbackConnection connection = new Http3LoopbackConnection(con);
@@ -61,10 +61,16 @@ namespace System.Net.Test.Common
             return connection;
         }
 
+        public override async Task<GenericLoopbackConnection> EstablishGenericConnectionAsync()
+        {
+            return await EstablishHttp3ConnectionAsync();
+        }
+
         public override async Task AcceptConnectionAsync(Func<GenericLoopbackConnection, Task> funcAsync)
         {
-            using GenericLoopbackConnection con = await EstablishGenericConnectionAsync().ConfigureAwait(false);
+            using Http3LoopbackConnection con = await EstablishHttp3ConnectionAsync().ConfigureAwait(false);
             await funcAsync(con).ConfigureAwait(false);
+            await con.ShutdownAsync();
         }
 
         public override async Task<HttpRequestData> HandleRequestAsync(HttpStatusCode statusCode = HttpStatusCode.OK, IList<HttpHeaderData> headers = null, string content = "")

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Finalization.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Finalization.cs
@@ -27,6 +27,12 @@ namespace System.Net.Http.Functional.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
         public async Task IncompleteResponseStream_ResponseDropped_CancelsRequestToServer()
         {
+            if (UseVersion == HttpVersion30)
+            {
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/53089")]
+                return;
+            }
+
             using (HttpClient client = CreateHttpClient())
             {
                 bool stopGCs = false;

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Finalization.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Finalization.cs
@@ -29,7 +29,7 @@ namespace System.Net.Http.Functional.Tests
         {
             if (UseVersion == HttpVersion30)
             {
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/53089")]
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/58234")]
                 return;
             }
 


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/57779

Add a ShutdownAsync method on the HTTP3 loopback connection. This will send a GOAWAY frame to the client and wait for the client to close the connection gracefully. It will also eat connection abort exceptions if the client already has closed the connection.

Use this method in AcceptConnectionAsync, after the user's connection handling code has finished. The intent here is to avoid the kind of data loss seen in https://github.com/dotnet/runtime/issues/57779. and avoid HTTP3-specific one-offs to reenable tests as in https://github.com/dotnet/runtime/pull/58041.

Also, some fixes to GetAsync_CancelDuringResponseBodyReceived_Unbuffered_TaskCanceledQuickly to work properly with these changes and clean up some unnecessarily complicated logic.

@ManickaP @CarnaViire 