### PR TITLE
Check normalize-on-load in LowerRetSingleRegStructLclVar

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3440,8 +3440,11 @@ void Lowering::LowerRetSingleRegStructLclVar(GenTreeUnOp* ret)
     {
         const var_types lclVarType = varDsc->GetRegisterType(lclVar);
         assert(lclVarType != TYP_UNDEF);
-        const var_types actualType = genActualType(lclVarType);
-        lclVar->ChangeType(actualType);
+        if (!varDsc->lvNormalizeOnLoad())
+        {
+            const var_types actualType = genActualType(lclVarType);
+            lclVar->ChangeType(actualType);
+        }
 
         if (varTypeUsesFloatReg(ret) != varTypeUsesFloatReg(lclVarType))
         {

--- a/src/tests/JIT/Regression/JitBlue/Runtime_58373/Runtime_58373.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_58373/Runtime_58373.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public unsafe class Runtime_58373
+{
+    public static int Main()
+    {
+        FillStack(0, 0, 0, 0, 0, 0, 0xdeadbeef);
+        short val1 = HalfToInt16Bits(0, 0, 0, 0, 0, 0, (Half)42f);
+        FillStack(0, 0, 0, 0, 0, 0, 0xf000baaa);
+        short val2 = HalfToInt16Bits(0, 0, 0, 0, 0, 0, (Half)42f);
+
+        return val1 == val2 ? 100 : -1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void FillStack(int a0, int a1, int a2, int a3, int a4, int a5, uint onStack)
+    {
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static short HalfToInt16Bits(int a0, int a1, int a2, int a3, int a4, int a5, Half h)
+    {
+        return *(short*)&h;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_58373/Runtime_58373.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_58373/Runtime_58373.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
We might need to normalize-on-load a single-reg struct that is being
returned, so make sure we do not lose that information.

Fix #58373

PTAL @sandreenko cc @dotnet/jit-contrib 