### PR TITLE
[release/6.0] Avoid not live built packages dependencies that are satisifed by the shared framework in M.E.Logging.Abstractions

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/Microsoft.Extensions.Logging.Abstractions.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/Microsoft.Extensions.Logging.Abstractions.csproj
@@ -30,7 +30,7 @@ Microsoft.Extensions.Logging.Abstractions.NullLogger</PackageDescription>
              Link="Common\System\Text\ValueStringBuilder.cs" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
     <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
   </ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/59161
Reported by customer via https://github.com/dotnet/runtime/issues/59158
Regressed with https://github.com/dotnet/runtime/commit/3897ee5902a3f4de51d75cb24ea59345aeb28782

## Customer Impact
Customers who reference the Microsoft.Extensions.Logging.Abstractions package transitively reference the System.Buffers and System.Memory packages when targeting .NETCoreApp even though those libraries are already satisfied by the shared framework.

It's undesirable to have the System.Buffers and System.Memory dependencies in the graph
as these aren't live built anymore and are only serviced on demand (for security issues) from the release/2.1 branch. 

## Testing
The package built locally doesn't contain the dependencies anymore for net6.0. Also, the runtime local package testing infrastructure restores the produced package and makes sure that all dependencies are satisfied.

## Risk
Low. The dependencies are present in the RC1 package and this change just removes them from the net6.0 asset.