### PR TITLE
Fix indentation in api prososal template

### DIFF
--- a/.github/ISSUE_TEMPLATE/02_api_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/02_api_proposal.yml
@@ -28,10 +28,10 @@ body:
         ```C#
         namespace System.Collections.Generic
         {
-             public class MyFancyCollection<T> : IEnumerable<T>
-             {
-                  public void Fancy(T item);
-             }
+            public class MyFancyCollection<T> : IEnumerable<T>
+            {
+                public void Fancy(T item);
+            }
         }
         ```     
     validations:


### PR DESCRIPTION
5 spaces were used when 4 is the convention.