### PR TITLE
Remove usage of [AggressiveOptimization]

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -16,9 +16,6 @@ namespace System.Text.Json.Serialization.Converters
     {
         internal override bool CanHaveIdMetadata => true;
 
-#if NET6_0_OR_GREATER
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-#endif
         internal override bool OnTryRead(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options, ref ReadStack state, [MaybeNullWhen(false)] out T value)
         {
             JsonTypeInfo jsonTypeInfo = state.Current.JsonTypeInfo;
@@ -249,9 +246,6 @@ namespace System.Text.Json.Serialization.Converters
             return true;
         }
 
-#if NET6_0_OR_GREATER
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-#endif
         internal sealed override bool OnTryWrite(
             Utf8JsonWriter writer,
             T value,

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -144,9 +144,6 @@ namespace System.Text.Json.Serialization
         /// <remarks>Note that the value of <seealso cref="HandleNull"/> determines if the converter handles null JSON tokens.</remarks>
         public abstract T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options);
 
-#if NET6_0_OR_GREATER
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-#endif
         internal bool TryRead(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options, ref ReadStack state, out T? value)
         {
             if (ConverterStrategy == ConverterStrategy.Value)
@@ -320,9 +317,6 @@ namespace System.Text.Json.Serialization
         /// </summary>
         private static bool IsNull(T value) => value is null;
 
-#if NET6_0_OR_GREATER
-        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-#endif
         internal bool TryWrite(Utf8JsonWriter writer, in T value, JsonSerializerOptions options, ref WriteStack state)
         {
             if (writer.CurrentDepth >= options.EffectiveMaxDepth)


### PR DESCRIPTION
Revert the 4 usages of [AggressiveOptimization].

The 2 in `ObjectDefaultConverter` that were reverted have loops which cause the jitter to re-jit them anyways, so the use of [AggressiveOptimization] really shouldn't do anything. 

The other 2 in `JsonConverter<T>` that remain do seem get up to a 3% benefit but only some of the time, and only measured against a local release build that is a non-R2R (non-crossgen2'd) STJ.dll image. In theory there shouldn't be a perf improvement since a R2R image automatically did the equivalent of [AggressiveOptimization] for all methods. When obtaining the fastest time from several runs, the benchmark (which measures serializer overhead) is faster with [AO], however the variability of these benchmarks overlap and are difficult to measure consistently. Perhaps with [AO] there is sometimes closer\faster memory locality with other methods.

Removing [AO] also has the benefit of supporting a "DynamicPGO" explicit mode that offers "best perf but slow start".

See https://github.com/dotnet/runtime/pull/57327#discussion_r688903969

I don't believe the changes to remove [AO] meet the bar to port to V6 at this time, since R2R performance should be the same in the vast majority because a "DynamicPGO" mode would need to be turned on explicitly.