### PR TITLE
Fix JitDump crash

### DIFF
--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -1466,6 +1466,7 @@ void* emitter::emitAllocAnyInstr(size_t sz, emitAttr opsz)
     info->idSize        = sz;
     info->idVarRefOffs  = 0;
     info->idMemCookie   = 0;
+    info->idFlags       = GTF_EMPTY;
     info->idFinallyCall = false;
     info->idCatchRet    = false;
     info->idCallSig     = nullptr;

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -8853,7 +8853,7 @@ void emitter::emitDispIns(
                 { // (val < 0)
                     printf("-0x%IX", -val);
                 }
-                emitDispCommentForHandle(srcVal, id->idDebugOnlyInfo()->idFlags & GTF_ICON_HDL_MASK);
+                emitDispCommentForHandle(srcVal, id->idDebugOnlyInfo()->idFlags);
             }
             break;
 


### PR DESCRIPTION
The `idFlags` field was uninitialized, so garbage could be
incorrectly considered a handle flag. I was seeing crashes
generating JitDump on Linux/Mac.

Also, `emitDispCommentForHandle` already masks with `GTF_ICON_HDL_MASK`,
so the caller doesn't need to do that.