### PR TITLE
Set *isMapped to false to satisfy 'out' semantics

### DIFF
--- a/src/coreclr/debug/di/module.cpp
+++ b/src/coreclr/debug/di/module.cpp
@@ -2755,6 +2755,7 @@ HRESULT CordbModule::IsMappedLayout(BOOL *isMapped)
     FAIL_IF_NEUTERED(this);
 
     HRESULT hr = S_OK;
+    *isMapped = FALSE;
     CordbProcess *pProcess = GetProcess();
 
     ATT_REQUIRE_STOPPED_MAY_FAIL(pProcess);

--- a/src/coreclr/inc/cordebug.idl
+++ b/src/coreclr/inc/cordebug.idl
@@ -5219,7 +5219,12 @@ interface ICorDebugModule4 : IUnknown
                       format while FALSE represents flat format.
      * Return Value:
      *     S_OK in successful case.
+     *     S_FALSE if they layout could not be determined.
      * Notes:
+     *     The pIsMapped value set in pIsMapped should only be interpreted as valid
+     *     when this function returns S_OK. All other return values (including
+     *     S_FALSE) indicate that the layout could not be determined and pIsMapped
+     *     should be ignored.
      */
     HRESULT IsMappedLayout([out] BOOL *pIsMapped);
 }


### PR DESCRIPTION
CordbModule::IsMappedLayout was not setting the out
parameter *isMapped to false before returning. The
function could therefore have a successful return code
(S_FALSE) without satisfying the constraint that out
parameters be set before return, resulting in undefined
behavior for code that merely checks for a successful
return, rather than S_OK.

This fix updates the function to set *isMapped to false
as soon as it has been verified. It also updates the
documentation of ICorDebugModule4::IsMappedLayout
to indicate that the value of pIsMapped cannot be assumed
to be valid when S_FALSE is returned.

Fixes #59393