### PR TITLE
System.Drawing.Common.Tests fail ToLogFont_Invoke tests on non English Windows

### DIFF
--- a/src/libraries/System.Drawing.Common/tests/FontTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/FontTests.cs
@@ -837,7 +837,7 @@ namespace System.Drawing.Tests
                 Assert.Equal(0, logFont.lfItalic);
                 Assert.Equal(0, logFont.lfUnderline);
                 Assert.Equal(0, logFont.lfStrikeOut);
-                Assert.Equal(SystemFonts.DefaultFont.GdiCharSet == 0 ? 1 : SystemFonts.DefaultFont.GdiCharSet, logFont.lfCharSet);
+                Assert.Equal(SystemFonts.DefaultFont.GdiCharSet <= 2 ? font.GdiCharSet : SystemFonts.DefaultFont.GdiCharSet, logFont.lfCharSet);
                 Assert.Equal(0, logFont.lfOutPrecision);
                 Assert.Equal(0, logFont.lfClipPrecision);
                 Assert.Equal(0, logFont.lfQuality);

--- a/src/libraries/System.Drawing.Common/tests/FontTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/FontTests.cs
@@ -800,7 +800,7 @@ namespace System.Drawing.Tests
                 Assert.Equal(font.Italic ? 1 : 0, logFont.lfItalic);
                 Assert.Equal(font.Underline ? 1 : 0, logFont.lfUnderline);
                 Assert.Equal(font.Strikeout ? 1 : 0, logFont.lfStrikeOut);
-                Assert.Equal(SystemFonts.DefaultFont.GdiCharSet == 0 ? font.GdiCharSet : SystemFonts.DefaultFont.GdiCharSet, logFont.lfCharSet);
+                Assert.Equal(SystemFonts.DefaultFont.GdiCharSet <= 2 ? font.GdiCharSet : SystemFonts.DefaultFont.GdiCharSet, logFont.lfCharSet);
                 Assert.Equal(0, logFont.lfOutPrecision);
                 Assert.Equal(0, logFont.lfClipPrecision);
                 Assert.Equal(0, logFont.lfQuality);

--- a/src/libraries/System.Drawing.Common/tests/FontTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/FontTests.cs
@@ -800,7 +800,7 @@ namespace System.Drawing.Tests
                 Assert.Equal(font.Italic ? 1 : 0, logFont.lfItalic);
                 Assert.Equal(font.Underline ? 1 : 0, logFont.lfUnderline);
                 Assert.Equal(font.Strikeout ? 1 : 0, logFont.lfStrikeOut);
-                Assert.Equal(font.GdiCharSet, logFont.lfCharSet);
+                Assert.Equal(SystemFonts.DefaultFont.GdiCharSet == 0 ? font.GdiCharSet : SystemFonts.DefaultFont.GdiCharSet, logFont.lfCharSet);
                 Assert.Equal(0, logFont.lfOutPrecision);
                 Assert.Equal(0, logFont.lfClipPrecision);
                 Assert.Equal(0, logFont.lfQuality);
@@ -837,7 +837,7 @@ namespace System.Drawing.Tests
                 Assert.Equal(0, logFont.lfItalic);
                 Assert.Equal(0, logFont.lfUnderline);
                 Assert.Equal(0, logFont.lfStrikeOut);
-                Assert.Equal(1, logFont.lfCharSet);
+                Assert.Equal(SystemFonts.DefaultFont.GdiCharSet == 0 ? 1 : SystemFonts.DefaultFont.GdiCharSet, logFont.lfCharSet);
                 Assert.Equal(0, logFont.lfOutPrecision);
                 Assert.Equal(0, logFont.lfClipPrecision);
                 Assert.Equal(0, logFont.lfQuality);


### PR DESCRIPTION
System.Drawing.Common.Tests fail ToLogFont_Invoke tests on non-English Windows.