### PR TITLE
Fix BinSkim warnings in System.IO.Compression.Native.dll

### DIFF
--- a/src/libraries/Native/Windows/CMakeLists.txt
+++ b/src/libraries/Native/Windows/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 cmake_policy(SET CMP0091 NEW)
 
 # C Compiler flags
-SET (CMAKE_C_FLAGS_INIT                     "/FC")
+SET (CMAKE_C_FLAGS_INIT                     "/W3 /FC")
 SET (CMAKE_C_FLAGS_DEBUG_INIT               "/Od /Zi")
 SET (CMAKE_C_FLAGS_RELEASE_INIT             "/Ox")
 SET (CMAKE_C_FLAGS_RELWITHDEBINFO_INIT      "/O2 /Zi")


### PR DESCRIPTION
Fixes "BA2007: 'System.IO.Compression.Native.dll' was compiled at too low a warning level (effective warning level 0 for one or more modules). Warning level 3 enables important static analysis in the compiler to flag bugs that can lead to memory corruption, information disclosure, or double-free vulnerabilities. To resolve this issue, compile at warning level 3 or higher by supplying /W3, /W4, or /Wall to the compiler, and resolve the warnings emitted.".

We used to have a `/W0` here that for whatever reason was acceptable for BinSkim in the past releases. That was deleted in #47344.

This BinSkim warning was reported in NativeAOT, but I assume this affects the 6.0 release as well.