### PR TITLE
Convert test from using XUnitBase to typical CoreCLR test pattern so

### DIFF
--- a/src/tests/Interop/ICustomMarshaler/Primitives/ICustomMarshaler.cs
+++ b/src/tests/Interop/ICustomMarshaler/Primitives/ICustomMarshaler.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace System.Runtime.InteropServices.Tests
 {
-    public class ICustomMarshalerTests : XunitBase
+    public class ICustomMarshalerTests
     {
         // To avoid having to create a native test library to reference in tests that
         // interact with native libraries, we can use a simple method from the C standard
@@ -19,8 +19,7 @@ namespace System.Runtime.InteropServices.Tests
         public const string LibcLibrary = "libc";
 #endif
 
-        [Fact]
-        public void CustomMarshaler_StringType_Success()
+        public static void CustomMarshaler_StringType_Success()
         {
             int val = 64001;
             Assert.Equal(val, MarshalerOnStringTypeMethod(val.ToString()));
@@ -42,8 +41,7 @@ namespace System.Runtime.InteropServices.Tests
         [DllImport(LibcLibrary, EntryPoint = "atoi")]
         public static extern int MarshalerOnStringTypeMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(StringForwardingCustomMarshaler))] string str);
 
-        [Fact]
-        public void CustomMarshaler_ArrayType_Success()
+        public static void CustomMarshaler_ArrayType_Success()
         {
             int val = 64001;
             Assert.Equal(val, MarshalerOnArrayTypeMethod(new string[] { val.ToString() }));
@@ -65,8 +63,7 @@ namespace System.Runtime.InteropServices.Tests
         [DllImport(LibcLibrary, EntryPoint = "atoi")]
         public static extern int MarshalerOnArrayTypeMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalType = "System.Runtime.InteropServices.Tests.ICustomMarshalerTests+ArrayForwardingCustomMarshaler")] string[] str);
 
-        [Fact]
-        public void CustomMarshaler_BoxedValueType_Success()
+        public static void CustomMarshaler_BoxedValueType_Success()
         {
             int val = 64001;
             Assert.Equal(val * 2, MarshalerOnBoxedValueTypeMethod(val));
@@ -93,8 +90,7 @@ namespace System.Runtime.InteropServices.Tests
         [DllImport(LibcLibrary, EntryPoint = "atoi")]
         public static extern int MarshalerOnBoxedValueTypeMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(BoxedValueTypeCustomMarshaler))] object i);
 
-        [Fact]
-        public void Parameter_CustomMarshalerProvidedOnClassType_ForwardsCorrectly()
+        public static void Parameter_CustomMarshalerProvidedOnClassType_ForwardsCorrectly()
         {
             int val = 64001;
             Assert.Equal((val * 2).ToString(), MarshalerOnClassTypeMethod(new StringContainer { Value = val.ToString() }).Value);
@@ -142,8 +138,7 @@ namespace System.Runtime.InteropServices.Tests
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ClassForwardingCustomMarshaler))]
         public static extern StringContainer MarshalerOnClassTypeMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ClassForwardingCustomMarshaler))] StringContainer str);
 
-        [Fact]
-        public void Parameter_CustomMarshalerProvided_CallsMethodsInCorrectOrdering()
+        public static void Parameter_CustomMarshalerProvided_CallsMethodsInCorrectOrdering()
         {
             Assert.Empty(OrderTrackingCustomMarshaler.Events);
 
@@ -221,8 +216,7 @@ namespace System.Runtime.InteropServices.Tests
         [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(OrderTrackingCustomMarshaler))]
         public static extern string OrderTrackingMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(OrderTrackingCustomMarshaler))] string str);
 
-        [Fact]
-        public void CustomMarshaler_BothMarshalTypeRefAndMarshalTypeProvided_PicksMarshalType()
+        public static void CustomMarshaler_BothMarshalTypeRefAndMarshalTypeProvided_PicksMarshalType()
         {
             Assert.Equal(2, BothTypeRefAndTypeMethod("64001"));
         }
