### PR TITLE
Create a parent CMake project for building app bundles on CI

### DIFF
--- a/eng/testing/AppleRunnerTemplate.sh
+++ b/eng/testing/AppleRunnerTemplate.sh
@@ -35,6 +35,8 @@ if [[ "$TARGET" == "ios-device" ]]; then SCHEME_SDK=Release-iphoneos; fi
 if [[ "$TARGET" == "tvos-device" ]]; then SCHEME_SDK=Release-appletvos; fi
 if [[ "$TARGET" == "maccatalyst" ]]; then SCHEME_SDK=Release-maccatalyst; fi
 
+if [[ "$TARGET" == "ios-device" || "$TARGET" == "tvos-device" ]]; then SIGNAL_APP_END="--signal-app-end"; fi
+
 cd $EXECUTION_DIR
 
 # it doesn't support parallel execution yet, so, here is a hand-made semaphore:
@@ -62,6 +64,7 @@ $HARNESS_RUNNER apple $XHARNESS_CMD    \
     --targets="$TARGET" \
     --xcode="$XCODE_PATH"   \
     --output-directory="$XHARNESS_OUT" \
+    $SIGNAL_APP_END \
     $ADDITIONAL_ARGS
 
 _exitCode=$?

--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -2,7 +2,8 @@
   <PropertyGroup>
     <!-- OutDir is not set early enough to set this property in .props file. -->
     <BundleDir>$([MSBuild]::NormalizeDirectory('$(OutDir)', 'AppBundle'))</BundleDir>
-    <PublishDir Condition="'$(UseAppBundleRootForBuildingTests)' == 'true' and '$(IgnoreForCI)' != 'true'">$(AppBundleRoot)$(AssemblyName)</PublishDir>
+    <PublishDir Condition="'$(UseAppBundleRootForBuildingTests)' == 'true' and '$(IgnoreForCI)' != 'true' and '$(IsFunctionalTest)' != 'true'">$(AppBundleRoot)tests\$(AssemblyName)</PublishDir>
+    <PublishDir Condition="'$(UseAppBundleRootForBuildingTests)' == 'true' and '$(IgnoreForCI)' != 'true' and '$(IsFunctionalTest)' == 'true'">$(AppBundleRoot)runonly\$(AssemblyName)</PublishDir>
     <BundleDir Condition="'$(UseAppBundleRootForBuildingTests)' == 'true' and '$(IgnoreForCI)' != 'true'">$([MSBuild]::NormalizeDirectory('$(PublishDir)', 'AppBundle'))</BundleDir>
     <RunScriptOutputPath>$([MSBuild]::NormalizePath('$(BundleDir)', '$(RunScriptOutputName)'))</RunScriptOutputPath>
     <RunAOTCompilation Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS'">true</RunAOTCompilation>

--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <!-- OutDir is not set early enough to set this property in .props file. -->
     <BundleDir>$([MSBuild]::NormalizeDirectory('$(OutDir)', 'AppBundle'))</BundleDir>
+    <PublishDir Condition="'$(UseAppBundleRootForBuildingTests)' == 'true' and '$(IgnoreForCI)' != 'true'">$(AppBundleRoot)$(AssemblyName)</PublishDir>
+    <BundleDir Condition="'$(UseAppBundleRootForBuildingTests)' == 'true' and '$(IgnoreForCI)' != 'true'">$([MSBuild]::NormalizeDirectory('$(PublishDir)', 'AppBundle'))</BundleDir>
     <RunScriptOutputPath>$([MSBuild]::NormalizePath('$(BundleDir)', '$(RunScriptOutputName)'))</RunScriptOutputPath>
     <RunAOTCompilation Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS'">true</RunAOTCompilation>
 
@@ -159,6 +161,10 @@
       <Optimized>true</Optimized>
       <MainLibraryFileName Condition="'$(MainLibraryFileName)' == ''">AppleTestRunner.dll</MainLibraryFileName>
       <_MobileIntermediateOutputPath Condition="'$(RunAOTCompilation)' == 'true'">$(IntermediateOutputPath)mobile</_MobileIntermediateOutputPath>
