### PR TITLE
Cleanup defines in System.Linq.Expressions

### DIFF
--- a/src/libraries/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/libraries/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -3,9 +3,7 @@
     <FeatureInterpret>true</FeatureInterpret>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppCurrent)-iOS;$(NetCoreAppCurrent)-tvOS;$(NetCoreAppCurrent)-MacCatalyst</TargetFrameworks>
     <Nullable>enable</Nullable>
-    <IsInterpreting>false</IsInterpreting>
-    <IsInterpreting Condition="'$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true' or '$(TargetsMacCatalyst)' == 'true'">true</IsInterpreting>
-    <DefineConstants> $(DefineConstants);FEATURE_DLG_INVOKE;FEATURE_FAST_CREATE</DefineConstants>
+    <IsInterpreting Condition="'$(IsInterpreting)' == '' and ('$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true' or '$(TargetsMacCatalyst)' == 'true')">true</IsInterpreting>
     <DefineConstants Condition=" '$(IsInterpreting)' != 'true' ">$(DefineConstants);FEATURE_COMPILE</DefineConstants>
     <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
   </PropertyGroup>

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
@@ -13,11 +13,8 @@ namespace System.Linq.Expressions.Interpreter
 {
     internal partial class CallInstruction
     {
-#if FEATURE_DLG_INVOKE
         private const int MaxHelpers = 5;
-#endif
 
-#if FEATURE_FAST_CREATE
         private const int MaxArgs = 3;
 
         /// <summary>
@@ -156,9 +153,7 @@ namespace System.Linq.Expressions.Interpreter
                 default: return SlowCreate(target, pi);
             }
         }
-#endif
 
-#if FEATURE_DLG_INVOKE
         [return: DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes.PublicConstructors)]
         private static Type GetHelperType(MethodInfo info, Type[] arrTypes)
         {
@@ -211,10 +206,8 @@ namespace System.Linq.Expressions.Interpreter
             }
             return t;
         }
-#endif
     }
 
-#if FEATURE_DLG_INVOKE
     internal sealed class ActionCallInstruction : CallInstruction
     {
         private readonly Action _target;
@@ -577,6 +570,4 @@ namespace System.Linq.Expressions.Interpreter
 
         public override string ToString() => "Call(" + _target.Method + ")";
     }
-
-#endif
 }

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -20,9 +20,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public override string InstructionName => "Call";
 
-#if FEATURE_DLG_INVOKE
         private static readonly CacheDict<MethodInfo, CallInstruction> s_cache = new CacheDict<MethodInfo, CallInstruction>(256);
-#endif
 
         public static CallInstruction Create(MethodInfo info)
         {
@@ -47,9 +45,6 @@ namespace System.Linq.Expressions.Interpreter
                 return GetArrayAccessor(info, argumentCount);
             }
 
-#if !FEATURE_DLG_INVOKE
-            return new MethodInfoCallInstruction(info, argumentCount);
-#else
             if (!info.IsStatic && info.DeclaringType!.IsValueType)
             {
                 return new MethodInfoCallInstruction(info, argumentCount);
@@ -83,13 +78,11 @@ namespace System.Linq.Expressions.Interpreter
             // create it
             try
             {
-#if FEATURE_FAST_CREATE
                 if (argumentCount < MaxArgs)
                 {
                     res = FastCreate(info, parameters);
                 }
                 else
-#endif
                 {
                     res = SlowCreate(info, parameters);
                 }
@@ -119,7 +112,6 @@ namespace System.Linq.Expressions.Interpreter
             }
 
             return res;
-#endif
         }
 
         private static CallInstruction GetArrayAccessor(MethodInfo info, int argumentCount)
@@ -171,14 +163,11 @@ namespace System.Linq.Expressions.Interpreter
         {
             array.SetValue(value, index0, index1, index2);
         }
-#if FEATURE_DLG_INVOKE
         private static bool ShouldCache(MethodInfo info)
         {
             return true;
         }
-#endif
 
-#if FEATURE_FAST_CREATE
         /// <summary>
         /// Gets the next type or null if no more types are available.
         /// </summary>
@@ -213,9 +202,7 @@ namespace System.Linq.Expressions.Interpreter
         {
             return pi.Length != index || (pi.Length == index && !target.IsStatic);
         }
-#endif
 
-#if FEATURE_DLG_INVOKE
         /// <summary>
         /// Uses reflection to create new instance of the appropriate ReflectedCaller
         /// </summary>
@@ -243,7 +230,6 @@ namespace System.Linq.Expressions.Interpreter
                 throw ContractUtils.Unreachable;
             }
         }
-#endif
 
         #endregion
 


### PR DESCRIPTION
Remove always defined defines as per #39174
I change condition on `IsInterpreting`, to be able override
default `InInterpreting` value somehow in NativeAOT,
as per https://github.com/dotnet/runtimelab/issues/106