### PR TITLE
Add internal AppExecLink support to link APIs

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Interop.Errors.cs
+++ b/src/libraries/Common/src/Interop/Windows/Interop.Errors.cs
@@ -91,6 +91,7 @@ internal static partial class Interop
         internal const int ERROR_EVENTLOG_FILE_CHANGED = 0x5DF;
         internal const int ERROR_TRUSTED_RELATIONSHIP_FAILURE = 0x6FD;
         internal const int ERROR_RESOURCE_LANG_NOT_FOUND = 0x717;
+        internal const int ERROR_CANT_ACCESS_FILE = 0x780;
         internal const int ERROR_NOT_A_REPARSE_POINT = 0x1126;
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FileOperations.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FileOperations.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
             internal const uint IO_REPARSE_TAG_FILE_PLACEHOLDER = 0x80000015;
             internal const uint IO_REPARSE_TAG_MOUNT_POINT = 0xA0000003;
             internal const uint IO_REPARSE_TAG_SYMLINK = 0xA000000C;
+            internal const uint IO_REPARSE_TAG_APPEXECLINK = 0x8000001B;
         }
 
         internal static partial class FileOperations

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.REPARSE_DATA_BUFFER.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.REPARSE_DATA_BUFFER.cs
@@ -38,5 +38,14 @@ internal static partial class Interop
             public ushort PrintNameOffset;
             public ushort PrintNameLength;
         }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct AppExecLinkReparseBuffer
+        {
+            public uint ReparseTag;
+            public ushort ReparseDataLength;
+            public ushort Reserved;
+            public uint StringCount;
+        }
     }
 }

--- a/src/libraries/Common/src/System/IO/FileSystem.Attributes.Windows.cs
+++ b/src/libraries/Common/src/System/IO/FileSystem.Attributes.Windows.cs
@@ -132,7 +132,6 @@ namespace System.IO
                 case Interop.Errors.ERROR_NETWORK_ACCESS_DENIED:
                 case Interop.Errors.ERROR_INVALID_HANDLE:           // eg from \\.\CON
                 case Interop.Errors.ERROR_FILENAME_EXCED_RANGE:     // Path is too long
-                case Interop.Errors.ERROR_CANT_ACCESS_FILE:         // Possibly broken AppExecLink
                     return true;
                 default:
                     return false;

--- a/src/libraries/Common/src/System/IO/FileSystem.Attributes.Windows.cs
+++ b/src/libraries/Common/src/System/IO/FileSystem.Attributes.Windows.cs
@@ -118,6 +118,8 @@ namespace System.IO
 
         internal static bool IsPathUnreachableError(int errorCode)
         {
+            // This switch should *not* catch:
+            // ERROR_ACCESS_DENIED, ERROR_SHARING_VIOLATION, ERROR_SEM_TIMEOUT
             switch (errorCode)
             {
                 case Interop.Errors.ERROR_FILE_NOT_FOUND:
@@ -132,6 +134,7 @@ namespace System.IO
                 case Interop.Errors.ERROR_NETWORK_ACCESS_DENIED:
                 case Interop.Errors.ERROR_INVALID_HANDLE:           // eg from \\.\CON
                 case Interop.Errors.ERROR_FILENAME_EXCED_RANGE:     // Path is too long
+                case Interop.Errors.ERROR_CANT_ACCESS_FILE:         // Broken AppExecLink files may cause this
                     return true;
                 default:
                     return false;

--- a/src/libraries/Common/src/System/IO/FileSystem.Attributes.Windows.cs
+++ b/src/libraries/Common/src/System/IO/FileSystem.Attributes.Windows.cs
@@ -132,6 +132,7 @@ namespace System.IO
                 case Interop.Errors.ERROR_NETWORK_ACCESS_DENIED:
                 case Interop.Errors.ERROR_INVALID_HANDLE:           // eg from \\.\CON
                 case Interop.Errors.ERROR_FILENAME_EXCED_RANGE:     // Path is too long
+                case Interop.Errors.ERROR_CANT_ACCESS_FILE:         // Possibly broken AppExecLink
                     return true;
                 default:
                     return false;

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -289,6 +289,35 @@ namespace System
             }
         }
 
