### PR TITLE
Allow StoreLclVar src to be IND/FLD.

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -5016,7 +5016,17 @@ void CodeGen::genCodeForIndir(GenTreeIndir* tree)
     else
     {
         genConsumeAddress(addr);
-        emit->emitInsLoadInd(ins_Load(targetType), emitTypeSize(tree), tree->GetRegNum(), tree);
+        instruction loadIns = ins_Load(targetType);
+        if (tree->DontExtend())
+        {
+            assert(varTypeIsSmall(tree));
+            // The user of this IND does not need
+            // the upper bits to be set, so we don't need to use longer
+            // INS_movzx/INS_movsx and can use INS_mov instead.
+            // It usually happens when the real type is a small struct.
+            loadIns = INS_mov;
+        }
+        emit->emitInsLoadInd(loadIns, emitTypeSize(tree), tree->GetRegNum(), tree);
     }
 
     genProduceReg(tree);

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -527,9 +527,16 @@ enum GenTreeFlags : unsigned int
                                               //             alignment of 1 byte)
     GTF_IND_INVARIANT           = 0x01000000, // GT_IND   -- the target is invariant (a prejit indirection)
     GTF_IND_NONNULL             = 0x00400000, // GT_IND   -- the indirection never returns null (zero)
+#if defined(TARGET_XARCH)
+    GTF_IND_DONT_EXTEND         = 0x00200000, // GT_IND   -- the indirection does not need to extend for small types
+#endif // TARGET_XARCH
 
     GTF_IND_FLAGS = GTF_IND_VOLATILE | GTF_IND_NONFAULTING | GTF_IND_TLS_REF | GTF_IND_UNALIGNED | GTF_IND_INVARIANT |
-                    GTF_IND_NONNULL | GTF_IND_TGT_NOT_HEAP | GTF_IND_TGT_HEAP,
+                    GTF_IND_NONNULL | GTF_IND_TGT_NOT_HEAP | GTF_IND_TGT_HEAP
+#if defined(TARGET_XARCH)
+                     | GTF_IND_DONT_EXTEND 
+#endif // TARGET_XARCH
+                    ,
 
     GTF_ADDRMODE_NO_CSE         = 0x80000000, // GT_ADD/GT_MUL/GT_LSH -- Do not CSE this node only, forms complex
                                               //                         addressing mode
@@ -6639,6 +6646,23 @@ struct GenTreeIndir : public GenTreeOp
     {
         return (gtFlags & GTF_IND_UNALIGNED) != 0;
     }
+
+#if defined(TARGET_XARCH)
+    void SetDontExtend()
+    {
+        gtFlags |= GTF_IND_DONT_EXTEND;
+    }
+
+    void ClearDontExtend()
+    {
+        gtFlags &= ~GTF_IND_DONT_EXTEND;
+    }
+
+    bool DontExtend() const
+    {
+        return (gtFlags & GTF_IND_DONT_EXTEND) != 0;
+    }
+#endif // TARGET_XARCH
 
 #if DEBUGGABLE_GENTREE
     // Used only for GenTree::GetVtableForOper()

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -2013,7 +2013,6 @@ void Compiler::fgComputeLifeLIR(VARSET_TP& life, BasicBlock* block, VARSET_VALAR
                     {
                         Lowering::TransformUnusedIndirection(data->AsIndir(), this, block);
                     }
-
                 }
                 break;
             }

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -2006,7 +2006,14 @@ void Compiler::fgComputeLifeLIR(VARSET_TP& life, BasicBlock* block, VARSET_VALAR
 
                 if (isDeadStore && fgTryRemoveDeadStoreLIR(node, lclVarNode, block))
                 {
-                    lclVarNode->Data()->SetUnusedValue();
+                    GenTree* data = lclVarNode->Data();
+                    data->SetUnusedValue();
+
+                    if (data->isIndir())
+                    {
+                        Lowering::TransformUnusedIndirection(data->AsIndir(), this, block);
+                    }
+
                 }
                 break;
             }

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3566,7 +3566,7 @@ void Lowering::LowerStoreLocCommon(GenTreeLclVarCommon* lclStore)
         }
         else
         {
-            assert(src->OperIs(GT_INIT_VAL));
+            assert(src->OperIsInitVal());
             convertToStoreObj = true;
         }
 

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3525,14 +3525,40 @@ void Lowering::LowerStoreLocCommon(GenTreeLclVarCommon* lclStore)
                 convertToStoreObj = false;
             }
         }
