### PR TITLE
[release/6.0-rc2] Split install_location to file-per-architecture

### DIFF
--- a/src/installer/pkg/sfx/installers/osx_scripts/host/postinstall
+++ b/src/installer/pkg/sfx/installers/osx_scripts/host/postinstall
@@ -6,21 +6,19 @@
 
 PACKAGE=$1
 INSTALL_DESTINATION=$2
+[ "${InstallerTargetArchitecture}" == "x64" ] && X64_INSTALL_DESTINATION=$2 || X64_INSTALL_DESTINATION=$2/x64
 
 # A temporary fix for the permissions issue(s)
 chmod 755 $INSTALL_DESTINATION/dotnet
 
-if [ -e /etc/dotnet/install_location ]; then
-    # clear out any entries for this architecture if they exist
-    sed -i old '/^${InstallerTargetArchitecture}=/d' /etc/dotnet/install_location
-else
-    mkdir -p /etc/dotnet    
-fi
-
-echo ${InstallerTargetArchitecture}=$INSTALL_DESTINATION | tee -a /etc/dotnet/install_location
+mkdir -p /etc/dotnet
+# set install_location (legacy location) to x64 location (regardless of wether or not we're installing x64)
+echo $X64_INSTALL_DESTINATION | tee /etc/dotnet/install_location
+# set install_location_arch to point to this installed location
+echo $INSTALL_DESTINATION | tee /etc/dotnet/install_location_${InstallerTargetArchitecture}
 
 # if we're running on the native architecture
-if [[ "$(uname -m)" =~ "${UnameMachineRegex}" ]]; then
+if [[ "$(uname -m)" =~ ${UnameMachineRegex} && "$(sysctl -i -n sysctl.proc_translated)" != "1" ]]; then
     # Add the installation directory to the system-wide paths
     # But first create the directory if it doesn't exist
     mkdir -p /etc/paths.d

--- a/src/installer/tests/HostActivation.Tests/Constants.cs
+++ b/src/installer/tests/HostActivation.Tests/Constants.cs
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             public const string DefaultInstallPath = "_DOTNET_TEST_DEFAULT_INSTALL_PATH";
             public const string RegistryPath = "_DOTNET_TEST_REGISTRY_PATH";
             public const string GloballyRegisteredPath = "_DOTNET_TEST_GLOBALLY_REGISTERED_PATH";
-            public const string InstallLocationFilePath = "_DOTNET_TEST_INSTALL_LOCATION_FILE_PATH";
+            public const string InstallLocationPath = "_DOTNET_TEST_INSTALL_LOCATION_PATH";
         }
 
         public static class RuntimeId

--- a/src/installer/tests/HostActivation.Tests/InstallLocationCommandResultExtensions.cs
+++ b/src/installer/tests/HostActivation.Tests/InstallLocationCommandResultExtensions.cs
@@ -3,6 +3,7 @@
 
 
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
 using FluentAssertions;
 using Microsoft.DotNet.Cli.Build.Framework;
@@ -45,14 +46,14 @@ namespace HostActivation.Tests
             return assertion.HaveStdErrContaining($"Using global installation location [{installLocation}]");
         }
 
-        public static AndConstraint<CommandResultAssertions> HaveFoundDefaultInstallLocationInConfigFile(this CommandResultAssertions assertion, string installLocation)
+        public static AndConstraint<CommandResultAssertions> HaveLookedForDefaultInstallLocation(this CommandResultAssertions assertion, string installLocationPath)
         {
-            return assertion.HaveStdErrContaining($"Found install location path '{installLocation}'.");
+            return assertion.HaveStdErrContaining($"Looking for install_location file in '{Path.Combine(installLocationPath, "install_location")}'.");
         }
 
-        public static AndConstraint<CommandResultAssertions> HaveFoundArchSpecificInstallLocationInConfigFile(this CommandResultAssertions assertion, string installLocation, string arch)
+        public static AndConstraint<CommandResultAssertions> HaveLookedForArchitectureSpecificInstallLocation(this CommandResultAssertions assertion, string installLocationPath, string architecture)
         {
-            return assertion.HaveStdErrContaining($"Found architecture-specific install location path: '{installLocation}' ('{arch}').");
+            return assertion.HaveStdErrContaining($"Looking for architecture specific install_location file in '{Path.Combine(installLocationPath, "install_location_" + architecture.ToLowerInvariant())}'.");
         }
     }
 }

--- a/src/native/corehost/hostmisc/pal.unix.cpp
+++ b/src/native/corehost/hostmisc/pal.unix.cpp
@@ -383,12 +383,12 @@ pal::string_t pal::get_dotnet_self_registered_config_location()
 {
     //  ***Used only for testing***
     pal::string_t environment_install_location_override;
-    if (test_only_getenv(_X("_DOTNET_TEST_INSTALL_LOCATION_FILE_PATH"), &environment_install_location_override))
+    if (test_only_getenv(_X("_DOTNET_TEST_INSTALL_LOCATION_PATH"), &environment_install_location_override))
     {
         return environment_install_location_override;
     }
 
-    return _X("/etc/dotnet/install_location");
+    return _X("/etc/dotnet");
 }
 
 namespace
@@ -414,6 +414,42 @@ namespace
     }
 }
 
