### PR TITLE
Always write sample events in EventPipe based on sample frequency.

### DIFF
--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -2580,15 +2580,17 @@ ep_rt_mono_sample_profiler_write_sampling_event_for_threads (
 	THREAD_INFO_TYPE adapter = { { 0 } };
 	for (uint32_t i = 0; i < sampled_thread_count; ++i) {
 		EventPipeSampleProfileStackWalkData *data = &g_array_index (_ep_rt_mono_sampled_thread_callstacks, EventPipeSampleProfileStackWalkData, i);
-		// Check if we have an async frame, if so we will need to make sure all frames are registered in regular jit info table.
-		// TODO: An async frame can contain wrapper methods (no way to check during stackwalk), we could skip writing profile event
-		// for this specific stackwalk or we could cleanup stack_frames before writing profile event.
-		if (data->stack_walk_data.async_frame) {
-			for (int i = 0; i < data->stack_contents.next_available_frame; ++i)
-				mono_jit_info_table_find_internal ((gpointer)data->stack_contents.stack_frames [i], TRUE, FALSE);
+		if ((data->stack_walk_data.top_frame && data->payload_data == EP_SAMPLE_PROFILER_SAMPLE_TYPE_EXTERNAL) || (data->payload_data != EP_SAMPLE_PROFILER_SAMPLE_TYPE_ERROR && ep_stack_contents_get_length (&data->stack_contents) > 0)) {
+			// Check if we have an async frame, if so we will need to make sure all frames are registered in regular jit info table.
+			// TODO: An async frame can contain wrapper methods (no way to check during stackwalk), we could skip writing profile event
+			// for this specific stackwalk or we could cleanup stack_frames before writing profile event.
+			if (data->stack_walk_data.async_frame) {
+				for (int i = 0; i < data->stack_contents.next_available_frame; ++i)
+					mono_jit_info_table_find_internal ((gpointer)data->stack_contents.stack_frames [i], TRUE, FALSE);
+			}
+			mono_thread_info_set_tid (&adapter, ep_rt_uint64_t_to_thread_id_t (data->thread_id));
+			ep_write_sample_profile_event (sampling_thread, sampling_event, &adapter, &data->stack_contents, (uint8_t *)&data->payload_data, sizeof (data->payload_data));
 		}
-		mono_thread_info_set_tid (&adapter, ep_rt_uint64_t_to_thread_id_t (data->thread_id));
-		ep_write_sample_profile_event (sampling_thread, sampling_event, &adapter, &data->stack_contents, (uint8_t *)&data->payload_data, sizeof (data->payload_data));
 	}
 
 	// Current thread count will be our next maximum sampled threads.


### PR DESCRIPTION
If no managed frames are located on stack, sample was dropped and not emitted into EventPipe by sample profiler. This cause issues in tooling that try to do thread time calculations based on sample, especially in cases where embedded threads returned to native code during several samples before calling back into runtime. In such scenarios the last sampled event would be prolonged, giving false information that that stack frame lasted much longer than it really did.

Always writing samples into EventPipe will also visualize time an attached thread spend outside of runtime, not running managed code.

Fix should open up for better visualization as described in https://github.com/xamarin/xamarin-android/issues/6243.

We can do similar fix to CoreCLR as well:

https://github.com/dotnet/runtime/blob/db042594240709d61e6e9fc44c0d5b88ccb7a579/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.cpp#L117)

but I'm splitting fixes into different PR's since MonoVM's embedding scenario makes this scenario much more likely to occur (already observed in different embedding scenarios) than CoreCLR.