### PR TITLE
Undo struct promotion on "RetInd" code path

### DIFF
--- a/src/coreclr/jit/clrjit.natvis
+++ b/src/coreclr/jit/clrjit.natvis
@@ -65,8 +65,8 @@ Documentation for VS debugger format specifiers: https://docs.microsoft.com/en-u
   </Type>
 
   <Type Name="LclVarDsc">
-    <DisplayString Condition="lvReason==0">[{lvType,en}]</DisplayString>
-    <DisplayString>[{lvType,en}-{lvReason,s}]</DisplayString>
+    <DisplayString Condition="lvReason==0">[V{lvSlotNum,d}: {lvType,en}]</DisplayString>
+    <DisplayString>[V{lvSlotNum,d}: {lvType,en}-{lvReason,s}]</DisplayString>
   </Type>
 
   <Type Name="GenTreeLclVar" Inheritable="false">

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -502,6 +502,9 @@ public:
     unsigned char lvUnusedStruct : 1; // All references to this promoted struct are through its field locals.
                                       // I.e. there is no longer any reference to the struct directly.
                                       // In this case we can simply remove this struct local.
+
+    unsigned char lvUndoneStructPromotion : 1; // The struct promotion was undone and hence there should be no
+                                               // reference to the fields of this struct.
 #endif
 
     unsigned char lvLRACandidate : 1; // Tracked for linear scan register allocation purposes

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -4075,6 +4075,16 @@ void Compiler::lvaMarkLclRefs(GenTree* tree, BasicBlock* block, Statement* stmt,
 
     varDsc->incRefCnts(weight, this);
 
+#ifdef DEBUG
+    if (varDsc->lvIsStructField)
+    {
+        // If ref count was increased for struct field, ensure that the
+        // parent struct is still promoted.
+        LclVarDsc* parentStruct = &lvaTable[varDsc->lvParentLcl];
+        assert(!parentStruct->lvUndoneStructPromotion);
+    }
+#endif
+
     if (!isRecompute)
     {
         if (lvaVarAddrExposed(lclNum))

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13864,13 +13864,10 @@ GenTree* Compiler::fgMorphRetInd(GenTreeUnOp* ret)
 
     if (addr->OperIs(GT_ADDR) && addr->gtGetOp1()->OperIs(GT_LCL_VAR))
     {
-        if (fgGlobalMorph)
+        // If struct promotion was undone, adjust the annotations
+        if (fgGlobalMorph && fgMorphImplicitByRefArgs(addr))
         {
-            // If struct promotion was undone, adjust the annotations
-            if (fgMorphImplicitByRefArgs(addr))
-            {
-                return ind;
-            }
+            return ind;
         }
 
         // If `return` retypes LCL_VAR as a smaller struct it should not set `doNotEnregister` on that

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13867,7 +13867,7 @@ GenTree* Compiler::fgMorphRetInd(GenTreeUnOp* ret)
         if (fgGlobalMorph)
         {
             // If struct promotion was undone, adjust the annotations
-            if(fgMorphImplicitByRefArgs(addr))
+            if (fgMorphImplicitByRefArgs(addr))
             {
                 return ind;
             }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -17535,6 +17535,8 @@ void Compiler::fgRetypeImplicitByRefArgs()
 
 void Compiler::fgMarkDemotedImplicitByRefArgs()
 {
+    JITDUMP("\n*************** In fgMarkDemotedImplicitByRefArgs()\n");
+
 #if (defined(TARGET_AMD64) && !defined(UNIX_AMD64_ABI)) || defined(TARGET_ARM64)
 
     for (unsigned lclNum = 0; lclNum < info.compArgsCount; lclNum++)
@@ -17543,6 +17545,8 @@ void Compiler::fgMarkDemotedImplicitByRefArgs()
 
         if (lvaIsImplicitByRefLocal(lclNum))
         {
+            JITDUMP("Clearing annotation for V%02d\n", lclNum);
+
             if (varDsc->lvPromoted)
             {
                 // The parameter is simply a pointer now, so clear lvPromoted.  It was left set
@@ -17569,7 +17573,8 @@ void Compiler::fgMarkDemotedImplicitByRefArgs()
                 LclVarDsc* structVarDsc     = &lvaTable[structLclNum];
                 structVarDsc->lvAddrExposed = false;
 #ifdef DEBUG
-                structVarDsc->lvUnusedStruct = true;
+                structVarDsc->lvUnusedStruct          = true;
+                structVarDsc->lvUndoneStructPromotion = true;
 #endif // DEBUG
 
                 unsigned fieldLclStart = structVarDsc->lvFieldLclStart;
@@ -17578,6 +17583,8 @@ void Compiler::fgMarkDemotedImplicitByRefArgs()
 
                 for (unsigned fieldLclNum = fieldLclStart; fieldLclNum < fieldLclStop; ++fieldLclNum)
                 {
+                    JITDUMP("Fixing pointer for field V%02d from V%02d to V%02d\n", fieldLclNum, lclNum, structLclNum);
+
                     // Fix the pointer to the parent local.
                     LclVarDsc* fieldVarDsc = &lvaTable[fieldLclNum];
                     assert(fieldVarDsc->lvParentLcl == lclNum);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13864,6 +13864,15 @@ GenTree* Compiler::fgMorphRetInd(GenTreeUnOp* ret)
 
     if (addr->OperIs(GT_ADDR) && addr->gtGetOp1()->OperIs(GT_LCL_VAR))
     {
+        if (fgGlobalMorph)
+        {
+            // If struct promotion was undone, adjust the annotations
+            if(fgMorphImplicitByRefArgs(addr))
+            {
+                return ind;
+            }
+        }
+
         // If `return` retypes LCL_VAR as a smaller struct it should not set `doNotEnregister` on that
         // LclVar.
         // Example: in `Vector128:AsVector2` we have RETURN SIMD8(OBJ SIMD8(ADDR byref(LCL_VAR SIMD16))).

--- a/src/tests/JIT/Methodical/explicit/coverage/body_short.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/body_short.cs
@@ -82,6 +82,8 @@ internal class TestApp
     }
     private static short test_0_17(short num, AA init, AA zero)
     {
+        //short result = ;
+        //Console.WriteLine(result);
         return AA.call_target_ref(ref init.q);
     }
     private static short test_1_0(short num, ref AA r_init, ref AA r_zero)
@@ -598,613 +600,614 @@ internal class TestApp
             Console.WriteLine("test_0_17() failed.");
             return 118;
         }
-        AA.verify_all(); AA.reset();
-        if (test_1_0(100, ref AA._init, ref AA._zero) != 100)
-        {
-            Console.WriteLine("test_1_0() failed.");
-            return 119;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_1_1(100, ref AA._init, ref AA._zero) != 100)
-        {
-            Console.WriteLine("test_1_1() failed.");
-            return 120;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_1_2(100, ref AA._init, ref AA._zero) != 100)
-        {
-            Console.WriteLine("test_1_2() failed.");
-            return 121;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_1_3(100, ref AA._init, ref AA._zero) != 100)
-        {
-            Console.WriteLine("test_1_3() failed.");
-            return 122;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_1_4(100, ref AA._init, ref AA._zero) != 100)
-        {
-            Console.WriteLine("test_1_4() failed.");
-            return 123;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_1_5(100, ref AA._init, ref AA._zero) != 100)
-        {
-            Console.WriteLine("test_1_5() failed.");
-            return 124;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_1_6(100, ref AA._init, ref AA._zero) != 100)
-        {
-            Console.WriteLine("test_1_6() failed.");
-            return 125;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_1_7(100, ref AA._init, ref AA._zero) != 100)
-        {
-            Console.WriteLine("test_1_7() failed.");
-            return 126;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_1_8(100, ref AA._init, ref AA._zero) != 100)
-        {
-            Console.WriteLine("test_1_8() failed.");
-            return 127;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_1_9(100, ref AA._init, ref AA._zero) != 100)
-        {
-            Console.WriteLine("test_1_9() failed.");
-            return 128;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_1_10(100, ref AA._init, ref AA._zero) != 100)
-        {
-            Console.WriteLine("test_1_10() failed.");
-            return 129;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_1_11(100, ref AA._init, ref AA._zero) != 100)
-        {
-            Console.WriteLine("test_1_11() failed.");
-            return 130;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_1_12(100, ref AA._init, ref AA._zero) != 100)
-        {
-            Console.WriteLine("test_1_12() failed.");
-            return 131;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_1_13(100, ref AA._init, ref AA._zero) != 100)
-        {
-            Console.WriteLine("test_1_13() failed.");
-            return 132;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_1_14(100, ref AA._init, ref AA._zero) != 100)
-        {
-            Console.WriteLine("test_1_14() failed.");
-            return 133;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_1_15(100, ref AA._init, ref AA._zero) != 100)
-        {
-            Console.WriteLine("test_1_15() failed.");
-            return 134;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_1_16(100, ref AA._init, ref AA._zero) != 100)
-        {
-            Console.WriteLine("test_1_16() failed.");
-            return 135;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_1_17(100, ref AA._init, ref AA._zero) != 100)
-        {
-            Console.WriteLine("test_1_17() failed.");
-            return 136;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_2_0(100) != 100)
-        {
-            Console.WriteLine("test_2_0() failed.");
-            return 137;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_2_1(100) != 100)
-        {
-            Console.WriteLine("test_2_1() failed.");
-            return 138;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_2_2(100) != 100)
-        {
-            Console.WriteLine("test_2_2() failed.");
-            return 139;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_2_3(100) != 100)
-        {
-            Console.WriteLine("test_2_3() failed.");
-            return 140;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_2_4(100) != 100)
-        {
-            Console.WriteLine("test_2_4() failed.");
-            return 141;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_2_5(100) != 100)
-        {
-            Console.WriteLine("test_2_5() failed.");
-            return 142;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_2_6(100) != 100)
-        {
-            Console.WriteLine("test_2_6() failed.");
-            return 143;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_2_7(100) != 100)
-        {
-            Console.WriteLine("test_2_7() failed.");
-            return 144;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_2_8(100) != 100)
-        {
-            Console.WriteLine("test_2_8() failed.");
-            return 145;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_2_9(100) != 100)
-        {
-            Console.WriteLine("test_2_9() failed.");
-            return 146;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_2_10(100) != 100)
-        {
-            Console.WriteLine("test_2_10() failed.");
-            return 147;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_2_11(100) != 100)
-        {
-            Console.WriteLine("test_2_11() failed.");
-            return 148;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_2_12(100) != 100)
-        {
-            Console.WriteLine("test_2_12() failed.");
-            return 149;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_2_13(100) != 100)
-        {
-            Console.WriteLine("test_2_13() failed.");
-            return 150;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_2_14(100) != 100)
-        {
-            Console.WriteLine("test_2_14() failed.");
-            return 151;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_2_15(100) != 100)
-        {
-            Console.WriteLine("test_2_15() failed.");
-            return 152;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_2_16(100) != 100)
-        {
-            Console.WriteLine("test_2_16() failed.");
-            return 153;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_2_17(100) != 100)
-        {
-            Console.WriteLine("test_2_17() failed.");
-            return 154;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_3_0(100) != 100)
-        {
-            Console.WriteLine("test_3_0() failed.");
-            return 155;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_3_1(100) != 100)
-        {
-            Console.WriteLine("test_3_1() failed.");
-            return 156;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_3_2(100) != 100)
-        {
-            Console.WriteLine("test_3_2() failed.");
-            return 157;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_3_3(100) != 100)
-        {
-            Console.WriteLine("test_3_3() failed.");
-            return 158;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_3_4(100) != 100)
-        {
-            Console.WriteLine("test_3_4() failed.");
-            return 159;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_3_5(100) != 100)
-        {
-            Console.WriteLine("test_3_5() failed.");
-            return 160;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_3_6(100) != 100)
-        {
-            Console.WriteLine("test_3_6() failed.");
-            return 161;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_3_7(100) != 100)
-        {
-            Console.WriteLine("test_3_7() failed.");
-            return 162;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_3_8(100) != 100)
-        {
-            Console.WriteLine("test_3_8() failed.");
-            return 163;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_3_9(100) != 100)
-        {
-            Console.WriteLine("test_3_9() failed.");
-            return 164;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_3_10(100) != 100)
-        {
-            Console.WriteLine("test_3_10() failed.");
-            return 165;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_3_11(100) != 100)
-        {
-            Console.WriteLine("test_3_11() failed.");
-            return 166;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_3_12(100) != 100)
-        {
-            Console.WriteLine("test_3_12() failed.");
-            return 167;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_3_13(100) != 100)
-        {
-            Console.WriteLine("test_3_13() failed.");
-            return 168;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_3_14(100) != 100)
-        {
-            Console.WriteLine("test_3_14() failed.");
-            return 169;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_3_15(100) != 100)
-        {
-            Console.WriteLine("test_3_15() failed.");
-            return 170;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_3_16(100) != 100)
-        {
-            Console.WriteLine("test_3_16() failed.");
-            return 171;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_3_17(100) != 100)
-        {
-            Console.WriteLine("test_3_17() failed.");
-            return 172;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_4_0(100) != 100)
-        {
-            Console.WriteLine("test_4_0() failed.");
-            return 173;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_4_1(100) != 100)
-        {
-            Console.WriteLine("test_4_1() failed.");
-            return 174;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_4_2(100) != 100)
-        {
-            Console.WriteLine("test_4_2() failed.");
-            return 175;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_4_3(100) != 100)
-        {
-            Console.WriteLine("test_4_3() failed.");
-            return 176;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_4_4(100) != 100)
-        {
-            Console.WriteLine("test_4_4() failed.");
-            return 177;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_4_5(100) != 100)
-        {
-            Console.WriteLine("test_4_5() failed.");
-            return 178;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_4_6(100) != 100)
-        {
-            Console.WriteLine("test_4_6() failed.");
-            return 179;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_4_7(100) != 100)
-        {
-            Console.WriteLine("test_4_7() failed.");
-            return 180;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_4_8(100) != 100)
-        {
-            Console.WriteLine("test_4_8() failed.");
-            return 181;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_4_9(100) != 100)
-        {
-            Console.WriteLine("test_4_9() failed.");
-            return 182;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_4_10(100) != 100)
-        {
-            Console.WriteLine("test_4_10() failed.");
-            return 183;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_4_11(100) != 100)
-        {
-            Console.WriteLine("test_4_11() failed.");
-            return 184;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_4_12(100) != 100)
-        {
-            Console.WriteLine("test_4_12() failed.");
-            return 185;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_4_13(100) != 100)
-        {
-            Console.WriteLine("test_4_13() failed.");
-            return 186;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_4_14(100) != 100)
-        {
-            Console.WriteLine("test_4_14() failed.");
-            return 187;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_4_15(100) != 100)
-        {
-            Console.WriteLine("test_4_15() failed.");
-            return 188;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_4_16(100) != 100)
-        {
-            Console.WriteLine("test_4_16() failed.");
-            return 189;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_4_17(100) != 100)
-        {
-            Console.WriteLine("test_4_17() failed.");
-            return 190;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_5_0(100) != 100)
-        {
-            Console.WriteLine("test_5_0() failed.");
-            return 191;
-        }
-        AA.verify_all(); AA.reset();
-        if (test_6_0(100, __makeref(AA._init)) != 100)
-        {
-            Console.WriteLine("test_6_0() failed.");
-            return 192;
-        }
-        AA.verify_all(); AA.reset();
-        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        {
-            if (test_7_0(100, p_init, p_zero) != 100)
-            {
-                Console.WriteLine("test_7_0() failed.");
-                return 193;
-            }
-        }
-        AA.verify_all(); AA.reset();
-        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        {
-            if (test_7_1(100, p_init, p_zero) != 100)
-            {
-                Console.WriteLine("test_7_1() failed.");
-                return 194;
-            }
-        }
-        AA.verify_all(); AA.reset();
-        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        {
-            if (test_7_2(100, p_init, p_zero) != 100)
-            {
-                Console.WriteLine("test_7_2() failed.");
-                return 195;
-            }
-        }
-        AA.verify_all(); AA.reset();
-        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        {
-            if (test_7_3(100, p_init, p_zero) != 100)
-            {
-                Console.WriteLine("test_7_3() failed.");
-                return 196;
-            }
-        }
-        AA.verify_all(); AA.reset();
-        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        {
-            if (test_7_4(100, p_init, p_zero) != 100)
-            {
-                Console.WriteLine("test_7_4() failed.");
-                return 197;
-            }
-        }
-        AA.verify_all(); AA.reset();
-        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        {
-            if (test_7_5(100, p_init, p_zero) != 100)
-            {
-                Console.WriteLine("test_7_5() failed.");
-                return 198;
-            }
-        }
-        AA.verify_all(); AA.reset();
-        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        {
-            if (test_7_6(100, p_init, p_zero) != 100)
-            {
-                Console.WriteLine("test_7_6() failed.");
-                return 199;
-            }
-        }
-        AA.verify_all(); AA.reset();
-        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        {
-            if (test_7_7(100, p_init, p_zero) != 100)
-            {
-                Console.WriteLine("test_7_7() failed.");
-                return 200;
-            }
-        }
-        AA.verify_all(); AA.reset();
-        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        {
-            if (test_7_8(100, p_init, p_zero) != 100)
-            {
-                Console.WriteLine("test_7_8() failed.");
-                return 201;
-            }
-        }
-        AA.verify_all(); AA.reset();
-        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        {
-            if (test_7_9(100, p_init, p_zero) != 100)
-            {
-                Console.WriteLine("test_7_9() failed.");
-                return 202;
-            }
-        }
-        AA.verify_all(); AA.reset();
-        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        {
-            if (test_7_10(100, p_init, p_zero) != 100)
-            {
-                Console.WriteLine("test_7_10() failed.");
-                return 203;
-            }
-        }
-        AA.verify_all(); AA.reset();
-        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        {
-            if (test_7_11(100, p_init, p_zero) != 100)
-            {
-                Console.WriteLine("test_7_11() failed.");
-                return 204;
-            }
-        }
-        AA.verify_all(); AA.reset();
-        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        {
-            if (test_7_12(100, p_init, p_zero) != 100)
-            {
-                Console.WriteLine("test_7_12() failed.");
-                return 205;
-            }
-        }
-        AA.verify_all(); AA.reset();
-        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        {
-            if (test_7_13(100, p_init, p_zero) != 100)
-            {
-                Console.WriteLine("test_7_13() failed.");
-                return 206;
-            }
-        }
-        AA.verify_all(); AA.reset();
-        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        {
-            if (test_7_14(100, p_init, p_zero) != 100)
-            {
-                Console.WriteLine("test_7_14() failed.");
-                return 207;
-            }
-        }
-        AA.verify_all(); AA.reset();
-        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        {
-            if (test_7_15(100, p_init, p_zero) != 100)
-            {
-                Console.WriteLine("test_7_15() failed.");
-                return 208;
-            }
-        }
-        AA.verify_all(); AA.reset();
-        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        {
-            if (test_7_16(100, p_init, p_zero) != 100)
-            {
-                Console.WriteLine("test_7_16() failed.");
-                return 209;
-            }
-        }
-        AA.verify_all(); AA.reset();
-        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        {
-            if (test_7_17(100, p_init, p_zero) != 100)
-            {
-                Console.WriteLine("test_7_17() failed.");
-                return 210;
-            }
-        }
-        AA.verify_all(); Console.WriteLine("All tests passed.");
+        //AA.verify_all(); AA.reset();
+        //if (test_1_0(100, ref AA._init, ref AA._zero) != 100)
+        //{
+        //    Console.WriteLine("test_1_0() failed.");
+        //    return 119;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_1_1(100, ref AA._init, ref AA._zero) != 100)
+        //{
+        //    Console.WriteLine("test_1_1() failed.");
+        //    return 120;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_1_2(100, ref AA._init, ref AA._zero) != 100)
+        //{
+        //    Console.WriteLine("test_1_2() failed.");
+        //    return 121;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_1_3(100, ref AA._init, ref AA._zero) != 100)
+        //{
+        //    Console.WriteLine("test_1_3() failed.");
+        //    return 122;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_1_4(100, ref AA._init, ref AA._zero) != 100)
+        //{
+        //    Console.WriteLine("test_1_4() failed.");
+        //    return 123;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_1_5(100, ref AA._init, ref AA._zero) != 100)
+        //{
+        //    Console.WriteLine("test_1_5() failed.");
+        //    return 124;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_1_6(100, ref AA._init, ref AA._zero) != 100)
+        //{
+        //    Console.WriteLine("test_1_6() failed.");
+        //    return 125;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_1_7(100, ref AA._init, ref AA._zero) != 100)
+        //{
+        //    Console.WriteLine("test_1_7() failed.");
+        //    return 126;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_1_8(100, ref AA._init, ref AA._zero) != 100)
+        //{
+        //    Console.WriteLine("test_1_8() failed.");
+        //    return 127;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_1_9(100, ref AA._init, ref AA._zero) != 100)
+        //{
+        //    Console.WriteLine("test_1_9() failed.");
+        //    return 128;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_1_10(100, ref AA._init, ref AA._zero) != 100)
+        //{
+        //    Console.WriteLine("test_1_10() failed.");
+        //    return 129;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_1_11(100, ref AA._init, ref AA._zero) != 100)
+        //{
+        //    Console.WriteLine("test_1_11() failed.");
+        //    return 130;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_1_12(100, ref AA._init, ref AA._zero) != 100)
+        //{
+        //    Console.WriteLine("test_1_12() failed.");
+        //    return 131;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_1_13(100, ref AA._init, ref AA._zero) != 100)
+        //{
+        //    Console.WriteLine("test_1_13() failed.");
+        //    return 132;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_1_14(100, ref AA._init, ref AA._zero) != 100)
+        //{
+        //    Console.WriteLine("test_1_14() failed.");
+        //    return 133;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_1_15(100, ref AA._init, ref AA._zero) != 100)
+        //{
+        //    Console.WriteLine("test_1_15() failed.");
+        //    return 134;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_1_16(100, ref AA._init, ref AA._zero) != 100)
+        //{
+        //    Console.WriteLine("test_1_16() failed.");
+        //    return 135;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_1_17(100, ref AA._init, ref AA._zero) != 100)
+        //{
+        //    Console.WriteLine("test_1_17() failed.");
+        //    return 136;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_2_0(100) != 100)
+        //{
+        //    Console.WriteLine("test_2_0() failed.");
+        //    return 137;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_2_1(100) != 100)
+        //{
+        //    Console.WriteLine("test_2_1() failed.");
+        //    return 138;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_2_2(100) != 100)
+        //{
+        //    Console.WriteLine("test_2_2() failed.");
+        //    return 139;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_2_3(100) != 100)
+        //{
+        //    Console.WriteLine("test_2_3() failed.");
+        //    return 140;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_2_4(100) != 100)
+        //{
+        //    Console.WriteLine("test_2_4() failed.");
+        //    return 141;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_2_5(100) != 100)
+        //{
+        //    Console.WriteLine("test_2_5() failed.");
+        //    return 142;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_2_6(100) != 100)
+        //{
+        //    Console.WriteLine("test_2_6() failed.");
+        //    return 143;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_2_7(100) != 100)
+        //{
+        //    Console.WriteLine("test_2_7() failed.");
+        //    return 144;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_2_8(100) != 100)
+        //{
+        //    Console.WriteLine("test_2_8() failed.");
+        //    return 145;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_2_9(100) != 100)
+        //{
+        //    Console.WriteLine("test_2_9() failed.");
+        //    return 146;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_2_10(100) != 100)
+        //{
+        //    Console.WriteLine("test_2_10() failed.");
+        //    return 147;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_2_11(100) != 100)
+        //{
+        //    Console.WriteLine("test_2_11() failed.");
+        //    return 148;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_2_12(100) != 100)
+        //{
+        //    Console.WriteLine("test_2_12() failed.");
+        //    return 149;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_2_13(100) != 100)
+        //{
+        //    Console.WriteLine("test_2_13() failed.");
+        //    return 150;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_2_14(100) != 100)
+        //{
+        //    Console.WriteLine("test_2_14() failed.");
+        //    return 151;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_2_15(100) != 100)
+        //{
+        //    Console.WriteLine("test_2_15() failed.");
+        //    return 152;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_2_16(100) != 100)
+        //{
+        //    Console.WriteLine("test_2_16() failed.");
+        //    return 153;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_2_17(100) != 100)
+        //{
+        //    Console.WriteLine("test_2_17() failed.");
+        //    return 154;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_3_0(100) != 100)
+        //{
+        //    Console.WriteLine("test_3_0() failed.");
+        //    return 155;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_3_1(100) != 100)
+        //{
+        //    Console.WriteLine("test_3_1() failed.");
+        //    return 156;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_3_2(100) != 100)
+        //{
+        //    Console.WriteLine("test_3_2() failed.");
+        //    return 157;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_3_3(100) != 100)
+        //{
+        //    Console.WriteLine("test_3_3() failed.");
+        //    return 158;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_3_4(100) != 100)
+        //{
+        //    Console.WriteLine("test_3_4() failed.");
+        //    return 159;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_3_5(100) != 100)
+        //{
+        //    Console.WriteLine("test_3_5() failed.");
+        //    return 160;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_3_6(100) != 100)
+        //{
+        //    Console.WriteLine("test_3_6() failed.");
+        //    return 161;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_3_7(100) != 100)
+        //{
+        //    Console.WriteLine("test_3_7() failed.");
+        //    return 162;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_3_8(100) != 100)
+        //{
+        //    Console.WriteLine("test_3_8() failed.");
+        //    return 163;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_3_9(100) != 100)
+        //{
+        //    Console.WriteLine("test_3_9() failed.");
+        //    return 164;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_3_10(100) != 100)
+        //{
+        //    Console.WriteLine("test_3_10() failed.");
+        //    return 165;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_3_11(100) != 100)
+        //{
+        //    Console.WriteLine("test_3_11() failed.");
+        //    return 166;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_3_12(100) != 100)
+        //{
+        //    Console.WriteLine("test_3_12() failed.");
+        //    return 167;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_3_13(100) != 100)
+        //{
+        //    Console.WriteLine("test_3_13() failed.");
+        //    return 168;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_3_14(100) != 100)
+        //{
+        //    Console.WriteLine("test_3_14() failed.");
+        //    return 169;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_3_15(100) != 100)
+        //{
+        //    Console.WriteLine("test_3_15() failed.");
+        //    return 170;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_3_16(100) != 100)
+        //{
+        //    Console.WriteLine("test_3_16() failed.");
+        //    return 171;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_3_17(100) != 100)
+        //{
+        //    Console.WriteLine("test_3_17() failed.");
+        //    return 172;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_4_0(100) != 100)
+        //{
+        //    Console.WriteLine("test_4_0() failed.");
+        //    return 173;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_4_1(100) != 100)
+        //{
+        //    Console.WriteLine("test_4_1() failed.");
+        //    return 174;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_4_2(100) != 100)
+        //{
+        //    Console.WriteLine("test_4_2() failed.");
+        //    return 175;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_4_3(100) != 100)
+        //{
+        //    Console.WriteLine("test_4_3() failed.");
+        //    return 176;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_4_4(100) != 100)
+        //{
+        //    Console.WriteLine("test_4_4() failed.");
+        //    return 177;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_4_5(100) != 100)
+        //{
+        //    Console.WriteLine("test_4_5() failed.");
+        //    return 178;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_4_6(100) != 100)
+        //{
+        //    Console.WriteLine("test_4_6() failed.");
+        //    return 179;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_4_7(100) != 100)
+        //{
+        //    Console.WriteLine("test_4_7() failed.");
+        //    return 180;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_4_8(100) != 100)
+        //{
+        //    Console.WriteLine("test_4_8() failed.");
+        //    return 181;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_4_9(100) != 100)
+        //{
+        //    Console.WriteLine("test_4_9() failed.");
+        //    return 182;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_4_10(100) != 100)
+        //{
+        //    Console.WriteLine("test_4_10() failed.");
+        //    return 183;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_4_11(100) != 100)
+        //{
+        //    Console.WriteLine("test_4_11() failed.");
+        //    return 184;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_4_12(100) != 100)
+        //{
+        //    Console.WriteLine("test_4_12() failed.");
+        //    return 185;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_4_13(100) != 100)
+        //{
+        //    Console.WriteLine("test_4_13() failed.");
+        //    return 186;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_4_14(100) != 100)
+        //{
+        //    Console.WriteLine("test_4_14() failed.");
+        //    return 187;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_4_15(100) != 100)
+        //{
+        //    Console.WriteLine("test_4_15() failed.");
+        //    return 188;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_4_16(100) != 100)
+        //{
+        //    Console.WriteLine("test_4_16() failed.");
+        //    return 189;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_4_17(100) != 100)
+        //{
+        //    Console.WriteLine("test_4_17() failed.");
+        //    return 190;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_5_0(100) != 100)
+        //{
+        //    Console.WriteLine("test_5_0() failed.");
+        //    return 191;
+        //}
+        //AA.verify_all(); AA.reset();
+        //if (test_6_0(100, __makeref(AA._init)) != 100)
+        //{
+        //    Console.WriteLine("test_6_0() failed.");
+        //    return 192;
+        //}
+        //AA.verify_all(); AA.reset();
+        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        //{
+        //    if (test_7_0(100, p_init, p_zero) != 100)
+        //    {
+        //        Console.WriteLine("test_7_0() failed.");
+        //        return 193;
+        //    }
+        //}
+        //AA.verify_all(); AA.reset();
+        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        //{
+        //    if (test_7_1(100, p_init, p_zero) != 100)
+        //    {
+        //        Console.WriteLine("test_7_1() failed.");
+        //        return 194;
+        //    }
+        //}
+        //AA.verify_all(); AA.reset();
+        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        //{
+        //    if (test_7_2(100, p_init, p_zero) != 100)
+        //    {
+        //        Console.WriteLine("test_7_2() failed.");
+        //        return 195;
+        //    }
+        //}
+        //AA.verify_all(); AA.reset();
+        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        //{
+        //    if (test_7_3(100, p_init, p_zero) != 100)
+        //    {
+        //        Console.WriteLine("test_7_3() failed.");
+        //        return 196;
+        //    }
+        //}
+        //AA.verify_all(); AA.reset();
+        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        //{
+        //    if (test_7_4(100, p_init, p_zero) != 100)
+        //    {
+        //        Console.WriteLine("test_7_4() failed.");
+        //        return 197;
+        //    }
+        //}
+        //AA.verify_all(); AA.reset();
+        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        //{
+        //    if (test_7_5(100, p_init, p_zero) != 100)
+        //    {
+        //        Console.WriteLine("test_7_5() failed.");
+        //        return 198;
+        //    }
+        //}
+        //AA.verify_all(); AA.reset();
+        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        //{
+        //    if (test_7_6(100, p_init, p_zero) != 100)
+        //    {
+        //        Console.WriteLine("test_7_6() failed.");
+        //        return 199;
+        //    }
+        //}
+        //AA.verify_all(); AA.reset();
+        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        //{
+        //    if (test_7_7(100, p_init, p_zero) != 100)
+        //    {
+        //        Console.WriteLine("test_7_7() failed.");
+        //        return 200;
+        //    }
+        //}
+        //AA.verify_all(); AA.reset();
+        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        //{
+        //    if (test_7_8(100, p_init, p_zero) != 100)
+        //    {
+        //        Console.WriteLine("test_7_8() failed.");
+        //        return 201;
+        //    }
+        //}
+        //AA.verify_all(); AA.reset();
+        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        //{
+        //    if (test_7_9(100, p_init, p_zero) != 100)
+        //    {
+        //        Console.WriteLine("test_7_9() failed.");
+        //        return 202;
+        //    }
+        //}
+        //AA.verify_all(); AA.reset();
+        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        //{
+        //    if (test_7_10(100, p_init, p_zero) != 100)
+        //    {
+        //        Console.WriteLine("test_7_10() failed.");
+        //        return 203;
+        //    }
+        //}
+        //AA.verify_all(); AA.reset();
+        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        //{
+        //    if (test_7_11(100, p_init, p_zero) != 100)
+        //    {
+        //        Console.WriteLine("test_7_11() failed.");
+        //        return 204;
+        //    }
+        //}
+        //AA.verify_all(); AA.reset();
+        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        //{
+        //    if (test_7_12(100, p_init, p_zero) != 100)
+        //    {
+        //        Console.WriteLine("test_7_12() failed.");
+        //        return 205;
+        //    }
+        //}
+        //AA.verify_all(); AA.reset();
+        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        //{
+        //    if (test_7_13(100, p_init, p_zero) != 100)
+        //    {
+        //        Console.WriteLine("test_7_13() failed.");
+        //        return 206;
+        //    }
+        //}
+        //AA.verify_all(); AA.reset();
+        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        //{
+        //    if (test_7_14(100, p_init, p_zero) != 100)
+        //    {
+        //        Console.WriteLine("test_7_14() failed.");
+        //        return 207;
+        //    }
+        //}
+        //AA.verify_all(); AA.reset();
+        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        //{
+        //    if (test_7_15(100, p_init, p_zero) != 100)
+        //    {
+        //        Console.WriteLine("test_7_15() failed.");
+        //        return 208;
+        //    }
+        //}
+        //AA.verify_all(); AA.reset();
+        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        //{
+        //    if (test_7_16(100, p_init, p_zero) != 100)
+        //    {
+        //        Console.WriteLine("test_7_16() failed.");
+        //        return 209;
+        //    }
+        //}
+        //AA.verify_all(); AA.reset();
+        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        //{
+        //    if (test_7_17(100, p_init, p_zero) != 100)
+        //    {
+        //        Console.WriteLine("test_7_17() failed.");
+        //        return 210;
+        //    }
+        //}
+        //AA.verify_all();
+        Console.WriteLine("All tests passed.");
         return 100;
     }
 }

--- a/src/tests/JIT/Methodical/explicit/coverage/body_short.cs
+++ b/src/tests/JIT/Methodical/explicit/coverage/body_short.cs
@@ -82,8 +82,6 @@ internal class TestApp
     }
     private static short test_0_17(short num, AA init, AA zero)
     {
-        //short result = ;
-        //Console.WriteLine(result);
         return AA.call_target_ref(ref init.q);
     }
     private static short test_1_0(short num, ref AA r_init, ref AA r_zero)
@@ -600,614 +598,613 @@ internal class TestApp
             Console.WriteLine("test_0_17() failed.");
             return 118;
         }
-        //AA.verify_all(); AA.reset();
-        //if (test_1_0(100, ref AA._init, ref AA._zero) != 100)
-        //{
-        //    Console.WriteLine("test_1_0() failed.");
-        //    return 119;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_1_1(100, ref AA._init, ref AA._zero) != 100)
-        //{
-        //    Console.WriteLine("test_1_1() failed.");
-        //    return 120;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_1_2(100, ref AA._init, ref AA._zero) != 100)
-        //{
-        //    Console.WriteLine("test_1_2() failed.");
-        //    return 121;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_1_3(100, ref AA._init, ref AA._zero) != 100)
-        //{
-        //    Console.WriteLine("test_1_3() failed.");
-        //    return 122;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_1_4(100, ref AA._init, ref AA._zero) != 100)
-        //{
-        //    Console.WriteLine("test_1_4() failed.");
-        //    return 123;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_1_5(100, ref AA._init, ref AA._zero) != 100)
-        //{
-        //    Console.WriteLine("test_1_5() failed.");
-        //    return 124;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_1_6(100, ref AA._init, ref AA._zero) != 100)
-        //{
-        //    Console.WriteLine("test_1_6() failed.");
-        //    return 125;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_1_7(100, ref AA._init, ref AA._zero) != 100)
-        //{
-        //    Console.WriteLine("test_1_7() failed.");
-        //    return 126;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_1_8(100, ref AA._init, ref AA._zero) != 100)
-        //{
-        //    Console.WriteLine("test_1_8() failed.");
-        //    return 127;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_1_9(100, ref AA._init, ref AA._zero) != 100)
-        //{
-        //    Console.WriteLine("test_1_9() failed.");
-        //    return 128;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_1_10(100, ref AA._init, ref AA._zero) != 100)
-        //{
-        //    Console.WriteLine("test_1_10() failed.");
-        //    return 129;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_1_11(100, ref AA._init, ref AA._zero) != 100)
-        //{
-        //    Console.WriteLine("test_1_11() failed.");
-        //    return 130;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_1_12(100, ref AA._init, ref AA._zero) != 100)
-        //{
-        //    Console.WriteLine("test_1_12() failed.");
-        //    return 131;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_1_13(100, ref AA._init, ref AA._zero) != 100)
-        //{
-        //    Console.WriteLine("test_1_13() failed.");
-        //    return 132;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_1_14(100, ref AA._init, ref AA._zero) != 100)
-        //{
-        //    Console.WriteLine("test_1_14() failed.");
-        //    return 133;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_1_15(100, ref AA._init, ref AA._zero) != 100)
-        //{
-        //    Console.WriteLine("test_1_15() failed.");
-        //    return 134;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_1_16(100, ref AA._init, ref AA._zero) != 100)
-        //{
-        //    Console.WriteLine("test_1_16() failed.");
-        //    return 135;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_1_17(100, ref AA._init, ref AA._zero) != 100)
-        //{
-        //    Console.WriteLine("test_1_17() failed.");
-        //    return 136;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_2_0(100) != 100)
-        //{
-        //    Console.WriteLine("test_2_0() failed.");
-        //    return 137;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_2_1(100) != 100)
-        //{
-        //    Console.WriteLine("test_2_1() failed.");
-        //    return 138;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_2_2(100) != 100)
-        //{
-        //    Console.WriteLine("test_2_2() failed.");
-        //    return 139;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_2_3(100) != 100)
-        //{
-        //    Console.WriteLine("test_2_3() failed.");
-        //    return 140;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_2_4(100) != 100)
-        //{
-        //    Console.WriteLine("test_2_4() failed.");
-        //    return 141;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_2_5(100) != 100)
-        //{
-        //    Console.WriteLine("test_2_5() failed.");
-        //    return 142;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_2_6(100) != 100)
-        //{
-        //    Console.WriteLine("test_2_6() failed.");
-        //    return 143;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_2_7(100) != 100)
-        //{
-        //    Console.WriteLine("test_2_7() failed.");
-        //    return 144;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_2_8(100) != 100)
-        //{
-        //    Console.WriteLine("test_2_8() failed.");
-        //    return 145;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_2_9(100) != 100)
-        //{
-        //    Console.WriteLine("test_2_9() failed.");
-        //    return 146;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_2_10(100) != 100)
-        //{
-        //    Console.WriteLine("test_2_10() failed.");
-        //    return 147;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_2_11(100) != 100)
-        //{
-        //    Console.WriteLine("test_2_11() failed.");
-        //    return 148;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_2_12(100) != 100)
-        //{
-        //    Console.WriteLine("test_2_12() failed.");
-        //    return 149;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_2_13(100) != 100)
-        //{
-        //    Console.WriteLine("test_2_13() failed.");
-        //    return 150;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_2_14(100) != 100)
-        //{
-        //    Console.WriteLine("test_2_14() failed.");
-        //    return 151;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_2_15(100) != 100)
-        //{
-        //    Console.WriteLine("test_2_15() failed.");
-        //    return 152;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_2_16(100) != 100)
-        //{
-        //    Console.WriteLine("test_2_16() failed.");
-        //    return 153;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_2_17(100) != 100)
-        //{
-        //    Console.WriteLine("test_2_17() failed.");
-        //    return 154;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_3_0(100) != 100)
-        //{
-        //    Console.WriteLine("test_3_0() failed.");
-        //    return 155;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_3_1(100) != 100)
-        //{
-        //    Console.WriteLine("test_3_1() failed.");
-        //    return 156;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_3_2(100) != 100)
-        //{
-        //    Console.WriteLine("test_3_2() failed.");
-        //    return 157;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_3_3(100) != 100)
-        //{
-        //    Console.WriteLine("test_3_3() failed.");
-        //    return 158;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_3_4(100) != 100)
-        //{
-        //    Console.WriteLine("test_3_4() failed.");
-        //    return 159;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_3_5(100) != 100)
-        //{
-        //    Console.WriteLine("test_3_5() failed.");
-        //    return 160;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_3_6(100) != 100)
-        //{
-        //    Console.WriteLine("test_3_6() failed.");
-        //    return 161;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_3_7(100) != 100)
-        //{
-        //    Console.WriteLine("test_3_7() failed.");
-        //    return 162;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_3_8(100) != 100)
-        //{
-        //    Console.WriteLine("test_3_8() failed.");
-        //    return 163;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_3_9(100) != 100)
-        //{
-        //    Console.WriteLine("test_3_9() failed.");
-        //    return 164;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_3_10(100) != 100)
-        //{
-        //    Console.WriteLine("test_3_10() failed.");
-        //    return 165;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_3_11(100) != 100)
-        //{
-        //    Console.WriteLine("test_3_11() failed.");
-        //    return 166;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_3_12(100) != 100)
-        //{
-        //    Console.WriteLine("test_3_12() failed.");
-        //    return 167;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_3_13(100) != 100)
-        //{
-        //    Console.WriteLine("test_3_13() failed.");
-        //    return 168;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_3_14(100) != 100)
-        //{
-        //    Console.WriteLine("test_3_14() failed.");
-        //    return 169;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_3_15(100) != 100)
-        //{
-        //    Console.WriteLine("test_3_15() failed.");
-        //    return 170;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_3_16(100) != 100)
-        //{
-        //    Console.WriteLine("test_3_16() failed.");
-        //    return 171;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_3_17(100) != 100)
-        //{
-        //    Console.WriteLine("test_3_17() failed.");
-        //    return 172;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_4_0(100) != 100)
-        //{
-        //    Console.WriteLine("test_4_0() failed.");
-        //    return 173;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_4_1(100) != 100)
-        //{
-        //    Console.WriteLine("test_4_1() failed.");
-        //    return 174;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_4_2(100) != 100)
-        //{
-        //    Console.WriteLine("test_4_2() failed.");
-        //    return 175;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_4_3(100) != 100)
-        //{
-        //    Console.WriteLine("test_4_3() failed.");
-        //    return 176;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_4_4(100) != 100)
-        //{
-        //    Console.WriteLine("test_4_4() failed.");
-        //    return 177;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_4_5(100) != 100)
-        //{
-        //    Console.WriteLine("test_4_5() failed.");
-        //    return 178;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_4_6(100) != 100)
-        //{
-        //    Console.WriteLine("test_4_6() failed.");
-        //    return 179;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_4_7(100) != 100)
-        //{
-        //    Console.WriteLine("test_4_7() failed.");
-        //    return 180;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_4_8(100) != 100)
-        //{
-        //    Console.WriteLine("test_4_8() failed.");
-        //    return 181;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_4_9(100) != 100)
-        //{
-        //    Console.WriteLine("test_4_9() failed.");
-        //    return 182;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_4_10(100) != 100)
-        //{
-        //    Console.WriteLine("test_4_10() failed.");
-        //    return 183;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_4_11(100) != 100)
-        //{
-        //    Console.WriteLine("test_4_11() failed.");
-        //    return 184;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_4_12(100) != 100)
-        //{
-        //    Console.WriteLine("test_4_12() failed.");
-        //    return 185;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_4_13(100) != 100)
-        //{
-        //    Console.WriteLine("test_4_13() failed.");
-        //    return 186;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_4_14(100) != 100)
-        //{
-        //    Console.WriteLine("test_4_14() failed.");
-        //    return 187;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_4_15(100) != 100)
-        //{
-        //    Console.WriteLine("test_4_15() failed.");
-        //    return 188;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_4_16(100) != 100)
-        //{
-        //    Console.WriteLine("test_4_16() failed.");
-        //    return 189;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_4_17(100) != 100)
-        //{
-        //    Console.WriteLine("test_4_17() failed.");
-        //    return 190;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_5_0(100) != 100)
-        //{
-        //    Console.WriteLine("test_5_0() failed.");
-        //    return 191;
-        //}
-        //AA.verify_all(); AA.reset();
-        //if (test_6_0(100, __makeref(AA._init)) != 100)
-        //{
-        //    Console.WriteLine("test_6_0() failed.");
-        //    return 192;
-        //}
-        //AA.verify_all(); AA.reset();
-        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        //{
-        //    if (test_7_0(100, p_init, p_zero) != 100)
-        //    {
-        //        Console.WriteLine("test_7_0() failed.");
-        //        return 193;
-        //    }
-        //}
-        //AA.verify_all(); AA.reset();
-        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        //{
-        //    if (test_7_1(100, p_init, p_zero) != 100)
-        //    {
-        //        Console.WriteLine("test_7_1() failed.");
-        //        return 194;
-        //    }
-        //}
-        //AA.verify_all(); AA.reset();
-        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        //{
-        //    if (test_7_2(100, p_init, p_zero) != 100)
-        //    {
-        //        Console.WriteLine("test_7_2() failed.");
-        //        return 195;
-        //    }
-        //}
-        //AA.verify_all(); AA.reset();
-        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        //{
-        //    if (test_7_3(100, p_init, p_zero) != 100)
-        //    {
-        //        Console.WriteLine("test_7_3() failed.");
-        //        return 196;
-        //    }
-        //}
-        //AA.verify_all(); AA.reset();
-        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        //{
-        //    if (test_7_4(100, p_init, p_zero) != 100)
-        //    {
-        //        Console.WriteLine("test_7_4() failed.");
-        //        return 197;
-        //    }
-        //}
-        //AA.verify_all(); AA.reset();
-        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        //{
-        //    if (test_7_5(100, p_init, p_zero) != 100)
-        //    {
-        //        Console.WriteLine("test_7_5() failed.");
-        //        return 198;
-        //    }
-        //}
-        //AA.verify_all(); AA.reset();
-        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        //{
-        //    if (test_7_6(100, p_init, p_zero) != 100)
-        //    {
-        //        Console.WriteLine("test_7_6() failed.");
-        //        return 199;
-        //    }
-        //}
-        //AA.verify_all(); AA.reset();
-        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        //{
-        //    if (test_7_7(100, p_init, p_zero) != 100)
-        //    {
-        //        Console.WriteLine("test_7_7() failed.");
-        //        return 200;
-        //    }
-        //}
-        //AA.verify_all(); AA.reset();
-        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        //{
-        //    if (test_7_8(100, p_init, p_zero) != 100)
-        //    {
-        //        Console.WriteLine("test_7_8() failed.");
-        //        return 201;
-        //    }
-        //}
-        //AA.verify_all(); AA.reset();
-        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        //{
-        //    if (test_7_9(100, p_init, p_zero) != 100)
-        //    {
-        //        Console.WriteLine("test_7_9() failed.");
-        //        return 202;
-        //    }
-        //}
-        //AA.verify_all(); AA.reset();
-        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        //{
-        //    if (test_7_10(100, p_init, p_zero) != 100)
-        //    {
-        //        Console.WriteLine("test_7_10() failed.");
-        //        return 203;
-        //    }
-        //}
-        //AA.verify_all(); AA.reset();
-        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        //{
-        //    if (test_7_11(100, p_init, p_zero) != 100)
-        //    {
-        //        Console.WriteLine("test_7_11() failed.");
-        //        return 204;
-        //    }
-        //}
-        //AA.verify_all(); AA.reset();
-        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        //{
-        //    if (test_7_12(100, p_init, p_zero) != 100)
-        //    {
-        //        Console.WriteLine("test_7_12() failed.");
-        //        return 205;
-        //    }
-        //}
-        //AA.verify_all(); AA.reset();
-        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        //{
-        //    if (test_7_13(100, p_init, p_zero) != 100)
-        //    {
-        //        Console.WriteLine("test_7_13() failed.");
-        //        return 206;
-        //    }
-        //}
-        //AA.verify_all(); AA.reset();
-        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        //{
-        //    if (test_7_14(100, p_init, p_zero) != 100)
-        //    {
-        //        Console.WriteLine("test_7_14() failed.");
-        //        return 207;
-        //    }
-        //}
-        //AA.verify_all(); AA.reset();
-        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        //{
-        //    if (test_7_15(100, p_init, p_zero) != 100)
-        //    {
-        //        Console.WriteLine("test_7_15() failed.");
-        //        return 208;
-        //    }
-        //}
-        //AA.verify_all(); AA.reset();
-        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        //{
-        //    if (test_7_16(100, p_init, p_zero) != 100)
-        //    {
-        //        Console.WriteLine("test_7_16() failed.");
-        //        return 209;
-        //    }
-        //}
-        //AA.verify_all(); AA.reset();
-        //fixed (void* p_init = &AA._init, p_zero = &AA._zero)
-        //{
-        //    if (test_7_17(100, p_init, p_zero) != 100)
-        //    {
-        //        Console.WriteLine("test_7_17() failed.");
-        //        return 210;
-        //    }
-        //}
-        //AA.verify_all();
-        Console.WriteLine("All tests passed.");
+        AA.verify_all(); AA.reset();
+        if (test_1_0(100, ref AA._init, ref AA._zero) != 100)
+        {
+            Console.WriteLine("test_1_0() failed.");
+            return 119;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_1_1(100, ref AA._init, ref AA._zero) != 100)
+        {
+            Console.WriteLine("test_1_1() failed.");
+            return 120;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_1_2(100, ref AA._init, ref AA._zero) != 100)
+        {
+            Console.WriteLine("test_1_2() failed.");
+            return 121;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_1_3(100, ref AA._init, ref AA._zero) != 100)
+        {
+            Console.WriteLine("test_1_3() failed.");
+            return 122;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_1_4(100, ref AA._init, ref AA._zero) != 100)
+        {
+            Console.WriteLine("test_1_4() failed.");
+            return 123;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_1_5(100, ref AA._init, ref AA._zero) != 100)
+        {
+            Console.WriteLine("test_1_5() failed.");
+            return 124;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_1_6(100, ref AA._init, ref AA._zero) != 100)
+        {
+            Console.WriteLine("test_1_6() failed.");
+            return 125;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_1_7(100, ref AA._init, ref AA._zero) != 100)
+        {
+            Console.WriteLine("test_1_7() failed.");
+            return 126;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_1_8(100, ref AA._init, ref AA._zero) != 100)
+        {
+            Console.WriteLine("test_1_8() failed.");
+            return 127;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_1_9(100, ref AA._init, ref AA._zero) != 100)
+        {
+            Console.WriteLine("test_1_9() failed.");
+            return 128;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_1_10(100, ref AA._init, ref AA._zero) != 100)
+        {
+            Console.WriteLine("test_1_10() failed.");
+            return 129;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_1_11(100, ref AA._init, ref AA._zero) != 100)
+        {
+            Console.WriteLine("test_1_11() failed.");
+            return 130;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_1_12(100, ref AA._init, ref AA._zero) != 100)
+        {
+            Console.WriteLine("test_1_12() failed.");
+            return 131;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_1_13(100, ref AA._init, ref AA._zero) != 100)
+        {
+            Console.WriteLine("test_1_13() failed.");
+            return 132;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_1_14(100, ref AA._init, ref AA._zero) != 100)
+        {
+            Console.WriteLine("test_1_14() failed.");
+            return 133;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_1_15(100, ref AA._init, ref AA._zero) != 100)
+        {
+            Console.WriteLine("test_1_15() failed.");
+            return 134;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_1_16(100, ref AA._init, ref AA._zero) != 100)
+        {
+            Console.WriteLine("test_1_16() failed.");
+            return 135;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_1_17(100, ref AA._init, ref AA._zero) != 100)
+        {
+            Console.WriteLine("test_1_17() failed.");
+            return 136;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_2_0(100) != 100)
+        {
+            Console.WriteLine("test_2_0() failed.");
+            return 137;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_2_1(100) != 100)
+        {
+            Console.WriteLine("test_2_1() failed.");
+            return 138;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_2_2(100) != 100)
+        {
+            Console.WriteLine("test_2_2() failed.");
+            return 139;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_2_3(100) != 100)
+        {
+            Console.WriteLine("test_2_3() failed.");
+            return 140;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_2_4(100) != 100)
+        {
+            Console.WriteLine("test_2_4() failed.");
+            return 141;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_2_5(100) != 100)
+        {
+            Console.WriteLine("test_2_5() failed.");
+            return 142;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_2_6(100) != 100)
+        {
+            Console.WriteLine("test_2_6() failed.");
+            return 143;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_2_7(100) != 100)
+        {
+            Console.WriteLine("test_2_7() failed.");
+            return 144;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_2_8(100) != 100)
+        {
+            Console.WriteLine("test_2_8() failed.");
+            return 145;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_2_9(100) != 100)
+        {
+            Console.WriteLine("test_2_9() failed.");
+            return 146;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_2_10(100) != 100)
+        {
+            Console.WriteLine("test_2_10() failed.");
+            return 147;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_2_11(100) != 100)
+        {
+            Console.WriteLine("test_2_11() failed.");
+            return 148;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_2_12(100) != 100)
+        {
+            Console.WriteLine("test_2_12() failed.");
+            return 149;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_2_13(100) != 100)
+        {
+            Console.WriteLine("test_2_13() failed.");
+            return 150;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_2_14(100) != 100)
+        {
+            Console.WriteLine("test_2_14() failed.");
+            return 151;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_2_15(100) != 100)
+        {
+            Console.WriteLine("test_2_15() failed.");
+            return 152;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_2_16(100) != 100)
+        {
+            Console.WriteLine("test_2_16() failed.");
+            return 153;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_2_17(100) != 100)
+        {
+            Console.WriteLine("test_2_17() failed.");
+            return 154;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_3_0(100) != 100)
+        {
+            Console.WriteLine("test_3_0() failed.");
+            return 155;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_3_1(100) != 100)
+        {
+            Console.WriteLine("test_3_1() failed.");
+            return 156;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_3_2(100) != 100)
+        {
+            Console.WriteLine("test_3_2() failed.");
+            return 157;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_3_3(100) != 100)
+        {
+            Console.WriteLine("test_3_3() failed.");
+            return 158;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_3_4(100) != 100)
+        {
+            Console.WriteLine("test_3_4() failed.");
+            return 159;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_3_5(100) != 100)
+        {
+            Console.WriteLine("test_3_5() failed.");
+            return 160;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_3_6(100) != 100)
+        {
+            Console.WriteLine("test_3_6() failed.");
+            return 161;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_3_7(100) != 100)
+        {
+            Console.WriteLine("test_3_7() failed.");
+            return 162;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_3_8(100) != 100)
+        {
+            Console.WriteLine("test_3_8() failed.");
+            return 163;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_3_9(100) != 100)
+        {
+            Console.WriteLine("test_3_9() failed.");
+            return 164;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_3_10(100) != 100)
+        {
+            Console.WriteLine("test_3_10() failed.");
+            return 165;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_3_11(100) != 100)
+        {
+            Console.WriteLine("test_3_11() failed.");
+            return 166;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_3_12(100) != 100)
+        {
+            Console.WriteLine("test_3_12() failed.");
+            return 167;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_3_13(100) != 100)
+        {
+            Console.WriteLine("test_3_13() failed.");
+            return 168;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_3_14(100) != 100)
+        {
+            Console.WriteLine("test_3_14() failed.");
+            return 169;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_3_15(100) != 100)
+        {
+            Console.WriteLine("test_3_15() failed.");
+            return 170;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_3_16(100) != 100)
+        {
+            Console.WriteLine("test_3_16() failed.");
+            return 171;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_3_17(100) != 100)
+        {
+            Console.WriteLine("test_3_17() failed.");
+            return 172;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_4_0(100) != 100)
+        {
+            Console.WriteLine("test_4_0() failed.");
+            return 173;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_4_1(100) != 100)
+        {
+            Console.WriteLine("test_4_1() failed.");
+            return 174;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_4_2(100) != 100)
+        {
+            Console.WriteLine("test_4_2() failed.");
+            return 175;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_4_3(100) != 100)
+        {
+            Console.WriteLine("test_4_3() failed.");
+            return 176;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_4_4(100) != 100)
+        {
+            Console.WriteLine("test_4_4() failed.");
+            return 177;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_4_5(100) != 100)
+        {
+            Console.WriteLine("test_4_5() failed.");
+            return 178;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_4_6(100) != 100)
+        {
+            Console.WriteLine("test_4_6() failed.");
+            return 179;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_4_7(100) != 100)
+        {
+            Console.WriteLine("test_4_7() failed.");
+            return 180;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_4_8(100) != 100)
+        {
+            Console.WriteLine("test_4_8() failed.");
+            return 181;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_4_9(100) != 100)
+        {
+            Console.WriteLine("test_4_9() failed.");
+            return 182;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_4_10(100) != 100)
+        {
+            Console.WriteLine("test_4_10() failed.");
+            return 183;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_4_11(100) != 100)
+        {
+            Console.WriteLine("test_4_11() failed.");
+            return 184;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_4_12(100) != 100)
+        {
+            Console.WriteLine("test_4_12() failed.");
+            return 185;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_4_13(100) != 100)
+        {
+            Console.WriteLine("test_4_13() failed.");
+            return 186;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_4_14(100) != 100)
+        {
+            Console.WriteLine("test_4_14() failed.");
+            return 187;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_4_15(100) != 100)
+        {
+            Console.WriteLine("test_4_15() failed.");
+            return 188;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_4_16(100) != 100)
+        {
+            Console.WriteLine("test_4_16() failed.");
+            return 189;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_4_17(100) != 100)
+        {
+            Console.WriteLine("test_4_17() failed.");
+            return 190;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_5_0(100) != 100)
+        {
+            Console.WriteLine("test_5_0() failed.");
+            return 191;
+        }
+        AA.verify_all(); AA.reset();
+        if (test_6_0(100, __makeref(AA._init)) != 100)
+        {
+            Console.WriteLine("test_6_0() failed.");
+            return 192;
+        }
+        AA.verify_all(); AA.reset();
+        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        {
+            if (test_7_0(100, p_init, p_zero) != 100)
+            {
+                Console.WriteLine("test_7_0() failed.");
+                return 193;
+            }
+        }
+        AA.verify_all(); AA.reset();
+        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        {
+            if (test_7_1(100, p_init, p_zero) != 100)
+            {
+                Console.WriteLine("test_7_1() failed.");
+                return 194;
+            }
+        }
+        AA.verify_all(); AA.reset();
+        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        {
+            if (test_7_2(100, p_init, p_zero) != 100)
+            {
+                Console.WriteLine("test_7_2() failed.");
+                return 195;
+            }
+        }
+        AA.verify_all(); AA.reset();
+        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        {
+            if (test_7_3(100, p_init, p_zero) != 100)
+            {
+                Console.WriteLine("test_7_3() failed.");
+                return 196;
+            }
+        }
+        AA.verify_all(); AA.reset();
+        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        {
+            if (test_7_4(100, p_init, p_zero) != 100)
+            {
+                Console.WriteLine("test_7_4() failed.");
+                return 197;
+            }
+        }
+        AA.verify_all(); AA.reset();
+        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        {
+            if (test_7_5(100, p_init, p_zero) != 100)
+            {
+                Console.WriteLine("test_7_5() failed.");
+                return 198;
+            }
+        }
+        AA.verify_all(); AA.reset();
+        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        {
+            if (test_7_6(100, p_init, p_zero) != 100)
+            {
+                Console.WriteLine("test_7_6() failed.");
+                return 199;
+            }
+        }
+        AA.verify_all(); AA.reset();
+        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        {
+            if (test_7_7(100, p_init, p_zero) != 100)
+            {
+                Console.WriteLine("test_7_7() failed.");
+                return 200;
+            }
+        }
+        AA.verify_all(); AA.reset();
+        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        {
+            if (test_7_8(100, p_init, p_zero) != 100)
+            {
+                Console.WriteLine("test_7_8() failed.");
+                return 201;
+            }
+        }
+        AA.verify_all(); AA.reset();
+        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        {
+            if (test_7_9(100, p_init, p_zero) != 100)
+            {
+                Console.WriteLine("test_7_9() failed.");
+                return 202;
+            }
+        }
+        AA.verify_all(); AA.reset();
+        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        {
+            if (test_7_10(100, p_init, p_zero) != 100)
+            {
+                Console.WriteLine("test_7_10() failed.");
+                return 203;
+            }
+        }
+        AA.verify_all(); AA.reset();
+        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        {
+            if (test_7_11(100, p_init, p_zero) != 100)
+            {
+                Console.WriteLine("test_7_11() failed.");
+                return 204;
+            }
+        }
+        AA.verify_all(); AA.reset();
+        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        {
+            if (test_7_12(100, p_init, p_zero) != 100)
+            {
+                Console.WriteLine("test_7_12() failed.");
+                return 205;
+            }
+        }
+        AA.verify_all(); AA.reset();
+        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        {
+            if (test_7_13(100, p_init, p_zero) != 100)
+            {
+                Console.WriteLine("test_7_13() failed.");
+                return 206;
+            }
+        }
+        AA.verify_all(); AA.reset();
+        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        {
+            if (test_7_14(100, p_init, p_zero) != 100)
+            {
+                Console.WriteLine("test_7_14() failed.");
+                return 207;
+            }
+        }
+        AA.verify_all(); AA.reset();
+        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        {
+            if (test_7_15(100, p_init, p_zero) != 100)
+            {
+                Console.WriteLine("test_7_15() failed.");
+                return 208;
+            }
+        }
+        AA.verify_all(); AA.reset();
+        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        {
+            if (test_7_16(100, p_init, p_zero) != 100)
+            {
+                Console.WriteLine("test_7_16() failed.");
+                return 209;
+            }
+        }
+        AA.verify_all(); AA.reset();
+        fixed (void* p_init = &AA._init, p_zero = &AA._zero)
+        {
+            if (test_7_17(100, p_init, p_zero) != 100)
+            {
+                Console.WriteLine("test_7_17() failed.");
+                return 210;
+            }
+        }
+        AA.verify_all(); Console.WriteLine("All tests passed.");
         return 100;
     }
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_57912/Runtime_57912.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_57912/Runtime_57912.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct AA
+{
+    public short tmp1;
+    public short q;
+
+    public ushort tmp2;
+    public int tmp3;
+
+    public AA(short qq)
+    {
+        tmp1 = 106;
+        tmp2 = 107;
+        tmp3 = 108;
+        q = qq;
+    }
+    
+    // The test verifies that we accurately update the byref variable that is a field of struct.
+    public static short call_target_ref(ref short arg) { arg = 100; return arg; }
+}
+
+   
+public class Runtime_57912
+{
+
+    public static int Main()
+    {
+        return (int)test_0_17(100, new AA(100), new AA(0));
+    }
+    
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static short test_0_17(int num, AA init, AA zero)
+    {
+        return AA.call_target_ref(ref init.q);
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_57912/Runtime_57912.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_57912/Runtime_57912.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>True</Optimize>
+    <DebugType>None</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set DOTNET_JitEnableFinallyCloning=0
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export DOTNET_JitEnableFinallyCloning=0
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_57912/Runtime_57912.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_57912/Runtime_57912.csproj
@@ -7,14 +7,4 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
-  <PropertyGroup>
-    <CLRTestBatchPreCommands><![CDATA[
-$(CLRTestBatchPreCommands)
-set DOTNET_JitEnableFinallyCloning=0
-]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export DOTNET_JitEnableFinallyCloning=0
-]]></BashCLRTestPreCommands>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
When we undo the struct promotion, we revert all the promoted fields except in the code path where we would return the promoted field. We were keeping the promoted field leading to bad codegen.

No asmdiff on libraries/benchmarks/coreclr_test. 

Since the original repro needed jitstress switch, I verified that this PR fixes the code we geenrate.

Fixes: https://github.com/dotnet/runtime/issues/57912