### PR TITLE
Antigen: Change Antigen's helixqueue to public

### DIFF
--- a/eng/pipelines/common/download-specific-artifact-step.yml
+++ b/eng/pipelines/common/download-specific-artifact-step.yml
@@ -11,11 +11,11 @@ steps:
     displayName: 'Download specific ${{ parameters.displayName }}'
     inputs:
       buildType: specific
-      project:  'internal' # 'internal' or 'public'
+      project:  'public' # 'internal' or 'public'
       pipeline: 'Antigen'
       buildVersionToDownload: specific
-      branchName: 'kpathak/antigen-ci'
-      buildId: '1385069'
+      branchName: 'refs/pull/59376/head'
+      buildId: '1387378'
       downloadType: single
       downloadPath: '$(Build.SourcesDirectory)/__download__'
       artifactName: '${{ parameters.artifactName }}'

--- a/eng/pipelines/coreclr/exploratory.yml
+++ b/eng/pipelines/coreclr/exploratory.yml
@@ -47,5 +47,3 @@ jobs:
     jobParameters:
       testGroup: outerloop
       liveLibrariesBuildConfig: Release
-      collectionType: pmi
-      collectionName: libraries

--- a/eng/pipelines/coreclr/exploratory.yml
+++ b/eng/pipelines/coreclr/exploratory.yml
@@ -12,22 +12,22 @@ schedules:
 
 jobs:
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-    buildConfig: checked
-    platforms:
-    # Linux tests are built on the OSX machines.
-    # - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
-    - windows_x64
-    - windows_x86
-    - windows_arm64
-    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-    jobParameters:
-      testGroup: outerloop
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+#     buildConfig: checked
+#     platforms:
+#     # Linux tests are built on the OSX machines.
+#     # - OSX_x64
+#     - Linux_arm
+#     - Linux_arm64
+#     - Linux_x64
+#     - windows_x64
+#     - windows_x86
+#     - windows_arm64
+#     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+#     jobParameters:
+#       testGroup: outerloop
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:

--- a/eng/pipelines/coreclr/exploratory.yml
+++ b/eng/pipelines/coreclr/exploratory.yml
@@ -12,36 +12,36 @@ schedules:
 
 jobs:
 
-# - template: /eng/pipelines/common/platform-matrix.yml
-#   parameters:
-#     jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-#     buildConfig: checked
-#     platforms:
-#     # Linux tests are built on the OSX machines.
-#     # - OSX_x64
-#     - Linux_arm
-#     - Linux_arm64
-#     - Linux_x64
-#     - windows_x64
-#     - windows_x86
-#     - windows_arm64
-#     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
-#     jobParameters:
-#       testGroup: outerloop
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+    buildConfig: checked
+    platforms:
+    # Linux tests are built on the OSX machines.
+    # - OSX_x64
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
+    - windows_x64
+    - windows_x86
+    - windows_arm64
+    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+    jobParameters:
+      testGroup: outerloop
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
     jobTemplate: /eng/pipelines/coreclr/templates/jit-exploratory-job.yml
     buildConfig: checked
     platforms:
-    # # Linux tests are built on the OSX machines.
-    # # - OSX_x64
-    # - Linux_arm
-    # - Linux_arm64
-    # - Linux_x64
+    # Linux tests are built on the OSX machines.
+    # - OSX_x64
+    - Linux_arm
+    - Linux_arm64
+    - Linux_x64
     - windows_x64
-    # - windows_x86
-    # - windows_arm64
+    - windows_x86
+    - windows_arm64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:

--- a/eng/pipelines/coreclr/exploratory.yml
+++ b/eng/pipelines/coreclr/exploratory.yml
@@ -34,14 +34,14 @@ jobs:
     jobTemplate: /eng/pipelines/coreclr/templates/jit-exploratory-job.yml
     buildConfig: checked
     platforms:
-    # Linux tests are built on the OSX machines.
-    # - OSX_x64
-    - Linux_arm
-    - Linux_arm64
-    - Linux_x64
+    # # Linux tests are built on the OSX machines.
+    # # - OSX_x64
+    # - Linux_arm
+    # - Linux_arm64
+    # - Linux_x64
     - windows_x64
