### PR TITLE
CI matrix change: drop OSX 10.13

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -94,7 +94,6 @@ jobs:
     # OSX x64
     - ${{ if eq(parameters.platform, 'OSX_x64') }}:
       - ${{ if eq(parameters.jobParameters.isFullMatrix, true) }}:
-        - OSX.1013.Amd64.Open
         - OSX.1014.Amd64.Open
         - OSX.1015.Amd64.Open
       - ${{ if eq(parameters.jobParameters.isFullMatrix, false) }}:

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -97,7 +97,6 @@ jobs:
         - OSX.1014.Amd64.Open
         - OSX.1015.Amd64.Open
       - ${{ if eq(parameters.jobParameters.isFullMatrix, false) }}:
-        - OSX.1014.Amd64.Open
         - OSX.1015.Amd64.Open
 
     # Android


### PR DESCRIPTION
Changes in CI matrix:

| OS | What to do | Notes
| - | - | -
| macOS 10.13 | Drop it (EOL)
| macOS 10.14 | Drop PR (as we have 10.15)

part of #57947 