### PR TITLE
JIT: relax assert in lvaSetDoNotEnregister

### DIFF
--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -2614,8 +2614,14 @@ void Compiler::lvaSetVarDoNotEnregister(unsigned varNum DEBUGARG(DoNotEnregister
             assert(varTypeIsStruct(varDsc));
             break;
         case DNER_IsStructArg:
-            JITDUMP("it is a struct arg\n");
-            assert(varTypeIsStruct(varDsc));
+            if (varTypeIsStruct(varDsc))
+            {
+                JITDUMP("it is a struct arg\n");
+            }
+            else
+            {
+                JITDUMP("it is reinterpreted as a struct arg\n");                
+            }
             break;
         case DNER_BlockOp:
             JITDUMP("written in a block op\n");

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -2620,7 +2620,7 @@ void Compiler::lvaSetVarDoNotEnregister(unsigned varNum DEBUGARG(DoNotEnregister
             }
             else
             {
-                JITDUMP("it is reinterpreted as a struct arg\n");                
+                JITDUMP("it is reinterpreted as a struct arg\n");
             }
             break;
         case DNER_BlockOp:


### PR DESCRIPTION
If user code reinterprets a non-struct local as a struct (say via `Unsafe.As`)
at a call site, then we may see `DNER_IsStructArg` used for that local. Remove
an assert and update the descriptive text.

Fixes #58518.