### PR TITLE
Add explicit APIs to Double/Single/Half/TimeOnly

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Double.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Double.cs
@@ -756,6 +756,30 @@ namespace System
         static double IFloatingPoint<double>.Truncate(double x)
             => Math.Truncate(x);
 
+        [RequiresPreviewFeatures]
+        static bool IFloatingPoint<double>.IsFinite(double d) => IsFinite(d);
+
+        [RequiresPreviewFeatures]
+        static bool IFloatingPoint<double>.IsInfinity(double d) => IsInfinity(d);
+
+        [RequiresPreviewFeatures]
+        static bool IFloatingPoint<double>.IsNaN(double d) => IsNaN(d);
+
+        [RequiresPreviewFeatures]
+        static bool IFloatingPoint<double>.IsNegative(double d) => IsNegative(d);
+
+        [RequiresPreviewFeatures]
+        static bool IFloatingPoint<double>.IsNegativeInfinity(double d) => IsNegativeInfinity(d);
+
+        [RequiresPreviewFeatures]
+        static bool IFloatingPoint<double>.IsNormal(double d) => IsNormal(d);
+
+        [RequiresPreviewFeatures]
+        static bool IFloatingPoint<double>.IsPositiveInfinity(double d) => IsPositiveInfinity(d);
+
+        [RequiresPreviewFeatures]
+        static bool IFloatingPoint<double>.IsSubnormal(double d) => IsSubnormal(d);
+
         // static double IFloatingPoint<double>.AcosPi(double x)
         //     => Math.AcosPi(x);
         //

--- a/src/libraries/System.Private.CoreLib/src/System/Half.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Half.cs
@@ -1059,6 +1059,31 @@ namespace System
         static Half IFloatingPoint<Half>.Truncate(Half x)
             => (Half)MathF.Truncate((float)x);
 
+        [RequiresPreviewFeatures]
+        static bool IFloatingPoint<Half>.IsFinite(Half x) => IsFinite(x);
+
+        [RequiresPreviewFeatures]
+        static bool IFloatingPoint<Half>.IsInfinity(Half x) => IsInfinity(x);
+
+        [RequiresPreviewFeatures]
+        static bool IFloatingPoint<Half>.IsNaN(Half x) => IsNaN(x);
+
+        [RequiresPreviewFeatures]
+        static bool IFloatingPoint<Half>.IsNegative(Half x) => IsNegative(x);
+
+        [RequiresPreviewFeatures]
+        static bool IFloatingPoint<Half>.IsNegativeInfinity(Half x) => IsNegativeInfinity(x);
+
+        [RequiresPreviewFeatures]
+        static bool IFloatingPoint<Half>.IsNormal(Half x) => IsNormal(x);
+
+        [RequiresPreviewFeatures]
+        static bool IFloatingPoint<Half>.IsPositiveInfinity(Half x) => IsPositiveInfinity(x);
+
+        [RequiresPreviewFeatures]
+        static bool IFloatingPoint<Half>.IsSubnormal(Half x) => IsSubnormal(x);
+
+
         // static Half IFloatingPoint<Half>.AcosPi(Half x)
         //     => (Half)MathF.AcosPi((float)x);
         //

--- a/src/libraries/System.Private.CoreLib/src/System/Single.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Single.cs
@@ -748,6 +748,30 @@ namespace System
         static float IFloatingPoint<float>.Truncate(float x)
             => MathF.Truncate(x);
 
