### PR TITLE
[mono] Optimize thread state transition

### DIFF
--- a/src/mono/mono/metadata/marshal-ilgen.c
+++ b/src/mono/mono/metadata/marshal-ilgen.c
@@ -1920,12 +1920,11 @@ gc_safe_transition_builder_add_locals (GCSafeTransitionBuilder *builder)
  *
  */
 static void
-gc_safe_transition_builder_emit_enter (GCSafeTransitionBuilder *builder, MonoMethod *method, gboolean aot)
+gc_safe_transition_builder_emit_enter (GCSafeTransitionBuilder *builder, MonoMethod *method, MonoMethodSignature *sig, gboolean aot)
 {
 	// Copy all arguments to local volatile variables so they are saved on the stack
 	// before the GC transition.
 	int i;
-	MonoMethodSignature *sig = method->signature;
 	for (i = 0; i < sig->param_count; i++) {
 		MonoType *t = sig->params [i];
 		if (MONO_TYPE_IS_REFERENCE (t)) {
@@ -2124,7 +2123,7 @@ emit_native_wrapper_ilgen (MonoImage *image, MonoMethodBuilder *mb, MonoMethodSi
 
 	// In coop mode need to register blocking state during native call
 	if (need_gc_safe)
-		gc_safe_transition_builder_emit_enter (&gc_safe_transition_builder, &piinfo->method, aot);
+		gc_safe_transition_builder_emit_enter (&gc_safe_transition_builder, &piinfo->method, sig, aot);
 
 	/* push all arguments */
 
@@ -6725,7 +6724,7 @@ emit_native_icall_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 	}
 
 	if (need_gc_safe)
-		gc_safe_transition_builder_emit_enter (&gc_safe_transition_builder, &piinfo->method, aot);
+		gc_safe_transition_builder_emit_enter (&gc_safe_transition_builder, &piinfo->method, csig, aot);
 
 	if (aot) {
 		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);

--- a/src/mono/mono/metadata/method-builder-ilgen.c
+++ b/src/mono/mono/metadata/method-builder-ilgen.c
@@ -250,6 +250,27 @@ mono_mb_add_local (MonoMethodBuilder *mb, MonoType *type)
 }
 
 /**
+ * mono_mb_add_volatile_local:
+ */
+int
+mono_mb_add_volatile_local (MonoMethodBuilder *mb, MonoType *type)
+{
+	int local = mono_mb_add_local (mb, type);
+
+	if (!mb->volatile_locals) {
+		mb->volatile_locals = mono_bitset_new (local + 256, 0);
+	} else if (local >= mono_bitset_size (mb->volatile_locals)) {
+		MonoBitSet *new_set = mono_bitset_clone (mb->volatile_locals, local + 256);
+		mono_bitset_free (mb->volatile_locals);
+		mb->volatile_locals = new_set;
+	}
+
+	mono_bitset_set (mb->volatile_locals, local);
+
+	return local;
+}
+
+/**
  * mono_mb_patch_addr:
  */
 void

--- a/src/mono/mono/metadata/method-builder-ilgen.h
+++ b/src/mono/mono/metadata/method-builder-ilgen.h
@@ -64,6 +64,9 @@ mono_mb_emit_icall_id (MonoMethodBuilder *mb, MonoJitICallId jit_icall_id);
 int
 mono_mb_add_local (MonoMethodBuilder *mb, MonoType *type);
 
+int
+mono_mb_add_volatile_local (MonoMethodBuilder *mb, MonoType *type);
+
 void
 mono_mb_emit_ldarg (MonoMethodBuilder *mb, guint argnum);
 

--- a/src/mono/mono/metadata/sgen-mono.c
+++ b/src/mono/mono/metadata/sgen-mono.c
@@ -2364,23 +2364,8 @@ sgen_client_scan_thread_data (void *start_nursery, void *end_nursery, gboolean p
 					conservative_stack_mark = TRUE;
 				}
 				//FIXME we should eventually use the new stack_mark from coop
+				// On coop GC we force a spill of all registers into the stack.
 				sgen_conservatively_pin_objects_from ((void **)aligned_stack_start, (void **)info->client_info.info.stack_end, start_nursery, end_nursery, PIN_TYPE_STACK);
-			}
-
-			if (!precise) {
-				sgen_conservatively_pin_objects_from ((void**)&info->client_info.ctx, (void**)(&info->client_info.ctx + 1),
-					start_nursery, end_nursery, PIN_TYPE_STACK);
-
-				{
-					// This is used on Coop GC for platforms where we cannot get the data for individual registers.
-					// We force a spill of all registers into the stack and pass a chunk of data into sgen.
-					//FIXME under coop, for now, what we need to ensure is that we scan any extra memory from info->client_info.info.stack_end to stack_mark
-					MonoThreadUnwindState *state = &info->client_info.info.thread_saved_state [SELF_SUSPEND_STATE_INDEX];
-					if (state && state->gc_stackdata) {
-						sgen_conservatively_pin_objects_from ((void **)state->gc_stackdata, (void**)((char*)state->gc_stackdata + state->gc_stackdata_size),
-							start_nursery, end_nursery, PIN_TYPE_STACK);
-					}
-				}
 			}
 		}
 		if (gc_callbacks.interp_mark_func) {

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -1982,10 +1982,8 @@ mono_arch_create_vars (MonoCompile *cfg)
 		cfg->arch.bp_tramp_var = ins;
 	}
 
