### PR TITLE
[MonoVM] Report original DLL name when P/Invoke lookup fails

### DIFF
--- a/src/mono/mono/metadata/native-library.c
+++ b/src/mono/mono/metadata/native-library.c
@@ -951,6 +951,7 @@ lookup_pinvoke_call_impl (MonoMethod *method, MonoLookupPInvokeStatus *status_ou
 	const char *new_import = NULL;
 	const char *orig_scope = NULL;
 	const char *new_scope = NULL;
+	const char *error_scope = NULL;
 	char *error_msg = NULL;
 	MonoDl *module = NULL;
 	gpointer addr = NULL;
@@ -996,6 +997,8 @@ lookup_pinvoke_call_impl (MonoMethod *method, MonoLookupPInvokeStatus *status_ou
 	new_scope = g_strdup (orig_scope);
 	new_import = g_strdup (orig_import);
 #endif
+
+	error_scope = new_scope;
 
 	/* If qcalls are disabled, we fall back to the normal pinvoke code for them */
 #ifndef DISABLE_QCALLS
@@ -1051,10 +1054,10 @@ retry_with_libcoreclr:
 	if (!module) {
 		mono_trace (G_LOG_LEVEL_WARNING, MONO_TRACE_DLLIMPORT,
 				"DllImport unable to load library '%s'.",
-				new_scope);
+				error_scope);
 
 		status_out->err_code = LOOKUP_PINVOKE_ERR_NO_LIB;
-		status_out->err_arg = g_strdup (new_scope);
+		status_out->err_arg = g_strdup (error_scope);
 		goto exit;
 	}
 
@@ -1066,7 +1069,7 @@ retry_with_libcoreclr:
 	if (!addr) {
 #ifndef HOST_WIN32
 		if (strcmp (new_scope, "__Internal") == 0) {
-			g_free ((char *)new_scope);
+			g_assert (error_scope == new_scope);
 			new_scope = g_strdup (MONO_LOADER_LIBRARY_NAME);
 			goto retry_with_libcoreclr;
 		}
@@ -1078,6 +1081,9 @@ retry_with_libcoreclr:
 	piinfo->addr = addr;
 
 exit:
+	if (error_scope != new_scope) {
+		g_free ((char *)error_scope);
+	}
 	g_free ((char *)new_import);
 	g_free ((char *)new_scope);
 	g_free (error_msg);


### PR DESCRIPTION
Ref: https://github.com/dotnet/runtime/issues/58185