### PR TITLE
Fix FileSystemAclExtensions.Create when passing a null FileSecurity

### DIFF
--- a/src/libraries/System.IO.FileSystem.AccessControl/ref/System.IO.FileSystem.AccessControl.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/ref/System.IO.FileSystem.AccessControl.cs
@@ -9,7 +9,7 @@ namespace System.IO
     public static partial class FileSystemAclExtensions
     {
         public static void Create(this System.IO.DirectoryInfo directoryInfo, System.Security.AccessControl.DirectorySecurity directorySecurity) { }
-        public static System.IO.FileStream Create(this System.IO.FileInfo fileInfo, System.IO.FileMode mode, System.Security.AccessControl.FileSystemRights rights, System.IO.FileShare share, int bufferSize, System.IO.FileOptions options, System.Security.AccessControl.FileSecurity fileSecurity) { throw null; }
+        public static System.IO.FileStream Create(this System.IO.FileInfo fileInfo, System.IO.FileMode mode, System.Security.AccessControl.FileSystemRights rights, System.IO.FileShare share, int bufferSize, System.IO.FileOptions options, System.Security.AccessControl.FileSecurity? fileSecurity) { throw null; }
         public static System.IO.DirectoryInfo CreateDirectory(this System.Security.AccessControl.DirectorySecurity directorySecurity, string path) { throw null; }
         public static System.Security.AccessControl.DirectorySecurity GetAccessControl(this System.IO.DirectoryInfo directoryInfo) { throw null; }
         public static System.Security.AccessControl.DirectorySecurity GetAccessControl(this System.IO.DirectoryInfo directoryInfo, System.Security.AccessControl.AccessControlSections includeSections) { throw null; }

--- a/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
@@ -340,7 +340,9 @@ namespace System.IO
                 SafeFileHandle handle;
                 using (DisableMediaInsertionPrompt.Create())
                 {
-                    handle = Interop.Kernel32.CreateFile(fullPath, (int)rights, share, secAttrs, mode, flagsAndAttributes, IntPtr.Zero);
+                    // The Inheritable bit is only set in the SECURITY_ATTRIBUTES struct,
+                    // and should not be passed to the CreateFile P/Invoke.
+                    handle = Interop.Kernel32.CreateFile(fullPath, (int)rights, (share & ~FileShare.Inheritable), secAttrs, mode, flagsAndAttributes, IntPtr.Zero);
                     ValidateFileHandle(handle, fullPath);
                 }
                 return handle;

--- a/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/System/IO/FileSystemAclExtensions.cs
@@ -297,7 +297,6 @@ namespace System.IO
             (rights & FileSystemRights.Synchronize) != 0 ||
             ((int)rights & Interop.Kernel32.GenericOperations.GENERIC_WRITE) != 0;
 
-
         private static unsafe SafeFileHandle CreateFileHandle(string fullPath, FileMode mode, FileSystemRights rights, FileShare share, FileOptions options, FileSecurity? security)
         {
             Debug.Assert(fullPath != null);

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
@@ -289,10 +289,11 @@ namespace System.IO
                 CreateFileWithSecurity(info, FileMode.CreateNew, FileSystemRights.WriteData, FileShare.Delete, DefaultBufferSize, FileOptions.None, security));
         }
 
-        [Fact]
-        public void FileInfo_Create_NullFileSecurity()
+        [Theory]
+        [MemberData(nameof(ValidArgumentsWriteableStreamNullFileSecurity))]
+        public void FileInfo_Create_NullFileSecurity(FileMode mode, FileSystemRights rights, FileShare share, int bufferSize)
         {
-            Verify_FileSecurity_CreateFile(expectedSecurity: null);
+            Verify_FileSecurity_CreateFile(mode, rights, share, bufferSize, FileOptions.None, expectedSecurity: null);
         }
 
         [Fact]
@@ -546,6 +547,29 @@ namespace System.IO
             // yield return new object[] { FileSystemRights.WriteData }; // WriteData == CreateFiles
             yield return new object[] { FileSystemRights.WriteExtendedAttributes };
         }
