### PR TITLE
[wasm] windows: Fail the build if provisioning fails

### DIFF
--- a/eng/pipelines/mono/update-machine-certs.ps1
+++ b/eng/pipelines/mono/update-machine-certs.ps1
@@ -1,3 +1,28 @@
 # This seems to update the machine cert store so that python can download the files as required by emscripten's install
 # Based on info at https://pypi.org/project/certifi/
 pip install certifi
+
+$WebsiteURL="storage.googleapis.com"
+Try {
+    $Conn = New-Object System.Net.Sockets.TcpClient($WebsiteURL,443)
+
+    Try {
+        $Stream = New-Object System.Net.Security.SslStream($Conn.GetStream())
+        $Stream.AuthenticateAsClient($WebsiteURL)
+
+        $Cert = $Stream.Get_RemoteCertificate()
+
+        $ValidTo = [datetime]::Parse($Cert.GetExpirationDatestring())
+
+        Write-Host "`nConnection Successfull" -ForegroundColor DarkGreen
+        Write-Host "Website: $WebsiteURL"
+    }
+    Catch { Throw $_ }
+    Finally { $Conn.close() }
+    }
+    Catch {
+            Write-Host "`nError occurred connecting to $($WebsiteURL)" -ForegroundColor Yellow
+            Write-Host "Website: $WebsiteURL"
+            Write-Host "Status:" $_.exception.innerexception.message -ForegroundColor Yellow
+            Write-Host ""
+}

--- a/eng/pipelines/mono/update-machine-certs.ps1
+++ b/eng/pipelines/mono/update-machine-certs.ps1
@@ -1,25 +1,3 @@
 # This seems to update the machine cert store so that python can download the files as required by emscripten's install
-$WebsiteURL="storage.googleapis.com"
-Try {
-    $Conn = New-Object System.Net.Sockets.TcpClient($WebsiteURL,443) 
-  
-    Try {
-        $Stream = New-Object System.Net.Security.SslStream($Conn.GetStream())
-        $Stream.AuthenticateAsClient($WebsiteURL) 
-   
-        $Cert = $Stream.Get_RemoteCertificate()
- 
-        $ValidTo = [datetime]::Parse($Cert.GetExpirationDatestring())
-   
-        Write-Host "`nConnection Successfull" -ForegroundColor DarkGreen
-        Write-Host "Website: $WebsiteURL"
-    }
-    Catch { Throw $_ }
-    Finally { $Conn.close() }
-    }
-    Catch {
-            Write-Host "`nError occurred connecting to $($WebsiteURL)" -ForegroundColor Yellow
-            Write-Host "Website: $WebsiteURL"
-            Write-Host "Status:" $_.exception.innerexception.message -ForegroundColor Yellow
-            Write-Host ""
-}
+# Based on info at https://pypi.org/project/certifi/
+pip install certifi

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -152,7 +152,7 @@
     <Exec Command="git clone https://github.com/emscripten-core/emsdk.git emsdk"
           WorkingDirectory="$(WasmLocalPath)"
           IgnoreStandardErrorWarningFormat="true" />
-      <Exec Command="git checkout $(EmscriptenVersion) &amp;&amp; $(InstallCmd) &amp;&amp; $(ActivateCmd)"
+    <Exec Command="git checkout $(EmscriptenVersion) &amp;&amp; $(InstallCmd) &amp;&amp; $(ActivateCmd)"
           WorkingDirectory="$(EMSDK_PATH)"
           IgnoreStandardErrorWarningFormat="true" />
   </Target>

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -136,18 +136,23 @@
 
     <PropertyGroup>
       <EmsdkExt Condition="'$(OS)' != 'Windows_NT'">.sh</EmsdkExt>
-      <EmsdkExt Condition="'$(OS)' == 'Windows_NT'">.bat</EmsdkExt>
+      <EmsdkExt Condition="'$(OS)' == 'Windows_NT'">.ps1</EmsdkExt>
       <EMSDK_PATH>$(ProvisionEmscriptenDir)</EMSDK_PATH>
       <WasmLocalPath>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'wasm'))</WasmLocalPath>
       <EmsdkLocalPath>emsdk</EmsdkLocalPath>
       <EmscriptenVersion>%(_VersionLines.Identity)</EmscriptenVersion>
+
+      <InstallCmd>./emsdk$(EmsdkExt) install $(EmscriptenVersion)</InstallCmd>
+      <ActivateCmd>./emsdk$(EmsdkExt) activate $(EmscriptenVersion)</ActivateCmd>
+      <InstallCmd Condition="'$(OS)' == 'Windows_NT'">powershell -NonInteractive -command &quot;&amp; $(InstallCmd); Exit $LastExitCode &quot;</InstallCmd>
+      <ActivateCmd Condition="'$(OS)' == 'Windows_NT'">powershell -NonInteractive -command &quot;&amp; $(ActivateCmd); Exit $LastExitCode &quot;</ActivateCmd>
     </PropertyGroup>
 
     <RemoveDir Directories="$(EMSDK_PATH)" />
     <Exec Command="git clone https://github.com/emscripten-core/emsdk.git emsdk"
           WorkingDirectory="$(WasmLocalPath)"
           IgnoreStandardErrorWarningFormat="true" />
-    <Exec Command="git checkout $(EmscriptenVersion) &amp;&amp; emsdk$(EmsdkExt) install $(EmscriptenVersion) &amp;&amp; emsdk$(EmsdkExt) activate $(EmscriptenVersion)"
+      <Exec Command="git checkout $(EmscriptenVersion) &amp;&amp; $(InstallCmd) &amp;&amp; $(ActivateCmd)"
           WorkingDirectory="$(EMSDK_PATH)"
           IgnoreStandardErrorWarningFormat="true" />
   </Target>


### PR DESCRIPTION
.. and install the certificates for use by python.

Fixes https://github.com/dotnet/runtime/issues/59556 .