### PR TITLE
[release/6.0] Fix TimeZoneInfo.HasIanaId when using Local Time Zone

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -85,7 +85,8 @@ namespace System
                                             timeZone._standardDisplayName,
                                             timeZone._daylightDisplayName,
                                             timeZone._adjustmentRules,
-                                            disableDaylightSavingTime: false);
+                                            disableDaylightSavingTime: false,
+                                            timeZone.HasIanaId);
 
                         _localTimeZone = timeZone;
                     }
@@ -1954,7 +1955,7 @@ namespace System
                 else
                 {
                     value = new TimeZoneInfo(match!._id, match._baseUtcOffset, match._displayName, match._standardDisplayName,
-                                          match._daylightDisplayName, match._adjustmentRules, disableDaylightSavingTime: false);
+                                          match._daylightDisplayName, match._adjustmentRules, disableDaylightSavingTime: false, match.HasIanaId);
                 }
             }
             else

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2642,12 +2642,32 @@ namespace System.Tests
         }
 
         public static bool SupportIanaNamesConversion => PlatformDetection.IsNotBrowser && PlatformDetection.ICUVersion.Major >= 52;
+        public static bool SupportIanaNamesConversionAndRemoteExecution => SupportIanaNamesConversion && RemoteExecutor.IsSupported;
+
+        // This test is executed using the remote execution because it needs to run before creating the time zone cache to ensure testing with that state.
+        // There are already other tests that test after creating the cache.
+        [ConditionalFact(nameof(SupportIanaNamesConversionAndRemoteExecution))]
+        public static void IsIanaIdWithNotCacheTest()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                Assert.Equal(!s_isWindows || TimeZoneInfo.Local.Id.Equals("Utc", StringComparison.OrdinalIgnoreCase), TimeZoneInfo.Local.HasIanaId);
+
+                TimeZoneInfo tzi = TimeZoneInfo.FindSystemTimeZoneById("W. Europe Standard Time");
+                Assert.False(tzi.HasIanaId);
+
+                tzi = TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");
+                Assert.True(tzi.HasIanaId);
+            }).Dispose();
+        }
 
         [ConditionalFact(nameof(SupportIanaNamesConversion))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/52072", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public static void IsIanaIdTest()
         {
             bool expected = !s_isWindows;
+
+            Assert.Equal((expected || TimeZoneInfo.Local.Id.Equals("Utc", StringComparison.OrdinalIgnoreCase)), TimeZoneInfo.Local.HasIanaId);
 
             foreach (TimeZoneInfo tzi in TimeZoneInfo.GetSystemTimeZones())
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/58326

Backport of #58392 to release/6.0

/cc @tarekgh

## Customer Impact

Without this fix, users of `TimeZoneInfo.HasIanaId` can get wrong values when using `TimeZoneInfo.Local`.

We have exposed the new property `TimeZoneInfo.HasIanaId` in .NET 6.0. This property tells if the Time Zone object is created with IANA Id. This property returns the correct results except when using `TimeZoneInfo.Local`. The reason is when we initialize `TimeZoneInfo.Local` property we clone the object before returning it, but we missed cloning `HasIanaId` property inside the returned object. The fix is to ensure `HasIanaId` is initialized correctly in `TimeZoneInfo.Local`.

## Testing

I tested this on Windows and Linux. Also, I have run the whole regression tests with the fix without any problem. I added more tests to cover the test gap for the functionality we are fixing here.

## Risk

Is low. The fix is scoped to the `HasIanaId` property only which is a newly exposed property in .NET 6.0. The change is well tested and added more tests too.