### PR TITLE
Turn off release branch in perf-slow.yml for release/6.0

### DIFF
--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -1,3 +1,5 @@
+trigger: none
+
 variables:
   - template: /eng/pipelines/common/variables.yml
 

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -3,7 +3,6 @@ trigger:
   branches:
     include:
     - main
-    - release/6.0
   paths:
     include:
     - '*'

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -1,23 +1,3 @@
-trigger:
-  batch: true
-  branches:
-    include:
-    - main
-  paths:
-    include:
-    - '*'
-    - src/libraries/System.Private.CoreLib/*
-    exclude:
-    - .github/*
-    - docs/*
-    - CODE-OF-CONDUCT.md
-    - CONTRIBUTING.md
-    - LICENSE.TXT
-    - PATENTS.TXT
-    - README.md
-    - SECURITY.md
-    - THIRD-PARTY-NOTICES.TXT
-
 variables:
   - template: /eng/pipelines/common/variables.yml
 


### PR DESCRIPTION
Created to resolve https://github.com/dotnet/performance/issues/1964
Due to limited machine count, release branch runs need to be turned off for the perf-slow pipeline for release/6.0.