### PR TITLE
Update `GetCurrFrame()` assert during x86 function unwind

### DIFF
--- a/src/coreclr/vm/excep.h
+++ b/src/coreclr/vm/excep.h
@@ -109,7 +109,6 @@ EXTERN_C VOID STDCALL ResetCurrentContext();
 #ifdef _DEBUG
 void CheckStackBarrier(EXCEPTION_REGISTRATION_RECORD *exRecord);
 #endif
-EXCEPTION_REGISTRATION_RECORD *FindNestedEstablisherFrame(EXCEPTION_REGISTRATION_RECORD *pEstablisherFrame);
 LFH LookForHandler(const EXCEPTION_POINTERS *pExceptionPointers, Thread *pThread, ThrowCallbackType *tct);
 StackWalkAction COMPlusThrowCallback (CrawlFrame *pCf, ThrowCallbackType *pData);
 void UnwindFrames(Thread *pThread, ThrowCallbackType *tct);
@@ -515,7 +514,6 @@ VOID __cdecl PopSEHRecords(LPVOID pTargetSP);
 VOID UnwindExceptionTrackerAndResumeInInterceptionFrame(ExInfo* pExInfo, EHContext* context);
 #endif // TARGET_X86 && DEBUGGING_SUPPORTED
 
-BOOL PopNestedExceptionRecords(LPVOID pTargetSP, BOOL bCheckForUnknownHandlers = FALSE);
 VOID PopNestedExceptionRecords(LPVOID pTargetSP, T_CONTEXT *pCtx, void *pSEH);
 
 // Misc functions to access and update the SEH chain. Be very, very careful about updating the SEH chain.

--- a/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyDll.cpp
+++ b/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyDll.cpp
@@ -64,4 +64,12 @@ extern "C" DLL_EXPORT int STDMETHODCALLTYPE CallManagedProcCatchException(CALLBA
         return -1;
     }
 }
+
+extern "C" DLL_EXPORT int STDMETHODCALLTYPE RaiseSE(unsigned short ec)
+{
+    HRESULT res = MAKE_HRESULT(SEVERITY_ERROR, /* facility */ 0, ec);
+    RaiseException(res, 0, 0, NULL);
+
+    return -1; // Should never return
+}
 #endif // _WIN32


### PR DESCRIPTION
After careful examination of the current scenario and stepping through the unwind code, it was determined the issue is the assert is too strict. There are now cases where an exception frame can exist but not be active in the current context. Consider the following scenario with functions A and B.

Function A contains an inline P/Invoke and also calls function B, which also contains an inline P/Invoke. During the set up of function A an `InlinedCallFrame` (called ICF1) is created to handle the case where A calls the P/Invoke. During the invocation of function B another `InlinedCallFrame` (called ICF2) is created. If the inline P/Invoke in B throws a managed exception during invocation the unwind logic gets consumed if B attempts to catch the exception. It correctly pops off ICF2 and also correctly finds the managed try/catch in B. However, it will assert that the possible top exception frame is above the current target location on the stack.

This invariant is not true in all cases because we now have ICF1 which is on the exception stack but not active in the current call. Adding this to the assert is the fix. Additional tests were also added for SEH related scenarios.

Fixes #57915

/cc @AndyAyersMS @davidwrighton @jkoritzinsky @elinor-fung @janvorli 