### PR TITLE
Address Windows recommendations for Link APIs 

### DIFF
--- a/src/libraries/Common/src/System/IO/PathInternal.Windows.cs
+++ b/src/libraries/Common/src/System/IO/PathInternal.Windows.cs
@@ -46,6 +46,7 @@ namespace System.IO
 
         internal const string DirectorySeparatorCharAsString = "\\";
 
+        internal const string NTPathPrefix = @"\??\";
         internal const string ExtendedPathPrefix = @"\\?\";
         internal const string UncPathPrefix = @"\\";
         internal const string UncExtendedPrefixToInsert = @"?\UNC\";

--- a/src/libraries/Common/src/System/IO/PathInternal.Windows.cs
+++ b/src/libraries/Common/src/System/IO/PathInternal.Windows.cs
@@ -51,6 +51,7 @@ namespace System.IO
         internal const string UncPathPrefix = @"\\";
         internal const string UncExtendedPrefixToInsert = @"?\UNC\";
         internal const string UncExtendedPathPrefix = @"\\?\UNC\";
+        internal const string UncNTPathPrefix = @"\??\UNC\";
         internal const string DevicePathPrefix = @"\\.\";
         internal const string ParentDirectoryPrefix = @"..\";
 

--- a/src/libraries/System.IO.FileSystem/tests/Base/SymbolicLinks/BaseSymbolicLinks.FileSystem.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Base/SymbolicLinks/BaseSymbolicLinks.FileSystem.cs
@@ -295,6 +295,22 @@ namespace System.IO.Tests
             Assert.Throws<IOException>(() => ResolveLinkTarget(tail, returnFinalTarget: true));
         }
 
