### PR TITLE
Delete a legacy local for arm32.

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4009,10 +4009,6 @@ public:
         void CheckRetypedAsScalar(CORINFO_FIELD_HANDLE fieldHnd, var_types requestedType);
 #endif // DEBUG
 
-#ifdef TARGET_ARM
-        bool GetRequiresScratchVar();
-#endif // TARGET_ARM
-
     private:
         bool CanPromoteStructVar(unsigned lclNum);
         bool ShouldPromoteStructVar(unsigned lclNum);
@@ -4025,10 +4021,6 @@ public:
     private:
         Compiler*              compiler;
         lvaStructPromotionInfo structPromotionInfo;
-
-#ifdef TARGET_ARM
-        bool requiresScratchVar;
-#endif // TARGET_ARM
 
 #ifdef DEBUG
         typedef JitHashTable<CORINFO_FIELD_HANDLE, JitPtrKeyFuncs<CORINFO_FIELD_STRUCT_>, var_types>

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -1629,28 +1629,11 @@ bool Compiler::lvaFieldOffsetCmp::operator()(const lvaStructFieldInfo& field1, c
 Compiler::StructPromotionHelper::StructPromotionHelper(Compiler* compiler)
     : compiler(compiler)
     , structPromotionInfo()
-#ifdef TARGET_ARM
-    , requiresScratchVar(false)
-#endif // TARGET_ARM
 #ifdef DEBUG
     , retypedFieldsMap(compiler->getAllocator(CMK_DebugOnly))
 #endif // DEBUG
 {
 }
-
-#ifdef TARGET_ARM
-//--------------------------------------------------------------------------------------------
-// GetRequiresScratchVar - do we need a stack area to assemble small fields in order to place them in a register.
-//
-// Return value:
-//   true if there was a small promoted variable and scratch var is required .
-//
-bool Compiler::StructPromotionHelper::GetRequiresScratchVar()
-{
-    return requiresScratchVar;
-}
-
-#endif // TARGET_ARM
 
 //--------------------------------------------------------------------------------------------
 // TryPromoteStructVar - promote struct var if it is possible and profitable.
@@ -1843,14 +1826,6 @@ bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE 
         {
             // Don't promote vars whose struct types violates the invariant.  (Alignment == size for primitives.)
             return false;
-        }
-        // If we have any small fields we will allocate a single PromotedStructScratch local var for the method.
-        // This is a stack area that we use to assemble the small fields in order to place them in a register
-        // argument.
-        //
-        if (fieldInfo.fldSize < TARGET_POINTER_SIZE)
-        {
-            requiresScratchVar = true;
         }
 #endif // TARGET_ARM
     }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -16985,20 +16985,6 @@ void Compiler::fgPromoteStructs()
         }
     }
 
-#ifdef TARGET_ARM
-    if (structPromotionHelper->GetRequiresScratchVar())
-    {
-        // Ensure that the scratch variable is allocated, in case we
-        // pass a promoted struct as an argument.
-        if (lvaPromotedStructAssemblyScratchVar == BAD_VAR_NUM)
-        {
-            lvaPromotedStructAssemblyScratchVar =
-                lvaGrabTempWithImplicitUse(false DEBUGARG("promoted struct assembly scratch var."));
-            lvaTable[lvaPromotedStructAssemblyScratchVar].lvType = TYP_I_IMPL;
-        }
-    }
-#endif // TARGET_ARM
-
 #ifdef DEBUG
     if (verbose)
     {


### PR DESCRIPTION
arm32 diffs are ridiculous:
```
Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.arm\coreclr_tests.pmi.Linux.arm.checked.mch
 Total bytes of delta: -29750 (-0.61% of base)
 6510 total files with Code Size differences (6480 improved, 30 regressed), 812 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.arm\libraries.crossgen2.Linux.arm.checked.mch
 Total bytes of delta: -5052 (-0.52% of base)
 1422 total files with Code Size differences (1281 improved, 141 regressed), 1341 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.arm\libraries.pmi.Linux.arm.checked.mch
 Total bytes of delta: -19056 (-0.42% of base)
 5770 total files with Code Size differences (5222 improved, 548 regressed), 4956 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.arm\libraries_tests.pmi.Linux.arm.checked.mch
 Total bytes of delta: -102454 (-0.46% of base)
 31375 total files with Code Size differences (29448 improved, 1927 regressed), 5178 unchanged.
```

Diff example:
 ```diff
-; Total bytes of code 16, prolog size 12, PerfScore 7.60, instruction count 6
+; Total bytes of code 4, prolog size 2, PerfScore 2.40, instruction count 2

-G_M10046_IG01:        ; func=00, offs=000000H, size=000CH
+G_M10046_IG01:        ; func=00, offs=000000H, size=0002H

-IN0001: 000000      push    {lr}
-IN0002: 000002      sub     sp, 12
-IN0003: 000004      mov     lr, 0
-IN0004: 000008      str     lr, [sp+0x04]
+IN0001: 000000      push    {r3,lr}

-G_M10046_IG02:        ; offs=00000CH, size=0004H
+G_M10046_IG02:        ; offs=000002H, size=0002H

-IN0005: 00000C      add     sp, 12
-IN0006: 00000E      pop     {pc}
+IN0002: 000002      pop     {r3,pc}
```

The regressions are also improvements, we just reduce the size of `mustInitLcl` and sometimes replace loop with unroll that takes more instructions.

The use of this local stopped in https://github.com/dotnet/runtime/commit/3e131bf886af2844c6f74f1ee4bdf47eeb07d765, before it was used for LEGACY_BACKEND but not `#ifdef` with it.

