### PR TITLE
JIT: Skip covariant store checks when jit sees exact Array's type

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -22236,9 +22236,11 @@ bool Compiler::impCanSkipCovariantStoreCheck(GenTree* value, GenTree* array)
         return true;
     }
 
-    // Check for T[] with T exact.
-    if (!impIsClassExact(arrayElementHandle))
+    const bool arrayTypeIsSealed = impIsClassExact(arrayElementHandle);
+
+    if (!arrayIsExact && !arrayTypeIsSealed)
     {
+        // Bail out if we don't know array's exact type
         return false;
     }
 
@@ -22246,7 +22248,16 @@ bool Compiler::impCanSkipCovariantStoreCheck(GenTree* value, GenTree* array)
     bool                 valueIsNonNull = false;
     CORINFO_CLASS_HANDLE valueHandle    = gtGetClassHandle(value, &valueIsExact, &valueIsNonNull);
 
-    if (valueHandle == arrayElementHandle)
+    // Array's type is sealed and equals to value's type
+    if (arrayTypeIsSealed && (valueHandle == arrayElementHandle))
+    {
+        JITDUMP("\nstelem to T[] with T exact: skipping covariant store check\n");
+        return true;
+    }
+
+    // Array's type is not sealed but we know its exact type
+    if (arrayIsExact &&
+        (info.compCompHnd->compareTypesForCast(valueHandle, arrayElementHandle) == TypeCompareState::Must))
     {
         JITDUMP("\nstelem to T[] with T exact: skipping covariant store check\n");
         return true;

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -22238,7 +22238,7 @@ bool Compiler::impCanSkipCovariantStoreCheck(GenTree* value, GenTree* array)
 
     const bool arrayTypeIsSealed = impIsClassExact(arrayElementHandle);
 
-    if (!arrayIsExact && !arrayTypeIsSealed)
+    if ((!arrayIsExact && !arrayTypeIsSealed) || (arrayElementHandle == NO_CLASS_HANDLE))
     {
         // Bail out if we don't know array's exact type
         return false;
@@ -22256,7 +22256,7 @@ bool Compiler::impCanSkipCovariantStoreCheck(GenTree* value, GenTree* array)
     }
 
     // Array's type is not sealed but we know its exact type
-    if (arrayIsExact &&
+    if (arrayIsExact && (arrayElementHandle != NO_CLASS_HANDLE) && 
         (info.compCompHnd->compareTypesForCast(valueHandle, arrayElementHandle) == TypeCompareState::Must))
     {
         JITDUMP("\nstelem to T[] with T exact: skipping covariant store check\n");

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -22256,7 +22256,7 @@ bool Compiler::impCanSkipCovariantStoreCheck(GenTree* value, GenTree* array)
     }
 
     // Array's type is not sealed but we know its exact type
-    if (arrayIsExact && (valueHandle != NO_CLASS_HANDLE) && 
+    if (arrayIsExact && (valueHandle != NO_CLASS_HANDLE) &&
         (info.compCompHnd->compareTypesForCast(valueHandle, arrayElementHandle) == TypeCompareState::Must))
     {
         JITDUMP("\nstelem to T[] with T exact: skipping covariant store check\n");

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -22256,7 +22256,7 @@ bool Compiler::impCanSkipCovariantStoreCheck(GenTree* value, GenTree* array)
     }
 
     // Array's type is not sealed but we know its exact type
-    if (arrayIsExact && (arrayElementHandle != NO_CLASS_HANDLE) && 
+    if (arrayIsExact && (valueHandle != NO_CLASS_HANDLE) && 
         (info.compCompHnd->compareTypesForCast(valueHandle, arrayElementHandle) == TypeCompareState::Must))
     {
         JITDUMP("\nstelem to T[] with T exact: skipping covariant store check\n");


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/58487

```csharp
class A { }
class B : A { }

class Program
{
    static void Main()
    {
        A[] array = new A[2];
        array[0] = new A();
        array[1] = new B();
        Console.ReadKey();
    }
}
```
Codegen diff for `Main`: https://www.diffchecker.com/1eou2uvN


diffs are small:

## libraries.crossgen2.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 1475
Total bytes of diff: 1473
Total bytes of delta: -2 (-0.14% of base)
Total relative delta: 0.06
    diff is an improvement.
    relative diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          12 : 6791.dasm (7.19% of base)

Top file improvements (bytes):
         -14 : 162171.dasm (-1.07% of base)

2 total files with Code Size differences (1 improved, 1 regressed), 0 unchanged.

Top method regressions (bytes):
          12 ( 7.19% of base) : 6791.dasm - System.Xml.Schema.XmlSchemaSimpleTypeUnion:Clone():System.Xml.Schema.XmlSchemaObject:this

Top method improvements (bytes):
         -14 (-1.07% of base) : 162171.dasm - System.Speech.Internal.AudioFormatConverter:ConvertFormat(int):System.Speech.AudioFormat.SpeechAudioFormatInfo

Top method regressions (percentages):
          12 ( 7.19% of base) : 6791.dasm - System.Xml.Schema.XmlSchemaSimpleTypeUnion:Clone():System.Xml.Schema.XmlSchemaObject:this

Top method improvements (percentages):
         -14 (-1.07% of base) : 162171.dasm - System.Speech.Internal.AudioFormatConverter:ConvertFormat(int):System.Speech.AudioFormat.SpeechAudioFormatInfo

2 total methods with Code Size differences (1 improved, 1 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries.pmi.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 1723
Total bytes of diff: 1725
Total bytes of delta: 2 (0.12% of base)
Total relative delta: 0.06
    diff is a regression.
    relative diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          12 : 138801.dasm (7.02% of base)

Top file improvements (bytes):
         -10 : 150146.dasm (-0.64% of base)

2 total files with Code Size differences (1 improved, 1 regressed), 0 unchanged.

Top method regressions (bytes):
          12 ( 7.02% of base) : 138801.dasm - System.Xml.Schema.XmlSchemaSimpleTypeUnion:Clone():System.Xml.Schema.XmlSchemaObject:this

Top method improvements (bytes):
         -10 (-0.64% of base) : 150146.dasm - System.Speech.Internal.AudioFormatConverter:ConvertFormat(int):System.Speech.AudioFormat.SpeechAudioFormatInfo

Top method regressions (percentages):
          12 ( 7.02% of base) : 138801.dasm - System.Xml.Schema.XmlSchemaSimpleTypeUnion:Clone():System.Xml.Schema.XmlSchemaObject:this

Top method improvements (percentages):
         -10 (-0.64% of base) : 150146.dasm - System.Speech.Internal.AudioFormatConverter:ConvertFormat(int):System.Speech.AudioFormat.SpeechAudioFormatInfo

2 total methods with Code Size differences (1 improved, 1 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

## libraries_tests.pmi.windows.x64.checked.mch:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 19163
Total bytes of diff: 18894
Total bytes of delta: -269 (-1.40% of base)
Total relative delta: -0.16
    diff is an improvement.
    relative diff is an improvement.
```
<details>

<summary>Detail diffs</summary>

```


Top file improvements (bytes):
         -80 : 202527.dasm (-3.39% of base)
         -73 : 202508.dasm (-4.70% of base)
         -48 : 202528.dasm (-1.04% of base)
         -45 : 202521.dasm (-2.62% of base)
          -9 : 202562.dasm (-0.31% of base)
          -3 : 5939.dasm (-0.22% of base)
          -2 : 136525.dasm (-0.55% of base)
          -1 : 134549.dasm (-0.16% of base)
          -1 : 5897.dasm (-0.18% of base)
          -1 : 136516.dasm (-0.30% of base)
          -1 : 134542.dasm (-0.18% of base)
          -1 : 9015.dasm (-0.38% of base)
          -1 : 202509.dasm (-0.10% of base)
          -1 : 134540.dasm (-0.18% of base)
          -1 : 9002.dasm (-1.22% of base)
          -1 : 136514.dasm (-0.30% of base)

16 total files with Code Size differences (16 improved, 0 regressed), 0 unchanged.

Top method improvements (bytes):
         -80 (-3.39% of base) : 202527.dasm - System.Reflection.Metadata.Tests.MetadataReaderTests:ValidateSignature():this
         -73 (-4.70% of base) : 202508.dasm - System.Reflection.Metadata.Tests.MetadataReaderTests:ValidateTypeSpecTable():this
         -48 (-1.04% of base) : 202528.dasm - System.Reflection.Metadata.Tests.MetadataReaderTests:ValidateConstantTable():this
         -45 (-2.62% of base) : 202521.dasm - System.Reflection.Metadata.Tests.MetadataReaderTests:ValidateFieldMarshal():this
          -9 (-0.31% of base) : 202562.dasm - System.Reflection.Metadata.Tests.MetadataReaderTests:ValidateModuleRefTableAndFileTableManaged():this
          -3 (-0.22% of base) : 5939.dasm - Microsoft.CodeAnalysis.Shared.Extensions.SyntaxGeneratorExtensions:AddMemberChecks(Microsoft.CodeAnalysis.Editing.SyntaxGenerator,Microsoft.CodeAnalysis.Compilation,System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.ISymbol, Microsoft.CodeAnalysis, Version=3.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],Microsoft.CodeAnalysis.SyntaxNode,Microsoft.CodeAnalysis.PooledObjects.ArrayBuilder`1[[Microsoft.CodeAnalysis.SyntaxNode, Microsoft.CodeAnalysis, Version=3.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]])
          -2 (-0.55% of base) : 136525.dasm - Microsoft.CodeAnalysis.VisualBasic.CodeGeneration.VisualBasicSyntaxGenerator:RemoveNode(Microsoft.CodeAnalysis.SyntaxNode,Microsoft.CodeAnalysis.SyntaxNode,int):Microsoft.CodeAnalysis.SyntaxNode:this
          -1 (-0.18% of base) : 134542.dasm - Microsoft.CodeAnalysis.CSharp.CodeGeneration.CSharpSyntaxGenerator:InsertNodesAfter(Microsoft.CodeAnalysis.SyntaxNode,Microsoft.CodeAnalysis.SyntaxNode,System.Collections.Generic.IEnumerable`1[[Microsoft.CodeAnalysis.SyntaxNode, Microsoft.CodeAnalysis, Version=3.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]):Microsoft.CodeAnalysis.SyntaxNode:this
          -1 (-0.18% of base) : 134540.dasm - Microsoft.CodeAnalysis.CSharp.CodeGeneration.CSharpSyntaxGenerator:InsertNodesBefore(Microsoft.CodeAnalysis.SyntaxNode,Microsoft.CodeAnalysis.SyntaxNode,System.Collections.Generic.IEnumerable`1[[Microsoft.CodeAnalysis.SyntaxNode, Microsoft.CodeAnalysis, Version=3.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]):Microsoft.CodeAnalysis.SyntaxNode:this
          -1 (-0.16% of base) : 134549.dasm - Microsoft.CodeAnalysis.CSharp.CodeGeneration.CSharpSyntaxGenerator:RemoveNodeInternal(Microsoft.CodeAnalysis.SyntaxNode,Microsoft.CodeAnalysis.SyntaxNode,int):Microsoft.CodeAnalysis.SyntaxNode:this
          -1 (-1.22% of base) : 9002.dasm - Microsoft.CodeAnalysis.Editing.SyntaxGenerator:RemoveNode(Microsoft.CodeAnalysis.SyntaxNode,Microsoft.CodeAnalysis.SyntaxNode,int):Microsoft.CodeAnalysis.SyntaxNode:this
          -1 (-0.38% of base) : 9015.dasm - Microsoft.CodeAnalysis.Editing.SyntaxGenerator:ReplaceRange(Microsoft.CodeAnalysis.SyntaxNode,Microsoft.CodeAnalysis.SyntaxNode,System.Collections.Generic.IEnumerable`1[[Microsoft.CodeAnalysis.SyntaxNode, Microsoft.CodeAnalysis, Version=3.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]):Microsoft.CodeAnalysis.SyntaxNode
          -1 (-0.18% of base) : 5897.dasm - Microsoft.CodeAnalysis.Shared.Extensions.SyntaxGeneratorExtensions:GetMemberForGetHashCode(Microsoft.CodeAnalysis.Editing.SyntaxGenerator,Microsoft.CodeAnalysis.Compilation,Microsoft.CodeAnalysis.ISymbol,bool):Microsoft.CodeAnalysis.SyntaxNode
          -1 (-0.30% of base) : 136516.dasm - Microsoft.CodeAnalysis.VisualBasic.CodeGeneration.VisualBasicSyntaxGenerator:InsertNodesAfter(Microsoft.CodeAnalysis.SyntaxNode,Microsoft.CodeAnalysis.SyntaxNode,System.Collections.Generic.IEnumerable`1[[Microsoft.CodeAnalysis.SyntaxNode, Microsoft.CodeAnalysis, Version=3.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]):Microsoft.CodeAnalysis.SyntaxNode:this
          -1 (-0.30% of base) : 136514.dasm - Microsoft.CodeAnalysis.VisualBasic.CodeGeneration.VisualBasicSyntaxGenerator:InsertNodesBefore(Microsoft.CodeAnalysis.SyntaxNode,Microsoft.CodeAnalysis.SyntaxNode,System.Collections.Generic.IEnumerable`1[[Microsoft.CodeAnalysis.SyntaxNode, Microsoft.CodeAnalysis, Version=3.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]):Microsoft.CodeAnalysis.SyntaxNode:this
          -1 (-0.10% of base) : 202509.dasm - System.Reflection.Metadata.Tests.MetadataReaderTests:ValidateTypeSpecTableMod():this

Top method improvements (percentages):
         -73 (-4.70% of base) : 202508.dasm - System.Reflection.Metadata.Tests.MetadataReaderTests:ValidateTypeSpecTable():this
         -80 (-3.39% of base) : 202527.dasm - System.Reflection.Metadata.Tests.MetadataReaderTests:ValidateSignature():this
         -45 (-2.62% of base) : 202521.dasm - System.Reflection.Metadata.Tests.MetadataReaderTests:ValidateFieldMarshal():this
          -1 (-1.22% of base) : 9002.dasm - Microsoft.CodeAnalysis.Editing.SyntaxGenerator:RemoveNode(Microsoft.CodeAnalysis.SyntaxNode,Microsoft.CodeAnalysis.SyntaxNode,int):Microsoft.CodeAnalysis.SyntaxNode:this
         -48 (-1.04% of base) : 202528.dasm - System.Reflection.Metadata.Tests.MetadataReaderTests:ValidateConstantTable():this
          -2 (-0.55% of base) : 136525.dasm - Microsoft.CodeAnalysis.VisualBasic.CodeGeneration.VisualBasicSyntaxGenerator:RemoveNode(Microsoft.CodeAnalysis.SyntaxNode,Microsoft.CodeAnalysis.SyntaxNode,int):Microsoft.CodeAnalysis.SyntaxNode:this
          -1 (-0.38% of base) : 9015.dasm - Microsoft.CodeAnalysis.Editing.SyntaxGenerator:ReplaceRange(Microsoft.CodeAnalysis.SyntaxNode,Microsoft.CodeAnalysis.SyntaxNode,System.Collections.Generic.IEnumerable`1[[Microsoft.CodeAnalysis.SyntaxNode, Microsoft.CodeAnalysis, Version=3.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]):Microsoft.CodeAnalysis.SyntaxNode
          -9 (-0.31% of base) : 202562.dasm - System.Reflection.Metadata.Tests.MetadataReaderTests:ValidateModuleRefTableAndFileTableManaged():this
          -1 (-0.30% of base) : 136516.dasm - Microsoft.CodeAnalysis.VisualBasic.CodeGeneration.VisualBasicSyntaxGenerator:InsertNodesAfter(Microsoft.CodeAnalysis.SyntaxNode,Microsoft.CodeAnalysis.SyntaxNode,System.Collections.Generic.IEnumerable`1[[Microsoft.CodeAnalysis.SyntaxNode, Microsoft.CodeAnalysis, Version=3.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]):Microsoft.CodeAnalysis.SyntaxNode:this
          -1 (-0.30% of base) : 136514.dasm - Microsoft.CodeAnalysis.VisualBasic.CodeGeneration.VisualBasicSyntaxGenerator:InsertNodesBefore(Microsoft.CodeAnalysis.SyntaxNode,Microsoft.CodeAnalysis.SyntaxNode,System.Collections.Generic.IEnumerable`1[[Microsoft.CodeAnalysis.SyntaxNode, Microsoft.CodeAnalysis, Version=3.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]):Microsoft.CodeAnalysis.SyntaxNode:this
          -3 (-0.22% of base) : 5939.dasm - Microsoft.CodeAnalysis.Shared.Extensions.SyntaxGeneratorExtensions:AddMemberChecks(Microsoft.CodeAnalysis.Editing.SyntaxGenerator,Microsoft.CodeAnalysis.Compilation,System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.ISymbol, Microsoft.CodeAnalysis, Version=3.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],Microsoft.CodeAnalysis.SyntaxNode,Microsoft.CodeAnalysis.PooledObjects.ArrayBuilder`1[[Microsoft.CodeAnalysis.SyntaxNode, Microsoft.CodeAnalysis, Version=3.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]])
          -1 (-0.18% of base) : 5897.dasm - Microsoft.CodeAnalysis.Shared.Extensions.SyntaxGeneratorExtensions:GetMemberForGetHashCode(Microsoft.CodeAnalysis.Editing.SyntaxGenerator,Microsoft.CodeAnalysis.Compilation,Microsoft.CodeAnalysis.ISymbol,bool):Microsoft.CodeAnalysis.SyntaxNode
          -1 (-0.18% of base) : 134542.dasm - Microsoft.CodeAnalysis.CSharp.CodeGeneration.CSharpSyntaxGenerator:InsertNodesAfter(Microsoft.CodeAnalysis.SyntaxNode,Microsoft.CodeAnalysis.SyntaxNode,System.Collections.Generic.IEnumerable`1[[Microsoft.CodeAnalysis.SyntaxNode, Microsoft.CodeAnalysis, Version=3.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]):Microsoft.CodeAnalysis.SyntaxNode:this
          -1 (-0.18% of base) : 134540.dasm - Microsoft.CodeAnalysis.CSharp.CodeGeneration.CSharpSyntaxGenerator:InsertNodesBefore(Microsoft.CodeAnalysis.SyntaxNode,Microsoft.CodeAnalysis.SyntaxNode,System.Collections.Generic.IEnumerable`1[[Microsoft.CodeAnalysis.SyntaxNode, Microsoft.CodeAnalysis, Version=3.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]):Microsoft.CodeAnalysis.SyntaxNode:this
          -1 (-0.16% of base) : 134549.dasm - Microsoft.CodeAnalysis.CSharp.CodeGeneration.CSharpSyntaxGenerator:RemoveNodeInternal(Microsoft.CodeAnalysis.SyntaxNode,Microsoft.CodeAnalysis.SyntaxNode,int):Microsoft.CodeAnalysis.SyntaxNode:this
          -1 (-0.10% of base) : 202509.dasm - System.Reflection.Metadata.Tests.MetadataReaderTests:ValidateTypeSpecTableMod():this

16 total methods with Code Size differences (16 improved, 0 regressed), 0 unchanged.

```

</details>

--------------------------------------------------------------------------------

size regressions mostly due to inlined rangechecks, previously they were done in the helper itself