### PR TITLE
Add test for implicit time zone conversion for mobile platforms

### DIFF
--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2641,6 +2641,7 @@ namespace System.Tests
 
         public static bool SupportIanaNamesConversion => PlatformDetection.IsNotMobile && PlatformDetection.ICUVersion.Major >= 52;
         public static bool SupportIanaNamesConversionAndRemoteExecution => SupportIanaNamesConversion && RemoteExecutor.IsSupported;
+        public static bool DoesNotSupportIanaNamesConversion => !SupportIanaNamesConversion;
 
         // This test is executed using the remote execution because it needs to run before creating the time zone cache to ensure testing with that state.
         // There are already other tests that test after creating the cache.
@@ -2673,6 +2674,14 @@ namespace System.Tests
 
             Assert.False(TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time").HasIanaId, $" should not be IANA Id.");
             Assert.True(TimeZoneInfo.FindSystemTimeZoneById("America/Los_Angeles").HasIanaId, $"'America/Los_Angeles' should be IANA Id");
+        }
+
+        [ConditionalFact(nameof(DoesNotSupportIanaNamesConversion))]
+        public static void UnsupportedImplicitConversionTest()
+        {
+            string nonNativeTzName = s_isWindows ? "America/Los_Angeles" : "Pacific Standard Time";
+
+            Assert.Throws<TimeZoneNotFoundException>(() => TimeZoneInfo.FindSystemTimeZoneById(nonNativeTzName));
         }
 
         [ConditionalTheory(nameof(SupportIanaNamesConversion))]


### PR DESCRIPTION
Ref: https://github.com/dotnet/runtime/pull/58562#issuecomment-912684176