### PR TITLE
Remove unnecessary unsafe keyword

### DIFF
--- a/src/libraries/System.Console/src/System/ConsolePal.iOS.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.iOS.cs
@@ -22,7 +22,7 @@ namespace System
 
         public override int Read(Span<byte> buffer) => throw Error.GetReadNotSupported();
 
-        public override unsafe void Write(ReadOnlySpan<byte> buffer)
+        public override void Write(ReadOnlySpan<byte> buffer)
         {
             int maxCharCount = _encoding.GetMaxCharCount(buffer.Length);
             char[]? pooledBuffer = null;


### PR DESCRIPTION
A small cleanup after https://github.com/dotnet/runtime/pull/56713.