### PR TITLE
[MonoVM] Fix calculation of code size for AOT assemblies mixing JIT and LLVM

### DIFF
--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -3534,7 +3534,17 @@ mono_aot_find_jit_info (MonoImage *image, gpointer addr)
 		else
 			code_len = amodule->llvm_code_end - code;
 	} else {
-		code_len = (guint8*)methods [pos + 1] - (guint8*)methods [pos];
+		guint8* code_end = (guint8*)methods [pos + 1];
+
+		if (code >= amodule->jit_code_start && code < amodule->jit_code_end && code_end > amodule->jit_code_end) {
+			code_end = amodule->jit_code_end;
+		}
+
+		if (code >= amodule->llvm_code_start && code < amodule->llvm_code_end && code_end > amodule->llvm_code_end) {
+			code_end = amodule->llvm_code_end;
+		}
+
+		code_len = code_end - code;
 	}
 #endif
 


### PR DESCRIPTION
Fixes #56100

Here's a little bit of background on the problem. When multiple AOT modules got linked into the same executable for iOS/MacCatalyst the LLVM and JIT code sections of different modules got interleaved. The resulting AOT module info looks something like this:

```
JIT start: 0x101002100 JIT end: 0x1010035e0
LLVM start: 0x104c027c8 LLVM end: 0x104c603e8
Sorted methods:
  0x101002250
  0x101002390
  0x101002470
  0x104c027c8
  0x104c027e0
  ...
```

The previous code incorrectly assumed that the third method had a code size `0x104c027c8 - 0x101002470`. When inserted into lookup table any of the AOT code inside the range `0x1010035e0 (JIT code end) - 0x104c027c8 (LLVM code start)` would incorrectly end up being mapped to the last JIT method.

(Note: The JIT name here is misleading.)