### PR TITLE
Add `JitEnregStats` complus.

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -991,7 +991,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
         else
         {
             //  If the local variable has its address exposed then bail
-            if (lclVar->lvAddrExposed)
+            if (lclVar->IsAddressExposed())
             {
                 goto DONE_ASSERTION; // Don't make an assertion
             }
@@ -1022,7 +1022,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
         LclVarDsc* lclVar = &lvaTable[lclNum];
 
         //  If the local variable has its address exposed then bail
-        if (lclVar->lvAddrExposed)
+        if (lclVar->IsAddressExposed())
         {
             goto DONE_ASSERTION; // Don't make an assertion
         }
@@ -1210,7 +1210,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
                     }
 
                     //  If the local variable has its address exposed then bail
-                    if (lclVar2->lvAddrExposed)
+                    if (lclVar2->IsAddressExposed())
                     {
                         goto DONE_ASSERTION; // Don't make an assertion
                     }

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -3680,8 +3680,8 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
                     // refcnt.  This is in contrast with the non-LSRA case in which all
                     // non-tracked args are assumed live on entry.
                     noway_assert((varDsc->lvRefCnt() == 0) || (varDsc->lvType == TYP_STRUCT) ||
-                                 (varDsc->lvAddrExposed && compiler->info.compIsVarArgs) ||
-                                 (varDsc->lvAddrExposed && compiler->opts.compUseSoftFP));
+                                 (varDsc->IsAddressExposed() && compiler->info.compIsVarArgs) ||
+                                 (varDsc->IsAddressExposed() && compiler->opts.compUseSoftFP));
 #endif // !TARGET_X86
                 }
                 // Mark it as processed and be done with it
@@ -12551,7 +12551,7 @@ void CodeGen::genPoisonFrame(regMaskTP regLiveIn)
     for (unsigned varNum = 0; varNum < compiler->info.compLocalsCount; varNum++)
     {
         LclVarDsc* varDsc = compiler->lvaGetDesc(varNum);
-        if (varDsc->lvIsParam || varDsc->lvMustInit || !varDsc->lvAddrExposed)
+        if (varDsc->lvIsParam || varDsc->lvMustInit || !varDsc->IsAddressExposed())
         {
             continue;
         }

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -51,7 +51,7 @@ void CodeGen::genInitializeRegisterState()
             continue;
         }
 
-        if (varDsc->lvAddrExposed)
+        if (varDsc->IsAddressExposed())
         {
             continue;
         }

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -9721,17 +9721,11 @@ void Compiler::EnregisterStats::RecordLocal(const LclVarDsc* varDsc)
             case DoNotEnregisterReason::AddrExposed:
                 m_addrExposed++;
                 break;
-            case DoNotEnregisterReason::NotRegSizeStruct:
-                m_notRegSizeStruct++;
-                break;
             case DoNotEnregisterReason::DontEnregStructs:
                 m_dontEnregStructs++;
                 break;
-            case DoNotEnregisterReason::IsStructArg:
-                m_structArg++;
-                break;
-            case DoNotEnregisterReason::BlockOp:
-                m_blockOp++;
+            case DoNotEnregisterReason::NotRegSizeStruct:
+                m_notRegSizeStruct++;
                 break;
             case DoNotEnregisterReason::LocalField:
                 m_localField++;
@@ -9742,6 +9736,12 @@ void Compiler::EnregisterStats::RecordLocal(const LclVarDsc* varDsc)
             case DoNotEnregisterReason::LiveInOutOfHandler:
                 m_liveInOutHndlr++;
                 break;
+            case DoNotEnregisterReason::BlockOp:
+                m_blockOp++;
+                break;
+            case DoNotEnregisterReason::IsStructArg:
+                m_structArg++;
+                break;
             case DoNotEnregisterReason::DepField:
                 m_depField++;
                 break;
@@ -9751,14 +9751,14 @@ void Compiler::EnregisterStats::RecordLocal(const LclVarDsc* varDsc)
             case DoNotEnregisterReason::MinOptsGC:
                 m_minOptsGC++;
                 break;
-#ifdef JIT32_GCENCODER
-            case DoNotEnregisterReason::PinningRef:
-                m_PinningRef++;
-                break;
-#endif
 #if !defined(TARGET_64BIT)
             case DoNotEnregisterReason::LongParamField:
                 m_longParamField++;
+                break;
+#endif
+#ifdef JIT32_GCENCODER
+            case DoNotEnregisterReason::PinningRef:
+                m_PinningRef++;
                 break;
 #endif
             case DoNotEnregisterReason::LclAddrNode:
@@ -9883,24 +9883,22 @@ void Compiler::EnregisterStats::Dump(FILE* fout) const
     }
 
     PRINT_STATS(m_addrExposed, notEnreg);
-    PRINT_STATS(m_notRegSizeStruct, notEnreg);
     PRINT_STATS(m_dontEnregStructs, notEnreg);
-    PRINT_STATS(m_structArg, notEnreg);
-    PRINT_STATS(m_blockOp, notEnreg);
-    PRINT_STATS(m_addrExposed, notEnreg);
+    PRINT_STATS(m_notRegSizeStruct, notEnreg);
     PRINT_STATS(m_localField, notEnreg);
     PRINT_STATS(m_VMNeedsStackAddr, notEnreg);
     PRINT_STATS(m_liveInOutHndlr, notEnreg);
+    PRINT_STATS(m_blockOp, notEnreg);
+    PRINT_STATS(m_structArg, notEnreg);
     PRINT_STATS(m_depField, notEnreg);
     PRINT_STATS(m_noRegVars, notEnreg);
     PRINT_STATS(m_minOptsGC, notEnreg);
-
-#ifdef JIT32_GCENCODER
-    PRINT_STATS(m_PinningRef, notEnreg);
-#endif // JIT32_GCENCODER
 #if !defined(TARGET_64BIT)
     PRINT_STATS(m_longParamField, notEnreg);
 #endif // !TARGET_64BIT
+#ifdef JIT32_GCENCODER
+    PRINT_STATS(m_PinningRef, notEnreg);
+#endif // JIT32_GCENCODER
     PRINT_STATS(m_lclAddrNode, notEnreg);
     PRINT_STATS(m_castTakesAddr, notEnreg);
     PRINT_STATS(m_storeBlkSrc, notEnreg);
@@ -9918,10 +9916,10 @@ void Compiler::EnregisterStats::Dump(FILE* fout) const
     PRINT_STATS(m_parentExposed, m_addrExposed);
     PRINT_STATS(m_tooConservative, m_addrExposed);
     PRINT_STATS(m_escapeAddress, m_addrExposed);
+    PRINT_STATS(m_wideIndir, m_addrExposed);
     PRINT_STATS(m_osrExposed, m_addrExposed);
     PRINT_STATS(m_stressLclFld, m_addrExposed);
     PRINT_STATS(m_copyFldByFld, m_addrExposed);
     PRINT_STATS(m_dispatchRetBuf, m_addrExposed);
-    PRINT_STATS(m_wideIndir, m_addrExposed);
 }
 #endif // TRACK_ENREG_STATS

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -9704,7 +9704,7 @@ void Compiler::EnregisterStats::RecordLocal(const LclVarDsc* varDsc)
     m_totalNumberOfVars++;
     if (varDsc->TypeGet() == TYP_STRUCT)
     {
-        m_totalNumberOfStrutVars++;
+        m_totalNumberOfStructVars++;
     }
     if (!varDsc->lvDoNotEnregister)
     {
@@ -9839,7 +9839,7 @@ void Compiler::EnregisterStats::RecordLocal(const LclVarDsc* varDsc)
 void Compiler::EnregisterStats::Dump(FILE* fout) const
 {
     const unsigned totalNumberOfNotStructVars =
-        s_enregisterStats.m_totalNumberOfVars - s_enregisterStats.m_totalNumberOfStrutVars;
+        s_enregisterStats.m_totalNumberOfVars - s_enregisterStats.m_totalNumberOfStructVars;
     const unsigned totalNumberOfNotStructEnregVars =
         s_enregisterStats.m_totalNumberOfEnregVars - s_enregisterStats.m_totalNumberOfStructEnregVars;
     const unsigned notEnreg = s_enregisterStats.m_totalNumberOfVars - s_enregisterStats.m_totalNumberOfEnregVars;
@@ -9854,12 +9854,12 @@ void Compiler::EnregisterStats::Dump(FILE* fout) const
             m_totalNumberOfVars, m_totalNumberOfEnregVars, m_totalNumberOfVars - m_totalNumberOfEnregVars,
             (float)m_totalNumberOfEnregVars / m_totalNumberOfVars);
 
-    if (m_totalNumberOfStrutVars != 0)
+    if (m_totalNumberOfStructVars != 0)
     {
         fprintf(fout, "total number of struct locals: %d, number of enregistered: %d, notEnreg: %d, ratio: %.2f\n",
-                m_totalNumberOfStrutVars, m_totalNumberOfStructEnregVars,
-                m_totalNumberOfStrutVars - m_totalNumberOfStructEnregVars,
-                (float)m_totalNumberOfStructEnregVars / m_totalNumberOfStrutVars);
+                m_totalNumberOfStructVars, m_totalNumberOfStructEnregVars,
+                m_totalNumberOfStructVars - m_totalNumberOfStructEnregVars,
+                (float)m_totalNumberOfStructEnregVars / m_totalNumberOfStructVars);
     }
 
     const unsigned numberOfPrimitiveLocals = totalNumberOfNotStructVars - totalNumberOfNotStructEnregVars;
