### PR TITLE
[debugger] Avoid calling debugger_agent_single_step_from_context when thread is not attached yet

### DIFF
--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -6080,8 +6080,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 
 	if (method->wrapper_type == MONO_WRAPPER_OTHER)	{
 		WrapperInfo *info = mono_marshal_get_wrapper_info (method);
-		if (info->subtype == WRAPPER_SUBTYPE_INTERP_IN)
-		{
+		if (info->subtype == WRAPPER_SUBTYPE_INTERP_IN) {
 			/* We could hit a seq point before attaching to the JIT (#8338) */
 			seq_points = FALSE;
 		}

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -6078,6 +6078,15 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 		seq_points = FALSE;
 	}
 
+	if (method->wrapper_type == MONO_WRAPPER_OTHER)	{
+		WrapperInfo *info = mono_marshal_get_wrapper_info (method);
+		if (info->subtype == WRAPPER_SUBTYPE_INTERP_IN)
+		{
+			/* We could hit a seq point before attaching to the JIT (#8338) */
+			seq_points = FALSE;
+		}
+	}
+
 	if (cfg->prof_coverage) {
 		if (cfg->compile_aot)
 			g_error ("Coverage profiling is not supported with AOT.");


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1383962

This happens because a WebView embedded in an Android app can call back into the runtime on a native thread that the runtime has not seen before. The callback goes through a wrapper method. The wrapper method is responsible for registering the thread with the runtime. We were incorrectly inserting debugger sequence points in the wrapper method. As a result, if the debugger begins a suspend (which turns on single stepping - which relies on sequence points), the unregistered thread would call back to the debugger which would crash because we have no info about the thread.