### PR TITLE
[System.IO.Hashing] Expose methods to get 32-bits and 64-bits hash values

### DIFF
--- a/src/libraries/System.IO.Hashing/src/System.IO.Hashing.csproj
+++ b/src/libraries/System.IO.Hashing/src/System.IO.Hashing.csproj
@@ -22,6 +22,8 @@ System.IO.Hashing.XxHash32</PackageDescription>
     <Compile Include="System\IO\Hashing\XxHash64.cs" />
     <Compile Include="System\IO\Hashing\XxHash64.State.cs" />
     <Compile Include="System\IO\Hashing\NonCryptographicHashAlgorithm.cs" />
+    <Compile Include="System\IO\Hashing\NonCryptographicHashAlgorithm32.cs" />
+    <Compile Include="System\IO\Hashing\NonCryptographicHashAlgorithm64.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <Reference Include="System.Buffers" />

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc32.Table.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc32.Table.cs
@@ -3,7 +3,7 @@
 
 namespace System.IO.Hashing
 {
-    public sealed partial class Crc32 : NonCryptographicHashAlgorithm
+    public sealed partial class Crc32
     {
         // Pre-computed CRC-32 transition table.
         // While this implementation is based on the standard CRC-32 polynomial,

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc32.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc32.cs
@@ -23,20 +23,11 @@ namespace System.IO.Hashing
     ///     compatible with the cyclic redundancy check described in ITU-T I.363.5.
     ///   </para>
     /// </remarks>
-    public sealed partial class Crc32 : NonCryptographicHashAlgorithm
+    public sealed partial class Crc32 : NonCryptographicHashAlgorithm32
     {
         private const uint InitialState = 0xFFFF_FFFFu;
-        private const int Size = sizeof(uint);
 
         private uint _crc = InitialState;
-
-        /// <summary>
-        ///   Initializes a new instance of the <see cref="Crc32"/> class.
-        /// </summary>
-        public Crc32()
-            : base(Size)
-        {
-        }
 
         /// <summary>
         ///   Appends the contents of <paramref name="source"/> to the data already
@@ -56,6 +47,13 @@ namespace System.IO.Hashing
             _crc = InitialState;
         }
 
+        /// <inheritdoc/>
+        protected override int GetHash()
+        {
+            // The finalization step of the CRC is to perform the ones' complement.
+            return (int)~_crc;
+        }
+
         /// <summary>
         ///   Writes the computed hash value to <paramref name="destination"/>
         ///   without modifying accumulated state.
@@ -63,8 +61,7 @@ namespace System.IO.Hashing
         /// <param name="destination">The buffer that receives the computed hash value.</param>
         protected override void GetCurrentHashCore(Span<byte> destination)
         {
-            // The finalization step of the CRC is to perform the ones' complement.
-            BinaryPrimitives.WriteUInt32LittleEndian(destination, ~_crc);
+            BinaryPrimitives.WriteInt32LittleEndian(destination, GetHash());
         }
 
         /// <summary>
@@ -73,7 +70,7 @@ namespace System.IO.Hashing
         /// </summary>
         protected override void GetHashAndResetCore(Span<byte> destination)
         {
-            BinaryPrimitives.WriteUInt32LittleEndian(destination, ~_crc);
+            BinaryPrimitives.WriteInt32LittleEndian(destination, GetHash());
             _crc = InitialState;
         }
 

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc64.Table.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc64.Table.cs
@@ -3,7 +3,7 @@
 
 namespace System.IO.Hashing
 {
-    public sealed partial class Crc64 : NonCryptographicHashAlgorithm
+    public sealed partial class Crc64
     {
         // Pre-computed CRC-64 transition table.
         private static readonly ulong[] s_crcLookup = GenerateTable(0x42F0E1EBA9EA3693);

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc64.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc64.cs
@@ -22,20 +22,11 @@ namespace System.IO.Hashing
     ///     compatible with the cyclic redundancy check described in ISO 3309.
     ///   </para>
     /// </remarks>
-    public sealed partial class Crc64 : NonCryptographicHashAlgorithm
+    public sealed partial class Crc64 : NonCryptographicHashAlgorithm64
     {
         private const ulong InitialState = 0UL;
-        private const int Size = sizeof(ulong);
 
         private ulong _crc = InitialState;
-
-        /// <summary>
-        ///   Initializes a new instance of the <see cref="Crc64"/> class.
-        /// </summary>
-        public Crc64()
-            : base(Size)
-        {
-        }
 
         /// <summary>
         ///   Appends the contents of <paramref name="source"/> to the data already
@@ -55,6 +46,12 @@ namespace System.IO.Hashing
             _crc = InitialState;
         }
 
+        /// <inheritdoc/>
+        protected override long GetHash()
+        {
+            return (long)_crc;
+        }
+
         /// <summary>
         ///   Writes the computed hash value to <paramref name="destination"/>
         ///   without modifying accumulated state.
@@ -62,7 +59,7 @@ namespace System.IO.Hashing
         /// <param name="destination">The buffer that receives the computed hash value.</param>
         protected override void GetCurrentHashCore(Span<byte> destination)
         {
-            BinaryPrimitives.WriteUInt64BigEndian(destination, _crc);
+            BinaryPrimitives.WriteInt64BigEndian(destination, GetHash());
         }
 
         /// <summary>
@@ -71,7 +68,7 @@ namespace System.IO.Hashing
         /// </summary>
         protected override void GetHashAndResetCore(Span<byte> destination)
         {
-            BinaryPrimitives.WriteUInt64BigEndian(destination, _crc);
+            BinaryPrimitives.WriteInt64BigEndian(destination, GetHash());
             _crc = InitialState;
         }
 

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/NonCryptographicHashAlgorithm32.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/NonCryptographicHashAlgorithm32.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.IO.Hashing
+{
+    /// <summary>
+    ///   Represents a non-cryptographic hash algorithm whose hash size is 32 bits.
+    /// </summary>
+    public abstract class NonCryptographicHashAlgorithm32 : NonCryptographicHashAlgorithm
+    {
+        protected const int Size = sizeof(uint);
+
+        protected NonCryptographicHashAlgorithm32() : base(Size)
+        {
+        }
+
+        /// <summary>
+        /// Gets the computed 32 bits hash value without modifying accumulated state.
+        /// </summary>
+        /// <returns>The computed hash value.</returns>
+        protected abstract int GetHash();
+    }
+}

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/NonCryptographicHashAlgorithm64.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/NonCryptographicHashAlgorithm64.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.IO.Hashing
+{
+    /// <summary>
+    ///   Represents a non-cryptographic hash algorithm whose hash size is 64 bits.
+    /// </summary>
+    public abstract class NonCryptographicHashAlgorithm64 : NonCryptographicHashAlgorithm
+    {
+        protected const int Size = sizeof(ulong);
+
+        protected NonCryptographicHashAlgorithm64() : base(Size)
+        {
+        }
+
+        /// <summary>
+        /// Gets the computed 64 bits hash value without modifying accumulated state.
+        /// </summary>
+        /// <returns>The computed hash value.</returns>
+        protected abstract long GetHash();
+    }
+}

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.cs
@@ -11,9 +11,8 @@ namespace System.IO.Hashing
     /// <summary>
     ///   Provides an implementation of the XxHash64 algorithm.
     /// </summary>
-    public sealed partial class XxHash64 : NonCryptographicHashAlgorithm
+    public sealed partial class XxHash64 : NonCryptographicHashAlgorithm64
     {
-        private const int HashSize = sizeof(ulong);
         private const int StripeSize = 4 * sizeof(ulong);
 
         private readonly ulong _seed;
@@ -41,7 +40,6 @@ namespace System.IO.Hashing
         ///   The hash seed value for computations from this instance.
         /// </param>
         public XxHash64(long seed)
-            : base(HashSize)
         {
             _seed = (ulong)seed;
             Reset();
@@ -104,11 +102,8 @@ namespace System.IO.Hashing
             }
         }
 
-        /// <summary>
-        ///   Writes the computed hash value to <paramref name="destination"/>
-        ///   without modifying accumulated state.
-        /// </summary>
-        protected override void GetCurrentHashCore(Span<byte> destination)
+        /// <inheritdoc/>
+        protected override long GetHash()
         {
             int remainingLength = _length & 0x1F;
             ReadOnlySpan<byte> remaining = ReadOnlySpan<byte>.Empty;
@@ -118,8 +113,16 @@ namespace System.IO.Hashing
                 remaining = new ReadOnlySpan<byte>(_holdback, 0, remainingLength);
             }
 
-            ulong acc = _state.Complete(_length, remaining);
-            BinaryPrimitives.WriteUInt64BigEndian(destination, acc);
+            return (long)_state.Complete(_length, remaining);
+        }
+
+        /// <summary>
+        ///   Writes the computed hash value to <paramref name="destination"/>
+        ///   without modifying accumulated state.
+        /// </summary>
+        protected override void GetCurrentHashCore(Span<byte> destination)
+        {
+            BinaryPrimitives.WriteInt64BigEndian(destination, GetHash());
         }
 
         /// <summary>
@@ -163,7 +166,7 @@ namespace System.IO.Hashing
         /// <returns>The XxHash64 hash of the provided data.</returns>
         public static byte[] Hash(ReadOnlySpan<byte> source, long seed = 0)
         {
-            byte[] ret = new byte[HashSize];
+            byte[] ret = new byte[Size];
             StaticHash(source, ret, seed);
             return ret;
         }
@@ -183,7 +186,7 @@ namespace System.IO.Hashing
         /// </returns>
         public static bool TryHash(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten, long seed = 0)
         {
-            if (destination.Length < HashSize)
+            if (destination.Length < Size)
             {
                 bytesWritten = 0;
                 return false;
@@ -204,7 +207,7 @@ namespace System.IO.Hashing
         /// </returns>
         public static int Hash(ReadOnlySpan<byte> source, Span<byte> destination, long seed = 0)
         {
-            if (destination.Length < HashSize)
+            if (destination.Length < Size)
                 throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
 
             return StaticHash(source, destination, seed);
@@ -223,7 +226,7 @@ namespace System.IO.Hashing
 
             ulong val = state.Complete(totalLength, source);
             BinaryPrimitives.WriteUInt64BigEndian(destination, val);
-            return HashSize;
+            return Size;
         }
     }
 }


### PR DESCRIPTION
I can see why the `GetCurrentHash` method returns `byte[]` (to be flexible with the size of the different hashes) but given the currently supported non cryptographic hashes (crc32, crc64, xxHash32 and xxHash64) it makes sense to return 32-bits and 64-bits value as respectively `int` and `long`. (`uint` and `ulong` are ruled out because they would not be CLS compliant)

This commit introduces two new intermediate abstract classes, `NonCryptographicHashAlgorithm32` and `NonCryptographicHashAlgorithm64` that expose respectively `int GetHash() ` and `long GetHash()`.

Crc32 and XxHash32 now inherit from `NonCryptographicHashAlgorithm32`.

Crc64 and XxHash64 now inherit from `NonCryptographicHashAlgorithm64`.

Maybe this design is not the most appropriate but in one way or another I think getting the hash as a 32-bit or 64-bit value is something that should definitely go into System.IO.Hashing.

As a consumer of this new System.IO.Hashing package I was *very* surprised that this was not available.

/cc @bartonjs