### PR TITLE
Improve ReliabilityFramework

### DIFF
--- a/src/tests/GC/Stress/Framework/ReliabilityConfiguration.cs
+++ b/src/tests/GC/Stress/Framework/ReliabilityConfiguration.cs
@@ -201,7 +201,13 @@ public class ReliabilityConfig : IEnumerable, IEnumerator
             // time span
             try
             {
-                returnValue = unchecked((int)(TimeSpan.Parse(timeValue).Ticks / TimeSpan.TicksPerMinute));
+                long ticks = TimeSpan.Parse(timeValue).Ticks;
+                returnValue = unchecked((int)(ticks / TimeSpan.TicksPerMinute));
+                if ((ticks != 0) && (returnValue == 0))
+                {
+                    // If the specified duration is less than a minute, run for at least a minute anyway.
+                    returnValue = 1;
+                }
             }
             catch
             {

--- a/src/tests/GC/Stress/Framework/ReliabilityFramework.cs
+++ b/src/tests/GC/Stress/Framework/ReliabilityFramework.cs
@@ -288,7 +288,6 @@ public class ReliabilityFramework
 
         GC.Collect(2);
         GC.WaitForPendingFinalizers();
-
         return (retVal);
     }
 

--- a/src/tests/GC/Stress/Framework/ReliabilityFramework.cs
+++ b/src/tests/GC/Stress/Framework/ReliabilityFramework.cs
@@ -59,6 +59,11 @@ internal class CustomAssemblyResolver : AssemblyLoadContext
         Console.WriteLine("CustomAssemblyLoader: Got request to load {0}", assemblyName.ToString());
 
         string strPath;
+        if (assemblyName.Name.StartsWith("System.Console"))
+        {
+            return null;
+        }
+        else
         if (assemblyName.Name.StartsWith("System."))
         {
             Console.WriteLine("CustomAssemblyLoader: this looks like a framework assembly");
@@ -283,8 +288,7 @@ public class ReliabilityFramework
 
         GC.Collect(2);
         GC.WaitForPendingFinalizers();
-        
-        Environment.Exit(0);
+
         return (retVal);
     }
 
@@ -944,6 +948,7 @@ public class ReliabilityFramework
             }
 
             Thread newThread = new Thread(new ParameterizedThreadStart(this.StartTestWorker));
+            newThread.IsBackground = true;
 
             // check the thread requirements and set appropriately.
             switch ((test.TestAttrs & TestAttributes.RequiresThread))

--- a/src/tests/GC/Stress/Framework/ReliabilityFramework.cs
+++ b/src/tests/GC/Stress/Framework/ReliabilityFramework.cs
@@ -33,55 +33,33 @@ internal class CustomAssemblyResolver : AssemblyLoadContext
 
     public CustomAssemblyResolver()
     {
-        Console.WriteLine("CustomAssemblyResolver initializing");
         _frameworkPath = Environment.GetEnvironmentVariable("BVT_ROOT");
         if (_frameworkPath == null)
         {
-            Console.WriteLine("CustomAssemblyResolver: BVT_ROOT not set");
             _frameworkPath = Environment.GetEnvironmentVariable("CORE_ROOT");
         }
 
         if (_frameworkPath == null)
         {
-            Console.WriteLine("CustomAssemblyResolver: CORE_ROOT not set");
             _frameworkPath = Directory.GetCurrentDirectory();
         }
 
-        Console.WriteLine("CustomAssemblyResolver: looking for framework libraries at path: {0}", _frameworkPath);
         string stressFrameworkDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-        Console.WriteLine("CustomAssemblyResolver: currently executing assembly is at path: {0}", stressFrameworkDir);
         _testsPath = Path.Combine(stressFrameworkDir, "Tests");
-        Console.WriteLine("CustomAssemblyResolver: looking for tests in dir: {0}", _testsPath);
     }
 
     protected override Assembly Load(AssemblyName assemblyName)
     {
-        Console.WriteLine("CustomAssemblyLoader: Got request to load {0}", assemblyName.ToString());
-
         string strPath;
-        if (assemblyName.Name.StartsWith("System.Console"))
-        {
-            return null;
-        }
-        else
         if (assemblyName.Name.StartsWith("System."))
         {
-            Console.WriteLine("CustomAssemblyLoader: this looks like a framework assembly");
             strPath = Path.Combine(_frameworkPath, assemblyName.Name + ".dll");
         }
         else
         {
-            Console.WriteLine("CustomAssemblyLoader: this looks like a test");
             strPath = Path.Combine(_testsPath, assemblyName.Name + ".dll");
         }
-
-        Console.WriteLine("Incoming AssemblyName: {0}", assemblyName.ToString());
-        Console.WriteLine("Trying to Load: {0}", strPath);
-        Console.WriteLine("Computed AssemblyName: {0}", GetAssemblyName(strPath).ToString());
         Assembly asmLoaded = LoadFromAssemblyPath(strPath);
-
-        Console.WriteLine("Loaded {0} from {1}", asmLoaded.FullName, asmLoaded.Location);
-
         return asmLoaded;
     }
 }
