### PR TITLE
Updated ConvertTo_String tests in System.Drawing.Common.Tests for null values

### DIFF
--- a/src/libraries/System.Drawing.Common/tests/System/Drawing/IconConverterTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/System/Drawing/IconConverterTests.cs
@@ -5,6 +5,7 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.Globalization;
 using System.IO;
+using System.Tests;
 using Xunit;
 
 namespace System.ComponentModel.TypeConverterTests
@@ -171,7 +172,14 @@ namespace System.ComponentModel.TypeConverterTests
             Assert.Throws<NotSupportedException>(() => _icoConvFrmTD.ConvertTo(null, CultureInfo.InvariantCulture, _icon, typeof(object)));
             Assert.Throws<NotSupportedException>(() => _icoConvFrmTD.ConvertTo(null, CultureInfo.InvariantCulture, _icon, typeof(int)));
 
-            Assert.Equal("(none)", (string)_icoConv.ConvertTo(null, typeof(string)));
+            using (new ThreadCultureChange(CultureInfo.CreateSpecificCulture("fr-FR"), CultureInfo.InvariantCulture))
+            {
+                Assert.Equal("(none)", (string)_icoConv.ConvertTo(null, typeof(string)));
+                Assert.Equal("(none)", (string)_icoConv.ConvertTo(null, CultureInfo.CreateSpecificCulture("ru-RU"), null, typeof(string)));
+
+                Assert.Equal("(none)", (string)_icoConvFrmTD.ConvertTo(null, typeof(string)));
+                Assert.Equal("(none)", (string)_icoConvFrmTD.ConvertTo(null, CultureInfo.CreateSpecificCulture("de-DE"), null, typeof(string)));
+            }
         }
     }
 }

--- a/src/libraries/System.Drawing.Common/tests/System/Drawing/ImageConverterTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/System/Drawing/ImageConverterTests.cs
@@ -5,6 +5,7 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.Globalization;
 using System.IO;
+using System.Tests;
 using Xunit;
 
 namespace System.ComponentModel.TypeConverterTests
@@ -137,8 +138,6 @@ namespace System.ComponentModel.TypeConverterTests
             Assert.Equal(_image.Height, newImage.Height);
             Assert.Equal(_image.Width, newImage.Width);
 
-            Assert.Equal("(none)", _imgConvFrmTD.ConvertTo(null, CultureInfo.InvariantCulture, null, typeof(string)));
-
             newImage = (Image)_imgConvFrmTD.ConvertFrom(null, CultureInfo.InvariantCulture, _imageBytes);
 
             Assert.Equal(_image.Height, newImage.Height);
@@ -170,6 +169,15 @@ namespace System.ComponentModel.TypeConverterTests
             Assert.Equal(_imageStr, (string)_imgConv.ConvertTo(_image, typeof(string)));
             Assert.Equal(_imageStr, (string)_imgConvFrmTD.ConvertTo(null, CultureInfo.InvariantCulture, _image, typeof(string)));
             Assert.Equal(_imageStr, (string)_imgConvFrmTD.ConvertTo(_image, typeof(string)));
+
+            using (new ThreadCultureChange(CultureInfo.CreateSpecificCulture("fr-FR"), CultureInfo.InvariantCulture))
+            {
+                Assert.Equal("(none)", (string)_imgConv.ConvertTo(null, typeof(string)));
+                Assert.Equal("(none)", (string)_imgConv.ConvertTo(null, CultureInfo.CreateSpecificCulture("ru-RU"), null, typeof(string)));
+
+                Assert.Equal("(none)", (string)_imgConvFrmTD.ConvertTo(null, typeof(string)));
+                Assert.Equal("(none)", (string)_imgConvFrmTD.ConvertTo(null, CultureInfo.CreateSpecificCulture("de-DE"), null, typeof(string)));
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]

--- a/src/libraries/System.Drawing.Common/tests/System/Drawing/ImageFormatConverterTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/System/Drawing/ImageFormatConverterTests.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Globalization;
+using System.Tests;
 using Xunit;
 
 namespace System.ComponentModel.TypeConverterTests
@@ -132,6 +133,12 @@ namespace System.ComponentModel.TypeConverterTests
 
             Assert.Equal(_imageFmtStr, (string)_imgFmtConvFrmTD.ConvertTo(null, CultureInfo.InvariantCulture, _imageFmt, typeof(string)));
             Assert.Equal(_imageFmtStr, (string)_imgFmtConvFrmTD.ConvertTo(_imageFmt, typeof(string)));
+
+            Assert.Equal(string.Empty, (string)_imgFmtConv.ConvertTo(null, typeof(string)));
+            Assert.Equal(string.Empty, (string)_imgFmtConv.ConvertTo(null, CultureInfo.CreateSpecificCulture("ru-RU"), null, typeof(string)));
+
+            Assert.Equal(string.Empty, (string)_imgFmtConvFrmTD.ConvertTo(null, typeof(string)));
+            Assert.Equal(string.Empty, (string)_imgFmtConvFrmTD.ConvertTo(null, CultureInfo.CreateSpecificCulture("de-DE"), null, typeof(string)));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]

--- a/src/libraries/System.Drawing.Common/tests/System/Drawing/Printing/MarginsConverterTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/System/Drawing/Printing/MarginsConverterTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
 using System.Globalization;
+using System.Tests;
 using Xunit;
 
 namespace System.Drawing.Printing.Tests
@@ -139,6 +140,9 @@ namespace System.Drawing.Printing.Tests
                 Assert.Throws<NotSupportedException>(() => mc.ConvertTo(context, culture, new object(), typeof(object)));
                 Assert.Throws<NotSupportedException>(() => mc.ConvertTo(context, culture, 12, typeof(int)));
                 Assert.Throws<NotSupportedException>(() => mc.ConvertTo(context, culture, guid, typeof(Guid)));
+
+                Assert.Equal(string.Empty, (string)mc.ConvertTo(null, typeof(string)));
+                Assert.Equal(string.Empty, (string)mc.ConvertTo(context, CultureInfo.CreateSpecificCulture("ru-RU"), null, typeof(string)));
             }
         }
 


### PR DESCRIPTION
I updated ConvertTo_String tests in System.Drawing.Common.Tests for null values to do not fail with non-English UI.

Fix #59333 issue.