### PR TITLE
Reflection nullability API: improve test coverage, fix bug found

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/NullabilityInfoContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/NullabilityInfoContext.cs
@@ -482,7 +482,7 @@ namespace System.Reflection
             {
                 NullabilityState state = nullability.ReadState;
 
-                if (!ParseNullableState(metaType.GetCustomAttributesData(), 0, ref state))
+                if (state == NullabilityState.NotNull && !ParseNullableState(metaType.GetCustomAttributesData(), 0, ref state))
                 {
                     state = GetNullableContext(metaType);
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/NullabilityInfoContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/NullabilityInfoContext.cs
@@ -13,7 +13,6 @@ namespace System.Reflection
     public sealed class NullabilityInfoContext
     {
         private const string CompilerServicesNameSpace = "System.Runtime.CompilerServices";
-        private const string ValueTuple = nameof(System.ValueTuple);
         private readonly Dictionary<Module, NotAnnotatedStatus> _publicOnlyModules = new();
         private readonly Dictionary<MemberInfo, NullabilityState> _context = new();
 
@@ -388,7 +387,7 @@ namespace System.Reflection
                 {
                     Type t = Nullable.GetUnderlyingType(genericArguments[i]) ?? genericArguments[i];
 
-                    if (!t.IsValueType || t.Name.StartsWith(ValueTuple))
+                    if (!t.IsValueType || t.IsGenericType)
                     {
                         offset++;
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/NullabilityInfoContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/NullabilityInfoContext.cs
@@ -388,7 +388,7 @@ namespace System.Reflection
                 {
                     Type t = Nullable.GetUnderlyingType(genericArguments[i]) ?? genericArguments[i];
 
-                    if (!t.IsValueType || t.Name.Contains(ValueTuple))
+                    if (!t.IsValueType || t.Name.StartsWith(ValueTuple))
                     {
                         offset++;
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/NullabilityInfoContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/NullabilityInfoContext.cs
@@ -13,6 +13,7 @@ namespace System.Reflection
     public sealed class NullabilityInfoContext
     {
         private const string CompilerServicesNameSpace = "System.Runtime.CompilerServices";
+        private const string ValueTuple = nameof(System.ValueTuple);
         private readonly Dictionary<Module, NotAnnotatedStatus> _publicOnlyModules = new();
         private readonly Dictionary<MemberInfo, NullabilityState> _context = new();
 
@@ -385,12 +386,14 @@ namespace System.Reflection
 
                 for (int i = 0, offset = 0; i < genericArguments.Length; i++)
                 {
-                    if (!genericArguments[i].IsValueType)
+                    Type t = Nullable.GetUnderlyingType(genericArguments[i]) ?? genericArguments[i];
+
+                    if (!t.IsValueType || t.Name.Contains(ValueTuple))
                     {
                         offset++;
                     }
 
-                    genericArgumentsState[i] = GetNullabilityInfo(memberInfo, genericArguments[i], customAttributes, offset);
+                    genericArgumentsState[i] = GetNullabilityInfo(memberInfo, genericArguments[i], customAttributes, index + offset);
                 }
             }
 

--- a/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
@@ -33,7 +33,7 @@ namespace System.Reflection.Tests
             yield return new object[] { "FieldAllowNull2", NullabilityState.NotNull, NullabilityState.Nullable, typeof(string) };
             yield return new object[] { "FieldNotNull", NullabilityState.NotNull, NullabilityState.Nullable, typeof(string) };
             yield return new object[] { "FieldMaybeNull", NullabilityState.Nullable, NullabilityState.NotNull, typeof(string) };
-            yield return new object[] { "FieldMaybeNull", NullabilityState.Nullable, NullabilityState.NotNull, typeof(string) };
+            yield return new object[] { "FieldMaybeNull2", NullabilityState.Nullable, NullabilityState.NotNull, typeof(string) };
             yield return new object[] { "FieldNotNull2", NullabilityState.NotNull, NullabilityState.Nullable, typeof(string) };
         }
 
@@ -433,7 +433,7 @@ namespace System.Reflection.Tests
             Assert.Equal(type, nullability.Type);
         }
 
-        public static IEnumerable<object[]> GenericNotnullConstraintTestData()
+        public static IEnumerable<object[]> GenericNotnullConstraintFieldsTestData()
         {
             yield return new object[] { "FieldNullable", NullabilityState.NotNull, NullabilityState.NotNull, typeof(string) };
             yield return new object[] { "FieldUnknown", NullabilityState.Unknown, NullabilityState.Unknown, typeof(string) };
@@ -441,8 +441,8 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
-        [MemberData(nameof(GenericNotnullConstraintTestData))]
-        public void GenericNotNullConstraintTest(string fieldName, NullabilityState readState, NullabilityState writeState, Type type)
+        [MemberData(nameof(GenericNotnullConstraintFieldsTestData))]
+        public void GenericNotNullConstraintFieldsTest(string fieldName, NullabilityState readState, NullabilityState writeState, Type type)
         {
             FieldInfo field = typeof(GenericTestConstrainedNotNull<string>).GetField(fieldName, flags)!;
             NullabilityInfo nullability = nullabilityContext.Create(field);
@@ -451,7 +451,25 @@ namespace System.Reflection.Tests
             Assert.Equal(type, nullability.Type);
         }
 
-        public static IEnumerable<object[]> GenericStructConstraintTestData()
+        public static IEnumerable<object[]> GenericNotnullConstraintPropertiesTestData()
+        {
+            yield return new object[] { "PropertyNullable", NullabilityState.NotNull, NullabilityState.NotNull, typeof(string) };
+            yield return new object[] { "PropertyUnknown", NullabilityState.Unknown, NullabilityState.Unknown, typeof(string) };
+            yield return new object[] { "PropertyNullableEnabled", NullabilityState.NotNull, NullabilityState.NotNull, typeof(string) };
+        }
+
+        [Theory]
+        [MemberData(nameof(GenericNotnullConstraintPropertiesTestData))]
+        public void GenericNotNullConstraintPropertiesTest(string propertyName, NullabilityState readState, NullabilityState writeState, Type type)
+        {
+            PropertyInfo field = typeof(GenericTestConstrainedNotNull<string>).GetProperty(propertyName, flags)!;
+            NullabilityInfo nullability = nullabilityContext.Create(field);
+            Assert.Equal(readState, nullability.ReadState);
+            Assert.Equal(writeState, nullability.WriteState);
+            Assert.Equal(type, nullability.Type);
+        }
+
+        public static IEnumerable<object[]> GenericStructConstraintFieldsTestData()
         {
             yield return new object[] { "FieldNullable", NullabilityState.Nullable, NullabilityState.Nullable, typeof(int?) };
             yield return new object[] { "FieldUnknown", NullabilityState.NotNull, NullabilityState.NotNull, typeof(int) };
@@ -459,10 +477,28 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
-        [MemberData(nameof(GenericStructConstraintTestData))]
-        public void GenericStructConstraintTest(string fieldName, NullabilityState readState, NullabilityState writeState, Type type)
+        [MemberData(nameof(GenericStructConstraintFieldsTestData))]
+        public void GenericStructConstraintFieldsTest(string fieldName, NullabilityState readState, NullabilityState writeState, Type type)
         {
             FieldInfo field = typeof(GenericTestConstrainedStruct<int>).GetField(fieldName, flags)!;
+            NullabilityInfo nullability = nullabilityContext.Create(field);
+            Assert.Equal(readState, nullability.ReadState);
+            Assert.Equal(writeState, nullability.WriteState);
+            Assert.Equal(type, nullability.Type);
+        }
+
+        public static IEnumerable<object[]> GenericStructConstraintPropertiesTestData()
+        {
+            yield return new object[] { "PropertyNullable", NullabilityState.Nullable, NullabilityState.Nullable, typeof(int?) };
+            yield return new object[] { "PropertyUnknown", NullabilityState.NotNull, NullabilityState.NotNull, typeof(int) };
+            yield return new object[] { "PropertyNullableEnabled", NullabilityState.NotNull, NullabilityState.NotNull, typeof(int) };
+        }
+
+        [Theory]
+        [MemberData(nameof(GenericStructConstraintPropertiesTestData))]
+        public void GenericStructConstraintPropertiesTest(string propertyName, NullabilityState readState, NullabilityState writeState, Type type)
+        {
+            PropertyInfo field = typeof(GenericTestConstrainedStruct<int>).GetProperty(propertyName, flags)!;
             NullabilityInfo nullability = nullabilityContext.Create(field);
             Assert.Equal(readState, nullability.ReadState);
             Assert.Equal(writeState, nullability.WriteState);
@@ -555,6 +591,31 @@ namespace System.Reflection.Tests
             Assert.NotNull(nullability.ElementType);
             Assert.Equal(elementState, nullability.ElementType!.ReadState);
             Assert.Empty(nullability.GenericTypeArguments);
+        }
+
+        public static IEnumerable<object[]> MethodReturnsTupleTestData()
+        {
+            // public Tuple<string?, string>? MethodReturnsTupleNullNonNull() => null;
+            yield return new object[] { "MethodReturnsTupleNullNonNull", NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable };
+            // public Tuple<string?, int> MethodReturnsTupleNullNonNot() => null!
+            yield return new object[] { "MethodReturnsTupleNullNonNot", NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.NotNull };
+            // public (int?, string)? MethodReturnsValueTupleNullNonNull() => null;
+            yield return new object[] { "MethodReturnsValueTupleNullNonNull", NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable };
+            // public (string?, string) MethodReturnsValueTupleNullNonNon() => (null, string.Empty);
+            yield return new object[] { "MethodReturnsValueTupleNullNonNon", NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.NotNull };
+        }
+
+        [Theory]
+        [SkipOnMono("Disabling NullablePublicOnly feature not work for Mono tests")]
+        [MemberData(nameof(MethodReturnsTupleTestData))]
+        public void MethodReturnsTupleTest(string methodName, NullabilityState param1, NullabilityState param2, NullabilityState readState)
+        {
+            MethodInfo method = testType.GetMethod(methodName, flags)!;
+            NullabilityInfo nullability = nullabilityContext.Create(method.ReturnParameter);
+            Assert.Equal(readState, nullability.ReadState);
+            Assert.Null(nullability.ElementType);
+            Assert.Equal(param1, nullability.GenericTypeArguments[0].ReadState);
+            Assert.Equal(param2, nullability.GenericTypeArguments[1].ReadState);
         }
 
         public static IEnumerable<object[]> MethodGenericReturnParameterTestData()
@@ -705,6 +766,8 @@ namespace System.Reflection.Tests
         public static IEnumerable<object[]> DifferentContextTestData()
         {
             yield return new object[] { "PropertyDisabled", NullabilityState.Unknown, NullabilityState.Unknown, typeof(string) };
+            yield return new object[] { "PropertyDisabledAllowNull", NullabilityState.Unknown, NullabilityState.Unknown, typeof(string) };
+            yield return new object[] { "PropertyDisabledMaybeNull", NullabilityState.Unknown, NullabilityState.Unknown, typeof(string) };
             yield return new object[] { "PropertyEnabledAllowNull", NullabilityState.NotNull, NullabilityState.Nullable, typeof(string) };
             yield return new object[] { "PropertyEnabledNotNull", NullabilityState.NotNull, NullabilityState.Nullable, typeof(string) };
             yield return new object[] { "PropertyEnabledMaybeNull", NullabilityState.Nullable, NullabilityState.NotNull, typeof(string) };
@@ -766,15 +829,15 @@ namespace System.Reflection.Tests
             Assert.Equal(NullabilityState.Nullable, notNullIfNotNull.WriteState);
             Assert.Equal(NullabilityState.Nullable, nullabilityContext.Create(allowNullParameter[1]).ReadState);
 
-            // [return: NotNullIfNotNull("nullable")] public string? NullablNotNullIfNotNullReturn(string? nullable, [NotNull] ref string? readNotNull)
-            ParameterInfo[] nullablNotNullIfNotNullReturn = type.GetMethod("NullablNotNullIfNotNullReturn", flags)!.GetParameters();
-            NullabilityInfo returnNotNullIfNotNull = nullabilityContext.Create(type.GetMethod("NullablNotNullIfNotNullReturn", flags)!.ReturnParameter);
-            NullabilityInfo readNotNull = nullabilityContext.Create(nullablNotNullIfNotNullReturn[1]);
+            // [return: NotNullIfNotNull("nullable")] public string? NullableNotNullIfNotNullReturn(string? nullable, [NotNull] ref string? readNotNull)
+            ParameterInfo[] nullableNotNullIfNotNullReturn = type.GetMethod("NullableNotNullIfNotNullReturn", flags)!.GetParameters();
+            NullabilityInfo returnNotNullIfNotNull = nullabilityContext.Create(type.GetMethod("NullableNotNullIfNotNullReturn", flags)!.ReturnParameter);
+            NullabilityInfo readNotNull = nullabilityContext.Create(nullableNotNullIfNotNullReturn[1]);
             Assert.Equal(NullabilityState.Nullable, returnNotNullIfNotNull.ReadState);
             Assert.Equal(NullabilityState.Nullable, returnNotNullIfNotNull.WriteState);
             Assert.Equal(NullabilityState.NotNull, readNotNull.ReadState);
             Assert.Equal(NullabilityState.Nullable, readNotNull.WriteState);
-            Assert.Equal(NullabilityState.Nullable, nullabilityContext.Create(nullablNotNullIfNotNullReturn[0]).ReadState);
+            Assert.Equal(NullabilityState.Nullable, nullabilityContext.Create(nullableNotNullIfNotNullReturn[0]).ReadState);
 
             // public bool TryGetOutParameters(string id, [NotNullWhen(true)] out string? value, [MaybeNullWhen(false)] out string value2)
             ParameterInfo[] tryGetOutParameters = type.GetMethod("TryGetOutParameters", flags)!.GetParameters();
@@ -785,6 +848,36 @@ namespace System.Reflection.Tests
             Assert.Equal(NullabilityState.Nullable, maybeNullWhenParam.ReadState);
             Assert.Equal(NullabilityState.NotNull, maybeNullWhenParam.WriteState);
             Assert.Equal(NullabilityState.NotNull, nullabilityContext.Create(tryGetOutParameters[0]).ReadState);
+        }
+
+        public static IEnumerable<object[]> NestedGenericsReturnParameterData()
+        {
+            // public IEnumerable<Tuple<(string name, object? value), int>?> MethodReturnsEnumerableNonTupleNonNonNullValueTupleNonNullNon() => null!;
+            yield return new object[] { "MethodReturnsEnumerableNonTupleNonNonNullValueTupleNonNullNon",
+                NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable };
+            // public IEnumerable<Tuple<(string? name, object value)?, int>?>? MethodReturnsEnumerableNullTupleNullNonNullValueTupleNullNonNull() => null!;
+            yield return new object[] { "MethodReturnsEnumerableNullTupleNullNonNullValueTupleNullNonNull",
+                NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.NotNull };
+            // public IEnumerable<Tuple<Tuple<string, object?>, int>?> MethodReturnsEnumerableNonTupleNonNonNullTupleNonNullNon() => null!;
+            yield return new object[] { "MethodReturnsEnumerableNonTupleNonNonNullTupleNonNullNon",
+                NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable };
+        }
+
+        [Theory]
+        [MemberData(nameof(NestedGenericsReturnParameterData))]
+        public void NestedGenericsReturnParameterTest(string methodName, NullabilityState enumState, NullabilityState innerTupleState,
+            NullabilityState intState, NullabilityState outerTupleState, NullabilityState stringState, NullabilityState objectState)
+        {
+            NullabilityInfo enumerabeNullability = nullabilityContext.Create(typeof(TypeWithNotNullContext).GetMethod(methodName, flags)!.ReturnParameter);
+            Assert.Equal(enumState, enumerabeNullability.ReadState);
+            NullabilityInfo tupleNullability = enumerabeNullability.GenericTypeArguments[0];
+            Assert.Equal(outerTupleState, tupleNullability.ReadState);
+            Assert.Equal(innerTupleState, tupleNullability.GenericTypeArguments[0].ReadState);
+            Assert.Equal(intState, tupleNullability.GenericTypeArguments[1].ReadState);
+            NullabilityInfo valueTupleNullability = tupleNullability.GenericTypeArguments[0];
+            Assert.Equal(innerTupleState, valueTupleNullability.ReadState);
+            Assert.Equal(stringState, valueTupleNullability.GenericTypeArguments[0].ReadState);
+            Assert.Equal(objectState, valueTupleNullability.GenericTypeArguments[1].ReadState);
         }
 
         public static IEnumerable<object[]> RefReturnData()
@@ -846,6 +939,8 @@ namespace System.Reflection.Tests
     public class TypeWithNullableContext
     {
 #nullable disable
+        [AllowNull] public string PropertyDisabledAllowNull { get; set; }
+        [MaybeNull] public string PropertyDisabledMaybeNull { get; set; }
         public string PropertyDisabled { get; set; }
         public ref string RefReturnUnknown(ref string id) { return ref id; }
 #nullable enable
@@ -858,12 +953,13 @@ namespace System.Reflection.Tests
         bool NotNullWhenParameter([DisallowNull] string? disallowNull, [NotNullWhen(true)] ref string? notNullWhen, Type? nullableType) { return false; }
         public bool MaybeNullParameters([MaybeNull] string maybeNull, [MaybeNullWhen(false)] out string maybeNullWhen, Type? nullableType) { maybeNullWhen = null; return false; }
         public string? AllowNullParameter([AllowNull] string allowNull, [NotNullIfNotNull("allowNull")] string? notNullIfNotNull) { return null; }
-        [return: NotNullIfNotNull("nullable")] public string? NullablNotNullIfNotNullReturn(string? nullable, [NotNull] ref string? readNotNull) { readNotNull = string.Empty; return null!; }
+        [return: NotNullIfNotNull("nullable")] public string? NullableNotNullIfNotNullReturn(string? nullable, [NotNull] ref string? readNotNull) { readNotNull = string.Empty; return null!; }
         public ref string? RefReturnNullable([AllowNull] ref string id) { return ref id!; }
         [return: MaybeNull] public ref string RefReturnMaybeNull([DisallowNull] ref string? id) { return ref id; }
         [return: NotNull] public ref string? RefReturnNotNull([NotNull] ref string? id) { id = string.Empty; return ref id!; }
         public ref string RefReturnNotNullable([MaybeNull] ref string id) { return ref id; }
         public bool TryGetOutParameters(string id, [NotNullWhen(true)] out string? value, [MaybeNullWhen(false)] out string value2) { value = null; value2 = null; return false; }
+        public IEnumerable<Tuple<(string name, object? value), object>?> MethodReturnsEnumerableNonTupleNonNonNullValueTupleNonNullNon() => null!;
     }
 
     public class TypeWithNoContext
@@ -880,8 +976,6 @@ namespace System.Reflection.Tests
         public string? PropertyEnabledNullable { get; set; }
         public string PropertyEnabledNonNullable { get; set; } = null!;
 #nullable disable
-        [return: NotNull, MaybeNull]
-        public string MethodNullableDisabled([AllowNull] string value, string ret) { return null; }
     }
 
     public class TypeWithNotNullContext
@@ -970,8 +1064,13 @@ namespace System.Reflection.Tests
         [return: NotNull, MaybeNull] public string[]? MethodReturnsNonNotNull() => null!; // only NotNull is applicable
         [return: MaybeNull] public string[] MethodReturnsNonMaybeNull() => null;
         public string[] MethodReturnsNonNon() => null!;
-        public Tuple<string?, string>? MethodTupleNullNonNull() => null;
-        public IEnumerable<Tuple<(string name, object? value), object>?> MethodEnumerableNonNonNullUnknownNullNonNullNon() => null!;
+        public Tuple<string?, string>? MethodReturnsTupleNullNonNull() => null;
+        public Tuple<string?, int> MethodReturnsTupleNullNonNot() => null!;
+        public (int?, string)? MethodReturnsValueTupleNullNonNull() => null;
+        public (string?, string) MethodReturnsValueTupleNullNonNon() => (null, string.Empty);
+        public IEnumerable<Tuple<(string name, object? value), int>?> MethodReturnsEnumerableNonTupleNonNonNullValueTupleNonNullNon() => null!;
+        public IEnumerable<Tuple<(string? name, object value)?, int>?>? MethodReturnsEnumerableNullTupleNullNonNullValueTupleNullNonNull() => null!;
+        public IEnumerable<Tuple<Tuple<string, object?>, int>?> MethodReturnsEnumerableNonTupleNonNonNullTupleNonNullNon() => null!;
         public void MethodNullNonNullNonNon(string? s, IDictionary<Type, string?[]> dict) { }
         public void MethodNonNullNonNullNotNull(string s, [NotNull] IDictionary<Type, string[]?>? dict) { dict = new Dictionary<Type, string[]?>(); }
         public void MethodNullNonNullNullNon(string? s, IDictionary<Type, string?[]?> dict) { }
@@ -1041,6 +1140,7 @@ namespace System.Reflection.Tests
         public T FieldNullableEnabled = default!;
         public T? FieldNullable;
         public T PropertyNullableEnabled { get; set; } = default!;
+        public T? PropertyNullable { get; set; } = default!;
     }
 
     internal class GenericTestConstrainedStruct<T> where T : struct
@@ -1053,5 +1153,6 @@ namespace System.Reflection.Tests
         public T FieldNullableEnabled;
         public T? FieldNullable;
         public T PropertyNullableEnabled { get; set; }
+        public T? PropertyNullable { get; set; }
     }
 }

--- a/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
@@ -861,6 +861,15 @@ namespace System.Reflection.Tests
             // public IEnumerable<Tuple<Tuple<string, object?>, int>?> MethodReturnsEnumerableNonTupleNonNonNullTupleNonNullNon() => null!;
             yield return new object[] { "MethodReturnsEnumerableNonTupleNonNonNullTupleNonNullNon",
                 NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable };
+            // public IEnumerable<GenericStruct<Tuple<string, object?>?, int>?>? MethodReturnsEnumerableNullStructNullNonNonTupleNonNullNull() => null;
+            yield return new object[] { "MethodReturnsEnumerableNullStructNullNonNullTupleNonNullNull",
+                NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable };
+            // public IEnumerable<Tuple<GenericStruct<string, object?>?, int>?>? MethodReturnsEnumerableNullTupleNullNonNullStructNonNullNull() => null;
+            yield return new object[] { "MethodReturnsEnumerableNullTupleNullNonNullStructNonNullNull",
+                NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable };
+            // public IEnumerable<(GenericStruct<string, object?> str, int? count)> MethodReturnsEnumerableNonValueTupleNonNullNonTupleNonNullNon() => null!;
+            yield return new object[] { "MethodReturnsEnumerableNonValueTupleNonNullNonStructNonNullNon",
+                NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.Nullable };
         }
 
         [Theory]
@@ -1072,11 +1081,16 @@ namespace System.Reflection.Tests
         public IEnumerable<Tuple<(string name, object? value), int>?> MethodReturnsEnumerableNonTupleNonNonNullValueTupleNonNullNon() => null!;
         public IEnumerable<Tuple<(string? name, object value)?, int>?>? MethodReturnsEnumerableNullTupleNullNonNullValueTupleNullNonNull() => null!;
         public IEnumerable<Tuple<Tuple<string, object?>, int>?> MethodReturnsEnumerableNonTupleNonNonNullTupleNonNullNon() => null!;
+        public IEnumerable<GenericStruct<Tuple<string, object?>?, int>?>? MethodReturnsEnumerableNullStructNullNonNullTupleNonNullNull() => null;
+        public IEnumerable<Tuple<GenericStruct<string, object?>?, int>?>? MethodReturnsEnumerableNullTupleNullNonNullStructNonNullNull() => null;
+        public IEnumerable<(GenericStruct<string, object?> str, int? count)> MethodReturnsEnumerableNonValueTupleNonNullNonStructNonNullNon() => null!;
         public void MethodNullNonNullNonNon(string? s, IDictionary<Type, string?[]> dict) { }
         public void MethodNonNullNonNullNotNull(string s, [NotNull] IDictionary<Type, string[]?>? dict) { dict = new Dictionary<Type, string[]?>(); }
         public void MethodNullNonNullNullNon(string? s, IDictionary<Type, string?[]?> dict) { }
         public void MethodAllowNullNonNonNonNull([AllowNull] string s, IDictionary<Type, string[]>? dict) { }
     }
+
+    public struct GenericStruct<T, Y> { }
 
     internal class GenericTest<T>
     {

--- a/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
@@ -865,6 +865,7 @@ namespace System.Reflection.Tests
 
         [Theory]
         [MemberData(nameof(NestedGenericsReturnParameterData))]
+        [SkipOnMono("Nullability attributes trimmed on Mono")]
         public void NestedGenericsReturnParameterTest(string methodName, NullabilityState enumState, NullabilityState innerTupleState,
             NullabilityState intState, NullabilityState outerTupleState, NullabilityState stringState, NullabilityState objectState)
         {

--- a/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Reflection/NullabilityInfoContextTests.cs
@@ -121,7 +121,7 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
-        [SkipOnMono("Disabling NullablePublicOnly feature not work for Mono tests")]
+        [SkipOnMono("Nullability attributes trimmed on Mono")]
         [MemberData(nameof(ArrayPropertyTestData))]
         public void ArrayPropertyTest(string propertyName, NullabilityState elementState, NullabilityState propertyState)
         {
@@ -143,7 +143,7 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
-        [SkipOnMono("Disabling NullablePublicOnly feature not work for Mono tests")]
+        [SkipOnMono("Nullability attributes trimmed on Mono")]
         [MemberData(nameof(GenericArrayPropertyTestData))]
         public void GenericArrayPropertyTest(string propertyName, NullabilityState elementState, NullabilityState propertyState)
         {
@@ -167,7 +167,7 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
-        [SkipOnMono("Disabling NullablePublicOnly feature not work for Mono tests")]
+        [SkipOnMono("Nullability attributes trimmed on Mono")]
         [MemberData(nameof(JaggedArrayPropertyTestData))]
         public void JaggedArrayPropertyTest(string propertyName, NullabilityState innermodtElementState, NullabilityState elementState, NullabilityState propertyState)
         {
@@ -192,7 +192,7 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
-        [SkipOnMono("Disabling NullablePublicOnly feature not work for Mono tests")]
+        [SkipOnMono("Nullability attributes trimmed on Mono")]
         [MemberData(nameof(TuplePropertyTestData))]
         public void TuplePropertyTest(string propertyName, NullabilityState genericParam1, NullabilityState genericParam2, NullabilityState genericParam3, NullabilityState propertyState)
         {
@@ -217,7 +217,7 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
-        [SkipOnMono("Disabling NullablePublicOnly feature not work for Mono tests")]
+        [SkipOnMono("Nullability attributes trimmed on Mono")]
         [MemberData(nameof(GenericTuplePropertyTestData))]
         public void GenericTuplePropertyTest(string propertyName, NullabilityState genericParam1, NullabilityState genericParam2, NullabilityState genericParam3, NullabilityState propertyState)
         {
@@ -243,7 +243,7 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
-        [SkipOnMono("Disabling NullablePublicOnly feature not work for Mono tests")]
+        [SkipOnMono("Nullability attributes trimmed on Mono")]
         [MemberData(nameof(DictionaryPropertyTestData))]
         public void DictionaryPropertyTest(string propertyName, NullabilityState keyState, NullabilityState valueElement, NullabilityState valueState, NullabilityState propertyState)
         {
@@ -269,7 +269,7 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
-        [SkipOnMono("Disabling NullablePublicOnly feature not work for Mono tests")]
+        [SkipOnMono("Nullability attributes trimmed on Mono")]
         [MemberData(nameof(GenericDictionaryPropertyTestData))]
         public void GenericDictionaryPropertyTest(string propertyName, NullabilityState keyState, NullabilityState valueElement, NullabilityState valueState, NullabilityState propertyState)
         {
@@ -435,7 +435,7 @@ namespace System.Reflection.Tests
 
         public static IEnumerable<object[]> GenericNotnullConstraintFieldsTestData()
         {
-            yield return new object[] { "FieldNullable", NullabilityState.NotNull, NullabilityState.NotNull, typeof(string) };
+            yield return new object[] { "FieldNullable", NullabilityState.Nullable, NullabilityState.Nullable, typeof(string) };
             yield return new object[] { "FieldUnknown", NullabilityState.Unknown, NullabilityState.Unknown, typeof(string) };
             yield return new object[] { "FieldNullableEnabled", NullabilityState.NotNull, NullabilityState.NotNull, typeof(string) };
         }
@@ -453,7 +453,7 @@ namespace System.Reflection.Tests
 
         public static IEnumerable<object[]> GenericNotnullConstraintPropertiesTestData()
         {
-            yield return new object[] { "PropertyNullable", NullabilityState.NotNull, NullabilityState.NotNull, typeof(string) };
+            yield return new object[] { "PropertyNullable", NullabilityState.Nullable, NullabilityState.Nullable, typeof(string) };
             yield return new object[] { "PropertyUnknown", NullabilityState.Unknown, NullabilityState.Unknown, typeof(string) };
             yield return new object[] { "PropertyNullableEnabled", NullabilityState.NotNull, NullabilityState.NotNull, typeof(string) };
         }
@@ -462,8 +462,8 @@ namespace System.Reflection.Tests
         [MemberData(nameof(GenericNotnullConstraintPropertiesTestData))]
         public void GenericNotNullConstraintPropertiesTest(string propertyName, NullabilityState readState, NullabilityState writeState, Type type)
         {
-            PropertyInfo field = typeof(GenericTestConstrainedNotNull<string>).GetProperty(propertyName, flags)!;
-            NullabilityInfo nullability = nullabilityContext.Create(field);
+            PropertyInfo property = typeof(GenericTestConstrainedNotNull<string>).GetProperty(propertyName, flags)!;
+            NullabilityInfo nullability = nullabilityContext.Create(property);
             Assert.Equal(readState, nullability.ReadState);
             Assert.Equal(writeState, nullability.WriteState);
             Assert.Equal(type, nullability.Type);
@@ -498,8 +498,8 @@ namespace System.Reflection.Tests
         [MemberData(nameof(GenericStructConstraintPropertiesTestData))]
         public void GenericStructConstraintPropertiesTest(string propertyName, NullabilityState readState, NullabilityState writeState, Type type)
         {
-            PropertyInfo field = typeof(GenericTestConstrainedStruct<int>).GetProperty(propertyName, flags)!;
-            NullabilityInfo nullability = nullabilityContext.Create(field);
+            PropertyInfo property = typeof(GenericTestConstrainedStruct<int>).GetProperty(propertyName, flags)!;
+            NullabilityInfo nullability = nullabilityContext.Create(property);
             Assert.Equal(readState, nullability.ReadState);
             Assert.Equal(writeState, nullability.WriteState);
             Assert.Equal(type, nullability.Type);
@@ -580,7 +580,7 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
-        [SkipOnMono("Disabling NullablePublicOnly feature not work for Mono tests")]
+        [SkipOnMono("Nullability attributes trimmed on Mono")]
         [MemberData(nameof(MethodReturnParameterTestData))]
         public void MethodReturnParameterTest(string methodName, NullabilityState elementState, NullabilityState readState)
         {
@@ -606,7 +606,7 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
-        [SkipOnMono("Disabling NullablePublicOnly feature not work for Mono tests")]
+        [SkipOnMono("Nullability attributes trimmed on Mono")]
         [MemberData(nameof(MethodReturnsTupleTestData))]
         public void MethodReturnsTupleTest(string methodName, NullabilityState param1, NullabilityState param2, NullabilityState readState)
         {
@@ -630,7 +630,7 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
-        [SkipOnMono("Disabling NullablePublicOnly feature not work for Mono tests")]
+        [SkipOnMono("Nullability attributes trimmed on Mono")]
         [MemberData(nameof(MethodGenericReturnParameterTestData))]
         public void MethodGenericReturnParameterTest(string methodName, NullabilityState readState, NullabilityState elementState)
         {
@@ -653,7 +653,7 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
-        [SkipOnMono("Disabling NullablePublicOnly feature not work for Mono tests")]
+        [SkipOnMono("Nullability attributes trimmed on Mono")]
         [MemberData(nameof(MethodParametersTestData))]
         public void MethodParametersTest(string methodName, NullabilityState stringState, NullabilityState dictKey, NullabilityState dictValueElement, NullabilityState dictValue, NullabilityState dictionaryState)
         {
@@ -677,7 +677,7 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
-        [SkipOnMono("Disabling NullablePublicOnly feature not work for Mono tests")]
+        [SkipOnMono("Nullability attributes trimmed on Mono")]
         [MemberData(nameof(MethodGenericParametersTestData))]
         public void MethodGenericParametersTest(string methodName, NullabilityState param1State, NullabilityState dictKey, NullabilityState dictValue, NullabilityState dictionaryState)
         {
@@ -855,18 +855,23 @@ namespace System.Reflection.Tests
             // public IEnumerable<Tuple<(string name, object? value), int>?> MethodReturnsEnumerableNonTupleNonNonNullValueTupleNonNullNon() => null!;
             yield return new object[] { "MethodReturnsEnumerableNonTupleNonNonNullValueTupleNonNullNon",
                 NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable };
+
             // public IEnumerable<Tuple<(string? name, object value)?, int>?>? MethodReturnsEnumerableNullTupleNullNonNullValueTupleNullNonNull() => null!;
             yield return new object[] { "MethodReturnsEnumerableNullTupleNullNonNullValueTupleNullNonNull",
                 NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.NotNull };
+
             // public IEnumerable<Tuple<Tuple<string, object?>, int>?> MethodReturnsEnumerableNonTupleNonNonNullTupleNonNullNon() => null!;
             yield return new object[] { "MethodReturnsEnumerableNonTupleNonNonNullTupleNonNullNon",
                 NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable };
+
             // public IEnumerable<GenericStruct<Tuple<string, object?>?, int>?>? MethodReturnsEnumerableNullStructNullNonNonTupleNonNullNull() => null;
             yield return new object[] { "MethodReturnsEnumerableNullStructNullNonNullTupleNonNullNull",
                 NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable };
+
             // public IEnumerable<Tuple<GenericStruct<string, object?>?, int>?>? MethodReturnsEnumerableNullTupleNullNonNullStructNonNullNull() => null;
             yield return new object[] { "MethodReturnsEnumerableNullTupleNullNonNullStructNonNullNull",
                 NullabilityState.Nullable, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.Nullable };
+
             // public IEnumerable<(GenericStruct<string, object?> str, int? count)> MethodReturnsEnumerableNonValueTupleNonNullNonTupleNonNullNon() => null!;
             yield return new object[] { "MethodReturnsEnumerableNonValueTupleNonNullNonStructNonNullNon",
                 NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.Nullable, NullabilityState.NotNull, NullabilityState.NotNull, NullabilityState.Nullable };


### PR DESCRIPTION
Related to: https://github.com/dotnet/runtime/pull/58390#issuecomment-909455748 cc @danmoseley 

### Reflection nullability context API updates

- Improve test coverage by adding unused members into new/existing tests
- Removed one unused member
- fix a bug found in indexing generic type parameters