### PR TITLE
Ensure proper memory ordering in allocator::copy_with_no_repair

### DIFF
--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -754,6 +754,11 @@ public:
         {
             alloc_list* al = &(allocator_to_copy->alloc_list_of (i));
             alloc_list_tail_of(i) = al->alloc_list_tail();
+#if !defined(TARGET_AMD64) && !defined(TARGET_X86)
+            // ensure that the write to the tail is seen by
+            // the allocating thread *before* the write to the head
+            MemoryBarrier();
+#endif
             alloc_list_head_of(i) = al->alloc_list_head();
         }
     }


### PR DESCRIPTION
The method allocator::copy_with_no_repair is called at the end of background_ephemeral_sweep to copy over the free list data that it found for gen 0. There is no synchronization, but we are careful to copy items in a sequence that makes sure things work correctly for x86 and x64. However, on other platforms, we need a memory barrier.

This is a tentative fix for issue #57956 - it seems possible that the issue is caused by the lack of synchronization in copy_with_no_repair, but there is no proof yet.