+      <GenerateXcodeProject>true</GenerateXcodeProject>
+      <GenerateCMakeProject>false</GenerateCMakeProject>
+      <GenerateXcodeProject Condition="'$(UseAppBundleRootForBuildingTests)' == 'true'">false</GenerateXcodeProject>
+      <GenerateCMakeProject Condition="'$(UseAppBundleRootForBuildingTests)' == 'true' and '$(IgnoreForCI)' != 'true'">true</GenerateCMakeProject>
     </PropertyGroup>
     <PropertyGroup>
       <AOTMode Condition="'$(TargetOS)' != 'MacCatalyst'">Full</AOTMode>
@@ -217,8 +223,9 @@
         ForceInterpreter="$(MonoForceInterpreter)"
         InvariantGlobalization="$(InvariantGlobalization)"
         UseConsoleUITemplate="True"
-        GenerateXcodeProject="True"
-        BuildAppBundle="True"
+        GenerateXcodeProject="$(GenerateXcodeProject)"
+        GenerateCMakeProject="$(GenerateCMakeProject)"
+        BuildAppBundle="$(GenerateXcodeProject)"
         Optimized="$(Optimized)"
         DevTeamProvisioning="$(DevTeamProvisioning)"
         OutputDirectory="$(BundleDir)"
@@ -226,17 +233,17 @@
         <Output TaskParameter="AppBundlePath" PropertyName="AppBundlePath" />
         <Output TaskParameter="XcodeProjectPath" PropertyName="XcodeProjectPath" />
     </AppleAppBuilderTask>
-    <Message Importance="High" Text="Xcode: $(XcodeProjectPath)"/>
-    <Message Importance="High" Text="App: $(AppBundlePath)"/>
+    <Message Importance="High" Text="Xcode: $(XcodeProjectPath)" Condition="'$(GenerateXcodeProject)' == 'true'" />
+    <Message Importance="High" Text="App: $(AppBundlePath)" Condition="'$(GenerateXcodeProject)' == 'true'"/>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(GenerateXcodeProject)' == 'true'">
       <_appFiles Include="$(AppBundlePath)/../**/*" />
     </ItemGroup>
 
     <Copy SourceFiles="@(_appFiles)"
           DestinationFolder="$(TestArchiveTestsDir)/%(RecursiveDir)"
           SkipUnchangedFiles="true"
-          Condition="'$(ArchiveTests)' == 'true' and '$(IgnoreForCI)' != 'true'" />
+          Condition="'$(ArchiveTests)' == 'true' and '$(IgnoreForCI)' != 'true' and '$(GenerateXcodeProject)' == 'true'" />
 
     <RemoveDir Condition="'$(ArchiveTests)' == 'true' and '$(IgnoreForCI)' != 'true'" 
                Directories="$(OutDir)" />

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -116,6 +116,9 @@
     <TestArchiveTestsDir>$(TestArchiveTestsRoot)$(OSPlatformConfig)/</TestArchiveTestsDir>
     <TestArchiveRuntimeRoot>$(TestArchiveRoot)runtime/</TestArchiveRuntimeRoot>
 
+    <UseAppBundleRootForBuildingTests Condition="'$(ArchiveTests)' == 'true' and ('$(TargetOS)' == 'MacCatalyst' or '$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'iOSSimulator' or '$(TargetOS)' == 'tvOS' or '$(TargetOS)' == 'tvOSSimulator')">true</UseAppBundleRootForBuildingTests>
+    <AppBundleRoot Condition="'$(UseAppBundleRootForBuildingTests)' == 'true'">$(ArtifactsDir)bundles\</AppBundleRoot>
+
     <NetCoreAppCurrentRefPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'ref', '$(NetCoreAppCurrent)'))</NetCoreAppCurrentRefPath>
     <NetCoreAppCurrentRuntimePath>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'runtime', '$(NetCoreAppCurrent)-$(TargetOS)-$(Configuration)-$(TargetArchitecture)'))</NetCoreAppCurrentRuntimePath>
 

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -363,10 +363,12 @@
 
     <ItemGroup>
       <NormalTestAppBundles Include="$(NormalTestsAppBundleRoot)*/AppBundle/CMakeLists.txt" />
