### PR TITLE
Optimize DateTimeOffset

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Constants.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Constants.cs
@@ -20,7 +20,7 @@ namespace System.Buffers.Text
         //   ex. 1,234,567,890
         public const int GroupSize = 3;
 
-        public static readonly TimeSpan NullUtcOffset = TimeSpan.MinValue;  // Utc offsets must range from -14:00 to 14:00 so this is never a valid offset.
+        public static TimeSpan NullUtcOffset => new TimeSpan(long.MinValue);  // Utc offsets must range from -14:00 to 14:00 so this is never a valid offset.
 
         public const int DateTimeMaxUtcOffsetHours = 14; // The UTC offset portion of a TimeSpan or DateTime can be no more than 14 hours and no less than -14 hours.
 

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Date.G.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Date.G.cs
@@ -41,7 +41,6 @@ namespace System.Buffers.Text
             { var unused = destination[MinimumBytesNeeded - 1]; }
 
             value.GetDate(out int year, out int month, out int day);
-            value.GetTime(out int hour, out int minute, out int second);
 
             FormattingHelpers.WriteTwoDecimalDigits((uint)month, destination, 0);
             destination[2] = Utf8Constants.Slash;
@@ -51,6 +50,8 @@ namespace System.Buffers.Text
 
             FormattingHelpers.WriteFourDecimalDigits((uint)year, destination, 6);
             destination[10] = Utf8Constants.Space;
+
+            value.GetTime(out int hour, out int minute, out int second);
 
             FormattingHelpers.WriteTwoDecimalDigits((uint)hour, destination, 11);
             destination[13] = Utf8Constants.Colon;

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Date.L.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Date.L.cs
@@ -21,9 +21,6 @@ namespace System.Buffers.Text
                 return false;
             }
 
-            value.GetDate(out int year, out int month, out int day);
-            value.GetTime(out int hour, out int minute, out int second);
-
             uint dayAbbrev = s_dayAbbreviationsLowercase[(int)value.DayOfWeek];
 
             destination[0] = (byte)dayAbbrev;
@@ -33,6 +30,8 @@ namespace System.Buffers.Text
             destination[2] = (byte)dayAbbrev;
             destination[3] = Utf8Constants.Comma;
             destination[4] = Utf8Constants.Space;
+
+            value.GetDate(out int year, out int month, out int day);
 
             FormattingHelpers.WriteTwoDecimalDigits((uint)day, destination, 5);
             destination[7] = Utf8Constants.Space;
@@ -47,6 +46,8 @@ namespace System.Buffers.Text
 
             FormattingHelpers.WriteFourDecimalDigits((uint)year, destination, 12);
             destination[16] = Utf8Constants.Space;
+
+            value.GetTime(out int hour, out int minute, out int second);
 
             FormattingHelpers.WriteTwoDecimalDigits((uint)hour, destination, 17);
             destination[19] = Utf8Constants.Colon;

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Date.O.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Date.O.cs
@@ -51,7 +51,6 @@ namespace System.Buffers.Text
             { _ = destination[MinimumBytesNeeded - 1]; }
 
             value.GetDate(out int year, out int month, out int day);
-            value.GetTimePrecise(out int hour, out int minute, out int second, out int ticks);
 
             FormattingHelpers.WriteFourDecimalDigits((uint)year, destination, 0);
             destination[4] = Utf8Constants.Minus;
@@ -61,6 +60,8 @@ namespace System.Buffers.Text
 
             FormattingHelpers.WriteTwoDecimalDigits((uint)day, destination, 8);
             destination[10] = TimeMarker;
+
+            value.GetTimePrecise(out int hour, out int minute, out int second, out int ticks);
 
             FormattingHelpers.WriteTwoDecimalDigits((uint)hour, destination, 11);
             destination[13] = Utf8Constants.Colon;

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Date.R.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Date.R.cs
@@ -21,9 +21,6 @@ namespace System.Buffers.Text
                 return false;
             }
 
-            value.GetDate(out int year, out int month, out int day);
-            value.GetTime(out int hour, out int minute, out int second);
-
             uint dayAbbrev = s_dayAbbreviations[(int)value.DayOfWeek];
 
             destination[0] = (byte)dayAbbrev;
@@ -33,6 +30,8 @@ namespace System.Buffers.Text
             destination[2] = (byte)dayAbbrev;
             destination[3] = Utf8Constants.Comma;
             destination[4] = Utf8Constants.Space;
+
+            value.GetDate(out int year, out int month, out int day);
 
             FormattingHelpers.WriteTwoDecimalDigits((uint)day, destination, 5);
             destination[7] = Utf8Constants.Space;
@@ -47,6 +46,8 @@ namespace System.Buffers.Text
 
             FormattingHelpers.WriteFourDecimalDigits((uint)year, destination, 12);
             destination[16] = Utf8Constants.Space;
+
+            value.GetTime(out int hour, out int minute, out int second);
 
             FormattingHelpers.WriteTwoDecimalDigits((uint)hour, destination, 17);
             destination[19] = Utf8Constants.Colon;