@@ -618,8 +596,6 @@ public class ReliabilityFramework
         // so we start new tests sooner (so they start BEFORE we drop below our minimum CPU)
 
         //Console.WriteLine("RF - TestStarter found {0} tests to run", totalTestsToRun);
-        if ((_curTestSet.DefaultTestStartMode != TestStartModeEnum.AssemblyLoadContextLoader) && (_curTestSet.SuppressConsoleOutputFromTests))
-            Console.SetOut(System.IO.TextWriter.Null);
 
         /************************************************************************
          * loop until we've run out of time or have executed all of the tests.
@@ -1509,32 +1485,21 @@ public class ReliabilityFramework
     /// <param name="paths"></param>
     private void TestPreLoader_Process(ReliabilityTest test, string[] paths)
     {
-        Console.WriteLine("Preloading for process mode");
-
-        Console.WriteLine("basepath: {0}, asm: {1}", test.BasePath, test.Assembly);
-        foreach (var path in paths)
-        {
-            Console.WriteLine(" path: {0}", path);
-        }
         string realpath = ReliabilityConfig.ConvertPotentiallyRelativeFilenameToFullPath(test.BasePath, test.Assembly);
         Debug.Assert(test.TestObject == null);
-        Console.WriteLine("Real path: {0}", realpath);
         if (File.Exists(realpath))
         {
             test.TestObject = realpath;
         }
         else if (File.Exists((string)test.Assembly))
         {
-            Console.WriteLine("asm path: {0}", test.Assembly);
             test.TestObject = test.Assembly;
         }
         else
         {
             foreach (string path in paths)
             {
-                Console.WriteLine("Candidate path: {0}", path);
                 string fullPath = ReliabilityConfig.ConvertPotentiallyRelativeFilenameToFullPath(path, (string)test.Assembly);
-                Console.WriteLine("Candidate full path: {0}", fullPath);
                 if (File.Exists(fullPath))
                 {
                     test.TestObject = fullPath;
@@ -1557,6 +1522,18 @@ public class ReliabilityFramework
             Type[] testTypes = AssemblyExtensions.GetTypes(testAssembly);
             MethodInfo methodInfo = null;
 
+            if (test.SuppressConsoleOutput)
+            {
+                // Console.SetOut(System.IO.TextWriter.Null);
+                Assembly consoleAssembly = resolver.LoadFromAssemblyPath(typeof(Console).Assembly.Location);
+                Type consoleType = consoleAssembly.GetType("System.Console");
+                MethodInfo setOutMethod = consoleType.GetMethod("SetOut", BindingFlags.Public | BindingFlags.Static);
+                Type textWriterType = setOutMethod.GetParameters()[0].ParameterType;
+                FieldInfo nullField = textWriterType.GetField("Null", BindingFlags.Public | BindingFlags.Static);
+                object nullInstance = nullField.GetValue(null);
+                setOutMethod.Invoke(null, new object[] { nullInstance });
+            }
+
             if (testTypes != null)
             {
                 foreach (Type t in testTypes)
@@ -1573,7 +1550,7 @@ public class ReliabilityFramework
             test.EntryPointMethod = methodInfo;
         }
     }
-        /// <summary>
+    /// <summary>
     /// This method will send a failure message to the test owner that their test has failed.
     /// </summary>
     /// <param name="testCase">the test case which failed</param>

--- a/src/tests/GC/Stress/Tests/RedBlackTree.cs
+++ b/src/tests/GC/Stress/Tests/RedBlackTree.cs
@@ -77,21 +77,21 @@ public class Tree
     {
         if (curr == null) return 0;
 
-        if(expectBalanced && notRed && curr.color == Color.Red)
+        if (expectBalanced && notRed && curr.color == Color.Red)
             TestLibrary.TestFramework.LogError("", "Rule 5: Red node, with red child, or red right child");
-        if (curr.parent != parent) 
-            TestLibrary.TestFramework.LogError("","Parent pointer has become corrupt.");
+        if (curr.parent != parent)
+            TestLibrary.TestFramework.LogError("", "Parent pointer has become corrupt.");
 
-        if(curr.left == null && curr.right != null)
+        if (curr.left == null && curr.right != null)
             TestLibrary.TestFramework.LogError("", "Not left leaning.");
 
-        if (curr.key > max && curr.key < min) 
+        if (curr.key > max && curr.key < min)
             TestLibrary.TestFramework.LogError("", "Rule 1: Tree is not sorted");
 
         var leftRank = CheckTreeRecursive(expectBalanced, curr.left, curr, min, curr.key, curr.color == Color.Red);
         var rightRank = CheckTreeRecursive(expectBalanced, curr.right, curr, curr.key, max, true);
 
-        if (expectBalanced && leftRank!=rightRank) 
+        if (expectBalanced && leftRank != rightRank)
             TestLibrary.TestFramework.LogError("", "Rule 6: Tree is not balanced");
 
         var currRank = curr.color == Color.Black ? leftRank + 1 : leftRank;
@@ -173,14 +173,15 @@ public class Tree
         }
     }
 
-    public void InsertNode(ref Node curr, Node newNode, Node parent) {
+    public void InsertNode(ref Node curr, Node newNode, Node parent)
+    {
         if (curr == null)
         {
             curr = newNode;
             newNode.parent = parent;
             return;
         }
-        
+
         if (newNode.key < curr.key)
         {
             InsertNode(ref curr.left, newNode, curr);
@@ -200,9 +201,9 @@ public class Tree
         InsertNode(ref _root, n, null);
 
         // Adjust tree after insertion
-        if(_root.color != Color.Black) 
+        if (_root.color != Color.Black)
             _root.color = Color.Black;
-        
+
         CheckTree(true);
     }
 
@@ -292,7 +293,7 @@ public class Tree
 
     public bool DeleteNode(ref Node n, int key)
     {
-        
+
         if (n.key != key && n.left == null && n.right == null)
         {
             Fixup(ref n);
@@ -300,14 +301,14 @@ public class Tree
         }
 
         var result = false;
-        if (n.key > key) 
-        { 
-            if(!IsRed(n.left) && !IsRed(n.left.left)) 
+        if (n.key > key)
+        {
+            if (!IsRed(n.left) && !IsRed(n.left.left))
                 MoveRedLeft(ref n);
-            
+
             result = DeleteNode(ref n.left, key);
-        } 
-        else 
+        }
+        else
         {
             if (IsRed(n.left)) RotateRight(ref n);
 
@@ -353,7 +354,7 @@ public class Tree
 
         if (!IsRed(curr.left) && !IsRed(curr.left.left))
             MoveRedLeft(ref curr);
-        
+
         min = DeleteMin(ref curr.left);
 
         Fixup(ref curr);
@@ -370,7 +371,7 @@ public class Tree
     public void PrintTree(Node r, String offset)
     {
         if (r == null) return;
-        
+
         offset = offset + " ";
 
         if (r.left != null) PrintTree(r.left, offset);

--- a/src/tests/GC/Stress/Tests/concurrentspin2.cs
+++ b/src/tests/GC/Stress/Tests/concurrentspin2.cs
@@ -156,7 +156,7 @@ internal class ConcurrentRepro
         ThreadStart startDelegate = new ThreadStart(priorityTest.RunTest);
 
         // create threads
-        Thread[] threads = new Thread[parameters[1]];        
+        Thread[] threads = new Thread[parameters[1]];
         for (int i = 0; i < threads.Length; i++)
         {
             threads[i] = new Thread(startDelegate);

--- a/src/tests/GC/Stress/Tests/concurrentspin2.cs
+++ b/src/tests/GC/Stress/Tests/concurrentspin2.cs
@@ -156,10 +156,11 @@ internal class ConcurrentRepro
         ThreadStart startDelegate = new ThreadStart(priorityTest.RunTest);
 
         // create threads
-        Thread[] threads = new Thread[parameters[1]];
+        Thread[] threads = new Thread[parameters[1]];        
         for (int i = 0; i < threads.Length; i++)
         {
             threads[i] = new Thread(startDelegate);
+            threads[i].IsBackground = true;
             threads[i].Name = String.Format("Thread{0}", i);
             //if (i % 2 == 0)
             //{

--- a/src/tests/GC/Stress/testmix_gc.config
+++ b/src/tests/GC/Stress/testmix_gc.config
@@ -11,7 +11,8 @@
             installDetours="false" 
             minimumTests="0" 
             minMaxTestUseCPUCount="true" 
-            suppressConsoleOutputFromTests="true">
+            suppressConsoleOutputFromTests="true"
+            debugBreakOnTestHang="true">
     <Assembly id="DirectedGraph.dll"
             successCode="100"
             filename="DirectedGraph.dll"


### PR DESCRIPTION
- If the test was configured to run for less than a minute, runs it for a minute anyway instead of running indefinitely.
- Logging the number of bgc and fgc by using private reflection.
- Make sure we successfully unload and preload the test again when all test completes.
- Make sure we terminate the process when the main thread exits
- Make sure `suppressConsoleOutputFromTests` works for `processLoader`. (@janvorli - now I suppressed all copies)
- Eliminated unnecessary console outputs.
- Found and fix some formatting issues.