### PR TITLE
[release/6.0-rc2][wasm] Bump sdk version for workload testing to 6.0.100-rc.2.21467.10

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -164,7 +164,7 @@
     <SQLitePCLRawbundle_greenVersion>2.0.4</SQLitePCLRawbundle_greenVersion>
     <MoqVersion>4.12.0</MoqVersion>
     <FsCheckVersion>2.14.3</FsCheckVersion>
-    <SdkVersionForWorkloadTesting>6.0.100-rc.2.21463.12</SdkVersionForWorkloadTesting>
+    <SdkVersionForWorkloadTesting>6.0.100-rc.2.21467.10</SdkVersionForWorkloadTesting>
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>6.0.0-preview-20210916.1</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->

--- a/src/mono/wasm/BlazorOverwrite.targets
+++ b/src/mono/wasm/BlazorOverwrite.targets
@@ -73,11 +73,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DisableAutoWasmPublishApp>true</DisableAutoWasmPublishApp>
     <EnableDefaultWasmAssembliesToBundle>false</EnableDefaultWasmAssembliesToBundle>
     <WasmNestedPublishAppDependsOn>ComputeFilesToPublish;_GatherWasmFilesToPublish;$(WasmNestedPublishAppDependsOn)</WasmNestedPublishAppDependsOn>
-    <_ScrambleDotnetJsFileNameAfterThisTarget Condition="'$(UsingBrowserRuntimeWorkload)' != 'true'">ResolveRuntimePackAssets</_ScrambleDotnetJsFileNameAfterThisTarget>
-    <_ScrambleDotnetJsFileNameAfterThisTarget Condition="'$(UsingBrowserRuntimeWorkload)' == 'true'">WasmBuildApp</_ScrambleDotnetJsFileNameAfterThisTarget>
-
-    <!-- Workaround https://github.com/dotnet/sdk/issues/20923 where we end up with two publish dirs - 'Publish', and 'publish' -->
-    <PublishDirName Condition="'$(PublishDirName)' == 'publish'">Publish</PublishDirName>
   </PropertyGroup>
 
   <ItemGroup>