--- a/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.cs
@@ -563,7 +563,7 @@ namespace System
             return CreateValidateOffset(dateResult, offset);
         }
 
-        public TimeSpan Subtract(DateTimeOffset value) => _dateTime.Subtract(value._dateTime);
+        public TimeSpan Subtract(DateTimeOffset value) => new TimeSpan(UtcTicks - value.UtcTicks);
 
         public DateTimeOffset Subtract(TimeSpan value) => Add(ClockDateTime.Subtract(value));
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Calendar.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Calendar.cs
@@ -114,7 +114,7 @@ namespace System.Globalization
         /// <summary>
         /// This is used to convert CurrentEra(0) to an appropriate era value.
         /// </summary>
-        internal virtual int CurrentEraValue
+        internal int CurrentEraValue
         {
             get
             {
@@ -638,7 +638,7 @@ namespace System.Globalization
             return year >= GetYear(MinSupportedDateTime) && year <= GetYear(MaxSupportedDateTime);
         }
 
-        internal virtual bool IsValidMonth(int year, int month, int era)
+        internal bool IsValidMonth(int year, int month, int era)
         {
             return IsValidYear(year, era) && month >= 1 && month <= GetMonthsInYear(year, era);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
@@ -332,12 +332,14 @@ namespace System.Globalization
             }
         }
 
-        public static DateTimeFormatInfo GetInstance(IFormatProvider? provider) =>
-            provider == null ? CurrentInfo :
-            provider is CultureInfo cultureProvider && !cultureProvider._isInherited ? cultureProvider.DateTimeFormat :
-            provider is DateTimeFormatInfo info ? info :
-            provider.GetFormat(typeof(DateTimeFormatInfo)) is DateTimeFormatInfo info2 ? info2 :
-            CurrentInfo; // Couldn't get anything, just use currentInfo as fallback
+        public static DateTimeFormatInfo GetInstance(IFormatProvider? provider) => provider switch
+        {
+            null => CurrentInfo,
+            CultureInfo { _isInherited: false, _dateTimeInfo: { } info } => info,
+            DateTimeFormatInfo info => info,
+            _ => provider.GetFormat(typeof(DateTimeFormatInfo)) as DateTimeFormatInfo ??
+                CurrentInfo // Couldn't get anything, just use currentInfo as fallback
+        };
 
         public object? GetFormat(Type? formatType)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/GregorianCalendarHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/GregorianCalendarHelper.cs
@@ -67,6 +67,8 @@ namespace System.Globalization
         private readonly int m_minYear;
         private readonly Calendar m_Cal;
         private readonly EraInfo[] m_EraInfo;
+        private readonly long _minSupportedTicks;
+        private readonly long _maxSupportedTicks;
 
         // Construct an instance of gregorian calendar.
         internal GregorianCalendarHelper(Calendar cal, EraInfo[] eraInfo)
@@ -75,6 +77,8 @@ namespace System.Globalization
             m_EraInfo = eraInfo;
             m_maxYear = eraInfo[0].maxEraYear;
             m_minYear = eraInfo[0].minEraYear;
+            _minSupportedTicks = cal.MinSupportedDateTime.Ticks;
+            _maxSupportedTicks = cal.MaxSupportedDateTime.Ticks;
         }
 
         // EraInfo.yearOffset:  The offset to Gregorian year when the era starts. Gregorian Year = Era Year + yearOffset
