### PR TITLE
[Release/6.0] Throw error if assembly version for ref pack assemblies  doesnot match assembly version shipped in 6.0.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,7 +20,7 @@
     <UsingToolMicrosoftNetILLinkTasks>true</UsingToolMicrosoftNetILLinkTasks>
     <UsingToolIbcOptimization>false</UsingToolIbcOptimization>
     <UsingToolXliff>false</UsingToolXliff>
-    <LastReleasedStableAssemblyVersion>6.0.0.0</LastReleasedStableAssemblyVersion>
+    <LastReleasedStableAssemblyVersion>$(AssemblyVersion)</LastReleasedStableAssemblyVersion>
   </PropertyGroup>
   <!--
     Servicing build settings for Setup/Installer packages. Instructions:

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,6 +20,7 @@
     <UsingToolMicrosoftNetILLinkTasks>true</UsingToolMicrosoftNetILLinkTasks>
     <UsingToolIbcOptimization>false</UsingToolIbcOptimization>
     <UsingToolXliff>false</UsingToolXliff>
+    <LastReleasedStableAssemblyVersion>6.0.0.0</LastReleasedStableAssemblyVersion>
   </PropertyGroup>
   <!--
     Servicing build settings for Setup/Installer packages. Instructions:

--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -257,7 +257,7 @@
   </Target>
 
   <Target Name="ValidateAssemblyVersionsInRefPack" 
-          Condition="$(_AssemblyInTargetingPack) == 'true' and '$(PreReleaseVersionLabel)' != 'servicing'" 
+          Condition="$(_AssemblyInTargetingPack) == 'true' and '$(PreReleaseVersionLabel)' == 'servicing'" 
           AfterTargets="CoreCompile" >
     <Error Condition="'$(AssemblyVersion)' != '$(LastReleasedStableAssemblyVersion)'" Text="AssemblyVersion should match last released assembly version $(LastReleasedStableAssemblyVersion)" />
   </Target>

--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -256,4 +256,10 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="ValidateAssemblyVersionsInRefPack" 
+          Condition="$(_AssemblyInTargetingPack) == 'true' and '$(PreReleaseVersionLabel)' != 'servicing'" 
+          AfterTargets="CoreCompile" >
+    <Error Condition="'$(AssemblyVersion)' != '$(LastReleasedStableAssemblyVersion)'" Text="AssemblyVersion should match last released assembly version $(LastReleasedStableAssemblyVersion)" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
This step is being added as an extra precaution to avoid incrementing the assembly versions for assemblies in the ref pack.
We already automatically calculate it.