### PR TITLE
Microsoft.VisualBasic.Core.Tests fail tests with NaN conversion

### DIFF
--- a/src/libraries/Microsoft.VisualBasic.Core/tests/ConversionsTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/ConversionsTests.cs
@@ -2639,7 +2639,7 @@ namespace Microsoft.VisualBasic.Tests
             yield return new object[] { (float)1, "1" };
             yield return new object[] { float.PositiveInfinity, float.PositiveInfinity.ToString() };
             yield return new object[] { float.NegativeInfinity, float.NegativeInfinity.ToString() };
-            yield return new object[] { float.NaN, "NaN" };
+            yield return new object[] { float.NaN, float.NaN.ToString() };
 
             // double.
             yield return new object[] { (double)(-1), "-1" };
@@ -2647,7 +2647,7 @@ namespace Microsoft.VisualBasic.Tests
             yield return new object[] { (double)1, "1" };
             yield return new object[] { double.PositiveInfinity, double.PositiveInfinity.ToString() };
             yield return new object[] { double.NegativeInfinity, double.NegativeInfinity.ToString() };
-            yield return new object[] { double.NaN, "NaN" };
+            yield return new object[] { double.NaN, double.NaN.ToString() };
 
             // decimal.
             yield return new object[] { decimal.MinValue, decimal.MinValue.ToString() };

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/SingleTypeTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/SingleTypeTests.cs
@@ -65,7 +65,9 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
                 Assert.Equal(expected, SingleType.FromString(value, System.Globalization.NumberFormatInfo.InvariantInfo));
             }
             else
+            {
                 Assert.Equal(expected, SingleType.FromString(value, numberFormat));
+            }
         }
 
         [Theory]

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/SingleTypeTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/SingleTypeTests.cs
@@ -13,10 +13,17 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         [Theory]
         [MemberData(nameof(FromObject_TestData))]
         [MemberData(nameof(FromString_TestData))]
-        public void FromObject(object value, float expected)
+        public void FromObject(object value, float expected, System.Globalization.NumberFormatInfo numberFormat = null)
         {
-            Assert.Equal(expected, SingleType.FromObject(value));
-            Assert.Equal(expected, SingleType.FromObject(value, System.Globalization.NumberFormatInfo.InvariantInfo));
+            if (numberFormat is null)
+            {
+                Assert.Equal(expected, SingleType.FromObject(value));
+                Assert.Equal(expected, SingleType.FromObject(value, System.Globalization.NumberFormatInfo.InvariantInfo));
+            }
+            else
+            {
+                Assert.Equal(expected, SingleType.FromObject(value, numberFormat));
+            }
         }
 
         [Theory]
@@ -50,10 +57,15 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
 
         [Theory]
         [MemberData(nameof(FromString_TestData))]
-        public void FromString(string value, float expected)
+        public void FromString(string value, float expected, System.Globalization.NumberFormatInfo numberFormat = null)
         {
-            Assert.Equal(expected, SingleType.FromString(value));
-            Assert.Equal(expected, SingleType.FromString(value, System.Globalization.NumberFormatInfo.InvariantInfo));
+            if (numberFormat is null)
+            {
+                Assert.Equal(expected, SingleType.FromString(value));
+                Assert.Equal(expected, SingleType.FromString(value, System.Globalization.NumberFormatInfo.InvariantInfo));
+            }
+            else
+                Assert.Equal(expected, SingleType.FromString(value, numberFormat));
         }
 
         [Theory]
@@ -228,7 +240,8 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
             yield return new object[] { " &o5", (float)5 };
             yield return new object[] { "&o0", (float)0 };
             yield return new object[] { "18446744073709551616", 18446744073709551616.0f };
-            yield return new object[] { double.NaN.ToString(), float.NaN };
+            yield return new object[] { double.NaN.ToString(), float.NaN, System.Globalization.NumberFormatInfo.CurrentInfo };
+            yield return new object[] { "NaN", float.NaN, System.Globalization.NumberFormatInfo.InvariantInfo };
         }
 
         public static IEnumerable<object[]> FromString_Other_TestData()

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/StringTypeTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/StringTypeTests.cs
@@ -246,7 +246,7 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
             yield return new object[] { (float)1, "1" };
             yield return new object[] { float.PositiveInfinity, float.PositiveInfinity.ToString() };
             yield return new object[] { float.NegativeInfinity, float.NegativeInfinity.ToString() };
-            yield return new object[] { float.NaN, "NaN" };
+            yield return new object[] { float.NaN, float.NaN.ToString() };
         }
 
         public static IEnumerable<object[]> FromDouble_TestData()
@@ -256,7 +256,7 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
             yield return new object[] { (double)1, "1" };
             yield return new object[] { double.PositiveInfinity, double.PositiveInfinity.ToString() };
             yield return new object[] { double.NegativeInfinity, double.NegativeInfinity.ToString() };
-            yield return new object[] { double.NaN, "NaN" };
+            yield return new object[] { double.NaN, double.NaN.ToString() };
         }
 
         public static IEnumerable<object[]> FromDecimal_TestData()


### PR DESCRIPTION
When the current culture is not English, then Microsoft.VisualBasic.Core.Tests fail tests with NaN conversion.