### PR TITLE
<EnablePreviewFeatures> for HttpStress

### DIFF
--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/HttpStress.csproj
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/HttpStress.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
According to build logs, [CA2252](https://github.com/dotnet/designs/blob/main/accepted/2021/preview-features/preview-features.md) kicked in and started to fail the builds because of https://github.com/dotnet/aspnetcore/pull/34810:

https://dev.azure.com/dnceng/public/_build/results?buildId=1375236

/cc @ManickaP 