### PR TITLE
Add execute bit to postinstall script

### DIFF
--- a/src/installer/pkg/sfx/installers/dotnet-host.proj
+++ b/src/installer/pkg/sfx/installers/dotnet-host.proj
@@ -105,6 +105,8 @@
                               Properties="$(_MacOSScriptsTemplateProperties)">
       <Output TaskParameter="ResolvedOutputPath" ItemName="FileWrites" />
     </GenerateFileFromTemplate>
+
+    <Exec Condition="!$([MSBuild]::IsOSPlatform('windows'))" Command="chmod +x %(_MacOSScript.Destination)" />
   </Target>
 
   <ItemGroup>


### PR DESCRIPTION
Workaround https://github.com/dotnet/arcade/issues/7954

I regressed this when switching to use a template.  The template doesn't preserve the execute bit from the scripts.  That persists to the final package which then fails to install.