### PR TITLE
Use live-built corehost on s390x for creating testhost

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -218,6 +218,10 @@
     <MicrosoftNetCoreAppRuntimePackNativeDir>$([MSBuild]::NormalizeDirectory('$(MicrosoftNetCoreAppRuntimePackRidDir)', 'native'))</MicrosoftNetCoreAppRuntimePackNativeDir>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <DotNetHostBinDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', '$(OutputRid).$(Configuration)', 'corehost'))</DotNetHostBinDir>
+  </PropertyGroup>
+
   <!--Feature switches -->
   <PropertyGroup>
     <EnableNgenOptimization Condition="'$(EnableNgenOptimization)' == '' and ('$(Configuration)' == 'Release' or '$(Configuration)' == 'Checked')">true</EnableNgenOptimization>

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -120,7 +120,14 @@
     <SubsetName Include="Mono.WasmRuntime" Description="The WebAssembly runtime." />
     <SubsetName Include="Mono.MsCorDbi" Description="The implementation of ICorDebug interface." />
     <SubsetName Include="Mono.Workloads" OnDemand="true" Description="Builds the installers and the insertion metadata for Blazor workloads." />
-    
+
+    <!-- Host -->
+    <SubsetName Include="Host" Description="The .NET hosts, packages, hosting libraries, and tests." />
+    <SubsetName Include="Host.Native" Description="The .NET hosts." />
+    <SubsetName Include="Host.Pkg" Description="The .NET host packages." />
+    <SubsetName Include="Host.Tools" Description="The .NET hosting libraries." />
+    <SubsetName Include="Host.Tests" Description="The .NET hosting tests." />
+
     <!-- Libs -->
     <SubsetName Include="Libs" Description="The libraries native part, refs and source assemblies, test infra and packages, but NOT the tests (use Libs.Tests to request those explicitly)" />
     <SubsetName Include="Libs.Native" Description="The native libraries used in the shared framework." />
@@ -129,13 +136,6 @@
     <SubsetName Include="Libs.PreTest" Description="Test assets which are necessary to run tests." />
     <SubsetName Include="Libs.Packages" Description="The projects that produce NuGet packages from libraries." />
     <SubsetName Include="Libs.Tests" OnDemand="true" Description="The test projects. Note that building this doesn't execute tests: you must also pass the '-test' argument." />
-
-    <!-- Host -->
-    <SubsetName Include="Host" Description="The .NET hosts, packages, hosting libraries, and tests." />
-    <SubsetName Include="Host.Native" Description="The .NET hosts." />
-    <SubsetName Include="Host.Pkg" Description="The .NET host packages." />
-    <SubsetName Include="Host.Tools" Description="The .NET hosting libraries." />
-    <SubsetName Include="Host.Tests" Description="The .NET hosting tests." />
 
     <!-- Packs -->
     <SubsetName Include="Packs" Description="Builds the shared framework packs, archives, bundles, installers, and the framework pack tests." />
@@ -264,31 +264,6 @@
     <ProjectToBuild Include="$(WorkloadsProjectRoot)\workloads.csproj" Category="mono" />
   </ItemGroup>
 
-  <!-- Libraries sets -->
-  <ItemGroup Condition="$(_subset.Contains('+libs.native+'))">
-    <ProjectToBuild Include="$(LibrariesProjectRoot)Native\build-native.proj" Category="libs" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(_subset.Contains('+libs.ref+'))">
-    <ProjectToBuild Include="$(LibrariesProjectRoot)ref.proj" Category="libs" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(_subset.Contains('+libs.src+'))">
-    <ProjectToBuild Include="$(LibrariesProjectRoot)src.proj" Category="libs" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(_subset.Contains('+mono.wasmruntime+'))">
-    <ProjectToBuild Include="$(MonoProjectRoot)wasm\wasm.proj" Category="mono" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(_subset.Contains('+libs.pretest+'))">
-    <ProjectToBuild Include="$(LibrariesProjectRoot)pretest.proj" Category="libs"  />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(_subset.Contains('+libs.tests+'))">
-    <ProjectToBuild Include="$(LibrariesProjectRoot)tests.proj" Category="libs" Test="true" />
-  </ItemGroup>
-
   <!-- Host sets -->
   <ItemGroup Condition="$(_subset.Contains('+host.native+'))">
     <CorehostProjectToBuild Include="$(SharedNativeRoot)corehost\corehost.proj" SignPhase="Binaries" BuildInParallel="false" />
