### PR TITLE
[tests] Fix PlatformDetection.IsMonoInterpreter for mobile

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -464,17 +464,7 @@ namespace System
             return false;
         }
 
-        private static bool GetIsRunningOnMonoInterpreter()
-        {
-#if NETCOREAPP
-            if (IsBrowser)
-                return RuntimeFeature.IsDynamicCodeSupported;
-#endif
-            // This is a temporary solution because mono does not support interpreter detection
-            // within the runtime.
-            var val = Environment.GetEnvironmentVariable("MONO_ENV_OPTIONS");
-            return (val != null && val.Contains("--interpreter"));
-        }
+        private static bool GetIsRunningOnMonoInterpreter() => IsMonoRuntime && RuntimeFeature.IsDynamicCodeSupported && !RuntimeFeature.IsDynamicCodeCompiled;
 
         private static bool GetIsBrowserDomSupported()
         {

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -464,7 +464,14 @@ namespace System
             return false;
         }
 
-        private static bool GetIsRunningOnMonoInterpreter() => IsMonoRuntime && RuntimeFeature.IsDynamicCodeSupported && !RuntimeFeature.IsDynamicCodeCompiled;
+        private static bool GetIsRunningOnMonoInterpreter()
+        {
+#if NETCOREAPP
+            return IsMonoRuntime && RuntimeFeature.IsDynamicCodeSupported && !RuntimeFeature.IsDynamicCodeCompiled;
+#else
+            return false;
+#endif
+        }
 
         private static bool GetIsBrowserDomSupported()
         {

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -170,7 +170,6 @@
     <ProjectExclusions Include="$(RepoRoot)/src/tests/FunctionalTests/tvOS/Simulator/AOT/tvOS.Simulator.Aot.Test.csproj" />
     <!-- Crashes randomly during test runs https://github.com/dotnet/runtime/issues/52460 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Tasks\tests\System.Threading.Tasks.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Tasks.Dataflow\tests\System.Threading.Tasks.Dataflow.Tests.csproj" />
 
     <!-- Crash https://github.com/dotnet/runtime/issues/56085 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/System.Text.Json.SourceGeneration.Roslyn3.11.Tests.csproj" />


### PR DESCRIPTION
Checking for `MONO_ENV_OPTIONS` is not reliable for the mobile test runners because they use the embedding API to enable the interpreter, rather than setting an environment variable.

Instead detect the interpreter by checking the values of the `IsDynamicCodeSupported` and `IsDynamicCodeCompiled` runtime features.

Re-enable the `System.Threading.Tasks.Dataflow.Tests` testsuite on Apple platforms

Fixes https://github.com/dotnet/runtime/issues/52460