### PR TITLE
Fix gtCloneExpr when cloning during R2R compilation a GT_ALLOCOBJ node

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -7461,6 +7461,7 @@ GenTreeAllocObj* Compiler::gtNewAllocObjNode(CORINFO_RESOLVED_TOKEN* pResolvedTo
 #ifdef FEATURE_READYTORUN
     if (usingReadyToRunHelper)
     {
+        assert(lookup.addr != nullptr);
         allocObj->gtEntryPoint = lookup;
     }
 #endif
@@ -7865,6 +7866,9 @@ GenTree* Compiler::gtCloneExpr(
                 copy                        = new (this, GT_ALLOCOBJ)
                     GenTreeAllocObj(tree->TypeGet(), asAllocObj->gtNewHelper, asAllocObj->gtHelperHasSideEffects,
                                     asAllocObj->gtAllocObjClsHnd, asAllocObj->gtOp1);
+#ifdef FEATURE_READYTORUN
+                copy->AsAllocObj()->gtEntryPoint = asAllocObj->gtEntryPoint;
+#endif
             }
             break;
 

--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -481,6 +481,10 @@ GenTree* ObjectAllocator::MorphAllocObjNodeIntoHelperCall(GenTreeAllocObj* alloc
         assert(comp->opts.IsReadyToRun());
         helperCall->AsCall()->setEntryPoint(entryPoint);
     }
+    else
+    {
+        assert(helper != CORINFO_HELP_READYTORUN_NEW); // If this is true, then we should have collected a non-null entrypoint above
+    }
 #endif
 
     return helperCall;

--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -483,7 +483,8 @@ GenTree* ObjectAllocator::MorphAllocObjNodeIntoHelperCall(GenTreeAllocObj* alloc
     }
     else
     {
-        assert(helper != CORINFO_HELP_READYTORUN_NEW); // If this is true, then we should have collected a non-null entrypoint above
+        assert(helper != CORINFO_HELP_READYTORUN_NEW); // If this is true, then we should have collected a non-null
+                                                       // entrypoint above
     }
 #endif
 


### PR DESCRIPTION
- Without this fix cloned expressions with allocations will fail
- This is most common in profile guided code around devirtualization, but I believe it can occur in other where gtCloneExpr is used
- Symptom of the failure is a compilation failure during crossgen2