### PR TITLE
Change channel passed to ci_setup to track runtime branch

### DIFF
--- a/eng/testing/performance/performance-setup.ps1
+++ b/eng/testing/performance/performance-setup.ps1
@@ -97,7 +97,8 @@ if ($iOSMono) {
 }
 
 # FIX ME: This is a workaround until we get this from the actual pipeline
-$CommonSetupArguments="--channel main --queue $Queue --build-number $BuildNumber --build-configs $Configurations --architecture $Architecture"
+$CleanedBranchName = $Branch.replace('refs/heads/', '')
+$CommonSetupArguments="--channel $CleanedBranchName --queue $Queue --build-number $BuildNumber --build-configs $Configurations --architecture $Architecture"
 $SetupArguments = "--repository https://github.com/$Repository --branch $Branch --get-perf-hash --commit-sha $CommitSha $CommonSetupArguments"
 
 if($NoPGO)

--- a/eng/testing/performance/performance-setup.ps1
+++ b/eng/testing/performance/performance-setup.ps1
@@ -97,7 +97,11 @@ if ($iOSMono) {
 }
 
 # FIX ME: This is a workaround until we get this from the actual pipeline
-$CleanedBranchName = $Branch.replace('refs/heads/', '')
+$CleanedBranchName = "main"
+if($Branch.Contains("refs/heads/release"))
+{
+    $CleanedBranchName = $Branch.replace('refs/heads/', '')
+}
 $CommonSetupArguments="--channel $CleanedBranchName --queue $Queue --build-number $BuildNumber --build-configs $Configurations --architecture $Architecture"
 $SetupArguments = "--repository https://github.com/$Repository --branch $Branch --get-perf-hash --commit-sha $CommitSha $CommonSetupArguments"
 


### PR DESCRIPTION
With this change we move to specifing the channel that is passed to ci_setup,
instead of it always being main. The allows us to have the runtime branch
help decide the correct version of the sdk that we should pull down with
dotnet-install. This means that going forward, we will need to have channels
that match the names of all branches that we plan to run from the runtime
side. If we do not, the sdk installation step will fail during ci_setup.