### PR TITLE
Some more cleanups in Assembly/Binder/Loader area

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeModule.cs
@@ -30,9 +30,6 @@ namespace System.Reflection
         {
             return GetTypes(this);
         }
-
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern bool IsResource(RuntimeModule module);
         #endregion
 
         #region Module overrides
@@ -472,7 +469,8 @@ namespace System.Reflection
 
         public override bool IsResource()
         {
-            return IsResource(this);
+            // CoreClr does not support resource-only modules.
+            return false;
         }
 
         [RequiresUnreferencedCode("Fields might be removed")]

--- a/src/coreclr/binder/bindertracing.cpp
+++ b/src/coreclr/binder/bindertracing.cpp
@@ -147,7 +147,7 @@ namespace
         DomainAssembly *parentAssembly = spec->GetParentAssembly();
         if (parentAssembly != nullptr)
         {
-            PEAssembly *pPEAssembly = parentAssembly->GetPEAssebmly();
+            PEAssembly *pPEAssembly = parentAssembly->GetPEAssembly();
             _ASSERTE(pPEAssembly != nullptr);
             pPEAssembly->GetDisplayName(request.RequestingAssembly);
 

--- a/src/coreclr/binder/bindertracing.cpp
+++ b/src/coreclr/binder/bindertracing.cpp
@@ -147,12 +147,12 @@ namespace
         DomainAssembly *parentAssembly = spec->GetParentAssembly();
         if (parentAssembly != nullptr)
         {
-            PEAssembly *peAssembly = parentAssembly->GetFile();
-            _ASSERTE(peAssembly != nullptr);
-            peAssembly->GetDisplayName(request.RequestingAssembly);
+            PEAssembly *pPEAssembly = parentAssembly->GetPEAssebmly();
+            _ASSERTE(pPEAssembly != nullptr);
+            pPEAssembly->GetDisplayName(request.RequestingAssembly);
 
             AppDomain *domain = parentAssembly->GetAppDomain();
-            AssemblyBinder *binder = peAssembly->GetAssemblyBinder();
+            AssemblyBinder *binder = pPEAssembly->GetAssemblyBinder();
 
             GetAssemblyLoadContextNameFromBinder(binder, domain, request.RequestingAssemblyLoadContext);
         }

--- a/src/coreclr/debug/createdump/crashinfo.cpp
+++ b/src/coreclr/debug/createdump/crashinfo.cpp
@@ -320,7 +320,7 @@ CrashInfo::EnumerateManagedModules(IXCLRDataProcess* pClrDataProcess)
         if (SUCCEEDED(hr = moduleData.Request(pClrDataModule.GetPtr())))
         {
             TRACE("MODULE: %" PRIA PRIx64 " dyn %d inmem %d file %d pe %" PRIA PRIx64 " pdb %" PRIA PRIx64, (uint64_t)moduleData.LoadedPEAddress, moduleData.IsDynamic,
-                moduleData.IsInMemory, moduleData.IsFileLayout, (uint64_t)moduleData.PEFile, (uint64_t)moduleData.InMemoryPdbAddress);
+                moduleData.IsInMemory, moduleData.IsFileLayout, (uint64_t)moduleData.PEAssembly, (uint64_t)moduleData.InMemoryPdbAddress);
 
             if (!moduleData.IsDynamic && moduleData.LoadedPEAddress != 0)
             {

--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -7184,7 +7184,7 @@ GetDacTableAddress(ICorDebugDataTarget* dataTarget, ULONG64 baseAddress, PULONG6
         return E_INVALIDARG;
     }
 #endif
-    // On MacOS, FreeBSD or NetBSD use the RVA include pPEAssembly
+    // On MacOS, FreeBSD or NetBSD use the RVA include file
     *dacTableAddress = baseAddress + DAC_TABLE_RVA;
 #else
     // On Linux/MacOS try to get the dac table address via the export symbol

--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -679,11 +679,6 @@ MetaEnum::New(Module* mod,
         *handle = TO_CDENUM(NULL);
     }
 
-    if (!mod->GetPEAssembly()->HasMetadata())
-    {
-        return S_FALSE;
-    }
-
     metaEnum = new (nothrow) MetaEnum;
     if (!metaEnum)
     {
@@ -6477,7 +6472,7 @@ ClrDataAccess::GetMetaDataFileInfoFromPEFile(PEAssembly *pPEAssembly,
     isNGEN = false;
     if (pDir == NULL || pDir->Size == 0)
     {
-        mdImage = pPEAssembly->GetILimage();
+        mdImage = pPEAssembly->GetPEImage();
         if (mdImage != NULL)
         {
             layout = mdImage->GetLoadedLayout();

--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this pPEAssembly to you under the MIT license.
+// The .NET Foundation licenses this file to you under the MIT license.
 //*****************************************************************************
 // File: daccess.cpp
 //

--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// The .NET Foundation licenses this pPEAssembly to you under the MIT license.
 //*****************************************************************************
 // File: daccess.cpp
 //
@@ -679,7 +679,7 @@ MetaEnum::New(Module* mod,
         *handle = TO_CDENUM(NULL);
     }
 
-    if (!mod->GetFile()->HasMetadata())
+    if (!mod->GetPEAssembly()->HasMetadata())
     {
         return S_FALSE;
     }
@@ -4079,9 +4079,9 @@ ClrDataAccess::GetModuleByAddress(
         {
             TADDR base;
             ULONG32 length;
-            PEFile* file = modDef->GetFile();
+            PEAssembly* pPEAssembly = modDef->GetPEAssembly();
 
-            if ((base = PTR_TO_TADDR(file->GetLoadedImageContents(&length))))
+            if ((base = PTR_TO_TADDR(pPEAssembly->GetLoadedImageContents(&length))))
             {
                 if (TO_CDADDR(base) <= address &&
                     TO_CDADDR(base + length) > address)
@@ -4133,9 +4133,9 @@ ClrDataAccess::StartEnumMethodDefinitionsByAddress(
         {
             TADDR base;
             ULONG32 length;
-            PEFile* file = modDef->GetFile();
+            PEAssembly* assembly = modDef->GetPEAssembly();
 
-            if ((base = PTR_TO_TADDR(file->GetLoadedImageContents(&length))))
+            if ((base = PTR_TO_TADDR(assembly->GetLoadedImageContents(&length))))
             {
                 if (TO_CDADDR(base) <= address &&
                     TO_CDADDR(base + length) > address)
@@ -6459,7 +6459,7 @@ ClrDataAccess::GetHostGcNotificationTable()
 }
 
 /* static */ bool
-ClrDataAccess::GetMetaDataFileInfoFromPEFile(PEFile *pPEFile,
+ClrDataAccess::GetMetaDataFileInfoFromPEFile(PEAssembly *pPEAssembly,
                                              DWORD &dwTimeStamp,
                                              DWORD &dwSize,
                                              DWORD &dwDataSize,
@@ -6477,7 +6477,7 @@ ClrDataAccess::GetMetaDataFileInfoFromPEFile(PEFile *pPEFile,
     isNGEN = false;
     if (pDir == NULL || pDir->Size == 0)
     {
-        mdImage = pPEFile->GetILimage();
+        mdImage = pPEAssembly->GetILimage();
         if (mdImage != NULL)
         {
             layout = mdImage->GetLoadedLayout();
@@ -6526,7 +6526,7 @@ ClrDataAccess::GetMetaDataFileInfoFromPEFile(PEFile *pPEFile,
 }
 
 /* static */
-bool ClrDataAccess::GetILImageInfoFromNgenPEFile(PEFile *peFile,
+bool ClrDataAccess::GetILImageInfoFromNgenPEFile(PEAssembly *pPEAssembly,
                                                  DWORD &dwTimeStamp,
                                                  DWORD &dwSize,
                                                  __out_ecount(cchFilePath) LPWSTR wszFilePath,
@@ -6536,10 +6536,10 @@ bool ClrDataAccess::GetILImageInfoFromNgenPEFile(PEFile *peFile,
     DWORD dwWritten = 0;
 
     // use the IL File name
-    if (!peFile->GetPath().DacGetUnicode(cchFilePath, wszFilePath, (COUNT_T *)(&dwWritten)))
+    if (!pPEAssembly->GetPath().DacGetUnicode(cchFilePath, wszFilePath, (COUNT_T *)(&dwWritten)))
     {
         // Use DAC hint to retrieve the IL name.
-        peFile->GetModuleFileNameHint().DacGetUnicode(cchFilePath, wszFilePath, (COUNT_T *)(&dwWritten));
+        pPEAssembly->GetModuleFileNameHint().DacGetUnicode(cchFilePath, wszFilePath, (COUNT_T *)(&dwWritten));
     }
     dwTimeStamp = 0;
     dwSize = 0;
@@ -6603,7 +6603,7 @@ bool ClrDataAccess::GetILImageNameFromNgenImage( LPCWSTR ilExtension,
 #endif // FEATURE_CORESYSTEM
 
 void *
-ClrDataAccess::GetMetaDataFromHost(PEFile* peFile,
+ClrDataAccess::GetMetaDataFromHost(PEAssembly* pPEAssembly,
                                    bool* isAlternate)
 {
     DWORD imageTimestamp, imageSize, dataSize;
@@ -6634,7 +6634,7 @@ ClrDataAccess::GetMetaDataFromHost(PEFile* peFile,
     // so the field remains for now.
 
     if (!ClrDataAccess::GetMetaDataFileInfoFromPEFile(
-            peFile,
+            pPEAssembly,
             imageTimestamp,
             imageSize,
             dataSize,
@@ -6647,7 +6647,7 @@ ClrDataAccess::GetMetaDataFromHost(PEFile* peFile,
     }
 
     // try direct match for the image that is loaded into the managed process
-    peFile->GetLoadedMetadata((COUNT_T *)(&dataSize));
+    pPEAssembly->GetLoadedMetadata((COUNT_T *)(&dataSize));
 
     DWORD allocSize = 0;
     if (!ClrSafeInt<DWORD>::addition(dataSize, sizeof(DAC_INSTANCE), allocSize))
@@ -6665,7 +6665,7 @@ ClrDataAccess::GetMetaDataFromHost(PEFile* peFile,
     buffer = (void*)(inst + 1);
 
     // APIs implemented by hosting debugger.  It can use the path/filename, timestamp, and
-    // file size to find an exact match for the image.  If that fails for an ngen'ed image,
+    // pPEAssembly size to find an exact match for the image.  If that fails for an ngen'ed image,
     // we can request the IL image which it came from.
     if (m_legacyMetaDataLocator)
     {
@@ -6701,7 +6701,7 @@ ClrDataAccess::GetMetaDataFromHost(PEFile* peFile,
         //
         isAlt = true;
         if (!ClrDataAccess::GetILImageInfoFromNgenPEFile(
-                peFile,
+                pPEAssembly,
                 imageTimestamp,
                 imageSize,
                 uniPath,
@@ -6781,13 +6781,13 @@ ErrExit:
 
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 //
-// Given a PEFile or a ReflectionModule try to find the corresponding metadata
+// Given a PEAssembly or a ReflectionModule try to find the corresponding metadata
 // We will first ask debugger to locate it. If fail, we will try
 // to get it from the target process
 //
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 IMDInternalImport*
-ClrDataAccess::GetMDImport(const PEFile* peFile, const ReflectionModule* reflectionModule, bool throwEx)
+ClrDataAccess::GetMDImport(const PEAssembly* pPEAssembly, const ReflectionModule* reflectionModule, bool throwEx)
 {
     HRESULT     status;
     PTR_CVOID mdBaseTarget = NULL;
@@ -6796,22 +6796,22 @@ ClrDataAccess::GetMDImport(const PEFile* peFile, const ReflectionModule* reflect
     PVOID       mdBaseHost = NULL;
     bool        isAlternate = false;
 
-    _ASSERTE((peFile == NULL && reflectionModule != NULL) || (peFile != NULL && reflectionModule == NULL));
-    TADDR       peFileAddr = (peFile != NULL) ? dac_cast<TADDR>(peFile) : dac_cast<TADDR>(reflectionModule);
+    _ASSERTE((pPEAssembly == NULL && reflectionModule != NULL) || (pPEAssembly != NULL && reflectionModule == NULL));
+    TADDR     peAssemblyAddr = (pPEAssembly != NULL) ? dac_cast<TADDR>(pPEAssembly) : dac_cast<TADDR>(reflectionModule);
 
     //
     // Look for one we've already created.
     //
-    mdImport = m_mdImports.Get(peFileAddr);
+    mdImport = m_mdImports.Get(peAssemblyAddr);
     if (mdImport != NULL)
     {
         return mdImport;
     }
 
-    if (peFile != NULL)
+    if (pPEAssembly != NULL)
     {
         // Get the metadata size
-        mdBaseTarget = ((PEFile*)peFile)->GetLoadedMetadata(&mdSize);
+        mdBaseTarget = const_cast<PEAssembly*>(pPEAssembly)->GetLoadedMetadata(&mdSize);
     }
     else if (reflectionModule != NULL)
     {
@@ -6862,12 +6862,12 @@ ClrDataAccess::GetMDImport(const PEFile* peFile, const ReflectionModule* reflect
     }
 
     // Try to see if debugger can locate it
-    if (peFile != NULL && mdBaseHost == NULL && (m_target3 || m_legacyMetaDataLocator))
+    if (pPEAssembly != NULL && mdBaseHost == NULL && (m_target3 || m_legacyMetaDataLocator))
     {
         // We couldn't read the metadata from memory.  Ask
         // the target for metadata as it may be able to
         // provide it from some alternate means.
-        mdBaseHost = GetMetaDataFromHost(const_cast<PEFile *>(peFile), &isAlternate);
+        mdBaseHost = GetMetaDataFromHost(const_cast<PEAssembly *>(pPEAssembly), &isAlternate);
     }
 
     if (mdBaseHost == NULL)
@@ -6902,7 +6902,7 @@ ClrDataAccess::GetMDImport(const PEFile* peFile, const ReflectionModule* reflect
     // The m_mdImports list does get cleaned up by calls to ClrDataAccess::Flush,
     // i.e. every time the process changes state.
 
-    if (m_mdImports.Add(peFileAddr, mdImport, isAlternate) == NULL)
+    if (m_mdImports.Add(peAssemblyAddr, mdImport, isAlternate) == NULL)
     {
         mdImport->Release();
         DacError(E_OUTOFMEMORY);
@@ -6970,9 +6970,9 @@ HRESULT ClrDataAccess::VerifyDlls()
     }
 
     // Read the debug directory timestamp from the target mscorwks image using DAC
-    // Note that we don't use the PE timestamp because the PE file might be changed in ways
+    // Note that we don't use the PE timestamp because the PE pPEAssembly might be changed in ways
     // that don't effect the PDB (and therefore don't effect DAC).  Specifically, we rebase
-    // our DLLs at the end of a build, that changes the PE file, but not the PDB.
+    // our DLLs at the end of a build, that changes the PE pPEAssembly, but not the PDB.
     // Note that if we wanted to be extra careful, we could read the CV contents (which includes
     // the GUID signature) and verify it matches.  Using the timestamp is useful for helpful error
     // messages, and should be sufficient in any real scenario.
@@ -7189,7 +7189,7 @@ GetDacTableAddress(ICorDebugDataTarget* dataTarget, ULONG64 baseAddress, PULONG6
         return E_INVALIDARG;
     }
 #endif
-    // On MacOS, FreeBSD or NetBSD use the RVA include file
+    // On MacOS, FreeBSD or NetBSD use the RVA include pPEAssembly
     *dacTableAddress = baseAddress + DAC_TABLE_RVA;
 #else
     // On Linux/MacOS try to get the dac table address via the export symbol

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -4201,7 +4201,7 @@ HRESULT DacDbiInterfaceImpl::IsModuleMapped(VMPTR_Module pModule, OUT BOOL *isMo
         PTR_PEAssembly pPEAssembly = pTargetModule->GetPEAssembly();
         _ASSERTE(pPEAssembly != NULL);
 
-        if (pPEAssembly->HasLoadedIL())
+        if (pPEAssembly->HasLoadedPEImage())
         {
             *isModuleMapped = pPEAssembly->GetLoadedLayout()->IsMapped();
             hr = S_OK;

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -4203,7 +4203,7 @@ HRESULT DacDbiInterfaceImpl::IsModuleMapped(VMPTR_Module pModule, OUT BOOL *isMo
 
         if (pPEAssembly->HasLoadedIL())
         {
-            *isModuleMapped = pPEAssembly->GetLoadedIL()->IsMapped();
+            *isModuleMapped = pPEAssembly->GetLoadedLayout()->IsMapped();
             hr = S_OK;
         }
     }

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -272,7 +272,7 @@ DacDbiInterfaceImpl::DacDbiInterfaceImpl(
 ) : ClrDataAccess(pTarget),
     m_pAllocator(pAllocator),
     m_pMetaDataLookup(pMetaDataLookup),
-    m_pCachedPEFile(VMPTR_PEFile::NullPtr()),
+    m_pCachedPEAssembly(VMPTR_PEAssembly::NullPtr()),
     m_pCachedImporter(NULL),
     m_isCachedHijackFunctionValid(FALSE)
 {
@@ -307,7 +307,7 @@ DacDbiInterfaceImpl::~DacDbiInterfaceImpl()
 // Called from DAC-ized code to get a IMDInternalImport
 //
 // Arguments:
-//    pPEFile - PE file for which to get importer for
+//    pPEAssembly - PE file for which to get importer for
 //    fThrowEx - if true, throw instead of returning NULL.
 //
 // Returns:
@@ -324,7 +324,7 @@ DacDbiInterfaceImpl::~DacDbiInterfaceImpl()
 //    This is an Internal importer, not a public Metadata importer.
 //
 interface IMDInternalImport* DacDbiInterfaceImpl::GetMDImport(
-    const PEFile* pPEFile,
+    const PEAssembly* pPEAssembly,
     const ReflectionModule * pReflectionModule,
     bool fThrowEx)
 {
@@ -335,23 +335,23 @@ interface IMDInternalImport* DacDbiInterfaceImpl::GetMDImport(
     IDacDbiInterface::IMetaDataLookup * pLookup = m_pMetaDataLookup;
     _ASSERTE(pLookup != NULL);
 
-    VMPTR_PEFile vmPEFile = VMPTR_PEFile::NullPtr();
+    VMPTR_PEAssembly vmPEAssembly = VMPTR_PEAssembly::NullPtr();
 
-    if (pPEFile != NULL)
+    if (pPEAssembly != NULL)
     {
-        vmPEFile.SetHostPtr(pPEFile);
+        vmPEAssembly.SetHostPtr(pPEAssembly);
     }
     else if (pReflectionModule != NULL)
     {
         // SOS and ClrDataAccess rely on special logic to find the metadata for methods in dynamic modules.
         // We don't need to.  The RS has already taken care of the special logic for us.
-        // So here we just grab the PEFile off of the ReflectionModule and continue down the normal
+        // So here we just grab the PEAssembly off of the ReflectionModule and continue down the normal
         // code path.  See code:ClrDataAccess::GetMDImport for comparison.
-        vmPEFile.SetHostPtr(pReflectionModule->GetFile());
+        vmPEAssembly.SetHostPtr(pReflectionModule->GetPEAssembly());
     }
 
     // Optimize for the case where the VM queries the same Importer many times in a row.
-    if (m_pCachedPEFile == vmPEFile)
+    if (m_pCachedPEAssembly == vmPEAssembly)
     {
         return m_pCachedImporter;
     }
@@ -370,7 +370,7 @@ interface IMDInternalImport* DacDbiInterfaceImpl::GetMDImport(
         // To get the old codepath that uses the v2 metadata lookup methods,
         // you'd have to load DAC only and then you'll get ClrDataAccess's implementation
         // of this function.
-        pInternal = pLookup->LookupMetaData(vmPEFile, isILMetaDataForNI);
+        pInternal = pLookup->LookupMetaData(vmPEAssembly, isILMetaDataForNI);
     }
     EX_CATCH
     {
@@ -397,7 +397,7 @@ interface IMDInternalImport* DacDbiInterfaceImpl::GetMDImport(
     else
     {
         // Cache it such that it we look for the exact same Importer again, we'll return it.
-        m_pCachedPEFile   = vmPEFile;
+        m_pCachedPEAssembly   = vmPEAssembly;
         m_pCachedImporter = pInternal;
     }
 
@@ -445,7 +445,7 @@ HRESULT DacDbiInterfaceImpl::FlushCache()
     // That would remove host DAC instances while they're being used.
     DD_NON_REENTRANT_MAY_THROW;
 
-    m_pCachedPEFile = VMPTR_PEFile::NullPtr();
+    m_pCachedPEAssembly = VMPTR_PEAssembly::NullPtr();
     m_pCachedImporter = NULL;
     m_isCachedHijackFunctionValid = FALSE;
 
@@ -1227,7 +1227,7 @@ mdSignature DacDbiInterfaceImpl::GetILCodeAndSigHelper(Module *       pModule,
 }
 
 
-bool DacDbiInterfaceImpl::GetMetaDataFileInfoFromPEFile(VMPTR_PEFile vmPEFile,
+bool DacDbiInterfaceImpl::GetMetaDataFileInfoFromPEFile(VMPTR_PEAssembly vmPEAssembly,
                                                         DWORD &dwTimeStamp,
                                                         DWORD &dwSize,
                                                         bool  &isNGEN,
@@ -1237,14 +1237,14 @@ bool DacDbiInterfaceImpl::GetMetaDataFileInfoFromPEFile(VMPTR_PEFile vmPEFile,
 
     DWORD dwDataSize;
     DWORD dwRvaHint;
-    PEFile * pPEFile = vmPEFile.GetDacPtr();
-    _ASSERTE(pPEFile != NULL);
-    if (pPEFile == NULL)
+    PEAssembly * pPEAssembly = vmPEAssembly.GetDacPtr();
+    _ASSERTE(pPEAssembly != NULL);
+    if (pPEAssembly == NULL)
         return false;
 
     WCHAR wszFilePath[MAX_LONGPATH] = {0};
     DWORD cchFilePath = MAX_LONGPATH;
-    bool ret = ClrDataAccess::GetMetaDataFileInfoFromPEFile(pPEFile,
+    bool ret = ClrDataAccess::GetMetaDataFileInfoFromPEFile(pPEAssembly,
                                                             dwTimeStamp,
                                                             dwSize,
                                                             dwDataSize,
@@ -1258,7 +1258,7 @@ bool DacDbiInterfaceImpl::GetMetaDataFileInfoFromPEFile(VMPTR_PEFile vmPEFile,
 }
 
 
-bool DacDbiInterfaceImpl::GetILImageInfoFromNgenPEFile(VMPTR_PEFile vmPEFile,
+bool DacDbiInterfaceImpl::GetILImageInfoFromNgenPEFile(VMPTR_PEAssembly vmPEAssembly,
                                                        DWORD &dwTimeStamp,
                                                        DWORD &dwSize,
                                                        IStringHolder* pStrFilename)
@@ -4137,16 +4137,16 @@ BOOL DacDbiInterfaceImpl::GetModulePath(VMPTR_Module vmModule,
     DD_ENTER_MAY_THROW;
 
     Module * pModule = vmModule.GetDacPtr();
-    PEFile * pFile = pModule->GetFile();
-    if (pFile != NULL)
+    PEAssembly * pPEAssembly = pModule->GetPEAssembly();
+    if (pPEAssembly != NULL)
     {
-        if( !pFile->GetPath().IsEmpty() )
+        if( !pPEAssembly->GetPath().IsEmpty() )
         {
             // Module has an on-disk path
-            const WCHAR * szPath = pFile->GetPath().DacGetRawUnicode();
+            const WCHAR * szPath = pPEAssembly->GetPath().DacGetRawUnicode();
             if (szPath == NULL)
             {
-                szPath = pFile->GetModuleFileNameHint().DacGetRawUnicode();
+                szPath = pPEAssembly->GetModuleFileNameHint().DacGetRawUnicode();
                 if (szPath == NULL)
                 {
                     goto NoFileName;
@@ -4198,12 +4198,12 @@ HRESULT DacDbiInterfaceImpl::IsModuleMapped(VMPTR_Module pModule, OUT BOOL *isMo
 
     EX_TRY
     {
-        PTR_PEFile pPEFile = pTargetModule->GetFile();
-        _ASSERTE(pPEFile != NULL);
+        PTR_PEAssembly pPEAssembly = pTargetModule->GetPEAssembly();
+        _ASSERTE(pPEAssembly != NULL);
 
-        if (pPEFile->HasLoadedIL())
+        if (pPEAssembly->HasLoadedIL())
         {
-            *isModuleMapped = pPEFile->GetLoadedIL()->IsMapped();
+            *isModuleMapped = pPEAssembly->GetLoadedIL()->IsMapped();
             hr = S_OK;
         }
     }
@@ -4296,11 +4296,11 @@ void DacDbiInterfaceImpl::GetMetadata(VMPTR_Module vmModule, TargetBuffer * pTar
     }
     else
     {
-        PEFile * pFile = pModule->GetFile();
+        PEAssembly * pPEAssembly = pModule->GetPEAssembly();
 
         // For non-dynamic modules, metadata is in the pe-image.
         COUNT_T size;
-        CORDB_ADDRESS address = PTR_TO_CORDB_ADDRESS(dac_cast<TADDR>(pFile->GetLoadedMetadata(&size)));
+        CORDB_ADDRESS address = PTR_TO_CORDB_ADDRESS(dac_cast<TADDR>(pPEAssembly->GetLoadedMetadata(&size)));
 
         pTargetBuffer->Init(address, (ULONG) size);
     }
@@ -4386,9 +4386,9 @@ void DacDbiInterfaceImpl::GetModuleData(VMPTR_Module vmModule, ModuleInfo * pDat
     ZeroMemory(pData, sizeof(*pData));
 
     Module     * pModule      = vmModule.GetDacPtr();
-    PEFile     * pFile        = pModule->GetFile();
+    PEAssembly * pPEAssembly        = pModule->GetPEAssembly();
 
-    pData->vmPEFile.SetHostPtr(pFile);
+    pData->vmPEAssembly.SetHostPtr(pPEAssembly);
     pData->vmAssembly.SetHostPtr(pModule->GetAssembly());
 
     // Is it dynamic?
@@ -4403,15 +4403,15 @@ void DacDbiInterfaceImpl::GetModuleData(VMPTR_Module vmModule, ModuleInfo * pDat
     if (!fIsDynamic)
     {
         COUNT_T size = 0;
-        pData->pPEBaseAddress = PTR_TO_TADDR(pFile->GetDebuggerContents(&size));
+        pData->pPEBaseAddress = PTR_TO_TADDR(pPEAssembly->GetDebuggerContents(&size));
         pData->nPESize = (ULONG) size;
     }
 
     // In-memory is determined by whether the module has a filename.
     pData->fInMemory = FALSE;
-    if (pFile != NULL)
+    if (pPEAssembly != NULL)
     {
-        pData->fInMemory = pFile->GetPath().IsEmpty();
+        pData->fInMemory = pPEAssembly->GetPath().IsEmpty();
     }
 }
 
@@ -7316,13 +7316,13 @@ void DacDbiInterfaceImpl::GetGCHeapInformation(COR_HEAPINFO * pHeapInfo)
 }
 
 
-HRESULT DacDbiInterfaceImpl::GetPEFileMDInternalRW(VMPTR_PEFile vmPEFile, OUT TADDR* pAddrMDInternalRW)
+HRESULT DacDbiInterfaceImpl::GetPEFileMDInternalRW(VMPTR_PEAssembly vmPEAssembly, OUT TADDR* pAddrMDInternalRW)
 {
     DD_ENTER_MAY_THROW;
     if (pAddrMDInternalRW == NULL)
         return E_INVALIDARG;
-    PEFile * pPEFile = vmPEFile.GetDacPtr();
-    *pAddrMDInternalRW = pPEFile->GetMDInternalRWAddress();
+    PEAssembly * pPEAssembly = vmPEAssembly.GetDacPtr();
+    *pAddrMDInternalRW = pPEAssembly->GetMDInternalRWAddress();
     return S_OK;
 }
 

--- a/src/coreclr/debug/daccess/dacdbiimpl.h
+++ b/src/coreclr/debug/daccess/dacdbiimpl.h
@@ -53,7 +53,7 @@ public:
 
     // Overridden from ClrDataAccess. Gets an internal metadata importer for the file.
     virtual IMDInternalImport* GetMDImport(
-        const PEFile* pPEFile,
+        const PEAssembly* pPEAssembly,
         const ReflectionModule * pReflectionModule,
         bool fThrowEx);
 
@@ -149,7 +149,7 @@ public:
     HRESULT GetTypeLayout(COR_TYPEID id, COR_TYPE_LAYOUT *pLayout);
     HRESULT GetArrayLayout(COR_TYPEID id, COR_ARRAY_LAYOUT *pLayout);
     void GetGCHeapInformation(COR_HEAPINFO * pHeapInfo);
-    HRESULT GetPEFileMDInternalRW(VMPTR_PEFile vmPEFile, OUT TADDR* pAddrMDInternalRW);
+    HRESULT GetPEFileMDInternalRW(VMPTR_PEAssembly vmPEAssembly, OUT TADDR* pAddrMDInternalRW);
     HRESULT GetReJitInfo(VMPTR_Module vmModule, mdMethodDef methodTk, OUT VMPTR_ReJitInfo* pReJitInfo);
     HRESULT GetActiveRejitILCodeVersionNode(VMPTR_Module vmModule, mdMethodDef methodTk, OUT VMPTR_ILCodeVersionNode* pVmILCodeVersionNode);
     HRESULT GetReJitInfo(VMPTR_MethodDesc vmMethod, CORDB_ADDRESS codeStartAddress, OUT VMPTR_ReJitInfo* pReJitInfo);
@@ -952,15 +952,15 @@ protected:
     IMetaDataLookup * m_pMetaDataLookup;
 
 
-    // Metadata lookups is just a property on the PEFile in the normal builds,
+    // Metadata lookups is just a property on the PEAssembly in the normal builds,
     // and so VM code tends to access the same metadata importer many times in a row.
     // Cache the most-recently used to avoid excessive redundant lookups.
 
-    // PEFile of Cached Importer. Invalidated between Flush calls. If this is Non-null,
+    // PEAssembly of Cached Importer. Invalidated between Flush calls. If this is Non-null,
     // then the importer is m_pCachedImporter, and we can avoid using IMetaDataLookup
-    VMPTR_PEFile m_pCachedPEFile;
+    VMPTR_PEAssembly m_pCachedPEAssembly;
 
-    // Value of cached importer, corresponds with m_pCachedPEFile.
+    // Value of cached importer, corresponds with m_pCachedPEAssembly.
     IMDInternalImport  * m_pCachedImporter;
 
     // Value of cached hijack function list, corresponds to g_pDebugger->m_rgHijackFunction
@@ -1104,13 +1104,13 @@ private:
 public:
     // APIs for picking up the info needed for a debugger to look up an ngen image or IL image
     // from it's search path.
-    bool GetMetaDataFileInfoFromPEFile(VMPTR_PEFile vmPEFile,
+    bool GetMetaDataFileInfoFromPEFile(VMPTR_PEAssembly vmPEAssembly,
                                        DWORD &dwTimeStamp,
                                        DWORD &dwSize,
                                        bool  &isNGEN,
                                        IStringHolder* pStrFilename);
 
-    bool GetILImageInfoFromNgenPEFile(VMPTR_PEFile vmPEFile,
+    bool GetILImageInfoFromNgenPEFile(VMPTR_PEAssembly vmPEAssembly,
                                       DWORD &dwTimeStamp,
                                       DWORD &dwSize,
                                       IStringHolder* pStrFilename);

--- a/src/coreclr/debug/daccess/dacfn.cpp
+++ b/src/coreclr/debug/daccess/dacfn.cpp
@@ -1304,7 +1304,7 @@ DacSetMethodDescEnumerated(LPCVOID pMD)
 
 // This gets called from DAC-ized code in the VM.
 IMDInternalImport*
-DacGetMDImport(const PEFile* peFile, bool throwEx)
+DacGetMDImport(const PEAssembly* pPEAssembly, bool throwEx)
 {
     if (!g_dacImpl)
     {
@@ -1312,7 +1312,7 @@ DacGetMDImport(const PEFile* peFile, bool throwEx)
         UNREACHABLE();
     }
 
-    return g_dacImpl->GetMDImport(peFile, throwEx);
+    return g_dacImpl->GetMDImport(pPEAssembly, throwEx);
 }
 
 IMDInternalImport*

--- a/src/coreclr/debug/daccess/dacimpl.h
+++ b/src/coreclr/debug/daccess/dacimpl.h
@@ -132,7 +132,7 @@ class ReflectionModule;
 struct DAC_MD_IMPORT
 {
     DAC_MD_IMPORT* next;       // list link field
-    TADDR peFile;              // a TADDR for a PEFile* or a ReflectionModule*
+    TADDR peFile;              // a TADDR for a PEAssembly* or a ReflectionModule*
     IMDInternalImport* impl;   // Associated metadata interface
     bool isAlternate;          // for NGEN images set to true if the metadata corresponds to the IL image
 
@@ -151,7 +151,7 @@ struct DAC_MD_IMPORT
 
 
 // This class maintains a cache of IMDInternalImport* and their corresponding
-// source (a PEFile* or a ReflectionModule*), as a singly-linked list of
+// source (a PEAssembly* or a ReflectionModule*), as a singly-linked list of
 // DAC_MD_IMPORT nodes.  The cache is flushed whenever the process state changes
 // by calling its Flush() member function.
 class MDImportsCache
@@ -1352,18 +1352,18 @@ public:
     JITNotification* GetHostJitNotificationTable();
     GcNotification*  GetHostGcNotificationTable();
 
-    void* GetMetaDataFromHost(PEFile* peFile,
+    void* GetMetaDataFromHost(PEAssembly* pPEAssembly,
                               bool* isAlternate);
 
     virtual
-    interface IMDInternalImport* GetMDImport(const PEFile* peFile,
+    interface IMDInternalImport* GetMDImport(const PEAssembly* pPEAssembly,
                                              const ReflectionModule* reflectionModule,
                                              bool throwEx);
 
-    interface IMDInternalImport* GetMDImport(const PEFile* peFile,
+    interface IMDInternalImport* GetMDImport(const PEAssembly* pPEAssembly,
                                              bool throwEx)
     {
-        return GetMDImport(peFile, NULL, throwEx);
+        return GetMDImport(pPEAssembly, NULL, throwEx);
     }
 
     interface IMDInternalImport* GetMDImport(const ReflectionModule* reflectionModule,
@@ -1501,7 +1501,7 @@ private:
 public:
     // APIs for picking up the info needed for a debugger to look up an ngen image or IL image
     // from it's search path.
-    static bool GetMetaDataFileInfoFromPEFile(PEFile *pPEFile,
+    static bool GetMetaDataFileInfoFromPEFile(PEAssembly *pPEAssembly,
                                               DWORD &dwImageTimestamp,
                                               DWORD &dwImageSize,
                                               DWORD &dwDataSize,
@@ -1510,7 +1510,7 @@ public:
                                               __out_ecount(cchFilePath) LPWSTR wszFilePath,
                                               DWORD cchFilePath);
 
-    static bool GetILImageInfoFromNgenPEFile(PEFile *peFile,
+    static bool GetILImageInfoFromNgenPEFile(PEAssembly *pPEAssembly,
                                              DWORD &dwTimeStamp,
                                              DWORD &dwSize,
                                              __out_ecount(cchPath) LPWSTR wszPath,

--- a/src/coreclr/debug/daccess/enummem.cpp
+++ b/src/coreclr/debug/daccess/enummem.cpp
@@ -94,7 +94,7 @@ HRESULT ClrDataAccess::EnumMemCollectImages()
                 if (
                     file->GetPath().IsEmpty() && // is in-memory
                     file->HasMetadata() &&       // skip resource assemblies
-                    file->IsLoaded(FALSE) &&     // skip files not yet loaded
+                    file->IsLoaded() &&     // skip files not yet loaded
                     !file->IsDynamic())          // skip dynamic (GetLoadedIL asserts anyway)
                 {
                     pStartAddr = PTR_TO_TADDR(file->GetLoadedIL()->GetBase());

--- a/src/coreclr/debug/daccess/enummem.cpp
+++ b/src/coreclr/debug/daccess/enummem.cpp
@@ -93,9 +93,7 @@ HRESULT ClrDataAccess::EnumMemCollectImages()
                 // and people may have come to rely on this - so we'll include them for now.
                 if (
                     assembly->GetPath().IsEmpty() && // is in-memory
-                    assembly->HasMetadata() &&       // skip resource assemblies
-                    assembly->IsLoaded() &&     // skip files not yet loaded
-                    !assembly->IsDynamic())          // skip dynamic (GetLoadedLayout asserts anyway)
+                    assembly->HasLoadedPEImage())         // skip files not yet loaded or Dynamic
                 {
                     pStartAddr = PTR_TO_TADDR(assembly->GetLoadedLayout()->GetBase());
                     ulSize = assembly->GetLoadedLayout()->GetSize();
@@ -636,7 +634,7 @@ HRESULT ClrDataAccess::EnumMemDumpModuleList(CLRDataEnumMemoryFlags flags)
                 // the DOS header, PE headers, and IMAGE_COR20_HEADER for the Flags member.
                 // We expose no API today to find this out.
                 PTR_PEAssembly pPEAssembly = modDef->GetPEAssembly();
-                PEImage * pILImage = pPEAssembly->GetILimage();
+                PEImage * pILImage = pPEAssembly->GetPEImage();
 
                 // Implicitly gets the COR header.
                 if ((pILImage) && (pILImage->HasLoadedLayout()))

--- a/src/coreclr/debug/daccess/enummem.cpp
+++ b/src/coreclr/debug/daccess/enummem.cpp
@@ -95,10 +95,10 @@ HRESULT ClrDataAccess::EnumMemCollectImages()
                     assembly->GetPath().IsEmpty() && // is in-memory
                     assembly->HasMetadata() &&       // skip resource assemblies
                     assembly->IsLoaded() &&     // skip files not yet loaded
-                    !assembly->IsDynamic())          // skip dynamic (GetLoadedIL asserts anyway)
+                    !assembly->IsDynamic())          // skip dynamic (GetLoadedLayout asserts anyway)
                 {
-                    pStartAddr = PTR_TO_TADDR(assembly->GetLoadedIL()->GetBase());
-                    ulSize = assembly->GetLoadedIL()->GetSize();
+                    pStartAddr = PTR_TO_TADDR(assembly->GetLoadedLayout()->GetBase());
+                    ulSize = assembly->GetLoadedLayout()->GetSize();
                 }
 
                 // memory are mapped in in GetOsPageSize() size.

--- a/src/coreclr/debug/daccess/enummem.cpp
+++ b/src/coreclr/debug/daccess/enummem.cpp
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this assembly to you under the MIT license.
+// The .NET Foundation licenses this file to you under the MIT license.
 //*****************************************************************************
 // File: enummem.cpp
 //

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -2063,9 +2063,8 @@ ClrDataAccess::GetPEFileName(CLRDATA_ADDRESS addr, unsigned int count, __out_z _
     }
     else if (!pPEAssembly->IsDynamic())
     {
-        PEAssembly *pAssembly = pPEAssembly->GetAssembly();
         StackSString displayName;
-        pAssembly->GetDisplayName(displayName, 0);
+        pPEAssembly->GetDisplayName(displayName, 0);
 
         if (displayName.IsEmpty())
         {

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -1507,7 +1507,7 @@ ClrDataAccess::GetObjectClassName(CLRDATA_ADDRESS obj, unsigned int count, __out
         // There is a case where metadata was unloaded and the AppendType call will fail.
         // This is when an AppDomain has been unloaded but not yet collected.
         PEAssembly *pPEAssembly = mt->GetModule()->GetPEAssembly();
-        if (pPEAssembly->GetILimage() == NULL)
+        if (pPEAssembly->GetPEImage() == NULL)
         {
             if (pNeeded)
                 *pNeeded = 16;
@@ -1771,7 +1771,7 @@ ClrDataAccess::GetMethodTableName(CLRDATA_ADDRESS mt, unsigned int count, __out_
         // There is a case where metadata was unloaded and the AppendType call will fail.
         // This is when an AppDomain has been unloaded but not yet collected.
         PEAssembly *pPEAssembly = pMT->GetModule()->GetPEAssembly();
-        if (pPEAssembly->GetILimage() == NULL)
+        if (pPEAssembly->GetPEImage() == NULL)
         {
             if (pNeeded)
                 *pNeeded = 16;

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -1506,8 +1506,8 @@ ClrDataAccess::GetObjectClassName(CLRDATA_ADDRESS obj, unsigned int count, __out
     {
         // There is a case where metadata was unloaded and the AppendType call will fail.
         // This is when an AppDomain has been unloaded but not yet collected.
-        PEFile *pPEFile = mt->GetModule()->GetFile();
-        if (pPEFile->GetILimage() == NULL)
+        PEAssembly *pPEAssembly = mt->GetModule()->GetPEAssembly();
+        if (pPEAssembly->GetILimage() == NULL)
         {
             if (pNeeded)
                 *pNeeded = 16;
@@ -1645,14 +1645,14 @@ ClrDataAccess::GetModuleData(CLRDATA_ADDRESS addr, struct DacpModuleData *Module
 
     ZeroMemory(ModuleData,sizeof(DacpModuleData));
     ModuleData->Address = addr;
-    ModuleData->File = HOST_CDADDR(pModule->GetFile());
+    ModuleData->PEAssembly = HOST_CDADDR(pModule->GetPEAssembly());
     COUNT_T metadataSize = 0;
-    if (!pModule->GetFile()->IsDynamic())
+    if (!pModule->GetPEAssembly()->IsDynamic())
     {
-        ModuleData->ilBase = (CLRDATA_ADDRESS)(ULONG_PTR) pModule->GetFile()->GetIJWBase();
+        ModuleData->ilBase = (CLRDATA_ADDRESS)(ULONG_PTR) pModule->GetPEAssembly()->GetIJWBase();
     }
 
-    ModuleData->metadataStart = (CLRDATA_ADDRESS)dac_cast<TADDR>(pModule->GetFile()->GetLoadedMetadata(&metadataSize));
+    ModuleData->metadataStart = (CLRDATA_ADDRESS)dac_cast<TADDR>(pModule->GetPEAssembly()->GetLoadedMetadata(&metadataSize));
     ModuleData->metadataSize = (SIZE_T) metadataSize;
 
     ModuleData->bIsReflection = pModule->IsReflection();
@@ -1770,8 +1770,8 @@ ClrDataAccess::GetMethodTableName(CLRDATA_ADDRESS mt, unsigned int count, __out_
     {
         // There is a case where metadata was unloaded and the AppendType call will fail.
         // This is when an AppDomain has been unloaded but not yet collected.
-        PEFile *pPEFile = pMT->GetModule()->GetFile();
-        if (pPEFile->GetILimage() == NULL)
+        PEAssembly *pPEAssembly = pMT->GetModule()->GetPEAssembly();
+        if (pPEAssembly->GetILimage() == NULL)
         {
             if (pNeeded)
                 *pNeeded = 16;
@@ -2053,17 +2053,17 @@ ClrDataAccess::GetPEFileName(CLRDATA_ADDRESS addr, unsigned int count, __out_z _
         return E_INVALIDARG;
 
     SOSDacEnter();
-    PEFile* pPEFile = PTR_PEFile(TO_TADDR(addr));
+    PEAssembly* pPEAssembly = PTR_PEAssembly(TO_TADDR(addr));
 
     // Turn from bytes to wide characters
-    if (!pPEFile->GetPath().IsEmpty())
+    if (!pPEAssembly->GetPath().IsEmpty())
     {
-        if (!pPEFile->GetPath().DacGetUnicode(count, fileName, pNeeded))
+        if (!pPEAssembly->GetPath().DacGetUnicode(count, fileName, pNeeded))
             hr = E_FAIL;
     }
-    else if (!pPEFile->IsDynamic())
+    else if (!pPEAssembly->IsDynamic())
     {
-        PEAssembly *pAssembly = pPEFile->GetAssembly();
+        PEAssembly *pAssembly = pPEAssembly->GetAssembly();
         StackSString displayName;
         pAssembly->GetDisplayName(displayName, 0);
 
@@ -2112,11 +2112,11 @@ ClrDataAccess::GetPEFileBase(CLRDATA_ADDRESS addr, CLRDATA_ADDRESS *base)
 
     SOSDacEnter();
 
-    PEFile* pPEFile = PTR_PEFile(TO_TADDR(addr));
+    PEAssembly* pPEAssembly = PTR_PEAssembly(TO_TADDR(addr));
 
     // More fields later?
-    if (!pPEFile->IsDynamic())
-        *base = TO_CDADDR(pPEFile->GetIJWBase());
+    if (!pPEAssembly->IsDynamic())
+        *base = TO_CDADDR(pPEAssembly->GetIJWBase());
     else
         *base = NULL;
 
@@ -4768,8 +4768,8 @@ HRESULT ClrDataAccess::GetAssemblyLoadContext(CLRDATA_ADDRESS methodTable, CLRDA
     PTR_MethodTable pMT = PTR_MethodTable(CLRDATA_ADDRESS_TO_TADDR(methodTable));
     PTR_Module pModule = pMT->GetModule();
 
-    PTR_PEFile pPEFile = pModule->GetFile();
-    PTR_AssemblyBinder pBinder = pPEFile->GetAssemblyBinder();
+    PTR_PEAssembly pPEAssembly = pModule->GetPEAssembly();
+    PTR_AssemblyBinder pBinder = pPEAssembly->GetAssemblyBinder();
 
     INT_PTR managedAssemblyLoadContextHandle = pBinder->GetManagedAssemblyLoadContext();
 

--- a/src/coreclr/debug/daccess/task.cpp
+++ b/src/coreclr/debug/daccess/task.cpp
@@ -2736,7 +2736,7 @@ ClrDataModule::RequestGetModuleData(
         // Can not get the assembly layout for a dynamic module
         if (!outGMD->IsDynamic)
         {
-            outGMD->IsFileLayout = pPEAssembly->GetLoaded()->IsFlat();
+            outGMD->IsFileLayout = pPEAssembly->GetLoadedLayout()->IsFlat();
         }
     }
 

--- a/src/coreclr/debug/daccess/task.cpp
+++ b/src/coreclr/debug/daccess/task.cpp
@@ -2455,19 +2455,11 @@ ClrDataModule::GetVersionId(
 
     EX_TRY
     {
-        if (!m_module->GetPEAssembly()->HasMetadata())
+        GUID mdVid;
+        status = m_module->GetMDImport()->GetScopeProps(NULL, &mdVid);
+        if (SUCCEEDED(status))
         {
-            status = E_NOINTERFACE;
-        }
-        else
-        {
-            GUID mdVid;
-
-            status = m_module->GetMDImport()->GetScopeProps(NULL, &mdVid);
-            if (SUCCEEDED(status))
-            {
-                *vid = mdVid;
-            }
+            *vid = mdVid;
         }
     }
     EX_CATCH
@@ -2873,17 +2865,10 @@ ClrDataModule::GetMdInterface(PVOID* retIface)
     {
         if (m_mdImport == NULL)
         {
-            if (!m_module->GetPEAssembly()->HasMetadata())
-            {
-                status = E_NOINTERFACE;
-                goto Exit;
-            }
-
             //
             // Make sure internal MD is in RW format.
             //
             IMDInternalImport* rwMd;
-
             status = ConvertMDInternalImport(m_module->GetMDImport(), &rwMd);
             if (FAILED(status))
             {

--- a/src/coreclr/debug/daccess/task.cpp
+++ b/src/coreclr/debug/daccess/task.cpp
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this assembly to you under the MIT license.
+// The .NET Foundation licenses this file to you under the MIT license.
 //*****************************************************************************
 // File: task.cpp
 //

--- a/src/coreclr/debug/daccess/task.cpp
+++ b/src/coreclr/debug/daccess/task.cpp
@@ -2499,10 +2499,7 @@ ClrDataModule::GetFlags(
         {
             (*flags) |= CLRDATA_MODULE_IS_DYNAMIC;
         }
-        if (m_module->IsIStream())
-        {
-            (*flags) |= CLRDATA_MODULE_IS_MEMORY_STREAM;
-        }
+
         PTR_Assembly pAssembly = m_module->GetAssembly();
         PTR_BaseDomain pBaseDomain = pAssembly->GetDomain();
         if (pBaseDomain->IsAppDomain())

--- a/src/coreclr/debug/di/module.cpp
+++ b/src/coreclr/debug/di/module.cpp
@@ -82,7 +82,7 @@ CordbModule::CordbModule(
 
     m_fDynamic  = modInfo.fIsDynamic;
     m_fInMemory = modInfo.fInMemory;
-    m_vmPEFile = modInfo.vmPEFile;
+    m_vmPEFile = modInfo.vmPEAssembly;
 
     if (!vmDomainFile.IsNull())
     {
@@ -268,13 +268,13 @@ IDacDbiInterface::SymbolFormat CordbModule::GetInMemorySymbolStream(IStream ** p
 // Accessor for PE file.
 //
 // Returns:
-//    VMPTR_PEFile for this module. Should always be non-null
+//    VMPTR_PEAssembly for this module. Should always be non-null
 //
 // Notes:
 //    A main usage of this is to find the proper internal MetaData importer.
-//    DACized code needs to map from PEFile --> IMDInternalImport.
+//    DACized code needs to map from PEAssembly --> IMDInternalImport.
 //
-VMPTR_PEFile CordbModule::GetPEFile()
+VMPTR_PEAssembly CordbModule::GetPEFile()
 {
     return m_vmPEFile;
 }

--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -290,10 +290,10 @@ static inline DWORD CordbGetWaitTimeout()
 
 //----------------------------------------------------------------------------
 // Implementation of IDacDbiInterface::IMetaDataLookup.
-// lookup Internal Metadata Importer keyed by PEFile
+// lookup Internal Metadata Importer keyed by PEAssembly
 // isILMetaDataForNGENImage is true iff the IMDInternalImport returned represents a pointer to
 // metadata from an IL image when the module was an ngen'ed image.
-IMDInternalImport * CordbProcess::LookupMetaData(VMPTR_PEFile vmPEFile, bool &isILMetaDataForNGENImage)
+IMDInternalImport * CordbProcess::LookupMetaData(VMPTR_PEAssembly vmPEAssembly, bool &isILMetaDataForNGENImage)
 {
     INTERNAL_DAC_CALLBACK(this);
 
@@ -312,7 +312,7 @@ IMDInternalImport * CordbProcess::LookupMetaData(VMPTR_PEFile vmPEFile, bool &is
              pModule != NULL;
              pModule = pAppDomain->m_modules.FindNext(&hashFindModule))
         {
-            if (pModule->GetPEFile() == vmPEFile)
+            if (pModule->GetPEFile() == vmPEAssembly)
             {
                 pMDII = NULL;
                 ALLOW_DATATARGET_MISSING_MEMORY(
@@ -341,7 +341,7 @@ IMDInternalImport * CordbProcess::LookupMetaData(VMPTR_PEFile vmPEFile, bool &is
              pModule != NULL;
              pModule = pAppDomain->m_modules.FindNext(&hashFindModule))
         {
-            if (pModule->GetPEFile() == vmPEFile)
+            if (pModule->GetPEFile() == vmPEAssembly)
             {
                 pMDII = NULL;
                 ALLOW_DATATARGET_MISSING_MEMORY(
@@ -354,7 +354,7 @@ IMDInternalImport * CordbProcess::LookupMetaData(VMPTR_PEFile vmPEFile, bool &is
                     // debugger if it can find the metadata elsewhere.
                     // If this was live debugging, we should have just gotten the memory contents.
                     // Thus this code is for dump debugging, when you don't have the metadata in the dump.
-                    pMDII = LookupMetaDataFromDebugger(vmPEFile, isILMetaDataForNGENImage, pModule);
+                    pMDII = LookupMetaDataFromDebugger(vmPEAssembly, isILMetaDataForNGENImage, pModule);
                 }
                 return pMDII;
             }
@@ -366,7 +366,7 @@ IMDInternalImport * CordbProcess::LookupMetaData(VMPTR_PEFile vmPEFile, bool &is
 
 
 IMDInternalImport * CordbProcess::LookupMetaDataFromDebugger(
-    VMPTR_PEFile vmPEFile,
+    VMPTR_PEAssembly vmPEAssembly,
     bool &isILMetaDataForNGENImage,
     CordbModule * pModule)
 {
@@ -377,7 +377,7 @@ IMDInternalImport * CordbProcess::LookupMetaDataFromDebugger(
     IMDInternalImport * pMDII = NULL;
 
     // First, see if the debugger can locate the exact metadata we want.
-    if (this->GetDAC()->GetMetaDataFileInfoFromPEFile(vmPEFile, dwImageTimeStamp, dwImageSize, isNGEN, &filePath))
+    if (this->GetDAC()->GetMetaDataFileInfoFromPEFile(vmPEAssembly, dwImageTimeStamp, dwImageSize, isNGEN, &filePath))
     {
         _ASSERTE(filePath.IsSet());
 
@@ -408,7 +408,7 @@ IMDInternalImport * CordbProcess::LookupMetaDataFromDebugger(
         filePath.Clear();
         if ((pMDII == NULL) &&
             (isNGEN) &&
-            (this->GetDAC()->GetILImageInfoFromNgenPEFile(vmPEFile, dwImageTimeStamp, dwImageSize, &filePath)))
+            (this->GetDAC()->GetILImageInfoFromNgenPEFile(vmPEAssembly, dwImageTimeStamp, dwImageSize, &filePath)))
         {
             _ASSERTE(filePath.IsSet());
 
@@ -496,7 +496,7 @@ IMDInternalImport * CordbProcess::LookupMetaDataFromDebuggerForSingleFile(
         if (SUCCEEDED(hr))
         {
             // While we're successfully returning a metadata reader, remember that there's
-            // absolutely no guarantee this metadata is an exact match for the vmPEFile.
+            // absolutely no guarantee this metadata is an exact match for the vmPEAssembly.
             // The debugger could literally send us back a path to any managed file with
             // metadata content that is readable and we'll 'succeed'.
             // For now, this is by-design.  A debugger should be allowed to decide if it wants

--- a/src/coreclr/debug/di/rspriv.h
+++ b/src/coreclr/debug/di/rspriv.h
@@ -2975,10 +2975,10 @@ public:
     //-----------------------------------------------------------
     // IMetaDataLookup
     // -----------------------------------------------------------
-    IMDInternalImport * LookupMetaData(VMPTR_PEFile vmPEFile, bool &isILMetaDataForNGENImage);
+    IMDInternalImport * LookupMetaData(VMPTR_PEAssembly vmPEAssembly, bool &isILMetaDataForNGENImage);
 
     // Helper functions for LookupMetaData implementation
-    IMDInternalImport * LookupMetaDataFromDebugger(VMPTR_PEFile vmPEFile,
+    IMDInternalImport * LookupMetaDataFromDebugger(VMPTR_PEAssembly vmPEAssembly,
                                                    bool &isILMetaDataForNGENImage,
                                                    CordbModule * pModule);
 
@@ -4368,7 +4368,7 @@ public:
     IDacDbiInterface::SymbolFormat GetInMemorySymbolStream(IStream ** ppStream);
 
     // accessor for PE file
-    VMPTR_PEFile GetPEFile();
+    VMPTR_PEAssembly GetPEFile();
 
 
     IMetaDataImport * GetMetaDataImporter();
@@ -4419,9 +4419,9 @@ private:
     // "Global" class for this module. Global functions + vars exist in this class.
     RSSmartPtr<CordbClass> m_pClass;
 
-    // Handle to PEFile, useful for metadata lookups.
+    // Handle to PEAssembly, useful for metadata lookups.
     // this should always be non-null.
-    VMPTR_PEFile    m_vmPEFile;
+    VMPTR_PEAssembly    m_vmPEFile;
 
 
     // Public metadata importer. This is lazily initialized and accessed from code:GetMetaDataImporter

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -9537,21 +9537,6 @@ void Debugger::LoadModule(Module* pRuntimeModule,
 
     SENDIPCEVENT_END;
 
-    // need to update pdb stream for SQL passed in pdb stream
-    // regardless attach or not.
-    //
-    if (pRuntimeModule->IsIStream())
-    {
-        // Just ignore failures. Caller was just sending a debug event and we don't
-        // want that to interop non-debugging functionality.
-        HRESULT hr = S_OK;
-        EX_TRY
-        {
-            SendUpdateModuleSymsEventAndBlock(pRuntimeModule, pAppDomain);
-        }
-        EX_CATCH_HRESULT(hr);
-    }
-
     // Now that we're done with the load module event, can no longer change Jit flags.
     module->SetCanChangeJitFlags(false);
 }
@@ -9710,7 +9695,7 @@ void Debugger::UnloadModule(Module* pRuntimeModule,
 
         STRESS_LOG6(LF_CORDB, LL_INFO10000,
             "D::UM: Unloading RTMod:%#08x (DomFile: %#08x, IsISStream:%#08x); DMod:%#08x(RTMod:%#08x DomFile: %#08x)\n",
-            pRuntimeModule, pRuntimeModule->GetDomainFile(), pRuntimeModule->IsIStream(),
+            pRuntimeModule, pRuntimeModule->GetDomainFile(), false,
             module, module->GetRuntimeModule(), module->GetDomainFile());
 
         // Note: the appdomain the module was loaded in must match the appdomain we're unloading it from. If it doesn't,

--- a/src/coreclr/debug/inc/dacdbiinterface.h
+++ b/src/coreclr/debug/inc/dacdbiinterface.h
@@ -521,7 +521,7 @@ public:
     //
     //    For dynamic modules, the CLR will eagerly serialize the metadata at "debuggable" points. This
     //    could be after each type is loaded; or after a bulk update.
-    //    For non-dynamic modules (both in-memory and file-based), the metadata exists in the PEFile's image.
+    //    For non-dynamic modules (both in-memory and file-based), the metadata exists in the PEAssembly's image.
     //
     //    Failure cases:
     //    This should succeed in normal, live-debugging scenarios. However, common failure paths here would be:
@@ -2379,14 +2379,14 @@ public:
     CLR_DEBUGGING_PROCESS_FLAGS GetAttachStateFlags() = 0;
 
     virtual
-    bool GetMetaDataFileInfoFromPEFile(VMPTR_PEFile vmPEFile,
+    bool GetMetaDataFileInfoFromPEFile(VMPTR_PEAssembly vmPEAssembly,
                                        DWORD & dwTimeStamp,
                                        DWORD & dwImageSize,
                                        bool  & isNGEN,
                                        IStringHolder* pStrFilename) = 0;
 
     virtual
-    bool GetILImageInfoFromNgenPEFile(VMPTR_PEFile vmPEFile,
+    bool GetILImageInfoFromNgenPEFile(VMPTR_PEAssembly vmPEAssembly,
                                       DWORD & dwTimeStamp,
                                       DWORD & dwSize,
                                       IStringHolder* pStrFilename) = 0;
@@ -2512,17 +2512,17 @@ public:
     virtual
     void GetGCHeapInformation(OUT COR_HEAPINFO * pHeapInfo) = 0;
 
-    // If a PEFile has an RW capable IMDInternalImport, this returns the address of the MDInternalRW
+    // If a PEAssembly has an RW capable IMDInternalImport, this returns the address of the MDInternalRW
     // object which implements it.
     //
     //
     // Arguments:
-    //    vmPEFile - target PEFile to get metadata MDInternalRW for.
-    //    pAddrMDInternalRW - If a PEFile has an RW capable IMDInternalImport, this will be set to the address
+    //    vmPEAssembly - target PEAssembly to get metadata MDInternalRW for.
+    //    pAddrMDInternalRW - If a PEAssembly has an RW capable IMDInternalImport, this will be set to the address
     //                        of the MDInternalRW object which implements it. Otherwise it will be NULL.
     //
     virtual
-    HRESULT GetPEFileMDInternalRW(VMPTR_PEFile vmPEFile, OUT TADDR* pAddrMDInternalRW) = 0;
+    HRESULT GetPEFileMDInternalRW(VMPTR_PEAssembly vmPEAssembly, OUT TADDR* pAddrMDInternalRW) = 0;
 
     // DEPRECATED - use GetActiveRejitILCodeVersionNode
     // Retrieves the active ReJitInfo for a given module/methodDef, if it exists.
@@ -2814,7 +2814,7 @@ public:
     {
     public:
         //
-        // Lookup a metadata importer via PEFile.
+        // Lookup a metadata importer via PEAssembly.
         //
         // Returns:
         //    A IMDInternalImport used by dac-ized VM code. The object is NOT addref-ed. See lifespan notes below.
@@ -2822,7 +2822,7 @@ public:
         //    Throws on exceptional circumstances (eg, detects the debuggee is corrupted).
         //
         // Notes:
-        //    IMDInternalImport is a property of PEFile. The DAC-ized code uses it as a weak reference,
+        //    IMDInternalImport is a property of PEAssembly. The DAC-ized code uses it as a weak reference,
         //    and so we avoid doing an AddRef() here because that would mean we need to add Release() calls
         //    in DAC-only paths.
         //    The metadata importers are not DAC-ized, and thus we have a local copy in the host.
@@ -2837,7 +2837,7 @@ public:
         //    - the reference count of the returned object is not adjusted.
         //
         virtual
-        IMDInternalImport * LookupMetaData(VMPTR_PEFile addressPEFile, bool &isILMetaDataForNGENImage) = 0;
+        IMDInternalImport * LookupMetaData(VMPTR_PEAssembly addressPEAssembly, bool &isILMetaDataForNGENImage) = 0;
     };
 
 }; // end IDacDbiInterface

--- a/src/coreclr/debug/inc/dacdbistructures.h
+++ b/src/coreclr/debug/inc/dacdbistructures.h
@@ -186,10 +186,10 @@ struct MSLAYOUT ModuleInfo
     // (such as for a dynamic module that's not persisted to disk).
     CORDB_ADDRESS pPEBaseAddress;
 
-    // The PEFile associated with the module. Every module (even non-file-based ones) has a PEFile.
+    // The PEAssembly associated with the module. Every module (even non-file-based ones) has a PEAssembly.
     // This is critical because DAC may ask for a metadata importer via PE-file.
-    // a PEFile may have 1 or more PEImage child objects (1 for IL, 1 for native image, etc)
-    VMPTR_PEFile vmPEFile;
+    // a PEAssembly may have 1 or more PEImage child objects (1 for IL, 1 for native image, etc)
+    VMPTR_PEAssembly vmPEAssembly;
 
     // The PE Base address and size of the module. These may be 0 if there is no image
     // (such as for a dynamic module that's not persisted to disk).

--- a/src/coreclr/debug/inc/dbgipcevents.h
+++ b/src/coreclr/debug/inc/dbgipcevents.h
@@ -858,7 +858,7 @@ DEFINE_VMPTR(class Module,          PTR_Module,         VMPTR_Module);
 DEFINE_VMPTR(class DomainAssembly,  PTR_DomainAssembly, VMPTR_DomainAssembly);
 DEFINE_VMPTR(class Assembly,        PTR_Assembly,       VMPTR_Assembly);
 
-DEFINE_VMPTR(class PEFile,          PTR_PEFile,         VMPTR_PEFile);
+DEFINE_VMPTR(class PEAssembly,      PTR_PEAssembly,     VMPTR_PEAssembly);
 DEFINE_VMPTR(class MethodDesc,      PTR_MethodDesc,     VMPTR_MethodDesc);
 DEFINE_VMPTR(class FieldDesc,       PTR_FieldDesc,      VMPTR_FieldDesc);
 

--- a/src/coreclr/inc/corhdr.h
+++ b/src/coreclr/inc/corhdr.h
@@ -227,7 +227,7 @@ typedef struct IMAGE_COR20_HEADER
     };
 
     // This is the blob of managed resources. Fetched using code:AssemblyNative.GetResource and
-    // code:PEFile.GetResource and accessible from managed code from
+    // code:PEAssembly.GetResource and accessible from managed code from
 	// System.Assembly.GetManifestResourceStream.  The meta data has a table that maps names to offsets into
 	// this blob, so logically the blob is a set of resources.
     IMAGE_DATA_DIRECTORY    Resources;

--- a/src/coreclr/inc/daccess.h
+++ b/src/coreclr/inc/daccess.h
@@ -769,7 +769,7 @@ HRESULT DacReplacePatchesInHostMemory(MemoryRange range, PVOID pBuffer);
 #ifdef __cplusplus
 }
 class ReflectionModule;
-interface IMDInternalImport* DacGetMDImport(const class PEFile* peFile,
+interface IMDInternalImport* DacGetMDImport(const class PEAssembly* pPEAssembly,
                                             bool throwEx);
 interface IMDInternalImport* DacGetMDImport(const ReflectionModule* reflectionModule,
                                             bool throwEx);

--- a/src/coreclr/inc/dacprivate.h
+++ b/src/coreclr/inc/dacprivate.h
@@ -230,8 +230,8 @@ struct MSLAYOUT DacpThreadLocalModuleData
 struct MSLAYOUT DacpModuleData
 {
     CLRDATA_ADDRESS Address = 0;
-    CLRDATA_ADDRESS File = 0; // A PEFile addr
-    CLRDATA_ADDRESS  ilBase = 0;
+    CLRDATA_ADDRESS PEAssembly = 0; // A PEAssembly addr
+    CLRDATA_ADDRESS ilBase = 0;
     CLRDATA_ADDRESS metadataStart = 0;
     ULONG64 metadataSize = 0;
     CLRDATA_ADDRESS Assembly = 0; // Assembly pointer
@@ -981,7 +981,7 @@ struct MSLAYOUT DacpGetModuleData
     BOOL IsDynamic = FALSE;
     BOOL IsInMemory = FALSE;
     BOOL IsFileLayout = FALSE;
-    CLRDATA_ADDRESS PEFile = 0;
+    CLRDATA_ADDRESS PEAssembly = 0;
     CLRDATA_ADDRESS LoadedPEAddress = 0;
     ULONG64 LoadedPESize = 0;
     CLRDATA_ADDRESS InMemoryPdbAddress = 0;

--- a/src/coreclr/inc/vptr_list.h
+++ b/src/coreclr/inc/vptr_list.h
@@ -39,7 +39,6 @@ VPTR_CLASS(DelegateInvokeStubManager)
 VPTR_CLASS(TailCallStubManager)
 #endif
 VPTR_CLASS(CallCountingStubManager)
-VPTR_CLASS(PEFile)
 VPTR_CLASS(PEAssembly)
 VPTR_CLASS(PEImageLayout)
 VPTR_CLASS(RawImageLayout)

--- a/src/coreclr/vm/CMakeLists.txt
+++ b/src/coreclr/vm/CMakeLists.txt
@@ -106,7 +106,7 @@ set(VM_SOURCES_DAC_AND_WKS_COMMON
     nativeimage.cpp
     object.cpp
     onstackreplacement.cpp
-    pefile.cpp
+    peassembly.cpp
     peimage.cpp
     perfmap.cpp
     perfinfo.cpp
@@ -207,8 +207,8 @@ set(VM_HEADERS_DAC_AND_WKS_COMMON
     object.h
     object.inl
     onstackreplacement.h
-    pefile.h
-    pefile.inl
+    peassembly.h
+    peassembly.inl
     peimage.h
     peimage.inl
     peimagelayout.h

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -1041,7 +1041,6 @@ void SystemDomain::Attach()
 
     // Create the one and only app domain
     AppDomain::Create();
-    AppDomain::GetCurrentDomain()->CreateBinderContext();
 
     // Each domain gets its own ReJitManager, and ReJitManager has its own static
     // initialization to run
@@ -1839,6 +1838,8 @@ void AppDomain::Create()
     pDomain->InitVSD();
 
     pDomain->SetStage(AppDomain::STAGE_OPEN);
+    pDomain->CreateDefaultBinder();
+
     pDomain.SuppressRelease();
 
     m_pTheAppDomain = pDomain;
@@ -4040,7 +4041,7 @@ AppDomain::RaiseUnhandledExceptionEvent(OBJECTREF *pThrowable, BOOL isTerminatin
 }
 
 
-DefaultAssemblyBinder *AppDomain::CreateBinderContext()
+DefaultAssemblyBinder *AppDomain::CreateDefaultBinder()
 {
     CONTRACT(DefaultAssemblyBinder *)
     {

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -1319,9 +1319,8 @@ void SystemDomain::LoadBaseSystemClasses()
 
     ETWOnStartup(LdSysBases_V1, LdSysBasesEnd_V1);
 
-    {
-        m_pSystemPEAssembly = PEAssembly::OpenSystem();
-    }
+    m_pSystemPEAssembly = PEAssembly::OpenSystem();
+
     // Only partially load the system assembly. Other parts of the code will want to access
     // the globals in this function before finishing the load.
     m_pSystemAssembly = DefaultDomain()->LoadDomainAssembly(NULL, m_pSystemPEAssembly, FILE_LOAD_POST_LOADLIBRARY)->GetCurrentAssembly();
@@ -3686,7 +3685,7 @@ PEAssembly * AppDomain::BindAssemblySpec(
                     else
                     {
                         // IsSystem on the PEAssembly should be false, even for CoreLib satellites
-                        result = PEAssembly::Open(boundAssembly, FALSE);
+                        result = PEAssembly::Open(boundAssembly);
                     }
 
                     // Setup the reference to the binder, which performed the bind, into the AssemblySpec

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -1974,7 +1974,7 @@ public:
         return m_tpIndex;
     }
 
-    DefaultAssemblyBinder *CreateBinderContext();
+    DefaultAssemblyBinder *CreateDefaultBinder();
 
     void SetIgnoreUnhandledExceptions()
     {

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -2374,7 +2374,7 @@ private:
         static key_t GetKey(element_t const & elem)
         {
             STATIC_CONTRACT_WRAPPER;
-            return elem->GetPEAssebmly()->GetHostAssembly();
+            return elem->GetPEAssembly()->GetHostAssembly();
         }
 
         static BOOL Equals(key_t key1, key_t key2)

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -2396,20 +2396,8 @@ private:
         static bool IsDeleted(const element_t & e) { return dac_cast<TADDR>(e) == (TADDR)-1; }
     };
 
-    struct OriginalFileHostAssemblyHashTraits : public HostAssemblyHashTraits
-    {
-    public:
-        static key_t GetKey(element_t const & elem)
-        {
-            STATIC_CONTRACT_WRAPPER;
-            return elem->GetOriginalPEAssembly()->GetHostAssembly();
-        }
-    };
-
     typedef SHash<HostAssemblyHashTraits> HostAssemblyMap;
-    typedef SHash<OriginalFileHostAssemblyHashTraits> OriginalFileHostAssemblyMap;
     HostAssemblyMap   m_hostAssemblyMap;
-    OriginalFileHostAssemblyMap   m_hostAssemblyMapForOrigFile;
     CrstExplicitInit  m_crstHostAssemblyMap;
     // Lock to serialize all Add operations (in addition to the "read-lock" above)
     CrstExplicitInit  m_crstHostAssemblyMapAdd;
@@ -2426,11 +2414,6 @@ private:
     // Called from DomainAssembly::Begin.
     void PublishHostedAssembly(
         DomainAssembly* pAssembly);
-
-    // Called from DomainAssembly::UpdatePEFile.
-    void UpdatePublishHostedAssembly(
-        DomainAssembly* pAssembly,
-        PTR_PEAssembly pPEAssembly);
 
     // Called from DomainAssembly::~DomainAssembly
     void UnPublishHostedAssembly(

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -700,7 +700,7 @@ class PEFileListLock : public ListLock
 {
 public:
 #ifndef DACCESS_COMPILE
-    ListLockEntry *FindFileLock(PEFile *pFile)
+    ListLockEntry *FindFileLock(PEAssembly *pPEAssembly)
     {
         STATIC_CONTRACT_NOTHROW;
         STATIC_CONTRACT_GC_NOTRIGGER;
@@ -714,7 +714,7 @@ public:
              pEntry != NULL;
              pEntry = pEntry->m_pNext)
         {
-            if (((PEFile *)pEntry->m_data)->Equals(pFile))
+            if (((PEAssembly *)pEntry->m_data)->Equals(pPEAssembly))
             {
                 return pEntry;
             }
@@ -777,7 +777,7 @@ private:
     HRESULT                 m_cachedHR;
 
 public:
-    static FileLoadLock *Create(PEFileListLock *pLock, PEFile *pFile, DomainFile *pDomainFile);
+    static FileLoadLock *Create(PEFileListLock *pLock, PEAssembly *pPEAssembly, DomainFile *pDomainFile);
 
     ~FileLoadLock();
     DomainFile *GetDomainFile();
@@ -807,7 +807,7 @@ public:
 
 private:
 
-    FileLoadLock(PEFileListLock *pLock, PEFile *pFile, DomainFile *pDomainFile);
+    FileLoadLock(PEFileListLock *pLock, PEAssembly *pPEAssembly, DomainFile *pDomainFile);
 
     static void HolderLeave(FileLoadLock *pThis);
 
@@ -1812,11 +1812,11 @@ public:
         FindAssemblyOptions_IncludeFailedToLoad     = 0x1
     };
 
-    DomainAssembly * FindAssembly(PEAssembly * pFile, FindAssemblyOptions options = FindAssemblyOptions_None) DAC_EMPTY_RET(NULL);
+    DomainAssembly * FindAssembly(PEAssembly* pPEAssembly, FindAssemblyOptions options = FindAssemblyOptions_None) DAC_EMPTY_RET(NULL);
 
 
     Assembly *LoadAssembly(AssemblySpec* pIdentity,
-                           PEAssembly *pFile,
+                           PEAssembly *pPEAssembly,
                            FileLoadLevel targetLevel);
 
     // this function does not provide caching, you must use LoadDomainAssembly
@@ -1826,11 +1826,11 @@ public:
     // resulting in multiple DomainAssembly objects that share the same PEAssembly for ngen image
     //which is violating our internal assumptions
     DomainAssembly *LoadDomainAssemblyInternal( AssemblySpec* pIdentity,
-                                                PEAssembly *pFile,
+                                                PEAssembly *pPEAssembly,
                                                 FileLoadLevel targetLevel);
 
     DomainAssembly *LoadDomainAssembly( AssemblySpec* pIdentity,
-                                        PEAssembly *pFile,
+                                        PEAssembly *pPEAssembly,
                                         FileLoadLevel targetLevel);
 
 
@@ -1859,8 +1859,8 @@ public:
     BOOL IsCached(AssemblySpec *pSpec);
 #endif // DACCESS_COMPILE
 
-    BOOL AddFileToCache(AssemblySpec* pSpec, PEAssembly *pFile, BOOL fAllowFailure = FALSE);
-    BOOL RemoveFileFromCache(PEAssembly *pFile);
+    BOOL AddFileToCache(AssemblySpec* pSpec, PEAssembly *pPEAssembly, BOOL fAllowFailure = FALSE);
+    BOOL RemoveFileFromCache(PEAssembly *pPEAssembly);
 
     BOOL AddAssemblyToCache(AssemblySpec* pSpec, DomainAssembly *pAssembly);
     BOOL RemoveAssemblyFromCache(DomainAssembly* pAssembly);
@@ -2364,7 +2364,7 @@ private:
     //-----------------------------------------------------------
     // Static BINDER_SPACE::Assembly -> DomainAssembly mapping functions.
     // This map does not maintain a reference count to either key or value.
-    // PEFile maintains a reference count on the BINDER_SPACE::Assembly through its code:PEFile::m_pHostAssembly field.
+    // PEAssembly maintains a reference count on the BINDER_SPACE::Assembly through its code:PEAssembly::m_pHostAssembly field.
     // It is removed from this hash table by code:DomainAssembly::~DomainAssembly.
     struct HostAssemblyHashTraits : public DefaultSHashTraits<PTR_DomainAssembly>
     {
@@ -2374,7 +2374,7 @@ private:
         static key_t GetKey(element_t const & elem)
         {
             STATIC_CONTRACT_WRAPPER;
-            return elem->GetFile()->GetHostAssembly();
+            return elem->GetPEAssebmly()->GetHostAssembly();
         }
 
         static BOOL Equals(key_t key1, key_t key2)
@@ -2402,7 +2402,7 @@ private:
         static key_t GetKey(element_t const & elem)
         {
             STATIC_CONTRACT_WRAPPER;
-            return elem->GetOriginalFile()->GetHostAssembly();
+            return elem->GetOriginalPEAssembly()->GetHostAssembly();
         }
     };
 
@@ -2430,7 +2430,7 @@ private:
     // Called from DomainAssembly::UpdatePEFile.
     void UpdatePublishHostedAssembly(
         DomainAssembly* pAssembly,
-        PTR_PEFile pFile);
+        PTR_PEAssembly pPEAssembly);
 
     // Called from DomainAssembly::~DomainAssembly
     void UnPublishHostedAssembly(
@@ -2512,12 +2512,12 @@ public:
         return m_pSystemDomain;
     }
 
-    static PEAssembly* SystemFile()
+    static PEAssembly* SystemPEAssembly()
     {
         WRAPPER_NO_CONTRACT;
 
         _ASSERTE(m_pSystemDomain);
-        return System()->m_pSystemFile;
+        return System()->m_pSystemPEAssembly;
     }
 
     static Assembly* SystemAssembly()
@@ -2708,7 +2708,7 @@ private:
     }
 #endif
 
-    PTR_PEAssembly  m_pSystemFile;      // Single assembly (here for quicker reference);
+    PTR_PEAssembly  m_pSystemPEAssembly;// Single assembly (here for quicker reference);
     PTR_Assembly    m_pSystemAssembly;  // Single assembly (here for quicker reference);
 
     GlobalLoaderAllocator m_GlobalAllocator;

--- a/src/coreclr/vm/assembly.cpp
+++ b/src/coreclr/vm/assembly.cpp
@@ -817,7 +817,7 @@ Module *Assembly::FindModuleByExportedType(mdExportedType mdType,
 
             // Note that we don't want to attempt a LoadModule if a GetModuleIfLoaded will
             // succeed, because it has a stronger contract.
-            Module *pModule = GetManifestModule()->GetModuleIfLoaded(mdLinkRef, TRUE, FALSE);
+            Module *pModule = GetManifestModule()->GetModuleIfLoaded(mdLinkRef);
 #ifdef DACCESS_COMPILE
             return pModule;
 #else
@@ -830,7 +830,7 @@ Module *Assembly::FindModuleByExportedType(mdExportedType mdType,
             // We should never get here in the GC case - the above should have succeeded.
             CONSISTENCY_CHECK(!FORBIDGC_LOADER_USE_ENABLED());
 
-            DomainFile * pDomainModule = GetManifestModule()->LoadModule(::GetAppDomain(), mdLinkRef, FALSE, loadFlag!=Loader::Load);
+            DomainFile * pDomainModule = GetManifestModule()->LoadModule(::GetAppDomain(), mdLinkRef);
 
             if (pDomainModule == NULL)
                 RETURN NULL;
@@ -953,11 +953,11 @@ Module * Assembly::FindModuleByTypeRef(
                 // Either we're not supposed to load, or we're doing a GC or stackwalk
                 // in which case we shouldn't need to load.  So just look up the module
                 // and return what we find.
-                RETURN(pModule->LookupModule(tkType,FALSE));
+                RETURN(pModule->LookupModule(tkType));
             }
 
 #ifndef DACCESS_COMPILE
-            DomainFile * pActualDomainFile = pModule->LoadModule(::GetAppDomain(), tkType, FALSE, loadFlag!=Loader::Load);
+            DomainFile * pActualDomainFile = pModule->LoadModule(::GetAppDomain(), tkType, loadFlag!=Loader::Load);
             if (pActualDomainFile == NULL)
             {
                 RETURN NULL;
@@ -1056,7 +1056,7 @@ Module *Assembly::FindModuleByName(LPCSTR pszModuleName)
         ThrowHR(COR_E_UNAUTHORIZEDACCESS);
 
     if (this == SystemDomain::SystemAssembly())
-        RETURN m_pManifest->GetModuleIfLoaded(kFile, TRUE, TRUE);
+        RETURN m_pManifest->GetModuleIfLoaded(kFile);
     else
         RETURN m_pManifest->LoadModule(::GetAppDomain(), kFile)->GetModule();
 }

--- a/src/coreclr/vm/assembly.cpp
+++ b/src/coreclr/vm/assembly.cpp
@@ -66,7 +66,7 @@ static CrstStatic g_friendAssembliesCrst;
 
 namespace
 {
-    static void DefineEmitScope(GUID iid, void** ppEmit)
+    void DefineEmitScope(GUID iid, void** ppEmit)
     {
         CONTRACT_VOID
         {

--- a/src/coreclr/vm/assembly.cpp
+++ b/src/coreclr/vm/assembly.cpp
@@ -877,7 +877,11 @@ Module *Assembly::FindModuleByExportedType(mdExportedType mdType,
             // We should never get here in the GC case - the above should have succeeded.
             CONSISTENCY_CHECK(!FORBIDGC_LOADER_USE_ENABLED());
 
-            DomainFile * pDomainModule = GetManifestModule()->LoadModule(::GetAppDomain(), mdLinkRef);
+            DomainFile* pDomainModule = NULL;
+            if (loadFlag == Loader::Load)
+            {
+                pDomainModule = GetManifestModule()->LoadModule(::GetAppDomain(), mdLinkRef);
+            }
 
             if (pDomainModule == NULL)
                 RETURN NULL;

--- a/src/coreclr/vm/assembly.cpp
+++ b/src/coreclr/vm/assembly.cpp
@@ -1657,7 +1657,7 @@ MethodDesc* Assembly::GetEntryPoint()
         break;
 
     case mdtMethodDef:
-        if (m_pManifestFile->GetPersistentMDImport()->IsValidToken(mdEntry))
+        if (m_pManifestFile->GetMDImport()->IsValidToken(mdEntry))
             pModule = m_pManifest;
         break;
     }
@@ -2240,7 +2240,7 @@ ReleaseHolder<FriendAssemblyDescriptor> FriendAssemblyDescriptor::CreateFriendAs
     ReleaseHolder<FriendAssemblyDescriptor> pFriendAssemblies = new FriendAssemblyDescriptor;
 
     // We're going to do this twice, once for InternalsVisibleTo and once for IgnoresAccessChecks
-    ReleaseHolder<IMDInternalImport> pImport(pAssembly->GetMDImportWithRef());
+    IMDInternalImport* pImport = pAssembly->GetMDImport();
     for(int count = 0 ; count < 2 ; ++count)
     {
         _ASSERTE(pImport != NULL);

--- a/src/coreclr/vm/assembly.hpp
+++ b/src/coreclr/vm/assembly.hpp
@@ -79,13 +79,13 @@ class Assembly
     friend class ClrDataAccess;
 
 public:
-    Assembly(BaseDomain *pDomain, PEAssembly *pFile, DebuggerAssemblyControlFlags debuggerFlags, BOOL fIsCollectible);
+    Assembly(BaseDomain *pDomain, PEAssembly *pPEAssembly, DebuggerAssemblyControlFlags debuggerFlags, BOOL fIsCollectible);
     void Init(AllocMemTracker *pamTracker, LoaderAllocator *pLoaderAllocator);
 
     void StartUnload();
     void Terminate( BOOL signalProfiler = TRUE );
 
-    static Assembly *Create(BaseDomain *pDomain, PEAssembly *pFile, DebuggerAssemblyControlFlags debuggerFlags, BOOL fIsCollectible, AllocMemTracker *pamTracker, LoaderAllocator *pLoaderAllocator);
+    static Assembly *Create(BaseDomain *pDomain, PEAssembly *pPEAssembly, DebuggerAssemblyControlFlags debuggerFlags, BOOL fIsCollectible, AllocMemTracker *pamTracker, LoaderAllocator *pLoaderAllocator);
     static void Initialize();
 
     BOOL IsSystem() { WRAPPER_NO_CONTRACT; return m_pManifestFile->IsSystem(); }

--- a/src/coreclr/vm/assembly.hpp
+++ b/src/coreclr/vm/assembly.hpp
@@ -299,7 +299,7 @@ public:
     {
         WRAPPER_NO_CONTRACT;
         SUPPORTS_DAC;
-        return m_pManifestFile->GetPersistentMDImport();
+        return m_pManifestFile->GetMDImport();
     }
 
     HRESULT GetCustomAttribute(mdToken parentToken,

--- a/src/coreclr/vm/assembly.hpp
+++ b/src/coreclr/vm/assembly.hpp
@@ -312,14 +312,6 @@ public:
         return GetManifestModule()->GetCustomAttribute(parentToken, attribute, ppData, pcbData);
     }
 
-#ifndef DACCESS_COMPILE
-    IMetaDataAssemblyImport* GetManifestAssemblyImporter()
-    {
-        WRAPPER_NO_CONTRACT;
-        return m_pManifestFile->GetAssemblyImporter();
-    }
-#endif // DACCESS_COMPILE
-
     mdAssembly GetManifestToken()
     {
         LIMITED_METHOD_CONTRACT;

--- a/src/coreclr/vm/assemblybinder.cpp
+++ b/src/coreclr/vm/assemblybinder.cpp
@@ -32,7 +32,7 @@ NativeImage* AssemblyBinder::LoadNativeImage(Module* componentModule, LPCUTF8 na
     STANDARD_VM_CONTRACT;
 
     BaseDomain::LoadLockHolder lock(AppDomain::GetCurrentDomain());
-    AssemblyBinder* binder = componentModule->GetFile()->GetAssemblyBinder();
+    AssemblyBinder* binder = componentModule->GetPEAssembly()->GetAssemblyBinder();
     PTR_LoaderAllocator moduleLoaderAllocator = componentModule->GetLoaderAllocator();
 
     bool isNewNativeImage;

--- a/src/coreclr/vm/assemblyname.cpp
+++ b/src/coreclr/vm/assemblyname.cpp
@@ -56,7 +56,7 @@ FCIMPL1(Object*, AssemblyNameNative::GetFileInformation, StringObject* filenameU
     // waiting for it to happen during HasNTHeaders. This allows us to
     // get the assembly name for images that contain native code for a
     // non-native platform.
-    PEImageLayoutHolder pLayout(pImage->GetLayout(PEImageLayout::LAYOUT_FLAT, PEImage::LAYOUT_CREATEIFNEEDED));
+    PEImageLayoutHolder pLayout(pImage->GetLayout(PEImageLayout::LAYOUT_FLAT));
 
     pImage->VerifyIsAssembly();
 

--- a/src/coreclr/vm/assemblyname.cpp
+++ b/src/coreclr/vm/assemblyname.cpp
@@ -56,7 +56,7 @@ FCIMPL1(Object*, AssemblyNameNative::GetFileInformation, StringObject* filenameU
     // waiting for it to happen during HasNTHeaders. This allows us to
     // get the assembly name for images that contain native code for a
     // non-native platform.
-    PEImageLayoutHolder pLayout(pImage->GetLayout(PEImageLayout::LAYOUT_FLAT));
+    PEImageLayout* pLayout = pImage->GetLayout(PEImageLayout::LAYOUT_FLAT);
 
     pImage->VerifyIsAssembly();
 

--- a/src/coreclr/vm/assemblyname.cpp
+++ b/src/coreclr/vm/assemblyname.cpp
@@ -56,7 +56,7 @@ FCIMPL1(Object*, AssemblyNameNative::GetFileInformation, StringObject* filenameU
     // waiting for it to happen during HasNTHeaders. This allows us to
     // get the assembly name for images that contain native code for a
     // non-native platform.
-    PEImageLayout* pLayout = pImage->GetLayout(PEImageLayout::LAYOUT_FLAT);
+    PEImageLayout* pLayout = pImage->GetOrCreateLayout(PEImageLayout::LAYOUT_FLAT);
 
     pImage->VerifyIsAssembly();
 

--- a/src/coreclr/vm/assemblynative.cpp
+++ b/src/coreclr/vm/assemblynative.cpp
@@ -108,7 +108,7 @@ void QCALLTYPE AssemblyNative::InternalLoad(QCall::ObjectHandleOnStack assemblyN
     {
         // If the requesting assembly has Fallback LoadContext binder available,
         // then set it up in the AssemblySpec.
-        PEFile *pRefAssemblyManifestFile = pRefAssembly->GetManifestFile();
+        PEAssembly *pRefAssemblyManifestFile = pRefAssembly->GetManifestFile();
         spec.SetFallbackBinderForRequestingAssembly(pRefAssemblyManifestFile->GetFallbackBinder());
     }
 
@@ -157,7 +157,7 @@ Assembly* AssemblyNative::LoadFromPEImage(AssemblyBinder* pBinder, PEImage *pIma
 
     // Set the caller's assembly to be CoreLib
     DomainAssembly *pCallersAssembly = SystemDomain::System()->SystemAssembly()->GetDomainAssembly();
-    PEAssembly *pParentAssembly = pCallersAssembly->GetFile();
+    PEAssembly *pParentAssembly = pCallersAssembly->GetPEAssebmly();
 
     // Initialize the AssemblySpec
     AssemblySpec spec;
@@ -351,7 +351,7 @@ void QCALLTYPE AssemblyNative::GetLocation(QCall::AssemblyHandle pAssembly, QCal
     BEGIN_QCALL;
 
     {
-        retString.Set(pAssembly->GetFile()->GetPath());
+        retString.Set(pAssembly->GetPEAssebmly()->GetPath());
     }
 
     END_QCALL;
@@ -449,7 +449,7 @@ FCIMPL1(FC_BOOL_RET, AssemblyNative::IsDynamic, AssemblyBaseObject* pAssemblyUNS
     if (refAssembly == NULL)
         FCThrowRes(kArgumentNullException, W("Arg_InvalidHandle"));
 
-    FC_RETURN_BOOL(refAssembly->GetDomainAssembly()->GetFile()->IsDynamic());
+    FC_RETURN_BOOL(refAssembly->GetDomainAssembly()->GetPEAssebmly()->IsDynamic());
 }
 FCIMPLEND
 
@@ -461,7 +461,7 @@ void QCALLTYPE AssemblyNative::GetVersion(QCall::AssemblyHandle pAssembly, INT32
 
     UINT16 major=0xffff, minor=0xffff, build=0xffff, revision=0xffff;
 
-    pAssembly->GetFile()->GetVersion(&major, &minor, &build, &revision);
+    pAssembly->GetPEAssebmly()->GetVersion(&major, &minor, &build, &revision);
 
     *pMajorVersion = major;
     *pMinorVersion = minor;
@@ -478,7 +478,7 @@ void QCALLTYPE AssemblyNative::GetPublicKey(QCall::AssemblyHandle pAssembly, QCa
     BEGIN_QCALL;
 
     DWORD cbPublicKey = 0;
-    const void *pbPublicKey = pAssembly->GetFile()->GetPublicKey(&cbPublicKey);
+    const void *pbPublicKey = pAssembly->GetPEAssebmly()->GetPublicKey(&cbPublicKey);
     retPublicKey.SetByteArray((BYTE *)pbPublicKey, cbPublicKey);
 
     END_QCALL;
@@ -499,7 +499,7 @@ void QCALLTYPE AssemblyNative::GetLocale(QCall::AssemblyHandle pAssembly, QCall:
 
     BEGIN_QCALL;
 
-    LPCUTF8 pLocale = pAssembly->GetFile()->GetLocale();
+    LPCUTF8 pLocale = pAssembly->GetPEAssebmly()->GetLocale();
     if(pLocale)
     {
         retString.Set(pLocale);
@@ -519,7 +519,7 @@ BOOL QCALLTYPE AssemblyNative::GetCodeBase(QCall::AssemblyHandle pAssembly, QCal
     StackSString codebase;
 
     {
-        ret = pAssembly->GetFile()->GetCodeBase(codebase);
+        ret = pAssembly->GetPEAssebmly()->GetCodeBase(codebase);
     }
 
     retString.Set(codebase);
@@ -534,7 +534,7 @@ INT32 QCALLTYPE AssemblyNative::GetHashAlgorithm(QCall::AssemblyHandle pAssembly
 
     INT32 retVal=0;
     BEGIN_QCALL;
-    retVal = pAssembly->GetFile()->GetHashAlgId();
+    retVal = pAssembly->GetPEAssebmly()->GetHashAlgId();
     END_QCALL;
     return retVal;
 }
@@ -545,7 +545,7 @@ INT32 QCALLTYPE AssemblyNative::GetFlags(QCall::AssemblyHandle pAssembly)
 
     INT32 retVal=0;
     BEGIN_QCALL;
-    retVal = pAssembly->GetFile()->GetFlags();
+    retVal = pAssembly->GetPEAssebmly()->GetFlags();
     END_QCALL;
     return retVal;
 }
@@ -1065,7 +1065,7 @@ void QCALLTYPE AssemblyNative::GetFullName(QCall::AssemblyHandle pAssembly, QCal
     BEGIN_QCALL;
 
     StackSString name;
-    pAssembly->GetFile()->GetDisplayName(name);
+    pAssembly->GetPEAssebmly()->GetDisplayName(name);
     retString.Set(name);
 
     END_QCALL;
@@ -1135,12 +1135,12 @@ void QCALLTYPE AssemblyNative::GetImageRuntimeVersion(QCall::AssemblyHandle pAss
 
     BEGIN_QCALL;
 
-    // Retrieve the PEFile from the assembly.
-    PEFile* pPEFile = pAssembly->GetFile();
-    PREFIX_ASSUME(pPEFile!=NULL);
+    // Retrieve the PEAssembly from the assembly.
+    PEAssembly* pPEAssembly = pAssembly->GetPEAssebmly();
+    PREFIX_ASSUME(pPEAssembly!=NULL);
 
     LPCSTR pszVersion = NULL;
-    IfFailThrow(pPEFile->GetMDImport()->GetVersionString(&pszVersion));
+    IfFailThrow(pPEAssembly->GetMDImport()->GetVersionString(&pszVersion));
 
     SString version(SString::Utf8, pszVersion);
 
@@ -1253,7 +1253,7 @@ INT_PTR QCALLTYPE AssemblyNative::GetLoadContextForAssembly(QCall::AssemblyHandl
 
     _ASSERTE(pAssembly != NULL);
 
-    AssemblyBinder* pAssemblyBinder = pAssembly->GetFile()->GetAssemblyBinder();
+    AssemblyBinder* pAssemblyBinder = pAssembly->GetPEAssebmly()->GetAssemblyBinder();
 
     if (!pAssemblyBinder->IsDefault())
     {
@@ -1284,7 +1284,7 @@ BOOL QCALLTYPE AssemblyNative::InternalTryGetRawMetadata(
     _ASSERTE(lengthRef != nullptr);
 
     static_assert_no_msg(sizeof(*lengthRef) == sizeof(COUNT_T));
-    metadata = assembly->GetFile()->GetLoadedMetadata(reinterpret_cast<COUNT_T *>(lengthRef));
+    metadata = assembly->GetPEAssebmly()->GetLoadedMetadata(reinterpret_cast<COUNT_T *>(lengthRef));
     *blobRef = reinterpret_cast<UINT8 *>(const_cast<PTR_VOID>(metadata));
     _ASSERTE(*lengthRef >= 0);
 

--- a/src/coreclr/vm/assemblynative.cpp
+++ b/src/coreclr/vm/assemblynative.cpp
@@ -289,7 +289,7 @@ void QCALLTYPE AssemblyNative::LoadFromStream(INT_PTR ptrNativeAssemblyBinder, I
     // we created above. We need pointer comparison instead of pe image equivalence
     // to avoid mixed binaries/PDB pairs of other images.
     // This applies to both Desktop CLR and CoreCLR, with or without fusion.
-    BOOL fIsSameAssembly = (pLoadedAssembly->GetManifestFile()->GetILimage() == pILImage);
+    BOOL fIsSameAssembly = (pLoadedAssembly->GetManifestFile()->GetPEImage() == pILImage);
 
     // Setting the PDB info is only applicable for our original assembly.
     // This applies to both Desktop CLR and CoreCLR, with or without fusion.

--- a/src/coreclr/vm/assemblynative.cpp
+++ b/src/coreclr/vm/assemblynative.cpp
@@ -639,7 +639,7 @@ void QCALLTYPE AssemblyNative::GetModules(QCall::AssemblyHandle pAssembly, BOOL 
     mdFile mdFile;
     while (pAssembly->GetMDImport()->EnumNext(&phEnum, &mdFile))
     {
-        DomainFile *pModule = pAssembly->GetModule()->LoadModule(GetAppDomain(), mdFile, fGetResourceModules, !fLoadIfNotFound);
+        DomainFile *pModule = pAssembly->GetModule()->LoadModule(GetAppDomain(), mdFile, !fLoadIfNotFound);
 
         if (pModule) {
             modules.Append(pModule);

--- a/src/coreclr/vm/assemblynative.hpp
+++ b/src/coreclr/vm/assemblynative.hpp
@@ -108,7 +108,7 @@ public:
     static FCDECL0(uint32_t, GetAssemblyCount);
 
     //
-    // PEFile QCalls
+    // PEAssembly QCalls
     //
 
     static INT_PTR QCALLTYPE InitializeAssemblyLoadContext(INT_PTR ptrManagedAssemblyLoadContext, BOOL fRepresentsTPALoadContext, BOOL fIsCollectible);

--- a/src/coreclr/vm/assemblyspec.cpp
+++ b/src/coreclr/vm/assemblyspec.cpp
@@ -690,7 +690,7 @@ AssemblyBinder* AssemblySpec::GetBinderFromParentAssembly(AppDomain *pDomain)
     if(pParentDomainAssembly != NULL)
     {
         // Get the PEAssembly associated with the parent's domain assembly
-        PEAssembly *pParentPEAssembly = pParentDomainAssembly->GetFile();
+        PEAssembly *pParentPEAssembly = pParentDomainAssembly->GetPEAssebmly();
         pParentAssemblyBinder = pParentPEAssembly->GetAssemblyBinder();
     }
 
@@ -754,7 +754,7 @@ DomainAssembly *AssemblySpec::LoadDomainAssembly(FileLoadLevel targetLevel,
     if (pAssembly)
     {
         BinderTracing::AssemblyBindOperation bindOperation(this);
-        bindOperation.SetResult(pAssembly->GetFile(), true /*cached*/);
+        bindOperation.SetResult(pAssembly->GetPEAssebmly(), true /*cached*/);
 
         pDomain->LoadDomainFile(pAssembly, targetLevel);
         RETURN pAssembly;
@@ -1219,7 +1219,7 @@ BOOL AssemblySpecBindingCache::StoreAssembly(AssemblySpec *pSpec, DomainAssembly
 
     UPTR key = (UPTR)pSpec->Hash();
 
-    AssemblyBinder* pBinderContextForLookup = pAssembly->GetFile()->GetAssemblyBinder();
+    AssemblyBinder* pBinderContextForLookup = pAssembly->GetPEAssebmly()->GetAssemblyBinder();
     key = key ^ (UPTR)pBinderContextForLookup;
 
     if (!pSpec->GetBinder())
@@ -1240,13 +1240,13 @@ BOOL AssemblySpecBindingCache::StoreAssembly(AssemblySpec *pSpec, DomainAssembly
         }
 
         entry = abHolder.CreateAssemblyBinding(pHeap);
-        entry->Init(pSpec,pAssembly->GetFile(),pAssembly,NULL,pHeap, abHolder.GetPamTracker());
+        entry->Init(pSpec,pAssembly->GetPEAssebmly(),pAssembly,NULL,pHeap, abHolder.GetPamTracker());
 
         m_map.InsertValue(key, entry);
 
         abHolder.SuppressRelease();
 
-        STRESS_LOG2(LF_CLASSLOADER,LL_INFO10,"StoreFile (StoreAssembly): Add cached entry (%p) with PEFile %p",entry,pAssembly->GetFile());
+        STRESS_LOG2(LF_CLASSLOADER,LL_INFO10,"StorePEAssembly (StoreAssembly): Add cached entry (%p) with PEAssembly %p",entry,pAssembly->GetPEAssebmly());
         RETURN TRUE;
     }
     else
@@ -1263,7 +1263,7 @@ BOOL AssemblySpecBindingCache::StoreAssembly(AssemblySpec *pSpec, DomainAssembly
             {
                 // OK if we have have a matching PEAssembly
                 if (entry->GetFile() != NULL
-                    && pAssembly->GetFile()->Equals(entry->GetFile()))
+                    && pAssembly->GetPEAssebmly()->Equals(entry->GetFile()))
                 {
                     entry->SetAssembly(pAssembly);
                     RETURN TRUE;
@@ -1280,7 +1280,7 @@ BOOL AssemblySpecBindingCache::StoreAssembly(AssemblySpec *pSpec, DomainAssembly
 // Returns TRUE if add was successful - if FALSE is returned, caller should honor current
 // cached value to ensure consistency.
 
-BOOL AssemblySpecBindingCache::StoreFile(AssemblySpec *pSpec, PEAssembly *pFile)
+BOOL AssemblySpecBindingCache::StorePEAssembly(AssemblySpec *pSpec, PEAssembly *pPEAssembly)
 {
     CONTRACT(BOOL)
     {
@@ -1288,14 +1288,14 @@ BOOL AssemblySpecBindingCache::StoreFile(AssemblySpec *pSpec, PEAssembly *pFile)
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION((!RETVAL) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupFile(this, pSpec, pFile)));
+        POSTCONDITION((!RETVAL) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupFile(this, pSpec, pPEAssembly)));
         INJECT_FAULT(COMPlusThrowOM(););
     }
     CONTRACT_END;
 
     UPTR key = (UPTR)pSpec->Hash();
 
-    AssemblyBinder* pBinderContextForLookup = pFile->GetAssemblyBinder();
+    AssemblyBinder* pBinderContextForLookup = pPEAssembly->GetAssemblyBinder();
     key = key ^ (UPTR)pBinderContextForLookup;
 
     if (!pSpec->GetBinder())
@@ -1325,12 +1325,12 @@ BOOL AssemblySpecBindingCache::StoreFile(AssemblySpec *pSpec, PEAssembly *pFile)
 
         entry = abHolder.CreateAssemblyBinding(pHeap);
 
-        entry->Init(pSpec,pFile,NULL,NULL,pHeap, abHolder.GetPamTracker());
+        entry->Init(pSpec, pPEAssembly,NULL,NULL,pHeap, abHolder.GetPamTracker());
 
         m_map.InsertValue(key, entry);
         abHolder.SuppressRelease();
 
-        STRESS_LOG2(LF_CLASSLOADER,LL_INFO10,"StoreFile: Add cached entry (%p) with PEFile %p\n", entry, pFile);
+        STRESS_LOG2(LF_CLASSLOADER,LL_INFO10,"StorePEAssembly: Add cached entry (%p) with PEAssembly %p\n", entry, pPEAssembly);
 
         RETURN TRUE;
     }
@@ -1340,7 +1340,7 @@ BOOL AssemblySpecBindingCache::StoreFile(AssemblySpec *pSpec, PEAssembly *pFile)
         {
             // OK if this is a duplicate
             if (entry->GetFile() != NULL
-                && pFile->Equals(entry->GetFile()))
+                && pPEAssembly->Equals(entry->GetFile()))
                 RETURN TRUE;
         }
         else
@@ -1350,7 +1350,7 @@ BOOL AssemblySpecBindingCache::StoreFile(AssemblySpec *pSpec, PEAssembly *pFile)
             entry->ThrowIfError();
 
         }
-        STRESS_LOG2(LF_CLASSLOADER,LL_INFO10,"Incompatible cached entry found (%p) when adding PEFile %p\n", entry, pFile);
+        STRESS_LOG2(LF_CLASSLOADER,LL_INFO10,"Incompatible cached entry found (%p) when adding PEAssembly %p\n", entry, pPEAssembly);
         // Invalid cache transition (see above note about state transitions)
         RETURN FALSE;
     }
@@ -1396,7 +1396,7 @@ BOOL AssemblySpecBindingCache::StoreException(AssemblySpec *pSpec, Exception* pE
         m_map.InsertValue(key, entry);
         abHolder.SuppressRelease();
 
-        STRESS_LOG2(LF_CLASSLOADER,LL_INFO10,"StoreFile (StoreException): Add cached entry (%p) with exception %p",entry,pEx);
+        STRESS_LOG2(LF_CLASSLOADER,LL_INFO10,"StorePEAssembly (StoreException): Add cached entry (%p) with exception %p",entry,pEx);
         RETURN TRUE;
     }
     else

--- a/src/coreclr/vm/assemblyspec.cpp
+++ b/src/coreclr/vm/assemblyspec.cpp
@@ -231,7 +231,7 @@ void AssemblySpec::InitializeSpec(PEAssembly * pFile)
         INJECT_FAULT(COMPlusThrowOM(););
     }
     CONTRACTL_END;
-    ReleaseHolder<IMDInternalImport> pImport(pFile->GetMDImportWithRef());
+    IMDInternalImport* pImport = pFile->GetMDImport();
     mdAssembly a;
     IfFailThrow(pImport->GetAssemblyFromScope(&a));
 

--- a/src/coreclr/vm/assemblyspec.cpp
+++ b/src/coreclr/vm/assemblyspec.cpp
@@ -690,7 +690,7 @@ AssemblyBinder* AssemblySpec::GetBinderFromParentAssembly(AppDomain *pDomain)
     if(pParentDomainAssembly != NULL)
     {
         // Get the PEAssembly associated with the parent's domain assembly
-        PEAssembly *pParentPEAssembly = pParentDomainAssembly->GetPEAssebmly();
+        PEAssembly *pParentPEAssembly = pParentDomainAssembly->GetPEAssembly();
         pParentAssemblyBinder = pParentPEAssembly->GetAssemblyBinder();
     }
 
@@ -754,7 +754,7 @@ DomainAssembly *AssemblySpec::LoadDomainAssembly(FileLoadLevel targetLevel,
     if (pAssembly)
     {
         BinderTracing::AssemblyBindOperation bindOperation(this);
-        bindOperation.SetResult(pAssembly->GetPEAssebmly(), true /*cached*/);
+        bindOperation.SetResult(pAssembly->GetPEAssembly(), true /*cached*/);
 
         pDomain->LoadDomainFile(pAssembly, targetLevel);
         RETURN pAssembly;
@@ -1219,7 +1219,7 @@ BOOL AssemblySpecBindingCache::StoreAssembly(AssemblySpec *pSpec, DomainAssembly
 
     UPTR key = (UPTR)pSpec->Hash();
 
-    AssemblyBinder* pBinderContextForLookup = pAssembly->GetPEAssebmly()->GetAssemblyBinder();
+    AssemblyBinder* pBinderContextForLookup = pAssembly->GetPEAssembly()->GetAssemblyBinder();
     key = key ^ (UPTR)pBinderContextForLookup;
 
     if (!pSpec->GetBinder())
@@ -1240,13 +1240,13 @@ BOOL AssemblySpecBindingCache::StoreAssembly(AssemblySpec *pSpec, DomainAssembly
         }
 
         entry = abHolder.CreateAssemblyBinding(pHeap);
-        entry->Init(pSpec,pAssembly->GetPEAssebmly(),pAssembly,NULL,pHeap, abHolder.GetPamTracker());
+        entry->Init(pSpec,pAssembly->GetPEAssembly(),pAssembly,NULL,pHeap, abHolder.GetPamTracker());
 
         m_map.InsertValue(key, entry);
 
         abHolder.SuppressRelease();
 
-        STRESS_LOG2(LF_CLASSLOADER,LL_INFO10,"StorePEAssembly (StoreAssembly): Add cached entry (%p) with PEAssembly %p",entry,pAssembly->GetPEAssebmly());
+        STRESS_LOG2(LF_CLASSLOADER,LL_INFO10,"StorePEAssembly (StoreAssembly): Add cached entry (%p) with PEAssembly %p",entry,pAssembly->GetPEAssembly());
         RETURN TRUE;
     }
     else
@@ -1263,7 +1263,7 @@ BOOL AssemblySpecBindingCache::StoreAssembly(AssemblySpec *pSpec, DomainAssembly
             {
                 // OK if we have have a matching PEAssembly
                 if (entry->GetFile() != NULL
-                    && pAssembly->GetPEAssebmly()->Equals(entry->GetFile()))
+                    && pAssembly->GetPEAssembly()->Equals(entry->GetFile()))
                 {
                     entry->SetAssembly(pAssembly);
                     RETURN TRUE;

--- a/src/coreclr/vm/assemblyspec.hpp
+++ b/src/coreclr/vm/assemblyspec.hpp
@@ -102,7 +102,7 @@ class AssemblySpec  : public BaseAssemblySpec
     };
 
 
-    void InitializeSpec(PEAssembly *pFile);
+    void InitializeSpec(PEAssembly* pPEAssembly);
     HRESULT InitializeSpec(StackingAllocator* alloc,
                         ASSEMBLYNAMEREF* pName,
                         BOOL fParse = TRUE);
@@ -332,8 +332,8 @@ class AssemblySpecBindingCache
         {
             WRAPPER_NO_CONTRACT;
 
-            if (m_pFile != NULL)
-                m_pFile->Release();
+            if (m_pPEAssembly != NULL)
+                m_pPEAssembly->Release();
 
             if (m_exceptionType==EXTYPE_EE)
                 delete m_pException;
@@ -341,7 +341,7 @@ class AssemblySpecBindingCache
 
         inline DomainAssembly* GetAssembly(){ LIMITED_METHOD_CONTRACT; return m_pAssembly;};
         inline void SetAssembly(DomainAssembly* pAssembly){ LIMITED_METHOD_CONTRACT;  m_pAssembly=pAssembly;};
-        inline PEAssembly* GetFile(){ LIMITED_METHOD_CONTRACT; return m_pFile;};
+        inline PEAssembly* GetFile(){ LIMITED_METHOD_CONTRACT; return m_pPEAssembly;};
         inline BOOL IsError(){ LIMITED_METHOD_CONTRACT; return (m_exceptionType!=EXTYPE_NONE);};
 
         // bound to the file, but failed later
@@ -365,7 +365,7 @@ class AssemblySpecBindingCache
                 default: _ASSERTE(!"Unexpected exception type");
             }
         };
-        inline void Init(AssemblySpec* pSpec, PEAssembly* pFile, DomainAssembly* pAssembly, Exception* pEx, LoaderHeap *pHeap, AllocMemTracker *pamTracker)
+        inline void Init(AssemblySpec* pSpec, PEAssembly* pPEAssembly, DomainAssembly* pAssembly, Exception* pEx, LoaderHeap *pHeap, AllocMemTracker *pamTracker)
         {
             CONTRACTL
             {
@@ -375,7 +375,7 @@ class AssemblySpecBindingCache
             }
             CONTRACTL_END;
 
-            InitInternal(pSpec,pFile,pAssembly);
+            InitInternal(pSpec,pPEAssembly,pAssembly);
             if (pHeap != NULL)
             {
                 m_spec.CloneFieldsToLoaderHeap(AssemblySpec::ALL_OWNED,pHeap, pamTracker);
@@ -444,19 +444,19 @@ class AssemblySpecBindingCache
         };
     protected:
 
-        inline void InitInternal(AssemblySpec* pSpec, PEAssembly* pFile, DomainAssembly* pAssembly )
+        inline void InitInternal(AssemblySpec* pSpec, PEAssembly* pPEAssembly, DomainAssembly* pAssembly )
         {
             WRAPPER_NO_CONTRACT;
             m_spec.CopyFrom(pSpec);
-            m_pFile = pFile;
-            if (m_pFile)
-                m_pFile->AddRef();
+            m_pPEAssembly = pPEAssembly;
+            if (m_pPEAssembly)
+                m_pPEAssembly->AddRef();
             m_pAssembly = pAssembly;
             m_exceptionType=EXTYPE_NONE;
         }
 
         AssemblySpec    m_spec;
-        PEAssembly      *m_pFile;
+        PEAssembly      *m_pPEAssembly;
         DomainAssembly  *m_pAssembly;
         enum{
             EXTYPE_NONE               = 0x00000000,
@@ -490,7 +490,7 @@ class AssemblySpecBindingCache
     PEAssembly *LookupFile(AssemblySpec *pSpec, BOOL fThrow = TRUE);
 
     BOOL StoreAssembly(AssemblySpec *pSpec, DomainAssembly *pAssembly);
-    BOOL StoreFile(AssemblySpec *pSpec, PEAssembly *pFile);
+    BOOL StorePEAssembly(AssemblySpec *pSpec, PEAssembly *pPEAssembly);
 
     BOOL StoreException(AssemblySpec *pSpec, Exception* pEx);
 

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -494,7 +494,7 @@ void Module::Initialize(AllocMemTracker *pamTracker, LPCWSTR szName)
         {
             // For composite images, manifest metadata gets loaded as part of the native image
             COUNT_T cMeta = 0;
-            if (GetPEAssembly()->GetILimage()->GetNativeManifestMetadata(&cMeta) != NULL)
+            if (GetPEAssembly()->GetPEImage()->GetNativeManifestMetadata(&cMeta) != NULL)
             {
                 // Load the native assembly import
                 GetNativeAssemblyImport(TRUE /* loadAllowed */);
@@ -2374,7 +2374,7 @@ BOOL Module::IsInSameVersionBubble(Module *target)
     {
         // Check if the current module's image has native manifest metadata, otherwise the current->GetNativeAssemblyImport() asserts.
         COUNT_T cMeta=0;
-        const void* pMeta = GetPEAssembly()->GetILimage()->GetNativeManifestMetadata(&cMeta);
+        const void* pMeta = GetPEAssembly()->GetPEImage()->GetNativeManifestMetadata(&cMeta);
         if (pMeta == NULL)
         {
             return FALSE;
@@ -3038,7 +3038,7 @@ BOOL Module::IsSigInIL(PCCOR_SIGNATURE signature)
     }
     CONTRACTL_END;
 
-    return m_pPEAssembly->IsPtrInILImage(signature);
+    return m_pPEAssembly->IsPtrInPEImage(signature);
 }
 
 void Module::InitializeStringData(DWORD token, EEStringData *pstrData, CQuickBytes *pqb)
@@ -3160,7 +3160,7 @@ BYTE *Module::GetProfilerBase()
     {
         RETURN NULL;
     }
-    else if (m_pPEAssembly->IsLoaded())
+    else if (m_pPEAssembly->HasLoadedPEImage())
     {
         RETURN  (BYTE*)(m_pPEAssembly->GetLoadedLayout()->GetBase());
     }
@@ -4615,7 +4615,7 @@ IMDInternalImport* Module::GetNativeAssemblyImport(BOOL loadAllowed)
     }
     CONTRACT_END;
 
-    RETURN GetPEAssembly()->GetILimage()->GetNativeMDImport(loadAllowed);
+    RETURN GetPEAssembly()->GetPEImage()->GetNativeMDImport(loadAllowed);
 }
 
 BYTE* Module::GetNativeFixupBlobData(RVA rva)

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -494,7 +494,7 @@ void Module::Initialize(AllocMemTracker *pamTracker, LPCWSTR szName)
         {
             // For composite images, manifest metadata gets loaded as part of the native image
             COUNT_T cMeta = 0;
-            if (GetPEAssembly()->GetOpenedILimage()->GetNativeManifestMetadata(&cMeta) != NULL)
+            if (GetPEAssembly()->GetILimage()->GetNativeManifestMetadata(&cMeta) != NULL)
             {
                 // Load the native assembly import
                 GetNativeAssemblyImport(TRUE /* loadAllowed */);
@@ -742,7 +742,6 @@ Module *Module::Create(Assembly *pAssembly, mdFile moduleRef, PEAssembly *pPEAss
         STANDARD_VM_CHECK;
         PRECONDITION(CheckPointer(pAssembly));
         PRECONDITION(CheckPointer(pPEAssembly));
-        PRECONDITION(!IsNilToken(moduleRef) || pPEAssembly->IsAssembly());
         POSTCONDITION(CheckPointer(RETVAL));
         POSTCONDITION(RETVAL->GetPEAssembly() == pPEAssembly);
     }
@@ -2375,7 +2374,7 @@ BOOL Module::IsInSameVersionBubble(Module *target)
     {
         // Check if the current module's image has native manifest metadata, otherwise the current->GetNativeAssemblyImport() asserts.
         COUNT_T cMeta=0;
-        const void* pMeta = GetPEAssembly()->GetOpenedILimage()->GetNativeManifestMetadata(&cMeta);
+        const void* pMeta = GetPEAssembly()->GetILimage()->GetNativeManifestMetadata(&cMeta);
         if (pMeta == NULL)
         {
             return FALSE;
@@ -4618,7 +4617,7 @@ IMDInternalImport* Module::GetNativeAssemblyImport(BOOL loadAllowed)
     }
     CONTRACT_END;
 
-    RETURN GetPEAssembly()->GetOpenedILimage()->GetNativeMDImport(loadAllowed);
+    RETURN GetPEAssembly()->GetILimage()->GetNativeMDImport(loadAllowed);
 }
 
 BYTE* Module::GetNativeFixupBlobData(RVA rva)
@@ -6959,7 +6958,6 @@ ReflectionModule *ReflectionModule::Create(Assembly *pAssembly, PEAssembly *pPEA
     // Hoist CONTRACT into separate routine because of EX incompatibility
 
     mdFile token;
-    _ASSERTE(pPEAssembly->IsAssembly());
     token = mdFileNil;
 
     // Initial memory block for Modules must be zero-initialized (to make it harder

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -3374,9 +3374,7 @@ DomainAssembly * Module::LoadAssembly(mdAssemblyRef kAssemblyRef)
     }
 
     {
-        PEAssemblyHolder pPEAssembly = GetDomainAssembly()->GetPEAssembly()->LoadAssembly(
-                kAssemblyRef,
-                NULL);
+        PEAssemblyHolder pPEAssembly = GetDomainAssembly()->GetPEAssembly()->LoadAssembly(kAssemblyRef);
         AssemblySpec spec;
         spec.InitializeSpec(kAssemblyRef, GetMDImport(), GetDomainAssembly());
         // Set the binding context in the AssemblySpec if one is available. This can happen if the LoadAssembly ended up

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -3162,7 +3162,7 @@ BYTE *Module::GetProfilerBase()
     }
     else if (m_pPEAssembly->IsLoaded())
     {
-        RETURN  (BYTE*)(m_pPEAssembly->GetLoadedIL()->GetBase());
+        RETURN  (BYTE*)(m_pPEAssembly->GetLoadedLayout()->GetBase());
     }
     else
     {
@@ -4124,7 +4124,7 @@ using GetTokenForVTableEntry_t = mdToken(STDMETHODCALLTYPE*)(HMODULE module, BYT
 static HMODULE GetIJWHostForModule(Module* module)
 {
 #if !defined(TARGET_UNIX)
-    PEDecoder* pe = module->GetPEAssembly()->GetLoadedIL();
+    PEDecoder* pe = module->GetPEAssembly()->GetLoadedLayout();
 
     BYTE* baseAddress = (BYTE*)module->GetPEAssembly()->GetIJWBase();
 

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -43,7 +43,6 @@
 
 #include "ilinstrumentation.h"
 
-class PELoader;
 class Stub;
 class MethodDesc;
 class FieldDesc;

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -1258,7 +1258,7 @@ protected:
             return DacGetMDImport(GetReflectionModule(), true);
         }
 #endif // DACCESS_COMPILE
-        return m_pPEAssembly->GetPersistentMDImport();
+        return m_pPEAssembly->GetMDImport();
     }
 
 #ifndef DACCESS_COMPILE

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -1153,7 +1153,6 @@ protected:
         return m_moduleRef;
     }
 
-    BOOL IsResource() const { WRAPPER_NO_CONTRACT; SUPPORTS_DAC; return GetFile()->IsResource(); }
     BOOL IsPEFile() const { WRAPPER_NO_CONTRACT; return !GetFile()->IsDynamic(); }
     BOOL IsReflection() const { WRAPPER_NO_CONTRACT; SUPPORTS_DAC; return GetFile()->IsDynamic(); }
     BOOL IsIbcOptimized() const { WRAPPER_NO_CONTRACT; return GetFile()->IsIbcOptimized(); }
@@ -1169,8 +1168,6 @@ protected:
     }
 
     virtual BOOL IsEditAndContinueCapable() const { return FALSE; }
-
-    BOOL IsIStream() { LIMITED_METHOD_CONTRACT; return GetFile()->IsIStream(); }
 
     BOOL IsSystem() { WRAPPER_NO_CONTRACT; SUPPORTS_DAC; return m_file->IsSystem(); }
 
@@ -1379,54 +1376,26 @@ protected:
     {
         LIMITED_METHOD_CONTRACT;
         SUPPORTS_DAC;
-        {
-            // IsResource() may lock when accessing metadata, but this is only in debug,
-            // for the assert below
-            CONTRACT_VIOLATION(TakesLockViolation);
-
-            _ASSERTE(!IsResource());
-        }
 
         return m_pAvailableClasses;
     }
 #ifndef DACCESS_COMPILE
     void SetAvailableClassHash(EEClassHashTable *pAvailableClasses)
     {
-        LIMITED_METHOD_CONTRACT;
-        {
-            // IsResource() may lock when accessing metadata, but this is only in debug,
-            // for the assert below
-            CONTRACT_VIOLATION(TakesLockViolation);
 
-            _ASSERTE(!IsResource());
-        }
         m_pAvailableClasses = pAvailableClasses;
     }
 #endif // !DACCESS_COMPILE
     PTR_EEClassHashTable GetAvailableClassCaseInsHash()
     {
         LIMITED_METHOD_CONTRACT;
-        SUPPORTS_DAC;
-        {
-            // IsResource() may lock when accessing metadata, but this is only in debug,
-            // for the assert below
-            CONTRACT_VIOLATION(TakesLockViolation);
 
-            _ASSERTE(!IsResource());
-        }
         return m_pAvailableClassesCaseIns;
     }
 #ifndef DACCESS_COMPILE
     void SetAvailableClassCaseInsHash(EEClassHashTable *pAvailableClassesCaseIns)
     {
-        LIMITED_METHOD_CONTRACT;
-        {
-            // IsResource() may lock when accessing metadata, but this is only in debug,
-            // for the assert below
-            CONTRACT_VIOLATION(TakesLockViolation);
 
-            _ASSERTE(!IsResource());
-        }
         m_pAvailableClassesCaseIns = pAvailableClassesCaseIns;
     }
 #endif // !DACCESS_COMPILE
@@ -1436,26 +1405,14 @@ protected:
     {
         LIMITED_METHOD_CONTRACT;
         SUPPORTS_DAC;
-        {
-            // IsResource() may lock when accessing metadata, but this is only in debug,
-            // for the assert below
-            CONTRACT_VIOLATION(TakesLockViolation);
 
-            _ASSERTE(!IsResource());
-        }
         return m_pAvailableParamTypes;
     }
 
     InstMethodHashTable *GetInstMethodHashTable()
     {
         LIMITED_METHOD_CONTRACT;
-        {
-            // IsResource() may lock when accessing metadata, but this is only in debug,
-            // for the assert below
-            CONTRACT_VIOLATION(TakesLockViolation);
 
-            _ASSERTE(!IsResource());
-        }
         return m_pInstMethodHashTable;
     }
 
@@ -1484,9 +1441,9 @@ protected:
 public:
 
     DomainAssembly * LoadAssembly(mdAssemblyRef kAssemblyRef);
-    Module *GetModuleIfLoaded(mdFile kFile, BOOL onlyLoadedInAppDomain, BOOL loadAllowed);
-    DomainFile *LoadModule(AppDomain *pDomain, mdFile kFile, BOOL loadResources = TRUE, BOOL bindOnly = FALSE);
-    PTR_Module LookupModule(mdToken kFile, BOOL loadResources = TRUE); //wrapper over GetModuleIfLoaded, takes modulerefs as well
+    Module *GetModuleIfLoaded(mdFile kFile);
+    DomainFile *LoadModule(AppDomain *pDomain, mdFile kFile, BOOL bindOnly = FALSE);
+    PTR_Module LookupModule(mdToken kFile); //wrapper over GetModuleIfLoaded, takes modulerefs as well
     DWORD GetAssemblyRefFlags(mdAssemblyRef tkAssemblyRef);
 
     // RID maps

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -19,7 +19,7 @@
 #include "corsym.h"
 #include "typehandle.h"
 #include "arraylist.h"
-#include "pefile.h"
+#include "peassembly.h"
 #include "typehash.h"
 #include "contractimpl.h"
 #include "bitmask.h"

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -1431,7 +1431,7 @@ public:
 
     DomainAssembly * LoadAssembly(mdAssemblyRef kAssemblyRef);
     Module *GetModuleIfLoaded(mdFile kFile);
-    DomainFile *LoadModule(AppDomain *pDomain, mdFile kFile, BOOL bindOnly = FALSE);
+    DomainFile *LoadModule(AppDomain *pDomain, mdFile kFile);
     PTR_Module LookupModule(mdToken kFile); //wrapper over GetModuleIfLoaded, takes modulerefs as well
     DWORD GetAssemblyRefFlags(mdAssemblyRef tkAssemblyRef);
 

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -1277,13 +1277,6 @@ protected:
         return m_pPEAssembly->GetRWImporter();
     }
 
-    IMetaDataAssemblyImport *GetAssemblyImporter()
-    {
-        WRAPPER_NO_CONTRACT;
-
-        return m_pPEAssembly->GetAssemblyImporter();
-    }
-
     HRESULT GetReadablePublicMetaDataInterface(DWORD dwOpenFlags, REFIID riid, LPVOID * ppvInterface);
 #endif // !DACCESS_COMPILE
 

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -848,7 +848,6 @@ void EEStartupHelper()
         // Setup the domains. Threads are started in a default domain.
 
         // Static initialization
-        PEAssembly::Attach();
         BaseDomain::Attach();
         SystemDomain::Attach();
 

--- a/src/coreclr/vm/clrex.cpp
+++ b/src/coreclr/vm/clrex.cpp
@@ -1733,7 +1733,7 @@ void DECLSPEC_NORETURN EEFileLoadException::Throw(AssemblySpec  *pSpec, HRESULT 
 }
 
 /* static */
-void DECLSPEC_NORETURN EEFileLoadException::Throw(PEFile *pFile, HRESULT hr, Exception *pInnerException /* = NULL*/)
+void DECLSPEC_NORETURN EEFileLoadException::Throw(PEAssembly *pPEAssembly, HRESULT hr, Exception *pInnerException /* = NULL*/)
 {
     CONTRACTL
     {
@@ -1749,11 +1749,8 @@ void DECLSPEC_NORETURN EEFileLoadException::Throw(PEFile *pFile, HRESULT hr, Exc
         COMPlusThrowOM();
 
     StackSString name;
+    pPEAssembly->GetDisplayName(name);
 
-    if (pFile->IsAssembly())
-        ((PEAssembly*)pFile)->GetDisplayName(name);
-    else
-        name = StackSString(SString::Utf8, pFile->GetSimpleName());
     EX_THROW_WITH_INNER(EEFileLoadException, (name, hr), pInnerException);
 
 }

--- a/src/coreclr/vm/clrex.h
+++ b/src/coreclr/vm/clrex.h
@@ -18,7 +18,6 @@
 
 class BaseBind;
 class AssemblySpec;
-class PEFile;
 class PEAssembly;
 
 enum StackTraceElementFlags
@@ -678,7 +677,7 @@ class EEFileLoadException : public EEException
 
     static RuntimeExceptionKind GetFileLoadKind(HRESULT hr);
     static void DECLSPEC_NORETURN Throw(AssemblySpec *pSpec, HRESULT hr, Exception *pInnerException = NULL);
-    static void DECLSPEC_NORETURN Throw(PEFile *pFile, HRESULT hr, Exception *pInnerException = NULL);
+    static void DECLSPEC_NORETURN Throw(PEAssembly *pPEAssembly, HRESULT hr, Exception *pInnerException = NULL);
     static void DECLSPEC_NORETURN Throw(LPCWSTR path, HRESULT hr, Exception *pInnerException = NULL);
     static void DECLSPEC_NORETURN Throw(PEAssembly *parent, const void *memory, COUNT_T size, HRESULT hr, Exception *pInnerException = NULL);
     static BOOL CheckType(Exception* ex); // typeof(EEFileLoadException)

--- a/src/coreclr/vm/commodule.cpp
+++ b/src/coreclr/vm/commodule.cpp
@@ -721,10 +721,10 @@ HINSTANCE QCALLTYPE COMModule::GetHINSTANCE(QCall::ModuleHandle pModule)
 
     // This returns the base address
     // Other modules should have zero base
-    PEFile *pPEFile = pModule->GetFile();
-    if (!pPEFile->IsDynamic())
+    PEAssembly *pPEAssembly = pModule->GetPEAssembly();
+    if (!pPEAssembly->IsDynamic())
     {
-        hMod = (HMODULE) pModule->GetFile()->GetManagedFileContents();
+        hMod = (HMODULE) pModule->GetPEAssembly()->GetManagedFileContents();
     }
 
     //If we don't have an hMod, set it to -1 so that they know that there's none

--- a/src/coreclr/vm/commodule.cpp
+++ b/src/coreclr/vm/commodule.cpp
@@ -651,12 +651,12 @@ void QCALLTYPE COMModule::GetScopeName(QCall::ModuleHandle pModule, QCall::Strin
 
     BEGIN_QCALL;
 
-    LPCSTR    szName = NULL;
     if (!pModule->GetMDImport()->IsValidToken(pModule->GetMDImport()->GetModuleFromScope()))
     {
         ThrowHR(COR_E_BADIMAGEFORMAT);
     }
 
+    LPCSTR    szName = NULL;
     IfFailThrow(pModule->GetMDImport()->GetScopeProps(&szName, 0));
     retString.Set(szName);
 

--- a/src/coreclr/vm/commodule.h
+++ b/src/coreclr/vm/commodule.h
@@ -90,8 +90,6 @@ public:
     static
     void QCALLTYPE SetModuleName(QCall::ModuleHandle pModule, LPCWSTR wszModuleName);
 
-    static FCDECL1(FC_BOOL_RET, IsResource, ReflectModuleBaseObject* pModuleUNSAFE);
-
     static FCDECL1(Object*,     GetMethods,             ReflectModuleBaseObject* refThisUNSAFE);
 
     static

--- a/src/coreclr/vm/common.h
+++ b/src/coreclr/vm/common.h
@@ -345,7 +345,7 @@ inline void ClrRestoreNonvolatileContext(PCONTEXT ContextRecord)
 #include "specialstatics.h"
 #include "object.h"  // <NICE> We should not really need to put this so early... </NICE>
 #include "gchelpers.h"
-#include "pefile.h"
+#include "peassembly.h"
 #include "clrex.h"
 #include "clsload.hpp"  // <NICE> We should not really need to put this so early... </NICE>
 #include "siginfo.hpp"
@@ -362,7 +362,7 @@ inline void ClrRestoreNonvolatileContext(PCONTEXT ContextRecord)
 #include "appdomain.hpp"
 #include "appdomain.inl"
 #include "assembly.hpp"
-#include "pefile.inl"
+#include "peassembly.inl"
 #include "excep.h"
 #include "method.hpp"
 #include "field.h"

--- a/src/coreclr/vm/coreassemblyspec.cpp
+++ b/src/coreclr/vm/coreassemblyspec.cpp
@@ -116,7 +116,7 @@ STDAPI BinderAcquirePEImage(LPCWSTR             wszAssemblyPath,
     {
         PEImageHolder pImage = PEImage::OpenImage(wszAssemblyPath, MDInternalImport_Default, bundleFileLocation);
 
-        // Make sure that the IL image can be opened if the native image is not available.
+        // Make sure that the IL image can be opened.
         hr=pImage->TryOpenFile();
         if (FAILED(hr))
         {

--- a/src/coreclr/vm/coreassemblyspec.cpp
+++ b/src/coreclr/vm/coreassemblyspec.cpp
@@ -144,7 +144,7 @@ STDAPI BinderAcquireImport(PEImage                  *pPEImage,
 
     EX_TRY
     {
-        PEImageLayoutHolder pLayout(pPEImage->GetLayout(PEImageLayout::LAYOUT_ANY,PEImage::LAYOUT_CREATEIFNEEDED));
+        PEImageLayoutHolder pLayout(pPEImage->GetLayout(PEImageLayout::LAYOUT_ANY));
 
         // CheckCorHeader includes check of NT headers too
         if (!pLayout->CheckCorHeader())

--- a/src/coreclr/vm/coreassemblyspec.cpp
+++ b/src/coreclr/vm/coreassemblyspec.cpp
@@ -144,7 +144,7 @@ STDAPI BinderAcquireImport(PEImage                  *pPEImage,
 
     EX_TRY
     {
-        PEImageLayoutHolder pLayout(pPEImage->GetLayout(PEImageLayout::LAYOUT_ANY));
+        PEImageLayout* pLayout = pPEImage->GetLayout(PEImageLayout::LAYOUT_ANY);
 
         // CheckCorHeader includes check of NT headers too
         if (!pLayout->CheckCorHeader())

--- a/src/coreclr/vm/coreassemblyspec.cpp
+++ b/src/coreclr/vm/coreassemblyspec.cpp
@@ -144,7 +144,7 @@ STDAPI BinderAcquireImport(PEImage                  *pPEImage,
 
     EX_TRY
     {
-        PEImageLayout* pLayout = pPEImage->GetLayout(PEImageLayout::LAYOUT_ANY);
+        PEImageLayout* pLayout = pPEImage->GetOrCreateLayout(PEImageLayout::LAYOUT_ANY);
 
         // CheckCorHeader includes check of NT headers too
         if (!pLayout->CheckCorHeader())

--- a/src/coreclr/vm/corhost.cpp
+++ b/src/coreclr/vm/corhost.cpp
@@ -612,8 +612,6 @@ HRESULT CorHost2::CreateAppDomainWithManager(
     if (dwFlags & APPDOMAIN_FORCE_TRIVIAL_WAIT_OPERATIONS)
         pDomain->SetForceTrivialWaitOperations();
 
-    pDomain->CreateBinderContext();
-
     {
         GCX_COOP();
 

--- a/src/coreclr/vm/debugdebugger.cpp
+++ b/src/coreclr/vm/debugdebugger.cpp
@@ -713,11 +713,11 @@ FCIMPL4(void, DebugStackTrace::GetStackFramesInternal,
                     I4 *pMethodToken = (I4 *)((I4ARRAYREF)pStackFrameHelper->rgiMethodToken)->GetDirectPointerToNonObjectElements();
                     pMethodToken[iNumValidFrames] = pMethod->GetMemberDef();
 
-                    PEFile *pPEFile = pModule->GetFile();
+                    PEAssembly *pPEAssembly = pModule->GetPEAssembly();
 
                     // Get the address and size of the loaded PE image
                     COUNT_T peSize;
-                    PTR_CVOID peAddress = pPEFile->GetLoadedImageContents(&peSize);
+                    PTR_CVOID peAddress = pPEAssembly->GetLoadedImageContents(&peSize);
 
                     // Save the PE address and size
                     PTR_CVOID *pLoadedPeAddress = (PTR_CVOID *)pStackFrameHelper->rgLoadedPeAddress->GetDataPtr();
@@ -727,11 +727,11 @@ FCIMPL4(void, DebugStackTrace::GetStackFramesInternal,
                     pLoadedPeSize[iNumValidFrames] = (I4)peSize;
 
                     // Set flag indicating PE file in memory has the on disk layout
-                    if (!pPEFile->IsDynamic())
+                    if (!pPEAssembly->IsDynamic())
                     {
                         // This flag is only available for non-dynamic assemblies.
                         U1 *pIsFileLayout = (U1 *)((BOOLARRAYREF)pStackFrameHelper->rgiIsFileLayout)->GetDirectPointerToNonObjectElements();
-                        pIsFileLayout[iNumValidFrames] = (U1) pPEFile->GetLoaded()->IsFlat();
+                        pIsFileLayout[iNumValidFrames] = (U1) pPEAssembly->GetLoaded()->IsFlat();
                     }
 
                     // If there is a in memory symbol stream
@@ -750,7 +750,7 @@ FCIMPL4(void, DebugStackTrace::GetStackFramesInternal,
                     else
                     {
                         // Set the pdb path (assembly file name)
-                        SString assemblyPath = pPEFile->GetIdentityPath();
+                        SString assemblyPath = pPEAssembly->GetIdentityPath();
                         if (!assemblyPath.IsEmpty())
                         {
                             OBJECTREF obj = (OBJECTREF)StringObject::NewString(assemblyPath);

--- a/src/coreclr/vm/debugdebugger.cpp
+++ b/src/coreclr/vm/debugdebugger.cpp
@@ -731,7 +731,7 @@ FCIMPL4(void, DebugStackTrace::GetStackFramesInternal,
                     {
                         // This flag is only available for non-dynamic assemblies.
                         U1 *pIsFileLayout = (U1 *)((BOOLARRAYREF)pStackFrameHelper->rgiIsFileLayout)->GetDirectPointerToNonObjectElements();
-                        pIsFileLayout[iNumValidFrames] = (U1) pPEAssembly->GetLoaded()->IsFlat();
+                        pIsFileLayout[iNumValidFrames] = (U1) pPEAssembly->GetLoadedLayout()->IsFlat();
                     }
 
                     // If there is a in memory symbol stream

--- a/src/coreclr/vm/domainfile.cpp
+++ b/src/coreclr/vm/domainfile.cpp
@@ -33,7 +33,6 @@
 DomainFile::DomainFile(AppDomain *pDomain, PEAssembly *pPEAssembly)
   : m_pDomain(pDomain),
     m_pPEAssembly(pPEAssembly),
-    m_pOriginalPEAssembly(NULL),
     m_pModule(NULL),
     m_level(FILE_LOAD_CREATE),
     m_pError(NULL),
@@ -69,8 +68,6 @@ DomainFile::~DomainFile()
     CONTRACTL_END;
 
     m_pPEAssembly->Release();
-    if(m_pOriginalPEAssembly)
-        m_pOriginalPEAssembly->Release();
     if (m_pDynamicMethodTable)
         m_pDynamicMethodTable->Destroy();
     delete m_pError;

--- a/src/coreclr/vm/domainfile.cpp
+++ b/src/coreclr/vm/domainfile.cpp
@@ -746,7 +746,6 @@ void DomainAssembly::SetAssembly(Assembly* pAssembly)
 {
     STANDARD_VM_CONTRACT;
 
-    UpdatePEFile(pAssembly->GetManifestFile());
     _ASSERTE(pAssembly->GetManifestModule()->GetPEAssembly()==m_pPEAssembly);
     m_pAssembly = pAssembly;
     m_pModule = pAssembly->GetManifestModule();

--- a/src/coreclr/vm/domainfile.cpp
+++ b/src/coreclr/vm/domainfile.cpp
@@ -881,9 +881,6 @@ void DomainAssembly::Allocate()
         assemblyHolder = pAssembly = Assembly::Create(m_pDomain, GetPEAssembly(), GetDebuggerInfoBits(), this->IsCollectible(), pamTracker, this->IsCollectible() ? this->GetLoaderAllocator() : NULL);
         assemblyHolder->SetIsTenured();
 
-        //@todo! This is too early to be calling SuppressRelease. The right place to call it is below after
-        // the CANNOTTHROWCOMPLUSEXCEPTION. Right now, we have to do this to unblock OOM injection testing quickly
-        // as doing the right thing is nontrivial.
         pamTracker->SuppressRelease();
         assemblyHolder.SuppressRelease();
     }

--- a/src/coreclr/vm/domainfile.cpp
+++ b/src/coreclr/vm/domainfile.cpp
@@ -744,6 +744,8 @@ void DomainAssembly::SetAssembly(Assembly* pAssembly)
     STANDARD_VM_CONTRACT;
 
     _ASSERTE(pAssembly->GetManifestModule()->GetPEAssembly()==m_pPEAssembly);
+    _ASSERTE(m_pAssembly == NULL);
+
     m_pAssembly = pAssembly;
     m_pModule = pAssembly->GetManifestModule();
 

--- a/src/coreclr/vm/domainfile.cpp
+++ b/src/coreclr/vm/domainfile.cpp
@@ -597,8 +597,7 @@ void DomainFile::VtableFixups()
 {
     WRAPPER_NO_CONTRACT;
 
-    if (!GetCurrentModule()->IsResource())
-        GetCurrentModule()->FixupVTables();
+    GetCurrentModule()->FixupVTables();
 }
 
 void DomainFile::FinishLoad()

--- a/src/coreclr/vm/domainfile.h
+++ b/src/coreclr/vm/domainfile.h
@@ -308,8 +308,7 @@ class DomainFile
     // ------------------------------------------------------------
 
     PTR_AppDomain               m_pDomain;
-    PTR_PEAssembly                  m_pPEAssembly;
-    PTR_PEAssembly                  m_pOriginalPEAssembly;  // keep file alive just in case someone is sitill using it. If this is not NULL then m_pPEAssembly contains reused file from the shared assembly
+    PTR_PEAssembly              m_pPEAssembly;
     PTR_Module                  m_pModule;
     FileLoadLevel               m_level;
     LOADERHANDLE                m_hExposedModuleObject;

--- a/src/coreclr/vm/domainfile.h
+++ b/src/coreclr/vm/domainfile.h
@@ -96,7 +96,7 @@ class DomainFile
     IMDInternalImport *GetMDImport()
     {
         WRAPPER_NO_CONTRACT;
-        return m_pPEAssembly->GetPersistentMDImport();
+        return m_pPEAssembly->GetMDImport();
     }
 
     OBJECTREF GetExposedModuleObjectIfExists()

--- a/src/coreclr/vm/domainfile.h
+++ b/src/coreclr/vm/domainfile.h
@@ -93,13 +93,6 @@ class DomainFile
         return m_pPEAssembly;
     }
 
-    PEAssembly *GetOriginalPEAssembly()
-    {
-        LIMITED_METHOD_DAC_CONTRACT;
-        return m_pOriginalPEAssembly!= NULL ? m_pOriginalPEAssembly : m_pPEAssembly;
-    }
-
-
     IMDInternalImport *GetMDImport()
     {
         WRAPPER_NO_CONTRACT;
@@ -605,10 +598,6 @@ private:
     void DeliverSyncEvents();
     void DeliverAsyncEvents();
 #endif
-
-    void UpdatePEFile(PTR_PEAssembly pFile);
-
-    BOOL IsInstrumented();
 
  public:
     ULONG HashIdentity();

--- a/src/coreclr/vm/domainfile.h
+++ b/src/coreclr/vm/domainfile.h
@@ -87,23 +87,23 @@ class DomainFile
         return m_pDomain;
     }
 
-    PEFile *GetFile()
+    PEAssembly *GetPEAssembly()
     {
         LIMITED_METHOD_DAC_CONTRACT;
-        return m_pFile;
+        return m_pPEAssembly;
     }
 
-    PEFile *GetOriginalFile()
+    PEAssembly *GetOriginalPEAssembly()
     {
         LIMITED_METHOD_DAC_CONTRACT;
-        return m_pOriginalFile!= NULL ? m_pOriginalFile : m_pFile;
+        return m_pOriginalPEAssembly!= NULL ? m_pOriginalPEAssembly : m_pPEAssembly;
     }
 
 
     IMDInternalImport *GetMDImport()
     {
         WRAPPER_NO_CONTRACT;
-        return m_pFile->GetPersistentMDImport();
+        return m_pPEAssembly->GetPersistentMDImport();
     }
 
     OBJECTREF GetExposedModuleObjectIfExists()
@@ -120,20 +120,20 @@ class DomainFile
     BOOL IsSystem()
     {
         WRAPPER_NO_CONTRACT;
-        return GetFile()->IsSystem();
+        return GetPEAssembly()->IsSystem();
     }
 
     LPCUTF8 GetSimpleName()
     {
         WRAPPER_NO_CONTRACT;
-        return GetFile()->GetSimpleName();
+        return GetPEAssembly()->GetSimpleName();
     }
 
 #ifdef LOGGING
     LPCWSTR GetDebugName()
     {
         WRAPPER_NO_CONTRACT;
-        return GetFile()->GetDebugName();
+        return GetPEAssembly()->GetDebugName();
     }
 #endif
 
@@ -252,8 +252,8 @@ class DomainFile
     // ------------------------------------------------------------
 
 #ifndef DACCESS_COMPILE
-    BOOL Equals(DomainFile *pFile) { WRAPPER_NO_CONTRACT; return GetFile()->Equals(pFile->GetFile()); }
-    BOOL Equals(PEFile *pFile) { WRAPPER_NO_CONTRACT; return GetFile()->Equals(pFile); }
+    BOOL Equals(DomainFile *pFile) { WRAPPER_NO_CONTRACT; return GetPEAssembly()->Equals(pFile->GetPEAssembly()); }
+    BOOL Equals(PEAssembly *pPEAssembly) { WRAPPER_NO_CONTRACT; return GetPEAssembly()->Equals(pPEAssembly); }
 #endif // DACCESS_COMPILE
 
     Module* GetCurrentModule();
@@ -279,7 +279,7 @@ class DomainFile
     friend class Module;
     friend class FileLoadLock;
 
-    DomainFile(AppDomain *pDomain, PEFile *pFile);
+    DomainFile(AppDomain *pDomain, PEAssembly *pPEAssembly);
 
     BOOL DoIncrementalLoad(FileLoadLevel targetLevel);
     void ClearLoading() { LIMITED_METHOD_CONTRACT; m_loading = FALSE; }
@@ -307,7 +307,7 @@ class DomainFile
     void SetDebuggerNotified() { LIMITED_METHOD_CONTRACT; m_notifyflags|=DEBUGGER_NOTIFIED; }
     void SetShouldNotifyDebugger() { LIMITED_METHOD_CONTRACT; m_notifyflags|=DEBUGGER_NEEDNOTIFICATION; }
 #ifndef DACCESS_COMPILE
-    void UpdatePEFileWorker(PTR_PEFile pFile);
+    void UpdatePEFileWorker(PTR_PEAssembly pFile);
 #endif
 
     // ------------------------------------------------------------
@@ -315,8 +315,8 @@ class DomainFile
     // ------------------------------------------------------------
 
     PTR_AppDomain               m_pDomain;
-    PTR_PEFile                  m_pFile;
-    PTR_PEFile                  m_pOriginalFile;  // keep file alive just in case someone is sitill using it. If this is not NULL then m_pFile contains reused file from the shared assembly
+    PTR_PEAssembly                  m_pPEAssembly;
+    PTR_PEAssembly                  m_pOriginalPEAssembly;  // keep file alive just in case someone is sitill using it. If this is not NULL then m_pPEAssembly contains reused file from the shared assembly
     PTR_Module                  m_pModule;
     FileLoadLevel               m_level;
     LOADERHANDLE                m_hExposedModuleObject;
@@ -425,10 +425,10 @@ public:
     // Public API
     // ------------------------------------------------------------
 
-    PEAssembly *GetFile()
+    PEAssembly *GetPEAssebmly()
     {
         LIMITED_METHOD_CONTRACT;
-        return PTR_PEAssembly(m_pFile);
+        return PTR_PEAssembly(m_pPEAssembly);
     }
 
     LoaderAllocator *GetLoaderAllocator()
@@ -592,7 +592,7 @@ public:
 public:
     ~DomainAssembly();
 private:
-    DomainAssembly(AppDomain *pDomain, PEFile *pFile, LoaderAllocator *pLoaderAllocator);
+    DomainAssembly(AppDomain *pDomain, PEAssembly *pPEAssembly, LoaderAllocator *pLoaderAllocator);
 #endif
 
     // ------------------------------------------------------------
@@ -606,7 +606,7 @@ private:
     void DeliverAsyncEvents();
 #endif
 
-    void UpdatePEFile(PTR_PEFile pFile);
+    void UpdatePEFile(PTR_PEAssembly pFile);
 
     BOOL IsInstrumented();
 

--- a/src/coreclr/vm/domainfile.h
+++ b/src/coreclr/vm/domainfile.h
@@ -90,7 +90,7 @@ class DomainFile
     PEAssembly *GetPEAssembly()
     {
         LIMITED_METHOD_DAC_CONTRACT;
-        return m_pPEAssembly;
+        return PTR_PEAssembly(m_pPEAssembly);
     }
 
     IMDInternalImport *GetMDImport()
@@ -299,9 +299,6 @@ class DomainFile
     void SetProfilerNotified() { LIMITED_METHOD_CONTRACT; m_notifyflags|= PROFILER_NOTIFIED; }
     void SetDebuggerNotified() { LIMITED_METHOD_CONTRACT; m_notifyflags|=DEBUGGER_NOTIFIED; }
     void SetShouldNotifyDebugger() { LIMITED_METHOD_CONTRACT; m_notifyflags|=DEBUGGER_NEEDNOTIFICATION; }
-#ifndef DACCESS_COMPILE
-    void UpdatePEFileWorker(PTR_PEAssembly pFile);
-#endif
 
     // ------------------------------------------------------------
     // Instance data
@@ -416,12 +413,6 @@ public:
     // ------------------------------------------------------------
     // Public API
     // ------------------------------------------------------------
-
-    PEAssembly *GetPEAssebmly()
-    {
-        LIMITED_METHOD_CONTRACT;
-        return PTR_PEAssembly(m_pPEAssembly);
-    }
 
     LoaderAllocator *GetLoaderAllocator()
     {

--- a/src/coreclr/vm/domainfile.inl
+++ b/src/coreclr/vm/domainfile.inl
@@ -59,19 +59,19 @@ inline Assembly* DomainAssembly::GetAssembly()
 }
 
 #ifndef DACCESS_COMPILE
-inline void DomainFile::UpdatePEFileWorker(PTR_PEFile pFile)
+inline void DomainFile::UpdatePEFileWorker(PTR_PEAssembly pFile)
 {
     LIMITED_METHOD_CONTRACT;
     CONSISTENCY_CHECK(CheckPointer(pFile));
-    if (pFile==m_pFile)
+    if (pFile==m_pPEAssembly)
         return;
-    _ASSERTE(m_pOriginalFile==NULL);
-    m_pOriginalFile=m_pFile;
+    _ASSERTE(m_pOriginalPEAssembly==NULL);
+    m_pOriginalPEAssembly=m_pPEAssembly;
     pFile->AddRef();
-    m_pFile=pFile;
+    m_pPEAssembly=pFile;
 }
 
-inline void DomainAssembly::UpdatePEFile(PTR_PEFile pFile)
+inline void DomainAssembly::UpdatePEFile(PTR_PEAssembly pFile)
 {
     CONTRACTL
     {
@@ -90,7 +90,7 @@ inline void DomainAssembly::UpdatePEFile(PTR_PEFile pFile)
 inline ULONG DomainAssembly::HashIdentity()
 {
     WRAPPER_NO_CONTRACT;
-    return GetFile()->HashIdentity();
+    return GetPEAssebmly()->HashIdentity();
 }
 
 inline BOOL DomainAssembly::IsCollectible()

--- a/src/coreclr/vm/domainfile.inl
+++ b/src/coreclr/vm/domainfile.inl
@@ -58,35 +58,6 @@ inline Assembly* DomainAssembly::GetAssembly()
     return m_pAssembly;
 }
 
-#ifndef DACCESS_COMPILE
-inline void DomainFile::UpdatePEFileWorker(PTR_PEAssembly pFile)
-{
-    LIMITED_METHOD_CONTRACT;
-    CONSISTENCY_CHECK(CheckPointer(pFile));
-    if (pFile==m_pPEAssembly)
-        return;
-    _ASSERTE(m_pOriginalPEAssembly==NULL);
-    m_pOriginalPEAssembly=m_pPEAssembly;
-    pFile->AddRef();
-    m_pPEAssembly=pFile;
-}
-
-inline void DomainAssembly::UpdatePEFile(PTR_PEAssembly pFile)
-{
-    CONTRACTL
-    {
-        THROWS;
-        GC_NOTRIGGER;
-        MODE_ANY;
-        CAN_TAKE_LOCK;
-    }
-    CONTRACTL_END;
-
-    GetAppDomain()->UpdatePublishHostedAssembly(this, pFile);
-}
-
-#endif // DACCESS_COMPILE
-
 inline ULONG DomainAssembly::HashIdentity()
 {
     WRAPPER_NO_CONTRACT;

--- a/src/coreclr/vm/domainfile.inl
+++ b/src/coreclr/vm/domainfile.inl
@@ -61,7 +61,7 @@ inline Assembly* DomainAssembly::GetAssembly()
 inline ULONG DomainAssembly::HashIdentity()
 {
     WRAPPER_NO_CONTRACT;
-    return GetPEAssebmly()->HashIdentity();
+    return GetPEAssembly()->HashIdentity();
 }
 
 inline BOOL DomainAssembly::IsCollectible()

--- a/src/coreclr/vm/dwbucketmanager.hpp
+++ b/src/coreclr/vm/dwbucketmanager.hpp
@@ -701,7 +701,7 @@ void BaseBucketParamsManager::GetModuleTimeStamp(__out_ecount(maxLength) WCHAR* 
         {
             // We only store the IL timestamp in the native image for the
             // manifest module.  We should consider fixing this for Orcas.
-            PTR_PEFile pFile = pModule->GetAssembly()->GetManifestModule()->GetFile();
+            PTR_PEAssembly pFile = pModule->GetAssembly()->GetManifestModule()->GetPEAssembly();
 
             // for dynamic modules use 0 as the time stamp
             ULONG ulTimeStamp = 0;
@@ -957,13 +957,13 @@ bool BaseBucketParamsManager::GetFileVersionInfoForModule(Module* pModule, USHOR
 
     bool succeeded = false;
 
-    PEFile* pFile = pModule->GetFile();
-    if (pFile)
+    PEAssembly* pPEAssembly = pModule->GetPEAssembly();
+    if (pPEAssembly)
     {
         // if we failed to get the version info from the native image then fall back to the IL image.
         if (!succeeded)
         {
-            LPCWSTR modulePath = pFile->GetPath().GetUnicode();
+            LPCWSTR modulePath = pPEAssembly->GetPath().GetUnicode();
             if (modulePath != NULL && modulePath != SString::Empty() && SUCCEEDED(DwGetFileVersionInfo(modulePath, major, minor, build, revision)))
             {
                 succeeded = true;

--- a/src/coreclr/vm/dwbucketmanager.hpp
+++ b/src/coreclr/vm/dwbucketmanager.hpp
@@ -708,7 +708,7 @@ void BaseBucketParamsManager::GetModuleTimeStamp(__out_ecount(maxLength) WCHAR* 
 
             if (!pFile->IsDynamic())
             {
-                ulTimeStamp = pFile->GetILImageTimeDateStamp();
+                ulTimeStamp = pFile->GetPEImageTimeDateStamp();
                 _ASSERTE(ulTimeStamp != 0);
             }
 

--- a/src/coreclr/vm/ecalllist.h
+++ b/src/coreclr/vm/ecalllist.h
@@ -314,7 +314,6 @@ FCFuncStart(gCOMModuleFuncs)
     QCFuncElement("GetScopeName", COMModule::GetScopeName)
     FCFuncElement("GetTypes", COMModule::GetTypes)
     QCFuncElement("GetFullyQualifiedName", COMModule::GetFullyQualifiedName)
-    FCFuncElement("IsResource", COMModule::IsResource)
 FCFuncEnd()
 
 FCFuncStart(gCOMModuleBuilderFuncs)

--- a/src/coreclr/vm/eedbginterfaceimpl.h
+++ b/src/coreclr/vm/eedbginterfaceimpl.h
@@ -26,7 +26,7 @@
 #include "debugdebugger.h"
 
 #include "eeconfig.h"
-#include "pefile.h"
+#include "peassembly.h"
 
 class EEDbgInterfaceImpl : public EEDebugInterface
 {

--- a/src/coreclr/vm/encee.cpp
+++ b/src/coreclr/vm/encee.cpp
@@ -35,8 +35,8 @@ static int g_BreakOnEnCResolveField = -1;
 // The constructor phase initializes just enough so that Destruct() can be safely called.
 // It cannot throw or fail.
 //
-EditAndContinueModule::EditAndContinueModule(Assembly *pAssembly, mdToken moduleRef, PEFile *file)
-  : Module(pAssembly, moduleRef, file)
+EditAndContinueModule::EditAndContinueModule(Assembly *pAssembly, mdToken moduleRef, PEAssembly *m_pPEAssembly)
+  : Module(pAssembly, moduleRef, m_pPEAssembly)
 {
     CONTRACTL
     {
@@ -175,7 +175,7 @@ HRESULT EditAndContinueModule::ApplyEditAndContinue(
     {
         // ConvertMDInternalToReadWrite should only ever be called on EnC capable files.
         _ASSERTE(IsEditAndContinueCapable()); // this also checks that the file is EnC capable
-        GetFile()->ConvertMDInternalToReadWrite();
+        GetPEAssembly()->ConvertMDInternalToReadWrite();
     }
     EX_CATCH_HRESULT(hr);
 

--- a/src/coreclr/vm/encee.cpp
+++ b/src/coreclr/vm/encee.cpp
@@ -35,8 +35,8 @@ static int g_BreakOnEnCResolveField = -1;
 // The constructor phase initializes just enough so that Destruct() can be safely called.
 // It cannot throw or fail.
 //
-EditAndContinueModule::EditAndContinueModule(Assembly *pAssembly, mdToken moduleRef, PEAssembly *m_pPEAssembly)
-  : Module(pAssembly, moduleRef, m_pPEAssembly)
+EditAndContinueModule::EditAndContinueModule(Assembly *pAssembly, mdToken moduleRef, PEAssembly *pPEAssembly)
+  : Module(pAssembly, moduleRef, pPEAssembly)
 {
     CONTRACTL
     {

--- a/src/coreclr/vm/encee.h
+++ b/src/coreclr/vm/encee.h
@@ -202,13 +202,13 @@ class EditAndContinueModule : public Module
     // Return the minimum permissable address for new IL to be stored at
     // This can't be less than the current load address because then we'd
     // have negative RVAs.
-    BYTE *GetEnCBase() { return (BYTE *) GetFile()->GetManagedFileContents(); }
+    BYTE *GetEnCBase() { return (BYTE *) GetPEAssembly()->GetManagedFileContents(); }
 #endif // DACCESS_COMPILE
 
 private:
     // Constructor is invoked only by Module::Create
-    friend Module *Module::Create(Assembly *pAssembly, mdToken moduleRef, PEFile *file, AllocMemTracker *pamTracker);
-    EditAndContinueModule(Assembly *pAssembly, mdToken moduleRef, PEFile *file);
+    friend Module *Module::Create(Assembly *pAssembly, mdToken moduleRef, PEAssembly *pPEAssembly, AllocMemTracker *pamTracker);
+    EditAndContinueModule(Assembly *pAssembly, mdToken moduleRef, PEAssembly *pPEAssembly);
 
 protected:
 #ifndef DACCESS_COMPILE

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -6139,7 +6139,7 @@ static void GetCodeViewInfo(Module * pModule, CV_INFO_PDB70 * pCvInfoIL, CV_INFO
     _ASSERTE(pPEAssembly != NULL);
 
     PTR_PEImageLayout pLayout = NULL;
-    if (pPEAssembly->HasILimage())
+    if (pPEAssembly->HasPEImage())
     {
         pLayout = pPEAssembly->GetLoadedLayout();
     }
@@ -6338,7 +6338,7 @@ VOID ETW::LoaderLog::SendModuleEvent(Module *pModule, DWORD dwEventOptions, BOOL
 
     if(!bIsDynamicAssembly)
     {
-        ModuleILPath = (PWCHAR)pModule->GetAssembly()->GetManifestFile()->GetILimage()->GetPath().GetUnicode();
+        ModuleILPath = (PWCHAR)pModule->GetAssembly()->GetManifestFile()->GetPEImage()->GetPath().GetUnicode();
         ModuleNativePath = (PWCHAR)pEmptyString;
     }
 

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -6135,13 +6135,13 @@ static void GetCodeViewInfo(Module * pModule, CV_INFO_PDB70 * pCvInfoIL, CV_INFO
     ZeroMemory(pCvInfoIL, sizeof(*pCvInfoIL));
     ZeroMemory(pCvInfoNative, sizeof(*pCvInfoNative));
 
-    PTR_PEFile pPEFile = pModule->GetFile();
-    _ASSERTE(pPEFile != NULL);
+    PTR_PEAssembly pPEAssembly = pModule->GetPEAssembly();
+    _ASSERTE(pPEAssembly != NULL);
 
     PTR_PEImageLayout pLayout = NULL;
-    if (pPEFile->HasOpenedILimage())
+    if (pPEAssembly->HasOpenedILimage())
     {
-        pLayout = pPEFile->GetLoadedIL();
+        pLayout = pPEAssembly->GetLoadedIL();
     }
 
     if (pLayout == NULL)

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -6139,7 +6139,7 @@ static void GetCodeViewInfo(Module * pModule, CV_INFO_PDB70 * pCvInfoIL, CV_INFO
     _ASSERTE(pPEAssembly != NULL);
 
     PTR_PEImageLayout pLayout = NULL;
-    if (pPEAssembly->HasOpenedILimage())
+    if (pPEAssembly->HasILimage())
     {
         pLayout = pPEAssembly->GetLoadedIL();
     }

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -6141,7 +6141,7 @@ static void GetCodeViewInfo(Module * pModule, CV_INFO_PDB70 * pCvInfoIL, CV_INFO
     PTR_PEImageLayout pLayout = NULL;
     if (pPEAssembly->HasILimage())
     {
-        pLayout = pPEAssembly->GetLoadedIL();
+        pLayout = pPEAssembly->GetLoadedLayout();
     }
 
     if (pLayout == NULL)

--- a/src/coreclr/vm/exceptmacros.h
+++ b/src/coreclr/vm/exceptmacros.h
@@ -520,7 +520,7 @@ VOID ThrowBadFormatWorkerT(UINT resID, T * pImgObj DEBUGARG(__in_z const char *c
 // Worker macro for throwing BadImageFormat exceptions.
 //
 //     resID:     resource ID in mscorrc.rc. Message may not have substitutions. resID is permitted (but not encouraged) to be 0.
-//     imgObj:    one of Module* or PEFile* or PEImage* (must support GetPathForErrorMessages method.)
+//     imgObj:    one of Module* or PEAssembly* or PEImage* (must support GetPathForErrorMessages method.)
 //
 #define IfFailThrowBF(hresult, resID, imgObj)   \
     do                                          \

--- a/src/coreclr/vm/inlinetracking.cpp
+++ b/src/coreclr/vm/inlinetracking.cpp
@@ -45,7 +45,7 @@ bool MethodInModule::operator <(const MethodInModule& other) const
             }
             else
             {
-                m_module->GetFile()->GetMVID(&thisGuid);
+                m_module->GetPEAssembly()->GetMVID(&thisGuid);
             }
 
             if (other.m_module == NULL)
@@ -54,7 +54,7 @@ bool MethodInModule::operator <(const MethodInModule& other) const
             }
             else
             {
-                other.m_module->GetFile()->GetMVID(&otherGuid);
+                other.m_module->GetPEAssembly()->GetMVID(&otherGuid);
             }
 
             return memcmp(&thisGuid, &otherGuid, sizeof(GUID)) < 0;

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -984,7 +984,7 @@ void CEEInfo::resolveToken(/* IN, OUT */ CORINFO_RESOLVED_TOKEN * pResolvedToken
                 ThrowBadTokenException(pResolvedToken);
 
             {
-                DomainFile *pTargetModule = pModule->LoadModule(GetAppDomain(), metaTOK, FALSE /* loadResources */);
+                DomainFile *pTargetModule = pModule->LoadModule(GetAppDomain(), metaTOK);
                 if (pTargetModule == NULL)
                     COMPlusThrowHR(COR_E_BADIMAGEFORMAT);
                 th = TypeHandle(pTargetModule->GetModule()->GetGlobalMethodTable());

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -12818,7 +12818,7 @@ PCODE UnsafeJitFunction(PrepareCodeConfig* config,
                 LARGE_INTEGER methodJitTimeStop;
                 QueryPerformanceCounter(&methodJitTimeStop);
                 SString codeBase;
-                ftn->GetModule()->GetDomainFile()->GetPEAssembly()->GetCodeBaseOrName(codeBase);
+                ftn->GetModule()->GetDomainFile()->GetPEAssembly()->GetPathOrCodeBase(codeBase);
                 codeBase.AppendPrintf(W(",0x%x,%d,%d\n"),
                                  //(const WCHAR *)codeBase, //module name
                                  ftn->GetMemberDef(), //method token

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -7798,14 +7798,14 @@ void CEEInfo::reportInliningDecision (CORINFO_METHOD_HANDLE inlinerHnd,
     if (LoggingOn(LF_JIT, LL_INFO100000))
     {
         SString currentMethodName;
-        currentMethodName.AppendUTF8(m_pMethodBeingCompiled->GetModule_NoLogging()->GetFile()->GetSimpleName());
+        currentMethodName.AppendUTF8(m_pMethodBeingCompiled->GetModule_NoLogging()->GetPEAssembly()->GetSimpleName());
         currentMethodName.Append(L'/');
         TypeString::AppendMethodInternal(currentMethodName, m_pMethodBeingCompiled, TypeString::FormatBasic);
 
         SString inlineeMethodName;
         if (GetMethod(inlineeHnd))
         {
-            inlineeMethodName.AppendUTF8(GetMethod(inlineeHnd)->GetModule_NoLogging()->GetFile()->GetSimpleName());
+            inlineeMethodName.AppendUTF8(GetMethod(inlineeHnd)->GetModule_NoLogging()->GetPEAssembly()->GetSimpleName());
             inlineeMethodName.Append(L'/');
             TypeString::AppendMethodInternal(inlineeMethodName, GetMethod(inlineeHnd), TypeString::FormatBasic);
         }
@@ -7817,7 +7817,7 @@ void CEEInfo::reportInliningDecision (CORINFO_METHOD_HANDLE inlinerHnd,
         SString inlinerMethodName;
         if (GetMethod(inlinerHnd))
         {
-            inlinerMethodName.AppendUTF8(GetMethod(inlinerHnd)->GetModule_NoLogging()->GetFile()->GetSimpleName());
+            inlinerMethodName.AppendUTF8(GetMethod(inlinerHnd)->GetModule_NoLogging()->GetPEAssembly()->GetSimpleName());
             inlinerMethodName.Append(L'/');
             TypeString::AppendMethodInternal(inlinerMethodName, GetMethod(inlinerHnd), TypeString::FormatBasic);
         }
@@ -12818,7 +12818,7 @@ PCODE UnsafeJitFunction(PrepareCodeConfig* config,
                 LARGE_INTEGER methodJitTimeStop;
                 QueryPerformanceCounter(&methodJitTimeStop);
                 SString codeBase;
-                ftn->GetModule()->GetDomainFile()->GetFile()->GetCodeBaseOrName(codeBase);
+                ftn->GetModule()->GetDomainFile()->GetPEAssembly()->GetCodeBaseOrName(codeBase);
                 codeBase.AppendPrintf(W(",0x%x,%d,%d\n"),
                                  //(const WCHAR *)codeBase, //module name
                                  ftn->GetMemberDef(), //method token

--- a/src/coreclr/vm/loaderallocator.cpp
+++ b/src/coreclr/vm/loaderallocator.cpp
@@ -481,9 +481,9 @@ LoaderAllocator * LoaderAllocator::GCLoaderAllocators_RemoveAssemblies(AppDomain
 
             if (!domainAssemblyToRemove->GetAssembly()->IsDynamic())
             {
-                pAppDomain->RemoveFileFromCache(domainAssemblyToRemove->GetFile());
+                pAppDomain->RemoveFileFromCache(domainAssemblyToRemove->GetPEAssembly());
                 AssemblySpec spec;
-                spec.InitializeSpec(domainAssemblyToRemove->GetFile());
+                spec.InitializeSpec(domainAssemblyToRemove->GetPEAssembly());
                 VERIFY(pAppDomain->RemoveAssemblyFromCache(domainAssemblyToRemove));
             }
 

--- a/src/coreclr/vm/memberload.cpp
+++ b/src/coreclr/vm/memberload.cpp
@@ -277,7 +277,7 @@ void MemberLoader::GetDescFromMemberRef(Module * pModule,
     {
     case mdtModuleRef:
         {
-            DomainFile *pTargetModule = pModule->LoadModule(GetAppDomain(), parent, FALSE /* loadResources */);
+            DomainFile *pTargetModule = pModule->LoadModule(GetAppDomain(), parent);
             if (pTargetModule == NULL)
                 COMPlusThrowHR(COR_E_BADIMAGEFORMAT);
             typeHnd = TypeHandle(pTargetModule->GetModule()->GetGlobalMethodTable());

--- a/src/coreclr/vm/methoditer.cpp
+++ b/src/coreclr/vm/methoditer.cpp
@@ -83,9 +83,6 @@ ADVANCE_MODULE:
     if  (!m_moduleIterator.Next())
         goto ADVANCE_ASSEMBLY;
 
-    if (GetCurrentModule()->IsResource())
-        goto ADVANCE_MODULE;
-
     if (m_mainMD->HasClassInstantiation())
     {
         m_typeIterator.Reset();

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -4339,7 +4339,7 @@ VOID    MethodTableBuilder::InitializeFieldDescs(FieldDesc *pFieldDescList,
 
                 // Ensure that the IL image is loaded. Note that this assembly may
                 // have an ngen image, but this type may have failed to load during ngen.
-                GetModule()->GetFile()->LoadLibrary();
+                GetModule()->GetPEAssembly()->LoadLibrary();
 
                 DWORD fldSize;
                 if (FieldDescElementType == ELEMENT_TYPE_VALUETYPE)
@@ -11216,7 +11216,7 @@ BOOL MethodTableBuilder::NeedsAlignedBaseOffset()
     // Always use the ReadyToRun field layout algorithm if the source IL image was ReadyToRun, independent on
     // whether ReadyToRun is actually enabled for the module. It is required to allow mixing and matching
     // ReadyToRun images with and without input bubble enabled.
-    if (!GetModule()->GetFile()->IsReadyToRun())
+    if (!GetModule()->GetPEAssembly()->IsReadyToRun())
     {
         // Always use ReadyToRun field layout algorithm to produce ReadyToRun images
         return FALSE;

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -4339,7 +4339,7 @@ VOID    MethodTableBuilder::InitializeFieldDescs(FieldDesc *pFieldDescList,
 
                 // Ensure that the IL image is loaded. Note that this assembly may
                 // have an ngen image, but this type may have failed to load during ngen.
-                GetModule()->GetFile()->LoadLibrary(FALSE);
+                GetModule()->GetFile()->LoadLibrary();
 
                 DWORD fldSize;
                 if (FieldDescElementType == ELEMENT_TYPE_VALUETYPE)

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -4337,9 +4337,8 @@ VOID    MethodTableBuilder::InitializeFieldDescs(FieldDesc *pFieldDescList,
                 DWORD rva;
                 IfFailThrow(pInternalImport->GetFieldRVA(pFD->GetMemberDef(), &rva));
 
-                // Ensure that the IL image is loaded. Note that this assembly may
-                // have an ngen image, but this type may have failed to load during ngen.
-                GetModule()->GetPEAssembly()->LoadLibrary();
+                // Ensure that the IL image is loaded.
+                GetModule()->GetPEAssembly()->EnsureLoaded();
 
                 DWORD fldSize;
                 if (FieldDescElementType == ELEMENT_TYPE_VALUETYPE)

--- a/src/coreclr/vm/multicorejit.cpp
+++ b/src/coreclr/vm/multicorejit.cpp
@@ -255,25 +255,20 @@ bool ModuleVersion::GetModuleVersion(Module * pModule)
     // GetMVID can throw exception
     EX_TRY
     {
-        PEAssembly * pPEAssembly = pModule->GetPEAssembly();
+        PEAssembly * pAsm = pModule->GetPEAssembly();
 
-        if (pPEAssembly != NULL)
+        if (pAsm != NULL)
         {
-            PEAssembly * pAsm = pPEAssembly->GetAssembly();
+            // CorAssemblyFlags, only 16-bit used
+            versionFlags = pAsm->GetFlags();
 
-            if (pAsm != NULL)
-            {
-                // CorAssemblyFlags, only 16-bit used
-                versionFlags = pAsm->GetFlags();
+            _ASSERTE((versionFlags & 0x80000000) == 0);
 
-                _ASSERTE((versionFlags & 0x80000000) == 0);
+            pAsm->GetVersion(&major, &minor, &build, &revision);
 
-                pAsm->GetVersion(& major, & minor, & build, & revision);
+            pAsm->GetMVID(&mvid);
 
-                pAsm->GetMVID(& mvid);
-
-                hr = S_OK;
-            }
+            hr = S_OK;
         }
 
         // If the load context is LOADFROM, store it in the flags.

--- a/src/coreclr/vm/multicorejit.cpp
+++ b/src/coreclr/vm/multicorejit.cpp
@@ -255,11 +255,11 @@ bool ModuleVersion::GetModuleVersion(Module * pModule)
     // GetMVID can throw exception
     EX_TRY
     {
-        PEFile * pFile = pModule->GetFile();
+        PEAssembly * pPEAssembly = pModule->GetPEAssembly();
 
-        if (pFile != NULL)
+        if (pPEAssembly != NULL)
         {
-            PEAssembly * pAsm = pFile->GetAssembly();
+            PEAssembly * pAsm = pPEAssembly->GetAssembly();
 
             if (pAsm != NULL)
             {

--- a/src/coreclr/vm/multicorejitplayer.cpp
+++ b/src/coreclr/vm/multicorejitplayer.cpp
@@ -396,11 +396,6 @@ bool MulticoreJitManager::ModuleHasNoCode(Module * pModule)
 {
     LIMITED_METHOD_CONTRACT;
 
-    if (pModule->IsResource())
-    {
-        return true;
-    }
-
     IMDInternalImport * pImport = pModule->GetMDImport();
 
     if (pImport != NULL)

--- a/src/coreclr/vm/multicorejitplayer.cpp
+++ b/src/coreclr/vm/multicorejitplayer.cpp
@@ -429,15 +429,15 @@ bool MulticoreJitManager::IsSupportedModule(Module * pModule, bool fMethodJit)
         return false;
     }
 
-    PEFile * pFile = pModule->GetFile();
+    PEAssembly * pPEAssembly = pModule->GetPEAssembly();
 
     // dynamic module.
-    if (pFile->IsDynamic()) // Ignore dynamic modules
+    if (pPEAssembly->IsDynamic()) // Ignore dynamic modules
     {
         return false;
     }
 
-    if (pFile->GetPath().IsEmpty()) // Ignore in-memory modules
+    if (pPEAssembly->GetPath().IsEmpty()) // Ignore in-memory modules
     {
         return false;
     }

--- a/src/coreclr/vm/nativeimage.cpp
+++ b/src/coreclr/vm/nativeimage.cpp
@@ -146,7 +146,7 @@ NativeImage *NativeImage::Open(
     BundleFileLocation bundleFileLocation = Bundle::ProbeAppBundle(fullPath, /*pathIsBundleRelative */ true);
     if (bundleFileLocation.IsValid())
     {
-        PEImageHolder pImage = PEImage::OpenImage(fullPath, MDInternalImport_NoCache, bundleFileLocation);
+        PEImageHolder pImage = PEImage::OpenImage(fullPath, MDInternalImport_Default, bundleFileLocation);
         peLoadedImage = pImage->GetLayout(PEImageLayout::LAYOUT_MAPPED);
     }
 

--- a/src/coreclr/vm/nativeimage.cpp
+++ b/src/coreclr/vm/nativeimage.cpp
@@ -147,7 +147,7 @@ NativeImage *NativeImage::Open(
     if (bundleFileLocation.IsValid())
     {
         PEImageHolder pImage = PEImage::OpenImage(fullPath, MDInternalImport_Default, bundleFileLocation);
-        peLoadedImage = pImage->GetLayout(PEImageLayout::LAYOUT_MAPPED);
+        peLoadedImage = pImage->GetOrCreateLayout(PEImageLayout::LAYOUT_MAPPED);
         peLoadedImage.SuppressRelease();
     }
 

--- a/src/coreclr/vm/nativeimage.cpp
+++ b/src/coreclr/vm/nativeimage.cpp
@@ -147,7 +147,7 @@ NativeImage *NativeImage::Open(
     if (bundleFileLocation.IsValid())
     {
         PEImageHolder pImage = PEImage::OpenImage(fullPath, MDInternalImport_NoCache, bundleFileLocation);
-        peLoadedImage = pImage->GetLayout(PEImageLayout::LAYOUT_MAPPED, PEImage::LAYOUT_CREATEIFNEEDED);
+        peLoadedImage = pImage->GetLayout(PEImageLayout::LAYOUT_MAPPED);
     }
 
     if (peLoadedImage.IsNull())

--- a/src/coreclr/vm/nativeimage.cpp
+++ b/src/coreclr/vm/nativeimage.cpp
@@ -148,6 +148,7 @@ NativeImage *NativeImage::Open(
     {
         PEImageHolder pImage = PEImage::OpenImage(fullPath, MDInternalImport_Default, bundleFileLocation);
         peLoadedImage = pImage->GetLayout(PEImageLayout::LAYOUT_MAPPED);
+        peLoadedImage.SuppressRelease();
     }
 
     if (peLoadedImage.IsNull())

--- a/src/coreclr/vm/nativeimage.h
+++ b/src/coreclr/vm/nativeimage.h
@@ -57,7 +57,7 @@ public:
 };
 
 class ReadyToRunInfo;
-class PEFile;
+class PEAssembly;
 class PEImage;
 
 // This class represents a  ReadyToRun image with native OS-specific envelope. As of today,

--- a/src/coreclr/vm/nativelibrary.cpp
+++ b/src/coreclr/vm/nativelibrary.cpp
@@ -318,7 +318,7 @@ namespace
 #endif // !TARGET_UNIX
 
         NATIVE_LIBRARY_HANDLE hmod = NULL;
-        PEFile *pManifestFile = pAssembly->GetManifestFile();
+        PEAssembly *pManifestFile = pAssembly->GetManifestFile();
         PTR_AssemblyBinder pBinder = pManifestFile->GetAssemblyBinder();
 
         //Step 0: Check if  the assembly was bound using TPA.

--- a/src/coreclr/vm/peassembly.cpp
+++ b/src/coreclr/vm/peassembly.cpp
@@ -640,7 +640,7 @@ void PEAssembly::GetEmbeddedResource(DWORD dwOffset, DWORD *cbResource, PBYTE *p
     EnsureImageOpened();
     PEImage* image = GetILimage();
 
-    PEImageLayoutHolder theImage(image->GetLayout(PEImageLayout::LAYOUT_ANY));
+    PEImageLayout* theImage = image->GetLayout(PEImageLayout::LAYOUT_ANY);
     if (!theImage->CheckResource(dwOffset))
         ThrowHR(COR_E_BADIMAGEFORMAT);
 
@@ -1288,7 +1288,7 @@ void PEAssembly::EnsureImageOpened()
     if (IsDynamic())
         return;
 
-    GetILimage()->GetLayout(PEImageLayout::LAYOUT_ANY)->Release();
+    GetILimage()->GetLayout(PEImageLayout::LAYOUT_ANY);
 }
 
 #endif // #ifndef DACCESS_COMPILE

--- a/src/coreclr/vm/peassembly.cpp
+++ b/src/coreclr/vm/peassembly.cpp
@@ -8,7 +8,7 @@
 
 
 #include "common.h"
-#include "pefile.h"
+#include "peassembly.h"
 #include "eecontract.h"
 #include "eeconfig.h"
 #include "eventtrace.h"

--- a/src/coreclr/vm/peassembly.cpp
+++ b/src/coreclr/vm/peassembly.cpp
@@ -642,10 +642,7 @@ void PEAssembly::GetEmbeddedResource(DWORD dwOffset, DWORD *cbResource, PBYTE *p
 // File loading
 // ------------------------------------------------------------
 
-PEAssembly *
-PEAssembly::LoadAssembly(
-    mdAssemblyRef       kAssemblyRef,
-    IMDInternalImport * pImport)
+PEAssembly* PEAssembly::LoadAssembly(mdAssemblyRef kAssemblyRef)
 {
     CONTRACT(PEAssembly *)
     {
@@ -658,9 +655,7 @@ PEAssembly::LoadAssembly(
     }
     CONTRACT_END;
 
-    if (pImport == NULL)
-        pImport = GetPersistentMDImport();
-
+    IMDInternalImport* pImport = GetPersistentMDImport();
     if (((TypeFromToken(kAssemblyRef) != mdtAssembly) &&
          (TypeFromToken(kAssemblyRef) != mdtAssemblyRef)) ||
         (!pImport->IsValidToken(kAssemblyRef)))

--- a/src/coreclr/vm/peassembly.cpp
+++ b/src/coreclr/vm/peassembly.cpp
@@ -640,7 +640,7 @@ void PEAssembly::GetEmbeddedResource(DWORD dwOffset, DWORD *cbResource, PBYTE *p
     EnsureImageOpened();
     PEImage* image = GetILimage();
 
-    PEImageLayoutHolder theImage(image->GetLayout(PEImageLayout::LAYOUT_ANY,PEImage::LAYOUT_CREATEIFNEEDED));
+    PEImageLayoutHolder theImage(image->GetLayout(PEImageLayout::LAYOUT_ANY));
     if (!theImage->CheckResource(dwOffset))
         ThrowHR(COR_E_BADIMAGEFORMAT);
 
@@ -1288,7 +1288,7 @@ void PEAssembly::EnsureImageOpened()
     if (IsDynamic())
         return;
 
-    GetILimage()->GetLayout(PEImageLayout::LAYOUT_ANY,PEImage::LAYOUT_CREATEIFNEEDED)->Release();
+    GetILimage()->GetLayout(PEImageLayout::LAYOUT_ANY)->Release();
 }
 
 #endif // #ifndef DACCESS_COMPILE

--- a/src/coreclr/vm/peassembly.cpp
+++ b/src/coreclr/vm/peassembly.cpp
@@ -730,10 +730,8 @@ void PEAssembly::GetPEKindAndMachine(DWORD* pdwKind, DWORD* pdwMachine)
 
     if (IsDynamic())
     {
-        if (pdwKind)
-            *pdwKind = 0;
-        if (pdwMachine)
-            *pdwMachine = 0;
+        *pdwKind = 0;
+        *pdwMachine = 0;
         return;
     }
 

--- a/src/coreclr/vm/peassembly.cpp
+++ b/src/coreclr/vm/peassembly.cpp
@@ -269,7 +269,7 @@ BOOL PEAssembly::Equals(PEImage *pImage)
 // Descriptive strings
 // ------------------------------------------------------------
 
-void PEAssembly::GetCodeBaseOrName(SString &result)
+void PEAssembly::GetPathOrCodeBase(SString &result)
 {
     CONTRACTL
     {
@@ -285,12 +285,10 @@ void PEAssembly::GetCodeBaseOrName(SString &result)
     {
         result.Set(m_openedILimage->GetPath());
     }
-    else if (IsAssembly())
-    {
-        ((PEAssembly*)this)->GetCodeBase(result);
-    }
     else
-        result.SetUTF8(GetSimpleName());
+    {
+        GetCodeBase(result);
+    }
 }
 
 
@@ -926,7 +924,7 @@ PEAssembly::PEAssembly(
     }
 
 #if _DEBUG
-    GetCodeBaseOrName(m_debugName);
+    GetPathOrCodeBase(m_debugName);
     m_debugName.Normalize();
     m_pDebugName = m_debugName;
 #endif
@@ -1104,13 +1102,14 @@ BOOL PEAssembly::GetCodeBase(SString &result)
     }
     CONTRACTL_END;
 
-    auto ilImage = GetILimage();
-    if (ilImage == nullptr || !ilImage->IsInBundle())
+    PEImage* ilImage = GetILimage();
+    if (ilImage == NULL || !ilImage->IsInBundle())
     {
         // All other cases use the file path.
         result.Set(GetEffectivePath());
         if (!result.IsEmpty())
             PathToUrl(result);
+
         return TRUE;
     }
     else
@@ -1290,7 +1289,8 @@ void PEAssembly::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
     {
         m_openedILimage->EnumMemoryRegions(flags);
     }
-    if (GetILimage().IsValid())
+
+    if (HasILimage())
     {
         GetILimage()->EnumMemoryRegions(flags);
     }

--- a/src/coreclr/vm/peassembly.h
+++ b/src/coreclr/vm/peassembly.h
@@ -88,8 +88,6 @@ class PEAssembly final
     // ------------------------------------------------------------
     VPTR_BASE_CONCRETE_VTABLE_CLASS(PEAssembly)
 
-    // friend class Assembly;
-
 public:
 
     // ------------------------------------------------------------

--- a/src/coreclr/vm/peassembly.h
+++ b/src/coreclr/vm/peassembly.h
@@ -303,15 +303,7 @@ public:
             GC_TRIGGERS;
         }
         CONTRACTL_END;
-#ifndef DACCESS_COMPILE
-        if (m_openedILimage == NULL && m_identity != NULL)
-        {
-            PEImage* pOpenedILimage;
-            m_identity->Clone(&pOpenedILimage);
-            if (InterlockedCompareExchangeT(&m_openedILimage, pOpenedILimage, NULL) != NULL)
-                pOpenedILimage->Release();
-        }
-#endif
+
         return m_openedILimage;
     }
 
@@ -497,9 +489,7 @@ private:
     SString                 m_debugName;
 #endif
 
-    // Identity image
-    PTR_PEImage              m_identity;
-    // IL image, NULL if we didn't need to open the file
+    // IL image, NULL if dynamic
     PTR_PEImage              m_openedILimage;
 
     PTR_PEAssembly           m_creator;

--- a/src/coreclr/vm/peassembly.h
+++ b/src/coreclr/vm/peassembly.h
@@ -139,7 +139,7 @@ public:
 #endif // DACCESS_COMPILE
 
     // Full name is the most descriptive name available (path, codebase, or name as appropriate)
-    void GetCodeBaseOrName(SString &result);
+    void GetPathOrCodeBase(SString &result);
 
 #ifdef LOGGING
     // This is useful for log messages
@@ -159,7 +159,6 @@ public:
     // Classification
     // ------------------------------------------------------------
 
-    BOOL IsAssembly() const;
     PTR_PEAssembly AsAssembly();
     BOOL IsSystem() const;
     BOOL IsDynamic() const;
@@ -294,38 +293,22 @@ public:
 
     void LoadLibrary();
 
-    PTR_PEImage GetILimage()
-    {
-        CONTRACTL
-        {
-            THROWS;
-            MODE_ANY;
-            GC_TRIGGERS;
-        }
-        CONTRACTL_END;
-
-        return m_openedILimage;
-    }
-
-    PEImage* GetOpenedILimage()
+    PEImage* GetILimage()
     {
         LIMITED_METHOD_DAC_CONTRACT;
-        _ASSERTE(HasOpenedILimage());
         return m_openedILimage;
     }
 
-
-    BOOL HasOpenedILimage()
+    BOOL HasILimage()
     {
         LIMITED_METHOD_DAC_CONTRACT;
         return m_openedILimage != NULL;
-
     }
 
     BOOL HasLoadedIL()
     {
         LIMITED_METHOD_DAC_CONTRACT;
-        return HasOpenedILimage() && GetOpenedILimage()->HasLoadedLayout();
+        return HasILimage() && GetILimage()->HasLoadedLayout();
     }
 
     LPCWSTR GetPathForErrorMessages();

--- a/src/coreclr/vm/peassembly.h
+++ b/src/coreclr/vm/peassembly.h
@@ -199,16 +199,9 @@ public:
     // ------------------------------------------------------------
 
     BOOL IsReadyToRun();
-    WORD GetSubsystem();
-
-    mdToken GetEntryPointToken(
-#ifdef _DEBUG
-        BOOL bAssumeLoaded = FALSE
-#endif //_DEBUG
-    );
+    mdToken GetEntryPointToken();
 
     BOOL IsILOnly();
-    BOOL IsDll();
     TADDR GetIL(RVA il);
 
     PTR_VOID GetRvaField(RVA field);

--- a/src/coreclr/vm/peassembly.h
+++ b/src/coreclr/vm/peassembly.h
@@ -353,9 +353,7 @@ public:
     // This opens the canonical System.Private.CoreLib.dll
     static PEAssembly* OpenSystem();
 
-    static PEAssembly* Open(
-        BINDER_SPACE::Assembly* pBindResult,
-        BOOL isSystem);
+    static PEAssembly* Open(BINDER_SPACE::Assembly* pBindResult);
 
     static PEAssembly* Create(
         PEAssembly* pParentAssembly,

--- a/src/coreclr/vm/peassembly.h
+++ b/src/coreclr/vm/peassembly.h
@@ -7,8 +7,8 @@
 // --------------------------------------------------------------------------------
 
 
-#ifndef PEFILE_H_
-#define PEFILE_H_
+#ifndef PEASSEMBLY_H_
+#define PEASSEMBLY_H_
 
 // --------------------------------------------------------------------------------
 // Required headers
@@ -550,4 +550,4 @@ public:
 
 typedef ReleaseHolder<PEAssembly> PEAssemblyHolder;
 
-#endif  // PEFILE_H_
+#endif  // PEASSEMBLY_H_

--- a/src/coreclr/vm/peassembly.h
+++ b/src/coreclr/vm/peassembly.h
@@ -294,9 +294,7 @@ public:
     // File loading
     // ------------------------------------------------------------
 
-    PEAssembly * LoadAssembly(
-            mdAssemblyRef       kAssemblyRef,
-            IMDInternalImport * pImport = NULL);
+    PEAssembly * LoadAssembly(mdAssemblyRef kAssemblyRef);
 
     void LoadLibrary();
 

--- a/src/coreclr/vm/peassembly.h
+++ b/src/coreclr/vm/peassembly.h
@@ -416,7 +416,6 @@ private:
     void OpenImporter();
     void OpenEmitter();
 
-
 private:
 
  // ------------------------------------------------------------

--- a/src/coreclr/vm/peassembly.inl
+++ b/src/coreclr/vm/peassembly.inl
@@ -363,28 +363,13 @@ inline BOOL PEAssembly::IsReadyToRun()
     }
 }
 
-inline WORD PEAssembly::GetSubsystem()
-{
-    WRAPPER_NO_CONTRACT;
-
-    if (IsDynamic())
-        return 0;
-
-    return GetLoadedLayout()->GetSubsystem();
-}
-
-inline mdToken PEAssembly::GetEntryPointToken(
-#ifdef _DEBUG
-            BOOL bAssumeLoaded
-#endif //_DEBUG
-            )
+inline mdToken PEAssembly::GetEntryPointToken()
 {
     WRAPPER_NO_CONTRACT;
 
     if (IsDynamic())
         return mdTokenNil;
 
-    _ASSERTE (!bAssumeLoaded || HasLoadedPEImage ());
     return GetPEImage()->GetEntryPointToken();
 }
 
@@ -399,16 +384,6 @@ inline BOOL PEAssembly::IsILOnly()
         return FALSE;
 
     return GetPEImage()->IsILOnly();
-}
-
-inline BOOL PEAssembly::IsDll()
-{
-    WRAPPER_NO_CONTRACT;
-
-    if (IsDynamic())
-        return TRUE;
-
-    return GetPEImage()->IsDll();
 }
 
 inline PTR_VOID PEAssembly::GetRvaField(RVA field)

--- a/src/coreclr/vm/peassembly.inl
+++ b/src/coreclr/vm/peassembly.inl
@@ -88,7 +88,7 @@ inline ULONG PEAssembly::HashIdentity()
 {
     CONTRACTL
     {
-        PRECONDITION(CheckPointer(m_identity));
+        PRECONDITION(CheckPointer(m_openedILimage));
         MODE_ANY;
         THROWS;
         GC_TRIGGERS;
@@ -169,11 +169,12 @@ inline const SString& PEAssembly::GetPath()
     }
     CONTRACTL_END;
 
-    if (IsDynamic() || m_identity->IsInBundle ())
+    if (IsDynamic() || m_openedILimage->IsInBundle ())
     {
         return SString::Empty();
     }
-    return m_identity->GetPath();
+
+    return m_openedILimage->GetPath();
 }
 
 //
@@ -192,11 +193,12 @@ inline const SString& PEAssembly::GetIdentityPath()
     }
     CONTRACTL_END;
 
-    if (m_identity == nullptr)
+    if (m_openedILimage == nullptr)
     {
         return SString::Empty();
     }
-    return m_identity->GetPath();
+
+    return m_openedILimage->GetPath();
 }
 
 #ifdef DACCESS_COMPILE
@@ -216,7 +218,7 @@ inline const SString &PEAssembly::GetModuleFileNameHint()
         return SString::Empty();
     }
     else
-        return m_identity->GetModuleFileNameHintForDAC();
+        return m_openedILimage->GetModuleFileNameHintForDAC();
 }
 #endif // DACCESS_COMPILE
 
@@ -272,7 +274,7 @@ inline BOOL PEAssembly::IsDynamic() const
     LIMITED_METHOD_CONTRACT;
     SUPPORTS_DAC;
 
-    return m_identity == NULL;
+    return m_openedILimage == NULL;
 }
 
 inline PEAssembly *PEAssembly::GetAssembly() const

--- a/src/coreclr/vm/peassembly.inl
+++ b/src/coreclr/vm/peassembly.inl
@@ -247,13 +247,6 @@ inline LPCWSTR PEAssembly::GetDebugName()
 // Classification
 // ------------------------------------------------------------
 
-inline BOOL PEAssembly::IsAssembly() const
-{
-    LIMITED_METHOD_DAC_CONTRACT;
-
-    return true;
-}
-
 inline PTR_PEAssembly PEAssembly::AsAssembly()
 {
     LIMITED_METHOD_DAC_CONTRACT;
@@ -280,7 +273,6 @@ inline BOOL PEAssembly::IsDynamic() const
 inline PEAssembly *PEAssembly::GetAssembly() const
 {
     WRAPPER_NO_CONTRACT;
-    _ASSERTE(IsAssembly());
     return dac_cast<PTR_PEAssembly>(this);
 }
 
@@ -449,7 +441,7 @@ inline BOOL PEAssembly::IsReadyToRun()
     }
     CONTRACTL_END;
 
-    if (HasOpenedILimage())
+    if (HasILimage())
     {
         return GetLoadedIL()->HasReadyToRunHeader();
     }
@@ -481,7 +473,7 @@ inline mdToken PEAssembly::GetEntryPointToken(
         return mdTokenNil;
 
     _ASSERTE (!bAssumeLoaded || HasLoadedIL ());
-    return GetOpenedILimage()->GetEntryPointToken();
+    return GetILimage()->GetEntryPointToken();
 }
 
 inline BOOL PEAssembly::IsILOnly()
@@ -494,7 +486,7 @@ inline BOOL PEAssembly::IsILOnly()
     if (IsDynamic())
         return FALSE;
 
-    return GetOpenedILimage()->IsILOnly();
+    return GetILimage()->IsILOnly();
 }
 
 inline BOOL PEAssembly::IsDll()
@@ -504,7 +496,7 @@ inline BOOL PEAssembly::IsDll()
     if (IsDynamic())
         return TRUE;
 
-    return GetOpenedILimage()->IsDll();
+    return GetILimage()->IsDll();
 }
 
 inline PTR_VOID PEAssembly::GetRvaField(RVA field)
@@ -847,9 +839,9 @@ inline BOOL PEAssembly::IsPtrInILImage(PTR_CVOID data)
     }
     CONTRACTL_END;
 
-    if (HasOpenedILimage())
+    if (HasILimage())
     {
-        return GetOpenedILimage()->IsPtrInImage(data);
+        return GetILimage()->IsPtrInImage(data);
     }
     else
         return FALSE;
@@ -863,9 +855,9 @@ inline PTR_PEImageLayout PEAssembly::GetLoadedIL()
     LIMITED_METHOD_CONTRACT;
     SUPPORTS_DAC;
 
-    _ASSERTE(HasOpenedILimage());
+    _ASSERTE(HasILimage());
 
-    return GetOpenedILimage()->GetLoadedLayout();
+    return GetILimage()->GetLoadedLayout();
 };
 
 inline BOOL PEAssembly::IsLoaded()
@@ -1013,7 +1005,6 @@ inline DWORD PEAssembly::GetFlags()
 {
     CONTRACTL
     {
-        PRECONDITION(IsAssembly());
         INSTANCE_CHECK;
         if (FORBIDGC_LOADER_USE_ENABLED()) NOTHROW; else THROWS;
         if (FORBIDGC_LOADER_USE_ENABLED()) GC_NOTRIGGER; else GC_TRIGGERS;
@@ -1033,7 +1024,6 @@ inline HRESULT PEAssembly::GetFlagsNoTrigger(DWORD * pdwFlags)
 {
     CONTRACTL
     {
-        PRECONDITION(IsAssembly());
         INSTANCE_CHECK;
         NOTHROW;
         GC_NOTRIGGER;

--- a/src/coreclr/vm/peassembly.inl
+++ b/src/coreclr/vm/peassembly.inl
@@ -6,8 +6,8 @@
 
 // --------------------------------------------------------------------------------
 
-#ifndef PEFILE_INL_
-#define PEFILE_INL_
+#ifndef PEASSEMBLY_INL_
+#define PEASSEMBLY_INL_
 
 #include "check.h"
 #include "simplerwlock.hpp"
@@ -1060,4 +1060,4 @@ inline void PEAssembly::OpenMDImport()
     OpenMDImport_Unsafe();
 }
 
-#endif  // PEFILE_INL_
+#endif  // PEASSEMBLY_INL_

--- a/src/coreclr/vm/pefile.cpp
+++ b/src/coreclr/vm/pefile.cpp
@@ -863,7 +863,8 @@ PEAssembly::PEAssembly(
                 PEFile *creator,
                 BOOL isSystem,
                 PEImage * pPEImageIL /*= NULL*/,
-                BINDER_SPACE::Assembly * pHostAssembly /*= NULL*/)
+                BINDER_SPACE::Assembly * pHostAssembly /*= NULL*/) :
+    PEFile()
 {
     CONTRACTL
     {

--- a/src/coreclr/vm/pefile.cpp
+++ b/src/coreclr/vm/pefile.cpp
@@ -178,7 +178,7 @@ static void ValidatePEFileMachineType(PEFile *peFile)
     return;   // If we got here, all is good.
 }
 
-void PEFile::LoadLibrary(BOOL allowNativeSkip/*=TRUE*/) // if allowNativeSkip==FALSE force IL image load
+void PEFile::LoadLibrary()
 {
     CONTRACT_VOID
     {
@@ -192,7 +192,7 @@ void PEFile::LoadLibrary(BOOL allowNativeSkip/*=TRUE*/) // if allowNativeSkip==F
     ValidatePEFileMachineType(this);
 
     // See if we've already loaded it.
-    if (CheckLoaded(allowNativeSkip))
+    if (CheckLoaded())
     {
         RETURN;
     }
@@ -429,7 +429,7 @@ void PEFile::GetCodeBaseOrName(SString &result)
 
 
 
-CHECK PEFile::CheckLoaded(BOOL bAllowNativeSkip/*=TRUE*/)
+CHECK PEFile::CheckLoaded()
 {
     CONTRACT_CHECK
     {
@@ -440,7 +440,7 @@ CHECK PEFile::CheckLoaded(BOOL bAllowNativeSkip/*=TRUE*/)
     }
     CONTRACT_CHECK_END;
 
-    CHECK(IsLoaded(bAllowNativeSkip));
+    CHECK(IsLoaded());
 
     CHECK_OK;
 }

--- a/src/coreclr/vm/pefile.cpp
+++ b/src/coreclr/vm/pefile.cpp
@@ -851,7 +851,7 @@ ULONG PEFile::GetILImageTimeDateStamp()
 
 // Statics initialization.
 /* static */
-void PEAssembly::Attach()
+void PEFile::Attach()
 {
     STANDARD_VM_CONTRACT;
 }
@@ -962,7 +962,7 @@ PEAssembly::PEAssembly(
 #endif // !DACCESS_COMPILE
 
 
-PEAssembly *PEAssembly::Open(
+PEAssembly *PEFile::Open(
     PEAssembly *       pParent,
     PEImage *          pPEImageIL,
     BINDER_SPACE::Assembly * pHostAssembly)
@@ -981,7 +981,7 @@ PEAssembly *PEAssembly::Open(
 }
 
 
-PEAssembly::~PEAssembly()
+PEFile::~PEFile()
 {
     CONTRACTL
     {
@@ -1012,7 +1012,7 @@ PEAssembly::~PEAssembly()
 }
 
 /* static */
-PEAssembly *PEAssembly::OpenSystem()
+PEAssembly *PEFile::OpenSystem()
 {
     STANDARD_VM_CONTRACT;
 
@@ -1037,7 +1037,7 @@ PEAssembly *PEAssembly::OpenSystem()
 }
 
 /* static */
-PEAssembly *PEAssembly::DoOpenSystem()
+PEAssembly *PEFile::DoOpenSystem()
 {
     CONTRACT(PEAssembly *)
     {
@@ -1053,7 +1053,7 @@ PEAssembly *PEAssembly::DoOpenSystem()
     RETURN new PEAssembly(pBoundAssembly, NULL, NULL, TRUE);
 }
 
-PEAssembly* PEAssembly::Open(BINDER_SPACE::Assembly* pBindResult,
+PEAssembly* PEFile::Open(BINDER_SPACE::Assembly* pBindResult,
                                    BOOL isSystem)
 {
 
@@ -1062,7 +1062,7 @@ PEAssembly* PEAssembly::Open(BINDER_SPACE::Assembly* pBindResult,
 };
 
 /* static */
-PEAssembly *PEAssembly::Create(PEAssembly *pParentAssembly,
+PEAssembly *PEFile::Create(PEAssembly *pParentAssembly,
                                IMetaDataAssemblyEmit *pAssemblyEmit)
 {
     CONTRACT(PEAssembly *)
@@ -1095,7 +1095,7 @@ PEAssembly *PEAssembly::Create(PEAssembly *pParentAssembly,
 
 // Effective path is the path of nearest parent (creator) assembly which has a nonempty path.
 
-const SString &PEAssembly::GetEffectivePath()
+const SString &PEFile::GetEffectivePath()
 {
     CONTRACTL
     {
@@ -1106,7 +1106,7 @@ const SString &PEAssembly::GetEffectivePath()
     }
     CONTRACTL_END;
 
-    PEAssembly *pAssembly = this;
+    PEAssembly *pAssembly = (PEAssembly*)this;
 
     while (pAssembly->m_identity == NULL
            || pAssembly->m_identity->GetPath().IsEmpty())
@@ -1125,7 +1125,7 @@ const SString &PEAssembly::GetEffectivePath()
 // Note this may be obtained from the parent PEFile if we don't have a path or fusion
 // assembly.
 // Returns false if the assembly was loaded from a bundle, true otherwise
-BOOL PEAssembly::GetCodeBase(SString &result)
+BOOL PEFile::GetCodeBase(SString &result)
 {
     CONTRACTL
     {
@@ -1154,7 +1154,7 @@ BOOL PEAssembly::GetCodeBase(SString &result)
 }
 
 /* static */
-void PEAssembly::PathToUrl(SString &string)
+void PEFile::PathToUrl(SString &string)
 {
     CONTRACTL
     {
@@ -1195,7 +1195,7 @@ void PEAssembly::PathToUrl(SString &string)
     }
 }
 
-void PEAssembly::UrlToPath(SString &string)
+void PEFile::UrlToPath(SString &string)
 {
     CONTRACT_VOID
     {
@@ -1224,7 +1224,7 @@ void PEAssembly::UrlToPath(SString &string)
     RETURN;
 }
 
-BOOL PEAssembly::FindLastPathSeparator(const SString &path, SString::Iterator &i)
+BOOL PEFile::FindLastPathSeparator(const SString &path, SString::Iterator &i)
 {
 #ifdef TARGET_UNIX
     SString::Iterator slash = i;
@@ -1305,8 +1305,7 @@ void PEFile::EnsureImageOpened()
 
 #ifdef DACCESS_COMPILE
 
-void
-PEFile::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
+void PEFile::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
 {
     WRAPPER_NO_CONTRACT;
     SUPPORTS_DAC;
@@ -1328,14 +1327,6 @@ PEFile::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
     {
         GetILimage()->EnumMemoryRegions(flags);
     }
-}
-
-void
-PEAssembly::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
-{
-    WRAPPER_NO_CONTRACT;
-
-    PEFile::EnumMemoryRegions(flags);
 
     if (m_creator.IsValid())
     {

--- a/src/coreclr/vm/pefile.h
+++ b/src/coreclr/vm/pefile.h
@@ -325,8 +325,9 @@ protected:
     // Internal routines
     // ------------------------------------------------------------
 
-    // just to make the DAC happy.
+    // just to make the DAC and GCC happy.
     virtual ~PEFile() {}
+    PEFile() {}
 
     void OpenMDImport();
     void OpenMDImport_Unsafe();

--- a/src/coreclr/vm/pefile.h
+++ b/src/coreclr/vm/pefile.h
@@ -117,7 +117,7 @@ private:
     friend class DomainFile;
 
 public:
-    void LoadLibrary(BOOL allowNativeSkip = TRUE);
+    void LoadLibrary();
 
 
 private:
@@ -182,7 +182,7 @@ public:
     // Checks
     // ------------------------------------------------------------
 
-    CHECK CheckLoaded(BOOL allowNativeSkip = TRUE);
+    CHECK CheckLoaded();
     void ValidateForExecution();
     BOOL IsMarkedAsNoPlatform();
 
@@ -312,7 +312,7 @@ public:
     PTR_PEImageLayout GetLoadedIL();
     IStream * GetPdbStream();
     void ClearPdbStream();
-    BOOL IsLoaded(BOOL bAllowNativeSkip=TRUE) ;
+    BOOL IsLoaded() ;
     BOOL IsPtrInILImage(PTR_CVOID data);
 
     // ------------------------------------------------------------

--- a/src/coreclr/vm/pefile.h
+++ b/src/coreclr/vm/pefile.h
@@ -140,12 +140,6 @@ protected:
 
 public:
     // ------------------------------------------------------------
-    // Generic PEFile - can be used to access metadata
-    // ------------------------------------------------------------
-
-    static PEFile *Open(PEImage *image);
-
-    // ------------------------------------------------------------
     // Identity
     // ------------------------------------------------------------
 
@@ -195,9 +189,7 @@ public:
     PTR_PEAssembly AsAssembly();
     BOOL IsSystem() const;
     BOOL IsDynamic() const;
-    BOOL IsResource() const;
-    BOOL IsIStream() const;
-    // Returns self (if assembly) or containing assembly (if module)
+    // Returns self 
     PEAssembly *GetAssembly() const;
 
     // ------------------------------------------------------------
@@ -221,7 +213,6 @@ public:
 
     LPCUTF8 GetSimpleName();
     HRESULT GetScopeName(LPCUTF8 * pszName);
-    BOOL IsStrongNameVerified();
     BOOL IsStrongNamed();
     const void *GetPublicKey(DWORD *pcbPK);
     ULONG GetHashAlgId();
@@ -331,25 +322,11 @@ public:
 
 protected:
     // ------------------------------------------------------------
-    // Internal constants
-    // ------------------------------------------------------------
-
-    enum
-    {
-        PEFILE_SYSTEM                 = 0x01,
-        PEFILE_ASSEMBLY               = 0x02,
-    };
-
-    // ------------------------------------------------------------
     // Internal routines
     // ------------------------------------------------------------
 
-#ifndef DACCESS_COMPILE
-    PEFile(PEImage *image);
-    virtual ~PEFile();
-#else
+    // just to make the DAC happy.
     virtual ~PEFile() {}
-#endif
 
     void OpenMDImport();
     void OpenMDImport_Unsafe();
@@ -395,7 +372,7 @@ protected:
     IMetaDataEmit           *m_pEmitter;
     SimpleRWLock            *m_pMetadataLock;
     Volatile<LONG>           m_refCount;
-    int                      m_flags;
+    bool                     m_isSystem;
 
 public:
 
@@ -576,7 +553,7 @@ class PEAssembly : public PEFile
         BINDER_SPACE::Assembly* pBindResultInfo,
         IMetaDataEmit *pEmit,
         PEFile *creator,
-        BOOL system,
+        BOOL isSystem,
         PEImage * pPEImageIL = NULL,
         BINDER_SPACE::Assembly * pHostAssembly = NULL
         );

--- a/src/coreclr/vm/pefile.inl
+++ b/src/coreclr/vm/pefile.inl
@@ -897,7 +897,7 @@ inline const void *PEFile::GetManagedFileContents(COUNT_T *pSize/*=NULL*/)
 
     // Right now, we will trigger a LoadLibrary for the caller's sake,
     // even if we are in a scenario where we could normally avoid it.
-    LoadLibrary(FALSE);
+    LoadLibrary();
 
     if (pSize != NULL)
         *pSize = GetLoadedIL()->GetSize();
@@ -940,7 +940,7 @@ inline PTR_PEImageLayout PEFile::GetLoadedIL()
     return GetOpenedILimage()->GetLoadedLayout();
 };
 
-inline BOOL PEFile::IsLoaded(BOOL bAllowNative/*=TRUE*/)
+inline BOOL PEFile::IsLoaded()
 {
     CONTRACTL
     {

--- a/src/coreclr/vm/pefile.inl
+++ b/src/coreclr/vm/pefile.inl
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // --------------------------------------------------------------------------------
-// PEFile.inl
+// PEAssembly.inl
 //
 
 // --------------------------------------------------------------------------------
@@ -15,7 +15,7 @@
 #include "peimagelayout.inl"
 
 #if CHECK_INVARIANTS
-inline CHECK PEFile::Invariant()
+inline CHECK PEAssembly::Invariant()
 {
     CONTRACT_CHECK
     {
@@ -46,7 +46,7 @@ inline CHECK PEFile::Invariant()
 // AddRef/Release
 // ------------------------------------------------------------
 
-inline ULONG PEFile::AddRef()
+inline ULONG PEAssembly::AddRef()
 {
     CONTRACTL
     {
@@ -61,7 +61,7 @@ inline ULONG PEFile::AddRef()
     return FastInterlockIncrement(&m_refCount);
 }
 
-inline ULONG PEFile::Release()
+inline ULONG PEAssembly::Release()
 {
     CONTRACT(COUNT_T)
     {
@@ -84,7 +84,7 @@ inline ULONG PEFile::Release()
 // Identity
 // ------------------------------------------------------------
 
-inline ULONG PEFile::HashIdentity()
+inline ULONG PEAssembly::HashIdentity()
 {
     CONTRACTL
     {
@@ -97,7 +97,7 @@ inline ULONG PEFile::HashIdentity()
     return m_pHostAssembly->GetAssemblyName()->Hash(BINDER_SPACE::AssemblyName::INCLUDE_VERSION);
 }
 
-inline void PEFile::ValidateForExecution()
+inline void PEAssembly::ValidateForExecution()
 {
     CONTRACTL
     {
@@ -131,14 +131,14 @@ inline void PEFile::ValidateForExecution()
 }
 
 
-inline BOOL PEFile::IsMarkedAsNoPlatform()
+inline BOOL PEAssembly::IsMarkedAsNoPlatform()
 {
     WRAPPER_NO_CONTRACT;
     return (IsAfPA_NoPlatform(GetFlags()));
 }
 
 
-inline void PEFile::GetMVID(GUID *pMvid)
+inline void PEAssembly::GetMVID(GUID *pMvid)
 {
     CONTRACTL
     {
@@ -156,7 +156,7 @@ inline void PEFile::GetMVID(GUID *pMvid)
 // Descriptive strings
 // ------------------------------------------------------------
 
-inline const SString& PEFile::GetPath()
+inline const SString& PEAssembly::GetPath()
 {
     CONTRACTL
     {
@@ -179,7 +179,7 @@ inline const SString& PEFile::GetPath()
 //
 // Returns the identity path even for single-file/bundled apps.
 //
-inline const SString& PEFile::GetIdentityPath()
+inline const SString& PEAssembly::GetIdentityPath()
 {
     CONTRACTL
     {
@@ -200,7 +200,7 @@ inline const SString& PEFile::GetIdentityPath()
 }
 
 #ifdef DACCESS_COMPILE
-inline const SString &PEFile::GetModuleFileNameHint()
+inline const SString &PEAssembly::GetModuleFileNameHint()
 {
     CONTRACTL
     {
@@ -221,7 +221,7 @@ inline const SString &PEFile::GetModuleFileNameHint()
 #endif // DACCESS_COMPILE
 
 #ifdef LOGGING
-inline LPCWSTR PEFile::GetDebugName()
+inline LPCWSTR PEAssembly::GetDebugName()
 {
     CONTRACTL
     {
@@ -245,21 +245,21 @@ inline LPCWSTR PEFile::GetDebugName()
 // Classification
 // ------------------------------------------------------------
 
-inline BOOL PEFile::IsAssembly() const
+inline BOOL PEAssembly::IsAssembly() const
 {
     LIMITED_METHOD_DAC_CONTRACT;
 
     return true;
 }
 
-inline PTR_PEAssembly PEFile::AsAssembly()
+inline PTR_PEAssembly PEAssembly::AsAssembly()
 {
     LIMITED_METHOD_DAC_CONTRACT;
 
     return dac_cast<PTR_PEAssembly>(this);
 }
 
-inline BOOL PEFile::IsSystem() const
+inline BOOL PEAssembly::IsSystem() const
 {
     LIMITED_METHOD_CONTRACT;
     SUPPORTS_DAC;
@@ -267,7 +267,7 @@ inline BOOL PEFile::IsSystem() const
     return m_isSystem;
 }
 
-inline BOOL PEFile::IsDynamic() const
+inline BOOL PEAssembly::IsDynamic() const
 {
     LIMITED_METHOD_CONTRACT;
     SUPPORTS_DAC;
@@ -275,7 +275,7 @@ inline BOOL PEFile::IsDynamic() const
     return m_identity == NULL;
 }
 
-inline PEAssembly *PEFile::GetAssembly() const
+inline PEAssembly *PEAssembly::GetAssembly() const
 {
     WRAPPER_NO_CONTRACT;
     _ASSERTE(IsAssembly());
@@ -286,7 +286,7 @@ inline PEAssembly *PEFile::GetAssembly() const
 // Metadata access
 // ------------------------------------------------------------
 
-inline BOOL PEFile::HasMetadata()
+inline BOOL PEAssembly::HasMetadata()
 {
     CONTRACTL
     {
@@ -301,7 +301,7 @@ inline BOOL PEFile::HasMetadata()
     return true;
 }
 
-inline IMDInternalImportHolder PEFile::GetMDImport()
+inline IMDInternalImportHolder PEAssembly::GetMDImport()
 {
     WRAPPER_NO_CONTRACT;
     if (m_bHasPersistentMDImport)
@@ -310,7 +310,7 @@ inline IMDInternalImportHolder PEFile::GetMDImport()
         return IMDInternalImportHolder(GetMDImportWithRef(),TRUE);
 };
 
-inline IMDInternalImport* PEFile::GetPersistentMDImport()
+inline IMDInternalImport* PEAssembly::GetPersistentMDImport()
 {
 /*
     CONTRACT(IMDInternalImport *)
@@ -335,7 +335,7 @@ inline IMDInternalImport* PEFile::GetPersistentMDImport()
 #endif
 }
 
-inline IMDInternalImport *PEFile::GetMDImportWithRef()
+inline IMDInternalImport *PEAssembly::GetMDImportWithRef()
 {
 /*
     CONTRACT(IMDInternalImport *)
@@ -372,7 +372,7 @@ inline IMDInternalImport *PEFile::GetMDImportWithRef()
 
 #ifndef DACCESS_COMPILE
 
-inline IMetaDataImport2 *PEFile::GetRWImporter()
+inline IMetaDataImport2 *PEAssembly::GetRWImporter()
 {
     CONTRACT(IMetaDataImport2 *)
     {
@@ -391,7 +391,7 @@ inline IMetaDataImport2 *PEFile::GetRWImporter()
     RETURN m_pImporter;
 }
 
-inline IMetaDataEmit *PEFile::GetEmitter()
+inline IMetaDataEmit *PEAssembly::GetEmitter()
 {
     CONTRACT(IMetaDataEmit *)
     {
@@ -416,7 +416,7 @@ inline IMetaDataEmit *PEFile::GetEmitter()
 // Same as the managed Module.ScopeName property, this unconditionally looks in the
 // metadata Module table to get the name.  Useful for profilers and others who don't
 // like sugar coating on their names.
-inline HRESULT PEFile::GetScopeName(LPCUTF8 * pszName)
+inline HRESULT PEAssembly::GetScopeName(LPCUTF8 * pszName)
 {
     CONTRACTL
     {
@@ -436,14 +436,7 @@ inline HRESULT PEFile::GetScopeName(LPCUTF8 * pszName)
 // PE file access
 // ------------------------------------------------------------
 
-inline BOOL PEFile::IsIbcOptimized()
-{
-    WRAPPER_NO_CONTRACT;
-
-    return FALSE;
-}
-
-inline BOOL PEFile::IsReadyToRun()
+inline BOOL PEAssembly::IsReadyToRun()
 {
     CONTRACTL
     {
@@ -464,7 +457,7 @@ inline BOOL PEFile::IsReadyToRun()
     }
 }
 
-inline WORD PEFile::GetSubsystem()
+inline WORD PEAssembly::GetSubsystem()
 {
     WRAPPER_NO_CONTRACT;
 
@@ -474,7 +467,7 @@ inline WORD PEFile::GetSubsystem()
     return GetLoadedIL()->GetSubsystem();
 }
 
-inline mdToken PEFile::GetEntryPointToken(
+inline mdToken PEAssembly::GetEntryPointToken(
 #ifdef _DEBUG
             BOOL bAssumeLoaded
 #endif //_DEBUG
@@ -489,7 +482,7 @@ inline mdToken PEFile::GetEntryPointToken(
     return GetOpenedILimage()->GetEntryPointToken();
 }
 
-inline BOOL PEFile::IsILOnly()
+inline BOOL PEAssembly::IsILOnly()
 {
     WRAPPER_NO_CONTRACT;
     SUPPORTS_DAC;
@@ -502,7 +495,7 @@ inline BOOL PEFile::IsILOnly()
     return GetOpenedILimage()->IsILOnly();
 }
 
-inline BOOL PEFile::IsDll()
+inline BOOL PEAssembly::IsDll()
 {
     WRAPPER_NO_CONTRACT;
 
@@ -512,7 +505,7 @@ inline BOOL PEFile::IsDll()
     return GetOpenedILimage()->IsDll();
 }
 
-inline PTR_VOID PEFile::GetRvaField(RVA field)
+inline PTR_VOID PEAssembly::GetRvaField(RVA field)
 {
     CONTRACT(void *)
     {
@@ -534,7 +527,7 @@ inline PTR_VOID PEFile::GetRvaField(RVA field)
     RETURN dac_cast<PTR_VOID>(GetLoadedIL()->GetRvaData(field,NULL_OK));
 }
 
-inline CHECK PEFile::CheckRvaField(RVA field)
+inline CHECK PEAssembly::CheckRvaField(RVA field)
 {
     CONTRACT_CHECK
     {
@@ -554,7 +547,7 @@ inline CHECK PEFile::CheckRvaField(RVA field)
     CHECK_OK;
 }
 
-inline CHECK PEFile::CheckRvaField(RVA field, COUNT_T size)
+inline CHECK PEAssembly::CheckRvaField(RVA field, COUNT_T size)
 {
     CONTRACT_CHECK
     {
@@ -574,7 +567,7 @@ inline CHECK PEFile::CheckRvaField(RVA field, COUNT_T size)
     CHECK_OK;
 }
 
-inline BOOL PEFile::HasTls()
+inline BOOL PEAssembly::HasTls()
 {
     CONTRACTL
     {
@@ -596,7 +589,7 @@ inline BOOL PEFile::HasTls()
         return GetLoadedIL()->HasTls();
 }
 
-inline BOOL PEFile::IsRvaFieldTls(RVA field)
+inline BOOL PEAssembly::IsRvaFieldTls(RVA field)
 {
     CONTRACTL
     {
@@ -620,7 +613,7 @@ inline BOOL PEFile::IsRvaFieldTls(RVA field)
             && address < (dac_cast<PTR_BYTE>(tlsRange)+tlsSize));
 }
 
-inline UINT32 PEFile::GetFieldTlsOffset(RVA field)
+inline UINT32 PEAssembly::GetFieldTlsOffset(RVA field)
 {
     CONTRACTL
     {
@@ -638,7 +631,7 @@ inline UINT32 PEFile::GetFieldTlsOffset(RVA field)
                                 dac_cast<PTR_BYTE>(GetLoadedIL()->GetTlsRange()));
 }
 
-inline UINT32 PEFile::GetTlsIndex()
+inline UINT32 PEAssembly::GetTlsIndex()
 {
     CONTRACTL
     {
@@ -654,7 +647,7 @@ inline UINT32 PEFile::GetTlsIndex()
     return GetLoadedIL()->GetTlsIndex();
 }
 
-inline const void *PEFile::GetInternalPInvokeTarget(RVA target)
+inline const void *PEAssembly::GetInternalPInvokeTarget(RVA target)
 {
     CONTRACT(void *)
     {
@@ -672,7 +665,7 @@ inline const void *PEFile::GetInternalPInvokeTarget(RVA target)
     RETURN (void*)GetLoadedIL()->GetRvaData(target);
 }
 
-inline CHECK PEFile::CheckInternalPInvokeTarget(RVA target)
+inline CHECK PEAssembly::CheckInternalPInvokeTarget(RVA target)
 {
     CONTRACT_CHECK
     {
@@ -691,7 +684,7 @@ inline CHECK PEFile::CheckInternalPInvokeTarget(RVA target)
     CHECK_OK;
 }
 
-inline IMAGE_COR_VTABLEFIXUP *PEFile::GetVTableFixups(COUNT_T *pCount/*=NULL*/)
+inline IMAGE_COR_VTABLEFIXUP *PEAssembly::GetVTableFixups(COUNT_T *pCount/*=NULL*/)
 {
     CONTRACT(IMAGE_COR_VTABLEFIXUP *)
     {
@@ -714,7 +707,7 @@ inline IMAGE_COR_VTABLEFIXUP *PEFile::GetVTableFixups(COUNT_T *pCount/*=NULL*/)
         RETURN GetLoadedIL()->GetVTableFixups(pCount);
 }
 
-inline void *PEFile::GetVTable(RVA rva)
+inline void *PEAssembly::GetVTable(RVA rva)
 {
     CONTRACT(void *)
     {
@@ -734,7 +727,7 @@ inline void *PEFile::GetVTable(RVA rva)
 }
 
 // @todo: this is bad to expose. But it is needed to support current IJW thunks
-inline HMODULE PEFile::GetIJWBase()
+inline HMODULE PEAssembly::GetIJWBase()
 {
     CONTRACTL
     {
@@ -751,7 +744,7 @@ inline HMODULE PEFile::GetIJWBase()
     return (HMODULE) dac_cast<TADDR>(GetLoadedIL()->GetBase());
 }
 
-inline PTR_VOID PEFile::GetDebuggerContents(COUNT_T *pSize/*=NULL*/)
+inline PTR_VOID PEAssembly::GetDebuggerContents(COUNT_T *pSize/*=NULL*/)
 {
     CONTRACT(PTR_VOID)
     {
@@ -784,7 +777,7 @@ inline PTR_VOID PEFile::GetDebuggerContents(COUNT_T *pSize/*=NULL*/)
     }
 }
 
-inline PTR_CVOID PEFile::GetLoadedImageContents(COUNT_T *pSize/*=NULL*/)
+inline PTR_CVOID PEAssembly::GetLoadedImageContents(COUNT_T *pSize/*=NULL*/)
 {
     CONTRACTL
     {
@@ -815,7 +808,7 @@ inline PTR_CVOID PEFile::GetLoadedImageContents(COUNT_T *pSize/*=NULL*/)
 }
 
 #ifndef DACCESS_COMPILE
-inline const void *PEFile::GetManagedFileContents(COUNT_T *pSize/*=NULL*/)
+inline const void *PEAssembly::GetManagedFileContents(COUNT_T *pSize/*=NULL*/)
 {
     CONTRACT(const void *)
     {
@@ -840,7 +833,7 @@ inline const void *PEFile::GetManagedFileContents(COUNT_T *pSize/*=NULL*/)
 }
 #endif // DACCESS_COMPILE
 
-inline BOOL PEFile::IsPtrInILImage(PTR_CVOID data)
+inline BOOL PEAssembly::IsPtrInILImage(PTR_CVOID data)
 {
     CONTRACTL
     {
@@ -863,7 +856,7 @@ inline BOOL PEFile::IsPtrInILImage(PTR_CVOID data)
 // Native image access
 // ------------------------------------------------------------
 
-inline PTR_PEImageLayout PEFile::GetLoadedIL()
+inline PTR_PEImageLayout PEAssembly::GetLoadedIL()
 {
     LIMITED_METHOD_CONTRACT;
     SUPPORTS_DAC;
@@ -873,7 +866,7 @@ inline PTR_PEImageLayout PEFile::GetLoadedIL()
     return GetOpenedILimage()->GetLoadedLayout();
 };
 
-inline BOOL PEFile::IsLoaded()
+inline BOOL PEAssembly::IsLoaded()
 {
     CONTRACTL
     {
@@ -888,7 +881,7 @@ inline BOOL PEFile::IsLoaded()
 };
 
 
-inline PTR_PEImageLayout PEFile::GetLoaded()
+inline PTR_PEImageLayout PEAssembly::GetLoaded()
 {
     WRAPPER_NO_CONTRACT;
     SUPPORTS_DAC;
@@ -899,7 +892,7 @@ inline PTR_PEImageLayout PEFile::GetLoaded()
 // ------------------------------------------------------------
 // Descriptive strings
 // ------------------------------------------------------------
-inline void PEFile::GetDisplayName(SString &result, DWORD flags)
+inline void PEAssembly::GetDisplayName(SString &result, DWORD flags)
 {
     CONTRACTL
     {
@@ -912,7 +905,7 @@ inline void PEFile::GetDisplayName(SString &result, DWORD flags)
 
 #ifndef DACCESS_COMPILE
     AssemblySpec spec;
-    spec.InitializeSpec((PEAssembly*)this);
+    spec.InitializeSpec(this);
     spec.GetFileOrDisplayName(flags, result);
 #else
     DacNotImpl();
@@ -923,7 +916,7 @@ inline void PEFile::GetDisplayName(SString &result, DWORD flags)
 // Metadata access
 // ------------------------------------------------------------
 
-inline LPCSTR PEFile::GetSimpleName()
+inline LPCSTR PEAssembly::GetSimpleName()
 {
     CONTRACTL
     {
@@ -947,7 +940,7 @@ inline LPCSTR PEFile::GetSimpleName()
     return name;
 }
 
-inline BOOL PEFile::IsStrongNamed()
+inline BOOL PEAssembly::IsStrongNamed()
 {
     CONTRACTL
     {
@@ -968,7 +961,7 @@ inline BOOL PEFile::IsStrongNamed()
 // Check to see if this assembly has had its strong name signature verified yet.
 //
 
-inline const void *PEFile::GetPublicKey(DWORD *pcbPK)
+inline const void *PEAssembly::GetPublicKey(DWORD *pcbPK)
 {
     CONTRACTL
     {
@@ -984,7 +977,7 @@ inline const void *PEFile::GetPublicKey(DWORD *pcbPK)
     return pPK;
 }
 
-inline ULONG PEFile::GetHashAlgId()
+inline ULONG PEAssembly::GetHashAlgId()
 {
     CONTRACTL
     {
@@ -999,7 +992,7 @@ inline ULONG PEFile::GetHashAlgId()
     return hashAlgId;
 }
 
-inline LPCSTR PEFile::GetLocale()
+inline LPCSTR PEAssembly::GetLocale()
 {
     CONTRACTL
     {
@@ -1014,7 +1007,7 @@ inline LPCSTR PEFile::GetLocale()
     return md.szLocale;
 }
 
-inline DWORD PEFile::GetFlags()
+inline DWORD PEAssembly::GetFlags()
 {
     CONTRACTL
     {
@@ -1033,8 +1026,8 @@ inline DWORD PEFile::GetFlags()
 }
 
 // In the cases where you know the module is loaded, and cannot tolerate triggering and
-// loading, this alternative to PEFile::GetFlags is useful.  Profiling API uses this.
-inline HRESULT PEFile::GetFlagsNoTrigger(DWORD * pdwFlags)
+// loading, this alternative to PEAssembly::GetFlags is useful.  Profiling API uses this.
+inline HRESULT PEAssembly::GetFlagsNoTrigger(DWORD * pdwFlags)
 {
     CONTRACTL
     {
@@ -1059,7 +1052,7 @@ inline HRESULT PEFile::GetFlagsNoTrigger(DWORD * pdwFlags)
 // Metadata access
 // ------------------------------------------------------------
 
-inline void PEFile::OpenMDImport()
+inline void PEAssembly::OpenMDImport()
 {
     WRAPPER_NO_CONTRACT;
     //need synchronization
@@ -1067,8 +1060,4 @@ inline void PEFile::OpenMDImport()
     OpenMDImport_Unsafe();
 }
 
-inline PEFile* PEFile::Dummy()
-{
-    return (PEFile*)(-1);
-}
 #endif  // PEFILE_INL_

--- a/src/coreclr/vm/pefile.inl
+++ b/src/coreclr/vm/pefile.inl
@@ -84,7 +84,7 @@ inline ULONG PEFile::Release()
 // Identity
 // ------------------------------------------------------------
 
-inline ULONG PEAssembly::HashIdentity()
+inline ULONG PEFile::HashIdentity()
 {
     CONTRACTL
     {
@@ -412,36 +412,6 @@ inline IMetaDataEmit *PEFile::GetEmitter()
 
 
 #endif // DACCESS_COMPILE
-
-// The simple name is not actually very simple. The name returned comes from one of
-// various metadata tables, depending on whether this is a manifest module,
-// non-manifest module, or something else
-inline LPCUTF8 PEFile::GetSimpleName()
-{
-    CONTRACT(LPCUTF8)
-    {
-        INSTANCE_CHECK;
-        MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL));
-        NOTHROW;
-        SUPPORTS_DAC;
-        WRAPPER(GC_TRIGGERS);
-    }
-    CONTRACT_END;
-
-    if (IsAssembly())
-        RETURN dac_cast<PTR_PEAssembly>(this)->GetSimpleName();
-    else
-    {
-        LPCUTF8 szScopeName;
-        if (FAILED(GetScopeName(&szScopeName)))
-        {
-            szScopeName = "";
-        }
-        RETURN szScopeName;
-    }
-}
-
 
 // Same as the managed Module.ScopeName property, this unconditionally looks in the
 // metadata Module table to get the name.  Useful for profilers and others who don't
@@ -929,7 +899,7 @@ inline PTR_PEImageLayout PEFile::GetLoaded()
 // ------------------------------------------------------------
 // Descriptive strings
 // ------------------------------------------------------------
-inline void PEAssembly::GetDisplayName(SString &result, DWORD flags)
+inline void PEFile::GetDisplayName(SString &result, DWORD flags)
 {
     CONTRACTL
     {
@@ -942,7 +912,7 @@ inline void PEAssembly::GetDisplayName(SString &result, DWORD flags)
 
 #ifndef DACCESS_COMPILE
     AssemblySpec spec;
-    spec.InitializeSpec(this);
+    spec.InitializeSpec((PEAssembly*)this);
     spec.GetFileOrDisplayName(flags, result);
 #else
     DacNotImpl();
@@ -953,7 +923,7 @@ inline void PEAssembly::GetDisplayName(SString &result, DWORD flags)
 // Metadata access
 // ------------------------------------------------------------
 
-inline LPCSTR PEAssembly::GetSimpleName()
+inline LPCSTR PEFile::GetSimpleName()
 {
     CONTRACTL
     {

--- a/src/coreclr/vm/peimage.cpp
+++ b/src/coreclr/vm/peimage.cpp
@@ -895,11 +895,6 @@ PTR_PEImageLayout PEImage::GetLayoutInternal(DWORD imageLayoutMask)
         }
     }
 
-    if (pRetVal != NULL)
-    {
-        pRetVal->AddRef();
-    }
-
     return pRetVal;
 }
 

--- a/src/coreclr/vm/peimage.cpp
+++ b/src/coreclr/vm/peimage.cpp
@@ -27,7 +27,7 @@ PtrHashMap *PEImage::s_ijwFixupDataHash;
 #ifndef TARGET_UNIX
 namespace
 {
-    void static GetPathFromDll(HINSTANCE hMod, SString& result)
+    void GetPathFromDll(HINSTANCE hMod, SString& result)
     {
         CONTRACTL
         {
@@ -268,7 +268,7 @@ BOOL PEImage::CompareImage(UPTR u1, UPTR u2)
 
     if (pLocator->m_bIsInBundle != pImage->IsInBundle())
     {
-        return false;
+        return FALSE;
     }
 
     BOOL ret = FALSE;

--- a/src/coreclr/vm/peimage.h
+++ b/src/coreclr/vm/peimage.h
@@ -198,7 +198,6 @@ public:
     WORD GetSubsystem();
     BOOL  IsFileLocked();
 
-    BOOL IsIbcOptimized();
     BOOL Has32BitNTHeaders();
 
     void VerifyIsAssembly();

--- a/src/coreclr/vm/peimage.h
+++ b/src/coreclr/vm/peimage.h
@@ -28,8 +28,6 @@ class SimpleRWLock;
 class Crst;
 class Thread;
 
-Thread* GetThreadNULLOk();
-
 // --------------------------------------------------------------------------------
 // PEImage is a PE file loaded by our "simulated LoadLibrary" mechanism.  A PEImage
 // can be loaded either FLAT (same layout as on disk) or MAPPED (PE sections
@@ -63,10 +61,10 @@ public:
     // Public constants
     // ------------------------------------------------------------
 
-    PTR_PEImageLayout GetLayout(DWORD imageLayoutMask);
-    PTR_PEImageLayout GetLoadedLayout();
     BOOL IsOpened();
+    PTR_PEImageLayout GetLayout(DWORD imageLayoutMask);
     BOOL HasLoadedLayout();
+    PTR_PEImageLayout GetLoadedLayout();
 
 public:
     // ------------------------------------------------------------

--- a/src/coreclr/vm/peimage.h
+++ b/src/coreclr/vm/peimage.h
@@ -92,20 +92,6 @@ public:
         MDInternalImportFlags flags = MDInternalImport_Default,
         BundleFileLocation bundleFileLocation = BundleFileLocation::Invalid());
 
-
-    // clones the image (this is pretty much about cached / noncached difference)
-    void Clone(PTR_PEImage* ppImage)
-    {
-        if (GetPath().IsEmpty())
-        {
-            AddRef();
-            *ppImage = this;
-        }
-        else
-            *ppImage = PEImage::OpenImage(GetPath(), MDInternalImport_Default);
-
-    };
-
     static PTR_PEImage FindByPath(LPCWSTR pPath, BOOL isInBundle = TRUE);
     void AddToHashMap();
 
@@ -149,12 +135,15 @@ public:
 
     BOOL HasContents() ;
     BOOL IsPtrInImage(PTR_CVOID data);
-    CHECK CheckFormat();
 
     // Check utilites
-    CHECK CheckILFormat();
-    static CHECK CheckCanonicalFullPath(const SString &path);
     static CHECK CheckStartup();
+    static CHECK CheckCanonicalFullPath(const SString& path);
+
+    CHECK CheckFormat();
+    CHECK CheckILFormat();
+    CHECK CheckUniqueInstance();
+
     PTR_CVOID GetMetadata(COUNT_T *pSize = NULL);
 
 #ifndef TARGET_UNIX
@@ -180,7 +169,7 @@ public:
     BOOL IsILOnly();
     BOOL IsDll();
     WORD GetSubsystem();
-    BOOL  IsFileLocked();
+    BOOL IsFileLocked();
 
     BOOL Has32BitNTHeaders();
 

--- a/src/coreclr/vm/peimage.h
+++ b/src/coreclr/vm/peimage.h
@@ -91,7 +91,7 @@ public:
 #endif
 
     BOOL IsOpened();
-    PTR_PEImageLayout GetLayout(DWORD imageLayoutMask);
+    PTR_PEImageLayout GetOrCreateLayout(DWORD imageLayoutMask);
 
     BOOL HasLoadedLayout();
     PTR_PEImageLayout GetLoadedLayout();
@@ -108,7 +108,6 @@ public:
     INT64 GetSize() const;
     INT64 GetUncompressedSize() const;
 
-    void SetFileHandle(HANDLE hFile);
     HRESULT TryOpenFile();
 
     LPCWSTR GetPathForErrorMessages();
@@ -159,7 +158,7 @@ public:
 private:
 #ifndef DACCESS_COMPILE
     // Get or create the layout corresponding to the mask, with an AddRef
-    PTR_PEImageLayout GetLayoutInternal(DWORD imageLayoutMask);
+    PTR_PEImageLayout GetOrCreateLayoutInternal(DWORD imageLayoutMask);
 
     // Create the mapped layout
     PTR_PEImageLayout CreateLayoutMapped();

--- a/src/coreclr/vm/peimage.h
+++ b/src/coreclr/vm/peimage.h
@@ -56,18 +56,14 @@ struct CV_INFO_PDB70
 
 typedef DPTR(class PEImage)                PTR_PEImage;
 
-class PEImage
+class PEImage final
 {
 public:
     // ------------------------------------------------------------
     // Public constants
     // ------------------------------------------------------------
 
-    enum
-    {
-        LAYOUT_CREATEIFNEEDED=1
-    };
-    PTR_PEImageLayout GetLayout(DWORD imageLayoutMask,DWORD flags); //with ref
+    PTR_PEImageLayout GetLayout(DWORD imageLayoutMask); //with ref
     PTR_PEImageLayout GetLoadedLayout(); //no ref
     BOOL IsOpened();
     BOOL HasLoadedLayout();
@@ -105,8 +101,8 @@ public:
         BundleFileLocation bundleFileLocation = BundleFileLocation::Invalid());
 
 
-    // clones the image with new flags (this is pretty much about cached / noncached difference)
-    void Clone(MDInternalImportFlags flags, PTR_PEImage* ppImage)
+    // clones the image (this is pretty much about cached / noncached difference)
+    void Clone(PTR_PEImage* ppImage)
     {
         if (GetPath().IsEmpty())
         {
@@ -114,15 +110,11 @@ public:
             *ppImage = this;
         }
         else
-            *ppImage = PEImage::OpenImage(GetPath(), flags);
+            *ppImage = PEImage::OpenImage(GetPath(), MDInternalImport_Default);
 
     };
 
-    static PTR_PEImage FindById(UINT64 uStreamAsmId, DWORD dwModuleId);
-    static PTR_PEImage FindByPath(LPCWSTR pPath,
-                                  BOOL isInBundle = TRUE);
-    static PTR_PEImage FindByShortPath(LPCWSTR pPath);
-    static PTR_PEImage FindByLongPath(LPCWSTR pPath);
+    static PTR_PEImage FindByPath(LPCWSTR pPath, BOOL isInBundle = TRUE);
     void AddToHashMap();
 
     void   Load();
@@ -205,7 +197,7 @@ public:
 private:
 #ifndef DACCESS_COMPILE
     // Get or create the layout corresponding to the mask, with an AddRef
-    PTR_PEImageLayout GetLayoutInternal(DWORD imageLayoutMask, DWORD flags);
+    PTR_PEImageLayout GetLayoutInternal(DWORD imageLayoutMask);
 
     // Create the mapped layout
     PTR_PEImageLayout CreateLayoutMapped();

--- a/src/coreclr/vm/peimage.h
+++ b/src/coreclr/vm/peimage.h
@@ -88,7 +88,6 @@ public:
     void   Load();
     void   LoadNoFile();
     void   LoadFromMapped();
-    void   SetLoadedHMODULE(HMODULE hMod);
 #endif
 
     BOOL IsOpened();
@@ -101,9 +100,6 @@ public:
     ULONG GetPathHash();
     const SString& GetPath();
     const SString& GetPathToLoad();
-#ifndef TARGET_UNIX
-    static void GetPathFromDll(HINSTANCE hMod, SString& result);
-#endif // !TARGET_UNIX
 
     BOOL IsFile();
     BOOL IsInBundle() const;
@@ -147,7 +143,6 @@ public:
     // Check utilites
     static CHECK CheckStartup();
     static CHECK CheckCanonicalFullPath(const SString& path);
-    static CHECK CheckLayoutFormat(PEDecoder* pe);
 
     CHECK CheckFormat();
     CHECK CheckILFormat();
@@ -214,7 +209,7 @@ public:
     {
     private:
         Crst            m_lock;
-        void* m_base;
+        void*           m_base;
         DWORD           m_flags;
         PTR_LoaderHeap  m_DllThunkHeap;
 

--- a/src/coreclr/vm/peimage.h
+++ b/src/coreclr/vm/peimage.h
@@ -63,8 +63,8 @@ public:
     // Public constants
     // ------------------------------------------------------------
 
-    PTR_PEImageLayout GetLayout(DWORD imageLayoutMask); //with ref
-    PTR_PEImageLayout GetLoadedLayout(); //no ref
+    PTR_PEImageLayout GetLayout(DWORD imageLayoutMask);
+    PTR_PEImageLayout GetLoadedLayout();
     BOOL IsOpened();
     BOOL HasLoadedLayout();
 
@@ -74,14 +74,6 @@ public:
     // ------------------------------------------------------------
 
     static void Startup();
-
-    // Normal constructed PEImages do NOT share images between calls and
-    // cannot be accessed by Get methods.
-    //
-    // DO NOT USE these unless you want a private copy-on-write mapping of
-    // the file.
-
-
 
 public:
     ~PEImage();

--- a/src/coreclr/vm/peimage.inl
+++ b/src/coreclr/vm/peimage.inl
@@ -184,37 +184,37 @@ inline BOOL PEImage::IsReferenceAssembly()
 inline BOOL PEImage::HasNTHeaders()
 {
     WRAPPER_NO_CONTRACT;
-    return GetLayout(PEImageLayout::LAYOUT_ANY)->HasNTHeaders();
+    return GetOrCreateLayout(PEImageLayout::LAYOUT_ANY)->HasNTHeaders();
 }
 
 inline BOOL PEImage::HasCorHeader()
 {
     WRAPPER_NO_CONTRACT;
-    return GetLayout(PEImageLayout::LAYOUT_ANY)->HasCorHeader();
+    return GetOrCreateLayout(PEImageLayout::LAYOUT_ANY)->HasCorHeader();
 }
 
 inline BOOL PEImage::IsComponentAssembly()
 {
     WRAPPER_NO_CONTRACT;
-    return GetLayout(PEImageLayout::LAYOUT_ANY)->IsComponentAssembly();
+    return GetOrCreateLayout(PEImageLayout::LAYOUT_ANY)->IsComponentAssembly();
 }
 
 inline BOOL PEImage::HasReadyToRunHeader()
 {
     WRAPPER_NO_CONTRACT;
-    return GetLayout(PEImageLayout::LAYOUT_ANY)->HasReadyToRunHeader();
+    return GetOrCreateLayout(PEImageLayout::LAYOUT_ANY)->HasReadyToRunHeader();
 }
 
 inline BOOL PEImage::HasDirectoryEntry(int entry)
 {
     WRAPPER_NO_CONTRACT;
-    return GetLayout(PEImageLayout::LAYOUT_ANY)->HasDirectoryEntry(entry);
+    return GetOrCreateLayout(PEImageLayout::LAYOUT_ANY)->HasDirectoryEntry(entry);
 }
 
 inline mdToken PEImage::GetEntryPointToken()
 {
     WRAPPER_NO_CONTRACT;
-    PEImageLayout* pLayout = GetLayout(PEImageLayout::LAYOUT_ANY);
+    PEImageLayout* pLayout = GetOrCreateLayout(PEImageLayout::LAYOUT_ANY);
     if (!pLayout->HasManagedEntryPoint())
         return mdTokenNil;
     return pLayout->GetEntryPointToken();
@@ -223,7 +223,7 @@ inline mdToken PEImage::GetEntryPointToken()
 inline DWORD PEImage::GetCorHeaderFlags()
 {
     WRAPPER_NO_CONTRACT;
-    return VAL32(GetLayout(PEImageLayout::LAYOUT_ANY)->GetCorHeader()->Flags);
+    return VAL32(GetOrCreateLayout(PEImageLayout::LAYOUT_ANY)->GetCorHeader()->Flags);
 }
 
 inline BOOL PEImage::MDImportLoaded()
@@ -240,32 +240,32 @@ inline BOOL PEImage::HasV1Metadata()
 inline BOOL PEImage::IsILOnly()
 {
     WRAPPER_NO_CONTRACT;
-    return GetLayout(PEImageLayout::LAYOUT_ANY)->IsILOnly();
+    return GetOrCreateLayout(PEImageLayout::LAYOUT_ANY)->IsILOnly();
 }
 
 inline PTR_CVOID PEImage::GetNativeManifestMetadata(COUNT_T *pSize)
 {
     WRAPPER_NO_CONTRACT;
-    return GetLayout(PEImageLayout::LAYOUT_ANY)->GetNativeManifestMetadata(pSize);
+    return GetOrCreateLayout(PEImageLayout::LAYOUT_ANY)->GetNativeManifestMetadata(pSize);
 }
 
 inline PTR_CVOID PEImage::GetMetadata(COUNT_T *pSize)
 {
     WRAPPER_NO_CONTRACT;
-    return GetLayout(PEImageLayout::LAYOUT_ANY)->GetMetadata(pSize);
+    return GetOrCreateLayout(PEImageLayout::LAYOUT_ANY)->GetMetadata(pSize);
 }
 
 inline BOOL PEImage::HasContents()
 {
     WRAPPER_NO_CONTRACT;
-    return GetLayout(PEImageLayout::LAYOUT_ANY)->HasContents();
+    return GetOrCreateLayout(PEImageLayout::LAYOUT_ANY)->HasContents();
 }
 
 
 inline CHECK PEImage::CheckFormat()
 {
     WRAPPER_NO_CONTRACT;
-    CHECK(GetLayout(PEImageLayout::LAYOUT_ANY)->CheckFormat());
+    CHECK(GetOrCreateLayout(PEImageLayout::LAYOUT_ANY)->CheckFormat());
     CHECK_OK;
 }
 
@@ -368,7 +368,7 @@ inline void PEImage::AddToHashMap()
 inline BOOL PEImage::Has32BitNTHeaders()
 {
     WRAPPER_NO_CONTRACT;
-    return GetLayout(PEImageLayout::LAYOUT_ANY)->Has32BitNTHeaders();
+    return GetOrCreateLayout(PEImageLayout::LAYOUT_ANY)->Has32BitNTHeaders();
 }
 
 inline BOOL PEImage::HasPath()
@@ -411,7 +411,7 @@ inline void  PEImage::GetPEKindAndMachine(DWORD* pdwKind, DWORD* pdwMachine)
     {
         // Compute result into a local variables first
         DWORD dwPEKind, dwMachine;
-        GetLayout(PEImageLayout::LAYOUT_ANY)->GetPEKindAndMachine(&dwPEKind, &dwMachine);
+        GetOrCreateLayout(PEImageLayout::LAYOUT_ANY)->GetPEKindAndMachine(&dwPEKind, &dwMachine);
 
         // Write the final results - first machine, then kind.
         m_dwMachine = dwMachine;

--- a/src/coreclr/vm/peimage.inl
+++ b/src/coreclr/vm/peimage.inl
@@ -334,11 +334,6 @@ inline BOOL PEImage::IsDll()
     }
 }
 
-inline BOOL PEImage::IsIbcOptimized()
-{
-    return false;
-}
-
 inline PTR_CVOID PEImage::GetNativeManifestMetadata(COUNT_T *pSize)
 {
     WRAPPER_NO_CONTRACT;

--- a/src/coreclr/vm/peimage.inl
+++ b/src/coreclr/vm/peimage.inl
@@ -197,7 +197,7 @@ inline BOOL PEImage::HasNTHeaders()
         return GetLoadedLayout()->HasNTHeaders();
     else
     {
-        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY,LAYOUT_CREATEIFNEEDED));
+        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY));
         return pLayout->HasNTHeaders();
     }
 }
@@ -209,7 +209,7 @@ inline BOOL PEImage::HasCorHeader()
         return GetLoadedLayout()->HasCorHeader();
     else
     {
-        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY,LAYOUT_CREATEIFNEEDED));
+        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY));
         return pLayout->HasCorHeader();
     }
 }
@@ -221,7 +221,7 @@ inline BOOL PEImage::IsComponentAssembly()
         return GetLoadedLayout()->IsComponentAssembly();
     else
     {
-        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY,LAYOUT_CREATEIFNEEDED));
+        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY));
         return pLayout->IsComponentAssembly();
     }
 }
@@ -233,7 +233,7 @@ inline BOOL PEImage::HasReadyToRunHeader()
         return GetLoadedLayout()->HasReadyToRunHeader();
     else
     {
-        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY,LAYOUT_CREATEIFNEEDED));
+        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY));
         return pLayout->HasReadyToRunHeader();
     }
 }
@@ -245,7 +245,7 @@ inline BOOL PEImage::HasDirectoryEntry(int entry)
         return GetLoadedLayout()->HasDirectoryEntry(entry);
     else
     {
-        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY,LAYOUT_CREATEIFNEEDED));
+        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY));
         return pLayout->HasDirectoryEntry(entry);
     }
 }
@@ -262,7 +262,7 @@ inline mdToken PEImage::GetEntryPointToken()
     }
     else
     {
-        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY,LAYOUT_CREATEIFNEEDED));
+        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY));
         if (!pLayout->HasManagedEntryPoint())
             return mdTokenNil;
         return pLayout->GetEntryPointToken();
@@ -280,7 +280,7 @@ inline DWORD PEImage::GetCorHeaderFlags()
     }
     else
     {
-        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY,LAYOUT_CREATEIFNEEDED));
+        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY));
         return VAL32(pLayout->GetCorHeader()->Flags);
     }
 }
@@ -303,7 +303,7 @@ inline BOOL PEImage::IsILOnly()
         return GetLoadedLayout()->IsILOnly();
     else
     {
-        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY,LAYOUT_CREATEIFNEEDED));
+        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY));
         return pLayout->IsILOnly();
     }
 }
@@ -317,7 +317,7 @@ inline WORD PEImage::GetSubsystem()
         return GetLoadedLayout()->GetSubsystem();
     else
     {
-        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY,LAYOUT_CREATEIFNEEDED));
+        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY));
         return pLayout->GetSubsystem();
     }
 }
@@ -329,7 +329,7 @@ inline BOOL PEImage::IsDll()
         return GetLoadedLayout()->IsDll();
     else
     {
-        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY,LAYOUT_CREATEIFNEEDED));
+        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY));
         return pLayout->IsDll();
     }
 }
@@ -341,7 +341,7 @@ inline PTR_CVOID PEImage::GetNativeManifestMetadata(COUNT_T *pSize)
         return GetLoadedLayout()->GetNativeManifestMetadata(pSize);
     else
     {
-        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY,LAYOUT_CREATEIFNEEDED));
+        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY));
         return pLayout->GetNativeManifestMetadata(pSize);
     }
 }
@@ -353,7 +353,7 @@ inline PTR_CVOID PEImage::GetMetadata(COUNT_T *pSize)
         return GetLoadedLayout()->GetMetadata(pSize);
     else
     {
-        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY,LAYOUT_CREATEIFNEEDED));
+        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY));
         return pLayout->GetMetadata(pSize);
     }
 }
@@ -365,7 +365,7 @@ inline BOOL PEImage::HasContents()
         return GetLoadedLayout()->HasContents();
     else
     {
-        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY,LAYOUT_CREATEIFNEEDED));
+        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY));
         return pLayout->HasContents();
     }
 }
@@ -378,7 +378,7 @@ inline CHECK PEImage::CheckFormat()
         CHECK(GetLoadedLayout()->CheckFormat());
     else
     {
-        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY,LAYOUT_CREATEIFNEEDED));
+        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY));
         CHECK(pLayout->CheckFormat());
     }
     CHECK_OK;
@@ -424,15 +424,13 @@ inline PTR_PEImage PEImage::FindByPath(LPCWSTR pPath, BOOL isInBundle /* = TRUE 
     DWORD dwHash = CaseHashHelper(pPath, (COUNT_T) wcslen(pPath));
 #endif
     return (PEImage *) s_Images->LookupValue(dwHash, &locator);
-
 }
 
 /* static */
 inline PTR_PEImage PEImage::OpenImage(LPCWSTR pPath, MDInternalImportFlags flags /* = MDInternalImport_Default */, BundleFileLocation bundleFileLocation)
 {
-    BOOL fUseCache = !((flags & MDInternalImport_NoCache) == MDInternalImport_NoCache);
-
-    if (!fUseCache)
+    BOOL forbidCache = (flags & MDInternalImport_NoCache);
+    if (forbidCache)
     {
         PEImageHolder pImage(new PEImage);
         pImage->Init(pPath, bundleFileLocation);
@@ -442,8 +440,6 @@ inline PTR_PEImage PEImage::OpenImage(LPCWSTR pPath, MDInternalImportFlags flags
     CrstHolder holder(&s_hashLock);
 
     PEImage* found = FindByPath(pPath, bundleFileLocation.IsValid());
-
-
     if (found == (PEImage*) INVALIDENTRY)
     {
         // We did not find the entry in the Cache, and we've been asked to only use the cache.
@@ -501,7 +497,7 @@ inline BOOL PEImage::Has32BitNTHeaders()
         return GetLoadedLayout()->Has32BitNTHeaders();
     else
     {
-        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY,LAYOUT_CREATEIFNEEDED));
+        PEImageLayoutHolder pLayout(GetLayout(PEImageLayout::LAYOUT_ANY));
         return pLayout->Has32BitNTHeaders();
     }
 }
@@ -553,8 +549,7 @@ inline void PEImage::CachePEKindAndMachine()
     }
     else
     {
-        pLayout.Assign(GetLayout(PEImageLayout::LAYOUT_MAPPED|PEImageLayout::LAYOUT_FLAT,
-                                 PEImage::LAYOUT_CREATEIFNEEDED));
+        pLayout.Assign(GetLayout(PEImageLayout::LAYOUT_MAPPED|PEImageLayout::LAYOUT_FLAT));
     }
 
     // Compute result into a local variables first

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -806,7 +806,7 @@ PEImageLayout::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
 {
     WRAPPER_NO_CONTRACT;
     DAC_ENUM_VTHIS();
-    EMEM_OUT(("MEM: %p PEFile\n", dac_cast<TADDR>(this)));
+    EMEM_OUT(("MEM: %p PEAssembly\n", dac_cast<TADDR>(this)));
     PEDecoder::EnumMemoryRegions(flags,false);
 }
 #endif //DACCESS_COMPILE

--- a/src/coreclr/vm/perfinfo.cpp
+++ b/src/coreclr/vm/perfinfo.cpp
@@ -48,7 +48,7 @@ void PerfInfo::LogImage(PEAssembly* pPEAssembly, WCHAR* guid)
     SIZE_T baseAddr = 0;
     if (pPEAssembly->IsReadyToRun())
     {
-        PEImageLayout *pLoadedLayout = pPEAssembly->GetLoaded();
+        PEImageLayout *pLoadedLayout = pPEAssembly->GetLoadedLayout();
         if (pLoadedLayout)
         {
             baseAddr = (SIZE_T)pLoadedLayout->GetBase();

--- a/src/coreclr/vm/perfinfo.cpp
+++ b/src/coreclr/vm/perfinfo.cpp
@@ -27,28 +27,28 @@ PerfInfo::PerfInfo(int pid)
 }
 
 // Logs image loads into the process' perfinfo-%d.map file
-void PerfInfo::LogImage(PEFile* pFile, WCHAR* guid)
+void PerfInfo::LogImage(PEAssembly* pPEAssembly, WCHAR* guid)
 {
     CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
         MODE_PREEMPTIVE;
-        PRECONDITION(pFile != nullptr);
+        PRECONDITION(pPEAssembly != nullptr);
         PRECONDITION(guid != nullptr);
     } CONTRACTL_END;
 
     SString value;
-    const SString& path = pFile->GetPath();
+    const SString& path = pPEAssembly->GetPath();
     if (path.IsEmpty())
     {
         return;
     }
 
     SIZE_T baseAddr = 0;
-    if (pFile->IsReadyToRun())
+    if (pPEAssembly->IsReadyToRun())
     {
-        PEImageLayout *pLoadedLayout = pFile->GetLoaded();
+        PEImageLayout *pLoadedLayout = pPEAssembly->GetLoaded();
         if (pLoadedLayout)
         {
             baseAddr = (SIZE_T)pLoadedLayout->GetBase();

--- a/src/coreclr/vm/perfinfo.h
+++ b/src/coreclr/vm/perfinfo.h
@@ -22,7 +22,7 @@ class PerfInfo {
 public:
     PerfInfo(int pid);
     ~PerfInfo();
-    void LogImage(PEFile* pFile, WCHAR* guid);
+    void LogImage(PEAssembly* pPEAssembly, WCHAR* guid);
 
 private:
     CFileStream* m_Stream;

--- a/src/coreclr/vm/perfmap.cpp
+++ b/src/coreclr/vm/perfmap.cpp
@@ -219,22 +219,22 @@ void PerfMap::LogMethod(MethodDesc * pMethod, PCODE pCode, size_t codeSize, cons
 }
 
 
-void PerfMap::LogImageLoad(PEFile * pFile)
+void PerfMap::LogImageLoad(PEAssembly * pPEAssembly)
 {
     if (s_enabled)
     {
-        s_Current->LogImage(pFile);
+        s_Current->LogImage(pPEAssembly);
     }
 }
 
 // Log an image load to the map.
-void PerfMap::LogImage(PEFile * pFile)
+void PerfMap::LogImage(PEAssembly * pPEAssembly)
 {
     CONTRACTL{
         THROWS;
         GC_NOTRIGGER;
         MODE_PREEMPTIVE;
-        PRECONDITION(pFile != nullptr);
+        PRECONDITION(pPEAssembly != nullptr);
     } CONTRACTL_END;
 
 
@@ -247,9 +247,9 @@ void PerfMap::LogImage(PEFile * pFile)
     EX_TRY
     {
         WCHAR wszSignature[39];
-        GetNativeImageSignature(pFile, wszSignature, lengthof(wszSignature));
+        GetNativeImageSignature(pPEAssembly, wszSignature, lengthof(wszSignature));
 
-        m_PerfInfo->LogImage(pFile, wszSignature);
+        m_PerfInfo->LogImage(pPEAssembly, wszSignature);
     }
     EX_CATCH{} EX_END_CATCH(SwallowAllExceptions);
 }
@@ -361,10 +361,10 @@ void PerfMap::LogStubs(const char* stubType, const char* stubOwner, PCODE pCode,
     EX_CATCH{} EX_END_CATCH(SwallowAllExceptions);
 }
 
-void PerfMap::GetNativeImageSignature(PEFile * pFile, WCHAR * pwszSig, unsigned int nSigSize)
+void PerfMap::GetNativeImageSignature(PEAssembly * pPEAssembly, WCHAR * pwszSig, unsigned int nSigSize)
 {
     CONTRACTL{
-        PRECONDITION(pFile != nullptr);
+        PRECONDITION(pPEAssembly != nullptr);
         PRECONDITION(pwszSig != nullptr);
         PRECONDITION(nSigSize >= 39);
     } CONTRACTL_END;
@@ -372,7 +372,7 @@ void PerfMap::GetNativeImageSignature(PEFile * pFile, WCHAR * pwszSig, unsigned 
     // We use the MVID as the signature, since ready to run images
     // don't have a native image signature.
     GUID mvid;
-    pFile->GetMVID(&mvid);
+    pPEAssembly->GetMVID(&mvid);
     if(!StringFromGUID2(mvid, pwszSig, nSigSize))
     {
         pwszSig[0] = '\0';
@@ -417,7 +417,7 @@ void NativeImagePerfMap::LogDataForModule(Module * pModule)
 {
     STANDARD_VM_CONTRACT;
 
-    PEImageLayout * pLoadedLayout = pModule->GetFile()->GetLoaded();
+    PEImageLayout * pLoadedLayout = pModule->GetPEAssembly()->GetLoaded();
     _ASSERTE(pLoadedLayout != nullptr);
 
     ReadyToRunInfo::MethodIterator mi(pModule->GetReadyToRunInfo());

--- a/src/coreclr/vm/perfmap.cpp
+++ b/src/coreclr/vm/perfmap.cpp
@@ -417,7 +417,7 @@ void NativeImagePerfMap::LogDataForModule(Module * pModule)
 {
     STANDARD_VM_CONTRACT;
 
-    PEImageLayout * pLoadedLayout = pModule->GetPEAssembly()->GetLoaded();
+    PEImageLayout * pLoadedLayout = pModule->GetPEAssembly()->GetLoadedLayout();
     _ASSERTE(pLoadedLayout != nullptr);
 
     ReadyToRunInfo::MethodIterator mi(pModule->GetReadyToRunInfo());

--- a/src/coreclr/vm/perfmap.h
+++ b/src/coreclr/vm/perfmap.h
@@ -57,17 +57,17 @@ protected:
     void LogMethod(MethodDesc * pMethod, PCODE pCode, size_t codeSize, const char *optimizationTier);
 
     // Does the actual work to log an image
-    void LogImage(PEFile * pFile);
+    void LogImage(PEAssembly * pPEAssembly);
 
     // Get the image signature and store it as a string.
-    static void GetNativeImageSignature(PEFile * pFile, WCHAR * pwszSig, unsigned int nSigSize);
+    static void GetNativeImageSignature(PEAssembly * pPEAssembly, WCHAR * pwszSig, unsigned int nSigSize);
 
 public:
     // Initialize the map for the current process.
     static void Initialize();
 
     // Log a native image load to the map.
-    static void LogImageLoad(PEFile * pFile);
+    static void LogImageLoad(PEAssembly * pPEAssembly);
 
     // Log a JIT compiled method to the map.
     static void LogJITCompiledMethod(MethodDesc * pMethod, PCODE pCode, size_t codeSize, PrepareCodeConfig *pConfig);

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -4020,11 +4020,6 @@ DWORD ProfToEEInterfaceImpl::GetModuleFlags(Module * pModule)
         dwRet |= COR_PRF_MODULE_COLLECTIBLE;
     }
 
-    if (pModule->IsResource())
-    {
-        dwRet |= COR_PRF_MODULE_RESOURCE;
-    }
-
     return dwRet;
 }
 
@@ -4242,14 +4237,6 @@ HRESULT ProfToEEInterfaceImpl::GetModuleMetaData(ModuleID    moduleId,
     if (pModule->IsBeingUnloaded())
     {
         return CORPROF_E_DATAINCOMPLETE;
-    }
-
-    // Make sure we can get the importer first
-    if (pModule->IsResource())
-    {
-        if (ppOut)
-            *ppOut = NULL;
-        return S_FALSE;
     }
 
     // Decide which type of open mode we are in to see which you require.
@@ -4482,7 +4469,7 @@ HRESULT ProfToEEInterfaceImpl::SetILFunctionBody(ModuleID    moduleId,
         // Yay!
         MODE_ANY;
 
-        // Module::SetDynamicIL & PEFile::CheckLoaded & PEFile::GetEmitter take locks
+        // Module::SetDynamicIL & PEFile::GetEmitter take locks
         CAN_TAKE_LOCK;
 
     }

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -3997,9 +3997,9 @@ DWORD ProfToEEInterfaceImpl::GetModuleFlags(Module * pModule)
     }
 #endif
     // Not Dynamic.
-    if (pPEAssembly->HasILimage())
+    if (pPEAssembly->HasPEImage())
     {
-        PEImage * pILImage = pPEAssembly->GetILimage();
+        PEImage * pILImage = pPEAssembly->GetPEImage();
         if (pILImage->IsFile())
         {
             dwRet |= COR_PRF_MODULE_DISK;
@@ -4286,7 +4286,7 @@ HRESULT ProfToEEInterfaceImpl::GetILFunctionBody(ModuleID    moduleId,
         // Yay!
         MODE_ANY;
 
-        // PEAssembly::CheckLoaded & Module::GetDynamicIL both take a lock
+        // PEAssembly::HasLoadedPEImage & Module::GetDynamicIL both take a lock
         CAN_TAKE_LOCK;
 
     }
@@ -4326,7 +4326,7 @@ HRESULT ProfToEEInterfaceImpl::GetILFunctionBody(ModuleID    moduleId,
 
     PEAssembly *pPEAssembly = pModule->GetPEAssembly();
 
-    if (!pPEAssembly->CheckLoaded())
+    if (!pPEAssembly->HasLoadedPEImage())
         return (CORPROF_E_DATAINCOMPLETE);
 
     LPCBYTE pbMethod = NULL;
@@ -4436,7 +4436,7 @@ HRESULT ProfToEEInterfaceImpl::GetILFunctionBodyAllocator(ModuleID         modul
     Module * pModule = (Module *) moduleId;
 
     if (pModule->IsBeingUnloaded() ||
-        !pModule->GetPEAssembly()->CheckLoaded())
+        !pModule->GetPEAssembly()->HasLoadedPEImage())
     {
         return (CORPROF_E_DATAINCOMPLETE);
     }

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -4286,7 +4286,7 @@ HRESULT ProfToEEInterfaceImpl::GetILFunctionBody(ModuleID    moduleId,
         // Yay!
         MODE_ANY;
 
-        // PEAssembly::HasLoadedPEImage & Module::GetDynamicIL both take a lock
+        // Module::GetDynamicIL both take a lock
         CAN_TAKE_LOCK;
 
     }

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -3996,10 +3996,10 @@ DWORD ProfToEEInterfaceImpl::GetModuleFlags(Module * pModule)
         dwRet |= (COR_PRF_MODULE_DISK | COR_PRF_MODULE_NGEN);
     }
 #endif
-    // Not NGEN or ReadyToRun.
-    if (pPEAssembly->HasOpenedILimage())
+    // Not Dynamic.
+    if (pPEAssembly->HasILimage())
     {
-        PEImage * pILImage = pPEAssembly->GetOpenedILimage();
+        PEImage * pILImage = pPEAssembly->GetILimage();
         if (pILImage->IsFile())
         {
             dwRet |= COR_PRF_MODULE_DISK;

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -4004,7 +4004,7 @@ DWORD ProfToEEInterfaceImpl::GetModuleFlags(Module * pModule)
         {
             dwRet |= COR_PRF_MODULE_DISK;
         }
-        if (pPEAssembly->GetLoadedIL()->IsFlat())
+        if (pPEAssembly->GetLoadedLayout()->IsFlat())
         {
             dwRet |= COR_PRF_MODULE_FLAT_LAYOUT;
         }

--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -535,7 +535,7 @@ PTR_ReadyToRunInfo ReadyToRunInfo::Initialize(Module * pModule, AllocMemTracker 
         return NULL;
     }
 
-    PEImageLayout * pLayout = pFile->GetLoadedIL();
+    PEImageLayout * pLayout = pFile->GetLoadedLayout();
     if (!pLayout->HasReadyToRunHeader())
     {
         DoLog("Ready to Run header not found");

--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -529,9 +529,9 @@ PTR_ReadyToRunInfo ReadyToRunInfo::Initialize(Module * pModule, AllocMemTracker 
         return NULL;
     }
 
-    if (!pFile->HasLoadedIL())
+    if (!pFile->HasLoadedPEImage())
     {
-        DoLog("Ready to Run disabled - no loaded IL image");
+        DoLog("Ready to Run disabled - no loaded PE image");
         return NULL;
     }
 

--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -392,7 +392,7 @@ BOOL ReadyToRunInfo::IsReadyToRunEnabled()
 // Any other value: Handle of the log file.
 static  FILE * volatile s_r2rLogFile = (FILE *)(-1);
 
-static void LogR2r(const char *msg, PEFile *pFile)
+static void LogR2r(const char *msg, PEAssembly *pPEAssembly)
 {
     STANDARD_VM_CONTRACT;
 
@@ -430,7 +430,7 @@ static void LogR2r(const char *msg, PEFile *pFile)
     if (r2rLogFile == NULL)
         return;
 
-    fprintf(r2rLogFile, "%s: \"%S\".\n", msg, pFile->GetPath().GetUnicode());
+    fprintf(r2rLogFile, "%s: \"%S\".\n", msg, pPEAssembly->GetPath().GetUnicode());
     fflush(r2rLogFile);
 }
 
@@ -503,7 +503,7 @@ static NativeImage *AcquireCompositeImage(Module * pModule, PEImageLayout * pLay
 
     if (ownerCompositeExecutableName != NULL)
     {
-        AssemblyBinder *binder = pModule->GetFile()->GetAssemblyBinder();
+        AssemblyBinder *binder = pModule->GetPEAssembly()->GetAssemblyBinder();
         return binder->LoadNativeImage(pModule, ownerCompositeExecutableName);
     }
 
@@ -514,7 +514,7 @@ PTR_ReadyToRunInfo ReadyToRunInfo::Initialize(Module * pModule, AllocMemTracker 
 {
     STANDARD_VM_CONTRACT;
 
-    PEFile * pFile = pModule->GetFile();
+    PEAssembly * pFile = pModule->GetPEAssembly();
 
     if (!IsReadyToRunEnabled())
     {

--- a/src/coreclr/vm/runtimehandles.cpp
+++ b/src/coreclr/vm/runtimehandles.cpp
@@ -2742,10 +2742,6 @@ FCIMPL1(INT32, ModuleHandle::GetMDStreamVersion, ReflectModuleBaseObject * pModu
         FCThrowRes(kArgumentNullException, W("Arg_InvalidHandle"));
 
     Module *pModule = refModule->GetModule();
-
-    if (pModule->IsResource())
-        return 0;
-
     return pModule->GetMDImport()->GetMetadataStreamVersion();
 }
 FCIMPLEND
@@ -2787,10 +2783,6 @@ FCIMPL1(INT32, ModuleHandle::GetToken, ReflectModuleBaseObject * pModuleUNSAFE) 
         FCThrowRes(kArgumentNullException, W("Arg_InvalidHandle"));
 
     Module *pModule = refModule->GetModule();
-
-    if (pModule->IsResource())
-        return mdModuleNil;
-
     return pModule->GetMDImport()->GetModuleFromScope();
 }
 FCIMPLEND
@@ -2805,10 +2797,6 @@ FCIMPL1(IMDInternalImport*, ModuleHandle::GetMetadataImport, ReflectModuleBaseOb
         FCThrowRes(kArgumentNullException, W("Arg_InvalidHandle"));
 
     Module *pModule = refModule->GetModule();
-
-    if (pModule->IsResource())
-        return NULL;
-
     return pModule->GetMDImport();
 }
 FCIMPLEND

--- a/src/coreclr/vm/runtimehandles.cpp
+++ b/src/coreclr/vm/runtimehandles.cpp
@@ -2728,7 +2728,7 @@ void QCALLTYPE ModuleHandle::GetPEKind(QCall::ModuleHandle pModule, DWORD* pdwPE
     QCALL_CONTRACT;
 
     BEGIN_QCALL;
-    pModule->GetFile()->GetPEKindAndMachine(pdwPEKind, pdwMachine);
+    pModule->GetPEAssembly()->GetPEKindAndMachine(pdwPEKind, pdwMachine);
     END_QCALL;
 }
 

--- a/src/coreclr/vm/siginfo.cpp
+++ b/src/coreclr/vm/siginfo.cpp
@@ -3547,7 +3547,7 @@ ErrExit:
 #ifdef DACCESS_COMPILE
     ThrowHR(hr);
 #else
-    EEFileLoadException::Throw(pModule2->GetFile(), hr);
+    EEFileLoadException::Throw(pModule2->GetPEAssembly(), hr);
 #endif //!DACCESS_COMPILE
 } // CompareTypeTokens
 

--- a/src/coreclr/vm/typeparse.cpp
+++ b/src/coreclr/vm/typeparse.cpp
@@ -1479,7 +1479,7 @@ DomainAssembly * LoadDomainAssembly(
     {
         // If the requesting assembly has Fallback LoadContext binder available,
         // then set it up in the AssemblySpec.
-        PEFile *pRequestingAssemblyManifestFile = pRequestingAssembly->GetManifestFile();
+        PEAssembly *pRequestingAssemblyManifestFile = pRequestingAssembly->GetManifestFile();
         spec.SetFallbackBinderForRequestingAssembly(pRequestingAssemblyManifestFile->GetFallbackBinder());
     }
 

--- a/src/coreclr/vm/typeparse.cpp
+++ b/src/coreclr/vm/typeparse.cpp
@@ -1415,7 +1415,7 @@ TypeName::GetTypeHaveAssemblyHelper(
                 if (pManifestModule->LookupFile(mdFile))
                     continue;
 
-                pManifestModule->LoadModule(GetAppDomain(), mdFile, FALSE);
+                pManifestModule->LoadModule(GetAppDomain(), mdFile);
 
                 th = GetTypeHaveAssemblyHelper(pAssembly, bThrowIfNotFound, bIgnoreCase, NULL, FALSE);
 


### PR DESCRIPTION
More tidy-up and removal of no longer necessary code.

- [x] moved default binder allocation to `AppDomain::Create`
As discussed in the previous PR.
- [x] folded `PEFile` into `PEAssembly`. We only have `PEAssembly` now.
All the PE files we deal with are assemblies and `PEFile` is unnecessary abstraction that was created to support modules, resource-only files, `IStream` things provided by SQL host, etc... None of that exists any more.
- [x] Renames and cleanups related to the `PEAssembly` change.
Unlike `PEFile`, `PEAssembly` is always an assembly, never a native Resource PE, always has metadata, has `MDImport` right after construction, its `PEImage` is opened at construction and also has metadata, and so on... 
Many checks and conditions could be simplified.
- [x] `AppDomain` no longer has a scenario when a hosted assembly is updated after publishing, so the code supporting such scenario can be removed.
- [x] Some cleanup of `PEImage` - moved instance filed declarations together, sorted related public/private members, removed unused/redundant stuff. 
I.E. `GetLayout` is always called with `LAYOUT_CREATEIFNEEDED`, so the flag is unnecessary, and similar changes. Overall functionality is the same as before. 