+      <NormalTestCMakeEntries Include="cmake_minimum_required(VERSION 3.16)" />
       <NormalTestCMakeEntries Include="project(NormalTestAppBundles)" />
       <NormalTestCMakeEntries Include="add_subdirectory(%(NormalTestAppBundles.RootDir)%(NormalTestAppBundles.Directory) %(NormalTestAppBundles.RecursiveDir) EXCLUDE_FROM_ALL)" />
 
       <FunctionalTestAppBundles Include="$(FunctionalTestsAppBundleRoot)*/AppBundle/CMakeLists.txt" />
+      <FunctionalTestCMakeEntries Include="cmake_minimum_required(VERSION 3.16)" />
       <FunctionalTestCMakeEntries Include="project(FunctionalTestAppBundles)" />
       <FunctionalTestCMakeEntries Include="add_subdirectory(%(FunctionalTestAppBundles.RootDir)%(FunctionalTestAppBundles.Directory) %(FunctionalTestAppBundles.RecursiveDir) EXCLUDE_FROM_ALL)" />
     </ItemGroup>
@@ -378,13 +380,15 @@
         TargetOS="$(TargetOS)"
         Arch="$(TargetArchitecture)"
         ProjectName="NormalTestAppBundles"
-        CMakeListsDirectory="$(NormalTestsAllAppBundlesRoot)" />
+        CMakeListsDirectory="$(NormalTestsAllAppBundlesRoot)"
+        Condition="'@(NormalTestAppBundles)' != ''" />
 
     <XcodeCreateProject
         TargetOS="$(TargetOS)"
         Arch="$(TargetArchitecture)"
         ProjectName="FunctionalTestAppBundles"
-        CMakeListsDirectory="$(FunctionalTestsAllAppBundlesRoot)" />
+        CMakeListsDirectory="$(FunctionalTestsAllAppBundlesRoot)"
+        Condition="'@(FunctionalTestAppBundles)' != ''" />
 
     <MakeDir Directories="$(TestArchiveNormalTestsDir)" />
     <MakeDir Directories="$(TestArchiveFunctionalTestsDir)" />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -332,6 +332,52 @@
           Condition="'$(TestAssemblies)' == 'true' and
                      '$(Coverage)' == 'true'" />
 
+  <!-- Build Apple app bundles using AppBundleRoot -->
+  <UsingTask Condition="'$(UseAppBundleRootForBuildingTests)' == 'true'"
+             TaskName="XcodeCreateProject"
+             AssemblyFile="$(AppleAppBuilderTasksAssemblyPath)" />
+
+  <UsingTask Condition="'$(UseAppBundleRootForBuildingTests)' == 'true'"
+             TaskName="XcodeBuildApp"
+             AssemblyFile="$(AppleAppBuilderTasksAssemblyPath)" />
+
+  <Target Condition="'$(UseAppBundleRootForBuildingTests)' == 'true'"
+          Name="BuildAppleAppBundles"
+          AfterTargets="Build">
+
+    <ItemGroup>
+      <AppBundles Include="$(AppBundleRoot)/*/AppBundle/CMakeLists.txt" />
+      <CMakeEntries Include="project(AllAppBundles)" />
+      <CMakeEntries Include="add_subdirectory(%(AppBundles.RootDir)%(AppBundles.Directory) %(AppBundles.RecursiveDir) EXCLUDE_FROM_ALL)" />
+    </ItemGroup>
+
+    <WriteLinesToFile File="$(AppBundleRoot)/all/CMakeLists.txt" Lines="@(CMakeEntries)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+
+    <XcodeCreateProject
+        TargetOS="$(TargetOS)"
+        Arch="$(TargetArchitecture)"
+        ProjectName="AllAppBundles"
+        CMakeListsDirectory="$(AppBundleRoot)/all" />
+
+    <ItemGroup>
+      <!-- xcodeproj are not files but directories -->
+      <XcodeProjects Include="$([System.IO.Directory]::GetDirectories('$(AppBundleRoot)/all/AllAppBundles/%(AppBundles.RecursiveDir)', '*.xcodeproj'))" />
+    </ItemGroup>
+
+    <MakeDir Directories="$(TestArchiveTestsDir)" />
+
+    <XcodeBuildApp
+        TargetOS="$(TargetOS)"
+        Arch="$(TargetArchitecture)"
+        XcodeProjectPath="%(XcodeProjects.Identity)"
+        DevTeamProvisioning="$(DevTeamProvisioning)"
+        Optimized="True"
+        DestinationFolder="$(TestArchiveTestsDir)" /> <!-- TODO: TestArchiveTestsRoot is different for when IsFunctionalTest==true but this is only set in the context of the .csproj so we need to find another solution here -->
+
+    <RemoveDir Condition="'$(ArchiveTests)' == 'true'"
+               Directories="$(AppBundleRoot)" />
+  </Target>
+
   <!-- Restoring all trimming test projects upfront in one single call to RestoreTrimmingProjects
   so as to avoid possible race conditions that could happen if we restore each individually. -->
   <Target Name="RestoreTrimmingProjects"

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -395,8 +395,8 @@
 
     <ItemGroup>
       <!-- xcodeproj are directories, not files -->
