### PR TITLE
[release/5.0] Notify Reference Tracker runtime of disconnect at the right time

### DIFF
--- a/src/coreclr/src/interop/comwrappers.cpp
+++ b/src/coreclr/src/interop/comwrappers.cpp
@@ -791,17 +791,6 @@ void NativeObjectWrapperContext::Destroy(_In_ NativeObjectWrapperContext* wrappe
 {
     _ASSERTE(wrapper != nullptr);
 
-    // Check if the tracker object manager should be informed prior to being destroyed.
-    IReferenceTracker* trackerMaybe = wrapper->GetReferenceTracker();
-    if (trackerMaybe != nullptr)
-    {
-        // We only call this during a GC so ignore the failure as
-        // there is no way we can handle it at this point.
-        HRESULT hr = TrackerObjectManager::BeforeWrapperDestroyed(trackerMaybe);
-        _ASSERTE(SUCCEEDED(hr));
-        (void)hr;
-    }
-
     // Manually trigger the destructor since placement
     // new was used to allocate the object.
     wrapper->~NativeObjectWrapperContext();

--- a/src/coreclr/src/interop/comwrappers.hpp
+++ b/src/coreclr/src/interop/comwrappers.hpp
@@ -190,8 +190,8 @@ public:
     // Called after wrapper has been created.
     static HRESULT AfterWrapperCreated(_In_ IReferenceTracker* obj);
 
-    // Called before wrapper is about to be destroyed (the same lifetime as short weak handle).
-    static HRESULT BeforeWrapperDestroyed(_In_ IReferenceTracker* obj);
+    // Called before wrapper is about to be finalized (the same lifetime as short weak handle).
+    static HRESULT BeforeWrapperFinalized(_In_ IReferenceTracker* obj);
 
 public:
     // Begin the reference tracking process for external objects.

--- a/src/coreclr/src/interop/inc/interoplib.h
+++ b/src/coreclr/src/interop/inc/interoplib.h
@@ -90,7 +90,7 @@ namespace InteropLib
 
         // Destroy the supplied wrapper.
         // Optionally notify the wrapper of collection at the same time.
-        void DestroyWrapperForExternal(_In_ void* context, _In_ bool notifyIsCollected = false) noexcept;
+        void DestroyWrapperForExternal(_In_ void* context, _In_ bool notifyIsBeingCollected = false) noexcept;
 
         // Separate the supplied wrapper from the tracker runtime.
         void SeparateWrapperFromTrackerRuntime(_In_ void* context) noexcept;

--- a/src/coreclr/src/interop/inc/interoplib.h
+++ b/src/coreclr/src/interop/inc/interoplib.h
@@ -85,8 +85,12 @@ namespace InteropLib
             _In_ size_t contextSize,
             _Out_ ExternalWrapperResult* result) noexcept;
 
+        // Inform the wrapper it is being collected.
+        void NotifyWrapperForExternalIsBeingCollected(_In_ void* context) noexcept;
+
         // Destroy the supplied wrapper.
-        void DestroyWrapperForExternal(_In_ void* context) noexcept;
+        // Optionally notify the wrapper of collection at the same time.
+        void DestroyWrapperForExternal(_In_ void* context, _In_ bool notifyIsCollected = false) noexcept;
 
         // Separate the supplied wrapper from the tracker runtime.
         void SeparateWrapperFromTrackerRuntime(_In_ void* context) noexcept;

--- a/src/coreclr/src/interop/interoplib.cpp
+++ b/src/coreclr/src/interop/interoplib.cpp
@@ -169,7 +169,7 @@ namespace InteropLib
             }
         }
 
-        void DestroyWrapperForExternal(_In_ void* contextMaybe, _In_ bool notifyIsCollected) noexcept
+        void DestroyWrapperForExternal(_In_ void* contextMaybe, _In_ bool notifyIsBeingCollected) noexcept
         {
             NativeObjectWrapperContext* context = NativeObjectWrapperContext::MapFromRuntimeContext(contextMaybe);
 

--- a/src/coreclr/src/interop/interoplib.cpp
+++ b/src/coreclr/src/interop/interoplib.cpp
@@ -150,12 +150,34 @@ namespace InteropLib
             return S_OK;
         }
 
-        void DestroyWrapperForExternal(_In_ void* contextMaybe) noexcept
+        void NotifyWrapperForExternalIsBeingCollected(_In_ void* contextMaybe) noexcept
         {
             NativeObjectWrapperContext* context = NativeObjectWrapperContext::MapFromRuntimeContext(contextMaybe);
 
             // A caller should not be destroying a context without knowing if the context is valid.
             _ASSERTE(context != nullptr);
+
+            // Check if the tracker object manager should be informed of collection.
+            IReferenceTracker* trackerMaybe = context->GetReferenceTracker();
+            if (trackerMaybe != nullptr)
+            {
+                // We only call this during a GC so ignore the failure as
+                // there is no way we can handle it at this point.
+                HRESULT hr = TrackerObjectManager::BeforeWrapperFinalized(trackerMaybe);
+                _ASSERTE(SUCCEEDED(hr));
+                (void)hr;
+            }
+        }
+
+        void DestroyWrapperForExternal(_In_ void* contextMaybe, _In_ bool notifyIsCollected) noexcept
+        {
+            NativeObjectWrapperContext* context = NativeObjectWrapperContext::MapFromRuntimeContext(contextMaybe);
+
+            // A caller should not be destroying a context without knowing if the context is valid.
+            _ASSERTE(context != nullptr);
+
+            if (notifyIsCollected)
+                NotifyWrapperForExternalIsBeingCollected(contextMaybe);
 
             NativeObjectWrapperContext::Destroy(context);
         }

