### PR TITLE
Add test that GetCustomAttribute returns string.Empty

### DIFF
--- a/src/libraries/System.Reflection/tests/CustomAttributeTests.cs
+++ b/src/libraries/System.Reflection/tests/CustomAttributeTests.cs
@@ -76,5 +76,58 @@ namespace System.Reflection.Tests
             Assert.Equal(1, attr.ObjectArray.Length);
             Assert.Null(attr.StringArray);
         }
+
+        public class StringValuedAttribute : Attribute
+        {
+            public StringValuedAttribute (string s)
+            {
+                NamedField = s;
+            }
+            public StringValuedAttribute () {}
+            public string NamedProperty
+            {
+                get => NamedField;
+                set { NamedField = value; }
+            }
+            public string NamedField;
+        }
+
+        internal class ClassWithAttrs
+        {
+            [StringValuedAttribute("")]
+            public void M1() {}
+
+            [StringValuedAttribute(NamedProperty = "")]
+            public void M2() {}
+
+            [StringValuedAttribute(NamedField = "")]
+            public void M3() {}
+        }
+
+        [Fact]
+        public void StringAttributeValueRefEqualsStringEmpty () {
+            StringValuedAttribute attr;
+            attr = typeof (ClassWithAttrs).GetMethod("M1")
+                .GetCustomAttributes(typeof(StringValuedAttribute), true)
+                .Cast<StringValuedAttribute>()
+                .Single();
+
+            Assert.Same(string.Empty, attr.NamedField);
+
+            attr = typeof (ClassWithAttrs).GetMethod("M2")
+                .GetCustomAttributes(typeof(StringValuedAttribute), true)
+                .Cast<StringValuedAttribute>()
+                .Single();
+            
+            Assert.Same(string.Empty, attr.NamedField);
+
+
+            attr = typeof (ClassWithAttrs).GetMethod("M3")
+                .GetCustomAttributes(typeof(StringValuedAttribute), true)
+                .Cast<StringValuedAttribute>()
+                .Single();
+            
+            Assert.Same(string.Empty, attr.NamedField);
+        }
     }
 }


### PR DESCRIPTION
And not a new string object that happens to be `""`

Adds a testcase for https://github.com/dotnet/runtime/pull/58023