### PR TITLE
Allow users passing FILE_FLAG_BACKUP_SEMANTICS as FileOptions

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs_buffer_fo.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/ctor_str_fm_fa_fs_buffer_fo.cs
@@ -34,12 +34,14 @@ namespace System.IO.Tests
         [InlineData(FileOptions.SequentialScan)]
         [InlineData(FileOptions.WriteThrough)]
         [InlineData((FileOptions)0x20000000)] // FILE_FLAG_NO_BUFFERING on Windows
+        [InlineData((FileOptions)0x02000000)] // FILE_FLAG_BACKUP_SEMANTICS on Windows
         [InlineData(FileOptions.Asynchronous)]
         [InlineData(FileOptions.Asynchronous | FileOptions.DeleteOnClose)]
         [InlineData(FileOptions.Asynchronous | FileOptions.RandomAccess)]
         [InlineData(FileOptions.Asynchronous | FileOptions.SequentialScan)]
         [InlineData(FileOptions.Asynchronous | FileOptions.WriteThrough)]
         [InlineData(FileOptions.Asynchronous | (FileOptions)0x20000000)]
+        [InlineData(FileOptions.Asynchronous | (FileOptions)0x02000000)]
         [InlineData(FileOptions.Asynchronous | FileOptions.DeleteOnClose | FileOptions.RandomAccess | FileOptions.SequentialScan | FileOptions.WriteThrough)]
         public void ValidFileOptions(FileOptions option)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileOptions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileOptions.cs
@@ -14,12 +14,12 @@ namespace System.IO
         None = 0,
         WriteThrough = unchecked((int)0x80000000),
         Asynchronous = unchecked((int)0x40000000), // FILE_FLAG_OVERLAPPED
-        // NoBuffering = 0x20000000,
+        // NoBuffering = 0x20000000, // FILE_FLAG_NO_BUFFERING
         RandomAccess = 0x10000000,
         DeleteOnClose = 0x04000000,
         SequentialScan = 0x08000000,
         // AllowPosix = 0x01000000,  // FILE_FLAG_POSIX_SEMANTICS
-        // BackupOrRestore,
+        // BackupOrRestore = 0x02000000, // FILE_FLAG_BACKUP_SEMANTICS
         // DisallowReparsePoint = 0x00200000, // FILE_FLAG_OPEN_REPARSE_POINT
         // NoRemoteRecall = 0x00100000, // FILE_FLAG_OPEN_NO_RECALL
         // FirstPipeInstance = 0x00080000, // FILE_FLAG_FIRST_PIPE_INSTANCE

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStreamOptions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStreamOptions.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO.Strategies;
+
 namespace System.IO
 {
     public sealed class FileStreamOptions
@@ -77,8 +79,7 @@ namespace System.IO
             get => _options;
             set
             {
-                // NOTE: any change to FileOptions enum needs to be matched here in the error validation
-                if (value != FileOptions.None && (value & ~(FileOptions.WriteThrough | FileOptions.Asynchronous | FileOptions.RandomAccess | FileOptions.DeleteOnClose | FileOptions.SequentialScan | FileOptions.Encrypted | (FileOptions)0x20000000 /* NoBuffering */)) != 0)
+                if (FileStreamHelpers.AreInvalid(value))
                 {
                     ThrowHelper.ArgumentOutOfRangeException_Enum_Value();
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.cs
@@ -8,6 +8,11 @@ namespace System.IO.Strategies
 {
     internal static partial class FileStreamHelpers
     {
+        // NOTE: any change to FileOptions enum needs to be matched here as it's used in the error validation
+        private const FileOptions ValidFileOptions = FileOptions.WriteThrough | FileOptions.Asynchronous | FileOptions.RandomAccess
+            | FileOptions.DeleteOnClose | FileOptions.SequentialScan | FileOptions.Encrypted
+            | (FileOptions)0x20000000 /* NoBuffering */ | (FileOptions)0x02000000 /* BackupOrRestore */;
+
         /// <summary>Caches whether Serialization Guard has been disabled for file writes</summary>
         private static int s_cachedSerializationSwitch;
 
@@ -97,7 +102,7 @@ namespace System.IO.Strategies
             }
 
             // NOTE: any change to FileOptions enum needs to be matched here in the error validation
-            if (options != FileOptions.None && (options & ~(FileOptions.WriteThrough | FileOptions.Asynchronous | FileOptions.RandomAccess | FileOptions.DeleteOnClose | FileOptions.SequentialScan | FileOptions.Encrypted | (FileOptions)0x20000000 /* NoBuffering */)) != 0)
+            if (AreInvalid(options))
             {
                 throw new ArgumentOutOfRangeException(nameof(options), SR.ArgumentOutOfRange_Enum);
             }
@@ -135,5 +140,7 @@ namespace System.IO.Strategies
                 SerializationInfo.ThrowIfDeserializationInProgress("AllowFileWrites", ref s_cachedSerializationSwitch);
             }
         }
+
+        internal static bool AreInvalid(FileOptions options) => options != FileOptions.None && (options & ~ValidFileOptions) != 0;
     }
 }


### PR DESCRIPTION
Similarly to `FILE_FLAG_NO_BUFFERING`, we can allow users for passing `FILE_FLAG_BACKUP_SEMANTICS` as `FileOptions

Contributes to #27086

Motivation: https://github.com/dotnet/runtime/issues/27086#issuecomment-913862633