### PR TITLE
Make bashing to constants nicer

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -2747,22 +2747,18 @@ GenTree* Compiler::optConstantAssertionProp(AssertionDsc*        curAssertion,
             {
                 return nullptr;
             }
-            newTree->ChangeOperConst(GT_CNS_DBL);
-            newTree->AsDblCon()->gtDconVal = curAssertion->op2.dconVal;
+            newTree->BashToConst(curAssertion->op2.dconVal, tree->TypeGet());
             break;
 
         case O2K_CONST_LONG:
 
             if (newTree->gtType == TYP_LONG)
             {
-                newTree->ChangeOperConst(GT_CNS_NATIVELONG);
-                newTree->AsIntConCommon()->SetLngValue(curAssertion->op2.lconVal);
+                newTree->BashToConst(curAssertion->op2.lconVal);
             }
             else
             {
-                newTree->ChangeOperConst(GT_CNS_INT);
-                newTree->AsIntCon()->gtIconVal = (int)curAssertion->op2.lconVal;
-                newTree->gtType                = TYP_INT;
+                newTree->BashToConst(static_cast<int32_t>(curAssertion->op2.lconVal));
             }
             break;
 
@@ -2805,14 +2801,15 @@ GenTree* Compiler::optConstantAssertionProp(AssertionDsc*        curAssertion,
                 else
 #endif // FEATURE_SIMD
                 {
-                    newTree->ChangeOperConst(GT_CNS_INT);
-                    newTree->AsIntCon()->gtIconVal = curAssertion->op2.u1.iconVal;
-                    newTree->ClearIconHandleMask();
-                    if (newTree->TypeIs(TYP_STRUCT))
+                    var_types type = tree->TypeGet();
+                    if (type == TYP_STRUCT)
                     {
                         // LCL_VAR can be init with a GT_CNS_INT, keep its type INT, not STRUCT.
-                        newTree->ChangeType(TYP_INT);
+                        type = TYP_INT;
                     }
+
+                    newTree->BashToConst(curAssertion->op2.u1.iconVal, type);
+                    newTree->ClearIconHandleMask();
                 }
                 // If we're doing an array index address, assume any constant propagated contributes to the index.
                 if (isArrIndex)
@@ -3316,13 +3313,11 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, Gen
 
         if (curAssertion->assertionKind == OAK_EQUAL)
         {
-            tree->ChangeOperConst(GT_CNS_INT);
-            tree->AsIntCon()->gtIconVal = 0;
+            tree->BashToConst(0);
         }
         else
         {
-            tree->ChangeOperConst(GT_CNS_INT);
-            tree->AsIntCon()->gtIconVal = 1;
+            tree->BashToConst(1);
         }
 
         newTree = fgMorphTree(tree);
@@ -3408,8 +3403,7 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, Gen
         // Change the oper to const.
         if (genActualType(op1->TypeGet()) == TYP_INT)
         {
-            op1->ChangeOperConst(GT_CNS_INT);
-            op1->AsIntCon()->gtIconVal = vnStore->ConstantValue<int>(vnCns);
+            op1->BashToConst(vnStore->ConstantValue<int>(vnCns));
 
             if (vnStore->IsVNHandle(vnCns))
             {
@@ -3418,8 +3412,7 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, Gen
         }
         else if (op1->TypeGet() == TYP_LONG)
         {
-            op1->ChangeOperConst(GT_CNS_NATIVELONG);
-            op1->AsIntConCommon()->SetLngValue(vnStore->ConstantValue<INT64>(vnCns));
+            op1->BashToConst(vnStore->ConstantValue<INT64>(vnCns));
 
             if (vnStore->IsVNHandle(vnCns))
             {
@@ -3429,8 +3422,7 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, Gen
         else if (op1->TypeGet() == TYP_DOUBLE)
         {
             double constant = vnStore->ConstantValue<double>(vnCns);
-            op1->ChangeOperConst(GT_CNS_DBL);
-            op1->AsDblCon()->gtDconVal = constant;
+            op1->BashToConst(constant);
 
             // Nothing can be equal to NaN. So if IL had "op1 == NaN", then we already made op1 NaN,
             // which will yield a false correctly. Instead if IL had "op1 != NaN", then we already
@@ -3441,29 +3433,27 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, Gen
         else if (op1->TypeGet() == TYP_FLOAT)
         {
             float constant = vnStore->ConstantValue<float>(vnCns);
-            op1->ChangeOperConst(GT_CNS_DBL);
-            op1->AsDblCon()->gtDconVal = constant;
+            op1->BashToConst(constant);
+
             // See comments for TYP_DOUBLE.
             allowReverse = (_isnan(constant) == 0);
         }
         else if (op1->TypeGet() == TYP_REF)
         {
-            op1->ChangeOperConst(GT_CNS_INT);
+            op1->BashToConst(0, TYP_REF);
             // The only constant of TYP_REF that ValueNumbering supports is 'null'
             noway_assert(vnStore->ConstantValue<size_t>(vnCns) == 0);
-            op1->AsIntCon()->gtIconVal = 0;
         }
         else if (op1->TypeGet() == TYP_BYREF)
         {
-            op1->ChangeOperConst(GT_CNS_INT);
-            op1->AsIntCon()->gtIconVal = static_cast<target_ssize_t>(vnStore->ConstantValue<size_t>(vnCns));
+            op1->BashToConst(static_cast<target_ssize_t>(vnStore->ConstantValue<size_t>(vnCns)), TYP_BYREF);
         }
         else
         {
             noway_assert(!"unknown type in Global_RelOp");
         }
 
-        op1->gtVNPair.SetBoth(vnCns); // Preserve the ValueNumPair, as ChangeOperConst/SetOper will clear it.
+        op1->gtVNPair.SetBoth(vnCns); // Preserve the ValueNumPair, as BashToConst will clear it.
 
         // set foldResult to either 0 or 1
         bool foldResult = assertionKindIsEqual;
@@ -3497,17 +3487,15 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions, Gen
 #endif
         // If floating point, don't just substitute op1 with op2, this won't work if
         // op2 is NaN. Just turn it into a "true" or "false" yielding expression.
-        if (op1->TypeGet() == TYP_DOUBLE || op1->TypeGet() == TYP_FLOAT)
+        if (op1->TypeIs(TYP_FLOAT, TYP_DOUBLE))
         {
             // Note we can't trust the OAK_EQUAL as the value could end up being a NaN
             // violating the assertion. However, we create OAK_EQUAL assertions for floating
             // point only on JTrue nodes, so if the condition held earlier, it will hold
             // now. We don't create OAK_EQUAL assertion on floating point from GT_ASG
             // because we depend on value num which would constant prop the NaN.
-            op1->ChangeOperConst(GT_CNS_DBL);
-            op1->AsDblCon()->gtDconVal = 0;
-            op2->ChangeOperConst(GT_CNS_DBL);
-            op2->AsDblCon()->gtDconVal = 0;
+            op1->BashToConst(0.0, op1->TypeGet());
+            op2->BashToConst(0.0, op2->TypeGet());
         }
         // Change the op1 LclVar to the op2 LclVar
         else

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1400,23 +1400,9 @@ inline void GenTree::SetOperResetFlags(genTreeOps oper)
     gtFlags &= GTF_NODE_MASK;
 }
 
-inline void GenTree::ChangeOperConst(genTreeOps oper)
-{
-#ifdef TARGET_64BIT
-    assert(oper != GT_CNS_LNG); // We should never see a GT_CNS_LNG for a 64-bit target!
-#endif
-    assert(OperIsConst(oper)); // use ChangeOper() instead
-    SetOperResetFlags(oper);
-    // Some constant subtypes have additional fields that must be initialized.
-    if (oper == GT_CNS_INT)
-    {
-        AsIntCon()->gtFieldSeq = FieldSeqStore::NotAField();
-    }
-}
-
 inline void GenTree::ChangeOper(genTreeOps oper, ValueNumberUpdate vnUpdate)
 {
-    assert(!OperIsConst(oper)); // use ChangeOperConst() instead
+    assert(!OperIsConst(oper)); // use BashToConst() instead
 
     GenTreeFlags mask = GTF_COMMON_MASK;
     if (this->OperIsIndirOrArrLength() && OperIsIndirOrArrLength(oper))
@@ -1462,6 +1448,94 @@ inline void GenTree::ChangeOperUnchecked(genTreeOps oper)
     }
     SetOperRaw(oper); // Trust the caller and don't use SetOper()
     gtFlags &= mask;
+}
+
+//------------------------------------------------------------------------
+// BashToConst: Bash the node to a constant one.
+//
+// The function will infer the node's new oper from the type: GT_CNS_INT
+// or GT_CNS_LNG for integers and GC types, GT_CNS_DBL for floats/doubles.
+//
+// The type is inferred from "value"'s type ("T") unless an explicit
+// one is provided via the second argument, in which case it is checked
+// for compatibility with "value". So, e. g., "BashToConst(0)" will bash
+// to GT_CNS_INT, type TYP_INT, "BashToConst(0, TYP_REF)" will bash to the
+// canonical "null" node, but "BashToConst(0.0, TYP_INT)" will assert.
+//
+// Arguments:
+//    value - Value which the bashed constant will have
+//    type  - Type the bashed node will have
+//
+template <typename T>
+void GenTree::BashToConst(T value, var_types type /* = TYP_UNDEF */)
+{
+    static_assert_no_msg((std::is_same<T, int32_t>::value || std::is_same<T, int64_t>::value ||
+                          std::is_same<T, long long>::value || std::is_same<T, float>::value ||
+                          std::is_same<T, double>::value));
+    static_assert_no_msg(sizeof(int64_t) == sizeof(long long));
+
+    var_types typeOfValue = TYP_UNDEF;
+    if (std::is_floating_point<T>::value)
+    {
+        assert((type == TYP_UNDEF) || varTypeIsFloating(type));
+        typeOfValue = std::is_same<T, float>::value ? TYP_FLOAT : TYP_DOUBLE;
+    }
+    else
+    {
+        assert((type == TYP_UNDEF) || varTypeIsIntegral(type) || varTypeIsGC(type));
+        typeOfValue = std::is_same<T, int32_t>::value ? TYP_INT : TYP_LONG;
+    }
+
+    if (type == TYP_UNDEF)
+    {
+        type = typeOfValue;
+    }
+
+    genTreeOps oper = GT_NONE;
+    if (varTypeIsFloating(type))
+    {
+        oper = GT_CNS_DBL;
+    }
+    else
+    {
+        oper = (type == TYP_LONG) ? GT_CNS_NATIVELONG : GT_CNS_INT;
+    }
+
+    SetOperResetFlags(oper);
+
+    gtType = type;
+
+    switch (oper)
+    {
+        case GT_CNS_INT:
+#if !defined(TARGET_64BIT)
+            assert(type != TYP_LONG);
+#endif
+            assert(varTypeIsIntegral(type) || varTypeIsGC(type));
+            if (genTypeSize(type) <= genTypeSize(TYP_INT))
+            {
+                assert(FitsIn<int32_t>(value));
+            }
+
+            AsIntCon()->SetIconValue(static_cast<ssize_t>(value));
+            AsIntCon()->gtFieldSeq = FieldSeqStore::NotAField();
+            break;
+
+#if !defined(TARGET_64BIT)
+        case GT_CNS_LNG:
+            assert(type == TYP_LONG);
+            AsLngCon()->SetLngValue(static_cast<int64_t>(value));
+            break;
+#endif
+
+        case GT_CNS_DBL:
+            assert(varTypeIsFloating(type));
+            AsDblCon()->gtDconVal = static_cast<double>(value);
+            break;
+
+        default:
+            unreached();
+    }
 }
 
 /*****************************************************************************

--- a/src/coreclr/jit/decomposelongs.cpp
+++ b/src/coreclr/jit/decomposelongs.cpp
@@ -671,13 +671,13 @@ GenTree* DecomposeLongs::DecomposeCnsLng(LIR::Use& use)
     assert(use.Def()->OperGet() == GT_CNS_LNG);
 
     GenTree* tree  = use.Def();
+    INT32    loVal = tree->AsLngCon()->LoVal();
     INT32    hiVal = tree->AsLngCon()->HiVal();
 
     GenTree* loResult = tree;
-    loResult->ChangeOperConst(GT_CNS_INT);
-    loResult->gtType = TYP_INT;
+    loResult->BashToConst(loVal);
 
-    GenTree* hiResult = new (m_compiler, GT_CNS_INT) GenTreeIntCon(TYP_INT, hiVal);
+    GenTree* hiResult = m_compiler->gtNewIconNode(hiVal);
     Range().InsertAfter(loResult, hiResult);
 
     return FinalizeDecomposition(use, loResult, hiResult, hiResult);

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -14675,9 +14675,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                         DISPTREE(tree);
 
                         // Fold into GT_IND of null byref.
-                        tree->ChangeOperConst(GT_CNS_INT);
-                        tree->ChangeType(TYP_BYREF);
-                        tree->AsIntCon()->SetIconValue(0);
+                        tree->BashToConst(0, TYP_BYREF);
                         if (vnStore != nullptr)
                         {
                             fgValueNumberTreeConst(tree);
@@ -14899,12 +14897,10 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
             // Also all conditional folding jumps here since the node hanging from
             // GT_JTRUE has to be a GT_CNS_INT - value 0 or 1.
 
-            tree->ChangeOperConst(GT_CNS_INT);
-            tree->ChangeType(TYP_INT);
             // Some operations are performed as 64 bit instead of 32 bit so the upper 32 bits
             // need to be discarded. Since constant values are stored as ssize_t and the node
             // has TYP_INT the result needs to be sign extended rather than zero extended.
-            tree->AsIntCon()->SetIconValue(static_cast<int>(i1));
+            tree->BashToConst(static_cast<int>(i1));
             tree->AsIntCon()->gtFieldSeq = fieldSeq;
             if (vnStore != nullptr)
             {
@@ -15120,8 +15116,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
             assert((GenTree::s_gtNodeSizes[GT_CNS_NATIVELONG] == TREE_NODE_SZ_SMALL) ||
                    (tree->gtDebugFlags & GTF_DEBUG_NODE_LARGE));
 
-            tree->ChangeOperConst(GT_CNS_NATIVELONG);
-            tree->AsIntConCommon()->SetLngValue(lval1);
+            tree->BashToConst(lval1);
             if (vnStore != nullptr)
             {
                 fgValueNumberTreeConst(tree);
@@ -15279,8 +15274,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
             assert((GenTree::s_gtNodeSizes[GT_CNS_DBL] == TREE_NODE_SZ_SMALL) ||
                    (tree->gtDebugFlags & GTF_DEBUG_NODE_LARGE));
 
-            tree->ChangeOperConst(GT_CNS_DBL);
-            tree->AsDblCon()->gtDconVal = d1;
+            tree->BashToConst(d1, tree->TypeGet());
             if (vnStore != nullptr)
             {
                 fgValueNumberTreeConst(tree);

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1933,7 +1933,6 @@ public:
     void SetOper(genTreeOps oper, ValueNumberUpdate vnUpdate = CLEAR_VN); // set gtOper
     void SetOperResetFlags(genTreeOps oper);                              // set gtOper and reset flags
 
-    void ChangeOperConst(genTreeOps oper); // ChangeOper(constOper)
     // set gtOper and only keep GTF_COMMON_MASK flags
     void ChangeOper(genTreeOps oper, ValueNumberUpdate vnUpdate = CLEAR_VN);
     void ChangeOperUnchecked(genTreeOps oper);
@@ -1954,6 +1953,9 @@ public:
             }
         }
     }
+
+    template <typename T>
+    void BashToConst(T value, var_types type = TYP_UNDEF);
 
 #if NODEBASH_STATS
     static void RecordOperBashing(genTreeOps operOld, genTreeOps operNew);

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3315,9 +3315,7 @@ void Lowering::LowerRetStruct(GenTreeUnOp* ret)
                 // Do not expect `initblock` for SIMD* types,
                 // only 'initobj'.
                 assert(retVal->AsIntCon()->IconValue() == 0);
-                retVal->ChangeOperConst(GT_CNS_DBL);
-                retVal->ChangeType(TYP_FLOAT);
-                retVal->AsDblCon()->gtDconVal = 0;
+                retVal->BashToConst(0.0, TYP_FLOAT);
             }
             break;
 

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -142,23 +142,21 @@ void Lowering::LowerStoreIndir(GenTreeStoreInd* node)
         {
             float fltCns = static_cast<float>(dblCns); // should be a safe round-trip
             intCns       = static_cast<ssize_t>(*reinterpret_cast<UINT32*>(&fltCns));
-            type         = TYP_UINT;
+            type         = TYP_INT;
         }
 #ifdef TARGET_AMD64
         else
         {
             assert(node->TypeIs(TYP_DOUBLE));
             intCns = static_cast<ssize_t>(*reinterpret_cast<UINT64*>(&dblCns));
-            type   = TYP_ULONG;
+            type   = TYP_LONG;
         }
 #endif
 
         if (type != TYP_UNKNOWN)
         {
             data->SetContained();
-            data->ChangeOperConst(GT_CNS_INT);
-            data->AsIntCon()->SetIconValue(intCns);
-            data->ChangeType(type);
+            data->BashToConst(intCns, type);
             node->ChangeType(type);
         }
     }

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -141,14 +141,14 @@ void Lowering::LowerStoreIndir(GenTreeStoreInd* node)
         if (node->TypeIs(TYP_FLOAT))
         {
             float fltCns = static_cast<float>(dblCns); // should be a safe round-trip
-            intCns       = static_cast<ssize_t>(*reinterpret_cast<UINT32*>(&fltCns));
+            intCns       = static_cast<ssize_t>(*reinterpret_cast<INT32*>(&fltCns));
             type         = TYP_INT;
         }
 #ifdef TARGET_AMD64
         else
         {
             assert(node->TypeIs(TYP_DOUBLE));
-            intCns = static_cast<ssize_t>(*reinterpret_cast<UINT64*>(&dblCns));
+            intCns = static_cast<ssize_t>(*reinterpret_cast<INT64*>(&dblCns));
             type   = TYP_LONG;
         }
 #endif

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -796,24 +796,21 @@ OPTIMIZECAST:
                         // need type of oper to be same as tree
                         if (tree->gtType == TYP_LONG)
                         {
-                            commaOp2->ChangeOperConst(GT_CNS_NATIVELONG);
-                            commaOp2->AsIntConCommon()->SetLngValue(0);
                             /* Change the types of oper and commaOp2 to TYP_LONG */
-                            oper->gtType = commaOp2->gtType = TYP_LONG;
+                            commaOp2->BashToConst(0LL);
+                            oper->gtType = TYP_LONG;
                         }
                         else if (varTypeIsFloating(tree->gtType))
                         {
-                            commaOp2->ChangeOperConst(GT_CNS_DBL);
-                            commaOp2->AsDblCon()->gtDconVal = 0.0;
                             // Change the types of oper and commaOp2
-                            oper->gtType = commaOp2->gtType = tree->gtType;
+                            commaOp2->BashToConst(0.0, tree->TypeGet());
+                            oper->gtType = tree->gtType;
                         }
                         else
                         {
-                            commaOp2->ChangeOperConst(GT_CNS_INT);
-                            commaOp2->AsIntCon()->gtIconVal = 0;
                             /* Change the types of oper and commaOp2 to TYP_INT */
-                            oper->gtType = commaOp2->gtType = TYP_INT;
+                            commaOp2->BashToConst(0);
+                            oper->gtType = TYP_INT;
                         }
                     }
 
@@ -13455,24 +13452,21 @@ DONE_MORPHING_CHILDREN:
                         // need type of oper to be same as tree
                         if (typ == TYP_LONG)
                         {
-                            commaOp2->ChangeOperConst(GT_CNS_NATIVELONG);
-                            commaOp2->AsIntConCommon()->SetLngValue(0);
                             /* Change the types of oper and commaOp2 to TYP_LONG */
-                            op1->gtType = commaOp2->gtType = TYP_LONG;
+                            commaOp2->BashToConst(0LL);
+                            op1->gtType = TYP_LONG;
                         }
                         else if (varTypeIsFloating(typ))
                         {
-                            commaOp2->ChangeOperConst(GT_CNS_DBL);
-                            commaOp2->AsDblCon()->gtDconVal = 0.0;
                             /* Change the types of oper and commaOp2 to TYP_DOUBLE */
-                            op1->gtType = commaOp2->gtType = TYP_DOUBLE;
+                            commaOp2->BashToConst(0.0);
+                            op1->gtType = TYP_DOUBLE;
                         }
                         else
                         {
-                            commaOp2->ChangeOperConst(GT_CNS_INT);
-                            commaOp2->AsIntConCommon()->SetIconValue(0);
                             /* Change the types of oper and commaOp2 to TYP_INT */
-                            op1->gtType = commaOp2->gtType = TYP_INT;
+                            commaOp2->BashToConst(0);
+                            op1->gtType = TYP_INT;
                         }
 
                         /* Return the GT_COMMA node as the new tree */
@@ -13522,11 +13516,9 @@ DONE_MORPHING_CHILDREN:
 
                     GenTree* commaOp2 = op2->AsOp()->gtOp2;
 
-                    commaOp2->ChangeOperConst(GT_CNS_NATIVELONG);
-                    commaOp2->AsIntConCommon()->SetLngValue(0);
-
                     /* Change the types of oper and commaOp2 to TYP_LONG */
-                    op2->gtType = commaOp2->gtType = TYP_LONG;
+                    commaOp2->BashToConst(0LL);
+                    op2->gtType = TYP_LONG;
                 }
 
                 if ((genActualType(typ) == TYP_INT) &&
@@ -13536,10 +13528,9 @@ DONE_MORPHING_CHILDREN:
 
                     GenTree* commaOp2 = op2->AsOp()->gtOp2;
 
-                    commaOp2->ChangeOperConst(GT_CNS_INT);
-                    commaOp2->AsIntCon()->gtIconVal = 0;
                     /* Change the types of oper and commaOp2 to TYP_INT */
-                    op2->gtType = commaOp2->gtType = TYP_INT;
+                    commaOp2->BashToConst(0);
+                    op2->gtType = TYP_INT;
                 }
 
                 if ((typ == TYP_BYREF) && (genActualType(op2->gtType) == TYP_I_IMPL))
@@ -13548,9 +13539,8 @@ DONE_MORPHING_CHILDREN:
 
                     GenTree* commaOp2 = op2->AsOp()->gtOp2;
 
-                    commaOp2->ChangeOperConst(GT_CNS_INT);
-                    commaOp2->AsIntCon()->gtIconVal = 0;
                     /* Change the types of oper and commaOp2 to TYP_BYREF */
+                    commaOp2->BashToConst(0, TYP_BYREF);
                     op2->gtType = commaOp2->gtType = TYP_BYREF;
                 }
 
