### PR TITLE
JIT: add PGO random stress testing support

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -480,6 +480,9 @@ jobs:
           - defaultpgo
           - dynamicpgo
           - fullpgo
+          - fullpgo_random_gdv
+          - fullpgo_random_edge
+          - fullpgo_random_gdv_edge
         ${{ if in(parameters.testGroup, 'gc-longrunning') }}:
           longRunningGcTests: true
           scenarios:

--- a/eng/pipelines/libraries/run-test-job.yml
+++ b/eng/pipelines/libraries/run-test-job.yml
@@ -199,4 +199,7 @@ jobs:
               - defaultpgo
               - dynamicpgo
               - fullpgo
+              - fullpgo_random_gdv
+              - fullpgo_random_edge
+              - fullpgo_random_gdv_edge
 

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -2326,7 +2326,7 @@ void EfficientEdgeCountReconstructor::Prepare()
 
                     // Ensure at least one return has nonzero counts.
                     //
-                    if ((rval <= 0.5) && !isReturn || (nZeroReturns < (nReturns - 1)))
+                    if ((rval <= 0.5) && (!isReturn || (nZeroReturns < (nReturns - 1))))
                     {
                         profileCount = 0;
                         if (isReturn)

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -2229,6 +2229,14 @@ public:
 //
 void EfficientEdgeCountReconstructor::Prepare()
 {
+#ifdef DEBUG
+    // If we're going to assign random counts we want to make sure
+    // at least one BBJ_RETURN block has nonzero counts.
+    //
+    unsigned nReturns     = 0;
+    unsigned nZeroReturns = 0;
+#endif
+
     // Create per-block info, and set up the key to block map.
     //
     for (BasicBlock* const block : m_comp->Blocks())
@@ -2241,6 +2249,13 @@ void EfficientEdgeCountReconstructor::Prepare()
         //
         m_blocks++;
         m_unknownBlocks++;
+
+#ifdef DEBUG
+        if (block->bbJumpKind == BBJ_RETURN)
+        {
+            nReturns++;
+        }
+#endif
     }
 
     // Create edges for schema entries with edge counts, and set them up in
@@ -2254,17 +2269,6 @@ void EfficientEdgeCountReconstructor::Prepare()
             case ICorJitInfo::PgoInstrumentationKind::EdgeIntCount:
             case ICorJitInfo::PgoInstrumentationKind::EdgeLongCount:
             {
-                // Optimization TODO: if profileCount is zero, we can just ignore this edge
-                // and the right things will happen.
-                //
-                uint64_t const profileCount =
-                    schemaEntry.InstrumentationKind == ICorJitInfo::PgoInstrumentationKind::EdgeIntCount
-                        ? *(uint32_t*)(m_comp->fgPgoData + schemaEntry.Offset)
-                        : *(uint64_t*)(m_comp->fgPgoData + schemaEntry.Offset);
-                BasicBlock::weight_t const weight = (BasicBlock::weight_t)profileCount;
-
-                m_allWeightsZero &= (profileCount == 0);
-
                 // Find the blocks.
                 //
                 BasicBlock* sourceBlock = nullptr;
@@ -2290,6 +2294,68 @@ void EfficientEdgeCountReconstructor::Prepare()
                     Mismatch();
                     continue;
                 }
+
+                // Optimization TODO: if profileCount is zero, we can just ignore this edge
+                // and the right things will happen.
+                //
+                uint64_t profileCount =
+                    schemaEntry.InstrumentationKind == ICorJitInfo::PgoInstrumentationKind::EdgeIntCount
+                        ? *(uint32_t*)(m_comp->fgPgoData + schemaEntry.Offset)
+                        : *(uint64_t*)(m_comp->fgPgoData + schemaEntry.Offset);
+
+#ifdef DEBUG
+                // Optional stress mode to use a random count. Because edge profile counters have
+                // little redundancy, random count assignments should generally lead to a consistent
+                // set of block counts.
+                //
+                const bool useRandom = (JitConfig.JitRandomEdgeCounts() != 0) && (nReturns > 0);
+
+                if (useRandom)
+                {
+                    // Reuse the random inliner's random state.
+                    // Config setting will serve as the random seed, if no other seed has been supplied already.
+                    //
+                    CLRRandom* const random =
+                        m_comp->impInlineRoot()->m_inlineStrategy->GetRandom(JitConfig.JitRandomEdgeCounts());
+
+                    const bool isReturn = sourceBlock->bbJumpKind == BBJ_RETURN;
+
+                    // We simulate the distribution of counts seen in StdOptimizationData.Mibc.
+                    //
+                    const double rval = random->NextDouble();
+
+                    // Ensure at least one return has nonzero counts.
+                    //
+                    if ((rval <= 0.5) && !isReturn || (nZeroReturns < (nReturns - 1)))
+                    {
+                        profileCount = 0;
+                        if (isReturn)
+                        {
+                            nZeroReturns++;
+                        }
+                    }
+                    else if (rval <= 0.85)
+                    {
+                        profileCount = random->Next(1, 101);
+                    }
+                    else if (rval <= 0.96)
+                    {
+                        profileCount = random->Next(101, 10001);
+                    }
+                    else if (rval <= 0.995)
+                    {
+                        profileCount = random->Next(10001, 100001);
+                    }
+                    else
+                    {
+                        profileCount = random->Next(100001, 1000001);
+                    }
+                }
+#endif
+
+                BasicBlock::weight_t const weight = (BasicBlock::weight_t)profileCount;
+
+                m_allWeightsZero &= (profileCount == 0);
 
                 Edge* const edge = new (m_allocator) Edge(sourceBlock, targetBlock);
 

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -516,7 +516,8 @@ CONFIG_INTEGER(JitCollect64BitCounts, W("JitCollect64BitCounts"), 0) // Collect 
 // Profile consumption options
 CONFIG_INTEGER(JitDisablePgo, W("JitDisablePgo"), 0) // Ignore pgo data for all methods
 #if defined(DEBUG)
-CONFIG_STRING(JitEnablePgoRange, W("JitEnablePgoRange")) // Enable pgo data for only some methods
+CONFIG_STRING(JitEnablePgoRange, W("JitEnablePgoRange"))         // Enable pgo data for only some methods
+CONFIG_INTEGER(JitRandomEdgeCounts, W("JitRandomEdgeCounts"), 0) // Substitute random values for edge counts
 CONFIG_INTEGER(JitCrossCheckDevirtualizationAndPGO, W("JitCrossCheckDevirtualizationAndPGO"), 0)
 CONFIG_INTEGER(JitNoteFailedExactDevirtualization, W("JitNoteFailedExactDevirtualization"), 0)
 #endif // debug

--- a/src/coreclr/jit/likelyclass.cpp
+++ b/src/coreclr/jit/likelyclass.cpp
@@ -312,7 +312,7 @@ CORINFO_CLASS_HANDLE Compiler::getRandomClass(ICorJitInfo::PgoInstrumentationSch
 
             // Choose an entry at random.
             //
-            unsigned                  randomEntryIndex = random->Next(0, h.countHistogramElements - 1);
+            unsigned                  randomEntryIndex = random->Next(0, h.countHistogramElements);
             LikelyClassHistogramEntry randomEntry      = h.HistogramEntryAt(randomEntryIndex);
 
             if (ICorJitInfo::IsUnknownTypeHandle(randomEntry.m_mt))

--- a/src/tests/Common/testenvironment.proj
+++ b/src/tests/Common/testenvironment.proj
@@ -59,6 +59,8 @@
       COMPlus_JitInlinePolicyProfile;
       COMPlus_JitClassProfiling;
       COMPlus_JitEdgeProfiling;
+      COMPlus_JitRandomGuardedDevirtualization;
+      COMPlus_JitRandomEdgeCounts;
       RunningIlasmRoundTrip
     </COMPlusVariables>
   </PropertyGroup>
@@ -157,6 +159,9 @@
     <TestEnvironment Include="defaultpgo" TieredPGO="1" TieredCompilation="1" />
     <TestEnvironment Include="dynamicpgo" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" />
     <TestEnvironment Include="fullpgo" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0"/>
+    <TestEnvironment Include="fullpgo_random_gdv" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitRandomGuardedDevirtualization="1"/>
+    <TestEnvironment Include="fullpgo_random_edge" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitRandomEdgeCounts="1"/>
+    <TestEnvironment Include="fullpgo_random_gdv_edge" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitRandomGuardedDevirtualization="1" JitRandomEdgeCounts="1"/>
     <TestEnvironment Include="gcstandalone" Condition="'$(TargetsWindows)' == 'true'" GCName="clrgc.dll"/>
     <TestEnvironment Include="gcstandalone" Condition="'$(TargetsWindows)' != 'true'" GCName="libclrgc.so"/>
     <TestEnvironment Include="gcstandaloneserver" Condition="'$(TargetsWindows)' == 'true'" gcServer="1" GCName="clrgc.dll"/>


### PR DESCRIPTION
Enable the previously added RandomGDV for various PGO CI pipelines.

Add a new `JitRandomEdgeCount` mode to provide random but plausible
PGO data for edge counters. Because of the way sparse edge counting works
this data will most ofen end up providing a consistent set of block counts.

Enable this mode in PGO pipelines, and also a mode that randomzies both
counts and GDV selections.