### PR TITLE
Use getpwuid(3) in corehost for the $HOME-less user

### DIFF
--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleExtractToSpecificPath.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleExtractToSpecificPath.cs
@@ -223,14 +223,33 @@ namespace AppHost.Bundle.Tests
 
         [Fact]
         [SkipOnPlatform(TestPlatforms.Windows, "On Windows the default extraction path is determined by calling GetTempPath which looks at multiple places and can't really be undefined.")]
-        private void Bundle_extraction_default_undefined()
+        private void Bundle_extraction_fallsback_to_getpwuid_when_HOME_env_var_is_undefined()
         {
+            string home = Environment.GetEnvironmentVariable("HOME");
+            // suppose we are testing on a system where HOME is not set, use System.Environment (which also fallsback to getpwuid)
+            if (string.IsNullOrEmpty(home))
+            {
+                home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            }
+
+            DirectoryInfo sharedExtractDirInfo = BundleHelper.GetExtractionDir(sharedTestState.TestFixture, sharedTestState.DefaultBundledAppBundler);
+            string sharedExtractDir = sharedExtractDirInfo.FullName;
+            string extractDirSubPath = sharedExtractDir.Substring(sharedExtractDir.LastIndexOf("extract/") + "extract/".Length);
+            string realExtractDir = Path.Combine(home, ".net", extractDirSubPath);
+            var expectedExtractDir = new DirectoryInfo(realExtractDir);
+
             Command.Create(sharedTestState.DefaultBundledAppExecutablePath)
                 .CaptureStdErr()
                 .CaptureStdOut()
                 .EnvironmentVariable("HOME", null)
-                .Execute().Should().Fail()
-                .And.HaveStdErrContaining("Failed to determine default extraction location. Environment variable '$HOME' is not defined.");
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello World");
+
+            var extractedFiles = BundleHelper.GetExtractedFiles(sharedTestState.TestFixture, BundleOptions.BundleNativeBinaries);
+            expectedExtractDir.Should().HaveFiles(extractedFiles);
         }
 
         public class SharedTestState : SharedTestStateBase, IDisposable

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -352,7 +352,30 @@ bool get_extraction_base_parent_directory(pal::string_t& directory)
     }
     else
     {
-        trace::error(_X("Failed to determine default extraction location. Environment variable '$HOME' is not defined."));
+        // fallback to the POSIX standard getpwuid() library function
+        struct passwd* pwuid = NULL;
+        errno = 0;
+        do
+        {
+            pwuid = getpwuid(getuid());
+        } while (pwuid == NULL && errno == EINTR);
+
+        if (pwuid != NULL)
+        {
+            directory.assign(pwuid->pw_dir);
+            if (is_read_write_able_directory(directory))
+            {
+                return true;
+            }
+            else
+            {
+                trace::error(_X("Failed to determine default extraction location. Environment variable '$HOME' is not defined and directory reported by getpwuid(3) [%s] either doesn't exist or is not accessible for read/write."), pwuid->pw_dir);
+            }
+        }
+        else
+        {
+            trace::error(_X("Failed to determine default extraction location. Environment variable '$HOME' is not defined and getpwuid(3) returned NULL."));
+        }
     }
 
     return false;

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -369,12 +369,12 @@ bool get_extraction_base_parent_directory(pal::string_t& directory)
             }
             else
             {
-                trace::error(_X("Failed to determine default extraction location. Environment variable '$HOME' is not defined and directory reported by getpwuid(3) [%s] either doesn't exist or is not accessible for read/write."), pwuid->pw_dir);
+                trace::error(_X("Failed to determine default extraction location. Environment variable '$HOME' is not defined and directory reported by getpwuid() [%s] either doesn't exist or is not accessible for read/write."), pwuid->pw_dir);
             }
         }
         else
         {
-            trace::error(_X("Failed to determine default extraction location. Environment variable '$HOME' is not defined and getpwuid(3) returned NULL."));
+            trace::error(_X("Failed to determine default extraction location. Environment variable '$HOME' is not defined and getpwuid() returned NULL."));
         }
     }
 


### PR DESCRIPTION
In other parts of dotnet/runtime repo <sup>[[1](https://github.com/dotnet/runtime/blob/57bfe474518ab5b7cfe6bf7424a79ce3af9d6657/src/libraries/Native/Unix/System.Native/pal_networking.c#L3038-L3056)] [[2](https://github.com/dotnet/runtime/blob/57bfe474518ab5b7cfe6bf7424a79ce3af9d6657/src/libraries/System.Private.CoreLib/src/System/IO/PersistedFiles.Unix.cs#L125-L137)] [[3](https://github.com/dotnet/runtime/blob/57bfe474518ab5b7cfe6bf7424a79ce3af9d6657/src/libraries/Native/Unix/System.Native/pal_uid.c#L65-L68)]</sup>, we attempt to retrieve user home directory from `getpwuid_r` when the environment variable `HOME` is not set. Use the same fallback in corehost.