### PR TITLE
FreeBSD12 version cleanup and process and thread enhancements

### DIFF
--- a/docs/workflow/requirements/freebsd-requirements.md
+++ b/docs/workflow/requirements/freebsd-requirements.md
@@ -11,7 +11,7 @@ Since there is no official build and FreeBSD package, native build on FreeBSD is
 Environment
 ===========
 
-These instructions were validated for and on FreeBSD 11.3 and 12.1.
+These instructions were validated for and on FreeBSD 12.2.
 
 Build using Docker on Linux
 ---------------------------
@@ -20,7 +20,7 @@ This is similar to [Linux](linux-requirements.md) instructions. https://github.c
 with all needed prerequisites to build. As the example bellow may become stale, https://github.com/dotnet/versions/blob/master/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-master.json offers list of latest Docker tags.
 
 ```sh
-TAG=mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-freebsd-11-20200430154008-a84b0d2
+TAG=mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-freebsd-12-20210917001307-f13d79e
 docker run --rm --volume $(pwd):$(pwd) --workdir $(pwd) --env ROOTFS_DIR=/crossrootfs/x64 -ti  $TAG ./build.sh -cross -os FreeBSD
 ```
 

--- a/src/coreclr/gc/unix/configure.cmake
+++ b/src/coreclr/gc/unix/configure.cmake
@@ -18,8 +18,13 @@ check_cxx_source_compiles("
     }
     " HAVE_PTHREAD_THREADID_NP)
 
+if(HAVE_PTHREAD_NP_H)
+  set(PTHREAD_NP_H_INCLUDE "#include <pthread_np.h>")
+endif()
+
 check_cxx_source_compiles("
     #include <pthread.h>
+    ${PTHREAD_NP_H_INCLUDE}
     #include <stdint.h>
 
     int main()

--- a/src/coreclr/pal/src/include/pal/thread.hpp
+++ b/src/coreclr/pal/src/include/pal/thread.hpp
@@ -767,12 +767,8 @@ inline SIZE_T PlatformGetCurrentThreadId() {
     return (SIZE_T)tid;
 }
 #elif defined(__FreeBSD__)
-#include <sys/thr.h>
-inline SIZE_T PlatformGetCurrentThreadId() {
-    long tid;
-    thr_self(&tid);
-    return (SIZE_T)tid;
-}
+#include <pthread_np.h>
+#define PlatformGetCurrentThreadId() (SIZE_T)pthread_getthreadid_np()
 #elif defined(__NetBSD__)
 #include <lwp.h>
 #define PlatformGetCurrentThreadId() (SIZE_T)_lwp_self()

--- a/src/coreclr/pal/src/init/pal.cpp
+++ b/src/coreclr/pal/src/init/pal.cpp
@@ -88,6 +88,10 @@ int CacheLineSize;
 #endif
 #endif
 
+#ifdef __FreeBSD__
+#include <sys/user.h>
+#endif
+
 #include <algorithm>
 
 using namespace CorUnix;
@@ -854,14 +858,18 @@ PAL_IsDebuggerPresent()
     close(status_fd);
 
     return debugger_present;
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) || defined(__FreeBSD__)
     struct kinfo_proc info = {};
     size_t size = sizeof(info);
     int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid() };
     int ret = sysctl(mib, sizeof(mib)/sizeof(*mib), &info, &size, NULL, 0);
 
     if (ret == 0)
+#if defined(__APPLE__)
         return ((info.kp_proc.p_flag & P_TRACED) != 0);
+#else // __FreeBSD__
+        return ((info.ki_flag & P_TRACED) != 0);
+#endif
 
     return FALSE;
 #elif defined(__NetBSD__)

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -113,6 +113,11 @@ extern "C"
 #include <kvm.h>
 #endif
 
+#ifdef __FreeBSD__
+#include <sys/sysctl.h>
+#include <sys/user.h>
+#endif
+
 extern char *g_szCoreCLRPath;
 
 using namespace CorUnix;
@@ -2045,7 +2050,7 @@ GetProcessIdDisambiguationKey(DWORD processId, UINT64 *disambiguationKey)
 
     *disambiguationKey = 0;
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(__FreeBSD__)
 
     // On OS X, we return the process start time expressed in Unix time (the number of seconds
     // since the start of the Unix epoch).
