### PR TITLE
Skip eventpipe_readevents for arm32

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -255,6 +255,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/profiler/eventpipe/eventpipe/*">
             <Issue>TraceEvent can't parse unaligned floats on arm32</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/profiler/eventpipe/eventpipe_readevents/*">
+            <Issue>TraceEvent can't parse unaligned floats on arm32</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/regress/vsw/373472/**">
             <Issue>Allocates large contiguous array that is not consistently available on 32-bit platforms</Issue>
         </ExcludeList>


### PR DESCRIPTION
Originally there was only one eventpipe test, and eventpipe_readevents was added in https://github.com/dotnet/runtime/pull/37002. 
Both should be skipped for the same reason.

cc @alpencolt 