### PR TITLE
Change loop cloning condition blocks flow graph

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7735,8 +7735,8 @@ public:
     bool optDeriveLoopCloningConditions(unsigned loopNum, LoopCloneContext* context);
     BasicBlock* optInsertLoopChoiceConditions(LoopCloneContext* context,
                                               unsigned          loopNum,
-                                              BasicBlock*       head,
-                                              BasicBlock*       slow);
+                                              BasicBlock*       slowHead,
+                                              BasicBlock*       insertAfter);
 
 protected:
     ssize_t optGetArrayRefScaleAndIndex(GenTree* mul, GenTree** pIndex DEBUGARG(bool bRngChk));

--- a/src/coreclr/jit/loopcloning.h
+++ b/src/coreclr/jit/loopcloning.h
@@ -692,8 +692,11 @@ struct LoopCloneContext
         blockConditions.resize(loopCount, nullptr);
     }
 
-    // Evaluate conditions into a JTRUE stmt and put it in the block. Reverse condition if 'reverse' is true.
-    void CondToStmtInBlock(Compiler* comp, JitExpandArrayStack<LC_Condition>& conds, BasicBlock* block, bool reverse);
+    // Evaluate conditions into a JTRUE stmt and put it in a new block after `insertAfter`.
+    BasicBlock* CondToStmtInBlock(Compiler*                          comp,
+                                  JitExpandArrayStack<LC_Condition>& conds,
+                                  BasicBlock*                        slowHead,
+                                  BasicBlock*                        insertAfter);
 
     // Get all the optimization information for loop "loopNum"; this information is held in "optInfo" array.
     // If NULL this allocates the optInfo[loopNum] array for "loopNum".


### PR DESCRIPTION
Currently, the loop choice condition blocks are created in a way that creates
a confusing flow graph. Restructure them to be simpler, and lay the path for
future work.

The simpler layout (and, hopefully, code and logic to create them) also
lays the groundwork to potentially put the slow path loop in the loop table,
if desired, as it creates a "standard" loop header layout.

While the flow graph has an extra block or two, there are almost no diffs,
as subsequent phases clean up any extras.

There are a few diffs where the new layout enables some downstream optimization
phases that were stymied by the old layout, but mostly in cases where we leave
around dead code slow cloned blocks (a known issue). Also, there are a couple
trivial CSE changes.