### PR TITLE
[Stress] Enable POST by disabling InternalServerError suppression

### DIFF
--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
@@ -508,12 +508,6 @@ namespace HttpStress
 
         private static void ValidateStatusCode(HttpResponseMessage m, HttpStatusCode expectedStatus = HttpStatusCode.OK)
         {
-            // [ActiveIssue("https://github.com/dotnet/runtime/issues/55261")]
-            if (m.StatusCode == HttpStatusCode.InternalServerError)
-            {
-                throw new Exception("IGNORE");
-            }
-
             if (m.StatusCode != expectedStatus)
             {
                 throw new Exception($"Expected status code {expectedStatus}, got {m.StatusCode}");

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
@@ -508,6 +508,12 @@ namespace HttpStress
 
         private static void ValidateStatusCode(HttpResponseMessage m, HttpStatusCode expectedStatus = HttpStatusCode.OK)
         {
+            // [ActiveIssue("https://github.com/dotnet/runtime/issues/55261")]
+            if (m.StatusCode == HttpStatusCode.InternalServerError && m.Version == HttpVersion.Version30)
+            {
+                throw new Exception("IGNORE");
+            }
+            
             if (m.StatusCode != expectedStatus)
             {
                 throw new Exception($"Expected status code {expectedStatus}, got {m.StatusCode}");

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
@@ -513,7 +513,7 @@ namespace HttpStress
             {
                 throw new Exception("IGNORE");
             }
-            
+
             if (m.StatusCode != expectedStatus)
             {
                 throw new Exception($"Expected status code {expectedStatus}, got {m.StatusCode}");

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
@@ -209,11 +209,6 @@ namespace HttpStress
                     {
                         _aggregator.RecordCancellation(opIndex, stopwatch.Elapsed);
                     }
-                    catch (Exception e) when (e.Message == "IGNORE")
-                    {
-                        // [ActiveIssue("https://github.com/dotnet/runtime/issues/55261")]
-                        // See ClientOperations.ValidateStatusCode
-                    }
                     catch (Exception e)
                     {
                         _aggregator.RecordFailure(e, opIndex, stopwatch.Elapsed, requestContext.IsCancellationRequested, taskNum: taskNum, iteration: i);

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
@@ -209,6 +209,11 @@ namespace HttpStress
                     {
                         _aggregator.RecordCancellation(opIndex, stopwatch.Elapsed);
                     }
+                    catch (Exception e) when (e.Message == "IGNORE")
+                    {
+                        // [ActiveIssue("https://github.com/dotnet/runtime/issues/55261")]
+                        // See ClientOperations.ValidateStatusCode
+                    }
                     catch (Exception e)
                     {
                         _aggregator.RecordFailure(e, opIndex, stopwatch.Elapsed, requestContext.IsCancellationRequested, taskNum: taskNum, iteration: i);


### PR DESCRIPTION
Enable HTTP/2 POST stress tests because, the Kestrel's issue with an incorrect HTTP/2 stream resetting seems to be fixed by dotnet/aspnetcore#34768.

Contributes to #55261