### PR TITLE
Remove MethodTable::GetClassCtorInfoIfExists (always null)

### DIFF
--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -1983,26 +1983,6 @@ BOOL Module::IsPreV4Assembly()
     return !!(m_dwPersistedFlags & IS_PRE_V4_ASSEMBLY);
 }
 
-
-ArrayDPTR(PTR_MethodTable) ModuleCtorInfo::GetGCStaticMTs(DWORD index)
-{
-    LIMITED_METHOD_CONTRACT;
-
-    if (index < numHotGCStaticsMTs)
-    {
-        _ASSERTE(ppHotGCStaticsMTs != NULL);
-
-        return ppHotGCStaticsMTs + index;
-    }
-    else
-    {
-        _ASSERTE(ppColdGCStaticsMTs != NULL);
-
-        // shift the start of the cold table because all cold offsets are also shifted
-        return ppColdGCStaticsMTs + (index - numHotGCStaticsMTs);
-    }
-}
-
 DWORD Module::AllocateDynamicEntry(MethodTable *pMT)
 {
     CONTRACTL
@@ -7724,25 +7704,6 @@ CHECK Module::CheckActivated()
 }
 
 #ifdef DACCESS_COMPILE
-
-void
-ModuleCtorInfo::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
-{
-    SUPPORTS_DAC;
-
-    // This class is contained so do not enumerate 'this'.
-    DacEnumMemoryRegion(dac_cast<TADDR>(ppMT), numElements *
-                        sizeof(MethodTable *));
-    DacEnumMemoryRegion(dac_cast<TADDR>(cctorInfoHot), numElementsHot *
-                        sizeof(ClassCtorInfoEntry));
-    DacEnumMemoryRegion(dac_cast<TADDR>(cctorInfoCold),
-                        (numElements - numElementsHot) *
-                        sizeof(ClassCtorInfoEntry));
-    DacEnumMemoryRegion(dac_cast<TADDR>(hotHashOffsets), numHotHashes *
-                        sizeof(DWORD));
-    DacEnumMemoryRegion(dac_cast<TADDR>(coldHashOffsets), numColdHashes *
-                        sizeof(DWORD));
-}
 
 void Module::EnumMemoryRegions(CLRDataEnumMemoryFlags flags,
                                bool enumThis)

--- a/src/coreclr/vm/class.h
+++ b/src/coreclr/vm/class.h
@@ -80,7 +80,6 @@ class   MethodDesc;
 class   MethodDescChunk;
 class   MethodTable;
 class   Module;
-struct  ModuleCtorInfo;
 class   Object;
 class   Stub;
 class   Substitution;

--- a/src/coreclr/vm/classcompat.h
+++ b/src/coreclr/vm/classcompat.h
@@ -49,7 +49,6 @@ class   MethodDescChunk;
 class   MethodNameHash;
 class   MethodTable;
 class   Module;
-struct  ModuleCtorInfo;
 class   Object;
 class   Stub;
 class   Substitution;

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -6111,14 +6111,6 @@ WORD MethodTable::GetNumBoxedThreadStatics ()
     return GetClass()->GetNumBoxedThreadStatics();
 }
 
-//==========================================================================================
-ClassCtorInfoEntry* MethodTable::GetClassCtorInfoIfExists()
-{
-    LIMITED_METHOD_CONTRACT;
-
-    return NULL;
-}
-
 #ifdef _DEBUG
 //==========================================================================================
 // Returns true if pointer to the parent method table has been initialized/restored already.

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -32,7 +32,6 @@
 class    AppDomain;
 class    ArrayClass;
 class    ArrayMethodDesc;
-struct   ClassCtorInfoEntry;
 class ClassLoader;
 class FCallMethodDesc;
 class    EEClass;
@@ -847,10 +846,6 @@ public:
     BOOL HasClassConstructor();
     void SetHasClassConstructor();
     WORD GetClassConstructorSlot();
-    void SetClassConstructorSlot (WORD wCCtorSlot);
-
-    ClassCtorInfoEntry* GetClassCtorInfoIfExists();
-
 
     void GetSavedExtent(TADDR *ppStart, TADDR *ppEnd);
 
@@ -866,9 +861,6 @@ public:
     static OBJECTREF AllocateStaticBox(MethodTable* pFieldMT, BOOL fPinned, OBJECTHANDLE* pHandle = 0);
 
     void CheckRestore();
-
-    // Perform restore actions on type key components of method table (EEClass pointer + Module, generic args)
-    void DoRestoreTypeKey();
 
     inline BOOL HasUnrestoredTypeKey() const
     {


### PR DESCRIPTION
cc @AaronRobinsonMSFT @davidwrighton @jkoritzinsky 