### PR TITLE
Use new cross-build images for arm/arm64 builds

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -117,7 +117,7 @@ jobs:
       targetRid: linux-musl-arm
       platform: Linux_musl_arm
       container:
-        image: ubuntu-16.04-cross-arm-alpine-20210719121212-044d5b9
+        image: ubuntu-16.04-cross-arm-alpine-20210923140502-78f7860
         registry: mcr
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
@@ -144,7 +144,7 @@ jobs:
       targetRid: linux-musl-arm64
       platform: Linux_musl_arm64
       container:
-        image: ubuntu-16.04-cross-arm64-alpine-20210719121212-b2c2436
+        image: ubuntu-16.04-cross-arm64-alpine-20210923140502-78f7860
         registry: mcr
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}


### PR DESCRIPTION
Align Alpine versions in cross-build.

before:

```sh
$ ARM32_URN=mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm-alpine-20210719121212-044d5b9
$ ARM64_URN=mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-alpine-20210719121212-b2c2436

$ docker run $ARM32_URN grep VERSION /crossrootfs/arm/etc/os-release
VERSION_ID=3.13.5

$ docker run $ARM64_URN grep VERSION /crossrootfs/arm64/etc/os-release
VERSION_ID=3.9.6
```

after:

```sh
$ ARM32_URN=mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm-alpine-20210923140502-78f7860
$ ARM64_URN=mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-alpine-20210923140502-78f7860

$ docker run $ARM32_URN grep VERSION /crossrootfs/arm/etc/os-release
VERSION_ID=3.13.6

$ docker run $ARM64_URN grep VERSION /crossrootfs/arm64/etc/os-release
VERSION_ID=3.13.6
```

cc @janvorli