### PR TITLE
roll r2r jobs into crossgen2-outerloop

### DIFF
--- a/eng/pipelines/coreclr/crossgen2-outerloop.yml
+++ b/eng/pipelines/coreclr/crossgen2-outerloop.yml
@@ -2,7 +2,7 @@ trigger: none
 
 schedules:
 - cron: "0 5 * * *"
-  displayName: Sun, Tue, Thu at 11:00 PM (UTC-8:00)
+  displayName: Mon through Sun at 9:00 PM (UTC-8:00)
   branches:
     include:
     - main

--- a/eng/pipelines/coreclr/crossgen2-outerloop.yml
+++ b/eng/pipelines/coreclr/crossgen2-outerloop.yml
@@ -1,7 +1,7 @@
 trigger: none
 
 schedules:
-- cron: "0 7 * * 0,2,4"
+- cron: "0 5 * * *"
   displayName: Sun, Tue, Thu at 11:00 PM (UTC-8:00)
   branches:
     include:
@@ -23,7 +23,6 @@ jobs:
     - windows_x86    
     - windows_x64
     - windows_arm64
-    - windows_arm
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
       testGroup: outerloop
@@ -55,7 +54,6 @@ jobs:
     - windows_x86
     - windows_x64
     - windows_arm64
-    - windows_arm
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
       isOfficialBuild: false
@@ -91,7 +89,7 @@ jobs:
       displayNameArgs: R2R_Composite
       liveLibrariesBuildConfig: Release
 
-# Limited outerloop testing in non-composite mode
+# Outerloop testing in non-composite mode
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
     jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -103,7 +101,6 @@ jobs:
     - Linux_x64
     - OSX_x64
     - OSX_arm64
-    - windows_arm
     - windows_arm64
     - windows_x64
     - windows_x86

--- a/eng/pipelines/coreclr/crossgen2-outerloop.yml
+++ b/eng/pipelines/coreclr/crossgen2-outerloop.yml
@@ -15,12 +15,15 @@ jobs:
     jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
     buildConfig: checked
     platforms:
+    - Linux_arm
     - Linux_x64
     - Linux_arm64
     - OSX_arm64
     - OSX_x64
+    - windows_x86    
     - windows_x64
     - windows_arm64
+    - windows_arm
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
       testGroup: outerloop
@@ -83,9 +86,8 @@ jobs:
     jobParameters:
       testGroup: outerloop
       readyToRun: true
-      crossgen2: true
       compositeBuildMode: true
-      displayNameArgs: Composite
+      displayNameArgs: R2R_Composite
       liveLibrariesBuildConfig: Release
 
 # Limited outerloop testing in non-composite mode
@@ -95,12 +97,19 @@ jobs:
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     buildConfig: checked
     platforms:
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
     - OSX_x64
+    - OSX_arm64
+    - windows_arm
+    - windows_arm64
+    - windows_x64
+    - windows_x86
     jobParameters:
       testGroup: outerloop
       readyToRun: true
-      crossgen2: true
-      displayNameArgs: R2R_CG2
+      displayNameArgs: R2R
       liveLibrariesBuildConfig: Release
 
 # Build Crossgen2 baselines

--- a/eng/pipelines/coreclr/crossgen2-outerloop.yml
+++ b/eng/pipelines/coreclr/crossgen2-outerloop.yml
@@ -55,6 +55,7 @@ jobs:
     - windows_x86
     - windows_x64
     - windows_arm64
+    - windows_arm
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
       isOfficialBuild: false


### PR DESCRIPTION
With crossgen1 now defunct merging R2R and crossgen2 outerloops runs into a single CI. This should help with reducing duplication of CI runs. 

Contributes to https://github.com/dotnet/runtime/issues/58120