### PR TITLE
The signal enum in the native library should match the managed code.

### DIFF
--- a/src/libraries/Native/Unix/System.Native/pal_signal.h
+++ b/src/libraries/Native/Unix/System.Native/pal_signal.h
@@ -40,8 +40,8 @@ typedef enum
     PosixSignalSIGQUIT = -3,
     PosixSignalSIGTERM = -4,
     PosixSignalSIGCHLD = -5,
-    PosixSignalSIGWINCH = -6,
-    PosixSignalSIGCONT = -7,
+    PosixSignalSIGCONT = -6,
+    PosixSignalSIGWINCH = -7,
     PosixSignalSIGTTIN = -8,
     PosixSignalSIGTTOU = -9,
     PosixSignalSIGTSTP = -10


### PR DESCRIPTION
the native library enum for the posix signal and the managed enum `PosixSignal` don't match and they probably should.