+        [RequiresPreviewFeatures]
+        static bool IFloatingPoint<float>.IsFinite(float x) => IsFinite(x);
+
+        [RequiresPreviewFeatures]
+        static bool IFloatingPoint<float>.IsInfinity(float x) => IsInfinity(x);
+
+        [RequiresPreviewFeatures]
+        static bool IFloatingPoint<float>.IsNaN(float x) => IsNaN(x);
+
+        [RequiresPreviewFeatures]
+        static bool IFloatingPoint<float>.IsNegative(float x) => IsNegative(x);
+
+        [RequiresPreviewFeatures]
+        static bool IFloatingPoint<float>.IsNegativeInfinity(float x) => IsNegativeInfinity(x);
+
+        [RequiresPreviewFeatures]
+        static bool IFloatingPoint<float>.IsNormal(float x) => IsNormal(x);
+
+        [RequiresPreviewFeatures]
+        static bool IFloatingPoint<float>.IsPositiveInfinity(float x) => IsPositiveInfinity(x);
+
+        [RequiresPreviewFeatures]
+        static bool IFloatingPoint<float>.IsSubnormal(float x) => IsSubnormal(x);
+
         // static float IFloatingPoint<float>.AcosPi(float x)
         //     => MathF.AcosPi(x);
         //

--- a/src/libraries/System.Private.CoreLib/src/System/TimeOnly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeOnly.cs
@@ -974,6 +974,13 @@ namespace System
         // [RequiresPreviewFeatures]
         // static checked TimeSpan ISubtractionOperators<TimeOnly, TimeOnly, TimeSpan>.operator -(TimeOnly left, TimeOnly right)
         //     => checked(left - right);