@@ -243,8 +237,7 @@ namespace System.Runtime.InteropServices.Tests
         [DllImport(LibcLibrary, EntryPoint = "atoi", CallingConvention = CallingConvention.Cdecl)]
         public static extern int BothTypeRefAndTypeMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalType = "System.Runtime.InteropServices.Tests.ICustomMarshalerTests+OverridingCustomMarshaler", MarshalTypeRef = typeof(StringForwardingCustomMarshaler))] string str);
 
-        [Fact]
-        public void Parameter_CookieProvided_PassesCookieToGetInstance()
+        public static void Parameter_CookieProvided_PassesCookieToGetInstance()
         {
             int val = 64001;
             Assert.Equal(val, CustomCookieMethod(val.ToString()));
@@ -273,8 +266,7 @@ namespace System.Runtime.InteropServices.Tests
         [DllImport(LibcLibrary, EntryPoint = "atoi", CallingConvention = CallingConvention.Cdecl)]
         public static extern int CustomCookieMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(CookieTrackingCustomMarshaler), MarshalCookie = "Cookie")] string str);
 
-        [Fact]
-        public void Parameter_NotCustomMarshalerType_UsesSpecifiedMarshaler()
+        public static void Parameter_NotCustomMarshalerType_UsesSpecifiedMarshaler()
         {
             int val = 64001;
             Assert.Equal(val, NonCustomMarshalerTypeMethod(val.ToString()));
@@ -283,8 +275,7 @@ namespace System.Runtime.InteropServices.Tests
         [DllImport(LibcLibrary, EntryPoint = "atoi", CallingConvention = CallingConvention.Cdecl)]
         public static extern int NonCustomMarshalerTypeMethod([MarshalAs(UnmanagedType.LPStr, MarshalTypeRef = typeof(OverridingCustomMarshaler))] string str);
 
-        [Fact]
-        public void CustomMarshaler_Generic_Success()
+        public static void CustomMarshaler_Generic_Success()
         {
             Assert.Equal(234, GenericGetInstanceCustomMarshalerMethod("64001"));
         }
@@ -308,8 +299,7 @@ namespace System.Runtime.InteropServices.Tests
         [DllImport(LibcLibrary, EntryPoint = "atoi", CallingConvention = CallingConvention.Cdecl)]
         public static extern int GenericGetInstanceCustomMarshalerMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(GenericCustomMarshaler<int>))] string str);
 
-        [Fact]
-        public void CustomMarshaler_ValueTypeWithStringType_Success()
+        public static void CustomMarshaler_ValueTypeWithStringType_Success()
         {
             Assert.Equal(234, ValueTypeMarshalerOnStringTypeMethod("64001"));
         }
@@ -333,8 +323,7 @@ namespace System.Runtime.InteropServices.Tests
         [DllImport(LibcLibrary, EntryPoint = "atoi", CallingConvention = CallingConvention.Cdecl)]
         public static extern int ValueTypeMarshalerOnStringTypeMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(CustomMarshalerValueType))] string str);
 
-        [Fact]
-        public void Parameter_MarshalerOnValueType_ThrowsMarshalDirectiveException()
+        public static void Parameter_MarshalerOnValueType_ThrowsMarshalDirectiveException()
         {
             Assert.Throws<MarshalDirectiveException>(() => MarshalerOnValueTypeMethod(0));
         }
@@ -342,8 +331,7 @@ namespace System.Runtime.InteropServices.Tests
         [DllImport(LibcLibrary, EntryPoint = "atoi", CallingConvention = CallingConvention.Cdecl)]
         public static extern int MarshalerOnValueTypeMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(StringForwardingCustomMarshaler))] int str);
 
-        [Fact]
-        public unsafe void Parameter_MarshalerOnPointer_ThrowsMarshalDirectiveException()
+        public static unsafe void Parameter_MarshalerOnPointer_ThrowsMarshalDirectiveException()
         {
             Assert.Throws<MarshalDirectiveException>(() => MarshalerOnPointerMethod(null));
         }
