### PR TITLE
Implement UriCreationOptions

### DIFF
--- a/src/libraries/System.Private.Uri/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.Uri/src/Resources/Strings.resx
@@ -198,4 +198,7 @@
   <data name="net_uri_InitializeCalledAlreadyOrTooLate" xml:space="preserve">
     <value>UriParser's base InitializeAndValidate may only be called once on a single Uri instance and only from an override of InitializeAndValidate.</value>
   </data>
+  <data name="net_uri_GetComponentsCalledWhenCanonicalizationDisabled" xml:space="preserve">
+    <value>GetComponents() may not be used for Path/Query on a Uri instance created with UriCreationOptions.DangerousDisablePathAndQueryCanonicalization.</value>
+  </data>
 </root>

--- a/src/libraries/System.Private.Uri/src/System.Private.Uri.csproj
+++ b/src/libraries/System.Private.Uri/src/System.Private.Uri.csproj
@@ -24,6 +24,7 @@
     <Compile Include="System\UncNameHelper.cs" />
     <Compile Include="System\Uri.cs" />
     <Compile Include="System\UriBuilder.cs" />
+    <Compile Include="System\UriCreationOptions.cs" />
     <Compile Include="System\UriEnumTypes.cs" />
     <Compile Include="System\UriExt.cs" />
     <Compile Include="System\UriFormatException.cs" />

--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -121,6 +121,9 @@ namespace System
             IriCanonical = 0x78000000000,
             UnixPath = 0x100000000000,
 
+            /// <summary>
+            /// Disables any validation/normalization past the authority. Fragments will always be empty. GetComponents will throw for Path/Query.
+            /// </summary>
             DisablePathAndQueryCanonicalization = 0x200000000000,
 
             /// <summary>
