### PR TITLE
[mono][wasm] Rework the handling of GC references in AOTed code.

### DIFF
--- a/src/mono/mono/mini/ir-emit.h
+++ b/src/mono/mono/mini/ir-emit.h
@@ -61,11 +61,7 @@ alloc_ireg_ref (MonoCompile *cfg)
 		mono_mark_vreg_as_ref (cfg, vreg);
 
 #ifdef TARGET_WASM
-	/*
-	 * For GC stack scanning to work, have to spill all reference variables to the stack.
-	 */
-	MonoInst *ins = mono_compile_create_var_for_vreg (cfg, m_class_get_byval_arg (mono_get_object_class ()), OP_LOCAL, vreg);
-	ins->flags |= MONO_INST_VOLATILE;
+		mono_mark_vreg_as_ref (cfg, vreg);
 #endif
 
 	return vreg;

--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -669,6 +669,11 @@ mono_compile_create_var_for_vreg (MonoCompile *cfg, MonoType *type, int opcode, 
 			}
 		}
 	}
+
+#ifdef TARGET_WASM
+	if (mini_type_is_reference (type))
+		mono_mark_vreg_as_ref (cfg, vreg);
+#endif
 	
 	cfg->varinfo [num] = inst;
 


### PR DESCRIPTION
Previously, variables holding GC refs were marked volatile so they
were loaded/stored to the C stack on every access. Since the stack
is conservatively scanned, all the objects pointed to by it are pinned,
so there is no need to load them on every access. Instead of
marking them as volatile, allocate a 'gc pinning' area on the stack,
and store ref variables to it after they are assigned. This improves
code size and performance.