### PR TITLE
PosixSignalRegistrationTests.Unix: validate signal pal mapping

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/PosixSignalRegistrationTests.Unix.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/PosixSignalRegistrationTests.Unix.cs
@@ -59,11 +59,12 @@ namespace System.Tests
                     semaphore.Release();
                 });
 
-                // Use 'kill' executable with signal name to validate the signal pal mapping.
+                // Use 'kill' command with signal name to validate the signal pal mapping.
+                string sigArg = signalStr.StartsWith("SIG") ? signalStr.Substring(3) : signalStr;
                 using var process = Process.Start(new ProcessStartInfo
                     {
-                        FileName = "kill",
-                        ArgumentList = { "-s", signalStr, Environment.ProcessId.ToString(CultureInfo.InvariantCulture) }
+                        FileName = "/bin/sh", // Use a shell because not all platforms include a 'kill' executable.
+                        ArgumentList = { "-c", $"kill -s {sigArg} {Environment.ProcessId.ToString(CultureInfo.InvariantCulture)}" }
                     });
                 process.WaitForExit();
                 Assert.Equal(0, process.ExitCode);

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/PosixSignalRegistrationTests.Unix.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/PosixSignalRegistrationTests.Unix.cs
@@ -64,7 +64,7 @@ namespace System.Tests
                 using var process = Process.Start(new ProcessStartInfo
                     {
                         FileName = "/bin/sh", // Use a shell because not all platforms include a 'kill' executable.
-                        ArgumentList = { "-c", $"kill -s {sigArg} {Environment.ProcessId.ToString(CultureInfo.InvariantCulture)}" }
+                        ArgumentList = { "-c", $"kill -s {sigArg} {Environment.ProcessId.ToString()}" }
                     });
                 process.WaitForExit();
                 Assert.Equal(0, process.ExitCode);

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/PosixSignalRegistrationTests.Unix.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/PosixSignalRegistrationTests.Unix.cs
@@ -3,6 +3,7 @@
 
 using Xunit;
 using System.Diagnostics;
+using System.Globalization;
 using System.Threading;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
@@ -62,7 +63,7 @@ namespace System.Tests
                 using var process = Process.Start(new ProcessStartInfo
                     {
                         FileName = "kill",
-                        ArgumentList = { "-s", signalStr, Environment.ProcessId.ToString() }
+                        ArgumentList = { "-s", signalStr, Environment.ProcessId.ToString(CultureInfo.InvariantCulture) }
                     });
                 process.WaitForExit();
                 Assert.Equal(0, process.ExitCode);

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/PosixSignalRegistrationTests.Unix.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/PosixSignalRegistrationTests.Unix.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Xunit;
+using System.Diagnostics;
 using System.Threading;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
@@ -57,7 +58,15 @@ namespace System.Tests
                     semaphore.Release();
                 });
 
-                kill(signal);
+                // Use 'kill' executable with signal name to validate the signal pal mapping.
+                using var process = Process.Start(new ProcessStartInfo
+                    {
+                        FileName = "kill",
+                        ArgumentList = { "-s", signalStr, Environment.ProcessId.ToString() }
+                    });
+                process.WaitForExit();
+                Assert.Equal(0, process.ExitCode);
+
                 bool entered = semaphore.Wait(SuccessTimeout);
                 Assert.True(entered);
             }, s.ToString()).Dispose();


### PR DESCRIPTION
Catches wrong mappings as in https://github.com/dotnet/runtime/pull/58658.

cc @stephentoub @JamesWTruher