### PR TITLE
Get rid of ModuleDesc.GetTypeResolutionFailure

### DIFF
--- a/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
+++ b/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
@@ -32,7 +32,7 @@ namespace ILCompiler
             {
                 if (!type.IsArrayTypeWithoutGenericInterfaces())
                 {
-                    MetadataType arrayShadowType = type.Context.SystemModule.GetType("System", "Array`1", NotFoundBehavior.ReturnNull);
+                    MetadataType arrayShadowType = type.Context.SystemModule.GetType("System", "Array`1", throwIfNotFound: false);
                     if (arrayShadowType != null)
                     {
                         return arrayShadowType.MakeInstantiatedType(((ArrayType)type).ElementType);

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataTypeSystemContext.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataTypeSystemContext.cs
@@ -73,7 +73,7 @@ namespace Internal.TypeSystem
             {
                 // Require System.Object to be present as a minimal sanity check. 
                 // The set of required well-known types is not strictly defined since different .NET profiles implement different subsets.
-                MetadataType type = systemModule.GetType("System", s_wellKnownTypeNames[typeIndex], typeIndex == (int)WellKnownType.Object ? NotFoundBehavior.Throw : NotFoundBehavior.ReturnNull);
+                MetadataType type = systemModule.GetType("System", s_wellKnownTypeNames[typeIndex], throwIfNotFound: typeIndex == (int)WellKnownType.Object);
                 if (type != null)
                 {
                     type.SetWellKnownType((WellKnownType)(typeIndex + 1));

--- a/src/coreclr/tools/Common/TypeSystem/Common/ModuleDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/ModuleDesc.cs
@@ -28,14 +28,17 @@ namespace Internal.TypeSystem
         }
 
         /// <summary>
-        /// Gets a type in this module with the specified name.
-        /// If notFoundBehavior == NotFoundBehavior.ReturnResolutionFailure
-        /// then ModuleDesc.GetTypeResolutionFailure will be set to the failure, and the function will return null
+        /// Gets a type in this module or null.
         /// </summary>
-        public abstract MetadataType GetType(string nameSpace, string name, NotFoundBehavior notFoundBehavior = NotFoundBehavior.Throw);
+        public MetadataType GetType(string nameSpace, string name, bool throwIfNotFound = true)
+        {
+            return (MetadataType)GetType(nameSpace, name, throwIfNotFound ? NotFoundBehavior.Throw : NotFoundBehavior.ReturnNull);
+        }
 
-        [ThreadStatic]
-        public static ResolutionFailure GetTypeResolutionFailure;
+        /// <summary>
+        /// Gets a type in this module with the specified name, a resolution failure object, or null.
+        /// </summary>
+        public abstract object GetType(string nameSpace, string name, NotFoundBehavior notFoundBehavior);
 
         /// <summary>
         /// Gets the global &lt;Module&gt; type.

--- a/src/coreclr/tools/Common/TypeSystem/Common/Utilities/CustomAttributeTypeNameParser.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/Utilities/CustomAttributeTypeNameParser.cs
@@ -276,7 +276,7 @@ namespace Internal.TypeSystem
                 namespaceName = fullName.Substring(0, split);
                 typeName = fullName.Substring(split + 1);
             }
-            return module.GetType(namespaceName, typeName, throwIfNotFound ? NotFoundBehavior.Throw : NotFoundBehavior.ReturnNull);
+            return module.GetType(namespaceName, typeName, throwIfNotFound);
         }
 
         private static AssemblyName FindAssemblyIfNamePresent(string name)

--- a/src/coreclr/tools/Common/TypeSystem/IL/HelperExtensions.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/HelperExtensions.cs
@@ -22,7 +22,7 @@ namespace Internal.IL
 
         public static MetadataType GetOptionalHelperType(this TypeSystemContext context, string name)
         {
-            MetadataType helperType = context.SystemModule.GetType(HelperTypesNamespace, name, NotFoundBehavior.ReturnNull);
+            MetadataType helperType = context.SystemModule.GetType(HelperTypesNamespace, name, throwIfNotFound: false);
             return helperType;
         }
 
@@ -111,7 +111,7 @@ namespace Internal.IL
         /// </summary>
         public static MetadataType GetKnownType(this ModuleDesc module, string @namespace, string name)
         {
-            MetadataType type = module.GetType(@namespace, name, NotFoundBehavior.ReturnNull);
+            MetadataType type = module.GetType(@namespace, name, throwIfNotFound: false);
             if (type == null)
             {
                 throw new InvalidOperationException(

--- a/src/coreclr/tools/ILVerification/SimpleArrayOfTRuntimeInterfacesAlgorithm.cs
+++ b/src/coreclr/tools/ILVerification/SimpleArrayOfTRuntimeInterfacesAlgorithm.cs
@@ -35,7 +35,7 @@ namespace ILVerify
             int count = 0;
             for (int i = 0; i < s_genericRuntimeInterfacesNames.Length; ++i)
             {
-                MetadataType runtimeInterface =_systemModule.GetType("System.Collections.Generic", s_genericRuntimeInterfacesNames[i], NotFoundBehavior.ReturnNull);
+                MetadataType runtimeInterface =_systemModule.GetType("System.Collections.Generic", s_genericRuntimeInterfacesNames[i], throwIfNotFound: false);
                 if (runtimeInterface != null)
                     _genericRuntimeInterfaces[count++] = runtimeInterface;
             };

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IBC/MIbcProfileParser.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IBC/MIbcProfileParser.cs
@@ -516,7 +516,7 @@ namespace ILCompiler.IBC
                     throw new NotImplementedException();
                 }
 
-                public override MetadataType GetType(string nameSpace, string name, NotFoundBehavior notFoundBehavior)
+                public override object GetType(string nameSpace, string name, NotFoundBehavior notFoundBehavior)
                 {
                     TypeSystemContext context = Context;
 
@@ -529,11 +529,10 @@ namespace ILCompiler.IBC
                         if (notFoundBehavior != NotFoundBehavior.ReturnNull)
                         {
                             var failure = ResolutionFailure.GetTypeLoadResolutionFailure(nameSpace, name, "System.Private.Canon");
-                            ModuleDesc.GetTypeResolutionFailure = failure;
                             if (notFoundBehavior == NotFoundBehavior.Throw)
                                 failure.Throw();
 
-                            return null;
+                            return failure;
                         }
                         return null;
                     }

--- a/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemModule.cs
+++ b/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemModule.cs
@@ -71,15 +71,15 @@ namespace Microsoft.Diagnostics.Tools.Pgo.TypeRefTypeSystem
             return type;
         }
 
-        public override MetadataType GetType(string nameSpace, string name, NotFoundBehavior notFoundBehavior)
+        public override object GetType(string nameSpace, string name, NotFoundBehavior notFoundBehavior)
         {
             MetadataType type = GetTypeInternal(nameSpace, name);
             if ((type == null) && notFoundBehavior != NotFoundBehavior.ReturnNull)
             {
                 ResolutionFailure failure = ResolutionFailure.GetTypeLoadResolutionFailure(nameSpace, name, this);
-                ModuleDesc.GetTypeResolutionFailure = failure;
                 if (notFoundBehavior == NotFoundBehavior.Throw)
                     failure.Throw();
+                return failure;
             }
             return type;
         }


### PR DESCRIPTION
`ModuleDesc.GetTypeResolutionFailure` is bug prone (see #50845). It feels easier to just have `ModuleDesc.GetType` return `object`.

Most consumers will want to just call a helper that returns `MetadataType` and takes a `bool` though.

Cc @dotnet/crossgen-contrib 