### PR TITLE
Fix unloadability issue in AppDomain::FindAssembly 

### DIFF
--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -3251,8 +3251,8 @@ DomainAssembly * AppDomain::FindAssembly(PEAssembly * pFile, FindAssemblyOptions
             !pManifestFile->IsResource() &&
             pManifestFile->Equals(pFile))
         {
-            // Caller already has PEAssembly, so we can give DomainAssembly away freely without AddRef
-            return pDomainAssembly.Extract();
+            // Caller already has PEAssembly, so we can give DomainAssembly away freely without added reference
+            return pDomainAssembly.GetValue();
         }
     }
     return NULL;


### PR DESCRIPTION
There is a bug in AppDomain::FindAssembly code path that iterates over
the domain assemblies. The iteration loop leaves the refcount of the
LoaderAllocator related to the returned DomainAssembly bumped, but
nothing ever decrements it. So when a code that needs to be unloaded
ends up in that code path, all the managed things like managed
LoaderAllocator, LoaderAllocatorScout are destroyed, but the unloading
doesn't complete due to the refcount.

We have never found it before as this code path is never executed in any
of the coreclr tests even with unloadability testing option.

The problem was reported yesterday by @StephenMolloy who has found
it when working on making Xml serializer behave with unloadability.