### PR TITLE
Improve error messages expanding single-file

### DIFF
--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -341,7 +341,18 @@ bool get_extraction_base_parent_directory(pal::string_t& directory)
     // check for the POSIX standard environment variable
     if (pal::getenv(_X("HOME"), &directory))
     {
-        return is_read_write_able_directory(directory);
+        if (is_read_write_able_directory(directory))
+        {
+            return true;
+        }
+        else
+        {
+            trace::error(_X("Default extraction directory [%s] either doesn't exist or is not accessible for read/write."), directory.c_str());
+        }
+    }
+    else
+    {
+        trace::error(_X("Failed to determine default extraction location. Environment variable '$HOME' is not defined."));
     }
 
     return false;
@@ -367,6 +378,7 @@ bool pal::get_default_bundle_extraction_base_dir(pal::string_t& extraction_dir)
     }
     else if (errno != EEXIST)
     {
+        trace::error(_X("Failed to create default extraction directory [%s]. %s"), extraction_dir.c_str(), pal::strerror(errno));
         return false;
     }
 

--- a/src/native/corehost/hostmisc/pal.windows.cpp
+++ b/src/native/corehost/hostmisc/pal.windows.cpp
@@ -573,6 +573,7 @@ bool pal::get_default_bundle_extraction_base_dir(pal::string_t& extraction_dir)
 {
     if (!get_extraction_base_parent_directory(extraction_dir))
     {
+        trace::error(_X("Failed to determine default extraction location. Check if 'TMP' or 'TEMP' points to existing path."));
         return false;
     }
 
@@ -588,6 +589,7 @@ bool pal::get_default_bundle_extraction_base_dir(pal::string_t& extraction_dir)
     if (CreateDirectoryW(extraction_dir.c_str(), NULL) == 0 &&
         GetLastError() != ERROR_ALREADY_EXISTS)
     {
+        trace::error(_X("Failed to create default extraction directory [%s]. %s, error code: %d"), extraction_dir.c_str(), pal::strerror(errno), GetLastError());
         return false;
     }
 


### PR DESCRIPTION
Followup to the discussion on this issue: https://github.com/dotnet/runtime/issues/53346#issuecomment-853768833

In some cases if `$HOME` is not defined the extraction doesn't provide helpful error message. This change improves the errors by exactly specifying what failed. Added a couple of tests for this as well.