@@ -13783,10 +13773,7 @@ SKIP:
             // Simply make this into an integer comparison.
             cmp->gtOp1 = op1->AsCast()->CastOp();
 
-            int64_t op2Value = op2->LngValue();
-            op2->ChangeOperConst(GT_CNS_INT);
-            op2->ChangeType(TYP_INT);
-            op2->SetIconValue(static_cast<int32_t>(op2Value));
+            op2->BashToConst(static_cast<int32_t>(op2->LngValue()));
             fgUpdateConstTreeValueNumber(op2);
         }
 
@@ -13828,19 +13815,13 @@ SKIP:
         assert(andMask == andOp->gtGetOp2());
 
         // Now replace the mask node.
-        int32_t maskValue = static_cast<int32_t>(andMask->LngValue());
-        andMask->SetOper(GT_CNS_INT);
-        andMask->ChangeType(TYP_INT);
-        andMask->SetIconValue(maskValue);
+        andMask->BashToConst(static_cast<int32_t>(andMask->LngValue()));
 
         // Now change the type of the AND node.
         andOp->ChangeType(TYP_INT);
 
         // Finally we replace the comparand.
-        int32_t op2Value = static_cast<int32_t>(op2->LngValue());
-        op2->SetOper(GT_CNS_INT);
-        op2->ChangeType(TYP_INT);
-        op2->SetIconValue(op2Value);
+        op2->BashToConst(static_cast<int32_t>(op2->LngValue()));
     }
 
     return cmp;

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -4876,9 +4876,7 @@ bool Compiler::optNarrowTree(GenTree* tree, var_types srct, var_types dstt, Valu
 
                 if (doit)
                 {
-                    tree->ChangeOperConst(GT_CNS_INT);
-                    tree->gtType                = TYP_INT;
-                    tree->AsIntCon()->gtIconVal = (int)lval;
+                    tree->BashToConst(static_cast<int32_t>(lval));
                     if (vnStore != nullptr)
                     {
                         fgValueNumberTreeConst(tree);

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -246,8 +246,7 @@ bool Compiler::optRedundantBranch(BasicBlock* const block)
 
     JITDUMP("\nRedundant branch opt in " FMT_BB ":\n", block->bbNum);
 
-    tree->ChangeOperConst(GT_CNS_INT);
-    tree->AsIntCon()->gtIconVal = relopValue;
+    tree->BashToConst(relopValue);
 
     fgMorphBlockStmt(block, stmt DEBUGARG(__FUNCTION__));
     return true;


### PR DESCRIPTION
Replace `ChangeOperConst` with `BashToConst`.

The nature of bashing to a constant is that the code doing it practically always wants to set the constant value and the type so it makes sense to do all three at once - it also enables some more stringent asserts.

But mostly this method is for convenience.

Unfortunately, the second commit causes diffs, because now containment is enabled where it was not previously (for `float` constants with the upper bit set). Even more unfortunately, this causes the following regression in `System.Numerics.Tests.Perf_Quaternion:ConjugateBenchmark` (and two sister benchmarks):
```diff
-       mov      eax, 0xD1FFAB1E
-       mov      dword ptr [rdx], eax
-       mov      dword ptr [rdx+4], eax
-       mov      dword ptr [rdx+8], eax
+       mov      dword ptr [rdx], 0xD1FFAB1E
+       mov      dword ptr [rdx+4], 0xD1FFAB1E
+       mov      dword ptr [rdx+8], 0xD1FFAB1E
```
I have built the benchmarks locally and can measure ~20-40% increase in time, though the accuracy of such measurements is highly questionable as the benchmarks "take" `0.1 ns`, with errors of the same magnitude. It is a CQ regression, so, given fixing it properly is out of scope for this PR, I see a few ways to address the problem:

1) Abandon the change.
2) Abandon the new assert.
3) Quirk the lowering transform to retain the previous behavior.

Without the second commit, there is one other source of diffs, which has to do with the fact that the old code in assertion propagation for relops left nodes with small types unchanged, and `gtFoldExprConst` fails to fold things like `EQ(bool 0, int 0)`. The new code (correctly) retypes the node to `TYP_INT`, thus enabling the folding. I have checked that using "actual" types in `gtFoldExprConst` does not yield much beyond what this PR enables already.

Diffs with the second commit: [`win-x64`](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-58171/win-x64.md), [`win-arm64`](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-58171/win-arm64.md), [`win-x86`](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-58171/win-x86.md), [`linux-x64`](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-58171/linux-x64.md).