### PR TITLE
Define s390x ABI values when cross-compiling

### DIFF
--- a/src/mono/mono/metadata/abi.c
+++ b/src/mono/mono/metadata/abi.c
@@ -20,6 +20,10 @@ const static AbiDetails mono_abi_details = {	\
 
 DECLARE_ABI_DETAILS (1, 2, 4, 8, 4, 8, 4)
 
+#elif TARGET_S390X
+
+DECLARE_ABI_DETAILS (1, 2, 4, 8, 4, 8, 8)
+
 #else
 
 #define DECL_OFFSET(struct,field)


### PR DESCRIPTION
Add ABI definitions for TARGET_S390X when cross-compiling.