### PR TITLE
Convert the check for stdatomic.h into a compile step as opposed to existence check

### DIFF
--- a/src/coreclr/pal/src/libunwind/configure.cmake
+++ b/src/coreclr/pal/src/libunwind/configure.cmake
@@ -17,8 +17,7 @@ if(CLR_CMAKE_HOST_WIN32)
     endif (NOT HAVE_STDALIGN_H)
 
     # MSVC compiler is currently missing C11 stdatomic.h header
-    # Fake it until support is added
-    check_include_files(stdatomic.h HAVE_STDATOMIC_H)
+    check_c_source_compiles("#include <stdatomic.h> void main() { _Atomic int a; }" HAVE_STDATOMIC_H)
     if (NOT HAVE_STDATOMIC_H)
         configure_file(include/win/fakestdatomic.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/stdatomic.h COPYONLY)
     endif (NOT HAVE_STDATOMIC_H)


### PR DESCRIPTION
This is done because MSVC's STL provides the file as compilable for C++23 but not currently for C11/C17.

I was able to confirm locally the proposed fix in the issue - #57618.

Fixes #57618

/cc @jkoritzinsky 