### PR TITLE
[MonoVM] Reduce P/Invoke GC transition asserts in release builds

### DIFF
--- a/src/mono/mono/utils/mono-threads-coop.c
+++ b/src/mono/mono/utils/mono-threads-coop.c
@@ -95,7 +95,7 @@ coop_tls_pop (gpointer received_cookie)
 static void
 check_info (MonoThreadInfo *info, const gchar *action, const gchar *state, const char *func)
 {
-#ifdef ENABLE_CHECKED_BUILD_GC
+#ifdef ENABLE_CHECKED_BUILD
 	g_assertf (info, "%s Cannot %s GC %s region if the thread is not attached", func, action, state);
 	g_assertf (mono_thread_info_is_current (info), "%s [%p] Cannot %s GC %s region on a different thread", func, mono_thread_info_get_tid (info), action, state);
 	g_assertf (mono_thread_info_is_live (info), "%s [%p] Cannot %s GC %s region if the thread is not live", func, mono_thread_info_get_tid (info), action, state);

--- a/src/mono/mono/utils/mono-threads-coop.c
+++ b/src/mono/mono/utils/mono-threads-coop.c
@@ -95,12 +95,9 @@ coop_tls_pop (gpointer received_cookie)
 static void
 check_info (MonoThreadInfo *info, const gchar *action, const gchar *state, const char *func)
 {
-	if (!info)
-		g_error ("%s Cannot %s GC %s region if the thread is not attached", func, action, state);
-	if (!mono_thread_info_is_current (info))
-		g_error ("%s [%p] Cannot %s GC %s region on a different thread", func, mono_thread_info_get_tid (info), action, state);
-	if (!mono_thread_info_is_live (info))
-		g_error ("%s [%p] Cannot %s GC %s region if the thread is not live", func, mono_thread_info_get_tid (info), action, state);
+	g_assertf (info, "%s Cannot %s GC %s region if the thread is not attached", func, action, state);
+	g_assertf (mono_thread_info_is_current (info), "%s [%p] Cannot %s GC %s region on a different thread", func, mono_thread_info_get_tid (info), action, state);
+	g_assertf (mono_thread_info_is_live (info), "%s [%p] Cannot %s GC %s region if the thread is not live", func, mono_thread_info_get_tid (info), action, state);
 }
 
 static int coop_reset_blocking_count;

--- a/src/mono/mono/utils/mono-threads-coop.c
+++ b/src/mono/mono/utils/mono-threads-coop.c
@@ -95,9 +95,11 @@ coop_tls_pop (gpointer received_cookie)
 static void
 check_info (MonoThreadInfo *info, const gchar *action, const gchar *state, const char *func)
 {
+#ifdef ENABLE_CHECKED_BUILD_GC
 	g_assertf (info, "%s Cannot %s GC %s region if the thread is not attached", func, action, state);
 	g_assertf (mono_thread_info_is_current (info), "%s [%p] Cannot %s GC %s region on a different thread", func, mono_thread_info_get_tid (info), action, state);
 	g_assertf (mono_thread_info_is_live (info), "%s [%p] Cannot %s GC %s region if the thread is not live", func, mono_thread_info_get_tid (info), action, state);
+#endif
 }
 
 static int coop_reset_blocking_count;

--- a/src/mono/mono/utils/mono-threads-state-machine.c
+++ b/src/mono/mono/utils/mono-threads-state-machine.c
@@ -105,7 +105,7 @@ unwrap_thread_state (MonoThreadInfo* info,
 static void
 check_thread_state (MonoThreadInfo* info)
 {
-#ifdef ENABLE_CHECKED_BUILD_THREAD
+#ifdef ENABLE_CHECKED_BUILD
 	int raw_state, cur_state, suspend_count;
 	gboolean no_safepoints;
 	UNWRAP_THREAD_STATE (raw_state, cur_state, suspend_count, no_safepoints, info);

--- a/src/mono/mono/utils/mono-threads-state-machine.c
+++ b/src/mono/mono/utils/mono-threads-state-machine.c
@@ -105,6 +105,7 @@ unwrap_thread_state (MonoThreadInfo* info,
 static void
 check_thread_state (MonoThreadInfo* info)
 {
+#ifdef ENABLE_CHECKED_BUILD_THREAD
 	int raw_state, cur_state, suspend_count;
 	gboolean no_safepoints;
 	UNWRAP_THREAD_STATE (raw_state, cur_state, suspend_count, no_safepoints, info);
@@ -133,6 +134,7 @@ check_thread_state (MonoThreadInfo* info)
 	default:
 		g_error ("Invalid state %d", cur_state);
 	}
+#endif
 }
 
 static void


### PR DESCRIPTION
Profiling shows that large part of the GC transition overhead (~30%) in #58939 is caused by assert-style checks. Disabling them seems to be the best bang-for-the-buck option for reducing the overhead without fundamental changes to the code.