### PR TITLE
[mono] win32 implementation of g_get_current_dir

### DIFF
--- a/src/mono/mono/eglib/gfile-posix.c
+++ b/src/mono/mono/eglib/gfile-posix.c
@@ -161,26 +161,3 @@ g_file_open_tmp (const gchar *tmpl, gchar **name_used, GError **gerror)
 	}
 	return fd;
 }
-
-gchar *
-g_get_current_dir (void)
-{
-	int s = 32;
-	char *buffer = NULL, *r;
-	gboolean fail;
-	
-	do {
-		buffer = g_realloc (buffer, s);
-		r = getcwd (buffer, s);
-		fail = (r == NULL && errno == ERANGE);
-		if (fail) {
-			s <<= 1;
-		}
-	} while (fail);
-
-	/* On amd64 sometimes the bottom 32-bits of r == the bottom 32-bits of buffer
-	 * but the top 32-bits of r have overflown to 0xffffffff (seriously, getcwd
-	 * so we return the buffer here since it has a pointer to the valid string
-	 */
-	return buffer;
-}

--- a/src/mono/mono/eglib/gmisc-win32.c
+++ b/src/mono/mono/eglib/gmisc-win32.c
@@ -232,3 +232,35 @@ g_get_tmp_dir (void)
 	}
 	return tmp_dir;
 }
+
+gchar *
+g_get_current_dir (void)
+{
+	gunichar2 *buffer = NULL;
+	gchar* val = NULL;
+	gint32 retval, buffer_size = MAX_PATH;
+
+	buffer = g_new (gunichar2, buffer_size);
+	retval = GetCurrentDirectoryW (buffer_size, buffer);
+
+	if (retval != 0) {
+		// the size might be larger than MAX_PATH
+		// https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=cmd
+		if (retval > buffer_size) {
+			buffer_size = retval;
+			buffer = g_realloc (buffer, buffer_size*sizeof(gunichar2));
+			retval = GetCurrentDirectoryW (buffer_size, buffer);
+		}
+
+		val = u16to8 (buffer);
+	} else {
+		if (GetLastError () != ERROR_ENVVAR_NOT_FOUND) {
+			val = g_malloc (1);
+			*val = 0;
+		}
+	}
+
+	g_free (buffer);
+
+	return val;
+}


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/56163

The `getcwd` call is returning the string encoded in system character
encoding.

Use native `GetCurrentDirectoryW` call instead and convert to utf-8.