### PR TITLE
delay locking in `ConcurrentDictionary.GrowTable` until necessary

### DIFF
--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -1987,9 +1987,6 @@ namespace System.Collections.Concurrent
                     _budget = int.MaxValue;
                 }
 
-                // Now acquire all other locks for the table
-                AcquireLocks(1, tables._locks.Length, ref locksAcquired);
-
                 object[] newLocks = tables._locks;
 
                 // Add more locks
@@ -2006,6 +2003,9 @@ namespace System.Collections.Concurrent
                 var newBuckets = new Node[newLength];
                 var newCountPerLock = new int[newLocks.Length];
                 var newTables = new Tables(newBuckets, newLocks, newCountPerLock);
+
+                // Now acquire all other locks for the table
+                AcquireLocks(1, tables._locks.Length, ref locksAcquired);
 
                 // Copy all data into a new table, creating new nodes for all elements
                 foreach (Node? bucket in tables._buckets)


### PR DESCRIPTION
Lock 0 has already been acquired, meaning that no-one else can be resizing, so, from what I can tell, we can safely create the new locks and table *before* locking the rest of the table. Acquire all locks is only required when copying over the buckets.