### PR TITLE
Skip System.Text.Json tests on iOS/tvOS that don't work

### DIFF
--- a/src/libraries/System.Text.Json/tests/Common/CollectionTests/CollectionTests.Dictionary.NonStringKey.cs
+++ b/src/libraries/System.Text.Json/tests/Common/CollectionTests/CollectionTests.Dictionary.NonStringKey.cs
@@ -578,6 +578,7 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/58204", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void RoundtripAllDictionaryConverters()
         {
             const string Expected = @"{""1"":1}";

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonArrayTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonArrayTests.cs
@@ -196,7 +196,7 @@ namespace System.Text.Json.Nodes.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => jArray.CopyTo(arr, -1));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void ConvertJSONArrayToIListOfJsonNode()
         {
             dynamic obj = JsonSerializer.Deserialize<JsonArray>("[42]");

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonArrayTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonArrayTests.cs
@@ -196,10 +196,10 @@ namespace System.Text.Json.Nodes.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => jArray.CopyTo(arr, -1));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [Fact]
         public static void ConvertJSONArrayToIListOfJsonNode()
         {
-            dynamic obj = JsonSerializer.Deserialize<JsonArray>("[42]");
+            JsonArray obj = JsonSerializer.Deserialize<JsonArray>("[42]");
             Assert.Equal(42, (int)obj[0]);
 
             IList<JsonNode> ilist = obj;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/NewtonsoftTests/JsonSerializerTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/NewtonsoftTests/JsonSerializerTests.cs
@@ -65,6 +65,7 @@ namespace System.Text.Json.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/58204", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public void IncompleteContainers()
         {
             JsonException e = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<IList<object>>("[1,"));

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CacheTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CacheTests.cs
@@ -168,6 +168,7 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(WriteSuccessCases))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/58204", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static async Task MultipleTypes(ITestClass testObj)
         {
             Type type = testObj.GetType();

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CollectionTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CollectionTests.cs
@@ -1,8 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Xunit;
+
 namespace System.Text.Json.Serialization.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/58204", TestPlatforms.iOS | TestPlatforms.tvOS)]
     public sealed partial class CollectionTestsDynamic : CollectionTests
     {
         public CollectionTestsDynamic() : base(JsonSerializerWrapperForString.StringSerializer, JsonSerializerWrapperForStream.AsyncStreamSerializer) { }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CustomConverterTests/CustomConverterTests.Dynamic.Sample.Tests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CustomConverterTests/CustomConverterTests.Dynamic.Sample.Tests.cs
@@ -22,7 +22,7 @@ namespace System.Text.Json.Serialization.Tests
             Hello = 77
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void VerifyPrimitives()
         {
             var options = new JsonSerializerOptions();
@@ -67,7 +67,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(4.2, dbl);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void VerifyArray()
         {
             var options = new JsonSerializerOptions();
@@ -97,7 +97,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(10, (int)obj.MyArray[0]);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void JsonDynamicTypes_Serialize()
         {
             var options = new JsonSerializerOptions();
@@ -149,7 +149,7 @@ namespace System.Text.Json.Serialization.Tests
             JsonTestHelper.AssertJsonEqual("{\"One\":1,\"Two\":2}", json);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void JsonDynamicTypes_Deserialize()
         {
             var options = new JsonSerializerOptions();
@@ -164,7 +164,7 @@ namespace System.Text.Json.Serialization.Tests
             JsonSerializer.Deserialize<JsonDynamicString>("\"str\"", options);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void JsonDynamicTypes_Deserialize_AsObject()
         {
             var options = new JsonSerializerOptions();
@@ -181,7 +181,7 @@ namespace System.Text.Json.Serialization.Tests
         /// <summary>
         /// Use a mutable DOM with the 'dynamic' keyword.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void VerifyMutableDom_UsingDynamicKeyword()
         {
             var options = new JsonSerializerOptions();
@@ -221,7 +221,7 @@ namespace System.Text.Json.Serialization.Tests
         /// <summary>
         /// Use a mutable DOM without the 'dynamic' keyword.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void VerifyMutableDom_WithoutUsingDynamicKeyword()
         {
             var options = new JsonSerializerOptions();
@@ -263,7 +263,7 @@ namespace System.Text.Json.Serialization.Tests
         /// Use a mutable DOM without the 'dynamic' keyword and use round-trippable values
         /// meaning the 'JsonDynamicType' values are used instead of raw primitives.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void VerifyMutableDom_WithoutUsingDynamicKeyword_JsonDynamicType()
         {
             var options = new JsonSerializerOptions();
@@ -306,7 +306,7 @@ namespace System.Text.Json.Serialization.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void DynamicObject_MissingProperty()
         {
             var options = new JsonSerializerOptions();
@@ -317,7 +317,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(null, obj.NonExistingProperty);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void DynamicObject_CaseSensitivity()
         {
             var options = new JsonSerializerOptions();
@@ -338,7 +338,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(42, (int)obj.MYPROPERTY);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void NamingPoliciesAreNotUsed()
         {
             const string Json = "{\"myProperty\":42}";
@@ -353,7 +353,7 @@ namespace System.Text.Json.Serialization.Tests
             JsonTestHelper.AssertJsonEqual(Json, json);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void NullHandling()
         {
             var options = new JsonSerializerOptions();
@@ -363,7 +363,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Null(obj);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void QuotedNumbers_Deserialize()
         {
             var options = new JsonSerializerOptions();
@@ -381,7 +381,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(float.NaN, (float)obj);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void QuotedNumbers_Serialize()
         {
             var options = new JsonSerializerOptions();

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/DynamicTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/DynamicTests.cs
@@ -37,7 +37,7 @@ namespace System.Text.Json.Serialization.Tests
             return myDynamic;
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void DynamicKeyword()
         {
             dynamic myDynamic = GetExpandoObject();
@@ -100,7 +100,7 @@ namespace System.Text.Json.Serialization.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
         public static void ExpandoObject()
         {
             ExpandoObject expando = JsonSerializer.Deserialize<ExpandoObject>(Json);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NullableTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NullableTests.cs
@@ -11,6 +11,7 @@ namespace System.Text.Json.Serialization.Tests
     public static partial class NullableTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/58204", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void DictionaryWithNullableValue()
         {
             Dictionary<string, float?> dictWithFloatValue = new Dictionary<string, float?> { { "key", 42.0f } };
@@ -170,6 +171,7 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/58204", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void ClassWithDictionariesWithNullableValues()
         {
             string json =

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NumberHandlingTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NumberHandlingTests.cs
@@ -360,6 +360,7 @@ namespace System.Text.Json.Serialization.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/49936", TestPlatforms.Android)]
+        [ActiveIssue("foo", TestPlatforms.iOS)]
         public static void Number_AsCollectionElement_RoundTrip()
         {
             RunAsCollectionElementTest(JsonNumberTestData.Bytes);
@@ -603,6 +604,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/39674", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoInterpreter))]
         [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", RuntimeConfiguration.Checked)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/58204", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void DictionariesRoundTrip()
         {
             RunAllDictionariessRoundTripTest(JsonNumberTestData.ULongs);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NumberHandlingTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NumberHandlingTests.cs
@@ -360,7 +360,7 @@ namespace System.Text.Json.Serialization.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/49936", TestPlatforms.Android)]
-        [ActiveIssue("foo", TestPlatforms.iOS)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/58204", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void Number_AsCollectionElement_RoundTrip()
         {
             RunAsCollectionElementTest(JsonNumberTestData.Bytes);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Object.ReadTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Object.ReadTests.cs
@@ -368,6 +368,7 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/58204", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void ReadClassWithStringToPrimitiveDictionary()
         {
             TestClassWithStringToPrimitiveDictionary obj = JsonSerializer.Deserialize<TestClassWithStringToPrimitiveDictionary>(TestClassWithStringToPrimitiveDictionary.s_data);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Object.WriteTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Object.WriteTests.cs
@@ -17,6 +17,7 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(WriteSuccessCases))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/58204", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void Write(ITestClass testObj)
         {
             var options = new JsonSerializerOptions { IncludeFields = true };

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/ReadValueTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/ReadValueTests.cs
@@ -508,6 +508,7 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/58204", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void ReadClasses()
         {
             {

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/ReferenceHandlerTests.Deserialize.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/ReferenceHandlerTests.Deserialize.cs
@@ -1240,6 +1240,7 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ReadSuccessCases))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/58204", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void ReadTestClassesWithExtensionOption(Type classType, byte[] data)
         {
             var options = new JsonSerializerOptions { IncludeFields = true, ReferenceHandler = ReferenceHandler.Preserve };

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/SpanTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/SpanTests.cs
@@ -17,6 +17,7 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ReadSuccessCases))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/58204", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void Read(Type classType, byte[] data)
         {
             var options = new JsonSerializerOptions { IncludeFields = true };
@@ -27,6 +28,7 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(ReadSuccessCases))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/58204", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public static void ReadFromStream(Type classType, byte[] data)
         {
             MemoryStream stream = new MemoryStream(data);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Stream.Collections.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Stream.Collections.cs
@@ -18,6 +18,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/35927", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoInterpreter))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/35927", TestPlatforms.Browser)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/58204", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public async Task HandleCollectionsAsync()
         {
             await RunTestAsync<string>();


### PR DESCRIPTION
A number of tests using `dynamic` can't work on iOS devices due to "dynamic invoke" (where Mono does an indirect runtime invoke using a single universal invoke wrapper) not being supported, added PlatformDetection checks for System.Reflection.Emit since that is a close enough approximation for those.

A few other tests run into an "Attempting to JIT compile method" issue that is tracked by https://github.com/dotnet/runtime/issues/58204