### PR TITLE
Make sure EventPipe streaming thread won't write session->streaming_thread after session free.

### DIFF
--- a/src/native/eventpipe/ep-session.c
+++ b/src/native/eventpipe/ep-session.c
@@ -68,10 +68,9 @@ EP_RT_DEFINE_THREAD_FUNC (streaming_thread)
 			ep_rt_thread_sleep (timeout_ns);
 		}
 
+		session->streaming_thread = NULL;
 		ep_rt_wait_event_set (&session->rt_thread_shutdown_event);
 	EP_GCX_PREEMP_EXIT
-
-	session->streaming_thread = NULL;
 
 	if (!success)
 		ep_disable ((EventPipeSessionID)session);


### PR DESCRIPTION
In case where `ep_disable` is called by a different thread (stop tracing IPC command) there was a race between streaming thread setting `session->streaming_thread` to `NULL` and IPC command triggering a call to `disable_holding_lock` and freeing session.

Resetting the `session->streaming_thread` in streaming thread must happens before it signals its shutdown event to prevent the race causing heap corruption, writing NULL into freed memory.

Probably root cause of https://github.com/dotnet/runtime/issues/57461.