### PR TITLE
Suppress SendPacketsElement_FileStreamMultiPartMixed_MultipleFileStreams_Success test on Windows 11

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
@@ -6,6 +6,8 @@ using System.IO;
 using System.Net.Test.Common;
 using System.Threading;
 
+using Microsoft.DotNet.XUnitExtensions;
+
 using Xunit;
 using Xunit.Abstractions;
 
@@ -579,8 +581,15 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public void SendPacketsElement_FileStreamMultiPartMixed_MultipleFileStreams_Success() {
+            
+            if (PlatformDetection.IsWindows10Version22000OrGreater)
+            {
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/58898")]
+                throw new SkipTestException("Unstable on Windows 11");
+            }
+
             using (var stream = new FileStream(TestFileName, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, FileOptions.Asynchronous))
             using (var stream2 = new FileStream(TestFileName, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, FileOptions.Asynchronous)) {
                 var elements = new[]


### PR DESCRIPTION


Related to #58898

# Description

Since we added Windows 11 to the CI matrix, this test starts timeout. This PR suppress this test on Windows 11 temporarly. 
