### PR TITLE
Undo breaking change compat in GetMethodNativeMap

### DIFF
--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -6042,7 +6042,7 @@ ClrDataAccess::GetMethodVarInfo(MethodDesc* methodDesc,
     }
     else
     {
-        nativeCodeStartAddr - PCODEToPINSTR(methodDesc->GetNativeCode());
+        nativeCodeStartAddr = PCODEToPINSTR(methodDesc->GetNativeCode());
     }
 
     DebugInfoRequest request;

--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -6030,13 +6030,20 @@ ClrDataAccess::GetMethodVarInfo(MethodDesc* methodDesc,
     SUPPORTS_DAC;
     COUNT_T countNativeVarInfo;
     NewHolder<ICorDebugInfo::NativeVarInfo> nativeVars(NULL);
-
-    NativeCodeVersion requestedNativeCodeVersion = ExecutionManager::GetNativeCodeVersion(address);
-    if (requestedNativeCodeVersion.IsNull() || requestedNativeCodeVersion.GetNativeCode() == NULL)
+    TADDR nativeCodeStartAddr;
+    if (address != NULL)
     {
-        return E_INVALIDARG;
+        NativeCodeVersion requestedNativeCodeVersion = ExecutionManager::GetNativeCodeVersion(address);
+        if (requestedNativeCodeVersion.IsNull() || requestedNativeCodeVersion.GetNativeCode() == NULL)
+        {
+            return E_INVALIDARG;
+        }
+        nativeCodeStartAddr = PCODEToPINSTR(requestedNativeCodeVersion.GetNativeCode());
     }
-    TADDR nativeCodeStartAddr = PCODEToPINSTR(requestedNativeCodeVersion.GetNativeCode());
+    else
+    {
+        nativeCodeStartAddr - PCODEToPINSTR(methodDesc->GetNativeCode());
+    }
 
     DebugInfoRequest request;
     request.InitFromStartingAddr(methodDesc, nativeCodeStartAddr);
@@ -6081,13 +6088,20 @@ ClrDataAccess::GetMethodNativeMap(MethodDesc* methodDesc,
 
     // Use the DebugInfoStore to get IL->Native maps.
     // It doesn't matter whether we're jitted, ngenned etc.
-
-    NativeCodeVersion requestedNativeCodeVersion = ExecutionManager::GetNativeCodeVersion(address);
-    if (requestedNativeCodeVersion.IsNull() || requestedNativeCodeVersion.GetNativeCode() == NULL)
+    TADDR nativeCodeStartAddr;
+    if (address != NULL)
     {
-        return E_INVALIDARG;
+        NativeCodeVersion requestedNativeCodeVersion = ExecutionManager::GetNativeCodeVersion(address);
+        if (requestedNativeCodeVersion.IsNull() || requestedNativeCodeVersion.GetNativeCode() == NULL)
+        {
+            return E_INVALIDARG;
+        }
+        nativeCodeStartAddr = PCODEToPINSTR(requestedNativeCodeVersion.GetNativeCode());
     }
-    TADDR nativeCodeStartAddr = PCODEToPINSTR(requestedNativeCodeVersion.GetNativeCode());
+    else
+    {
+        nativeCodeStartAddr = PCODEToPINSTR(methodDesc->GetNativeCode());
+    }
 
     DebugInfoRequest request;
     request.InitFromStartingAddr(methodDesc, nativeCodeStartAddr);


### PR DESCRIPTION
Introduced by https://github.com/dotnet/runtime/pull/57176 for the case where address == 0. This just reverts to the old behavior in that case. 