### PR TITLE
Bump RC2 intellisense version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -166,7 +166,7 @@
     <FsCheckVersion>2.14.3</FsCheckVersion>
     <SdkVersionForWorkloadTesting>6.0.100-rc.2.21463.12</SdkVersionForWorkloadTesting>
     <!-- Docs -->
-    <MicrosoftPrivateIntellisenseVersion>5.0.0-preview-20201009.2</MicrosoftPrivateIntellisenseVersion>
+    <MicrosoftPrivateIntellisenseVersion>6.0.0-preview-20210916.1</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->
     <MicrosoftNETILLinkTasksVersion>6.0.100-1.21459.1</MicrosoftNETILLinkTasksVersion>
     <MicrosoftNETILLinkAnalyzerPackageVersion>$(MicrosoftNETILLinkTasksVersion)</MicrosoftNETILLinkAnalyzerPackageVersion>


### PR DESCRIPTION
The .NET 6.0 RC1 documentation is live now in MS Docs: https://docs.microsoft.com/en-us/dotnet/api/?view=net-6.0

We generated the IntelliSense nuget package version for that branch, and we made sure it got pushed to the correct expected feed (`dotnet6-transport`). Here's the pipeline output of the package push: https://apidrop.visualstudio.com/Content%20CI/_build/results?buildId=253493&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=11e7ea89-affe-5194-cdc6-0171c3394706

This is a cherry-pick of the change already [merged in main](https://github.com/dotnet/runtime/pull/59115).