### PR TITLE
Fix nullability bug in System.Diagnostics.TraceSource Switch

### DIFF
--- a/src/libraries/System.Diagnostics.TraceSource/ref/System.Diagnostics.TraceSource.cs
+++ b/src/libraries/System.Diagnostics.TraceSource/ref/System.Diagnostics.TraceSource.cs
@@ -69,7 +69,7 @@ namespace System.Diagnostics
     public abstract partial class Switch
     {
         protected Switch(string displayName, string? description) { }
-        protected Switch(string displayName, string? description, string? defaultSwitchValue) { }
+        protected Switch(string displayName, string? description, string defaultSwitchValue) { }
         public System.Collections.Specialized.StringDictionary Attributes { get { throw null; } }
         public string Description { get { throw null; } }
         public string DisplayName { get { throw null; } }

--- a/src/libraries/System.Diagnostics.TraceSource/src/System/Diagnostics/Switch.cs
+++ b/src/libraries/System.Diagnostics.TraceSource/src/System/Diagnostics/Switch.cs
@@ -24,7 +24,7 @@ namespace System.Diagnostics
         private volatile bool _initialized;
         private bool _initializing;
         private volatile string _switchValueString = string.Empty;
-        private readonly string? _defaultValue;
+        private readonly string _defaultValue;
         private object? _initializedLock;
 
         private static readonly List<WeakReference<Switch>> s_switches = new List<WeakReference<Switch>>();
@@ -53,7 +53,7 @@ namespace System.Diagnostics
         {
         }
 
-        protected Switch(string displayName, string? description, string? defaultSwitchValue)
+        protected Switch(string displayName, string? description, string defaultSwitchValue)
         {
             // displayName is used as a hashtable key, so it can never
             // be null.
@@ -203,7 +203,7 @@ namespace System.Diagnostics
                     // called again, we don't want to get caught in an infinite loop.
                     _initializing = true;
 
-                    _switchValueString = _defaultValue!;
+                    _switchValueString = _defaultValue;
                     OnValueChanged();
                     _initialized = true;
                     _initializing = false;


### PR DESCRIPTION
Related to https://github.com/dotnet/runtime/pull/58026#issuecomment-905108340

The base constructor was annotated incorrectly, `defaultSwitchValue` cannot be null