### PR TITLE
documentation for HttpRequestOptions

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
@@ -115,6 +115,9 @@ namespace System.Net.Http
         [Obsolete("HttpRequestMessage.Properties has been deprecated. Use Options instead.")]
         public IDictionary<string, object?> Properties => Options;
 
+        /// <summary>
+        /// Gets the collection of options to configure the HTTP request.
+        /// </summary>
         public HttpRequestOptions Options => _options ??= new HttpRequestOptions();
 
         public HttpRequestMessage()

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestOptions.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestOptions.cs
@@ -6,6 +6,9 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace System.Net.Http
 {
+    /// <summary>
+    /// Represents a collection of options for an HTTP request.
+    /// </summary>
     public sealed class HttpRequestOptions : IDictionary<string, object?>
     {
         private Dictionary<string, object?> Options { get; } = new Dictionary<string, object?>();
@@ -36,6 +39,19 @@ namespace System.Net.Http
         bool IDictionary<string, object?>.Remove(string key) => Options.Remove(key);
         bool ICollection<KeyValuePair<string, object?>>.Remove(KeyValuePair<string, object?> item) => ((IDictionary<string, object?>)Options).Remove(item);
         bool IDictionary<string, object?>.TryGetValue(string key, out object? value) => Options.TryGetValue(key, out value);
+
+        /// <summary>
+        /// Initializes a new instance of the HttpRequestOptions class.
+        /// </summary>
+        public HttpRequestOptions() { }
+
+        /// <summary>
+        /// Gets the value of a given HTTP request option.
+        /// </summary>
+        /// <param name="key">Strongly typed key to get the value of HTTP request option. For example <code>new HttpRequestOptionsKey&lt;bool&gt;("WebAssemblyEnableStreamingResponse")</code></param>
+        /// <param name="value">Returns the value of HTTP request option.</param>
+        /// <typeparam name="TValue">The type of the HTTP value as defined by <code>key</code> parameter.</typeparam>
+        /// <returns>True, if an option is retrieved.</returns>
         public bool TryGetValue<TValue>(HttpRequestOptionsKey<TValue> key, [MaybeNullWhen(false)] out TValue value)
         {
             if (Options.TryGetValue(key.Key, out object? _value) && _value is TValue tvalue)
@@ -48,6 +64,12 @@ namespace System.Net.Http
             return false;
         }
 
+        /// <summary>
+        /// Sets the value of a given request option.
+        /// </summary>
+        /// <param name="key">Strongly typed key to get the value of HTTP request option. For example <code>new HttpRequestOptionsKey&lt;bool&gt;("WebAssemblyEnableStreamingResponse")</code></param>
+        /// <param name="value">The value of the HTTP request option.</param>
+        /// <typeparam name="TValue">The type of the HTTP value as defined by <code>key</code> parameter.</typeparam>
         public void Set<TValue>(HttpRequestOptionsKey<TValue> key, TValue value)
         {
             Options[key.Key] = value;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestOptionsKey.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestOptionsKey.cs
@@ -5,9 +5,21 @@ using System;
 
 namespace System.Net.Http
 {
+    /// <summary>
+    /// Represents a key in the options for an HTTP request.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value of the option.</typeparam>
     public readonly struct HttpRequestOptionsKey<TValue>
     {
+        /// <summary>
+        /// Gets the name of the option.
+        /// </summary>
         public string Key { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the HttpRequestOptionsKey using the supplied key name.
+        /// </summary>
+        /// <param name="key">Name of the HTTP request option.</param>
         public HttpRequestOptionsKey(string key)
         {
             Key = key;


### PR DESCRIPTION
missing doc for HttpRequestOptions, HttpRequestOptionsKey and HttpRequestMessage.Options
Fixes https://github.com/dotnet/runtime/issues/43859
Merge after https://github.com/dotnet/dotnet-api-docs/pull/7129 review