+bool get_install_location_from_file(const pal::string_t& file_path, bool& file_found, pal::string_t& install_location)
+{
+    file_found = true;
+    bool install_location_found = false;
+    FILE* install_location_file = pal::file_open(file_path, "r");
+    if (install_location_file != nullptr)
+    {
+        if (!get_line_from_file(install_location_file, install_location))
+        {
+            trace::warning(_X("Did not find any install location in '%s'."), file_path.c_str());
+        }
+        else
+        {
+            install_location_found = true;
+        }
+
+        fclose(install_location_file);
+        if (install_location_found)
+            return true;
+    }
+    else
+    {
+        if (errno == ENOENT)
+        {
+            trace::verbose(_X("The install_location file ['%s'] does not exist - skipping."), file_path.c_str());
+            file_found = false;
+        }
+        else
+        {
+            trace::error(_X("The install_location file ['%s'] failed to open: %s."), file_path.c_str(), pal::strerror(errno));
+        }
+    }
+
+    return false;
+}
+
 bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
 {
     recv->clear();
@@ -427,71 +463,31 @@ bool pal::get_dotnet_self_registered_dir(pal::string_t* recv)
     }
     //  ***************************
 
-    pal::string_t install_location_file_path = get_dotnet_self_registered_config_location();
-    trace::verbose(_X("Looking for install_location file in '%s'."), install_location_file_path.c_str());
-    FILE* install_location_file = pal::file_open(install_location_file_path, "r");
-    if (install_location_file == nullptr)
-    {
-        if (errno == ENOENT)
-        {
-            trace::verbose(_X("The install_location file ['%s'] does not exist - skipping."), install_location_file_path.c_str());
-        }
-        else
-        {
-            trace::error(_X("The install_location file ['%s'] failed to open: %s."), install_location_file_path.c_str(), pal::strerror(errno));
-        }
-
-        return false;
-    }
+    pal::string_t install_location_path = get_dotnet_self_registered_config_location();
+    pal::string_t arch_specific_install_location_file_path = install_location_path;
+    append_path(&arch_specific_install_location_file_path, (_X("install_location_") + to_lower(get_arch())).c_str());
+    trace::verbose(_X("Looking for architecture specific install_location file in '%s'."), arch_specific_install_location_file_path.c_str());
 
     pal::string_t install_location;
-    int current_line = 0;
-    bool is_first_line = true, install_location_found = false;
-
-    while (get_line_from_file(install_location_file, install_location))
+    bool file_found = false;
+    if (!get_install_location_from_file(arch_specific_install_location_file_path, file_found, install_location))
     {
-        current_line++;
-        size_t arch_sep = install_location.find(_X('='));
-        if (arch_sep == pal::string_t::npos)
+        if (file_found)
         {
-            if (is_first_line)
-            {
-                recv->assign(install_location);
-                install_location_found = true;
-                trace::verbose(_X("Found install location path '%s'."), install_location.c_str());
-            }
-            else
-            {
-                trace::warning(_X("Found unprefixed install location path '%s' on line %d."), install_location.c_str(), current_line);
-                trace::warning(_X("Only the first line in '%s' may not have an architecture prefix."), install_location_file_path.c_str());
-            }
-
-            is_first_line = false;
-            continue;
+            return false;
         }
 
-        pal::string_t arch_prefix = install_location.substr(0, arch_sep);
-        pal::string_t path_to_location = install_location.substr(arch_sep + 1);
+        pal::string_t legacy_install_location_file_path = install_location_path;
+        append_path(&legacy_install_location_file_path, _X("install_location"));
+        trace::verbose(_X("Looking for install_location file in '%s'."), legacy_install_location_file_path.c_str());
 
-        trace::verbose(_X("Found architecture-specific install location path: '%s' ('%s')."), path_to_location.c_str(), arch_prefix.c_str());
-        if (pal::strcasecmp(arch_prefix.c_str(), get_arch()) == 0)
+        if (!get_install_location_from_file(legacy_install_location_file_path, file_found, install_location))
         {
-            recv->assign(path_to_location);
-            install_location_found = true;
-            trace::verbose(_X("Found architecture-specific install location path matching the current host architecture ('%s'): '%s'."), arch_prefix.c_str(), path_to_location.c_str());
-            break;
+            return false;
         }
-
-        is_first_line = false;
     }
 
-    fclose(install_location_file);
-    if (!install_location_found)
-    {
-        trace::warning(_X("Did not find any install location in '%s'."), install_location_file_path.c_str());
-        return false;
-    }
-
+    recv->assign(install_location);
     trace::verbose(_X("Using install location '%s'."), recv->c_str());
     return true;
 }


### PR DESCRIPTION
To make things easier to install and play better with side-by-side we are splitting up the install_location file into architecture specific files.

This also fixes a bug we discovered in testing that failed to write the path on mac.

## Customer Impact

Enables mac/linux host to locate the runtime.  Ensures future-proof + downlevel-proof design of host location probing that reduces complexity from installers.  Increases likelihood that future .NET versions will not break old versions should new architectures come along (or vice-versa).

## Testing

Host tests updated to cover new scenarios, run during build validation.
Manual testing of installation script across scenarios of x64, arm64, x64 on arm64, x64 from rosetta on arm64.

## Risk

Low.  RC2 is the first release that actually supports this scenario from installers.
The host change will break folks on mac who were manually setting things up, but if they use the installers they will automatically get the fix.