### PR TITLE
Add notes about not calling src-gen APIs directly and make them non-browsable

### DIFF
--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -948,6 +948,7 @@ namespace System.Text.Json.Serialization
 }
 namespace System.Text.Json.Serialization.Metadata
 {
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public sealed partial class JsonCollectionInfoValues<TCollection>
     {
         public JsonCollectionInfoValues() { }
@@ -957,6 +958,7 @@ namespace System.Text.Json.Serialization.Metadata
         public System.Text.Json.Serialization.JsonNumberHandling NumberHandling { get { throw null; } init { } }
         public System.Action<System.Text.Json.Utf8JsonWriter, TCollection>? SerializeHandler { get { throw null; } init { } }
     }
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public static partial class JsonMetadataServices
     {
         public static System.Text.Json.Serialization.JsonConverter<bool> BooleanConverter { get { throw null; } }
@@ -1017,6 +1019,7 @@ namespace System.Text.Json.Serialization.Metadata
         public static System.Text.Json.Serialization.JsonConverter<T> GetEnumConverter<T>(System.Text.Json.JsonSerializerOptions options) where T : struct { throw null; }
         public static System.Text.Json.Serialization.JsonConverter<T?> GetNullableConverter<T>(System.Text.Json.Serialization.Metadata.JsonTypeInfo<T> underlyingTypeInfo) where T : struct { throw null; }
     }
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public sealed partial class JsonObjectInfoValues<T>
     {
         public JsonObjectInfoValues() { }
@@ -1027,6 +1030,7 @@ namespace System.Text.Json.Serialization.Metadata
         public System.Func<System.Text.Json.Serialization.JsonSerializerContext, System.Text.Json.Serialization.Metadata.JsonPropertyInfo[]>? PropertyMetadataInitializer { get { throw null; } init { } }
         public System.Action<System.Text.Json.Utf8JsonWriter, T>? SerializeHandler { get { throw null; } init { } }
     }
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public sealed partial class JsonParameterInfoValues
     {
         public JsonParameterInfoValues() { }
@@ -1036,10 +1040,12 @@ namespace System.Text.Json.Serialization.Metadata
         public System.Type ParameterType { get { throw null; } init { } }
         public int Position { get { throw null; } init { } }
     }
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public abstract partial class JsonPropertyInfo
     {
         internal JsonPropertyInfo() { }
     }
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public sealed partial class JsonPropertyInfoValues<T>
     {
         public JsonPropertyInfoValues() { }
@@ -1058,10 +1064,12 @@ namespace System.Text.Json.Serialization.Metadata
         public System.Text.Json.Serialization.Metadata.JsonTypeInfo PropertyTypeInfo { get { throw null; } init { } }
         public System.Action<object, T?>? Setter { get { throw null; } init { } }
     }
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public partial class JsonTypeInfo
     {
         internal JsonTypeInfo() { }
     }
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public abstract partial class JsonTypeInfo<T> : System.Text.Json.Serialization.Metadata.JsonTypeInfo
     {
         internal JsonTypeInfo() { }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonCollectionInfoValuesOfTCollection.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonCollectionInfoValuesOfTCollection.cs
@@ -1,37 +1,46 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel;
+
 namespace System.Text.Json.Serialization.Metadata
 {
     /// <summary>
     /// Provides serialization metadata about a collection type.
     /// </summary>
     /// <typeparam name="TCollection">The collection type.</typeparam>
+    /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public sealed class JsonCollectionInfoValues<TCollection>
     {
         /// <summary>
         /// A <see cref="Func{TResult}"/> to create an instance of the collection when deserializing.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public Func<TCollection>? ObjectCreator { get; init; }
 
         /// <summary>
         /// If a dictionary type, the <see cref="JsonTypeInfo"/> instance representing the key type.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public JsonTypeInfo? KeyInfo { get; init; }
 
         /// <summary>
         /// A <see cref="JsonTypeInfo"/> instance representing the element type.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public JsonTypeInfo ElementInfo { get; init; } = null!;
 
         /// <summary>
         /// The <see cref="JsonNumberHandling"/> option to apply to number collection elements.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public JsonNumberHandling NumberHandling { get; init; }
 
         /// <summary>
         /// An optimized serialization implementation assuming pre-determined <see cref="JsonSourceGenerationOptionsAttribute"/> defaults.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public Action<Utf8JsonWriter, TCollection>? SerializeHandler { get; init; }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Collections.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Collections.cs
@@ -17,6 +17,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <param name="options">The <see cref="JsonSerializerOptions"/> to use.</param>
         /// <param name="collectionInfo">Provides serialization metadata about the collection type.</param>
         /// <returns>Serialization metadata for the given type.</returns>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonTypeInfo<TElement[]> CreateArrayInfo<TElement>(JsonSerializerOptions options, JsonCollectionInfoValues<TElement[]> collectionInfo)
             => new JsonTypeInfoInternal<TElement[]>(
                 options,
@@ -31,6 +32,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <param name="options">The <see cref="JsonSerializerOptions"/> to use.</param>
         /// <param name="collectionInfo">Provides serialization metadata about the collection type.</param>
         /// <returns>Serialization metadata for the given type.</returns>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonTypeInfo<TCollection> CreateListInfo<TCollection, TElement>(
             JsonSerializerOptions options,
             JsonCollectionInfoValues<TCollection> collectionInfo)
@@ -49,6 +51,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <param name="options"></param>
         /// <param name="collectionInfo">Provides serialization metadata about the collection type.</param>
         /// <returns>Serialization metadata for the given type.</returns>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonTypeInfo<TCollection> CreateDictionaryInfo<TCollection, TKey, TValue>(
             JsonSerializerOptions options,
             JsonCollectionInfoValues<TCollection> collectionInfo)
@@ -72,6 +75,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <param name="collectionInfo">Provides serialization metadata about the collection type.</param>
         /// <param name="createRangeFunc">A method to create an immutable dictionary instance.</param>
         /// <returns>Serialization metadata for the given type.</returns>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
 #pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
         public static JsonTypeInfo<TCollection> CreateImmutableDictionaryInfo<TCollection, TKey, TValue>(
             JsonSerializerOptions options,
@@ -94,6 +98,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <param name="options"></param>
         /// <param name="collectionInfo">Provides serialization metadata about the collection type.</param>
         /// <returns>Serialization metadata for the given type.</returns>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonTypeInfo<TCollection> CreateIDictionaryInfo<TCollection, TKey, TValue>(
             JsonSerializerOptions options,
             JsonCollectionInfoValues<TCollection> collectionInfo)
@@ -113,6 +118,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <param name="options"></param>
         /// <param name="collectionInfo">Provides serialization metadata about the collection type.</param>
         /// <returns>Serialization metadata for the given type.</returns>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonTypeInfo<TCollection> CreateIReadOnlyDictionaryInfo<TCollection, TKey, TValue>(
             JsonSerializerOptions options,
             JsonCollectionInfoValues<TCollection> collectionInfo)
@@ -133,6 +139,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <param name="collectionInfo">Provides serialization metadata about the collection type.</param>
         /// <param name="createRangeFunc">A method to create an immutable dictionary instance.</param>
         /// <returns>Serialization metadata for the given type.</returns>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
 #pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
         public static JsonTypeInfo<TCollection> CreateImmutableEnumerableInfo<TCollection, TElement>(
             JsonSerializerOptions options,
@@ -152,6 +159,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <param name="options"></param>
         /// <param name="collectionInfo">Provides serialization metadata about the collection type.</param>
         /// <returns>Serialization metadata for the given type.</returns>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonTypeInfo<TCollection> CreateIListInfo<TCollection>(
             JsonSerializerOptions options,
             JsonCollectionInfoValues<TCollection> collectionInfo)
@@ -169,6 +177,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <param name="options"></param>
         /// <param name="collectionInfo">Provides serialization metadata about the collection type.</param>
         /// <returns>Serialization metadata for the given type.</returns>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonTypeInfo<TCollection> CreateIListInfo<TCollection, TElement>(
             JsonSerializerOptions options,
             JsonCollectionInfoValues<TCollection> collectionInfo)
@@ -186,6 +195,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <param name="options"></param>
         /// <param name="collectionInfo">Provides serialization metadata about the collection type.</param>
         /// <returns>Serialization metadata for the given type.</returns>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonTypeInfo<TCollection> CreateISetInfo<TCollection, TElement>(
             JsonSerializerOptions options,
             JsonCollectionInfoValues<TCollection> collectionInfo)
