### PR TITLE
Fix buffering bugs in TextFieldParser

### DIFF
--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/FileIO/TextFieldParser.vb
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/FileIO/TextFieldParser.vb
@@ -690,16 +690,14 @@ Namespace Microsoft.VisualBasic.FileIO
 
             ' No need to slide if we're already at the beginning
             If m_Position > 0 Then
-                Dim BufferLength As Integer = m_Buffer.Length
-                Dim TempArray(BufferLength - 1) As Char
-                Array.Copy(m_Buffer, m_Position, TempArray, 0, BufferLength - m_Position)
+                Dim ContentLength As Integer = m_CharsRead - m_Position
 
-                ' Fill the rest of the buffer
-                Dim CharsRead As Integer = m_Reader.Read(TempArray, BufferLength - m_Position, m_Position)
-                m_CharsRead = m_CharsRead - m_Position + CharsRead
+                Array.Copy(m_Buffer, m_Position, m_Buffer, 0, ContentLength)
 
+                ' Try to fill the rest of the buffer
+                Dim CharsRead As Integer = m_Reader.Read(m_Buffer, ContentLength, m_Buffer.Length - ContentLength)
+                m_CharsRead = ContentLength + CharsRead
                 m_Position = 0
-                m_Buffer = TempArray
 
                 Return CharsRead
             End If
@@ -717,26 +715,29 @@ Namespace Microsoft.VisualBasic.FileIO
 
             Debug.Assert(m_Buffer IsNot Nothing, "There's no buffer")
             Debug.Assert(m_Reader IsNot Nothing, "There's no StreamReader")
+            Debug.Assert(m_Position = 0, "Non-zero position")
 
             ' Set cursor
             m_PeekPosition = m_CharsRead
 
-            ' Create a larger buffer and copy our data into it
-            Dim BufferSize As Integer = m_Buffer.Length + DEFAULT_BUFFER_LENGTH
+            If m_CharsRead = m_Buffer.Length Then
+                ' Create a larger buffer and copy our data into it
+                Dim BufferSize As Integer = m_Buffer.Length + DEFAULT_BUFFER_LENGTH
 
-            ' Make sure the buffer hasn't grown too large
-            If BufferSize > m_MaxBufferSize Then
-                Throw GetInvalidOperationException(SR.TextFieldParser_BufferExceededMaxSize)
+                ' Make sure the buffer hasn't grown too large
+                If BufferSize > m_MaxBufferSize Then
+                    Throw GetInvalidOperationException(SR.TextFieldParser_BufferExceededMaxSize)
+                End If
+
+                Dim TempArray(BufferSize - 1) As Char
+                Array.Copy(m_Buffer, TempArray, m_Buffer.Length)
+                m_Buffer = TempArray
             End If
 
-            Dim TempArray(BufferSize - 1) As Char
+            Dim CharsRead As Integer = m_Reader.Read(m_Buffer, m_CharsRead, m_Buffer.Length - m_CharsRead)
+            Debug.Assert(CharsRead <= m_Buffer.Length - m_CharsRead, "We've read more chars than we have space for")
 
-            Array.Copy(m_Buffer, TempArray, m_Buffer.Length)
-            Dim CharsRead As Integer = m_Reader.Read(TempArray, m_Buffer.Length, DEFAULT_BUFFER_LENGTH)
-            m_Buffer = TempArray
             m_CharsRead += CharsRead
-
-            Debug.Assert(m_CharsRead <= BufferSize, "We've read more chars than we have space for")
 
             Return CharsRead
         End Function


### PR DESCRIPTION
Three bugs being fixed here:
1. The SlideCursorToStartOfBuffer method is incorrectly assuming that the buffer is filled to its end (that m_Buffer.Length = m_CharsRead).  As a result, two things happen.  First, we copy more data than is needed to the temporary buffer; that's just unnecessary but not harmful.  But second, when it issues a read to fill the remainder of the buffer, it does so at the wrong position, both leaving zeros in the buffer that end up getting parsed as real data and losing real data from the end.
2. IncreaseBufferSize assumes m_CharsRead = m_Buffer.Length, which may not be the case.  As with (1), this can result in it reading into the wrong part of the array and leaving garbage that gets processed.
3. IncreaseBufferSize is always increasing the buffer size, even if only a small portion of the buffer is used.  This can then result in the whole operation failing when it repeatedly increases the buffer size and ends up failing due to ticking over the max buffer threshold.