@@ -351,8 +339,7 @@ namespace System.Runtime.InteropServices.Tests
         [DllImport(LibcLibrary, EntryPoint = "atoi", CallingConvention = CallingConvention.Cdecl)]
         public static unsafe extern int MarshalerOnPointerMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(StringForwardingCustomMarshaler))] int* str);
 
-        [Fact]
-        public void Parameter_NullICustomMarshaler_ThrowsTypeLoadException()
+        public static void Parameter_NullICustomMarshaler_ThrowsTypeLoadException()
         {
             Assert.Throws<TypeLoadException>(() => NullCustomMarshalerMethod(""));
         }
@@ -360,8 +347,7 @@ namespace System.Runtime.InteropServices.Tests
         [DllImport(LibcLibrary, EntryPoint = "atoi", CallingConvention = CallingConvention.Cdecl)]
         public static extern int NullCustomMarshalerMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = null)] string str);
 
-        [Fact]
-        public void Parameter_NotICustomMarshaler_ThrowsApplicationException()
+        public static void Parameter_NotICustomMarshaler_ThrowsApplicationException()
         {
             Assert.Throws<ApplicationException>(() => NonICustomMarshalerMethod(""));
         }
@@ -369,8 +355,7 @@ namespace System.Runtime.InteropServices.Tests
         [DllImport(LibcLibrary, EntryPoint = "atoi", CallingConvention = CallingConvention.Cdecl)]
         public static extern int NonICustomMarshalerMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(string))] string str);
 
-        [Fact]
-        public void Parameter_OpenGenericICustomMarshaler_ThrowsTypeLoadException()
+        public static void Parameter_OpenGenericICustomMarshaler_ThrowsTypeLoadException()
         {
             Assert.Throws<TypeLoadException>(() => OpenGenericICustomMarshalerMethod(""));
         }
@@ -378,8 +363,7 @@ namespace System.Runtime.InteropServices.Tests
         [DllImport(LibcLibrary, EntryPoint = "atoi", CallingConvention = CallingConvention.Cdecl)]
         public static extern int OpenGenericICustomMarshalerMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(GenericCustomMarshaler<>))] string str);
 
-        [Fact]
-        public void Parameter_GetInstanceMethodDoesntExist_ThrowsApplicationException()
+        public static void Parameter_GetInstanceMethodDoesntExist_ThrowsApplicationException()
         {
             Assert.Throws<ApplicationException>(() => NoGetInstanceMethod(""));
         }
@@ -398,8 +382,7 @@ namespace System.Runtime.InteropServices.Tests
         [DllImport(LibcLibrary, EntryPoint = "atoi", CallingConvention = CallingConvention.Cdecl)]
         public static extern int NoGetInstanceMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(NoGetInstanceCustomMarshaler))] string str);
 
-        [Fact]
-        public void Parameter_GetInstanceMethodInstanceMethod_ThrowsApplicationException()
+        public static void Parameter_GetInstanceMethodInstanceMethod_ThrowsApplicationException()
         {
             Assert.Throws<ApplicationException>(() => InstanceGetInstanceMethod(""));
         }
@@ -419,8 +402,7 @@ namespace System.Runtime.InteropServices.Tests
         [DllImport(LibcLibrary, EntryPoint = "atoi", CallingConvention = CallingConvention.Cdecl)]
         public static extern int InstanceGetInstanceMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(InstanceGetInstanceCustomMarshaler))] string str);
 
-        [Fact]
-        public void Parameter_GetInstanceMethodNoParameters_ThrowsApplicationException()
+        public static void Parameter_GetInstanceMethodNoParameters_ThrowsApplicationException()
         {
             Assert.Throws<ApplicationException>(() => NoParametersGetInstanceMethod(""));
         }