-      <XcodeProjects Include="$([System.IO.Directory]::GetDirectories('$(NormalTestsAllAppBundlesRoot)NormalTestAppBundles/%(NormalTestAppBundles.RecursiveDir)', '*.xcodeproj'))" DestinationFolder="$(TestArchiveNormalTestsDir)" />
-      <XcodeProjects Include="$([System.IO.Directory]::GetDirectories('$(FunctionalTestsAllAppBundlesRoot)FunctionalTestAppBundles/%(FunctionalTestAppBundles.RecursiveDir)', '*.xcodeproj'))" DestinationFolder="$(TestArchiveFunctionalTestsDir)" />
+      <XcodeProjects Condition="'@(NormalTestAppBundles)' != ''" Include="$([System.IO.Directory]::GetDirectories('$(NormalTestsAllAppBundlesRoot)NormalTestAppBundles/%(NormalTestAppBundles.RecursiveDir)', '*.xcodeproj'))" DestinationFolder="$(TestArchiveNormalTestsDir)" />
+      <XcodeProjects Condition="'@(FunctionalTestAppBundles)' != ''" Include="$([System.IO.Directory]::GetDirectories('$(FunctionalTestsAllAppBundlesRoot)FunctionalTestAppBundles/%(FunctionalTestAppBundles.RecursiveDir)', '*.xcodeproj'))" DestinationFolder="$(TestArchiveFunctionalTestsDir)" />
     </ItemGroup>
 
     <XcodeBuildApp

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -345,26 +345,55 @@
           Name="BuildAppleAppBundles"
           AfterTargets="Build">
 
+    <PropertyGroup>
+      <!-- TODO: Unify this with TestArchiveTestsRoot in src/libraries/Directory.Build.props somehow,
+                 we can't use IsFunctionalTest==true here because it is only set in the context of the .csproj -->
+      <TestArchiveNormalTestsRoot>$(TestArchiveRoot)tests/</TestArchiveNormalTestsRoot>
+      <TestArchiveFunctionalTestsRoot>$(TestArchiveRoot)runonly/</TestArchiveFunctionalTestsRoot>
+
+      <TestArchiveNormalTestsDir>$(TestArchiveNormalTestsRoot)$(OSPlatformConfig)/</TestArchiveNormalTestsDir>
+      <TestArchiveFunctionalTestsDir>$(TestArchiveFunctionalTestsRoot)$(OSPlatformConfig)/</TestArchiveFunctionalTestsDir>
+
+      <NormalTestsAppBundleRoot>$(AppBundleRoot)/tests/</NormalTestsAppBundleRoot>
+      <FunctionalTestsAppBundleRoot>$(AppBundleRoot)/runonly/</FunctionalTestsAppBundleRoot>
+
+      <NormalTestsAllAppBundlesRoot>$(AppBundleRoot)/tests.all/</NormalTestsAllAppBundlesRoot>
+      <FunctionalTestsAllAppBundlesRoot>$(AppBundleRoot)/runonly.all/</FunctionalTestsAllAppBundlesRoot>
+    </PropertyGroup>
+
     <ItemGroup>
