### PR TITLE
Process.Unix: handle ETXTBSY error when executing file that was just written by .NET.

### DIFF
--- a/src/installer/tests/TestUtils/AppHostExtensions.cs
+++ b/src/installer/tests/TestUtils/AppHostExtensions.cs
@@ -39,26 +39,40 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         public static void SetWindowsGraphicalUserInterfaceBit(string appHostPath)
         {
-            using (var memoryMappedFile = MemoryMappedFile.CreateFromFile(appHostPath))
+            // Make a copy of apphost first, replace hash and overwrite app.exe, rather than
+            // overwrite app.exe and edit in place, because the file is opened as "write" for
+            // the replacement -- the test fails with ETXTBSY (exit code: 26) in Linux when
+            // executing a file opened in "write" mode.
+            string tempPath = appHostPath + ".tmp";
+            File.Copy(appHostPath, tempPath, true);
+            using (var memoryMappedFile = MemoryMappedFile.CreateFromFile(tempPath))
             {
                 using (MemoryMappedViewAccessor accessor = memoryMappedFile.CreateViewAccessor())
                 {
                     SetWindowsGraphicalUserInterfaceBit(accessor);
                 }
             }
+            File.Move(tempPath, appHostPath, true);
         }
 
         public static void BindAppHost(string appHostPath)
         {
             string appDll = $"{Path.GetFileNameWithoutExtension(appHostPath)}.dll";
 
+            // Make a copy of apphost first, replace hash and overwrite app.exe, rather than
+            // overwrite app.exe and edit in place, because the file is opened as "write" for
+            // the replacement -- the test fails with ETXTBSY (exit code: 26) in Linux when
+            // executing a file opened in "write" mode.
+            string tempPath = appHostPath + ".tmp";
+            File.Copy(appHostPath, tempPath, true);
             using (var sha256 = SHA256.Create())
             {
                 // Replace the hash with the managed DLL name.
                 var hash = sha256.ComputeHash(Encoding.UTF8.GetBytes("foobar"));
                 var hashStr = BitConverter.ToString(hash).Replace("-", "").ToLower();
-                BinaryUtils.SearchAndReplace(appHostPath, Encoding.UTF8.GetBytes(hashStr), Encoding.UTF8.GetBytes(appDll));
+                BinaryUtils.SearchAndReplace(tempPath, Encoding.UTF8.GetBytes(hashStr), Encoding.UTF8.GetBytes(appDll));
             }
+            File.Move(tempPath, appHostPath, true);
         }
 
         /// <summary>

