### PR TITLE
[Release/6.0]fix the package version for non-shipping csproj packages

### DIFF
--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -31,8 +31,7 @@
 
   <PropertyGroup Condition="'$(ServicingVersion)' != ''">
     <!-- Always update the package version in servicing. -->
-    <PackageVersion>$(MajorVersion).$(MinorVersion).$(ServicingVersion)</PackageVersion>
-    <PackageVersion Condition="'$(VersionSuffix)' != ''">$(PackageVersion)-$(VersionSuffix)</PackageVersion>
+    <VersionPrefix>$(MajorVersion).$(MinorVersion).$(ServicingVersion)</VersionPrefix>
     <_IsWindowsDesktopApp Condition="$(WindowsDesktopCoreAppLibrary.Contains('$(AssemblyName);'))">true</_IsWindowsDesktopApp>
     <_IsAspNetCoreApp Condition="$(AspNetCoreAppLibrary.Contains('$(AssemblyName);'))">true</_IsAspNetCoreApp>
     <_AssemblyInTargetingPack Condition="'$(IsNETCoreAppSrc)' == 'true' or '$(_IsAspNetCoreApp)' == 'true' or '$(_IsWindowsDesktopApp)' == 'true'">true</_AssemblyInTargetingPack>

--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -32,6 +32,7 @@
   <PropertyGroup Condition="'$(ServicingVersion)' != ''">
     <!-- Always update the package version in servicing. -->
     <PackageVersion>$(MajorVersion).$(MinorVersion).$(ServicingVersion)</PackageVersion>
+    <PackageVersion Condition="'$(VersionSuffix)' != ''">$(PackageVersion)-$(VersionSuffix)</PackageVersion>
     <_IsWindowsDesktopApp Condition="$(WindowsDesktopCoreAppLibrary.Contains('$(AssemblyName);'))">true</_IsWindowsDesktopApp>
     <_IsAspNetCoreApp Condition="$(AspNetCoreAppLibrary.Contains('$(AssemblyName);'))">true</_IsAspNetCoreApp>
     <_AssemblyInTargetingPack Condition="'$(IsNETCoreAppSrc)' == 'true' or '$(_IsAspNetCoreApp)' == 'true' or '$(_IsWindowsDesktopApp)' == 'true'">true</_AssemblyInTargetingPack>


### PR DESCRIPTION
We override the Arcade package version with custom $(ServicingVersion) for each package, hence in some cases end up removing the version suffix
Version suffix is applied by the arcade whenever it is non-empty. Following the same convention here