### PR TITLE
Cleanup reflection RuntimeType checks

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Assembly.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Assembly.CoreCLR.cs
@@ -92,10 +92,6 @@ namespace System.Reflection
             return entryAssembly;
         }
 
-        // Exists to faciliate code sharing between CoreCLR and CoreRT.
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal bool IsRuntimeImplemented() => this is RuntimeAssembly;
-
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern uint GetAssemblyCount();
     }

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
@@ -1131,9 +1131,7 @@ namespace System.Reflection.Emit
             if (attributeType == null)
                 throw new ArgumentNullException(nameof(attributeType));
 
-            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
-
-            if (attributeRuntimeType == null)
+            if (attributeType.UnderlyingSystemType is not RuntimeType attributeRuntimeType)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.GetCustomAttributes(m_bakedRuntimeType, attributeRuntimeType, inherit);
@@ -1147,9 +1145,7 @@ namespace System.Reflection.Emit
             if (attributeType == null)
                 throw new ArgumentNullException(nameof(attributeType));
 
-            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
-
-            if (attributeRuntimeType == null)
+            if (attributeType.UnderlyingSystemType is not RuntimeType attributeRuntimeType)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.IsDefined(m_bakedRuntimeType, attributeRuntimeType, inherit);

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -299,9 +299,7 @@ namespace System.Reflection
             if (attributeType == null)
                 throw new ArgumentNullException(nameof(attributeType));
 
-            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
-
-            if (attributeRuntimeType == null)
+            if (attributeType.UnderlyingSystemType is not RuntimeType attributeRuntimeType)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType);
@@ -312,9 +310,7 @@ namespace System.Reflection
             if (attributeType == null)
                 throw new ArgumentNullException(nameof(attributeType));
 
-            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
-
-            if (attributeRuntimeType == null)
+            if (attributeType.UnderlyingSystemType is not RuntimeType attributeRuntimeType)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.IsDefined(this, attributeRuntimeType);

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
@@ -175,9 +175,7 @@ namespace System.Reflection
             if (attributeType == null)
                 throw new ArgumentNullException(nameof(attributeType));
 
-            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
-
-            if (attributeRuntimeType == null)
+            if (attributeType.UnderlyingSystemType is not RuntimeType attributeRuntimeType)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType);
@@ -188,9 +186,7 @@ namespace System.Reflection
             if (attributeType == null)
                 throw new ArgumentNullException(nameof(attributeType));
 
-            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
-
-            if (attributeRuntimeType == null)
+            if (attributeType.UnderlyingSystemType is not RuntimeType attributeRuntimeType)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.IsDefined(this, attributeRuntimeType);

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeEventInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeEventInfo.cs
@@ -81,9 +81,7 @@ namespace System.Reflection
             if (attributeType == null)
                 throw new ArgumentNullException(nameof(attributeType));
 
-            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
-
-            if (attributeRuntimeType == null)
+            if (attributeType.UnderlyingSystemType is not RuntimeType attributeRuntimeType)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType);
@@ -94,9 +92,7 @@ namespace System.Reflection
             if (attributeType == null)
                 throw new ArgumentNullException(nameof(attributeType));
 
-            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
-
-            if (attributeRuntimeType == null)
+            if (attributeType.UnderlyingSystemType is not RuntimeType attributeRuntimeType)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.IsDefined(this, attributeRuntimeType);

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeFieldInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeFieldInfo.cs
@@ -66,9 +66,7 @@ namespace System.Reflection
             if (attributeType == null)
                 throw new ArgumentNullException(nameof(attributeType));
 
-            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
-
-            if (attributeRuntimeType == null)
+            if (attributeType.UnderlyingSystemType is not RuntimeType attributeRuntimeType)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType);
@@ -79,9 +77,7 @@ namespace System.Reflection
             if (attributeType == null)
                 throw new ArgumentNullException(nameof(attributeType));
 
-            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
-
-            if (attributeRuntimeType == null)
+            if (attributeType.UnderlyingSystemType is not RuntimeType attributeRuntimeType)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.IsDefined(this, attributeRuntimeType);

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeMethodInfo.cs
@@ -248,9 +248,7 @@ namespace System.Reflection
             if (attributeType == null)
                 throw new ArgumentNullException(nameof(attributeType));
 
-            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
-
-            if (attributeRuntimeType == null)
+            if (attributeType.UnderlyingSystemType is not RuntimeType attributeRuntimeType)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType, inherit);
@@ -261,9 +259,7 @@ namespace System.Reflection
             if (attributeType == null)
                 throw new ArgumentNullException(nameof(attributeType));
 