+
+        private static readonly FileSystemRights[] s_writeableFileSystemRights = new[]
+        {
+            FileSystemRights.WriteData,
+            FileSystemRights.AppendData,
+            FileSystemRights.WriteExtendedAttributes,
+            FileSystemRights.DeleteSubdirectoriesAndFiles,
+            FileSystemRights.WriteAttributes,
+            FileSystemRights.Delete,
+            FileSystemRights.ChangePermissions,
+            FileSystemRights.TakeOwnership,
+            FileSystemRights.Synchronize,
+            FileSystemRights.FullControl,
+            FileSystemRights.Modify,
+            FileSystemRights.Write
+        };
+
+        public static IEnumerable<object[]> ValidArgumentsWriteableStreamNullFileSecurity() =>
+            from mode in new[] { FileMode.Create, FileMode.CreateNew, FileMode.OpenOrCreate }
+            from rights in s_writeableFileSystemRights
+            from share in new[] { FileShare.None, FileShare.Read, FileShare.Write, FileShare.ReadWrite }
+            from bufferSize in new[] { 1, DefaultBufferSize }
+            select new object[] { mode, rights, share, bufferSize };
 
         private void Verify_FileSecurity_CreateFile(FileSecurity expectedSecurity)
         {

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
@@ -292,10 +292,7 @@ namespace System.IO
         [Fact]
         public void FileInfo_Create_NullFileSecurity()
         {
-            var info = new FileInfo("path");
-
-            Assert.Throws<ArgumentNullException>("fileSecurity", () =>
-                CreateFileWithSecurity(info, FileMode.CreateNew, FileSystemRights.WriteData, FileShare.Delete, DefaultBufferSize, FileOptions.None, null));
+            Verify_FileSecurity_CreateFile(expectedSecurity: null);
         }
 
         [Fact]
@@ -380,7 +377,8 @@ namespace System.IO
             }
             else
             {
-                info.Create(mode, rights, share, bufferSize, options, security);
+                info.Create(mode, rights, share, bufferSize, options, security).Dispose();
+                Assert.True(info.Exists);
             }
         }
 
@@ -410,7 +408,6 @@ namespace System.IO
             FileSecurity actualSecurity = actualInfo.GetAccessControl(AccessControlSections.Access);
             VerifyAccessSecurity(expectedSecurity, actualSecurity);
         }
-
 
         [Theory]
         [MemberData(nameof(RightsToDeny))]
@@ -565,9 +562,12 @@ namespace System.IO
             Assert.True(fileInfo.Exists);
             tempRootDir.CreatedSubfiles.Add(fileInfo);
 
-            var actualFileInfo = new FileInfo(path);
-            FileSecurity actualSecurity = actualFileInfo.GetAccessControl(AccessControlSections.Access);
-            VerifyAccessSecurity(expectedSecurity, actualSecurity);
+            if (expectedSecurity != null)
+            {
+                var actualFileInfo = new FileInfo(path);
+                FileSecurity actualSecurity = actualFileInfo.GetAccessControl(AccessControlSections.Access);
+                VerifyAccessSecurity(expectedSecurity, actualSecurity);
+            }
         }
 
         private void Verify_DirectorySecurity_CreateDirectory(DirectorySecurity expectedSecurity)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/57768

Fixes in this PR:

- The ACL extension method `FileStream.Create` should accept a `null` `FileSecurity` parameter so the behavior can match .NET Framework. The ref definition had to be changed to a nullable parameter. @bartonjs @GrabYourPitchforks @stephentoub  Do I need to go through API review to request this change or can we validate it here? ~This will be marked as a breaking change because an exception case was removed~.

- `FileStream` throws `ArgumentOutOfRangeException` if the passed `FileAccess` is not valid. In .NET Framework, this was not a problem because all the ACL logic was contained within the `FileStream` constructor, so it was possible to simply pass the `FileSystemRights` enum value casted as a `FileAccess` enum value to the p/invoke. Here, the ACL logic is in an extension method, and we don't want to do such casting. To address this, I am now _mapping_ all the writeable `FileSystemRights` values to a `FileAccess` write or read value. I left a detailed explanation [here](https://github.com/dotnet/runtime/issues/57768#issuecomment-923503098) of what we were doing before.

- Additional bug fix: The `FileShare.Inheritable` bit needs to be saved in the `SECURITY_ATTRIBUTES` struct (we are already doing this), but should not be passed to the `CreateFile` P/Invoke (we were not doing this). Otherwise, the P/Invoke causes an `IOException` to be thrown with the message `The parameter is incorrect`.

- Added unit tests to verify all the write combinations when the `FileSecurity` argument is `null`, which also includes the code example in the original issue.