-        else if (!src->OperIs(GT_LCL_VAR))
+        else if (src->OperIs(GT_LCL_VAR))
         {
-            convertToStoreObj = true;
+            convertToStoreObj = false;
+        }
+        else if (src->OperIs(GT_IND, GT_OBJ, GT_BLK, GT_LCL_FLD))
+        {
+            if (src->TypeIs(TYP_STRUCT))
+            {
+                src->ChangeType(lclRegType);
+                if (src->OperIs(GT_IND, GT_OBJ, GT_BLK))
+                {
+                    if (src->OperIs(GT_OBJ, GT_BLK))
+                    {
+                        src->SetOper(GT_IND);
+                    }
+                    // This logic is skipped for struct indir in
+                    // `Lowering::LowerIndir` because we don't know the size.
+                    // Do it now.
+                    GenTreeIndir* indir = src->AsIndir();
+                    LowerIndir(indir);
+#if defined(TARGET_XARCH)
+                    if (varTypeIsSmall(lclRegType))
+                    {
+                        indir->SetDontExtend();
+                    }
+#endif // TARGET_XARCH
+                }
+            }
+            convertToStoreObj = false;
         }
         else
         {
-            assert(src->OperIs(GT_LCL_VAR));
-            convertToStoreObj = false;
+            assert(src->OperIs(GT_INIT_VAL));
+            convertToStoreObj = true;
         }
 
         if (convertToStoreObj)
@@ -7214,6 +7240,7 @@ void Lowering::TransformUnusedIndirection(GenTreeIndir* ind, Compiler* comp, Bas
     bool           useNullCheck          = false;
 #else  // TARGET_XARCH
     bool useNullCheck = !ind->Addr()->isContained();
+    ind->ClearDontExtend();
 #endif // !TARGET_XARCH
 
     if (useNullCheck && !ind->OperIs(GT_NULLCHECK))
@@ -7311,14 +7338,6 @@ bool Lowering::TryTransformStoreObjAsStoreInd(GenTreeBlk* blkNode)
         return false;
     }
 
-    if (varTypeIsSmall(regType) && !src->IsConstInitVal() && !src->IsLocal())
-    {
-        // source operand INDIR will use a widening instruction
-        // and generate worse code, like `movzx` instead of `mov`
-        // on x64.
-        return false;
-    }
-
     JITDUMP("Replacing STORE_OBJ with STOREIND for [%06u]\n", blkNode->gtTreeID);
     blkNode->ChangeOper(GT_STOREIND);
     blkNode->ChangeType(regType);
@@ -7341,6 +7360,14 @@ bool Lowering::TryTransformStoreObjAsStoreInd(GenTreeBlk* blkNode)
     {
         assert(src->TypeIs(regType) || src->IsCnsIntOrI() || src->IsCall());
     }
+
+#if defined(TARGET_XARCH)
+    if (varTypeIsSmall(regType) && src->OperIs(GT_IND))
+    {
+        src->AsIndir()->SetDontExtend();
+    }
+#endif // TARGET_XARCH
+
     LowerStoreIndirCommon(blkNode->AsStoreInd());
     return true;
 }


### PR DESCRIPTION
This change allows `STORE_LCL_VAR(IND/LCL_FLD)` to stay as is in lowering without transforming them into `STORE_OBJ(ADDR(LCL_VAR), IND/LCL_FLD)` and allows the local to be enregistered.

You can see the changes with `COMPLUS_JitEnregStats=1`, for example, for benchmarks.run.windows.x64.checked.mch:
```diff
-total number of locals: 346736, number of enregistered: 309780, notEnreg: 36956, ratio: 0.89
-total number of struct locals: 10920, number of enregistered: 86, notEnreg: 10834, ratio: 0.01
+total number of locals: 346736, number of enregistered: 309849, notEnreg: 36887, ratio: 0.89
+total number of struct locals: 10920, number of enregistered: 155, notEnreg: 10765, ratio: 0.01

-m_blockOp 449, ratio: 0.01
+m_blockOp 379, ratio: 0.01
+m_lclAddrNode 1, ratio: 0.00
```

