### PR TITLE
Fix race condition with cancellation tokens in Read/Flush operations

### DIFF
--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeAwaitable.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeAwaitable.cs
@@ -61,7 +61,9 @@ namespace System.IO.Pipelines
                 // the state of the awaitable as yet.
                 if (_cancellationTokenRegistration == default(CancellationTokenRegistration))
                 {
+#if DEBUG
                     Debug.Assert(previousAwaitableState == _awaitableState, "The awaitable state changed!");
+#endif
 
                     cancellationToken.ThrowIfCancellationRequested();
                 }

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeAwaitable.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeAwaitable.cs
@@ -50,6 +50,8 @@ namespace System.IO.Pipelines
             // Don't register if already completed, we would immediately unregistered in ObserveCancellation
             if (cancellationToken.CanBeCanceled && !IsCompleted)
             {
+                var previousAwaitableState = _awaitableState;
+
                 _cancellationTokenRegistration = cancellationToken.UnsafeRegister(callback, state);
 
                 // If we get back the default CancellationTokenRegistration then it means the
@@ -57,6 +59,8 @@ namespace System.IO.Pipelines
                 // the state of the awaitable as yet.
                 if (_cancellationTokenRegistration == default(CancellationTokenRegistration))
                 {
+                    Debug.Assert(previousAwaitableState == _awaitableState, "The awaitable state changed!");
+
                     cancellationToken.ThrowIfCancellationRequested();
                 }
 

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeAwaitable.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeAwaitable.cs
@@ -50,7 +50,9 @@ namespace System.IO.Pipelines
             // Don't register if already completed, we would immediately unregistered in ObserveCancellation
             if (cancellationToken.CanBeCanceled && !IsCompleted)
             {
+#if DEBUG
                 var previousAwaitableState = _awaitableState;
+#endif
 
                 _cancellationTokenRegistration = cancellationToken.UnsafeRegister(callback, state);
 


### PR DESCRIPTION
- There's a tight race where UnsafeRegister can fire inline and then ReadAsync never completes. This is because the cancellation token property has not been assigned yet so the callback noops. This change checks the result of the UnsafeRegister operation to see if ran synchronously and throws if it did. We also move any state transitions to after these checks to make sure the PipeAwaitable state doesn't change before throwing.

Fixes #58909

cc @zlatanov 

PS: We conveniently added an overload that takes the cancellation token in .NET 6 but I didn't try to use it here.