### PR TITLE
Single-file apps should not use copy-on-write mapping of the .exe on windows.

### DIFF
--- a/src/native/corehost/bundle/info.cpp
+++ b/src/native/corehost/bundle/info.cpp
@@ -108,7 +108,14 @@ char* info_t::config_t::map(const pal::string_t& path, const location_t* &locati
     // * There is no performance limitation due to a larger sized mapping, since we actually only read the pages with relevant contents.
     // * Files that are too large to be mapped (ex: that exhaust 32-bit virtual address space) are not supported. 
 
+#ifdef _WIN32
+    // Since we can't use in-situ parsing on Windows, as JSON data is encoded in
+    // UTF-8 and the host expects wide strings.
+    // We do not need COW and read-only mapping will be enough.
+    char* addr = (char*)pal::mmap_read(app->m_bundle_path);
+#else // _WIN32
     char* addr = (char*)pal::mmap_copy_on_write(app->m_bundle_path);
+#endif // _WIN32
     if (addr == nullptr)
     {
         trace::error(_X("Failure processing application bundle."));


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/55405     (App published as single file fails to run in Windows 10.0.17763 containers)

## Customer Impact

Regression from  .NET Core 2.1 and 3.1 causing failure when a single-file app runs in a Windows 10.0.17763 container. 

```
Failed to map file. CreateFileMappingW(C:\app\app.exe) failed with error 5
Failure processing application bundle.
Failed to map bundle file [C:\app\app.runtimeconfig.json]
```
(This is a relatively old 2018 RS5 build, but it is an LTS so it will be around for a while)


## Testing

Manually verified in an actual container. Regular Unit tests.

## Risk

Very low. 

We do not benefit from copy-on-write part of the mapping on Windows since we do not do in-situ json parsing due to UTF8/UTF16 differences. We basically request COW for consistency with Unix. Somehow it triggers unexpected "access denied" failure for superhost-style single-file apps on this particular build/container. 

Since we do not do in-situ parsing on Windows, a read-only mapping is sufficient and we should request just what we need.