@@ -113,115 +108,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <Import Project="Microsoft.NET.Sdk.BlazorWebAssembly.ServiceWorkerAssetsManifest.targets" Condition="'$(ServiceWorkerAssetsManifest)' != ''" />
-
-  <Target Name="_ScrambleDotnetJsFileNameForPublish">
-    <!--
-      We want the dotnet.js file output to have a version to better work with caching. We'll append the runtime version to the file name as soon as file has been discovered.
-    -->
-    <PropertyGroup>
-      <_DotNetJsVersion>$(BundledNETCoreAppPackageVersion)</_DotNetJsVersion>
-      <_DotNetJsVersion Condition="'$(RuntimeFrameworkVersion)' != ''">$(RuntimeFrameworkVersion)</_DotNetJsVersion>
-      <_BlazorDotnetJsFileName>dotnet.$(_DotNetJsVersion).js</_BlazorDotnetJsFileName>
-    </PropertyGroup>
-
-    <ItemGroup Condition="@(WasmNativeAsset->Count()) != 0">
-      <_DotNetJsItem Remove="@(_DotNetJsItem)" />
-      <_DotNetJsItem Include="@(WasmNativeAsset)" Condition="'%(WasmNativeAsset.FileName)%(WasmNativeAsset.Extension)' == 'dotnet.js'">
-        <RelativePath>_framework/$(_BlazorDotnetJsFileName)</RelativePath>
-        <AssetType>native</AssetType>
-        <CopyLocal>true</CopyLocal>
-      </_DotNetJsItem>
-    </ItemGroup>
-
-    <ItemGroup>
-      <_DotnetJsStaticWebAssetCandidate Remove="@(_DotnetJsStaticWebAssetCandidate)" />
-      <_DotnetJsCopyCandidates Remove="@(_DotnetJsCopyCandidates)" />
-    </ItemGroup>
-
-    <DefineStaticWebAssets Condition="'@(_DotNetJsItem->Count())' != '0'"
-      CandidateAssets="@(_DotNetJsItem)"
-      SourceId="$(PackageId)"
-      SourceType="Computed"
-      AssetKind="Build"
-      AssetRole="Primary"
-      AssetTraitName="BlazorWebAssemblyResource"
-      AssetTraitValue="native"
-      CopyToOutputDirectory="PreserveNewest"
-      CopyToPublishDirectory="Never"
-      ContentRoot="$(IntermediateOutputPath)\blazor"
-      BasePath="$(StaticWebAssetBasePath)"
-    >
-      <Output TaskParameter="Assets" ItemName="_DotnetJsStaticWebAssetCandidate" />
-      <Output TaskParameter="CopyCandidates" ItemName="_DotnetJsCopyCandidates" />
-    </DefineStaticWebAssets>
-
-    <Copy
-      SourceFiles="@(_DotnetJsCopyCandidates)"
-      DestinationFiles="@(_DotnetJsCopyCandidates->'%(TargetPath)')"
-      SkipUnchangedFiles="true"
-      OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)" />
-
-    <ItemGroup Condition="'@(_DotNetJsItem->Count())' != '0'">
-      <ReferenceCopyLocalPaths Remove="@(_DotNetJsItem)" />
-      <_DotnetJsStaticWebAsset Include="@(_DotnetJsStaticWebAssetCandidate->'%(ContentRoot)_framework\dotnet.js')" />
-      <_BlazorStaticWebAsset Include="@(_DotnetJsStaticWebAsset)" />
-    </ItemGroup>
-  </Target>
-
-  <Target Name="_ScrambleDotnetJsFileName" AfterTargets="$(_ScrambleDotnetJsFileNameAfterThisTarget)">
-    <!--
-      We want the dotnet.js file output to have a version to better work with caching. We'll append the runtime version to the file name as soon as file has been discovered.
-    -->
-    <PropertyGroup>
-      <_DotNetJsVersion>$(BundledNETCoreAppPackageVersion)</_DotNetJsVersion>
-      <_DotNetJsVersion Condition="'$(RuntimeFrameworkVersion)' != ''">$(RuntimeFrameworkVersion)</_DotNetJsVersion>
-      <_BlazorDotnetJsFileName>dotnet.$(_DotNetJsVersion).js</_BlazorDotnetJsFileName>
-    </PropertyGroup>
-
-    <ItemGroup Condition="@(WasmNativeAsset->Count()) == 0">
-      <_DotNetJsItem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.DestinationSubPath)' == 'dotnet.js' AND '%(ReferenceCopyLocalPaths.AssetType)' == 'native'">
-        <RelativePath>_framework/$(_BlazorDotnetJsFileName)</RelativePath>
-      </_DotNetJsItem>
-    </ItemGroup>
-
-    <ItemGroup Condition="@(WasmNativeAsset->Count()) != 0">
-      <_DotNetJsItem Remove="@(_DotNetJsItem)" />
-      <_DotNetJsItem Include="@(WasmNativeAsset)" Condition="'%(WasmNativeAsset.FileName)%(WasmNativeAsset.Extension)' == 'dotnet.js'">
-        <RelativePath>_framework/$(_BlazorDotnetJsFileName)</RelativePath>
-        <AssetType>native</AssetType>
-        <CopyLocal>true</CopyLocal>
-      </_DotNetJsItem>
-    </ItemGroup>
-
-    <DefineStaticWebAssets Condition="'@(_DotNetJsItem->Count())' != '0'"
-      CandidateAssets="@(_DotNetJsItem)"
-      SourceId="$(PackageId)"
-      SourceType="Computed"
-      AssetKind="Build"
-      AssetRole="Primary"
-      AssetTraitName="BlazorWebAssemblyResource"
-      AssetTraitValue="native"
-      CopyToOutputDirectory="PreserveNewest"
-      CopyToPublishDirectory="Never"
-      ContentRoot="$(IntermediateOutputPath)\blazor"
-      BasePath="$(StaticWebAssetBasePath)"
-    >
-      <Output TaskParameter="Assets" ItemName="_DotnetJsStaticWebAssetCandidate" />
-      <Output TaskParameter="CopyCandidates" ItemName="_DotnetJsCopyCandidates" />
-    </DefineStaticWebAssets>
-
-    <Copy
-      SourceFiles="@(_DotnetJsCopyCandidates)"
-      DestinationFiles="@(_DotnetJsCopyCandidates->'%(TargetPath)')"
-      SkipUnchangedFiles="true"
-      OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)" />
-
-    <ItemGroup Condition="'@(_DotNetJsItem->Count())' != '0'">
-      <ReferenceCopyLocalPaths Remove="@(_DotNetJsItem)" />
-      <_DotnetJsStaticWebAsset Include="@(_DotnetJsStaticWebAssetCandidate->'%(ContentRoot)_framework\dotnet.js')" />
-      <_BlazorStaticWebAsset Include="@(_DotnetJsStaticWebAsset)" />
-    </ItemGroup>
-  </Target>
 
   <Target Name="_BlazorWasmNativeForBuild" DependsOnTargets="_GatherWasmFilesToBuild;WasmBuildApp" Condition="'$(UsingBrowserRuntimeWorkload)' == 'true'" />
 
