### PR TITLE
Fix building GC on Android

### DIFF
--- a/src/coreclr/gc/unix/config.gc.h.in
+++ b/src/coreclr/gc/unix/config.gc.h.in
@@ -21,6 +21,7 @@
 #cmakedefine01 HAVE_SCHED_SETAFFINITY
 #cmakedefine01 HAVE_PTHREAD_SETAFFINITY_NP
 #cmakedefine01 HAVE_PTHREAD_NP_H
+#cmakedefine01 HAVE_POSIX_MADVISE
 #cmakedefine01 HAVE_CPUSET_T
 #cmakedefine01 HAVE__SC_AVPHYS_PAGES
 #cmakedefine01 HAVE__SC_PHYS_PAGES

--- a/src/coreclr/gc/unix/configure.cmake
+++ b/src/coreclr/gc/unix/configure.cmake
@@ -69,22 +69,28 @@ check_cxx_source_runs("
     }
     " HAVE_SCHED_GETCPU)
 
-check_library_exists(pthread pthread_condattr_setclock "" HAVE_PTHREAD_CONDATTR_SETCLOCK)
-
 check_symbol_exists(
     clock_gettime_nsec_np
     time.h
     HAVE_CLOCK_GETTIME_NSEC_NP)
 
+check_symbol_exists(
+    posix_madvise
+    sys/mman.h
+    HAVE_POSIX_MADVISE)
+
 check_library_exists(c sched_getaffinity "" HAVE_SCHED_GETAFFINITY)
 check_library_exists(c sched_setaffinity "" HAVE_SCHED_SETAFFINITY)
 check_library_exists(pthread pthread_create "" HAVE_LIBPTHREAD)
+check_library_exists(c pthread_create "" HAVE_PTHREAD_IN_LIBC)
 
 if (HAVE_LIBPTHREAD)
   set(PTHREAD_LIBRARY pthread)
 elseif (HAVE_PTHREAD_IN_LIBC)
   set(PTHREAD_LIBRARY c)
 endif()
+
+check_library_exists(${PTHREAD_LIBRARY} pthread_condattr_setclock "" HAVE_PTHREAD_CONDATTR_SETCLOCK)
 
 check_library_exists(${PTHREAD_LIBRARY} pthread_setaffinity_np "" HAVE_PTHREAD_SETAFFINITY_NP)
 

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -781,8 +781,13 @@ bool GCToOSInterface::VirtualReset(void * address, size_t size, bool unlock)
     if (st != 0)
 #endif
     {
+#if HAVE_POSIX_MADVISE
         // In case the MADV_FREE is not supported, use MADV_DONTNEED
         st = posix_madvise(address, size, MADV_DONTNEED);
+#else
+        // If we don't have posix_madvise, report failure
+        st = EINVAL;
+#endif
     }
 
     return (st == 0);


### PR DESCRIPTION
* `posix_madvise` is only available starting Android API 23. This repo targets 21.
* We had checks for `HAVE_PTHREAD_IN_LIBC` in the GC CMake files but weren't actually using/defining it.