### PR TITLE
Prevent cache from being resized

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -137,9 +137,19 @@ namespace Microsoft.Extensions.Caching.Memory
                 priorEntry.SetExpired(EvictionReason.Replaced);
             }
 
-            bool exceedsCapacity = UpdateCacheSizeExceedsCapacity(entry);
+            if (entry.CheckExpired(utcNow))
+            {
+                entry.InvokeEvictionCallbacks();
+                if (priorEntry != null)
+                {
+                    RemoveEntry(priorEntry);
+                }
+                StartScanForExpiredItemsIfNeeded(utcNow);
+                return;
+            }
 
-            if (!entry.CheckExpired(utcNow) && !exceedsCapacity)
+            bool exceedsCapacity = UpdateCacheSizeExceedsCapacity(entry);
+            if (!exceedsCapacity)
             {
                 bool entryAdded = false;
 
@@ -192,22 +202,8 @@ namespace Microsoft.Extensions.Caching.Memory
             }
             else
             {
-                if (exceedsCapacity)
-                {
-                    // The entry was not added due to overcapacity
-                    entry.SetExpired(EvictionReason.Capacity);
-
-                    TriggerOvercapacityCompaction();
-                }
-                else
-                {
-                    if (_options.SizeLimit.HasValue)
-                    {
-                        // Entry could not be added due to being expired, reset cache size
-                        Interlocked.Add(ref _cacheSize, -entry.Size.Value);
-                    }
-                }
-
+                entry.SetExpired(EvictionReason.Capacity);
+                TriggerOvercapacityCompaction();
                 entry.InvokeEvictionCallbacks();
                 if (priorEntry != null)
                 {


### PR DESCRIPTION
In the current implementation, additional work is done if a cache entry has already expired, but the cache is large enough to accept it.  Consider the case when `exceedsCapacity = false` and `entry.CheckExpired` returns true. The cache first [grows](https://github.com/mapogolions/runtime/blob/234b7891e4bd400f0c1e1cdea808a5bf144f49ee/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs#L140) even if the entry has expired and then [shrinks](https://github.com/mapogolions/runtime/blob/234b7891e4bd400f0c1e1cdea808a5bf144f49ee/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs#L207). It would be great in this case not to perform any manipulations regarding the cache size.
The approach I suggested would only change that expired entries won't be able to trigger cache compaction. (`exceedsCapacity = true` and `entry.CheckExpired` returns true)