### PR TITLE
Update ServiceProviderServiceExtensions.cs

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceProviderServiceExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceProviderServiceExtensions.cs
@@ -47,12 +47,16 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(serviceType));
             }
 
+            object? service = null;
             if (provider is ISupportRequiredService requiredServiceSupportingProvider)
             {
-                return requiredServiceSupportingProvider.GetRequiredService(serviceType);
+                service = requiredServiceSupportingProvider.GetRequiredService(serviceType);
             }
-
-            object? service = provider.GetService(serviceType);
+            else
+            {
+                service = provider.GetService(serviceType);
+            }
+            
             if (service == null)
             {
                 throw new InvalidOperationException(SR.Format(SR.NoServiceRegistered, serviceType));

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceProviderServiceExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceProviderServiceExtensions.cs
@@ -56,7 +56,6 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 service = provider.GetService(serviceType);
             }
-            
             if (service == null)
             {
                 throw new InvalidOperationException(SR.Format(SR.NoServiceRegistered, serviceType));


### PR DESCRIPTION
When an provider implements ISupportRequiredService  and returns a null the InvalidOperationException should be thrown.