### PR TITLE
Use less calls for MoveDirectory

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/Directory.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Directory.cs
@@ -271,7 +271,6 @@ namespace System.IO
             bool sameDirectoryDifferentCase =
                 directoriesAreCaseVariants &&
                 destDirNameFromFullPath.Equals(sourceDirNameFromFullPath, fileSystemSensitivity);
-            bool sourcePathIsFile = FileSystem.FileExists(fullsourceDirName);
 
             // If the destination directories are the exact same name
             if (!sameDirectoryDifferentCase && string.Equals(sourcePath, destPath, fileSystemSensitivity))
@@ -283,6 +282,8 @@ namespace System.IO
             // Compare paths for the same, skip this step if we already know the paths are identical.
             if (!sourceRoot.Equals(destinationRoot, StringComparison.OrdinalIgnoreCase))
                 throw new IOException(SR.IO_SourceDestMustHaveSameRoot);
+
+            bool sourcePathIsFile = FileSystem.FileExists(fullsourceDirName);
 
             // Windows will throw if the source file/directory doesn't exist, we preemptively check
             // to make sure our cross platform behavior matches .NET Framework behavior.

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
@@ -43,7 +43,7 @@ namespace System.IO
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_FileEncryption);
         }
 
-        private static void LinkOrCopyFile (string sourceFullPath, string destFullPath)
+        private static void LinkOrCopyFile(string sourceFullPath, string destFullPath)
         {
             if (Interop.Sys.Link(sourceFullPath, destFullPath) >= 0)
                 return;
@@ -128,9 +128,9 @@ namespace System.IO
                 // Check source and destination are not the same.
                 if (sourceStat.Dev == destStat.Dev &&
                     sourceStat.Ino == destStat.Ino)
-                  {
-                      throw new IOException(SR.Format(SR.IO_CannotReplaceSameFile, sourceFullPath, destFullPath));
-                  }
+                {
+                    throw new IOException(SR.Format(SR.IO_CannotReplaceSameFile, sourceFullPath, destFullPath));
+                }
             }
 
             if (destBackupFullPath != null)
@@ -372,23 +372,10 @@ namespace System.IO
 
         public static void MoveDirectory(string sourceFullPath, string destFullPath)
         {
-            // Windows doesn't care if you try and copy a file via "MoveDirectory"...
-            if (FileExists(sourceFullPath))
-            {
-                // ... but it doesn't like the source to have a trailing slash ...
-
-                // On Windows we end up with ERROR_INVALID_NAME, which is
-                // "The filename, directory name, or volume label syntax is incorrect."
-                //
-                // This surfaces as an IOException, if we let it go beyond here it would
-                // give DirectoryNotFound.
-
-                if (Path.EndsInDirectorySeparator(sourceFullPath))
-                    throw new IOException(SR.Format(SR.IO_PathNotFound_Path, sourceFullPath));
-
-                // ... but it doesn't care if the destination has a trailing separator.
+            // We have to check, if the source path does not end with a trailing separator.
+            // To match windows behaviour, Unix does not want trailing separators for both paths when it moves a file.
+            if (!Path.EndsInDirectorySeparator(sourceFullPath))
                 destFullPath = Path.TrimEndingDirectorySeparator(destFullPath);
-            }
 
             if (FileExists(destFullPath))
             {


### PR DESCRIPTION
reopened because I was not paying attention to workflow... :man_facepalming:

See #58240
This fix is trying to overcome the concept of matching a universal behaviour inside a platform aware implementation.

All checks for consistent behaviours can be done within the public Directory implementation.
The missing bits which are only relevant for Unix are being left e.g. matching trailing seperators on both paths.

This might be redundant, given that Windows would handle such cases, so we dont have to do the checks beforehand, but given that we can reduce calls on both Unix and Windows runtimes should be a slight improvement.
There is only a single FileExist call for Unix and for windows we won't execute the move operation and wait for exceptions.