### PR TITLE
[mono] Fix framework references on Mac Catalyst

### DIFF
--- a/src/mono/mono/mini/CMakeLists.txt
+++ b/src/mono/mono/mini/CMakeLists.txt
@@ -23,7 +23,7 @@ if(HOST_DARWIN)
   set(OS_LIBS "-framework CoreFoundation" "-framework Foundation")
 
   if(CMAKE_SYSTEM_VARIANT STREQUAL "MacCatalyst")
-    set(OS_LIBS "-lobjc" "-lc++")
+    set(OS_LIBS ${OS_LIBS} "-lobjc" "-lc++")
   endif()
 elseif(HOST_IOS)
 set(OS_LIBS "-framework CoreFoundation" "-lobjc" "-lc++")


### PR DESCRIPTION
Technically this has no effect since the referenced frameworks are currently not referenced by any code on macOS/MacCatalyst, only on iOS/tvOS. I hit it with a change that was referencing functions from CoreFoundation and it was failing specifically on the MacCatalyst builds which was a bit annoying.