### PR TITLE
Fix SIMD temp register interference

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -1891,7 +1891,7 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
 // genMultiRegStoreToSIMDLocal: store multi-reg value to a single-reg SIMD local
 //
 // Arguments:
-//    lclNode  -  GentreeLclVar of GT_STORE_LCL_VAR
+//    lclNode  -  GenTreeLclVar of GT_STORE_LCL_VAR
 //
 // Return Value:
 //    None
@@ -1996,6 +1996,7 @@ void CodeGen::genMultiRegStoreToSIMDLocal(GenTreeLclVar* lclNode)
     else
     {
         regNumber tempXmm = lclNode->GetSingleTempReg();
+        assert(tempXmm != targetReg);
         inst_Mov(TYP_FLOAT, tempXmm, reg1, /* canSkip */ false);
         GetEmitter()->emitIns_SIMD_R_R_R(INS_punpckldq, size, targetReg, targetReg, tempXmm);
     }

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -3413,6 +3413,8 @@ int LinearScan::BuildStoreLoc(GenTreeLclVarCommon* storeLoc)
             {
                 // Need an additional register to create a SIMD8 from EAX/EDX without SSE4.1.
                 buildInternalFloatRegisterDefForNode(storeLoc, allSIMDRegs());
+                // This internal register must be different from the target register.
+                setInternalRegsDelayFree = true;
             }
         }
 #endif // FEATURE_SIMD && TARGET_X86 && TARGET_WINDOWS


### PR DESCRIPTION
On Windows/x86, if a call returns a SIMD8 in two registers
(eax, edx), and needs to be assembled and stored into a single
SIMD register, AND we don't have the SSE41 ABI available (because
the hardware doesn't support it, or we specifically disable it),
then we need a temporary register. In the failure case, the target
register and temporary register were the same, and then interfered
with each other. The fix is to force the temporary register to
be different from the target register.

No SPMI asm diffs

Fixes #58899
