### PR TITLE
[release/6.0] Address Windows recommendations for Link APIs  (#58592)

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/Base/SymbolicLinks/BaseSymbolicLinks.FileSystem.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Base/SymbolicLinks/BaseSymbolicLinks.FileSystem.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.IO.Enumeration;
 using System.Linq;
 using Xunit;
@@ -158,7 +157,7 @@ namespace System.IO.Tests
         }
 
         [Theory]
-        [MemberData(nameof(ResolveLinkTarget_PathToTarget_Data))]
+        [MemberData(nameof(SymbolicLink_ResolveLinkTarget_PathToTarget_Data))]
         public void ResolveLinkTarget_Succeeds(string pathToTarget, bool returnFinalTarget)
         {
             string linkPath = GetRandomLinkPath();
@@ -345,32 +344,6 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public void CreateSymbolicLink_WrongTargetType_Throws()
-        {
-            // dirLink -> file
-            // fileLink -> dir
-
-            string targetPath = GetRandomFilePath();
-            CreateFileOrDirectory(targetPath, createOpposite: true); // The underlying file system entry needs to be different
-            Assert.Throws<IOException>(() => CreateSymbolicLink(GetRandomFilePath(), targetPath));
-        }
-
-        [Fact]
-        public void CreateSymbolicLink_WrongTargetType_Indirect_Throws()
-        {
-            // link-2 (dir) -> link-1 (file) -> file
-            // link-2 (file) -> link-1 (dir) -> dir
-            string targetPath = GetRandomFilePath();
-            string firstLinkPath = GetRandomFilePath();
-            string secondLinkPath = GetRandomFilePath();
-
-            CreateFileOrDirectory(targetPath, createOpposite: true);
-            CreateSymbolicLink_Opposite(firstLinkPath, targetPath);
-
-            Assert.Throws<IOException>(() => CreateSymbolicLink(secondLinkPath, firstLinkPath));
-        }
-
-        [Fact]
         public void CreateSymbolicLink_CorrectTargetType_Indirect_Succeeds()
         {
             // link-2 (file) -> link-1 (file) -> file
@@ -429,14 +402,14 @@ namespace System.IO.Tests
             Assert.True(link2Info.Exists);
             Assert.True(link2Info.Attributes.HasFlag(FileAttributes.ReparsePoint));
             AssertIsCorrectTypeAndDirectoryAttribute(link2Info);
-            Assert.Equal(link2Target, link2Info.LinkTarget);
+            AssertPathEquals_RelativeSegments(link2Target, link2Info.LinkTarget);
 
             // link1 to link2
             FileSystemInfo link1Info = CreateSymbolicLink(link1Path, link1Target);
             Assert.True(link1Info.Exists);
             Assert.True(link1Info.Attributes.HasFlag(FileAttributes.ReparsePoint));
             AssertIsCorrectTypeAndDirectoryAttribute(link1Info);
-            Assert.Equal(link1Target, link1Info.LinkTarget);
+            AssertPathEquals_RelativeSegments(link1Target, link1Info.LinkTarget);
 
             // link1: do not follow symlinks
             FileSystemInfo link1TargetInfo = ResolveLinkTarget(link1Path, returnFinalTarget: false);
@@ -444,7 +417,7 @@ namespace System.IO.Tests
             AssertIsCorrectTypeAndDirectoryAttribute(link1TargetInfo);
             Assert.True(link1TargetInfo.Attributes.HasFlag(FileAttributes.ReparsePoint));
             Assert.Equal(link2Path, link1TargetInfo.FullName);
-            Assert.Equal(link2Target, link1TargetInfo.LinkTarget);
+            AssertPathEquals_RelativeSegments(link2Target, link1TargetInfo.LinkTarget);
 
             // link2: do not follow symlinks
             FileSystemInfo link2TargetInfo = ResolveLinkTarget(link2Path, returnFinalTarget: false);
@@ -460,6 +433,19 @@ namespace System.IO.Tests
             AssertIsCorrectTypeAndDirectoryAttribute(finalTarget);
             Assert.False(finalTarget.Attributes.HasFlag(FileAttributes.ReparsePoint));
             Assert.Equal(filePath, finalTarget.FullName);
+
+            void AssertPathEquals_RelativeSegments(string expected, string actual)
+            {
+#if WINDOWS
+                // DeviceIoControl canonicalizes the target path i.e: removes redundant segments.
+                int rootLength = PathInternal.GetRootLength(expected);
+                if (rootLength > 0)
+                {
+                    expected = PathInternal.RemoveRelativeSegments(expected, rootLength);
+                }
+#endif
+                Assert.Equal(expected, actual);
+            }
         }
 
         // Must call inside a remote executor
@@ -510,51 +496,6 @@ namespace System.IO.Tests
                     FileSystemName.MatchesWin32Expression("*.exe", entry.FileName) &&
                     (entry.Attributes & FileAttributes.ReparsePoint) != 0
             }.FirstOrDefault();