+        /// <summary>
+        /// Returns true if the current Windows machine has an Application Execution Alias directory
+        /// located in %LOCALAPPDATA%\Microsoft\WindowsApps, with at least one *.exe file inside.
+        /// </summary>
+        public static bool HasUsableAppExecLinksDirectory
+        {
+            get
+            {
+                try
+                {
+                    if (OperatingSystem.IsWindows())
+                    {
+                        string localAppData = Environment.GetEnvironmentVariable("LOCALAPPDATA");
+                        if (string.IsNullOrWhiteSpace(localAppData))
+                        {
+                            return false;
+                        }
+                        string windowsAppsDir = Path.Join(localAppData, "Microsoft", "WindowsApps");
+                        if (Directory.Exists(windowsAppsDir))
+                        {
+                            return Directory.GetFiles(windowsAppsDir, "*.exe", new EnumerationOptions() { RecurseSubdirectories = true, MaxRecursionDepth = 3 }).Length > 0;
+                        }
+                    }
+                }
+                catch { }
+                return false;
+            }
+        }
+
         private static Version GetICUVersion()
         {
             int version = 0;

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -11,6 +11,8 @@ using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 using Microsoft.Win32;
 using Xunit;
+using System.IO.Enumeration;
+using System.Linq;
 
 namespace System
 {
@@ -309,7 +311,16 @@ namespace System
                         string windowsAppsDir = Path.Join(localAppData, "Microsoft", "WindowsApps");
                         if (Directory.Exists(windowsAppsDir))
                         {
-                            return Directory.GetFiles(windowsAppsDir, "*.exe", new EnumerationOptions() { RecurseSubdirectories = true, MaxRecursionDepth = 3 }).Length > 0;
+                            // return Directory.GetFiles(windowsAppsDir, "*.exe", new EnumerationOptions() { RecurseSubdirectories = true, MaxRecursionDepth = 3 }).Length > 0;
+                            return new FileSystemEnumerable<string?>(
+                                   windowsAppsDir,
+                                   (ref FileSystemEntry entry) => null,
+                                   new EnumerationOptions { RecurseSubdirectories = true })
+                            {
+                                ShouldIncludePredicate = (ref FileSystemEntry entry) =>
+                                    FileSystemName.MatchesWin32Expression("*.exe", entry.FileName) &&
+                                    entry.Attributes.HasFlag(FileAttributes.ReparsePoint)
+                            }.Any();
                         }
                     }
                 }

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -299,32 +299,27 @@ namespace System
         {
             get
             {
-                try
+                if (OperatingSystem.IsWindows())
                 {
-                    if (OperatingSystem.IsWindows())
+                    string localAppData = Environment.GetEnvironmentVariable("LOCALAPPDATA");
+                    if (string.IsNullOrWhiteSpace(localAppData))
                     {
-                        string localAppData = Environment.GetEnvironmentVariable("LOCALAPPDATA");
-                        if (string.IsNullOrWhiteSpace(localAppData))
+                        return false;
+                    }
+                    string windowsAppsDir = Path.Join(localAppData, "Microsoft", "WindowsApps");
+                    if (Directory.Exists(windowsAppsDir))
+                    {
+                        return new FileSystemEnumerable<string?>(
+                                windowsAppsDir,
+                                (ref FileSystemEntry entry) => null,
+                                new EnumerationOptions { RecurseSubdirectories = true })
                         {
-                            return false;
-                        }
-                        string windowsAppsDir = Path.Join(localAppData, "Microsoft", "WindowsApps");
-                        if (Directory.Exists(windowsAppsDir))
-                        {
-                            // return Directory.GetFiles(windowsAppsDir, "*.exe", new EnumerationOptions() { RecurseSubdirectories = true, MaxRecursionDepth = 3 }).Length > 0;
-                            return new FileSystemEnumerable<string?>(
-                                   windowsAppsDir,
-                                   (ref FileSystemEntry entry) => null,
-                                   new EnumerationOptions { RecurseSubdirectories = true })
-                            {
-                                ShouldIncludePredicate = (ref FileSystemEntry entry) =>
-                                    FileSystemName.MatchesWin32Expression("*.exe", entry.FileName) &&
-                                    entry.Attributes.HasFlag(FileAttributes.ReparsePoint)
-                            }.Any();
-                        }
+                            ShouldIncludePredicate = (ref FileSystemEntry entry) =>
+                                FileSystemName.MatchesWin32Expression("*.exe", entry.FileName) &&
+                                entry.Attributes.HasFlag(FileAttributes.ReparsePoint)
+                        }.Any();
                     }
                 }
-                catch { }
                 return false;
             }
         }

