### PR TITLE
Ignore the DuplicateExtension status from macOS 12.

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.c
@@ -195,7 +195,7 @@ static void MergeStatusCodes(CFTypeRef key, CFTypeRef value, void* context)
     }
     else if (CFEqual(keyString, CFSTR("NonEmptySubject")) || CFEqual(keyString, CFSTR("GrayListedKey")) ||
              CFEqual(keyString, CFSTR("CTRequired")) || CFEqual(keyString, CFSTR("GrayListedLeaf")) ||
-             CFEqual(keyString, CFSTR("IdLinkage")))
+             CFEqual(keyString, CFSTR("IdLinkage")) || CFEqual(keyString, CFSTR("DuplicateExtension")))
     {
         // Not a "problem" that we report.
     }


### PR DESCRIPTION
MacOS 12 introduces a new X.509 chain status, `DuplicateExtension`. As we do not report this in Windows and nor do we have a flag to map it to, we ignore it from macOS.

The existing test `TimestampTokenTests.TwoEkuExtensions` covers this scenario.

Closes #58833.