### PR TITLE
Conditionally build tests, using the conds on which we submit tests to Helix

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -284,7 +284,16 @@
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)*\tests\**\*.Tests.csproj"
                       Exclude="@(ProjectExclusions)"
-                      Condition="'$(TestAssemblies)' == 'true'" />
+                      Condition="'$(TestAssemblies)' == 'true' and
+                                    ('$(ContinuousIntegrationBuild)' != 'true' or
+                                    ('$(RuntimeFlavor)' == 'CoreCLR' and
+                                       '$(librariesContainsChange)' == 'true' and
+                                       '$(CoreCLRContainsChange)' == 'true' and
+                                       '$(isFullMatrix)' == 'true') or
+                                    ('$(RuntimeFlavor)' == 'Mono' and
+                                       '$(librariesContainsChange)' == 'true' and
+                                       '$(monoContainsChange)' == 'true' and
+                                       '$(isFullMatrix)' == 'true'))" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)testPackages\testPackages.proj"
                       Condition="'$(TestPackages)' == 'true'" />
     <TrimmingTestProjects Include="$(MSBuildThisFileDirectory)*\tests\**\*.TrimmingTests.proj"

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -288,9 +288,9 @@
                                     ('$(ContinuousIntegrationBuild)' != 'true' or
                                      '$(RuntimeFlavor)' != 'Mono' or
                                     ('$(RuntimeFlavor)' == 'Mono' and
-                                       '$(librariesContainsChange)' == 'true' and
-                                       '$(monoContainsChange)' == 'true' and
-                                       '$(isFullMatrix)' == 'true'))" />
+                                       ('$(librariesContainsChange)' == 'true' or
+                                       '$(monoContainsChange)' == 'true' or
+                                       '$(isFullMatrix)' == 'true')))" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)testPackages\testPackages.proj"
                       Condition="'$(TestPackages)' == 'true'" />
     <TrimmingTestProjects Include="$(MSBuildThisFileDirectory)*\tests\**\*.TrimmingTests.proj"

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -286,10 +286,7 @@
                       Exclude="@(ProjectExclusions)"
                       Condition="'$(TestAssemblies)' == 'true' and
                                     ('$(ContinuousIntegrationBuild)' != 'true' or
-                                    ('$(RuntimeFlavor)' == 'CoreCLR' and
-                                       '$(librariesContainsChange)' == 'true' and
-                                       '$(CoreCLRContainsChange)' == 'true' and
-                                       '$(isFullMatrix)' == 'true') or
+                                     '$(RuntimeFlavor)' != 'Mono' or
                                     ('$(RuntimeFlavor)' == 'Mono' and
                                        '$(librariesContainsChange)' == 'true' and
                                        '$(monoContainsChange)' == 'true' and


### PR DESCRIPTION
Still build functional etc tests, as a sanity check, but gate the libraries test builds behind a big ol' if statement

This PR submission _should_ do a test build.

Additionally, keep the functional tests around - their building (or not building) is as much what we're testing as whether they run fine or not on Helix.