### PR TITLE
Ignore MSBuild_Logs/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ artifacts/
 bld/
 [Bb]in/
 [Oo]bj/
+MSBuild_Logs/
 msbuild.log
 msbuild.err
 msbuild.wrn


### PR DESCRIPTION
This is a new directory used by msbuild for logging, since https://github.com/dotnet/msbuild/commit/cdb5077c451180ab38161e0b5e70f5448e70355b.