### PR TITLE
Fail early on CMake check failure when building coreclr

### DIFF
--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -282,13 +282,13 @@ REM Set the remaining variables based upon the determined build configuration
 
 echo %__MsgPrefix%Checking prerequisites
 
-set __CMakeNeeded=1
-if %__BuildNative%==0 if %__BuildCrossArchNative%==0 set __CMakeNeeded=0
-if %__CMakeNeeded%==1 (
-    REM Eval the output from set-cmake-path.ps1
-    for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy ByPass "& ""%__RepoRootDir%\eng\native\set-cmake-path.ps1"""') do %%a
-    echo %__MsgPrefix%Using CMake from !CMakePath!
-)
+if %__BuildNative%==0 if %__BuildCrossArchNative%==0 goto SkipLocateCMake
+
+REM Eval the output from set-cmake-path.ps1
+for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy ByPass "& ""%__RepoRootDir%\eng\native\set-cmake-path.ps1"""') do %%a
+echo %__MsgPrefix%Using CMake from !CMakePath!
+
+:SkipLocateCMake
 
 REM NumberOfCores is an WMI property providing number of physical cores on machine
 REM processor(s). It is used to set optimal level of CL parallelism during native build step


### PR DESCRIPTION
Pull the call of `set-cmake-path.ps1` out of the if block so that the error code propagates.

`build.cmd clr` should now fail earlier with something like:
```
CMake 3.16.4 or newer is required for building this repository. The newest version of CMake installed is 3.16.0. Please install CMake 3.16.4 or newer from https://cmake.org/download/.
D:\runtime\src\coreclr\runtime.proj(46,5): error MSB3073: The command ""D:\runtime\src\coreclr\build-runtime.cmd" -x64 -debug" exited with code 1.
```
instead of erroring about a missing file (that wasn't built) later.

cc @dotnet/runtime-infrastructure 