### PR TITLE
Change compile time dependency of ICU API ucol_setMaxVariable to be runtime instead.

### DIFF
--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim.c
@@ -388,15 +388,16 @@ static void InitializeVariableMaxAndTopPointers(char* symbolVersion)
         return;
     }
 
-    char symbolName[SYMBOL_NAME_SIZE];
-
 #if defined(TARGET_OSX) || defined(TARGET_ANDROID)
-    // Nothing to do here
-    // OSX and Android always run against ICU version which has ucol_setMaxVariable. We don't need more than that.
+    // OSX and Android always run against ICU version which has ucol_setMaxVariable.
+    // We shouldn't come here.
+    assert(false);
 #elif defined(TARGET_WINDOWS)
+    char symbolName[SYMBOL_NAME_SIZE];
     sprintf_s(symbolName, SYMBOL_NAME_SIZE, "ucol_setVariableTop%s", symbolVersion);
     ucol_setVariableTop_ptr = (ucol_setVariableTop_func)GetProcAddress((HMODULE)libicui18n, symbolName);
 #else
+    char symbolName[SYMBOL_NAME_SIZE];
     sprintf(symbolName, "ucol_setVariableTop%s", symbolVersion);
     ucol_setVariableTop_ptr = (ucol_setVariableTop_func)dlsym(libicui18n, symbolName);
 #endif // defined(TARGET_OSX) || defined(TARGET_ANDROID)

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal.h
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal.h
@@ -53,11 +53,17 @@
 #include "pal_compiler.h"
 
 #if !defined(STATIC_ICU)
+// ucol_setVariableTop is a deprecated function on the newer ICU versions and ucol_setMaxVariable should be used instead.
+// As can run against ICU versions which not supported ucol_setMaxVariable, we'll dynamically try to get the pointer to ucol_setVariableTop
+// when we couldn't get a pointer to ucol_setMaxVariable.
+typedef uint32_t (U_EXPORT2 *ucol_setVariableTop_func)(UCollator* coll, const UChar* varTop, int32_t len, UErrorCode* status);
+extern ucol_setVariableTop_func ucol_setVariableTop_ptr;
 
-#if !defined(TARGET_ANDROID)
 // (U_ICU_VERSION_MAJOR_NUM < 52)
 // The following APIs are not supported in the ICU versions less than 52. We need to define them manually.
 // We have to do runtime check before using the pointers to these APIs. That is why these are listed in the FOR_ALL_OPTIONAL_ICU_FUNCTIONS list.
+#if !defined(TARGET_ANDROID)
+U_CAPI void U_EXPORT2 ucol_setMaxVariable(UCollator* coll, UColReorderCode group, UErrorCode* pErrorCode);
 U_CAPI int32_t U_EXPORT2 ucal_getTimeZoneIDForWindowsID(const UChar* winid, int32_t len, const char* region, UChar* id, int32_t idCapacity, UErrorCode* status);
 U_CAPI int32_t U_EXPORT2 ucal_getWindowsTimeZoneID(const UChar* id, int32_t len, UChar* winid, int32_t winidCapacity, UErrorCode* status);
 #endif
