### PR TITLE
Fewer AddressExposedReason::TOO_CONSERVATIVE 

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -7469,14 +7469,8 @@ void CodeGen::genFnProlog()
 
     if (compiler->info.compPublishStubParam)
     {
-#if CPU_LOAD_STORE_ARCH
         GetEmitter()->emitIns_S_R(ins_Store(TYP_I_IMPL), EA_PTRSIZE, REG_SECRET_STUB_PARAM,
                                   compiler->lvaStubArgumentVar, 0);
-#else
-        // mov [lvaStubArgumentVar], EAX
-        GetEmitter()->emitIns_AR_R(ins_Store(TYP_I_IMPL), EA_PTRSIZE, REG_SECRET_STUB_PARAM, genFramePointerReg(),
-                                   compiler->lvaTable[compiler->lvaStubArgumentVar].GetStackOffset());
-#endif
         assert(intRegState.rsCalleeRegArgMaskLiveIn & RBM_SECRET_STUB_PARAM);
 
         // It's no longer live; clear it out so it can be used after this in the prolog

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4476,6 +4476,11 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
             assert(lvaStubArgumentVar == BAD_VAR_NUM);
             lvaStubArgumentVar                  = lvaGrabTempWithImplicitUse(false DEBUGARG("stub argument"));
             lvaTable[lvaStubArgumentVar].lvType = TYP_I_IMPL;
+            // TODO-CQ: there is no need to mark it as doNotEnreg. There are no stores for this local
+            // before codegen so liveness and LSRA mark it as "liveIn" and always allocate a stack slot for it.
+            // However, it would be better to process it like other argument locals and keep it in
+            // a reg for the whole method without spilling to the stack when possible.
+            lvaSetVarDoNotEnregister(lvaStubArgumentVar DEBUGARG(DoNotEnregisterReason::VMNeedsStackAddr));
         }
     };
     DoPhase(this, PHASE_PRE_IMPORT, preImportPhase);

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1758,11 +1758,6 @@ inline unsigned Compiler::lvaGrabTempWithImplicitUse(bool shortLifetime DEBUGARG
 
     LclVarDsc* varDsc = &lvaTable[lclNum];
 
-    // This will prevent it from being optimized away
-    // TODO-CQ: We shouldn't have to go as far as to declare these
-    // address-exposed -- DoNotEnregister should suffice?
-    lvaSetVarAddrExposed(lclNum DEBUGARG(AddressExposedReason::TOO_CONSERVATIVE));
-
     // Note the implicit use
     varDsc->lvImplicitlyReferenced = 1;
 

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -1404,8 +1404,11 @@ _Done:
     if (!getNeedsGSSecurityCookie() && InlineeCompiler->getNeedsGSSecurityCookie())
     {
         setNeedsGSSecurityCookie();
-        const unsigned dummy   = lvaGrabTempWithImplicitUse(false DEBUGARG("GSCookie dummy for inlinee"));
-        lvaTable[dummy].lvType = TYP_INT;
+        const unsigned dummy         = lvaGrabTempWithImplicitUse(false DEBUGARG("GSCookie dummy for inlinee"));
+        LclVarDsc*     gsCookieDummy = lvaGetDesc(dummy);
+        gsCookieDummy->lvType        = TYP_INT;
+        gsCookieDummy->lvIsTemp      = true; // It is not alive at all, set the flag to prevent zero-init.
+        lvaSetVarDoNotEnregister(dummy DEBUGARG(DoNotEnregisterReason::VMNeedsStackAddr));
     }
 
     // If there is non-NULL return, replace the GT_CALL with its return value expression,

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -2757,6 +2757,9 @@ void Compiler::fgAddInternal()
 
         lvaInlinedPInvokeFrameVar = lvaGrabTempWithImplicitUse(false DEBUGARG("Pinvoke FrameVar"));
 
+        // Lowering::InsertPInvokeMethodProlog will create a call with this local addr as an argument.
+        lvaSetVarAddrExposed(lvaInlinedPInvokeFrameVar DEBUGARG(AddressExposedReason::ESCAPE_ADDRESS));
+
         LclVarDsc* varDsc = &lvaTable[lvaInlinedPInvokeFrameVar];
         varDsc->lvType    = TYP_BLK;
         // Make room for the inlined frame.

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -12196,7 +12196,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 /* The ARGLIST cookie is a hidden 'last' parameter, we have already
                    adjusted the arg count cos this is like fetching the last param */
                 assertImp(0 < numArgs);
-                assert(lvaTable[lvaVarargsHandleArg].IsAddressExposed());
                 lclNum = lvaVarargsHandleArg;
                 op1    = gtNewLclvNode(lclNum, TYP_I_IMPL DEBUGARG(opcodeOffs + sz + 1));
                 op1    = gtNewOperNode(GT_ADDR, TYP_BYREF, op1);

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -1234,7 +1234,7 @@ void Compiler::lvaInitVarArgsHandle(InitVarDscInfo* varDscInfo)
         assert(mostRecentlyActivePhase == PHASE_PRE_IMPORT);
 
         // TODO-Cleanup: this is preImportation phase, why do we try to work with regs here?
-        // this could should probably be deleted.
+        // Should it be just deleted?
         if (varDscInfo->canEnreg(TYP_I_IMPL))
         {
             /* Another register argument */

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -1231,8 +1231,10 @@ void Compiler::lvaInitVarArgsHandle(InitVarDscInfo* varDscInfo)
         LclVarDsc* varDsc = varDscInfo->varDsc;
         varDsc->lvType    = TYP_I_IMPL;
         varDsc->lvIsParam = 1;
-        lvaSetVarDoNotEnregister(lvaVarargsHandleArg DEBUGARG(DoNotEnregisterReason::VMNeedsStackAddr));
+        assert(mostRecentlyActivePhase == PHASE_PRE_IMPORT);
 
+        // TODO-Cleanup: this is preImportation phase, why do we try to work with regs here?
+        // this could should probably be deleted.
         if (varDscInfo->canEnreg(TYP_I_IMPL))
         {
             /* Another register argument */

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -339,8 +339,11 @@ void Compiler::lvaInitTypeRef()
     {
         // Ensure that there will be at least one stack variable since
         // we require that the GSCookie does not have a 0 stack offset.
-        unsigned dummy         = lvaGrabTempWithImplicitUse(false DEBUGARG("GSCookie dummy"));
-        lvaTable[dummy].lvType = TYP_INT;
+        unsigned   dummy         = lvaGrabTempWithImplicitUse(false DEBUGARG("GSCookie dummy"));
+        LclVarDsc* gsCookieDummy = lvaGetDesc(dummy);
+        gsCookieDummy->lvType    = TYP_INT;
+        gsCookieDummy->lvIsTemp  = true; // It is not alive at all, set the flag to prevent zero-init.
+        lvaSetVarDoNotEnregister(dummy DEBUGARG(DoNotEnregisterReason::VMNeedsStackAddr));
     }
 
     // Allocate the lvaOutgoingArgSpaceVar now because we can run into problems in the
@@ -1228,13 +1231,7 @@ void Compiler::lvaInitVarArgsHandle(InitVarDscInfo* varDscInfo)
         LclVarDsc* varDsc = varDscInfo->varDsc;
         varDsc->lvType    = TYP_I_IMPL;
         varDsc->lvIsParam = 1;
-        // Make sure this lives in the stack -- address may be reported to the VM.
-        // TODO-CQ: This should probably be:
-        //   lvaSetVarDoNotEnregister(varDscInfo->varNum DEBUGARG(VMNeedsStackAddr));
-        // But that causes problems, so, for expedience, I switched back to this heavyweight
-        // hammer.  But I think it should be possible to switch; it may just work now
-        // that other problems are fixed.
-        lvaSetVarAddrExposed(varDscInfo->varNum DEBUGARG(AddressExposedReason::TOO_CONSERVATIVE));
+        lvaSetVarDoNotEnregister(lvaVarargsHandleArg DEBUGARG(DoNotEnregisterReason::VMNeedsStackAddr));
 
         if (varDscInfo->canEnreg(TYP_I_IMPL))
         {
@@ -4348,6 +4345,7 @@ void Compiler::lvaMarkLocalVars()
             lvaPSPSym            = lvaGrabTempWithImplicitUse(false DEBUGARG("PSPSym"));
             LclVarDsc* lclPSPSym = &lvaTable[lvaPSPSym];
             lclPSPSym->lvType    = TYP_I_IMPL;
+            lvaSetVarDoNotEnregister(lvaPSPSym DEBUGARG(DoNotEnregisterReason::VMNeedsStackAddr));
         }
 #endif // FEATURE_EH_FUNCLETS
 

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -1231,6 +1231,13 @@ void Compiler::lvaInitVarArgsHandle(InitVarDscInfo* varDscInfo)
         LclVarDsc* varDsc = varDscInfo->varDsc;
         varDsc->lvType    = TYP_I_IMPL;
         varDsc->lvIsParam = 1;
+#if defined(TARGET_X86)
+        // Codegen will need it for x86 scope info.
+        varDsc->lvImplicitlyReferenced = 1;
+#endif // TARGET_X86
+
+        lvaSetVarDoNotEnregister(lvaVarargsHandleArg DEBUGARG(DoNotEnregisterReason::VMNeedsStackAddr));
+
         assert(mostRecentlyActivePhase == PHASE_PRE_IMPORT);
 
         // TODO-Cleanup: this is preImportation phase, why do we try to work with regs here?
@@ -7385,7 +7392,7 @@ void Compiler::lvaDumpEntry(unsigned lclNum, FrameLayoutState curState, size_t r
         }
 
         // The register or stack location field is 11 characters wide.
-        if (varDsc->lvRefCnt() == 0)
+        if ((varDsc->lvRefCnt() == 0) && !varDsc->lvImplicitlyReferenced)
         {
             printf("zero-ref   ");
         }

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -4066,8 +4066,11 @@ void Lowering::InsertPInvokeMethodProlog()
     const CORINFO_EE_INFO*                       pInfo         = comp->eeGetEEInfo();
     const CORINFO_EE_INFO::InlinedCallFrameInfo& callFrameInfo = pInfo->inlinedCallFrameInfo;
 
-    // First arg:  &compiler->lvaInlinedPInvokeFrameVar + callFrameInfo.offsetOfFrameVptr
-
+// First arg:  &compiler->lvaInlinedPInvokeFrameVar + callFrameInfo.offsetOfFrameVptr
+#if defined(DEBUG)
+    const LclVarDsc* inlinedPInvokeDsc = comp->lvaGetDesc(comp->lvaInlinedPInvokeFrameVar);
+    assert(inlinedPInvokeDsc->IsAddressExposed());
+#endif // DEBUG
     GenTree* frameAddr = new (comp, GT_LCL_FLD_ADDR)
         GenTreeLclFld(GT_LCL_FLD_ADDR, TYP_BYREF, comp->lvaInlinedPInvokeFrameVar, callFrameInfo.offsetOfFrameVptr);
 
@@ -4111,7 +4114,7 @@ void Lowering::InsertPInvokeMethodProlog()
         GenTreeLclFld(GT_STORE_LCL_FLD, TYP_I_IMPL, comp->lvaInlinedPInvokeFrameVar, callFrameInfo.offsetOfCallSiteSP);
     storeSP->gtOp1 = PhysReg(REG_SPBASE);
     storeSP->gtFlags |= GTF_VAR_DEF;
-    comp->lvaSetVarDoNotEnregister(comp->lvaInlinedPInvokeFrameVar DEBUGARG(DoNotEnregisterReason::LocalField));
+    assert(inlinedPInvokeDsc->lvDoNotEnregister);
 
     firstBlockRange.InsertBefore(insertionPoint, LIR::SeqTree(comp, storeSP));
     DISPTREERANGE(firstBlockRange, storeSP);
@@ -4127,6 +4130,8 @@ void Lowering::InsertPInvokeMethodProlog()
     GenTreeLclFld* storeFP =
         new (comp, GT_STORE_LCL_FLD) GenTreeLclFld(GT_STORE_LCL_FLD, TYP_I_IMPL, comp->lvaInlinedPInvokeFrameVar,
                                                    callFrameInfo.offsetOfCalleeSavedFP);
+    assert(inlinedPInvokeDsc->lvDoNotEnregister);
+
     storeFP->gtOp1 = PhysReg(REG_FPBASE);
     storeFP->gtFlags |= GTF_VAR_DEF;
 
@@ -4409,8 +4414,12 @@ void Lowering::InsertPInvokeCallEpilog(GenTreeCall* call)
 
         // First argument is the address of the frame variable.
         GenTree* frameAddr =
-            new (comp, GT_LCL_VAR) GenTreeLclVar(GT_LCL_VAR, TYP_BYREF, comp->lvaInlinedPInvokeFrameVar);
-        frameAddr->SetOperRaw(GT_LCL_VAR_ADDR);
+            new (comp, GT_LCL_FLD_ADDR) GenTreeLclFld(GT_LCL_FLD_ADDR, TYP_BYREF, comp->lvaInlinedPInvokeFrameVar, 0);
+
+#if defined(DEBUG)
+        const LclVarDsc* inlinedPInvokeDsc = comp->lvaGetDesc(comp->lvaInlinedPInvokeFrameVar);
+        assert(inlinedPInvokeDsc->IsAddressExposed());
+#endif // DEBUG
 
         // Insert call to CORINFO_HELP_JIT_PINVOKE_END
         GenTreeCall* helperCall =

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -4413,8 +4413,7 @@ void Lowering::InsertPInvokeCallEpilog(GenTreeCall* call)
         noway_assert(comp->lvaInlinedPInvokeFrameVar != BAD_VAR_NUM);
 
         // First argument is the address of the frame variable.
-        GenTree* frameAddr =
-            new (comp, GT_LCL_FLD_ADDR) GenTreeLclFld(GT_LCL_FLD_ADDR, TYP_BYREF, comp->lvaInlinedPInvokeFrameVar, 0);
+        GenTree* frameAddr = comp->gtNewLclVarAddrNode(comp->lvaInlinedPInvokeFrameVar, TYP_BYREF);
 
 #if defined(DEBUG)
         const LclVarDsc* inlinedPInvokeDsc = comp->lvaGetDesc(comp->lvaInlinedPInvokeFrameVar);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -2098,7 +2098,8 @@ GenTree* Compiler::fgMakeTmpArgNode(fgArgTabEntry* curArgTabEntry)
         {
             var_types addrType = TYP_BYREF;
             arg                = gtNewOperNode(GT_ADDR, addrType, arg);
-            addrNode           = arg;
+            lvaSetVarAddrExposed(tmpVarNum DEBUGARG(AddressExposedReason::ESCAPE_ADDRESS));
+            addrNode = arg;
 
 #if FEATURE_MULTIREG_ARGS
 #ifdef TARGET_ARM64
@@ -2137,10 +2138,6 @@ GenTree* Compiler::fgMakeTmpArgNode(fgArgTabEntry* curArgTabEntry)
     if (addrNode != nullptr)
     {
         assert(addrNode->gtOper == GT_ADDR);
-
-        // This will prevent this LclVar from being optimized away
-        lvaSetVarAddrExposed(tmpVarNum DEBUGARG(AddressExposedReason::TOO_CONSERVATIVE));
-
         // the child of a GT_ADDR is required to have this flag set
         addrNode->AsOp()->gtOp1->gtFlags |= GTF_DONT_CSE;
     }


### PR DESCRIPTION
A few improvements here and there, no actual regressions. The good benefit is that we can tail-call more methods and it should affect the performance better than just the size decrease.

```
Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.x64\coreclr_tests.pmi.windows.x64.checked.mch
 Total bytes of delta: -392 (-2.39% of base)
 85 total files with Code Size differences (80 improved, 5 regressed), 7 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.x64\libraries.crossgen2.windows.x64.checked.mch
 Total bytes of delta: -70 (-2.86% of base)
 10 total files with Code Size differences (10 improved, 0 regressed), 0 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.x64\libraries.pmi.windows.x64.checked.mch
 Total bytes of delta: -69 (-2.33% of base)
 10 total files with Code Size differences (10 improved, 0 regressed), 0 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.x64\libraries_tests.pmi.windows.x64.checked.mch
 Total bytes of delta: -68 (-1.01% of base)
 20 total files with Code Size differences (17 improved, 3 regressed), 1 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.arm64\coreclr_tests.pmi.Linux.arm64.checked.mch
 Total bytes of delta: -184 (-0.81% of base)
 46 total files with Code Size differences (46 improved, 0 regressed), 5 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.arm64\libraries.crossgen2.Linux.arm64.checked.mch
 Total bytes of delta: -8 (-0.85% of base)
 2 total files with Code Size differences (2 improved, 0 regressed), 0 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.arm64\libraries.pmi.Linux.arm64.checked.mch
 Total bytes of delta: -24 (-0.20% of base)
 6 total files with Code Size differences (6 improved, 0 regressed), 1 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.arm64\libraries_tests.pmi.Linux.arm64.checked.mch
 Total bytes of delta: -56 (-0.34% of base)
 17 total files with Code Size differences (15 improved, 2 regressed), 7 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.x64\benchmarks.run.Linux.x64.checked.mch
 Total bytes of delta: -17 (-0.56% of base)
 5 total files with Code Size differences (5 improved, 0 regressed), 0 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.x64\coreclr_tests.pmi.Linux.x64.checked.mch
 Total bytes of delta: -466 (-2.44% of base)
 39 total files with Code Size differences (38 improved, 1 regressed), 8 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.x64\libraries.crossgen2.Linux.x64.checked.mch
 Total bytes of delta: -16 (-2.36% of base)
 2 total files with Code Size differences (2 improved, 0 regressed), 0 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.x64\libraries.pmi.Linux.x64.checked.mch
 Total bytes of delta: -34 (-0.60% of base)
 6 total files with Code Size differences (6 improved, 0 regressed), 0 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.x64\libraries_tests.pmi.Linux.x64.checked.mch
 Total bytes of delta: -216 (-1.30% of base)
 23 total files with Code Size differences (22 improved, 1 regressed), 1 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.arm64\benchmarks.run.windows.arm64.checked.mch
 Total bytes of delta: -20 (-0.72% of base)
 5 total files with Code Size differences (5 improved, 0 regressed), 0 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.arm64\coreclr_tests.pmi.windows.arm64.checked.mch
 Total bytes of delta: -392 (-1.21% of base)
 98 total files with Code Size differences (98 improved, 0 regressed), 11 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.arm64\libraries.crossgen2.windows.arm64.checked.mch
 Total bytes of delta: -44 (-1.14% of base)
 11 total files with Code Size differences (11 improved, 0 regressed), 0 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.arm64\libraries.pmi.windows.arm64.checked.mch
 Total bytes of delta: -48 (-0.32% of base)
 10 total files with Code Size differences (10 improved, 0 regressed), 7 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.arm64\libraries_tests.pmi.windows.arm64.checked.mch
 Total bytes of delta: -80 (-0.51% of base)
 23 total files with Code Size differences (21 improved, 2 regressed), 5 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.x86\benchmarks.run.windows.x86.checked.mch
 Total bytes of delta: -63 (-0.74% of base)
 16 total files with Code Size differences (15 improved, 1 regressed), 2 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.x86\coreclr_tests.pmi.windows.x86.checked.mch
 Total bytes of delta: -400 (-0.45% of base)
 87 total files with Code Size differences (82 improved, 5 regressed), 45 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.x86\libraries.crossgen2.windows.x86.checked.mch
 Total bytes of delta: -140 (-0.41% of base)
 61 total files with Code Size differences (48 improved, 13 regressed), 0 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.x86\libraries.pmi.windows.x86.checked.mch
 Total bytes of delta: -161 (-0.29% of base)
 77 total files with Code Size differences (58 improved, 19 regressed), 7 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.windows.x86\libraries_tests.pmi.windows.x86.checked.mch
 Total bytes of delta: -582 (-0.56% of base)
 187 total files with Code Size differences (173 improved, 14 regressed), 19 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.arm\coreclr_tests.pmi.Linux.arm.checked.mch
 Total bytes of delta: -74 (-0.42% of base)
 38 total files with Code Size differences (33 improved, 5 regressed), 0 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.arm\libraries.crossgen2.Linux.arm.checked.mch
 Total bytes of delta: -4 (-0.54% of base)
 2 total files with Code Size differences (2 improved, 0 regressed), 0 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.arm\libraries.pmi.Linux.arm.checked.mch
 Total bytes of delta: -4 (-0.57% of base)
 2 total files with Code Size differences (2 improved, 0 regressed), 0 unchanged.

Running asm diffs of D:\Sergey\git\runtime\artifacts\spmi\mch\5ed35c58-857b-48dd-a818-7c0136dc9f73.Linux.arm\libraries_tests.pmi.Linux.arm.checked.mch
 Total bytes of delta: -28 (-0.46% of base)
 14 total files with Code Size differences (13 improved, 1 regressed), 1 unchanged.
```

Enreg stat:
```diff
Locals enregistration statistics:
-total number of locals: 346731, number of enregistered: 309775, notEnreg: 36956, ratio: 0.89
+total number of locals: 346731, number of enregistered: 309776, notEnreg: 36955, ratio: 0.89
total number of struct locals: 10920, number of enregistered: 86, notEnreg: 10834, ratio: 0.01
-total number of primitive locals: 335811, number of enregistered: 309689, notEnreg: 26122, ratio: 0.92
+total number of primitive locals: 335811, number of enregistered: 309690, notEnreg: 26121, ratio: 0.92
-m_addrExposed 16176, ratio: 0.44
+m_addrExposed 14059, ratio: 0.38
m_notRegSizeStruct 403, ratio: 0.01
m_localField 3219, ratio: 0.09
+m_VMNeedsStackAddr 2116, ratio: 0.06
                                    
m_liveInOutHndlr 642, ratio: 0.02
m_blockOp 449, ratio: 0.01
m_structArg 26, ratio: 0.00
m_depField 952, ratio: 0.03
m_noRegVars 14819, ratio: 0.40
m_castTakesAddr 12, ratio: 0.00
m_swizzleArg 171, ratio: 0.00
m_blockOpRet 87, ratio: 0.00

Addr exposed details:
-m_parentExposed 5123, ratio: 0.32
+m_parentExposed 5123, ratio: 0.36
-m_tooConservative 3434, ratio: 0.21
+m_tooConservative 235, ratio: 0.02
-m_escapeAddress 7384, ratio: 0.46
+m_escapeAddress 8466, ratio: 0.60
m_wideIndir 7, ratio: 0.00
-m_copyFldByFld 228, ratio: 0.01
+m_copyFldByFld 228, ratio: 0.02
```

Diff example:

Before, tail call is blocked because JIT thinks there is an address exposed var:
```
IN0004: 000031 call     hackishModuleName:hackishMethodName()
IN0005: 000036 nop      

G_M57568_IG03:        ; offs=000037H, size=0005H, bbWeight=1    PerfScore 1.25, epilog, nogc, extend

IN000c: 000037 add      rsp, 40
IN000d: 00003B ret      
```
After, do tailcall.
```
G_M57568_IG03:        ; offs=000028H, size=0005H, bbWeight=1    PerfScore 2.00, epilog, nogc, extend

IN0008: 000028 jmp      hackishModuleName:hackishMethodName()
```