### PR TITLE
dotnet-pgo: Don't ignore `ilOffset` in `GetLikelyClass`

### DIFF
--- a/src/coreclr/tools/dotnet-pgo/Program.cs
+++ b/src/coreclr/tools/dotnet-pgo/Program.cs
@@ -741,6 +741,9 @@ namespace Microsoft.Diagnostics.Tools.Pgo
             for (int i = 0; i < schema.Length; i++)
             {
                 var elem = schema[i];
+                if (elem.ILOffset != ilOffset)
+                    continue;
+                
                 if (elem.InstrumentationKind == PgoInstrumentationKind.GetLikelyClass)
                 {
                     Trace.Assert(elem.Count == 1);


### PR DESCRIPTION
From my understanding, `GetLikelyClass` function https://github.com/dotnet/runtime/blob/78593b9e095f974305b2033b465455e458e30267/src/coreclr/tools/dotnet-pgo/Program.cs#L733-L789 accepts array of `PgoSchemaElem[]` and returns a single most popular class.

The problem that `PgoSchemaElem[]` describe all call-sites in a method, not just a single one so we need to take `iLOffset` into account. The `ilOffset` argument was unused.

cc @jakobbotsch

UPD: ah, nvm, it's used only for DUMP/COMPARE so a minor issue