### PR TITLE
Fix regression in Regex lowercasing in parser

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/RegexCultureTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexCultureTests.cs
@@ -69,6 +69,20 @@ namespace System.Text.RegularExpressions.Tests
             }
         }
 
+        [Theory]
+        [InlineData(RegexOptions.None)]
+        [InlineData(RegexOptions.Compiled)]
+        public void CharactersLowercasedOneByOne(RegexOptions options)
+        {
+            using (new ThreadCultureChange("en-US"))
+            {
+                Assert.True(new Regex("\uD801\uDC00", options | RegexOptions.IgnoreCase).IsMatch("\uD801\uDC00"));
+                Assert.True(new Regex("\uD801\uDC00", options | RegexOptions.IgnoreCase).IsMatch("abcdefg\uD801\uDC00"));
+                Assert.True(new Regex("\uD801", options | RegexOptions.IgnoreCase).IsMatch("\uD801\uDC00"));
+                Assert.True(new Regex("\uDC00", options | RegexOptions.IgnoreCase).IsMatch("\uD801\uDC00"));
+            }
+        }
+
         /// <summary>
         /// See https://en.wikipedia.org/wiki/Dotted_and_dotless_I
         /// </summary>


### PR DESCRIPTION
For better or worse, Regex matches char by char, without any attention paid to surrogate pairs and the like.  In .NET Core 3.0, a change was made to the regex parser that used ToLower on a whole string rather than calling ToLower on each individual char, but this then leads to inconsistencies with how the matching is performed, making it so that things that used to match no longer do.

Regression introduced in https://github.com/dotnet/corefx/pull/30632#discussion_r197645669
cc: @ViktorHofer 