### PR TITLE
Fix IDE0062 warning in NumberFormatInfo.cs

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/NumberFormatInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/NumberFormatInfo.cs
@@ -733,9 +733,9 @@ namespace System.Globalization
             if ((style & (InvalidNumberStyles | NumberStyles.AllowHexSpecifier)) != 0
                 && (style & ~NumberStyles.HexNumber) != 0)
             {
-                throwInvalid(style);
+                ThrowInvalid(style);
 
-                void throwInvalid(NumberStyles value)
+                static void ThrowInvalid(NumberStyles value)
                 {
                     if ((value & InvalidNumberStyles) != 0)
                     {
@@ -752,9 +752,9 @@ namespace System.Globalization
             // Check for undefined flags or hex number
             if ((style & (InvalidNumberStyles | NumberStyles.AllowHexSpecifier)) != 0)
             {
-                throwInvalid(style);
+                ThrowInvalid(style);
 
-                void throwInvalid(NumberStyles value)
+                static void ThrowInvalid(NumberStyles value)
                 {
                     if ((value & InvalidNumberStyles) != 0)
                     {


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/58314 is pulling in an arcade update that's failing with IDE0062 on this code.  Cherry-picking the commit I added there to fix it as that PR appears to have other problems.