### PR TITLE
Arm: Use correct form of store instruction when data is float

### DIFF
--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -1360,7 +1360,7 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
             instGen_MemoryBarrier();
         }
 
-        GetEmitter()->emitInsLoadStoreOp(ins_Store(type), emitActualTypeSize(type), data->GetRegNum(), tree);
+        GetEmitter()->emitInsLoadStoreOp(ins_Store(data->TypeGet()), emitActualTypeSize(type), data->GetRegNum(), tree);
 
         // If store was to a variable, update variable liveness after instruction was emitted.
         genUpdateLife(tree);

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -1320,7 +1320,7 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
     GenTree*  addr = tree->Addr();
     var_types type = tree->TypeGet();
 
-    assert(!varTypeIsFloating(type));
+    assert(!varTypeIsFloating(type) || (type == data->TypeGet()));
 
     GCInfo::WriteBarrierForm writeBarrierForm = gcInfo.gcIsWriteBarrierCandidate(tree, data);
     if (writeBarrierForm != GCInfo::WBF_NoBarrier)

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -1360,7 +1360,7 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
             instGen_MemoryBarrier();
         }
 
-        regNumber   dataReg = data->GetRegNum();
+        regNumber dataReg = data->GetRegNum();
         GetEmitter()->emitInsLoadStoreOp(ins_StoreFromSrc(dataReg, type), emitActualTypeSize(type), dataReg, tree);
 
         // If store was to a variable, update variable liveness after instruction was emitted.

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -1360,8 +1360,8 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
             instGen_MemoryBarrier();
         }
 
-        var_types strType = varTypeIsFloating(data->TypeGet()) ? data->TypeGet() : type;
-        GetEmitter()->emitInsLoadStoreOp(ins_Store(strType), emitActualTypeSize(strType), data->GetRegNum(), tree);
+        regNumber   dataReg = data->GetRegNum();
+        GetEmitter()->emitInsLoadStoreOp(ins_StoreFromSrc(dataReg, type), emitActualTypeSize(type), dataReg, tree);
 
         // If store was to a variable, update variable liveness after instruction was emitted.
         genUpdateLife(tree);

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -1361,8 +1361,7 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
         }
 
         var_types strType = varTypeIsFloating(data->TypeGet()) ? data->TypeGet() : type;
-        GetEmitter()->emitInsLoadStoreOp(ins_Store(strType), emitActualTypeSize(strType), data->GetRegNum(),
-                                         tree);
+        GetEmitter()->emitInsLoadStoreOp(ins_Store(strType), emitActualTypeSize(strType), data->GetRegNum(), tree);
 
         // If store was to a variable, update variable liveness after instruction was emitted.
         genUpdateLife(tree);

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -1320,7 +1320,7 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
     GenTree*  addr = tree->Addr();
     var_types type = tree->TypeGet();
 
-    assert(!varTypeIsFloating(type) || (type == data->TypeGet()));
+    assert(!varTypeIsFloating(type));
 
     GCInfo::WriteBarrierForm writeBarrierForm = gcInfo.gcIsWriteBarrierCandidate(tree, data);
     if (writeBarrierForm != GCInfo::WBF_NoBarrier)
@@ -1360,7 +1360,9 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
             instGen_MemoryBarrier();
         }
 
-        GetEmitter()->emitInsLoadStoreOp(ins_Store(data->TypeGet()), emitActualTypeSize(type), data->GetRegNum(), tree);
+        var_types strType = varTypeIsFloating(data->TypeGet()) ? data->TypeGet() : type;
+        GetEmitter()->emitInsLoadStoreOp(ins_Store(strType), emitActualTypeSize(strType), data->GetRegNum(),
+                                         tree);
 
         // If store was to a variable, update variable liveness after instruction was emitted.
         genUpdateLife(tree);

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -3263,8 +3263,8 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
             dataReg = data->GetRegNum();
         }
 
