### PR TITLE
Fix TimeZoneInfo.HasIanaId when using Local Time Zone

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -85,7 +85,8 @@ namespace System
                                             timeZone._standardDisplayName,
                                             timeZone._daylightDisplayName,
                                             timeZone._adjustmentRules,
-                                            disableDaylightSavingTime: false);
+                                            disableDaylightSavingTime: false,
+                                            timeZone.HasIanaId);
 
                         _localTimeZone = timeZone;
                     }
@@ -1954,7 +1955,7 @@ namespace System
                 else
                 {
                     value = new TimeZoneInfo(match!._id, match._baseUtcOffset, match._displayName, match._standardDisplayName,
-                                          match._daylightDisplayName, match._adjustmentRules, disableDaylightSavingTime: false);
+                                          match._daylightDisplayName, match._adjustmentRules, disableDaylightSavingTime: false, match.HasIanaId);
                 }
             }
             else

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2647,13 +2647,16 @@ namespace System.Tests
         [ConditionalFact(nameof(SupportIanaNamesConversionAndRemoteExecution))]
         public static void IsIanaIdWithNotCacheTest()
         {
-            Assert.Equal(!s_isWindows, TimeZoneInfo.Local.HasIanaId);
+            RemoteExecutor.Invoke(() =>
+            {
+                Assert.Equal(!s_isWindows, TimeZoneInfo.Local.HasIanaId);
 
-            TimeZoneInfo tzi = TimeZoneInfo.FindSystemTimeZoneById("W. Europe Standard Time");
-            Assert.False(tzi.HasIanaId);
+                TimeZoneInfo tzi = TimeZoneInfo.FindSystemTimeZoneById("W. Europe Standard Time");
+                Assert.False(tzi.HasIanaId);
 
-            tzi = TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");
-            Assert.True(tzi.HasIanaId);
+                tzi = TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");
+                Assert.True(tzi.HasIanaId);
+            }).Dispose();
         }
 
         [ConditionalFact(nameof(SupportIanaNamesConversion))]

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2646,6 +2646,8 @@ namespace System.Tests
         {
             bool expected = !s_isWindows;
 
+            Assert.Equal(expected, TimeZoneInfo.Local.HasIanaId);
+
             foreach (TimeZoneInfo tzi in TimeZoneInfo.GetSystemTimeZones())
             {
                 Assert.True((expected || tzi.Id.Equals("Utc", StringComparison.OrdinalIgnoreCase)) == tzi.HasIanaId, $"`{tzi.Id}` has wrong IANA Id indicator");

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2640,6 +2640,21 @@ namespace System.Tests
         }
 
         public static bool SupportIanaNamesConversion => PlatformDetection.IsNotBrowser && PlatformDetection.ICUVersion.Major >= 52;
+        public static bool SupportIanaNamesConversionAndRemoteExecution => SupportIanaNamesConversion && RemoteExecutor.IsSupported;
+
+        // This test is executed with the remote execution because it needs to run before creating the time zone cache to ensure testing in the right state.
+        // There already ther tests which test after creating the cache.
+        [ConditionalFact(nameof(SupportIanaNamesConversionAndRemoteExecution))]
+        public static void IsIanaIdWithNotCacheTest()
+        {
+            Assert.Equal(!s_isWindows, TimeZoneInfo.Local.HasIanaId);
+
+            TimeZoneInfo tzi = TimeZoneInfo.FindSystemTimeZoneById("W. Europe Standard Time");
+            Assert.False(tzi.HasIanaId);
+
+            tzi = TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");
+            Assert.True(tzi.HasIanaId);
+        }
 
         [ConditionalFact(nameof(SupportIanaNamesConversion))]
         public static void IsIanaIdTest()

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2649,7 +2649,7 @@ namespace System.Tests
         {
             RemoteExecutor.Invoke(() =>
             {
-                Assert.Equal(!s_isWindows, TimeZoneInfo.Local.HasIanaId);
+                Assert.Equal(!s_isWindows || TimeZoneInfo.Local.Id.Equals("Utc", StringComparison.OrdinalIgnoreCase), TimeZoneInfo.Local.HasIanaId);
 
                 TimeZoneInfo tzi = TimeZoneInfo.FindSystemTimeZoneById("W. Europe Standard Time");
                 Assert.False(tzi.HasIanaId);
@@ -2664,7 +2664,7 @@ namespace System.Tests
         {
             bool expected = !s_isWindows;
 
-            Assert.Equal(expected, TimeZoneInfo.Local.HasIanaId);
+            Assert.Equal((expected || TimeZoneInfo.Local.Id.Equals("Utc", StringComparison.OrdinalIgnoreCase)), TimeZoneInfo.Local.HasIanaId);
 
             foreach (TimeZoneInfo tzi in TimeZoneInfo.GetSystemTimeZones())
             {

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2642,8 +2642,8 @@ namespace System.Tests
         public static bool SupportIanaNamesConversion => PlatformDetection.IsNotBrowser && PlatformDetection.ICUVersion.Major >= 52;
         public static bool SupportIanaNamesConversionAndRemoteExecution => SupportIanaNamesConversion && RemoteExecutor.IsSupported;
 
-        // This test is executed with the remote execution because it needs to run before creating the time zone cache to ensure testing in the right state.
-        // There already ther tests which test after creating the cache.
+        // This test is executed using the remote execution because it needs to run before creating the time zone cache to ensure testing with that state.
+        // There are already other tests that test after creating the cache.
         [ConditionalFact(nameof(SupportIanaNamesConversionAndRemoteExecution))]
         public static void IsIanaIdWithNotCacheTest()
         {


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/58326

We have exposed the new property `TimeZoneInfo.HasIanaId` in .NET 6.0. This property tells if the Time Zone object is created with IANA Id. This property returns the correct results except when using `TimeZoneInfo.Local`. The reason is when we initialize TimeZoneInfo.Local property we clone the object before returning it, but we missed cloning `HasIanaId` property inside the returned object. The fix is to ensure `HasIanaId` is initialized correctly in `TimeZoneInfo.Local`.