@@ -203,6 +213,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <param name="options"></param>
         /// <param name="collectionInfo">Provides serialization metadata about the collection type.</param>
         /// <returns>Serialization metadata for the given type.</returns>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonTypeInfo<TCollection> CreateICollectionInfo<TCollection, TElement>(
             JsonSerializerOptions options,
             JsonCollectionInfoValues<TCollection> collectionInfo)
@@ -220,6 +231,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <param name="options"></param>
         /// <param name="collectionInfo">Provides serialization metadata about the collection type.</param>
         /// <returns>Serialization metadata for the given type.</returns>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonTypeInfo<TCollection> CreateStackInfo<TCollection, TElement>(
             JsonSerializerOptions options,
             JsonCollectionInfoValues<TCollection> collectionInfo)
@@ -237,6 +249,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <param name="options"></param>
         /// <param name="collectionInfo">Provides serialization metadata about the collection type.</param>
         /// <returns>Serialization metadata for the given type.</returns>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonTypeInfo<TCollection> CreateQueueInfo<TCollection, TElement>(
             JsonSerializerOptions options,
             JsonCollectionInfoValues<TCollection> collectionInfo)
@@ -254,6 +267,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <param name="options"></param>
         /// <param name="collectionInfo">Provides serialization metadata about the collection type.</param>
         /// <returns>Serialization metadata for the given type.</returns>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonTypeInfo<TCollection> CreateConcurrentStackInfo<TCollection, TElement>(
             JsonSerializerOptions options,
             JsonCollectionInfoValues<TCollection> collectionInfo)
