### PR TITLE
Change logic to not break private runs

### DIFF
--- a/eng/testing/performance/performance-setup.ps1
+++ b/eng/testing/performance/performance-setup.ps1
@@ -97,7 +97,11 @@ if ($iOSMono) {
 }
 
 # FIX ME: This is a workaround until we get this from the actual pipeline
-$CleanedBranchName = $Branch.replace('refs/heads/', '')
+$CleanedBranchName = "main"
+if($Branch.Contains("refs/heads/release"))
+{
+    $CleanedBranchName = $Branch.replace('refs/heads/', '')
+}
 $CommonSetupArguments="--channel $CleanedBranchName --queue $Queue --build-number $BuildNumber --build-configs $Configurations --architecture $Architecture"
 $SetupArguments = "--repository https://github.com/$Repository --branch $Branch --get-perf-hash --commit-sha $CommitSha $CommonSetupArguments"
 


### PR DESCRIPTION
The previous change here broke private runs as it required the channel map
to have an entry matching the name of the runtime branch you were testing.
This fix now defaults the channel to main for private runs.