### PR TITLE
Prevent racing on installer shared props/targets

### DIFF
--- a/src/installer/tests/TestUtils/TestProjectFixture.cs
+++ b/src/installer/tests/TestUtils/TestProjectFixture.cs
@@ -78,12 +78,11 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
 #nullable enable
 
-        private static object? s_buildFilesLock = null;
+        private readonly static object? s_buildFilesLock = new object();
 
         private TestProject CopyTestProject(TestProject sourceTestProject)
         {
-            if (s_buildFilesLock is null &&
-                Interlocked.CompareExchange(ref s_buildFilesLock, new object(), null) is not null)
+            lock (s_buildFilesLock)
             {
                 // Prevent in-process race condition since the TestArtifactsPath is shared by the current
                 // assembly

--- a/src/installer/tests/TestUtils/TestProjectFixture.cs
+++ b/src/installer/tests/TestUtils/TestProjectFixture.cs
@@ -91,6 +91,10 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
             static void EnsureDirectoryBuildFiles(string testAssetsFolder, string testArtifactDirectory)
             {
+                if (Directory.Exists(testArtifactDirectory))
+                {
+                    return;
+                }
                 Directory.CreateDirectory(testArtifactDirectory);
 
                 // write an empty Directory.Build.* file to ensure that msbuild doesn't pick up
@@ -100,13 +104,8 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
                 static void EnsureTestProjectsFileContent(string testAssetsFolder, string dir, string type)
                 {
-                    var fileName = Path.Combine(dir, $"Directory.Build.{type}");
-                    if (File.Exists(fileName))
-                    {
-                        return;
-                    }
                     File.WriteAllText(
-                        fileName,
+                        Path.Combine(dir, $"Directory.Build.{type}"),
                         string.Join(
                             Environment.NewLine,
                             "<Project>",

--- a/src/installer/tests/TestUtils/TestProjectFixture.cs
+++ b/src/installer/tests/TestUtils/TestProjectFixture.cs
@@ -100,8 +100,14 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
                 static void EnsureTestProjectsFileContent(string testAssetsFolder, string dir, string type)
                 {
+                    var fileName = Path.Combine(dir, $"Directory.Build.{type}");
+                    if (File.Exists(fileName))
+                    {
+                        return;
+                    }
+
                     File.WriteAllText(
-                        Path.Combine(dir, $"Directory.Build.{type}"),
+                        fileName,
                         string.Join(
                             Environment.NewLine,
                             "<Project>",

--- a/src/installer/tests/TestUtils/TestProjectFixture.cs
+++ b/src/installer/tests/TestUtils/TestProjectFixture.cs
@@ -76,9 +76,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
             }
         }
 
-#nullable enable
-
-        private readonly static object? s_buildFilesLock = new object();
+        private readonly static object s_buildFilesLock = new object();
 
         private TestProject CopyTestProject(TestProject sourceTestProject)
         {
@@ -102,8 +100,13 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
                 static void EnsureTestProjectsFileContent(string testAssetsFolder, string dir, string type)
                 {
+                    var fileName = Path.Combine(dir, $"Directory.Build.{type}");
+                    if (File.Exists(fileName))
+                    {
+                        return;
+                    }
                     File.WriteAllText(
-                        Path.Combine(dir, $"Directory.Build.{type}"),
+                        fileName,
                         string.Join(
                             Environment.NewLine,
                             "<Project>",
@@ -112,8 +115,6 @@ namespace Microsoft.DotNet.CoreSetup.Test
                 }
             }
         }
-
-#nullable restore
 
         private void ValidateRequiredDirectories(RepoDirectoriesProvider repoDirectoriesProvider)
         {

--- a/src/installer/tests/TestUtils/TestProjectFixture.cs
+++ b/src/installer/tests/TestUtils/TestProjectFixture.cs
@@ -91,10 +91,6 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
             static void EnsureDirectoryBuildFiles(string testAssetsFolder, string testArtifactDirectory)
             {
-                if (Directory.Exists(testArtifactDirectory))
-                {
-                    return;
-                }
                 Directory.CreateDirectory(testArtifactDirectory);
 
                 // write an empty Directory.Build.* file to ensure that msbuild doesn't pick up


### PR DESCRIPTION
Should prevent the CI failures we see around broken Directory.Build.props/targets files in the host tests