### PR TITLE
Enhance:  BackgroundService blocked the execution of whole host

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
@@ -27,13 +27,13 @@ namespace Microsoft.Extensions.Hosting
         /// Triggered when the application host is ready to start the service.
         /// </summary>
         /// <param name="cancellationToken">Indicates that the start process has been aborted.</param>
-        public virtual Task StartAsync(CancellationToken cancellationToken)
+        public virtual async Task StartAsync(CancellationToken cancellationToken)
         {
             // Create linked token to allow cancelling executing task from provided token
             _stoppingCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
             // Store the task we're executing
-            _executingTask = ExecuteAsync(_stoppingCts.Token);
+            _executingTask = await ExecuteAsync(_stoppingCts.Token);
 
             // If the task is completed then return it, this will bubble cancellation and failure to the caller
             if (_executingTask.IsCompleted)


### PR DESCRIPTION
There is an issue about it : https://github.com/dotnet/runtime/issues/36063. 

And currently, we have found ways to avoid it such as overriding StartAsync method and call its base function asyncly, as below.   

        public override async Task StartAsync(CancellationToken cancellationToken)
        {
            _logger.LogInformation("WorkerTwo starting at: {time}", DateTimeOffset.Now);

            await base.StartAsync(cancellationToken);
        }