### PR TITLE
Updating dependencies from https://github.com/dotnet/arcade build 20210923.5

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -14,77 +14,77 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.21467.3">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.21473.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>dd9dbfedbdb31401bb16bba8366f31bbd382549b</Sha>
+      <Sha>c575da80f465e0b5fb98f416be92bb98b2f54b41</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="6.0.0-beta.21467.3">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="6.0.0-beta.21473.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>dd9dbfedbdb31401bb16bba8366f31bbd382549b</Sha>
+      <Sha>c575da80f465e0b5fb98f416be92bb98b2f54b41</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="6.0.0-beta.21467.3">
+    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="6.0.0-beta.21473.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>dd9dbfedbdb31401bb16bba8366f31bbd382549b</Sha>
+      <Sha>c575da80f465e0b5fb98f416be92bb98b2f54b41</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="6.0.0-beta.21467.3">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="6.0.0-beta.21473.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>dd9dbfedbdb31401bb16bba8366f31bbd382549b</Sha>
+      <Sha>c575da80f465e0b5fb98f416be92bb98b2f54b41</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenFacades" Version="6.0.0-beta.21467.3">
+    <Dependency Name="Microsoft.DotNet.GenFacades" Version="6.0.0-beta.21473.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>dd9dbfedbdb31401bb16bba8366f31bbd382549b</Sha>
+      <Sha>c575da80f465e0b5fb98f416be92bb98b2f54b41</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="6.0.0-beta.21467.3">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="6.0.0-beta.21473.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>dd9dbfedbdb31401bb16bba8366f31bbd382549b</Sha>
+      <Sha>c575da80f465e0b5fb98f416be92bb98b2f54b41</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitConsoleRunner" Version="2.5.1-beta.21467.3">
+    <Dependency Name="Microsoft.DotNet.XUnitConsoleRunner" Version="2.5.1-beta.21473.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>dd9dbfedbdb31401bb16bba8366f31bbd382549b</Sha>
+      <Sha>c575da80f465e0b5fb98f416be92bb98b2f54b41</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Archives" Version="6.0.0-beta.21467.3">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Archives" Version="6.0.0-beta.21473.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>dd9dbfedbdb31401bb16bba8366f31bbd382549b</Sha>
+      <Sha>c575da80f465e0b5fb98f416be92bb98b2f54b41</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="6.0.0-beta.21467.3">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="6.0.0-beta.21473.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>dd9dbfedbdb31401bb16bba8366f31bbd382549b</Sha>
+      <Sha>c575da80f465e0b5fb98f416be92bb98b2f54b41</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="6.0.0-beta.21467.3">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="6.0.0-beta.21473.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>dd9dbfedbdb31401bb16bba8366f31bbd382549b</Sha>
+      <Sha>c575da80f465e0b5fb98f416be92bb98b2f54b41</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="6.0.0-beta.21467.3">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="6.0.0-beta.21473.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>dd9dbfedbdb31401bb16bba8366f31bbd382549b</Sha>
+      <Sha>c575da80f465e0b5fb98f416be92bb98b2f54b41</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="6.0.0-beta.21467.3">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="6.0.0-beta.21473.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>dd9dbfedbdb31401bb16bba8366f31bbd382549b</Sha>
+      <Sha>c575da80f465e0b5fb98f416be92bb98b2f54b41</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="6.0.0-beta.21467.3">
+    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="6.0.0-beta.21473.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>dd9dbfedbdb31401bb16bba8366f31bbd382549b</Sha>
+      <Sha>c575da80f465e0b5fb98f416be92bb98b2f54b41</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk" Version="6.0.0-beta.21467.3">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk" Version="6.0.0-beta.21473.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>dd9dbfedbdb31401bb16bba8366f31bbd382549b</Sha>
+      <Sha>c575da80f465e0b5fb98f416be92bb98b2f54b41</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="6.0.0-beta.21467.3">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="6.0.0-beta.21473.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>dd9dbfedbdb31401bb16bba8366f31bbd382549b</Sha>
+      <Sha>c575da80f465e0b5fb98f416be92bb98b2f54b41</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="6.0.0-beta.21467.3">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="6.0.0-beta.21473.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>dd9dbfedbdb31401bb16bba8366f31bbd382549b</Sha>
+      <Sha>c575da80f465e0b5fb98f416be92bb98b2f54b41</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.VersionTools.Tasks" Version="6.0.0-beta.21467.3">
+    <Dependency Name="Microsoft.DotNet.VersionTools.Tasks" Version="6.0.0-beta.21473.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>dd9dbfedbdb31401bb16bba8366f31bbd382549b</Sha>
+      <Sha>c575da80f465e0b5fb98f416be92bb98b2f54b41</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="6.0.0-beta.21467.3">
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="6.0.0-beta.21473.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>dd9dbfedbdb31401bb16bba8366f31bbd382549b</Sha>
+      <Sha>c575da80f465e0b5fb98f416be92bb98b2f54b41</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Test.Sdk" Version="16.9.0-preview-20201201-01">
       <Uri>https://github.com/microsoft/vstest</Uri>