@@ -164,15 +170,6 @@ U_CAPI int32_t U_EXPORT2 ucal_getWindowsTimeZoneID(const UChar* id, int32_t len,
     PER_FUNCTION_BLOCK(usearch_setPattern, libicui18n, true) \
     PER_FUNCTION_BLOCK(usearch_setText, libicui18n, true)
 
-#if HAVE_SET_MAX_VARIABLE
-#define FOR_ALL_SET_VARIABLE_ICU_FUNCTIONS \
-    PER_FUNCTION_BLOCK(ucol_setMaxVariable, libicui18n, true)
-#else
-
-#define FOR_ALL_SET_VARIABLE_ICU_FUNCTIONS \
-    PER_FUNCTION_BLOCK(ucol_setVariableTop, libicui18n, true)
-#endif
-
 #if defined(TARGET_WINDOWS)
 #define FOR_ALL_OS_CONDITIONAL_ICU_FUNCTIONS \
     PER_FUNCTION_BLOCK(ucurr_forLocale, libicuuc, true) \
@@ -195,11 +192,11 @@ U_CAPI int32_t U_EXPORT2 ucal_getWindowsTimeZoneID(const UChar* id, int32_t len,
 // Otherwise, we'll just not provide the functionality to users which needed these APIs.
 #define FOR_ALL_OPTIONAL_ICU_FUNCTIONS \
     PER_FUNCTION_BLOCK(ucal_getWindowsTimeZoneID, libicui18n, false) \
-    PER_FUNCTION_BLOCK(ucal_getTimeZoneIDForWindowsID, libicui18n, false)
+    PER_FUNCTION_BLOCK(ucal_getTimeZoneIDForWindowsID, libicui18n, false) \
+    PER_FUNCTION_BLOCK(ucol_setMaxVariable, libicui18n, false)
 
 #define FOR_ALL_ICU_FUNCTIONS \
     FOR_ALL_UNCONDITIONAL_ICU_FUNCTIONS \
-    FOR_ALL_SET_VARIABLE_ICU_FUNCTIONS \
     FOR_ALL_OPTIONAL_ICU_FUNCTIONS \
     FOR_ALL_OS_CONDITIONAL_ICU_FUNCTIONS
 
@@ -249,11 +246,7 @@ FOR_ALL_ICU_FUNCTIONS
 #define ucol_openRules(...) ucol_openRules_ptr(__VA_ARGS__)
 #define ucol_safeClone(...) ucol_safeClone_ptr(__VA_ARGS__)
 #define ucol_setAttribute(...) ucol_setAttribute_ptr(__VA_ARGS__)
-#if HAVE_SET_MAX_VARIABLE
 #define ucol_setMaxVariable(...) ucol_setMaxVariable_ptr(__VA_ARGS__)
-#else
-#define ucol_setVariableTop(...) ucol_setVariableTop_ptr(__VA_ARGS__)
-#endif
 #define ucol_strcoll(...) ucol_strcoll_ptr(__VA_ARGS__)
 #define ucurr_forLocale(...) ucurr_forLocale_ptr(__VA_ARGS__)
 #define ucurr_getName(...) ucurr_getName_ptr(__VA_ARGS__)

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal.h
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal.h
@@ -56,13 +56,13 @@
 // ucol_setVariableTop is a deprecated function on the newer ICU versions and ucol_setMaxVariable should be used instead.
 // As can run against ICU versions which not supported ucol_setMaxVariable, we'll dynamically try to get the pointer to ucol_setVariableTop
 // when we couldn't get a pointer to ucol_setMaxVariable.
-typedef uint32_t (U_EXPORT2 *ucol_setVariableTop_func)(UCollator* coll, const UChar* varTop, int32_t len, UErrorCode* status);
+typedef uint32_t (*ucol_setVariableTop_func)(UCollator* coll, const UChar* varTop, int32_t len, UErrorCode* status);
 extern ucol_setVariableTop_func ucol_setVariableTop_ptr;
 
+#if !defined(TARGET_ANDROID)
 // (U_ICU_VERSION_MAJOR_NUM < 52)
 // The following APIs are not supported in the ICU versions less than 52. We need to define them manually.
 // We have to do runtime check before using the pointers to these APIs. That is why these are listed in the FOR_ALL_OPTIONAL_ICU_FUNCTIONS list.
-#if !defined(TARGET_ANDROID)
 U_CAPI void U_EXPORT2 ucol_setMaxVariable(UCollator* coll, UColReorderCode group, UErrorCode* pErrorCode);
 U_CAPI int32_t U_EXPORT2 ucal_getTimeZoneIDForWindowsID(const UChar* winid, int32_t len, const char* region, UChar* id, int32_t idCapacity, UErrorCode* status);
 U_CAPI int32_t U_EXPORT2 ucal_getWindowsTimeZoneID(const UChar* id, int32_t len, UChar* winid, int32_t winidCapacity, UErrorCode* status);


### PR DESCRIPTION
During building the runtime, we have a compile-time check to decide to link against the ICU API ucol_setVariableTop or ucol_setMaxVariable according to the ICU version installed on the build machine. That causes problems as we may compile against a higher version of ICU, and we run against a lower version of ICU which causes an error like
```
dotnet --version

Cannot get symbol ucol_setMaxVariable_50 from libicui18n
Error: /lib64/libicui18n.so.50: undefined symbol: ucol_setMaxVariable_50
```

And cannot run dotnet or any .NET app on Linux. https://github.com/dotnet/runtime/issues/57983 is example of the reported issue for that problem.

This change is getting rid of the compile-time check and making it a runtime check instead. 

