### PR TITLE
Mark MultipleALCs as GCStressIncompatible

### DIFF
--- a/src/tests/Interop/ICustomMarshaler/ConflictingNames/MultipleALCs.csproj
+++ b/src/tests/Interop/ICustomMarshaler/ConflictingNames/MultipleALCs.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="RunInALC.cs" />


### PR DESCRIPTION
@mangod9 PTAL - disabling the test under GCStressIncompatible until #47696 is relolved