+        [Theory]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [InlineData(@"\??\", false)]
+        [InlineData(@"\??\", true)]
+        [InlineData(@"\\?\", false)]
+        [InlineData(@"\\?\", true)]
+        public void ResolveLinkTarget_ExtendedPrefix_IsNotTrimmed(string prefix, bool returnFinalTarget)
+        {
+            string linkPath = GetRandomLinkPath();
+            string targetPathWithPrefix = Path.Join(prefix, GetRandomFilePath());
+            CreateSymbolicLink(linkPath, targetPathWithPrefix);
+
+            FileSystemInfo info = ResolveLinkTarget(linkPath, returnFinalTarget);
+            Assert.Equal(targetPathWithPrefix, info.FullName);
+        }
+
         private string CreateChainOfLinks(string target, int length, bool relative)
         {
             string previousPath = target;

--- a/src/libraries/System.IO.FileSystem/tests/Base/SymbolicLinks/BaseSymbolicLinks.FileSystem.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Base/SymbolicLinks/BaseSymbolicLinks.FileSystem.cs
@@ -361,32 +361,6 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public void CreateSymbolicLink_WrongTargetType_Throws()
-        {
-            // dirLink -> file
-            // fileLink -> dir
-
-            string targetPath = GetRandomFilePath();
-            CreateFileOrDirectory(targetPath, createOpposite: true); // The underlying file system entry needs to be different
-            Assert.Throws<IOException>(() => CreateSymbolicLink(GetRandomFilePath(), targetPath));
-        }
-
-        [Fact]
-        public void CreateSymbolicLink_WrongTargetType_Indirect_Throws()
-        {
-            // link-2 (dir) -> link-1 (file) -> file
-            // link-2 (file) -> link-1 (dir) -> dir
-            string targetPath = GetRandomFilePath();
-            string firstLinkPath = GetRandomFilePath();
-            string secondLinkPath = GetRandomFilePath();
-
-            CreateFileOrDirectory(targetPath, createOpposite: true);
-            CreateSymbolicLink_Opposite(firstLinkPath, targetPath);
-
-            Assert.Throws<IOException>(() => CreateSymbolicLink(secondLinkPath, firstLinkPath));
-        }
-
-        [Fact]
         public void CreateSymbolicLink_CorrectTargetType_Indirect_Succeeds()
         {
             // link-2 (file) -> link-1 (file) -> file

--- a/src/libraries/System.IO.FileSystem/tests/Base/SymbolicLinks/BaseSymbolicLinks.FileSystemInfo.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Base/SymbolicLinks/BaseSymbolicLinks.FileSystemInfo.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.IO.Tests
@@ -54,7 +52,7 @@ namespace System.IO.Tests
         }
 
         [Theory]
-        [MemberData(nameof(LinkTarget_PathToTarget_Data))]
+        [MemberData(nameof(SymbolicLink_LinkTarget_PathToTarget_Data))]
         public void LinkTarget_Succeeds(string pathToTarget)
         {
             FileSystemInfo linkInfo = CreateSymbolicLink(GetRandomLinkPath(), pathToTarget);
@@ -85,30 +83,6 @@ namespace System.IO.Tests
             linkInfo.Refresh();
             Assert.Equal(newPathToTarget, linkInfo.LinkTarget);
             Assert.Equal(newLinkInfo.LinkTarget, linkInfo.LinkTarget);
-        }
-
-        [Theory]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        [InlineData(@"\??\")]
-        [InlineData(@"\\?\")]
-        public void LinkTarget_ExtendedPrefix_IsNotTrimmed(string prefix)
-        {
-            string linkPath = GetRandomLinkPath();
-            string targetPathWithPrefix = Path.Join(prefix, GetRandomFilePath());
-
-            FileSystemInfo info = CreateSymbolicLink(linkPath, targetPathWithPrefix);
-            Assert.Equal(targetPathWithPrefix, info.LinkTarget);
-        }
-
-        public static IEnumerable<object[]> LinkTarget_PathToTarget_Data
-        {
-            get
-            {
-                foreach (string path in PathToTargetData)
-                {
-                    yield return new object[] { path };
-                }
-            }
         }
     }
 }

--- a/src/libraries/System.IO.FileSystem/tests/Base/SymbolicLinks/BaseSymbolicLinks.FileSystemInfo.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Base/SymbolicLinks/BaseSymbolicLinks.FileSystemInfo.cs
@@ -87,6 +87,19 @@ namespace System.IO.Tests
             Assert.Equal(newLinkInfo.LinkTarget, linkInfo.LinkTarget);
         }
 
+        [Theory]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [InlineData(@"\??\")]
+        [InlineData(@"\\?\")]
+        public void LinkTarget_ExtendedPrefix_IsNotTrimmed(string prefix)
+        {
+            string linkPath = GetRandomLinkPath();
+            string targetPathWithPrefix = Path.Join(prefix, GetRandomFilePath());
+
+            FileSystemInfo info = CreateSymbolicLink(linkPath, targetPathWithPrefix);
+            Assert.Equal(targetPathWithPrefix, info.LinkTarget);
+        }
+
         public static IEnumerable<object[]> LinkTarget_PathToTarget_Data
         {
             get

--- a/src/libraries/System.IO.FileSystem/tests/Base/SymbolicLinks/BaseSymbolicLinks.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Base/SymbolicLinks/BaseSymbolicLinks.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace System.IO.Tests
@@ -44,6 +46,96 @@ namespace System.IO.Tests
             Directory.CreateDirectory(tempCwd);
             Directory.SetCurrentDirectory(tempCwd);
             return tempCwd;
+        }
+
+        public static IEnumerable<object[]> SymbolicLink_LinkTarget_PathToTarget_Data
+        {
+            get
+            {
+                foreach (string path in PathToTargetData.Union(PathToTargetUncData))
+                {
+                    yield return new object[] { path };
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> SymbolicLink_ResolveLinkTarget_PathToTarget_Data
+        {
+            get
+            {
+                foreach (string path in PathToTargetData.Union(PathToTargetUncData))
+                {
+                    yield return new object[] { path, false };
+                    yield return new object[] { path, true };
+                }
+            }
+        }
+
+        // Junctions doesn't support remote shares.
+        public static IEnumerable<object[]> Junction_LinkTarget_PathToTarget_Data
+        {
+            get
+            {
+                foreach (string path in PathToTargetData)
+                {
+                    yield return new object[] { path };
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> Junction_ResolveLinkTarget_PathToTarget_Data
+        {
+            get
+            {
+                foreach (string path in PathToTargetData)
+                {
+                    yield return new object[] { path, false };
+                    yield return new object[] { path, true };
+                }
+            }
+        }
+
+        internal static IEnumerable<string> PathToTargetData
+        {
+            get
+            {
+                if (OperatingSystem.IsWindows())
+                {
+                    //Non-rooted relative
+                    yield return "foo";
+                    yield return @".\foo";
+                    yield return @"..\foo";
+                    // Rooted relative
+                    yield return @"\foo";
+                    // Rooted absolute
+                    yield return Path.Combine(Path.GetTempPath(), "foo");
+                    // Extended DOS
+                    yield return Path.Combine(@"\\?\", Path.GetTempPath(), "foo");
+                }
+                else
+                {
+                    //Non-rooted relative
+                    yield return "foo";
+                    yield return "./foo";
+                    yield return "../foo";
+                    // Rooted relative
+                    yield return "/foo";
+                    // Rooted absolute
+                    Path.Combine(Path.GetTempPath(), "foo");
+                }
+            }
+        }
+
+        internal static IEnumerable<string> PathToTargetUncData
+        {
+            get
+            {
+                if (OperatingSystem.IsWindows())
+                {
+                    // UNC/Remote Share
+                    yield return @"\\LOCALHOST\share\path";
+                }
+            }
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -2658,9 +2658,6 @@
   </data>
   <data name="IO_BindHandleFailed" xml:space="preserve">
     <value>BindHandle for ThreadPool failed on this handle.</value>
-  </data>
-  <data name="IO_InconsistentLinkType" xml:space="preserve">
-    <value>The link's file system entry type is inconsistent with that of its target: {0}</value>
   </data>
   <data name="IO_FileExists_Name" xml:space="preserve">
     <value>The file '{0}' already exists.</value>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
@@ -571,16 +571,6 @@ namespace System.IO
         internal static void CreateSymbolicLink(string path, string pathToTarget, bool isDirectory)
         {
             string pathToTargetFullPath = PathInternal.GetLinkTargetFullPath(path, pathToTarget);
-
-            // Fail if the target exists but is not consistent with the expected filesystem entry type
-            if (Interop.Sys.Stat(pathToTargetFullPath, out Interop.Sys.FileStatus targetInfo) == 0)
-            {
-                if (isDirectory != ((targetInfo.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR))
-                {
-                    throw new IOException(SR.Format(SR.IO_InconsistentLinkType, path));
-                }
-            }
-
             Interop.CheckIo(Interop.Sys.SymLink(pathToTarget, path), path, isDirectory);
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
@@ -415,16 +415,6 @@ namespace System.IO
         internal static void CreateSymbolicLink(string path, string pathToTarget, bool isDirectory)
         {
             string pathToTargetFullPath = PathInternal.GetLinkTargetFullPath(path, pathToTarget);
-
-            Interop.Kernel32.WIN32_FILE_ATTRIBUTE_DATA data = default;
-            int errorCode = FillAttributeInfo(pathToTargetFullPath, ref data, returnErrorOnNotFound: true);
-            if (errorCode == Interop.Errors.ERROR_SUCCESS &&
-                data.dwFileAttributes != -1 &&
-                isDirectory != ((data.dwFileAttributes & Interop.Kernel32.FileAttributes.FILE_ATTRIBUTE_DIRECTORY) != 0))
-            {
-                throw new IOException(SR.Format(SR.IO_InconsistentLinkType, path));
-            }
-
             Interop.Kernel32.CreateSymbolicLink(path, pathToTarget, isDirectory);
         }
 
@@ -502,8 +492,7 @@ namespace System.IO
                 success = MemoryMarshal.TryRead(bufferSpan, out Interop.Kernel32.SymbolicLinkReparseBuffer rbSymlink);
                 Debug.Assert(success);
 
-                // We use PrintName(Offset|Length) instead of SubstituteName(Offset|Length) since is more friendly to the end-user,
-                // however, there's no guarantee that the NT prefix doesn't show up.
+                // We use PrintName(Offset|Length) instead of SubstituteName(Offset|Length) since is more friendly to the end-user,                // however, there's no guarantee that the NT prefix doesn't show up.
 
                 // PrintName can return a NT path if the link was created explicitly targeting a file/folder in such way.
                 //   e.g: mklink /D linkName \??\C:\path\to\target.

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
@@ -506,13 +506,13 @@ namespace System.IO
                     if (!isRelative)
                     {
                         // Absolute target is in NT format and we need to clean it up before return it to the user.
-                        if (targetPath.StartsWith(PathInternal.UncNTPathPrefix))
+                        if (targetPath.StartsWith(PathInternal.UncNTPathPrefix.AsSpan()))
                         {
                             // We need to prepend the Win32 equivalent of UNC NT prefix.
-                            return Path.Join(PathInternal.UncPathPrefix, targetPath.Slice(PathInternal.UncNTPathPrefix.Length)).ToString();
+                            return Path.Join(PathInternal.UncPathPrefix.AsSpan(), targetPath.Slice(PathInternal.UncNTPathPrefix.Length)).ToString();
                         }
 
-                        Debug.Assert(targetPath.StartsWith(PathInternal.NTPathPrefix));
+                        Debug.Assert(targetPath.StartsWith(PathInternal.NTPathPrefix.AsSpan()));
                         return targetPath.Slice(PathInternal.NTPathPrefix.Length).ToString();
                     }
                     else if (returnFullPath)
@@ -536,7 +536,7 @@ namespace System.IO
 
                     // Unlike symbolic links, mount point paths cannot be relative.
                     Debug.Assert(!PathInternal.IsPartiallyQualified(targetPath));
-                    Debug.Assert(targetPath.StartsWith(PathInternal.NTPathPrefix));
+                    Debug.Assert(targetPath.StartsWith(PathInternal.NTPathPrefix.AsSpan()));
                     return targetPath.Slice(PathInternal.NTPathPrefix.Length).ToString();
                 }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Windows.cs
@@ -492,41 +492,52 @@ namespace System.IO
                 success = MemoryMarshal.TryRead(bufferSpan, out Interop.Kernel32.SymbolicLinkReparseBuffer rbSymlink);
                 Debug.Assert(success);
 
-                // We use PrintName(Offset|Length) instead of SubstituteName(Offset|Length) since is more friendly to the end-user,                // however, there's no guarantee that the NT prefix doesn't show up.
-
-                // PrintName can return a NT path if the link was created explicitly targeting a file/folder in such way.
-                //   e.g: mklink /D linkName \??\C:\path\to\target.
+                // We always use SubstituteName(Offset|Length) instead of PrintName(Offset|Length),
+                // the latter is just the display name of the reparse point and it can show something completely unrelated to the target.
 
                 if (rbSymlink.ReparseTag == Interop.Kernel32.IOReparseOptions.IO_REPARSE_TAG_SYMLINK)
                 {
-                    int printNameOffset = sizeof(Interop.Kernel32.SymbolicLinkReparseBuffer) + rbSymlink.PrintNameOffset;
-                    int printNameLength = rbSymlink.PrintNameLength;
+                    int offset = sizeof(Interop.Kernel32.SymbolicLinkReparseBuffer) + rbSymlink.SubstituteNameOffset;
+                    int length = rbSymlink.SubstituteNameLength;
 
-                    Span<char> targetPath = MemoryMarshal.Cast<byte, char>(bufferSpan.Slice(printNameOffset, printNameLength));
+                    Span<char> targetPath = MemoryMarshal.Cast<byte, char>(bufferSpan.Slice(offset, length));
 
-                    if (returnFullPath &&
-                        (rbSymlink.Flags & Interop.Kernel32.SYMLINK_FLAG_RELATIVE) != 0 &&
-                        !targetPath.StartsWith(PathInternal.NTPathPrefix.AsSpan())) // Edge-case: SYMLINK_FLAG_RELATIVE is incorrectly set when the target starts with \??\.
+                    bool isRelative = (rbSymlink.Flags & Interop.Kernel32.SYMLINK_FLAG_RELATIVE) != 0;
+                    if (!isRelative)
                     {
-                        // Target path is relative and is for ResolveLinkTarget(), we need to append the link directory.
-                        return Path.Join(Path.GetDirectoryName(linkPath.AsSpan()), targetPath);
-                    }
+                        // Absolute target is in NT format and we need to clean it up before return it to the user.
+                        if (targetPath.StartsWith(PathInternal.UncNTPathPrefix))
+                        {
+                            // We need to prepend the Win32 equivalent of UNC NT prefix.
+                            return Path.Join(PathInternal.UncPathPrefix, targetPath.Slice(PathInternal.UncNTPathPrefix.Length)).ToString();
+                        }
 
-                    return targetPath.ToString();
+                        Debug.Assert(targetPath.StartsWith(PathInternal.NTPathPrefix));
+                        return targetPath.Slice(PathInternal.NTPathPrefix.Length).ToString();
+                    }
+                    else if (returnFullPath)
+                    {
+                        return Path.Join(Path.GetDirectoryName(linkPath.AsSpan()), targetPath).ToString();
+                    }
+                    else
+                    {
+                        return targetPath.ToString();
+                    }
                 }
                 else if (rbSymlink.ReparseTag == Interop.Kernel32.IOReparseOptions.IO_REPARSE_TAG_MOUNT_POINT)
                 {
                     success = MemoryMarshal.TryRead(bufferSpan, out Interop.Kernel32.MountPointReparseBuffer rbMountPoint);
                     Debug.Assert(success);
 
-                    int printNameOffset = sizeof(Interop.Kernel32.MountPointReparseBuffer) + rbMountPoint.PrintNameOffset;
-                    int printNameLength = rbMountPoint.PrintNameLength;
+                    int offset = sizeof(Interop.Kernel32.MountPointReparseBuffer) + rbMountPoint.SubstituteNameOffset;
+                    int length = rbMountPoint.SubstituteNameLength;
 
-                    Span<char> targetPath = MemoryMarshal.Cast<byte, char>(bufferSpan.Slice(printNameOffset, printNameLength));
+                    Span<char> targetPath = MemoryMarshal.Cast<byte, char>(bufferSpan.Slice(offset, length));
 
-                    // Unlike symlinks, mount point paths cannot be relative
+                    // Unlike symbolic links, mount point paths cannot be relative.
                     Debug.Assert(!PathInternal.IsPartiallyQualified(targetPath));
-                    return targetPath.ToString();
+                    Debug.Assert(targetPath.StartsWith(PathInternal.NTPathPrefix));
+                    return targetPath.Slice(PathInternal.NTPathPrefix.Length).ToString();
                 }
 
                 return null;


### PR DESCRIPTION
* ~~https://github.com/dotnet/runtime/commit/1ce2f3034b8bb0c73eb10235dac20f0e354e9f8e: Even though `REPARSE_DATA_BUFFER`'s `PrintName` is more end-user-friendly vs `SubstituteName`, there's no guarantee that NT prefix (`\??\`) won't be there, we got recommended that we should take our cautions with that and apply logic to trim the prefix as needed. 
However, in further investigation I've noticed that a symlink/junction created with NT prefix, that is `mklink foo \??\C:\Users\david\bar` cannot be resolved by Windows. therefore my approach here is to always return the unadultered `PrintName` in such case. If Windows is unable to resolve such paths, we should defer users to reason about them themselves.
I've also found a bug in `DeviceIoControl` where `REPARSE_DATA_BUFFER.Flags` will contain `SYMLINK_FLAG_RELATIVE` for NT paths (e.g: `\??\C:\foo`), which is incorrect given that such paths will always be treated as absolute.~~

* https://github.com/dotnet/runtime/commit/2a5cda148cafd9837e811c2b520af9ade9251e5f: Another recommendation from Windows is that we should not run any validation in the link's target when it is being created since all validations should occur at resolution time, therefore, I've removed the "file-must-target-file" validation that we initially wrote.

* https://github.com/dotnet/runtime/pull/58592/commits/fbcfe3ed943be74cd9a0c61166a2d0dc67609e79 UPDATE: After further digging, we should not use PrintName as it can display a different target to the one intended, see: https://www.tiraniddo.dev/2016/02/tracking-down-root-cause-of-windows.html 
cc @GrabYourPitchforks.