### PR TITLE
[release/6.0] Enhance CrossGen2 to emit PerfMap debug directory entry

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Diagnostics/PerfMapWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Diagnostics/PerfMapWriter.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 
+using Internal.ReadyToRunDiagnosticsConstants;
 using Internal.TypeSystem;
 
 namespace ILCompiler.Diagnostics
@@ -16,14 +17,8 @@ namespace ILCompiler.Diagnostics
         public const int LegacyCrossgen1FormatVersion = 0;
 
         public const int CurrentFormatVersion = 1;
-        
-        public enum PseudoRVA : uint
-        {
-            OutputGuid         = 0xFFFFFFFF,
-            TargetOS           = 0xFFFFFFFE,
-            TargetArchitecture = 0xFFFFFFFD,
-            FormatVersion      = 0xFFFFFFFC,
-        }
+
+        const int HeaderEntriesPseudoLength = 0;
 
         private TextWriter _writer;
 
@@ -32,7 +27,7 @@ namespace ILCompiler.Diagnostics
             _writer = writer;
         }
 
-        public static void Write(string perfMapFileName, int perfMapFormatVersion, IEnumerable<MethodInfo> methods, IEnumerable<AssemblyInfo> inputAssemblies, TargetOS targetOS, TargetArchitecture targetArch)
+        public static void Write(string perfMapFileName, int perfMapFormatVersion, IEnumerable<MethodInfo> methods, IEnumerable<AssemblyInfo> inputAssemblies, TargetDetails details)
         {
             if (perfMapFormatVersion > CurrentFormatVersion)
             {
@@ -41,22 +36,10 @@ namespace ILCompiler.Diagnostics
 
             using (TextWriter writer = new StreamWriter(perfMapFileName))
             {
-                IEnumerable<AssemblyInfo> orderedInputs = inputAssemblies.OrderBy(asm => asm.Name, StringComparer.OrdinalIgnoreCase);
 
                 PerfMapWriter perfMapWriter = new PerfMapWriter(writer);
-
-                List<byte> inputHash = new List<byte>();
-                foreach (AssemblyInfo inputAssembly in orderedInputs)
-                {
-                    inputHash.AddRange(inputAssembly.Mvid.ToByteArray());
-                }
-                inputHash.Add((byte)targetOS);
-                inputHash.Add((byte)targetArch);
-                Guid outputGuid = new Guid(MD5.HashData(inputHash.ToArray()));
-                perfMapWriter.WriteLine(outputGuid.ToString(), (uint)PseudoRVA.OutputGuid, 0);
-                perfMapWriter.WriteLine(targetOS.ToString(), (uint)PseudoRVA.TargetOS, 0);
-                perfMapWriter.WriteLine(targetArch.ToString(), (uint)PseudoRVA.TargetArchitecture, 0);
-                perfMapWriter.WriteLine(CurrentFormatVersion.ToString(), (uint)PseudoRVA.FormatVersion, 0);
+                byte[] signature = PerfMapV1SignatureHelper(inputAssemblies, details);
+                WritePerfMapV1Header(inputAssemblies, details, perfMapWriter);
 
                 foreach (MethodInfo methodInfo in methods)
                 {
@@ -70,6 +53,92 @@ namespace ILCompiler.Diagnostics
                     }
                 }
             }
+        }
+
+        private static void WritePerfMapV1Header(IEnumerable<AssemblyInfo> inputAssemblies, TargetDetails details, PerfMapWriter perfMapWriter)
+        {
+            byte[] signature = PerfMapV1SignatureHelper(inputAssemblies, details);
+
+            // Make sure these get emitted in this order, other tools in the ecosystem like the symbol uploader and PerfView rely on this.
+            // In particular, the order of it. Append only.
+            string signatureFormatted = Convert.ToHexString(signature);
+
+            PerfmapTokensForTarget targetTokens = TranslateTargetDetailsToPerfmapConstants(details);
+
+            perfMapWriter.WriteLine(signatureFormatted, (uint)PerfMapPseudoRVAToken.OutputSignature, HeaderEntriesPseudoLength);
+            perfMapWriter.WriteLine(CurrentFormatVersion.ToString(), (uint)PerfMapPseudoRVAToken.FormatVersion, HeaderEntriesPseudoLength);
+            perfMapWriter.WriteLine(((uint)targetTokens.OperatingSystem).ToString(), (uint)PerfMapPseudoRVAToken.TargetOS, HeaderEntriesPseudoLength);
+            perfMapWriter.WriteLine(((uint)targetTokens.Architecture).ToString(), (uint)PerfMapPseudoRVAToken.TargetArchitecture, HeaderEntriesPseudoLength);
+            perfMapWriter.WriteLine(((uint)targetTokens.Abi).ToString(), (uint)PerfMapPseudoRVAToken.TargetABI, HeaderEntriesPseudoLength);
+        }
+
+        public static byte[] PerfMapV1SignatureHelper(IEnumerable<AssemblyInfo> inputAssemblies, TargetDetails details)
+        {
+            IEnumerable<AssemblyInfo> orderedInputs = inputAssemblies.OrderBy(asm => asm.Name, StringComparer.OrdinalIgnoreCase);
+            List<byte> inputHash = new List<byte>();
+            foreach (AssemblyInfo inputAssembly in orderedInputs)
+            {
+                inputHash.AddRange(inputAssembly.Mvid.ToByteArray());
+            }
+
+            PerfmapTokensForTarget targetTokens = TranslateTargetDetailsToPerfmapConstants(details);
+
+            byte[] buffer = new byte[12];
+            if (!BitConverter.TryWriteBytes(buffer.AsSpan(0, sizeof(uint)), (uint)targetTokens.OperatingSystem)
+                || !BitConverter.TryWriteBytes(buffer.AsSpan(4, sizeof(uint)), (uint)targetTokens.Architecture)
+                || !BitConverter.TryWriteBytes(buffer.AsSpan(8, sizeof(uint)), (uint)targetTokens.Abi))
+            {
+                throw new InvalidOperationException();
+            }
+
+            if (!BitConverter.IsLittleEndian)
+            {
+                buffer.AsSpan(0, sizeof(uint)).Reverse();
+                buffer.AsSpan(4, sizeof(uint)).Reverse();
+                buffer.AsSpan(8, sizeof(uint)).Reverse();
+            }
+
+            inputHash.AddRange(buffer);
+            byte[] hash = MD5.HashData(inputHash.ToArray());
+
+            return hash;
+        }
+
+        internal record struct PerfmapTokensForTarget(PerfMapOSToken OperatingSystem, PerfMapArchitectureToken Architecture, PerfMapAbiToken Abi);
+
+        private static PerfmapTokensForTarget TranslateTargetDetailsToPerfmapConstants(TargetDetails details)
+        {
+            PerfMapOSToken osToken = details.OperatingSystem switch
+            {
+                TargetOS.Unknown => PerfMapOSToken.Unknown,
+                TargetOS.Windows => PerfMapOSToken.Windows,
+                TargetOS.Linux => PerfMapOSToken.Linux,
+                TargetOS.OSX => PerfMapOSToken.OSX,
+                TargetOS.FreeBSD => PerfMapOSToken.FreeBSD,
+                TargetOS.NetBSD => PerfMapOSToken.NetBSD,
+                TargetOS.SunOS => PerfMapOSToken.SunOS,
+                _ => throw new NotImplementedException(details.OperatingSystem.ToString())
+            };
+
+            PerfMapAbiToken abiToken = details.Abi switch
+            {
+                TargetAbi.Unknown => PerfMapAbiToken.Unknown,
+                TargetAbi.CoreRT => PerfMapAbiToken.Default,
+                TargetAbi.CoreRTArmel => PerfMapAbiToken.Armel,
+                _ => throw new NotImplementedException(details.Abi.ToString())
+            };
+
+            PerfMapArchitectureToken archToken = details.Architecture switch
+            {
+                TargetArchitecture.Unknown => PerfMapArchitectureToken.Unknown,
+                TargetArchitecture.ARM => PerfMapArchitectureToken.ARM,
+                TargetArchitecture.ARM64 => PerfMapArchitectureToken.ARM64,
+                TargetArchitecture.X64 => PerfMapArchitectureToken.X64,
+                TargetArchitecture.X86 => PerfMapArchitectureToken.X86,
+                _ => throw new NotImplementedException(details.Architecture.ToString())
+            };
+
+            return new PerfmapTokensForTarget(osToken, archToken, abiToken);
         }
 
         private void WriteLine(string methodName, uint rva, uint length)

