### PR TITLE
Skip ExportPkcs7_Empty test on mobile platforms

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_x509.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Android/pal_x509.c
@@ -154,7 +154,6 @@ int32_t AndroidCryptoNative_X509ExportPkcs7(jobject* /*X509Certificate[]*/ certs
                                             int32_t* outLen)
 {
     abort_if_invalid_pointer_argument (certs);
-    abort_if_negative_integer_argument (certsLen);
 
     JNIEnv* env = GetJNIEnv();
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -1549,6 +1549,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [SkipOnPlatform(PlatformSupport.MobileAppleCrypto, "PKCS#7 export is not available")]
         public static void ExportPkcs7_Empty()
         {
             X509Certificate2Collection cc = new X509Certificate2Collection();


### PR DESCRIPTION
The test made it through and was failing on CI.  PKCS#7 export is not supported on mobile platforms.