### PR TITLE
Print "callsites by likely classes" chart in 'dotnet-pgo dump' command

### DIFF
--- a/src/coreclr/tools/Common/Pgo/TypeSystemEntityOrUnknown.cs
+++ b/src/coreclr/tools/Common/Pgo/TypeSystemEntityOrUnknown.cs
@@ -24,6 +24,7 @@ namespace Internal.Pgo
         public FieldDesc AsField => _data as FieldDesc;
         public int AsUnknown => (!(_data is int)) || _data == null ? 0 : (int)_data;
         public bool IsNull => _data == null;
+        public bool IsUnknown => _data is int;
 
         public bool Equals(TypeSystemEntityOrUnknown other)
         {

--- a/src/coreclr/tools/Common/Pgo/TypeSystemEntityOrUnknown.cs
+++ b/src/coreclr/tools/Common/Pgo/TypeSystemEntityOrUnknown.cs
@@ -37,7 +37,7 @@ namespace Internal.Pgo
             }
         }
 
-        public override int GetHashCode() => _data.GetHashCode();
+        public override int GetHashCode() => _data?.GetHashCode() ?? 0;
 
         public override bool Equals(object obj) => obj is TypeSystemEntityOrUnknown other && other.Equals(this);
 

--- a/src/coreclr/tools/dotnet-pgo/Program.cs
+++ b/src/coreclr/tools/dotnet-pgo/Program.cs
@@ -674,8 +674,8 @@ namespace Microsoft.Diagnostics.Tools.Pgo
         /// the number of unique classes seen at that call-site</param>
         static void PrintCallsitesByLikelyClassesChart(int[] callSites)
         {
-            const int maxLikelyClasses = 8;
-            const int tableWidth = 20;
+            const int maxLikelyClasses = 10;
+            const int tableWidth = 25;
 
             if (callSites.Length < 1)
                 return;
@@ -702,7 +702,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                 int shareWidth = (int)(Math.Round(share * tableWidth));
                 bool lastRow = (i == rows.Length - 1);
 
-                Console.Write($"{(lastRow ? "  ≥" : "   ")}{i}: [");
+                Console.Write($"{(lastRow ? "  ≥" : "   ")}{i,2}: [");
                 Console.Write(new string('#', shareWidth));
                 Console.Write(new string('.', tableWidth - shareWidth));
                 Console.Write("] ");

--- a/src/coreclr/tools/dotnet-pgo/Program.cs
+++ b/src/coreclr/tools/dotnet-pgo/Program.cs
@@ -675,7 +675,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
         static void PrintCallsitesByLikelyClassesChart(int[] callSites)
         {
             const int maxLikelyClasses = 10;
-            const int tableWidth = 25;
+            const int tableWidth = 20;
 
             if (callSites.Length < 1)
                 return;
@@ -727,7 +727,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
         static void PrintLikelihoodHistogram(double[] likelihoods)
         {
             const int columns = 10;
-            const int tableWidth = 25;
+            const int tableWidth = 20;
             int columnWidth = 100 / columns;
 
             if (likelihoods.Length == 0)
@@ -865,6 +865,9 @@ namespace Microsoft.Diagnostics.Tools.Pgo
             for (int i = 0; i < schema.Length; i++)
             {
                 var elem = schema[i];
+                if (elem.ILOffset == ilOffset)
+                    continue;
+
                 if (elem.InstrumentationKind == PgoInstrumentationKind.GetLikelyClass)
                 {
                     Trace.Assert(elem.Count == 1);
@@ -888,7 +891,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
 
                     int totalCount = histogram.Sum(g => g.Count());
                     // The number of unknown type handles matters for the likelihood, but not for the most likely class that we pick, so we can remove them now.
-                    histogram.RemoveAll(e => IsUnknownTypeHandle(e.Key.AsUnknown));
+                    histogram.RemoveAll(e => e.Key.IsNull || e.Key.IsUnknown);
                     if (histogram.Count == 0)
                         return new GetLikelyClassResult { IsUnknown = true };
 


### PR DESCRIPTION
Now `dotnet-pgo dump` command prints a sort of a chart (it already prints some statistics so I'm just extending it), e.g. here is the chart for `StandardOptimizations.mibc`:
```
dotnet-pgo dump StandardOptimizations.mibc output.txt
```
Prints:
```
Call-sites grouped by number of likely classes seen:

          0: [#########...........] 44.7% (455) - call-sites with 'null's
          1: [###########.........] 52.8% (538) - monomorphic call-sites
          2: [....................]  1.5% (15)
          3: [....................]  0.1% (1)
          4: [....................]  0.4% (4)
          5: [....................]  0.4% (4)
          6: [....................]  0.0% (0)
          7: [....................]  0.0% (0)
          8: [....................]  0.1% (1)
          9: [....................]  0.0% (0)
        ≥10: [....................]  0.0% (0)


Likelihoods of the most popular likely classes:

  [ 0- 10%]: [#########...........] 455
  (10- 20%]: [##..................] 102
  (20- 30%]: [#...................] 43
  (30- 40%]: [#...................] 26
  (40- 50%]: [....................] 13
  (50- 60%]: [....................] 0
  (60- 70%]: [....................] 5
  (70- 80%]: [....................] 5
  (80- 90%]: [....................] 3
  (90-100%]: [#######.............] 366
```
I tested it on a console app where I simulated several scenarios and the chart displayed everything correctly. Also, here is a console app to play with the function: https://gist.github.com/EgorBo/d9e75a6af5b691c93c10fc14e6394962

Btw, if you wonder what are the callsites with 8 or more in our `StandardOptimizations.mibc` here is an example:
```
      "Method": "[Microsoft.Build]Microsoft.Build.BackEnd.BuildComponentFactoryCollection+BuildComponentEntry.ShutdownSingletonInstance()",
      "InstrumentationData": [

        {
          "ILOffset": 33,
          "InstrumentationKind": "TypeHandleHistogramTypeHandle",
          "Other": -1073741824,
          "Data": [
            "[Microsoft.Build]Microsoft.Build.BackEnd.Logging.LoggingService",
            "[Microsoft.Build]Microsoft.Build.BackEnd.Scheduler",
            "[Microsoft.Build]Microsoft.Build.BackEnd.ConfigCache",
            "[Microsoft.Build]Microsoft.Build.BackEnd.ResultsCache",
            "[Microsoft.Build]Microsoft.Build.BackEnd.NodeManager",
            "[Microsoft.Build]Microsoft.Build.BackEnd.NodeProviderOutOfProcTaskHost",
            "[Microsoft.Build]Microsoft.Build.BackEnd.NodeProviderInProc",
            "[Microsoft.Build]Microsoft.Build.BackEnd.Components.Caching.RegisteredTaskObjectCache",
            "[Microsoft.Build]Microsoft.Build.BackEnd.NodeProviderOutOfProcTaskHost",
            "[Microsoft.Build]Microsoft.Build.BackEnd.Scheduler",
            "[Microsoft.Build]Microsoft.Build.BackEnd.ConfigCache",
            "[Microsoft.Build]Microsoft.Build.BackEnd.BuildRequestEngine",
            "[Microsoft.Build]Microsoft.Build.BackEnd.SdkResolution.MainNodeSdkResolverService",
            "[Microsoft.Build]Microsoft.Build.BackEnd.TaskHostNodeManager",
            "[Microsoft.Build]Microsoft.Build.BackEnd.NodeProviderInProc",
            "[Microsoft.Build]Microsoft.Build.BackEnd.NodeProviderOutOfProc",
            "[Microsoft.Build]Microsoft.Build.BackEnd.Logging.LoggingService",
            "[Microsoft.Build]Microsoft.Build.BackEnd.Scheduler",
            "[Microsoft.Build]Microsoft.Build.BackEnd.ConfigCache",
            "[Microsoft.Build]Microsoft.Build.BackEnd.ResultsCache",
            "[Microsoft.Build]Microsoft.Build.BackEnd.NodeManager",
            "[Microsoft.Build]Microsoft.Build.BackEnd.TaskHostNodeManager",
            "[Microsoft.Build]Microsoft.Build.BackEnd.NodeProviderInProc",
            "[Microsoft.Build]Microsoft.Build.BackEnd.NodeProviderOutOfProc",
            "[Microsoft.Build]Microsoft.Build.BackEnd.Logging.LoggingService",
            "[Microsoft.Build]Microsoft.Build.BackEnd.Scheduler",
            "[Microsoft.Build]Microsoft.Build.BackEnd.NodeProviderOutOfProcTaskHost",
            "[Microsoft.Build]Microsoft.Build.BackEnd.SdkResolution.MainNodeSdkResolverService",
            "[Microsoft.Build]Microsoft.Build.BackEnd.NodeManager",
            "[Microsoft.Build]Microsoft.Build.BackEnd.TaskHostNodeManager",
            "[Microsoft.Build]Microsoft.Build.BackEnd.BuildRequestEngine",
            "[Microsoft.Build]Microsoft.Build.BackEnd.NodeProviderOutOfProc"
          ]
        },
```

/cc @dotnet/jit-contrib @AndyAyersMS @jakobbotsch 