### PR TITLE
[mono] Replace -disable-fp-elim with -frame-pointer=all

### DIFF
--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -1149,7 +1149,7 @@ arch_init (MonoAotCompile *acfg)
 
 			if (strstr (acfg->aot_opts.mtriple, "ios")) {
 				g_string_append (acfg->llc_args, " -mattr=+v7");
-				g_string_append (acfg->llc_args, " -exception-model=dwarf -disable-fp-elim");
+				g_string_append (acfg->llc_args, " -exception-model=dwarf -frame-pointer=all");
 			}
 		}
 


### PR DESCRIPTION
`-disable-fp-elim` was removed in LLVM 8 in commit b7cef81fd36c85e52b115b9ed6d1fb92d63781d6.
Also see https://reviews.llvm.org/D56351.

The replacement option, `-frame-pointer`, is still present in LLVM 11.

Fixes https://github.com/dotnet/runtime/issues/58112.