### PR TITLE
support FEATURE_INTERPRETER on linux-x64

### DIFF
--- a/src/coreclr/vm/interpreter.cpp
+++ b/src/coreclr/vm/interpreter.cpp
@@ -90,7 +90,14 @@ InterpreterMethodInfo::InterpreterMethodInfo(CEEInfo* comp, CORINFO_METHOD_INFO*
         hasRetBuff = false;
     }
 #endif
-#if defined(HOST_ARM) || defined(HOST_AMD64)|| defined(HOST_ARM64)
+
+#if defined(UNIX_AMD64_ABI)
+    // ...or it fits into two registers.
+    if (hasRetBuff && getClassSize(methInfo->args.retTypeClass) <= 2 * sizeof(void*))
+    {
+        hasRetBuff = false;
+    }
+#elif defined(HOST_ARM) || defined(HOST_AMD64)|| defined(HOST_ARM64)
     // ...or it fits into one register.
     if (hasRetBuff && getClassSize(methInfo->args.retTypeClass) <= sizeof(void*))
     {
@@ -474,6 +481,7 @@ void Interpreter::ArgState::AddArg(unsigned canonIndex, short numSlots, bool noR
     _ASSERTE(!noReg);
     _ASSERTE(!twoSlotAlign);
     AddArgAmd64(canonIndex, numSlots, /*isFloatingType*/false);
+    return;
 #else // !HOST_AMD64
 #if defined(HOST_X86) || defined(HOST_ARM64)
     _ASSERTE(!twoSlotAlign); // Shouldn't use this flag on x86 (it wouldn't work right in the stack, at least).
@@ -538,7 +546,37 @@ void Interpreter::ArgState::AddArg(unsigned canonIndex, short numSlots, bool noR
 }
 
 #if defined(HOST_AMD64)
-// AMD64 calling convention allows any type that can be contained in 64 bits to be passed in registers,
+
+#if defined(UNIX_AMD64_ABI)
+void Interpreter::ArgState::AddArgAmd64(unsigned canonIndex, unsigned short numSlots, bool isFloatingType)
+{
+    int regSlots = numFPRegArgSlots + numRegArgs;
+    if (isFloatingType && numFPRegArgSlots + 1 < MaxNumFPRegArgSlots)
+    {
+        _ASSERTE(numSlots == 1);
+        argIsReg[canonIndex]   = ARS_FloatReg;
+        argOffsets[canonIndex] = regSlots * sizeof(void*);
+        fpArgsUsed |= (0x1 << regSlots);
+        numFPRegArgSlots += 1;
+        return;
+    }
+    else if (numSlots < 3 && (numRegArgs + numSlots <= NumberOfIntegerRegArgs()))
+    {
+        argIsReg[canonIndex]   = ARS_IntReg;
+        argOffsets[canonIndex] = regSlots * sizeof(void*);
+        numRegArgs += numSlots;
+    }
+    else
+    {
+        argIsReg[canonIndex] = ARS_NotReg;
+        ClrSafeInt<short> offset(callerArgStackSlots * sizeof(void*));
+        _ASSERTE(!offset.IsOverflow());
+        argOffsets[canonIndex] = offset.Value();
+        callerArgStackSlots += numSlots;
+    }
+}
+#else
+// Windows AMD64 calling convention allows any type that can be contained in 64 bits to be passed in registers,
 // if not contained or they are of a size not a power of 2, then they are passed by reference on the stack.
 // RCX, RDX, R8, R9 are the int arg registers. XMM0-3 overlap with the integer registers and are used
 // for floating point arguments.
@@ -574,6 +612,7 @@ void Interpreter::ArgState::AddArgAmd64(unsigned canonIndex, unsigned short numS
         callerArgStackSlots += 1;
     }
 }
+#endif //UNIX_AMD64_ABI
 #endif
 
 void Interpreter::ArgState::AddFPArg(unsigned canonIndex, unsigned short numSlots, bool twoSlotAlign)
@@ -1185,6 +1224,9 @@ CorJitResult Interpreter::GenerateInterpreterStub(CEEInfo* comp,
             // See StubLinkerCPU::EmitProlog for the layout of the stack
             unsigned       intRegArgBaseOffset = (argState.numFPRegArgSlots) * sizeof(void*);
             unsigned short stackArgBaseOffset = (unsigned short) ((argState.numRegArgs + argState.numFPRegArgSlots) * sizeof(void*));
+#elif defined(UNIX_AMD64_ABI)
+            unsigned       intRegArgBaseOffset = 0;
+            unsigned short stackArgBaseOffset = (2 + argState.numRegArgs + argState.numFPRegArgSlots) * sizeof(void*);
 #elif defined(HOST_AMD64)
             unsigned short stackArgBaseOffset = (argState.numRegArgs) * sizeof(void*);
 #else
@@ -1227,7 +1269,7 @@ CorJitResult Interpreter::GenerateInterpreterStub(CEEInfo* comp,
                         if (!jmpCall) { sl.X86EmitPushReg(kEDX); }
                         argState.argOffsets[k] = (argState.numRegArgs - regArgsFound)*sizeof(void*);
                     }
-#elif defined(HOST_ARM) || defined(HOST_ARM64)
+#elif defined(HOST_ARM) || defined(HOST_ARM64) || defined(UNIX_AMD64_ABI)
                     argState.argOffsets[k] += intRegArgBaseOffset;
 #elif defined(HOST_AMD64)
                     // First home the register arguments in the stack space allocated by the caller.
@@ -1239,7 +1281,7 @@ CorJitResult Interpreter::GenerateInterpreterStub(CEEInfo* comp,
 #error unsupported platform
 #endif
                 }
-#if defined(HOST_AMD64)
+#if defined(HOST_AMD64) && !defined(UNIX_AMD64_ABI)
                 else if (argState.argIsReg[k] == ArgState::ARS_FloatReg)
                 {
                     // Increment regArgsFound since float/int arguments have overlapping registers.
@@ -1346,6 +1388,65 @@ CorJitResult Interpreter::GenerateInterpreterStub(CEEInfo* comp,
         }
         sl.X86EmitPopReg(kEBP);
         sl.X86EmitReturn(static_cast<WORD>(argState.callerArgStackSlots * sizeof(void*)));
+#elif defined(UNIX_AMD64_ABI)
+        bool hasTowRetSlots = info->args.retType == CORINFO_TYPE_VALUECLASS &&
+            getClassSize(info->args.retTypeClass) == 16;
+
+        int fixedTwoSlotSize = 16;
+
+        int argSize = (argState.numFPRegArgSlots +  argState.numRegArgs) * sizeof(void*);
+
+        int stackSize = argSize + fixedTwoSlotSize; // Fixed two slot for possible "retbuf", access address by "m_ilArgs-16"
+
+        if (stackSize % 16 == 0) { // for $rsp align requirement
+            stackSize += 8;
+        }
+
+        sl.X86EmitSubEsp(stackSize);
+
+        X86Reg intArgsRegs[] = {ARGUMENT_kREG1, ARGUMENT_kREG2, kRDX, kRCX, kR8, kR9};
+        int    indexGP       = 0;
+        int    indexFP       = 0;
+        for (int i = 0; i < argState.numRegArgs + argState.numFPRegArgSlots; i++)
+        {
+            int offs = i * sizeof(void*) + 16;
+            if (argState.fpArgsUsed & (1 << i))
+            {
+                sl.X64EmitMovSDToMem(static_cast<X86Reg>(indexFP), static_cast<X86Reg>(kESP_Unsafe), offs);
+                indexFP++;
+            }
+            else
+            {
+                sl.X86EmitIndexRegStoreRSP(offs, intArgsRegs[indexGP]);
+                indexGP++;
+            }
+        }
+
+        // Pass "ilArgs", i.e. just the point where registers have been homed, as 2nd arg.
+        sl.X86EmitIndexLeaRSP(ARGUMENT_kREG2, static_cast<X86Reg>(kESP_Unsafe), fixedTwoSlotSize);
+
+        // If we have IL stubs pass the stub context in R10 or else pass NULL.
+#if INTERP_ILSTUBS
+        if (pMD->IsILStub())
+        {
+            sl.X86EmitMovRegReg(kRDX, kR10);
+        }
+        else
+#endif
+        {
+            // For a non-ILStub method, push NULL as the StubContext argument.
+            sl.X86EmitZeroOutReg(ARGUMENT_kREG1);
+            sl.X86EmitMovRegReg(kRDX, ARGUMENT_kREG1);
+        }
+        sl.X86EmitRegLoad(ARGUMENT_kREG1, reinterpret_cast<UINT_PTR>(interpMethInfo));
+
+        sl.X86EmitCall(sl.NewExternalCodeLabel(interpretMethodFunc), 0);
+        if (hasTowRetSlots) {
+            sl.X86EmitEspOffset(0x8b, kRAX, 0);
+            sl.X86EmitEspOffset(0x8b, kRDX, 8);
+        }
+        sl.X86EmitAddEsp(stackSize);
+        sl.X86EmitReturn(0);
 #elif defined(HOST_AMD64)
         // Pass "ilArgs", i.e. just the point where registers have been homed, as 2nd arg
         sl.X86EmitIndexLeaRSP(ARGUMENT_kREG2, static_cast<X86Reg>(kESP_Unsafe), 8);
@@ -2274,6 +2375,14 @@ EvalLoop:
                         // The ostack value *is* the struct value.
                         memcpy(GetHFARetBuffAddr(static_cast<unsigned>(sz)), OpStackGetAddr(0, sz), sz);
                     }
+                }
+#elif defined(UNIX_AMD64_ABI)
+                // Is it an struct contained in $rax and $rdx
+                else if (m_methInfo->m_returnType == CORINFO_TYPE_VALUECLASS
+                         && sz == 16)
+                {
+                    //The Fixed Two slot return buffer address
+                    memcpy(m_ilArgs-16, OpStackGet<void*>(0), sz);
                 }
 #endif
                 else if (CorInfoTypeIsFloatingPoint(m_methInfo->m_returnType) &&
@@ -9299,6 +9408,9 @@ void Interpreter::DoCallWork(bool virtualCall, void* thisArg, CORINFO_RESOLVED_T
             HFAReturnArgSlots = (HFAReturnArgSlots + sizeof(ARG_SLOT) - 1) / sizeof(ARG_SLOT);
         }
     }
+#elif defined(UNIX_AMD64_ABI)
+    unsigned HasTwoSlotBuf = sigInfo.retType == CORINFO_TYPE_VALUECLASS &&
+        getClassSize(sigInfo.retTypeClass) == 16;
 #endif
 
     // Point B
@@ -9531,7 +9643,8 @@ void Interpreter::DoCallWork(bool virtualCall, void* thisArg, CORINFO_RESOLVED_T
     }
 
     // This is the argument slot that will be used to hold the return value.
-    ARG_SLOT retVal = 0;
+    // In UNIX_AMD64_ABI, return type may have need tow ARG_SLOTs.
+    ARG_SLOT retVals[2] = {0, 0};
 #if !defined(HOST_ARM) && !defined(UNIX_AMD64_ABI)
     _ASSERTE (NUMBER_RETURNVALUE_SLOTS == 1);
 #endif
@@ -9799,7 +9912,7 @@ void Interpreter::DoCallWork(bool virtualCall, void* thisArg, CORINFO_RESOLVED_T
 #if INTERP_ILCYCLE_PROFILE
             bool b = CycleTimer::GetThreadCyclesS(&startCycles); _ASSERTE(b);
 #endif // INTERP_ILCYCLE_PROFILE
-            retVal = InterpretMethodBody(methInfo, true, reinterpret_cast<BYTE*>(args), NULL);
+            retVals[0] = InterpretMethodBody(methInfo, true, reinterpret_cast<BYTE*>(args), NULL);
             pCscd = NULL;  // Nothing to cache.
         }
         else
@@ -9810,7 +9923,12 @@ void Interpreter::DoCallWork(bool virtualCall, void* thisArg, CORINFO_RESOLVED_T
 #if INTERP_ILCYCLE_PROFILE
             bool b = CycleTimer::GetThreadCyclesS(&startCycles); _ASSERTE(b);
 #endif // INTERP_ILCYCLE_PROFILE
-            mdcs.CallTargetWorker(args, &retVal, sizeof(retVal));
+
+#if defined(UNIX_AMD64_ABI)
+            mdcs.CallTargetWorker(args, retVals, HasTwoSlotBuf ? 16: 8);
+#else
+            mdcs.CallTargetWorker(args, retVals, 8);
+#endif
 
             if (pCscd != NULL)
             {
@@ -9874,7 +9992,7 @@ void Interpreter::DoCallWork(bool virtualCall, void* thisArg, CORINFO_RESOLVED_T
         if (size_t(m_callThisArg) == 0x1)
         {
             _ASSERTE_MSG(sigInfo.retType == CORINFO_TYPE_VOID, "Constructor for var-sized object becomes factory method that returns result.");
-            OpStackSet<Object*>(m_curStackHt, reinterpret_cast<Object*>(retVal));
+            OpStackSet<Object*>(m_curStackHt, reinterpret_cast<Object*>(retVals[0]));
             OpStackTypeSet(m_curStackHt, InterpreterType(CORINFO_TYPE_CLASS));
             m_curStackHt++;
         }
@@ -9884,38 +10002,38 @@ void Interpreter::DoCallWork(bool virtualCall, void* thisArg, CORINFO_RESOLVED_T
             {
             case CORINFO_TYPE_BOOL:
             case CORINFO_TYPE_BYTE:
-                OpStackSet<INT32>(m_curStackHt, static_cast<INT8>(retVal));
+                OpStackSet<INT32>(m_curStackHt, static_cast<INT8>(retVals[0]));
                 break;
             case CORINFO_TYPE_UBYTE:
-                OpStackSet<UINT32>(m_curStackHt, static_cast<UINT8>(retVal));
+                OpStackSet<UINT32>(m_curStackHt, static_cast<UINT8>(retVals[0]));
                 break;
             case CORINFO_TYPE_SHORT:
-                OpStackSet<INT32>(m_curStackHt, static_cast<INT16>(retVal));
+                OpStackSet<INT32>(m_curStackHt, static_cast<INT16>(retVals[0]));
                 break;
             case CORINFO_TYPE_USHORT:
             case CORINFO_TYPE_CHAR:
-                OpStackSet<UINT32>(m_curStackHt, static_cast<UINT16>(retVal));
+                OpStackSet<UINT32>(m_curStackHt, static_cast<UINT16>(retVals[0]));
                 break;
             case CORINFO_TYPE_INT:
             case CORINFO_TYPE_UINT:
             case CORINFO_TYPE_FLOAT:
-                OpStackSet<INT32>(m_curStackHt, static_cast<INT32>(retVal));
+                OpStackSet<INT32>(m_curStackHt, static_cast<INT32>(retVals[0]));
                 break;
             case CORINFO_TYPE_LONG:
             case CORINFO_TYPE_ULONG:
             case CORINFO_TYPE_DOUBLE:
-                OpStackSet<INT64>(m_curStackHt, static_cast<INT64>(retVal));
+                OpStackSet<INT64>(m_curStackHt, static_cast<INT64>(retVals[0]));
                 break;
             case CORINFO_TYPE_NATIVEINT:
             case CORINFO_TYPE_NATIVEUINT:
             case CORINFO_TYPE_PTR:
-                OpStackSet<NativeInt>(m_curStackHt, static_cast<NativeInt>(retVal));
+                OpStackSet<NativeInt>(m_curStackHt, static_cast<NativeInt>(retVals[0]));
                 break;
             case CORINFO_TYPE_CLASS:
-                OpStackSet<Object*>(m_curStackHt, reinterpret_cast<Object*>(retVal));
+                OpStackSet<Object*>(m_curStackHt, reinterpret_cast<Object*>(retVals[0]));
                 break;
             case CORINFO_TYPE_BYREF:
-                OpStackSet<void*>(m_curStackHt, reinterpret_cast<void*>(retVal));
+                OpStackSet<void*>(m_curStackHt, reinterpret_cast<void*>(retVals[0]));
                 break;
             case CORINFO_TYPE_VALUECLASS:
             case CORINFO_TYPE_REFANY:
@@ -9952,9 +10070,17 @@ void Interpreter::DoCallWork(bool virtualCall, void* thisArg, CORINFO_RESOLVED_T
                     {
                         OpStackSet<INT64>(m_curStackHt, GetSmallStructValue(&smallStructRetVal, retTypeSz));
                     }
+#if defined(UNIX_AMD64_ABI)
+                    else if (HasTwoSlotBuf)
+                    {
+                        void* dst = LargeStructOperandStackPush(16);
+                        CopyValueClassUnchecked(dst, retVals, GetMethodTableFromClsHnd(retTypeClsHnd));
+                        OpStackSet<void*>(m_curStackHt, dst);
+                    }
+#endif
                     else
                     {
-                        OpStackSet<UINT64>(m_curStackHt, retVal);
+                        OpStackSet<UINT64>(m_curStackHt, retVals[0]);
                     }
                     // We already created this interpreter type, so use it.
                     OpStackTypeSet(m_curStackHt, retTypeIt.StackNormalize());
@@ -10133,7 +10259,10 @@ void Interpreter::CallI()
         retTypeClsHnd = sigInfo.retTypeClass;
         retTypeIt = InterpreterType(&m_interpCeeInfo, retTypeClsHnd);
         retTypeSz = retTypeIt.Size(&m_interpCeeInfo);
-#if defined(HOST_AMD64)
+
+#if defined(UNIX_AMD64_ABI)
+        //
+#elif defined(HOST_AMD64)
         // TODO: Investigate why HasRetBuffArg can't be used. pMD is a hacked up MD for the
         // calli because it belongs to the current method. Doing what the JIT does.
         hasRetBuffArg = (retTypeSz > sizeof(void*)) || ((retTypeSz & (retTypeSz - 1)) != 0);

--- a/src/coreclr/vm/interpreter.h
+++ b/src/coreclr/vm/interpreter.h
@@ -318,7 +318,7 @@ public:
     bool IsLargeStruct(CEEInfo* ceeInfo) const
     {
         intptr_t asInt = reinterpret_cast<intptr_t>(m_tp);
-#ifdef TARGET_AMD64
+#if defined(TARGET_AMD64) && !defined(UNIX_AMD64_ABI)
         if (asInt == CORINFO_TYPE_SHIFTED_REFANY)
         {
             return true;
@@ -998,7 +998,11 @@ private:
 #elif defined(HOST_ARM64)
         static const int MaxNumFPRegArgSlots = 8;
 #elif defined(HOST_AMD64)
+#if defined(UNIX_AMD64_ABI)
+        static const int MaxNumFPRegArgSlots = 8;
+#else
         static const int MaxNumFPRegArgSlots = 4;
+#endif
 #endif
 
         ~ArgState()
@@ -1090,7 +1094,7 @@ private:
     {
         if (!m_directCall)
         {
-#if defined(HOST_AMD64)
+#if defined(HOST_AMD64) && !defined(UNIX_AMD64_ABI)
             // In AMD64, a reference to the struct is passed if its size exceeds the word size.
             // Dereference the arg to get to the ref of the struct.
             if (GetArgType(argNum).IsLargeStruct(&m_interpCeeInfo))
@@ -2047,8 +2051,15 @@ private:
 inline
 unsigned short Interpreter::NumberOfIntegerRegArgs() { return 2; }
 #elif  defined(HOST_AMD64)
-unsigned short Interpreter::NumberOfIntegerRegArgs() { return 4; }
-#elif  defined(HOST_ARM)
+unsigned short Interpreter::NumberOfIntegerRegArgs()
+{
+#if defined(UNIX_AMD64_ABI)
+    return 6;
+#else
+    return 4;
+#endif
+}
+#elif defined(HOST_ARM)
 unsigned short Interpreter::NumberOfIntegerRegArgs() { return 4; }
 #elif defined(HOST_ARM64)
 unsigned short Interpreter::NumberOfIntegerRegArgs() { return 8; }

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -8451,7 +8451,7 @@ bool CEEInfo::isIntrinsicType(CORINFO_CLASS_HANDLE classHnd)
 void CEEInfo::getMethodVTableOffset (CORINFO_METHOD_HANDLE methodHnd,
                                      unsigned * pOffsetOfIndirection,
                                      unsigned * pOffsetAfterIndirection,
-                                     bool * isRelative) 
+                                     bool * isRelative)
 {
     CONTRACTL {
         NOTHROW;
@@ -10783,6 +10783,12 @@ void CEEJitInfo::WriteCode(EEJitManager * jitMgr)
         THROWS;
         GC_TRIGGERS;
     } CONTRACTL_END;
+
+#ifdef FEATURE_INTERPRETER
+    // TODO: the InterpterCEEInfo doesn't support features about W^X.
+    // see also #53173
+    if (m_pCodeHeap == nullptr) return;
+#endif
 
     WriteCodeBytes();
 


### PR DESCRIPTION
linux-x64 uses System-V ABI which has some different behaviors from Windows X64 ABI.
the main different effects interpter is
1. linux-x64 use "RDI,RSI,RDX,RCX,R8,R9" instead "RCX,RDX,R8,R9" as argument registers. (and available integral/float arguments number is also different).
2. linux-x64 will split small struct into two registers instead use "pointer" like win-x64.
3. linux-x64 pass integral and float argument registers standalone instead "shadow" like win-x64.

This PR can run some simple hello world. Test under archlinux amd64.

The result of `./src/tests/run.sh -env` with env
```
export COMPlus_InterpreterJITThreshold=10
export COMPlus_Interpret='*'
export COMPlus_InterpreterHWIntrinsicsIsSupportedFalse=1
export COMPlus_InterpreterDoLoopMethods=1
export COMPlus_InterpreterPrintPostMortem=1
```
is
```
  === TEST EXECUTION SUMMARY ===
     baseservices.callconvs.XUnitWrapper                  Total:    1, Errors: 0, Failed:   1, Skipped: 0, Time:    2.901s
     baseservices.compilerservices.XUnitWrapper           Total:    2, Errors: 0, Failed:   1, Skipped: 0, Time:    1.433s
     baseservices.exceptions.XUnitWrapper.dll             Total:    0
     baseservices.mono.XUnitWrapper.dll                   Total:    0
     baseservices.threading.XUnitWrapper                  Total:    7, Errors: 0, Failed:   2, Skipped: 0, Time:    9.286s
     baseservices.TieredCompilation.XUnitWrapper          Total:   14, Errors: 0, Failed:   0, Skipped: 0, Time:   29.160s
     baseservices.typeequivalence.XUnitWrapper            Total:    1, Errors: 0, Failed:   0, Skipped: 0, Time:    0.671s
     baseservices.varargs.XUnitWrapper                    Total:    2, Errors: 0, Failed:   1, Skipped: 0, Time:    1.610s
     CoreMangLib.system.XUnitWrapper                      Total:    1, Errors: 0, Failed:   0, Skipped: 0, Time:    1.268s
     Exceptions.ForeignThread.XUnitWrapper                Total:    1, Errors: 0, Failed:   0, Skipped: 0, Time:    1.594s
     GC.API.XUnitWrapper                                  Total:   32, Errors: 0, Failed:   3, Skipped: 0, Time:  117.714s
     GC.Coverage.XUnitWrapper                             Total:    2, Errors: 0, Failed:   0, Skipped: 0, Time:    5.158s
     GC.Features.XUnitWrapper                             Total:   21, Errors: 0, Failed:   4, Skipped: 0, Time:   80.811s
     GC.LargeMemory.XUnitWrapper                          Total:    3, Errors: 0, Failed:   0, Skipped: 0, Time:    4.241s
     GC.Regressions.XUnitWrapper                          Total:   10, Errors: 0, Failed:   0, Skipped: 0, Time:   22.607s
     GC.Scenarios.XUnitWrapper                            Total:   37, Errors: 0, Failed:   1, Skipped: 0, Time:  632.196s
     GC.Stress.XUnitWrapper                               Total:    1, Errors: 0, Failed:   0, Skipped: 0, Time:    0.061s
     ilasm.PortablePdb.XUnitWrapper                       Total:    1, Errors: 0, Failed:   1, Skipped: 0, Time:   12.912s
     ilasm.System.XUnitWrapper                            Total:    1, Errors: 0, Failed:   0, Skipped: 0, Time:    4.170s
     Interop.COM.XUnitWrapper                             Total:    4, Errors: 0, Failed:   0, Skipped: 0, Time:    4.198s
     Interop.DllImportAttribute.XUnitWrapper              Total:    2, Errors: 0, Failed:   0, Skipped: 0, Time:    2.395s
     Interop.ExecInDefAppDom.XUnitWrapper.dll             Total:    0
     Interop.ICastable.XUnitWrapper                       Total:    1, Errors: 0, Failed:   0, Skipped: 0, Time:    1.874s
     Interop.ICustomMarshaler.XUnitWrapper                Total:    3, Errors: 0, Failed:   1, Skipped: 0, Time:    1.777s
     Interop.IDynamicInterfaceCastable.XUnitWrapper       Total:    1, Errors: 0, Failed:   0, Skipped: 0, Time:    2.401s
     Interop.LayoutClass.XUnitWrapper                     Total:    1, Errors: 0, Failed:   0, Skipped: 0, Time:    1.918s
     Interop.MarshalAPI.XUnitWrapper                      Total:    1, Errors: 0, Failed:   0, Skipped: 0, Time:    1.929s
     Interop.NativeLibrary.XUnitWrapper                   Total:    4, Errors: 0, Failed:   0, Skipped: 0, Time:    3.906s
     Interop.PInvoke.XUnitWrapper                         Total:   28, Errors: 0, Failed:   1, Skipped: 0, Time:   17.603s
     Interop.StringMarshalling.XUnitWrapper               Total:    3, Errors: 0, Failed:   0, Skipped: 0, Time:    1.572s
     Interop.StructMarshalling.XUnitWrapper               Total:    3, Errors: 0, Failed:   0, Skipped: 0, Time:    3.766s
     Interop.StructPacking.XUnitWrapper                   Total:    1, Errors: 0, Failed:   0, Skipped: 0, Time:    2.427s
     Interop.SuppressGCTransition.XUnitWrapper            Total:    1, Errors: 0, Failed:   1, Skipped: 0, Time:    2.568s
     Interop.UnmanagedCallConv.XUnitWrapper               Total:    1, Errors: 0, Failed:   0, Skipped: 0, Time:    1.405s
     Interop.UnmanagedCallersOnly.XUnitWrapper            Total:    1, Errors: 0, Failed:   1, Skipped: 0, Time:    2.390s
     JIT.CheckProjects.XUnitWrapper                       Total:    1, Errors: 0, Failed:   0, Skipped: 0, Time:    1.407s
     JIT.CodeGenBringUpTests.XUnitWrapper                 Total:   32, Errors: 0, Failed:  14, Skipped: 0, Time:   21.884s
     JIT.Directed.XUnitWrapper                            Total:  141, Errors: 0, Failed:  42, Skipped: 0, Time:   91.588s
     JIT.Generics.XUnitWrapper                            Total:   42, Errors: 0, Failed:   4, Skipped: 0, Time:   31.964s
     JIT.HardwareIntrinsics.XUnitWrapper                  Total:  358, Errors: 0, Failed: 175, Skipped: 0, Time:  288.600s
     JIT.IL_Conformance.XUnitWrapper                      Total:  112, Errors: 0, Failed:   0, Skipped: 0, Time:   66.807s
     JIT.Intrinsics.XUnitWrapper                          Total:   25, Errors: 0, Failed:   3, Skipped: 0, Time:   11.697s
     JIT.jit64.XUnitWrapper                               Total:   90, Errors: 0, Failed:  34, Skipped: 0, Time:   76.331s
     JIT.Math.XUnitWrapper                                Total:    2, Errors: 0, Failed:   0, Skipped: 0, Time:    3.357s
     JIT.Methodical.XUnitWrapper                          Total:  763, Errors: 0, Failed: 160, Skipped: 0, Time:  551.555s
     JIT.opt.XUnitWrapper                                 Total:   85, Errors: 0, Failed:  11, Skipped: 0, Time:   59.278s
     JIT.Performance.XUnitWrapper                         Total:   85, Errors: 0, Failed:   8, Skipped: 0, Time:  920.546s
     JIT.Regression.XUnitWrapper                          Total:  677, Errors: 0, Failed: 240, Skipped: 0, Time:  411.193s
     JIT.RyuJIT.XUnitWrapper                              Total:    1, Errors: 0, Failed:   0, Skipped: 0, Time:    1.557s
     JIT.SIMD.XUnitWrapper                                Total:  101, Errors: 0, Failed:  22, Skipped: 0, Time:   69.754s
     JIT.Stress.XUnitWrapper                              Total:    5, Errors: 0, Failed:   0, Skipped: 0, Time:    0.061s
     JIT.superpmi.XUnitWrapper                            Total:    3, Errors: 0, Failed:   2, Skipped: 0, Time:   24.931s
     Loader.AssemblyDependencyResolver.XUnitWrapper       Total:    1, Errors: 0, Failed:   0, Skipped: 0, Time:    3.314s
     Loader.AssemblyLoadContext30Extensions.XUnitWrapper  Total:    1, Errors: 0, Failed:   0, Skipped: 0, Time:    1.563s
     Loader.binding.XUnitWrapper                          Total:    1, Errors: 0, Failed:   1, Skipped: 0, Time:   39.761s
     Loader.classloader.XUnitWrapper                      Total:  122, Errors: 0, Failed:  45, Skipped: 0, Time:   72.771s
     Loader.CollectibleAssemblies.XUnitWrapper            Total:    2, Errors: 0, Failed:   0, Skipped: 0, Time:    2.675s
     Loader.ContextualReflection.XUnitWrapper             Total:    1, Errors: 0, Failed:   0, Skipped: 0, Time:    3.437s
     profiler.elt.XUnitWrapper                            Total:    2, Errors: 0, Failed:   2, Skipped: 0, Time:    6.685s
     profiler.eventpipe.XUnitWrapper                      Total:    3, Errors: 0, Failed:   3, Skipped: 0, Time:   12.594s
     profiler.gc.XUnitWrapper                             Total:    3, Errors: 0, Failed:   3, Skipped: 0, Time:    8.489s
     profiler.multiple.XUnitWrapper                       Total:    1, Errors: 0, Failed:   1, Skipped: 0, Time:   13.115s
     profiler.rejit.XUnitWrapper                          Total:    1, Errors: 0, Failed:   0, Skipped: 0, Time:    0.047s
     profiler.transitions.XUnitWrapper                    Total:    1, Errors: 0, Failed:   1, Skipped: 0, Time:    3.678s
     profiler.unittest.XUnitWrapper                       Total:    3, Errors: 0, Failed:   3, Skipped: 0, Time:   12.384s
     readytorun.coreroot_determinism.XUnitWrapper         Total:    1, Errors: 0, Failed:   1, Skipped: 0, Time:    7.118s
     readytorun.crossgen2.XUnitWrapper                    Total:    2, Errors: 0, Failed:   2, Skipped: 0, Time:    3.246s
     readytorun.determinism.XUnitWrapper                  Total:    1, Errors: 0, Failed:   0, Skipped: 0, Time:    9.603s
     readytorun.DynamicMethodGCStress.XUnitWrapper.dll    Total:    0
     readytorun.multifolder.XUnitWrapper                  Total:    1, Errors: 0, Failed:   0, Skipped: 0, Time:    2.406s
     readytorun.r2rdump.XUnitWrapper                      Total:    1, Errors: 0, Failed:   1, Skipped: 0, Time:    8.858s
     readytorun.tests.XUnitWrapper                        Total:    3, Errors: 0, Failed:   3, Skipped: 0, Time:    5.753s
     reflection.DefaultInterfaceMethods.XUnitWrapper      Total:    3, Errors: 0, Failed:   1, Skipped: 0, Time:    2.946s
     reflection.GenericAttribute.XUnitWrapper             Total:    1, Errors: 0, Failed:   0, Skipped: 0, Time:    1.878s
     reflection.Modifiers.XUnitWrapper                    Total:    1, Errors: 0, Failed:   0, Skipped: 0, Time:    1.370s
     reflection.RefEmit.XUnitWrapper                      Total:    1, Errors: 0, Failed:   0, Skipped: 0, Time:    2.241s
     reflection.regression.XUnitWrapper                   Total:    1, Errors: 0, Failed:   0, Skipped: 0, Time:    1.396s
     reflection.SetValue.XUnitWrapper                     Total:    2, Errors: 0, Failed:   1, Skipped: 0, Time:    2.826s
     reflection.StaticInterfaceMembers.XUnitWrapper       Total:    1, Errors: 0, Failed:   0, Skipped: 0, Time:    1.096s
     Regressions.coreclr.XUnitWrapper                     Total:   23, Errors: 0, Failed:  12, Skipped: 0, Time:    8.068s
     tracing.eventactivityidcontrol.XUnitWrapper          Total:    1, Errors: 0, Failed:   0, Skipped: 0, Time:    1.561s
     tracing.eventcounter.XUnitWrapper                    Total:    8, Errors: 0, Failed:   0, Skipped: 0, Time:    0.143s
     tracing.eventlistener.XUnitWrapper                   Total:    2, Errors: 0, Failed:   0, Skipped: 0, Time:    4.653s
     tracing.eventpipe.XUnitWrapper                       Total:   14, Errors: 0, Failed:   2, Skipped: 0, Time:   10.625s
     tracing.runtimeeventsource.XUnitWrapper              Total:    1, Errors: 0, Failed:   0, Skipped: 0, Time:    3.042s
                                                                 ----          -          ---           -        ---------
                                                    GRAND TOTAL: 2925          0          815           0        3871.775s (3897.923s)
```

The PR is split two commit. The first commit fixes some little compile problems, And The second implements the feature.

This will also fix https://github.com/dotnet/runtime/pull/37825#issuecomment-648553568