### PR TITLE
Set values for Nuget.Client EXPERIMENTAL_HTTP_RETRY

### DIFF
--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -1,4 +1,14 @@
 variables:
+
+# These values enable longer delays, configurable number of retries, and special understanding of TCP hang-up 
+# See https://github.com/NuGet/Home/issues/11027 for details
+- name: NUGET_ENABLE_EXPERIMENTAL_HTTP_RETRY
+  value: true
+- name: NUGET_EXPERIMENTAL_MAX_NETWORK_TRY_COUNT
+  value: 6
+- name: NUGET_EXPERIMENTAL_NETWORK_RETRY_DELAY_MILLISECONDS
+  value: 1000
+
 - name: isOfficialBuild
   value: ${{ and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}
 - name: isFullMatrix

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "6.0.100-rc.1.21411.28",
+    "version": "6.0.100-rc.2.21430.10",
     "allowPrerelease": true,
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "6.0.100-rc.1.21411.28"
+    "dotnet": "6.0.100-rc.2.21430.10"
   },
   "native-tools": {
     "cmake": "3.16.4",

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "6.0.100-rc.2.21430.10",
+    "version": "6.0.100-rc.1.21430.12",
     "allowPrerelease": true,
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "6.0.100-rc.2.21430.10"
+    "dotnet": "6.0.100-rc.1.21430.12"
   },
   "native-tools": {
     "cmake": "3.16.4",


### PR DESCRIPTION
Changes to try out experimental retry feature introduced in newer Nuget.Client.  Environmental values enable longer delays, configurable number of retries, and special understanding of TCP hang-up.   See https://github.com/NuGet/Home/issues/11027 for details

### Pipelines that had retry-inducing issues with restore, but did not fail from [the previous PR build](https://dev.azure.com/dnceng/public/_build/results?buildId=1328792&view=logs&j=3a9f831a-39fc-5a98-005d-1222ec2c60ca)

#### Mono Product Build windows x86 debug <-- HTTP Client timeout

```
  Failed to download package 'System.IO.FileSystem.Primitives.4.0.1' from 'https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.io.filesystem.primitives/4.0.1/system.io.filesystem.primitives.4.0.1.nupkg'.
  An error occurred while sending the request.
    Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond..
    A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.
```

#### Build Browser wasm Release AllSubsets_Mono_WasmBuildTests <-- TCP Socket hangup

```
  Retrying 'FindPackagesByIdAsync' for source 'https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/c9f8ac11-6bd8-4926-8306-f075241547f7/nuget/v3/flat2/system.collections.concurrent/index.json'.
  An error occurred while sending the request.
    Unable to read data from the transport connection: Connection reset by peer.
    Connection reset by peer
  Retrying 'FindPackagesByIdAsync' for source 'https://pkgs.dev.azure.com/azure-public/3ccf6661-f8ce-4e8a-bb2e-eff943ddd3c7/_packaging/58ca65bb-e6c1-4210-88ac-fa55c1cd7877/nuget/v3/flat2/system.net.http/index.json'.
  An error occurred while sending the request.
    Unable to read data from the transport connection: Connection reset by peer.
    Connection reset by peer
```

#### Libraries Build Linux x64 Debug <-- different kind of HTTP client timeout

```
  Retrying 'FindPackagesByIdAsync' for source 'https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/c9f8ac11-6bd8-4926-8306-f075241547f7/nuget/v3/flat2/microsoft.win32.registry/index.json'.
  The HTTP request to 'GET https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/c9f8ac11-6bd8-4926-8306-f075241547f7/nuget/v3/flat2/microsoft.win32.registry/index.json' has timed out after 100000ms.
```

#### CoreCLR Product Build windows arm checked <-- DNS failure

```
  Failed to download package 'System.Security.Cryptography.Csp.4.3.0' from 'https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/45bacae2-5efb-47c8-91e5-8ec20c22b4f8/nuget/v3/flat2/system.security.cryptography.csp/4.3.0/system.security.cryptography.csp.4.3.0.nupkg'.
  No such host is known. (7devsblobprodcus323.vsblob.vsassets.io:443)
    No such host is known.
```