### PR TITLE
[release/6.0-rc2] Fix ArrayPool leak with JsonDocument

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -54,7 +54,7 @@ namespace System.Text.Json
             _utf8Json = utf8Json;
             _parsedData = parsedData;
 
-            if (_extraRentedArrayPoolBytes != null)
+            if (extraRentedArrayPoolBytes != null)
             {
                 _hasExtraRentedArrayPoolBytes = true;
                 _extraRentedArrayPoolBytes = extraRentedArrayPoolBytes;


### PR DESCRIPTION
Fixes an issue introduced in 6.0 that prevents rented data from being returned to the ArrayPool.

Targeted fix of 7.0 https://github.com/dotnet/runtime/pull/59540

## Customer Impact

An ArrayPool leak for certain scenarios of `JsonDocument`. Since ArrayPool has buckets based on the requested size, the leak is not unbounded since a normal alloc will occur once a given bucket is full. However, that has an negative effect on CPU\GC behavior since normal allocs will occur instead of a pooled alloc.

## Testing

There are no tests to verify ArrayPool semantics.

## Risk

Low, fixes a single-line typo.
