### PR TITLE
Send RST_STREAM instead EOF when sending request body is cancelled

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -558,7 +558,9 @@ namespace System.Net.Test.Common
             do
             {
                 frame = await ReadFrameAsync(_timeout).ConfigureAwait(false);
-                if (frame == null && expectEndOfStream)
+
+                // Check if it was a zero-byte read or we got a RST_STREAM with the CANCEL code.
+                if ((frame == null || frame.Type == FrameType.RstStream && ((RstStreamFrame)frame).ErrorCode == 0x8) && expectEndOfStream)
                 {
                     break;
                 }

--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -560,7 +560,8 @@ namespace System.Net.Test.Common
                 frame = await ReadFrameAsync(_timeout).ConfigureAwait(false);
 
                 // Check if it was a zero-byte read or we got a RST_STREAM with the CANCEL code.
-                if ((frame == null || frame.Type == FrameType.RstStream && ((RstStreamFrame)frame).ErrorCode == 0x8) && expectEndOfStream)
+                if (expectEndOfStream
+                    && (frame == null || (frame.Type == FrameType.RstStream && ((RstStreamFrame)frame).ErrorCode == 0x8)))
                 {
                     break;
                 }


### PR DESCRIPTION
Fixes #58498