@@ -2056,7 +2061,11 @@ GetProcessIdDisambiguationKey(DWORD processId, UINT64 *disambiguationKey)
 
     if (ret == 0)
     {
+#if defined(__APPLE__)
         timeval procStartTime = info.kp_proc.p_starttime;
+#else // __FreeBSD__
+        timeval procStartTime = info.ki_start;
+#endif
         long secondsSinceEpoch = procStartTime.tv_sec;
 
         *disambiguationKey = secondsSinceEpoch;

--- a/src/coreclr/pal/src/thread/thread.cpp
+++ b/src/coreclr/pal/src/thread/thread.cpp
@@ -93,6 +93,8 @@ using namespace CorUnix;
 
 #ifdef __APPLE__
 #define MAX_THREAD_NAME_SIZE 63
+#elif defined(__FreeBSD__)
+#define MAX_THREAD_NAME_SIZE MAXCOMLEN
 #else
 #define MAX_THREAD_NAME_SIZE 15
 #endif
@@ -1598,8 +1600,8 @@ CorUnix::InternalSetThreadDescription(
     char *nameBuf = NULL;
 
 // The exact API of pthread_setname_np varies very wildly depending on OS.
-// For now, only Linux and macOS are implemented.
-#if defined(__linux__) || defined(__APPLE__)
+// For now, only Linux, macOS and FreeBSD are implemented.
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
 
     palError = InternalGetThreadDataFromHandle(
         pThread,
@@ -1646,14 +1648,14 @@ CorUnix::InternalSetThreadDescription(
     }
 
     // Null terminate early.
-    // pthread_setname_np only accepts up to 16 chars on Linux and
-    // 64 chars on macOS.
+    // pthread_setname_np only accepts up to 16 chars on Linux,
+    // 64 chars on macOS and 20 chars on FreeBSD.
     if (nameSize > MAX_THREAD_NAME_SIZE)
     {
         nameBuf[MAX_THREAD_NAME_SIZE] = '\0';
     }
     
-    #if defined(__linux__)
+    #if defined(__linux__) || defined(__FreeBSD__)
     error = pthread_setname_np(pTargetThread->GetPThreadSelf(), nameBuf);
     #endif
 
@@ -1686,7 +1688,7 @@ InternalSetThreadDescriptionExit:
         PAL_free(nameBuf);
     }
 
-#endif //defined(__linux__) || defined(__APPLE__)
+#endif //defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
 
     return palError;
 }

--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtime.compatibility.json
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtime.compatibility.json
@@ -2929,26 +2929,8 @@
     "any",
     "base"
   ],
