### PR TITLE
[mono] Remove MonoAssemblyContextKind MONO_ASMCTX_ enum

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -7012,7 +7012,7 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 			break;
 		}
 		MonoAssemblyByNameRequest byname_req;
-		mono_assembly_request_prepare_byname (&byname_req, MONO_ASMCTX_DEFAULT, mono_alc_get_default ());
+		mono_assembly_request_prepare_byname (&byname_req, mono_alc_get_default ());
 		MonoAssembly *assembly = mono_assembly_request_byname (aname, &byname_req, &status);
 		g_free (lookup_name);
 		if (!assembly) {

--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -721,7 +721,7 @@ mono_domain_assembly_preload (MonoAssemblyLoadContext *alc,
 		predicate_ud = aname;
 	}
 	MonoAssemblyOpenRequest req;
-	mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT, alc);
+	mono_assembly_request_prepare_open (&req, alc);
 	req.request.predicate = predicate;
 	req.request.predicate_ud = predicate_ud;
 
@@ -767,7 +767,6 @@ ves_icall_System_Reflection_Assembly_InternalLoad (MonoStringHandle name_handle,
 	MonoAssembly *ass = NULL;
 	MonoAssemblyName aname;
 	MonoAssemblyByNameRequest req;
-	MonoAssemblyContextKind asmctx;
 	MonoImageOpenStatus status = MONO_IMAGE_OK;
 	gboolean parsed;
 	char *name;
@@ -781,8 +780,7 @@ ves_icall_System_Reflection_Assembly_InternalLoad (MonoStringHandle name_handle,
 		g_assert_not_reached ();
 	
 	g_assert (alc);
-	asmctx = MONO_ASMCTX_DEFAULT;
-	mono_assembly_request_prepare_byname (&req, asmctx, alc);
+	mono_assembly_request_prepare_byname (&req, alc);
 	req.basedir = NULL;
 	/* Everything currently goes through this function, and the postload hook (aka the AppDomain.AssemblyResolve event)
 	 * is triggered under some scenarios. It's not completely obvious to me in what situations (if any) this should be disabled,

--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -598,7 +598,7 @@ mono_domain_fire_assembly_load (MonoAssemblyLoadContext *alc, MonoAssembly *asse
 	if (!MONO_BOOL (domain->domain))
 		goto leave; // This can happen during startup
 
-	if (!mono_runtime_get_no_exec () && assembly->context.kind != MONO_ASMCTX_INTERNAL)
+	if (!mono_runtime_get_no_exec () && !assembly->context.no_managed_load_event)
 		mono_domain_fire_assembly_load_event (domain, assembly, error_out);
 
 leave:

--- a/src/mono/mono/metadata/assembly-internals.h
+++ b/src/mono/mono/metadata/assembly-internals.h
@@ -68,13 +68,13 @@ mono_assembly_invoke_load_hook_internal (MonoAssemblyLoadContext *alc, MonoAssem
 typedef gboolean (*MonoAssemblyCandidatePredicate)(MonoAssembly *, gpointer);
 
 typedef struct MonoAssemblyLoadRequest {
-	/* Assembly Load context that is requesting an assembly. */
-	MonoAssemblyContextKind asmctx;
 	MonoAssemblyLoadContext *alc;
 	/* Predicate to apply to candidate assemblies. Optional. */
 	MonoAssemblyCandidatePredicate predicate;
 	/* user_data for predicate. Optional. */
 	gpointer predicate_ud;
+        /* Don't invoke the search hooks to find the assembly. Optional */
+        gboolean no_invoke_search_hook;
         /* Don't fire managed assembly loaded event. Optional. */
         gboolean no_managed_load_event;
 } MonoAssemblyLoadRequest;

--- a/src/mono/mono/metadata/assembly-internals.h
+++ b/src/mono/mono/metadata/assembly-internals.h
@@ -47,11 +47,6 @@ MONO_API MonoImage*    mono_assembly_load_module_checked (MonoAssembly *assembly
 
 MonoAssembly* mono_assembly_load_with_partial_name_internal (const char *name, MonoAssemblyLoadContext *alc, MonoImageOpenStatus *status);
 
-
-typedef gboolean (*MonoAssemblyAsmCtxFromPathFunc) (const char *absfname, MonoAssembly *requesting_assembly, gpointer user_data, MonoAssemblyContextKind *out_asmctx);
-
-void mono_install_assembly_asmctx_from_path_hook (MonoAssemblyAsmCtxFromPathFunc func, gpointer user_data);
-
 typedef MonoAssembly * (*MonoAssemblyPreLoadFuncV2) (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, char **assemblies_path, gpointer user_data, MonoError *error);
 
 void mono_install_assembly_preload_hook_v2 (MonoAssemblyPreLoadFuncV2 func, gpointer user_data, gboolean append);

--- a/src/mono/mono/metadata/assembly-internals.h
+++ b/src/mono/mono/metadata/assembly-internals.h
@@ -80,6 +80,8 @@ typedef struct MonoAssemblyLoadRequest {
 	MonoAssemblyCandidatePredicate predicate;
 	/* user_data for predicate. Optional. */
 	gpointer predicate_ud;
+        /* Don't fire managed assembly loaded event. Optional. */
+        gboolean no_managed_load_event;
 } MonoAssemblyLoadRequest;
 
 typedef struct MonoAssemblyOpenRequest {

--- a/src/mono/mono/metadata/assembly-internals.h
+++ b/src/mono/mono/metadata/assembly-internals.h
@@ -98,15 +98,12 @@ typedef struct MonoAssemblyByNameRequest {
 } MonoAssemblyByNameRequest;
 
 void                   mono_assembly_request_prepare_load (MonoAssemblyLoadRequest *req,
-							   MonoAssemblyContextKind asmctx,
 							   MonoAssemblyLoadContext *alc);
 
 void                   mono_assembly_request_prepare_open (MonoAssemblyOpenRequest *req,
-							   MonoAssemblyContextKind asmctx,
 							   MonoAssemblyLoadContext *alc);
 
 MONO_COMPONENT_API void mono_assembly_request_prepare_byname (MonoAssemblyByNameRequest *req,
-							     MonoAssemblyContextKind asmctx,
 							     MonoAssemblyLoadContext *alc);
 
 MonoAssembly*          mono_assembly_request_open (const char *filename,

--- a/src/mono/mono/metadata/assembly-internals.h
+++ b/src/mono/mono/metadata/assembly-internals.h
@@ -73,10 +73,10 @@ typedef struct MonoAssemblyLoadRequest {
 	MonoAssemblyCandidatePredicate predicate;
 	/* user_data for predicate. Optional. */
 	gpointer predicate_ud;
-        /* Don't invoke the search hooks to find the assembly. Optional */
-        gboolean no_invoke_search_hook;
-        /* Don't fire managed assembly loaded event. Optional. */
-        gboolean no_managed_load_event;
+	/* Don't invoke the search hooks to find the assembly. Optional */
+	gboolean no_invoke_search_hook;
+	/* Don't fire managed assembly loaded event. Optional. */
+	gboolean no_managed_load_event;
 } MonoAssemblyLoadRequest;
 
 typedef struct MonoAssemblyOpenRequest {

--- a/src/mono/mono/metadata/assembly-load-context.c
+++ b/src/mono/mono/metadata/assembly-load-context.c
@@ -355,7 +355,7 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalLoadFile (gpointer a
 
 	MonoAssembly *executing_assembly;
 	executing_assembly = mono_runtime_get_caller_from_stack_mark (stack_mark);
-	MonoAssembly *ass = mono_alc_load_file (alc, fname, executing_assembly, mono_alc_is_default (alc) ? MONO_ASMCTX_LOADFROM : MONO_ASMCTX_INDIVIDUAL, error);
+	MonoAssembly *ass = mono_alc_load_file (alc, fname, executing_assembly, mono_alc_is_default (alc) ? MONO_ASMCTX_DEFAULT : MONO_ASMCTX_INDIVIDUAL, error);
 	goto_if_nok (error, leave);
 
 	result = mono_assembly_get_object_handle (ass, error);

--- a/src/mono/mono/metadata/assembly-load-context.c
+++ b/src/mono/mono/metadata/assembly-load-context.c
@@ -312,7 +312,7 @@ leave:
 
 static
 MonoAssembly *
-mono_alc_load_file (MonoAssemblyLoadContext *alc, MonoStringHandle fname, MonoAssembly *executing_assembly, MonoAssemblyContextKind asmctx, MonoError *error)
+mono_alc_load_file (MonoAssemblyLoadContext *alc, MonoStringHandle fname, MonoAssembly *executing_assembly, gboolean no_invoke_search_hook, MonoError *error)
 {
 	MonoAssembly *ass = NULL;
 	HANDLE_FUNCTION_ENTER ();
@@ -333,7 +333,7 @@ mono_alc_load_file (MonoAssemblyLoadContext *alc, MonoStringHandle fname, MonoAs
 	MonoImageOpenStatus status;
 	MonoAssemblyOpenRequest req;
 	mono_assembly_request_prepare_open (&req, alc);
-        req.request.no_invoke_search_hook = asmctx == MONO_ASMCTX_INDIVIDUAL;
+        req.request.no_invoke_search_hook = no_invoke_search_hook;
 	req.requesting_assembly = executing_assembly;
 	ass = mono_assembly_request_open (filename, &req, &status);
 	if (!ass) {
@@ -356,7 +356,7 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalLoadFile (gpointer a
 
 	MonoAssembly *executing_assembly;
 	executing_assembly = mono_runtime_get_caller_from_stack_mark (stack_mark);
-	MonoAssembly *ass = mono_alc_load_file (alc, fname, executing_assembly, mono_alc_is_default (alc) ? MONO_ASMCTX_DEFAULT : MONO_ASMCTX_INDIVIDUAL, error);
+	MonoAssembly *ass = mono_alc_load_file (alc, fname, executing_assembly, !mono_alc_is_default (alc), error);
 	goto_if_nok (error, leave);
 
 	result = mono_assembly_get_object_handle (ass, error);

--- a/src/mono/mono/metadata/assembly-load-context.c
+++ b/src/mono/mono/metadata/assembly-load-context.c
@@ -333,7 +333,7 @@ mono_alc_load_file (MonoAssemblyLoadContext *alc, MonoStringHandle fname, MonoAs
 	MonoImageOpenStatus status;
 	MonoAssemblyOpenRequest req;
 	mono_assembly_request_prepare_open (&req, alc);
-        req.request.no_invoke_search_hook = no_invoke_search_hook;
+	req.request.no_invoke_search_hook = no_invoke_search_hook;
 	req.requesting_assembly = executing_assembly;
 	ass = mono_assembly_request_open (filename, &req, &status);
 	if (!ass) {
@@ -382,7 +382,7 @@ mono_alc_load_raw_bytes (MonoAssemblyLoadContext *alc, guint8 *assembly_data, gu
 
 	MonoAssemblyLoadRequest req;
 	mono_assembly_request_prepare_load (&req, alc);
-        req.no_invoke_search_hook = TRUE;
+	req.no_invoke_search_hook = TRUE;
 	ass = mono_assembly_request_load_from (image, "", &req, &status);
 
 	if (!ass) {

--- a/src/mono/mono/metadata/assembly-load-context.c
+++ b/src/mono/mono/metadata/assembly-load-context.c
@@ -332,7 +332,8 @@ mono_alc_load_file (MonoAssemblyLoadContext *alc, MonoStringHandle fname, MonoAs
 
 	MonoImageOpenStatus status;
 	MonoAssemblyOpenRequest req;
-	mono_assembly_request_prepare_open (&req, asmctx, alc);
+	mono_assembly_request_prepare_open (&req, alc);
+        req.request.no_invoke_search_hook = asmctx == MONO_ASMCTX_INDIVIDUAL;
 	req.requesting_assembly = executing_assembly;
 	ass = mono_assembly_request_open (filename, &req, &status);
 	if (!ass) {
@@ -380,7 +381,8 @@ mono_alc_load_raw_bytes (MonoAssemblyLoadContext *alc, guint8 *assembly_data, gu
 		mono_debug_open_image_from_memory (image, raw_symbol_data, raw_symbol_len);
 
 	MonoAssemblyLoadRequest req;
-	mono_assembly_request_prepare_load (&req, MONO_ASMCTX_INDIVIDUAL, alc);
+	mono_assembly_request_prepare_load (&req, alc);
+        req.no_invoke_search_hook = TRUE;
 	ass = mono_assembly_request_load_from (image, "", &req, &status);
 
 	if (!ass) {

--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -2308,6 +2308,7 @@ mono_assembly_request_load_from (MonoImage *image, const char *fname,
 	ass = g_new0 (MonoAssembly, 1);
 	ass->basedir = base_dir;
 	ass->context.kind = asmctx;
+        ass->context.no_managed_load_event = req->no_managed_load_event;
 	ass->image = image;
 
 	MONO_PROFILER_RAISE (assembly_loading, (ass));
@@ -3661,7 +3662,6 @@ mono_asmctx_get_name (const MonoAssemblyContext *asmctx)
 		"DEFAULT",
 		"LOADFROM",
 		"INDIVIDIUAL",
-		"INTERNAL"
 	};
 	g_assert (asmctx->kind >= 0 && asmctx->kind <= MONO_ASMCTX_LAST);
 	return names [asmctx->kind];

--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -2206,7 +2206,7 @@ mono_assembly_request_load_from (MonoImage *image, const char *fname,
 	 */
 	ass = g_new0 (MonoAssembly, 1);
 	ass->basedir = base_dir;
-        ass->context.no_managed_load_event = req->no_managed_load_event;
+	ass->context.no_managed_load_event = req->no_managed_load_event;
 	ass->image = image;
 
 	MONO_PROFILER_RAISE (assembly_loading, (ass));

--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -308,48 +308,42 @@ assembly_names_compare_versions (MonoAssemblyName *l, MonoAssemblyName *r, int m
 /**
  * mono_assembly_request_prepare_load:
  * \param req the load request to be initialized
- * \param asmctx the assembly load context kind
  * \param alc the AssemblyLoadContext in netcore
  *
  * Initialize an assembly loader request.  Its state will be reset and the assembly context kind will be prefilled with \p asmctx.
  */
 void
-mono_assembly_request_prepare_load (MonoAssemblyLoadRequest *req, MonoAssemblyContextKind asmctx, MonoAssemblyLoadContext *alc)
+mono_assembly_request_prepare_load (MonoAssemblyLoadRequest *req, MonoAssemblyLoadContext *alc)
 {
 	memset (req, 0, sizeof (MonoAssemblyLoadRequest));
-        req->no_invoke_search_hook = asmctx == MONO_ASMCTX_INDIVIDUAL; /* FIXME: do this in the callers */
 	req->alc = alc;
 }
 
 /**
  * mono_assembly_request_prepare_open:
  * \param req the open request to be initialized
- * \param asmctx the assembly load context kind
  * \param alc the AssemblyLoadContext in netcore
  *
  * Initialize an assembly loader request intended to be used for open operations.  Its state will be reset and the assembly context kind will be prefilled with \p asmctx.
  */
 void
-mono_assembly_request_prepare_open (MonoAssemblyOpenRequest *req, MonoAssemblyContextKind asmctx, MonoAssemblyLoadContext *alc)
+mono_assembly_request_prepare_open (MonoAssemblyOpenRequest *req, MonoAssemblyLoadContext *alc)
 {
 	memset (req, 0, sizeof (MonoAssemblyOpenRequest));
-        req->request.no_invoke_search_hook = asmctx == MONO_ASMCTX_INDIVIDUAL; /* FIXME: do this in the callers */
 	req->request.alc = alc;
 }
 
 /**
  * mono_assembly_request_prepare_byname:
  * \param req the byname request to be initialized
- * \param asmctx the assembly load context kind
  * \param alc the AssemblyLoadContext in netcore
  *
  * Initialize an assembly load by name request.  Its state will be reset and the assembly context kind will be prefilled with \p asmctx.
  */
 void
-mono_assembly_request_prepare_byname (MonoAssemblyByNameRequest *req, MonoAssemblyContextKind asmctx, MonoAssemblyLoadContext *alc)
+mono_assembly_request_prepare_byname (MonoAssemblyByNameRequest *req, MonoAssemblyLoadContext *alc)
 {
 	memset (req, 0, sizeof (MonoAssemblyByNameRequest));
-        req->request.no_invoke_search_hook = asmctx == MONO_ASMCTX_INDIVIDUAL; /* FIXME: do this in the callers */
 	req->request.alc = alc;
 }
 
@@ -1012,7 +1006,7 @@ search_bundle_for_assembly (MonoAssemblyLoadContext *alc, MonoAssemblyName *anam
 		image = mono_assembly_open_from_bundle (alc, name, &status, aname->culture);
 	}
 	if (image) {
-		mono_assembly_request_prepare_load (&req, MONO_ASMCTX_DEFAULT, alc);
+		mono_assembly_request_prepare_load (&req, alc);
 		return mono_assembly_request_load_from (image, aname->name, &req, &status);
 	}
 	return NULL;
@@ -1100,7 +1094,7 @@ netcore_load_reference (MonoAssemblyName *aname, MonoAssemblyLoadContext *alc, M
 
 		if (parent_name) {
 			MonoAssemblyOpenRequest req;
-			mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT, alc);
+			mono_assembly_request_prepare_open (&req, alc);
 			MonoAssembly *parent_assembly = mono_assembly_request_open (parent_name, &req, NULL);
 			parent_alc = mono_assembly_get_alc (parent_assembly);
 		}
@@ -1268,7 +1262,7 @@ mono_assembly_load_reference (MonoImage *image, int index)
 		}
 
 		MonoAssemblyByNameRequest req;
-		mono_assembly_request_prepare_byname (&req, MONO_ASMCTX_DEFAULT, mono_image_get_alc (image));
+		mono_assembly_request_prepare_byname (&req, mono_image_get_alc (image));
 		req.requesting_assembly = image->assembly;
 		//req.no_postload_search = TRUE; // FIXME: should this be set?
 		reference = mono_assembly_request_byname (&aname, &req, NULL);
@@ -1847,9 +1841,7 @@ mono_assembly_open_full (const char *filename, MonoImageOpenStatus *status, gboo
 	MonoAssembly *res;
 	MONO_ENTER_GC_UNSAFE;
 	MonoAssemblyOpenRequest req;
-	mono_assembly_request_prepare_open (&req,
-	                               MONO_ASMCTX_DEFAULT,
-	                               mono_alc_get_default ());
+	mono_assembly_request_prepare_open (&req, mono_alc_get_default ());
 	res = mono_assembly_request_open (filename, &req, status);
 	MONO_EXIT_GC_UNSAFE;
 	return res;
@@ -2123,7 +2115,7 @@ mono_assembly_open (const char *filename, MonoImageOpenStatus *status)
 	MonoAssembly *res;
 	MONO_ENTER_GC_UNSAFE;
 	MonoAssemblyOpenRequest req;
-	mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT, mono_alc_get_default ());
+	mono_assembly_request_prepare_open (&req, mono_alc_get_default ());
 	res = mono_assembly_request_open (filename, &req, status);
 	MONO_EXIT_GC_UNSAFE;
 	return res;
@@ -2163,7 +2155,7 @@ mono_assembly_load_from_full (MonoImage *image, const char*fname,
 	MonoImageOpenStatus def_status;
 	if (!status)
 		status = &def_status;
-	mono_assembly_request_prepare_load (&req, MONO_ASMCTX_DEFAULT, mono_alc_get_default ());
+	mono_assembly_request_prepare_load (&req, mono_alc_get_default ());
 	res = mono_assembly_request_load_from (image, fname, &req, status);
 	MONO_EXIT_GC_UNSAFE;
 	return res;
@@ -2355,7 +2347,7 @@ mono_assembly_load_from (MonoImage *image, const char *fname,
 	MonoImageOpenStatus def_status;
 	if (!status)
 		status = &def_status;
-	mono_assembly_request_prepare_load (&req, MONO_ASMCTX_DEFAULT, mono_alc_get_default ());
+	mono_assembly_request_prepare_load (&req, mono_alc_get_default ());
 	res = mono_assembly_request_load_from (image, fname, &req, status);
 	MONO_EXIT_GC_UNSAFE;
 	return res;
@@ -2971,7 +2963,7 @@ mono_assembly_load_corlib (MonoImageOpenStatus *status)
 {
 	MonoAssemblyName *aname;
 	MonoAssemblyOpenRequest req;
-	mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT, mono_alc_get_default ());
+	mono_assembly_request_prepare_open (&req, mono_alc_get_default ());
 
 	if (corlib) {
 		/* g_print ("corlib already loaded\n"); */
@@ -3051,7 +3043,7 @@ mono_assembly_load_full_alc (MonoGCHandle alc_gchandle, MonoAssemblyName *aname,
 	MonoAssemblyByNameRequest req;
 	MonoAssemblyLoadContext *alc = mono_alc_from_gchandle (alc_gchandle);
 
-	mono_assembly_request_prepare_byname (&req, MONO_ASMCTX_DEFAULT, alc);
+	mono_assembly_request_prepare_byname (&req, alc);
 	req.requesting_assembly = NULL;
 	req.basedir = basedir;
 	res = mono_assembly_request_byname (aname, &req, status);
@@ -3086,9 +3078,7 @@ mono_assembly_load_full (MonoAssemblyName *aname, const char *basedir, MonoImage
 	MonoAssembly *res;
 	MONO_ENTER_GC_UNSAFE;
 	MonoAssemblyByNameRequest req;
-	mono_assembly_request_prepare_byname (&req,
-										  MONO_ASMCTX_DEFAULT,
-										  mono_alc_get_default ());
+	mono_assembly_request_prepare_byname (&req, mono_alc_get_default ());
 	req.requesting_assembly = NULL;
 	req.basedir = basedir;
 	res = mono_assembly_request_byname (aname, &req, status);
@@ -3112,7 +3102,7 @@ MonoAssembly*
 mono_assembly_load (MonoAssemblyName *aname, const char *basedir, MonoImageOpenStatus *status)
 {
 	MonoAssemblyByNameRequest req;
-	mono_assembly_request_prepare_byname (&req, MONO_ASMCTX_DEFAULT, mono_alc_get_default ());
+	mono_assembly_request_prepare_byname (&req, mono_alc_get_default ());
 	req.requesting_assembly = NULL;
 	req.basedir = basedir;
 	return mono_assembly_request_byname (aname, &req, status);

--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -1973,13 +1973,6 @@ mono_assembly_request_open (const char *filename, const MonoAssemblyOpenRequest 
 	
 	image = NULL;
 
-	/* for LoadFrom(string), LoadFile(string) and Load(byte[]), allow them
-	 * to load problematic images.  Not sure if ReflectionOnlyLoad(string)
-	 * and ReflectionOnlyLoadFrom(string) should also be allowed - let's
-	 * say, yes.
-	 */
-	const gboolean load_from_context = load_req.asmctx == MONO_ASMCTX_LOADFROM || load_req.asmctx == MONO_ASMCTX_INDIVIDUAL;
-
 	// If VM built with mkbundle
 	loaded_from_bundle = FALSE;
 	if (bundles != NULL || satellite_bundles != NULL) {
@@ -1989,7 +1982,7 @@ mono_assembly_request_open (const char *filename, const MonoAssemblyOpenRequest 
 	}
 
 	if (!image)
-		image = mono_image_open_a_lot (load_req.alc, fname, status, load_from_context);
+		image = mono_image_open_a_lot (load_req.alc, fname, status);
 
 	if (!image){
 		if (*status == MONO_IMAGE_OK)

--- a/src/mono/mono/metadata/coree.c
+++ b/src/mono/mono/metadata/coree.c
@@ -121,7 +121,7 @@ BOOL STDMETHODCALLTYPE _CorDllMain(HINSTANCE hInst, DWORD dwReason, LPVOID lpRes
 		 */
 		if (table_info_get_rows (&image->tables [MONO_TABLE_ASSEMBLY]) && image->image_info->cli_cli_header.ch_vtable_fixups.rva) {
 			MonoAssemblyOpenRequest req;
-			mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT, alc);
+			mono_assembly_request_prepare_open (&req, alc);
 			assembly = mono_assembly_request_open (file_name, &req, NULL);
 		}
 
@@ -173,7 +173,7 @@ __int32 STDMETHODCALLTYPE _CorExeMain(void)
 	}
 
 	MonoAssemblyOpenRequest req;
-	mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT, mono_alc_get_default ());
+	mono_assembly_request_prepare_open (&req, mono_alc_get_default ());
 	assembly = mono_assembly_request_open (file_name, &req, NULL);
 	mono_close_exe_image ();
 	if (!assembly) {

--- a/src/mono/mono/metadata/domain.c
+++ b/src/mono/mono/metadata/domain.c
@@ -567,7 +567,7 @@ mono_domain_assembly_open_internal (MonoAssemblyLoadContext *alc, const char *na
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	MonoAssemblyOpenRequest req;
-	mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT, alc);
+	mono_assembly_request_prepare_open (&req, alc);
 	ass = mono_assembly_request_open (name, &req, NULL);
 
 	// On netcore, this is necessary because we check the AppContext.BaseDirectory property as part of the assembly lookup algorithm

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -5188,7 +5188,7 @@ ves_icall_System_Reflection_Assembly_InternalGetAssemblyName (MonoStringHandle f
 	mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "InternalGetAssemblyName (\"%s\")", filename);
 
 	MonoAssemblyLoadContext *alc = mono_alc_get_default ();
-	image = mono_image_open_a_lot (alc, filename, &status, FALSE);
+	image = mono_image_open_a_lot (alc, filename, &status);
 
 	if (!image){
 		if (status == MONO_IMAGE_IMAGE_INVALID)

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -1547,7 +1547,7 @@ type_from_parsed_name (MonoTypeNameParse *info, MonoStackCrawlMark *stack_mark, 
 
 	if (info->assembly.name) {
 		MonoAssemblyByNameRequest req;
-		mono_assembly_request_prepare_byname (&req, MONO_ASMCTX_DEFAULT, alc);
+		mono_assembly_request_prepare_byname (&req, alc);
 		req.requesting_assembly = assembly;
 		req.basedir = assembly ? assembly->basedir : NULL;
 		assembly = mono_assembly_request_byname (&info->assembly, &req, NULL);

--- a/src/mono/mono/metadata/image-internals.h
+++ b/src/mono/mono/metadata/image-internals.h
@@ -19,6 +19,6 @@ MonoImage*
 mono_image_load_module_checked (MonoImage *image, int idx, MonoError *error);
 
 MonoImage *
-mono_image_open_a_lot (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status, gboolean load_from_context);
+mono_image_open_a_lot (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status);
 
 #endif /* __MONO_METADATA_IMAGE_INTERNALS_H__ */

--- a/src/mono/mono/metadata/image.c
+++ b/src/mono/mono/metadata/image.c
@@ -105,7 +105,7 @@ mono_images_unlock(void)
 }
 
 static MonoImage *
-mono_image_open_a_lot_parameterized (MonoLoadedImages *li, MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status, gboolean load_from_context);
+mono_image_open_a_lot_parameterized (MonoLoadedImages *li, MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status);
 
 /* Maps string keys to MonoImageStorage values.
  *
@@ -1427,7 +1427,7 @@ mono_image_storage_new_raw_data (char *datac, guint32 data_len, gboolean raw_dat
 
 static MonoImage *
 do_mono_image_open (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status,
-					gboolean care_about_cli, gboolean care_about_pecoff, gboolean metadata_only, gboolean load_from_context)
+					gboolean care_about_cli, gboolean care_about_pecoff, gboolean metadata_only)
 {
 	MonoCLIImageInfo *iinfo;
 	MonoImage *image;
@@ -1455,7 +1455,6 @@ do_mono_image_open (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOp
 	image->name = mono_path_resolve_symlinks (fname);
 	image->filename = g_strdup (image->name);
 	image->metadata_only = metadata_only;
-	image->load_from_context = load_from_context;
 	image->ref_count = 1;
 	image->alc = alc;
 	return do_mono_image_load (image, status, care_about_cli, care_about_pecoff);
@@ -1779,11 +1778,11 @@ mono_image_open_full (const char *fname, MonoImageOpenStatus *status, gboolean r
 			*status = MONO_IMAGE_IMAGE_INVALID;
 		return NULL;
 	}
-	return mono_image_open_a_lot (mono_alc_get_default (), fname, status, FALSE);
+	return mono_image_open_a_lot (mono_alc_get_default (), fname, status);
 }
 
 static MonoImage *
-mono_image_open_a_lot_parameterized (MonoLoadedImages *li, MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status, gboolean load_from_context)
+mono_image_open_a_lot_parameterized (MonoLoadedImages *li, MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status)
 {
 	MonoImage *image;
 	GHashTable *loaded_images = mono_loaded_images_get_hash (li);
@@ -1884,7 +1883,7 @@ mono_image_open_a_lot_parameterized (MonoLoadedImages *li, MonoAssemblyLoadConte
 	mono_images_unlock ();
 
 	// Image not loaded, load it now
-	image = do_mono_image_open (alc, fname, status, TRUE, TRUE, FALSE, load_from_context);
+	image = do_mono_image_open (alc, fname, status, TRUE, TRUE, FALSE);
 	if (image == NULL)
 		return NULL;
 
@@ -1892,10 +1891,10 @@ mono_image_open_a_lot_parameterized (MonoLoadedImages *li, MonoAssemblyLoadConte
 }
 
 MonoImage *
-mono_image_open_a_lot (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status, gboolean load_from_context)
+mono_image_open_a_lot (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status)
 {
 	MonoLoadedImages *li = mono_alc_get_loaded_images (alc);
-	return mono_image_open_a_lot_parameterized (li, alc, fname, status, load_from_context);
+	return mono_image_open_a_lot_parameterized (li, alc, fname, status);
 }
 
 /**
@@ -1910,7 +1909,7 @@ mono_image_open_a_lot (MonoAssemblyLoadContext *alc, const char *fname, MonoImag
 MonoImage *
 mono_image_open (const char *fname, MonoImageOpenStatus *status)
 {
-	return mono_image_open_a_lot (mono_alc_get_default (), fname, status, FALSE);
+	return mono_image_open_a_lot (mono_alc_get_default (), fname, status);
 }
 
 /**
@@ -1928,7 +1927,7 @@ mono_pe_file_open (const char *fname, MonoImageOpenStatus *status)
 {
 	g_return_val_if_fail (fname != NULL, NULL);
 	
-	return do_mono_image_open (mono_alc_get_default (), fname, status, FALSE, TRUE, FALSE, FALSE);
+	return do_mono_image_open (mono_alc_get_default (), fname, status, FALSE, TRUE, FALSE);
 }
 
 /**
@@ -1943,7 +1942,7 @@ mono_image_open_raw (MonoAssemblyLoadContext *alc, const char *fname, MonoImageO
 {
 	g_return_val_if_fail (fname != NULL, NULL);
 	
-	return do_mono_image_open (alc, fname, status, FALSE, FALSE, FALSE, FALSE);
+	return do_mono_image_open (alc, fname, status, FALSE, FALSE, FALSE);
 }
 
 /*
@@ -1954,7 +1953,7 @@ mono_image_open_raw (MonoAssemblyLoadContext *alc, const char *fname, MonoImageO
 MonoImage *
 mono_image_open_metadata_only (MonoAssemblyLoadContext *alc, const char *fname, MonoImageOpenStatus *status)
 {
-	return do_mono_image_open (alc, fname, status, TRUE, TRUE, TRUE, FALSE);
+	return do_mono_image_open (alc, fname, status, TRUE, TRUE, TRUE);
 }
 
 /**

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -187,8 +187,8 @@ struct MonoTypeNameParse {
 
 
 typedef struct _MonoAssemblyContext {
-        /* Don't fire managed load event for this assembly */
-        guint8 no_managed_load_event : 1;
+	/* Don't fire managed load event for this assembly */
+	guint8 no_managed_load_event : 1;
 } MonoAssemblyContext;
 
 struct _MonoAssembly {

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -189,8 +189,6 @@ struct MonoTypeNameParse {
 typedef enum MonoAssemblyContextKind {
 	/* Default assembly context: Load(String) and assembly references */
 	MONO_ASMCTX_DEFAULT = 0,
-	/* LoadFrom context: LoadFrom() and references */
-	MONO_ASMCTX_LOADFROM = 1,
 	/* Individual assembly context (.NET Framework docs call this "not in
 	 * any context"): LoadFile(String) and Load(byte[]) are here.
 	 */

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -329,9 +329,6 @@ struct _MonoImage {
 	/* Whenever this image contains metadata only without PE data */
 	guint8 metadata_only : 1;
 
-	/*  Whether this image belongs to load-from context */
-	guint8 load_from_context: 1;
-
 	guint8 checked_module_cctor : 1;
 	guint8 has_module_cctor : 1;
 

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -195,14 +195,14 @@ typedef enum MonoAssemblyContextKind {
 	 * any context"): LoadFile(String) and Load(byte[]) are here.
 	 */
 	MONO_ASMCTX_INDIVIDUAL = 2,
-	/* Used internally by the runtime, not visible to managed code */
-	MONO_ASMCTX_INTERNAL = 3,
 
-	MONO_ASMCTX_LAST = 3
+	MONO_ASMCTX_LAST = 2
 } MonoAssemblyContextKind;
 
 typedef struct _MonoAssemblyContext {
 	MonoAssemblyContextKind kind;
+        /* Don't fire managed load event for this assembly */
+        guint8 no_managed_load_event : 1;
 } MonoAssemblyContext;
 
 struct _MonoAssembly {

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -186,17 +186,6 @@ struct MonoTypeNameParse {
 };
 
 
-typedef enum MonoAssemblyContextKind {
-	/* Default assembly context: Load(String) and assembly references */
-	MONO_ASMCTX_DEFAULT = 0,
-	/* Individual assembly context (.NET Framework docs call this "not in
-	 * any context"): LoadFile(String) and Load(byte[]) are here.
-	 */
-	MONO_ASMCTX_INDIVIDUAL = 2,
-
-	MONO_ASMCTX_LAST = 2
-} MonoAssemblyContextKind;
-
 typedef struct _MonoAssemblyContext {
         /* Don't fire managed load event for this assembly */
         guint8 no_managed_load_event : 1;

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -198,7 +198,6 @@ typedef enum MonoAssemblyContextKind {
 } MonoAssemblyContextKind;
 
 typedef struct _MonoAssemblyContext {
-	MonoAssemblyContextKind kind;
         /* Don't fire managed load event for this assembly */
         guint8 no_managed_load_event : 1;
 } MonoAssemblyContext;
@@ -1098,9 +1097,6 @@ mono_type_in_image (MonoType *type, MonoImage *image);
 
 gboolean
 mono_type_is_valid_generic_argument (MonoType *type);
-
-MonoAssemblyContextKind
-mono_asmctx_get_kind (const MonoAssemblyContext *ctx);
 
 void
 mono_metadata_get_class_guid (MonoClass* klass, uint8_t* guid, MonoError *error);

--- a/src/mono/mono/metadata/reflection.c
+++ b/src/mono/mono/metadata/reflection.c
@@ -1977,7 +1977,7 @@ _mono_reflection_get_type_from_info (MonoAssemblyLoadContext *alc, MonoTypeNameP
 		if (!assembly) {
 			/* then we must load the assembly ourselve - see #60439 */
 			MonoAssemblyByNameRequest req;
-			mono_assembly_request_prepare_byname (&req, MONO_ASMCTX_DEFAULT, alc);
+			mono_assembly_request_prepare_byname (&req, alc);
 			req.requesting_assembly = NULL;
 			req.basedir = image ? image->assembly->basedir : NULL;
 			assembly = mono_assembly_request_byname (&info->assembly, &req, NULL);

--- a/src/mono/mono/metadata/sre.c
+++ b/src/mono/mono/metadata/sre.c
@@ -1268,11 +1268,6 @@ mono_reflection_dynimage_basic_init (MonoReflectionAssemblyBuilder *assemblyb, M
 		}
 	}
 
-	/* SRE assemblies are loaded into the individual loading context, ie,
-	 * they only fire AssemblyResolve events, they don't cause probing for
-	 * referenced assemblies to happen. */
-	assembly->assembly.context.kind = MONO_ASMCTX_INDIVIDUAL;
-
 	char *assembly_name = mono_string_to_utf8_checked_internal (assemblyb->name, error);
 	return_if_nok (error);
 	image = mono_dynamic_image_create (assembly, assembly_name, g_strdup ("RefEmit_YouForgotToDefineAModule"));

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -2388,10 +2388,11 @@ load_container_amodule (MonoAssemblyLoadContext *alc)
 	MonoAssemblyOpenRequest req;
 	gchar *dll = g_strdup_printf (		"%s.dll", local_ref);
 	/*
-	 * Using INTERNAL avoids firing managed assembly load events
-	 * whose execution might require this module to be already loaded.
+	 * Don't fire managed assembly load events whose execution
+	 * might require this module to be already loaded.
 	 */
-	mono_assembly_request_prepare_open (&req, MONO_ASMCTX_INTERNAL, alc);
+	mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT, alc);
+        req.request.no_managed_load_event = TRUE;
 	MonoAssembly *assm = mono_assembly_request_open (dll, &req, &status);
 	if (!assm) {
 		gchar *exe = g_strdup_printf ("%s.exe", local_ref);

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -319,7 +319,7 @@ load_image (MonoAotModule *amodule, int index, MonoError *error)
 		assembly = mono_get_corlib ()->assembly;
 	} else {
 		MonoAssemblyByNameRequest req;
-		mono_assembly_request_prepare_byname (&req, MONO_ASMCTX_DEFAULT, alc);
+		mono_assembly_request_prepare_byname (&req, alc);
 		req.basedir = amodule->assembly->basedir;
 		assembly = mono_assembly_request_byname (&amodule->image_names [index], &req, &status);
 	}
@@ -2391,7 +2391,7 @@ load_container_amodule (MonoAssemblyLoadContext *alc)
 	 * Don't fire managed assembly load events whose execution
 	 * might require this module to be already loaded.
 	 */
-	mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT, alc);
+	mono_assembly_request_prepare_open (&req, alc);
         req.request.no_managed_load_event = TRUE;
 	MonoAssembly *assm = mono_assembly_request_open (dll, &req, &status);
 	if (!assm) {

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -2392,7 +2392,7 @@ load_container_amodule (MonoAssemblyLoadContext *alc)
 	 * might require this module to be already loaded.
 	 */
 	mono_assembly_request_prepare_open (&req, alc);
-        req.request.no_managed_load_event = TRUE;
+	req.request.no_managed_load_event = TRUE;
 	MonoAssembly *assm = mono_assembly_request_open (dll, &req, &status);
 	if (!assm) {
 		gchar *exe = g_strdup_printf ("%s.exe", local_ref);

--- a/src/mono/mono/mini/driver.c
+++ b/src/mono/mono/mini/driver.c
@@ -708,7 +708,7 @@ mini_regression_list (int verbose, int count, char *images [])
 	total_run =  total = 0;
 	for (i = 0; i < count; ++i) {
 		MonoAssemblyOpenRequest req;
-		mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT, mono_alc_get_default ());
+		mono_assembly_request_prepare_open (&req, mono_alc_get_default ());
 		ass = mono_assembly_request_open (images [i], &req, NULL);
 		if (!ass) {
 			g_warning ("failed to load assembly: %s", images [i]);
@@ -851,7 +851,7 @@ mono_interp_regression_list (int verbose, int count, char *images [])
 	total_run = total = 0;
 	for (i = 0; i < count; ++i) {
 		MonoAssemblyOpenRequest req;
-		mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT, mono_alc_get_default ());
+		mono_assembly_request_prepare_open (&req, mono_alc_get_default ());
 		MonoAssembly *ass = mono_assembly_request_open (images [i], &req, NULL);
 		if (!ass) {
 			g_warning ("failed to load assembly: %s", images [i]);
@@ -1481,7 +1481,7 @@ load_agent (MonoDomain *domain, char *desc)
 	}
 
 	MonoAssemblyOpenRequest req;
-	mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT, mono_alc_get_default ());
+	mono_assembly_request_prepare_open (&req, mono_alc_get_default ());
 	agent_assembly = mono_assembly_request_open (agent, &req, &open_status);
 	if (!agent_assembly) {
 		fprintf (stderr, "Cannot open agent assembly '%s': %s.\n", agent, mono_image_strerror (open_status));
@@ -2638,7 +2638,7 @@ mono_main (int argc, char* argv[])
 	}
 
 	MonoAssemblyOpenRequest open_req;
-	mono_assembly_request_prepare_open (&open_req, MONO_ASMCTX_DEFAULT, mono_alc_get_default ());
+	mono_assembly_request_prepare_open (&open_req, mono_alc_get_default ());
 	assembly = mono_assembly_request_open (aname, &open_req, &open_status);
 	if (!assembly && !mono_compile_aot) {
 		fprintf (stderr, "Cannot open assembly '%s': %s.\n", aname, mono_image_strerror (open_status));

--- a/src/mono/mono/mini/interp/whitebox.c
+++ b/src/mono/mono/mini/interp/whitebox.c
@@ -100,7 +100,7 @@ static MonoImage *
 load_assembly (const char *path, MonoDomain *root_domain)
 {
 	MonoAssemblyOpenRequest req;
-	mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT, mono_alc_get_default ());
+	mono_assembly_request_prepare_open (&req, mono_alc_get_default ());
 	MonoAssembly *ass = mono_assembly_request_open (path, &req, NULL);
 	if (!ass)
 		g_error ("failed to load assembly: %s", path);

--- a/src/mono/mono/mini/monovm.c
+++ b/src/mono/mono/mini/monovm.c
@@ -115,7 +115,7 @@ mono_core_preload_hook (MonoAssemblyLoadContext *alc, MonoAssemblyName *aname, c
 	for (int i = 0; i < a->assembly_count; ++i) {
 		if (basename_len == a->basename_lens [i] && !g_strncasecmp (basename, a->basenames [i], a->basename_lens [i])) {
 			MonoAssemblyOpenRequest req;
-			mono_assembly_request_prepare_open (&req, MONO_ASMCTX_DEFAULT, default_alc);
+			mono_assembly_request_prepare_open (&req, default_alc);
 			req.request.predicate = predicate;
 			req.request.predicate_ud = predicate_ud;
 


### PR DESCRIPTION
The `MONO_ASMCTX_` enum was used in mono/mono to approximate .NET Framework assembly contexts.  In .NET 5 onward, we use MonoAssemblyLoadContext structs to represent ALCs.  The ASMCTX values are no longer necessary.

Best to review this commit by commit:

1. Delete `MonoImage:load_from_context` bit, and also the `load_from_context` parameter of  `mono_image_open_a_lot`.  The bit was only written, not read anymore.
2. Drop `MONO_ASMCTX_INTERNAL`. Add `MonoAssemblyLoadRequest:no_managed_load_event`.  Use a bit on the request ot ask for the managed load event not to fire, instead of an ASMCTX enum value.
3. drop `MONO_ASMCTX_LOADFROM` and `asmctx_from_path_hook`.  The `Assembly.LoadFrom`  behavior for loading referenced assemblies is handled entirely in managed code in .NET 6+.
4. Get rid of `MonoAssemblyContext:kind` field. It no longer has any functional effect on the loader behavior.
5. Drop MonoAssemblyContextKind field from load requests.  Add a `no_invoke_search_hook` load request bit to implement the behavior of `MONO_ASMCTX_INDIVIDUAL`.
6. Remove the `asmctx` arg from load requests.
7. Remove `MONO_ASMCTX_DEFAULT` and `MONO_ASMCTX_INDIVIDUAL` - pass a boolean flag in the one remaining place that made a distinction.


Fixes #37304