### PR TITLE
Remove two async state machines for typical HTTP/1.1 request path

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.cs
@@ -206,7 +206,7 @@ namespace System.Net.Http
         private static ValueTask<HttpResponseMessage> InnerSendAsync(HttpRequestMessage request, bool async, bool isProxyAuth, bool doRequestAuth, HttpConnectionPool pool, CancellationToken cancellationToken)
         {
             return isProxyAuth ?
-                pool.SendWithRetryAsync(request, async, doRequestAuth, cancellationToken) :
+                pool.SendWithVersionDetectionAndRetryAsync(request, async, doRequestAuth, cancellationToken) :
                 pool.SendWithProxyAuthAsync(request, async, doRequestAuth, cancellationToken);
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -413,11 +413,12 @@ namespace System.Net.Http
         // we will remove it from the list of available connections, if it is present there.
         // If not, then it must be unavailable at the moment; we will detect this and ensure it is not added back to the available pool.
 
-        private static HttpRequestException GetVersionException(HttpRequestMessage request, int desiredVersion)
+        [DoesNotReturn]
+        private static void ThrowGetVersionException(HttpRequestMessage request, int desiredVersion)
         {
             Debug.Assert(desiredVersion == 2 || desiredVersion == 3);
 
-            return new HttpRequestException(SR.Format(SR.net_http_requested_version_cannot_establish, request.Version, request.VersionPolicy, desiredVersion));
+            throw new HttpRequestException(SR.Format(SR.net_http_requested_version_cannot_establish, request.Version, request.VersionPolicy, desiredVersion));
         }
 
         private bool CheckExpirationOnGet(HttpConnectionBase connection)
@@ -889,79 +890,42 @@ namespace System.Net.Http
         [SupportedOSPlatform("macos")]
         private async ValueTask<HttpResponseMessage?> TrySendUsingHttp3Async(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
         {
-            if (_http3Enabled && (request.Version.Major >= 3 || (request.VersionPolicy == HttpVersionPolicy.RequestVersionOrHigher && IsSecure)))
+            // Loop in case we get a 421 and need to send the request to a different authority.
+            while (true)
             {
-                // Loop in case we get a 421 and need to send the request to a different authority.
-                while (true)
+                HttpAuthority? authority = _http3Authority;
+
+                // If H3 is explicitly requested, assume prenegotiated H3.
+                if (request.Version.Major >= 3 && request.VersionPolicy != HttpVersionPolicy.RequestVersionOrLower)
                 {
-                    HttpAuthority? authority = _http3Authority;
-
-                    // If H3 is explicitly requested, assume prenegotiated H3.
-                    if (request.Version.Major >= 3 && request.VersionPolicy != HttpVersionPolicy.RequestVersionOrLower)
-                    {
-                        authority = authority ?? _originAuthority;
-                    }
-
-                    if (authority == null)
-                    {
-                        break;
-                    }
-
-                    if (IsAltSvcBlocked(authority))
-                    {
-                        throw GetVersionException(request, 3);
-                    }
-
-                    Http3Connection connection = await GetHttp3ConnectionAsync(request, authority, cancellationToken).ConfigureAwait(false);
-                    HttpResponseMessage response = await connection.SendAsync(request, async, cancellationToken).ConfigureAwait(false);
-
-                    // If an Alt-Svc authority returns 421, it means it can't actually handle the request.
-                    // An authority is supposed to be able to handle ALL requests to the origin, so this is a server bug.
-                    // In this case, we blocklist the authority and retry the request at the origin.
-                    if (response.StatusCode == HttpStatusCode.MisdirectedRequest && connection.Authority != _originAuthority)
-                    {
-                        response.Dispose();
-                        BlocklistAuthority(connection.Authority);
-                        continue;
-                    }
-
-                    return response;
-                }
-            }
-
-            // We cannot use HTTP/3. Do not continue if downgrade is not allowed.
-            if (request.Version.Major >= 3 && request.VersionPolicy != HttpVersionPolicy.RequestVersionOrLower)
-            {
-                throw GetVersionException(request, 3);
-            }
-
-            return null;
-        }
-
-        // Returns null if HTTP2 cannot be used.
-        private async ValueTask<HttpResponseMessage?> TrySendUsingHttp2Async(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
-        {
-            // Send using HTTP/2 if we can.
-            if (_http2Enabled && (request.Version.Major >= 2 || (request.VersionPolicy == HttpVersionPolicy.RequestVersionOrHigher && IsSecure)) &&
-               // If the connection is not secured and downgrade is possible, prefer HTTP/1.1.
-               (request.VersionPolicy != HttpVersionPolicy.RequestVersionOrLower || IsSecure))
-            {
-                Http2Connection? connection = await GetHttp2ConnectionAsync(request, async, cancellationToken).ConfigureAwait(false);
-                if (connection is not null)
-                {
-                    return await connection.SendAsync(request, async, cancellationToken).ConfigureAwait(false);
+                    authority ??= _originAuthority;
                 }
 
-                Debug.Assert(!_http2Enabled);
-            }
+                if (authority == null)
+                {
+                    return null;
+                }
 
-            // We cannot use HTTP/2. Do not continue if downgrade is not allowed.
-            if (request.Version.Major >= 2 && request.VersionPolicy != HttpVersionPolicy.RequestVersionOrLower)
-            {
-                throw GetVersionException(request, 2);
-            }
+                if (IsAltSvcBlocked(authority))
+                {
+                    ThrowGetVersionException(request, 3);
+                }
 
-            return null;
+                Http3Connection connection = await GetHttp3ConnectionAsync(request, authority, cancellationToken).ConfigureAwait(false);
+                HttpResponseMessage response = await connection.SendAsync(request, async, cancellationToken).ConfigureAwait(false);
+
+                // If an Alt-Svc authority returns 421, it means it can't actually handle the request.
+                // An authority is supposed to be able to handle ALL requests to the origin, so this is a server bug.
+                // In this case, we blocklist the authority and retry the request at the origin.
+                if (response.StatusCode == HttpStatusCode.MisdirectedRequest && connection.Authority != _originAuthority)
+                {
+                    response.Dispose();
+                    BlocklistAuthority(connection.Authority);
+                    continue;
+                }
+
+                return response;
+            }
         }
 
         /// <summary>Check for the Alt-Svc header, to upgrade to HTTP/3.</summary>
@@ -973,30 +937,53 @@ namespace System.Net.Http
             }
         }
 
