### PR TITLE
Use `BitOperations.Log2` in SortedSet.

### DIFF
--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
 using System.Runtime.Serialization;
 using Interlocked = System.Threading.Interlocked;
 
@@ -2075,16 +2076,7 @@ namespace System.Collections.Generic
         }
 
         // Used for set checking operations (using enumerables) that rely on counting
-        private static int Log2(int value)
-        {
-            int result = 0;
-            while (value > 0)
-            {
-                result++;
-                value >>= 1;
-            }
-            return result;
-        }
+        private static int Log2(int value) => BitOperations.Log2((uint) value);
 
         #endregion
     }


### PR DESCRIPTION
Fixes Issue N/A

main PR N/A

# Description

The `System.Collections.Generic.SortedSet` class had its own naïve implementation of the integer logarithm. This PR replaces it with `BitOperations.Log2`.

# Customer Impact

Customers would experience a slightly slower integer logarithm implementation, and a slightly increased code size.

# Regression

No

# Testing

😕

# Risk

The risk is minimal. Even if there is a problem with the function, it would have little effect since it is used only to calculate the initial capacity when creating temporary collection objects.