--- a/src/coreclr/src/interop/interoplib.cpp
+++ b/src/coreclr/src/interop/interoplib.cpp
@@ -176,7 +176,7 @@ namespace InteropLib
             // A caller should not be destroying a context without knowing if the context is valid.
             _ASSERTE(context != nullptr);
 
-            if (notifyIsCollected)
+            if (notifyIsBeingCollected)
                 NotifyWrapperForExternalIsBeingCollected(contextMaybe);
 
             NativeObjectWrapperContext::Destroy(context);

--- a/src/coreclr/src/interop/trackerobjectmanager.cpp
+++ b/src/coreclr/src/interop/trackerobjectmanager.cpp
@@ -302,13 +302,13 @@ HRESULT TrackerObjectManager::AfterWrapperCreated(_In_ IReferenceTracker* obj)
     return S_OK;
 }
 
-HRESULT TrackerObjectManager::BeforeWrapperDestroyed(_In_ IReferenceTracker* obj)
+HRESULT TrackerObjectManager::BeforeWrapperFinalized(_In_ IReferenceTracker* obj)
 {
     _ASSERTE(obj != nullptr);
 
     HRESULT hr;
 
-    // Notify tracker runtime that we are about to destroy a wrapper
+    // Notify tracker runtime that we are about to finalize a wrapper
     // (same timing as short weak handle) for this object.
     // They need this information to disconnect weak refs and stop firing events,
     // so that they can avoid resurrecting the object.

--- a/src/coreclr/src/vm/interoplibinterface.cpp
+++ b/src/coreclr/src/vm/interoplibinterface.cpp
@@ -170,7 +170,7 @@ namespace
                 // We also request collection notification since this holder is presently
                 // only used for new activation of wrappers therefore the notification won't occur
                 // at the typical time of before finalization.
-                InteropLib::Com::DestroyWrapperForExternal(Result.Context, /* notifyIsCollected */ true);
+                InteropLib::Com::DestroyWrapperForExternal(Result.Context, /* notifyIsBeingCollected */ true);
             }
         }
         InteropLib::Com::ExternalWrapperResult* operator&()

--- a/src/coreclr/src/vm/interoplibinterface.cpp
+++ b/src/coreclr/src/vm/interoplibinterface.cpp
@@ -167,7 +167,10 @@ namespace
             if (Result.Context != NULL)
             {
                 GCX_PREEMP();
-                InteropLib::Com::DestroyWrapperForExternal(Result.Context);
+                // We also request collection notification since this holder is presently
+                // only used for new activation of wrappers therefore the notification won't occur
+                // at the typical time of before finalization.
+                InteropLib::Com::DestroyWrapperForExternal(Result.Context, /* notifyIsCollected */ true);
             }
         }
         InteropLib::Com::ExternalWrapperResult* operator&()
@@ -472,7 +475,11 @@ namespace
                 if (!cxt->IsSet(ExternalObjectContext::Flags_Detached)
                     && !GCHeapUtilities::GetGCHeap()->IsPromoted(OBJECTREFToObject(cxt->GetObjectRef())))
                 {
+                    // Indicate the wrapper entry has been detached.
                     cxt->MarkDetached();
+
+                    // Notify the wrapper it was not promoted and is being collected.
+                    InteropLib::Com::NotifyWrapperForExternalIsBeingCollected(cxt);
                 }
             }
         }

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -533,6 +533,9 @@ namespace ComWrappersTests
                 ValidateRuntimeTrackerScenario();
                 ValidateAggregationWithComObject();
                 ValidateAggregationWithReferenceTrackerObject();
+
+                // Ensure all objects have been cleaned up.
+                ForceGC();
             }
             catch (Exception e)
             {

--- a/src/tests/Interop/COM/ComWrappers/Common.cs
+++ b/src/tests/Interop/COM/ComWrappers/Common.cs
@@ -151,7 +151,7 @@ namespace ComWrappersTests.Common
         extern public static int Trigger_NotifyEndOfReferenceTrackingOnThread();
 
         [DllImport(nameof(MockReferenceTrackerRuntime))]
-        extern public static int IsWrapperConnected(IntPtr instance);
+        extern public static int IsTrackerObjectConnected(IntPtr instance);
     }
 
     [Guid("42951130-245C-485E-B60B-4ED4254256F8")]