-	if (cfg->method->save_lmf)
-		cfg->create_lmf_var = TRUE;
-
 	if (cfg->method->save_lmf) {
+		cfg->create_lmf_var = TRUE;
 		cfg->lmf_ir = TRUE;
 	}
 }

--- a/src/mono/mono/mini/mini-exceptions.c
+++ b/src/mono/mono/mini/mini-exceptions.c
@@ -3235,7 +3235,7 @@ mono_thread_state_init_from_monoctx (MonoThreadUnwindState *ctx, MonoContext *mc
 }
 
 /*returns false if the thread is not attached*/
-gboolean
+gboolean MONO_NEVER_INLINE
 mono_thread_state_init_from_current (MonoThreadUnwindState *ctx)
 {
 	MonoThreadInfo *thread = mono_thread_info_current_unchecked ();

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -2544,7 +2544,7 @@ MONO_COMPONENT_API void     mono_walk_stack_with_ctx               (MonoJitStack
 MONO_COMPONENT_API void     mono_walk_stack_with_state             (MonoJitStackWalk func, MonoThreadUnwindState *state, MonoUnwindOptions unwind_options, void *user_data);
 void     mono_walk_stack                        (MonoJitStackWalk func, MonoUnwindOptions options, void *user_data);
 gboolean mono_thread_state_init_from_sigctx     (MonoThreadUnwindState *ctx, void *sigctx);
-void     mono_thread_state_init                 (MonoThreadUnwindState *ctx);
+void     mono_thread_state_init                 (MonoThreadUnwindState *ctx, MonoThreadInfo *info);
 MONO_COMPONENT_API gboolean mono_thread_state_init_from_current    (MonoThreadUnwindState *ctx);
 MONO_COMPONENT_API gboolean mono_thread_state_init_from_monoctx    (MonoThreadUnwindState *ctx, MonoContext *mctx);
 

--- a/src/mono/mono/unit-tests/test-conc-hashtable.c
+++ b/src/mono/mono/unit-tests/test-conc-hashtable.c
@@ -319,7 +319,7 @@ benchmark_glib (void)
 }
 
 static void
-monotest_thread_state_init (MonoThreadUnwindState *ctx)
+monotest_thread_state_init (MonoThreadUnwindState *ctx, MonoThreadInfo *info)
 {
 }
 

--- a/src/mono/mono/utils/mono-stack-unwinding.h
+++ b/src/mono/mono/utils/mono-stack-unwinding.h
@@ -120,8 +120,6 @@ typedef struct {
 	MonoContext ctx;
 	gpointer unwind_data [3]; /*right now: domain, lmf and jit_tls*/
 	gboolean valid;
-	void *gc_stackdata;
-	int gc_stackdata_size;
 } MonoThreadUnwindState;
 
 

--- a/src/mono/mono/utils/mono-threads-coop.c
+++ b/src/mono/mono/utils/mono-threads-coop.c
@@ -84,9 +84,11 @@ coop_tls_pop (gpointer received_cookie)
 static void
 check_info (MonoThreadInfo *info, const gchar *action, const gchar *state, const char *func)
 {
+#ifdef ENABLE_CHECKED_BUILD_GC
 	g_assertf (info, "%s Cannot %s GC %s region if the thread is not attached", func, action, state);
 	g_assertf (mono_thread_info_is_current (info), "%s [%p] Cannot %s GC %s region on a different thread", func, mono_thread_info_get_tid (info), action, state);
 	g_assertf (mono_thread_info_is_live (info), "%s [%p] Cannot %s GC %s region if the thread is not live", func, mono_thread_info_get_tid (info), action, state);
+#endif
 }
 
 static int coop_reset_blocking_count;

--- a/src/mono/mono/utils/mono-threads-coop.c
+++ b/src/mono/mono/utils/mono-threads-coop.c
@@ -126,6 +126,10 @@ mono_threads_state_poll_with_info (MonoThreadInfo *info)
 	if (info->thread_state.state != STATE_ASYNC_SUSPEND_REQUESTED)
 		return;
 
+	/* Spill all registers to the stack to make the GC aware of the references */
+	MonoContext ctx;
+	MONO_CONTEXT_GET_CURRENT (ctx);
+
 	++coop_save_count;
 	mono_threads_get_runtime_callbacks ()->thread_state_init (&info->thread_saved_state [SELF_SUSPEND_STATE_INDEX], info);
 

--- a/src/mono/mono/utils/mono-threads-coop.c
+++ b/src/mono/mono/utils/mono-threads-coop.c
@@ -125,10 +125,10 @@ mono_threads_state_poll_with_info (MonoThreadInfo *info)
 	if (info->thread_state.state != STATE_ASYNC_SUSPEND_REQUESTED)
 		return;
 
-#ifdef MONO_CROSS_COMPILE
+#if defined(MONO_CROSS_COMPILE)
 	g_error ("Unreachable path on cross-compiler");
 	return;
-#else
+#elif MONO_ARCH_HAS_MONO_CONTEXT
 	/* Spill all registers to the stack to make the GC aware of the references */
 	MonoContext ctx;
 	MONO_CONTEXT_GET_CURRENT (ctx);

--- a/src/mono/mono/utils/mono-threads-coop.c
+++ b/src/mono/mono/utils/mono-threads-coop.c
@@ -138,7 +138,7 @@ mono_threads_state_poll_with_info (MonoThreadInfo *info)
 		return;
 
 	++coop_save_count;
-	mono_threads_get_runtime_callbacks ()->thread_state_init (&info->thread_saved_state [SELF_SUSPEND_STATE_INDEX]);
+	mono_threads_get_runtime_callbacks ()->thread_state_init_from_current (&info->thread_saved_state [SELF_SUSPEND_STATE_INDEX]);
 
 	/* commit the saved state and notify others if needed */
 	switch (mono_threads_transition_state_poll (info)) {
@@ -318,7 +318,7 @@ mono_threads_enter_gc_safe_region_unbalanced_with_info (MonoThreadInfo *info, Mo
 
 retry:
 	++coop_save_count;
-	mono_threads_get_runtime_callbacks ()->thread_state_init (&info->thread_saved_state [SELF_SUSPEND_STATE_INDEX]);
+	mono_threads_get_runtime_callbacks ()->thread_state_init_from_current (&info->thread_saved_state [SELF_SUSPEND_STATE_INDEX]);
 
 	switch (mono_threads_transition_do_blocking (info, function_name)) {
 	case DoBlockingContinue:

--- a/src/mono/mono/utils/mono-threads-coop.c
+++ b/src/mono/mono/utils/mono-threads-coop.c
@@ -84,12 +84,9 @@ coop_tls_pop (gpointer received_cookie)
 static void
 check_info (MonoThreadInfo *info, const gchar *action, const gchar *state, const char *func)
 {
-	if (!info)
-		g_error ("%s Cannot %s GC %s region if the thread is not attached", func, action, state);
-	if (!mono_thread_info_is_current (info))
-		g_error ("%s [%p] Cannot %s GC %s region on a different thread", func, mono_thread_info_get_tid (info), action, state);
-	if (!mono_thread_info_is_live (info))
-		g_error ("%s [%p] Cannot %s GC %s region if the thread is not live", func, mono_thread_info_get_tid (info), action, state);
+	g_assertf (info, "%s Cannot %s GC %s region if the thread is not attached", func, action, state);
+	g_assertf (mono_thread_info_is_current (info), "%s [%p] Cannot %s GC %s region on a different thread", func, mono_thread_info_get_tid (info), action, state);
+	g_assertf (mono_thread_info_is_live (info), "%s [%p] Cannot %s GC %s region if the thread is not live", func, mono_thread_info_get_tid (info), action, state);
 }
 
 static int coop_reset_blocking_count;

--- a/src/mono/mono/utils/mono-threads-coop.c
+++ b/src/mono/mono/utils/mono-threads-coop.c
@@ -314,7 +314,7 @@ mono_threads_enter_gc_safe_region_unbalanced_with_info (MonoThreadInfo *info, Mo
 	// (that are not previously stored anywhere on the stack), then GC won't detect that reference(s). Storing the stack
 	// and registers into a separate location makes sure we still see any registers temporary stored on stack due to optimizations
 	// done between stackdata snapshot and thread_state_init.
-	copy_stack_data (info, stackdata);
+	//copy_stack_data (info, stackdata);
 
 retry:
 	++coop_save_count;
@@ -474,7 +474,7 @@ mono_threads_enter_gc_unsafe_region_unbalanced_with_info (MonoThreadInfo *info, 
 
 	check_info (info, "enter", "unsafe", function_name);
 
-	copy_stack_data (info, stackdata);
+	//copy_stack_data (info, stackdata);
 
 	switch (mono_threads_transition_abort_blocking (info, function_name)) {
 	case AbortBlockingIgnore:

--- a/src/mono/mono/utils/mono-threads-state-machine.c
+++ b/src/mono/mono/utils/mono-threads-state-machine.c
@@ -105,6 +105,7 @@ unwrap_thread_state (MonoThreadInfo* info,
 static void
 check_thread_state (MonoThreadInfo* info)
 {
+#ifdef ENABLE_CHECKED_BUILD_THREAD
 	int raw_state, cur_state, suspend_count;
 	gboolean no_safepoints;
 	UNWRAP_THREAD_STATE (raw_state, cur_state, suspend_count, no_safepoints, info);
@@ -133,6 +134,7 @@ check_thread_state (MonoThreadInfo* info)
 	default:
 		g_error ("Invalid state %d", cur_state);
 	}
+#endif
 }
 
 static void

--- a/src/mono/mono/utils/mono-threads.c
+++ b/src/mono/mono/utils/mono-threads.c
@@ -514,7 +514,6 @@ register_thread (MonoThreadInfo *info)
 	g_assert (stsize);
 	info->stack_start_limit = staddr;
 	info->stack_end = staddr + stsize;
-	info->stackdata = g_byte_array_new ();
 
 	info->internal_thread_gchandle = NULL;
 
@@ -631,8 +630,6 @@ unregister_thread (void *arg)
 	mono_threads_transition_detach (info);
 
 	mono_thread_info_suspend_unlock ();
-
-	g_byte_array_free (info->stackdata, /*free_segment=*/TRUE);
 
 	/*now it's safe to free the thread info.*/
 	mono_thread_hazardous_try_free (info, free_thread_info);

--- a/src/mono/mono/utils/mono-threads.h
+++ b/src/mono/mono/utils/mono-threads.h
@@ -236,9 +236,6 @@ typedef struct _MonoThreadInfo {
 
 	gboolean suspend_can_continue;
 
-	/* This memory pool is used by coop GC to save stack data roots between GC unsafe regions */
-	GByteArray *stackdata;
-
 	/*In theory, only the posix backend needs this, but having it on mach/win32 simplifies things a lot.*/
 	MonoThreadUnwindState thread_saved_state [2]; //0 is self suspend, 1 is async suspend.
 
@@ -340,7 +337,7 @@ typedef struct {
 	macro (prefix, void, setup_async_callback, (MonoContext *ctx, void (*async_cb)(void *fun), gpointer user_data)) \
 	macro (prefix, gboolean, thread_state_init_from_sigctx, (MonoThreadUnwindState *state, void *sigctx)) \
 	macro (prefix, gboolean, thread_state_init_from_handle, (MonoThreadUnwindState *tctx, MonoThreadInfo *info, /*optional*/ void *sigctx)) \
-	macro (prefix, gboolean, thread_state_init_from_current, (MonoThreadUnwindState *tctx))
+	macro (prefix, void, thread_state_init, (MonoThreadUnwindState *tctx, MonoThreadInfo *info))
 
 typedef struct {
 	MONO_THREAD_INFO_RUNTIME_CALLBACKS (MONO_DECL_CALLBACK, unused)

--- a/src/mono/mono/utils/mono-threads.h
+++ b/src/mono/mono/utils/mono-threads.h
@@ -340,7 +340,7 @@ typedef struct {
 	macro (prefix, void, setup_async_callback, (MonoContext *ctx, void (*async_cb)(void *fun), gpointer user_data)) \
 	macro (prefix, gboolean, thread_state_init_from_sigctx, (MonoThreadUnwindState *state, void *sigctx)) \
 	macro (prefix, gboolean, thread_state_init_from_handle, (MonoThreadUnwindState *tctx, MonoThreadInfo *info, /*optional*/ void *sigctx)) \
-	macro (prefix, void, thread_state_init, (MonoThreadUnwindState *tctx)) \
+	macro (prefix, gboolean, thread_state_init_from_current, (MonoThreadUnwindState *tctx))
 
 typedef struct {
 	MONO_THREAD_INFO_RUNTIME_CALLBACKS (MONO_DECL_CALLBACK, unused)

--- a/src/mono/mono/utils/win64.asm
+++ b/src/mono/mono/utils/win64.asm
@@ -121,40 +121,6 @@ mono_context_get_current_avx PROC
 
 mono_context_get_current_avx endP
 
-; Implementation of __builtin_unwind_init under MSVC, dumping
-; nonvolatile registers into MonoBuiltinUnwindInfo *.
-
-copy_stack_data_internal_win32_wrapper PROC PUBLIC
-;rcx MonoThreadInfo *
-;rdx MonoStackData *
-;r8 MonoBuiltinUnwindInfo *
-;r9 CopyStackDataFunc
-
-	movaps xmmword ptr [r8 + 00h], xmm6
-	movaps xmmword ptr [r8 + 10h], xmm7
-	movaps xmmword ptr [r8 + 20h], xmm8
-	movaps xmmword ptr [r8 + 30h], xmm9
-	movaps xmmword ptr [r8 + 40h], xmm10
-	movaps xmmword ptr [r8 + 50h], xmm11
-	movaps xmmword ptr [r8 + 60h], xmm12
-	movaps xmmword ptr [r8 + 70h], xmm13
-	movaps xmmword ptr [r8 + 80h], xmm14
-	movaps xmmword ptr [r8 + 90h], xmm15
-
-	mov qword ptr [r8 + 0A0h], rbx
-	mov qword ptr [r8 + 0A8h], rsi
-	mov qword ptr [r8 + 0B0h], rdi
-	mov qword ptr [r8 + 0B8h], r12
-	mov qword ptr [r8 + 0C0h], r13
-	mov qword ptr [r8 + 0C8h], r14
-	mov qword ptr [r8 + 0D0h], r15
-	mov qword ptr [r8 + 0D8h], rbp
-
-	; tailcall, all parameters passed through to CopyStackDataFunc.
-	jmp r9
-
-copy_stack_data_internal_win32_wrapper endP
-
 endif
 
 end


### PR DESCRIPTION
**Ignore for reviews, just want to see the CI.**

This revamps the logic in how transitions from managed to native code happen with regards to GC. The core idea is to ensure that every possible reference is spilled to the stack before the transition to icall or P/Invoke.

The wrappers for P/Invoke (w/o `SuppressGCTransition`) ensure the spilling in the following way:
- Caller saved registers are saved by the caller of the P/Invoke wrapper
- Callee saved registers are saved by the LMF (Last Managed Frame) logic into the `MonoLMF` structure on the stack
- Argument registers for reference-type arguments are explicitly flushed to stack by generating IL that moves them to volatile local variables

The wrappers for P/Invoke with `SuppressGCTransition` don't get any special treatment since GC safe mode is not entered.

The wrappers for icalls don't enter GC safe mode themselves. In that regard they behave like P/Invoke with `SuppressGCTransition` and skip the explicit argument spilling. This should be safe if the icalls use `HANDLES` logic which should ensure proper tracking by GC if the icall eventually enters the GC safe mode.

Additionally, the following changes are present:
- `thread_state_init` captures only stack boundaries in the context
- General registers are not captured on transition to GC safe mode since all references are already spilled to stack
- SGen does not check the general registers in the thread context since it already checks the stack
- `copy_stack` is no longer necessary and it's removed; since all the references are spilled to the stack before the GC safe transition they stay on the stack for the duration of the native call
- State checks are disable for non-checked builds because of significant overhead

TODO:
- [ ] Update LLVM to handle `save_lmf`, add emiting of `llvm.eh.unwind.init` intrinsic to spill the callee saved registers
- [ ] Investigate preserveall cconv in LLVM
- [ ] Check JIT icalls
- [ ] Make sure that savepoints don't have GC hole
- [ ] Make sure other uses of `mono_threads_enter_gc_safe_region` are safe
- [ ] Verify that tests still pass