### PR TITLE
Fix PKCS7 export quirks

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/StorePal.Export.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/StorePal.Export.cs
@@ -118,6 +118,16 @@ namespace Internal.Cryptography.Pal
                     if (!Interop.crypt32.CertSaveStore(_certStore, CertEncodingType.All, dwSaveAs, CertStoreSaveTo.CERT_STORE_SAVE_TO_MEMORY, ref blob, 0))
                         throw Marshal.GetLastWin32Error().ToCryptographicException();
                 }
+
+                // When calling CertSaveStore to get the initial length, it returns a cbData that is big enough but
+                // not exactly the right size, at least in the case of PKCS7. So we need to right-size it once we
+                // know exactly how much was written.
+                if (exportedData.Length != blob.cbData)
+                {
+                    return exportedData[0..blob.cbData];
+                }
+
+                // If CertSaveStore calculation got the size right on the first try, then return the buffer as-is.
                 return exportedData;
             }
         }


### PR DESCRIPTION
On macOS, exporting an empty X509Certificate2Collection to PKCS7 would produce an exception. Instead, we return a pre-encoded empty PKCS7 result.

On Windows, the PKCS7 export would include trailing zeros in PKCS7 export. This occured because the first calls to CertSaveStore would return a size that is at least big enough, but not exact. This trims the result to the actual amount written on the second call.

Closes #59206 
Closes #59212