@@ -217,7 +221,9 @@ namespace System.Globalization
 
         internal void CheckTicksRange(long ticks)
         {
-            if (ticks < m_Cal.MinSupportedDateTime.Ticks || ticks > m_Cal.MaxSupportedDateTime.Ticks)
+            if (ticks < _minSupportedTicks || ticks > _maxSupportedTicks) ThrowOutOfRange();
+
+            void ThrowOutOfRange()
             {
                 throw new ArgumentOutOfRangeException(
                             "time",

--- a/src/libraries/System.Private.CoreLib/src/System/IO/File.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/File.cs
@@ -134,12 +134,12 @@ namespace System.IO
         {
             // File and Directory UTC APIs treat a DateTimeKind.Unspecified as UTC whereas
             // ToUniversalTime treats this as local.
-            if (dateTime.Kind != DateTimeKind.Local)
+            if (dateTime.Kind == DateTimeKind.Local)
             {
-                return new DateTimeOffset(dateTime.Ticks, default);
+                dateTime = dateTime.ToUniversalTime();
             }
 
-            return dateTime.ToUniversalTime();
+            return new DateTimeOffset(dateTime.Ticks, default);
         }
 
         public static void SetCreationTime(string path, DateTime creationTime)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/File.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/File.cs
@@ -130,12 +130,17 @@ namespace System.IO
         public static FileStream Open(string path, FileMode mode, FileAccess access, FileShare share)
             => new FileStream(path, mode, access, share);
 
-        // File and Directory UTC APIs treat a DateTimeKind.Unspecified as UTC whereas
-        // ToUniversalTime treats this as local.
         internal static DateTimeOffset GetUtcDateTimeOffset(DateTime dateTime)
-            => dateTime.Kind == DateTimeKind.Unspecified
-                ? DateTime.SpecifyKind(dateTime, DateTimeKind.Utc)
-                : dateTime.ToUniversalTime();
+        {
+            // File and Directory UTC APIs treat a DateTimeKind.Unspecified as UTC whereas
+            // ToUniversalTime treats this as local.
+            if (dateTime.Kind != DateTimeKind.Local)
+            {
+                return new DateTimeOffset(dateTime.Ticks, default);
+            }
+
+            return dateTime.ToUniversalTime();
+        }
 
         public static void SetCreationTime(string path, DateTime creationTime)
             => FileSystem.SetCreationTime(Path.GetFullPath(path), creationTime, asDirectory: false);

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
@@ -374,21 +374,17 @@ namespace System.IO
             bool asDirectory,
             long creationTime = -1,
             long lastAccessTime = -1,
-            long lastWriteTime = -1,
-            long changeTime = -1,
-            uint fileAttributes = 0)
+            long lastWriteTime = -1)
         {
+            Interop.Kernel32.FILE_BASIC_INFO basicInfo;
+            basicInfo.CreationTime = creationTime;
+            basicInfo.LastAccessTime = lastAccessTime;
+            basicInfo.LastWriteTime = lastWriteTime;
+            basicInfo.ChangeTime = -1;
+            basicInfo.FileAttributes = 0;
+
             using (SafeFileHandle handle = OpenHandle(fullPath, asDirectory))
             {
-                var basicInfo = new Interop.Kernel32.FILE_BASIC_INFO()
-                {
-                    CreationTime = creationTime,
-                    LastAccessTime = lastAccessTime,
-                    LastWriteTime = lastWriteTime,
-                    ChangeTime = changeTime,
-                    FileAttributes = fileAttributes
-                };
-
                 if (!Interop.Kernel32.SetFileInformationByHandle(handle, Interop.Kernel32.FileBasicInfo, &basicInfo, (uint)sizeof(Interop.Kernel32.FILE_BASIC_INFO)))
                 {
                     throw Win32Marshal.GetExceptionForLastWin32Error(fullPath);

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.StringSerializer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.StringSerializer.cs
@@ -537,7 +537,7 @@ namespace System
                 TransitionTime transition;
 
                 DateTime timeOfDay = GetNextDateTimeValue(TimeOfDayFormat);
-                timeOfDay = new DateTime(1, 1, 1, timeOfDay.Hour, timeOfDay.Minute, timeOfDay.Second, timeOfDay.Millisecond);
+                timeOfDay = DateTime.UnsafeCreate(timeOfDay.TimeOfDay.Ticks);
 
                 int month = GetNextInt32Value();
 

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.TransitionTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.TransitionTime.cs
@@ -94,13 +94,12 @@ namespace System
                 }
 
                 // DayOfWeek range 0-6
-                if ((int)dayOfWeek < 0 || (int)dayOfWeek > 6)
+                if ((uint)dayOfWeek > 6)
                 {
                     throw new ArgumentOutOfRangeException(nameof(dayOfWeek), SR.ArgumentOutOfRange_DayOfWeek);
                 }
 
-                timeOfDay.GetDate(out int timeOfDayYear, out int timeOfDayMonth, out int timeOfDayDay);
-                if (timeOfDayYear != 1 || timeOfDayMonth != 1 || timeOfDayDay != 1 || (timeOfDay.Ticks % TimeSpan.TicksPerMillisecond != 0))
+                if (timeOfDay.Ticks >= TimeSpan.TicksPerDay || (ulong)timeOfDay.Ticks % TimeSpan.TicksPerMillisecond != 0)
                 {
                     throw new ArgumentException(SR.Argument_DateTimeHasTicks, nameof(timeOfDay));
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.Unix.cs
@@ -1263,13 +1263,13 @@ namespace System
             // utc base offset delta increment
             TimeSpan adjustment = TimeSpan.Zero;
 
-            if (utcOffset > MaxOffset)
+            if (utcOffset.Ticks > MaxOffsetTicks)
             {
-                adjustment = MaxOffset - utcOffset;
+                adjustment = new TimeSpan(MaxOffsetTicks) - utcOffset;
             }
-            else if (utcOffset < MinOffset)
+            else if (utcOffset.Ticks < MinOffsetTicks)
             {
-                adjustment = MinOffset - utcOffset;
+                adjustment = new TimeSpan(MinOffsetTicks) - utcOffset;
             }
 
             if (adjustment != TimeSpan.Zero)


### PR DESCRIPTION
* Optimize and cleanup `DateTimeOffset`
* Some additional optimizations for `DateTime`
* Cleanup some uses of `DateTime[Offset]`
* Fix `DateTimeOffset.UtcNow` to not have Kind=Utc in its `_dateTime` value (the existing assert didn't catch it because it was basically a no-op). Added better asserts.