+
+        [RequiresPreviewFeatures]
+        static TimeOnly IMinMaxValue<TimeOnly>.MinValue => MinValue;
+
+        [RequiresPreviewFeatures]
+        static TimeOnly IMinMaxValue<TimeOnly>.MaxValue => MaxValue;
+
 #endif // FEATURE_GENERIC_MATH
     }
 }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -2553,6 +2553,23 @@ namespace System
         static double IFloatingPoint<double>.Truncate(double x) { throw null; }
 
         [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        static bool IFloatingPoint<double>.IsFinite(double d) { throw null; }
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        static bool IFloatingPoint<double>.IsInfinity(double d) { throw null; }
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        static bool IFloatingPoint<double>.IsNaN(double d) { throw null; }
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        static bool IFloatingPoint<double>.IsNegative(double d) { throw null; }
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        static bool IFloatingPoint<double>.IsNegativeInfinity(double d) { throw null; }
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        static bool IFloatingPoint<double>.IsNormal(double d) { throw null; }
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        static bool IFloatingPoint<double>.IsPositiveInfinity(double d) { throw null; }
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        static bool IFloatingPoint<double>.IsSubnormal(double d) { throw null; }
+
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
         static double IIncrementOperators<double>.operator ++(double value) { throw null; }
 
         [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
@@ -3268,6 +3285,23 @@ namespace System
         static System.Half IFloatingPoint<System.Half>.Tanh(System.Half x) { throw null; }
         [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
         static System.Half IFloatingPoint<System.Half>.Truncate(System.Half x) { throw null; }
+
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        static bool IFloatingPoint<Half>.IsFinite(Half x) { throw null; }
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        static bool IFloatingPoint<Half>.IsInfinity(Half x) { throw null; }
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        static bool IFloatingPoint<Half>.IsNaN(Half x) { throw null; }
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        static bool IFloatingPoint<Half>.IsNegative(Half x) { throw null; }
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        static bool IFloatingPoint<Half>.IsNegativeInfinity(Half x) { throw null; }
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        static bool IFloatingPoint<Half>.IsNormal(Half x) { throw null; }
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        static bool IFloatingPoint<Half>.IsPositiveInfinity(Half x) { throw null; }
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        static bool IFloatingPoint<Half>.IsSubnormal(Half x) { throw null; }
 
         [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
         static System.Half IIncrementOperators<System.Half>.operator ++(System.Half value) { throw null; }
@@ -5595,6 +5629,23 @@ namespace System
         static float IFloatingPoint<float>.Truncate(float x) { throw null; }
 
         [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        static bool IFloatingPoint<float>.IsFinite(float x) { throw null; }
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        static bool IFloatingPoint<float>.IsInfinity(float x) { throw null; }
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        static bool IFloatingPoint<float>.IsNaN(float x) { throw null; }
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        static bool IFloatingPoint<float>.IsNegative(float x) { throw null; }
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        static bool IFloatingPoint<float>.IsNegativeInfinity(float x) { throw null; }
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        static bool IFloatingPoint<float>.IsNormal(float x) { throw null; }
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        static bool IFloatingPoint<float>.IsPositiveInfinity(float x) { throw null; }
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        static bool IFloatingPoint<float>.IsSubnormal(float x) { throw null; }
+
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
         static float IIncrementOperators<float>.operator ++(float value) { throw null; }
 
         [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
@@ -6062,6 +6113,11 @@ namespace System
 
         [System.Runtime.Versioning.RequiresPreviewFeatures]
         static System.TimeSpan ISubtractionOperators<System.TimeOnly, System.TimeOnly, System.TimeSpan>.operator -(System.TimeOnly left, System.TimeOnly right) { throw null; }
+
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        static System.TimeOnly IMinMaxValue<System.TimeOnly>.MinValue { throw null; }
+        [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
+        static System.TimeOnly IMinMaxValue<System.TimeOnly>.MaxValue { throw null; }
 #endif // FEATURE_GENERIC_MATH
     }
     public partial class TimeoutException : System.SystemException

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -3287,21 +3287,21 @@ namespace System
         static System.Half IFloatingPoint<System.Half>.Truncate(System.Half x) { throw null; }
 
         [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
-        static bool IFloatingPoint<Half>.IsFinite(Half x) { throw null; }
+        static bool IFloatingPoint<System.Half>.IsFinite(System.Half x) { throw null; }
         [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
-        static bool IFloatingPoint<Half>.IsInfinity(Half x) { throw null; }
+        static bool IFloatingPoint<System.Half>.IsInfinity(System.Half x) { throw null; }
         [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
-        static bool IFloatingPoint<Half>.IsNaN(Half x) { throw null; }
+        static bool IFloatingPoint<System.Half>.IsNaN(System.Half x) { throw null; }
         [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
-        static bool IFloatingPoint<Half>.IsNegative(Half x) { throw null; }
+        static bool IFloatingPoint<System.Half>.IsNegative(System.Half x) { throw null; }
         [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
-        static bool IFloatingPoint<Half>.IsNegativeInfinity(Half x) { throw null; }
+        static bool IFloatingPoint<System.Half>.IsNegativeInfinity(System.Half x) { throw null; }
         [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
-        static bool IFloatingPoint<Half>.IsNormal(Half x) { throw null; }
+        static bool IFloatingPoint<System.Half>.IsNormal(System.Half x) { throw null; }
         [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
-        static bool IFloatingPoint<Half>.IsPositiveInfinity(Half x) { throw null; }
+        static bool IFloatingPoint<System.Half>.IsPositiveInfinity(System.Half x) { throw null; }
         [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
-        static bool IFloatingPoint<Half>.IsSubnormal(Half x) { throw null; }
+        static bool IFloatingPoint<System.Half>.IsSubnormal(System.Half x) { throw null; }
 
         [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
         static System.Half IIncrementOperators<System.Half>.operator ++(System.Half value) { throw null; }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -6115,9 +6115,9 @@ namespace System
         static System.TimeSpan ISubtractionOperators<System.TimeOnly, System.TimeOnly, System.TimeSpan>.operator -(System.TimeOnly left, System.TimeOnly right) { throw null; }
 
         [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
-        static System.TimeOnly IMinMaxValue<System.TimeOnly>.MinValue { throw null; }
+        static System.TimeOnly IMinMaxValue<System.TimeOnly>.MinValue { get { throw null; } }
         [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute]
-        static System.TimeOnly IMinMaxValue<System.TimeOnly>.MaxValue { throw null; }
+        static System.TimeOnly IMinMaxValue<System.TimeOnly>.MaxValue { get { throw null; } }
 #endif // FEATURE_GENERIC_MATH
     }
     public partial class TimeoutException : System.SystemException


### PR DESCRIPTION
As part of running CA2252 locally to test the dotnet/runtime build, the CA2252 analyzer tagged these APIs as being implicit implementations that didn't have the `[RequiresPreviewFeatures]` attribute. This PR fixes that. 

cc @jeffhandley 