### PR TITLE
Minor R2RTest improvements

### DIFF
--- a/src/coreclr/tools/r2rtest/BuildOptions.cs
+++ b/src/coreclr/tools/r2rtest/BuildOptions.cs
@@ -24,9 +24,12 @@ namespace R2RTest
         public bool NoCleanup { get; set; }
         public bool Map { get; set; }
         public bool Pdb { get; set; }
+
+        public bool Perfmap { get; set; }
         public FileInfo PackageList { get; set; }
         public int DegreeOfParallelism { get; set; }
         public bool Sequential { get; set; }
+        public int Iterations { get; set; } = 1;
         public bool Framework { get; set; }
         public bool UseFramework { get; set; }
         public bool Release { get; set; }

--- a/src/coreclr/tools/r2rtest/CommandLineOptions.cs
+++ b/src/coreclr/tools/r2rtest/CommandLineOptions.cs
@@ -52,8 +52,10 @@ namespace R2RTest
                         NoCleanup(),
                         Map(),
                         Pdb(),
+                        Perfmap(),
                         DegreeOfParallelism(),
                         Sequential(),
+                        Iterations(),
                         Framework(),
                         UseFramework(),
                         Release(),
@@ -89,8 +91,10 @@ namespace R2RTest
                         NoCleanup(),
                         Map(),
                         Pdb(),
+                        Perfmap(),
                         DegreeOfParallelism(),
                         Sequential(),
+                        Iterations(),
                         Framework(),
                         UseFramework(),
                         Release(),
@@ -119,10 +123,12 @@ namespace R2RTest
                         NoCleanup(),
                         Map(),
                         Pdb(),
+                        Perfmap(),
                         Crossgen2Parallelism(),
                         Crossgen2JitPath(),
                         DegreeOfParallelism(),
                         Sequential(),
+                        Iterations(),
                         Release(),
                         LargeBubble(),
                         Composite(),
@@ -148,6 +154,7 @@ namespace R2RTest
                         NoCleanup(),
                         Map(),
                         Pdb(),
+                        Perfmap(),
                         DegreeOfParallelism(),
                         CompilationTimeoutMinutes(),
                         ExecutionTimeoutMinutes(),
@@ -165,6 +172,7 @@ namespace R2RTest
                         Composite(),
                         Map(),
                         Pdb(),
+                        Perfmap(),
                         CompilationTimeoutMinutes(),
                         Crossgen2Path(),
                         MibcPath(),
@@ -227,11 +235,17 @@ namespace R2RTest
             Option Pdb() =>
                 new Option<bool>(new[] { "--pdb" }, "Generate PDB symbol information (Crossgen2 / Windows only)");
 
+            Option Perfmap() =>
+                new Option<bool>(new[] { "--perfmap" }, "Generate perfmap symbol information");
+
             Option DegreeOfParallelism() =>
                 new Option<int>(new[] { "--degree-of-parallelism", "-dop" }, "Override default compilation / execution DOP (default = logical processor count)");
 
             Option Sequential() =>
                 new Option<bool>(new[] { "--sequential" }, "Run tests sequentially");
+
+            Option Iterations() =>
+                new Option<int>(new[] { "--iterations" }, "Number of iterations for each test execution");
 
             Option Framework() =>
                 new Option<bool>(new[] { "--framework" }, "Precompile and use native framework");

--- a/src/coreclr/tools/r2rtest/Crossgen2Runner.cs
+++ b/src/coreclr/tools/r2rtest/Crossgen2Runner.cs
@@ -96,6 +96,12 @@ namespace R2RTest
                 yield return $"--pdb-path:{Path.GetDirectoryName(outputFileName)}";
             }
 
+            if (_options.Perfmap)
+            {
+                yield return $"--perfmap";
+                yield return $"--perfmap-path:{Path.GetDirectoryName(outputFileName)}";
+            }
+
             if (_options.TargetArch != null)
             {
                 yield return $"--targetarch={_options.TargetArch}";

--- a/src/coreclr/tools/r2rtest/ParallelRunner.cs
+++ b/src/coreclr/tools/r2rtest/ParallelRunner.cs
@@ -159,7 +159,14 @@ public sealed class ParallelRunner
         }
     }
 
-    private static void BuildEtwProcesses(int startIndex, int endIndex, int totalCount, int failureCount, List<ProcessInfo> processList, int degreeOfParallelism, bool measurePerf)
+    private static void BuildEtwProcesses(
+        int startIndex,
+        int endIndex,
+        int totalCount,
+        int failureCount,
+        List<ProcessInfo> processList,
+        int degreeOfParallelism,
+        bool measurePerf)
     {
         using (TraceEventSession traceEventSession = new TraceEventSession("ReadyToRunTestSession"))
         {


### PR DESCRIPTION
*) While working on Crossgen2 perfmap support I hit the need to
make R2RTest support creating perfmaps during CG2 compilation.

*) While I was there I also added a new command-line switch
--iterations to request each test be run given number of times;
this is based on Maoni's ask from some time ago.

Thanks

Tomas

/cc @dotnet/crossgen-contrib 