--- a/src/coreclr/tools/aot/ILCompiler.Diagnostics/ReadyToRunDiagnosticsConstants.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Diagnostics/ReadyToRunDiagnosticsConstants.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Internal.ReadyToRunDiagnosticsConstants;
+
+public enum PerfMapPseudoRVAToken : uint
+{
+    OutputSignature = 0xFFFFFFFF,
+    FormatVersion = 0xFFFFFFFE,
+    TargetOS = 0xFFFFFFFD,
+    TargetArchitecture = 0xFFFFFFFC,
+    TargetABI = 0xFFFFFFFB,
+}
+
+public enum PerfMapArchitectureToken : uint
+{
+    Unknown = 0,
+    ARM = 1,
+    ARM64 = 2,
+    X64 = 3,
+    X86 = 4,
+}
+
+public enum PerfMapOSToken : uint
+{
+    Unknown = 0,
+    Windows = 1,
+    Linux = 2,
+    OSX = 3,
+    FreeBSD = 4,
+    NetBSD = 5,
+    SunOS = 6,
+}
+
+public enum PerfMapAbiToken : uint
+{
+    Unknown = 0,
+    Default = 1,
+    Armel = 2,
+}

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/CodeGen/ReadyToRunObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/CodeGen/ReadyToRunObjectWriter.cs
@@ -27,7 +27,7 @@ namespace ILCompiler.DependencyAnalysis
     internal class ReadyToRunObjectWriter
     {
         /// <summary>
-        /// Nodefactory for which ObjectWriter is instantiated for. 
+        /// Nodefactory for which ObjectWriter is instantiated for.
         /// </summary>
         private readonly NodeFactory _nodeFactory;
 
@@ -234,6 +234,7 @@ namespace ILCompiler.DependencyAnalysis
                     peIdProvider);
 
                 NativeDebugDirectoryEntryNode nativeDebugDirectoryEntryNode = null;
