### PR TITLE
Add Crossgen2 symbol files to package

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
@@ -64,6 +64,18 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="AddCrossgen2SymbolFilesToPackage" BeforeTargets="GetFilesToPackage">
+    <ItemGroup>
+      <_Crossgen2SymbolFilesToPackage Include="@(Reference->'$(CoreCLRArtifactsPath)PDB\%(FileName).pdb')" />
+      <!-- Symbol files for JIT libraries are placed in a different location for Windows builds -->
+      <_Crossgen2SymbolFilesToPackage Include="@(NativeRuntimeAsset->'$(CoreCLRArtifactsPath)PDB\%(FileName).pdb')" Condition="'$(TargetOS)' == 'windows' and '%(FileName)' != 'crossgen2'" />
+      <_Crossgen2SymbolFilesToPackage Include="@(NativeRuntimeAsset->'$(CoreCLRArtifactsPath)%(FileName)%(Extension)$(SymbolsSuffix)')" Condition="'$(TargetOS)' != 'windows' and '%(FileName)' != 'crossgen2'" />
+      <_Crossgen2SymbolFilesToPackage Remove="@(_Crossgen2SymbolFilesToPackage)" Condition="!Exists('%(Identity)')" />
+
+      <_SymbolFilesToPackage Include="@(_Crossgen2SymbolFilesToPackage)" TargetPath="tools/" />
+    </ItemGroup>
+  </Target>
+
   <PropertyGroup Condition="'$(TargetOS)' == 'windows'">
     <!-- DiaSymReader for the target architecture, which is placed into the package -->
     <_diaSymTargetArch>$(TargetArchitecture)</_diaSymTargetArch>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
@@ -68,7 +68,7 @@
     <ItemGroup>
       <_Crossgen2SymbolFilesToPackage Include="@(Reference->'$(CoreCLRArtifactsPath)PDB\%(FileName).pdb')" />
       <!-- Symbol files for JIT libraries are placed in a different location for Windows builds -->
-      <_Crossgen2SymbolFilesToPackage Include="@(NativeRuntimeAsset->'$(CoreCLRArtifactsPath)PDB\%(FileName).pdb')" Condition="'$(TargetOS)' == 'windows' and '%(FileName)' != 'crossgen2'" />
+      <_Crossgen2SymbolFilesToPackage Include="@(NativeRuntimeAsset->'$(CoreCLRArtifactsPdbDir)%(FileName).pdb')" Condition="'$(TargetOS)' == 'windows' and '%(FileName)' != 'crossgen2'" />
       <_Crossgen2SymbolFilesToPackage Include="@(NativeRuntimeAsset->'$(CoreCLRArtifactsPath)%(FileName)%(Extension)$(SymbolsSuffix)')" Condition="'$(TargetOS)' != 'windows' and '%(FileName)' != 'crossgen2'" />
       <_Crossgen2SymbolFilesToPackage Remove="@(_Crossgen2SymbolFilesToPackage)" Condition="!Exists('%(Identity)')" />
 


### PR DESCRIPTION
Add Crossgen2 symbol files to Crossgen2 NuGet symbol packages to make debugging easier.  For instance, this PR adds the following symbol files to the Windows x64 package:
```
crossgen2.pdb
ILCompiler.DependencyAnalysisFramework.pdb
ILCompiler.Diagnostics.pdb
ILCompiler.ReadyToRun.pdb
ILCompiler.TypeSystem.ReadyToRun.pdb

clrjit_unix_arm_x64.pdb
clrjit_unix_arm64_x64.pdb
clrjit_unix_osx_arm64_x64.pdb
clrjit_unix_x64_x64.pdb
clrjit_win_arm_x64.pdb
clrjit_win_arm64_x64.pdb
clrjit_win_x64_x64.pdb
clrjit_win_x86_x64.pdb
jitinterface_x64.pdb
```
and the following symbol files to the Linux x64 package:
```
crossgen2.pdb
ILCompiler.DependencyAnalysisFramework.pdb
ILCompiler.Diagnostics.pdb
ILCompiler.ReadyToRun.pdb
ILCompiler.TypeSystem.ReadyToRun.pdb

libclrjit_unix_arm_x64.so.dbg
libclrjit_unix_arm64_x64.so.dbg
libclrjit_unix_osx_arm64_x64.so.dbg
libclrjit_unix_x64_x64.so.dbg
libclrjit_win_arm_x64.so.dbg
libclrjit_win_arm64_x64.so.dbg
libclrjit_win_x64_x64.so.dbg
libclrjit_win_x86_x64.so.dbg
libjitinterface_x64.so.dbg
```
Technically, packing `clrjit_win_x64_x64.pdb` for Windows x64 is not necessary since `clrjit_win_x64_x64.dll` points to `clrjit.pdb`; however, treating one of the JIT libraries specially is probably not worth extra complexity.

Fixes #57542. @dotnet/crossgen-contrib 