### PR TITLE
UpdateJson and CompilerServices.Unsafe versions

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -182,13 +182,13 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>b7e10374429b5af32debc4660aa9bce41cfb903e</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Json" Version="7.0.0-alpha.1.21456.1">
+    <Dependency Name="System.Text.Json" Version="7.0.0-alpha.1.21463.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>b7e10374429b5af32debc4660aa9bce41cfb903e</Sha>
+      <Sha>0becd27f728f9e1eeb2a168789418ad4191ade99</Sha>
     </Dependency>
-    <Dependency Name="System.Runtime.CompilerServices.Unsafe" Version="7.0.0-alpha.1.21456.1">
+    <Dependency Name="System.Runtime.CompilerServices.Unsafe" Version="7.0.0-alpha.1.21463.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>b7e10374429b5af32debc4660aa9bce41cfb903e</Sha>
+      <Sha>0becd27f728f9e1eeb2a168789418ad4191ade99</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="7.0.100-1.21460.1">
       <Uri>https://github.com/mono/linker</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -108,8 +108,8 @@
     <SystemSecurityCryptographyOpenSslVersion>5.0.0</SystemSecurityCryptographyOpenSslVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>
     <ServiceModelVersion>4.8.1</ServiceModelVersion>
-    <SystemTextJsonVersion>7.0.0-alpha.1.21456.1</SystemTextJsonVersion>
-    <SystemRuntimeCompilerServicesUnsafeVersion>7.0.0-alpha.1.21456.1</SystemRuntimeCompilerServicesUnsafeVersion>
+    <SystemTextJsonVersion>7.0.0-alpha.1.21463.1</SystemTextJsonVersion>
+    <SystemRuntimeCompilerServicesUnsafeVersion>7.0.0-alpha.1.21463.1</SystemRuntimeCompilerServicesUnsafeVersion>
     <SystemThreadingTasksExtensionsVersion>4.5.4</SystemThreadingTasksExtensionsVersion>
     <SystemValueTupleVersion>4.5.0</SystemValueTupleVersion>
     <runtimenativeSystemIOPortsVersion>7.0.0-alpha.1.21456.1</runtimenativeSystemIOPortsVersion>


### PR DESCRIPTION
This unblocks the SDK ingestion now that we are targeting net7.0. Microsoft.NET.HostModel needs to update to 7.0 Assembly Versions of these libraries.

NOTE: this is a subset of https://github.com/dotnet/runtime/pull/58999/files, but that PR has other changes and I wanted to get these changes in ASAP.