### PR TITLE
[release/6.0] Set the publishing infra version to 3

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,3 +1,6 @@
 <Project>
   <!-- TODO: Consolidate the Publishing.props files into here. -->
+  <PropertyGroup>
+    <PublishingVersion>3</PublishingVersion>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Before this was not important because runtime was calling its own publishing tasks with the property explicitly set, but since the introduction of arcade powered source build this property is needed to avoid ArPow from defaulting to v2.