### PR TITLE
Work around for forbidden "Roslyn4.0" in test name on Android

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -148,6 +148,10 @@
     <ProjectExclusions Include="$(RepoRoot)\src\tests\FunctionalTests\$(TargetOS)\Device\**\*.Test.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetOS)' == 'MacCatalyst'">
+    <ProjectExclusions Include="$(RepoRoot)/src/tests/FunctionalTests/iOS/Simulator/XmlFormatWriterGeneratorAOT/iOS.Simulator.XmlFormatWriterGeneratorAot.Test.csproj" />
+  </ItemGroup>
+
   <ItemGroup Condition="('$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'iOSSimulator' or '$(TargetOS)' == 'tvOS' or '$(TargetOS)' == 'tvOSSimulator' or '$(TargetOS)' == 'MacCatalyst') and '$(RunDisablediOSTests)' != 'true'">
     <!-- PNSE -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Quic/tests/FunctionalTests/System.Net.Quic.Functional.Tests.csproj" />

--- a/src/tasks/AndroidAppBuilder/ApkBuilder.cs
+++ b/src/tasks/AndroidAppBuilder/ApkBuilder.cs
@@ -360,7 +360,7 @@ public class ApkBuilder
         string monoRunnerPath = Path.Combine(javaSrcFolder, "MonoRunner.java");
 
         Regex checkNumerics = new Regex(@"\.(\d)");
-        if (checkNumerics.isMatch(ProjectName))
+        if (!string.IsNullOrEmpty(ProjectName) && checkNumerics.IsMatch(ProjectName))
             ProjectName = checkNumerics.Replace(ProjectName, @"_$1");
 
         string packageId = $"net.dot.{ProjectName}";

--- a/src/tasks/AndroidAppBuilder/ApkBuilder.cs
+++ b/src/tasks/AndroidAppBuilder/ApkBuilder.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -357,6 +358,10 @@ public class ApkBuilder
 
         string javaActivityPath = Path.Combine(javaSrcFolder, "MainActivity.java");
         string monoRunnerPath = Path.Combine(javaSrcFolder, "MonoRunner.java");
+
+        Regex checkNumerics = new Regex(@"\.(\d)");
+        if (checkNumerics.isMatch(ProjectName))
+            ProjectName = checkNumerics.Replace(ProjectName, @"_$1");
 
         string packageId = $"net.dot.{ProjectName}";
 


### PR DESCRIPTION
Android apk names must be valid Java class names, and It is forbidden in Java for a class name component to have a leading numeric digit. So whilst "net.dot.foo3_1" is legal, "net.dot.foo3.1" is illegal. Use a Regex to detect and rewrite all cases of this in AndroidAppBuilder