### PR TITLE
Turn on XHarness telemetry for mono runtime tests

### DIFF
--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -119,6 +119,7 @@
 
   <PropertyGroup Condition="'$(TargetOS)' == 'Android' or '$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'iOSSimulator'">
     <IncludeXHarnessCli>true</IncludeXHarnessCli>
+    <EnableXHarnessTelemetry>true</EnableXHarnessTelemetry>
   </PropertyGroup>
 
   <Import Project="testgrouping.proj" />


### PR DESCRIPTION
This is to start collecting better data on the Android arm64 tests from the rolling build