### PR TITLE
Append _FILE_OFFSET_BITS=64 to CMAKE_REQUIRED_DEFINITIONS

### DIFF
--- a/src/coreclr/pal/src/configure.cmake
+++ b/src/coreclr/pal/src/configure.cmake
@@ -28,6 +28,8 @@ else()
   set(CMAKE_RT_LIBS "")
 endif()
 
+list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_FILE_OFFSET_BITS=64)
+
 check_include_files(ieeefp.h HAVE_IEEEFP_H)
 check_include_files(sys/vmparam.h HAVE_SYS_VMPARAM_H)
 check_include_files(mach/vm_types.h HAVE_MACH_VM_TYPES_H)


### PR DESCRIPTION
After setting CMAKE_REQUIRED_DEFINITIONS in PAL introspection, we need
to append this definition.

Fixes #58481.
cc @janvorli