-    - windows_x86
-    - windows_arm64
+    # - windows_x86
+    # - windows_arm64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     jobParameters:

--- a/eng/pipelines/coreclr/templates/jit-exploratory-job.yml
+++ b/eng/pipelines/coreclr/templates/jit-exploratory-job.yml
@@ -42,10 +42,10 @@ jobs:
     testGroup: ${{ parameters.testGroup }}
     helixQueues: ${{ parameters.helixQueues }}
     additionalSetupParameters: ${{ parameters.additionalSetupParameters }}
-    # Test job depends on the corresponding build job
-    dependsOn:
-    - ${{ format('coreclr_{0}_product_build_{1}{2}_{3}_{4}', parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-    - ${{ format('libraries_build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.liveLibrariesBuildConfig) }}
+    # # Test job depends on the corresponding build job
+    # dependsOn:
+    # - ${{ format('coreclr_{0}_product_build_{1}{2}_{3}_{4}', parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
+    # - ${{ format('libraries_build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.liveLibrariesBuildConfig) }}
 
     variables: ${{ parameters.variables }}
 
@@ -55,7 +55,7 @@ jobs:
     # Extra steps that will be passed to the exploratory template and run before sending the job to helix (all of which is done in the template)
 
     # Optionally download live-built libraries
-    - template: /eng/pipelines/common/download-artifact-step.yml
+    - template: /eng/pipelines/common/download-specific-artifact-step.yml
       parameters:
         unpackFolder: $(librariesDownloadDir)
         cleanUnpackFolder: false
@@ -64,7 +64,7 @@ jobs:
         displayName: 'live-built libraries'
 
     # Download coreclr
-    - template: /eng/pipelines/common/download-artifact-step.yml
+    - template: /eng/pipelines/common/download-specific-artifact-step.yml
       parameters:
         unpackFolder: $(buildProductRootFolderPath)
         artifactFileName: '$(buildProductArtifactName)$(archiveExtension)'

--- a/eng/pipelines/coreclr/templates/jit-exploratory-job.yml
+++ b/eng/pipelines/coreclr/templates/jit-exploratory-job.yml
@@ -42,10 +42,10 @@ jobs:
     testGroup: ${{ parameters.testGroup }}
     helixQueues: ${{ parameters.helixQueues }}
     additionalSetupParameters: ${{ parameters.additionalSetupParameters }}
-    # # Test job depends on the corresponding build job
-    # dependsOn:
-    # - ${{ format('coreclr_{0}_product_build_{1}{2}_{3}_{4}', parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-    # - ${{ format('libraries_build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.liveLibrariesBuildConfig) }}
+    # Test job depends on the corresponding build job
+    dependsOn:
+    - ${{ format('coreclr_{0}_product_build_{1}{2}_{3}_{4}', parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
+    - ${{ format('libraries_build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.liveLibrariesBuildConfig) }}
 
     variables: ${{ parameters.variables }}
 
@@ -55,7 +55,7 @@ jobs:
     # Extra steps that will be passed to the exploratory template and run before sending the job to helix (all of which is done in the template)
 
     # Optionally download live-built libraries
-    - template: /eng/pipelines/common/download-specific-artifact-step.yml
+    - template: /eng/pipelines/common/download-artifact-step.yml
       parameters:
         unpackFolder: $(librariesDownloadDir)
         cleanUnpackFolder: false
@@ -64,7 +64,7 @@ jobs:
         displayName: 'live-built libraries'
 
     # Download coreclr
-    - template: /eng/pipelines/common/download-specific-artifact-step.yml
+    - template: /eng/pipelines/common/download-artifact-step.yml
       parameters:
         unpackFolder: $(buildProductRootFolderPath)
         artifactFileName: '$(buildProductArtifactName)$(archiveExtension)'

--- a/eng/pipelines/coreclr/templates/jit-exploratory-job.yml
+++ b/eng/pipelines/coreclr/templates/jit-exploratory-job.yml
@@ -17,8 +17,6 @@ parameters:
   runKind: ''
   runJobTemplate: '/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml'
   additionalSetupParameters: ''
-  collectionType: ''
-  collectionName: ''
 
 ### Exploratory job
 
@@ -42,8 +40,6 @@ jobs:
     codeGenType: ${{ parameters.codeGenType }}
     runKind: ${{ parameters.runKind }}
     testGroup: ${{ parameters.testGroup }}
-    collectionType: ${{ parameters.collectionType }}
-    collectionName: ${{ parameters.collectionName }}
     helixQueues: ${{ parameters.helixQueues }}
     additionalSetupParameters: ${{ parameters.additionalSetupParameters }}
     # Test job depends on the corresponding build job

--- a/eng/pipelines/coreclr/templates/jit-exploratory-job.yml
+++ b/eng/pipelines/coreclr/templates/jit-exploratory-job.yml
@@ -9,6 +9,7 @@ parameters:
   framework: net6.0 # Specify the appropriate framework when running release branches (ie netcoreapp3.0 for release/3.0)
   liveLibrariesBuildConfig: ''
   variables: {}
+  helixQueues: ''
   runtimeType: 'coreclr'
   pool: ''
   codeGenType: 'JIT'
@@ -43,6 +44,7 @@ jobs:
     testGroup: ${{ parameters.testGroup }}
     collectionType: ${{ parameters.collectionType }}
     collectionName: ${{ parameters.collectionName }}
+    helixQueues: ${{ parameters.helixQueues }}
     additionalSetupParameters: ${{ parameters.additionalSetupParameters }}
     # Test job depends on the corresponding build job
     dependsOn:

--- a/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
+++ b/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
@@ -100,7 +100,7 @@ jobs:
         HelixType: 'build/tests/'
         HelixTargetQueues: ${{ join(',', parameters.helixQueues) }}
         HelixPreCommands: $(HelixPreCommand)
-        creator: $(Build.DefinitionName)
+        creator: dotnet-bot
         WorkItemTimeout: 2:30 # 2.5 hours
         WorkItemDirectory: '$(WorkItemDirectory)'
         CorrelationPayloadDirectory: '$(CorrelationPayloadDirectory)'

--- a/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
+++ b/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
@@ -100,7 +100,7 @@ jobs:
         HelixType: 'build/tests/'
         HelixTargetQueues: ${{ join(',', parameters.helixQueues) }}
         HelixPreCommands: $(HelixPreCommand)
-        Creator: dotnet-bot
+        Creator: 'dotnet-bot'
         WorkItemTimeout: 2:30 # 2.5 hours
         WorkItemDirectory: '$(WorkItemDirectory)'
         CorrelationPayloadDirectory: '$(CorrelationPayloadDirectory)'

--- a/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
+++ b/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
@@ -137,3 +137,10 @@ jobs:
 
     - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/antigen_unique_issues.py -issues_directory $(IssuesSummaryLocation)
       displayName: ${{ format('Print unique issues ({0})', parameters.osGroup) }}
+
+    - task: PublishPipelineArtifact@1
+      displayName: Publish Antigen build logs
+      inputs:
+        targetPath: $(Build.SourcesDirectory)/artifacts/log
+        artifactName: 'Antigen_BuildLogs__$(archType)_$(buildConfig)'
+      condition: always()

--- a/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
+++ b/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
@@ -102,7 +102,7 @@ jobs:
         HelixType: 'build/tests/'
         HelixTargetQueues: ${{ join(',', parameters.helixQueues) }}
         HelixPreCommands: $(HelixPreCommand)
-        Creator: $(Creator)
+        creator: $(Build.DefinitionName)
         WorkItemTimeout: 2:30 # 2.5 hours
         WorkItemDirectory: '$(WorkItemDirectory)'
         CorrelationPayloadDirectory: '$(CorrelationPayloadDirectory)'

--- a/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
+++ b/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
@@ -100,7 +100,7 @@ jobs:
         HelixType: 'build/tests/'
         HelixTargetQueues: ${{ join(',', parameters.helixQueues) }}
         HelixPreCommands: $(HelixPreCommand)
-        creator: dotnet-bot
+        Creator: dotnet-bot
         WorkItemTimeout: 2:30 # 2.5 hours
         WorkItemDirectory: '$(WorkItemDirectory)'
         CorrelationPayloadDirectory: '$(CorrelationPayloadDirectory)'

--- a/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
+++ b/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
@@ -20,8 +20,6 @@ parameters:
   codeGenType: 'JIT'              # optional -- Decides on the codegen technology if running on mono
   runKind: ''                     # required -- test category
   helixQueues: ''                 # required -- Helix queue
-  collectionType: ''
-  collectionName: ''
   dependOnEvaluatePaths: false
 
 jobs:

--- a/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
+++ b/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
@@ -94,17 +94,17 @@ jobs:
       displayName: ${{ format('Antigen setup ({0}-{1})', parameters.osGroup, parameters.archType) }}
 
       # Run exploratory tool in helix
-    - template: /eng/pipelines/coreclr/templates/superpmi-send-to-helix.yml
+    - template: /eng/pipelines/common/templates/runtimes/send-to-helix-step.yml
       parameters:
         HelixSource: '$(HelixSourcePrefix)/$(Build.Repository.Name)/$(Build.SourceBranch)' # sources must start with pr/, official/, prodcon/, or agent/
         HelixType: 'build/tests/'
         HelixTargetQueues: ${{ join(',', parameters.helixQueues) }}
         HelixPreCommands: $(HelixPreCommand)
-        Creator: 'dotnet-bot'
+        creator: dotnet-bot
         WorkItemTimeout: 2:30 # 2.5 hours
         WorkItemDirectory: '$(WorkItemDirectory)'
         CorrelationPayloadDirectory: '$(CorrelationPayloadDirectory)'
-        ProjectFile: 'exploratory.proj'
+        helixProjectArguments: '$(Build.SourcesDirectory)/src/coreclr/scripts/exploratory.proj'
         BuildConfig: ${{ parameters.buildConfig }}
         osGroup: ${{ parameters.osGroup }}
         RunConfiguration: '$(RunConfiguration)'

--- a/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
+++ b/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
@@ -110,7 +110,7 @@ jobs:
         osGroup: ${{ parameters.osGroup }}
         RunConfiguration: '$(RunConfiguration)'
         ToolName: '$(ToolName)'
-        continueOnError: true # Run the future step i.e. merge-mch step even if this step fails.
+        continueOnError: true
 
     - template: /eng/pipelines/common/upload-artifact-step.yml
       parameters:
@@ -138,6 +138,7 @@ jobs:
 
     - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/antigen_unique_issues.py -issues_directory $(IssuesSummaryLocation)
       displayName: ${{ format('Print unique issues ({0})', parameters.osGroup) }}
+      continueOnError: true
 
     - task: PublishPipelineArtifact@1
       displayName: Publish Antigen build logs

--- a/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
+++ b/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
@@ -96,6 +96,7 @@ jobs:
       # Run exploratory tool in helix
     - template: /eng/pipelines/common/templates/runtimes/send-to-helix-step.yml
       parameters:
+        displayName: 'Send job to Helix'
         helixBuild: $(Build.BuildNumber)
         helixSource: $(_HelixSource)
         helixType: 'build/tests/'

--- a/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
+++ b/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
@@ -19,6 +19,7 @@ parameters:
   runtimeType: 'coreclr'          # optional -- Sets the runtime as coreclr or mono
   codeGenType: 'JIT'              # optional -- Decides on the codegen technology if running on mono
   runKind: ''                     # required -- test category
+  helixQueues: ''                 # required -- Helix queue
   collectionType: ''
   collectionName: ''
   dependOnEvaluatePaths: false
@@ -98,9 +99,8 @@ jobs:
     - template: /eng/pipelines/coreclr/templates/superpmi-send-to-helix.yml
       parameters:
         HelixSource: '$(HelixSourcePrefix)/$(Build.Repository.Name)/$(Build.SourceBranch)' # sources must start with pr/, official/, prodcon/, or agent/
-        HelixType: 'test/superpmi/$(CollectionName)/$(CollectionType)/$(_Framework)/$(Architecture)'
-        HelixAccessToken: $(HelixApiAccessToken)
-        HelixTargetQueues: $(Queue)
+        HelixType: 'build/tests/'
+        HelixTargetQueues: ${{ join(',', parameters.helixQueues) }}
         HelixPreCommands: $(HelixPreCommand)
         Creator: $(Creator)
         WorkItemTimeout: 2:30 # 2.5 hours

--- a/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
+++ b/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
@@ -96,6 +96,7 @@ jobs:
       # Run exploratory tool in helix
     - template: /eng/pipelines/common/templates/runtimes/send-to-helix-step.yml
       parameters:
+        helixBuild: $(Build.BuildNumber)
         helixSource: $(_HelixSource)
         helixType: 'build/tests/'
         helixQueues: ${{ join(',', parameters.helixQueues) }}

--- a/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
+++ b/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
@@ -96,10 +96,9 @@ jobs:
       # Run exploratory tool in helix
     - template: /eng/pipelines/common/templates/runtimes/send-to-helix-step.yml
       parameters:
-        HelixSource: '$(HelixSourcePrefix)/$(Build.Repository.Name)/$(Build.SourceBranch)' # sources must start with pr/, official/, prodcon/, or agent/
-        HelixType: 'build/tests/'
-        HelixTargetQueues: ${{ join(',', parameters.helixQueues) }}
-        HelixPreCommands: $(HelixPreCommand)
+        helixSource: $(_HelixSource)
+        helixType: 'build/tests/'
+        helixQueues: ${{ join(',', parameters.helixQueues) }}
         creator: dotnet-bot
         WorkItemTimeout: 2:30 # 2.5 hours
         WorkItemDirectory: '$(WorkItemDirectory)'

--- a/src/coreclr/scripts/antigen_setup.py
+++ b/src/coreclr/scripts/antigen_setup.py
@@ -89,15 +89,6 @@ def main(main_args):
     helix_source_prefix = "official"
     creator = ""
     ci = True
-    if is_windows:
-        helix_queue = "Windows.10.Arm64" if arch_name == "arm64" else "Windows.10.Amd64.X86"
-    else:
-        if arch_name == "arm":
-            helix_queue = "(Ubuntu.1804.Arm32)Ubuntu.1804.Armarch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7-bfcd90a-20200121150440"
-        elif arch_name == "arm64":
-            helix_queue = "(Ubuntu.1804.Arm64)Ubuntu.1804.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8-20210531091519-97d8652"
-        else:
-            helix_queue = "Ubuntu.1804.Amd64"
 
     # create exploratory directory
     print('Copying {} -> {}'.format(scripts_src_directory, coreroot_dst_directory))
@@ -150,7 +141,6 @@ def main(main_args):
     set_pipeline_variable("WorkItemDirectory", workitem_directory)
     set_pipeline_variable("RunConfiguration", run_configuration)
     set_pipeline_variable("Creator", creator)
-    set_pipeline_variable("Queue", helix_queue)
     set_pipeline_variable("HelixSourcePrefix", helix_source_prefix)
 
 if __name__ == "__main__":

--- a/src/coreclr/scripts/exploratory.proj
+++ b/src/coreclr/scripts/exploratory.proj
@@ -29,6 +29,12 @@
     <EnableAzurePipelinesReporter>false</EnableAzurePipelinesReporter>
     <EnableXUnitReporter>false</EnableXUnitReporter>
     <WorkItemTimeout>2:30</WorkItemTimeout>
+    <Creator>$(_Creator)</Creator>
+    <HelixAccessToken>$(_HelixAccessToken)</HelixAccessToken>
+    <HelixBuild>$(_HelixBuild)</HelixBuild>
+    <HelixSource>$(_HelixSource)</HelixSource>
+    <HelixTargetQueues>$(_HelixTargetQueues)</HelixTargetQueues>
+    <HelixType>$(_HelixType)</HelixType>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(AGENT_OS)' == 'Windows_NT' ">


### PR DESCRIPTION
I mistakenly had internal helixqueue used for "public" Antigen pipeline. Switch it to public queue and made surrounding changes.