### PR TITLE
Ignore NOPs in impIsTailCallILPattern

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -8147,6 +8147,12 @@ bool Compiler::impIsTailCallILPattern(
 
     OPCODE nextOpcode = (OPCODE)getU1LittleEndian(codeAddrOfNextOpcode);
 
+    // Ignore NOPs
+    while ((nextOpcode == CEE_NOP) && (codeAddrOfNextOpcode + 1 < codeEnd))
+    {
+        nextOpcode = (OPCODE)getU1LittleEndian(++codeAddrOfNextOpcode);
+    }
+
     return (nextOpcode == CEE_RET);
 }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/58622
codegen for `bar`:
Before:
```asm
G_M34324_IG01:        
IN0004: 000000 sub      rsp, 40
G_M34324_IG02:        
IN0001: 000004 cmp      dword ptr [rcx], ecx
IN0002: 000006 call     [bar@12:bar(byref):this]
IN0003: 00000C nop
G_M34324_IG03:        
IN0005: 00000D add      rsp, 40
IN0006: 000011 ret
```
After:
```asm
G_M34324_IG01:        
G_M34324_IG02:        
IN0001: 000000 align    [0 bytes]
G_M34324_IG03: 
IN0002: 000000 jmp      SHORT G_M34324_IG03
```

/cc @jakobbotsch @dotnet/jit-contrib 