### PR TITLE
only cache credentials on success

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -818,7 +818,7 @@ namespace System.Net.Security
                     // This call may bump up the credential reference count further.
                     // Note that thumbPrint is retrieved from a safe cert object that was possible cloned from the user passed cert.
                     //
-                    if (!cachedCreds && _securityContext != null && !_securityContext.IsInvalid && _credentialsHandle != null && !_credentialsHandle.IsInvalid)
+                    if (!cachedCreds && status.ErrorCode == SecurityStatusPalErrorCode.OK && _securityContext != null && !_securityContext.IsInvalid && _credentialsHandle != null && !_credentialsHandle.IsInvalid)
                     {
                         SslSessionsCache.CacheCredential(_credentialsHandle, thumbPrint, _sslAuthenticationOptions.EnabledSslProtocols, _sslAuthenticationOptions.IsServer, _sslAuthenticationOptions.EncryptionPolicy);
                     }


### PR DESCRIPTION
This is not what I expected. But I could reproduce the `Safe handle has been closed` error with few hundred runs. 
With this change I did ~ 5000 runs without single failure. There may be more to it but this definitely seems to help.

I have some ideas why we do not see this more:

https://github.com/dotnet/runtime/blob/f3390fdb46ece449e15515a925a81aa535059f19/src/libraries/System.Net.Security/src/System/Net/Security/SslSessionsCache.cs#L196-L209

With this we would try to string the cache only on multiples of 32. With certificate, protocols and EncryptionPolicy that generally would be never on clients as there is typically no client certificate, few protocol variations and nobody sane should not use anything but `Encrypt` policy. 

So it tales some effort to even hit the reduction code - perhaps by crafting many unique certificates. 
For future investigations, lowering `CheckExpiredModulo` makes it much easier to test that code. 

While we lock on cache changes, we don't seems to when we retrieving cached value. 
And all the entries stored in the cache are disposed. 
And we seems to allocate a lot while attempting to shrink:
https://github.com/dotnet/runtime/blob/f3390fdb46ece449e15515a925a81aa535059f19/src/libraries/System.Net.Security/src/System/Net/Security/SslSessionsCache.cs#L224-L225

So while the caching may be improved, I did not find anything particularly wrong. 
My current speculation is that the observed issue is caused by polluting cache with bad values. 
With the added extra check my local runs are now happy. 

Fixes #30724
Fixes #46770