### PR TITLE
[release/5.0] Additional RPMs for CBL-Mariner

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -62,7 +62,7 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2e26f9ebee3ac27803aa5f2df50192a46393d108</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" Version="5.0.0-beta.21427.7">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" Version="5.0.0-beta.21473.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>2e26f9ebee3ac27803aa5f2df50192a46393d108</Sha>
     </Dependency>

--- a/global.json
+++ b/global.json
@@ -14,7 +14,7 @@
   "msbuild-sdks": {
     "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "5.0.0-beta.21427.7",
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.21427.7",
-    "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.21427.7",
+    "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.21473.2",
     "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.21427.7",
     "Microsoft.FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
     "Microsoft.NET.Sdk.IL": "5.0.0-preview.8.20359.4",

--- a/src/installer/Directory.Build.targets
+++ b/src/installer/Directory.Build.targets
@@ -190,6 +190,13 @@
       <SharedFrameworkInstallerFile>$(SharedFrameworkInstallerStart)$(SharedFrameworkNugetVersion)-$(TargetArchitecture)$(InstallerExtension)</SharedFrameworkInstallerFile>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(InstallerExtension)' == '.rpm'">
+      <_CblMarinerVersionSuffix>cm.1</_CblMarinerVersionSuffix>
+      <SharedHostInstallerFileCblMariner>$(SharedHostInstallerStart)$(SharedFrameworkNugetVersion)-$(_CblMarinerVersionSuffix)-$(TargetArchitecture)$(InstallerExtension)</SharedHostInstallerFileCblMariner>
+      <HostFxrInstallerFileCblMariner>$(HostFxrInstallerStart)$(HostResolverVersion)-$(_CblMarinerVersionSuffix)-$(TargetArchitecture)$(InstallerExtension)</HostFxrInstallerFileCblMariner>
+      <SharedFrameworkInstallerFileCblMariner>$(SharedFrameworkInstallerStart)$(SharedFrameworkNugetVersion)-$(_CblMarinerVersionSuffix)-$(TargetArchitecture)$(InstallerExtension)</SharedFrameworkInstallerFileCblMariner>
+    </PropertyGroup>
+
     <!-- Runtime-deps Deb package is distro version agnostic. -->
     <PropertyGroup Condition="'$(InstallerExtension)' == '.deb'">
       <DotnetRuntimeDependenciesPackageInstallerFile>$(DotnetRuntimeDependenciesPackageInstallerStart)$(SharedFrameworkNugetVersion)-$(TargetArchitecture)$(InstallerExtension)</DotnetRuntimeDependenciesPackageInstallerFile>

--- a/src/installer/pkg/packaging/rpm/package.targets
+++ b/src/installer/pkg/packaging/rpm/package.targets
@@ -27,6 +27,7 @@
       <RpmPackageVersion>$(HostPackageVersion)</RpmPackageVersion>
       <InputRoot>$(SharedHostPublishRoot)</InputRoot>
       <RpmFile>$(SharedHostInstallerFile)</RpmFile>
+      <RpmFileCblMariner>$(SharedHostInstallerFileCblMariner)</RpmFileCblMariner>
       <ConfigJsonName>dotnet-sharedhost-rpm_config.json</ConfigJsonName>
       <ConfigJsonFile>$(rpmPackagingConfigPath)$(ConfigJsonName)</ConfigJsonFile>
       <RpmIntermediatesDir>$(PackagesIntermediateDir)$(RpmPackageName)/$(RpmPackageVersion)</RpmIntermediatesDir>
@@ -122,6 +123,12 @@
           SkipUnchangedFiles="False"
           UseHardlinksIfPossible="False" />
 
+    <Copy SourceFiles="@(GeneratedRpmFiles)"
+          DestinationFiles="$(RpmFileCblMariner)"
+          OverwriteReadOnlyFiles="True"
+          SkipUnchangedFiles="False"
+          UseHardlinksIfPossible="False" />
+
     <!--
       Clean up dotnet symlink. Later build steps are confused and fail because the symlink points to
       a path that doesn't exist on the build machine.
@@ -135,6 +142,7 @@
       <RpmPackageVersion>$(HostResolverPackageVersion)</RpmPackageVersion>
       <InputRoot>$(HostFxrPublishRoot)</InputRoot>
       <RpmFile>$(HostFxrInstallerFile)</RpmFile>
+      <RpmFileCblMariner>$(HostFxrInstallerFileCblMariner)</RpmFileCblMariner>
       <ConfigJsonName>dotnet-hostfxr-rpm_config.json</ConfigJsonName>
       <ConfigJsonFile>$(rpmPackagingConfigPath)$(ConfigJsonName)</ConfigJsonFile>
       <RpmIntermediatesDir>$(PackagesIntermediateDir)$(RpmPackageName)/$(RpmPackageVersion)</RpmIntermediatesDir>
@@ -214,6 +222,12 @@
           SkipUnchangedFiles="False"
           UseHardlinksIfPossible="False" />
 
+    <Copy SourceFiles="@(GeneratedRpmFiles)"
+          DestinationFiles="$(RpmFileCblMariner)"
+          OverwriteReadOnlyFiles="True"
+          SkipUnchangedFiles="False"
+          UseHardlinksIfPossible="False" />
+
   </Target>
 
   <Target Name="GenerateSharedFrameworkRpm">
@@ -222,6 +236,7 @@
       <RpmPackageVersion>$(RuntimePackageVersion)</RpmPackageVersion>
       <InputRoot>$(SharedFrameworkPublishRoot)</InputRoot>
       <RpmFile>$(SharedFrameworkInstallerFile)</RpmFile>
+      <RpmFileCblMariner>$(SharedFrameworkInstallerFileCblMariner)</RpmFileCblMariner>
       <ConfigJsonName>dotnet-sharedframework-rpm_config.json</ConfigJsonName>
       <ConfigJsonFile>$(rpmPackagingConfigPath)$(ConfigJsonName)</ConfigJsonFile>
       <RpmIntermediatesDir>$(PackagesIntermediateDir)$(RpmPackageName)/$(RpmPackageVersion)</RpmIntermediatesDir>
@@ -309,6 +324,12 @@
 
     <Copy SourceFiles="@(GeneratedRpmFiles)"
           DestinationFiles="$(RpmFile)"
+          OverwriteReadOnlyFiles="True"
+          SkipUnchangedFiles="False"
+          UseHardlinksIfPossible="False" />
+
+    <Copy SourceFiles="@(GeneratedRpmFiles)"
+          DestinationFiles="$(RpmFileCblMariner)"
           OverwriteReadOnlyFiles="True"
           SkipUnchangedFiles="False"
           UseHardlinksIfPossible="False" />


### PR DESCRIPTION
Backport of https://github.com/dotnet/arcade/pull/7812

This also brings newer Arcade to pick up change in shared infra: https://github.com/dotnet/arcade/pull/7951

Host, hostfxr, deps and shared-fx packaging uses infra in runtime repo. Other projects (i.e. AppHost) use shared infra.