### PR TITLE
CI test

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -14350,6 +14350,14 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     {
                         BADCODE("tailcall. has to be followed by call, callvirt or calli");
                     }
+                    else if ((impGetNonPrefixOpcode(codeAddr + sizeof(mdToken) + 1, codeEndp) == CEE_POP) &&
+                             (impGetNonPrefixOpcode(codeAddr + sizeof(mdToken) + 2, codeEndp) == CEE_RET))
+                    {
+                        // Compat: Jit64 tolerates "tail.call + pop + ret"
+                        JITDUMP("Ignore tail prefix if the call is followed by CEE_POP + CEE_RET\n")
+                        prefixFlags &= PREFIX_TAILCALL_EXPLICIT;
+                        break;
+                    }
                 }
                 assert(sz == 0);
                 goto PREFIX;

--- a/src/tests/JIT/opt/Tailcall/TailCallPopRet.il
+++ b/src/tests/JIT/opt/Tailcall/TailCallPopRet.il
@@ -1,0 +1,34 @@
+.assembly extern System.Private.CoreLib {}
+.assembly TailCallPopRet {}
+
+.class TailCallPopRet extends [System.Private.CoreLib]System.Object
+{
+    .field static int32 retCode
+
+    .method hidebysig static int32 NonVoidMethod () cil managed noinlining 
+    {
+        .maxstack 8
+        ldc.i4.s 100
+        stsfld int32 TailCallPopRet::retCode
+        ldc.i4.s 42
+        ret
+    }
+
+    .method hidebysig static void VoidMethod () cil managed noinlining 
+    {
+        .maxstack 8
+        tail. // Jit64 tolerates pop between tailcall and ret
+        call int32 TailCallPopRet::NonVoidMethod()
+        pop
+        ret
+    }
+
+    .method hidebysig static int32 Main () cil managed 
+    {
+        .entrypoint
+        .maxstack 8
+        call void TailCallPopRet::VoidMethod()
+        ldsfld int32 TailCallPopRet::retCode
+        ret
+    }
+}

--- a/src/tests/JIT/opt/Tailcall/TailCallPopRet.ilproj
+++ b/src/tests/JIT/opt/Tailcall/TailCallPopRet.ilproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="TailCallPopRet.il" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
.NET Framework allows `pop` between `tail.` prefixed `call`s and `ret` opcodes
I am not sure we should support it in .NET Core, but I want to run CI tests