### PR TITLE
JIT: allow suppressing some dumps or parts of dumps

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2675,7 +2675,14 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
     opts.dspOrder = false;
     if (compIsForInlining())
     {
-        verbose = impInlineInfo->InlinerCompiler->verbose;
+        if (JitConfig.JitDumpNoInlinePhases() == 0)
+        {
+            verbose = impInlineInfo->InlinerCompiler->verbose;
+        }
+        else
+        {
+            verbose = false;
+        }
     }
     else
     {
@@ -2833,6 +2840,8 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
             }
         }
     }
+
+    verboseDump &= (JitConfig.JitDumpNoTier0() == 0) || !jitFlags->IsSet(JitFlags::JIT_FLAG_TIER0);
 
     if (verboseDump)
     {

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2673,9 +2673,12 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
 
 #ifdef DEBUG
     opts.dspOrder = false;
+
+    // Optionally suppress inliner compiler instance dumping.
+    //
     if (compIsForInlining())
     {
-        if (JitConfig.JitDumpNoInlinePhases() == 0)
+        if (JitConfig.JitDumpInlinePhases() > 0)
         {
             verbose = impInlineInfo->InlinerCompiler->verbose;
         }
@@ -2841,7 +2844,12 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
         }
     }
 
-    verboseDump &= (JitConfig.JitDumpNoTier0() == 0) || !jitFlags->IsSet(JitFlags::JIT_FLAG_TIER0);
+    // Optionally suppress dumping Tier0 jit requests.
+    //
+    if (verboseDump && jitFlags->IsSet(JitFlags::JIT_FLAG_TIER0))
+    {
+        verboseDump = (JitConfig.JitDumpTier0() > 0);
+    }
 
     if (verboseDump)
     {

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -175,7 +175,9 @@ CONFIG_STRING(JitDisasmAssemblies, W("JitDisasmAssemblies")) // Only show JitDis
                                                              // from this semicolon-delimited list of assemblies.
 CONFIG_INTEGER(JitDisasmWithGC, W("JitDisasmWithGC"), 0)     // Dump interleaved GC Info for any method disassembled.
 CONFIG_METHODSET(JitDump, W("JitDump"))                      // Dumps trees for specified method
-CONFIG_METHODSET(JitEHDump, W("JitEHDump"))                  // Dump the EH table for the method, as reported to the VM
+CONFIG_INTEGER(JitDumpNoTier0, W("JitDumpNoTier0"), 0)       // Suppress dumping for tier0 requests
+CONFIG_INTEGER(JitDumpNoInlinePhases, W("JitDumpNoInlinePhases"), 0) // Suppress dumping of inline compiler phases
+CONFIG_METHODSET(JitEHDump, W("JitEHDump")) // Dump the EH table for the method, as reported to the VM
 CONFIG_METHODSET(JitExclude, W("JitExclude"))
 CONFIG_METHODSET(JitForceProcedureSplitting, W("JitForceProcedureSplitting"))
 CONFIG_METHODSET(JitGCDump, W("JitGCDump"))

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -175,8 +175,8 @@ CONFIG_STRING(JitDisasmAssemblies, W("JitDisasmAssemblies")) // Only show JitDis
                                                              // from this semicolon-delimited list of assemblies.
 CONFIG_INTEGER(JitDisasmWithGC, W("JitDisasmWithGC"), 0)     // Dump interleaved GC Info for any method disassembled.
 CONFIG_METHODSET(JitDump, W("JitDump"))                      // Dumps trees for specified method
-CONFIG_INTEGER(JitDumpNoTier0, W("JitDumpNoTier0"), 0)       // Suppress dumping for tier0 requests
-CONFIG_INTEGER(JitDumpNoInlinePhases, W("JitDumpNoInlinePhases"), 0) // Suppress dumping of inline compiler phases
+CONFIG_INTEGER(JitDumpTier0, W("JitDumpTier0"), 1)           // Dump tier0 requests
+CONFIG_INTEGER(JitDumpInlinePhases, W("JitDumpInlinePhases"), 1) // Dump inline compiler phases
 CONFIG_METHODSET(JitEHDump, W("JitEHDump")) // Dump the EH table for the method, as reported to the VM
 CONFIG_METHODSET(JitExclude, W("JitExclude"))
 CONFIG_METHODSET(JitForceProcedureSplitting, W("JitForceProcedureSplitting"))


### PR DESCRIPTION
Another bit of code that I've had lying around that might be generally useful.
* Optionally suppress Tier0 compilation dumps
* Optionally suppress dumps from inline compiler phases

Setting JitDumpNoTier0 prevents you from getting two dumps when you specify
dumping a method by name or hash, when TC is enabled.