### PR TITLE
[wasm][debugger] Fix concurrent access to cache.

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -1224,9 +1224,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             commandParamsWriter.Write(typeId);
 
             var reader = await SendDebuggerAgentCommand<CmdType>(sessionId, CmdType.GetProperties, commandParams, token);
-            var ms = new MemoryStream();
-            reader.BaseStream.CopyTo(ms);
-            typeInfo.PropertiesBuffer = ms.ToArray();
+            typeInfo.PropertiesBuffer = reader.ReadBytes((int)reader.BaseStream.Length);
             reader.BaseStream.Position = 0;
             return reader;
         }

--- a/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/MonoSDBHelper.cs
@@ -366,7 +366,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         public int DebugId { get; }
         public string Name { get; }
         public List<FieldTypeClass> FieldsList { get; set; }
-        public MonoBinaryReader PropertiesBinaryReader { get; set; }
+        public byte[] PropertiesBuffer { get; set; }
         public List<int> TypeParamsOrArgsForGenericType { get; set; }
 
         public TypeInfoWithDebugInformation(TypeInfo typeInfo, int debugId, string name)
@@ -1212,18 +1212,23 @@ namespace Microsoft.WebAssembly.Diagnostics
             if (typeInfo == null)
                 return null;
 
-            if (typeInfo.PropertiesBinaryReader != null)
+            if (typeInfo.PropertiesBuffer != null)
             {
-                typeInfo.PropertiesBinaryReader.BaseStream.Seek(0, SeekOrigin.Begin);
-                return typeInfo.PropertiesBinaryReader;
+                var retDebuggerCmd = new MemoryStream(typeInfo.PropertiesBuffer);
+                var retDebuggerCmdReader = new MonoBinaryReader(retDebuggerCmd);
+                return retDebuggerCmdReader;
             }
 
             var commandParams = new MemoryStream();
             var commandParamsWriter = new MonoBinaryWriter(commandParams);
             commandParamsWriter.Write(typeId);
 
-            typeInfo.PropertiesBinaryReader = await SendDebuggerAgentCommand<CmdType>(sessionId, CmdType.GetProperties, commandParams, token);
-            return typeInfo.PropertiesBinaryReader;
+            var reader = await SendDebuggerAgentCommand<CmdType>(sessionId, CmdType.GetProperties, commandParams, token);
+            var ms = new MemoryStream();
+            reader.BaseStream.CopyTo(ms);
+            typeInfo.PropertiesBuffer = ms.ToArray();
+            reader.BaseStream.Position = 0;
+            return reader;
         }
 
         public async Task<List<FieldTypeClass>> GetTypeFields(SessionId sessionId, int typeId, CancellationToken token)

--- a/src/mono/wasm/debugger/DebuggerTestSuite/CustomViewTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/CustomViewTests.cs
@@ -8,6 +8,7 @@ using Microsoft.WebAssembly.Diagnostics;
 using Newtonsoft.Json.Linq;
 using System.Threading;
 using Xunit;
+using System.Collections.Generic;
 
 namespace DebuggerTests
 {
@@ -88,7 +89,7 @@ namespace DebuggerTests
 
             pause_location = await StepAndCheck(StepKind.Over, "dotnet://debugger-test.dll/debugger-custom-view-test.cs", bp.Value["locations"][0]["lineNumber"].Value<int>()+2, bp.Value["locations"][0]["columnNumber"].Value<int>(),  "run");
 
-            System.Collections.Generic.List<Task<bool>> tasks = new System.Collections.Generic.List<Task<bool>>();
+            List<Task<bool>> tasks = new();
             for (int i = 0 ; i < 10; i++)
             {
                 var task = CheckProperties(pause_location);

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-custom-view-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-custom-view-test.cs
@@ -88,4 +88,23 @@ namespace DebuggerTests
             Console.WriteLine("break here");
         }
     }
+
+    class DebuggerCustomViewTest2
+    {
+        public static void run()
+        {
+            List<int> myList = new List<int> ();
+            List<int> myList2 = new List<int> ();
+            
+            myList.Add(1);
+            myList.Add(2);
+            myList.Add(3);
+            myList.Add(4);
+            myList2.Add(1);
+            myList2.Add(1);
+            myList2.Add(1);
+            myList2.Add(1);
+
+        }
+    }
 }


### PR DESCRIPTION
PropertiesBinaryReader could be access by more than one thread which was causing starting reading from the wrong position and skip positions.
Added a test case for it.
@lewing I would like to backport to rc2.