@@ -312,6 +287,31 @@
     <TestProjectToBuild Include="$(InstallerProjectRoot)tests\Microsoft.NET.HostModel.Tests\Microsoft.NET.HostModel.ComHost.Tests\Microsoft.NET.HostModel.ComHost.Tests.csproj" />
     <TestProjectToBuild Include="$(InstallerProjectRoot)tests\HostActivation.Tests\HostActivation.Tests.csproj" />
     <ProjectToBuild Include="@(TestProjectToBuild)" BuildInParallel="true" Test="true" Category="host" />
+  </ItemGroup>
+
+  <!-- Libraries sets -->
+  <ItemGroup Condition="$(_subset.Contains('+libs.native+'))">
+    <ProjectToBuild Include="$(LibrariesProjectRoot)Native\build-native.proj" Category="libs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(_subset.Contains('+libs.ref+'))">
+    <ProjectToBuild Include="$(LibrariesProjectRoot)ref.proj" Category="libs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(_subset.Contains('+libs.src+'))">
+    <ProjectToBuild Include="$(LibrariesProjectRoot)src.proj" Category="libs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(_subset.Contains('+mono.wasmruntime+'))">
+    <ProjectToBuild Include="$(MonoProjectRoot)wasm\wasm.proj" Category="mono" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(_subset.Contains('+libs.pretest+'))">
+    <ProjectToBuild Include="$(LibrariesProjectRoot)pretest.proj" Category="libs"  />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(_subset.Contains('+libs.tests+'))">
+    <ProjectToBuild Include="$(LibrariesProjectRoot)tests.proj" Category="libs" Test="true" />
   </ItemGroup>
 
   <!-- Packs sets -->

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -280,15 +280,6 @@
     <ProjectToBuild Include="@(PkgprojProjectToBuild)" Pack="true" Category="host" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(_subset.Contains('+host.tests+'))">
-    <TestProjectToBuild Include="$(InstallerProjectRoot)tests\Microsoft.NET.HostModel.Tests\AppHost.Bundle.Tests\AppHost.Bundle.Tests.csproj" />
-    <TestProjectToBuild Include="$(InstallerProjectRoot)tests\Microsoft.NET.HostModel.Tests\Microsoft.NET.HostModel.AppHost.Tests\Microsoft.NET.HostModel.AppHost.Tests.csproj" />
-    <TestProjectToBuild Include="$(InstallerProjectRoot)tests\Microsoft.NET.HostModel.Tests\Microsoft.NET.HostModel.Bundle.Tests\Microsoft.NET.HostModel.Bundle.Tests.csproj" />
-    <TestProjectToBuild Include="$(InstallerProjectRoot)tests\Microsoft.NET.HostModel.Tests\Microsoft.NET.HostModel.ComHost.Tests\Microsoft.NET.HostModel.ComHost.Tests.csproj" />
-    <TestProjectToBuild Include="$(InstallerProjectRoot)tests\HostActivation.Tests\HostActivation.Tests.csproj" />
-    <ProjectToBuild Include="@(TestProjectToBuild)" BuildInParallel="true" Test="true" Category="host" />
-  </ItemGroup>
-
   <!-- Libraries sets -->
   <ItemGroup Condition="$(_subset.Contains('+libs.native+'))">
     <ProjectToBuild Include="$(LibrariesProjectRoot)Native\build-native.proj" Category="libs" />
@@ -312,6 +303,16 @@
 
   <ItemGroup Condition="$(_subset.Contains('+libs.tests+'))">
     <ProjectToBuild Include="$(LibrariesProjectRoot)tests.proj" Category="libs" Test="true" />