@@ -206,9 +206,9 @@
       <Uri>https://github.com/dotnet/xharness</Uri>
       <Sha>e9669dc84ecd668d3bbb748758103e23b394ffef</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.PackageTesting" Version="6.0.0-beta.21467.3">
+    <Dependency Name="Microsoft.DotNet.PackageTesting" Version="6.0.0-beta.21473.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>dd9dbfedbdb31401bb16bba8366f31bbd382549b</Sha>
+      <Sha>c575da80f465e0b5fb98f416be92bb98b2f54b41</Sha>
     </Dependency>
     <Dependency Name="optimization.windows_nt-x64.MIBC.Runtime" Version="1.0.0-prerelease.21416.5">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -53,21 +53,21 @@
     <!-- SDK dependencies -->
     <MicrosoftDotNetCompatibilityVersion>1.0.0-rc.2.21419.17</MicrosoftDotNetCompatibilityVersion>
     <!-- Arcade dependencies -->
-    <MicrosoftDotNetApiCompatVersion>6.0.0-beta.21467.3</MicrosoftDotNetApiCompatVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.21467.3</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetCodeAnalysisVersion>6.0.0-beta.21467.3</MicrosoftDotNetCodeAnalysisVersion>
-    <MicrosoftDotNetGenAPIVersion>6.0.0-beta.21467.3</MicrosoftDotNetGenAPIVersion>
-    <MicrosoftDotNetGenFacadesVersion>6.0.0-beta.21467.3</MicrosoftDotNetGenFacadesVersion>
-    <MicrosoftDotNetXUnitExtensionsVersion>6.0.0-beta.21467.3</MicrosoftDotNetXUnitExtensionsVersion>
-    <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.21467.3</MicrosoftDotNetXUnitConsoleRunnerVersion>
-    <MicrosoftDotNetBuildTasksArchivesVersion>6.0.0-beta.21467.3</MicrosoftDotNetBuildTasksArchivesVersion>
-    <MicrosoftDotNetBuildTasksInstallersVersion>6.0.0-beta.21467.3</MicrosoftDotNetBuildTasksInstallersVersion>
-    <MicrosoftDotNetBuildTasksPackagingVersion>6.0.0-beta.21467.3</MicrosoftDotNetBuildTasksPackagingVersion>
-    <MicrosoftDotNetBuildTasksTemplatingVersion>6.0.0-beta.21467.3</MicrosoftDotNetBuildTasksTemplatingVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>6.0.0-beta.21467.3</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetRemoteExecutorVersion>6.0.0-beta.21467.3</MicrosoftDotNetRemoteExecutorVersion>
-    <MicrosoftDotNetVersionToolsTasksVersion>6.0.0-beta.21467.3</MicrosoftDotNetVersionToolsTasksVersion>
-    <MicrosoftDotNetPackageTestingVersion>6.0.0-beta.21467.3</MicrosoftDotNetPackageTestingVersion>
+    <MicrosoftDotNetApiCompatVersion>6.0.0-beta.21473.5</MicrosoftDotNetApiCompatVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>6.0.0-beta.21473.5</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetCodeAnalysisVersion>6.0.0-beta.21473.5</MicrosoftDotNetCodeAnalysisVersion>
+    <MicrosoftDotNetGenAPIVersion>6.0.0-beta.21473.5</MicrosoftDotNetGenAPIVersion>
+    <MicrosoftDotNetGenFacadesVersion>6.0.0-beta.21473.5</MicrosoftDotNetGenFacadesVersion>
+    <MicrosoftDotNetXUnitExtensionsVersion>6.0.0-beta.21473.5</MicrosoftDotNetXUnitExtensionsVersion>
+    <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.21473.5</MicrosoftDotNetXUnitConsoleRunnerVersion>
+    <MicrosoftDotNetBuildTasksArchivesVersion>6.0.0-beta.21473.5</MicrosoftDotNetBuildTasksArchivesVersion>
+    <MicrosoftDotNetBuildTasksInstallersVersion>6.0.0-beta.21473.5</MicrosoftDotNetBuildTasksInstallersVersion>
+    <MicrosoftDotNetBuildTasksPackagingVersion>6.0.0-beta.21473.5</MicrosoftDotNetBuildTasksPackagingVersion>
+    <MicrosoftDotNetBuildTasksTemplatingVersion>6.0.0-beta.21473.5</MicrosoftDotNetBuildTasksTemplatingVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>6.0.0-beta.21473.5</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetRemoteExecutorVersion>6.0.0-beta.21473.5</MicrosoftDotNetRemoteExecutorVersion>
+    <MicrosoftDotNetVersionToolsTasksVersion>6.0.0-beta.21473.5</MicrosoftDotNetVersionToolsTasksVersion>
+    <MicrosoftDotNetPackageTestingVersion>6.0.0-beta.21473.5</MicrosoftDotNetPackageTestingVersion>
     <!-- NuGet dependencies -->
     <NuGetBuildTasksPackVersion>6.0.0-preview.1.102</NuGetBuildTasksPackVersion>
     <!-- Installer dependencies -->

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -709,14 +709,7 @@ function MSBuild() {
       Write-PipelineSetVariable -Name 'NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS' -Value '20'
     }
 
