### PR TITLE
Fix memory leak in enqueue/dequeue of EventPipe callback data.

### DIFF
--- a/src/mono/mono/eventpipe/test/ep-provider-callback-dataqueue-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-provider-callback-dataqueue-tests.c
@@ -46,23 +46,26 @@ test_provider_callback_data_queue (void)
 	EventPipeProviderCallbackDataQueue callback_data_queue;
 	EventPipeProviderCallbackDataQueue *provider_callback_data_queue = ep_provider_callback_data_queue_init (&callback_data_queue);
 
-	EventPipeProviderCallbackData enqueue_callback_data;
-	EventPipeProviderCallbackData *provider_enqueue_callback_data = ep_provider_callback_data_init (
-		&enqueue_callback_data,
-		"",
-		provider_callback,
-		NULL,
-		1,
-		EP_EVENT_LEVEL_LOGALWAYS,
-		true);
-
-	for (uint32_t i = 0; i < 1000; ++i)
+	for (uint32_t i = 0; i < 1000; ++i) {
+		EventPipeProviderCallbackData enqueue_callback_data;
+		EventPipeProviderCallbackData *provider_enqueue_callback_data = ep_provider_callback_data_init (
+			&enqueue_callback_data,
+			"",
+			provider_callback,
+			NULL,
+			1,
+			EP_EVENT_LEVEL_LOGALWAYS,
+			true);
 		ep_provider_callback_data_queue_enqueue (provider_callback_data_queue, provider_enqueue_callback_data);
+		ep_provider_callback_data_fini (provider_enqueue_callback_data);
+	}
 
 	EventPipeProviderCallbackData dequeue_callback_data;
 	uint32_t deque_counter = 0;
-	while (ep_provider_callback_data_queue_try_dequeue (provider_callback_data_queue, &dequeue_callback_data))
+	while (ep_provider_callback_data_queue_try_dequeue(provider_callback_data_queue, &dequeue_callback_data)) {
 		deque_counter++;
+		ep_provider_callback_data_fini (&dequeue_callback_data);
+	}
 
 	if (deque_counter != 1000) {
 		result = FAILED ("Unexpected number of provider callback invokes");

--- a/src/mono/mono/eventpipe/test/ep-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-tests.c
@@ -620,7 +620,7 @@ test_create_delete_provider_with_callback (void)
 	EventPipeProvider *test_provider = NULL;
 	EventPipeProviderConfiguration provider_config;
 
-	EventPipeProviderConfiguration *current_provider_config =ep_provider_config_init (&provider_config, TEST_PROVIDER_NAME, 1, EP_EVENT_LEVEL_LOGALWAYS, "");
+	EventPipeProviderConfiguration *current_provider_config = ep_provider_config_init (&provider_config, TEST_PROVIDER_NAME, 1, EP_EVENT_LEVEL_LOGALWAYS, "");
 	ep_raise_error_if_nok (current_provider_config != NULL);
 
 	test_location = 1;

--- a/src/native/eventpipe/ep-config.c
+++ b/src/native/eventpipe/ep-config.c
@@ -113,6 +113,7 @@ config_register_provider (
 			EventPipeSessionProvider *session_provider = ep_rt_session_provider_list_find_by_name (ep_session_provider_list_get_providers_cref (providers), ep_provider_get_provider_name (provider));
 			if (session_provider) {
 				EventPipeProviderCallbackData provider_callback_data;
+				memset (&provider_callback_data, 0, sizeof (provider_callback_data));
 				provider_set_config (
 					provider,
 					keyword_for_all_sessions,
@@ -124,6 +125,7 @@ config_register_provider (
 					&provider_callback_data);
 				if (provider_callback_data_queue)
 					ep_provider_callback_data_queue_enqueue (provider_callback_data_queue, &provider_callback_data);
+				ep_provider_callback_data_fini (&provider_callback_data);
 			}
 		}
 	}
@@ -179,6 +181,7 @@ ep_config_init (EventPipeConfiguration *config)
 	while (ep_provider_callback_data_queue_try_dequeue (provider_callback_data_queue, &provider_callback_data)) {
 		ep_rt_prepare_provider_invoke_callback (&provider_callback_data);
 		provider_invoke_callback (&provider_callback_data);
+		ep_provider_callback_data_fini (&provider_callback_data);
 	}
 
 	// Create the metadata event.
@@ -552,6 +555,7 @@ config_enable_disable (
 					int64_t keyword_for_all_sessions;
 					EventPipeEventLevel level_for_all_sessions;
 					EventPipeProviderCallbackData provider_callback_data;
+					memset (&provider_callback_data, 0, sizeof (provider_callback_data));
 					config_compute_keyword_and_level (config, provider, &keyword_for_all_sessions, &level_for_all_sessions);
 					if (enable) {
 						provider_set_config (
@@ -576,6 +580,7 @@ config_enable_disable (
 					}
 					if (provider_callback_data_queue)
 						ep_provider_callback_data_queue_enqueue (provider_callback_data_queue, &provider_callback_data);
+					ep_provider_callback_data_fini (&provider_callback_data);
 				}
 			}
 		}

--- a/src/native/eventpipe/ep-types.h
+++ b/src/native/eventpipe/ep-types.h
@@ -97,6 +97,9 @@ EventPipeProviderCallbackData *
 ep_provider_callback_data_alloc_copy (EventPipeProviderCallbackData *provider_callback_data_src);
 
 EventPipeProviderCallbackData *
+ep_provider_callback_data_alloc_move (EventPipeProviderCallbackData *provider_callback_data_src);
+
+EventPipeProviderCallbackData *
 ep_provider_callback_data_init (
 	EventPipeProviderCallbackData *provider_callback_data,
 	const ep_char8_t *filter_data,
@@ -108,6 +111,11 @@ ep_provider_callback_data_init (
 
 EventPipeProviderCallbackData *
 ep_provider_callback_data_init_copy (
+	EventPipeProviderCallbackData *provider_callback_data_dst,
+	EventPipeProviderCallbackData *provider_callback_data_src);
+
+EventPipeProviderCallbackData *
+ep_provider_callback_data_init_move (
 	EventPipeProviderCallbackData *provider_callback_data_dst,
 	EventPipeProviderCallbackData *provider_callback_data_src);
 


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/56104 made sure provider callback data gets its own copy of filter data. This created a couple of memory leaks when queue/dequeue the callback data since callback data was not correctly freed in these scenarios leading to leaks of the copied filter data.

Was detected running the manual EventPipe native unit tests on Windows using its build in use of _CrtMemCheckpoint (only available in debug builds) automatically detecting memory leaks.

Fix makes sure callback data is moved into queue on enqueue and moved out in dequeue and that caller of dequeue make sure to free returned callback data using ep_provider_callback_data_fini when done using it. Doing a move instead of copy will also reduce the number of allocations when enqueue/dequeue callback data in provider callback queue.