### PR TITLE
[release/6.0] Fix Logging Source Generator to handle file-scoped namespaces (#57894)

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
@@ -438,11 +438,13 @@ namespace Microsoft.Extensions.Logging.Generators
                                         {
                                             // determine the namespace the class is declared in, if any
                                             SyntaxNode? potentialNamespaceParent = classDec.Parent;
-                                            while (potentialNamespaceParent != null && potentialNamespaceParent is not NamespaceDeclarationSyntax)
+                                            while (potentialNamespaceParent != null &&
+                                                   potentialNamespaceParent is not NamespaceDeclarationSyntax &&
+                                                   potentialNamespaceParent is not FileScopedNamespaceDeclarationSyntax)
                                             {
                                                 potentialNamespaceParent = potentialNamespaceParent.Parent;
                                             }
-                                            if (potentialNamespaceParent is NamespaceDeclarationSyntax namespaceParent)
+                                            if (potentialNamespaceParent is BaseNamespaceDeclarationSyntax namespaceParent)
                                             {
                                                 nspace = namespaceParent.Name.ToString();
                                                 while (true)

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
@@ -439,12 +439,20 @@ namespace Microsoft.Extensions.Logging.Generators
                                             // determine the namespace the class is declared in, if any
                                             SyntaxNode? potentialNamespaceParent = classDec.Parent;
                                             while (potentialNamespaceParent != null &&
-                                                   potentialNamespaceParent is not NamespaceDeclarationSyntax &&
-                                                   potentialNamespaceParent is not FileScopedNamespaceDeclarationSyntax)
+                                                   potentialNamespaceParent is not NamespaceDeclarationSyntax
+#if ROSLYN4_0_OR_GREATER
+                                                   && potentialNamespaceParent is not FileScopedNamespaceDeclarationSyntax
+#endif
+                                                   )
                                             {
                                                 potentialNamespaceParent = potentialNamespaceParent.Parent;
                                             }
+
+#if ROSLYN4_0_OR_GREATER
                                             if (potentialNamespaceParent is BaseNamespaceDeclarationSyntax namespaceParent)
+#else
+                                            if (potentialNamespaceParent is NamespaceDeclarationSyntax namespaceParent)
+#endif
                                             {
                                                 nspace = namespaceParent.Name.ToString();
                                                 while (true)

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorEmitterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorEmitterTests.cs
@@ -149,6 +149,20 @@ namespace Microsoft.Extensions.Logging.Generators.Tests.TestClasses
             await VerifyAgainstBaselineUsingFile("TestWithNestedClass.generated.txt", testSourceCode);
         }
 
+        [Fact]
+        public async Task TestBaseline_TestWithFileScopedNamespace_Success()
+        {
+            string testSourceCode = @"
+namespace Microsoft.Extensions.Logging.Generators.Tests.TestClasses;
+
+internal static partial class TestWithDefaultValues
+{
+    [LoggerMessage]
+    public static partial void M0(ILogger logger, LogLevel level);
+}";
+            await VerifyAgainstBaselineUsingFile("TestWithDefaultValues.generated.txt", testSourceCode);
+        }
+
         private async Task VerifyAgainstBaselineUsingFile(string filename, string testSourceCode)
         {
             string[] expectedLines = await File.ReadAllLinesAsync(Path.Combine("Baselines", filename)).ConfigureAwait(false);

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorParserTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorParserTests.cs
@@ -350,6 +350,24 @@ namespace Microsoft.Extensions.Logging.Generators.Tests
             Assert.Empty(diagnostics);
         }
 
+        [Fact]
+        public async Task FileScopedNamespaceOK()
+        {
+            IReadOnlyList<Diagnostic> diagnostics = await RunGenerator(@"
+                using Microsoft.Extensions.Logging;
+
+                namespace MyLibrary;
+
+                internal partial class Logger
+                {
+                    [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = ""Hello {Name}!"")]
+                    public static partial void Greeting(ILogger logger, string name);
+                }
+            ");
+
+            Assert.Empty(diagnostics);
+        }
+
         [Theory]
         [InlineData("false")]
         [InlineData("true")]


### PR DESCRIPTION
#### PR Content
Cherry pick of PR https://github.com/dotnet/runtime/pull/57894
Relates to #57880.

The feedback expressed in https://github.com/dotnet/runtime/pull/57894#issuecomment-918247048 improves the fix in main branch but we have as-is should be sufficient for release branch.

#### Customer Impact

Logging Source Generator fails to compile due to CS8795 error with file-scoped namespaces.
The fix will handle usages of file-scoped namespaces for logging method.

#### Testing
Included in PR

#### Risk
Low, since file-scoped namespace is a C#10 feature (check [here](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-10.0/file-scoped-namespaces)) and the logging source generator is a 6.0 feature and this fix is concerned with these two new features used in combination. 

/cc @danmoseley for M2 approval