### PR TITLE
[release/6.0] Change namespace of embedded Cecil in ILStrip task

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -122,9 +122,9 @@
       <Uri>https://github.com/dotnet/runtime-assets</Uri>
       <Sha>e46ee5551e1ecf232833eb18ef341eedbdb08f38</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CilStrip.Sources" Version="6.0.0-beta.21430.1">
+    <Dependency Name="Microsoft.DotNet.CilStrip.Sources" Version="6.0.0-beta.21457.5">
       <Uri>https://github.com/dotnet/runtime-assets</Uri>
-      <Sha>e46ee5551e1ecf232833eb18ef341eedbdb08f38</Sha>
+      <Sha>16f58bb2e869e434a13a91bab36f2517c276bf3e</Sha>
     </Dependency>
     <Dependency Name="runtime.linux-arm64.Microsoft.NETCore.Runtime.Mono.LLVM.Sdk" Version="11.1.0-alpha.1.21416.1">
       <Uri>https://github.com/dotnet/llvm-project</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -124,7 +124,7 @@
     <SystemRuntimeTimeZoneDataVersion>6.0.0-beta.21430.1</SystemRuntimeTimeZoneDataVersion>
     <SystemSecurityCryptographyX509CertificatesTestDataVersion>6.0.0-beta.21430.1</SystemSecurityCryptographyX509CertificatesTestDataVersion>
     <SystemWindowsExtensionsTestDataVersion>6.0.0-beta.21430.1</SystemWindowsExtensionsTestDataVersion>
-    <MicrosoftDotNetCilStripSourcesVersion>6.0.0-beta.21430.1</MicrosoftDotNetCilStripSourcesVersion>
+    <MicrosoftDotNetCilStripSourcesVersion>6.0.0-beta.21457.5</MicrosoftDotNetCilStripSourcesVersion>
     <!-- dotnet-optimization dependencies -->
     <optimizationwindows_ntx64MIBCRuntimeVersion>1.0.0-prerelease.21416.5</optimizationwindows_ntx64MIBCRuntimeVersion>
     <optimizationwindows_ntx86MIBCRuntimeVersion>1.0.0-prerelease.21416.5</optimizationwindows_ntx86MIBCRuntimeVersion>

--- a/src/tasks/ILStripTask/ILStrip.cs
+++ b/src/tasks/ILStripTask/ILStrip.cs
@@ -8,10 +8,10 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using Mono.Cecil;
-using Mono.Cecil.Binary;
-using Mono.Cecil.Cil;
-using Mono.Cecil.Metadata;
+using CilStrip.Mono.Cecil;
+using CilStrip.Mono.Cecil.Binary;
+using CilStrip.Mono.Cecil.Cil;
+using CilStrip.Mono.Cecil.Metadata;
 
 public class ILStrip : Microsoft.Build.Utilities.Task
 {


### PR DESCRIPTION
We hit a case where the ILStrip task assembly is IL-merged with a few other task assemblies on the Xamarin side which causes a clash because of trying to merge different Mono.Cecil versions.
Rename the Mono.Cecil used here to avoid that clash. Brings in https://github.com/dotnet/runtime-assets/pull/169

Backport of https://github.com/dotnet/runtime/pull/58764

## Customer Impact

None, this is an internal infrastructure change to avoid a name clash.

## Testing

Manual testing.

## Risk

None, not publicly observable.