### PR TITLE
FileSystem.Unix: Directory.Delete: remove per item syscall.

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/Directory/Delete.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/Delete.cs
@@ -119,35 +119,6 @@ namespace System.IO.Tests
             Assert.False(Directory.Exists(linkPath), "linkPath should no longer exist");
         }
 
-        [ConditionalFact(nameof(CanCreateSymbolicLinks))]
-        public void RecursiveDeletingDoesntFollowLinks()
-        {
-            var target = GetTestFilePath();
-            Directory.CreateDirectory(target);
-
-            var fileInTarget = Path.Combine(target, GetTestFileName());
-            File.WriteAllText(fileInTarget, "");
-
-            var linkParent = GetTestFilePath();
-            Directory.CreateDirectory(linkParent);
-
-            var linkPath = Path.Combine(linkParent, GetTestFileName());
-            Assert.True(MountHelper.CreateSymbolicLink(linkPath, target, isDirectory: true));
-
-            // Both the symlink and the target exist
-            Assert.True(Directory.Exists(target), "target should exist");
-            Assert.True(Directory.Exists(linkPath), "linkPath should exist");
-            Assert.True(File.Exists(fileInTarget), "fileInTarget should exist");
-
-            // Delete the parent folder of the symlink.
-            Directory.Delete(linkParent, true);
-
-            // Target should still exist
-            Assert.True(Directory.Exists(target), "target should still exist");
-            Assert.False(Directory.Exists(linkPath), "linkPath should no longer exist");
-            Assert.True(File.Exists(fileInTarget), "fileInTarget should exist");
-        }
-
         [ConditionalFact(nameof(UsingNewNormalization))]
         public void ExtendedDirectoryWithSubdirectories()
         {
@@ -318,6 +289,35 @@ namespace System.IO.Tests
                 Assert.Throws<IOException>(() => Delete(testDir.FullName, true));
             }
             Assert.True(testDir.Exists);
+        }
+
+        [ConditionalFact(nameof(CanCreateSymbolicLinks))]
+        public void RecursiveDeletingDoesntFollowLinks()
+        {
+            var target = GetTestFilePath();
+            Directory.CreateDirectory(target);
+
+            var fileInTarget = Path.Combine(target, GetTestFileName());
+            File.WriteAllText(fileInTarget, "");
+
+            var linkParent = GetTestFilePath();
+            Directory.CreateDirectory(linkParent);
+
+            var linkPath = Path.Combine(linkParent, GetTestFileName());
+            Assert.NotNull(Directory.CreateSymbolicLink(linkPath, target));
+
+            // Both the symlink and the target exist
+            Assert.True(Directory.Exists(target), "target should exist");
+            Assert.True(Directory.Exists(linkPath), "linkPath should exist");
+            Assert.True(File.Exists(fileInTarget), "fileInTarget should exist");
+
+            // Delete the parent folder of the symlink.
+            Delete(linkParent, true);
+
+            // Target should still exist
+            Assert.True(Directory.Exists(target), "target should still exist");
+            Assert.False(Directory.Exists(linkPath), "linkPath should no longer exist");
+            Assert.True(File.Exists(fileInTarget), "fileInTarget should exist");
         }
     }
 }

--- a/src/libraries/System.IO.FileSystem/tests/Directory/Delete.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/Delete.cs
@@ -308,7 +308,7 @@ namespace System.IO.Tests
 
             // Both the symlink and the target exist
             Assert.True(Directory.Exists(target), "target should exist");
-            Assert.True(Directory.Exists(linkPath) || File.Exists(linkPath), "linkPath should exist");
+            Assert.True(Directory.Exists(linkPath), "linkPath should exist");
             Assert.True(File.Exists(fileInTarget), "fileInTarget should exist");
 
             // Delete the parent folder of the symlink.
@@ -316,7 +316,7 @@ namespace System.IO.Tests
 
             // Target should still exist
             Assert.True(Directory.Exists(target), "target should still exist");
-            Assert.False(Directory.Exists(linkPath) || File.Exists(linkPath), "linkPath should no longer exist");
+            Assert.False(Directory.Exists(linkPath), "linkPath should no longer exist");
             Assert.True(File.Exists(fileInTarget), "fileInTarget should exist");
         }
     }

