### PR TITLE
[wasm] fix local build for NetCoreServer and RemoteLoopServer

### DIFF
--- a/src/libraries/Common/tests/System/Net/Prerequisites/LocalEchoServer.props
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/LocalEchoServer.props
@@ -7,11 +7,11 @@
     <!-- handle different path to middleware in Helix -->
     <_TestEchoMiddleware Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(OS)' == 'Windows_NT'">%HELIX_CORRELATION_PAYLOAD%/xharness/TestEchoMiddleware</_TestEchoMiddleware>
     <_TestEchoMiddleware Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(OS)' != 'Windows_NT'">$HELIX_CORRELATION_PAYLOAD/xharness/TestEchoMiddleware</_TestEchoMiddleware>
-    <_TestEchoMiddleware Condition="'$(ContinuousIntegrationBuild)' != 'true'">$(ArtifactsDir)bin/NetCoreServer/$(NetCoreAppCurrent)-$(Configuration)</_TestEchoMiddleware>
+    <_TestEchoMiddleware Condition="'$(ContinuousIntegrationBuild)' != 'true'">$(ArtifactsDir)bin/NetCoreServer/$(AspNetCoreAppCurrent)-$(Configuration)</_TestEchoMiddleware>
 
     <_RemoteLoopMiddleware Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(OS)' == 'Windows_NT'">%HELIX_CORRELATION_PAYLOAD%/xharness/RemoteLoopMiddleware</_RemoteLoopMiddleware>
     <_RemoteLoopMiddleware Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(OS)' != 'Windows_NT'">$HELIX_CORRELATION_PAYLOAD/xharness/RemoteLoopMiddleware</_RemoteLoopMiddleware>
-    <_RemoteLoopMiddleware Condition="'$(ContinuousIntegrationBuild)' != 'true'">$(ArtifactsDir)bin/RemoteLoopServer/$(NetCoreAppCurrent)-$(Configuration)</_RemoteLoopMiddleware>
+    <_RemoteLoopMiddleware Condition="'$(ContinuousIntegrationBuild)' != 'true'">$(ArtifactsDir)bin/RemoteLoopServer/$(AspNetCoreAppCurrent)-$(Configuration)</_RemoteLoopMiddleware>
 
     <WasmXHarnessArgs>$(WasmXHarnessArgs) --web-server-use-cors --web-server-use-https</WasmXHarnessArgs>
     <WasmXHarnessArgs>$(WasmXHarnessArgs) --set-web-server-http-env=DOTNET_TEST_WEBSOCKETHOST,DOTNET_TEST_HTTPHOST,DOTNET_TEST_REMOTE_LOOP_HOST</WasmXHarnessArgs>


### PR DESCRIPTION
Background:
`NetCoreServer`, and `RemoteLoopServer` use `AspNetCore` sdk with version `$(AspNetCoreAppCurrent)`. The test projects that use these servers target `$(NetCoreAppCurrent)`.

Before the `net7.0` switch, both of these versions were == `net6.0`. With the 7.0 switch, `NetCoreAppCurrent` is `net7.0`, but `AspNetCoreAppCurrent` is unchanged.

Issue:
Tests fail to run locally:

`XHarness` is passed the path to the assemblies for the two servers, and the path is constructed as:
`$(ArtifactsDir)bin/NetCoreServer/$(NetCoreAppCurrent)-$(Configuration)`

.. in `LocalEchoServer.props` imported by the test project. And this causes the path to have `net7.0`, even though the servers are built with `net6.0`.

This matches what is [done](https://github.com/dotnet/runtime/blob/main/src/libraries/sendtohelixhelp.proj) for helix, where the tests don't fail:
```xml
      <TestEchoMiddleware>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'bin', 'NetCoreServer', '$(AspNetCoreAppCurrent)-$(Configuration)'))</TestEchoMiddleware>
      <RemoteLoopMiddleware>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'bin', 'RemoteLoopServer', '$(AspNetCoreAppCurrent)-$(Configuration)'))</RemoteLoopMiddleware>
```