-      <AppBundles Include="$(AppBundleRoot)/*/AppBundle/CMakeLists.txt" />
-      <CMakeEntries Include="project(AllAppBundles)" />
-      <CMakeEntries Include="add_subdirectory(%(AppBundles.RootDir)%(AppBundles.Directory) %(AppBundles.RecursiveDir) EXCLUDE_FROM_ALL)" />
+      <NormalTestAppBundles Include="$(NormalTestsAppBundleRoot)*/AppBundle/CMakeLists.txt" />
+      <NormalTestCMakeEntries Include="project(NormalTestAppBundles)" />
+      <NormalTestCMakeEntries Include="add_subdirectory(%(NormalTestAppBundles.RootDir)%(NormalTestAppBundles.Directory) %(NormalTestAppBundles.RecursiveDir) EXCLUDE_FROM_ALL)" />
+
+      <FunctionalTestAppBundles Include="$(FunctionalTestsAppBundleRoot)*/AppBundle/CMakeLists.txt" />
+      <FunctionalTestCMakeEntries Include="project(FunctionalTestAppBundles)" />
+      <FunctionalTestCMakeEntries Include="add_subdirectory(%(FunctionalTestAppBundles.RootDir)%(FunctionalTestAppBundles.Directory) %(FunctionalTestAppBundles.RecursiveDir) EXCLUDE_FROM_ALL)" />
     </ItemGroup>
 
-    <WriteLinesToFile File="$(AppBundleRoot)/all/CMakeLists.txt" Lines="@(CMakeEntries)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+    <WriteLinesToFile File="$(NormalTestsAllAppBundlesRoot)CMakeLists.txt" Lines="@(NormalTestCMakeEntries)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+    <WriteLinesToFile File="$(FunctionalTestsAllAppBundlesRoot)CMakeLists.txt" Lines="@(FunctionalTestCMakeEntries)" Overwrite="true" WriteOnlyWhenDifferent="true" />
 
     <XcodeCreateProject
         TargetOS="$(TargetOS)"
         Arch="$(TargetArchitecture)"
-        ProjectName="AllAppBundles"
-        CMakeListsDirectory="$(AppBundleRoot)/all" />
+        ProjectName="NormalTestAppBundles"
+        CMakeListsDirectory="$(NormalTestsAllAppBundlesRoot)" />
+
+    <XcodeCreateProject
+        TargetOS="$(TargetOS)"
+        Arch="$(TargetArchitecture)"
+        ProjectName="FunctionalTestAppBundles"
+        CMakeListsDirectory="$(FunctionalTestsAllAppBundlesRoot)" />
+
+    <MakeDir Directories="$(TestArchiveNormalTestsDir)" />
+    <MakeDir Directories="$(TestArchiveFunctionalTestsDir)" />
 
     <ItemGroup>
-      <!-- xcodeproj are not files but directories -->
-      <XcodeProjects Include="$([System.IO.Directory]::GetDirectories('$(AppBundleRoot)/all/AllAppBundles/%(AppBundles.RecursiveDir)', '*.xcodeproj'))" />
+      <!-- xcodeproj are directories, not files -->
+      <XcodeProjects Include="$([System.IO.Directory]::GetDirectories('$(NormalTestsAllAppBundlesRoot)NormalTestAppBundles/%(NormalTestAppBundles.RecursiveDir)', '*.xcodeproj'))" DestinationFolder="$(TestArchiveNormalTestsDir)" />
+      <XcodeProjects Include="$([System.IO.Directory]::GetDirectories('$(FunctionalTestsAllAppBundlesRoot)FunctionalTestAppBundles/%(FunctionalTestAppBundles.RecursiveDir)', '*.xcodeproj'))" DestinationFolder="$(TestArchiveFunctionalTestsDir)" />
     </ItemGroup>
-
-    <MakeDir Directories="$(TestArchiveTestsDir)" />
 
     <XcodeBuildApp
         TargetOS="$(TargetOS)"
@@ -372,7 +401,7 @@
         XcodeProjectPath="%(XcodeProjects.Identity)"
         DevTeamProvisioning="$(DevTeamProvisioning)"
         Optimized="True"
