### PR TITLE
Emit diagnostics & exceptions for sourcegen handling init-only properties & JsonInclude attributes

### DIFF
--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
@@ -324,7 +324,7 @@ namespace {@namespace}
                             }}
                             else
                             {{
-                                throw new {InvalidOperationExceptionTypeRef}($""The converter '{{converter.GetType()}}' is not compatible with the type '{{typeToConvert}}'."");
+                                throw new {InvalidOperationExceptionTypeRef}(string.Format(""{SR.Exception_IncompatibleConverterType}"", converter.GetType(), typeToConvert));
                             }}
                         }}");
                 }
@@ -333,7 +333,7 @@ namespace {@namespace}
                     metadataInitSource.Append($@"
                         if (!converter.CanConvert(typeToConvert))
                         {{
-                            throw new {InvalidOperationExceptionTypeRef}($""The converter '{{converter.GetType()}}' is not compatible with the type '{{typeToConvert}}'."");
+                            throw new {InvalidOperationExceptionTypeRef}(string.Format(""{SR.Exception_IncompatibleConverterType}"", converter.GetType(), typeToConvert));
                         }}");
                 }
 
@@ -716,7 +716,7 @@ private static {JsonPropertyInfoTypeRef}[] {propInitMethodName}({JsonSerializerC
                         { DefaultIgnoreCondition: JsonIgnoreCondition.Always } => "getter: null",
                         { CanUseGetter: true } => $"getter: static (obj) => (({declaringTypeCompilableName})obj).{clrPropertyName}",
                         { CanUseGetter: false, HasJsonInclude: true }
-                            => @$"getter: static (obj) => throw new {InvalidOperationExceptionTypeRef}(""{SR.InaccessibleJsonIncludePropertiesNotSupportedTitle}"")",
+                            => @$"getter: static (obj) => throw new {InvalidOperationExceptionTypeRef}(""{SR.Format(SR.Exception_InaccessibleJsonIncludePropertiesNotSupported, typeGenerationSpec.Type.Name, memberMetadata.ClrName)}"")",
                         _ => "getter: null"
                     };
 
@@ -724,13 +724,13 @@ private static {JsonPropertyInfoTypeRef}[] {propInitMethodName}({JsonSerializerC
                     {
                         { DefaultIgnoreCondition: JsonIgnoreCondition.Always } => "setter: null",
                         { CanUseSetter: true, IsInitOnlySetter: true }
-                            => @$"setter: static (obj, value) => throw new {InvalidOperationExceptionTypeRef}(""{SR.InitOnlyPropertyDeserializationNotSupportedTitle}"")",
+                            => @$"setter: static (obj, value) => throw new {InvalidOperationExceptionTypeRef}(""{SR.Exception_InitOnlyPropertyDeserializationNotSupported}"")",
                         { CanUseSetter: true } when typeGenerationSpec.IsValueType
                             => $@"setter: static (obj, value) => {UnsafeTypeRef}.Unbox<{declaringTypeCompilableName}>(obj).{clrPropertyName} = value!",
                         { CanUseSetter: true }
                             => @$"setter: static (obj, value) => (({declaringTypeCompilableName})obj).{clrPropertyName} = value!",
                         { CanUseSetter: false, HasJsonInclude: true }
-                            => @$"setter: static (obj, value) => throw new {InvalidOperationExceptionTypeRef}(""{SR.InaccessibleJsonIncludePropertiesNotSupportedTitle}"")",
+                            => @$"setter: static (obj, value) => throw new {InvalidOperationExceptionTypeRef}(""{SR.Format(SR.Exception_InaccessibleJsonIncludePropertiesNotSupported, typeGenerationSpec.Type.Name, memberMetadata.ClrName)}"")",
                         _ => "setter: null",
                     };
 
@@ -824,12 +824,12 @@ private static {JsonParameterInfoValuesTypeRef}[] {typeGenerationSpec.TypeInfoPr
                     out Dictionary<string, PropertyGenerationSpec>? serializableProperties,
                     out bool castingRequiredForProps))
                 {
-                    string exceptionMessage = @$"""Invalid serializable-property configuration specified for type '{typeRef}'. For more information, see 'JsonSourceGenerationMode.Serialization'.""";
+                    string exceptionMessage = SR.Format(SR.Exception_InvalidSerializablePropertyConfiguration, typeRef);
 
                     return GenerateFastPathFuncForType(
                         serializeMethodName,
                         typeRef,
-                        $@"throw new {InvalidOperationExceptionTypeRef}({exceptionMessage});",
+                        $@"throw new {InvalidOperationExceptionTypeRef}(""{exceptionMessage}"");",
                         canBeNull: false); // Skip null check since we want to throw an exception straightaway.
                 }
 
@@ -1205,7 +1205,7 @@ private static {JsonSerializerOptionsTypeRef} {DefaultOptionsStaticVarName} {{ g
                 converter = factory.CreateConverter(type, {OptionsInstanceVariableName});
                 if (converter == null || converter is {JsonConverterFactoryTypeRef})
                 {{
-                    throw new {InvalidOperationExceptionTypeRef}($""The converter '{{factory.GetType()}}' cannot return null or a JsonConverterFactory instance."");
+                    throw new {InvalidOperationExceptionTypeRef}(string.Format(""{SR.Exception_InvalidJsonConverterFactoryOutput}"", factory.GetType()));
                 }}
             }}
 
@@ -1236,7 +1236,7 @@ private {JsonConverterTypeRef} {GetConverterFromFactoryMethodName}({TypeTypeRef}
     {JsonConverterTypeRef}? converter = factory.CreateConverter(type, {Emitter.OptionsInstanceVariableName});
     if (converter == null || converter is {JsonConverterFactoryTypeRef})
     {{
-        throw new {InvalidOperationExceptionTypeRef}($""The converter '{{factory.GetType()}}' cannot return null or a JsonConverterFactory instance."");
+        throw new {InvalidOperationExceptionTypeRef}(string.Format(""{SR.Exception_InvalidJsonConverterFactoryOutput}"", factory.GetType()));
     }}
      
     return converter;

--- a/src/libraries/System.Text.Json/gen/PropertyGenerationSpec.cs
+++ b/src/libraries/System.Text.Json/gen/PropertyGenerationSpec.cs
@@ -16,6 +16,9 @@ namespace System.Text.Json.SourceGeneration
         /// </summary>
         public bool IsProperty { get; init; }
 
+        /// <summary>
+        /// If representing a property, returns true if either the getter or setter are public.
+        /// </summary>
         public bool IsPublic { get; init; }
 
         public bool IsVirtual { get; init; }
@@ -38,6 +41,11 @@ namespace System.Text.Json.SourceGeneration
         /// Whether the property has a set method.
         /// </summary>
         public bool IsReadOnly { get; init; }
+
+        /// <summary>
+        /// Whether the property has an init-only set method.
+        /// </summary>
+        public bool IsInitOnlySetter { get; init; }
 
         /// <summary>
         /// Whether the property has a public or internal (only usable when JsonIncludeAttribute is specified)

--- a/src/libraries/System.Text.Json/gen/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/gen/Resources/Strings.resx
@@ -165,4 +165,20 @@
   <data name="InaccessibleJsonIncludePropertiesNotSupportedFormat" xml:space="preserve">
     <value>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</value>
   </data>
+  <!-- runtime exception messages -->
+  <data name="Exception_IncompatibleConverterType" xml:space="preserve">
+    <value>The converter '{0}' is not compatible with the type '{1}'.</value>
+  </data>
+  <data name="Exception_InitOnlyPropertyDeserializationNotSupported" xml:space="preserve">
+    <value>Deserialization of init-only properties is currently not supported in source generation mode.</value>
+  </data>
+  <data name="Exception_InaccessibleJsonIncludePropertiesNotSupported" xml:space="preserve">
+    <value>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</value>
+  </data>
+  <data name="Exception_InvalidSerializablePropertyConfiguration" xml:space="preserve">
+    <value>Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</value>
+  </data>
+  <data name="Exception_InvalidJsonConverterFactoryOutput" xml:space="preserve">
+    <value>The converter '{0}' cannot return null or a JsonConverterFactory instance.</value>
+  </data>
 </root>

--- a/src/libraries/System.Text.Json/gen/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/gen/Resources/Strings.resx
@@ -153,4 +153,16 @@
   <data name="DataExtensionPropertyInvalidTitle" xml:space="preserve">
     <value>Data extension property type invalid.</value>
   </data>
+  <data name="InitOnlyPropertyDeserializationNotSupportedTitle" xml:space="preserve">
+    <value>Deserialization of init-only properties is currently not supported in source generation mode.</value>
+  </data>
+  <data name="InitOnlyPropertyDeserializationNotSupportedFormat" xml:space="preserve">
+    <value>The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</value>
+  </data>
+  <data name="InaccessibleJsonIncludePropertiesNotSupportedTitle" xml:space="preserve">
+    <value>Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</value>
+  </data>
+  <data name="InaccessibleJsonIncludePropertiesNotSupportedFormat" xml:space="preserve">
+    <value>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</value>
+  </data>
 </root>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.cs.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.cs.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Duplicitní název typu</target>
         <note />
       </trans-unit>
+      <trans-unit id="Exception_InaccessibleJsonIncludePropertiesNotSupported">
+        <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
+        <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_IncompatibleConverterType">
+        <source>The converter '{0}' is not compatible with the type '{1}'.</source>
+        <target state="new">The converter '{0}' is not compatible with the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InitOnlyPropertyDeserializationNotSupported">
+        <source>Deserialization of init-only properties is currently not supported in source generation mode.</source>
+        <target state="new">Deserialization of init-only properties is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidJsonConverterFactoryOutput">
+        <source>The converter '{0}' cannot return null or a JsonConverterFactory instance.</source>
+        <target state="new">The converter '{0}' cannot return null or a JsonConverterFactory instance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidSerializablePropertyConfiguration">
+        <source>Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
         <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
         <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.cs.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.cs.xlf
@@ -32,6 +32,26 @@
         <target state="translated">Duplicitní název typu</target>
         <note />
       </trans-unit>
+      <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
+        <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
+        <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedTitle">
+        <source>Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</source>
+        <target state="new">Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitOnlyPropertyDeserializationNotSupportedFormat">
+        <source>The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</source>
+        <target state="new">The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitOnlyPropertyDeserializationNotSupportedTitle">
+        <source>Deserialization of init-only properties is currently not supported in source generation mode.</source>
+        <target state="new">Deserialization of init-only properties is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleJsonConstructorAttributeFormat">
         <source>Type '{0}' has multiple constructors annotated with 'JsonConstructorAttribute'.</source>
         <target state="translated">Typ {0} má více konstruktorů anotovaných s JsonConstructorAttribute. </target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.de.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.de.xlf
@@ -32,6 +32,26 @@
         <target state="translated">Doppelter Typname</target>
         <note />
       </trans-unit>
+      <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
+        <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
+        <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedTitle">
+        <source>Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</source>
+        <target state="new">Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitOnlyPropertyDeserializationNotSupportedFormat">
+        <source>The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</source>
+        <target state="new">The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitOnlyPropertyDeserializationNotSupportedTitle">
+        <source>Deserialization of init-only properties is currently not supported in source generation mode.</source>
+        <target state="new">Deserialization of init-only properties is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleJsonConstructorAttributeFormat">
         <source>Type '{0}' has multiple constructors annotated with 'JsonConstructorAttribute'.</source>
         <target state="translated">Typ "{0}" weist mehrere Konstruktoren mit dem Kommentar "JsonConstructorAttribute" auf.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.de.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.de.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Doppelter Typname</target>
         <note />
       </trans-unit>
+      <trans-unit id="Exception_InaccessibleJsonIncludePropertiesNotSupported">
+        <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
+        <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_IncompatibleConverterType">
+        <source>The converter '{0}' is not compatible with the type '{1}'.</source>
+        <target state="new">The converter '{0}' is not compatible with the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InitOnlyPropertyDeserializationNotSupported">
+        <source>Deserialization of init-only properties is currently not supported in source generation mode.</source>
+        <target state="new">Deserialization of init-only properties is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidJsonConverterFactoryOutput">
+        <source>The converter '{0}' cannot return null or a JsonConverterFactory instance.</source>
+        <target state="new">The converter '{0}' cannot return null or a JsonConverterFactory instance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidSerializablePropertyConfiguration">
+        <source>Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
         <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
         <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.es.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.es.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Nombre de tipo duplicado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Exception_InaccessibleJsonIncludePropertiesNotSupported">
+        <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
+        <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_IncompatibleConverterType">
+        <source>The converter '{0}' is not compatible with the type '{1}'.</source>
+        <target state="new">The converter '{0}' is not compatible with the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InitOnlyPropertyDeserializationNotSupported">
+        <source>Deserialization of init-only properties is currently not supported in source generation mode.</source>
+        <target state="new">Deserialization of init-only properties is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidJsonConverterFactoryOutput">
+        <source>The converter '{0}' cannot return null or a JsonConverterFactory instance.</source>
+        <target state="new">The converter '{0}' cannot return null or a JsonConverterFactory instance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidSerializablePropertyConfiguration">
+        <source>Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
         <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
         <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.es.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.es.xlf
@@ -32,6 +32,26 @@
         <target state="translated">Nombre de tipo duplicado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
+        <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
+        <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedTitle">
+        <source>Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</source>
+        <target state="new">Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitOnlyPropertyDeserializationNotSupportedFormat">
+        <source>The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</source>
+        <target state="new">The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitOnlyPropertyDeserializationNotSupportedTitle">
+        <source>Deserialization of init-only properties is currently not supported in source generation mode.</source>
+        <target state="new">Deserialization of init-only properties is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleJsonConstructorAttributeFormat">
         <source>Type '{0}' has multiple constructors annotated with 'JsonConstructorAttribute'.</source>
         <target state="translated">El tipo '{0}' tiene varios constructores anotados con 'JsonConstructorAttribute'.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.fr.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.fr.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Nom de type dupliqué.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Exception_InaccessibleJsonIncludePropertiesNotSupported">
+        <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
+        <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_IncompatibleConverterType">
+        <source>The converter '{0}' is not compatible with the type '{1}'.</source>
+        <target state="new">The converter '{0}' is not compatible with the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InitOnlyPropertyDeserializationNotSupported">
+        <source>Deserialization of init-only properties is currently not supported in source generation mode.</source>
+        <target state="new">Deserialization of init-only properties is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidJsonConverterFactoryOutput">
+        <source>The converter '{0}' cannot return null or a JsonConverterFactory instance.</source>
+        <target state="new">The converter '{0}' cannot return null or a JsonConverterFactory instance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidSerializablePropertyConfiguration">
+        <source>Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
         <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
         <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.fr.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.fr.xlf
@@ -32,6 +32,26 @@
         <target state="translated">Nom de type dupliqué.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
+        <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
+        <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedTitle">
+        <source>Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</source>
+        <target state="new">Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitOnlyPropertyDeserializationNotSupportedFormat">
+        <source>The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</source>
+        <target state="new">The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitOnlyPropertyDeserializationNotSupportedTitle">
+        <source>Deserialization of init-only properties is currently not supported in source generation mode.</source>
+        <target state="new">Deserialization of init-only properties is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleJsonConstructorAttributeFormat">
         <source>Type '{0}' has multiple constructors annotated with 'JsonConstructorAttribute'.</source>
         <target state="translated">Le type' {0} 'a plusieurs constructeurs annotés avec’JsonConstructorAttribute'.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.it.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.it.xlf
@@ -32,6 +32,26 @@
         <target state="translated">Nome di tipo duplicato.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
+        <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
+        <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedTitle">
+        <source>Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</source>
+        <target state="new">Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitOnlyPropertyDeserializationNotSupportedFormat">
+        <source>The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</source>
+        <target state="new">The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitOnlyPropertyDeserializationNotSupportedTitle">
+        <source>Deserialization of init-only properties is currently not supported in source generation mode.</source>
+        <target state="new">Deserialization of init-only properties is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleJsonConstructorAttributeFormat">
         <source>Type '{0}' has multiple constructors annotated with 'JsonConstructorAttribute'.</source>
         <target state="translated">Il tipo '{0}' contiene più costruttori che presentano l'annotazione 'JsonConstructorAttribute'.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.it.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.it.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Nome di tipo duplicato.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Exception_InaccessibleJsonIncludePropertiesNotSupported">
+        <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
+        <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_IncompatibleConverterType">
+        <source>The converter '{0}' is not compatible with the type '{1}'.</source>
+        <target state="new">The converter '{0}' is not compatible with the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InitOnlyPropertyDeserializationNotSupported">
+        <source>Deserialization of init-only properties is currently not supported in source generation mode.</source>
+        <target state="new">Deserialization of init-only properties is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidJsonConverterFactoryOutput">
+        <source>The converter '{0}' cannot return null or a JsonConverterFactory instance.</source>
+        <target state="new">The converter '{0}' cannot return null or a JsonConverterFactory instance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidSerializablePropertyConfiguration">
+        <source>Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
         <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
         <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ja.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ja.xlf
@@ -32,6 +32,26 @@
         <target state="translated">重複した種類名。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
+        <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
+        <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedTitle">
+        <source>Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</source>
+        <target state="new">Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitOnlyPropertyDeserializationNotSupportedFormat">
+        <source>The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</source>
+        <target state="new">The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitOnlyPropertyDeserializationNotSupportedTitle">
+        <source>Deserialization of init-only properties is currently not supported in source generation mode.</source>
+        <target state="new">Deserialization of init-only properties is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleJsonConstructorAttributeFormat">
         <source>Type '{0}' has multiple constructors annotated with 'JsonConstructorAttribute'.</source>
         <target state="translated">型 '{0}' には、'JsonConstructorAttribute' で注釈が付けられた複数のコンストラクターがあります。</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ja.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ja.xlf
@@ -32,6 +32,31 @@
         <target state="translated">重複した種類名。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Exception_InaccessibleJsonIncludePropertiesNotSupported">
+        <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
+        <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_IncompatibleConverterType">
+        <source>The converter '{0}' is not compatible with the type '{1}'.</source>
+        <target state="new">The converter '{0}' is not compatible with the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InitOnlyPropertyDeserializationNotSupported">
+        <source>Deserialization of init-only properties is currently not supported in source generation mode.</source>
+        <target state="new">Deserialization of init-only properties is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidJsonConverterFactoryOutput">
+        <source>The converter '{0}' cannot return null or a JsonConverterFactory instance.</source>
+        <target state="new">The converter '{0}' cannot return null or a JsonConverterFactory instance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidSerializablePropertyConfiguration">
+        <source>Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
         <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
         <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ko.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ko.xlf
@@ -32,6 +32,31 @@
         <target state="translated">중복된 형식 이름입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Exception_InaccessibleJsonIncludePropertiesNotSupported">
+        <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
+        <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_IncompatibleConverterType">
+        <source>The converter '{0}' is not compatible with the type '{1}'.</source>
+        <target state="new">The converter '{0}' is not compatible with the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InitOnlyPropertyDeserializationNotSupported">
+        <source>Deserialization of init-only properties is currently not supported in source generation mode.</source>
+        <target state="new">Deserialization of init-only properties is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidJsonConverterFactoryOutput">
+        <source>The converter '{0}' cannot return null or a JsonConverterFactory instance.</source>
+        <target state="new">The converter '{0}' cannot return null or a JsonConverterFactory instance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidSerializablePropertyConfiguration">
+        <source>Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
         <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
         <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ko.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ko.xlf
@@ -32,6 +32,26 @@
         <target state="translated">중복된 형식 이름입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
+        <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
+        <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedTitle">
+        <source>Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</source>
+        <target state="new">Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitOnlyPropertyDeserializationNotSupportedFormat">
+        <source>The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</source>
+        <target state="new">The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitOnlyPropertyDeserializationNotSupportedTitle">
+        <source>Deserialization of init-only properties is currently not supported in source generation mode.</source>
+        <target state="new">Deserialization of init-only properties is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleJsonConstructorAttributeFormat">
         <source>Type '{0}' has multiple constructors annotated with 'JsonConstructorAttribute'.</source>
         <target state="translated">'{0}' 형식에 'JsonConstructorAttribute'로 주석이 추가된 여러 생성자가 있습니다.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.pl.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.pl.xlf
@@ -32,6 +32,26 @@
         <target state="translated">Zduplikowana nazwa typu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
+        <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
+        <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedTitle">
+        <source>Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</source>
+        <target state="new">Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitOnlyPropertyDeserializationNotSupportedFormat">
+        <source>The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</source>
+        <target state="new">The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitOnlyPropertyDeserializationNotSupportedTitle">
+        <source>Deserialization of init-only properties is currently not supported in source generation mode.</source>
+        <target state="new">Deserialization of init-only properties is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleJsonConstructorAttributeFormat">
         <source>Type '{0}' has multiple constructors annotated with 'JsonConstructorAttribute'.</source>
         <target state="translated">Typ "{0}" ma wiele konstruktorów z adnotacją "JsonConstructorAttribute".</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.pl.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.pl.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Zduplikowana nazwa typu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Exception_InaccessibleJsonIncludePropertiesNotSupported">
+        <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
+        <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_IncompatibleConverterType">
+        <source>The converter '{0}' is not compatible with the type '{1}'.</source>
+        <target state="new">The converter '{0}' is not compatible with the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InitOnlyPropertyDeserializationNotSupported">
+        <source>Deserialization of init-only properties is currently not supported in source generation mode.</source>
+        <target state="new">Deserialization of init-only properties is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidJsonConverterFactoryOutput">
+        <source>The converter '{0}' cannot return null or a JsonConverterFactory instance.</source>
+        <target state="new">The converter '{0}' cannot return null or a JsonConverterFactory instance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidSerializablePropertyConfiguration">
+        <source>Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
         <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
         <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.pt-BR.xlf
@@ -32,6 +32,26 @@
         <target state="translated">Nome de tipo duplicado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
+        <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
+        <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedTitle">
+        <source>Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</source>
+        <target state="new">Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitOnlyPropertyDeserializationNotSupportedFormat">
+        <source>The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</source>
+        <target state="new">The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitOnlyPropertyDeserializationNotSupportedTitle">
+        <source>Deserialization of init-only properties is currently not supported in source generation mode.</source>
+        <target state="new">Deserialization of init-only properties is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleJsonConstructorAttributeFormat">
         <source>Type '{0}' has multiple constructors annotated with 'JsonConstructorAttribute'.</source>
         <target state="translated">O tipo '{0}' tem vários construtores anotados com 'JsonConstructorAttribute'.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.pt-BR.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Nome de tipo duplicado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Exception_InaccessibleJsonIncludePropertiesNotSupported">
+        <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
+        <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_IncompatibleConverterType">
+        <source>The converter '{0}' is not compatible with the type '{1}'.</source>
+        <target state="new">The converter '{0}' is not compatible with the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InitOnlyPropertyDeserializationNotSupported">
+        <source>Deserialization of init-only properties is currently not supported in source generation mode.</source>
+        <target state="new">Deserialization of init-only properties is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidJsonConverterFactoryOutput">
+        <source>The converter '{0}' cannot return null or a JsonConverterFactory instance.</source>
+        <target state="new">The converter '{0}' cannot return null or a JsonConverterFactory instance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidSerializablePropertyConfiguration">
+        <source>Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
         <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
         <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ru.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ru.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Дублирующееся имя типа.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Exception_InaccessibleJsonIncludePropertiesNotSupported">
+        <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
+        <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_IncompatibleConverterType">
+        <source>The converter '{0}' is not compatible with the type '{1}'.</source>
+        <target state="new">The converter '{0}' is not compatible with the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InitOnlyPropertyDeserializationNotSupported">
+        <source>Deserialization of init-only properties is currently not supported in source generation mode.</source>
+        <target state="new">Deserialization of init-only properties is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidJsonConverterFactoryOutput">
+        <source>The converter '{0}' cannot return null or a JsonConverterFactory instance.</source>
+        <target state="new">The converter '{0}' cannot return null or a JsonConverterFactory instance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidSerializablePropertyConfiguration">
+        <source>Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
         <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
         <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ru.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.ru.xlf
@@ -32,6 +32,26 @@
         <target state="translated">Дублирующееся имя типа.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
+        <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
+        <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedTitle">
+        <source>Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</source>
+        <target state="new">Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitOnlyPropertyDeserializationNotSupportedFormat">
+        <source>The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</source>
+        <target state="new">The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitOnlyPropertyDeserializationNotSupportedTitle">
+        <source>Deserialization of init-only properties is currently not supported in source generation mode.</source>
+        <target state="new">Deserialization of init-only properties is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleJsonConstructorAttributeFormat">
         <source>Type '{0}' has multiple constructors annotated with 'JsonConstructorAttribute'.</source>
         <target state="translated">Тип "{0}" имеет несколько конструкторов, аннотированных с использованием JsonConstructorAttribute.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.tr.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.tr.xlf
@@ -32,6 +32,26 @@
         <target state="translated">Yinelenen tür adı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
+        <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
+        <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedTitle">
+        <source>Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</source>
+        <target state="new">Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitOnlyPropertyDeserializationNotSupportedFormat">
+        <source>The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</source>
+        <target state="new">The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitOnlyPropertyDeserializationNotSupportedTitle">
+        <source>Deserialization of init-only properties is currently not supported in source generation mode.</source>
+        <target state="new">Deserialization of init-only properties is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleJsonConstructorAttributeFormat">
         <source>Type '{0}' has multiple constructors annotated with 'JsonConstructorAttribute'.</source>
         <target state="translated">'{0}' türünün 'JsonConstructorAttribute' ile açıklanan birden çok oluşturucusu var.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.tr.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.tr.xlf
@@ -32,6 +32,31 @@
         <target state="translated">Yinelenen tür adı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Exception_InaccessibleJsonIncludePropertiesNotSupported">
+        <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
+        <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_IncompatibleConverterType">
+        <source>The converter '{0}' is not compatible with the type '{1}'.</source>
+        <target state="new">The converter '{0}' is not compatible with the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InitOnlyPropertyDeserializationNotSupported">
+        <source>Deserialization of init-only properties is currently not supported in source generation mode.</source>
+        <target state="new">Deserialization of init-only properties is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidJsonConverterFactoryOutput">
+        <source>The converter '{0}' cannot return null or a JsonConverterFactory instance.</source>
+        <target state="new">The converter '{0}' cannot return null or a JsonConverterFactory instance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidSerializablePropertyConfiguration">
+        <source>Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
         <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
         <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.zh-Hans.xlf
@@ -32,6 +32,31 @@
         <target state="translated">重复的类型名称。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Exception_InaccessibleJsonIncludePropertiesNotSupported">
+        <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
+        <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_IncompatibleConverterType">
+        <source>The converter '{0}' is not compatible with the type '{1}'.</source>
+        <target state="new">The converter '{0}' is not compatible with the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InitOnlyPropertyDeserializationNotSupported">
+        <source>Deserialization of init-only properties is currently not supported in source generation mode.</source>
+        <target state="new">Deserialization of init-only properties is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidJsonConverterFactoryOutput">
+        <source>The converter '{0}' cannot return null or a JsonConverterFactory instance.</source>
+        <target state="new">The converter '{0}' cannot return null or a JsonConverterFactory instance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidSerializablePropertyConfiguration">
+        <source>Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
         <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
         <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.zh-Hans.xlf
@@ -32,6 +32,26 @@
         <target state="translated">重复的类型名称。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
+        <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
+        <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedTitle">
+        <source>Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</source>
+        <target state="new">Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitOnlyPropertyDeserializationNotSupportedFormat">
+        <source>The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</source>
+        <target state="new">The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitOnlyPropertyDeserializationNotSupportedTitle">
+        <source>Deserialization of init-only properties is currently not supported in source generation mode.</source>
+        <target state="new">Deserialization of init-only properties is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleJsonConstructorAttributeFormat">
         <source>Type '{0}' has multiple constructors annotated with 'JsonConstructorAttribute'.</source>
         <target state="translated">类型“{0}”具有用 “JsonConstructorAttribute” 批注的多个构造函数。</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.zh-Hant.xlf
@@ -32,6 +32,26 @@
         <target state="translated">重複類型名稱。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
+        <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
+        <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedTitle">
+        <source>Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</source>
+        <target state="new">Inaccessible properties annotated with the JsonIncludeAttribute are not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitOnlyPropertyDeserializationNotSupportedFormat">
+        <source>The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</source>
+        <target state="new">The type '{0}' defines init-only properties, deserialization of which is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InitOnlyPropertyDeserializationNotSupportedTitle">
+        <source>Deserialization of init-only properties is currently not supported in source generation mode.</source>
+        <target state="new">Deserialization of init-only properties is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MultipleJsonConstructorAttributeFormat">
         <source>Type '{0}' has multiple constructors annotated with 'JsonConstructorAttribute'.</source>
         <target state="translated">類型 '{0}' 包含多個以 'JsonConstructorAttribute' 註解的建構函式。</target>

--- a/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/libraries/System.Text.Json/gen/Resources/xlf/Strings.zh-Hant.xlf
@@ -32,6 +32,31 @@
         <target state="translated">重複類型名稱。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Exception_InaccessibleJsonIncludePropertiesNotSupported">
+        <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
+        <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_IncompatibleConverterType">
+        <source>The converter '{0}' is not compatible with the type '{1}'.</source>
+        <target state="new">The converter '{0}' is not compatible with the type '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InitOnlyPropertyDeserializationNotSupported">
+        <source>Deserialization of init-only properties is currently not supported in source generation mode.</source>
+        <target state="new">Deserialization of init-only properties is currently not supported in source generation mode.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidJsonConverterFactoryOutput">
+        <source>The converter '{0}' cannot return null or a JsonConverterFactory instance.</source>
+        <target state="new">The converter '{0}' cannot return null or a JsonConverterFactory instance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidSerializablePropertyConfiguration">
+        <source>Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</source>
+        <target state="new">Invalid serializable-property configuration specified for type '{0}'. For more information, see 'JsonSourceGenerationMode.Serialization'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InaccessibleJsonIncludePropertiesNotSupportedFormat">
         <source>The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</source>
         <target state="new">The member '{0}.{1}' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.</target>

--- a/src/libraries/System.Text.Json/tests/Common/PropertyVisibilityTests.NonPublicAccessors.cs
+++ b/src/libraries/System.Text.Json/tests/Common/PropertyVisibilityTests.NonPublicAccessors.cs
@@ -216,31 +216,46 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public virtual async Task HonorJsonPropertyName()
+        public virtual async Task HonorJsonPropertyName_PrivateGetter()
         {
-            string json = @"{""prop1"":1,""prop2"":2}";
+            string json = @"{""prop1"":1}";
 
-            var obj = await JsonSerializerWrapperForString.DeserializeWrapper<StructWithPropertiesWithJsonPropertyName>(json);
-            Assert.Equal(MySmallEnum.AnotherValue, obj.GetMyEnum);
-            Assert.Equal(2, obj.MyInt);
+            var obj = await JsonSerializerWrapperForString.DeserializeWrapper<StructWithPropertiesWithJsonPropertyName_PrivateGetter>(json);
+            Assert.Equal(MySmallEnum.AnotherValue, obj.GetProxy());
 
             json = await JsonSerializerWrapperForString.SerializeWrapper(obj);
             Assert.Contains(@"""prop1"":1", json);
+        }
+
+        [Fact]
+        public virtual async Task HonorJsonPropertyName_PrivateSetter()
+        {
+            string json = @"{""prop2"":2}";
+
+            var obj = await JsonSerializerWrapperForString.DeserializeWrapper<StructWithPropertiesWithJsonPropertyName_PrivateSetter>(json);
+            Assert.Equal(2, obj.MyInt);
+
+            json = await JsonSerializerWrapperForString.SerializeWrapper(obj);
             Assert.Contains(@"""prop2"":2", json);
         }
 
-        public struct StructWithPropertiesWithJsonPropertyName
+        public struct StructWithPropertiesWithJsonPropertyName_PrivateGetter
         {
             [JsonInclude]
             [JsonPropertyName("prop1")]
             public MySmallEnum MyEnum { private get; set; }
 
+            // For test validation.
+            internal MySmallEnum GetProxy() => MyEnum;
+        }
+
+        public struct StructWithPropertiesWithJsonPropertyName_PrivateSetter
+        {
             [JsonInclude]
             [JsonPropertyName("prop2")]
             public int MyInt { get; private set; }
 
-            // For test validation.
-            internal MySmallEnum GetMyEnum => MyEnum;
+            internal void SetProxy(int myInt) => MyInt = myInt;
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/System.Text.Json.SourceGeneration.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/System.Text.Json.SourceGeneration.Tests.csproj
@@ -4,7 +4,9 @@
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <!-- SYSLIB0020: JsonSerializerOptions.IgnoreNullValues is obsolete -->
-    <NoWarn>$(NoWarn);SYSLIB0020</NoWarn>
+    <!-- SYSLIB1037: Suppress init-only property deserialization warning -->
+    <!-- SYSLIB1038: Suppress JsonInclude on inaccessible members warning -->
+    <NoWarn>$(NoWarn);SYSLIB0020;SYSLIB1037;SYSLIB1038</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/CompilationHelper.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/CompilationHelper.cs
@@ -265,11 +265,72 @@ namespace System.Text.Json.SourceGeneration.UnitTests
             return CreateCompilation(source);
         }
 
+        public static Compilation CreateCompilationWithInitOnlyProperties()
+        {
+            string source = @"
+            using System;
+            using System.Text.Json.Serialization;
+
+            namespace HelloWorld
+            {                
+                public class Location
+                {
+                    public int Id { get; init; }
+                    public string Address1 { get; init; }
+                    public string Address2 { get; init; }
+                    public string City { get; init; }
+                    public string State { get; init; }
+                    public string PostalCode { get; init; }
+                    public string Name { get; init; }
+                    public string PhoneNumber { get; init; }
+                    public string Country { get; init; }
+                }
+
+                [JsonSerializable(typeof(Location))]
+                public partial class MyJsonContext : JsonSerializerContext
+                {
+                }
+            }";
+
+            return CreateCompilation(source);
+        }
+
+        public static Compilation CreateCompilationWithInaccessibleJsonIncludeProperties()
+        {
+            string source = @"
+            using System;
+            using System.Text.Json.Serialization;
+
+            namespace HelloWorld
+            {                
+                public class Location
+                {
+                    [JsonInclude]
+                    public int Id { get; private set; }
+                    [JsonInclude]
+                    public string Address1 { get; internal set; }
+                    [JsonInclude]
+                    private string Address2 { get; set; }
+                    [JsonInclude]
+                    public string PhoneNumber { internal get; set; }
+                    [JsonInclude]
+                    public string Country { private get; set; }
+                }
+
+                [JsonSerializable(typeof(Location))]
+                public partial class MyJsonContext : JsonSerializerContext
+                {
+                }
+            }";
+
+            return CreateCompilation(source);
+        }
+
         internal static void CheckDiagnosticMessages(ImmutableArray<Diagnostic> diagnostics, DiagnosticSeverity level, string[] expectedMessages)
         {
             string[] actualMessages = diagnostics.Where(diagnostic => diagnostic.Severity == level).Select(diagnostic => diagnostic.GetMessage()).ToArray();
 
-            // Can't depending on reflection order when generating type metadata.
+            // Can't depend on reflection order when generating type metadata.
             Array.Sort(actualMessages);
             Array.Sort(expectedMessages);
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/JsonSourceGeneratorDiagnosticsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Unit.Tests/JsonSourceGeneratorDiagnosticsTests.cs
@@ -190,5 +190,38 @@ public class Program
             CompilationHelper.CheckDiagnosticMessages(generatorDiags, DiagnosticSeverity.Warning, Array.Empty<string>());
             CompilationHelper.CheckDiagnosticMessages(generatorDiags, DiagnosticSeverity.Error, Array.Empty<string>());
         }
+
+        [Fact]
+        public void WarnOnClassesWithInitOnlyProperties()
+        {
+            Compilation compilation = CompilationHelper.CreateCompilationWithInitOnlyProperties();
+            JsonSourceGenerator generator = new JsonSourceGenerator();
+            CompilationHelper.RunGenerators(compilation, out var generatorDiags, generator);
+
+            string[] expectedWarningDiagnostics = new string[] { "The type 'Location' defines init-only properties, deserialization of which is currently not supported in source generation mode." };
+
+            CompilationHelper.CheckDiagnosticMessages(generatorDiags, DiagnosticSeverity.Info, Array.Empty<string>());
+            CompilationHelper.CheckDiagnosticMessages(generatorDiags, DiagnosticSeverity.Warning, expectedWarningDiagnostics);
+            CompilationHelper.CheckDiagnosticMessages(generatorDiags, DiagnosticSeverity.Error, Array.Empty<string>());
+        }
+
+        [Fact]
+        public void WarnOnClassesWithInaccessibleJsonIncludeProperties()
+        {
+            Compilation compilation = CompilationHelper.CreateCompilationWithInaccessibleJsonIncludeProperties();
+            JsonSourceGenerator generator = new JsonSourceGenerator();
+            CompilationHelper.RunGenerators(compilation, out var generatorDiags, generator);
+
+            string[] expectedWarningDiagnostics = new string[]
+            {
+                "The member 'Location.Id' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.",
+                "The member 'Location.Address2' has been annotated with the JsonIncludeAttribute but is not visible to the source generator.",
+                "The member 'Location.Country' has been annotated with the JsonIncludeAttribute but is not visible to the source generator."
+            };
+
+            CompilationHelper.CheckDiagnosticMessages(generatorDiags, DiagnosticSeverity.Info, Array.Empty<string>());
+            CompilationHelper.CheckDiagnosticMessages(generatorDiags, DiagnosticSeverity.Warning, expectedWarningDiagnostics);
+            CompilationHelper.CheckDiagnosticMessages(generatorDiags, DiagnosticSeverity.Error, Array.Empty<string>());
+        }
     }
 }


### PR DESCRIPTION
- Emit diagnostic warnings when sourcegen is handling init-only properties or inacessible JsonInclude members.
- Throw a runtime exception instead of ignoring the above members.
- Add localizations for runtime exception messages.

Contributes to #58770.
Fixes #58292.

Should be backported to release/6.0