### PR TITLE
Fix krb5 library SO name in the gss api shim

### DIFF
--- a/src/libraries/Native/Unix/System.Net.Security.Native/pal_gssapi.c
+++ b/src/libraries/Native/Unix/System.Net.Security.Native/pal_gssapi.c
@@ -123,7 +123,7 @@ static void* volatile s_gssLib = NULL;
 #define GSS_C_NT_HOSTBASED_SERVICE          (*GSS_C_NT_HOSTBASED_SERVICE_ptr)
 #define gss_mech_krb5                       (*gss_mech_krb5_ptr)
 
-#define gss_lib_name "libgssapi_krb5.so"
+#define gss_lib_name "libgssapi_krb5.so.2"
 
 static int32_t ensure_gss_shim_initialized()
 {


### PR DESCRIPTION
The library name used in the shim is a name of the build time library which
is usually installed only for development purposes. We should use
libgssapi_krb5.so.2 which is the underlying runtime library.

Close #59518