@@ -215,7 +215,7 @@ namespace ComWrappersTests.Common
             }
             else
             {
-                int isConnected = MockReferenceTrackerRuntime.IsWrapperConnected(this.classNative.Instance);
+                int isConnected = MockReferenceTrackerRuntime.IsTrackerObjectConnected(this.classNative.Instance);
                 if (isConnected != 0)
                 {
                     throw new Exception("TrackerObject should be disconnected prior to finalization");

--- a/src/tests/Interop/COM/ComWrappers/Common.cs
+++ b/src/tests/Interop/COM/ComWrappers/Common.cs
@@ -149,6 +149,9 @@ namespace ComWrappersTests.Common
 
         [DllImport(nameof(MockReferenceTrackerRuntime))]
         extern public static int Trigger_NotifyEndOfReferenceTrackingOnThread();
+
+        [DllImport(nameof(MockReferenceTrackerRuntime))]
+        extern public static int IsWrapperConnected(IntPtr instance);
     }
 
     [Guid("42951130-245C-485E-B60B-4ED4254256F8")]
@@ -212,6 +215,12 @@ namespace ComWrappersTests.Common
             }
             else
             {
+                int isConnected = MockReferenceTrackerRuntime.IsWrapperConnected(this.classNative.Instance);
+                if (isConnected != 0)
+                {
+                    throw new Exception("TrackerObject should be disconnected prior to finalization");
+                }
+
                 ComWrappersHelper.Cleanup(ref this.classNative);
             }
         }

--- a/src/tests/Interop/COM/ComWrappers/MockReferenceTrackerRuntime/ReferenceTrackerRuntime.cpp
+++ b/src/tests/Interop/COM/ComWrappers/MockReferenceTrackerRuntime/ReferenceTrackerRuntime.cpp
@@ -520,7 +520,7 @@ extern "C" DLL_EXPORT int STDMETHODCALLTYPE Trigger_NotifyEndOfReferenceTracking
     return TrackerRuntimeManager.NotifyEndOfReferenceTrackingOnThread();
 }
 
-extern "C" DLL_EXPORT BOOL STDMETHODCALLTYPE IsWrapperConnected(IUnknown* inst)
+extern "C" DLL_EXPORT BOOL STDMETHODCALLTYPE IsTrackerObjectConnected(IUnknown* inst)
 {
     auto trackerObject = reinterpret_cast<TrackerObject::TrackerObjectImpl*>(inst);
     return trackerObject->IsConnected() ? TRUE : FALSE;

--- a/src/tests/Interop/COM/ComWrappers/MockReferenceTrackerRuntime/ReferenceTrackerRuntime.cpp
+++ b/src/tests/Interop/COM/ComWrappers/MockReferenceTrackerRuntime/ReferenceTrackerRuntime.cpp
@@ -199,6 +199,11 @@ namespace
                 }
             }
 
+            bool IsConnected()
+            {
+                return _connected;
+            }
+
             STDMETHOD(AddObjectRef)(_In_ IUnknown* c, _Out_ int* id)
             {
                 assert(c != nullptr && id != nullptr);
@@ -513,6 +518,12 @@ extern "C" DLL_EXPORT void STDMETHODCALLTYPE ReleaseAllTrackerObjects()
 extern "C" DLL_EXPORT int STDMETHODCALLTYPE Trigger_NotifyEndOfReferenceTrackingOnThread()
 {
     return TrackerRuntimeManager.NotifyEndOfReferenceTrackingOnThread();
+}
+
+extern "C" DLL_EXPORT BOOL STDMETHODCALLTYPE IsWrapperConnected(IUnknown* inst)
+{
+    auto trackerObject = reinterpret_cast<TrackerObject::TrackerObjectImpl*>(inst);
+    return trackerObject->IsConnected() ? TRUE : FALSE;
 }
 
 extern "C" DLL_EXPORT int STDMETHODCALLTYPE UpdateTestObjectAsIUnknown(IUnknown *obj, int i, IUnknown **out)


### PR DESCRIPTION
Fixes https://github.com/microsoft/CsWinRT/issues/840

## Customer Impact

Based on misunderstanding of SyncBlock clean-up modes the indication of when an Native Object Wrapper was being collected was being done after the wrapper's Finalizer was run. However, this information must be conveyed prior to wrapper finalization and synchronously during the GC. See [`IReferenceTracker::DisconnectFromTrackerSource`](https://docs.microsoft.com/windows/win32/api/windows.ui.xaml.hosting.referencetracker/nf-windows-ui-xaml-hosting-referencetracker-ireferencetracker-disconnectfromtrackersource).

## Workaround

There are no workarounds for this issue.

## Testing

Added a tests. Have provided private binaries to [C#/WinRT](https://github.com/microsoft/CsWinRT) team for validation.

## Risk

Minimal. .NET 5 is the first release of `ComWrappers` and this issue only impacts WinRT scenarios.

---

/cc @davidwrighton @jkoritzinsky @elinor-fung