--- a/src/libraries/System.IO.FileSystem/tests/Directory/Delete.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/Delete.cs
@@ -119,6 +119,35 @@ namespace System.IO.Tests
             Assert.False(Directory.Exists(linkPath), "linkPath should no longer exist");
         }
 
+        [ConditionalFact(nameof(CanCreateSymbolicLinks))]
+        public void RecursiveDeletingDoesntFollowLinks()
+        {
+            var target = GetTestFilePath();
+            Directory.CreateDirectory(target);
+
+            var fileInTarget = Path.Combine(target, GetTestFileName());
+            File.WriteAllText(fileInTarget, "");
+
+            var linkParent = GetTestFilePath();
+            Directory.CreateDirectory(linkParent);
+
+            var linkPath = Path.Combine(linkParent, GetTestFileName());
+            Assert.True(MountHelper.CreateSymbolicLink(linkPath, target, isDirectory: true));
+
+            // Both the symlink and the target exist
+            Assert.True(Directory.Exists(target), "target should exist");
+            Assert.True(Directory.Exists(linkPath), "linkPath should exist");
+            Assert.True(File.Exists(fileInTarget), "fileInTarget should exist");
+
+            // Delete the parent folder of the symlink.
+            Directory.Delete(linkParent, true);
+
+            // Target should still exist
+            Assert.True(Directory.Exists(target), "target should still exist");
+            Assert.False(Directory.Exists(linkPath), "linkPath should no longer exist");
+            Assert.True(File.Exists(fileInTarget), "fileInTarget should exist");
+        }
+
         [ConditionalFact(nameof(UsingNewNormalization))]
         public void ExtendedDirectoryWithSubdirectories()
         {

--- a/src/libraries/System.IO.FileSystem/tests/Directory/Delete.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/Delete.cs
@@ -308,7 +308,7 @@ namespace System.IO.Tests
 
             // Both the symlink and the target exist
             Assert.True(Directory.Exists(target), "target should exist");
-            Assert.True(Directory.Exists(linkPath), "linkPath should exist");
+            Assert.True(Directory.Exists(linkPath) || File.Exists(linkPath), "linkPath should exist");
             Assert.True(File.Exists(fileInTarget), "fileInTarget should exist");
 
             // Delete the parent folder of the symlink.
@@ -316,7 +316,7 @@ namespace System.IO.Tests
 
             // Target should still exist
             Assert.True(Directory.Exists(target), "target should still exist");
-            Assert.False(Directory.Exists(linkPath), "linkPath should no longer exist");
+            Assert.False(Directory.Exists(linkPath) || File.Exists(linkPath), "linkPath should no longer exist");
             Assert.True(File.Exists(fileInTarget), "fileInTarget should exist");
         }
     }

--- a/src/libraries/System.IO.FileSystem/tests/File/Delete.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/Delete.cs
@@ -88,7 +88,7 @@ namespace System.IO.Tests
             var linkPath = GetTestFilePath();
 
             File.Create(path).Dispose();
-            Assert.NotNull(Directory.CreateSymbolicLink(linkPath, path));
+            Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: false));
 
             // Both the symlink and the target exist
             Assert.True(File.Exists(path), "path should exist");

--- a/src/libraries/System.IO.FileSystem/tests/File/Delete.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/Delete.cs
@@ -88,7 +88,7 @@ namespace System.IO.Tests
             var linkPath = GetTestFilePath();
 
             File.Create(path).Dispose();
-            Assert.True(MountHelper.CreateSymbolicLink(linkPath, path, isDirectory: false));
+            Assert.NotNull(Directory.CreateSymbolicLink(linkPath, path));
 
             // Both the symlink and the target exist
             Assert.True(File.Exists(path), "path should exist");


### PR DESCRIPTION
By recursing using FileSystemEnumerable we know the file type and
can omit the stat calls made by DirectoryInfo.Exists.

For the top level path, we can omit the call also and handle
non-directories when rmdir errno is ENOTDIR.

For the recursive case we can avoid recursion when the top level path rmdir
succeeds immediately.

FileSystemEntry is updated so IsSymbolicLink remembers the file is symbolic link
and does not make a syscall for it.