### PR TITLE
[wasm] browser-bench improvements

### DIFF
--- a/src/mono/sample/wasm/browser-bench/Exceptions.cs
+++ b/src/mono/sample/wasm/browser-bench/Exceptions.cs
@@ -20,8 +20,8 @@ namespace Sample
                 new TryCatchThrow(),
                 new TryCatchFilter(),
                 new TryCatchFilterInline(),
-                //new TryCatchFilterThrow(),
-                //new TryCatchFilterThrowApplies(),
+                new TryCatchFilterThrow(),
+                new TryCatchFilterThrowApplies(),
             };
         }
 
@@ -39,7 +39,7 @@ namespace Sample
 
         public abstract class ExcMeasurement : BenchTask.Measurement
         {
-            public override int InitialSamples => 10000;
+            public override int InitialSamples => 100000;
         }
 
         class NoExceptionHandling : ExcMeasurement

--- a/src/mono/sample/wasm/browser-bench/Json.cs
+++ b/src/mono/sample/wasm/browser-bench/Json.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 namespace Sample
@@ -36,6 +37,7 @@ namespace Sample
         string smallOrgChartJson;
         string largeOrgChartJson;
 
+        [UnconditionalSuppressMessage("Trim analysis error", "IL2026")]
         public override void Initialize()
         {
             jsonText = JsonSerializer.Serialize(tc);
@@ -49,6 +51,8 @@ namespace Sample
 
             public TextSerialize(JsonTask task) => this.task = task;
             public override string Name => "non-ASCII text serialize";
+
+            [UnconditionalSuppressMessage("Trim analysis error", "IL2026")]
             public override void RunStep() => JsonSerializer.Serialize(task.tc);
         }
 
@@ -58,6 +62,8 @@ namespace Sample
 
             public TextDeserialize(JsonTask task) => this.task = task;
             public override string Name => "non-ASCII text deserialize";
+
+            [UnconditionalSuppressMessage("Trim analysis error", "IL2026")]
             public override void RunStep() => JsonSerializer.Deserialize<TextContainer>(task.jsonText);
         }
 
@@ -67,6 +73,8 @@ namespace Sample
 
             public SmallSerialize(JsonTask task) => this.task = task;
             public override string Name => "small serialize";
+
+            [UnconditionalSuppressMessage("Trim analysis error", "IL2026")]
             public override void RunStep() => JsonSerializer.Serialize(task.smallOrgChart);
         }
 
@@ -76,6 +84,8 @@ namespace Sample
 
             public SmallDeserialize(JsonTask task) => this.task = task;
             public override string Name => "small deserialize";
+
+            [UnconditionalSuppressMessage("Trim analysis error", "IL2026")]
             public override void RunStep() => JsonSerializer.Deserialize<Person>(task.smallOrgChartJson);
         }
 
@@ -86,6 +96,8 @@ namespace Sample
             public LargeSerialize(JsonTask task) => this.task = task;
             public override string Name => "large serialize";
             public override int InitialSamples => 3;
+
+            [UnconditionalSuppressMessage("Trim analysis error", "IL2026")]
             public override void RunStep() => JsonSerializer.Serialize(task.largeOrgChart);
         }
 
@@ -96,6 +108,8 @@ namespace Sample
             public LargeDeserialize(JsonTask task) => this.task = task;
             public override string Name => "large deserialize";
             public override int InitialSamples => 3;
+
+            [UnconditionalSuppressMessage("Trim analysis error", "IL2026")]
             public override void RunStep() => JsonSerializer.Deserialize<Person>(task.largeOrgChartJson);
         }
 

--- a/src/mono/sample/wasm/browser-bench/Program.cs
+++ b/src/mono/sample/wasm/browser-bench/Program.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -19,7 +20,8 @@ namespace Sample
         BenchTask[] tasks =
         {
             new ExceptionsTask(),
-            new JsonTask ()
+            new JsonTask (),
+            new WebSocketTask()
         };
         static Test instance = new Test ();
 
@@ -30,6 +32,9 @@ namespace Sample
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
+        // the constructors of the task we care about are already used when createing tasks field
+        [UnconditionalSuppressMessage("Trim analysis error", "IL2057")]
+        [UnconditionalSuppressMessage("Trim analysis error", "IL2072")]
         public static void SetTasks(string taskNames)
         {
             Regex pattern;
@@ -165,7 +170,7 @@ namespace Sample
                     time *= 1000;
                     unit = "us";
                 }
-                sb.Append($"| {key,32} | {time,10:F4}{unit} |<br>".Replace (" ", "&nbsp;"));
+                sb.Append($"| {key.Replace('_',' '),38} | {time,10:F4}{unit} |<br>".Replace (" ", "&nbsp;"));
             }
             sb.Append("</tt>");
 

--- a/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
+++ b/src/mono/sample/wasm/browser-bench/Wasm.Browser.Bench.Sample.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <WasmCopyAppZipToHelixTestDir Condition="'$(ArchiveTests)' == 'true'">true</WasmCopyAppZipToHelixTestDir>
     <WasmMainJSPath>runtime.js</WasmMainJSPath>
-    <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Do not supress all linker warnings. Use UnconditionalSuppressMessage
attribute to supress these we know are ok.

Add new WebSocketTask to the default tasks array.

Enable disabled exception measurements as they don't crash anymore.

Improve summary output.

Example output:

| measurement | time |
|-:|-:|
|        Exceptions, NoExceptionHandling |     0.2288us |
|                   Exceptions, TryCatch |     0.2480us |
|              Exceptions, TryCatchThrow |     0.0083ms |
|             Exceptions, TryCatchFilter |     0.1917us |
|       Exceptions, TryCatchFilterInline |     0.0486us |
|        Exceptions, TryCatchFilterThrow |     0.0096ms |
| Exceptions, TryCatchFilterThrowApplies |     0.0092ms |
|         Json, non-ASCII text serialize |     0.6500ms |
|       Json, non-ASCII text deserialize |     2.1381ms |
|                  Json, small serialize |     0.1419ms |
|                Json, small deserialize |     0.2167ms |
|                  Json, large serialize |    36.9640ms |
|                Json, large deserialize |    59.0562ms |
|              WebSocket, PartialSend 1B |     0.0022ms |
|            WebSocket, PartialSend 64KB |     0.0690ms |
|             WebSocket, PartialSend 1MB |     1.1455ms |
|           WebSocket, PartialReceive 1B |     0.0060ms |
|         WebSocket, PartialReceive 10KB |     0.0080ms |
|        WebSocket, PartialReceive 100KB |     0.0000us |