### PR TITLE
Fix ep_rt_atomic_compare_exchange_size_t in Mono EventPipe shim.

### DIFF
--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -602,7 +602,11 @@ inline
 size_t
 ep_rt_atomic_compare_exchange_size_t (volatile size_t *target, size_t expected, size_t value)
 {
+#if SIZEOF_SIZE_T == 8
+	return (size_t)(mono_atomic_cas_i64((volatile gint64*)(target), (gint64)(value), (gint64)(expected)));
+#else
 	return (size_t)(mono_atomic_cas_i32 ((volatile gint32 *)(target), (gint32)(value), (gint32)(expected)));
+#endif
 }
 
 /*


### PR DESCRIPTION
ep_rt_atomic_compare_exchange_size_t was always truncated to gint32 on Mono 64-bit platforms. This commit use 32 or 64-bit cas version depending on SIZEOF_SIZE_T. NOTE, CoreCLR used a template function for this and already picks 32 or 64 bit version depending on size of size_t.

ep_rt_atomic_compare_exchange_size_t is currently used to reflect size of EventPipe buffer manager buffers and will most likely never need more than 2GB of data, but better to fix it and inline with CoreCLR shim implementation.