### PR TITLE
Delete shutdown special handling in a few CoreCLR PAL methods

### DIFF
--- a/src/coreclr/pal/src/loader/module.cpp
+++ b/src/coreclr/pal/src/loader/module.cpp
@@ -1144,13 +1144,6 @@ static BOOL LOADFreeLibrary(MODSTRUCT *module, BOOL fCallDllMain)
 
     LockModuleList();
 
-    if (terminator)
-    {
-        /* PAL shutdown is in progress - ignore FreeLibrary calls */
-        retval = TRUE;
-        goto done;
-    }
-
     if (!LOADValidateModule(module))
     {
         TRACE("Can't free invalid module %p\n", module);
@@ -1299,13 +1292,6 @@ DisableThreadLibraryCalls(
     ENTRY("DisableThreadLibraryCalls(hLibModule=%p)\n", hLibModule);
 
     LockModuleList();
-
-    if (terminator)
-    {
-        /* PAL shutdown in progress - ignore DisableThreadLibraryCalls */
-        ret = TRUE;
-        goto done;
-    }
 
     module = (MODSTRUCT *) hLibModule;
 

--- a/src/coreclr/pal/src/thread/thread.cpp
+++ b/src/coreclr/pal/src/thread/thread.cpp
@@ -551,41 +551,6 @@ CorUnix::InternalCreateThread(
     int iError = 0;
     size_t alignedStackSize;
 
-    if (0 != terminator)
-    {
-        //
-        // Since the PAL is in the middle of shutting down we don't want to
-        // create any new threads (since it's possible for that new thread
-        // to create another thread before the shutdown thread gets around
-        // to suspending it, and so on). We don't want to return an error
-        // here, though, as some programs (in particular, build) do not
-        // handle CreateThread errors properly -- instead, we just put
-        // the calling thread to sleep (unless it is the shutdown thread,
-        // which could occur if a DllMain PROCESS_DETACH handler tried to
-        // create a new thread for some odd reason).
-        //
-
-        ERROR("process is terminating, can't create new thread.\n");
-
-        if (pThread->GetThreadId() != static_cast<DWORD>(terminator))
-        {
-            while (true)
-            {
-                poll(NULL, 0, INFTIM);
-                sched_yield();
-            }
-        }
-        else
-        {
-            //
-            // This is the shutdown thread, so just return an error
-            //
-
-            palError = ERROR_PROCESS_ABORTED;
-            goto EXIT;
-        }
-    }
-
     /* Validate parameters */
 
     if (lpThreadAttributes != NULL)


### PR DESCRIPTION
We have stopped suspending threads during shutdown quite a while ago. We have missed cleanup in this place for some reason.

Fixes #58466