-        public async ValueTask<HttpResponseMessage> SendWithRetryAsync(HttpRequestMessage request, bool async, bool doRequestAuth, CancellationToken cancellationToken)
+        public async ValueTask<HttpResponseMessage> SendWithVersionDetectionAndRetryAsync(HttpRequestMessage request, bool async, bool doRequestAuth, CancellationToken cancellationToken)
         {
+            // Loop on connection failures (or other problems like version downgrade) and retry if possible.
             int retryCount = 0;
             while (true)
             {
-                // Loop on connection failures (or other problems like version downgrade) and retry if possible.
                 try
                 {
                     HttpResponseMessage? response = null;
 
-                    // HTTP/3
-                    if (IsHttp3Supported())
+                    // Use HTTP/3 if possible.
+                    if (IsHttp3Supported() && // guard to enable trimming HTTP/3 support
+                        _http3Enabled &&
+                        (request.Version.Major >= 3 || (request.VersionPolicy == HttpVersionPolicy.RequestVersionOrHigher && IsSecure)))
                     {
                         response = await TrySendUsingHttp3Async(request, async, cancellationToken).ConfigureAwait(false);
                     }
 
                     if (response is null)
                     {
-                        // HTTP/2
-                        response = await TrySendUsingHttp2Async(request, async, cancellationToken).ConfigureAwait(false);
+                        // We could not use HTTP/3. Do not continue if downgrade is not allowed.
+                        if (request.Version.Major >= 3 && request.VersionPolicy != HttpVersionPolicy.RequestVersionOrLower)
+                        {
+                            ThrowGetVersionException(request, 3);
+                        }
+
+                        // Use HTTP/2 if possible.
+                        if (_http2Enabled &&
+                            (request.Version.Major >= 2 || (request.VersionPolicy == HttpVersionPolicy.RequestVersionOrHigher && IsSecure)) &&
+                            (request.VersionPolicy != HttpVersionPolicy.RequestVersionOrLower || IsSecure)) // prefer HTTP/1.1 if connection is not secured and downgrade is possible
+                        {
+                            Http2Connection? connection = await GetHttp2ConnectionAsync(request, async, cancellationToken).ConfigureAwait(false);
+                            if (connection is not null)
+                            {
+                                response = await connection.SendAsync(request, async, cancellationToken).ConfigureAwait(false);
+                            }
+                        }
 
                         if (response is null)
                         {
-                            // HTTP/1.x
+                            // We could not use HTTP/2. Do not continue if downgrade is not allowed.
+                            if (request.Version.Major >= 2 && request.VersionPolicy != HttpVersionPolicy.RequestVersionOrLower)
+                            {
+                                ThrowGetVersionException(request, 2);
+                            }
+
+                            // Use HTTP/1.x.
                             HttpConnection connection = await GetHttp11ConnectionAsync(request, async, cancellationToken).ConfigureAwait(false);
                             connection.Acquire(); // In case we are doing Windows (i.e. connection-based) auth, we need to ensure that we hold on to this specific connection while auth is underway.
                             try
@@ -1319,7 +1306,7 @@ namespace System.Net.Http
                 return AuthenticationHelper.SendWithProxyAuthAsync(request, _proxyUri!, async, ProxyCredentials, doRequestAuth, this, cancellationToken);
             }
 
-            return SendWithRetryAsync(request, async, doRequestAuth, cancellationToken);
+            return SendWithVersionDetectionAndRetryAsync(request, async, doRequestAuth, cancellationToken);
         }
 
         public ValueTask<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, bool doRequestAuth, CancellationToken cancellationToken)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -969,6 +969,7 @@ namespace System.Net.Http
                             (request.VersionPolicy != HttpVersionPolicy.RequestVersionOrLower || IsSecure)) // prefer HTTP/1.1 if connection is not secured and downgrade is possible
                         {
                             Http2Connection? connection = await GetHttp2ConnectionAsync(request, async, cancellationToken).ConfigureAwait(false);
+                            Debug.Assert(connection is not null || !_http2Enabled);
                             if (connection is not null)
                             {
                                 response = await connection.SendAsync(request, async, cancellationToken).ConfigureAwait(false);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -887,7 +887,7 @@ namespace System.Net.Http
         [SupportedOSPlatform("windows")]
         [SupportedOSPlatform("linux")]
         [SupportedOSPlatform("macos")]
-        private async ValueTask<HttpResponseMessage?> TrySendUsingHttp3Async(HttpRequestMessage request, bool async, bool doRequestAuth, CancellationToken cancellationToken)
+        private async ValueTask<HttpResponseMessage?> TrySendUsingHttp3Async(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
         {
             if (_http3Enabled && (request.Version.Major >= 3 || (request.VersionPolicy == HttpVersionPolicy.RequestVersionOrHigher && IsSecure)))
             {
@@ -933,7 +933,7 @@ namespace System.Net.Http
         }
 
         // Returns null if HTTP2 cannot be used.
-        private async ValueTask<HttpResponseMessage?> TrySendUsingHttp2Async(HttpRequestMessage request, bool async, bool doRequestAuth, CancellationToken cancellationToken)
+        private async ValueTask<HttpResponseMessage?> TrySendUsingHttp2Async(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
         {
             // Send using HTTP/2 if we can.
             if (_http2Enabled && (request.Version.Major >= 2 || (request.VersionPolicy == HttpVersionPolicy.RequestVersionOrHigher && IsSecure)) &&
@@ -987,7 +987,7 @@ namespace System.Net.Http
 
                 if (IsHttp3Supported())
                 {
-                    response = await TrySendUsingHttp3Async(request, async, doRequestAuth, cancellationToken).ConfigureAwait(false);
+                    response = await TrySendUsingHttp3Async(request, async, cancellationToken).ConfigureAwait(false);
                     if (response is not null)
                     {
                         return response;
@@ -1000,7 +1000,7 @@ namespace System.Net.Http
                     throw GetVersionException(request, 3);
                 }
 
-                response = await TrySendUsingHttp2Async(request, async, doRequestAuth, cancellationToken).ConfigureAwait(false);
+                response = await TrySendUsingHttp2Async(request, async, cancellationToken).ConfigureAwait(false);
                 if (response is not null)
                 {
                     return response;


### PR DESCRIPTION
Rather than having a dedicated async method for SendAndProcessAltSvcAsync, we can just have the sole call site call DetermineVersionAndSendAsync and ProcessAltSvc. And in DetermineVersionAndSendAsync, special-case the default configuration for SocketsHttpHandler that will result in HTTP/1.1 messages being sent, such that we avoid all the tests for HTTP/2 and HTTP/3 and the async state machine for DetermineVersionAndSendAsync when HTTP/1.1 is being requested and used.

This doesn't entirely get us back to the allocation profile of .NET 5, but it's much closer.

|  Method |           Toolchain |     Mean |    Error |   StdDev | Ratio | Allocated |
|-------- |-------------------- |---------:|---------:|---------:|------:|----------:|
| Request |  \5.0.9\corerun.exe | 56.43 us | 0.829 us | 0.735 us |  1.00 |   1,416 B |
| Request |   \main\corerun.exe | 56.15 us | 0.735 us | 0.688 us |  1.00 |   1,886 B |
| Request |     \pr\corerun.exe | 55.07 us | 0.823 us | 0.770 us |  0.97 |   1,568 B |

I also noticed an unused parameter to the HTTP/2 and HTTP/3 try send async methods, so I removed those as well, removing those parameters from the corresponding state machines.

Best reviewed without whitespace diffing: https://github.com/dotnet/runtime/pull/58092/files?w=1

Fixes https://github.com/dotnet/runtime/issues/57977