@@ -265,6 +151,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
       <_BlazorConfigFileCandidates Include="@(StaticWebAsset)" Condition="'%(SourceType)' == 'Discovered'" />
 
+      <!-- Remove dotnet.js/wasm from runtime pack, in favor of the relinked ones in @(WasmNativeAsset) -->
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)"
                                Condition="@(WasmNativeAsset->Count()) > 0 and '%(FileName)' == 'dotnet' and ('%(Extension)' == '.wasm' or '%(Extension)' == '.js')" />
     </ItemGroup>
@@ -278,6 +165,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       TimeZoneSupport="$(_BlazorEnableTimeZoneSupport)"
       InvariantGlobalization="$(_BlazorInvariantGlobalization)"
       CopySymbols="$(_BlazorCopyOutputSymbolsToOutputDirectory)"
+      BundledNETCoreAppPackageVersion="$(BundledNETCoreAppPackageVersion)"
       OutputPath="$(OutputPath)"
     >
       <Output TaskParameter="AssetCandidates" ItemName="_BuildAssetsCandidates" />
@@ -490,6 +378,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
   </Target>
 
+  <!-- Wasm's Nested publish is run just to build the native bits. We don't need to run blazor targets for that -->
   <Target Name="ProcessPublishFilesForBlazor" DependsOnTargets="_ResolveBlazorWasmConfiguration;LoadStaticWebAssetsBuildManifest" AfterTargets="ILLink" Condition="'$(WasmBuildingForNestedPublish)' != 'true'">
     <PropertyGroup>
       <_BlazorAotEnabled>$(UsingBrowserRuntimeWorkload)</_BlazorAotEnabled>
@@ -519,6 +408,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       InvariantGlobalization="$(_BlazorInvariantGlobalization)"
       CopySymbols="$(CopyOutputSymbolsToPublishDirectory)"
       ExistingAssets="@(_BlazorPublishPrefilteredAssets)"
+      BundledNETCoreAppPackageVersion="$(BundledNETCoreAppPackageVersion)"
     >
       <Output TaskParameter="NewCandidates" ItemName="_NewBlazorPublishStaticWebAssets" />
       <Output TaskParameter="FilesToRemove" ItemName="_PublishResolvedFilesToRemove" />
@@ -649,7 +539,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <Target Name="_BlazorWasmNative"
-      DependsOnTargets="_EnsureWasmRuntimeWorkload;WasmTriggerPublishApp;_ScrambleDotnetJsFileNameForPublish"
+      DependsOnTargets="_EnsureWasmRuntimeWorkload;WasmTriggerPublishApp"
       BeforeTargets="ProcessPublishFilesForBlazor"
       Condition="'$(UsingBrowserRuntimeWorkload)' == 'true'" />
 

--- a/src/mono/wasm/BlazorOverwrite.targets
+++ b/src/mono/wasm/BlazorOverwrite.targets
@@ -114,7 +114,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_GatherWasmFilesToBuild">
     <ItemGroup>
       <WasmAssembliesToBundle Remove="@(WasmAssembliesToBundle)" />
