### PR TITLE
Fix ArrayPool leak with JsonDocument

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -75,7 +75,7 @@ namespace System.Text.Json
 
             if (_extraRentedArrayPoolBytes != null)
             {
-                byte[]? extraRentedBytes = Interlocked.Exchange(ref _extraRentedArrayPoolBytes, null);
+                byte[]? extraRentedBytes = Interlocked.Exchange<byte[]?>(ref _extraRentedArrayPoolBytes, null);
 
                 if (extraRentedBytes != null)
                 {
@@ -87,7 +87,7 @@ namespace System.Text.Json
             }
             else if (_extraPooledByteBufferWriter != null)
             {
-                PooledByteBufferWriter? extraBufferWriter = Interlocked.Exchange(ref _extraPooledByteBufferWriter, null);
+                PooledByteBufferWriter? extraBufferWriter = Interlocked.Exchange<PooledByteBufferWriter?>(ref _extraPooledByteBufferWriter, null);
                 extraBufferWriter?.Dispose();
             }
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -49,10 +49,8 @@ namespace System.Text.Json
             Debug.Assert(isDisposable ||
                 (extraRentedArrayPoolBytes == null && extraPooledByteBufferWriter == null));
 
-            // Exactly one of the rented values better be non-null if we're disposable.
-            Debug.Assert(!isDisposable ||
-                ((extraRentedArrayPoolBytes != null || extraPooledByteBufferWriter != null) &&
-                (extraRentedArrayPoolBytes == null || extraPooledByteBufferWriter == null)));
+            // Both rented values can't be specified.
+            Debug.Assert(extraRentedArrayPoolBytes == null || extraPooledByteBufferWriter == null);
 
             _utf8Json = utf8Json;
             _parsedData = parsedData;


### PR DESCRIPTION
Fixes a leak of `ArrayPool<byte>` used by `JsonDocument` under certain cases.

Leak created in 6.0 and due to typo:
` if (_extraRentedArrayPoolBytes != null)`
should have been
` if (extraRentedArrayPoolBytes != null)`

This should be ported to 6.0 ASAP.

Note that ArrayPool limits the number of entries, so this is not an unbounded leak.