### PR TITLE
Skip allocation for ZeroInit writeThru intervals

### DIFF
--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -4142,8 +4142,9 @@ void Compiler::lvaMarkLclRefs(GenTree* tree, BasicBlock* block, Statement* stmt,
             {
                 bool bbInALoop  = (block->bbFlags & BBF_BACKWARD_JUMP) != 0;
                 bool bbIsReturn = block->bbJumpKind == BBJ_RETURN;
-                // TODO: Zero-inits in LSRA are created with below condition. Try to use similar condition here as well.
-                // if (compiler->info.compInitMem || varTypeIsGC(varDsc->TypeGet()))
+                // TODO: Zero-inits in LSRA are created with below condition. But if filter out based on that condition
+                // we filter lot of interesting variables that would benefit otherwise with EH var enregistration.
+                //bool needsExplicitZeroInit = !varDsc->lvIsParam && (info.compInitMem || varTypeIsGC(varDsc->TypeGet()));
                 bool needsExplicitZeroInit = fgVarNeedsExplicitZeroInit(lclNum, bbInALoop, bbIsReturn);
 
                 if (varDsc->lvSingleDefRegCandidate || needsExplicitZeroInit)

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -4144,7 +4144,8 @@ void Compiler::lvaMarkLclRefs(GenTree* tree, BasicBlock* block, Statement* stmt,
                 bool bbIsReturn = block->bbJumpKind == BBJ_RETURN;
                 // TODO: Zero-inits in LSRA are created with below condition. But if filter out based on that condition
                 // we filter lot of interesting variables that would benefit otherwise with EH var enregistration.
-                //bool needsExplicitZeroInit = !varDsc->lvIsParam && (info.compInitMem || varTypeIsGC(varDsc->TypeGet()));
+                // bool needsExplicitZeroInit = !varDsc->lvIsParam && (info.compInitMem ||
+                // varTypeIsGC(varDsc->TypeGet()));
                 bool needsExplicitZeroInit = fgVarNeedsExplicitZeroInit(lclNum, bbInALoop, bbIsReturn);
 
                 if (varDsc->lvSingleDefRegCandidate || needsExplicitZeroInit)

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -4945,6 +4945,12 @@ void LinearScan::allocateRegisters()
                 // it to a different register file.
                 allocate = false;
             }
+            else if ((currentInterval->isWriteThru) && (refType == RefTypeZeroInit))
+            {
+                // For RefTypeZeroInit which is a write thru, there is no need to allocate register
+                // right away. It can be assigned when actually definition occurs.
+                allocate = false;
+            }
             if (!allocate)
             {
                 INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_NO_ENTRY_REG_ALLOCATED, currentInterval));

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -4949,6 +4949,7 @@ void LinearScan::allocateRegisters()
             {
                 // For RefTypeZeroInit which is a write thru, there is no need to allocate register
                 // right away. It can be assigned when actually definition occurs.
+                // In future, see if avoiding allocation for RefTypeZeroInit gives any benefit in general.
                 allocate = false;
             }
             if (!allocate)


### PR DESCRIPTION
Problem:
We assign a register to a variable that has zero initialization, but in the same block if there is another variable that needs the same register (eg. ABI requirement of FixedRegister), we would go ahead and assigning it although the earlier zeroInit variable was live into it. This happens because in the same block, we will only spill the variable at the end of that block and until then, the register stays assigned to the zero initialized variable.

We have enabled EH Write thru only for single-def variable. When we think that there could be a zero initialization, it technically means multiple definition and we bailout the EH write thru optimization. However, as [seen in this comment](https://github.com/dotnet/runtime/blob/2e36b6024f30bcd438fac61174609ddb52ac3151/src/coreclr/jit/lclvars.cpp#L4105-L4107), the condition to check if we will zero-init a variable or not is different during liveness vs. what we use in LSRA. Because of that, we ended up enregistering an EH var which got a register assigned during zero initialization. This works most often because at the end up block, we would record that the variable is live on stack (since `writeThru=true`). But if there was another variable in the same block that needs same register (eg. ABI requirement of FixedRegister), we would go ahead and assigning the same register that was earlier assigned to the zero initialized EH var causing the assert.
This is very uncommon situation and hence we haven't seen it in our test. For this to happen, we need to have an EH var which is not a param and is live-in inside the first block. In such situations, we would insert zero initiazation refposition. Next, there has to be another variable in the same block that needs same register which will trigger this issue.


There are 2 options to fix this problem:
1. We can be consistent in our check of zero-initialization [here](https://github.com/dotnet/runtime/blob/2e36b6024f30bcd438fac61174609ddb52ac3151/src/coreclr/jit/lclvars.cpp#L4105-L4107) and use same condition that we use in LSRA, but by doing that we miss lot of local variables from getting enregistered and benefit from this optimization. In https://github.com/dotnet/runtime/pull/47307, I tried it out and saw lot of regressions because of missed oppportunity. I again gathered those asmdiff numbers and the result is same, lot of regressions.
2. Another and better option is to not assign register for a `RefTypeZeroInit` refposition if the corresponding interval is `writeThru`. It works since we will be zero initialization the variable on stack and hence there is no point in assign a register at the zero-initialization point and not getting utilized. Once we delay the register allocation for this scenario, it opens an opportunity for other better and important refPositions to consume that register and giving us better code quality. I am see some good performance improvements by doing this. I did analyze some of the regressions and they happen for similar reason. We would allocate a high demanding register to a variable which gets spilled because other varibles need them. Earlier, this would have simply got assigned to the variable that was zero-initialized EH-write thru.


CodeSize/PerfScore Improvements: https://gist.github.com/kunalspathak/ce03a767cb67bf1e3311edbc099e7731

Fixes: https://github.com/dotnet/runtime/issues/58539