### PR TITLE
[HTTP/3] Stress disable offending op causing server errors

### DIFF
--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -50,7 +50,7 @@ jobs:
 
   - bash: |
       cd '$(httpStressProject)'
-      export HTTPSTRESS_CLIENT_ARGS="$HTTPSTRESS_CLIENT_ARGS -http 3.0"
+      export HTTPSTRESS_CLIENT_ARGS="$HTTPSTRESS_CLIENT_ARGS -http 3.0 -xops 10"
       export HTTPSTRESS_SERVER_ARGS="$HTTPSTRESS_SERVER_ARGS -http 3.0"
       docker-compose up --abort-on-container-exit --no-color
     displayName: Run HttpStress - HTTP 3.0

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
@@ -508,12 +508,6 @@ namespace HttpStress
 
         private static void ValidateStatusCode(HttpResponseMessage m, HttpStatusCode expectedStatus = HttpStatusCode.OK)
         {
-            // [ActiveIssue("https://github.com/dotnet/runtime/issues/55261")]
-            if (m.StatusCode == HttpStatusCode.InternalServerError)
-            {
-                throw new Exception("IGNORE");
-            }
-
             if (m.StatusCode != expectedStatus)
             {
                 throw new Exception($"Expected status code {expectedStatus}, got {m.StatusCode}");

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
@@ -209,11 +209,6 @@ namespace HttpStress
                     {
                         _aggregator.RecordCancellation(opIndex, stopwatch.Elapsed);
                     }
-                    catch (Exception e) when (e.Message == "IGNORE")
-                    {
-                        // [ActiveIssue("https://github.com/dotnet/runtime/issues/55261")]
-                        // See ClientOperations.ValidateStatusCode
-                    }
                     catch (Exception e)
                     {
                         _aggregator.RecordFailure(e, opIndex, stopwatch.Elapsed, requestContext.IsCancellationRequested, taskNum: taskNum, iteration: i);


### PR DESCRIPTION
Kestrel doesn't like Expect 100 Continue in H/3.

See https://github.com/dotnet/runtime/pull/58110#issuecomment-909340654
Contributes to #56310
Fixes #55261