### PR TITLE
Add delete operator in Crst class

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -399,8 +399,6 @@ if (CLR_CMAKE_HOST_UNIX)
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-misleading-indentation>)
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-stringop-overflow>)
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-stringop-truncation>)
-    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-mismatched-new-delete>)
-    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-free-nonheap-object>)
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-placement-new>)
 
     check_cxx_compiler_flag(-faligned-new COMPILER_SUPPORTS_F_ALIGNED_NEW)

--- a/src/coreclr/vm/crst.h
+++ b/src/coreclr/vm/crst.h
@@ -421,6 +421,12 @@ public:
         return new BYTE[size];
     }
 
+    void operator delete(void* mem)
+    {
+        WRAPPER_NO_CONTRACT;
+        delete[] (BYTE*)mem;
+    }
+
 private:
     // Do not use inplace operator new on Crst. A wrong destructor would be called if the constructor fails.
     // Use CrstStatic or CrstExplicitInit instead of the inplace operator new.


### PR DESCRIPTION
This + #58871 fix all `-Wmismatched-new-delete` and `-Wfree-nonheap-object` reported by gcc11. I have removed the suppressions.