### PR TITLE
Use OutputRid in test projects

### DIFF
--- a/src/tests/Common/ilasm/ilasm.ilproj
+++ b/src/tests/Common/ilasm/ilasm.ilproj
@@ -4,6 +4,6 @@
        needed by the IL SDK. -->
 
   <PropertyGroup>
-    <RuntimeIdentifier>$(PackageRID)</RuntimeIdentifier>
+    <RuntimeIdentifier>$(OutputRid)</RuntimeIdentifier>
   </PropertyGroup>
 </Project>

--- a/src/tests/Common/publishdependency.targets
+++ b/src/tests/Common/publishdependency.targets
@@ -28,7 +28,7 @@
   <Target Name="CopyDependencyToCoreRoot">
     <MSBuild Projects="@(CoreRootProjectFiles)"
              Targets="CopyDependencyToCoreRoot"
-             Properties="Language=C#;RuntimeIdentifier=$(PackageRID)" />
+             Properties="Language=C#;RuntimeIdentifier=$(OutputRid)" />
 
   </Target>
 </Project>

--- a/src/tests/Common/test_dependencies/test_dependencies.csproj
+++ b/src/tests/Common/test_dependencies/test_dependencies.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
     <DisableRarCache>true</DisableRarCache>
     <DisablePackageAssetsCache>true</DisablePackageAssetsCache>
-    <RuntimeIdentifiers>win-arm;win-arm64;win-x64;win-x86;$(PackageRID)</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-arm;win-arm64;win-x64;win-x86;$(OutputRid)</RuntimeIdentifiers>
     <IncludeOOBLibraries>true</IncludeOOBLibraries>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Common/test_dependencies_fs/test_dependencies.fsproj
+++ b/src/tests/Common/test_dependencies_fs/test_dependencies.fsproj
@@ -5,7 +5,7 @@
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
     <DisableRarCache>true</DisableRarCache>
     <DisablePackageAssetsCache>true</DisablePackageAssetsCache>
-    <RuntimeIdentifiers>win-arm;win-arm64;win-x64;win-x86;$(PackageRID)</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-arm;win-arm64;win-x64;win-x86;$(OutputRid)</RuntimeIdentifiers>
     <IncludeOOBLibraries>true</IncludeOOBLibraries>
   </PropertyGroup>
 

--- a/src/tests/run.proj
+++ b/src/tests/run.proj
@@ -589,8 +589,8 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
       <MonoLlvmPath>$(MonoBinDir)</MonoLlvmPath>
     </PropertyGroup>
     <PropertyGroup Condition="'$(CROSSCOMPILE)' != ''">
-      <AotCompiler>$(MonoBinDir)/cross/$(PackageRID)/mono-aot-cross</AotCompiler>
-      <MonoLlvmPath>$(MonoBinDir)/cross/$(PackageRID)</MonoLlvmPath>
+      <AotCompiler>$(MonoBinDir)/cross/$(OutputRid)/mono-aot-cross</AotCompiler>
+      <MonoLlvmPath>$(MonoBinDir)/cross/$(OutputRid)</MonoLlvmPath>
     </PropertyGroup>
 
     <ItemGroup>
@@ -826,7 +826,7 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
   <Target Name="CreateTestOverlay">
     <MSBuild Projects="$(MSBuildProjectFile)"
              Targets="CopyDependencyToCoreRoot"
-             Properties="Language=C#;PackageRID=$(PackageRID);RuntimeIdentifier=$(PackageRID)" />
+             Properties="Language=C#;OutputRid=$(OutputRid);RuntimeIdentifier=$(OutputRid)" />
   </Target>
 
   <Target Name="Build">


### PR DESCRIPTION
To test an outerloop test leg failure.

Fixes #55657