### PR TITLE
Handle shadowed property names in DiagnosticsSourceEventSource

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -1345,7 +1345,19 @@ namespace System.Diagnostics
                         }
                         else
                         {
-                            PropertyInfo? propertyInfo = typeInfo.GetProperty(propertyName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
+                            PropertyInfo? propertyInfo = typeInfo.GetDeclaredProperty(propertyName);
+                            if (propertyInfo == null)
+                            {
+                                foreach (PropertyInfo pi in typeInfo.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static))
+                                {
+                                    if (pi.Name == propertyName)
+                                    {
+                                        propertyInfo = pi;
+                                        break;
+                                    }
+                                }
+                            }
+
                             if (propertyInfo == null)
                             {
                                 Log.Message($"Property {propertyName} not found on {type}. Ensure the name is spelled correctly. If you published the application with PublishTrimmed=true, ensure the property was not trimmed away.");


### PR DESCRIPTION
Fixes #57709

If a class, such as `SqlLiteCommand`, has a shadowed property name, such as `SqlLiteCommand.Connection` and `DbCommand.Connection`, the logic in `DiagnosticSourceEventSource` will throw an ambiguous match exception when trying to resolve a property with that name.

This patch adds a fast path for most use cases that will only check the declared properties on the given type and won't fall back to the looping logic unless it needs to.

This should be ported to 6.0-rc2 if approved.