### PR TITLE
Process: throw ArgumentNullException when ArgumentList contains a null.

### DIFF
--- a/src/libraries/System.Diagnostics.Process/src/Resources/Strings.resx
+++ b/src/libraries/System.Diagnostics.Process/src/Resources/Strings.resx
@@ -326,6 +326,9 @@
   <data name="ArgumentAndArgumentListInitialized" xml:space="preserve">
     <value>Only one of Arguments or ArgumentList may be used.</value>
   </data>
+  <data name="ArgumentListMayNotContainNull" xml:space="preserve">
+    <value>ArgumentList may not contain null.</value>
+  </data>
   <data name="KillEntireProcessTree_DisallowedBecauseTreeContainsCallingProcess" xml:space="preserve">
     <value>Cannot be used to terminate a process tree containing the calling process.</value>
   </data>

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -1230,6 +1230,16 @@ namespace System.Diagnostics
             {
                 throw new InvalidOperationException(SR.ArgumentAndArgumentListInitialized);
             }
+            if (startInfo.HasArgumentList)
+            {
+                foreach (string arg in startInfo.ArgumentList)
+                {
+                    if (arg is null)
+                    {
+                        throw new ArgumentNullException(nameof(startInfo.ArgumentList));
+                    }
+                }
+            }
 
             //Cannot start a new process and store its handle if the object has been disposed, since finalization has been suppressed.
             CheckDisposed();

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -1232,9 +1232,10 @@ namespace System.Diagnostics
             }
             if (startInfo.HasArgumentList)
             {
-                foreach (string arg in startInfo.ArgumentList)
+                int argumentCount = startInfo.ArgumentList.Count;
+                for (int i = 0; i < argumentCount; i++)
                 {
-                    if (arg is null)
+                    if (startInfo.ArgumentList[i] is null)
                     {
                         throw new ArgumentNullException("item", SR.ArgumentListMayNotContainNull);
                     }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -1236,7 +1236,7 @@ namespace System.Diagnostics
                 {
                     if (arg is null)
                     {
-                        throw new ArgumentNullException(nameof(startInfo.ArgumentList));
+                        throw new ArgumentNullException("item", SR.ArgumentListMayNotContainNull);
                     }
                 }
             }

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -2223,7 +2223,7 @@ namespace System.Diagnostics.Tests
             Process testProcess = CreateProcess();
             testProcess.StartInfo = psi;
 
-            Assert.Throws<ArgumentNullException>(() => testProcess.Start());
+            AssertExtensions.Throws<ArgumentNullException>("item", () => testProcess.Start());
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -2214,6 +2214,18 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [Fact]
+        public void ArgumentListArgumentNullThrowsOnStart()
+        {
+            ProcessStartInfo psi = new ProcessStartInfo(GetCurrentProcessName());
+            psi.ArgumentList.Add(null);
+
+            Process testProcess = CreateProcess();
+            testProcess.StartInfo = psi;
+
+            Assert.Throws<ArgumentNullException>(() => testProcess.Start());
+        }
+
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void StartProcessWithSameArgumentList()


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/44034.