### PR TITLE
Fix trim_youngest_desired

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -38376,7 +38376,8 @@ size_t gc_heap::trim_youngest_desired (uint32_t memory_load,
     }
     else
     {
-        return max (mem_one_percent, total_min_allocation);
+        size_t total_max_allocation = max (mem_one_percent, total_min_allocation);
+        return min (total_new_allocation, total_max_allocation);
     }
 }
 


### PR DESCRIPTION
The case where we have high memory load and huge main memory can cause the return value to be larger than total_new_allocation.

As it turns out, this is contributing to issue #52592 - gen 0 budget shoots upruptly to 5.1 GB and drops back.
