### PR TITLE
Turn off release branch in perf-slow.yml

### DIFF
--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -3,7 +3,6 @@ trigger:
   branches:
     include:
     - main
-    - release/*
   paths:
     include:
     - '*'


### PR DESCRIPTION
Created to resolve https://github.com/dotnet/performance/issues/1964
Due to limited machine count, release branch runs need to be turned off for the perf-slow pipeline.