### PR TITLE
Add superpmi.exe option to break to the debugger on exception.

### DIFF
--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/errorhandling.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/errorhandling.cpp
@@ -5,6 +5,7 @@
 #include "errorhandling.h"
 #include "logging.h"
 #include "runtimedetails.h"
+#include "spmiutil.h"
 
 void MSC_ONLY(__declspec(noreturn)) ThrowException(DWORD exceptionCode)
 {
@@ -18,6 +19,9 @@ void MSC_ONLY(__declspec(noreturn)) ThrowException(DWORD exceptionCode, va_list 
     ULONG_PTR* ptr    = new ULONG_PTR();
     *ptr              = (ULONG_PTR)buffer;
     _vsnprintf_s(buffer, 8192, 8191, message, args);
+
+    if (BreakOnException())
+        __debugbreak();
 
     RaiseException(exceptionCode, 0, 1, ptr);
 }

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.cpp
@@ -21,6 +21,18 @@ void SetBreakOnDebugBreakOrAV(bool value)
     breakOnDebugBreakorAV = value;
 }
 
+static bool breakOnException = false;
+
+bool BreakOnException()
+{
+    return breakOnException;
+}
+
+void SetBreakOnException(bool value)
+{
+    breakOnException = value;
+}
+
 void DebugBreakorAV(int val)
 {
     if (IsDebuggerPresent())

--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/spmiutil.h
@@ -12,6 +12,9 @@
 bool BreakOnDebugBreakorAV();
 void SetBreakOnDebugBreakOrAV(bool value);
 
+bool BreakOnException();
+void SetBreakOnException(bool value);
+
 void DebugBreakorAV(int val); // Global(ish) error handler
 
 char* GetEnvironmentVariableWithDefaultA(const char* envVarName, const char* defaultValue = nullptr);

--- a/src/coreclr/ToolBox/superpmi/superpmi/commandline.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/commandline.cpp
@@ -36,6 +36,9 @@ void CommandLine::DumpHelp(const char* program)
     printf(" -boa\n");
     printf("     Break on assert from the JIT\n");
     printf("\n");
+    printf(" -box\n");
+    printf("     Break on exception thrown, such as for missing data during replay\n");
+    printf("\n");
     printf(" -v[erbosity] messagetypes\n");
     printf("     Controls which types of messages SuperPMI logs. Specify a string of\n");
     printf("     characters representing message categories to enable, where:\n");
@@ -335,6 +338,10 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
             else if ((_strnicmp(&argv[i][1], "boa", 3) == 0))
             {
                 o->breakOnAssert = true;
+            }
+            else if ((_strnicmp(&argv[i][1], "box", 3) == 0))
+            {
+                o->breakOnException = true;
             }
             else if ((_strnicmp(&argv[i][1], "verbosity", argLen) == 0))
             {

--- a/src/coreclr/ToolBox/superpmi/superpmi/commandline.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi/commandline.h
@@ -21,6 +21,7 @@ public:
             , reproName(nullptr)
             , breakOnError(false)
             , breakOnAssert(false)
+            , breakOnException(false)
             , applyDiff(false)
             , parallel(false)
 #if !defined(USE_MSVCDIS) && defined(USE_COREDISTOOLS)
@@ -55,6 +56,7 @@ public:
         char* reproName;
         bool  breakOnError;
         bool  breakOnAssert;
+        bool  breakOnException;
         bool  applyDiff;
         bool  parallel;        // User specified to use /parallel mode.
         bool  useCoreDisTools; // Use CoreDisTools library instead of Msvcdis

--- a/src/coreclr/ToolBox/superpmi/superpmi/parallelsuperpmi.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/parallelsuperpmi.cpp
@@ -394,6 +394,7 @@ char* ConstructChildProcessArgs(const CommandLine::Options& o)
 
     ADDARG_BOOL(o.breakOnError, "-boe");
     ADDARG_BOOL(o.breakOnAssert, "-boa");
+    ADDARG_BOOL(o.breakOnException, "-box");
     ADDARG_BOOL(o.applyDiff, "-applyDiff");
     ADDARG_STRING(o.reproName, "-reproName");
     ADDARG_STRING(o.writeLogFile, "-writeLogFile");

--- a/src/coreclr/ToolBox/superpmi/superpmi/superpmi.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/superpmi.cpp
@@ -181,6 +181,8 @@ int __cdecl main(int argc, char* argv[])
         return doParallelSuperPMI(o);
     }
 
+    SetBreakOnException(o.breakOnException);
+
     SetSuperPmiTargetArchitecture(o.targetArchitecture);
 
     if (o.methodStatsTypes != NULL &&


### PR DESCRIPTION
If you use `-box` (similar to pre-existing `-boa`, `-boe`), then
an exception will invoke a `DebugBreak`, which will stop in the
debugger when an exception is thrown during replay. This is helpful
when debugging (without needing to configure the debugger to catch
a specific exception).