### PR TITLE
Change namespace of embedded Cecil in ILStrip task

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -122,9 +122,9 @@
       <Uri>https://github.com/dotnet/runtime-assets</Uri>
       <Sha>d6c7cf7d70f2f6a61c22c494aedb9c18de85ad53</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CilStrip.Sources" Version="7.0.0-beta.21430.2">
+    <Dependency Name="Microsoft.DotNet.CilStrip.Sources" Version="7.0.0-beta.21457.4">
       <Uri>https://github.com/dotnet/runtime-assets</Uri>
-      <Sha>d6c7cf7d70f2f6a61c22c494aedb9c18de85ad53</Sha>
+      <Sha>1d113f16de55a39b39a3389f09c243cb6c44199b</Sha>
     </Dependency>
     <Dependency Name="runtime.linux-arm64.Microsoft.NETCore.Runtime.Mono.LLVM.Sdk" Version="11.1.0-alpha.1.21430.1">
       <Uri>https://github.com/dotnet/llvm-project</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -125,7 +125,7 @@
     <SystemRuntimeTimeZoneDataVersion>7.0.0-beta.21430.2</SystemRuntimeTimeZoneDataVersion>
     <SystemSecurityCryptographyX509CertificatesTestDataVersion>7.0.0-beta.21430.2</SystemSecurityCryptographyX509CertificatesTestDataVersion>
     <SystemWindowsExtensionsTestDataVersion>7.0.0-beta.21430.2</SystemWindowsExtensionsTestDataVersion>
-    <MicrosoftDotNetCilStripSourcesVersion>7.0.0-beta.21430.2</MicrosoftDotNetCilStripSourcesVersion>
+    <MicrosoftDotNetCilStripSourcesVersion>7.0.0-beta.21457.4</MicrosoftDotNetCilStripSourcesVersion>
     <!-- dotnet-optimization dependencies -->
     <optimizationwindows_ntx64MIBCRuntimeVersion>1.0.0-prerelease.21455.2</optimizationwindows_ntx64MIBCRuntimeVersion>
     <optimizationwindows_ntx86MIBCRuntimeVersion>1.0.0-prerelease.21455.2</optimizationwindows_ntx86MIBCRuntimeVersion>

--- a/src/tasks/ILStripTask/ILStrip.cs
+++ b/src/tasks/ILStripTask/ILStrip.cs
@@ -8,10 +8,10 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using Mono.Cecil;
-using Mono.Cecil.Binary;
-using Mono.Cecil.Cil;
-using Mono.Cecil.Metadata;
+using CilStrip.Mono.Cecil;
+using CilStrip.Mono.Cecil.Binary;
+using CilStrip.Mono.Cecil.Cil;
+using CilStrip.Mono.Cecil.Metadata;
 
 public class ILStrip : Microsoft.Build.Utilities.Task
 {


### PR DESCRIPTION
We hit a case where the ILStrip task assembly is IL-merged with a few other task assemblies on the Xamarin side which causes a clash because of trying to merge different Mono.Cecil versions.
Rename the Mono.Cecil used here to avoid that clash. Brings in https://github.com/dotnet/runtime-assets/pull/169