### PR TITLE
Don't trim PNSE assemblies and enable trimming for inbox assets on all .NETCoreApp versions

### DIFF
--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -55,6 +55,7 @@
     <!-- Enable trimming for any source project that's part of the shared framework.
          Don't attempt to trim PNSE assemblies which are generated from the reference source. -->
     <ILLinkTrimAssembly Condition="'$(ILLinkTrimAssembly)' == '' and
+                                   '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
                                    '$(IsNETCoreAppSrc)' == 'true' and
                                    '$(GeneratePlatformNotSupportedAssembly)' != 'true' and
                                    '$(GeneratePlatformNotSupportedAssemblyMessage)' == ''">true</ILLinkTrimAssembly>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -52,6 +52,12 @@
                                                   '$(DisableImplicitFrameworkReferences)' != 'true' and
                                                   '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
                                                   ('$(IsReferenceAssembly)' == 'true' or '$(IsSourceProject)' == 'true')">true</DisableImplicitAssemblyReferences>
+    <!-- Enable trimming for any source project that's part of the shared framework.
+         Don't attempt to trim PNSE assemblies which are generated from the reference source. -->
+    <ILLinkTrimAssembly Condition="'$(ILLinkTrimAssembly)' == '' and
+                                   '$(IsNETCoreAppSrc)' == 'true' and
+                                   '$(GeneratePlatformNotSupportedAssembly)' != 'true' and
+                                   '$(GeneratePlatformNotSupportedAssemblyMessage)' == ''">true</ILLinkTrimAssembly>
   </PropertyGroup>
 
   <Import Project="$(RepositoryEngineeringDir)versioning.targets" />
@@ -86,13 +92,6 @@
       <RuntimePath>$(NetCoreAppCurrentRuntimePath)</RuntimePath>
     </BinPlaceTargetFrameworks>
 
-    <BinPlaceTargetFrameworks Include="$(NetCoreAppCurrent)-$(TargetOS)"
-                              Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' or '$(BuildTargetFramework)' == ''">
-      <!-- enable trimming for any runtime project that's part of the shared framework and hasn't already set ILLinkTrimAssembly -->
-      <SetProperties Condition="'$(IsNETCoreAppSrc)' == 'true' and
-                                '$(BinPlaceRuntime)' == 'true' and
-                                '$(ILLinkTrimAssembly)' == ''">ILLinkTrimAssembly=true</SetProperties>
-    </BinPlaceTargetFrameworks>
     <BinPlaceDir Include="$(MicrosoftNetCoreAppRefPackDir)analyzers\dotnet\$(AnalyzerLanguage)"
                  Condition="'$(IsNETCoreAppAnalyzer)' == 'true'" />
 


### PR DESCRIPTION
Don't trim platform not supported assemblies, since even in "library" trimming mode, the trimmer might remove some non-public members if they are not called within the assembly. In the case of PNSE assemblies this is most likely always the case.

Contributes to https://github.com/dotnet/runtime/issues/58343
More information in https://github.com/dotnet/linker/issues/2238