-        var_types   type = varTypeIsFloating(data->TypeGet()) ? data->TypeGet() : tree->TypeGet();
-        instruction ins  = ins_Store(type);
+        var_types   type = tree->TypeGet();
+        instruction ins  = ins_StoreFromSrc(dataReg, type);
 
         if ((tree->gtFlags & GTF_IND_VOLATILE) != 0)
         {

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -3263,7 +3263,7 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
             dataReg = data->GetRegNum();
         }
 
-        var_types   type = tree->TypeGet();
+        var_types   type = varTypeIsFloating(data->TypeGet()) ? data->TypeGet() : tree->TypeGet();
         instruction ins  = ins_Store(type);
 
         if ((tree->gtFlags & GTF_IND_VOLATILE) != 0)

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -13399,7 +13399,7 @@ void emitter::emitDispFrameRef(int varx, int disp, int offs, bool asmfm)
 #endif // DEBUG
 
 // Generate code for a load or store operation with a potentially complex addressing mode
-// This method handles the case of a GT_IND with contained GT_LEA op1 of the x86 form [base + index*sccale + offset]
+// This method handles the case of a GT_IND with contained GT_LEA op1 of the x86 form [base + index*scale + offset]
 // Since Arm64 does not directly support this complex of an addressing mode
 // we may generates up to three instructions for this for Arm64
 //

--- a/src/tests/JIT/Methodical/structs/StructWithSingleFloat.cs
+++ b/src/tests/JIT/Methodical/structs/StructWithSingleFloat.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+// Note: In below test, when S2 struct is returned from Method1, incorrect "str" instruction was being
+//       generated while storing the return result into s_s2_16.
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+public class TestClass
+{
+    public struct S2
+    {
+        public float float_2;
+    }
+    static decimal s_decimal_3 = 2.0512820512820512820512820513m;
+    static S2 s_s2_16 = new S2();
+    decimal decimal_3 = 2.3m;
+    public S2 Method1(out decimal p_decimal_0)
+    {
+        unchecked
+        {
+            S2 s2_17 = new S2();
+            p_decimal_0 = s_decimal_3 + 15 + 4;
+            return s2_17;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public void Method0()
+    {
+        unchecked
+        {
+            s_s2_16 = Method1(out decimal_3);
+            return;
+        }
+    }
+    public static int Main(string[] args)
+    {
+        new TestClass().Method0();
+        return 100;
+    }
+}

--- a/src/tests/JIT/Methodical/structs/StructWithSingleFloat.cs
+++ b/src/tests/JIT/Methodical/structs/StructWithSingleFloat.cs
@@ -20,6 +20,7 @@ public class TestClass
         unchecked
         {
             S2 s2_17 = new S2();
+            s2_17.float_2 = 1.5f;
             p_decimal_0 = s_decimal_3 + 15 + 4;
             return s2_17;
         }
@@ -37,6 +38,6 @@ public class TestClass
     public static int Main(string[] args)
     {
         new TestClass().Method0();
-        return 100;
+        return s_s2_16.float_2 == 1.5f ? 100 : 0;
     }
 }

--- a/src/tests/JIT/Methodical/structs/StructWithSingleFloat.csproj
+++ b/src/tests/JIT/Methodical/structs/StructWithSingleFloat.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/JIT/Methodical/structs/StructWithSingleFloat.csproj
+++ b/src/tests/JIT/Methodical/structs/StructWithSingleFloat.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IlasmRoundTrip>true</IlasmRoundTrip>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="StructWithSingleFloat.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
We were not using the correct form of store instruction when the source operand is `float`.

It fixes below assert:

```
Assert failure(PID 19292 [0x00004b5c], Thread: 38368 [0x95e0]): Assertion failed 'isGeneralRegister(id->idReg1())' in 'TestClass:Method0():this' during 'Generate code' (IL size 18)

    File: D:\git\runtime\src\coreclr\jit\emitarm.cpp Line: 388
    Image: D:\git\runtime\artifacts\tests\coreclr\windows.x64.Checked\tests\Core_Root\corerun.exe
```