### PR TITLE
[wasm][debugger] Fix pause on exception behavior

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
@@ -267,6 +267,14 @@ namespace Microsoft.WebAssembly.Diagnostics
         Out
     }
 
+    internal enum PauseOnExceptionsKind
+    {
+        Unset,
+        None,
+        Uncaught,
+        All
+    }
+
     internal class ExecutionContext
     {
         public string DebugId { get; set; }
@@ -279,8 +287,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         public int Id { get; set; }
         public object AuxData { get; set; }
 
-        public bool PauseOnUncaught { get; set; }
-        public bool PauseOnCaught { get; set; }
+        public PauseOnExceptionsKind PauseOnExceptions { get; set; }
 
         public List<Frame> CallStack { get; set; }
 

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -442,18 +442,14 @@ namespace Microsoft.WebAssembly.Diagnostics
                 case "Debugger.setPauseOnExceptions":
                     {
                         string state = args["state"].Value<string>();
-                        switch (state)
+                        context.PauseOnExceptions = state switch
                         {
-                            case "all":
-                                context.PauseOnExceptions = PauseOnExceptionsKind.All;
-                                break;
-                            case "uncaught":
-                                context.PauseOnExceptions = PauseOnExceptionsKind.Uncaught;
-                                break;
-                            case "none":
-                                context.PauseOnExceptions = PauseOnExceptionsKind.None;
-                                break;
-                        }
+                            "all"      => PauseOnExceptionsKind.All,
+                            "uncaught" => PauseOnExceptionsKind.Uncaught,
+                            "none"     => PauseOnExceptionsKind.None,
+                            _          => PauseOnExceptionsKind.Unset
+                        };
+
                         if (context.IsRuntimeReady)
                             await SdbHelper.EnableExceptions(id, context.PauseOnExceptions, token);
                         // Pass this on to JS too

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -154,7 +154,8 @@ namespace Microsoft.WebAssembly.Diagnostics
                                 if (exceptionError == sPauseOnUncaught)
                                 {
                                     await SendCommand(sessionId, "Debugger.resume", new JObject(), token);
-                                    context.PauseOnExceptions = PauseOnExceptionsKind.Uncaught;
+                                    if (context.PauseOnExceptions == PauseOnExceptionsKind.Unset)
+                                        context.PauseOnExceptions = PauseOnExceptionsKind.Uncaught;
                                     return true;
                                 }
                                 if (exceptionError == sPauseOnCaught)

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -23,6 +23,8 @@ namespace Microsoft.WebAssembly.Diagnostics
         private static HttpClient client = new HttpClient();
         private HashSet<SessionId> sessions = new HashSet<SessionId>();
         private Dictionary<SessionId, ExecutionContext> contexts = new Dictionary<SessionId, ExecutionContext>();
+        private const string sPauseOnUncaught = "pause_on_uncaught";
+        private const string sPauseOnCaught = "pause_on_caught";
 
         public MonoProxy(ILoggerFactory loggerFactory, IList<string> urlSymbolServerList) : base(loggerFactory)
         {
@@ -122,11 +124,47 @@ namespace Microsoft.WebAssembly.Diagnostics
                         return true;
                     }
 
+                case "Runtime.exceptionThrown":
+                    {
+                        // Don't process events from sessions we aren't tracking
+                        if (!contexts.TryGetValue(sessionId, out ExecutionContext context))
+                            return false;
+
+                        if (!context.IsRuntimeReady)
+                        {
+                            string exceptionError = args?["exceptionDetails"]?["exception"]?["value"]?.Value<string>();
+                            if (exceptionError == sPauseOnUncaught || exceptionError == sPauseOnCaught)
+                                return true;
+                        }
+                        break;
+                    }
+
                 case "Debugger.paused":
                     {
                         // Don't process events from sessions we aren't tracking
                         if (!contexts.TryGetValue(sessionId, out ExecutionContext context))
                             return false;
+
+                        if (!context.IsRuntimeReady)
+                        {
+                            string reason = args?["reason"]?.Value<string>();
+                            if (reason == "exception")
+                            {
+                                string exceptionError = args?["data"]?["value"]?.Value<string>();
+                                if (exceptionError == sPauseOnUncaught)
+                                {
+                                    await SendCommand(sessionId, "Debugger.resume", new JObject(), token);
+                                    context.PauseOnExceptions = PauseOnExceptionsKind.Uncaught;
+                                    return true;
+                                }
+                                if (exceptionError == sPauseOnCaught)
+                                {
+                                    await SendCommand(sessionId, "Debugger.resume", new JObject(), token);
+                                    context.PauseOnExceptions = PauseOnExceptionsKind.All;
+                                    return true;
+                                }
+                            }
+                        }
 
                         //TODO figure out how to stich out more frames and, in particular what happens when real wasm is on the stack
                         string top_func = args?["callFrames"]?[0]?["functionName"]?.Value<string>();
@@ -403,20 +441,20 @@ namespace Microsoft.WebAssembly.Diagnostics
                 case "Debugger.setPauseOnExceptions":
                     {
                         string state = args["state"].Value<string>();
-                        context.PauseOnCaught = false;
-                        context.PauseOnUncaught = false;
                         switch (state)
                         {
                             case "all":
-                                context.PauseOnCaught = true;
-                                context.PauseOnUncaught = true;
+                                context.PauseOnExceptions = PauseOnExceptionsKind.All;
                                 break;
                             case "uncaught":
-                                context.PauseOnUncaught = true;
+                                context.PauseOnExceptions = PauseOnExceptionsKind.Uncaught;
+                                break;
+                            case "none":
+                                context.PauseOnExceptions = PauseOnExceptionsKind.None;
                                 break;
                         }
                         if (context.IsRuntimeReady)
-                            await SdbHelper.EnableExceptions(id, state, token);
+                            await SdbHelper.EnableExceptions(id, context.PauseOnExceptions, token);
                         // Pass this on to JS too
                         return false;
                     }
@@ -832,7 +870,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                         int object_id = retDebuggerCmdReader.ReadInt32();
                         var caught = retDebuggerCmdReader.ReadByte();
                         var exceptionObject = await SdbHelper.GetObjectValues(sessionId, object_id, GetObjectCommandOptions.WithProperties | GetObjectCommandOptions.OwnProperties, token);
-                        var exceptionObjectMessage = exceptionObject.FirstOrDefault(attr => attr["name"].Value<string>().Equals("message"));
+                        var exceptionObjectMessage = exceptionObject.FirstOrDefault(attr => attr["name"].Value<string>().Equals("_message"));
                         var data = JObject.FromObject(new
                         {
                             type = "object",
@@ -922,8 +960,7 @@ namespace Microsoft.WebAssembly.Diagnostics
                 {
                     context.BreakpointRequests[kvp.Key] = kvp.Value.Clone();
                 }
-                context.PauseOnCaught = previousContext.PauseOnCaught;
-                context.PauseOnUncaught = previousContext.PauseOnUncaught;
+                context.PauseOnExceptions = previousContext.PauseOnExceptions;
             }
 
             if (await IsRuntimeAlreadyReadyAlready(sessionId, token))
@@ -1187,10 +1224,8 @@ namespace Microsoft.WebAssembly.Diagnostics
                 Log("verbose", $"Failed to clear breakpoints");
             }
 
-            if (context.PauseOnCaught && context.PauseOnUncaught)
-                await SdbHelper.EnableExceptions(sessionId, "all", token);
-            else if (context.PauseOnUncaught)
-                await SdbHelper.EnableExceptions(sessionId, "uncaught", token);
+            if (context.PauseOnExceptions != PauseOnExceptionsKind.None && context.PauseOnExceptions != PauseOnExceptionsKind.Unset)
+                await SdbHelper.EnableExceptions(sessionId, context.PauseOnExceptions, token);
 
             await SdbHelper.SetProtocolVersion(sessionId, token);
             await SdbHelper.EnableReceiveRequests(sessionId, EventKind.UserBreak, token);
@@ -1352,10 +1387,23 @@ namespace Microsoft.WebAssembly.Diagnostics
             // see https://github.com/mono/mono/issues/19549 for background
             if (sessions.Add(sessionId))
             {
+                string checkUncaughtExceptions = "";
+                string checkCaughtExceptions = "";
+
+                //we only need this check if it's a non-vs debugging
+                if (sessionId == SessionId.Null)
+                {
+                    if (!contexts.TryGetValue(sessionId, out ExecutionContext context) || context.PauseOnExceptions == PauseOnExceptionsKind.Unset)
+                    {
+                        checkUncaughtExceptions = $"throw \"{sPauseOnUncaught}\";";
+                        checkCaughtExceptions = $"try {{throw \"{sPauseOnCaught}\";}} catch {{}}";
+                    }
+                }
+
                 await SendMonoCommand(sessionId, new MonoCommands("globalThis.dotnetDebugger = true"), token);
                 Result res = await SendCommand(sessionId,
                     "Page.addScriptToEvaluateOnNewDocument",
-                    JObject.FromObject(new { source = $"globalThis.dotnetDebugger = true; delete navigator.constructor.prototype.webdriver;" }),
+                    JObject.FromObject(new { source = $"globalThis.dotnetDebugger = true; delete navigator.constructor.prototype.webdriver; {checkCaughtExceptions} {checkUncaughtExceptions}" }),
                     token);
 
                 if (sessionId != SessionId.Null && !res.IsOk)

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -1388,8 +1388,8 @@ namespace Microsoft.WebAssembly.Diagnostics
             // see https://github.com/mono/mono/issues/19549 for background
             if (sessions.Add(sessionId))
             {
-                string checkUncaughtExceptions = "";
-                string checkCaughtExceptions = "";
+                string checkUncaughtExceptions = string.Empty;
+                string checkCaughtExceptions = string.Empty;
 
                 //we only need this check if it's a non-vs debugging
                 if (sessionId == SessionId.Null)

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -2212,6 +2212,12 @@ namespace Microsoft.WebAssembly.Diagnostics
         }
         public async Task<bool> EnableExceptions(SessionId sessionId, PauseOnExceptionsKind state, CancellationToken token)
         {
+            if (state == PauseOnExceptionsKind.Unset)
+            {
+                logger.LogDebug($"Trying to setPauseOnExceptions using status Unset");
+                return false;
+            }
+
             var commandParams = new MemoryStream();
             var commandParamsWriter = new MonoBinaryWriter(commandParams);
             commandParamsWriter.Write((byte)EventKind.Exception);

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -2210,7 +2210,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             }
             return array;
         }
-        public async Task<bool> EnableExceptions(SessionId sessionId, string state, CancellationToken token)
+        public async Task<bool> EnableExceptions(SessionId sessionId, PauseOnExceptionsKind state, CancellationToken token)
         {
             var commandParams = new MemoryStream();
             var commandParamsWriter = new MonoBinaryWriter(commandParams);
@@ -2219,14 +2219,16 @@ namespace Microsoft.WebAssembly.Diagnostics
             commandParamsWriter.Write((byte)1);
             commandParamsWriter.Write((byte)ModifierKind.ExceptionOnly);
             commandParamsWriter.Write(0); //exc_class
-            if (state == "all")
+            if (state == PauseOnExceptionsKind.All)
                 commandParamsWriter.Write((byte)1); //caught
             else
                 commandParamsWriter.Write((byte)0); //caught
-            if (state == "uncaught" || state == "all")
+
+            if (state == PauseOnExceptionsKind.Uncaught || state == PauseOnExceptionsKind.All)
                 commandParamsWriter.Write((byte)1); //uncaught
             else
                 commandParamsWriter.Write((byte)0); //uncaught
+
             commandParamsWriter.Write((byte)1);//subclasses
             commandParamsWriter.Write((byte)0);//not_filtered_feature
             commandParamsWriter.Write((byte)0);//everything_else

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-exception-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-exception-test.cs
@@ -52,4 +52,40 @@ namespace DebuggerTests
             this.message = message;
         }
     }
+
+    public class ExceptionTestsClassDefault
+    {
+        public class TestCaughtException
+        {
+            public void run()
+            {
+                try
+                {
+                    throw new Exception("not implemented caught");
+                }
+                catch
+                {
+                    Console.WriteLine("caught exception");
+                }
+            }
+        }
+
+        public class TestUncaughtException
+        {
+            public void run()
+            {
+                throw new Exception("not implemented uncaught");
+            }
+        }
+
+        public static void TestExceptions()
+        {
+            TestCaughtException f = new TestCaughtException();
+            f.run();
+
+            TestUncaughtException g = new TestUncaughtException();
+            g.run();
+        }
+
+    }
 }


### PR DESCRIPTION
- The initial status of Pause On Exception is correctly sent to BrowserDebugProxy when the debugging is started from VS. So we don't need the hacky to discover the initial status. And we will not print the message described in the issue below anymore.

- When we debugging from chrome this is still useful, but I couldn't hide the message printed on console. 

- Added more tests when throwing an Exception and not a CustomException as we were testing in the unit test before.

Fixes https://github.com/dotnet/runtime/issues/58509#issuecomment-912058745

@lewing I would like to backport to preview 2, do you think that makes sense?