+                PerfMapDebugDirectoryEntryNode perfMapDebugDirectoryEntryNode = null;
                 ISymbolDefinitionNode firstImportThunk = null;
                 ISymbolDefinitionNode lastImportThunk = null;
                 ObjectNode lastWrittenObjectNode = null;
@@ -259,6 +260,13 @@ namespace ILCompiler.DependencyAnalysis
                         // There should be only one NativeDebugDirectoryEntry.
                         Debug.Assert(nativeDebugDirectoryEntryNode == null);
                         nativeDebugDirectoryEntryNode = nddeNode;
+                    }
+
+                    if (node is PerfMapDebugDirectoryEntryNode pmdeNode)
+                    {
+                        // There should be only one PerfMapDebugDirectoryEntryNode.
+                        Debug.Assert(perfMapDebugDirectoryEntryNode is null);
+                        perfMapDebugDirectoryEntryNode = pmdeNode;
                     }
 
                     if (node is ImportThunk importThunkNode)
@@ -305,12 +313,20 @@ namespace ILCompiler.DependencyAnalysis
                 {
                     r2rPeBuilder.AddSymbolForRange(_nodeFactory.DelayLoadMethodCallThunks, firstImportThunk, lastImportThunk);
                 }
-                
+
 
                 if (_nodeFactory.Win32ResourcesNode != null)
                 {
                     Debug.Assert(_nodeFactory.Win32ResourcesNode.Size != 0);
                     r2rPeBuilder.SetWin32Resources(_nodeFactory.Win32ResourcesNode, _nodeFactory.Win32ResourcesNode.Size);
+                }
+
+                if (_outputInfoBuilder != null)
+                {
+                    foreach (string inputFile in _inputFiles)
+                    {
+                        _outputInfoBuilder.AddInputModule(_nodeFactory.TypeSystemContext.GetModuleFromPath(inputFile));
+                    }
                 }
 
                 using (var peStream = File.Create(_objectFilePath))
@@ -322,26 +338,36 @@ namespace ILCompiler.DependencyAnalysis
                         _mapFileBuilder.SetFileSize(peStream.Length);
                     }
 