@@ -9911,7 +9911,7 @@ void Compiler::EnregisterStats::Dump(FILE* fout) const
     fprintf(fout, "\nAddr exposed details:\n");
     if (m_addrExposed == 0)
     {
-        fprintf(fout, "\nNo address exosed locals to report.\n");
+        fprintf(fout, "\nNo address exposed locals to report.\n");
         return;
     }
 

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -9879,7 +9879,7 @@ void Compiler::EnregisterStats::Dump(FILE* fout) const
 #define PRINT_STATS(stat, total)                                                                                       \
     if (stat != 0)                                                                                                     \
     {                                                                                                                  \
-        fprintf(fout, #stat " %d, ratio: %.2f\n", stat, (float)stat / total);                                           \
+        fprintf(fout, #stat " %d, ratio: %.2f\n", stat, (float)stat / total);                                          \
     }
 
     PRINT_STATS(m_addrExposed, notEnreg);

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -9879,7 +9879,7 @@ void Compiler::EnregisterStats::Dump(FILE* fout) const
 #define PRINT_STATS(stat, total)                                                                                       \
     if (stat != 0)                                                                                                     \
     {                                                                                                                  \
-        fprintf(fout, #stat "%d, ratio: %.2f\n", stat, (float)stat / total);                                           \
+        fprintf(fout, #stat " %d, ratio: %.2f\n", stat, (float)stat / total);                                           \
     }
 
     PRINT_STATS(m_addrExposed, notEnreg);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -361,6 +361,51 @@ enum RefCountState
     RCS_NORMAL,  // normal ref counts (from lvaMarkRefs onward)
 };
 
+#ifdef DEBUG
+// Reasons why we can't enregister a local.
+enum class DoNotEnregisterReason
+{
+    None,
+    AddrExposed,      // the address of this local is exposed.
+    DontEnregStructs, // struct enregistration is disabled.
+    NotRegSizeStruct, // the struct size does not much any register size, usually the struct size is too big.
+    LocalField,       // the local is accessed with LCL_FLD, note we can do it not only for struct locals.
+    VMNeedsStackAddr,
+    LiveInOutOfHandler, // the local is alive in and out of exception handler and not signle def.
+    BlockOp,            // Is read or written via a block operation.
+    IsStructArg,        // Is a struct passed as an argument in a way that requires a stack location.
+    DepField,           // It is a field of a dependently promoted struct
+    NoRegVars,          // opts.compFlags & CLFLG_REGVAR is not set
+    MinOptsGC,          // It is a GC Ref and we are compiling MinOpts
+#if !defined(TARGET_64BIT)
+    LongParamField, // It is a decomposed field of a long parameter.
+#endif
+#ifdef JIT32_GCENCODER
+    PinningRef,
+#endif
+    LclAddrNode, // the local is accessed with LCL_ADDR_VAR/FLD.
+    CastTakesAddr,
+    StoreBlkSrc,    // the local is used as STORE_BLK source.
+    OneAsgRetyping, // fgMorphOneAsgBlockOp prevents this local from being enregister.
+    SwizzleArg,     // the local is passed using LCL_FLD as another type.
+    BlockOpRet      // the struct is returned and it promoted or there is a cast.
+};
+
+enum class AddressExposedReason
+{
+    NONE,
+    PARENT_EXPOSED,   // This is a promoted field but the parent is exposed.
+    TOO_CONSERVATIVE, // Were marked as exposed to be conservative, fix these places.
+    ESCAPE_ADDRESS,   // The address is escaping, for example, passed as call argument.
+    WIDE_INDIR,       // We access via indirection with wider type.
+    OSR_EXPOSED,      // It was exposed in the original method, osr has to repeat it.
+    STRESS_LCL_FLD,   // Stress mode replaces localVar with localFld and makes them addrExposed.
+    COPY_FLD_BY_FLD,  // Field by field copy takes the address of the local, can be fixed.
+    DISPATCH_RET_BUF  // Caller return buffer dispatch.
+};
+
+#endif // DEBUG
+
 class LclVarDsc
 {
 public:
@@ -403,29 +448,15 @@ public:
     }
     unsigned char lvPinned : 1; // is this a pinned variable?
 
-    unsigned char lvMustInit : 1;    // must be initialized
-    unsigned char lvAddrExposed : 1; // The address of this variable is "exposed" -- passed as an argument, stored in a
-                                     // global location, etc.
-                                     // We cannot reason reliably about the value of the variable.
+    unsigned char lvMustInit : 1; // must be initialized
+
     unsigned char lvDoNotEnregister : 1; // Do not enregister this variable.
     unsigned char lvFieldAccessed : 1;   // The var is a struct local, and a field of the variable is accessed.  Affects
                                          // struct promotion.
     unsigned char lvLiveInOutOfHndlr : 1; // The variable is live in or out of an exception handler, and therefore must
                                           // be on the stack (at least at those boundaries.)
 
-    unsigned char lvInSsa : 1; // The variable is in SSA form (set by SsaBuilder)
-
-#ifdef DEBUG
-    // These further document the reasons for setting "lvDoNotEnregister".  (Note that "lvAddrExposed" is one of the
-    // reasons;
-    // also, lvType == TYP_STRUCT prevents enregistration.  At least one of the reasons should be true.
-    unsigned char lvVMNeedsStackAddr : 1; // The VM may have access to a stack-relative address of the variable, and
-                                          // read/write its value.
-    unsigned char lvLclFieldExpr : 1;     // The variable is not a struct, but was accessed like one (e.g., reading a
-                                          // particular byte from an int).
-    unsigned char lvLclBlockOpAddr : 1;   // The variable was written to via a block operation that took its address.
-    unsigned char lvLiveAcrossUCall : 1;  // The variable is live across an unmanaged call.
-#endif
+    unsigned char lvInSsa : 1;       // The variable is in SSA form (set by SsaBuilder)
     unsigned char lvIsCSE : 1;       // Indicates if this LclVar is a CSE variable.
     unsigned char lvHasLdAddrOp : 1; // has ldloca or ldarga opcode on this local.
     unsigned char lvStackByref : 1;  // This is a compiler temporary of TYP_BYREF that is known to point into our local
@@ -674,6 +705,49 @@ public:
     bool lvIsMultiRegArgOrRet()
     {
         return lvIsMultiRegArg || lvIsMultiRegRet;
+    }
+
+private:
+    bool m_addrExposed : 1; // The address of this variable is "exposed" -- passed as an argument, stored in a
+                            // global location, etc.
+                            // We cannot reason reliably about the value of the variable.
+#if defined(DEBUG)
+    DoNotEnregisterReason m_doNotEnregReason;
+
+    AddressExposedReason m_addrExposedReason;
+
+public:
+    void SetDoNotEnregReason(DoNotEnregisterReason reason)
+    {
+        m_doNotEnregReason = reason;
+    }
+
+    DoNotEnregisterReason GetDoNotEnregReason() const
+    {
+        return m_doNotEnregReason;
+    }
+
+    AddressExposedReason GetAddrExposedReason() const
+    {
+        return m_addrExposedReason;
+    }
+#endif // DEBUG
+
+public:
+    void SetAddressExposed(bool value DEBUGARG(AddressExposedReason reason))
+    {
+        m_addrExposed = value;
+        INDEBUG(m_addrExposedReason = reason);
+    }
+
+    void CleanAddressExposed()
+    {
+        m_addrExposed = false;
+    }
+
+    bool IsAddressExposed() const
+    {
+        return m_addrExposed;
     }
 
 private:
@@ -947,14 +1021,14 @@ public:
     {
         return varTypeIsSmall(TypeGet()) &&
                // lvIsStructField is treated the same as the aliased local, see fgDoNormalizeOnStore.
-               (lvIsParam || lvAddrExposed || lvIsStructField);
+               (lvIsParam || m_addrExposed || lvIsStructField);
     }
 
     bool lvNormalizeOnStore() const
     {
         return varTypeIsSmall(TypeGet()) &&
                // lvIsStructField is treated the same as the aliased local, see fgDoNormalizeOnStore.
-               !(lvIsParam || lvAddrExposed || lvIsStructField);
+               !(lvIsParam || m_addrExposed || lvIsStructField);
     }
 
     void incRefCnts(weight_t weight, Compiler* pComp, RefCountState state = RCS_NORMAL, bool propagate = true);
@@ -3477,8 +3551,8 @@ public:
 #endif
 
     // Getters and setters for address-exposed and do-not-enregister local var properties.
-    bool lvaVarAddrExposed(unsigned varNum);
-    void lvaSetVarAddrExposed(unsigned varNum);
+    bool lvaVarAddrExposed(unsigned varNum) const;
+    void lvaSetVarAddrExposed(unsigned varNum DEBUGARG(AddressExposedReason reason));
     void lvaSetVarLiveInOutOfHandler(unsigned varNum);
     bool lvaVarDoNotEnregister(unsigned varNum);
 
@@ -3487,31 +3561,6 @@ public:
     bool lvaEnregEHVars;
     bool lvaEnregMultiRegVars;
 
-#ifdef DEBUG
-    // Reasons why we can't enregister.  Some of these correspond to debug properties of local vars.
-    enum DoNotEnregisterReason
-    {
-        DNER_AddrExposed,
-        DNER_IsStruct,
-        DNER_LocalField,
-        DNER_VMNeedsStackAddr,
-        DNER_LiveInOutOfHandler,
-        DNER_LiveAcrossUnmanagedCall,
-        DNER_BlockOp,     // Is read or written via a block operation that explicitly takes the address.
-        DNER_IsStructArg, // Is a struct passed as an argument in a way that requires a stack location.
-        DNER_DepField,    // It is a field of a dependently promoted struct
-        DNER_NoRegVars,   // opts.compFlags & CLFLG_REGVAR is not set
-        DNER_MinOptsGC,   // It is a GC Ref and we are compiling MinOpts
-#if !defined(TARGET_64BIT)
-        DNER_LongParamVar,   // It is a long parameter.
-        DNER_LongParamField, // It is a decomposed field of a long parameter.
-#endif
-#ifdef JIT32_GCENCODER
-        DNER_PinningRef,
-#endif
-    };
-
-#endif
     void lvaSetVarDoNotEnregister(unsigned varNum DEBUGARG(DoNotEnregisterReason reason));
 
     unsigned lvaVarargsHandleArg;
@@ -10174,6 +10223,56 @@ public:
 
     static void PrintAggregateLoopHoistStats(FILE* f);
 #endif // LOOP_HOIST_STATS
+
+#if TRACK_ENREG_STATS
+    class EnregStructStat
+    {
+    private:
+        unsigned m_totalNumberOfVars;
+        unsigned m_totalNumberOfStrutVars;
+        unsigned m_totalNumberOfEnregVars;
+        unsigned m_totalNumberOfStructEnregVars;
+
+        unsigned m_addrExposed;
+        unsigned m_VMNeedsStackAddr;
+        unsigned m_localField;
+        unsigned m_blockOp;
+        unsigned m_dontEnregStructs;
+        unsigned m_notRegSizeStruct;
+        unsigned m_structArg;
+        unsigned m_lclAddrNode;
+        unsigned m_castTakesAddr;
+        unsigned m_storeBlkSrc;
+        unsigned m_oneAsgRetyping;
+        unsigned m_swizzleArg;
+        unsigned m_blockOpRet;
+        unsigned lvLiveInOutOfHndlr;
+        unsigned lvDepField;
+        unsigned lvNoRegVars;
+        unsigned lvMinOptsGC;
+#ifdef JIT32_GCENCODER
+        unsigned lvPinningRef;
+#endif // JIT32_GCENCODER
+#if !defined(TARGET_64BIT)
+        unsigned lvLongParamField;
+        unsigned lvLongParamVar;
+#endif // !TARGET_64BIT
+        unsigned m_parentExposed;
+        unsigned m_tooConservative;
+        unsigned m_escapeAddress;
+        unsigned m_osrExposed;
+        unsigned m_stressLclFld;
+        unsigned m_copyFldByFld;
+        unsigned m_dispatchRetBuf;
+        unsigned m_wideIndir;
+
+    public:
+        void RecordLocal(const LclVarDsc* varDsc);
+        void Dump(FILE* fout) const;
+    };
+
+    static EnregStructStat s_enregStructStat;
+#endif // TRACK_ENREG_STATS
 
     bool compIsForImportOnly();
     bool compIsForInlining() const;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -10225,7 +10225,7 @@ public:
 #endif // LOOP_HOIST_STATS
 
 #if TRACK_ENREG_STATS
-    class EnregStructStat
+    class EnregisterStats
     {
     private:
         unsigned m_totalNumberOfVars;
@@ -10246,16 +10246,15 @@ public:
         unsigned m_oneAsgRetyping;
         unsigned m_swizzleArg;
         unsigned m_blockOpRet;
-        unsigned lvLiveInOutOfHndlr;
-        unsigned lvDepField;
-        unsigned lvNoRegVars;
-        unsigned lvMinOptsGC;
+        unsigned m_liveInOutHndlr;
+        unsigned m_depField;
+        unsigned m_noRegVars;
+        unsigned m_minOptsGC;
 #ifdef JIT32_GCENCODER
-        unsigned lvPinningRef;
+        unsigned m_PinningRef;
 #endif // JIT32_GCENCODER
 #if !defined(TARGET_64BIT)
-        unsigned lvLongParamField;
-        unsigned lvLongParamVar;
+        unsigned m_longParamField;
 #endif // !TARGET_64BIT
         unsigned m_parentExposed;
         unsigned m_tooConservative;
@@ -10271,7 +10270,7 @@ public:
         void Dump(FILE* fout) const;
     };
 
-    static EnregStructStat s_enregStructStat;
+    static EnregisterStats s_enregisterStats;
 #endif // TRACK_ENREG_STATS
 
     bool compIsForImportOnly();

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -450,6 +450,11 @@ public:
 
     unsigned char lvMustInit : 1; // must be initialized
 
+private:
+    bool m_addrExposed : 1; // The address of this variable is "exposed" -- passed as an argument, stored in a
+                            // global location, etc.
+                            // We cannot reason reliably about the value of the variable.
+public:
     unsigned char lvDoNotEnregister : 1; // Do not enregister this variable.
     unsigned char lvFieldAccessed : 1;   // The var is a struct local, and a field of the variable is accessed.  Affects
                                          // struct promotion.
@@ -707,11 +712,8 @@ public:
         return lvIsMultiRegArg || lvIsMultiRegRet;
     }
 
-private:
-    bool m_addrExposed : 1; // The address of this variable is "exposed" -- passed as an argument, stored in a
-                            // global location, etc.
-                            // We cannot reason reliably about the value of the variable.
 #if defined(DEBUG)
+private:
     DoNotEnregisterReason m_doNotEnregReason;
 
     AddressExposedReason m_addrExposedReason;
@@ -10229,7 +10231,7 @@ public:
     {
     private:
         unsigned m_totalNumberOfVars;
-        unsigned m_totalNumberOfStrutVars;
+        unsigned m_totalNumberOfStructVars;
         unsigned m_totalNumberOfEnregVars;
         unsigned m_totalNumberOfStructEnregVars;
 

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1715,7 +1715,7 @@ inline unsigned Compiler::lvaGrabTempWithImplicitUse(bool shortLifetime DEBUGARG
     // This will prevent it from being optimized away
     // TODO-CQ: We shouldn't have to go as far as to declare these
     // address-exposed -- DoNotEnregister should suffice?
-    lvaSetVarAddrExposed(lclNum);
+    lvaSetVarAddrExposed(lclNum DEBUGARG(AddressExposedReason::TOO_CONSERVATIVE));
 
     // Note the implicit use
     varDsc->lvImplicitlyReferenced = 1;
@@ -2210,10 +2210,10 @@ inline bool Compiler::lvaIsOriginalThisArg(unsigned varNum)
         // copy to a new local, and mark the original as DoNotEnregister, to
         // ensure that it is stack-allocated.  It should not be the case that the original one can be modified -- it
         // should not be written to, or address-exposed.
-        assert(!varDsc->lvHasILStoreOp &&
-               (!varDsc->lvAddrExposed || ((info.compMethodInfo->options & CORINFO_GENERICS_CTXT_FROM_THIS) != 0)));
+        assert(!varDsc->lvHasILStoreOp && (!varDsc->IsAddressExposed() ||
+                                           ((info.compMethodInfo->options & CORINFO_GENERICS_CTXT_FROM_THIS) != 0)));
 #else
-        assert(!varDsc->lvHasILStoreOp && !varDsc->lvAddrExposed);
+        assert(!varDsc->lvHasILStoreOp && !varDsc->IsAddressExposed());
 #endif
     }
 #endif

--- a/src/coreclr/jit/copyprop.cpp
+++ b/src/coreclr/jit/copyprop.cpp
@@ -232,7 +232,7 @@ void Compiler::optCopyProp(BasicBlock* block, Statement* stmt, GenTree* tree, Lc
         // 'c' with 'x.'
         if (!lvaTable[newLclNum].lvVerTypeInfo.IsThisPtr())
         {
-            if (lvaTable[newLclNum].lvAddrExposed)
+            if (lvaTable[newLclNum].IsAddressExposed())
             {
                 continue;
             }

--- a/src/coreclr/jit/decomposelongs.cpp
+++ b/src/coreclr/jit/decomposelongs.cpp
@@ -363,7 +363,7 @@ GenTree* DecomposeLongs::DecomposeLclVar(LIR::Use& use)
     }
     else
     {
-        m_compiler->lvaSetVarDoNotEnregister(varNum DEBUGARG(Compiler::DNER_LocalField));
+        m_compiler->lvaSetVarDoNotEnregister(varNum DEBUGARG(DoNotEnregisterReason::LocalField));
         loResult->SetOper(GT_LCL_FLD);
         loResult->AsLclFld()->SetLclOffs(0);
         loResult->AsLclFld()->SetFieldSeq(FieldSeqStore::NotAField());
@@ -2152,7 +2152,7 @@ void DecomposeLongs::PromoteLongVars()
             if (isParam)
             {
                 fieldVarDsc->lvIsParam = true;
-                m_compiler->lvaSetVarDoNotEnregister(varNum DEBUGARG(Compiler::DNER_LongParamField));
+                m_compiler->lvaSetVarDoNotEnregister(varNum DEBUGARG(DoNotEnregisterReason::LongParamField));
             }
         }
     }

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2823,7 +2823,7 @@ void Compiler::fgDebugCheckBBlist(bool checkBBNum /* = false */, bool checkBBRef
     {
         // For instance method:
         assert(info.compThisArg != BAD_VAR_NUM);
-        bool compThisArgAddrExposedOK = !lvaTable[info.compThisArg].lvAddrExposed;
+        bool compThisArgAddrExposedOK = !lvaTable[info.compThisArg].IsAddressExposed();
 
 #ifndef JIT32_GCENCODER
         compThisArgAddrExposedOK = compThisArgAddrExposedOK || copiedForGenericsCtxt;
@@ -2834,7 +2834,7 @@ void Compiler::fgDebugCheckBBlist(bool checkBBNum /* = false */, bool checkBBRef
         // written to or address-exposed.
         assert(compThisArgAddrExposedOK && !lvaTable[info.compThisArg].lvHasILStoreOp &&
                (lvaArg0Var == info.compThisArg ||
-                (lvaArg0Var != info.compThisArg && (lvaTable[lvaArg0Var].lvAddrExposed ||
+                (lvaArg0Var != info.compThisArg && (lvaTable[lvaArg0Var].IsAddressExposed() ||
                                                     lvaTable[lvaArg0Var].lvHasILStoreOp || copiedForGenericsCtxt))));
     }
 }

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -2959,7 +2959,7 @@ bool Compiler::fgBlockEndFavorsTailDuplication(BasicBlock* block, unsigned lclNu
     //
     LclVarDsc* const lclDsc = lvaGetDesc(lclNum);
 
-    if (lclDsc->lvAddrExposed)
+    if (lclDsc->IsAddressExposed())
     {
         return false;
     }

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -607,7 +607,7 @@ bool Compiler::fgMayExplicitTailCall()
 //
 //    jumpTarget[N] is set to 1 if IL offset N is a jump target in the method.
 //
-//    Also sets lvAddrExposed and lvHasILStoreOp, ilHasMultipleILStoreOp in lvaTable[].
+//    Also sets m_addrExposed and lvHasILStoreOp, ilHasMultipleILStoreOp in lvaTable[].
 
 #ifdef _PREFAST_
 #pragma warning(push)
@@ -2636,9 +2636,9 @@ void Compiler::fgAddInternal()
 #else  // JIT32_GCENCODER
             lva0CopiedForGenericsCtxt          = false;
 #endif // JIT32_GCENCODER
-            noway_assert(lva0CopiedForGenericsCtxt || !lvaTable[info.compThisArg].lvAddrExposed);
+            noway_assert(lva0CopiedForGenericsCtxt || !lvaTable[info.compThisArg].IsAddressExposed());
             noway_assert(!lvaTable[info.compThisArg].lvHasILStoreOp);
-            noway_assert(lvaTable[lvaArg0Var].lvAddrExposed || lvaTable[lvaArg0Var].lvHasILStoreOp ||
+            noway_assert(lvaTable[lvaArg0Var].IsAddressExposed() || lvaTable[lvaArg0Var].lvHasILStoreOp ||
                          lva0CopiedForGenericsCtxt);
 
             var_types thisType = lvaTable[info.compThisArg].TypeGet();
@@ -4589,7 +4589,7 @@ void Compiler::fgLclFldAssign(unsigned lclNum)
     assert(varTypeIsStruct(lvaTable[lclNum].lvType));
     if (lvaTable[lclNum].lvPromoted && lvaTable[lclNum].lvFieldCnt > 1)
     {
-        lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_LocalField));
+        lvaSetVarDoNotEnregister(lclNum DEBUGARG(DoNotEnregisterReason::LocalField));
     }
 }
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -1942,7 +1942,7 @@ Compiler::fgWalkResult Compiler::gtHasLocalsWithAddrOpCB(GenTree** pTree, fgWalk
         unsigned   lclNum = tree->AsLclVarCommon()->GetLclNum();
         LclVarDsc* varDsc = &comp->lvaTable[lclNum];
 
-        if (varDsc->lvHasLdAddrOp || varDsc->lvAddrExposed)
+        if (varDsc->lvHasLdAddrOp || varDsc->IsAddressExposed())
         {
             ((AddrTakenDsc*)data->pCallbackData)->hasAddrTakenLcl = true;
             return WALK_ABORT;
@@ -1954,7 +1954,7 @@ Compiler::fgWalkResult Compiler::gtHasLocalsWithAddrOpCB(GenTree** pTree, fgWalk
 
 /*****************************************************************************
  *
- *  Return true if this tree contains locals with lvHasLdAddrOp or lvAddrExposed
+ *  Return true if this tree contains locals with lvHasLdAddrOp or IsAddressExposed()
  *  flag(s) set.
  */
 
@@ -10743,7 +10743,7 @@ void Compiler::gtDispNode(GenTree* tree, IndentStack* indentStack, __in __in_z _
             if (tree->gtOper == GT_LCL_VAR || tree->gtOper == GT_STORE_LCL_VAR)
             {
                 LclVarDsc* varDsc = &lvaTable[tree->AsLclVarCommon()->GetLclNum()];
-                if (varDsc->lvAddrExposed)
+                if (varDsc->IsAddressExposed())
                 {
                     printf("(AX)"); // Variable has address exposed.
                 }

--- a/src/coreclr/jit/gschecks.cpp
+++ b/src/coreclr/jit/gschecks.cpp
@@ -26,7 +26,7 @@ void Compiler::gsGSChecksInitCookie()
     lvaGSSecurityCookie = lvaGrabTempWithImplicitUse(false DEBUGARG("GSSecurityCookie"));
 
     // Prevent cookie init/check from being optimized
-    lvaSetVarAddrExposed(lvaGSSecurityCookie);
+    lvaSetVarAddrExposed(lvaGSSecurityCookie DEBUGARG(AddressExposedReason::TOO_CONSERVATIVE));
     lvaTable[lvaGSSecurityCookie].lvType = type;
 
     info.compCompHnd->getGSCookie(&gsGlobalSecurityCookieVal, &gsGlobalSecurityCookieAddr);
@@ -402,13 +402,10 @@ void Compiler::gsParamsToShadows()
 #endif
         shadowVarDsc->lvRegStruct = varDsc->lvRegStruct;
 
-        shadowVarDsc->lvAddrExposed     = varDsc->lvAddrExposed;
+        shadowVarDsc->SetAddressExposed(varDsc->IsAddressExposed() DEBUGARG(varDsc->GetAddrExposedReason()));
         shadowVarDsc->lvDoNotEnregister = varDsc->lvDoNotEnregister;
 #ifdef DEBUG
-        shadowVarDsc->lvVMNeedsStackAddr = varDsc->lvVMNeedsStackAddr;
-        shadowVarDsc->lvLiveInOutOfHndlr = varDsc->lvLiveInOutOfHndlr;
-        shadowVarDsc->lvLclFieldExpr     = varDsc->lvLclFieldExpr;
-        shadowVarDsc->lvLiveAcrossUCall  = varDsc->lvLiveAcrossUCall;
+        shadowVarDsc->SetDoNotEnregReason(varDsc->GetDoNotEnregReason());
 #endif
         shadowVarDsc->lvVerTypeInfo = varDsc->lvVerTypeInfo;
         if (varTypeIsStruct(type))

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -509,7 +509,7 @@ inline void Compiler::impAppendStmtCheck(Statement* stmt, unsigned chkLevel)
             for (unsigned level = 0; level < chkLevel; level++)
             {
                 assert(!gtHasRef(verCurrentState.esStack[level].val, lclNum, false));
-                assert(!lvaTable[lclNum].lvAddrExposed ||
+                assert(!lvaTable[lclNum].IsAddressExposed() ||
                        (verCurrentState.esStack[level].val->gtFlags & GTF_SIDE_EFFECT) == 0);
             }
         }
@@ -12010,7 +12010,8 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 /* If the local is aliased or pinned, we need to spill calls and
                    indirections from the stack. */
 
-                if ((lvaTable[lclNum].lvAddrExposed || lvaTable[lclNum].lvHasLdAddrOp || lvaTable[lclNum].lvPinned) &&
+                if ((lvaTable[lclNum].IsAddressExposed() || lvaTable[lclNum].lvHasLdAddrOp ||
+                     lvaTable[lclNum].lvPinned) &&
                     (verCurrentState.esStackDepth > 0))
                 {
                     impSpillSideEffects(false,
@@ -12176,7 +12177,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 /* The ARGLIST cookie is a hidden 'last' parameter, we have already
                    adjusted the arg count cos this is like fetching the last param */
                 assertImp(0 < numArgs);
-                assert(lvaTable[lvaVarargsHandleArg].lvAddrExposed);
+                assert(lvaTable[lvaVarargsHandleArg].IsAddressExposed());
                 lclNum = lvaVarargsHandleArg;
                 op1    = gtNewLclvNode(lclNum, TYP_I_IMPL DEBUGARG(opcodeOffs + sz + 1));
                 op1    = gtNewOperNode(GT_ADDR, TYP_BYREF, op1);
@@ -20336,7 +20337,7 @@ GenTree* Compiler::impInlineFetchArg(unsigned lclNum, InlArgInfo* inlArgInfo, In
                 }
             }
 
-            assert(lvaTable[tmpNum].lvAddrExposed == 0);
+            assert(!lvaTable[tmpNum].IsAddressExposed());
             if (argInfo.argHasLdargaOp)
             {
                 lvaTable[tmpNum].lvHasLdAddrOp = 1;
@@ -22177,7 +22178,7 @@ bool Compiler::impCanSkipCovariantStoreCheck(GenTree* value, GenTree* array)
         {
             unsigned valueLcl = valueIndex->AsLclVar()->GetLclNum();
             unsigned arrayLcl = array->AsLclVar()->GetLclNum();
-            if ((valueLcl == arrayLcl) && !lvaGetDesc(arrayLcl)->lvAddrExposed)
+            if ((valueLcl == arrayLcl) && !lvaGetDesc(arrayLcl)->IsAddressExposed())
             {
                 JITDUMP("\nstelem of ref from same array: skipping covariant store check\n");
                 return true;

--- a/src/coreclr/jit/jit.h
+++ b/src/coreclr/jit/jit.h
@@ -440,6 +440,7 @@ public:
 #define MEASURE_MEM_ALLOC 1 // Collect memory allocation stats.
 #define LOOP_HOIST_STATS 1  // Collect loop hoisting stats.
 #define TRACK_LSRA_STATS 1  // Collect LSRA stats
+#define TRACK_ENREG_STATS 1 // Collect enregistration stats
 #else
 #define MEASURE_MEM_ALLOC 0 // You can set this to 1 to get memory stats in retail, as well
 #define LOOP_HOIST_STATS 0  // You can set this to 1 to get loop hoist stats in retail, as well

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -382,6 +382,10 @@ CONFIG_INTEGER(JitMinOptsTrackGCrefs, W("JitMinOptsTrackGCrefs"), JitMinOptsTrac
 // TODO-Cleanup: need to make 'MEASURE_MEM_ALLOC' well-defined here at all times.
 CONFIG_INTEGER(DisplayMemStats, W("JitMemStats"), 0) // Display JIT memory usage statistics
 
+#if defined(DEBUG)
+CONFIG_INTEGER(JitEnregStats, W("JitEnregStats"), 0) // Display JIT enregistration statistics
+#endif                                               // DEBUG
+
 CONFIG_INTEGER(JitAggressiveInlining, W("JitAggressiveInlining"), 0) // Aggressive inlining of all methods
 CONFIG_INTEGER(JitELTHookEnabled, W("JitELTHookEnabled"), 0)         // If 1, emit Enter/Leave/TailCall callbacks
 CONFIG_INTEGER(JitInlineSIMDMultiplier, W("JitInlineSIMDMultiplier"), 3)

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -608,7 +608,8 @@ public:
                             LclVarDsc* varDsc = m_compiler->lvaGetDesc(lclNum);
                             if (varDsc->lvFieldCnt > 1)
                             {
-                                m_compiler->lvaSetVarDoNotEnregister(lclNum DEBUGARG(Compiler::DNER_BlockOp));
+                                m_compiler->lvaSetVarDoNotEnregister(
+                                    lclNum DEBUGARG(DoNotEnregisterReason::BlockOpRet));
                             }
                         }
                     }
@@ -694,7 +695,8 @@ private:
                          (val.Node() == user->AsCall()->gtCallThisArg->GetNode());
         bool exposeParentLcl = varDsc->lvIsStructField && !isThisArg;
 
-        m_compiler->lvaSetVarAddrExposed(exposeParentLcl ? varDsc->lvParentLcl : val.LclNum());
+        m_compiler->lvaSetVarAddrExposed(exposeParentLcl ? varDsc->lvParentLcl
+                                                         : val.LclNum() DEBUGARG(AddressExposedReason::ESCAPE_ADDRESS));
 
 #ifdef TARGET_64BIT
         // If the address of a variable is passed in a call and the allocation size of the variable
@@ -806,7 +808,9 @@ private:
 
             if (isWide)
             {
-                m_compiler->lvaSetVarAddrExposed(varDsc->lvIsStructField ? varDsc->lvParentLcl : val.LclNum());
+                m_compiler->lvaSetVarAddrExposed(varDsc->lvIsStructField
+                                                     ? varDsc->lvParentLcl
+                                                     : val.LclNum() DEBUGARG(AddressExposedReason::WIDE_INDIR));
             }
             else
             {
@@ -1103,7 +1107,7 @@ private:
 
             // Promoted struct vars aren't currently handled here so the created LCL_FLD can't be
             // later transformed into a LCL_VAR and the variable cannot be enregistered.
-            m_compiler->lvaSetVarDoNotEnregister(val.LclNum() DEBUGARG(Compiler::DNER_LocalField));
+            m_compiler->lvaSetVarDoNotEnregister(val.LclNum() DEBUGARG(DoNotEnregisterReason::LocalField));
         }
         else
         {

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -308,9 +308,9 @@ void Compiler::lvaInitTypeRef()
             JITDUMP("-- V%02u is OSR exposed\n", varNum);
             varDsc->lvHasLdAddrOp = 1;
 
-            if (varDsc->lvType != TYP_STRUCT)
+            if (varDsc->lvType != TYP_STRUCT) // Why does it apply only to non-structs?
             {
-                lvaSetVarAddrExposed(varNum);
+                lvaSetVarAddrExposed(varNum DEBUGARG(AddressExposedReason::OSR_EXPOSED));
             }
         }
     }
@@ -1113,7 +1113,7 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo, unsigned skipArgs, un
             // TODO-CQ: We shouldn't have to go as far as to declare these
             // address-exposed -- DoNotEnregister should suffice.
 
-            lvaSetVarAddrExposed(varDscInfo->varNum);
+            lvaSetVarAddrExposed(varDscInfo->varNum DEBUGARG(AddressExposedReason::TOO_CONSERVATIVE));
 #endif // !TARGET_X86
         }
 
@@ -1121,7 +1121,7 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo, unsigned skipArgs, un
         {
             JITDUMP("-- V%02u is OSR exposed\n", varDscInfo->varNum);
             varDsc->lvHasLdAddrOp = 1;
-            lvaSetVarAddrExposed(varDscInfo->varNum);
+            lvaSetVarAddrExposed(varDscInfo->varNum DEBUGARG(AddressExposedReason::OSR_EXPOSED));
         }
     }
 
@@ -1230,11 +1230,11 @@ void Compiler::lvaInitVarArgsHandle(InitVarDscInfo* varDscInfo)
         varDsc->lvIsParam = 1;
         // Make sure this lives in the stack -- address may be reported to the VM.
         // TODO-CQ: This should probably be:
-        //   lvaSetVarDoNotEnregister(varDscInfo->varNum DEBUGARG(DNER_VMNeedsStackAddr));
+        //   lvaSetVarDoNotEnregister(varDscInfo->varNum DEBUGARG(VMNeedsStackAddr));
         // But that causes problems, so, for expedience, I switched back to this heavyweight
         // hammer.  But I think it should be possible to switch; it may just work now
         // that other problems are fixed.
-        lvaSetVarAddrExposed(varDscInfo->varNum);
+        lvaSetVarAddrExposed(varDscInfo->varNum DEBUGARG(AddressExposedReason::TOO_CONSERVATIVE));
 
         if (varDscInfo->canEnreg(TYP_I_IMPL))
         {
@@ -1555,12 +1555,12 @@ unsigned Compiler::compMap2ILvarNum(unsigned varNum) const
  * Returns true if variable "varNum" may be address-exposed.
  */
 
-bool Compiler::lvaVarAddrExposed(unsigned varNum)
+bool Compiler::lvaVarAddrExposed(unsigned varNum) const
 {
     noway_assert(varNum < lvaCount);
-    LclVarDsc* varDsc = &lvaTable[varNum];
+    const LclVarDsc* varDsc = &lvaTable[varNum];
 
-    return varDsc->lvAddrExposed;
+    return varDsc->IsAddressExposed();
 }
 
 /*****************************************************************************
@@ -1588,7 +1588,7 @@ void Compiler::lvSetMinOptsDoNotEnreg()
     assert(!compEnregLocals());
     for (unsigned lclNum = 0; lclNum < lvaCount; lclNum++)
     {
-        lvaSetVarDoNotEnregister(lclNum DEBUGARG(Compiler::DNER_NoRegVars));
+        lvaSetVarDoNotEnregister(lclNum DEBUGARG(DoNotEnregisterReason::NoRegVars));
     }
 }
 
@@ -2505,13 +2505,13 @@ unsigned Compiler::lvaGetFieldLocal(const LclVarDsc* varDsc, unsigned int fldOff
  *  If this is a promoted struct, label it's fields the same way.
  */
 
-void Compiler::lvaSetVarAddrExposed(unsigned varNum)
+void Compiler::lvaSetVarAddrExposed(unsigned varNum DEBUGARG(AddressExposedReason reason))
 {
     noway_assert(varNum < lvaCount);
 
     LclVarDsc* varDsc = &lvaTable[varNum];
 
-    varDsc->lvAddrExposed = 1;
+    varDsc->SetAddressExposed(true DEBUGARG(reason));
 
     if (varDsc->lvPromoted)
     {
@@ -2520,12 +2520,12 @@ void Compiler::lvaSetVarAddrExposed(unsigned varNum)
         for (unsigned i = varDsc->lvFieldLclStart; i < varDsc->lvFieldLclStart + varDsc->lvFieldCnt; ++i)
         {
             noway_assert(lvaTable[i].lvIsStructField);
-            lvaTable[i].lvAddrExposed = 1; // Make field local as address-exposed.
-            lvaSetVarDoNotEnregister(i DEBUGARG(DNER_AddrExposed));
+            lvaTable[i].SetAddressExposed(true DEBUGARG(AddressExposedReason::PARENT_EXPOSED));
+            lvaSetVarDoNotEnregister(i DEBUGARG(DoNotEnregisterReason::AddrExposed));
         }
     }
 
-    lvaSetVarDoNotEnregister(varNum DEBUGARG(DNER_AddrExposed));
+    lvaSetVarDoNotEnregister(varNum DEBUGARG(DoNotEnregisterReason::AddrExposed));
 }
 
 //------------------------------------------------------------------------
@@ -2553,7 +2553,7 @@ void Compiler::lvaSetVarLiveInOutOfHandler(unsigned varNum)
             // For now, only enregister an EH Var if it is a single def and whose refCnt > 1.
             if (!lvaEnregEHVars || !lvaTable[i].lvSingleDefRegCandidate || lvaTable[i].lvRefCnt() <= 1)
             {
-                lvaSetVarDoNotEnregister(i DEBUGARG(DNER_LiveInOutOfHandler));
+                lvaSetVarDoNotEnregister(i DEBUGARG(DoNotEnregisterReason::LiveInOutOfHandler));
             }
         }
     }
@@ -2561,7 +2561,7 @@ void Compiler::lvaSetVarLiveInOutOfHandler(unsigned varNum)
     // For now, only enregister an EH Var if it is a single def and whose refCnt > 1.
     if (!lvaEnregEHVars || !varDsc->lvSingleDefRegCandidate || varDsc->lvRefCnt() <= 1)
     {
-        lvaSetVarDoNotEnregister(varNum DEBUGARG(DNER_LiveInOutOfHandler));
+        lvaSetVarDoNotEnregister(varNum DEBUGARG(DoNotEnregisterReason::LiveInOutOfHandler));
     }
 #ifdef JIT32_GCENCODER
     else if (lvaKeepAliveAndReportThis() && (varNum == info.compThisArg))
@@ -2569,7 +2569,7 @@ void Compiler::lvaSetVarLiveInOutOfHandler(unsigned varNum)
         // For the JIT32_GCENCODER, when lvaKeepAliveAndReportThis is true, we must either keep the "this" pointer
         // in the same register for the entire method, or keep it on the stack. If it is EH-exposed, we can't ever
         // keep it in a register, since it must also be live on the stack. Therefore, we won't attempt to allocate it.
-        lvaSetVarDoNotEnregister(varNum DEBUGARG(DNER_LiveInOutOfHandler));
+        lvaSetVarDoNotEnregister(varNum DEBUGARG(DoNotEnregisterReason::LiveInOutOfHandler));
     }
 #endif // JIT32_GCENCODER
 }
@@ -2582,25 +2582,35 @@ void Compiler::lvaSetVarLiveInOutOfHandler(unsigned varNum)
 void Compiler::lvaSetVarDoNotEnregister(unsigned varNum DEBUGARG(DoNotEnregisterReason reason))
 {
     noway_assert(varNum < lvaCount);
-    LclVarDsc* varDsc         = &lvaTable[varNum];
+    LclVarDsc* varDsc = &lvaTable[varNum];
+    if (varDsc->lvDoNotEnregister == 1)
+    {
+        return;
+    }
     varDsc->lvDoNotEnregister = 1;
+    INDEBUG(varDsc->SetDoNotEnregReason(reason));
 
 #ifdef DEBUG
+
     if (verbose)
     {
         printf("\nLocal V%02u should not be enregistered because: ", varNum);
     }
     switch (reason)
     {
-        case DNER_AddrExposed:
+        case DoNotEnregisterReason::AddrExposed:
             JITDUMP("it is address exposed\n");
-            assert(varDsc->lvAddrExposed);
+            assert(varDsc->IsAddressExposed());
             break;
-        case DNER_IsStruct:
-            JITDUMP("it is a struct\n");
+        case DoNotEnregisterReason::NotRegSizeStruct:
+            JITDUMP("struct size does not match reg size\n");
             assert(varTypeIsStruct(varDsc));
             break;
-        case DNER_IsStructArg:
+        case DoNotEnregisterReason::DontEnregStructs:
+            JITDUMP("struct enregistration is disabled\n");
+            assert(varTypeIsStruct(varDsc));
+            break;
+        case DoNotEnregisterReason::IsStructArg:
             if (varTypeIsStruct(varDsc))
             {
                 JITDUMP("it is a struct arg\n");
@@ -2610,52 +2620,67 @@ void Compiler::lvaSetVarDoNotEnregister(unsigned varNum DEBUGARG(DoNotEnregister
                 JITDUMP("it is reinterpreted as a struct arg\n");
             }
             break;
-        case DNER_BlockOp:
-            JITDUMP("written in a block op\n");
-            varDsc->lvLclBlockOpAddr = 1;
+        case DoNotEnregisterReason::BlockOp:
+            JITDUMP("written/read in a block op\n");
             break;
-        case DNER_LocalField:
+        case DoNotEnregisterReason::LocalField:
             JITDUMP("was accessed as a local field\n");
-            varDsc->lvLclFieldExpr = 1;
             break;
-        case DNER_VMNeedsStackAddr:
-            JITDUMP("needs stack addr\n");
-            varDsc->lvVMNeedsStackAddr = 1;
+        case DoNotEnregisterReason::VMNeedsStackAddr:
+            JITDUMP("VM needs stack addr\n");
             break;
-        case DNER_LiveInOutOfHandler:
+        case DoNotEnregisterReason::LiveInOutOfHandler:
             JITDUMP("live in/out of a handler\n");
             varDsc->lvLiveInOutOfHndlr = 1;
             break;
-        case DNER_LiveAcrossUnmanagedCall:
-            JITDUMP("live across unmanaged call\n");
-            varDsc->lvLiveAcrossUCall = 1;
             break;
-        case DNER_DepField:
+        case DoNotEnregisterReason::DepField:
             JITDUMP("field of a dependently promoted struct\n");
             assert(varDsc->lvIsStructField && (lvaGetParentPromotionType(varNum) != PROMOTION_TYPE_INDEPENDENT));
             break;
-        case DNER_NoRegVars:
+        case DoNotEnregisterReason::NoRegVars:
             JITDUMP("opts.compFlags & CLFLG_REGVAR is not set\n");
             assert(!compEnregLocals());
             break;
-        case DNER_MinOptsGC:
-            JITDUMP("It is a GC Ref and we are compiling MinOpts\n");
+        case DoNotEnregisterReason::MinOptsGC:
+            JITDUMP("it is a GC Ref and we are compiling MinOpts\n");
             assert(!JitConfig.JitMinOptsTrackGCrefs() && varTypeIsGC(varDsc->TypeGet()));
             break;
 #ifdef JIT32_GCENCODER
-        case DNER_PinningRef:
+        case DoNotEnregisterReason::PinningRef:
             JITDUMP("pinning ref\n");
             assert(varDsc->lvPinned);
             break;
 #endif
 #if !defined(TARGET_64BIT)
-        case DNER_LongParamField:
+        case DoNotEnregisterReason::LongParamField:
             JITDUMP("it is a decomposed field of a long parameter\n");
             break;
-        case DNER_LongParamVar:
-            JITDUMP("it is a long parameter\n");
-            break;
 #endif
+        case DoNotEnregisterReason::LclAddrNode:
+            JITDUMP("LclAddrVar/Fld takes the address of this node\n");
+            break;
+
+        case DoNotEnregisterReason::CastTakesAddr:
+            JITDUMP("cast takes addr\n");
+            break;
+
+        case DoNotEnregisterReason::StoreBlkSrc:
+            JITDUMP("the local is used as store block src\n");
+            break;
+
+        case DoNotEnregisterReason::OneAsgRetyping:
+            JITDUMP("OneAsg forbids enreg\n");
+            break;
+
+        case DoNotEnregisterReason::SwizzleArg:
+            JITDUMP("SwizzleArg\n");
+            break;
+
+        case DoNotEnregisterReason::BlockOpRet:
+            JITDUMP("return uses a block op\n");
+            break;
+
         default:
             unreached();
             break;
@@ -3125,7 +3150,7 @@ unsigned Compiler::lvaLclSize(unsigned varNum)
     // We only need this Quirk for TARGET_64BIT
     if (lvaTable[varNum].lvQuirkToLong)
     {
-        noway_assert(lvaTable[varNum].lvAddrExposed);
+        noway_assert(lvaTable[varNum].IsAddressExposed());
         return genTypeStSz(TYP_LONG) * sizeof(int); // return 8  (2 * 4)
     }
 #endif
@@ -3476,11 +3501,11 @@ void Compiler::lvaSortByRefCount()
         // Pinned variables may not be tracked (a condition of the GCInfo representation)
         // or enregistered, on x86 -- it is believed that we can enregister pinned (more properly, "pinning")
         // references when using the general GC encoding.
-        if (varDsc->lvAddrExposed)
+        if (varDsc->IsAddressExposed())
         {
             varDsc->lvTracked = 0;
             assert(varDsc->lvType != TYP_STRUCT ||
-                   varDsc->lvDoNotEnregister); // For structs, should have set this when we set lvAddrExposed.
+                   varDsc->lvDoNotEnregister); // For structs, should have set this when we set m_addrExposed.
         }
         if (varTypeIsStruct(varDsc))
         {
@@ -3493,18 +3518,18 @@ void Compiler::lvaSortByRefCount()
             }
             else if (!varDsc->IsEnregisterableType())
             {
-                lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_IsStruct));
+                lvaSetVarDoNotEnregister(lclNum DEBUGARG(DoNotEnregisterReason::NotRegSizeStruct));
             }
             else if (varDsc->lvType == TYP_STRUCT)
             {
                 if (!varDsc->lvRegStruct && !compEnregStructLocals())
                 {
-                    lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_IsStruct));
+                    lvaSetVarDoNotEnregister(lclNum DEBUGARG(DoNotEnregisterReason::DontEnregStructs));
                 }
                 else if (varDsc->lvIsMultiRegArgOrRet())
                 {
                     // Prolog and return generators do not support SIMD<->general register moves.
-                    lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_IsStructArg));
+                    lvaSetVarDoNotEnregister(lclNum DEBUGARG(DoNotEnregisterReason::IsStructArg));
                 }
 #if defined(TARGET_ARM)
                 else if (varDsc->lvIsParam)
@@ -3512,30 +3537,30 @@ void Compiler::lvaSortByRefCount()
                     // On arm we prespill all struct args,
                     // TODO-Arm-CQ: keep them in registers, it will need a fix
                     // to "On the ARM we will spill any incoming struct args" logic in codegencommon.
-                    lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_IsStructArg));
+                    lvaSetVarDoNotEnregister(lclNum DEBUGARG(DoNotEnregisterReason::IsStructArg));
                 }
 #endif // TARGET_ARM
             }
         }
         if (varDsc->lvIsStructField && (lvaGetParentPromotionType(lclNum) != PROMOTION_TYPE_INDEPENDENT))
         {
-            lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_DepField));
+            lvaSetVarDoNotEnregister(lclNum DEBUGARG(DoNotEnregisterReason::DepField));
         }
         if (varDsc->lvPinned)
         {
             varDsc->lvTracked = 0;
 #ifdef JIT32_GCENCODER
-            lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_PinningRef));
+            lvaSetVarDoNotEnregister(lclNum DEBUGARG(DoNotEnregisterReason::PinningRef));
 #endif
         }
         if (opts.MinOpts() && !JitConfig.JitMinOptsTrackGCrefs() && varTypeIsGC(varDsc->TypeGet()))
         {
             varDsc->lvTracked = 0;
-            lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_MinOptsGC));
+            lvaSetVarDoNotEnregister(lclNum DEBUGARG(DoNotEnregisterReason::MinOptsGC));
         }
         if (!compEnregLocals())
         {
-            lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_NoRegVars));
+            lvaSetVarDoNotEnregister(lclNum DEBUGARG(DoNotEnregisterReason::NoRegVars));
         }
 #if defined(JIT32_GCENCODER) && defined(FEATURE_EH_FUNCLETS)
         if (lvaIsOriginalThisArg(lclNum) && (info.compMethodInfo->options & CORINFO_GENERICS_CTXT_FROM_THIS) != 0)
