### PR TITLE
[release/6.0-rc1][wasm] Require workloads if using `@(NativeFileReference)`

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -163,7 +163,7 @@
     <SQLitePCLRawbundle_greenVersion>2.0.4</SQLitePCLRawbundle_greenVersion>
     <MoqVersion>4.12.0</MoqVersion>
     <FsCheckVersion>2.14.3</FsCheckVersion>
-    <SdkVersionForWorkloadTesting>6.0.100-rc.1.21412.8</SdkVersionForWorkloadTesting>
+    <SdkVersionForWorkloadTesting>6.0.100-rc.1.21425.15</SdkVersionForWorkloadTesting>
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>5.0.0-preview-20201009.2</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.targets.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/WorkloadManifest.targets.in
@@ -8,8 +8,7 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(BrowserWorkloadDisabled)' == 'true'">
-        <_NativeBuildNeeded Condition="'$(RunAOTCompilation)' == 'true'">true</_NativeBuildNeeded>
-        <WorkloadDisabledWithReason Condition="'$(_NativeBuildNeeded)' == 'true'">WebAssembly workloads (required for AOT) are only supported for projects targeting net6.0+</WorkloadDisabledWithReason>
+        <_MissingNativeBuildNeededFor Condition="'$(RunAOTCompilation)' == 'true'">required for AOT</_MissingNativeBuildNeededFor>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'browser-wasm' AND '$(UsingBrowserRuntimeWorkload)' == ''">
@@ -128,7 +127,30 @@
                         />
     </ItemGroup>
 
-    <Target Name="ErrorDisabledWorkload" Condition="'$(WorkloadDisabledWithReason)' != ''" BeforeTargets="Publish">
-      <Error Text="$(WorkloadDisabledWithReason)" />
+    <Target Name="_CheckNativeBuildNeededButMissingWorkload"
+            Condition="'$(RuntimeIdentifier)' == 'browser-wasm' and '$(_MissingNativeBuildNeededFor)' == '' and '$(WasmNativeWorkload)' != 'true'"
+            BeforeTargets="Build">
+
+      <PropertyGroup Condition="@(NativeFileReference->Count()) > 0">
+        <_MissingNativeBuildNeededFor>(required for linking native libraries)</_MissingNativeBuildNeededFor>
+
+        <!-- fail with missing workload, only if it isn't *disabled* (eg. for net5.0 projects) -->
+        <_WorkloadNeeded Condition="'$(_MissingNativeBuildNeededFor)' != '' and '$(BrowserWorkloadDisabled)' != 'true'">true</_WorkloadNeeded>
+      </PropertyGroup>
+
+      <ItemGroup Condition="'$(_WorkloadNeeded)' == 'true'">
+        <MissingWorkloadPack Include="Microsoft.NET.Runtime.WebAssembly.Sdk" Version="$(RuntimePackInWorkloadVersion)" />
+      </ItemGroup>
+
+      <!-- based on Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.ImportWorkloads.targets -->
+      <ShowMissingWorkloads MissingWorkloadPacks="@(MissingWorkloadPack)"
+                            NetCoreRoot="$(NetCoreRoot)"
+                            NETCoreSdkVersion="$(NETCoreSdkVersion)"
+                            GenerateErrorsForMissingWorkloads="true"
+                            Condition="'$(_WorkloadNeeded)' == 'true'" />
+    </Target>
+
+    <Target Name="_ErrorDisabledWorkload" Condition="'$(_MissingNativeBuildNeededFor)' != ''" BeforeTargets="Build">
+      <Error Text="WebAssembly workloads, $(_MissingNativeBuildNeededFor), are only supported for projects targeting net6.0+" />
     </Target>
 </Project>

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/NativeLibraryTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/NativeLibraryTests.cs
@@ -17,7 +17,7 @@ namespace Wasm.Build.Tests
         {
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
         [BuildAndRun(aot: false)]
         [BuildAndRun(aot: true)]
         public void ProjectWithNativeReference(BuildArgs buildArgs, RunHost host, string id)
@@ -48,7 +48,7 @@ namespace Wasm.Build.Tests
             Assert.Contains("from pinvoke: 142", output);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
         [BuildAndRun(aot: false)]
         [BuildAndRun(aot: true)]
         public void ProjectUsingSkiaSharp(BuildArgs buildArgs, RunHost host, string id)


### PR DESCRIPTION
When a blazorwasm project has `$(RunAOTCompilation)=true`, then the `wasm-tools` workload is marked as required. But this is not done if the project wants to use native libraries, without AOT.

This PR makes the workload a requirement when such native libraries are being used (`@(NativeFileReference)`). This will cause the build to fail if the workload is not installed.

Fixes https://github.com/dotnet/runtime/issues/56678 .

## Customer Impact

Instead of the native library, silently, not getting linked, and failing at runtime, this fails the build.

## Testing

CI.  New tests added.

## Risk