@@ -441,8 +423,7 @@ namespace System.Runtime.InteropServices.Tests
         [DllImport(LibcLibrary, EntryPoint = "atoi", CallingConvention = CallingConvention.Cdecl)]
         public static extern int NoParametersGetInstanceMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(NoParameterGetInstanceCustomMarshaler))] string str);
 
-        [Fact]
-        public void Parameter_GetInstanceMethodNonStringParameter_ThrowsApplicationException()
+        public static void Parameter_GetInstanceMethodNonStringParameter_ThrowsApplicationException()
         {
             Assert.Throws<ApplicationException>(() => NonStringGetInstanceMethod(""));
         }
@@ -463,8 +444,7 @@ namespace System.Runtime.InteropServices.Tests
         [DllImport(LibcLibrary, EntryPoint = "atoi", CallingConvention = CallingConvention.Cdecl)]
         public static extern int NonStringGetInstanceMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(NonStringGetInstanceCustomMarshaler))] string str);
 
-        [Fact]
-        public void Parameter_GetInstanceMethodReturnsVoid_ThrowsApplicationException()
+        public static void Parameter_GetInstanceMethodReturnsVoid_ThrowsApplicationException()
         {
             Assert.Throws<ApplicationException>(() => VoidGetInstanceMethod(""));
         }
@@ -485,8 +465,7 @@ namespace System.Runtime.InteropServices.Tests
         [DllImport(LibcLibrary, EntryPoint = "atoi", CallingConvention = CallingConvention.Cdecl)]
         public static extern int VoidGetInstanceMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(VoidGetInstanceCustomMarshaler))] string str);
 
-        [Fact]
-        public void Parameter_GetInstanceMethodReturnsNull_ThrowsApplicationException()
+        public static void Parameter_GetInstanceMethodReturnsNull_ThrowsApplicationException()
         {
             Assert.Throws<ApplicationException>(() => NullGetInstanceMethod(""));
         }
@@ -507,8 +486,7 @@ namespace System.Runtime.InteropServices.Tests
         [DllImport(LibcLibrary, EntryPoint = "atoi", CallingConvention = CallingConvention.Cdecl)]
         public static extern int NullGetInstanceMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(NullGetInstanceCustomMarshaler))] string str);
 
-        [Fact]
-        public void Parameter_GetInstanceMethodThrows_ThrowsActualException()
+        public static void Parameter_GetInstanceMethodThrows_ThrowsActualException()
         {
             Assert.Throws<NotImplementedException>(() => ThrowingGetInstanceMethod(""));
         }
@@ -529,8 +507,7 @@ namespace System.Runtime.InteropServices.Tests
         [DllImport(LibcLibrary, EntryPoint = "atoi", CallingConvention = CallingConvention.Cdecl)]
         public static extern int ThrowingGetInstanceMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ThrowingGetInstanceCustomMarshaler))] string str);
 
-        [Fact]
-        public void Parameter_MarshalManagedToNativeThrows_ThrowsActualException()
+        public static void Parameter_MarshalManagedToNativeThrows_ThrowsActualException()
         {
             Assert.Throws<NotImplementedException>(() => ThrowingMarshalManagedToNativeMethod(""));
         }
@@ -551,8 +528,7 @@ namespace System.Runtime.InteropServices.Tests
         [DllImport(LibcLibrary, EntryPoint = "atoi", CallingConvention = CallingConvention.Cdecl)]
         public static extern int ThrowingMarshalManagedToNativeMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ThrowingMarshalManagedToNativeCustomMarshaler))] string str);
 
-        [Fact]
-        public void Parameter_CleanUpNativeDataMethodThrows_ThrowsActualException()
+        public static void Parameter_CleanUpNativeDataMethodThrows_ThrowsActualException()
         {
             Assert.Throws<NotImplementedException>(() => ThrowingCleanUpNativeDataMethod(""));
         }
