### PR TITLE
Fix incorrect tracking of sign bit

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -2022,6 +2022,11 @@ namespace System.Numerics
 
                 NumericsHelpers.DangerousMakeTwosComplement(xd); // Mutates xd
 
+                // For a shift of N x 32 bit,
+                // We check for a special sequence where its sign bit would be outside the uint array after 2's complement conversion.
+                // For example given [0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF], its 2's complement is [0x01, 0x00, 0x00]
+                // After a 32 bit right shift, it becomes [0x00, 0x00] which is [0x00, 0x00] when converted back.
+                // The expected result is [0x00, 0x00, 0xFFFFFFFF] (2's complement) or [0x00, 0x00, 0x01] when converted back
                 if (smallShift == 0 && xd[0] == 1)
                 {
                     bool allZero = true;

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -2022,9 +2022,9 @@ namespace System.Numerics
 
                 NumericsHelpers.DangerousMakeTwosComplement(xd); // Mutates xd
 
-                if (smallShift == 0)
+                if (smallShift == 0 && xd[0] == 1)
                 {
-                    bool allZero = xd[0] == 1;
+                    bool allZero = true;
                     foreach (uint b in xd[1..])
                     {
                         if (b != 0)

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -2071,7 +2071,6 @@ namespace System.Numerics
                     zd[^1] = 0xFFFFFFFF;
                 }
                 NumericsHelpers.DangerousMakeTwosComplement(zd); // Mutates zd
-
             }
 
             return new BigInteger(zd, zdArray, negx);

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -2023,26 +2023,12 @@ namespace System.Numerics
                 NumericsHelpers.DangerousMakeTwosComplement(xd); // Mutates xd
 
                 // For a shift of N x 32 bit,
-                // We check for a special sequence where its sign bit would be outside the uint array after 2's complement conversion.
+                // We check for a special case where its sign bit could be outside the uint array after 2's complement conversion.
                 // For example given [0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF], its 2's complement is [0x01, 0x00, 0x00]
                 // After a 32 bit right shift, it becomes [0x00, 0x00] which is [0x00, 0x00] when converted back.
                 // The expected result is [0x00, 0x00, 0xFFFFFFFF] (2's complement) or [0x00, 0x00, 0x01] when converted back
-                if (smallShift == 0 && xd[0] == 1)
-                {
-                    bool allZero = true;
-                    foreach (uint b in xd[1..])
-                    {
-                        if (b != 0)
-                        {
-                            allZero = false;
-                            break;
-                        }
-                    }
-                    if (allZero)
-                    {
-                        trackSignBit = true;
-                    }
-                }
+                // If the 2's component's last element is a 0, we will track the sign externally
+                trackSignBit = smallShift == 0 && xd[^1] == 0;
             }
 
             int zl = xd.Length - digitShift + (trackSignBit ? 1: 0);
@@ -2079,12 +2065,13 @@ namespace System.Numerics
             }
             if (negx)
             {
-                NumericsHelpers.DangerousMakeTwosComplement(zd); // Mutates zd
-
+                // Set the tracked sign to the last element
                 if (trackSignBit)
                 {
-                    zd[^1] = 1;
+                    zd[^1] = 0xFFFFFFFF;
                 }
+                NumericsHelpers.DangerousMakeTwosComplement(zd); // Mutates zd
+
             }
 
             return new BigInteger(zd, zdArray, negx);

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -2021,9 +2021,22 @@ namespace System.Numerics
                 }
 
                 NumericsHelpers.DangerousMakeTwosComplement(xd); // Mutates xd
-                if (xd[^1] == 0)
+
+                if (smallShift == 0)
                 {
-                    trackSignBit = true;
+                    bool allZero = xd[0] == 1;
+                    foreach (uint b in xd[1..])
+                    {
+                        if (b != 0)
+                        {
+                            allZero = false;
+                            break;
+                        }
+                    }
+                    if (allZero)
+                    {
+                        trackSignBit = true;
+                    }
                 }
             }
 

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/op_rightshift.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/op_rightshift.cs
@@ -63,11 +63,11 @@ namespace System.Numerics.Tests
                 VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>");
             }
 
-            // RightShift Method - Uint 0xffffffff 0x8000000 ... Large BigIntegers - 31 bit Shift
+            // RightShift Method - Uint 0xffffffff 0x8000000 ... Large BigIntegers - 32 bit Shift
             for (int i = 0; i < s_samples; i++)
             {
                 tempByteArray1 = GetRandomLengthFirstUIntMaxSecondUIntMSBMaxArray(s_random);
-                tempByteArray2 = new byte[] { (byte)31 };
+                tempByteArray2 = new byte[] { (byte)32 };
                 VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>");
             }
 

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/op_rightshift.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/op_rightshift.cs
@@ -63,6 +63,14 @@ namespace System.Numerics.Tests
                 VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>");
             }
 
+            // RightShift Method - Uint 0xffffffff 0x8000000 ... Large BigIntegers - 31 bit Shift
+            for (int i = 0; i < s_samples; i++)
+            {
+                tempByteArray1 = GetRandomLengthFirstUIntMaxSecondUIntMSBMaxArray(s_random);
+                tempByteArray2 = new byte[] { (byte)31 };
+                VerifyRightShiftString(Print(tempByteArray2) + Print(tempByteArray1) + "b>>");
+            }
+
             // RightShift Method - Large BigIntegers - large - Shift
             for (int i = 0; i < s_samples; i++)
             {
@@ -226,6 +234,15 @@ namespace System.Numerics.Tests
             int byteLength = 4 + gap * 4 + 1;
             byte[] array = new byte[byteLength];
             array[0] = 1;
+            array[^1] = 0xFF;
+            return array;
+        }
+        private static byte[] GetRandomLengthFirstUIntMaxSecondUIntMSBMaxArray(Random random)
+        {
+            int gap = random.Next(0, 128);
+            int byteLength = 4 + gap * 4 + 1;
+            byte[] array = new byte[byteLength];
+            array[^6] = 0x80;
             array[^1] = 0xFF;
             return array;
         }


### PR DESCRIPTION
Fixes #59509

The detection was sufficient but the sign tracking should have be done within the 2's complement space.

The fix is now to set the last uint element to be `0xFFFFFFFF` before converting the value back. 
Also added an additional check to make sure this is only done for N x 32 bit right shifts