### PR TITLE
Use non-deprecated Android Helix queue

### DIFF
--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -36,7 +36,7 @@ jobs:
 
     # Android x64
     - ${{ if in(parameters.platform, 'Android_x64') }}:
-      - Ubuntu.1804.Amd64.Android.Open
+      - Ubuntu.1804.Amd64.Android.29.Open
 
     # Browser wasm
     - ${{ if eq(parameters.platform, 'Browser_wasm') }}:

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -103,7 +103,7 @@ jobs:
 
     # Android
     - ${{ if in(parameters.platform, 'Android_x86', 'Android_x64') }}:
-      - Ubuntu.1804.Amd64.Android.Open
+      - Ubuntu.1804.Amd64.Android.29.Open
     - ${{ if in(parameters.platform, 'Android_arm', 'Android_arm64') }}:
       - Windows.10.Amd64.Android.Open
 


### PR DESCRIPTION
Ubuntu.1804.Amd64.Android.Open was redirected to Ubuntu.1804.Amd64.Android.29.Open, use that in the .yml

Fixes https://github.com/dotnet/core-eng/issues/13179