@@ -3551,7 +3576,7 @@ void Compiler::lvaSortByRefCount()
         //
         if (opts.MinOpts() && compHndBBtabCount > 0)
         {
-            lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_LiveInOutOfHandler));
+            lvaSetVarDoNotEnregister(lclNum DEBUGARG(DoNotEnregisterReason::LiveInOutOfHandler));
         }
         else
         {
@@ -3985,7 +4010,7 @@ void Compiler::lvaMarkLclRefs(GenTree* tree, BasicBlock* block, Statement* stmt,
     if (tree->OperIsLocalAddr())
     {
         LclVarDsc* varDsc = lvaGetDesc(tree->AsLclVarCommon());
-        assert(varDsc->lvAddrExposed);
+        assert(varDsc->IsAddressExposed());
         varDsc->incRefCnts(weight, this);
         return;
     }
@@ -7391,7 +7416,7 @@ void Compiler::lvaDumpEntry(unsigned lclNum, FrameLayoutState curState, size_t r
     if (varDsc->lvDoNotEnregister)
     {
         printf(" do-not-enreg[");
-        if (varDsc->lvAddrExposed)
+        if (varDsc->IsAddressExposed())
         {
             printf("X");
         }
@@ -7399,7 +7424,7 @@ void Compiler::lvaDumpEntry(unsigned lclNum, FrameLayoutState curState, size_t r
         {
             printf("S");
         }
-        if (varDsc->lvVMNeedsStackAddr)
+        if (varDsc->GetDoNotEnregReason() == DoNotEnregisterReason::VMNeedsStackAddr)
         {
             printf("V");
         }
@@ -7407,17 +7432,13 @@ void Compiler::lvaDumpEntry(unsigned lclNum, FrameLayoutState curState, size_t r
         {
             printf("%c", varDsc->lvSingleDefDisqualifyReason);
         }
-        if (varDsc->lvLclFieldExpr)
+        if (varDsc->GetDoNotEnregReason() == DoNotEnregisterReason::LocalField)
         {
             printf("F");
         }
-        if (varDsc->lvLclBlockOpAddr)
+        if (varDsc->GetDoNotEnregReason() == DoNotEnregisterReason::BlockOp)
         {
             printf("B");
-        }
-        if (varDsc->lvLiveAcrossUCall)
-        {
-            printf("U");
         }
         if (varDsc->lvIsMultiRegArg)
         {
@@ -7446,7 +7467,7 @@ void Compiler::lvaDumpEntry(unsigned lclNum, FrameLayoutState curState, size_t r
     {
         printf(" must-init");
     }
-    if (varDsc->lvAddrExposed)
+    if (varDsc->IsAddressExposed())
     {
         printf(" addr-exposed");
     }
@@ -8011,7 +8032,7 @@ Compiler::fgWalkResult Compiler::lvaStressLclFldCB(GenTree** pTree, fgWalkData* 
         {
             varDsc->lvExactSize = roundUp(padding + pComp->lvaLclSize(lclNum), TARGET_POINTER_SIZE);
             varDsc->lvType      = TYP_BLK;
-            pComp->lvaSetVarAddrExposed(lclNum);
+            pComp->lvaSetVarAddrExposed(lclNum DEBUGARG(AddressExposedReason::STRESS_LCL_FLD));
         }
 
         tree->gtFlags |= GTF_GLOB_REF;

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -2583,19 +2583,21 @@ void Compiler::lvaSetVarDoNotEnregister(unsigned varNum DEBUGARG(DoNotEnregister
 {
     noway_assert(varNum < lvaCount);
     LclVarDsc* varDsc = &lvaTable[varNum];
-    if (varDsc->lvDoNotEnregister == 1)
-    {
-        return;
-    }
-    varDsc->lvDoNotEnregister = 1;
-    INDEBUG(varDsc->SetDoNotEnregReason(reason));
+
+    const bool wasAlreadyMarkedDoNotEnreg = (varDsc->lvDoNotEnregister == 1);
+    varDsc->lvDoNotEnregister             = 1;
 
 #ifdef DEBUG
+    if (!wasAlreadyMarkedDoNotEnreg)
+    {
+        varDsc->SetDoNotEnregReason(reason);
+    }
 
     if (verbose)
     {
         printf("\nLocal V%02u should not be enregistered because: ", varNum);
     }
+
     switch (reason)
     {
         case DoNotEnregisterReason::AddrExposed:

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -2604,26 +2604,13 @@ void Compiler::lvaSetVarDoNotEnregister(unsigned varNum DEBUGARG(DoNotEnregister
             JITDUMP("it is address exposed\n");
             assert(varDsc->IsAddressExposed());
             break;
-        case DoNotEnregisterReason::NotRegSizeStruct:
-            JITDUMP("struct size does not match reg size\n");
-            assert(varTypeIsStruct(varDsc));
-            break;
         case DoNotEnregisterReason::DontEnregStructs:
             JITDUMP("struct enregistration is disabled\n");
             assert(varTypeIsStruct(varDsc));
             break;
-        case DoNotEnregisterReason::IsStructArg:
-            if (varTypeIsStruct(varDsc))
-            {
-                JITDUMP("it is a struct arg\n");
-            }
-            else
-            {
-                JITDUMP("it is reinterpreted as a struct arg\n");
-            }
-            break;
-        case DoNotEnregisterReason::BlockOp:
-            JITDUMP("written/read in a block op\n");
+        case DoNotEnregisterReason::NotRegSizeStruct:
+            JITDUMP("struct size does not match reg size\n");
+            assert(varTypeIsStruct(varDsc));
             break;
         case DoNotEnregisterReason::LocalField:
             JITDUMP("was accessed as a local field\n");
@@ -2635,6 +2622,18 @@ void Compiler::lvaSetVarDoNotEnregister(unsigned varNum DEBUGARG(DoNotEnregister
             JITDUMP("live in/out of a handler\n");
             varDsc->lvLiveInOutOfHndlr = 1;
             break;
+        case DoNotEnregisterReason::BlockOp:
+            JITDUMP("written/read in a block op\n");
+            break;
+        case DoNotEnregisterReason::IsStructArg:
+            if (varTypeIsStruct(varDsc))
+            {
+                JITDUMP("it is a struct arg\n");
+            }
+            else
+            {
+                JITDUMP("it is reinterpreted as a struct arg\n");
+            }
             break;
         case DoNotEnregisterReason::DepField:
             JITDUMP("field of a dependently promoted struct\n");
@@ -2648,15 +2647,15 @@ void Compiler::lvaSetVarDoNotEnregister(unsigned varNum DEBUGARG(DoNotEnregister
             JITDUMP("it is a GC Ref and we are compiling MinOpts\n");
             assert(!JitConfig.JitMinOptsTrackGCrefs() && varTypeIsGC(varDsc->TypeGet()));
             break;
+#if !defined(TARGET_64BIT)
+        case DoNotEnregisterReason::LongParamField:
+            JITDUMP("it is a decomposed field of a long parameter\n");
+            break;
+#endif
 #ifdef JIT32_GCENCODER
         case DoNotEnregisterReason::PinningRef:
             JITDUMP("pinning ref\n");
             assert(varDsc->lvPinned);
-            break;
-#endif
-#if !defined(TARGET_64BIT)
-        case DoNotEnregisterReason::LongParamField:
-            JITDUMP("it is a decomposed field of a long parameter\n");
             break;
 #endif
         case DoNotEnregisterReason::LclAddrNode:

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -47,7 +47,7 @@ void Compiler::fgMarkUseDef(GenTreeLclVarCommon* tree)
         // We don't treat stores to tracked locals as modifications of ByrefExposed memory;
         // Make sure no tracked local is addr-exposed, to make sure we don't incorrectly CSE byref
         // loads aliasing it across a store to it.
-        assert(!varDsc->lvAddrExposed);
+        assert(!varDsc->IsAddressExposed());
 
         if (compRationalIRForm && (varDsc->lvType != TYP_STRUCT) && !varTypeIsMultiReg(varDsc))
         {
@@ -70,7 +70,7 @@ void Compiler::fgMarkUseDef(GenTreeLclVarCommon* tree)
     }
     else
     {
-        if (varDsc->lvAddrExposed)
+        if (varDsc->IsAddressExposed())
         {
             // Reflect the effect on ByrefExposed memory
 
@@ -1613,7 +1613,8 @@ bool Compiler::fgComputeLifeTrackedLocalDef(VARSET_TP&           life,
             // of the variable has been exposed. Improved alias analysis could allow
             // stores to these sorts of variables to be removed at the cost of compile
             // time.
-            return !varDsc.lvAddrExposed && !(varDsc.lvIsStructField && lvaTable[varDsc.lvParentLcl].lvAddrExposed);
+            return !varDsc.IsAddressExposed() &&
+                   !(varDsc.lvIsStructField && lvaTable[varDsc.lvParentLcl].IsAddressExposed());
         }
     }
 
@@ -1727,7 +1728,7 @@ bool Compiler::fgComputeLifeUntrackedLocal(VARSET_TP&           life,
 
                 // Do not consider this store dead if the parent local variable is an address exposed local or
                 // if the struct has a custom layout and holes.
-                return !(varDsc.lvAddrExposed || (varDsc.lvCustomLayout && varDsc.lvContainsHoles));
+                return !(varDsc.IsAddressExposed() || (varDsc.lvCustomLayout && varDsc.lvContainsHoles));
             }
         }
         return false;
@@ -2217,8 +2218,8 @@ bool Compiler::fgRemoveDeadStore(GenTree**        pTree,
     assert(!compRationalIRForm);
 
     // Vars should have already been checked for address exposure by this point.
-    assert(!varDsc->lvIsStructField || !lvaTable[varDsc->lvParentLcl].lvAddrExposed);
-    assert(!varDsc->lvAddrExposed);
+    assert(!varDsc->lvIsStructField || !lvaTable[varDsc->lvParentLcl].IsAddressExposed());
+    assert(!varDsc->IsAddressExposed());
 
     GenTree*       asgNode  = nullptr;
     GenTree*       rhsNode  = nullptr;
@@ -2316,13 +2317,13 @@ bool Compiler::fgRemoveDeadStore(GenTree**        pTree,
 
         // Do not remove if this local variable represents
         // a promoted struct field of an address exposed local.
-        if (varDsc->lvIsStructField && lvaTable[varDsc->lvParentLcl].lvAddrExposed)
+        if (varDsc->lvIsStructField && lvaTable[varDsc->lvParentLcl].IsAddressExposed())
         {
             return false;
         }
 
         // Do not remove if the address of the variable has been exposed.
-        if (varDsc->lvAddrExposed)
+        if (varDsc->IsAddressExposed())
         {
             return false;
         }

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -297,7 +297,7 @@ GenTree* Lowering::LowerNode(GenTree* node)
                     lclNode->ClearMultiReg();
                     if (lclNode->TypeIs(TYP_STRUCT))
                     {
-                        comp->lvaSetVarDoNotEnregister(lclNode->GetLclNum() DEBUGARG(Compiler::DNER_BlockOp));
+                        comp->lvaSetVarDoNotEnregister(lclNode->GetLclNum() DEBUGARG(DoNotEnregisterReason::BlockOp));
                     }
                 }
             }
@@ -357,10 +357,15 @@ GenTree* Lowering::LowerNode(GenTree* node)
         case GT_LCL_FLD_ADDR:
         case GT_LCL_VAR_ADDR:
         {
-            // TODO-Cleanup: this is definitely not the best place for this detection,
-            // but for now it is the easiest. Move it to morph.
+
             const GenTreeLclVarCommon* lclAddr = node->AsLclVarCommon();
-            comp->lvaSetVarDoNotEnregister(lclAddr->GetLclNum() DEBUGARG(Compiler::DNER_BlockOp));
+            const LclVarDsc*           varDsc  = comp->lvaGetDesc(lclAddr);
+            if (!varDsc->lvDoNotEnregister)
+            {
+                // TODO-Cleanup: this is definitely not the best place for this detection,
+                // but for now it is the easiest. Move it to morph.
+                comp->lvaSetVarDoNotEnregister(lclAddr->GetLclNum() DEBUGARG(DoNotEnregisterReason::LclAddrNode));
+            }
         }
         break;
 
@@ -1239,7 +1244,7 @@ GenTree* Lowering::NewPutArg(GenTreeCall* call, GenTree* arg, fgArgTabEntry* inf
                         unsigned lclNum = objOp1->AsLclVarCommon()->GetLclNum();
                         if (comp->lvaTable[lclNum].lvType != TYP_STRUCT)
                         {
-                            comp->lvaSetVarDoNotEnregister(lclNum DEBUGARG(Compiler::DNER_VMNeedsStackAddr));
+                            comp->lvaSetVarDoNotEnregister(lclNum DEBUGARG(DoNotEnregisterReason::VMNeedsStackAddr));
                         }
                     }
 #endif // TARGET_X86
@@ -2069,11 +2074,15 @@ void Lowering::RehomeArgForFastTailCall(unsigned int lclNum,
         {
             tmpLclNum = comp->lvaGrabTemp(true DEBUGARG("Fast tail call lowering is creating a new local variable"));
 
-            LclVarDsc* callerArgDsc                     = comp->lvaGetDesc(lclNum);
-            var_types  tmpTyp                           = genActualType(callerArgDsc->TypeGet());
-            comp->lvaTable[tmpLclNum].lvType            = tmpTyp;
-            comp->lvaTable[tmpLclNum].lvDoNotEnregister = comp->lvaTable[lcl->GetLclNum()].lvDoNotEnregister;
-            GenTree* value                              = comp->gtNewLclvNode(lclNum, tmpTyp);
+            LclVarDsc* callerArgDsc          = comp->lvaGetDesc(lclNum);
+            var_types  tmpTyp                = genActualType(callerArgDsc->TypeGet());
+            comp->lvaTable[tmpLclNum].lvType = tmpTyp;
+            // TODO-CQ: I don't see why we should copy doNotEnreg.
+            comp->lvaTable[tmpLclNum].lvDoNotEnregister = callerArgDsc->lvDoNotEnregister;
+#ifdef DEBUG
+            comp->lvaTable[tmpLclNum].SetDoNotEnregReason(callerArgDsc->GetDoNotEnregReason());
+#endif // DEBUG
+            GenTree* value = comp->gtNewLclvNode(lclNum, tmpTyp);
 
             if (tmpTyp == TYP_STRUCT)
             {
@@ -3209,7 +3218,7 @@ void Lowering::LowerStoreLocCommon(GenTreeLclVarCommon* lclStore)
         {
             const unsigned lclNum = lclStore->GetLclNum();
             GenTreeLclVar* addr   = comp->gtNewLclVarAddrNode(lclNum, TYP_BYREF);
-            comp->lvaSetVarDoNotEnregister(lclNum DEBUGARG(Compiler::DNER_BlockOp));
+            comp->lvaSetVarDoNotEnregister(lclNum DEBUGARG(DoNotEnregisterReason::BlockOp));
 
             addr->gtFlags |= GTF_VAR_DEF;
             assert(!addr->IsPartialLclFld(comp));
@@ -3427,7 +3436,7 @@ void Lowering::LowerRetSingleRegStructLclVar(GenTreeUnOp* ret)
     {
         // TODO-1stClassStructs: We can no longer independently promote
         // or enregister this struct, since it is referenced as a whole.
-        comp->lvaSetVarDoNotEnregister(lclNum DEBUGARG(Compiler::DNER_BlockOp));
+        comp->lvaSetVarDoNotEnregister(lclNum DEBUGARG(DoNotEnregisterReason::BlockOpRet));
     }
 
     if (varDsc->lvDoNotEnregister)
@@ -3600,7 +3609,7 @@ GenTreeLclVar* Lowering::SpillStructCallResult(GenTreeCall* call) const
 {
     // TODO-1stClassStructs: we can support this in codegen for `GT_STORE_BLK` without new temps.
     const unsigned spillNum = comp->lvaGrabTemp(true DEBUGARG("Return value temp for an odd struct return size"));
-    comp->lvaSetVarDoNotEnregister(spillNum DEBUGARG(Compiler::DNER_LocalField));
+    comp->lvaSetVarDoNotEnregister(spillNum DEBUGARG(DoNotEnregisterReason::LocalField));
     CORINFO_CLASS_HANDLE retClsHnd = call->gtRetClsHnd;
     comp->lvaSetStruct(spillNum, retClsHnd, false);
     GenTreeLclFld* spill = new (comp, GT_STORE_LCL_FLD) GenTreeLclFld(GT_STORE_LCL_FLD, call->gtType, spillNum, 0);
@@ -4070,7 +4079,7 @@ void Lowering::InsertPInvokeMethodProlog()
         GenTreeLclFld(GT_STORE_LCL_FLD, TYP_I_IMPL, comp->lvaInlinedPInvokeFrameVar, callFrameInfo.offsetOfCallSiteSP);
     storeSP->gtOp1 = PhysReg(REG_SPBASE);
     storeSP->gtFlags |= GTF_VAR_DEF;
-    comp->lvaSetVarDoNotEnregister(comp->lvaInlinedPInvokeFrameVar DEBUGARG(Compiler::DNER_LocalField));
+    comp->lvaSetVarDoNotEnregister(comp->lvaInlinedPInvokeFrameVar DEBUGARG(DoNotEnregisterReason::LocalField));
 
     firstBlockRange.InsertBefore(insertionPoint, LIR::SeqTree(comp, storeSP));
     DISPTREERANGE(firstBlockRange, storeSP);
@@ -6351,7 +6360,7 @@ bool Lowering::CheckMultiRegLclVar(GenTreeLclVar* lclNode, const ReturnTypeDesc*
         lclNode->ClearMultiReg();
         if (varDsc->lvPromoted && !varDsc->lvDoNotEnregister)
         {
-            comp->lvaSetVarDoNotEnregister(lclNode->GetLclNum() DEBUGARG(Compiler::DNER_BlockOp));
+            comp->lvaSetVarDoNotEnregister(lclNode->GetLclNum() DEBUGARG(DoNotEnregisterReason::BlockOp));
         }
     }
 #endif

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -601,7 +601,7 @@ private:
         if (varDsc->lvTracked && !varDsc->lvDoNotEnregister)
         {
             assert(!m_lsra->isRegCandidate(varDsc));
-            comp->lvaSetVarDoNotEnregister(lclNum DEBUG_ARG(Compiler::DNER_LocalField));
+            comp->lvaSetVarDoNotEnregister(lclNum DEBUG_ARG(DoNotEnregisterReason::LocalField));
         }
     }
 

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -306,7 +306,7 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
         {
             // TODO-1stClassStructs: for now we can't work with STORE_BLOCK source in register.
             const unsigned srcLclNum = src->AsLclVar()->GetLclNum();
-            comp->lvaSetVarDoNotEnregister(srcLclNum DEBUGARG(Compiler::DNER_BlockOp));
+            comp->lvaSetVarDoNotEnregister(srcLclNum DEBUGARG(DoNotEnregisterReason::BlockOp));
         }
 
         if (blkNode->OperIs(GT_STORE_OBJ))

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -280,7 +280,7 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
         {
             // TODO-1stClassStructs: for now we can't work with STORE_BLOCK source in register.
             const unsigned srcLclNum = src->AsLclVar()->GetLclNum();
-            comp->lvaSetVarDoNotEnregister(srcLclNum DEBUGARG(Compiler::DNER_BlockOp));
+            comp->lvaSetVarDoNotEnregister(srcLclNum DEBUGARG(DoNotEnregisterReason::StoreBlkSrc));
         }
 
         if (blkNode->OperIs(GT_STORE_OBJ))

--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -200,7 +200,7 @@ void ObjectAllocator::MarkEscapingVarsAndBuildConnGraph()
         {
             m_ConnGraphAdjacencyMatrix[lclNum] = BitVecOps::MakeEmpty(&m_bitVecTraits);
 
-            if (comp->lvaTable[lclNum].lvAddrExposed)
+            if (comp->lvaTable[lclNum].IsAddressExposed())
             {
                 JITDUMP("   V%02u is address exposed\n", lclNum);
                 MarkLclVarAsEscaping(lclNum);

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -3601,7 +3601,7 @@ PhaseStatus Compiler::optUnrollLoops()
         iterOperType = optLoopTable[lnum].lpIterOperType();
         unsTest      = (optLoopTable[lnum].lpTestTree->gtFlags & GTF_UNSIGNED) != 0;
 
-        if (lvaTable[lvar].lvAddrExposed)
+        if (lvaTable[lvar].IsAddressExposed())
         {
             // If the loop iteration variable is address-exposed then bail
             continue;
@@ -7712,7 +7712,7 @@ Compiler::fgWalkResult Compiler::optValidRangeCheckIndex(GenTree** pTree, fgWalk
 
     if (tree->gtOper == GT_LCL_VAR)
     {
-        if (pData->pCompiler->lvaTable[tree->AsLclVarCommon()->GetLclNum()].lvAddrExposed)
+        if (pData->pCompiler->lvaTable[tree->AsLclVarCommon()->GetLclNum()].IsAddressExposed())
         {
             pData->bValidIndex = false;
             return WALK_ABORT;
@@ -7759,7 +7759,7 @@ bool Compiler::optIsRangeCheckRemovable(GenTree* tree)
             noway_assert(pArray->gtType == TYP_REF);
             noway_assert(pArray->AsLclVarCommon()->GetLclNum() < lvaCount);
 
-            if (lvaTable[pArray->AsLclVarCommon()->GetLclNum()].lvAddrExposed)
+            if (lvaTable[pArray->AsLclVarCommon()->GetLclNum()].IsAddressExposed())
             {
                 // If the array address has been taken, don't do the optimization
                 // (this restriction can be lowered a bit, but i don't think it's worth it)

--- a/src/coreclr/jit/rationalize.cpp
+++ b/src/coreclr/jit/rationalize.cpp
@@ -160,11 +160,11 @@ void Rationalizer::RewriteSIMDIndir(LIR::Use& use)
                 addr->gtFlags |= GTF_VAR_USEASG;
             }
 
-            comp->lvaSetVarDoNotEnregister(lclNum DEBUGARG(Compiler::DNER_LocalField));
+            comp->lvaSetVarDoNotEnregister(lclNum DEBUGARG(DoNotEnregisterReason::LocalField));
         }
         if (varDsc->lvPromotedStruct())
         {
-            comp->lvaSetVarDoNotEnregister(lclNum DEBUGARG(Compiler::DNER_IsStructArg));
+            comp->lvaSetVarDoNotEnregister(lclNum DEBUGARG(DoNotEnregisterReason::BlockOp));
         }
 
         addr->gtType = simdType;

--- a/src/coreclr/jit/regalloc.cpp
+++ b/src/coreclr/jit/regalloc.cpp
@@ -307,7 +307,7 @@ void Compiler::raMarkStkVars()
 
             if (!stkFixedArgInVarArgs)
             {
-                needSlot |= varDsc->lvAddrExposed;
+                needSlot |= varDsc->IsAddressExposed();
             }
 
 #if FEATURE_FIXED_OUT_ARGS

--- a/src/coreclr/jit/sideeffects.cpp
+++ b/src/coreclr/jit/sideeffects.cpp
@@ -209,7 +209,7 @@ AliasSet::NodeInfo::NodeInfo(Compiler* compiler, GenTree* node)
 
     // Now that we've determined whether or not this access is a read or a write and whether the accessed location is
     // memory or a lclVar, determine whther or not the location is addressable and udpate the alias set.
-    const bool isAddressableLocation = isMemoryAccess || compiler->lvaTable[lclNum].lvAddrExposed;
+    const bool isAddressableLocation = isMemoryAccess || compiler->lvaTable[lclNum].IsAddressExposed();
 
     if (!isWrite)
     {
@@ -255,7 +255,7 @@ void AliasSet::AddNode(Compiler* compiler, GenTree* node)
         if (operand->OperIsLocalRead())
         {
             const unsigned lclNum = operand->AsLclVarCommon()->GetLclNum();
-            if (compiler->lvaTable[lclNum].lvAddrExposed)
+            if (compiler->lvaTable[lclNum].IsAddressExposed())
             {
                 m_readsAddressableLocation = true;
             }
@@ -355,7 +355,7 @@ bool AliasSet::InterferesWith(const NodeInfo& other) const
                 // If this set writes any addressable location and the node uses an address-exposed lclVar,
                 // the set interferes with the node.
                 const unsigned lclNum = operand->AsLclVarCommon()->GetLclNum();
-                if (compiler->lvaTable[lclNum].lvAddrExposed && m_writesAddressableLocation)
+                if (compiler->lvaTable[lclNum].IsAddressExposed() && m_writesAddressableLocation)
                 {
                     return true;
                 }

--- a/src/coreclr/jit/ssabuilder.cpp
+++ b/src/coreclr/jit/ssabuilder.cpp
@@ -1630,7 +1630,7 @@ bool SsaBuilder::IncludeInSsa(unsigned lclNum)
 {
     LclVarDsc* varDsc = &m_pCompiler->lvaTable[lclNum];
 
-    if (varDsc->lvAddrExposed)
+    if (varDsc->IsAddressExposed())
     {
         return false; // We exclude address-exposed variables.
     }


### PR DESCRIPTION
This PR adds a `COMPlus/DOTNET_JitEnregStats ` to show additional information about our local enregistration.

Example output for aspnet.run.windows.x64.checked.mch:
```
Locals enregistration statistics:
total number of locals: 574832, number of enregistered: 345129, notEnreg: 229703, ratio: 0.60
total number of struct locals: 30650, number of enregistered: 369, notEnreg: 30281, ratio: 0.01
total number of primitive locals: 544182, number of enregistered: 344760, notEnreg: 199422, ratio: 0.63
m_addrExposed 34775, ratio: 0.15
m_notRegSizeStruct 639, ratio: 0.00
m_structArg 31, ratio: 0.00
m_blockOp 552, ratio: 0.00
m_localField 4798, ratio: 0.02
lvLiveInOutOfHndlr 1099, ratio: 0.00
lvDepField 1151, ratio: 0.01
lvNoRegVars 186363, ratio: 0.81
m_castTakedAddr 12, ratio: 0.00
m_swizzleArg 199, ratio: 0.00
m_blockOpRet 84, ratio: 0.00

Addr exposed details:
m_parentExposed 7910, ratio: 0.23
m_tooConservative 9008, ratio: 0.26
m_escapeAddress 17256, ratio: 0.50
m_copyFldByFld 593, ratio: 0.02
m_wideIndir 8, ratio: 0.00
```

I was surprised to see so many Tier0 (Min opts) methods in the collection but otherwise, it looks right (lvNoRegVars 186363, ratio: 0.81).

No diffs, but so some asserts in both base/diff spmi collection with `GT_PHI` https://github.com/dotnet/runtime/blob/3fd30b099700655f3f46b4afa588f1f0e8166b07/src/coreclr/jit/gentree.cpp#L7808-L7810 , has somebody else seen this and do we have an issue for it?