### PR TITLE
Fix ConfigurationManager when BaseDirectory starts with \\?"

### DIFF
--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
@@ -64,17 +64,7 @@ namespace System.Configuration
                 if (exeAssembly != null && !isSingleFile)
                 {
                     HasEntryAssembly = true;
-
-                    // The original .NET Framework code tried to get the local path without using Uri.
-                    // If we ever find a need to do this again be careful with the logic. "file:///" is
-                    // used for local paths and "file://" for UNCs. Simply removing the prefix will make
-                    // local paths relative on Unix (e.g. "file:///home" will become "home" instead of
-                    // "/home").
-                    string configBasePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, exeAssembly.ManifestModule.Name);
-                    Uri uri = new Uri(configBasePath);
-
-                    Debug.Assert(uri.IsFile);
-                    ApplicationUri = uri.LocalPath;
+                    ApplicationUri = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, exeAssembly.ManifestModule.Name);
                 }
                 else
                 {


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/56897

Currently WinForms designer launches the process such that it prepends `\\?\` because temporary directory it uses might end up with long path issues. This fixes the issue.

I did not find any scenarios where using Uri would have any benefits and Path.Combine seem to be fine to use.

Tested by creating a sample app which starts itself and prepends `\\?\` to its own path and then executing `ConfigurationManager.AppSettings.Get("foo")` - in the success path it should return null, currently it throws an exception (only when process is launched with `\\?\` prepended). Additionally tested the same when added `App.config` file with `foo` setting and made sure it read the value correctly.

Also tested by checking if `Path.Combine` correctly works for various paths (UNC, regular file path, `\\?\` prepended path).