-    if ($ci) {
-      $env:NUGET_ENABLE_EXPERIMENTAL_HTTP_RETRY = 'true'
-      $env:NUGET_EXPERIMENTAL_MAX_NETWORK_TRY_COUNT = 6
-      $env:NUGET_EXPERIMENTAL_NETWORK_RETRY_DELAY_MILLISECONDS = 1000
-      Write-PipelineSetVariable -Name 'NUGET_ENABLE_EXPERIMENTAL_HTTP_RETRY' -Value 'true'
-      Write-PipelineSetVariable -Name 'NUGET_EXPERIMENTAL_MAX_NETWORK_TRY_COUNT' -Value '6'
-      Write-PipelineSetVariable -Name 'NUGET_EXPERIMENTAL_NETWORK_RETRY_DELAY_MILLISECONDS' -Value '1000'
-    }
+    Enable-Nuget-EnhancedRetry
 
     $toolsetBuildProject = InitializeToolset
     $basePath = Split-Path -parent $toolsetBuildProject
@@ -763,6 +756,8 @@ function MSBuild-Core() {
       ExitWithExitCode 1
     }
   }
+
+  Enable-Nuget-EnhancedRetry
 
   $buildTool = InitializeBuildTool
 
@@ -902,5 +897,20 @@ function Try-LogClientIpAddress()
     catch
     {
         Write-Host "Unable to get this machine's effective IP address for logging: $_"
+    }
+}
+
+#
+# If $ci flag is set, turn on (and log that we did) special environment variables for improved Nuget client retry logic.
+#
+function Enable-Nuget-EnhancedRetry() {
+    if ($ci) {
+      Write-Host "Setting NUGET enhanced retry environment variables"
+      $env:NUGET_ENABLE_EXPERIMENTAL_HTTP_RETRY = 'true'
+      $env:NUGET_EXPERIMENTAL_MAX_NETWORK_TRY_COUNT = 6
+      $env:NUGET_EXPERIMENTAL_NETWORK_RETRY_DELAY_MILLISECONDS = 1000
+      Write-PipelineSetVariable -Name 'NUGET_ENABLE_EXPERIMENTAL_HTTP_RETRY' -Value 'true'
+      Write-PipelineSetVariable -Name 'NUGET_EXPERIMENTAL_MAX_NETWORK_TRY_COUNT' -Value '6'
+      Write-PipelineSetVariable -Name 'NUGET_EXPERIMENTAL_NETWORK_RETRY_DELAY_MILLISECONDS' -Value '1000'
     }
 }

--- a/global.json
+++ b/global.json
@@ -12,10 +12,10 @@
     "python3": "3.7.1"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "6.0.0-beta.21467.3",
-    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21467.3",
-    "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.21467.3",
-    "Microsoft.DotNet.SharedFramework.Sdk": "6.0.0-beta.21467.3",
+    "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "6.0.0-beta.21473.5",
+    "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21473.5",
+    "Microsoft.DotNet.Helix.Sdk": "6.0.0-beta.21473.5",
+    "Microsoft.DotNet.SharedFramework.Sdk": "6.0.0-beta.21473.5",
     "Microsoft.Build.NoTargets": "3.1.0",
     "Microsoft.Build.Traversal": "3.0.23",
     "Microsoft.NET.Sdk.IL": "6.0.0-rc.1.21415.6"


### PR DESCRIPTION
Not sure why this isn't happening automatically, but forcing here since we need this fix for RC2.