### PR TITLE
Consider finally that jumps to itself as non-empty

### DIFF
--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -181,9 +181,10 @@ PhaseStatus Compiler::fgRemoveEmptyFinally()
 
         JITDUMP("Remove now-unreachable handler " FMT_BB "\n", firstBlock->bbNum);
 
-        // Handler block should now be unreferenced, since the only
-        // explicit references to it were in call finallys.
-        firstBlock->bbRefs = 0;
+        // Since the handler block has an explicit reference from the call-finallys,
+        // decrease the reference count of handler block.
+        noway_assert(firstBlock->countOfInEdges() > 0);
+        firstBlock->bbRefs--;
 
         // Remove the handler block.
         const bool unreachable = true;

--- a/src/coreclr/jit/jiteh.cpp
+++ b/src/coreclr/jit/jiteh.cpp
@@ -4410,7 +4410,7 @@ void Compiler::fgExtendEHRegionBefore(BasicBlock* block)
 #endif // DEBUG
 
             // The first block of a handler has an artificial extra refcount. Transfer that to the new block.
-            assert(block->bbRefs > 0);
+            noway_assert(block->countOfInEdges() > 0);
             block->bbRefs--;
 
             HBtab->ebdHndBeg = bPrev;
@@ -4459,7 +4459,7 @@ void Compiler::fgExtendEHRegionBefore(BasicBlock* block)
 #endif // DEBUG
 
             // The first block of a filter has an artificial extra refcount. Transfer that to the new block.
-            assert(block->bbRefs > 0);
+            noway_assert(block->countOfInEdges() > 0);
             block->bbRefs--;
 
             HBtab->ebdFilter = bPrev;


### PR DESCRIPTION
We were assuming that if a `finally` is empty, it doesn't have any blocks pointing to it, but sometimes Roslyn would have a copy of code inside `finally` into a block that follows `finally` block, and directly jump to that block. 

```
IL to import:
IL_0000  72 33 11 00 70    ldstr        0x70001133
IL_0005  28 3c 00 00 0a    call         0xA00003C
IL_000a  de 02             leave.s      2 (IL_000e)
IL_000c  2b fe             br.s         -2 (IL_000c)
IL_000e  2b fe             br.s         -2 (IL_000e)
```

As such, after removing `CALL_FINALLY` block, the block inside `finally` can jump back to itself and hence one additional reference. As such, while removing empty finally, we should just decrease the reference count of finally block by 1 and then let `fgRemoveBlock()` take care of further reducing the reference count, if there exist one.

Fixes: https://github.com/dotnet/runtime/issues/58729