### PR TITLE
[release/6.0] Fix an issue with ILStripping mscorlib.dll

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -122,9 +122,9 @@
       <Uri>https://github.com/dotnet/runtime-assets</Uri>
       <Sha>16f58bb2e869e434a13a91bab36f2517c276bf3e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CilStrip.Sources" Version="6.0.0-beta.21457.5">
+    <Dependency Name="Microsoft.DotNet.CilStrip.Sources" Version="6.0.0-beta.21460.2">
       <Uri>https://github.com/dotnet/runtime-assets</Uri>
-      <Sha>16f58bb2e869e434a13a91bab36f2517c276bf3e</Sha>
+      <Sha>5257fe7bc29cbe5055dc264be48bd566ba4894dc</Sha>
     </Dependency>
     <Dependency Name="runtime.linux-arm64.Microsoft.NETCore.Runtime.Mono.LLVM.Sdk" Version="11.1.0-alpha.1.21416.1">
       <Uri>https://github.com/dotnet/llvm-project</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -124,7 +124,7 @@
     <SystemRuntimeTimeZoneDataVersion>6.0.0-beta.21457.5</SystemRuntimeTimeZoneDataVersion>
     <SystemSecurityCryptographyX509CertificatesTestDataVersion>6.0.0-beta.21457.5</SystemSecurityCryptographyX509CertificatesTestDataVersion>
     <SystemWindowsExtensionsTestDataVersion>6.0.0-beta.21457.5</SystemWindowsExtensionsTestDataVersion>
-    <MicrosoftDotNetCilStripSourcesVersion>6.0.0-beta.21457.5</MicrosoftDotNetCilStripSourcesVersion>
+    <MicrosoftDotNetCilStripSourcesVersion>6.0.0-beta.21460.2</MicrosoftDotNetCilStripSourcesVersion>
     <!-- dotnet-optimization dependencies -->
     <optimizationwindows_ntx64MIBCRuntimeVersion>1.0.0-prerelease.21416.5</optimizationwindows_ntx64MIBCRuntimeVersion>
     <optimizationwindows_ntx86MIBCRuntimeVersion>1.0.0-prerelease.21416.5</optimizationwindows_ntx86MIBCRuntimeVersion>


### PR DESCRIPTION
We considered mscorlib.dll as the "core" assembly instead of System.Private.CoreLib.dll which meant Cecil hit an issue while resolving types in it.
This only happened when the IL Linker was not being used since it'd have removed the mscorlib.dll facade.

Brings in https://github.com/dotnet/runtime-assets/pull/176