(1) doesn't exist in .NET Framework 4.8 but (2) and (3) do.  (1) is easily triggered by a stream that sporadically doesn't produce all the data requested; (2) and (3) end up needing a stream that frequently produces much less than requested.  This PR fixes all three.

Without the fixes included, here is how the tests being added here fail on main:
```
      Microsoft.VisualBasic.FileIO.Tests.TextFieldParserTests.ReadFields_PartialReadsFromStream_Large(fieldsInQuotes: False) [FAIL]
        Assert.Equal() Failure
        Expected: String[] ["sssssss", "s", "s", "s"]
        Actual:   String[] ["\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"...]
        Stack Trace:
          D:\repos\runtime\src\libraries\Microsoft.VisualBasic.Core\tests\Microsoft\VisualBasic\FileIO\TextFieldParserTests.cs(431,0): at Microsoft.VisualBasic.FileIO.Tests.TextFieldParserTests.ReadFields_PartialReadsFromStream(Boolean fieldsInQuotes, Int32 maxCount)
          D:\repos\runtime\src\libraries\Microsoft.VisualBasic.Core\tests\Microsoft\VisualBasic\FileIO\TextFieldParserTests.cs(383,0): at Microsoft.VisualBasic.FileIO.Tests.TextFieldParserTests.ReadFields_PartialReadsFromStream_Large(Boolean fieldsInQuotes)

      Microsoft.VisualBasic.FileIO.Tests.TextFieldParserTests.ReadFields_PartialReadsFromStream_Large(fieldsInQuotes: True) [FAIL]
        Microsoft.VisualBasic.FileIO.MalformedLineException : Line 535 cannot be parsed using the current Delimiters.
        Stack Trace:
          D:\repos\runtime\src\libraries\Microsoft.VisualBasic.Core\src\Microsoft\VisualBasic\FileIO\TextFieldParser.vb(917,0): at Microsoft.VisualBasic.FileIO.TextFieldParser.ParseDelimitedLine()
          D:\repos\runtime\src\libraries\Microsoft.VisualBasic.Core\src\Microsoft\VisualBasic\FileIO\TextFieldParser.vb(362,0): at Microsoft.VisualBasic.FileIO.TextFieldParser.ReadFields()
          D:\repos\runtime\src\libraries\Microsoft.VisualBasic.Core\tests\Microsoft\VisualBasic\FileIO\TextFieldParserTests.cs(430,0): at Microsoft.VisualBasic.FileIO.Tests.TextFieldParserTests.ReadFields_PartialReadsFromStream(Boolean fieldsInQuotes, Int32 maxCount)
          D:\repos\runtime\src\libraries\Microsoft.VisualBasic.Core\tests\Microsoft\VisualBasic\FileIO\TextFieldParserTests.cs(383,0): at Microsoft.VisualBasic.FileIO.Tests.TextFieldParserTests.ReadFields_PartialReadsFromStream_Large(Boolean fieldsInQuotes)

      Microsoft.VisualBasic.FileIO.Tests.TextFieldParserTests.ReadFields_PartialReadsFromStream_Small(fieldsInQuotes: False) [FAIL]
        Assert.Equal() Failure
        Expected: String[] ["s", "ss", "sssssss", "sssss"]
        Actual:   String[] ["\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"...]
        Stack Trace:
          D:\repos\runtime\src\libraries\Microsoft.VisualBasic.Core\tests\Microsoft\VisualBasic\FileIO\TextFieldParserTests.cs(431,0): at Microsoft.VisualBasic.FileIO.Tests.TextFieldParserTests.ReadFields_PartialReadsFromStream(Boolean fieldsInQuotes, Int32 maxCount)
          D:\repos\runtime\src\libraries\Microsoft.VisualBasic.Core\tests\Microsoft\VisualBasic\FileIO\TextFieldParserTests.cs(389,0): at Microsoft.VisualBasic.FileIO.Tests.TextFieldParserTests.ReadFields_PartialReadsFromStream_Small(Boolean fieldsInQuotes)
        Assert.Equal() Failure

      Microsoft.VisualBasic.FileIO.Tests.TextFieldParserTests.ReadFields_PartialReadsFromStream_Small(fieldsInQuotes: True) [FAIL]
        Expected: String[] ["ssssss", "s", "s", "sssss"]
        Actual:   String[] ["ssssss\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., "s", "s", "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"...]
        Stack Trace:
          D:\repos\runtime\src\libraries\Microsoft.VisualBasic.Core\tests\Microsoft\VisualBasic\FileIO\TextFieldParserTests.cs(431,0): at Microsoft.VisualBasic.FileIO.Tests.TextFieldParserTests.ReadFields_PartialReadsFromStream(Boolean fieldsInQuotes, Int32 maxCount)
          D:\repos\runtime\src\libraries\Microsoft.VisualBasic.Core\tests\Microsoft\VisualBasic\FileIO\TextFieldParserTests.cs(389,0): at Microsoft.VisualBasic.FileIO.Tests.TextFieldParserTests.ReadFields_PartialReadsFromStream_Small(Boolean fieldsInQuotes)

```
and on .NET Framework 4.8:
```
      Microsoft.VisualBasic.FileIO.Tests.TextFieldParserTests.ReadFields_PartialReadsFromStream_Small(fieldsInQuotes: False) [FAIL]
        System.InvalidOperationException : TextFieldParser is unable to complete the read operation because maximum buffer size has been exceeded.
        Stack Trace:
             at Microsoft.VisualBasic.FileIO.TextFieldParser.IncreaseBufferSize()
             at Microsoft.VisualBasic.FileIO.TextFieldParser.ReadNextLine(Int32& Cursor, ChangeBufferFunction ChangeBuffer)
             at Microsoft.VisualBasic.FileIO.TextFieldParser.PeekNextDataLine()
             at Microsoft.VisualBasic.FileIO.TextFieldParser.get_EndOfData()
          D:\repos\runtime\src\libraries\Microsoft.VisualBasic.Core\tests\Microsoft\VisualBasic\FileIO\TextFieldParserTests.cs(428,0): at Microsoft.VisualBasic.FileIO.Tests.TextFieldParserTests.ReadFields_PartialReadsFromStream(Boolean fieldsInQuotes, Int32 maxCount)
          D:\repos\runtime\src\libraries\Microsoft.VisualBasic.Core\tests\Microsoft\VisualBasic\FileIO\TextFieldParserTests.cs(389,0): at Microsoft.VisualBasic.FileIO.Tests.TextFieldParserTests.ReadFields_PartialReadsFromStream_Small(Boolean fieldsInQuotes)

      Microsoft.VisualBasic.FileIO.Tests.TextFieldParserTests.ReadFields_PartialReadsFromStream_Small(fieldsInQuotes: True) [FAIL]
        Assert.Equal() Failure
        Expected: String[] ["ssssss", "s", "s", "sssss"]
        Actual:   String[] ["ssssss\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., "s", "s", "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"...]
        Stack Trace:
          D:\repos\runtime\src\libraries\Microsoft.VisualBasic.Core\tests\Microsoft\VisualBasic\FileIO\TextFieldParserTests.cs(431,0): at Microsoft.VisualBasic.FileIO.Tests.TextFieldParserTests.ReadFields_PartialReadsFromStream(Boolean fieldsInQuotes, Int32 maxCount)
          D:\repos\runtime\src\libraries\Microsoft.VisualBasic.Core\tests\Microsoft\VisualBasic\FileIO\TextFieldParserTests.cs(389,0): at Microsoft.VisualBasic.FileIO.Tests.TextFieldParserTests.ReadFields_PartialReadsFromStream_Small(Boolean fieldsInQuotes)
```

Fixes https://github.com/dotnet/runtime/issues/58857
Fixes https://github.com/dotnet/runtime/issues/59371