-            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
-
-            if (attributeRuntimeType == null)
+            if (attributeType.UnderlyingSystemType is not RuntimeType attributeRuntimeType)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.IsDefined(this, attributeRuntimeType, inherit);

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
@@ -393,9 +393,7 @@ namespace System.Reflection
             if (attributeType == null)
                 throw new ArgumentNullException(nameof(attributeType));
 
-            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
-
-            if (attributeRuntimeType == null)
+            if (attributeType.UnderlyingSystemType is not RuntimeType attributeRuntimeType)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType);
@@ -406,9 +404,7 @@ namespace System.Reflection
             if (attributeType == null)
                 throw new ArgumentNullException(nameof(attributeType));
 
-            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
-
-            if (attributeRuntimeType == null)
+            if (attributeType.UnderlyingSystemType is not RuntimeType attributeRuntimeType)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.IsDefined(this, attributeRuntimeType);

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeParameterInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeParameterInfo.cs
@@ -515,9 +515,7 @@ namespace System.Reflection
             if (MdToken.IsNullToken(m_tkParamDef))
                 return Array.Empty<object>();
 
-            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
-
-            if (attributeRuntimeType == null)
+            if (attributeType.UnderlyingSystemType is not RuntimeType attributeRuntimeType)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType);
@@ -531,9 +529,7 @@ namespace System.Reflection
             if (MdToken.IsNullToken(m_tkParamDef))
                 return false;
 
-            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
-
-            if (attributeRuntimeType == null)
+            if (attributeType.UnderlyingSystemType is not RuntimeType attributeRuntimeType)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.IsDefined(this, attributeRuntimeType);

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimePropertyInfo.cs
@@ -142,9 +142,7 @@ namespace System.Reflection
             if (attributeType == null)
                 throw new ArgumentNullException(nameof(attributeType));
 
-            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
-
-            if (attributeRuntimeType == null)
+            if (attributeType.UnderlyingSystemType is not RuntimeType attributeRuntimeType)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType);
@@ -155,9 +153,7 @@ namespace System.Reflection
             if (attributeType == null)
                 throw new ArgumentNullException(nameof(attributeType));
 
-            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
-
-            if (attributeRuntimeType == null)
+            if (attributeType.UnderlyingSystemType is not RuntimeType attributeRuntimeType)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.IsDefined(this, attributeRuntimeType);

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
@@ -290,8 +290,7 @@ namespace System.Runtime.CompilerServices
         /// <returns>The allocated memory</returns>
         public static IntPtr AllocateTypeAssociatedMemory(Type type, int size)
         {
-            RuntimeType? rt = type as RuntimeType;
-            if (rt == null)
+            if (type is not RuntimeType rt)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(type));
 
             if (size < 0)

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -3532,7 +3532,7 @@ namespace System
                 RuntimeType valueType;
                 Pointer? pointer = value as Pointer;
                 if (pointer != null)
-                    valueType = (RuntimeType)pointer.GetPointerType();
+                    valueType = pointer.GetPointerType();
                 else
                     valueType = (RuntimeType)value.GetType();
 
@@ -3573,7 +3573,7 @@ namespace System
                     RuntimeType valueType;
                     Pointer? pointer = value as Pointer;
                     if (pointer != null)
-                        valueType = (RuntimeType)pointer.GetPointerType();
+                        valueType = pointer.GetPointerType();
                     else
                         valueType = (RuntimeType)value.GetType();
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Type.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Type.CoreCLR.cs
@@ -101,9 +101,5 @@ namespace System
         [Intrinsic]
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern bool operator !=(Type? left, Type? right);
-
-        // Exists to faciliate code sharing between CoreCLR and CoreRT.
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal bool IsRuntimeImplemented() => this is RuntimeType;
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Activator.RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Activator.RuntimeType.cs
@@ -32,10 +32,10 @@ namespace System
             if (activationAttributes?.Length > 0)
                 throw new PlatformNotSupportedException(SR.NotSupported_ActivAttr);
 
-            if (type.UnderlyingSystemType is RuntimeType rt)
-                return rt.CreateInstanceImpl(bindingAttr, binder, args, culture);
+            if (type.UnderlyingSystemType is not RuntimeType rt)
+                throw new ArgumentException(SR.Arg_MustBeType, nameof(type));
 
-            throw new ArgumentException(SR.Arg_MustBeType, nameof(type));
+            return rt.CreateInstanceImpl(bindingAttr, binder, args, culture);
         }
 
         [System.Security.DynamicSecurityMethod]

