### PR TITLE
Avoid resetting gen0 bricks for background_sweep

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -33297,8 +33297,6 @@ void gc_heap::background_mark_phase ()
 #endif //MULTIPLE_HEAPS
     }
 
-    gen0_bricks_cleared = FALSE;
-
     dprintf (2, ("end of bgc mark: loh: %d, poh: %d, soh: %d",
                  generation_size (loh_generation),
                  generation_size (poh_generation),


### PR DESCRIPTION
This is an attempt to make subsequent `find_first_object` faster after a `background_sweep` call.