### PR TITLE
Fix Native Digit Reading

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -2168,12 +2168,36 @@ namespace System.Globalization
                 nfi._currencyNegativePattern = GetLocaleInfoCoreUserOverride(LocaleNumberData.NegativeMonetaryNumberFormat);
                 nfi._numberNegativePattern = GetLocaleInfoCoreUserOverride(LocaleNumberData.NegativeNumberFormat);
 
+                nfi._nativeDigits = NumberFormatInfo.s_asciiDigits;
+
                 // LOCALE_SNATIVEDIGITS (array of 10 single character strings).
                 string digits = GetLocaleInfoCoreUserOverride(LocaleStringData.Digits);
-                nfi._nativeDigits = new string[10];
-                for (int i = 0; i < nfi._nativeDigits.Length; i++)
+
+                // if digits.Length < NumberFormatInfo.s_asciiDigits.Length means the native digits setting is messed up in the host machine.
+                // Instead of throwing IndexOutOfRangeException that will be hard to diagnose after the fact, we'll fall back to use the ASCII digits instead.
+                if (digits.Length >= NumberFormatInfo.s_asciiDigits.Length)
                 {
-                    nfi._nativeDigits[i] = char.ToString(digits[i]);
+                    // Try to check if the digits are all ASCII so we can avoid the array allocation and use the static array NumberFormatInfo.s_asciiDigits instead.
+                    // If we have non-ASCII digits, we should exit the loop very quickly.
+                    int i = 0;
+                    while (i < NumberFormatInfo.s_asciiDigits.Length)
+                    {
+                        if (digits[i] != NumberFormatInfo.s_asciiDigits[i][0])
+                        {
+                            break;
+                        }
+                        i++;
+                    }
+
+                    if (i < NumberFormatInfo.s_asciiDigits.Length)
+                    {
+                        // we have non-ASCII digits
+                        nfi._nativeDigits = new string[10];
+                        for (i = 0; i < nfi._nativeDigits.Length; i++)
+                        {
+                            nfi._nativeDigits[i] = char.ToString(digits[i]);
+                        }
+                    }
                 }
 
                 Debug.Assert(_sRealName != null);
@@ -2308,7 +2332,7 @@ namespace System.Globalization
             DecimalSeparator = 0x0000000E,
             /// <summary>thousand separator (corresponds to LOCALE_STHOUSAND)</summary>
             ThousandSeparator = 0x0000000F,
-            /// <summary>digit grouping (corresponds to LOCALE_SGROUPING)</summary>
+            /// <summary>native digits for 0-9, eg "0123456789" (corresponds to LOCALE_SNATIVEDIGITS)</summary>
             Digits = 0x00000013,
             /// <summary>local monetary symbol (corresponds to LOCALE_SCURRENCY)</summary>
             MonetarySymbol = 0x00000014,

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -2138,29 +2138,33 @@ namespace System.Globalization
 
             // if digits.Length < NumberFormatInfo.s_asciiDigits.Length means the native digits setting is messed up in the host machine.
             // Instead of throwing IndexOutOfRangeException that will be hard to diagnose after the fact, we'll fall back to use the ASCII digits instead.
-            if (digits.Length >= NumberFormatInfo.s_asciiDigits.Length)
+            if (digits.Length < NumberFormatInfo.s_asciiDigits.Length)
             {
-                // Try to check if the digits are all ASCII so we can avoid the array allocation and use the static array NumberFormatInfo.s_asciiDigits instead.
-                // If we have non-ASCII digits, we should exit the loop very quickly.
-                int i = 0;
-                while (i < NumberFormatInfo.s_asciiDigits.Length)
-                {
-                    if (digits[i] != NumberFormatInfo.s_asciiDigits[i][0])
-                    {
-                        break;
-                    }
-                    i++;
-                }
+                return result;
+            }
 
-                if (i < NumberFormatInfo.s_asciiDigits.Length)
+            // Try to check if the digits are all ASCII so we can avoid the array allocation and use the static array NumberFormatInfo.s_asciiDigits instead.
+            // If we have non-ASCII digits, we should exit the loop very quickly.
+            int i = 0;
+            while (i < NumberFormatInfo.s_asciiDigits.Length)
+            {
+                if (digits[i] != NumberFormatInfo.s_asciiDigits[i][0])
                 {
-                    // we have non-ASCII digits
-                    result = new string[10];
-                    for (i = 0; i < result.Length; i++)
-                    {
-                        result[i] = char.ToString(digits[i]);
-                    }
+                    break;
                 }
+                i++;
+            }
+
+            if (i >= NumberFormatInfo.s_asciiDigits.Length)
+            {
+                return result;
+            }
+
+            // we have non-ASCII digits
+            result = new string[10];
+            for (i = 0; i < result.Length; i++)
+            {
+                result[i] = char.ToString(digits[i]);
             }
 
             return result;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/NumberFormatInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/NumberFormatInfo.cs
@@ -35,6 +35,7 @@ namespace System.Globalization
     public sealed class NumberFormatInfo : IFormatProvider, ICloneable
     {
         private static volatile NumberFormatInfo? s_invariantInfo;
+        internal static readonly string[] s_asciiDigits = new string[] { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9" };
 
         internal int[] _numberGroupSizes = new int[] { 3 };
         internal int[] _currencyGroupSizes = new int[] { 3 };


### PR DESCRIPTION
When creating any culture, we read the culture data from the underlying OS library (either NLS or ICU). Part of the data we read is the culture native digits. We should get ten digits string (e.g. `0123456789`). Sometime the settings in the host machine get messed up and can return digits strings less than ten digits and that can cause .NET to throw `IndexOutOfRangeException`. Such failure is hard to diagnose after the fact especially when the collected dumps don't include the machine settings. This issue gets reported every while and recently we get it again from some customer. The change here is only read the returned digits data if it is ten digits. Otherwise, we'll fallback to ASCII digits 

It is hard to add a test for such fix as it will need to change the machine settings. But, I have tested manually and ensured it address the issue when having wrong settings.