-        }
-
-        public static IEnumerable<object[]> ResolveLinkTarget_PathToTarget_Data
-        {
-            get
-            {
-                foreach (string path in PathToTargetData)
-                {
-                    yield return new object[] { path, false };
-                    yield return new object[] { path, true };
-                }
-            }
-        }
-
-        internal static IEnumerable<string> PathToTargetData
-        {
-            get
-            {
-                if (OperatingSystem.IsWindows())
-                {
-                    //Non-rooted relative
-                    yield return "foo";
-                    yield return @".\foo";
-                    yield return @"..\foo";
-                    // Rooted relative
-                    yield return @"\foo";
-                    // Rooted absolute
-                    yield return Path.Combine(Path.GetTempPath(), "foo");
-                    // Extended DOS
-                    yield return Path.Combine(@"\\?\", Path.GetTempPath(), "foo");
-                    // UNC
-                    yield return @"\\LOCALHOST\share\path";
-                }
-                else
-                {
-                    //Non-rooted relative
-                    yield return "foo";
-                    yield return "./foo";
-                    yield return "../foo";
-                    // Rooted relative
-                    yield return "/foo";
-                    // Rooted absolute
-                    Path.Combine(Path.GetTempPath(), "foo");
-                }
-            }
         }
     }
 }

--- a/src/libraries/System.IO.FileSystem/tests/Base/SymbolicLinks/BaseSymbolicLinks.FileSystemInfo.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Base/SymbolicLinks/BaseSymbolicLinks.FileSystemInfo.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.Diagnostics;
 using Xunit;
 
 namespace System.IO.Tests
@@ -54,7 +52,7 @@ namespace System.IO.Tests
         }
 
         [Theory]
-        [MemberData(nameof(LinkTarget_PathToTarget_Data))]
+        [MemberData(nameof(SymbolicLink_LinkTarget_PathToTarget_Data))]
         public void LinkTarget_Succeeds(string pathToTarget)
         {
             FileSystemInfo linkInfo = CreateSymbolicLink(GetRandomLinkPath(), pathToTarget);
@@ -85,17 +83,6 @@ namespace System.IO.Tests
             linkInfo.Refresh();
             Assert.Equal(newPathToTarget, linkInfo.LinkTarget);
             Assert.Equal(newLinkInfo.LinkTarget, linkInfo.LinkTarget);
-        }
-
-        public static IEnumerable<object[]> LinkTarget_PathToTarget_Data
-        {
-            get
-            {
-                foreach (string path in PathToTargetData)
-                {
-                    yield return new object[] { path };
-                }
-            }
         }
     }
 }

--- a/src/libraries/System.IO.FileSystem/tests/Base/SymbolicLinks/BaseSymbolicLinks.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Base/SymbolicLinks/BaseSymbolicLinks.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace System.IO.Tests
@@ -44,6 +46,96 @@ namespace System.IO.Tests
             Directory.CreateDirectory(tempCwd);
             Directory.SetCurrentDirectory(tempCwd);
             return tempCwd;
