### PR TITLE
[unix x86] Fix GCMemoryInfoData size assertion

### DIFF
--- a/src/coreclr/vm/comutilnative.h
+++ b/src/coreclr/vm/comutilnative.h
@@ -101,7 +101,9 @@ public:
     UINT32 pauseTimePercent;
     UINT8 isCompaction;
     UINT8 isConcurrent;
+#ifndef UNIX_X86_ABI
     UINT8 padding[6];
+#endif
     GCGenerationInfo generationInfo0;
     GCGenerationInfo generationInfo1;
     GCGenerationInfo generationInfo2;


### PR DESCRIPTION
Fixes assertion on linux x86 after #58738:
```
Assert failure(PID 13816 [0x000035f8], Thread: 13816 [0x35f8]): Consistency check failed: Managed object size does not match unmanaged object size
man: 0x110, unman: 0x114, Name: System.GCMemoryInfoData
FAILED: size == expectedsize
    File: /home/tmustafin/dotnet/runtime/src/coreclr/vm/binder.cpp Line: 556
    Image: /home/tmustafin/dotnet/runtime/artifacts/bin/coreclr/Linux.x86.Checked/corerun

Aborted (core dumped)
```
cc @jkotas @MichalStrehovsky @gbalykov @alpencolt 