### PR TITLE
Fix an issue with ILStripping mscorlib.dll

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -122,9 +122,9 @@
       <Uri>https://github.com/dotnet/runtime-assets</Uri>
       <Sha>d6c7cf7d70f2f6a61c22c494aedb9c18de85ad53</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CilStrip.Sources" Version="7.0.0-beta.21457.4">
+    <Dependency Name="Microsoft.DotNet.CilStrip.Sources" Version="7.0.0-beta.21460.3">
       <Uri>https://github.com/dotnet/runtime-assets</Uri>
-      <Sha>1d113f16de55a39b39a3389f09c243cb6c44199b</Sha>
+      <Sha>0277a4eccfdc81728f8b750d75ed5110eb0289a0</Sha>
     </Dependency>
     <Dependency Name="runtime.linux-arm64.Microsoft.NETCore.Runtime.Mono.LLVM.Sdk" Version="11.1.0-alpha.1.21430.1">
       <Uri>https://github.com/dotnet/llvm-project</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -124,7 +124,7 @@
     <SystemRuntimeTimeZoneDataVersion>7.0.0-beta.21430.2</SystemRuntimeTimeZoneDataVersion>
     <SystemSecurityCryptographyX509CertificatesTestDataVersion>7.0.0-beta.21430.2</SystemSecurityCryptographyX509CertificatesTestDataVersion>
     <SystemWindowsExtensionsTestDataVersion>7.0.0-beta.21430.2</SystemWindowsExtensionsTestDataVersion>
-    <MicrosoftDotNetCilStripSourcesVersion>7.0.0-beta.21457.4</MicrosoftDotNetCilStripSourcesVersion>
+    <MicrosoftDotNetCilStripSourcesVersion>7.0.0-beta.21460.3</MicrosoftDotNetCilStripSourcesVersion>
     <!-- dotnet-optimization dependencies -->
     <optimizationwindows_ntx64MIBCRuntimeVersion>1.0.0-prerelease.21455.2</optimizationwindows_ntx64MIBCRuntimeVersion>
     <optimizationwindows_ntx86MIBCRuntimeVersion>1.0.0-prerelease.21455.2</optimizationwindows_ntx86MIBCRuntimeVersion>


### PR DESCRIPTION
We considered mscorlib.dll as the "core" assembly instead of System.Private.CoreLib.dll which meant Cecil hit an issue while resolving types in it.
This only happened when the IL Linker was not being used since it'd have removed the mscorlib.dll facade.

Brings in https://github.com/dotnet/runtime-assets/pull/176