### PR TITLE
Fix fgValueNumberArrIndexVal for wide reads

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -4243,10 +4243,10 @@ ValueNum Compiler::fgValueNumberArrIndexVal(GenTree*             tree,
     var_types indType = (tree == nullptr) ? elemTyp : tree->TypeGet();
     ValueNum  selectedElem;
 
-    if (fldSeq == FieldSeqStore::NotAField())
+    if ((fldSeq == FieldSeqStore::NotAField()) || (genTypeSize(indType) > genTypeSize(elemTyp)))
     {
         // This doesn't represent a proper array access
-        JITDUMP("    *** NotAField sequence encountered in fgValueNumberArrIndexVal\n");
+        JITDUMP("    *** Not a proper arrray access encountered in fgValueNumberArrIndexVal\n");
 
         // a new unique value number
         selectedElem = vnStore->VNForExpr(compCurBB, elemTyp);

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -4242,7 +4242,7 @@ ValueNum Compiler::fgValueNumberArrIndexVal(GenTree*             tree,
     var_types elemTyp = DecodeElemType(elemTypeEq);
     var_types indType = (tree == nullptr) ? elemTyp : tree->TypeGet();
     ValueNum  selectedElem;
-    unsigned  elemWidth = varTypeIsStruct(elemTyp) ? info.compCompHnd->getClassSize(elemTypeEq) : genTypeSize(elemTyp);
+    unsigned  elemWidth = elemTyp == TYP_STRUCT ? info.compCompHnd->getClassSize(elemTypeEq) : genTypeSize(elemTyp);
 
     if ((fldSeq == FieldSeqStore::NotAField()) || (genTypeSize(indType) > elemWidth))
     {

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -4242,8 +4242,9 @@ ValueNum Compiler::fgValueNumberArrIndexVal(GenTree*             tree,
     var_types elemTyp = DecodeElemType(elemTypeEq);
     var_types indType = (tree == nullptr) ? elemTyp : tree->TypeGet();
     ValueNum  selectedElem;
+    unsigned  elemWidth = varTypeIsStruct(elemTyp) ? info.compCompHnd->getClassSize(elemTypeEq) : genTypeSize(elemTyp);
 
-    if ((fldSeq == FieldSeqStore::NotAField()) || (genTypeSize(indType) > genTypeSize(elemTyp)))
+    if ((fldSeq == FieldSeqStore::NotAField()) || (genTypeSize(indType) > elemWidth))
     {
         // This doesn't represent a proper array access
         JITDUMP("    *** Not a proper arrray access encountered in fgValueNumberArrIndexVal\n");

--- a/src/tests/JIT/Regression/JitBlue/Runtime_57914/Runtime_57914.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_57914/Runtime_57914.cs
@@ -13,15 +13,17 @@ public class Program
 
     private static bool Test1()
     {
-        byte[] arr = new byte[2];
-        arr[0] = 1;
-        arr[1] = 2;
+        byte[] array = new byte[2];
+        array[0] = 1;
+        array[1] = 2;
 
-        short a1 = Unsafe.ReadUnaligned<short>(ref arr[0]);
-        arr[1] = 42;
-        short a2 = Unsafe.ReadUnaligned<short>(ref arr[0]);
+        // a1, a2 and a3 all have different values here
+        byte a1  = Unsafe.ReadUnaligned<byte>(ref array[0]);
+        short a2 = Unsafe.ReadUnaligned<short>(ref array[0]);
+        array[1] = 42;
+        short a3 = Unsafe.ReadUnaligned<short>(ref array[0]);
 
-        return a1 != a2;
+        return a1 != a2 && a1 != a3 && a2 != a3;
     }
 
     private static bool Test2()

--- a/src/tests/JIT/Regression/JitBlue/Runtime_57914/Runtime_57914.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_57914/Runtime_57914.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public class Program
+{
+    public static int Main()
+    {
+        return (Test1() && Test2()) ? 100 : 101;
+    }
+
+    private static bool Test1()
+    {
+        byte[] arr = new byte[2];
+        arr[0] = 1;
+        arr[1] = 2;
+
+        short a1 = Unsafe.ReadUnaligned<short>(ref arr[0]);
+        arr[1] = 42;
+        short a2 = Unsafe.ReadUnaligned<short>(ref arr[0]);
+
+        return a1 != a2;
+    }
+
+    private static bool Test2()
+    {
+        bool result = true;
+        byte[] buffer = new byte[4];
+        buffer[0] = 0x1;
+        buffer[1] = 0x2;
+        buffer[2] = 0x3;
+        buffer[3] = 0x4;
+
+        if (buffer.Length > 0)
+        {
+            int n = Unsafe.ReadUnaligned<int>(ref buffer[0]);
+            if (n != 0x4030201)
+                result = false;
+            Consume(n);
+        }
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void Consume(int n) {}
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_57914/Runtime_57914.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_57914/Runtime_57914.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/57914

Minimal repro:
```csharp
private static bool Test1()
{
    byte[] array = new byte[2];
    array[0] = 1;
    array[1] = 2;


    byte  a1 = Unsafe.ReadUnaligned<byte>(ref array[0]);
    short a2 = Unsafe.ReadUnaligned<short>(ref array[0]);
    array[1] = 42;
    short a3 = Unsafe.ReadUnaligned<short>(ref array[0]);

    return a1 == a2 && a1 == a3; // returns True currently
}
```
`a1`, `a2` and `a3` all have different values here with the same liberal VN resulting `Test1` to return true.

a1:
```
\--*  IND       byte   <l:$42, c:$401>
    \--*  ADD       byref  $300
        +--*  LCL_VAR   ref    V04 tmp1         u:2 $240
        \--*  CNS_INT   long   16 Fseq[#FirstElem] $181
```

a2:
```
\--*  IND       short  <l:$500, c:$5c1>
    \--*  LCL_VAR   byref  V07 tmp4         u:2 (last use) $300
```
(`$500` here is `$42` with NullRefExc)

a3:
```
\--*  IND       byte   <l:$42, c:$402>
    \--*  ADD       byref  $300
        +--*  LCL_VAR   ref    V04 tmp1         u:2 (last use) $240
        \--*  CNS_INT   long   16 Fseq[#FirstElem] $181
```

The fix is quite conservative - it treats such array element loads as "non-proper" and assign a unique VN.
SuperPMI diffs are empty.

PS: Doesn't reproduce on .NET 5.0

/cc @dotnet/jit-contrib 