-        DestinationFolder="$(TestArchiveTestsDir)" /> <!-- TODO: TestArchiveTestsRoot is different for when IsFunctionalTest==true but this is only set in the context of the .csproj so we need to find another solution here -->
+        DestinationFolder="%(XcodeProjects.DestinationFolder)" />
 
     <RemoveDir Condition="'$(ArchiveTests)' == 'true'"
                Directories="$(AppBundleRoot)" />

--- a/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
+++ b/src/tasks/AppleAppBuilder/AppleAppBuilder.cs
@@ -15,7 +15,7 @@ public class AppleAppBuilderTask : Task
     private string targetOS = TargetNames.iOS;
 
     /// <summary>
-    /// The Apple OS we are targeting (iOS or tvOS)
+    /// The Apple OS we are targeting (ios, tvos, iossimulator, tvossimulator)
     /// </summary>
     [Required]
     public string TargetOS
@@ -64,7 +64,7 @@ public class AppleAppBuilderTask : Task
     public ITaskItem[] Assemblies { get; set; } = Array.Empty<ITaskItem>();
 
     /// <summary>
-    /// Target arch, can be "arm64" (device) or "x64" (simulator) at the moment
+    /// Target arch, can be "arm64", "arm" or "x64" at the moment
     /// </summary>
     [Required]
     public string Arch { get; set; } = ""!;
@@ -105,6 +105,11 @@ public class AppleAppBuilderTask : Task
     /// Generate xcode project
     /// </summary>
     public bool GenerateXcodeProject { get; set; }
+
+    /// <summary>
+    /// Generate CMake project
+    /// </summary>
+    public bool GenerateCMakeProject { get; set; }
 
     /// <summary>
     /// Files to be ignored in AppDir
@@ -224,14 +229,12 @@ public class AppleAppBuilderTask : Task
                 throw new ArgumentException("Using DiagnosticPorts require diagnostics_tracing runtime component.");
         }
 
+        var generator = new Xcode(Log, TargetOS, Arch);
+
         if (GenerateXcodeProject)
         {
-            Xcode generator = new Xcode(Log, TargetOS, Arch);
-            generator.EnableRuntimeLogging = EnableRuntimeLogging;
-            generator.DiagnosticPorts = DiagnosticPorts;
-
             XcodeProjectPath = generator.GenerateXCode(ProjectName, MainLibraryFileName, assemblerFiles, assemblerFilesToLink,
-                AppDir, binDir, MonoRuntimeHeaders, !isDevice, UseConsoleUITemplate, ForceAOT, ForceInterpreter, InvariantGlobalization, Optimized, RuntimeComponents, NativeMainSource);
+                AppDir, binDir, MonoRuntimeHeaders, !isDevice, UseConsoleUITemplate, ForceAOT, ForceInterpreter, InvariantGlobalization, Optimized, EnableRuntimeLogging, DiagnosticPorts, RuntimeComponents, NativeMainSource);
 
             if (BuildAppBundle)
             {
@@ -242,9 +245,14 @@ public class AppleAppBuilderTask : Task
                 }
                 else
                 {
-                    AppBundlePath = generator.BuildAppBundle(XcodeProjectPath, Arch, Optimized, DevTeamProvisioning);
+                    AppBundlePath = generator.BuildAppBundle(XcodeProjectPath, Optimized, DevTeamProvisioning);
                 }
             }
+        }
+        else if (GenerateCMakeProject)
+        {
+             generator.GenerateCMake(ProjectName, MainLibraryFileName, assemblerFiles, assemblerFilesToLink,
+                AppDir, binDir, MonoRuntimeHeaders, !isDevice, UseConsoleUITemplate, ForceAOT, ForceInterpreter, InvariantGlobalization, Optimized, EnableRuntimeLogging, DiagnosticPorts, RuntimeComponents, NativeMainSource);
         }
 
         return true;


### PR DESCRIPTION
This allows us to not run the CMake configure step separately for each libraries test suite which speeds up the build.

Helps with https://github.com/dotnet/runtime/issues/58549