### PR TITLE
[HTTP/3] Fix content stream read hang

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -1044,6 +1044,14 @@ namespace System.Net.Http
                         _responseDataPayloadRemaining -= copyLen;
                         _recvBuffer.Discard(copyLen);
                         buffer = buffer.Slice(copyLen);
+
+                        // Stop, if we've reached the end of a data frame and start of the next data frame is not buffered yet
+                        // Waiting for the next data frame may cause a hang, e.g. in echo scenario
+                        // TODO: this is inefficient if data is already available in transport
+                        if (_responseDataPayloadRemaining == 0 && _recvBuffer.ActiveLength == 0)
+                        {
+                            break;
+                        }
                     }
                     else
                     {
@@ -1061,6 +1069,8 @@ namespace System.Net.Http
                         _responseDataPayloadRemaining -= bytesRead;
                         buffer = buffer.Slice(bytesRead);
 
+                        // Stop, if we've reached the end of a data frame. Waiting for the next data frame may cause a hang, e.g. in echo scenario
+                        // TODO: this is inefficient if data is already available in transport
                         if (_responseDataPayloadRemaining == 0)
                         {
                             break;
@@ -1106,6 +1116,14 @@ namespace System.Net.Http
                         _responseDataPayloadRemaining -= copyLen;
                         _recvBuffer.Discard(copyLen);
                         buffer = buffer.Slice(copyLen);
+
+                        // Stop, if we've reached the end of a data frame and start of the next data frame is not buffered yet
+                        // Waiting for the next data frame may cause a hang, e.g. in echo scenario
+                        // TODO: this is inefficient if data is already available in transport
+                        if (_responseDataPayloadRemaining == 0 && _recvBuffer.ActiveLength == 0)
+                        {
+                            break;
+                        }
                     }
                     else
                     {
@@ -1123,6 +1141,8 @@ namespace System.Net.Http
                         _responseDataPayloadRemaining -= bytesRead;
                         buffer = buffer.Slice(bytesRead);
 
+                        // Stop, if we've reached the end of a data frame. Waiting for the next data frame may cause a hang e.g. in echo scenario
+                        // TODO: this is inefficient if data is already available in transport
                         if (_responseDataPayloadRemaining == 0)
                         {
                             break;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -1069,12 +1069,9 @@ namespace System.Net.Http
                         _responseDataPayloadRemaining -= bytesRead;
                         buffer = buffer.Slice(bytesRead);
 
-                        // Stop, if we've reached the end of a data frame. Waiting for the next data frame may cause a hang, e.g. in echo scenario
+                        // Stop, even if we are in the middle of a data frame. Waiting for the next data may cause a hang
                         // TODO: this is inefficient if data is already available in transport
-                        if (_responseDataPayloadRemaining == 0)
-                        {
-                            break;
-                        }
+                        break;
                     }
                 }
 
@@ -1141,12 +1138,9 @@ namespace System.Net.Http
                         _responseDataPayloadRemaining -= bytesRead;
                         buffer = buffer.Slice(bytesRead);
 
-                        // Stop, if we've reached the end of a data frame. Waiting for the next data frame may cause a hang e.g. in echo scenario
+                        // Stop, even if we are in the middle of a data frame. Waiting for the next data may cause a hang
                         // TODO: this is inefficient if data is already available in transport
-                        if (_responseDataPayloadRemaining == 0)
-                        {
-                            break;
-                        }
+                        break;
                     }
                 }
 


### PR DESCRIPTION
The fix is similar to PR #56892 but for another branch (when data is buffered). The root cause is the same - if there's still space in user's buffer we'd start waiting for the next data frame to arrive (which will not happen in echo scenario).

Current code (including #56892 change) may be inefficient in case of small data frames that may be already available in transport, but refactoring that is too large of a change if we consider backporting. I thought #56891 would cover that, but it's QUIC specific, while we also have HTTP/3 specific problem here. I will create another issue later.

Fixes #57888