-      <WasmAssembliesToBundle Include="@(ReferenceCopyLocalPaths);@(MainAssembly)" Condition="'%(ReferenceCopyLocalPaths.Extension)' == '.dll'" />
+      <WasmAssembliesToBundle Include="@(IntermediateAssembly)" />
+      <WasmAssembliesToBundle Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Extension)' == '.dll'" />
       <WasmAssembliesToBundle Condition="'%(WasmAssembliesToBundle.FileName)' == 'Microsoft.JSInterop.WebAssembly'" AOT_InternalForceToInterpret="true" />
     </ItemGroup>
   </Target>

--- a/src/tests/BuildWasmApps/Wasm.Build.Tests/BlazorWasmBuildPublishTests.cs
+++ b/src/tests/BuildWasmApps/Wasm.Build.Tests/BlazorWasmBuildPublishTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -171,6 +172,57 @@ namespace Wasm.Build.Tests
             BlazorPublish(id, config, expectedFileType: NativeFilesType.Relinked);
         }
 
+        [ConditionalTheory(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
+        [InlineData("Debug")]
+        [InlineData("Release")]
+        public void WithDllImportInMainAssembly(string config)
+        {
+            // Based on https://github.com/dotnet/runtime/issues/59255
+            string id = $"blz_dllimp_{config}";
+            string projectFile = CreateProjectWithNativeReference(id);
+            string nativeSource = @"
+#include <stdio.h>
+
+extern ""C"" {
+    int cpp_add(int a, int b) {
+        return a + b;
+    }
+}";
+            File.WriteAllText(Path.Combine(_projectDir!, "mylib.cpp"), nativeSource);
+
+            string myDllImportCs = @$"
+            using System.Runtime.InteropServices;
+namespace {id};
+
+public static class MyDllImports
+{{
+    [DllImport(""mylib"")]
+    public static extern int cpp_add(int a, int b);
+}}";
+            File.WriteAllText(Path.Combine(_projectDir!, "Pages", "MyDllImport.cs"), myDllImportCs);
+
+            AddItemsPropertiesToProject(projectFile, extraItems: @"<NativeFileReference Include=""mylib.cpp"" />");
+
+            BlazorBuild(id, config, expectedFileType: NativeFilesType.Relinked);
+            CheckNativeFileLinked(forPublish: false);
+
+            BlazorPublish(id, config, expectedFileType: NativeFilesType.Relinked);
+            CheckNativeFileLinked(forPublish: true);
+
+            void CheckNativeFileLinked(bool forPublish)
+            {
+                // very crude way to check that the native file was linked in
+                // needed because we don't run the blazor app yet
+                string objBuildDir = Path.Combine(_projectDir!, "obj", config, "net6.0", "wasm", forPublish ? "for-publish" : "for-build");
+                string pinvokeTableHPath = Path.Combine(objBuildDir, "pinvoke-table.h");
+                Assert.True(File.Exists(pinvokeTableHPath), $"Could not find {pinvokeTableHPath}");
+
+                string pinvokeTableHContents = File.ReadAllText(pinvokeTableHPath);
+                string pattern = $"\"cpp_add\".*{id}";
+                Assert.True(Regex.IsMatch(pinvokeTableHContents, pattern),
+                                $"Could not find {pattern} in {pinvokeTableHPath}");
+            }
+        }
         private string CreateProjectWithNativeReference(string id)
         {
             CreateBlazorWasmTemplateProject(id);


### PR DESCRIPTION
.. and update the BlazorOverwrite.targets to match. (from sdk commit: e89f3d77dbd6f41890b10eafd98505261fa63755)

And apply the fix from https://github.com/dotnet/sdk/pull/21104 for https://github.com/dotnet/runtime/issues/59255 to `BlazorOverwrite.targets`.

## Customer impact

No customer impact, since is a *test only* change. `BlazorOverwrite.targets` is used only for tests.

## Testing

Manually tested, and adds a new test.

## Risk

None, since this is a *test only* change