### PR TITLE
Add System.Net.Http ServerCertificateCustomValidationCallback ILLink Suppression

### DIFF
--- a/src/libraries/System.Net.Http/src/ILLink/ILLink.Suppressions.LibraryBuild.xml
+++ b/src/libraries/System.Net.Http/src/ILLink/ILLink.Suppressions.LibraryBuild.xml
@@ -145,6 +145,18 @@
       <argument>ILLink</argument>
       <argument>IL2035</argument>
       <property name="Scope">member</property>
+      <property name="Target">M:System.Net.Http.HttpClientHandler.GetServerCertificateCustomValidationCallback</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2035</argument>
+      <property name="Scope">member</property>
+      <property name="Target">M:System.Net.Http.HttpClientHandler.SetServerCertificateCustomValidationCallback(System.Func{System.Net.Http.HttpRequestMessage,System.Security.Cryptography.X509Certificates.X509Certificate2,System.Security.Cryptography.X509Certificates.X509Chain,System.Net.Security.SslPolicyErrors,System.Boolean})</property>
+    </attribute>
+    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
+      <argument>ILLink</argument>
+      <argument>IL2035</argument>
+      <property name="Scope">member</property>
       <property name="Target">M:System.Net.Http.HttpClientHandler.GetCheckCertificateRevocationList()</property>
       <property name="Justification">The Xamarin.iOS and Mono.Android libraries are not present when running the trimmer analysis during our build. A consuming application will get a warning if these libraries aren't present when trimming the full app.</property>
     </attribute>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.InvokeNativeHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.InvokeNativeHandler.cs
@@ -62,6 +62,12 @@ namespace System.Net.Http
         [DynamicDependency("get_ClientCertificates", NativeHandlerType, AssemblyName)]
         private X509CertificateCollection GetClientCertificates() => (X509CertificateCollection)InvokeNativeHandlerMethod("get_ClientCertificates");
 
+        [DynamicDependency("get_ServerCertificateCustomValidationCallback", NativeHandlerType, AssemblyName)]
+        private Func<HttpRequestMessage, X509Certificate2?, X509Chain?, SslPolicyErrors, bool> GetServerCertificateCustomValidationCallback() => (Func<HttpRequestMessage, X509Certificate2?, X509Chain?, SslPolicyErrors, bool>)InvokeNativeHandlerMethod("get_ServerCertificateCustomValidationCallback");
+
+        [DynamicDependency("set_ServerCertificateCustomValidationCallback", NativeHandlerType, AssemblyName)]
+        private void SetServerCertificateCustomValidationCallback(Func<HttpRequestMessage, X509Certificate2?, X509Chain?, SslPolicyErrors, bool>? value) => InvokeNativeHandlerMethod("set_ServerCertificateCustomValidationCallback", value);
+
         [DynamicDependency("get_CheckCertificateRevocationList", NativeHandlerType, AssemblyName)]
         private bool GetCheckCertificateRevocationList() => (bool)InvokeNativeHandlerMethod("get_CheckCertificateRevocationList");
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs
@@ -426,7 +426,7 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    throw new PlatformNotSupportedException();
+                    return GetServerCertificateCustomValidationCallback();
                 }
                 else
                 {
@@ -437,7 +437,7 @@ namespace System.Net.Http
             {
                 if (IsNativeHandlerEnabled)
                 {
-                    throw new PlatformNotSupportedException();
+                    SetServerCertificateCustomValidationCallback(value);
                 }
                 else
                 {


### PR DESCRIPTION
Fixes #57537

During PR #57555, it was unclear what the correct suppression syntax would be for a return type of `Func<HttpRequestMessage, X509Certificate2?, X509Chain?, SslPolicyErrors, bool>`. With some helpful switches to generate the right warning suppression syntax via `--generate-warning-suppressions xml` in `RuntimePackILLinkArgs`, this PR adds the correct warning suppression.