### PR TITLE
[release/6.0] Replace S.S.Permissions ref with AccessControl in S.S.C.Xml

### DIFF
--- a/src/libraries/System.Security.Cryptography.Xml/ref/System.Security.Cryptography.Xml.csproj
+++ b/src/libraries/System.Security.Cryptography.Xml/ref/System.Security.Cryptography.Xml.csproj
@@ -13,7 +13,7 @@
     <ProjectReference Include="$(LibrariesProjectRoot)System.Xml.ReaderWriter\ref\System.Xml.ReaderWriter.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Security.Permissions\ref\System.Security.Permissions.csproj" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Security.AccessControl\ref\System.Security.AccessControl.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <Reference Include="System.Security" />

--- a/src/libraries/System.Security.Cryptography.Xml/src/System.Security.Cryptography.Xml.csproj
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System.Security.Cryptography.Xml.csproj
@@ -131,7 +131,7 @@ System.Security.Cryptography.Xml.XmlLicenseTransform</PackageDescription>
              Link="Common\System\HexConverter.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Security.Permissions\src\System.Security.Permissions.csproj" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Security.AccessControl\src\System.Security.AccessControl.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <ProjectReference Include="$(LibrariesProjectRoot)System.Security.Cryptography.Pkcs\src\System.Security.Cryptography.Pkcs.csproj" />


### PR DESCRIPTION
56894f09aaac6e635136dec68dfc174159911796 brought the
System.Security.AccessControl library and package back but
in the change, the reference in System.Security.Cryptography.Xml
to System.Security.Permissions wasn't replaced with the reference
to System.Security.AccessControl.

Discovered by @ericstj here: https://github.com/dotnet/runtime/pull/57816#issuecomment-912791297.

Dependencies section in the nuspec:
```
    <dependencies>
      <group targetFramework=".NETFramework4.6.1">
        <dependency id="System.Security.AccessControl" version="6.0.0-dev" exclude="Build,Analyzers" />
      </group>
      <group targetFramework="net6.0">
        <dependency id="System.Security.AccessControl" version="6.0.0-dev" exclude="Build,Analyzers" />
        <dependency id="System.Security.Cryptography.Pkcs" version="6.0.0-dev" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard2.0">
        <dependency id="System.Security.AccessControl" version="6.0.0-dev" exclude="Build,Analyzers" />
        <dependency id="System.Security.Cryptography.Pkcs" version="6.0.0-dev" exclude="Build,Analyzers" />
        <dependency id="System.Memory" version="4.5.4" exclude="Build,Analyzers" />
      </group>
    </dependencies>
```