### PR TITLE
Conditionally pack symbols based on keepNativeSymbols

### DIFF
--- a/src/libraries/System.IO.Ports/pkg/runtime.native.System.IO.Ports.props
+++ b/src/libraries/System.IO.Ports/pkg/runtime.native.System.IO.Ports.props
@@ -8,6 +8,7 @@
     <DebugType>none</DebugType>
     <IsPackable>true</IsPackable>
     <AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>$(SymbolsSuffix)</AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>
+    <!-- When KeepNativeSymbols is set, debug symbols are kept in the .so files.  Separate symbol files do not exist that need to be packed. -->
     <TargetsForTfmSpecificDebugSymbolsInPackage Condition="'$(KeepNativeSymbols)' != 'true'">$(TargetsForTfmSpecificDebugSymbolsInPackage);AddRuntimeSpecificNativeSymbolToPackage</TargetsForTfmSpecificDebugSymbolsInPackage>
     <UseRuntimePackageDisclaimer>true</UseRuntimePackageDisclaimer>
     <!-- This is a native package and doesn't contain any ref/lib assets. -->

--- a/src/libraries/System.IO.Ports/pkg/runtime.native.System.IO.Ports.props
+++ b/src/libraries/System.IO.Ports/pkg/runtime.native.System.IO.Ports.props
@@ -8,7 +8,7 @@
     <DebugType>none</DebugType>
     <IsPackable>true</IsPackable>
     <AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>$(SymbolsSuffix)</AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>
-    <TargetsForTfmSpecificDebugSymbolsInPackage Condition="'$(keepNativeSymbols)' != 'true'">$(TargetsForTfmSpecificDebugSymbolsInPackage);AddRuntimeSpecificNativeSymbolToPackage</TargetsForTfmSpecificDebugSymbolsInPackage>
+    <TargetsForTfmSpecificDebugSymbolsInPackage Condition="'$(KeepNativeSymbols)' != 'true'">$(TargetsForTfmSpecificDebugSymbolsInPackage);AddRuntimeSpecificNativeSymbolToPackage</TargetsForTfmSpecificDebugSymbolsInPackage>
     <UseRuntimePackageDisclaimer>true</UseRuntimePackageDisclaimer>
     <!-- This is a native package and doesn't contain any ref/lib assets. -->
     <NoWarn>$(NoWarn);NU5128</NoWarn>

--- a/src/libraries/System.IO.Ports/pkg/runtime.native.System.IO.Ports.props
+++ b/src/libraries/System.IO.Ports/pkg/runtime.native.System.IO.Ports.props
@@ -8,7 +8,7 @@
     <DebugType>none</DebugType>
     <IsPackable>true</IsPackable>
     <AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>$(SymbolsSuffix)</AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>
-    <TargetsForTfmSpecificDebugSymbolsInPackage>$(TargetsForTfmSpecificDebugSymbolsInPackage);AddRuntimeSpecificNativeSymbolToPackage</TargetsForTfmSpecificDebugSymbolsInPackage>
+    <TargetsForTfmSpecificDebugSymbolsInPackage Condition="'$(keepNativeSymbols)' != 'true'">$(TargetsForTfmSpecificDebugSymbolsInPackage);AddRuntimeSpecificNativeSymbolToPackage</TargetsForTfmSpecificDebugSymbolsInPackage>
     <UseRuntimePackageDisclaimer>true</UseRuntimePackageDisclaimer>
     <!-- This is a native package and doesn't contain any ref/lib assets. -->
     <NoWarn>$(NoWarn);NU5128</NoWarn>


### PR DESCRIPTION
Related to https://github.com/dotnet/runtime/issues/58455#issuecomment-911665744

Source build runs with `keepNativeSymbols=true` which prevents the symbols from being stripped out and placed into a separate .dbg files.  This supports the normal workflows used by distro package maintainers.  You can read more background [here](https://github.com/dotnet/source-build/pull/1776/files#diff-3cc321025ad7a47e73d552f56eba06e9fb93de57daff50548b9c5e3a98febdad).  This change conditions `TargetsForTfmSpecificDebugSymbolsInPackage` on the `keepNativeSymbols`.

FYI, I will port this to main as well once this PR gets approval.