--- a/src/libraries/System.Private.CoreLib/src/System/DefaultBinder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DefaultBinder.cs
@@ -527,7 +527,7 @@ namespace System
             for (i = 0; i < types.Length; i++)
             {
                 realTypes[i] = types[i].UnderlyingSystemType;
-                if (!(realTypes[i].IsRuntimeImplemented() || realTypes[i] is SignatureType))
+                if (!(realTypes[i] is RuntimeType || realTypes[i] is SignatureType))
                     throw new ArgumentException(SR.Arg_MustBeType, nameof(types));
             }
             types = realTypes;
@@ -566,8 +566,8 @@ namespace System
 
                     if (pCls.IsPrimitive)
                     {
-                        if (!type.UnderlyingSystemType.IsRuntimeImplemented() ||
-                            !CanChangePrimitive(type.UnderlyingSystemType, pCls.UnderlyingSystemType))
+                        if (type.UnderlyingSystemType is not RuntimeType rtType ||
+                            !CanChangePrimitive(rtType, pCls.UnderlyingSystemType))
                             break;
                     }
                     else
@@ -653,8 +653,8 @@ namespace System
 
                         if (pCls.IsPrimitive)
                         {
-                            if (!indexes[j].UnderlyingSystemType.IsRuntimeImplemented() ||
-                                !CanChangePrimitive(indexes[j].UnderlyingSystemType, pCls.UnderlyingSystemType))
+                            if (indexes[j].UnderlyingSystemType is not RuntimeType rtType ||
+                                !CanChangePrimitive(rtType, pCls.UnderlyingSystemType))
                                 break;
                         }
                         else
@@ -671,8 +671,8 @@ namespace System
                     {
                         if (candidates[i].PropertyType.IsPrimitive)
                         {
-                            if (!returnType.UnderlyingSystemType.IsRuntimeImplemented() ||
-                                !CanChangePrimitive(returnType.UnderlyingSystemType, candidates[i].PropertyType.UnderlyingSystemType))
+                            if (returnType.UnderlyingSystemType is not RuntimeType rtType ||
+                                !CanChangePrimitive(rtType, candidates[i].PropertyType.UnderlyingSystemType))
                                 continue;
                         }
                         else

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -1406,7 +1406,7 @@ namespace System
                 throw new ArgumentNullException(nameof(enumType));
             if (!enumType.IsEnum)
                 throw new ArgumentException(SR.Arg_MustBeEnum, nameof(enumType));
-            if (!(enumType is RuntimeType rtType))
+            if (enumType is not RuntimeType rtType)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(enumType));
             return rtType;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Pointer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Pointer.cs
@@ -12,11 +12,10 @@ namespace System.Reflection
     {
         // CoreCLR: Do not add or remove fields without updating the ReflectionPointer class in runtimehandles.h
         private readonly void* _ptr;
-        private readonly Type _ptrType;
+        private readonly RuntimeType _ptrType;
 
-        private Pointer(void* ptr, Type ptrType)
+        private Pointer(void* ptr, RuntimeType ptrType)
         {
-            Debug.Assert(ptrType.IsRuntimeImplemented()); // CoreCLR: For CoreRT's sake, _ptrType has to be declared as "Type", but in fact, it is always a RuntimeType. Code on CoreCLR expects this.
             _ptr = ptr;
             _ptrType = ptrType;
         }
@@ -27,10 +26,10 @@ namespace System.Reflection
                 throw new ArgumentNullException(nameof(type));
             if (!type.IsPointer)
                 throw new ArgumentException(SR.Arg_MustBePointer, nameof(ptr));
-            if (!type.IsRuntimeImplemented())
-                throw new ArgumentException(SR.Arg_MustBeType, nameof(ptr));
+            if (type is not RuntimeType rtType)
+                throw new ArgumentException(SR.Arg_MustBeType, nameof(type));
 
-            return new Pointer(ptr, type);
+            return new Pointer(ptr, rtType);
         }
 
         public static void* Unbox(object ptr)
@@ -57,7 +56,7 @@ namespace System.Reflection
             throw new PlatformNotSupportedException();
         }
 
-        internal Type GetPointerType() => _ptrType;
+        internal RuntimeType GetPointerType() => _ptrType;
         internal IntPtr GetPointerValue() => (IntPtr)_ptr;
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceManager.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceManager.cs
@@ -194,7 +194,7 @@ namespace System.Resources
                 throw new ArgumentNullException(nameof(baseName));
             if (null == assembly)
                 throw new ArgumentNullException(nameof(assembly));
-            if (!assembly.IsRuntimeImplemented())
+            if (assembly is not RuntimeAssembly)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeAssembly);
 
             MainAssembly = assembly;
