### PR TITLE
Add the argument checks to Unix-part of Mutex.OpenExistingWorker

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Mutex.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Mutex.Unix.cs
@@ -29,6 +29,16 @@ namespace System.Threading
 
         private static OpenExistingResult OpenExistingWorker(string name, out Mutex? result)
         {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (name.Length == 0)
+            {
+                throw new ArgumentException(SR.Argument_EmptyName, nameof(name));
+            }
+
             OpenExistingResult status = WaitSubsystem.OpenNamedMutex(name, out SafeWaitHandle? safeWaitHandle);
             result = status == OpenExistingResult.Success ? new Mutex(safeWaitHandle!) : null;
             return status;


### PR DESCRIPTION
The test run in https://github.com/dotnet/runtime/pull/59503 uncovered some System.Threading.Tests failures, e.g.:
 ```
<failure exception-type="Xunit.Sdk.EqualException">
    <message><![CDATA[Assert.Equal() Failure\n          ↓ (pos 0)\nExpected: name\nActual:   key\n          ↑ (pos 0)]]></message>
    <stack-trace><![CDATA[   at System.AssertExtensions.Throws[ArgumentNullException](String expectedParamName, Func`1 testCode)
        at System.Threading.Tests.MutexTests.OpenExisting_InvalidNames()
        at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)]]></stack-trace>
</failure>

...

<failure exception-type="Xunit.Sdk.ThrowsException">
    <message><![CDATA[Assert.Throws() Failure\nExpected: typeof(System.ArgumentException)\nActual:   (No exception was thrown)]]></message>
    <stack-trace><![CDATA[   at System.AssertExtensions.Throws[ArgumentException](String netCoreParamName, String netFxParamName, Func`1 testCode)
        at System.Threading.Tests.MutexTests.Ctor_InvalidNames_Unix()
        at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)]]></stack-trace>
</failure>

```

The reason seems to be that the unix-part of related code has no checks for null/empty string arguments which windows-part [does](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Threading/Mutex.Windows.cs#L44-L52) so that [the underlying code](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Threading/WaitSubsystem.WaitableObject.Unix.cs#L115) throws 