### PR TITLE
Schedule HTTP & SSL stress runs for release/6.0

### DIFF
--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -11,6 +11,7 @@ schedules:
   branches:
     include:
     - main
+    - release/6.0
 
 variables:
   - template: ../variables.yml

--- a/eng/pipelines/libraries/stress/ssl.yml
+++ b/eng/pipelines/libraries/stress/ssl.yml
@@ -11,6 +11,7 @@ schedules:
   branches:
     include:
     - main
+    - release/6.0
 
 variables:
   - template: ../variables.yml


### PR DESCRIPTION
We need this to make sure that NCL is stable for 6.0.

@dotnet/dncenghot is this the right way to setup this? If not can you please help?