### PR TITLE
LoggerMessage formatter performance improvements

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogValuesFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogValuesFormatter.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.Logging
     internal sealed class LogValuesFormatter
     {
         private const string NullValue = "(null)";
-        private static readonly char[] FormatDelimiters = {',', ':'};
+        private static readonly char[] FormatDelimiters = { ',', ':' };
         private readonly string _format;
         private readonly List<string> _valueNames = new List<string>();
 
@@ -23,7 +23,7 @@ namespace Microsoft.Extensions.Logging
         // - Be annotated as [SkipLocalsInit] to avoid zero'ing the stackalloc'd char span
         // - Format _valueNames.Count directly into a span
 
-        public LogValuesFormatter(string format)
+        public LogValuesFormatter(string format, ICollection<string>? formatParts = null, ICollection<string>? formats = null)
         {
             if (format == null)
             {
@@ -39,6 +39,7 @@ namespace Microsoft.Extensions.Logging
             while (scanIndex < endIndex)
             {
                 int openBraceIndex = FindBraceIndex(format, '{', scanIndex, endIndex);
+                formatParts?.Add(format.AsSpan(scanIndex, openBraceIndex - scanIndex).ToString());
                 if (scanIndex == 0 && openBraceIndex == endIndex)
                 {
                     // No holes found.
@@ -58,6 +59,8 @@ namespace Microsoft.Extensions.Logging
                     // Format item syntax : { index[,alignment][ :formatString] }.
                     int formatDelimiterIndex = FindIndexOfAny(format, FormatDelimiters, openBraceIndex, closeBraceIndex);
 
+                    formats?.Add(formatDelimiterIndex == closeBraceIndex ? null : format.Substring(formatDelimiterIndex + 1, closeBraceIndex - formatDelimiterIndex - 1));
+
                     vsb.Append(format.AsSpan(scanIndex, openBraceIndex - scanIndex + 1));
                     vsb.Append(_valueNames.Count.ToString());
                     _valueNames.Add(format.Substring(openBraceIndex + 1, formatDelimiterIndex - openBraceIndex - 1));
@@ -71,6 +74,10 @@ namespace Microsoft.Extensions.Logging
         }
 
         public string OriginalFormat { get; private set; }
+
+        /// <summary>
+        /// The names of the values to be formatted.
+        /// </summary>
         public List<string> ValueNames => _valueNames;
 
         private static int FindBraceIndex(string format, char brace, int startIndex, int endIndex)
@@ -248,6 +255,10 @@ namespace Microsoft.Extensions.Logging
 
             return value;
         }
+    }
+
+    internal sealed class LogValuesFormatter1
+    {
 
     }
 }


### PR DESCRIPTION
**Remark**: This is still a draft, but before I spend a lot of time, I'd appreciate a soft yay or nay from people responsible for the logging area. It will take more time and it'd be great if I could get some initial feedback. The initials numbers are amazing, and being given that this PR targets `LoggerMessage`, which should be high-perf, this looks like a potential huge gain for all the loggers calling the formatter.

---

This PR is a result of profiling/benchmarking a piece of code that touched `Durable Functions` and used `ApplicationInsight`. I found that the logger, that is provided as the official package, calls `formatter`, having the state not only logged as usual key-value pairs but also as a formatted string.

https://github.com/microsoft/ApplicationInsights-dotnet/blob/d54bae8aeaf74b6fa08c8033c2ce54ea6d8f437b/LOGGING/src/ILogger/ApplicationInsightsLogger.cs#L113

https://github.com/microsoft/ApplicationInsights-dotnet/blob/d54bae8aeaf74b6fa08c8033c2ce54ea6d8f437b/LOGGING/src/ILogger/ApplicationInsightsLogger.cs#L94

The idea behind this PR would be to improve the `formatter` built by `LoggerMessage` by capturing much more context during the build up of `LogValuesFormatter` and to use it when formatting the value. I'm aware that LogValues should be kept small (big structs are no-no for perf) and this can be amended later on by capturing the formatting info into a separate object.

### Benchmarks

Initial benchmarks, even with some functionality missing, looks extremely promising. Both the time and the allocations (no boxing!) are reduced 

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19042.1165 (20H2/October2020Update)
Intel Core i7-6700HQ CPU 2.60GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET SDK=6.0.100-preview.7.21379.14
  [Host]     : .NET 6.0.0 (6.0.21.37719), X64 RyuJIT
  DefaultJob : .NET 6.0.0 (6.0.21.37719), X64 RyuJIT


```
|                                                       Method |      Mean |    Error |    StdDev |    Median | Ratio | RatioSD |  Gen 0 | Allocated |
|------------------------------------------------------------- |----------:|---------:|----------:|----------:|------:|--------:|-------:|----------:|
|          &#39;int32 logged with the template: &quot;A value {Value}&quot;&#39; | 113.28 ns | 2.267 ns |  2.425 ns | 113.77 ns |  1.00 |    0.00 | 0.0204 |      64 B |
|          new &#39;int32 logged with the template: &quot;A value {Value}&quot;&#39; |  43.73 ns | 0.847 ns |  0.976 ns |  43.61 ns |  0.39 |    0.01 | 0.0127 |      40 B |
|                                                              |           |          |           |           |       |         |        |           |
|           &#39;Guid logged with the template: &quot;A value {Value}&quot;&#39; | 149.22 ns | 2.930 ns |  3.488 ns | 149.04 ns |  1.00 |    0.00 | 0.0458 |     144 B |
|           new &#39;Guid logged with the template: &quot;A value {Value}&quot;&#39; |  85.79 ns | 1.723 ns |  1.984 ns |  86.04 ns |  0.58 |    0.02 | 0.0356 |     112 B |
|                                                              |           |          |           |           |       |         |        |           |
| &#39;int32 logged with the template: &quot;A value {Value} was used&quot;&#39; | 146.91 ns | 5.435 ns | 15.419 ns | 142.06 ns |  1.00 |    0.00 | 0.0279 |      88 B |
| new &#39;int32 logged with the template: &quot;A value {Value} was used&quot;&#39; |  50.99 ns | 1.024 ns |  2.069 ns |  50.44 ns |  0.34 |    0.04 | 0.0204 |      64 B |
|                                                              |           |          |           |           |       |         |        |           |
|  &#39;Guid logged with the template: &quot;A value {Value} was used&quot;&#39; | 176.59 ns | 4.941 ns | 13.855 ns | 175.78 ns |  1.00 |    0.00 | 0.0508 |     160 B |
|  new &#39;Guid logged with the template: &quot;A value {Value} was used&quot;&#39; | 104.11 ns | 4.137 ns | 12.002 ns | 102.65 ns |  0.60 |    0.09 | 0.0408 |     128 B |