### PR TITLE
Check Options validations length instead of null

### DIFF
--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsFactory.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Extensions.Options
                 post.PostConfigure(name, options);
             }
 
-            if (_validations != null)
+            if (_validations.Length > 0)
             {
                 var failures = new List<string>();
                 foreach (IValidateOptions<TOptions> validate in _validations)


### PR DESCRIPTION
The `OptionsFactory` constructors ensure that the member variable
`_validations` is never null. Yet, the `Create` method checks whether
`_validations` is null before running them.

Check that the length of `_validations` is larger than zero instead of
checking for null. This eliminates a `List<>` allocation when there are
no validations.