-  "freebsd.11": [
-    "freebsd.11",
-    "freebsd",
-    "unix",
-    "any",
-    "base"
-  ],
-  "freebsd.11-x64": [
-    "freebsd.11-x64",
-    "freebsd.11",
-    "freebsd-x64",
-    "freebsd",
-    "unix-x64",
-    "unix",
-    "any",
-    "base"
-  ],
   "freebsd.12": [
     "freebsd.12",
-    "freebsd.11",
     "freebsd",
     "unix",
     "any",
@@ -2957,8 +2939,6 @@
   "freebsd.12-x64": [
     "freebsd.12-x64",
     "freebsd.12",
-    "freebsd.11-x64",
-    "freebsd.11",
     "freebsd-x64",
     "freebsd",
     "unix-x64",
@@ -2969,7 +2949,6 @@
   "freebsd.13": [
     "freebsd.13",
     "freebsd.12",
-    "freebsd.11",
     "freebsd",
     "unix",
     "any",
@@ -2980,8 +2959,6 @@
     "freebsd.13",
     "freebsd.12-x64",
     "freebsd.12",
-    "freebsd.11-x64",
-    "freebsd.11",
     "freebsd-x64",
     "freebsd",
     "unix-x64",

--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json
@@ -1134,26 +1134,15 @@
         "unix-x64"
       ]
     },
-    "freebsd.11": {
-      "#import": [
-        "freebsd"
-      ]
-    },
-    "freebsd.11-x64": {
-      "#import": [
-        "freebsd.11",
-        "freebsd-x64"
-      ]
-    },
     "freebsd.12": {
       "#import": [
-        "freebsd.11"
+        "freebsd"
       ]
     },
     "freebsd.12-x64": {
       "#import": [
         "freebsd.12",
-        "freebsd.11-x64"
+        "freebsd-x64"
       ]
     },
     "freebsd.13": {

--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtimeGroups.props
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtimeGroups.props
@@ -162,7 +162,7 @@
     <RuntimeGroup Include="freebsd">
       <Parent>unix</Parent>
       <Architectures>x64</Architectures>
-      <Versions>11;12;13</Versions>
+      <Versions>12;13</Versions>
     </RuntimeGroup>
 
     <RuntimeGroup Include="solaris">

--- a/src/libraries/Native/Unix/Common/pal_error_common.h
+++ b/src/libraries/Native/Unix/Common/pal_error_common.h
@@ -12,11 +12,6 @@
 #include <errno.h>
 #include <netdb.h>
 
-// ENODATA is not defined in FreeBSD 10.3 but is defined in 11.0
-#if defined(__FreeBSD__) & !defined(ENODATA)
-#define ENODATA ENOATTR
-#endif
-
 /**
  * Error codes returned via ConvertErrno.
  *
@@ -320,8 +315,10 @@ inline static int32_t ConvertErrorPlatformToPal(int32_t platformErrno)
             return Error_ESHUTDOWN;
         case EHOSTDOWN:
             return Error_EHOSTDOWN;
+#ifdef ENODATA // not available in FreeBSD
         case ENODATA:
             return Error_ENODATA;
+#endif
 
 // #if because these will trigger duplicate case label warnings when
 // they have the same value, which is permitted by POSIX and common.
@@ -508,8 +505,10 @@ inline static int32_t ConvertErrorPalToPlatform(int32_t error)
             return ESHUTDOWN;
         case Error_EHOSTDOWN:
             return EHOSTDOWN;
+#ifdef ENODATA // not available in FreeBSD
         case Error_ENODATA:
             return ENODATA;
+#endif
         case Error_EHOSTNOTFOUND:
             return EHOSTNOTFOUND;
         case Error_ESOCKETERROR:

--- a/src/libraries/Native/Unix/System.IO.Ports.Native/pal_serial.c
+++ b/src/libraries/Native/Unix/System.IO.Ports.Native/pal_serial.c
@@ -13,11 +13,6 @@
 #include <sys/socket.h>
 #include <pal_networking_common.h>
 
-// ENODATA is not defined in FreeBSD 10.3 but is defined in 11.0
-#if defined(__FreeBSD__) & !defined(ENODATA)
-#define ENODATA ENOATTR
-#endif
-
 /* Open device file in non-blocking mode and without controlling terminal */
 intptr_t SystemIoPortsNative_SerialPortOpen(const char * name)
 {

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.c
@@ -108,7 +108,7 @@ static void OpenLibraryOnce()
     }
 
     // FreeBSD uses a different suffix numbering convention.
-    // Current supported FreeBSD releases should use the order .11 -> .111 -> .8
+    // Current supported FreeBSD releases should use the order .11 -> .111
     if (libssl == NULL)
     {
         DlOpen(MAKELIB("11"));
@@ -117,11 +117,6 @@ static void OpenLibraryOnce()
     if (libssl == NULL)
     {
         DlOpen(MAKELIB("111"));
-    }
-
-    if (libssl == NULL)
-    {
-        DlOpen(MAKELIB("8"));
     }
 }
 

--- a/src/mono/mono/eventpipe/ds-rt-mono.c
+++ b/src/mono/mono/eventpipe/ds-rt-mono.c
@@ -49,6 +49,11 @@ ipc_get_process_id_disambiguation_key (
 #include <kvm.h>
 #endif
 
+#ifdef __FreeBSD__
+#include <sys/sysctl.h>
+#include <sys/user.h>
+#endif
+
 /*
 Get a numeric value that can be used to disambiguate between processes with the same PID,
 provided that one of them is still running. The numeric value can mean different things
@@ -68,7 +73,7 @@ ipc_get_process_id_disambiguation_key (
 
 	*key = 0;
 
-#if defined (__APPLE__)
+#if defined (__APPLE__) || defined (__FreeBSD__)
 	// On OS X, we return the process start time expressed in Unix time (the number of seconds
 	// since the start of the Unix epoch).
 	struct kinfo_proc info = {};
@@ -77,7 +82,11 @@ ipc_get_process_id_disambiguation_key (
 
 	const int result_sysctl = sysctl (mib, sizeof(mib)/sizeof(*mib), &info, &size, NULL, 0);
 	if (result_sysctl == 0) {
+#if defined (__APPLE__)
 		struct timeval proc_starttime = info.kp_proc.p_starttime;
+#else // __FreeBSD__
+		struct timeval proc_starttime = info.ki_start;
+#endif
 		long seconds_since_epoch = proc_starttime.tv_sec;
 		*key = seconds_since_epoch;
 		return true;

--- a/src/mono/mono/utils/mono-threads-freebsd.c
+++ b/src/mono/mono/utils/mono-threads-freebsd.c
@@ -9,7 +9,6 @@
 #include <mono/utils/mono-threads.h>
 #include <pthread.h>
 #include <pthread_np.h>
-#include <sys/thr.h>
 
 void
 mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize)
@@ -30,9 +29,7 @@ mono_threads_platform_get_stack_bounds (guint8 **staddr, size_t *stsize)
 guint64
 mono_native_thread_os_id_get (void)
 {
-	long tid;
-	thr_self (&tid);
-	return (guint64)tid;
+	return (guint64)pthread_getthreadid_np();
 }
 
 #else

--- a/src/mono/mono/utils/mono-threads-posix.c
+++ b/src/mono/mono/utils/mono-threads-posix.c
@@ -314,7 +314,11 @@ mono_native_thread_set_name (MonoNativeThreadId tid, const char *name)
 	if (!name) {
 		pthread_setname_np (tid, "");
 	} else {
+#if defined(__FreeBSD__)
+		char n [20];
+#else
 		char n [16];
+#endif
 
 		strncpy (n, name, sizeof (n) - 1);
 		n [sizeof (n) - 1] = '\0';


### PR DESCRIPTION
This builds and runs in Release but I've seen an assert in a Debug run that I'm still investigating. I just wanted to get some early feedback.

In particular is this line too messy/lazy? I think `HAVE_PTHREAD_GETTHREADID_NP ` is currently found for MacOS but it doesn't look in `pthread_np.h` where it's defined for FreeBSD. 

src/coreclr/gc/unix/gcenv.unix.cpp line 472
`#elif HAVE_PTHREAD_GETTHREADID_NP || defined(__FreeBSD__)`


#14537