### PR TITLE
CreateDirectory: eliminate some syscalls.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
@@ -277,6 +277,13 @@ namespace System.IO
             Debug.Assert(fullPath.Length > 0);
             Debug.Assert(PathInternal.IsDirectorySeparator(fullPath[0]));
 
+            int length = fullPath.Length;
+            if (length == 1)
+            {
+                // fullPath is '/'.
+                return;
+            }
+
             string errorString = fullPath;
             int result = Interop.Sys.MkDir(fullPath, (int)Interop.Sys.Permissions.Mask);
             if (result == 0)
@@ -297,9 +304,7 @@ namespace System.IO
             else if (errorInfo.Error == Interop.Error.ENOENT)
             {
                 // Some parts of the path don't exist yet.
-                Debug.Assert(fullPath.Length > 1);
 
-                int length = fullPath.Length;
                 // Trim trailling separator for parent directory lookup.
                 // The smallest path with trailing separator has length 3, for example '/a/'.
                 if (length >= 3 && Path.EndsInDirectorySeparator(fullPath))


### PR DESCRIPTION
This eliminates three syscalls per `Directory.CreateDirectory` when the path doesn't exist.

One is the initial check if the directory exist.

The other two are eliminating by using `mkdir` to check parent directory existence.
Instead of finding the first parent that exist using `stat`, we now end up creating the first parent that doesn't exist.

When `Directory.CreateDirectory` is called with a path that does exist, we are now making two syscalls instead of one.
If we want, we can avoid that regression by keeping the initial existence check. That costs us a syscall in the non-exists case.
A user can also avoid it by calling `Directory.Exists` before calling `Directory.CreateDirectory`.

Similar changes can be made to the Windows implementation.

@adamsitnik @stephentoub ptal.