--- a/src/installer/tests/TestUtils/AppHostExtensions.cs
+++ b/src/installer/tests/TestUtils/AppHostExtensions.cs
@@ -39,40 +39,26 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         public static void SetWindowsGraphicalUserInterfaceBit(string appHostPath)
         {
-            // Make a copy of apphost first, replace hash and overwrite app.exe, rather than
-            // overwrite app.exe and edit in place, because the file is opened as "write" for
-            // the replacement -- the test fails with ETXTBSY (exit code: 26) in Linux when
-            // executing a file opened in "write" mode.
-            string tempPath = appHostPath + ".tmp";
-            File.Copy(appHostPath, tempPath, true);
-            using (var memoryMappedFile = MemoryMappedFile.CreateFromFile(tempPath))
+            using (var memoryMappedFile = MemoryMappedFile.CreateFromFile(appHostPath))
             {
                 using (MemoryMappedViewAccessor accessor = memoryMappedFile.CreateViewAccessor())
                 {
                     SetWindowsGraphicalUserInterfaceBit(accessor);
                 }
             }
-            File.Move(tempPath, appHostPath, true);
         }
 
         public static void BindAppHost(string appHostPath)
         {
             string appDll = $"{Path.GetFileNameWithoutExtension(appHostPath)}.dll";
 
-            // Make a copy of apphost first, replace hash and overwrite app.exe, rather than
-            // overwrite app.exe and edit in place, because the file is opened as "write" for
-            // the replacement -- the test fails with ETXTBSY (exit code: 26) in Linux when
-            // executing a file opened in "write" mode.
-            string tempPath = appHostPath + ".tmp";
-            File.Copy(appHostPath, tempPath, true);
             using (var sha256 = SHA256.Create())
             {
                 // Replace the hash with the managed DLL name.
                 var hash = sha256.ComputeHash(Encoding.UTF8.GetBytes("foobar"));
                 var hashStr = BitConverter.ToString(hash).Replace("-", "").ToLower();
-                BinaryUtils.SearchAndReplace(tempPath, Encoding.UTF8.GetBytes(hashStr), Encoding.UTF8.GetBytes(appDll));
+                BinaryUtils.SearchAndReplace(appHostPath, Encoding.UTF8.GetBytes(hashStr), Encoding.UTF8.GetBytes(appDll));
             }
-            File.Move(tempPath, appHostPath, true);
         }
 
         /// <summary>

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.ConfigureTerminalForChildProcesses.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.ConfigureTerminalForChildProcesses.Unix.cs
@@ -17,7 +17,7 @@ namespace System.Diagnostics
             int childrenUsingTerminalRemaining = Interlocked.Add(ref s_childrenUsingTerminalCount, increment);
             if (increment > 0)
             {
-                Debug.Assert(s_processStartLock.IsReadLockHeld);
+                Debug.Assert(s_processStartLock.IsUpgradeableReadLockHeld);
                 Debug.Assert(configureConsole);
 
                 // At least one child is using the terminal.

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -560,8 +560,10 @@ namespace System.Diagnostics
                             // ETXTBSY means we're trying to execute a file that is open for write.
                             // This may be a file that was just written and closed, but is still referenced
                             // by another process that has forked but not yet exec-ed.
-                            // Using the s_processStartLock we wait for all processes to finish exec-ing
-                            // which causes the file to be closed (CLOEXEC).
+                            // Using the s_processStartLock we wait for all processes to finish exec-ing.
+                            // 'ForkAndExecProcess' returns when the a pipe gets closed by exec.
+                            // Unfortunately, the handle we care about may be closed after that. So this
+                            // doesn't work all the time.
                             s_processStartLock.EnterWriteLock();
                             s_processStartLock.ExitWriteLock();
 

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -557,7 +557,7 @@ namespace System.Diagnostics
                             retryOnTxtBsy = false;
 
                             // ETXTBSY means we're trying to execute a file that is open for write.
-                            // This may be a file that was just written and closed, but is still referenced 
+                            // This may be a file that was just written and closed, but is still referenced
                             // by another process that has forked but not yet exec-ed.
                             // Using the s_processStartLock we wait for all processes to finish exec-ing
                             // which causes the file to be closed (CLOEXEC).

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -547,6 +547,7 @@ namespace System.Diagnostics
                     else
                     {
                         Interop.ErrorInfo errorInfo = new Interop.ErrorInfo(errno);
+
                         if (!throwOnNoExec && errorInfo.Error == Interop.Error.ENOEXEC)
                         {
                             return false;

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -534,22 +534,18 @@ namespace System.Diagnostics.Tests
             // .NET specifically supports this case by waiting till all pending forks exec-ed, and then
             // retrying to start the process.
 
-            var threads = new Thread[20];
-            for (int i = 0; i < threads.Length; i++)
+            var tasks = new Task[20];
+            for (int i = 0; i < tasks.Length; i++)
             {
                 string directory = GetTestFileName(i);
                 Directory.CreateDirectory(directory);
 
-                threads[i] = new Thread(WriteAndExecute) { IsBackground = true };
-                threads[i].Start(directory);
+                tasks[i] = Task.Factory.StartNew(WriteAndExecute, directory, TaskCreationOptions.LongRunning);
             }
 
-            for (int i = 0; i < threads.Length; i++)
-            {
-                threads[i].Join();
-            }
+            Task.WaitAll(tasks);
 
-            void WriteAndExecute(object o)
+            static void WriteAndExecute(object o)
             {
                 var directory = o as string;
                 for (int i = 0; i < 100; i++)
@@ -1033,7 +1029,7 @@ namespace System.Diagnostics.Tests
 
         private static readonly string[] s_allowedProgramsToRun = new string[] { "xdg-open", "gnome-open", "kfmclient" };
 
-        private string WriteScriptFile(string directory, string name, int returnValue)
+        private static string WriteScriptFile(string directory, string name, int returnValue)
         {
             string filename = Path.Combine(directory, name);
             File.WriteAllText(filename, $"#!/bin/sh\nexit {returnValue}\n");

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -526,9 +526,10 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Linux)] // OSX doesn't fail when executing a file that is open for writing.
         public async Task ExecutingFileThatIsOpenForWritingDoesntHang()
         {
-            // A process fails to execute with 'ETXTBSY' when the executable is open for writing.
+            // On Linux, a process fails to execute with 'ETXTBSY' when the executable is open for writing.
             // Process.Unix has some special handling for that.
             // This test verifies it doesn't cause 'Process.Start' to hang indefinitely when the handle remains open.
 


### PR DESCRIPTION
ETXTBSY means we're trying to execute a file that is open for write.
This may be a file that was just written and closed, but is still referenced by another process that has forked but not yet exec-ed.

When this error occurs, we wait for all processes to finish exec-ing, which causes the file to be closed (CLOEXEC). Then we start the process again.

Fixes https://github.com/dotnet/runtime/issues/58964.

cc @agocke @jkotas @adamsitnik