there are some good diffs:
```
Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.x64\libraries.crossgen2.windows.x64.checked.mch
 Total bytes of delta: -18966 (-0.83% of base)
 696 total files with Code Size differences (615 improved, 81 regressed), 4834 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.x64\coreclr_tests.pmi.windows.x64.checked.mch
 Total bytes of delta: -26884 (-0.78% of base)
 374 total files with Code Size differences (356 improved, 18 regressed), 2652 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.x64\benchmarks.run.windows.x64.checked.mch
 Total bytes of delta: -1084 (-2.59% of base)
 31 total files with Code Size differences (29 improved, 2 regressed), 7 unchanged.

```


There are regressions due to SIMD register upper save/restore. Imagine that we write and read a local once, but between these 2 points we have N calls, it will cause 10 UpperVectoreStore/Restore to be generated. This is an LSRA issue, it should be able to see that SIMD lclVar is rarely used but has to be saved/restored often so it is not profitable to allocate it to a register.  
I have discussed this with @kunalspathak and he showed me that there are a few places already where we make such decisions:
https://github.com/dotnet/runtime/blob/cef245d28ae8d50f3bf0ad7adedc461cd45b085c/src/coreclr/jit/lsra.cpp#L4985-L5031


https://github.com/dotnet/runtime/blob/cef245d28ae8d50f3bf0ad7adedc461cd45b085c/src/coreclr/jit/lsra.cpp#L5351-L5359

The worst is:
```
Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.arm64\libraries.pmi.windows.arm64.checked.mch
 Total bytes of delta: 36396 (3.65% of base)
 2508 total files with Code Size differences (109 improved, 2399 regressed), 112 unchanged.
```

The regressions are not in benchmarks/asp so I think we can create an issue about it but take the change as is and plan the fix for 7.0.

<details>
  <summary>Full diffs</summary>

