### PR TITLE
Use cmakedefine in eglib config

### DIFF
--- a/src/mono/cmake/eglib-config.h.cmake.in
+++ b/src/mono/cmake/eglib-config.h.cmake.in
@@ -33,11 +33,14 @@
 
 #else
 
+#cmakedefine HAVE_ALLOCA_H 1
+#cmakedefine HAVE_UNISTD_H 1
+
 #ifdef HAVE_ALLOCA_H
 #define G_HAVE_ALLOCA_H
 #endif
 
-#if @HAVE_UNISTD_H@ == 1
+#if HAVE_UNISTD_H
 #define G_HAVE_UNISTD_H
 #endif
 


### PR DESCRIPTION
Both `config.h.in` and `eglib-config.h.cmake.in` are now configured via
cmake. However, only `config.h.in` is using `cmakedefine*` and
`eglib-config.h` was having no effect on introspection result.