@@ -573,7 +549,6 @@ namespace System.Runtime.InteropServices.Tests
         [DllImport(LibcLibrary, EntryPoint = "atoi", CallingConvention = CallingConvention.Cdecl)]
         public static extern int ThrowingCleanUpNativeDataMethod([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ThrowingCleanUpNativeDataCustomMarshaler))] string str);
 
-        [Fact]
         public static void Field_ParentIsStruct_ThrowsTypeLoadException()
         {
             Assert.Throws<TypeLoadException>(() => StructWithCustomMarshalerFieldMethod(new StructWithCustomMarshalerField()));
@@ -589,8 +564,7 @@ namespace System.Runtime.InteropServices.Tests
         public static extern int StructWithCustomMarshalerFieldMethod(StructWithCustomMarshalerField c);
 
 
-        [Fact]
-        public void Parameter_DifferentCustomMarshalerType_MarshalsCorrectly()
+        public static void Parameter_DifferentCustomMarshalerType_MarshalsCorrectly()
         {
             Assert.Equal(234, DifferentCustomMarshalerType("5678"));
         }
@@ -639,10 +613,46 @@ namespace System.Runtime.InteropServices.Tests
         [DllImport(LibcLibrary, EntryPoint = "atoi", CallingConvention = CallingConvention.Cdecl)]
         public static extern int DifferentCustomMarshalerType([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(OuterCustomMarshaler))] string str);
 
-
         public static int Main(String[] args)
         {
-            return new ICustomMarshalerTests().RunTests();
+            try
+            {
+                CustomMarshaler_StringType_Success();
+                CustomMarshaler_ArrayType_Success();
+                CustomMarshaler_BoxedValueType_Success();
+                Parameter_CustomMarshalerProvidedOnClassType_ForwardsCorrectly();
+                Parameter_CustomMarshalerProvided_CallsMethodsInCorrectOrdering();
+                CustomMarshaler_BothMarshalTypeRefAndMarshalTypeProvided_PicksMarshalType();
+                Parameter_CookieProvided_PassesCookieToGetInstance();
+                Parameter_NotCustomMarshalerType_UsesSpecifiedMarshaler();
+                CustomMarshaler_Generic_Success();
+                CustomMarshaler_ValueTypeWithStringType_Success();
+                Parameter_MarshalerOnValueType_ThrowsMarshalDirectiveException();
+                Parameter_MarshalerOnPointer_ThrowsMarshalDirectiveException();
+                Parameter_NullICustomMarshaler_ThrowsTypeLoadException();
+                Parameter_MarshalerOnPointer_ThrowsMarshalDirectiveException();
+                Parameter_NullICustomMarshaler_ThrowsTypeLoadException();
+                Parameter_NotICustomMarshaler_ThrowsApplicationException();
+                Parameter_OpenGenericICustomMarshaler_ThrowsTypeLoadException();
+                Parameter_GetInstanceMethodDoesntExist_ThrowsApplicationException();
+                Parameter_GetInstanceMethodInstanceMethod_ThrowsApplicationException();
+                Parameter_GetInstanceMethodNoParameters_ThrowsApplicationException();
+                Parameter_GetInstanceMethodNonStringParameter_ThrowsApplicationException();
+                Parameter_GetInstanceMethodReturnsVoid_ThrowsApplicationException();
+                Parameter_GetInstanceMethodReturnsNull_ThrowsApplicationException();
+                Parameter_GetInstanceMethodThrows_ThrowsActualException();
+                Parameter_MarshalManagedToNativeThrows_ThrowsActualException();
+                Parameter_CleanUpNativeDataMethodThrows_ThrowsActualException();
+                Field_ParentIsStruct_ThrowsTypeLoadException();
+                Parameter_DifferentCustomMarshalerType_MarshalsCorrectly();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"Test Failure: {e}");
+                return 101;
+            }
+
+            return 100;
         }
     }
 }


### PR DESCRIPTION
  test can be run under GCStress.

Fixes #58335 

/cc @jkoritzinsky @elinor-fung 