### PR TITLE
Do Contain analysis after inserting node in block range

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -2080,8 +2080,8 @@ void Lowering::RehomeArgForFastTailCall(unsigned int lclNum,
                 comp->lvaSetStruct(tmpLclNum, comp->lvaGetStruct(lclNum), false);
             }
             GenTreeLclVar* storeLclVar = comp->gtNewStoreLclVar(tmpLclNum, value);
-            ContainCheckRange(value, storeLclVar);
             BlockRange().InsertBefore(insertTempBefore, LIR::SeqTree(comp, storeLclVar));
+            ContainCheckRange(value, storeLclVar);
             LowerNode(storeLclVar);
         }
 


### PR DESCRIPTION
We were trying to do contain analysis on new added node before adding it in a block range. Since it is not present yet, we were asserting. Fixed it by inserting the node in block range before doing the analysis.

Fixes: https://github.com/dotnet/runtime/issues/58396