+  </ItemGroup>
+
+  <!-- Host.tests subset (consumes live built libraries assets so needs to come after libraries) -->
+  <ItemGroup Condition="$(_subset.Contains('+host.tests+'))">
+    <TestProjectToBuild Include="$(InstallerProjectRoot)tests\Microsoft.NET.HostModel.Tests\AppHost.Bundle.Tests\AppHost.Bundle.Tests.csproj" />
+    <TestProjectToBuild Include="$(InstallerProjectRoot)tests\Microsoft.NET.HostModel.Tests\Microsoft.NET.HostModel.AppHost.Tests\Microsoft.NET.HostModel.AppHost.Tests.csproj" />
+    <TestProjectToBuild Include="$(InstallerProjectRoot)tests\Microsoft.NET.HostModel.Tests\Microsoft.NET.HostModel.Bundle.Tests\Microsoft.NET.HostModel.Bundle.Tests.csproj" />
+    <TestProjectToBuild Include="$(InstallerProjectRoot)tests\Microsoft.NET.HostModel.Tests\Microsoft.NET.HostModel.ComHost.Tests\Microsoft.NET.HostModel.ComHost.Tests.csproj" />
+    <TestProjectToBuild Include="$(InstallerProjectRoot)tests\HostActivation.Tests\HostActivation.Tests.csproj" />
+    <ProjectToBuild Include="@(TestProjectToBuild)" BuildInParallel="true" Test="true" Category="host" />
   </ItemGroup>
 
   <!-- Packs sets -->

--- a/src/installer/pkg/Directory.Build.props
+++ b/src/installer/pkg/Directory.Build.props
@@ -3,7 +3,6 @@
 
   <PropertyGroup>
     <Platform>$(TargetArchitecture)</Platform>
-    <DotNetHostBinDir>$(ArtifactsBinDir)$(OutputRid).$(Configuration)\corehost</DotNetHostBinDir>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/libraries/externals.csproj
+++ b/src/libraries/externals.csproj
@@ -9,6 +9,7 @@
     <BinPlaceNative>true</BinPlaceNative>
     <BinPlaceRuntime>false</BinPlaceRuntime>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <UseLiveBuiltDotNetHost Condition="'$(TargetArchitecture)' == 's390x'">true</UseLiveBuiltDotNetHost>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
@@ -16,7 +17,7 @@
                       Version="$(MicrosoftDiaSymReaderNativeVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetsMobile)' != 'true'">
+  <ItemGroup Condition="'$(TargetsMobile)' != 'true' and '$(UseLiveBuiltDotNetHost)' != 'true'">
     <PackageReference Include="Microsoft.NETCore.DotNetHost"
                       Version="$(MicrosoftNETCoreDotNetHostVersion)" />
     <PackageReference Include="Microsoft.NETCore.DotNetHostPolicy"
@@ -38,14 +39,28 @@
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'%(Filename)' == 'apphost'" />
     </ItemGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(UseLiveBuiltDotNetHost)' != 'true'">
       <HostFxFile Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'hostfxr' or
                                                                   '%(ReferenceCopyLocalPaths.Filename)' == 'libhostfxr'" />
       <DotnetExe Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'dotnet'" />
     </ItemGroup>
 
+    <ItemGroup Condition="'$(UseLiveBuiltDotNetHost)' == 'true'">
+      <CoreHostFiles Include="$(DotNetHostBinDir)*" />
+      <HostFxFile Include="@(CoreHostFiles)" Condition="'%(CoreHostFiles.Filename)' == 'hostfxr' or
+                                                          '%(CoreHostFiles.Filename)' == 'libhostfxr'" />
+      <HostPolicyFile Include="@(CoreHostFiles)" Condition="'%(CoreHostFiles.Filename)' == 'hostpolicy' or
+                                                              '%(CoreHostFiles.Filename)' == 'libhostpolicy'" />
+      <DotnetExe Include="@(CoreHostFiles)" Condition="'%(CoreHostFiles.Filename)' == 'dotnet'" />
+    </ItemGroup>
+
     <Copy SourceFiles="@(HostFxFile)"
           DestinationFolder="$(NetCoreAppCurrentTestHostPath)host\fxr\$(ProductVersion)"
+          SkipUnchangedFiles="true"
+          UseHardlinksIfPossible="$(UseHardlink)" />
+
+    <Copy SourceFiles="@(HostPolicyFile)"
+          DestinationFolder="$(NetCoreAppCurrentTestHostPath)shared\Microsoft.NETCore.App\$(ProductVersion)"
           SkipUnchangedFiles="true"
           UseHardlinksIfPossible="$(UseHardlink)" />
 


### PR DESCRIPTION
This allows consuming the dotnet host that was just built instead of relying on a downloaded one (which doesn't exist for s390x).
We need to move the `host` subset build before the `libs` subset so that the artifacts are available before externals.csproj runs.