### PR TITLE
Move Android SDK logic to /eng

### DIFF
--- a/eng/native/init-compiler.sh
+++ b/eng/native/init-compiler.sh
@@ -5,9 +5,9 @@
 
 if [[ "$#" -lt 2 ]]; then
   echo "Usage..."
-  echo "detect-compiler.sh <Architecture> <compiler> <compiler major version> <compiler minor version>"
+  echo "init-compiler.sh <Architecture> <compiler> <compiler major version> <compiler minor version>"
   echo "Specify the target architecture."
-  echo "Specify the name of compiler (clang or gcc)."
+  echo "Specify the name of compiler (clang, gcc, or default for CMake-default)."
   echo "Specify the major version of compiler."
   echo "Specify the minor version of compiler."
   exit 1
@@ -41,70 +41,75 @@ check_version_exists() {
     echo "$desired_version"
 }
 
-if [[ -z "$CLR_CC" ]]; then
+if [[ "$compiler" == "default" ]]; then
+    # Don't set CC/CXX to anything and leave it up to CMake
+    true
+else
+    if [[ -z "$CLR_CC" ]]; then
 
-    # Set default versions
-    if [[ -z "$majorVersion" ]]; then
-        # note: gcc (all versions) and clang versions higher than 6 do not have minor version in file name, if it is zero.
-        if [[ "$compiler" == "clang" ]]; then versions=( 12 11 10 9 8 7 6.0 5.0 4.0 3.9 3.8 3.7 3.6 3.5 )
-        elif [[ "$compiler" == "gcc" ]]; then versions=( 11 10 9 8 7 6 5 4.9 ); fi
-
-        for version in "${versions[@]}"; do
-            parts=(${version//./ })
-            desired_version="$(check_version_exists "${parts[0]}" "${parts[1]}")"
-            if [[ "$desired_version" != "-1" ]]; then majorVersion="${parts[0]}"; break; fi
-        done
-
+        # Set default versions
         if [[ -z "$majorVersion" ]]; then
-            if command -v "$compiler" > /dev/null; then
-                if [[ "$(uname)" != "Darwin" ]]; then
-                    echo "WARN: Specific version of $compiler not found, falling back to use the one in PATH."
+            # note: gcc (all versions) and clang versions higher than 6 do not have minor version in file name, if it is zero.
+            if [[ "$compiler" == "clang" ]]; then versions=( 12 11 10 9 8 7 6.0 5.0 4.0 3.9 3.8 3.7 3.6 3.5 )
+            elif [[ "$compiler" == "gcc" ]]; then versions=( 11 10 9 8 7 6 5 4.9 ); fi
+
+            for version in "${versions[@]}"; do
+                parts=(${version//./ })
+                desired_version="$(check_version_exists "${parts[0]}" "${parts[1]}")"
+                if [[ "$desired_version" != "-1" ]]; then majorVersion="${parts[0]}"; break; fi
+            done
+
+            if [[ -z "$majorVersion" ]]; then
+                if command -v "$compiler" > /dev/null; then
+                    if [[ "$(uname)" != "Darwin" ]]; then
+                        echo "WARN: Specific version of $compiler not found, falling back to use the one in PATH."
+                    fi
+                    CC="$(command -v "$compiler")"
+                    CXX="$(command -v "$cxxCompiler")"
+                else
+                    echo "ERROR: No usable version of $compiler found."
+                    exit 1
                 fi
-                CC="$(command -v "$compiler")"
-                CXX="$(command -v "$cxxCompiler")"
             else
-                echo "ERROR: No usable version of $compiler found."
-                exit 1
-            fi
-        else
-            if [[ "$compiler" == "clang" && "$majorVersion" -lt 5 ]]; then
-                if [[ "$build_arch" == "arm" || "$build_arch" == "armel" ]]; then
-                    if command -v "$compiler" > /dev/null; then
-                        echo "WARN: Found clang version $majorVersion which is not supported on arm/armel architectures, falling back to use clang from PATH."
-                        CC="$(command -v "$compiler")"
-                        CXX="$(command -v "$cxxCompiler")"
-                    else
-                        echo "ERROR: Found clang version $majorVersion which is not supported on arm/armel architectures, and there is no clang in PATH."
-                        exit 1
+                if [[ "$compiler" == "clang" && "$majorVersion" -lt 5 ]]; then
+                    if [[ "$build_arch" == "arm" || "$build_arch" == "armel" ]]; then
+                        if command -v "$compiler" > /dev/null; then
+                            echo "WARN: Found clang version $majorVersion which is not supported on arm/armel architectures, falling back to use clang from PATH."
+                            CC="$(command -v "$compiler")"
+                            CXX="$(command -v "$cxxCompiler")"
+                        else
+                            echo "ERROR: Found clang version $majorVersion which is not supported on arm/armel architectures, and there is no clang in PATH."
+                            exit 1
+                        fi
                     fi
                 fi
             fi
+        else
+            desired_version="$(check_version_exists "$majorVersion" "$minorVersion")"
+            if [[ "$desired_version" == "-1" ]]; then
+                echo "ERROR: Could not find specific version of $compiler: $majorVersion $minorVersion."
+                exit 1
+            fi
+        fi
+
+        if [[ -z "$CC" ]]; then
+            CC="$(command -v "$compiler$desired_version")"
+            CXX="$(command -v "$cxxCompiler$desired_version")"
+            if [[ -z "$CXX" ]]; then CXX="$(command -v "$cxxCompiler")"; fi
         fi
     else
-        desired_version="$(check_version_exists "$majorVersion" "$minorVersion")"
-        if [[ "$desired_version" == "-1" ]]; then
-            echo "ERROR: Could not find specific version of $compiler: $majorVersion $minorVersion."
+        if [[ ! -f "$CLR_CC" ]]; then
+            echo "ERROR: CLR_CC is set but path '$CLR_CC' does not exist"
             exit 1
         fi
+        CC="$CLR_CC"
+        CXX="$CLR_CXX"
     fi
 
     if [[ -z "$CC" ]]; then
-        CC="$(command -v "$compiler$desired_version")"
-        CXX="$(command -v "$cxxCompiler$desired_version")"
-        if [[ -z "$CXX" ]]; then CXX="$(command -v "$cxxCompiler")"; fi
-    fi
-else
-    if [[ ! -f "$CLR_CC" ]]; then
-        echo "ERROR: CLR_CC is set but path '$CLR_CC' does not exist"
+        echo "ERROR: Unable to find $compiler."
         exit 1
     fi
-    CC="$CLR_CC"
-    CXX="$CLR_CXX"
-fi
-
-if [[ -z "$CC" ]]; then
-    echo "ERROR: Unable to find $compiler."
-    exit 1
 fi
 
 if [[ "$compiler" == "clang" ]]; then

--- a/src/libraries/Native/build-native.sh
+++ b/src/libraries/Native/build-native.sh
@@ -83,30 +83,8 @@ if [[ "$__TargetOS" == OSX ]]; then
         __CMakeArgs="-DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 $__CMakeArgs"
     fi
 elif [[ "$__TargetOS" == Android && -z "$ROOTFS_DIR" ]]; then
-    if [[ -z "$ANDROID_NDK_ROOT" ]]; then
-        echo "Error: You need to set the ANDROID_NDK_ROOT environment variable pointing to the Android NDK root."
-        exit 1
-    fi
-
-    # keep ANDROID_NATIVE_API_LEVEL in sync with src/mono/Directory.Build.props
-    __CMakeArgs="-DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_ROOT/build/cmake/android.toolchain.cmake -DANDROID_STL=none -DANDROID_NATIVE_API_LEVEL=21 $__CMakeArgs"
-
-    # workaround init-compiler.sh trying to detect clang, it's handled in android.toolchain.cmake already
-    export CLR_CC=$(which false)
-    export CLR_CXX=$(which false)
-
-    if [[ "$__BuildArch" == x64 ]]; then
-        __CMakeArgs="-DANDROID_ABI=x86_64 $__CMakeArgs"
-    elif [[ "$__BuildArch" == x86 ]]; then
-        __CMakeArgs="-DANDROID_ABI=x86 $__CMakeArgs"
-    elif [[ "$__BuildArch" == arm64 ]]; then
-        __CMakeArgs="-DANDROID_ABI=arm64-v8a $__CMakeArgs"
-    elif [[ "$__BuildArch" == arm ]]; then
-        __CMakeArgs="-DANDROID_ABI=armeabi-v7a $__CMakeArgs"
-    else
-        echo "Error: Unknown Android architecture $__BuildArch."
-        exit 1
-    fi
+    # Android SDK defaults to c++_static; we only need C support
+    __CMakeArgs="-DANDROID_STL=none $__CMakeArgs"
 elif [[ "$__TargetOS" == iOSSimulator ]]; then
     # set default iOS simulator deployment target
     # keep in sync with src/mono/Directory.Build.props

--- a/src/mono/Directory.Build.props
+++ b/src/mono/Directory.Build.props
@@ -28,7 +28,7 @@
     <watchOS64_32Version></watchOS64_32Version>
     <macOSVersion></macOSVersion>
 
-    <!-- Version of the Android SDK we target, keep in sync with src/libraries/Native/build-native.sh -->
+    <!-- Version of the Android SDK we target, keep in sync with eng/native/build-commons.sh -->
     <AndroidApiVersion>21</AndroidApiVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Moves the Android SDK logic to a common location so that it can be used in the entire repo.

In particular, it enables targeting Android from the coreclr partition.

(For anyone reading: don't get excited, I'm not actually porting the entire CoreCLR to Android. I just need this for testing NativeAOT on ARM64 Linux and Android is the only ARM64 hardware I own. Porting the NativeAOT part of CoreCLR to Android is easy enough.)

Mono could benefit from this move too, but it currently rolls its own copy of everything (not just Android).

The `export CLR_CC=$(which false)` part felt like a hack so I attempted to clean it up.

(Recommend disabling whitespace changes when reviewing.)