### PR TITLE
run System.IO.Tests .NET 5 compat tests on every OS

### DIFF
--- a/src/libraries/System.IO/tests/Net5CompatTests/System.IO.Net5Compat.Tests.csproj
+++ b/src/libraries/System.IO/tests/Net5CompatTests/System.IO.Net5Compat.Tests.csproj
@@ -4,8 +4,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TestRuntime>true</TestRuntime>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
-    <!-- Windows is currently the only OS for which we provide a new strategy, so we test the Net5Compat only for Windows -->
-    <TargetFrameworks>$(NetCoreAppCurrent)-windows</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\**\*.cs" />


### PR DESCRIPTION
It's something that we have missed when adding the new `UnixFileStreamStrategy`