### PR TITLE
Some more cleanups in Assembly/Binder area

### DIFF
--- a/src/coreclr/binder/assembly.cpp
+++ b/src/coreclr/binder/assembly.cpp
@@ -44,8 +44,7 @@ namespace BINDER_SPACE
         pAssemblyName->SetIsDefinition(TRUE);
 
         // validate architecture
-        PEKIND kAssemblyArchitecture = pAssemblyName->GetArchitecture();
-        if (!AssemblyBinderCommon::IsValidArchitecture(kAssemblyArchitecture))
+        if (!AssemblyBinderCommon::IsValidArchitecture(pAssemblyName->GetArchitecture()))
         {
             // Assembly image can't be executed on this platform
             IF_FAIL_GO(HRESULT_FROM_WIN32(ERROR_BAD_FORMAT));

--- a/src/coreclr/binder/assembly.cpp
+++ b/src/coreclr/binder/assembly.cpp
@@ -13,6 +13,7 @@
 #include "common.h"
 #include "assembly.hpp"
 #include "utils.hpp"
+#include "assemblybindercommon.hpp"
 
 namespace BINDER_SPACE
 {
@@ -60,7 +61,7 @@ namespace BINDER_SPACE
         SetAssemblyName(pAssemblyName.Extract(), FALSE /* fAddRef */);
 
         // Finally validate architecture
-        if (!IsValidArchitecture(kAssemblyArchitecture))
+        if (!AssemblyBinderCommon::IsValidArchitecture(kAssemblyArchitecture))
         {
             // Assembly image can't be executed on this platform
             IF_FAIL_GO(HRESULT_FROM_WIN32(ERROR_BAD_FORMAT));
@@ -79,31 +80,6 @@ namespace BINDER_SPACE
     {
         pPEImage->AddRef();
         m_pPEImage = pPEImage;
-    }
-
-    /* static */
-    PEKIND Assembly::GetSystemArchitecture()
-    {
-#if defined(TARGET_X86)
-        return peI386;
-#elif defined(TARGET_AMD64)
-        return peAMD64;
-#elif defined(TARGET_ARM)
-        return peARM;
-#elif defined(TARGET_ARM64)
-        return peARM64;
-#else
-        PORTABILITY_ASSERT("Assembly::GetSystemArchitecture");
-#endif
-    }
-
-    /* static */
-    BOOL Assembly::IsValidArchitecture(PEKIND kArchitecture)
-    {
-        if (!IsPlatformArchitecture(kArchitecture))
-            return TRUE;
-
-        return (kArchitecture == GetSystemArchitecture());
     }
 
     LPCWSTR Assembly::GetSimpleName()

--- a/src/coreclr/binder/assembly.cpp
+++ b/src/coreclr/binder/assembly.cpp
@@ -35,12 +35,7 @@ namespace BINDER_SPACE
 
     Assembly::~Assembly()
     {
-        if (m_pPEImage != NULL)
-        {
-            BinderReleasePEImage(m_pPEImage);
-            m_pPEImage = NULL;
-        }
-
+        SAFE_RELEASE(m_pPEImage);
         SAFE_RELEASE(m_pAssemblyName);
     }
 
@@ -73,6 +68,17 @@ namespace BINDER_SPACE
 
     Exit:
         return hr;
+    }
+
+    PEImage* Assembly::GetPEImage()
+    {
+        return m_pPEImage;
+    }
+
+    void Assembly::SetPEImage(PEImage* pPEImage)
+    {
+        pPEImage->AddRef();
+        m_pPEImage = pPEImage;
     }
 
     /* static */

--- a/src/coreclr/binder/assemblybindercommon.cpp
+++ b/src/coreclr/binder/assemblybindercommon.cpp
@@ -1167,7 +1167,7 @@ namespace BINDER_SPACE
 
     Exit:
 
-        BinderReleasePEImage(pPEImage);
+        SAFE_RELEASE(pPEImage);
 
         // Normalize file not found
         if ((FAILED(hr)) && IsFileNotFound(hr))

--- a/src/coreclr/binder/assemblybindercommon.cpp
+++ b/src/coreclr/binder/assemblybindercommon.cpp
@@ -509,7 +509,7 @@ namespace BINDER_SPACE
             hr = S_OK;
         }
 
-        if (!Assembly::IsValidArchitecture(pAssemblyName->GetArchitecture()))
+        if (!IsValidArchitecture(pAssemblyName->GetArchitecture()))
         {
             // Assembly reference contains wrong architecture
             IF_FAIL_GO(FUSION_E_INVALID_NAME);
@@ -1493,6 +1493,27 @@ HRESULT AssemblyBinderCommon::GetAssemblyIdentity(LPCSTR szTextualIdentity,
     EX_CATCH_HRESULT(hr);
 
     return hr;
+}
+
+BOOL AssemblyBinderCommon::IsValidArchitecture(PEKIND kArchitecture)
+{
+    if ((kArchitecture == peMSIL) || (kArchitecture == peNone))
+        return TRUE;
+
+    PEKIND processArchitecture =
+#if defined(TARGET_X86)
+        peI386;
+#elif defined(TARGET_AMD64)
+        peAMD64;
+#elif defined(TARGET_ARM)
+        peARM;
+#elif defined(TARGET_ARM64)
+        peARM64;
+#else
+        PORTABILITY_ASSERT("processArchitecture");
+#endif
+
+    return (kArchitecture == processArchitecture);
 }
 
 #endif // !defined(DACCESS_COMPILE)

--- a/src/coreclr/binder/assemblybindercommon.cpp
+++ b/src/coreclr/binder/assemblybindercommon.cpp
@@ -38,6 +38,10 @@ extern HRESULT RuntimeInvokeHostAssemblyResolver(INT_PTR pManagedAssemblyLoadCon
 
 #endif // !defined(DACCESS_COMPILE)
 
+STDAPI BinderAcquirePEImage(LPCTSTR            szAssemblyPath,
+    PEImage** ppPEImage,
+    BundleFileLocation bundleFileLocation);
+
 namespace BINDER_SPACE
 {
     namespace
@@ -1350,7 +1354,7 @@ Retry:
                 }
                 EX_CATCH
                 {
-                    hr = E_FAIL;
+                    hr = GET_EXCEPTION()->GetHR();
                     goto Exit;
                 }
                 EX_END_CATCH(SwallowAllExceptions);

--- a/src/coreclr/binder/assemblybindercommon.cpp
+++ b/src/coreclr/binder/assemblybindercommon.cpp
@@ -239,7 +239,6 @@ namespace BINDER_SPACE
     HRESULT AssemblyBinderCommon::BindAssembly(/* in */  AssemblyBinder      *pBinder,
                                                /* in */  AssemblyName        *pAssemblyName,
                                                /* in */  LPCWSTR              szCodeBase,
-                                               /* in */  PEAssembly          *pParentAssembly,
                                                /* in */  bool                 excludeAppPaths,
                                                /* out */ Assembly           **ppAssembly)
     {

--- a/src/coreclr/binder/assemblybindercommon.cpp
+++ b/src/coreclr/binder/assemblybindercommon.cpp
@@ -312,30 +312,6 @@ namespace BINDER_SPACE
         return hr;
     }
 
-#if !defined(DACCESS_COMPILE)
-    /* static */
-    HRESULT AssemblyBinderCommon::BindToSystem(BINDER_SPACE::Assembly** ppSystemAssembly)
-    {
-        HRESULT hr = S_OK;
-        _ASSERTE(ppSystemAssembly != NULL);
-
-        EX_TRY
-        {
-            ReleaseHolder<BINDER_SPACE::Assembly> pAsm;
-            StackSString systemPath(SystemDomain::System()->SystemDirectory());
-            hr = AssemblyBinderCommon::BindToSystem(systemPath, &pAsm);
-            if (SUCCEEDED(hr))
-            {
-                _ASSERTE(pAsm != NULL);
-                *ppSystemAssembly = pAsm.Extract();
-            }
-        }
-        EX_CATCH_HRESULT(hr);
-
-        return hr;
-    }
-#endif // !defined(DACCESS_COMPILE)
-
     /* static */
     HRESULT AssemblyBinderCommon::BindToSystem(SString   &systemDirectory,
                                                Assembly **ppSystemAssembly)
@@ -1428,7 +1404,7 @@ Exit:
     return hr;
 }
 
-HRESULT AssemblyBinderCommon::DefaultBinderSetupContext(DefaultAssemblyBinder** ppDefaultBinder)
+HRESULT AssemblyBinderCommon::CreateDefaultBinder(DefaultAssemblyBinder** ppDefaultBinder)
 {
     HRESULT hr = S_OK;
     EX_TRY
@@ -1450,47 +1426,6 @@ HRESULT AssemblyBinderCommon::DefaultBinderSetupContext(DefaultAssemblyBinder** 
     EX_CATCH_HRESULT(hr);
 
 Exit:
-    return hr;
-}
-
-HRESULT AssemblyBinderCommon::GetAssemblyIdentity(LPCSTR szTextualIdentity,
-                                                  BINDER_SPACE::ApplicationContext* pApplicationContext,
-                                                  NewHolder<AssemblyIdentityUTF8>& assemblyIdentityHolder)
-{
-    HRESULT hr = S_OK;
-    _ASSERTE(szTextualIdentity != NULL);
-
-    EX_TRY
-    {
-        AssemblyIdentityUTF8 * pAssemblyIdentity = NULL;
-        if (pApplicationContext != NULL)
-        {
-            // This returns a cached copy owned by application context
-            hr = pApplicationContext->GetAssemblyIdentity(szTextualIdentity, &pAssemblyIdentity);
-            if (SUCCEEDED(hr))
-            {
-                assemblyIdentityHolder = pAssemblyIdentity;
-                assemblyIdentityHolder.SuppressRelease();
-            }
-        }
-        else
-        {
-            SString sTextualIdentity;
-
-            sTextualIdentity.SetUTF8(szTextualIdentity);
-
-            // This is a private copy
-            pAssemblyIdentity = new AssemblyIdentityUTF8();
-            hr = TextualIdentityParser::Parse(sTextualIdentity, pAssemblyIdentity);
-            if (SUCCEEDED(hr))
-            {
-                pAssemblyIdentity->PopulateUTF8Fields();
-                assemblyIdentityHolder = pAssemblyIdentity;
-            }
-        }
-    }
-    EX_CATCH_HRESULT(hr);
-
     return hr;
 }
 

--- a/src/coreclr/binder/assemblyname.cpp
+++ b/src/coreclr/binder/assemblyname.cpp
@@ -12,6 +12,9 @@
 // ============================================================
 
 #include "assemblyname.hpp"
+#include "assemblybindercommon.hpp"
+
+#include "common.h"
 #include "utils.hpp"
 
 #include "textualidentityparser.hpp"
@@ -31,16 +34,13 @@ namespace BINDER_SPACE
     AssemblyName::AssemblyName()
     {
         m_cRef = 1;
-        m_dwNameFlags = NAME_FLAG_NONE;
+        m_isDefinition = false;
         // Default values present in every assembly name
         SetHave(AssemblyIdentity::IDENTITY_FLAG_CULTURE |
                 AssemblyIdentity::IDENTITY_FLAG_PUBLIC_KEY_TOKEN_NULL);
     }
 
-    HRESULT AssemblyName::Init(IMDInternalImport       *pIMetaDataAssemblyImport,
-                               PEKIND                   PeKind,
-                               mdAssemblyRef            mdar /* = 0 */,
-                               BOOL                     fIsDefinition /* = TRUE */)
+    HRESULT AssemblyName::Init(PEImage* pPEImage)
     {
         HRESULT hr = S_OK;
         mdAssembly mda = 0;
@@ -51,38 +51,28 @@ namespace BINDER_SPACE
         DWORD dwRefOrDefFlags = 0;
         DWORD dwHashAlgId = 0;
 
-        if (fIsDefinition)
-        {
-            // Get the assembly token
-            IF_FAIL_GO(pIMetaDataAssemblyImport->GetAssemblyFromScope(&mda));
-        }
+        ReleaseHolder<IMDInternalImport> pIMetaDataAssemblyImport;
+
+        PEKIND PeKind = peNone;
+        DWORD dwPAFlags[2];
+        IF_FAIL_GO(BinderAcquireImport(pPEImage, &pIMetaDataAssemblyImport, dwPAFlags));
+        IF_FAIL_GO(AssemblyBinderCommon::TranslatePEToArchitectureType(dwPAFlags, &PeKind));
+
+        _ASSERTE(pIMetaDataAssemblyImport != NULL);
+
+        // Get the assembly token
+        IF_FAIL_GO(pIMetaDataAssemblyImport->GetAssemblyFromScope(&mda));
 
         // Get name and metadata
-        if (fIsDefinition)
-        {
-            IF_FAIL_GO(pIMetaDataAssemblyImport->GetAssemblyProps(
-                            mda,            // [IN] The Assembly for which to get the properties.
-                            &pvPublicKeyToken,  // [OUT] Pointer to the PublicKeyToken blob.
-                            &dwPublicKeyToken,  // [OUT] Count of bytes in the PublicKeyToken Blob.
-                            &dwHashAlgId,   // [OUT] Hash Algorithm.
-                            &pAssemblyName, // [OUT] Name.
-                            &amd,           // [OUT] Assembly MetaData.
-                            &dwRefOrDefFlags // [OUT] Flags.
-                            ));
-        }
-        else
-        {
-            IF_FAIL_GO(pIMetaDataAssemblyImport->GetAssemblyRefProps(
-                            mdar,            // [IN] The Assembly for which to get the properties.
-                            &pvPublicKeyToken,  // [OUT] Pointer to the PublicKeyToken blob.
-                            &dwPublicKeyToken,  // [OUT] Count of bytes in the PublicKeyToken Blob.
-                            &pAssemblyName, // [OUT] Name.
-                            &amd,           // [OUT] Assembly MetaData.
-                            NULL, // [OUT] Hash blob.
-                            NULL, // [OUT] Count of bytes in hash blob.
-                            &dwRefOrDefFlags // [OUT] Flags.
-                            ));
-        }
+        IF_FAIL_GO(pIMetaDataAssemblyImport->GetAssemblyProps(
+                        mda,            // [IN] The Assembly for which to get the properties.
+                        &pvPublicKeyToken,  // [OUT] Pointer to the PublicKeyToken blob.
+                        &dwPublicKeyToken,  // [OUT] Count of bytes in the PublicKeyToken Blob.
+                        &dwHashAlgId,   // [OUT] Hash Algorithm.
+                        &pAssemblyName, // [OUT] Name.
+                        &amd,           // [OUT] Assembly MetaData.
+                        &dwRefOrDefFlags // [OUT] Flags.
+                        ));
 
         {
             StackSString culture;

--- a/src/coreclr/binder/assemblyname.cpp
+++ b/src/coreclr/binder/assemblyname.cpp
@@ -29,6 +29,10 @@ namespace
     const WCHAR* s_neutralCulture = W("neutral");
 }
 
+STDAPI BinderAcquireImport(PEImage* pPEImage,
+    IMDInternalImport** pIMetaDataAssemblyImport,
+    DWORD* pdwPAFlags);
+
 namespace BINDER_SPACE
 {
     AssemblyName::AssemblyName()
@@ -57,6 +61,7 @@ namespace BINDER_SPACE
         DWORD dwPAFlags[2];
         IF_FAIL_GO(BinderAcquireImport(pPEImage, &pIMetaDataAssemblyImport, dwPAFlags));
         IF_FAIL_GO(AssemblyBinderCommon::TranslatePEToArchitectureType(dwPAFlags, &PeKind));
+        SetArchitecture(PeKind);
 
         _ASSERTE(pIMetaDataAssemblyImport != NULL);
 
@@ -146,8 +151,6 @@ namespace BINDER_SPACE
 
             SetHave(AssemblyIdentity::IDENTITY_FLAG_PUBLIC_KEY_TOKEN);
         }
-
-        SetArchitecture(PeKind);
 
     Exit:
         return hr;

--- a/src/coreclr/binder/bindertracing.cpp
+++ b/src/coreclr/binder/bindertracing.cpp
@@ -152,9 +152,7 @@ namespace
             peAssembly->GetDisplayName(request.RequestingAssembly);
 
             AppDomain *domain = parentAssembly->GetAppDomain();
-            AssemblyBinder *binder = peAssembly->GetBinder();
-            if (binder == nullptr)
-                binder = domain->GetDefaultBinder(); // System.Private.CoreLib returns null
+            AssemblyBinder *binder = peAssembly->GetAssemblyBinder();
 
             GetAssemblyLoadContextNameFromBinder(binder, domain, request.RequestingAssemblyLoadContext);
         }

--- a/src/coreclr/binder/customassemblybinder.cpp
+++ b/src/coreclr/binder/customassemblybinder.cpp
@@ -111,20 +111,10 @@ HRESULT CustomAssemblyBinder::BindUsingPEImage( /* in */ PEImage *pPEImage,
     {
         ReleaseHolder<BINDER_SPACE::Assembly> pCoreCLRFoundAssembly;
         ReleaseHolder<BINDER_SPACE::AssemblyName> pAssemblyName;
-        ReleaseHolder<IMDInternalImport> pIMetaDataAssemblyImport;
-
-        PEKIND PeKind = peNone;
-
-        // Get the Metadata interface
-        DWORD dwPAFlags[2];
-        IF_FAIL_GO(BinderAcquireImport(pPEImage, &pIMetaDataAssemblyImport, dwPAFlags));
-        IF_FAIL_GO(AssemblyBinderCommon::TranslatePEToArchitectureType(dwPAFlags, &PeKind));
-
-        _ASSERTE(pIMetaDataAssemblyImport != NULL);
 
         // Using the information we just got, initialize the assemblyname
         SAFE_NEW(pAssemblyName, BINDER_SPACE::AssemblyName);
-        IF_FAIL_GO(pAssemblyName->Init(pIMetaDataAssemblyImport, PeKind));
+        IF_FAIL_GO(pAssemblyName->Init(pPEImage));
 
         // Validate architecture
         if (!BINDER_SPACE::Assembly::IsValidArchitecture(pAssemblyName->GetArchitecture()))
@@ -139,7 +129,7 @@ HRESULT CustomAssemblyBinder::BindUsingPEImage( /* in */ PEImage *pPEImage,
             IF_FAIL_GO(HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND));
         }
 
-        hr = AssemblyBinderCommon::BindUsingPEImage(this, pAssemblyName, pPEImage, PeKind, pIMetaDataAssemblyImport, &pCoreCLRFoundAssembly);
+        hr = AssemblyBinderCommon::BindUsingPEImage(this, pAssemblyName, pPEImage, &pCoreCLRFoundAssembly);
         if (hr == S_OK)
         {
             _ASSERTE(pCoreCLRFoundAssembly != NULL);

--- a/src/coreclr/binder/customassemblybinder.cpp
+++ b/src/coreclr/binder/customassemblybinder.cpp
@@ -28,7 +28,6 @@ HRESULT CustomAssemblyBinder::BindAssemblyByNameWorker(BINDER_SPACE::AssemblyNam
     hr = AssemblyBinderCommon::BindAssembly(this,
                                             pAssemblyName,
                                             NULL,  // szCodeBase
-                                            NULL,  // pParentAssembly
                                             false, //excludeAppPaths,
                                             ppCoreCLRFoundAssembly);
     if (!FAILED(hr))

--- a/src/coreclr/binder/customassemblybinder.cpp
+++ b/src/coreclr/binder/customassemblybinder.cpp
@@ -117,7 +117,7 @@ HRESULT CustomAssemblyBinder::BindUsingPEImage( /* in */ PEImage *pPEImage,
         IF_FAIL_GO(pAssemblyName->Init(pPEImage));
 
         // Validate architecture
-        if (!BINDER_SPACE::Assembly::IsValidArchitecture(pAssemblyName->GetArchitecture()))
+        if (!AssemblyBinderCommon::IsValidArchitecture(pAssemblyName->GetArchitecture()))
         {
             IF_FAIL_GO(HRESULT_FROM_WIN32(ERROR_BAD_FORMAT));
         }

--- a/src/coreclr/binder/defaultassemblybinder.cpp
+++ b/src/coreclr/binder/defaultassemblybinder.cpp
@@ -212,3 +212,27 @@ HRESULT DefaultAssemblyBinder::Bind(LPCWSTR                  wszCodeBase,
 
     return hr;
 }
+
+HRESULT DefaultAssemblyBinder::BindToSystem(BINDER_SPACE::Assembly** ppSystemAssembly)
+{
+    HRESULT hr = S_OK;
+    _ASSERTE(ppSystemAssembly != NULL);
+
+    EX_TRY
+    {
+        ReleaseHolder<BINDER_SPACE::Assembly> pAsm;
+        StackSString systemPath(SystemDomain::System()->SystemDirectory());
+        hr = AssemblyBinderCommon::BindToSystem(systemPath, &pAsm);
+        if (SUCCEEDED(hr))
+        {
+            _ASSERTE(pAsm != NULL);
+            *ppSystemAssembly = pAsm.Extract();
+        }
+
+        (*ppSystemAssembly)->SetBinder(this);
+    }
+    EX_CATCH_HRESULT(hr);
+
+    return hr;
+}
+

--- a/src/coreclr/binder/defaultassemblybinder.cpp
+++ b/src/coreclr/binder/defaultassemblybinder.cpp
@@ -127,7 +127,7 @@ HRESULT DefaultAssemblyBinder::BindUsingPEImage( /* in */ PEImage *pPEImage,
         IF_FAIL_GO(pAssemblyName->Init(pPEImage));
 
         // Validate architecture
-        if (!BINDER_SPACE::Assembly::IsValidArchitecture(pAssemblyName->GetArchitecture()))
+        if (!AssemblyBinderCommon::IsValidArchitecture(pAssemblyName->GetArchitecture()))
         {
             IF_FAIL_GO(HRESULT_FROM_WIN32(ERROR_BAD_FORMAT));
         }

--- a/src/coreclr/binder/defaultassemblybinder.cpp
+++ b/src/coreclr/binder/defaultassemblybinder.cpp
@@ -121,20 +121,10 @@ HRESULT DefaultAssemblyBinder::BindUsingPEImage( /* in */ PEImage *pPEImage,
     {
         ReleaseHolder<BINDER_SPACE::Assembly> pCoreCLRFoundAssembly;
         ReleaseHolder<BINDER_SPACE::AssemblyName> pAssemblyName;
-        ReleaseHolder<IMDInternalImport> pIMetaDataAssemblyImport;
-
-        PEKIND PeKind = peNone;
-
-        // Get the Metadata interface
-        DWORD dwPAFlags[2];
-        IF_FAIL_GO(BinderAcquireImport(pPEImage, &pIMetaDataAssemblyImport, dwPAFlags));
-        IF_FAIL_GO(AssemblyBinderCommon::TranslatePEToArchitectureType(dwPAFlags, &PeKind));
-
-        _ASSERTE(pIMetaDataAssemblyImport != NULL);
 
         // Using the information we just got, initialize the assemblyname
         SAFE_NEW(pAssemblyName, AssemblyName);
-        IF_FAIL_GO(pAssemblyName->Init(pIMetaDataAssemblyImport, PeKind));
+        IF_FAIL_GO(pAssemblyName->Init(pPEImage));
 
         // Validate architecture
         if (!BINDER_SPACE::Assembly::IsValidArchitecture(pAssemblyName->GetArchitecture()))
@@ -169,7 +159,7 @@ HRESULT DefaultAssemblyBinder::BindUsingPEImage( /* in */ PEImage *pPEImage,
             }
         }
 
-        hr = AssemblyBinderCommon::BindUsingPEImage(this, pAssemblyName, pPEImage, PeKind, pIMetaDataAssemblyImport, &pCoreCLRFoundAssembly);
+        hr = AssemblyBinderCommon::BindUsingPEImage(this, pAssemblyName, pPEImage, &pCoreCLRFoundAssembly);
         if (hr == S_OK)
         {
             _ASSERTE(pCoreCLRFoundAssembly != NULL);

--- a/src/coreclr/binder/defaultassemblybinder.cpp
+++ b/src/coreclr/binder/defaultassemblybinder.cpp
@@ -26,7 +26,6 @@ HRESULT DefaultAssemblyBinder::BindAssemblyByNameWorker(BINDER_SPACE::AssemblyNa
     hr = AssemblyBinderCommon::BindAssembly(this,
                                             pAssemblyName,
                                             NULL, // szCodeBase
-                                            NULL, // pParentAssembly
                                             excludeAppPaths,
                                             ppCoreCLRFoundAssembly);
     if (!FAILED(hr))
@@ -189,7 +188,6 @@ HRESULT DefaultAssemblyBinder::SetupBindingPaths(SString  &sTrustedPlatformAssem
 }
 
 HRESULT DefaultAssemblyBinder::Bind(LPCWSTR                  wszCodeBase,
-                                    PEAssembly              *pParentAssembly,
                                     BINDER_SPACE::Assembly **ppAssembly)
 {
     HRESULT hr = S_OK;
@@ -201,7 +199,6 @@ HRESULT DefaultAssemblyBinder::Bind(LPCWSTR                  wszCodeBase,
         hr = AssemblyBinderCommon::BindAssembly(this,
                                                 NULL, // pAssemblyName
                                                 wszCodeBase,
-                                                pParentAssembly,
                                                 false, // excludeAppPaths
                                                 &pAsm);
         if(SUCCEEDED(hr))

--- a/src/coreclr/binder/inc/assembly.hpp
+++ b/src/coreclr/binder/inc/assembly.hpp
@@ -61,9 +61,6 @@ namespace BINDER_SPACE
         PEImage* GetPEImage();
         BOOL GetIsInTPA();
 
-        static PEKIND GetSystemArchitecture();
-        static BOOL IsValidArchitecture(PEKIND kArchitecture);
-
         AssemblyLoaderAllocator* GetLoaderAllocator();
         inline AssemblyBinder* GetBinder()
         {

--- a/src/coreclr/binder/inc/assembly.hpp
+++ b/src/coreclr/binder/inc/assembly.hpp
@@ -35,10 +35,6 @@ STDAPI BinderAcquireImport(PEImage            *pPEImage,
                            IMDInternalImport **pIMetaDataAssemblyImport,
                            DWORD              *pdwPAFlags);
 
-STDAPI BinderReleasePEImage(PEImage *pPEImage);
-
-STDAPI BinderAddRefPEImage(PEImage *pPEImage);
-
 namespace BINDER_SPACE
 {
     // BINDER_SPACE::Assembly represents a result of binding to an actual assembly (PE image)
@@ -61,9 +57,9 @@ namespace BINDER_SPACE
         HRESULT Init(PEImage *pPEImage, BOOL fIsInTPA);
 
         LPCWSTR GetSimpleName();
-        inline AssemblyName *GetAssemblyName(BOOL fAddRef = FALSE);
-        inline PEImage* GetPEImage(BOOL fAddRef = FALSE);
-        inline BOOL GetIsInTPA();
+        AssemblyName *GetAssemblyName(BOOL fAddRef = FALSE);
+        PEImage* GetPEImage();
+        BOOL GetIsInTPA();
 
         static PEKIND GetSystemArchitecture();
         static BOOL IsValidArchitecture(PEKIND kArchitecture);
@@ -75,9 +71,9 @@ namespace BINDER_SPACE
         }
 
     private:
-        inline void SetPEImage(PEImage *pPEImage);
-        inline void SetAssemblyName(AssemblyName *pAssemblyName, BOOL fAddRef = TRUE);
-        inline void SetIsInTPA(BOOL fIsInTPA);
+        void SetPEImage(PEImage *pPEImage);
+        void SetAssemblyName(AssemblyName *pAssemblyName, BOOL fAddRef = TRUE);
+        void SetIsInTPA(BOOL fIsInTPA);
 
         LONG                     m_cRef;
         PEImage                 *m_pPEImage;

--- a/src/coreclr/binder/inc/assembly.hpp
+++ b/src/coreclr/binder/inc/assembly.hpp
@@ -29,14 +29,9 @@
 
 namespace BINDER_SPACE
 {
-    // BINDER_SPACE::Assembly represents a result of binding to an actual assembly (PE image)
+    // BINDER_SPACE::Assembly represents a result of binding to an actual assembly (PEImage)
     // It is basically a tuple of 1) physical assembly and 2) binder which created/owns this binding
     // We also store whether it was bound using TPA list
-    //
-    // UNDONE: perhaps rename to "BoundAssembly"?
-    //         check the ownership, if it is owned by the binder, do we need ref counting?
-    //         elaborate why IsInTPA needed
-    //
     class Assembly
     {
     public:

--- a/src/coreclr/binder/inc/assembly.hpp
+++ b/src/coreclr/binder/inc/assembly.hpp
@@ -27,14 +27,6 @@
 
 #include "bundle.h"
 
-STDAPI BinderAcquirePEImage(LPCTSTR            szAssemblyPath,
-                            PEImage          **ppPEImage,
-                            BundleFileLocation bundleFileLocation);
-
-STDAPI BinderAcquireImport(PEImage            *pPEImage,
-                           IMDInternalImport **pIMetaDataAssemblyImport,
-                           DWORD              *pdwPAFlags);
-
 namespace BINDER_SPACE
 {
     // BINDER_SPACE::Assembly represents a result of binding to an actual assembly (PE image)
@@ -61,17 +53,12 @@ namespace BINDER_SPACE
         PEImage* GetPEImage();
         BOOL GetIsInTPA();
 
-        AssemblyLoaderAllocator* GetLoaderAllocator();
         inline AssemblyBinder* GetBinder()
         {
             return m_pBinder;
         }
 
     private:
-        void SetPEImage(PEImage *pPEImage);
-        void SetAssemblyName(AssemblyName *pAssemblyName, BOOL fAddRef = TRUE);
-        void SetIsInTPA(BOOL fIsInTPA);
-
         LONG                     m_cRef;
         PEImage                 *m_pPEImage;
         AssemblyName            *m_pAssemblyName;

--- a/src/coreclr/binder/inc/assembly.inl
+++ b/src/coreclr/binder/inc/assembly.inl
@@ -31,25 +31,7 @@ inline ULONG Assembly::Release()
     return ulRef;
 }
 
-PEImage *Assembly::GetPEImage(BOOL fAddRef /* = FALSE */)
-{
-    PEImage *pPEImage = m_pPEImage;
-
-    if (fAddRef)
-    {
-        BinderAddRefPEImage(pPEImage);
-    }
-
-    return pPEImage;
-}
-
-void Assembly::SetPEImage(PEImage *pPEImage)
-{
-    BinderAddRefPEImage(pPEImage);
-    m_pPEImage = pPEImage;
-}
-
-AssemblyName *Assembly::GetAssemblyName(BOOL fAddRef /* = FALSE */)
+inline AssemblyName *Assembly::GetAssemblyName(BOOL fAddRef /* = FALSE */)
 {
     AssemblyName *pAssemblyName = m_pAssemblyName;
 
@@ -60,8 +42,7 @@ AssemblyName *Assembly::GetAssemblyName(BOOL fAddRef /* = FALSE */)
     return pAssemblyName;
 }
 
-void Assembly::SetAssemblyName(AssemblyName *pAssemblyName,
-                               BOOL          fAddRef /* = TRUE */)
+inline void Assembly::SetAssemblyName(AssemblyName *pAssemblyName, BOOL fAddRef /* = TRUE */)
 {
     SAFE_RELEASE(m_pAssemblyName);
 
@@ -72,13 +53,12 @@ void Assembly::SetAssemblyName(AssemblyName *pAssemblyName,
         pAssemblyName->AddRef();
     }
 }
-
-BOOL Assembly::GetIsInTPA()
+inline BOOL Assembly::GetIsInTPA()
 {
     return m_isInTPA;
 }
 
-void Assembly::SetIsInTPA(BOOL fIsInTPA)
+inline void Assembly::SetIsInTPA(BOOL fIsInTPA)
 {
     m_isInTPA = fIsInTPA;
 }

--- a/src/coreclr/binder/inc/assembly.inl
+++ b/src/coreclr/binder/inc/assembly.inl
@@ -42,25 +42,9 @@ inline AssemblyName *Assembly::GetAssemblyName(BOOL fAddRef /* = FALSE */)
     return pAssemblyName;
 }
 
-inline void Assembly::SetAssemblyName(AssemblyName *pAssemblyName, BOOL fAddRef /* = TRUE */)
-{
-    SAFE_RELEASE(m_pAssemblyName);
-
-    m_pAssemblyName = pAssemblyName;
-
-    if (fAddRef && (pAssemblyName != NULL))
-    {
-        pAssemblyName->AddRef();
-    }
-}
 inline BOOL Assembly::GetIsInTPA()
 {
     return m_isInTPA;
-}
-
-inline void Assembly::SetIsInTPA(BOOL fIsInTPA)
-{
-    m_isInTPA = fIsInTPA;
 }
 
 #endif

--- a/src/coreclr/binder/inc/assembly.inl
+++ b/src/coreclr/binder/inc/assembly.inl
@@ -75,37 +75,12 @@ void Assembly::SetAssemblyName(AssemblyName *pAssemblyName,
 
 BOOL Assembly::GetIsInTPA()
 {
-    return ((m_dwAssemblyFlags & FLAG_IS_IN_TPA) != 0);
+    return m_isInTPA;
 }
 
 void Assembly::SetIsInTPA(BOOL fIsInTPA)
 {
-    if (fIsInTPA)
-    {
-        m_dwAssemblyFlags |= FLAG_IS_IN_TPA;
-    }
-    else
-    {
-        m_dwAssemblyFlags &= ~FLAG_IS_IN_TPA;
-    }
-}
-
-SString &Assembly::GetPath()
-{
-    return m_assemblyPath;
-}
-
-IMDInternalImport *Assembly::GetMDImport()
-{
-    return m_pMDImport;
-}
-
-void Assembly::SetMDImport(IMDInternalImport *pMDImport)
-{
-    SAFE_RELEASE(m_pMDImport);
-
-    m_pMDImport = pMDImport;
-    m_pMDImport->AddRef();
+    m_isInTPA = fIsInTPA;
 }
 
 #endif

--- a/src/coreclr/binder/inc/assemblybindercommon.hpp
+++ b/src/coreclr/binder/inc/assemblybindercommon.hpp
@@ -75,6 +75,8 @@ namespace BINDER_SPACE
             BINDER_SPACE::ApplicationContext* pApplicationContext,
             NewHolder<BINDER_SPACE::AssemblyIdentityUTF8>& assemblyIdentityHolder);
 
+        static BOOL IsValidArchitecture(PEKIND kArchitecture);
+
     private:
         static HRESULT BindByName(/* in */  ApplicationContext *pApplicationContext,
                                   /* in */  AssemblyName       *pAssemblyName,

--- a/src/coreclr/binder/inc/assemblybindercommon.hpp
+++ b/src/coreclr/binder/inc/assemblybindercommon.hpp
@@ -50,7 +50,6 @@ namespace BINDER_SPACE
         static HRESULT GetAssembly(/* in */  SString     &assemblyPath,
                                    /* in */  BOOL         fIsInTPA,
                                    /* out */ Assembly   **ppAssembly,
-                                   /* in */  LPCTSTR      szMDAssemblyPath = NULL,
                                    /* in */  BundleFileLocation bundleFileLocation = BundleFileLocation::Invalid());
 
 #if !defined(DACCESS_COMPILE)
@@ -62,8 +61,6 @@ namespace BINDER_SPACE
         static HRESULT BindUsingPEImage(/* in */  AssemblyBinder     *pBinder,
                                         /* in */  BINDER_SPACE::AssemblyName *pAssemblyName,
                                         /* in */  PEImage            *pPEImage,
-                                        /* in */  PEKIND              peKind,
-                                        /* in */  IMDInternalImport  *pIMetaDataAssemblyImport,
                                         /* [retval] [out] */  Assembly **ppAssembly);
 #endif // !defined(DACCESS_COMPILE)
 

--- a/src/coreclr/binder/inc/assemblybindercommon.hpp
+++ b/src/coreclr/binder/inc/assemblybindercommon.hpp
@@ -23,14 +23,6 @@ class DefaultAssemblyBinder;
 class PEAssembly;
 class PEImage;
 
-STDAPI BinderAcquirePEImage(LPCTSTR            szAssemblyPath,
-                            PEImage            ** ppPEImage,
-                            BundleFileLocation bundleFileLocation);
-
-STDAPI BinderAcquireImport(PEImage* pPEImage,
-                           IMDInternalImport** pIMetaDataAssemblyImport,
-                           DWORD* pdwPAFlags);
-
 namespace BINDER_SPACE
 {
     class AssemblyIdentityUTF8;

--- a/src/coreclr/binder/inc/assemblybindercommon.hpp
+++ b/src/coreclr/binder/inc/assemblybindercommon.hpp
@@ -44,8 +44,6 @@ namespace BINDER_SPACE
                                     /* in */  bool                 excludeAppPaths,
                                     /* out */ Assembly           **ppAssembly);
 
-        static HRESULT BindToSystem(BINDER_SPACE::Assembly** ppSystemAssembly);
-
         static HRESULT BindToSystem(/* in */ SString    &systemDirectory,
                                     /* out */ Assembly **ppSystemAssembly);
 
@@ -73,14 +71,7 @@ namespace BINDER_SPACE
 
         static HRESULT TranslatePEToArchitectureType(DWORD  *pdwPAFlags, PEKIND *PeKind);
 
-        static HRESULT DefaultBinderSetupContext(DefaultAssemblyBinder** ppDefaultBinder);
-
-        // TODO: The call indicates that this can come from a case where
-        // pDomain->GetFusionContext() is null, hence this is static function
-        // which handles a null binder. See if this actually happens
-        static HRESULT GetAssemblyIdentity(LPCSTR     szTextualIdentity,
-            BINDER_SPACE::ApplicationContext* pApplicationContext,
-            NewHolder<BINDER_SPACE::AssemblyIdentityUTF8>& assemblyIdentityHolder);
+        static HRESULT CreateDefaultBinder(DefaultAssemblyBinder** ppDefaultBinder);
 
         static BOOL IsValidArchitecture(PEKIND kArchitecture);
 

--- a/src/coreclr/binder/inc/assemblybindercommon.hpp
+++ b/src/coreclr/binder/inc/assemblybindercommon.hpp
@@ -23,6 +23,14 @@ class DefaultAssemblyBinder;
 class PEAssembly;
 class PEImage;
 
+STDAPI BinderAcquirePEImage(LPCTSTR            szAssemblyPath,
+                            PEImage            ** ppPEImage,
+                            BundleFileLocation bundleFileLocation);
+
+STDAPI BinderAcquireImport(PEImage* pPEImage,
+                           IMDInternalImport** pIMetaDataAssemblyImport,
+                           DWORD* pdwPAFlags);
+
 namespace BINDER_SPACE
 {
     class AssemblyIdentityUTF8;
@@ -33,7 +41,6 @@ namespace BINDER_SPACE
         static HRESULT BindAssembly(/* in */  AssemblyBinder      *pBinder, 
                                     /* in */  AssemblyName        *pAssemblyName,
                                     /* in */  LPCWSTR              szCodeBase,
-                                    /* in */  PEAssembly          *pParentAssembly,
                                     /* in */  bool                 excludeAppPaths,
                                     /* out */ Assembly           **ppAssembly);
 

--- a/src/coreclr/binder/inc/assemblyname.hpp
+++ b/src/coreclr/binder/inc/assemblyname.hpp
@@ -17,6 +17,8 @@
 #include "bindertypes.hpp"
 #include "assemblyidentity.hpp"
 
+class PEImage;
+
 namespace BINDER_SPACE
 {
     class AssemblyName final : public AssemblyIdentity
@@ -40,11 +42,8 @@ namespace BINDER_SPACE
 
         AssemblyName();
 
-        HRESULT Init(/* in */ IMDInternalImport       *pIMetaDataAssemblyImport,
-                     /* in */ PEKIND                   PeKind,
-                     /* in */ mdAssemblyRef            mda = 0,
-                     /* in */ BOOL                     fIsDefinition = TRUE);
-        HRESULT Init(/* in */ const AssemblyNameData &data);
+        HRESULT AssemblyName::Init(PEImage* pPEImage);
+        HRESULT Init(const AssemblyNameData &data);
 
         ULONG AddRef();
         ULONG Release();
@@ -76,18 +75,11 @@ namespace BINDER_SPACE
         void GetDisplayName(/* out */ PathString &displayName,
                             /* in */  DWORD       dwIncludeFlags);
 
-    protected:
-        enum
-        {
-            NAME_FLAG_NONE                           = 0x00,
-            NAME_FLAG_RETARGETABLE                   = 0x01,
-            NAME_FLAG_DEFINITION                     = 0x02,
-        };
-
+    private:
         SString &GetNormalizedCulture();
 
         LONG           m_cRef;
-        DWORD          m_dwNameFlags;
+        bool           m_isDefinition;
     };
 
 #include "assemblyname.inl"

--- a/src/coreclr/binder/inc/assemblyname.hpp
+++ b/src/coreclr/binder/inc/assemblyname.hpp
@@ -42,7 +42,7 @@ namespace BINDER_SPACE
 
         AssemblyName();
 
-        HRESULT AssemblyName::Init(PEImage* pPEImage);
+        HRESULT Init(PEImage* pPEImage);
         HRESULT Init(const AssemblyNameData &data);
 
         ULONG AddRef();

--- a/src/coreclr/binder/inc/assemblyname.inl
+++ b/src/coreclr/binder/inc/assemblyname.inl
@@ -98,31 +98,21 @@ void AssemblyName::SetIsRetargetable(BOOL fIsRetargetable)
 {
     if (fIsRetargetable)
     {
-        m_dwNameFlags |= NAME_FLAG_RETARGETABLE;
         SetHave(AssemblyIdentity::IDENTITY_FLAG_RETARGETABLE);
     }
     else
     {
-        m_dwNameFlags &= ~NAME_FLAG_RETARGETABLE;
         SetClear(AssemblyIdentity::IDENTITY_FLAG_RETARGETABLE);
     }
 }
 
 BOOL AssemblyName::GetIsDefinition()
 {
-    return ((m_dwNameFlags & NAME_FLAG_DEFINITION) != 0);
+    return m_isDefinition;
 }
 
 void AssemblyName::SetIsDefinition(BOOL fIsDefinition)
 {
-    if (fIsDefinition)
-    {
-        m_dwNameFlags |= NAME_FLAG_DEFINITION;
-    }
-    else
-    {
-        m_dwNameFlags &= ~NAME_FLAG_DEFINITION;
-    }
+    m_isDefinition = fIsDefinition;
 }
-
 #endif

--- a/src/coreclr/binder/inc/defaultassemblybinder.h
+++ b/src/coreclr/binder/inc/defaultassemblybinder.h
@@ -38,8 +38,9 @@ public:
                               SString  &sPlatformResourceRoots,
                               SString  &sAppPaths);
 
-    HRESULT Bind(LPCWSTR      wszCodeBase,
-                 BINDER_SPACE::Assembly **ppAssembly);
+    HRESULT Bind(LPCWSTR wszCodeBase, BINDER_SPACE::Assembly **ppAssembly);
+
+    HRESULT BindToSystem(BINDER_SPACE::Assembly **ppSystemAssembly);
 
 private:
 

--- a/src/coreclr/binder/inc/defaultassemblybinder.h
+++ b/src/coreclr/binder/inc/defaultassemblybinder.h
@@ -39,7 +39,6 @@ public:
                               SString  &sAppPaths);
 
     HRESULT Bind(LPCWSTR      wszCodeBase,
-                 PEAssembly  *pParentAssembly,
                  BINDER_SPACE::Assembly **ppAssembly);
 
 private:

--- a/src/coreclr/vm/assembly.cpp
+++ b/src/coreclr/vm/assembly.cpp
@@ -485,19 +485,11 @@ Assembly *Assembly::CreateDynamic(AppDomain *pDomain, AssemblyBinder* pBinder, C
                 // Static assemblies with do not have fallback load context
                 _ASSERTE(pCallerAssemblyManifestFile->GetFallbackBinder() == nullptr);
 
-                if (pCallerAssemblyManifestFile->IsSystem())
-                {
-                    // CoreLibrary is always bound with default binder
-                    pFallbackBinder = pDomain->GetDefaultBinder();
-                }
-                else
-                {
-                    // Fetch the binder from the host assembly
-                    PTR_BINDER_SPACE_Assembly pCallerAssemblyHostAssembly = pCallerAssemblyManifestFile->GetHostAssembly();
-                    _ASSERTE(pCallerAssemblyHostAssembly != nullptr);
+                // Fetch the binder from the host assembly
+                PTR_BINDER_SPACE_Assembly pCallerAssemblyHostAssembly = pCallerAssemblyManifestFile->GetHostAssembly();
+                _ASSERTE(pCallerAssemblyHostAssembly != nullptr);
 
-                    pFallbackBinder = pCallerAssemblyHostAssembly->GetBinder();
-                }
+                pFallbackBinder = pCallerAssemblyHostAssembly->GetBinder();
             }
             else
             {

--- a/src/coreclr/vm/assembly.hpp
+++ b/src/coreclr/vm/assembly.hpp
@@ -227,8 +227,6 @@ public:
     PTR_BaseDomain GetDomain();
     PTR_LoaderAllocator GetLoaderAllocator() { LIMITED_METHOD_DAC_CONTRACT; return m_pLoaderAllocator; }
 
-    BOOL GetModuleZapFile(LPCWSTR name, SString &path);
-
 #ifdef LOGGING
     LPCWSTR GetDebugName()
     {

--- a/src/coreclr/vm/baseassemblyspec.cpp
+++ b/src/coreclr/vm/baseassemblyspec.cpp
@@ -103,32 +103,6 @@ BOOL BaseAssemblySpec::IsCoreLib()
                ( (iNameLen == CoreLibNameLen) || (m_pAssemblyName[CoreLibNameLen] == ',') ) ) ) );
 }
 
-BOOL BaseAssemblySpec::IsAssemblySpecForCoreLib()
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        INSTANCE_CHECK;
-        GC_NOTRIGGER;
-        MODE_ANY;
-        PRECONDITION(strlen(g_psBaseLibraryName) == CoreLibNameLen);
-    }
-    CONTRACTL_END;
-
-    BOOL fIsAssemblySpecForCoreLib = FALSE;
-
-    if (m_pAssemblyName)
-    {
-        size_t iNameLen = strlen(m_pAssemblyName);
-        fIsAssemblySpecForCoreLib = ( (iNameLen >= CoreLibNameLen) &&
-                 ( (!_stricmp(m_pAssemblyName, g_psBaseLibrary)) ||
-                 ( (!_strnicmp(m_pAssemblyName, g_psBaseLibraryName, CoreLibNameLen)) &&
-                   ( (iNameLen == CoreLibNameLen) || (m_pAssemblyName[CoreLibNameLen] == ',') ) ) ) );
-    }
-
-    return fIsAssemblySpecForCoreLib;
-}
-
 #define CORELIB_PUBLICKEY g_rbTheSilverlightPlatformKey
 
 

--- a/src/coreclr/vm/baseassemblyspec.h
+++ b/src/coreclr/vm/baseassemblyspec.h
@@ -77,8 +77,6 @@ public:
         return m_pBinder;
     }
 
-    BOOL IsAssemblySpecForCoreLib();
-
     HRESULT ParseName();
     DWORD Hash();
 

--- a/src/coreclr/vm/baseassemblyspec.inl
+++ b/src/coreclr/vm/baseassemblyspec.inl
@@ -318,14 +318,10 @@ inline BOOL BaseAssemblySpec::CompareEx(BaseAssemblySpec *pSpec, DWORD dwCompare
 
 
     // If the assemblySpec contains the binding context, then check if they match.
-    if (!(pSpec->IsAssemblySpecForCoreLib() && IsAssemblySpecForCoreLib()))
+    if (pSpec->m_pBinder != m_pBinder)
     {
-        if (pSpec->m_pBinder != m_pBinder)
-        {
-            return FALSE;
-        }
+        return FALSE;
     }
-
 
     return TRUE;
 }

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -3421,7 +3421,7 @@ DomainAssembly * Module::LoadAssembly(mdAssemblyRef kAssemblyRef)
         // Set the binding context in the AssemblySpec if one is available. This can happen if the LoadAssembly ended up
         // invoking the custom AssemblyLoadContext implementation that returned a reference to an assembly bound to a different
         // AssemblyLoadContext implementation.
-        AssemblyBinder *pBinder = pFile->GetBinder();
+        AssemblyBinder *pBinder = pFile->GetAssemblyBinder();
         if (pBinder != NULL)
         {
             spec.SetBinder(pBinder);

--- a/src/coreclr/vm/coreassemblyspec.cpp
+++ b/src/coreclr/vm/coreassemblyspec.cpp
@@ -186,7 +186,7 @@ HRESULT BaseAssemblySpec::ParseName()
 
     EX_TRY
     {
-        NewHolder<BINDER_SPACE::AssemblyIdentityUTF8> pAssemblyIdentity;
+        BINDER_SPACE::AssemblyIdentityUTF8* pAssemblyIdentity;
         AppDomain *pDomain = ::GetAppDomain();
         _ASSERTE(pDomain);
 
@@ -221,8 +221,6 @@ HRESULT BaseAssemblySpec::ParseName()
 
         // Copy and own any fields we do not already own
         CloneFields();
-
-        pAssemblyIdentity.SuppressRelease();
     }
     EX_CATCH_HRESULT(hr);
 

--- a/src/coreclr/vm/coreassemblyspec.cpp
+++ b/src/coreclr/vm/coreassemblyspec.cpp
@@ -192,12 +192,8 @@ HRESULT BaseAssemblySpec::ParseName()
 
         BINDER_SPACE::ApplicationContext *pAppContext = NULL;
         DefaultAssemblyBinder *pBinder = pDomain->GetDefaultBinder();
-        if (pBinder != NULL)
-        {
-            pAppContext = pBinder->GetAppContext();
-        }
 
-        hr = BINDER_SPACE::AssemblyBinderCommon::GetAssemblyIdentity(m_pAssemblyName, pAppContext, pAssemblyIdentity);
+        hr = pBinder->GetAppContext()->GetAssemblyIdentity(m_pAssemblyName, &pAssemblyIdentity);
 
         if (FAILED(hr))
         {
@@ -225,6 +221,8 @@ HRESULT BaseAssemblySpec::ParseName()
 
         // Copy and own any fields we do not already own
         CloneFields();
+
+        pAssemblyIdentity.SuppressRelease();
     }
     EX_CATCH_HRESULT(hr);
 

--- a/src/coreclr/vm/coreassemblyspec.cpp
+++ b/src/coreclr/vm/coreassemblyspec.cpp
@@ -91,9 +91,7 @@ HRESULT  AssemblySpec::Bind(AppDomain *pAppDomain, BINDER_SPACE::Assembly** ppAs
     }
     else
     {
-        hr = pAppDomain->GetDefaultBinder()->Bind(m_wszCodeBase,
-                                                  GetParentAssembly() ? GetParentAssembly()->GetFile() : NULL,
-                                                  &pPrivAsm);
+        hr = pAppDomain->GetDefaultBinder()->Bind(m_wszCodeBase, &pPrivAsm);
     }
 
     if (SUCCEEDED(hr))

--- a/src/coreclr/vm/coreassemblyspec.cpp
+++ b/src/coreclr/vm/coreassemblyspec.cpp
@@ -29,30 +29,6 @@
 #include "../binder/inc/assemblybindercommon.hpp"
 #include "../binder/inc/applicationcontext.hpp"
 
-STDAPI BinderAddRefPEImage(PEImage *pPEImage)
-{
-    HRESULT hr = S_OK;
-
-    if (pPEImage != NULL)
-    {
-        pPEImage->AddRef();
-    }
-
-    return hr;
-}
-
-STDAPI BinderReleasePEImage(PEImage *pPEImage)
-{
-    HRESULT hr = S_OK;
-
-    if (pPEImage != NULL)
-    {
-        pPEImage->Release();
-    }
-
-    return hr;
-}
-
 static VOID ThrowLoadError(AssemblySpec * pSpec, HRESULT hr)
 {
     CONTRACTL

--- a/src/coreclr/vm/nativelibrary.cpp
+++ b/src/coreclr/vm/nativelibrary.cpp
@@ -319,16 +319,9 @@ namespace
 
         NATIVE_LIBRARY_HANDLE hmod = NULL;
         PEFile *pManifestFile = pAssembly->GetManifestFile();
-        PTR_AssemblyBinder pBinder = pManifestFile->GetBinder();
+        PTR_AssemblyBinder pBinder = pManifestFile->GetAssemblyBinder();
 
         //Step 0: Check if  the assembly was bound using TPA.
-        //        The Binding Context can be null or an overridden TPA context
-        if (pBinder == NULL)
-        {
-            // If we do not have any binder associated, then return to the default resolution mechanism.
-            return NULL;
-        }
-
         AssemblyBinder *pCurrentBinder = pBinder;
 
         // For assemblies bound via default binder, we should use the standard mechanism to make the pinvoke call.
@@ -370,13 +363,7 @@ namespace
     {
         STANDARD_VM_CONTRACT;
 
-        PTR_AssemblyBinder pBinder = pAssembly->GetManifestFile()->GetBinder();
-        if (pBinder == NULL)
-        {
-            // GetBindingContext() returns NULL for System.Private.CoreLib
-            return NULL;
-        }
-
+        PTR_AssemblyBinder pBinder = pAssembly->GetManifestFile()->GetAssemblyBinder();
         return pBinder->GetManagedAssemblyLoadContext();
     }
 

--- a/src/coreclr/vm/pefile.cpp
+++ b/src/coreclr/vm/pefile.cpp
@@ -29,8 +29,7 @@
 #ifndef DACCESS_COMPILE
 
 // ================================================================================
-// PEFile class - this is an abstract base class for PEModule and PEAssembly
-// <TODO>@todo: rename TargetFile</TODO>
+// PEFile class - this is an abstract base class for PEAssembly
 // ================================================================================
 
 PEFile::PEFile(PEImage *identity) :
@@ -113,7 +112,6 @@ PEFile *PEFile::Open(PEImage *image)
         PRECONDITION(image != NULL);
         PRECONDITION(image->CheckFormat());
         POSTCONDITION(RETVAL != NULL);
-        POSTCONDITION(!RETVAL->IsModule());
         POSTCONDITION(!RETVAL->IsAssembly());
         THROWS;
         GC_TRIGGERS;

--- a/src/coreclr/vm/pefile.cpp
+++ b/src/coreclr/vm/pefile.cpp
@@ -46,7 +46,6 @@ PEFile::PEFile(PEImage *identity) :
     m_pMetadataLock(::new SimpleRWLock(PREEMPTIVE, LOCK_TYPE_DEFAULT)),
     m_refCount(1),
     m_flags(0),
-    m_pAssemblyBinder(nullptr),
     m_pHostAssembly(nullptr),
     m_pFallbackBinder(nullptr)
 {
@@ -1045,8 +1044,6 @@ PEAssembly::PEAssembly(
     m_debugName.Normalize();
     m_pDebugName = m_debugName;
 #endif
-
-    SetupAssemblyLoadContext();
 }
 #endif // !DACCESS_COMPILE
 
@@ -1123,10 +1120,10 @@ PEAssembly *PEAssembly::DoOpenSystem()
     CONTRACT_END;
 
     ETWOnStartup (FusionBinding_V1, FusionBindingEnd_V1);
-    ReleaseHolder<BINDER_SPACE::Assembly> pPrivAsm;
-    IfFailThrow(BINDER_SPACE::AssemblyBinderCommon::BindToSystem(&pPrivAsm));
+    ReleaseHolder<BINDER_SPACE::Assembly> pBoundAssembly;
+    IfFailThrow(GetAppDomain()->GetDefaultBinder()->BindToSystem(&pBoundAssembly));
 
-    RETURN new PEAssembly(pPrivAsm, NULL, NULL, TRUE);
+    RETURN new PEAssembly(pBoundAssembly, NULL, NULL, TRUE);
 }
 
 PEAssembly* PEAssembly::Open(BINDER_SPACE::Assembly* pBindResult,
@@ -1377,15 +1374,6 @@ void PEFile::EnsureImageOpened()
     GetILimage()->GetLayout(PEImageLayout::LAYOUT_ANY,PEImage::LAYOUT_CREATEIFNEEDED)->Release();
 }
 
-void PEFile::SetupAssemblyLoadContext()
-{
-    PTR_AssemblyBinder pBinder = GetBinder();
-
-    m_pAssemblyBinder = (pBinder != NULL) ?
-        pBinder :
-        AppDomain::GetCurrentDomain()->CreateBinderContext();
-}
-
 #endif // #ifndef DACCESS_COMPILE
 
 #ifdef DACCESS_COMPILE
@@ -1485,30 +1473,25 @@ TADDR PEFile::GetMDInternalRWAddress()
 #endif
 
 // Returns the AssemblyBinder* instance associated with the PEFile
-PTR_AssemblyBinder PEFile::GetBinder()
+PTR_AssemblyBinder PEFile::GetAssemblyBinder()
 {
     LIMITED_METHOD_CONTRACT;
 
     PTR_AssemblyBinder pBinder = NULL;
 
-    // CoreLibrary is always bound in context of the TPA Binder. However, since it gets loaded and published
-    // during EEStartup *before* DefaultContext Binder (aka TPAbinder) is initialized, we dont have a binding context to publish against.
-    if (!IsSystem())
+    BINDER_SPACE::Assembly* pHostAssembly = GetHostAssembly();
+    if (pHostAssembly)
     {
-        BINDER_SPACE::Assembly* pHostAssembly = GetHostAssembly();
-        if (pHostAssembly)
+        pBinder = dac_cast<PTR_AssemblyBinder>(pHostAssembly->GetBinder());
+    }
+    else
+    {
+        // If we do not have a host assembly, check if we are dealing with
+        // a dynamically emitted assembly and if so, use its fallback load context
+        // binder reference.
+        if (IsDynamic())
         {
-            pBinder = dac_cast<PTR_AssemblyBinder>(pHostAssembly->GetBinder());
-        }
-        else
-        {
-            // If we do not have a host assembly, check if we are dealing with
-            // a dynamically emitted assembly and if so, use its fallback load context
-            // binder reference.
-            if (IsDynamic())
-            {
-                pBinder = GetFallbackBinder();
-            }
+            pBinder = GetFallbackBinder();
         }
     }
 

--- a/src/coreclr/vm/pefile.h
+++ b/src/coreclr/vm/pefile.h
@@ -397,9 +397,6 @@ protected:
     Volatile<LONG>           m_refCount;
     int                      m_flags;
 
-    // AssemblyBinder that this PEFile is associated with
-    PTR_AssemblyBinder       m_pAssemblyBinder;
-
 public:
 
     PTR_PEImage GetILimage()
@@ -471,28 +468,17 @@ public:
     }
 
     // Returns the AssemblyBinder* instance associated with the PEFile
-    PTR_AssemblyBinder GetBinder();
+    // which owns the context into which the current PEFile was loaded.
+    PTR_AssemblyBinder GetAssemblyBinder();
 
 #ifndef DACCESS_COMPILE
-    void SetupAssemblyLoadContext();
-
     void SetFallbackBinder(PTR_AssemblyBinder pFallbackBinder)
     {
         LIMITED_METHOD_CONTRACT;
         m_pFallbackBinder = pFallbackBinder;
-        SetupAssemblyLoadContext();
     }
 
 #endif //!DACCESS_COMPILE
-
-    // Returns AssemblyBinder which owns the context into which the current PEFile was loaded.
-    PTR_AssemblyBinder GetAssemblyBinder()
-    {
-        LIMITED_METHOD_CONTRACT;
-
-        _ASSERTE(m_pAssemblyBinder != NULL);
-        return m_pAssemblyBinder;
-    }
 
     bool HasHostAssembly()
     { STATIC_CONTRACT_WRAPPER; return GetHostAssembly() != nullptr; }

--- a/src/coreclr/vm/pefile.h
+++ b/src/coreclr/vm/pefile.h
@@ -42,11 +42,9 @@ class Module;
 class EditAndContinueModule;
 
 class PEFile;
-class PEModule;
 class PEAssembly;
 class SimpleRWLock;
 
-typedef VPTR(PEModule) PTR_PEModule;
 typedef VPTR(PEAssembly) PTR_PEAssembly;
 
 // --------------------------------------------------------------------------------
@@ -78,9 +76,6 @@ typedef VPTR(PEAssembly) PTR_PEAssembly;
 //
 // 4. Dynamic - these are not actual PE images at all, but are placeholders
 //    for reflection-based modules.
-//
-// PEFiles are segmented into two subtypes: PEAssembly and PEModule.  The formere
-// is a file to be loaded as an assembly, and the latter is to be loaded as a module.
 //
 // See also file:..\inc\corhdr.h#ManagedHeader for more on the format of managed images.
 // See code:Module for more on modules
@@ -120,7 +115,6 @@ private:
     // ------------------------------------------------------------
 
     friend class DomainFile;
-    friend class PEModule;
 
 public:
     void LoadLibrary(BOOL allowNativeSkip = TRUE);
@@ -199,8 +193,6 @@ public:
 
     BOOL IsAssembly() const;
     PTR_PEAssembly AsAssembly();
-    BOOL IsModule() const;
-    PTR_PEModule AsModule();
     BOOL IsSystem() const;
     BOOL IsDynamic() const;
     BOOL IsResource() const;
@@ -346,7 +338,6 @@ protected:
     {
         PEFILE_SYSTEM                 = 0x01,
         PEFILE_ASSEMBLY               = 0x02,
-        PEFILE_MODULE                 = 0x04,
     };
 
     // ------------------------------------------------------------

--- a/src/coreclr/vm/pefile.inl
+++ b/src/coreclr/vm/pefile.inl
@@ -262,24 +262,6 @@ inline PTR_PEAssembly PEFile::AsAssembly()
         return dac_cast<PTR_PEAssembly>(nullptr);
 }
 
-inline BOOL PEFile::IsModule() const
-{
-    LIMITED_METHOD_CONTRACT;
-    SUPPORTS_DAC;
-
-    return (m_flags & PEFILE_MODULE) != 0;
-}
-
-inline PTR_PEModule PEFile::AsModule()
-{
-    LIMITED_METHOD_DAC_CONTRACT;
-
-    if (IsModule())
-        return dac_cast<PTR_PEModule>(this);
-    else
-        return dac_cast<PTR_PEModule>(nullptr);
-}
-
 inline BOOL PEFile::IsSystem() const
 {
     LIMITED_METHOD_CONTRACT;

--- a/src/coreclr/vm/peimage.cpp
+++ b/src/coreclr/vm/peimage.cpp
@@ -50,8 +50,6 @@ void PEImage::Startup()
     s_ijwFixupDataHash = ::new PtrHashMap;
     s_ijwFixupDataHash->Init(CompareIJWDataBase, FALSE, &ijwLock);
 
-    PEImageLayout::Startup();
-
     RETURN;
 }
 

--- a/src/coreclr/vm/peimage.h
+++ b/src/coreclr/vm/peimage.h
@@ -58,7 +58,6 @@ typedef DPTR(class PEImage)                PTR_PEImage;
 
 class PEImage
 {
-    friend class PEModule;
 public:
     // ------------------------------------------------------------
     // Public constants

--- a/src/coreclr/vm/peimagelayout.h
+++ b/src/coreclr/vm/peimagelayout.h
@@ -58,8 +58,6 @@ public:
 #endif
     PEImageLayout();
     virtual ~PEImageLayout();
-    static void Startup();
-    static CHECK CheckStartup();
     static BOOL CompareBase(UPTR path, UPTR mapping);
 
     // Refcount above images.

--- a/src/coreclr/vm/peimagelayout.h
+++ b/src/coreclr/vm/peimagelayout.h
@@ -31,7 +31,6 @@ typedef VPTR(class PEImageLayout) PTR_PEImageLayout;
 class PEImageLayout : public PEDecoder
 {
     VPTR_BASE_CONCRETE_VTABLE_CLASS(PEImageLayout)
-    friend class PEModule;
 public:
     // ------------------------------------------------------------
     // Public constants

--- a/src/coreclr/vm/peimagelayout.inl
+++ b/src/coreclr/vm/peimagelayout.inl
@@ -75,30 +75,6 @@ inline PEImageLayout::PEImageLayout()
     LIMITED_METHOD_CONTRACT;
 }
 
-inline void PEImageLayout::Startup()
-{
-    CONTRACT_VOID
-    {
-        THROWS;
-        GC_NOTRIGGER;
-        MODE_ANY;
-        POSTCONDITION(CheckStartup());
-        INJECT_FAULT(COMPlusThrowOM(););
-    }
-    CONTRACT_END;
-
-    if (CheckStartup())
-        RETURN;
-
-    RETURN;
-}
-
-inline CHECK PEImageLayout::CheckStartup()
-{
-    WRAPPER_NO_CONTRACT;
-    CHECK_OK;
-}
-
 inline BOOL PEImageLayout::CompareBase(UPTR base, UPTR mapping)
 {
     CONTRACTL


### PR DESCRIPTION
- [x] Reducing `BINDER_SPACE::Assembly` closer to what it represents. (basically a `{PEImage, binder}` tuple )
- [x] Made System lib to also have a binder. It is now possible and trivial to arrange, and it makes things more consistent.
- [x] Some unused code along the way 