### PR TITLE
[mono] Allow uses of pthread_condattr_setclock on Apple and Android

### DIFF
--- a/src/mono/mono/utils/mono-os-mutex.h
+++ b/src/mono/mono/utils/mono-os-mutex.h
@@ -36,7 +36,7 @@
 
 #if !defined(HOST_WIN32)
 
-#if !defined(CLOCK_MONOTONIC) || defined(HOST_DARWIN) || defined(HOST_ANDROID) || defined(HOST_WASM)
+#if !defined(CLOCK_MONOTONIC) || defined(HOST_WASM)
 #define BROKEN_CLOCK_SOURCE
 #endif
 


### PR DESCRIPTION
For Android, it seems like this was broken prior to NDK r21, but we require r21
as a minimum now.

For ios it was not available prior to ios 10, which is also our minimumm now.

Fixes #58737 