### PR TITLE
Fix publishing symbols for `dotnet` and `hostpolicy`

### DIFF
--- a/src/installer/pkg/projects/Directory.Build.targets
+++ b/src/installer/pkg/projects/Directory.Build.targets
@@ -6,6 +6,14 @@
       Needs to happen in Directory.Build.targets to allow all the pkgproj's to set Version property first.
     -->
     <StableVersion Condition="'$(IncludePreReleaseLabelInPackageVersion)' != 'true'">$(Version)</StableVersion>
+
+    <!--
+      Explicitly re-set the symbol package output path. The pkgproj files here end up importing the targets from
+      Microsoft.DotNet.Build.Tasks.Packaging (based on a PackageReference) before importing the Arcade targets hat
+      set defaults for project output paths. This means the value set by the packaging targets does not accountfor
+      the updated defaults from the Arcade targets.
+    -->
+    <SymbolPackageOutputPath>$(PackageOutputPath)</SymbolPackageOutputPath>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
The symbols for `dotnet` and `hostpolicy` are not being published to the public Microsoft symbol servers.

It looks like we are currently relying on the symbol packages for `Microsoft.NETCore.DotNetHost` and `Microsoft.NETCore.DotNetHostPolicy` to get symbols for `dotnet` and `hostpolicy` published.

The `pkgproj` projects in installer have a `PackageReference` to `Microsoft.DotNet.Build.Tasks.Packaging`: https://github.com/dotnet/runtime/blob/f7b441d6c14cfc60c2d02bdc6a087247806efb7c/src/installer/pkg/projects/Directory.Build.props#L129

That package includes a target that sets the `SymbolPackageOutputPath` based on the `PackageOutputPath`.
https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.Build.Tasks.Packaging/src/build/Packaging.targets#L63

However, the targets of that package are imported _before_ the project's `Directory.Build.targets`, which imports Arcade targets that set the default for `PackageOutputPath`:
https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.targets#L22

As a result, the symbol packages built by `src/installer/pkg/projects/*.pkgproj` end up in the wrong directory - For example, under `artifacts\bin\<project_name>\Release` instead of `artifacts\packages\Release\Shipping` - such that they do not get uploaded and published.

This was an unfortunate side effect of https://github.com/dotnet/runtime/pull/57036.

This change goes back to having `SymbolPackageOutputPath` explicitly set. It is not really intuitive / great, but given the desire to stop having these packages (https://github.com/dotnet/runtime/issues/35244, which will also need to make sure symbol publishing is covered by other things) and my expectation that we should backport to 6.0, I went with the simply bringing back the previous behaviour.

cc @dotnet/runtime-infrastructure @jkoritzinsky @vitek-karas 