### PR TITLE
Mark PLINQ as enabled in WASM and make browser compat changes

### DIFF
--- a/src/libraries/System.Linq.Parallel/Directory.Build.props
+++ b/src/libraries/System.Linq.Parallel/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms>
+    <!-- <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms> -->
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Linq.Parallel/Directory.Build.props
+++ b/src/libraries/System.Linq.Parallel/Directory.Build.props
@@ -2,6 +2,5 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <!-- <UnsupportedOSPlatforms>browser</UnsupportedOSPlatforms> -->
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Channels/AsynchronousChannel.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Channels/AsynchronousChannel.cs
@@ -17,6 +17,7 @@ namespace System.Linq.Parallel
     /// This is a bounded channel meant for single-producer/single-consumer scenarios.
     /// </summary>
     /// <typeparam name="T">Specifies the type of data in the channel.</typeparam>
+    [System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
     internal sealed class AsynchronousChannel<T> : IDisposable
     {
         // The producer will be blocked once the channel reaches a capacity, and unblocked

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Merging/AsynchronousChannelMergeEnumerator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Merging/AsynchronousChannelMergeEnumerator.cs
@@ -26,6 +26,7 @@ namespace System.Linq.Parallel
     ///
     /// </summary>
     /// <typeparam name="T"></typeparam>
+    [System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
     internal sealed class AsynchronousChannelMergeEnumerator<T> : MergeEnumerator<T>
     {
         private readonly AsynchronousChannel<T>[] _channels; // The channels being enumerated.
@@ -220,6 +221,7 @@ namespace System.Linq.Parallel
                                 break;
                             }
 
+                            Debug.Assert(!OperatingSystem.IsBrowser());
                             Debug.Assert(_consumerEvent != null);
                             //This Wait() does not require cancellation support as it will wake up when all the producers into the
                             //channel have finished.  Hence, if all the producers wake up on cancellation, so will this.

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Merging/AsynchronousChannelMergeEnumerator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Merging/AsynchronousChannelMergeEnumerator.cs
@@ -221,7 +221,7 @@ namespace System.Linq.Parallel
                                 break;
                             }
 
-                            Debug.Assert(!OperatingSystem.IsBrowser());
+                            Debug.Assert(!ParallelEnumerable.SinglePartitionMode);
                             Debug.Assert(_consumerEvent != null);
                             //This Wait() does not require cancellation support as it will wake up when all the producers into the
                             //channel have finished.  Hence, if all the producers wake up on cancellation, so will this.

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Merging/DefaultMergeHelper.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Merging/DefaultMergeHelper.cs
@@ -64,7 +64,7 @@ namespace System.Linq.Parallel
                 {
                     if (partitions.PartitionCount > 1)
                     {
-                        Debug.Assert(!OperatingSystem.IsBrowser());
+                        Debug.Assert(!ParallelEnumerable.SinglePartitionMode);
                         _asyncChannels =
                             MergeExecutor<TInputOutput>.MakeAsynchronousChannels(partitions.PartitionCount, options, consumerEvent, cancellationState.MergedCancellationToken);
                         _channelEnumerator = new AsynchronousChannelMergeEnumerator<TInputOutput>(_taskGroupState, _asyncChannels, consumerEvent);
@@ -100,7 +100,7 @@ namespace System.Linq.Parallel
         {
             if (_asyncChannels != null)
             {
-                Debug.Assert(!OperatingSystem.IsBrowser());
+                Debug.Assert(!ParallelEnumerable.SinglePartitionMode);
                 SpoolingTask.SpoolPipeline<TInputOutput, TIgnoreKey>(_taskGroupState, _partitions, _asyncChannels, _taskScheduler);
             }
             else if (_syncChannels != null)

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Merging/DefaultMergeHelper.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Merging/DefaultMergeHelper.cs
@@ -64,6 +64,7 @@ namespace System.Linq.Parallel
                 {
                     if (partitions.PartitionCount > 1)
                     {
+                        Debug.Assert(!OperatingSystem.IsBrowser());
                         _asyncChannels =
                             MergeExecutor<TInputOutput>.MakeAsynchronousChannels(partitions.PartitionCount, options, consumerEvent, cancellationState.MergedCancellationToken);
                         _channelEnumerator = new AsynchronousChannelMergeEnumerator<TInputOutput>(_taskGroupState, _asyncChannels, consumerEvent);
@@ -99,6 +100,7 @@ namespace System.Linq.Parallel
         {
             if (_asyncChannels != null)
             {
+                Debug.Assert(!OperatingSystem.IsBrowser());
                 SpoolingTask.SpoolPipeline<TInputOutput, TIgnoreKey>(_taskGroupState, _partitions, _asyncChannels, _taskScheduler);
             }
             else if (_syncChannels != null)

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Merging/MergeExecutor.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Merging/MergeExecutor.cs
@@ -64,7 +64,7 @@ namespace System.Linq.Parallel
 
                     if (partitions.PartitionCount > 1)
                     {
-                        Debug.Assert(!OperatingSystem.IsBrowser());
+                        Debug.Assert(!ParallelEnumerable.SinglePartitionMode);
                         // We use a pipelining ordered merge
                         mergeExecutor._mergeHelper = new OrderPreservingPipeliningMergeHelper<TInputOutput, TKey>(
                             partitions, taskScheduler, cancellationState, autoBuffered, queryId, partitions.KeyComparer);

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Merging/MergeExecutor.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Merging/MergeExecutor.cs
@@ -64,6 +64,7 @@ namespace System.Linq.Parallel
 
                     if (partitions.PartitionCount > 1)
                     {
+                        Debug.Assert(!OperatingSystem.IsBrowser());
                         // We use a pipelining ordered merge
                         mergeExecutor._mergeHelper = new OrderPreservingPipeliningMergeHelper<TInputOutput, TKey>(
                             partitions, taskScheduler, cancellationState, autoBuffered, queryId, partitions.KeyComparer);
@@ -140,6 +141,7 @@ namespace System.Linq.Parallel
         //     An array of asynchronous channels, one for each partition.
         //
 
+        [System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
         internal static AsynchronousChannel<TInputOutput>[] MakeAsynchronousChannels(int partitionCount, ParallelMergeOptions options, IntValueEvent? consumerEvent, CancellationToken cancellationToken)
         {
             AsynchronousChannel<TInputOutput>[] channels = new AsynchronousChannel<TInputOutput>[partitionCount];

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Merging/OrderPreservingPipeliningMergeHelper.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Merging/OrderPreservingPipeliningMergeHelper.cs
@@ -36,6 +36,7 @@ namespace System.Linq.Parallel
     /// Finally, if the producer notices that its buffer has exceeded an even greater threshold, it will
     /// go to sleep and wait until the consumer takes the entire buffer.
     /// </summary>
+    [System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
     internal sealed class OrderPreservingPipeliningMergeHelper<TOutput, TKey> : IMergeHelper<TOutput>
     {
         private readonly QueryTaskGroupState _taskGroupState; // State shared among tasks.
@@ -354,12 +355,14 @@ namespace System.Linq.Parallel
                     {
                         // Wake up all producers. Since the cancellation token has already been
                         // set, the producers will eventually stop after waking up.
-                        object[] locks = _mergeHelper._bufferLocks;
-                        for (int i = 0; i < locks.Length; i++)
-                        {
-                            lock (locks[i])
+                        if (!OperatingSystem.IsBrowser()) {
+                            object[] locks = _mergeHelper._bufferLocks;
+                            for (int i = 0; i < locks.Length; i++)
                             {
-                                Monitor.Pulse(locks[i]);
+                                lock (locks[i])
+                                {
+                                    Monitor.Pulse(locks[i]);
+                                }
                             }
                         }
 
@@ -398,6 +401,9 @@ namespace System.Linq.Parallel
                             return false;
                         }
 
+                        if (OperatingSystem.IsBrowser())
+                            return false;
+
                         _mergeHelper._consumerWaiting[producer] = true;
                         Monitor.Wait(bufferLock);
 
@@ -416,6 +422,7 @@ namespace System.Linq.Parallel
                     // If the producer is waiting, wake it up
                     if (_mergeHelper._producerWaiting[producer])
                     {
+                        Debug.Assert(!OperatingSystem.IsBrowser());
                         Monitor.Pulse(bufferLock);
                         _mergeHelper._producerWaiting[producer] = false;
                     }
@@ -469,15 +476,17 @@ namespace System.Linq.Parallel
             public override void Dispose()
             {
                 // Wake up any waiting producers
-                int partitionCount = _mergeHelper._buffers.Length;
-                for (int producer = 0; producer < partitionCount; producer++)
-                {
-                    object bufferLock = _mergeHelper._bufferLocks[producer];
-                    lock (bufferLock)
+                if (!OperatingSystem.IsBrowser()) {
+                    int partitionCount = _mergeHelper._buffers.Length;
+                    for (int producer = 0; producer < partitionCount; producer++)
                     {
-                        if (_mergeHelper._producerWaiting[producer])
+                        object bufferLock = _mergeHelper._bufferLocks[producer];
+                        lock (bufferLock)
                         {
-                            Monitor.Pulse(bufferLock);
+                            if (_mergeHelper._producerWaiting[producer])
+                            {
+                                Monitor.Pulse(bufferLock);
+                            }
                         }
                     }
                 }

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Merging/OrderPreservingPipeliningMergeHelper.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Merging/OrderPreservingPipeliningMergeHelper.cs
@@ -355,7 +355,7 @@ namespace System.Linq.Parallel
                     {
                         // Wake up all producers. Since the cancellation token has already been
                         // set, the producers will eventually stop after waking up.
-                        if (!OperatingSystem.IsBrowser()) {
+                        if (!ParallelEnumerable.SinglePartitionMode) {
                             object[] locks = _mergeHelper._bufferLocks;
                             for (int i = 0; i < locks.Length; i++)
                             {
@@ -401,7 +401,7 @@ namespace System.Linq.Parallel
                             return false;
                         }
 
-                        if (OperatingSystem.IsBrowser())
+                        if (ParallelEnumerable.SinglePartitionMode)
                             return false;
 
                         _mergeHelper._consumerWaiting[producer] = true;
@@ -422,7 +422,7 @@ namespace System.Linq.Parallel
                     // If the producer is waiting, wake it up
                     if (_mergeHelper._producerWaiting[producer])
                     {
-                        Debug.Assert(!OperatingSystem.IsBrowser());
+                        Debug.Assert(!ParallelEnumerable.SinglePartitionMode);
                         Monitor.Pulse(bufferLock);
                         _mergeHelper._producerWaiting[producer] = false;
                     }
@@ -476,7 +476,7 @@ namespace System.Linq.Parallel
             public override void Dispose()
             {
                 // Wake up any waiting producers
-                if (!OperatingSystem.IsBrowser()) {
+                if (!ParallelEnumerable.SinglePartitionMode) {
                     int partitionCount = _mergeHelper._buffers.Length;
                     for (int producer = 0; producer < partitionCount; producer++)
                     {

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/HashRepartitionEnumerator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/HashRepartitionEnumerator.cs
@@ -83,6 +83,9 @@ namespace System.Linq.Parallel
             _barrier = barrier;
             _valueExchangeMatrix = valueExchangeMatrix;
             _cancellationToken = cancellationToken;
+
+            if (OperatingSystem.IsBrowser())
+                Debug.Assert(partitionCount == 1);
         }
 
         //---------------------------------------------------------------------------------------
@@ -119,6 +122,8 @@ namespace System.Linq.Parallel
                 }
                 return false;
             }
+
+            Debug.Assert(!OperatingSystem.IsBrowser());
 
             Mutables? mutables = _mutables;
             if (mutables == null)

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/HashRepartitionEnumerator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/HashRepartitionEnumerator.cs
@@ -84,7 +84,7 @@ namespace System.Linq.Parallel
             _valueExchangeMatrix = valueExchangeMatrix;
             _cancellationToken = cancellationToken;
 
-            if (OperatingSystem.IsBrowser())
+            if (ParallelEnumerable.SinglePartitionMode)
                 Debug.Assert(partitionCount == 1);
         }
 
@@ -123,7 +123,7 @@ namespace System.Linq.Parallel
                 return false;
             }
 
-            Debug.Assert(!OperatingSystem.IsBrowser());
+            Debug.Assert(!ParallelEnumerable.SinglePartitionMode);
 
             Mutables? mutables = _mutables;
             if (mutables == null)

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/OrderedHashRepartitionEnumerator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/OrderedHashRepartitionEnumerator.cs
@@ -121,6 +121,8 @@ namespace System.Linq.Parallel
                 return false;
             }
 
+            Debug.Assert(!OperatingSystem.IsBrowser());
+
             Mutables? mutables = _mutables;
             if (mutables == null)
                 mutables = _mutables = new Mutables();

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/OrderedHashRepartitionEnumerator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/OrderedHashRepartitionEnumerator.cs
@@ -121,7 +121,7 @@ namespace System.Linq.Parallel
                 return false;
             }
 
-            Debug.Assert(!OperatingSystem.IsBrowser());
+            Debug.Assert(!ParallelEnumerable.SinglePartitionMode);
 
             Mutables? mutables = _mutables;
             if (mutables == null)

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/DefaultIfEmptyQueryOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/DefaultIfEmptyQueryOperator.cs
@@ -58,7 +58,7 @@ namespace System.Linq.Parallel
             PartitionedStream<TSource, TKey> inputStream, IPartitionedStreamRecipient<TSource> recipient, bool preferStriping, QuerySettings settings)
         {
             int partitionCount = inputStream.PartitionCount;
-            if (OperatingSystem.IsBrowser())
+            if (ParallelEnumerable.SinglePartitionMode)
                 Debug.Assert(partitionCount == 1);
 
             // Generate the shared data.
@@ -155,7 +155,7 @@ namespace System.Linq.Parallel
 
                     if (!moveNextResult)
                     {
-                        if (OperatingSystem.IsBrowser())
+                        if (ParallelEnumerable.SinglePartitionMode)
                         {
                             currentElement = _defaultValue;
                             currentKey = default(TKey)!;
@@ -194,8 +194,7 @@ namespace System.Linq.Parallel
                     // Every partition (but the 0th) will signal the latch the first time.
                     if (_partitionIndex != 0)
                     {
-                        if (!OperatingSystem.IsBrowser())
-                            _sharedLatch.Signal();
+                        _sharedLatch.Signal();
                     }
                 }
 

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/FirstQueryOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/FirstQueryOperator.cs
@@ -72,6 +72,8 @@ namespace System.Linq.Parallel
             PartitionedStream<TSource, TKey> inputStream, IPartitionedStreamRecipient<TSource> recipient, QuerySettings settings)
         {
             int partitionCount = inputStream.PartitionCount;
+            if (OperatingSystem.IsBrowser())
+                Debug.Assert(partitionCount == 1);
 
             // Generate the shared data.
             FirstQueryOperatorState<TKey> operatorState = new FirstQueryOperatorState<TKey>();
@@ -200,9 +202,11 @@ namespace System.Linq.Parallel
                 }
                 finally
                 {
-                    // No matter whether we exit due to an exception or normal completion, we must ensure
-                    // that we signal other partitions that we have completed.  Otherwise, we can cause deadlocks.
-                    _sharedBarrier.Signal();
+                    if (!OperatingSystem.IsBrowser()) {
+                        // No matter whether we exit due to an exception or normal completion, we must ensure
+                        // that we signal other partitions that we have completed.  Otherwise, we can cause deadlocks.
+                        _sharedBarrier.Signal();
+                    }
                 }
 
                 _alreadySearched = true;
@@ -210,7 +214,8 @@ namespace System.Linq.Parallel
                 // Wait only if we may have the result
                 if (_partitionId == _operatorState._partitionId)
                 {
-                    _sharedBarrier.Wait(_cancellationToken);
+                    if (!OperatingSystem.IsBrowser())
+                        _sharedBarrier.Wait(_cancellationToken);
 
                     // Now re-read the shared index. If it's the same as ours, we won and return true.
                     if (_partitionId == _operatorState._partitionId)

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/FirstQueryOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/FirstQueryOperator.cs
@@ -72,7 +72,7 @@ namespace System.Linq.Parallel
             PartitionedStream<TSource, TKey> inputStream, IPartitionedStreamRecipient<TSource> recipient, QuerySettings settings)
         {
             int partitionCount = inputStream.PartitionCount;
-            if (OperatingSystem.IsBrowser())
+            if (ParallelEnumerable.SinglePartitionMode)
                 Debug.Assert(partitionCount == 1);
 
             // Generate the shared data.
@@ -202,7 +202,7 @@ namespace System.Linq.Parallel
                 }
                 finally
                 {
-                    if (!OperatingSystem.IsBrowser()) {
+                    if (!ParallelEnumerable.SinglePartitionMode) {
                         // No matter whether we exit due to an exception or normal completion, we must ensure
                         // that we signal other partitions that we have completed.  Otherwise, we can cause deadlocks.
                         _sharedBarrier.Signal();
@@ -214,7 +214,7 @@ namespace System.Linq.Parallel
                 // Wait only if we may have the result
                 if (_partitionId == _operatorState._partitionId)
                 {
-                    if (!OperatingSystem.IsBrowser())
+                    if (!ParallelEnumerable.SinglePartitionMode)
                         _sharedBarrier.Wait(_cancellationToken);
 
                     // Now re-read the shared index. If it's the same as ours, we won and return true.

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/LastQueryOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/LastQueryOperator.cs
@@ -72,6 +72,8 @@ namespace System.Linq.Parallel
         private void WrapHelper<TKey>(PartitionedStream<TSource, TKey> inputStream, IPartitionedStreamRecipient<TSource> recipient, QuerySettings settings)
         {
             int partitionCount = inputStream.PartitionCount;
+            if (OperatingSystem.IsBrowser())
+                Debug.Assert(partitionCount == 1);
 
             // Generate the shared data.
             LastQueryOperatorState<TKey> operatorState = new LastQueryOperatorState<TKey>();
@@ -212,7 +214,8 @@ namespace System.Linq.Parallel
                 // Only if we have a candidate do we wait.
                 if (_partitionId == _operatorState._partitionId)
                 {
-                    _sharedBarrier.Wait(_cancellationToken);
+                    if (!OperatingSystem.IsBrowser())
+                        _sharedBarrier.Wait(_cancellationToken);
 
                     // Now re-read the shared index. If it's the same as ours, we won and return true.
                     if (_operatorState._partitionId == _partitionId)

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/LastQueryOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/LastQueryOperator.cs
@@ -72,7 +72,7 @@ namespace System.Linq.Parallel
         private void WrapHelper<TKey>(PartitionedStream<TSource, TKey> inputStream, IPartitionedStreamRecipient<TSource> recipient, QuerySettings settings)
         {
             int partitionCount = inputStream.PartitionCount;
-            if (OperatingSystem.IsBrowser())
+            if (ParallelEnumerable.SinglePartitionMode)
                 Debug.Assert(partitionCount == 1);
 
             // Generate the shared data.
@@ -214,7 +214,7 @@ namespace System.Linq.Parallel
                 // Only if we have a candidate do we wait.
                 if (_partitionId == _operatorState._partitionId)
                 {
-                    if (!OperatingSystem.IsBrowser())
+                    if (!ParallelEnumerable.SinglePartitionMode)
                         _sharedBarrier.Wait(_cancellationToken);
 
                     // Now re-read the shared index. If it's the same as ours, we won and return true.

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/TakeOrSkipQueryOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/TakeOrSkipQueryOperator.cs
@@ -108,7 +108,7 @@ namespace System.Linq.Parallel
             FixedMaxHeap<TKey> sharedIndices = new FixedMaxHeap<TKey>(_count, inputStream.KeyComparer); // an array used to track the sequence of indices leading up to the Nth index
             CountdownEvent sharedBarrier = new CountdownEvent(partitionCount); // a barrier to synchronize before yielding
 
-            if (OperatingSystem.IsBrowser())
+            if (ParallelEnumerable.SinglePartitionMode)
                 Debug.Assert(partitionCount == 1);
 
             PartitionedStream<TResult, TKey> outputStream =
@@ -225,7 +225,7 @@ namespace System.Linq.Parallel
                         }
                     }
 
-                    if (!OperatingSystem.IsBrowser()) {
+                    if (!ParallelEnumerable.SinglePartitionMode) {
                         // Before exiting the search phase, we will synchronize with others. This is a barrier.
                         _sharedBarrier.Signal();
                         _sharedBarrier.Wait(_cancellationToken);

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/TakeOrSkipQueryOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/TakeOrSkipQueryOperator.cs
@@ -108,6 +108,9 @@ namespace System.Linq.Parallel
             FixedMaxHeap<TKey> sharedIndices = new FixedMaxHeap<TKey>(_count, inputStream.KeyComparer); // an array used to track the sequence of indices leading up to the Nth index
             CountdownEvent sharedBarrier = new CountdownEvent(partitionCount); // a barrier to synchronize before yielding
 
+            if (OperatingSystem.IsBrowser())
+                Debug.Assert(partitionCount == 1);
+
             PartitionedStream<TResult, TKey> outputStream =
                 new PartitionedStream<TResult, TKey>(partitionCount, inputStream.KeyComparer, OrdinalIndexState);
             for (int i = 0; i < partitionCount; i++)
@@ -222,9 +225,11 @@ namespace System.Linq.Parallel
                         }
                     }
 
-                    // Before exiting the search phase, we will synchronize with others. This is a barrier.
-                    _sharedBarrier.Signal();
-                    _sharedBarrier.Wait(_cancellationToken);
+                    if (!OperatingSystem.IsBrowser()) {
+                        // Before exiting the search phase, we will synchronize with others. This is a barrier.
+                        _sharedBarrier.Signal();
+                        _sharedBarrier.Wait(_cancellationToken);
+                    }
 
                     // Publish the buffer and set the index to just before the 1st element.
                     _buffer = buffer;

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/TakeOrSkipWhileQueryOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/TakeOrSkipWhileQueryOperator.cs
@@ -127,6 +127,8 @@ namespace System.Linq.Parallel
         private void WrapHelper<TKey>(PartitionedStream<TResult, TKey> inputStream, IPartitionedStreamRecipient<TResult> recipient, QuerySettings settings)
         {
             int partitionCount = inputStream.PartitionCount;
+            if (OperatingSystem.IsBrowser())
+                Debug.Assert(partitionCount == 1);
 
             // Create shared data.
             OperatorState<TKey> operatorState = new OperatorState<TKey>();
@@ -321,13 +323,16 @@ namespace System.Linq.Parallel
                     }
                     finally
                     {
-                        // No matter whether we exit due to an exception or normal completion, we must ensure
-                        // that we signal other partitions that we have completed.  Otherwise, we can cause deadlocks.
-                        _sharedBarrier.Signal();
+                        if (!OperatingSystem.IsBrowser()) {
+                            // No matter whether we exit due to an exception or normal completion, we must ensure
+                            // that we signal other partitions that we have completed.  Otherwise, we can cause deadlocks.
+                            _sharedBarrier.Signal();
+                        }
                     }
 
                     // Before exiting the search phase, we will synchronize with others. This is a barrier.
-                    _sharedBarrier.Wait(_cancellationToken);
+                    if (!OperatingSystem.IsBrowser())
+                        _sharedBarrier.Wait(_cancellationToken);
 
                     // Publish the buffer and set the index to just before the 1st element.
                     _buffer = buffer;

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/TakeOrSkipWhileQueryOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/TakeOrSkipWhileQueryOperator.cs
@@ -127,7 +127,7 @@ namespace System.Linq.Parallel
         private void WrapHelper<TKey>(PartitionedStream<TResult, TKey> inputStream, IPartitionedStreamRecipient<TResult> recipient, QuerySettings settings)
         {
             int partitionCount = inputStream.PartitionCount;
-            if (OperatingSystem.IsBrowser())
+            if (ParallelEnumerable.SinglePartitionMode)
                 Debug.Assert(partitionCount == 1);
 
             // Create shared data.
@@ -323,7 +323,7 @@ namespace System.Linq.Parallel
                     }
                     finally
                     {
-                        if (!OperatingSystem.IsBrowser()) {
+                        if (!ParallelEnumerable.SinglePartitionMode) {
                             // No matter whether we exit due to an exception or normal completion, we must ensure
                             // that we signal other partitions that we have completed.  Otherwise, we can cause deadlocks.
                             _sharedBarrier.Signal();
@@ -331,7 +331,7 @@ namespace System.Linq.Parallel
                     }
 
                     // Before exiting the search phase, we will synchronize with others. This is a barrier.
-                    if (!OperatingSystem.IsBrowser())
+                    if (!ParallelEnumerable.SinglePartitionMode)
                         _sharedBarrier.Wait(_cancellationToken);
 
                     // Publish the buffer and set the index to just before the 1st element.

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Scheduling/OrderPreservingPipeliningSpoolingTask.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Scheduling/OrderPreservingPipeliningSpoolingTask.cs
@@ -18,6 +18,7 @@ using System.Diagnostics;
 
 namespace System.Linq.Parallel
 {
+    [System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
     internal sealed class OrderPreservingPipeliningSpoolingTask<TOutput, TKey> : SpoolingTaskBase
     {
         private readonly QueryTaskGroupState _taskGroupState; // State shared among tasks.

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Scheduling/SpoolingTask.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Scheduling/SpoolingTask.cs
@@ -82,6 +82,7 @@ namespace System.Linq.Parallel
         //     taskScheduler   - the task manager on which to execute
         //
 
+        [System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
         internal static void SpoolPipeline<TInputOutput, TIgnoreKey>(
             QueryTaskGroupState groupState, PartitionedStream<TInputOutput, TIgnoreKey> partitions,
             AsynchronousChannel<TInputOutput>[] channels, TaskScheduler taskScheduler)
@@ -264,6 +265,7 @@ namespace System.Linq.Parallel
     /// </summary>
     /// <typeparam name="TInputOutput"></typeparam>
     /// <typeparam name="TIgnoreKey"></typeparam>
+    [System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
     internal sealed class PipelineSpoolingTask<TInputOutput, TIgnoreKey> : SpoolingTaskBase
     {
         // The data source from which to pull data.

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Utils/Sorting.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Utils/Sorting.cs
@@ -204,6 +204,7 @@ namespace System.Linq.Parallel
             // Step 3. Enter into the merging phases, each separated by several barriers.
             if (_partitionCount > 1)
             {
+                Debug.Assert(!OperatingSystem.IsBrowser());
                 // We only need to merge if there is more than 1 partition.
                 MergeSortCooperatively();
             }
@@ -357,6 +358,7 @@ namespace System.Linq.Parallel
         // negatively impact speedups.
         //
 
+        [System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
         private void MergeSortCooperatively()
         {
             CancellationToken cancelToken = _groupState.CancellationState.MergedCancellationToken;

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Utils/Sorting.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Utils/Sorting.cs
@@ -204,7 +204,7 @@ namespace System.Linq.Parallel
             // Step 3. Enter into the merging phases, each separated by several barriers.
             if (_partitionCount > 1)
             {
-                Debug.Assert(!OperatingSystem.IsBrowser());
+                Debug.Assert(!ParallelEnumerable.SinglePartitionMode);
                 // We only need to merge if there is more than 1 partition.
                 MergeSortCooperatively();
             }

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/ParallelEnumerable.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/ParallelEnumerable.cs
@@ -62,6 +62,11 @@ namespace System.Linq
             + "System.Collections.Generic.IEnumerable<T>. To fix this problem, use the AsParallel() extension method "
             + "to convert the right data source to System.Linq.ParallelQuery<T>.";
 
+        // When running in single partition mode, PLINQ operations will occur on a single partition and will not
+        //  be executed in parallel, but will retain PLINQ semantics (exceptions wrapped as aggregates, etc).
+        [System.Runtime.Versioning.SupportedOSPlatformGuard("browser")]
+        internal static bool SinglePartitionMode => OperatingSystem.IsBrowser();
+
         //-----------------------------------------------------------------------------------
         // Converts any IEnumerable<TSource> into something that can be the target of parallel
         // query execution.

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/ParallelEnumerable.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/ParallelEnumerable.cs
@@ -63,7 +63,7 @@ namespace System.Linq
             + "to convert the right data source to System.Linq.ParallelQuery<T>.";
 
         // When running in single partition mode, PLINQ operations will occur on a single partition and will not
-        //  be executed in parallel, but will retain PLINQ semantics (exceptions wrapped as aggregates, etc).
+        // be executed in parallel, but will retain PLINQ semantics (exceptions wrapped as aggregates, etc).
         [System.Runtime.Versioning.SupportedOSPlatformGuard("browser")]
         internal static bool SinglePartitionMode => OperatingSystem.IsBrowser();
 

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -215,8 +215,6 @@
     <!-- Mono-Browser ignores runtimeconfig.template.json (e.g. for this it has "System.Globalization.EnforceJapaneseEraYearRanges": true) -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization.Calendars\tests\CalendarTestWithConfigSwitch\System.Globalization.CalendarsWithConfigSwitch.Tests.csproj" />
 
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Linq.Parallel\tests\System.Linq.Parallel.Tests.csproj" />
-
     <!-- https://github.com/dotnet/runtime/issues/37669 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.DependencyModel\tests\Microsoft.Extensions.DependencyModel.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Hosting\tests\UnitTests\Microsoft.Extensions.Hosting.Unit.Tests.csproj" />


### PR DESCRIPTION
This PR enables PLINQ for wasm and makes adjustments to avoid hitting threading code while in the browser, and ideally will fix #43752