```
  Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.x64\aspnet.run.windows.x64.checked.mch
 Total bytes of delta: 18 (0.00% of base)
 31 total files with Code Size differences (17 improved, 14 regressed), 261 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.x64\benchmarks.run.windows.x64.checked.mch
 Total bytes of delta: -1084 (-2.59% of base)
 31 total files with Code Size differences (29 improved, 2 regressed), 7 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.x64\coreclr_tests.pmi.windows.x64.checked.mch
 Total bytes of delta: -26884 (-0.78% of base)
 374 total files with Code Size differences (356 improved, 18 regressed), 2652 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.x64\libraries.crossgen2.windows.x64.checked.mch
 Total bytes of delta: -18966 (-0.83% of base)
 696 total files with Code Size differences (615 improved, 81 regressed), 4834 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.x64\libraries.pmi.windows.x64.checked.mch
 Total bytes of delta: -7902 (-0.62% of base)
 406 total files with Code Size differences (369 improved, 37 regressed), 3466 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.x64\libraries_tests.pmi.windows.x64.checked.mch
 Total bytes of delta: -9172 (-1.28% of base)
 565 total files with Code Size differences (454 improved, 111 regressed), 174 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.arm64\coreclr_tests.pmi.Linux.arm64.checked.mch
 Total bytes of delta: -9328 (-0.15% of base)
 282 total files with Code Size differences (223 improved, 59 regressed), 752 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.arm64\libraries.crossgen2.Linux.arm64.checked.mch
 Total bytes of delta: 26804 (1.06% of base)
 3112 total files with Code Size differences (731 improved, 2381 regressed), 970 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.arm64\libraries.pmi.Linux.arm64.checked.mch
 Total bytes of delta: 36544 (3.81% of base)
 2464 total files with Code Size differences (85 improved, 2379 regressed), 103 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.arm64\libraries_tests.pmi.Linux.arm64.checked.mch
 Total bytes of delta: -1332 (-0.35% of base)
 235 total files with Code Size differences (192 improved, 43 regressed), 111 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.x64\benchmarks.run.Linux.x64.checked.mch
 Total bytes of delta: -400 (-1.48% of base)
 27 total files with Code Size differences (26 improved, 1 regressed), 3 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.x64\coreclr_tests.pmi.Linux.x64.checked.mch
 Total bytes of delta: -1749 (-0.06% of base)
 147 total files with Code Size differences (147 improved, 0 regressed), 2632 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.x64\libraries.crossgen2.Linux.x64.checked.mch
 Total bytes of delta: -9922 (-0.60% of base)
 270 total files with Code Size differences (254 improved, 16 regressed), 2788 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.x64\libraries.pmi.Linux.x64.checked.mch
 Total bytes of delta: -3411 (-0.49% of base)
 145 total files with Code Size differences (140 improved, 5 regressed), 1331 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.x64\libraries_tests.pmi.Linux.x64.checked.mch
 Total bytes of delta: -4927 (-1.87% of base)
 233 total files with Code Size differences (218 improved, 15 regressed), 39 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.arm64\benchmarks.run.windows.arm64.checked.mch
 Total bytes of delta: -532 (-0.99% of base)
 20 total files with Code Size differences (19 improved, 1 regressed), 26 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.arm64\coreclr_tests.pmi.windows.arm64.checked.mch
 Total bytes of delta: -9484 (-0.15% of base)
 291 total files with Code Size differences (231 improved, 60 regressed), 751 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.arm64\libraries.crossgen2.windows.arm64.checked.mch
 Total bytes of delta: 26372 (1.02% of base)
 3173 total files with Code Size differences (774 improved, 2399 regressed), 978 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.arm64\libraries.pmi.windows.arm64.checked.mch
 Total bytes of delta: 36396 (3.65% of base)
 2508 total files with Code Size differences (109 improved, 2399 regressed), 112 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.arm64\libraries_tests.pmi.windows.arm64.checked.mch
 Total bytes of delta: -1060 (-0.20% of base)
 414 total files with Code Size differences (277 improved, 137 regressed), 133 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.x86\benchmarks.run.windows.x86.checked.mch
 Total bytes of delta: -701 (-2.86% of base)
 20 total files with Code Size differences (20 improved, 0 regressed), 12 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.x86\coreclr_tests.pmi.windows.x86.checked.mch
 Total bytes of delta: -2992 (-0.14% of base)
 404 total files with Code Size differences (404 improved, 0 regressed), 193 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.x86\libraries.crossgen2.windows.x86.checked.mch
 Total bytes of delta: -25537 (-1.59% of base)
 2593 total files with Code Size differences (2361 improved, 232 regressed), 1493 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.x86\libraries.pmi.windows.x86.checked.mch
 Total bytes of delta: -4008 (-0.79% of base)
 116 total files with Code Size differences (114 improved, 2 regressed), 1379 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.x86\libraries_tests.pmi.windows.x86.checked.mch
 Total bytes of delta: -10404 (-1.24% of base)
 315 total files with Code Size differences (313 improved, 2 regressed), 432 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.arm\coreclr_tests.pmi.Linux.arm.checked.mch
 Total bytes of delta: -90 (-0.00% of base)
 14 total files with Code Size differences (14 improved, 0 regressed), 372 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.arm\libraries.crossgen2.Linux.arm.checked.mch
 Total bytes of delta: -1518 (-0.15% of base)
 424 total files with Code Size differences (418 improved, 6 regressed), 1069 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.arm\libraries.pmi.Linux.arm.checked.mch
 Total bytes of delta: -4 (-0.00% of base)
 6 total files with Code Size differences (4 improved, 2 regressed), 44 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.arm\libraries_tests.pmi.Linux.arm.checked.mch
 Total bytes of delta: -222 (-0.32% of base)
 52 total files with Code Size differences (52 improved, 0 regressed), 29 unchanged.

```

</details>

<details>
  <summary>Diff example</summary>

```diff
-; Total bytes of code 35, prolog size 7, PerfScore 16.65, instruction count 9
+; Total bytes of code 15, prolog size 3, PerfScore 9.95, instruction count 5

-G_M9563_IG01:        ; func=00, offs=000000H, size=0007H
+G_M9563_IG01:        ; func=00, offs=000000H, size=0003H

-sub      rsp, 24
-vzeroupper 
+vzeroupper 

-G_M9563_IG02:        ; offs=000007H, size=0017H
+G_M9563_IG02:        ; offs=000003H, size=000BH

-vmovupd  xmm0, xmmword ptr [rcx]
-vmovupd  xmmword ptr [V03 rsp+08H], xmm0
-vmovupd  xmm0, xmmword ptr [V03 rsp+08H]
-vmovupd  xmmword ptr [rdx], xmm0
-mov      rax, rdx
+vmovupd  xmm0, xmmword ptr [rcx]
+vmovupd  xmmword ptr [rdx], xmm0
+mov      rax, rdx

-G_M9563_IG03:        ; offs=00001EH, size=0005H
+G_M9563_IG03:        ; offs=00000EH, size=0001H

-add      rsp, 24
ret
```
</details>