### PR TITLE
Fix EventPipe sample profiler resolution on Windows.

### DIFF
--- a/src/native/eventpipe/ep-sample-profiler.c
+++ b/src/native/eventpipe/ep-sample-profiler.c
@@ -198,10 +198,7 @@ sample_profiler_enable (void)
 
 	ep_requires_lock_held ();
 
-	const bool result = sample_profiler_load_dependecies ();
-	EP_ASSERT (result);
-
-	if (result && !sample_profiler_load_profiling_enabled ()) {
+	if (!sample_profiler_load_profiling_enabled ()) {
 		sample_profiler_store_profiling_enabled (true);
 
 		EP_ASSERT (!ep_rt_wait_event_is_valid (&_thread_shutdown_event));
@@ -272,6 +269,8 @@ ep_sample_profiler_enable (void)
 	// Check to see if the sample profiler event is enabled. If it is not, do not spin up the sampling thread.
 	if (!ep_event_is_enabled (_thread_time_event))
 		return;
+
+	sample_profiler_load_dependecies ();
 
 	if (_can_start_sampling)
 		sample_profiler_enable ();


### PR DESCRIPTION
If sample profiler was initially created before sampling has been enabled, happens when setting up sessions during startup,
sample_profiler_load_dependecies won't get called, meaning we won't setup timeBeginPeriod/timeEndPeriod on Windows, and won't adjust default scheduling resolution to 1ms staying on default 16ms.

There is a ref count check in current sample_profiler_enable checking if we should call sample_profiler_load_dependecies (_ref_count == 0), but in case where we can't start profiling _can_start_sampling == false, we won't call sample_profiler_enable but always increase _ref_count that in turn will prevent calls to sample_profiler_load_dependecies when enabling sample profiler and that in turn won't call timeBeginPeriod staying on default scheduling resolution.

Fix is to always call sample_profiler_load_dependecies making sure we will setup needed dependencies when _ref_count == 0.