### PR TITLE
FreeBSD fix for AF_UNIX IPC socket permission

### DIFF
--- a/src/coreclr/debug/debug-pal/unix/diagnosticsipc.cpp
+++ b/src/coreclr/debug/debug-pal/unix/diagnosticsipc.cpp
@@ -64,7 +64,7 @@ IpcStream::DiagnosticsIpc *IpcStream::DiagnosticsIpc::Create(const char *const p
     if (mode == ConnectionMode::CONNECT)
         return new IpcStream::DiagnosticsIpc(-1, &serverAddress, ConnectionMode::CONNECT);
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__FreeBSD__)
     mode_t prev_mask = umask(~(S_IRUSR | S_IWUSR)); // This will set the default permission bit to 600
 #endif // __APPLE__
 
@@ -73,14 +73,14 @@ IpcStream::DiagnosticsIpc *IpcStream::DiagnosticsIpc::Create(const char *const p
     {
         if (callback != nullptr)
             callback(strerror(errno), errno);
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__FreeBSD__)
         umask(prev_mask);
 #endif // __APPLE__
         _ASSERTE(!"Failed to create diagnostics IPC socket.");
         return nullptr;
     }
 
-#ifndef __APPLE__
+#if !(defined(__APPLE__) || defined(__FreeBSD__))
     if (fchmod(serverSocket, S_IRUSR | S_IWUSR) == -1)
     {
         if (callback != nullptr)
@@ -100,14 +100,14 @@ IpcStream::DiagnosticsIpc *IpcStream::DiagnosticsIpc::Create(const char *const p
         const int fSuccessClose = ::close(serverSocket);
         _ASSERTE(fSuccessClose != -1);
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__FreeBSD__)
         umask(prev_mask);
 #endif // __APPLE__
 
         return nullptr;
     }
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__FreeBSD__)
     umask(prev_mask);
 #endif // __APPLE__
 

--- a/src/native/eventpipe/ds-ipc-pal-socket.c
+++ b/src/native/eventpipe/ds-ipc-pal-socket.c
@@ -289,7 +289,7 @@ inline
 ds_ipc_mode_t
 ipc_socket_set_default_umask (void)
 {
-#if defined(DS_IPC_PAL_AF_UNIX) && defined(__APPLE__)
+#if defined(DS_IPC_PAL_AF_UNIX) && (defined(__APPLE__) || defined(__FreeBSD__))
 	// This will set the default permission bit to 600
 	return umask (~(S_IRUSR | S_IWUSR));
 #else
@@ -302,7 +302,7 @@ inline
 void
 ipc_socket_reset_umask (ds_ipc_mode_t mode)
 {
-#if defined(DS_IPC_PAL_AF_UNIX) && defined(__APPLE__)
+#if defined(DS_IPC_PAL_AF_UNIX) && (defined(__APPLE__) || defined(__FreeBSD__))
 	umask (mode);
 #endif
 }
@@ -412,7 +412,7 @@ inline
 int
 ipc_socket_set_permission (ds_ipc_socket_t s)
 {
-#if defined(DS_IPC_PAL_AF_UNIX) && !defined(__APPLE__)
+#if defined(DS_IPC_PAL_AF_UNIX) && !(defined(__APPLE__) || defined(__FreeBSD__))
 	int result_fchmod;
 	DS_ENTER_BLOCKING_PAL_SECTION;
 	do {


### PR DESCRIPTION
FreeBSD does not support changing AF_UNIX socket permissions with
fchmod() so use the same umask() method as __ APPLE __ builds.