-                    // Compute MD5 hash of the output image and store that in the native DebugDirectory entry
-                    using (var md5Hash = MD5.Create())
+                    if (nativeDebugDirectoryEntryNode is not null)
                     {
-                        peStream.Seek(0, SeekOrigin.Begin);
-                        byte[] hash = md5Hash.ComputeHash(peStream);
-                        byte[] rsdsEntry = nativeDebugDirectoryEntryNode.GenerateRSDSEntryData(hash);
+                        Debug.Assert(_generatePdbFile);
+                        // Compute MD5 hash of the output image and store that in the native DebugDirectory entry
+                        using (var md5Hash = MD5.Create())
+                        {
+                            peStream.Seek(0, SeekOrigin.Begin);
+                            byte[] hash = md5Hash.ComputeHash(peStream);
+                            byte[] rsdsEntry = nativeDebugDirectoryEntryNode.GenerateRSDSEntryData(hash);
 
-                        int offsetToUpdate = r2rPeBuilder.GetSymbolFilePosition(nativeDebugDirectoryEntryNode);
+                            int offsetToUpdate = r2rPeBuilder.GetSymbolFilePosition(nativeDebugDirectoryEntryNode);
+                            peStream.Seek(offsetToUpdate, SeekOrigin.Begin);
+                            peStream.Write(rsdsEntry);
+                        }
+                    }
+
+                    if (perfMapDebugDirectoryEntryNode is not null)
+                    {
+                        Debug.Assert(_generatePerfMapFile && _outputInfoBuilder is not null && _outputInfoBuilder.EnumerateInputAssemblies().Any());
+                        byte[] perfmapSig = PerfMapWriter.PerfMapV1SignatureHelper(_outputInfoBuilder.EnumerateInputAssemblies(), _nodeFactory.Target);
+                        byte[] perfMapEntry = perfMapDebugDirectoryEntryNode.GeneratePerfMapEntryData(perfmapSig, _perfMapFormatVersion);
+
+                        int offsetToUpdate = r2rPeBuilder.GetSymbolFilePosition(perfMapDebugDirectoryEntryNode);
                         peStream.Seek(offsetToUpdate, SeekOrigin.Begin);
-                        peStream.Write(rsdsEntry);
+                        peStream.Write(perfMapEntry);
                     }
                 }
 
                 if (_outputInfoBuilder != null)
                 {
-                    foreach (string inputFile in _inputFiles)
-                    {
-                        _outputInfoBuilder.AddInputModule(_nodeFactory.TypeSystemContext.GetModuleFromPath(inputFile));
-                    }
-
                     r2rPeBuilder.AddSections(_outputInfoBuilder);
 
                     if (_generateMapFile)
@@ -374,7 +400,7 @@ namespace ILCompiler.DependencyAnalysis
                         {
                             path = Path.GetDirectoryName(_objectFilePath);
                         }
-                        _symbolFileBuilder.SavePerfMap(path, _perfMapFormatVersion, _objectFilePath, _nodeFactory.Target.OperatingSystem, _nodeFactory.Target.Architecture);
+                        _symbolFileBuilder.SavePerfMap(path, _perfMapFormatVersion, _objectFilePath, _nodeFactory.Target);
                     }
 
                     if (_profileFileBuilder != null)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DebugDirectoryNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DebugDirectoryNode.cs
@@ -1,13 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Reflection.PortableExecutable;
 using Internal.Text;
+using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 
 namespace ILCompiler.DependencyAnalysis.ReadyToRun
@@ -26,9 +27,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         private EcmaModule _module;
         private NativeDebugDirectoryEntryNode _nativeEntry;
+        private PerfMapDebugDirectoryEntryNode _perfMapEntry;
+
         private bool _insertDeterministicEntry;
 
-        public DebugDirectoryNode(EcmaModule sourceModule, string outputFileName)
+        public DebugDirectoryNode(EcmaModule sourceModule, string outputFileName, bool shouldAddNiPdb, bool shouldGeneratePerfmap)
         {
             _module = sourceModule;
             _insertDeterministicEntry = sourceModule == null; // Mark module as deterministic if generating composite image
@@ -37,7 +40,16 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 pdbNameRoot = sourceModule.Assembly.GetName().Name;
             }
-            _nativeEntry = new NativeDebugDirectoryEntryNode(pdbNameRoot + ".ni.pdb");
+
+            if (shouldAddNiPdb)
+            {
+                _nativeEntry = new NativeDebugDirectoryEntryNode(pdbNameRoot + ".ni.pdb");
+            }
+
+            if (shouldGeneratePerfmap)
+            {
+                _perfMapEntry = new PerfMapDebugDirectoryEntryNode(pdbNameRoot + ".ni.r2rmap");
+            }
         }
 
         public override ObjectNodeSection Section => ObjectNodeSection.TextSection;
@@ -52,7 +64,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public int Offset => 0;
 