+        }
+
+        public static IEnumerable<object[]> SymbolicLink_LinkTarget_PathToTarget_Data
+        {
+            get
+            {
+                foreach (string path in PathToTargetData.Union(PathToTargetUncData))
+                {
+                    yield return new object[] { path };
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> SymbolicLink_ResolveLinkTarget_PathToTarget_Data
+        {
+            get
+            {
+                foreach (string path in PathToTargetData.Union(PathToTargetUncData))
+                {
+                    yield return new object[] { path, false };
+                    yield return new object[] { path, true };
+                }
+            }
+        }
+
+        // Junctions doesn't support remote shares.
+        public static IEnumerable<object[]> Junction_LinkTarget_PathToTarget_Data
+        {
+            get
+            {
+                foreach (string path in PathToTargetData)
+                {
+                    yield return new object[] { path };
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> Junction_ResolveLinkTarget_PathToTarget_Data
+        {
+            get
+            {
+                foreach (string path in PathToTargetData)
+                {
+                    yield return new object[] { path, false };
+                    yield return new object[] { path, true };
+                }
+            }
+        }
+
+        internal static IEnumerable<string> PathToTargetData
+        {
+            get
+            {
+                if (OperatingSystem.IsWindows())
+                {
+                    //Non-rooted relative
+                    yield return "foo";
+                    yield return @".\foo";
+                    yield return @"..\foo";
+                    // Rooted relative
+                    yield return @"\foo";
+                    // Rooted absolute
+                    yield return Path.Combine(Path.GetTempPath(), "foo");
+                    // Extended DOS
+                    yield return Path.Combine(@"\\?\", Path.GetTempPath(), "foo");
+                }
+                else
+                {
+                    //Non-rooted relative
+                    yield return "foo";
+                    yield return "./foo";
+                    yield return "../foo";
+                    // Rooted relative
+                    yield return "/foo";
+                    // Rooted absolute
+                    Path.Combine(Path.GetTempPath(), "foo");
+                }
+            }
+        }
+
+        internal static IEnumerable<string> PathToTargetUncData
+        {
+            get
+            {
+                if (OperatingSystem.IsWindows())
+                {
+                    // UNC/Remote Share
+                    yield return @"\\LOCALHOST\share\path";
+                }
+            }
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2659,9 +2659,6 @@
   <data name="IO_BindHandleFailed" xml:space="preserve">
     <value>BindHandle for ThreadPool failed on this handle.</value>
   </data>
-  <data name="IO_InconsistentLinkType" xml:space="preserve">
-    <value>The link's file system entry type is inconsistent with that of its target: {0}</value>
-  </data>
   <data name="IO_FileExists_Name" xml:space="preserve">
     <value>The file '{0}' already exists.</value>
   </data>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
@@ -571,16 +571,6 @@ namespace System.IO
         internal static void CreateSymbolicLink(string path, string pathToTarget, bool isDirectory)
         {
             string pathToTargetFullPath = PathInternal.GetLinkTargetFullPath(path, pathToTarget);
-
-            // Fail if the target exists but is not consistent with the expected filesystem entry type
-            if (Interop.Sys.Stat(pathToTargetFullPath, out Interop.Sys.FileStatus targetInfo) == 0)
-            {
-                if (isDirectory != ((targetInfo.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR))
-                {
-                    throw new IOException(SR.Format(SR.IO_InconsistentLinkType, path));
-                }
-            }
-
             Interop.CheckIo(Interop.Sys.SymLink(pathToTarget, path), path, isDirectory);
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/PathInternal.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/PathInternal.Windows.cs
@@ -46,10 +46,12 @@ namespace System.IO
 
         internal const string DirectorySeparatorCharAsString = "\\";
 
+        internal const string NTPathPrefix = @"\??\";
         internal const string ExtendedPathPrefix = @"\\?\";
         internal const string UncPathPrefix = @"\\";
         internal const string UncExtendedPrefixToInsert = @"?\UNC\";
         internal const string UncExtendedPathPrefix = @"\\?\UNC\";
+        internal const string UncNTPathPrefix = @"\??\UNC\";
         internal const string DevicePathPrefix = @"\\.\";
         internal const string ParentDirectoryPrefix = @"..\";
 


### PR DESCRIPTION
Backport of #58592 to release/6.0

## Customer Impact
Windows experts gave us advice related to our new Link APIs added to System.IO. This PR addresses the following:
* We should not run any validation in the link's target when it is being created since all validations should occur at resolution time, therefore, I've removed the "file-must-target-file" validation that we initially wrote.
* For Windows only: We should not use PrintName as there is no guarantee that the SubstituteName and PrintName in the REPARSE_DATA_BUFFER refer to the same file, I've changed the implementation to use SubstituteName.

## Testing
Updated/extended unit tests based on above changes.

## Risk
Low, we are performing the following:
* Remove one validation on CreateSymbolicLink
*  Parse an NT path (\\??\\C:\\...) to a "normal" Win32 path (C:\\...), however, there's [prior art](https://github.com/PowerShell/PowerShell/blob/74e283c4f9777f73e45e08f377b0b28415f65535/src/System.Management.Automation/namespaces/FileSystemProvider.cs#L8532-L8535) (in PowerShell) to this kind of parsing.

## Note
The bot failed to backport this automatically given a previous PR (https://github.com/dotnet/runtime/pull/57988) that unified the duplicated `PathInternal*.cs` files. 
This PR just adds two constants to one of those files.

cc @carlossanlop 