@@ -271,6 +285,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <param name="options"></param>
         /// <param name="collectionInfo">Provides serialization metadata about the collection type.</param>
         /// <returns>Serialization metadata for the given type.</returns>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonTypeInfo<TCollection> CreateConcurrentQueueInfo<TCollection, TElement>(
             JsonSerializerOptions options,
             JsonCollectionInfoValues<TCollection> collectionInfo)
@@ -288,6 +303,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <param name="options"></param>
         /// <param name="collectionInfo">Provides serialization metadata about the collection type.</param>
         /// <returns>Serialization metadata for the given type.</returns>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonTypeInfo<TCollection> CreateIEnumerableInfo<TCollection, TElement>(
             JsonSerializerOptions options,
             JsonCollectionInfoValues<TCollection> collectionInfo)
@@ -304,6 +320,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <param name="options"></param>
         /// <param name="collectionInfo">Provides serialization metadata about the collection type.</param>
         /// <returns>Serialization metadata for the given type.</returns>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonTypeInfo<TCollection> CreateIDictionaryInfo<TCollection>(
             JsonSerializerOptions options,
             JsonCollectionInfoValues<TCollection> collectionInfo)
@@ -322,6 +339,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <param name="collectionInfo">Provides serialization metadata about the collection type.</param>
         /// <param name="addFunc">A method for adding elements to the collection when using the serializer's code-paths.</param>
         /// <returns>Serialization metadata for the given type.</returns>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
 #pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
         public static JsonTypeInfo<TCollection> CreateStackInfo<TCollection>(
             JsonSerializerOptions options,
@@ -339,6 +357,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <param name="collectionInfo">Provides serialization metadata about the collection type.</param>
         /// <param name="addFunc">A method for adding elements to the collection when using the serializer's code-paths.</param>
         /// <returns>Serialization metadata for the given type.</returns>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
 #pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
         public static JsonTypeInfo<TCollection> CreateQueueInfo<TCollection>(
             JsonSerializerOptions options,
@@ -366,6 +385,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <param name="options"></param>
         /// <param name="collectionInfo">Provides serialization metadata about the collection type.</param>
         /// <returns>Serialization metadata for the given type.</returns>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonTypeInfo<TCollection> CreateIEnumerableInfo<TCollection>(
             JsonSerializerOptions options,
             JsonCollectionInfoValues<TCollection> collectionInfo)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Converters.cs
@@ -12,120 +12,140 @@ namespace System.Text.Json.Serialization.Metadata
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="bool"/> values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonConverter<bool> BooleanConverter => s_booleanConverter ??= new BooleanConverter();
         private static JsonConverter<bool>? s_booleanConverter;
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts byte array values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonConverter<byte[]> ByteArrayConverter => s_byteArrayConverter ??= new ByteArrayConverter();
         private static JsonConverter<byte[]>? s_byteArrayConverter;
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="byte"/> values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonConverter<byte> ByteConverter => s_byteConverter ??= new ByteConverter();
         private static JsonConverter<byte>? s_byteConverter;
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="char"/> values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonConverter<char> CharConverter => s_charConverter ??= new CharConverter();
         private static JsonConverter<char>? s_charConverter;
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="DateTime"/> values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonConverter<DateTime> DateTimeConverter => s_dateTimeConverter ??= new DateTimeConverter();
         private static JsonConverter<DateTime>? s_dateTimeConverter;
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="DateTimeOffset"/> values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonConverter<DateTimeOffset> DateTimeOffsetConverter => s_dateTimeOffsetConverter ??= new DateTimeOffsetConverter();
         private static JsonConverter<DateTimeOffset>? s_dateTimeOffsetConverter;
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="decimal"/> values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonConverter<decimal> DecimalConverter => s_decimalConverter ??= new DecimalConverter();
         private static JsonConverter<decimal>? s_decimalConverter;
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="double"/> values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonConverter<double> DoubleConverter => s_doubleConverter ??= new DoubleConverter();
         private static JsonConverter<double>? s_doubleConverter;
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="Guid"/> values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonConverter<Guid> GuidConverter => s_guidConverter ??= new GuidConverter();
         private static JsonConverter<Guid>? s_guidConverter;
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="short"/> values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonConverter<short> Int16Converter => s_int16Converter ??= new Int16Converter();
         private static JsonConverter<short>? s_int16Converter;
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="int"/> values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonConverter<int> Int32Converter => s_int32Converter ??= new Int32Converter();
         private static JsonConverter<int>? s_int32Converter;
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="long"/> values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonConverter<long> Int64Converter => s_int64Converter ??= new Int64Converter();
         private static JsonConverter<long>? s_int64Converter;
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="JsonArray"/> values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonConverter<JsonArray> JsonArrayConverter => s_jsonArrayConverter ??= new JsonArrayConverter();
         private static JsonConverter<JsonArray>? s_jsonArrayConverter;
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="JsonElement"/> values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonConverter<JsonElement> JsonElementConverter => s_jsonElementConverter ??= new JsonElementConverter();
         private static JsonConverter<JsonElement>? s_jsonElementConverter;
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="JsonNode"/> values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonConverter<JsonNode> JsonNodeConverter => s_jsonNodeConverter ??= new JsonNodeConverter();
         private static JsonConverter<JsonNode>? s_jsonNodeConverter;
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="JsonObject"/> values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonConverter<JsonObject> JsonObjectConverter => s_jsonObjectConverter ??= new JsonObjectConverter();
         private static JsonConverter<JsonObject>? s_jsonObjectConverter;
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="JsonArray"/> values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonConverter<JsonValue> JsonValueConverter => s_jsonValueConverter ??= new JsonValueConverter();
         private static JsonConverter<JsonValue>? s_jsonValueConverter;
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="object"/> values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonConverter<object?> ObjectConverter => s_objectConverter ??= new ObjectConverter();
         private static JsonConverter<object?>? s_objectConverter;
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="float"/> values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonConverter<float> SingleConverter => s_singleConverter ??= new SingleConverter();
         private static JsonConverter<float>? s_singleConverter;
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="sbyte"/> values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         [CLSCompliant(false)]
         public static JsonConverter<sbyte> SByteConverter => s_sbyteConverter ??= new SByteConverter();
         private static JsonConverter<sbyte>? s_sbyteConverter;
@@ -133,18 +153,21 @@ namespace System.Text.Json.Serialization.Metadata
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="string"/> values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonConverter<string> StringConverter => s_stringConverter ??= new StringConverter();
         private static JsonConverter<string>? s_stringConverter;
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="TimeSpan"/> values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonConverter<TimeSpan> TimeSpanConverter => s_timeSpanConverter ??= new TimeSpanConverter();
         private static JsonConverter<TimeSpan>? s_timeSpanConverter;
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="ushort"/> values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         [CLSCompliant(false)]
         public static JsonConverter<ushort> UInt16Converter => s_uint16Converter ??= new UInt16Converter();
         private static JsonConverter<ushort>? s_uint16Converter;
@@ -152,6 +175,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="uint"/> values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         [CLSCompliant(false)]
         public static JsonConverter<uint> UInt32Converter => s_uint32Converter ??= new UInt32Converter();
         private static JsonConverter<uint>? s_uint32Converter;
@@ -159,6 +183,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="ulong"/> values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         [CLSCompliant(false)]
         public static JsonConverter<ulong> UInt64Converter => s_uint64Converter ??= new UInt64Converter();
         private static JsonConverter<ulong>? s_uint64Converter;
@@ -166,12 +191,14 @@ namespace System.Text.Json.Serialization.Metadata
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="Uri"/> values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonConverter<Uri> UriConverter => s_uriConverter ??= new UriConverter();
         private static JsonConverter<Uri>? s_uriConverter;
 
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="Version"/> values.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonConverter<Version> VersionConverter => s_versionConverter ??= new VersionConverter();
         private static JsonConverter<Version>? s_versionConverter;
 
@@ -180,6 +207,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// </summary>
         /// <typeparam name="T">The generic definition for the type.</typeparam>
         /// <returns>A <see cref="JsonConverter{T}"/> instance that throws <see cref="NotSupportedException"/></returns>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonConverter<T> GetUnsupportedTypeConverter<T>()
             => new UnsupportedTypeConverter<T>();
 
@@ -189,6 +217,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <typeparam name="T">The generic definition for the enum type.</typeparam>
         /// <param name="options">The <see cref="JsonSerializerOptions"/> to use for serialization and deserialization.</param>
         /// <returns>A <see cref="JsonConverter{T}"/> instance that converts <typeparamref name="T"/> values.</returns>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonConverter<T> GetEnumConverter<T>(JsonSerializerOptions options) where T : struct, Enum
             => new EnumConverter<T>(EnumConverterOptions.AllowNumbers, options ?? throw new ArgumentNullException(nameof(options)));
 
@@ -198,6 +227,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <typeparam name="T">The generic definition for the underlying nullable type.</typeparam>
         /// <param name="underlyingTypeInfo">Serialization metadata for the underlying nullable type.</param>
         /// <returns>A <see cref="JsonConverter{T}"/> instance that converts <typeparamref name="T?"/> values</returns>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonConverter<T?> GetNullableConverter<T>(JsonTypeInfo<T> underlyingTypeInfo) where T : struct
         {
             if (underlyingTypeInfo == null)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.cs
@@ -8,6 +8,7 @@ namespace System.Text.Json.Serialization.Metadata
     /// <summary>
     /// Provides helpers to create and initialize metadata for JSON-serializable types.
     /// </summary>
+    /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static partial class JsonMetadataServices
     {
@@ -18,6 +19,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <param name="options">The <see cref="JsonSerializerOptions"/> to initialize the metadata with.</param>
         /// <param name="propertyInfo">Provides serialization metadata about the property or field.</param>
         /// <returns>A <see cref="JsonPropertyInfo"/> instance intialized with the provided metadata.</returns>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonPropertyInfo CreatePropertyInfo<T>(JsonSerializerOptions options, JsonPropertyInfoValues<T> propertyInfo)
         {
             if (options == null)
@@ -76,6 +78,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// <typeparam name="T">The type of the class or struct.</typeparam>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="options"/> or <paramref name="objectInfo"/> is null.</exception>
         /// <returns>A <see cref="JsonTypeInfo{T}"/> instance representing the class or struct.</returns>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonTypeInfo<T> CreateObjectInfo<T>(JsonSerializerOptions options, JsonObjectInfoValues<T> objectInfo) where T : notnull
             => new JsonTypeInfoInternal<T>(
                 options ?? throw new ArgumentNullException(nameof(options)),
@@ -86,6 +89,7 @@ namespace System.Text.Json.Serialization.Metadata
         /// </summary>
         /// <typeparam name="T">The generic type definition.</typeparam>
         /// <returns>A <see cref="JsonTypeInfo{T}"/> instance representing the type.</returns>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public static JsonTypeInfo<T> CreateValueInfo<T>(JsonSerializerOptions options, JsonConverter converter)
         {
             JsonTypeInfo<T> info = new JsonTypeInfoInternal<T>(options);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonObjectInfoValuesOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonObjectInfoValuesOfT.cs
@@ -1,42 +1,52 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel;
+
 namespace System.Text.Json.Serialization.Metadata
 {
     /// <summary>
     /// Provides serialization metadata about an object type with constructors, properties, and fields.
     /// </summary>
     /// <typeparam name="T">The object type to serialize or deserialize.</typeparam>
+    /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public sealed class JsonObjectInfoValues<T>
     {
         /// <summary>
         /// Provides a mechanism to create an instance of the class or struct when deserializing, using a parameterless constructor.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public Func<T>? ObjectCreator { get; init; }
 
         /// <summary>
         /// Provides a mechanism to create an instance of the class or struct when deserializing, using a parameterized constructor.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public Func<object[], T>? ObjectWithParameterizedConstructorCreator { get; init; }
 
         /// <summary>
         /// Provides a mechanism to initialize metadata for properties and fields of the class or struct.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public Func<JsonSerializerContext, JsonPropertyInfo[]>? PropertyMetadataInitializer { get; init; }
 
         /// <summary>
         /// Provides a mechanism to initialize metadata for a parameterized constructor of the class or struct to be used when deserializing.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public Func<JsonParameterInfoValues[]>? ConstructorParameterMetadataInitializer { get; init; }
 
         /// <summary>
         /// Specifies how number properties and fields should be processed when serializing and deserializing.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public JsonNumberHandling NumberHandling { get; init; }
 
         /// <summary>
         /// Provides a serialization implementation for instances of the class or struct which assumes options specified by <see cref="JsonSourceGenerationOptionsAttribute"/>.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public Action<Utf8JsonWriter, T>? SerializeHandler { get; init; }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonParameterInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonParameterInfo.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Reflection;
 
 namespace System.Text.Json.Serialization.Metadata
 {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonParameterInfoValues.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonParameterInfoValues.cs
@@ -1,36 +1,45 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel;
+
 namespace System.Text.Json.Serialization.Metadata
 {
     /// <summary>
     /// Provides information about a constructor parameter required for JSON deserialization.
     /// </summary>
+    /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public sealed class JsonParameterInfoValues
     {
         /// <summary>
         /// The name of the parameter.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public string Name { get; init; } = null!;
 
         /// <summary>
         /// The type of the parameter.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public Type ParameterType { get; init; } = null!;
 
         /// <summary>
         /// The zero-based position of the parameter in the formal parameter list.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public int Position { get; init; }
 
         /// <summary>
         /// Whether a default value was specified for the parameter.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public bool HasDefaultValue { get; init; }
 
         /// <summary>
         /// The default value of the parameter.
         /// </summary>
+        /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
         public object? DefaultValue { get; init; }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -12,7 +13,9 @@ namespace System.Text.Json.Serialization.Metadata
     /// <summary>
     /// Provides JSON serialization-related metadata about a type.
     /// </summary>
+    /// <remarks>This API is for use by the output of the System.Text.Json source generator and should not be called directly.</remarks>
     [DebuggerDisplay("ConverterStrategy.{ConverterStrategy}, {Type.Name}")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public partial class JsonTypeInfo
     {
         internal const string JsonObjectTypeName = "System.Text.Json.Nodes.JsonObject";


### PR DESCRIPTION
The notes about not calling the APIs directly will be ported to dotnet/dotnet-api-docs for 6.0.