@@ -414,6 +417,11 @@ namespace System
             DebugSetLeftCtor();
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Uri"/> class with the specified URI and additional <see cref="UriCreationOptions"/>.
+        /// </summary>
+        /// <param name="uriString">A string that identifies the resource to be represented by the <see cref="Uri"/> instance.</param>
+        /// <param name="creationOptions">Options that control how the <seealso cref="Uri"/> is created and behaves.</param>
         public Uri(string uriString, in UriCreationOptions creationOptions)
         {
             if (uriString is null)

--- a/src/libraries/System.Private.Uri/src/System/UriCreationOptions.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriCreationOptions.cs
@@ -3,8 +3,26 @@
 
 namespace System
 {
+    /// <summary>
+    /// Options that control how a <seealso cref="Uri"/> is created and behaves.
+    /// </summary>
     public struct UriCreationOptions
     {
-        public bool DangerousDisablePathAndQueryCanonicalization { readonly get; set; }
+        private bool _disablePathAndQueryCanonicalization;
+
+        /// <summary>
+        /// Disables validation and normalization of the Path and Query.
+        /// No transformations of the URI past the Authority will take place.
+        /// <see cref="Uri"/> instances created with this option do not support <see cref="Uri.Fragment"/>s.
+        /// <see cref="Uri.GetComponents(UriComponents, UriFormat)"/> may not be used for <see cref="UriComponents.Path"/> or <see cref="UriComponents.Query"/>.
+        /// Be aware that disabling canonicalization also means that reserved characters will not be escaped,
+        /// which may corrupt the HTTP request and makes the application subject to request smuggling.
+        /// Only set this option if you have ensured that the URI string is already sanitized.
+        /// </summary>
+        public bool DangerousDisablePathAndQueryCanonicalization
+        {
+            readonly get => _disablePathAndQueryCanonicalization;
+            set => _disablePathAndQueryCanonicalization = value;
+        }
     }
 }

--- a/src/libraries/System.Private.Uri/src/System/UriCreationOptions.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriCreationOptions.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System
+{
+    public struct UriCreationOptions
+    {
+        public bool DangerousDisablePathAndQueryCanonicalization { readonly get; set; }
+    }
+}

--- a/src/libraries/System.Private.Uri/src/System/UriExt.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriExt.cs
@@ -13,7 +13,7 @@ namespace System
         //
         // All public ctors go through here
         //
-        private void CreateThis(string? uri, bool dontEscape, UriKind uriKind)
+        private void CreateThis(string? uri, bool dontEscape, UriKind uriKind, in UriCreationOptions creationOptions = default)
         {
             DebugAssertInCtor();
 
@@ -30,6 +30,9 @@ namespace System
 
             if (dontEscape)
                 _flags |= Flags.UserEscaped;
+
+            if (creationOptions.DangerousDisablePathAndQueryCanonicalization)
+                _flags |= Flags.DisablePathAndQueryCanonicalization;
 
             ParsingError err = ParseScheme(_string, ref _flags, ref _syntax!);
 
@@ -259,6 +262,19 @@ namespace System
             return e is null && result != null;
         }
 
+        public static bool TryCreate([NotNullWhen(true)] string? uriString, in UriCreationOptions creationOptions, [NotNullWhen(true)] out Uri? result)
+        {
+            if (uriString is null)
+            {
+                result = null;
+                return false;
+            }
+            UriFormatException? e = null;
+            result = CreateHelper(uriString, false, UriKind.Absolute, ref e, in creationOptions);
+            result?.DebugSetLeftCtor();
+            return e is null && result != null;
+        }
+
         public static bool TryCreate(Uri? baseUri, string? relativeUri, [NotNullWhen(true)] out Uri? result)
         {
             if (TryCreate(relativeUri, UriKind.RelativeOrAbsolute, out Uri? relativeLink))
@@ -309,6 +325,16 @@ namespace System
         }
 
         public string GetComponents(UriComponents components, UriFormat format)
+        {
+            if (DisablePathAndQueryCanonicalization && (components & (UriComponents.Path | UriComponents.Query)) != 0)
+            {
+                throw new InvalidOperationException(SR.net_uri_GetComponentsCalledWhenCanonicalizationDisabled);
+            }
+
+            return InternalGetComponents(components, format);
+        }
+
+        private string InternalGetComponents(UriComponents components, UriFormat format)
         {
             if (((components & UriComponents.SerializationInfoString) != 0) && components != UriComponents.SerializationInfoString)
                 throw new ArgumentOutOfRangeException(nameof(components), components, SR.net_uri_NotJustSerialization);
@@ -590,7 +616,7 @@ namespace System
         //
         // a Uri.TryCreate() method goes through here.
         //
-        internal static Uri? CreateHelper(string uriString, bool dontEscape, UriKind uriKind, ref UriFormatException? e)
+        internal static Uri? CreateHelper(string uriString, bool dontEscape, UriKind uriKind, ref UriFormatException? e, in UriCreationOptions creationOptions = default)
         {
             // if (!Enum.IsDefined(typeof(UriKind), uriKind)) -- We currently believe that Enum.IsDefined() is too slow
             // to be used here.
@@ -605,6 +631,9 @@ namespace System
 
             if (dontEscape)
                 flags |= Flags.UserEscaped;
+
+            if (creationOptions.DangerousDisablePathAndQueryCanonicalization)
+                flags |= Flags.DisablePathAndQueryCanonicalization;
 
             // We won't use User factory for these errors
             if (err != ParsingError.None)

--- a/src/libraries/System.Private.Uri/src/System/UriExt.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriExt.cs
@@ -262,6 +262,13 @@ namespace System
             return e is null && result != null;
         }
 
+        /// <summary>
+        /// Creates a new <see cref="Uri"/> using the specified <see cref="string"/> instance and <see cref="UriCreationOptions"/>.
+        /// </summary>
+        /// <param name="uriString">The string representation of the <see cref="Uri"/>.</param>
+        /// <param name="creationOptions">Options that control how the <seealso cref="Uri"/> is created and behaves.</param>
+        /// <param name="result">The constructed <see cref="Uri"/>.</param>
+        /// <returns><see langword="true"/> if the <see cref="Uri"/> was successfully created; otherwise, <see langword="false"/>.</returns>
         public static bool TryCreate([NotNullWhen(true)] string? uriString, in UriCreationOptions creationOptions, [NotNullWhen(true)] out Uri? result)
         {
             if (uriString is null)

--- a/src/libraries/System.Private.Uri/src/System/UriScheme.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriScheme.cs
@@ -146,6 +146,9 @@ namespace System
             if (!uri.IsAbsoluteUri)
                 throw new InvalidOperationException(SR.net_uri_NotAbsolute);
 
+            if (uri.DisablePathAndQueryCanonicalization && (components & (UriComponents.Path | UriComponents.Query)) != 0)
+                throw new InvalidOperationException(SR.net_uri_GetComponentsCalledWhenCanonicalizationDisabled);
+
             return uri.GetComponentsHelper(components, format);
         }
 

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/System.Private.Uri.Functional.Tests.csproj
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/System.Private.Uri.Functional.Tests.csproj
@@ -17,6 +17,7 @@
     <Compile Include="UriBuilderParameterTest.cs" />
     <Compile Include="UriBuilderRefreshTest.cs" />
     <Compile Include="UriBuilderTests.cs" />
+    <Compile Include="UriCreationOptionsTest.cs" />
     <Compile Include="UriEscapingTest.cs" />
     <Compile Include="UriGetComponentsTest.cs" />
     <Compile Include="UriIpHostTest.cs" />

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UriCreationOptionsTest.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UriCreationOptionsTest.cs
@@ -1,0 +1,294 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace System.PrivateUri.Tests
+{
+    public class UriCreationOptionsTest
+    {
+        [Fact]
+        public void UriCreationOptions_HasReasonableDefaults()
+        {
+            UriCreationOptions options = default;
+
+            Assert.False(options.DangerousDisablePathAndQueryCanonicalization);
+        }
+
+        [Fact]
+        public void UriCreationOptions_StoresCorrectValues()
+        {
+            var options = new UriCreationOptions { DangerousDisablePathAndQueryCanonicalization = true };
+            Assert.True(options.DangerousDisablePathAndQueryCanonicalization);
+
+            options = new UriCreationOptions { DangerousDisablePathAndQueryCanonicalization = false };
+            Assert.False(options.DangerousDisablePathAndQueryCanonicalization);
+        }
+
+        public static IEnumerable<object[]> DisableCanonicalization_TestData()
+        {
+            var schemes = new string[] { "http", "hTTp", " http", "https" };
+            var hosts = new string[] { "foo", "f\u00F6\u00F6.com" };
+            var ports = new string[] { ":80", ":443", ":0123", ":", "" };
+
+            var pathAndQueries = new string[]
+            {
+                "",
+                " ",
+                "a b",
+                "a%20b",
+                "?a b",
+                "?a%20b",
+                "foo/./",
+                "foo/../",
+                "//\\//",
+                "%41",
+                "A?%41=%42",
+                "?%41=%42",
+                "? ",
+            };
+
+            var fragments = new string[] { "", "#", "#/foo ? %20%41/..//\\a" };
+            var unicodeInPathModes = new int[] { 0, 1, 2, 3 };
+            var pathDelimiters = new string[] { "", "/" };
+
+            // Get various combinations of paths with unicode characters and delimiters
+            string[] rawTargets = pathAndQueries
+                .SelectMany(pq => fragments.Select(fragment => pq + fragment))
+                .SelectMany(pqf => unicodeInPathModes.Select(unicodeMode => unicodeMode switch
+                {
+                    0 => pqf,
+                    1 => "\u00F6" + pqf,
+                    2 => pqf + "\u00F6",
+                    _ => pqf.Insert(pqf.Length / 2, "\u00F6")
+                }))
+                .ToHashSet()
+                .SelectMany(pqf => pathDelimiters.Select(delimiter => delimiter + pqf))
+                .Where(target => target.StartsWith('/') || target.StartsWith('?')) // Can't see where the authority ends and the path starts otherwise
+                .ToArray();
+
+            foreach (string scheme in schemes)
+            {
+                foreach (string host in hosts)
+                {
+                    foreach (string port in ports)
+                    {
+                        foreach (string rawTarget in rawTargets)
+                        {
+                            string uriString = $"{scheme}://{host}{port}{rawTarget}";
+
+                            int expectedPort = port.Length > 1 ? int.Parse(port.AsSpan(1)) : new Uri($"{scheme}://foo").Port;
+
+                            string expectedQuery = rawTarget.Contains('?') ? rawTarget.Substring(rawTarget.IndexOf('?')) : "";
+
+                            string expectedPath = rawTarget.Substring(0, rawTarget.Length - expectedQuery.Length);
+
+                            yield return new object[] { uriString, host, expectedPort, expectedPath, expectedQuery };
+                        }
+                    }
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(DisableCanonicalization_TestData))]
+        public void DisableCanonicalization_IsRespected(string uriString, string expectedHost, int expectedPort, string expectedPath, string expectedQuery)
+        {
+            var options = new UriCreationOptions { DangerousDisablePathAndQueryCanonicalization = true };
+
+            var uri = new Uri(uriString, options);
+            DoAsserts(uri);
+
+            Assert.True(Uri.TryCreate(uriString, options, out uri));
+            DoAsserts(uri);
+
+            void DoAsserts(Uri uri)
+            {
+                Assert.Equal(new Uri($"http://{expectedHost}").Host, uri.Host);
+                Assert.Equal(new Uri($"http://{expectedHost}").IdnHost, uri.IdnHost);
+
+                Assert.Equal(expectedPort, uri.Port);
+
+                Assert.Same(uri.AbsolutePath, uri.AbsolutePath);
+                Assert.Equal(expectedPath, uri.AbsolutePath);
+
+                Assert.Same(uri.Query, uri.Query);
+                Assert.Equal(expectedQuery, uri.Query);
+
+                string expectedPathAndQuery = expectedPath + expectedQuery;
+                Assert.Same(uri.PathAndQuery, uri.PathAndQuery);
+                Assert.Equal(expectedPathAndQuery, uri.PathAndQuery);
+
+                Assert.Same(uri.Fragment, uri.Fragment);
+                Assert.Empty(uri.Fragment); // Fragment is always empty if DisableCanonicalization is set
+            }
+        }
+
+        [Fact]
+        public void DisableCanonicalization_OnlyEqualToUrisWithMatchingFlag()
+        {
+            const string AbsoluteUri = "http://host";
+            const string Path = "/foo";
+
+            var absolute = new Uri(AbsoluteUri + Path, new UriCreationOptions { DangerousDisablePathAndQueryCanonicalization = false });
+            var absoluteRaw = new Uri(AbsoluteUri + Path, new UriCreationOptions { DangerousDisablePathAndQueryCanonicalization = true });
+            NotEqual(absolute, absoluteRaw);
+            Equal(absolute, absolute);
+            Equal(absoluteRaw, absoluteRaw);
+
+            var absoluteRawCopy = new Uri(AbsoluteUri + Path, new UriCreationOptions { DangerousDisablePathAndQueryCanonicalization = true });
+            Equal(absoluteRaw, absoluteRawCopy);
+
+            var absoluteRawDifferentPath = new Uri(AbsoluteUri + "/bar", new UriCreationOptions { DangerousDisablePathAndQueryCanonicalization = true });
+            NotEqual(absoluteRaw, absoluteRawDifferentPath);
+
+            var absoluteRawSameAuthority = new Uri(AbsoluteUri + ":80" + Path, new UriCreationOptions { DangerousDisablePathAndQueryCanonicalization = true });
+            Equal(absoluteRaw, absoluteRawSameAuthority);
+
+            static void Equal(Uri left, Uri right)
+            {
+                Assert.True(left.Equals(right));
+                Assert.True(right.Equals(left));
+                Assert.Equal(left.GetHashCode(), right.GetHashCode());
+            }
+
+            static void NotEqual(Uri left, Uri right)
+            {
+                Assert.False(left.Equals(right));
+                Assert.False(right.Equals(left));
+            }
+        }
+
+        private const string FilePathRawData = "//\\A%41 %20\u00F6/.././%5C%2F#%42?%43#%44";
+
+        public static IEnumerable<object[]> ImplicitFilePaths_TestData()
+        {
+            yield return Entry("C:/");
+            yield return Entry("C|/");
+
+            yield return Entry(@"//foo");
+            yield return Entry(@"\/foo");
+            yield return Entry(@"/\foo");
+            yield return Entry(@"\\foo");
+
+            if (!PlatformDetection.IsWindows)
+            {
+                yield return Entry("/foo");
+            }
+
+            static object[] Entry(string filePath) => new object[] { $"{filePath}/{FilePathRawData}" };
+        }
+
+        [Theory]
+        [MemberData(nameof(ImplicitFilePaths_TestData))]
+        public void DisableCanonicalization_WorksWithFileUris(string implicitFilePath)
+        {
+            var options = new UriCreationOptions { DangerousDisablePathAndQueryCanonicalization = true };
+
+            var uri = new Uri(implicitFilePath, options);
+            DoAsserts(uri);
+
+            Assert.True(Uri.TryCreate(implicitFilePath, options, out uri));
+            DoAsserts(uri);
+
+            static void DoAsserts(Uri uri)
+            {
+                Assert.True(uri.IsAbsoluteUri);
+                Assert.True(uri.IsFile);
+                Assert.Contains(FilePathRawData, uri.AbsolutePath);
+                Assert.Contains(FilePathRawData, uri.AbsoluteUri);
+                Assert.Contains(FilePathRawData, uri.ToString());
+            }
+        }
+
+        [Theory]
+        [InlineData("http")]
+        [InlineData("https")]
+        [InlineData("ftp")]
+        [InlineData("file")]
+        [InlineData("custom-unknown")]
+        [InlineData("custom-registered")]
+        public void DisableCanonicalization_WorksWithDifferentSchemes(string scheme)
+        {
+            if (scheme == "custom-registered")
+            {
+                scheme += "DisableCanonicalization";
+                UriParser.Register(new HttpStyleUriParser(), scheme, defaultPort: Random.Shared.Next(-1, 65536));
+            }
+
+            string uriString = $"{scheme}://host/p%41th?a=%42#fragm%45nt";
+            var options = new UriCreationOptions { DangerousDisablePathAndQueryCanonicalization = true };
+
+            var referenceUri = new Uri(uriString);
+
+            var uri = new Uri(uriString, options);
+            DoAsserts(uri);
+
+            Assert.True(Uri.TryCreate(uriString, options, out uri));
+            DoAsserts(uri);
+
+            void DoAsserts(Uri uri)
+            {
+                Assert.Same(referenceUri.Scheme, uri.Scheme);
+                Assert.Equal(referenceUri.Host, uri.Host);
+                Assert.Equal(referenceUri.IdnHost, uri.IdnHost);
+                Assert.Equal(referenceUri.Authority, uri.Authority);
+                Assert.Equal(referenceUri.Port, uri.Port);
+                Assert.Equal(referenceUri.IsDefaultPort, uri.IsDefaultPort);
+
+                string referencePath = "/pAth";
+                string referenceQuery = "?a=B";
+                string path = "/p%41th";
+                string query = "?a=%42#fragm%45nt";
+
+                if (scheme == "ftp") // No query
+                {
+                    referencePath += referenceQuery.Replace("?", "%3F");
+                    path += query;
+
+                    referenceQuery = string.Empty;
+                    query = string.Empty;
+                }
+
+                Assert.Equal(referencePath, referenceUri.AbsolutePath);
+                Assert.Equal(path, uri.AbsolutePath);
+
+                Assert.Equal(referenceQuery, referenceUri.Query);
+                Assert.Equal(query, uri.Query);
+
+                Assert.Equal(referencePath + referenceQuery, referenceUri.PathAndQuery);
+                Assert.Equal(path + query, uri.PathAndQuery);
+
+                Assert.Equal("#fragmEnt", referenceUri.Fragment);
+                Assert.Empty(uri.Fragment);
+
+                _ = referenceUri.GetComponents(UriComponents.AbsoluteUri, UriFormat.UriEscaped);
+                Assert.Throws<InvalidOperationException>(() => uri.GetComponents(UriComponents.Path, UriFormat.UriEscaped));
+            }
+        }
+
+        [Theory]
+        [InlineData(UriFormat.UriEscaped)]
+        [InlineData(UriFormat.Unescaped)]
+        [InlineData(UriFormat.SafeUnescaped)]
+        public void DisableCanonicalization_GetComponentsThrowsForPathAndQuery(UriFormat format)
+        {
+            var uri = new Uri("http://host/foo?bar=abc#fragment", new UriCreationOptions { DangerousDisablePathAndQueryCanonicalization = true });
+
+            Assert.Equal("http", uri.GetComponents(UriComponents.Scheme, format));
+            Assert.Equal("host", uri.GetComponents(UriComponents.Host, format));
+            Assert.Equal("80", uri.GetComponents(UriComponents.StrongPort, format));
+            Assert.Empty(uri.GetComponents(UriComponents.Fragment, format));
+
+            Assert.Throws<InvalidOperationException>(() => uri.GetComponents(UriComponents.Path, format));
+            Assert.Throws<InvalidOperationException>(() => uri.GetComponents(UriComponents.Query, format));
+            Assert.Throws<InvalidOperationException>(() => uri.GetComponents(UriComponents.PathAndQuery, format));
+            Assert.Throws<InvalidOperationException>(() => uri.GetComponents(UriComponents.AbsoluteUri, format));
+        }
+
+
+        private sealed class CustomUriParser : UriParser { }
+    }
+}

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -7716,6 +7716,7 @@ namespace System
         public Uri(string uriString) { }
         [System.ObsoleteAttribute("This constructor has been deprecated; the dontEscape parameter is always false. Use Uri(string) instead.")]
         public Uri(string uriString, bool dontEscape) { }
+        public Uri(string uriString, in System.UriCreationOptions creationOptions) { }
         public Uri(string uriString, System.UriKind uriKind) { }
         public Uri(System.Uri baseUri, string? relativeUri) { }
         [System.ObsoleteAttribute("This constructor has been deprecated; the dontEscape parameter is always false. Use Uri(Uri, string) instead.")]
@@ -7785,6 +7786,7 @@ namespace System
         protected virtual void Parse() { }
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) { }
         public override string ToString() { throw null; }
+        public static bool TryCreate([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? uriString, in System.UriCreationOptions creationOptions, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Uri? result) { throw null; }
         public static bool TryCreate([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] string? uriString, System.UriKind uriKind, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Uri? result) { throw null; }
         public static bool TryCreate(System.Uri? baseUri, string? relativeUri, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Uri? result) { throw null; }
         public static bool TryCreate(System.Uri? baseUri, System.Uri? relativeUri, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Uri? result) { throw null; }
@@ -7820,6 +7822,10 @@ namespace System
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? rparam) { throw null; }
         public override int GetHashCode() { throw null; }
         public override string ToString() { throw null; }
+    }
+    public partial struct UriCreationOptions
+    {
+        public bool DangerousDisablePathAndQueryCanonicalization { readonly get { throw null; } set { } }
     }
     [System.FlagsAttribute]
     public enum UriComponents


### PR DESCRIPTION
Fixes #52628
Fixes #58057

Implements a minimal subset of #59099:
The `Uri` constructor overloads and the `DangerousDisablePathAndQueryCanonicalization` property of `UriCreationOptions`.

Not yet implemented:
```c#
public struct UriCreationOptions
{
    public UriKind UriKind { readonly get; set; }
    public bool AllowImplicitFilePaths { readonly get; set; }
}
```