@@ -211,7 +211,7 @@ namespace System.Resources
                 throw new ArgumentNullException(nameof(baseName));
             if (null == assembly)
                 throw new ArgumentNullException(nameof(assembly));
-            if (!assembly.IsRuntimeImplemented())
+            if (assembly is not RuntimeAssembly)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeAssembly);
 
             MainAssembly = assembly;
@@ -228,7 +228,7 @@ namespace System.Resources
         {
             if (null == resourceSource)
                 throw new ArgumentNullException(nameof(resourceSource));
-            if (!resourceSource.IsRuntimeImplemented())
+            if (resourceSource is not RuntimeType)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType);
 
             _locationInfo = resourceSource;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
@@ -130,7 +130,7 @@ namespace System.Runtime.InteropServices
             {
                 throw new ArgumentNullException(nameof(t));
             }
-            if (!t.IsRuntimeImplemented())
+            if (t is not RuntimeType)
             {
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(t));
             }
@@ -589,7 +589,7 @@ namespace System.Runtime.InteropServices
             {
                 throw new ArgumentException(SR.Argument_NeedNonGenericType, nameof(structureType));
             }
-            if (!structureType.IsRuntimeImplemented())
+            if (structureType is not RuntimeType)
             {
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(structureType));
             }
@@ -1113,7 +1113,7 @@ namespace System.Runtime.InteropServices
             {
                 throw new ArgumentNullException(nameof(type));
             }
-            if (!type.IsRuntimeImplemented())
+            if (type is not RuntimeType)
             {
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(type));
             }
@@ -1161,7 +1161,7 @@ namespace System.Runtime.InteropServices
             {
                 throw new ArgumentNullException(nameof(t));
             }
-            if (!t.IsRuntimeImplemented())
+            if (t is not RuntimeType)
             {
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(t));
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.cs
@@ -88,7 +88,7 @@ namespace System.Runtime.InteropServices
                 throw new ArgumentNullException(nameof(libraryName));
             if (assembly == null)
                 throw new ArgumentNullException(nameof(assembly));
-            if (!assembly.IsRuntimeImplemented())
+            if (assembly is not RuntimeAssembly)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeAssembly);
 
             return LoadLibraryByName(libraryName,
@@ -124,7 +124,7 @@ namespace System.Runtime.InteropServices
                 throw new ArgumentNullException(nameof(libraryName));
             if (assembly == null)
                 throw new ArgumentNullException(nameof(assembly));
-            if (!assembly.IsRuntimeImplemented())
+            if (assembly is not RuntimeAssembly)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeAssembly);
 
             handle = LoadLibraryByName(libraryName,
@@ -211,7 +211,7 @@ namespace System.Runtime.InteropServices
                 throw new ArgumentNullException(nameof(assembly));
             if (resolver == null)
                 throw new ArgumentNullException(nameof(resolver));
-            if (!assembly.IsRuntimeImplemented())
+            if (assembly is not RuntimeAssembly)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeAssembly);
 
             if (s_nativeDllResolveMap == null)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Serialization/SerializationInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Serialization/SerializationInfo.cs
@@ -361,7 +361,7 @@ namespace System.Runtime.Serialization
                 throw new ArgumentNullException(nameof(type));
             }
 
-            if (!type.IsRuntimeImplemented())
+            if (type is not RuntimeType)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType);
 
             object? value = GetElement(name, out Type foundType);
