### PR TITLE
[tasks] [net472] Add ProjectReferences to JsonToItemsTaskFactory

### DIFF
--- a/src/tasks/JsonToItemsTaskFactory/JsonToItemsTaskFactory.csproj
+++ b/src/tasks/JsonToItemsTaskFactory/JsonToItemsTaskFactory.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkForNETFrameworkTasks)'">
     <!-- These versions should not be older than what Visual Studio MSBuild uses -->
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.2.0.1" PrivateAssets="all" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" PrivateAssets="all" />
     <PackageReference Include="System.Text.Json" Version="5.0.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/tasks/JsonToItemsTaskFactory/JsonToItemsTaskFactory.csproj
+++ b/src/tasks/JsonToItemsTaskFactory/JsonToItemsTaskFactory.csproj
@@ -15,6 +15,12 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(RefOnlyMicrosoftBuildUtilitiesCoreVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == '$(TargetFrameworkForNETFrameworkTasks)'">
+    <!-- These versions should not be older than what Visual Studio MSBuild uses -->
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.2.0.1" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Json" Version="5.0.0" PrivateAssets="all" />
+  </ItemGroup>
+
   <ItemGroup>
     <Compile Include="JsonToItemsTaskFactory.cs" />
   </ItemGroup>


### PR DESCRIPTION
Reference the same versions of System.Threding.Tasks.Extensions and System.Text.Json that MSBuild in Visual Studio 2022 uses.

Fixes build errors on maui-ios (and possibly blazorwasm) targets on Windows like:

```
System.MissingMethodException: Method not found: 'System.Threading.Tasks.ValueTask`1<!!0> System.Text.Json.JsonSerializer.DeserializeAsync(System.IO.Stream, System.Text.Json.JsonSerializerOptions, System.Threading.CancellationToken)'.
   at JsonToItemsTaskFactory.JsonToItemsTaskFactory.JsonToItemsTask.<GetJsonAsync>d__24.MoveNext()
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.Start[TStateMachine](TStateMachine& stateMachine)
   at JsonToItemsTaskFactory.JsonToItemsTaskFactory.JsonToItemsTask.GetJsonAsync(String jsonFilePath, FileStream file)
   at JsonToItemsTaskFactory.JsonToItemsTaskFactory.JsonToItemsTask.TryGetJson(String jsonFilePath, JsonModelRoot& json)
   at JsonToItemsTaskFactory.JsonToItemsTaskFactory.JsonToItemsTask.Execute()
   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
   at
   Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext()
```

from `C:\Program
Files\dotnet\packs\Microsoft.NET.Runtime.MonoTargets.Sdk\6.0.0-rc.1.21451.13\Sdk\RuntimeComponentManifest.targets`

Ultimately this is because msbuild has a binding redirect here:

https://github.com/dotnet/msbuild/blob/1a1f20e4980fd1b02426b62220480f86e6ec5abf/src/MSBuild/app.config#L97

that points to an older version of System.Threading.Tasks.Extensions than what they end up building with, but that happens to coincide with the one that the JsonToItemsTaskFactory task bundles.

Related PR https://github.com/dotnet/msbuild/pull/6830
