### PR TITLE
Cleanup defines in DirectoryServices.AccountManager

### DIFF
--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System.DirectoryServices.AccountManagement.csproj
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System.DirectoryServices.AccountManagement.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants>$(DefineConstants);FLAVOR_WHIDBEY;PAPI_AD;PAPI_REGSAM;USE_CTX_CACHE</DefineConstants>
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent);$(NetCoreAppMinimum)-windows;$(NetCoreAppMinimum);netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CA2249</NoWarn>

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADDNLinkedAttrSet.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADDNLinkedAttrSet.cs
@@ -708,18 +708,7 @@ namespace System.DirectoryServices.AccountManagement
                     {
                         ContextOptions remoteOptions = DefaultContextOptions.ADDefaultContextOption;
 
-#if USE_CTX_CACHE
                         PrincipalContext remoteCtx = SDSCache.Domain.GetContext(foreignSid.sidIssuerName, _storeCtx.Credentials, remoteOptions);
-#else
-                        PrincipalContext remoteCtx = new PrincipalContext(
-                                        ContextType.Domain,
-                                        foreignSid.sidIssuerName,
-                                        null,
-                                        (this.storeCtx.Credentials != null ? this.storeCtx.Credentials.UserName : null),
-                                        (this.storeCtx.Credentials != null ? storeCtx.storeCtx.Credentials.Password : null),
-                                        remoteOptions);
-
-#endif
                         foreignStoreCtx = remoteCtx.QueryCtx;
                     }
 

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADEntriesSet.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADEntriesSet.cs
@@ -113,5 +113,3 @@ namespace System.DirectoryServices.AccountManagement
         }
     }
 }
-
-// #endif // PAPI_AD

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx.cs
@@ -2154,18 +2154,7 @@ namespace System.DirectoryServices.AccountManagement
 
                     ContextOptions remoteOptions = DefaultContextOptions.ADDefaultContextOption;
 
-#if USE_CTX_CACHE
                     PrincipalContext remoteCtx = SDSCache.Domain.GetContext(domainName, this.credentials, remoteOptions);
-#else
-                    PrincipalContext remoteCtx = new PrincipalContext(
-                                    ContextType.Domain,
-                                    domainName,
-                                    null,
-                                    (this.credentials != null ? credentials.UserName : null),
-                                    (this.credentials != null ? credentials.Password : null),
-                                    remoteOptions);
-
-#endif
                     foreignStoreCtx = remoteCtx.QueryCtx;
                 }
 
@@ -2582,5 +2571,3 @@ namespace System.DirectoryServices.AccountManagement
         }
     }
 }
-
-//#endif  // PAPI_AD

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx_LoadStore.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx_LoadStore.cs
@@ -1723,5 +1723,3 @@ namespace System.DirectoryServices.AccountManagement
         }
     }
 }
-
-// #endif   // PAPI_AD

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx_Query.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx_Query.cs
@@ -1173,5 +1173,3 @@ namespace System.DirectoryServices.AccountManagement
         }
     }
 }
-
-//#endif  // PAPI_AD

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/SAM/SAMQuerySet.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/SAM/SAMQuerySet.cs
@@ -864,5 +864,3 @@ namespace System.DirectoryServices.AccountManagement
         }
     }
 }
-
-//#endif  // PAPI_REGSAM

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/SAM/SAMStoreCtx.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/SAM/SAMStoreCtx.cs
@@ -853,18 +853,7 @@ namespace System.DirectoryServices.AccountManagement
             // Since this is SAM, the remote principal must be an AD principal.
             // Build a PrincipalContext for the store which owns the principal
             // Use the ad default options so we turn sign and seal back on.
-#if USE_CTX_CACHE
             PrincipalContext remoteCtx = SDSCache.Domain.GetContext(domainName, _credentials, DefaultContextOptions.ADDefaultContextOption);
-#else
-            PrincipalContext remoteCtx = new PrincipalContext(
-                            ContextType.Domain,
-                            domainName,
-                            null,
-                            (this.credentials != null ? credentials.UserName : null),
-                            (this.credentials != null ? credentials.Password : null),
-                            DefaultContextOptions.ADDefaultContextOption);
-
-#endif
 
             SecurityIdentifier sidObj = new SecurityIdentifier(sid, 0);
 
@@ -1103,5 +1092,3 @@ namespace System.DirectoryServices.AccountManagement
         }
     }
 }
-
-// #endif  // PAPI_REGSAM

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/SAM/SAMStoreCtx_LoadStore.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/SAM/SAMStoreCtx_LoadStore.cs
@@ -1175,5 +1175,3 @@ namespace System.DirectoryServices.AccountManagement
         }
     }
 }
-
-// #endif   // PAPI_REGSAM

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/SAM/SAMStoreCtx_Query.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/SAM/SAMStoreCtx_Query.cs
@@ -146,5 +146,3 @@ namespace System.DirectoryServices.AccountManagement
         }
     }
 }
-
-//#endif  // PAPI_REGSAM

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/User.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/User.cs
@@ -180,23 +180,13 @@ namespace System.DirectoryServices.AccountManagement
                 {
                     GlobalDebug.WriteLineIf(GlobalDebug.Info, "User", "Current: is local user");
 
-#if PAPI_REGSAM
                     context = new PrincipalContext(ContextType.Machine);
-#else
-                    // This implementation doesn't support Reg-SAM/MSAM (machine principals)
-                    throw new NotSupportedException(SR.UserLocalNotSupportedOnPlatform);
-#endif // PAPI_REGSAM
                 }
                 else
                 {
                     GlobalDebug.WriteLineIf(GlobalDebug.Info, "User", "Current: is not local user");
 
-#if PAPI_AD
                     context = new PrincipalContext(ContextType.Domain);
-#else
-                    // This implementation doesn't support AD (domain principals)
-                    throw new NotSupportedException(SR.UserDomainNotSupportedOnPlatform);
-#endif // PAPI_AD
                 }
 
                 // Construct a query for the current user, using a SID IdentityClaim


### PR DESCRIPTION
Related to #39174
All defines does not used anywhere else and did not changed values.
From what I can find, they are from initial code dump.
I remove code in else branch because this was last suggestion in the mentioned issue.