### PR TITLE
Prevent AV in processinfo2 while suspended on Mono.

### DIFF
--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -1855,7 +1855,15 @@ inline
 const ep_char8_t *
 ep_rt_entrypoint_assembly_name_get_utf8 (void)
 {
-	return (const ep_char8_t *)m_image_get_assembly_name (mono_assembly_get_main ()->image);
+	MonoAssembly *main_assembly = mono_assembly_get_main ();
+	if (!main_assembly || !main_assembly->image)
+		return "";
+
+	const char *assembly_name = m_image_get_assembly_name (mono_assembly_get_main ()->image);
+	if (!assembly_name)
+		return "";
+
+	return (const ep_char8_t*)assembly_name;
 }
 
 static


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/55379 only fixed CoreCLR. This commit makes similar fix in Mono as well, making sure
src/tests/tracing/eventpipe/diagnosticport runtime test pass on Mono.