--- a/src/libraries/System.IO.FileSystem/tests/AppExecLinks.Windows.cs
+++ b/src/libraries/System.IO.FileSystem/tests/AppExecLinks.Windows.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace System.IO.Tests
+{
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public class AppExecLinks : BaseSymbolicLinks
+    {
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.HasUsableAppExecLinksDirectory))]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ResolveAppExecLinkTargets(bool returnFinalTarget)
+        {
+            string windowsAppsDir = Path.Join(Environment.GetEnvironmentVariable("LOCALAPPDATA"), "Microsoft", "WindowsApps");
+            var appExecLinkPaths = Directory.EnumerateFiles(windowsAppsDir, "*.exe", new EnumerationOptions { RecurseSubdirectories = true, MaxRecursionDepth = 3 });
+
+            foreach (string appExecLinkPath in appExecLinkPaths)
+            {
+                FileInfo linkInfo = new(appExecLinkPath);
+                Assert.Equal(0, linkInfo.Length);
+                Assert.True(linkInfo.Attributes.HasFlag(FileAttributes.ReparsePoint));
+
+                string? linkTarget = linkInfo.LinkTarget;
+                Assert.NotNull(linkTarget);
+                Assert.NotEqual(appExecLinkPath, linkTarget);
+
+                FileSystemInfo? targetInfoFromFileInfo = linkInfo.ResolveLinkTarget(returnFinalTarget);
+                VerifyFileInfo(targetInfoFromFileInfo);
+
+                FileSystemInfo? targetInfoFromFile = File.ResolveLinkTarget(appExecLinkPath, returnFinalTarget);
+                VerifyFileInfo(targetInfoFromFile);
+            }
+
+            void VerifyFileInfo(FileSystemInfo? info)
+            {
+                Assert.True(info is FileInfo);
+                if (info.Exists) // The target may not exist, that's ok
+                {
+                    Assert.True(((FileInfo)info).Length > 0);
+                    Assert.False(info.Attributes.HasFlag(FileAttributes.ReparsePoint));
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/libraries/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -75,13 +75,13 @@
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Stat.cs" Link="Interop\Unix\System.Native\Interop.Stat.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
+    <Compile Include="AppExecLinks.Windows.cs" />
     <Compile Include="Base\SymbolicLinks\BaseSymbolicLinks.Windows.cs" />
     <Compile Include="Directory\Delete.Windows.cs" />
     <Compile Include="FileSystemTest.Windows.cs" />
     <Compile Include="FileStream\ctor_options_as.Windows.cs" />
     <Compile Include="FileStream\FileStreamConformanceTests.Windows.cs" />
     <Compile Include="Junctions.Windows.cs" />
-    <Compile Include="AppExecLinks.Windows.cs" />
     <Compile Include="RandomAccess\Mixed.Windows.cs" />
     <Compile Include="RandomAccess\NoBuffering.Windows.cs" />
     <Compile Include="RandomAccess\SectorAlignedMemory.Windows.cs" />

--- a/src/libraries/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/libraries/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -81,6 +81,7 @@
     <Compile Include="FileStream\ctor_options_as.Windows.cs" />
     <Compile Include="FileStream\FileStreamConformanceTests.Windows.cs" />
     <Compile Include="Junctions.Windows.cs" />
+    <Compile Include="AppExecLinks.Windows.cs" />
     <Compile Include="RandomAccess\Mixed.Windows.cs" />
     <Compile Include="RandomAccess\NoBuffering.Windows.cs" />
     <Compile Include="RandomAccess\SectorAlignedMemory.Windows.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
@@ -576,18 +576,26 @@ namespace System.IO
                         count++;
                         if (count == 2)
                         {
-                            start = i + 1; // exclude null char
+                            if (i + 1 >= stringList.Length)
+                            {
+                                // Unexpectedly reached the end of the stringList
+                                // There won't be a third null char
+                                break;
+                            }
+
+                            start = i + 1; // +1 to exclude null char
                         }
                         else if (count == 3)
                         {
                             end = i;
-                            break;
+                            if (start > 0 && end > start)
+                            {
+                                return stringList
+                                    .Slice(start + 1, end - start - 1)
+                                    .ToString();
+                            }
                         }
                     }
-                }
-                if (start != -1 && end != -1)
-                {
-                    return stringList.Slice(start, end - start).ToString();
                 }
 
                 return null;
@@ -619,7 +627,7 @@ namespace System.IO
                 // If the handle fails because it is unreachable, is because the link was broken.
                 // We need to fallback to manually traverse the links and return the target of the last resolved link.
                 int error = Marshal.GetLastWin32Error();
-                if (IsPathUnreachableError(error) || error == Interop.Errors.ERROR_CANT_ACCESS_FILE /* Possibly broken AppExecLink */)
+                if (IsPathUnreachableError(error))
                 {
                     return GetFinalLinkTargetSlow(linkPath);
                 }


### PR DESCRIPTION
This is a continuation of https://github.com/dotnet/runtime/pull/57996 

AppExecLinks, also known as Application Execution Aliases, are a Windows-specific kind of symbolic link for Windows Apps. It's a scenario we should support when resolving links with our FileSystemInfo APIs or the static File/Directory APIs.

AppExecLinks are an [explicitly supported scenario](https://github.com/PowerShell/PowerShell/blob/56d22bc3865fca445145fd685d6d6f6d63194701/src/System.Management.Automation/namespaces/FileSystemProvider.cs#L8509) by PowerShell, along with mount points. Our APIs should handle these types of links as well, to facilitate the task of the PowerShell team to port their code to use these new link APIs.