@@ -378,7 +378,7 @@ namespace System.Runtime.Serialization
         internal object? GetValueNoThrow(string name, Type type)
         {
             Debug.Assert(type is not null, "[SerializationInfo.GetValue]type ==null");
-            Debug.Assert(type.IsRuntimeImplemented(), "[SerializationInfo.GetValue]type is not a runtime type");
+            Debug.Assert(type is RuntimeType, "[SerializationInfo.GetValue]type is not a runtime type");
 
             object? value = GetElementNoThrow(name, out Type? foundType);
             if (value == null)

--- a/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
@@ -58,9 +58,7 @@ namespace System
             if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
-            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
-
-            if (attributeRuntimeType == null)
+            if (attributeType.UnderlyingSystemType is not RuntimeType attributeRuntimeType)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.GetCustomAttributes(this, attributeRuntimeType, inherit);
@@ -245,9 +243,7 @@ namespace System
             if (attributeType is null)
                 throw new ArgumentNullException(nameof(attributeType));
 
-            RuntimeType? attributeRuntimeType = attributeType.UnderlyingSystemType as RuntimeType;
-
-            if (attributeRuntimeType == null)
+            if (attributeType.UnderlyingSystemType is not RuntimeType attributeRuntimeType)
                 throw new ArgumentException(SR.Arg_MustBeType, nameof(attributeType));
 
             return CustomAttribute.IsDefined(this, attributeRuntimeType, inherit);

--- a/src/libraries/System.Private.CoreLib/src/System/Type.Helpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Type.Helpers.cs
@@ -18,7 +18,7 @@ namespace System
                     return true;
 
                 Type? underlyingType = UnderlyingSystemType;
-                if (underlyingType.IsRuntimeImplemented())
+                if (underlyingType is RuntimeType)
                 {
                     do
                     {
@@ -345,7 +345,7 @@ namespace System
             // For backward-compatibility, we need to special case for the types
             // whose UnderlyingSystemType are runtime implemented.
             Type toType = this.UnderlyingSystemType;
-            if (toType?.IsRuntimeImplemented() == true)
+            if (toType is RuntimeType)
                 return toType.IsAssignableFrom(c);
 
             // If c is a subclass of this class, then c can be cast to this type.

--- a/src/mono/System.Private.CoreLib/src/System/Delegate.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Delegate.Mono.cs
@@ -130,7 +130,7 @@ namespace System
             if (method is null)
                 throw new ArgumentNullException(nameof(method));
 
-            if (!(type is RuntimeType rtType))
+            if (type is not RuntimeType rtType)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(type));
             if (!(method is RuntimeMethodInfo || method is System.Reflection.Emit.DynamicMethod))
                 throw new ArgumentException(SR.Argument_MustBeRuntimeMethodInfo, nameof(method));
@@ -166,7 +166,7 @@ namespace System
             if (method is null)
                 throw new ArgumentNullException(nameof(method));
 
-            if (!(type is RuntimeType rtType))
+            if (type is not RuntimeType rtType)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(type));
             if (!rtType.IsDelegate())
                 throw new ArgumentException(SR.Arg_MustBeDelegate, nameof(type));
@@ -194,10 +194,10 @@ namespace System
             if (method is null)
                 throw new ArgumentNullException(nameof(method));
 
-            if (!(type is RuntimeType rtType))
+            if (type is not RuntimeType rtType)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(type));
 
-            if (target is not RuntimeType())
+            if (target is not RuntimeType)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(target));
             if (!rtType.IsDelegate())
                 throw new ArgumentException(SR.Arg_MustBeDelegate, nameof(type));

--- a/src/mono/System.Private.CoreLib/src/System/Delegate.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Delegate.Mono.cs
@@ -99,7 +99,7 @@ namespace System
             if (method is null)
                 throw new ArgumentNullException(nameof(method));
 
-            if (!target.IsRuntimeImplemented())
+            if (target is not RuntimeType)
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(target));
 
             this.data = new DelegateData()
@@ -197,7 +197,7 @@ namespace System
             if (!(type is RuntimeType rtType))
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(type));
 
-            if (!target.IsRuntimeImplemented())
+            if (target is not RuntimeType())
                 throw new ArgumentException(SR.Argument_MustBeRuntimeType, nameof(target));
             if (!rtType.IsDelegate())
                 throw new ArgumentException(SR.Arg_MustBeDelegate, nameof(type));

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Assembly.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Assembly.Mono.cs
@@ -13,8 +13,6 @@ namespace System.Reflection
     [StructLayout(LayoutKind.Sequential)]
     public partial class Assembly
     {
-        internal bool IsRuntimeImplemented() => this is RuntimeAssembly;
-
         [System.Security.DynamicSecurityMethod] // Methods containing StackCrawlMark local var has to be marked DynamicSecurityMethod
         public static Assembly? LoadWithPartialName(string partialName)
         {

--- a/src/mono/System.Private.CoreLib/src/System/Type.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Type.Mono.cs
@@ -144,7 +144,7 @@ namespace System
             // CLR-compat: runtime types are never equal to non-runtime types
             // If `left` is a non-runtime type with a weird Equals implementation
             // this is where operator `==` would differ from `Equals` call.
-            if (left.IsRuntimeImplemented() || right.IsRuntimeImplemented())
+            if (left is RuntimeType || right is RuntimeType)
                 return false;
 
             return left.Equals(right);

--- a/src/mono/System.Private.CoreLib/src/System/Type.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Type.Mono.cs
@@ -20,8 +20,6 @@ namespace System
             return _impl.Value;
         }
 
-        internal bool IsRuntimeImplemented() => this is RuntimeType;
-
         internal virtual bool IsTypeBuilder() => false;
 
         public bool IsInterface


### PR DESCRIPTION
The helper methods to perform the runtime type checks are no longer needed.