### PR TITLE
[x86/Linux] Fix SIGSEGV on Debugger.Break() during debugging.

### DIFF
--- a/src/coreclr/debug/ee/frameinfo.cpp
+++ b/src/coreclr/debug/ee/frameinfo.cpp
@@ -2103,7 +2103,7 @@ StackWalkAction DebuggerWalkStack(Thread *thread,
 #endif
             memset((void *)&data, 0, sizeof(data));
 
-#if defined(TARGET_X86)
+#if !defined(FEATURE_EH_FUNCLETS)
             // @todo - this seems pointless. context->Eip will be 0; and when we copy it over to the DebuggerRD,
             // the context will be completely null.
             data.regDisplay.ControlPC = context->Eip;


### PR DESCRIPTION
SIGSEGV occur in src/vm/i386/cgenx86.cpp `HelperMethodFrame::UpdateRegDisplay()` at line `pRD->pCurrentContext->Eip = pRD->ControlPC = m_MachState.GetRetAddr();`, since `pRD->pCurrentContext` is NULL.
https://github.com/dotnet/runtime/blob/7691aa88ef3e7837e903ce95389e38a112a981c9/src/coreclr/vm/i386/cgenx86.cpp#L328

The point of issue - wrong code block compilation in DebuggerWalkStack() in case of Linux x86.
https://github.com/dotnet/runtime/blob/57bfe474518ab5b7cfe6bf7424a79ce3af9d6657/src/coreclr/debug/ee/frameinfo.cpp#L2106-L2123


CC @alpencolt