### PR TITLE
Change back superpmi benchmarks build to net6.0

### DIFF
--- a/src/coreclr/scripts/superpmi_benchmarks.py
+++ b/src/coreclr/scripts/superpmi_benchmarks.py
@@ -154,7 +154,7 @@ def build_and_run(coreclr_args, output_mch_name):
 
     run_command(
         [dotnet_exe, "build", project_file, "--configuration", "Release",
-         "--framework", "net7.0", "--no-restore", "/p:NuGetPackageRoot=" + artifacts_packages_directory,
+         "--framework", "net6.0", "--no-restore", "/p:NuGetPackageRoot=" + artifacts_packages_directory,
          "-o", artifacts_directory], _exit_on_fail=True)
 
     # Disable ReadyToRun so we always JIT R2R methods and collect them


### PR DESCRIPTION
When we upgraded all the projects to net7.0 in #58011, Microbenchmarks failed to build because `dotnet/performance`  scripts doesn't know about net7.0 yet. I have opened https://github.com/dotnet/performance/issues/2009 to track it but until then lets revert the framework to net6.0.

I have triggered superpmi collection and it works with this change.