-        public int Size => (GetNumDebugDirectoryEntriesInModule() + 1 + (_insertDeterministicEntry ? 1 : 0)) * ImageDebugDirectorySize;
+        public int Size => (GetNumDebugDirectoryEntriesInModule()
+            + (_nativeEntry is not null ? 1 : 0)
+            + (_perfMapEntry is not null ? 1 : 0)
+            + (_insertDeterministicEntry ? 1 : 0)) * ImageDebugDirectorySize;
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
@@ -83,32 +98,43 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             builder.RequireInitialPointerAlignment();
             builder.AddSymbol(this);
 
-            ImmutableArray<DebugDirectoryEntry> entries = default(ImmutableArray<DebugDirectoryEntry>);
+            ImmutableArray<DebugDirectoryEntry> entries = ImmutableArray<DebugDirectoryEntry>.Empty;
             if (_module != null)
                 entries = _module.PEReader.ReadDebugDirectory();
 
             int numEntries = GetNumDebugDirectoryEntriesInModule();
 
+            // Reuse the module's PDB entry
+            DebugDirectoryEntry pdbEntry = entries.Where(s => s.Type == DebugDirectoryEntryType.CodeView).FirstOrDefault();
+
             // First, write the native debug directory entry
+            if (_nativeEntry is not null)
             {
                 var entry = _nativeEntry;
 
                 builder.EmitUInt(0 /* Characteristics */);
-                if (numEntries > 0)
-                {
-                    builder.EmitUInt(entries[0].Stamp);
-                    builder.EmitUShort(entries[0].MajorVersion);
-                }
-                else
-                {
-                    builder.EmitUInt(0);
-                    builder.EmitUShort(0);
-                }
+                builder.EmitUInt(pdbEntry.Stamp);
+                builder.EmitUShort(pdbEntry.MajorVersion);
                 // Make sure the "is portable pdb" indicator (MinorVersion == 0x504d) is clear
                 // for the NGen debug directory entry since this debug directory can be copied
                 // from an existing entry which could be a portable pdb.
                 builder.EmitUShort(0 /* MinorVersion */);
                 builder.EmitInt((int)DebugDirectoryEntryType.CodeView);
+                builder.EmitInt(entry.Size);
+                builder.EmitReloc(entry, RelocType.IMAGE_REL_BASED_ADDR32NB);
+                builder.EmitReloc(entry, RelocType.IMAGE_REL_FILE_ABSOLUTE);
+            }
+
+            // Second emit a record for the perfmap
+            if (_perfMapEntry is not null)
+            {
+                var entry = _perfMapEntry;
+
+                builder.EmitUInt(0);        /* Characteristics */
+                builder.EmitUInt(0);        /* Stamp */
+                builder.EmitUShort(1);      /* Major */
+                builder.EmitUShort(0);      /* Minor */
+                builder.EmitInt((int)PerfMapDebugDirectoryEntryNode.PerfMapEntryType);
                 builder.EmitInt(entry.Size);
                 builder.EmitReloc(entry, RelocType.IMAGE_REL_BASED_ADDR32NB);
                 builder.EmitReloc(entry, RelocType.IMAGE_REL_FILE_ABSOLUTE);

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -236,7 +236,7 @@ namespace ILCompiler
         private readonly IEnumerable<string> _inputFiles;
 
         private readonly string _compositeRootPath;
-        
+
         private readonly bool _resilient;
 
         private readonly int _parallelism;
@@ -400,7 +400,9 @@ namespace ILCompiler
             }
 
             CopiedCorHeaderNode copiedCorHeader = new CopiedCorHeaderNode(inputModule);
