### PR TITLE
We should not call distribute_free_regions at the end of background GC

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -20703,14 +20703,14 @@ void gc_heap::gc1()
 #endif //FEATURE_LOH_COMPACTION
 
     decommit_ephemeral_segment_pages();
-#ifdef USE_REGIONS
-    distribute_free_regions();
-#endif //USE_REGIONS
-
     fire_pevents();
 
     if (!(settings.concurrent))
     {
+#ifdef USE_REGIONS
+        distribute_free_regions();
+#endif //USE_REGIONS
+
         rearrange_uoh_segments();
         update_end_ngc_time();
         update_end_gc_time_per_heap();


### PR DESCRIPTION
I screwed up when placing the call to distribute_free_regions for the WKS GC case - if we call this method in background GC, then it may run concurrently with user threads allocating and getting regions from the free lists.

So I moved the call a few lines down into an "if (!(settings.concurrent))".
