### PR TITLE
Arm64: Fix perfscore and display logic for LARGELDC

### DIFF
--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -12179,7 +12179,7 @@ void emitter::emitDispInsHex(instrDesc* id, BYTE* code, size_t sz)
         }
         else
         {
-            assert(sz == 0);
+            assert(id->idCodeSize() == sz);
             printf("              ");
         }
     }
@@ -13786,6 +13786,9 @@ void emitter::getMemoryOperation(instrDesc* id, unsigned* pMemAccessKind, bool* 
                 {
                     isLocalAccess = true;
                 }
+                break;
+            case IF_LARGELDC:
+                isLocalAccess = false;
                 break;
 
             default:


### PR DESCRIPTION
For LARGELDC format to load large constant, we were missing a case during perf score calculation. Also, the size assert during displaying instruction should be based on `idCodeSize()`.

Found from Antigen, the repro needs large code and lot of constants (the repro had around 14000 local variables. 