-            DebugDirectoryNode debugDirectory = new DebugDirectoryNode(inputModule, outputFile);
+            // Re-written components shouldn't have any additional diagnostic information - only information about the forwards.
+            // Even with all of this, we might be modifying the image in a silly manner - adding a directory when if didn't have one.
+            DebugDirectoryNode debugDirectory = new DebugDirectoryNode(inputModule, outputFile, shouldAddNiPdb: false, shouldGeneratePerfmap: false);
             NodeFactory componentFactory = new NodeFactory(
                 _nodeFactory.TypeSystemContext,
                 _nodeFactory.CompilationModuleGroup,
@@ -490,7 +492,7 @@ namespace ILCompiler
                 var fieldType = field.FieldType;
                 if (!fieldType.IsValueType)
                     continue;
-                
+
                 if (!IsLayoutFixedInCurrentVersionBubble(fieldType))
                 {
                     return false;
@@ -515,7 +517,7 @@ namespace ILCompiler
             {
                 return false;
             }
-            
+
             type = type.BaseType;
 
             if (type != null)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -219,7 +219,7 @@ namespace ILCompiler
             EcmaModule singleModule = _compilationGroup.IsCompositeBuildMode ? null : inputModules.First();
             CopiedCorHeaderNode corHeaderNode = new CopiedCorHeaderNode(singleModule);
             // TODO: proper support for multiple input files
-            DebugDirectoryNode debugDirectoryNode = new DebugDirectoryNode(singleModule, _outputFile);
+            DebugDirectoryNode debugDirectoryNode = new DebugDirectoryNode(singleModule, _outputFile, _generatePdbFile, _generatePerfMapFile);
 
             // Produce a ResourceData where the IBC PROFILE_DATA entry has been filtered out
             // TODO: proper support for multiple input files

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/SymbolFileBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/SymbolFileBuilder.cs
@@ -29,7 +29,7 @@ namespace ILCompiler.PEWriter
             new PdbWriter(pdbPath, PDBExtraData.None).WritePDBData(dllFileName, _outputInfoBuilder.EnumerateMethods());
         }
 
-        public void SavePerfMap(string perfMapPath, int perfMapFormatVersion, string dllFileName, TargetOS targetOS, TargetArchitecture targetArch)
+        public void SavePerfMap(string perfMapPath, int perfMapFormatVersion, string dllFileName, TargetDetails details)
         {
             string perfMapExtension;
             if (perfMapFormatVersion == PerfMapWriter.LegacyCrossgen1FormatVersion)
@@ -56,7 +56,7 @@ namespace ILCompiler.PEWriter
 
             string perfMapFileName = Path.Combine(perfMapPath, Path.GetFileNameWithoutExtension(dllFileName) + perfMapExtension);
             Console.WriteLine("Emitting PerfMap file: {0}", perfMapFileName);
-            PerfMapWriter.Write(perfMapFileName, perfMapFormatVersion, _outputInfoBuilder.EnumerateMethods(), _outputInfoBuilder.EnumerateInputAssemblies(), targetOS, targetArch);
+            PerfMapWriter.Write(perfMapFileName, perfMapFormatVersion, _outputInfoBuilder.EnumerateMethods(), _outputInfoBuilder.EnumerateInputAssemblies(), details);
         }
     }
 }

--- a/src/coreclr/tools/r2rdump/R2RDump.cs
+++ b/src/coreclr/tools/r2rdump/R2RDump.cs
@@ -146,7 +146,7 @@ namespace R2RDump
 
             return new StandaloneAssemblyMetadata(peReader);
         }
-        
+
         public SignatureFormattingOptions GetSignatureFormattingOptions()
         {
             if (signatureFormattingOptions == null)
@@ -434,7 +434,9 @@ namespace R2RDump
                     {
                         perfmapPath = Path.ChangeExtension(r2r.Filename, ".r2rmap");
                     }
-                    PerfMapWriter.Write(perfmapPath, _options.PerfmapFormatVersion, ProduceDebugInfoMethods(r2r), ProduceDebugInfoAssemblies(r2r), r2r.TargetOperatingSystem, r2r.TargetArchitecture);
+                    // TODO: can't seem to find any place that surfaces the ABI. This is for debugging purposes, so may not be as relevant to be correct.
+                    TargetDetails details = new TargetDetails(r2r.TargetArchitecture, r2r.TargetOperatingSystem, TargetAbi.CoreRT);
+                    PerfMapWriter.Write(perfmapPath, _options.PerfmapFormatVersion, ProduceDebugInfoMethods(r2r), ProduceDebugInfoAssemblies(r2r), details);
                 }
 
                 if (standardDump)
@@ -459,7 +461,7 @@ namespace R2RDump
                 mi.AssemblyName = method.ComponentReader.MetadataReader.GetString(method.ComponentReader.MetadataReader.GetAssemblyDefinition().Name);
                 mi.ColdRVA = 0;
                 mi.ColdLength = 0;
-                
+
                 yield return mi;
             }
         }


### PR DESCRIPTION
This is used to correlate PE's with their corresponding PerfMaps. For example the header in the perfmap could be:
```
FFFFFFFF 00 026D4D21B3EE3D93843FF7A964235822
FFFFFFFE 00 1
FFFFFFFD 00 1
FFFFFFFC 00 3
FFFFFFFB 00 1
```
And the PE will have the corresponding entries in the PE as:
```
PerfMap (Type 21):
        System.Private.CoreLib.ni.r2rmap, Signature = 026d4d21b3ee3d93843ff7a964235822, Version = 1
```

Port of #58552 without unnecessary changes.