### PR TITLE
Several improvements to regex source generator

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -1273,7 +1273,7 @@ namespace System.Text.RegularExpressions.Generator
                     // by comparing 2 or 4 characters at a time.  Because we might be compiling on one endianness and running on another,
                     // both little and big endian values are emitted and which is used is selected at run-time.
                     ReadOnlySpan<byte> byteStr = MemoryMarshal.AsBytes(str.AsSpan());
-                    bool useMultiCharReads = !caseInsensitive && byteStr.Length > sizeof(uint);
+                    bool useMultiCharReads = !caseInsensitive && byteStr.Length >= sizeof(uint);
                     if (useMultiCharReads)
                     {
                         writer.WriteLine($"ref byte byteStr = ref global::System.Runtime.InteropServices.MemoryMarshal.GetReference(global::System.Runtime.InteropServices.MemoryMarshal.AsBytes({textSpanLocal}));");

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Parser.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Parser.cs
@@ -170,8 +170,8 @@ namespace System.Text.RegularExpressions.Generator
             // Parse the input pattern
             try
             {
-                regexMethod.Tree = RegexParser.Parse(regexMethod.Pattern, (RegexOptions)regexMethod.Options, culture);
-                regexMethod.Code = RegexWriter.Write(regexMethod.Tree);
+                RegexTree tree = RegexParser.Parse(regexMethod.Pattern, (RegexOptions)regexMethod.Options, culture);
+                regexMethod.Code = RegexWriter.Write(tree);
             }
             catch (Exception e)
             {
@@ -239,7 +239,6 @@ namespace System.Text.RegularExpressions.Generator
             public int? Options;
             public int? MatchTimeout;
             public string Modifiers = string.Empty;
-            public RegexTree Tree;
             public RegexCode Code;
         }
     }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1512,35 +1512,38 @@ namespace System.Text.RegularExpressions
 
                     const char GroupChar = (char)0;
                     int lastindex = set.IndexOf(GroupChar, index + 1);
-                    string group = set.Substring(index, lastindex - index + 1);
-
-                    foreach (KeyValuePair<string, string> kvp in s_definedCategories)
+                    if (lastindex != -1)
                     {
-                        if (group.Equals(kvp.Value))
-                        {
-                            desc.Append((short)set[index + 1] > 0 ? "\\p{" : "\\P{").Append(kvp.Key).Append('}');
-                            found = true;
-                            break;
-                        }
-                    }
+                        string group = set.Substring(index, lastindex - index + 1);
 
-                    if (!found)
-                    {
-                        if (group.Equals(Word))
+                        foreach (KeyValuePair<string, string> kvp in s_definedCategories)
                         {
-                            desc.Append("\\w");
+                            if (group.Equals(kvp.Value))
+                            {
+                                desc.Append((short)set[index + 1] > 0 ? "\\p{" : "\\P{").Append(kvp.Key).Append('}');
+                                found = true;
+                                break;
+                            }
                         }
-                        else if (group.Equals(NotWord))
-                        {
-                            desc.Append("\\W");
-                        }
-                        else
-                        {
-                            // TODO: The code is incorrectly handling pretty-printing groups like \P{P}.
-                        }
-                    }
 
-                    index = lastindex;
+                        if (!found)
+                        {
+                            if (group.Equals(Word))
+                            {
+                                desc.Append("\\w");
+                            }
+                            else if (group.Equals(NotWord))
+                            {
+                                desc.Append("\\W");
+                            }
+                            else
+                            {
+                                // TODO: The code is incorrectly handling pretty-printing groups like \P{P}.
+                            }
+                        }
+
+                        index = lastindex;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
With the regex source generator spitting out C#, various things pop as to places we can make simple improvements.

Commits:

1. Just fixes a simple comparison that was emitted with ">" when it should have been ">=".  The effect of not using ">=" was we doing more comparisons than strictly necessary in some situations when comparing multiple characters in a regex pattern.

2. Given a pattern like `abc[def]ghi`, the RegexOptions.Compiled engine and source generator would emit a length check for the "abc", a length check for the "[def]", and a length check for the "ghi", but they can trivially be combined into a single length check that covers all three portions.  After fixing this in the source generator, I ported it back to Compiled.

3. For simple regexes that are just looking for a string, e.g. "abc", we currently end up doing the full comparison to find it as part of FindFirstChar, but then we re-compare it again in Go.  That's wasteful; in such a situation, Go can simply perform the capture and doesn't need to compare anything.  After fixing this in the source generator, I ported it back to Compiled.

4. The Boyer-Moore code we spit out in FindFirstChar is full of labels and gotos.  For the source generator, we can make it easier to read. e.g. for the pattern "abcdef":
Before:
```C#
protected override bool FindFirstChar()
{
    string runtext = base.runtext!;
    int runtextpos = base.runtextpos;
    int runtextend = base.runtextend;
    int ch;
                    
    // Minimum required length check
    if (runtextpos <= runtextend - 6)
    {
        // Boyer-Moore prefix matching
        runtextpos += 5;
        int offset = 0;
        goto Start;
                        
        DefaultAdvance:
        offset = 6;
                        
        Advance:
        runtextpos += offset;
                        
        Start:
        if (runtextpos >= runtextend)
        {
            goto ReturnFalse;
        }
                        
        ch = runtext[runtextpos];
        if (ch == 'f')
        {
            goto PartialMatch;
        }
        ch -= 97;
        if ((uint)ch > 5)
        {
            goto DefaultAdvance;
        }
        offset = "\u0005\u0004\u0003\u0002\u0001\0"[ch];
        goto Advance;
                        
        PartialMatch:
        int test = runtextpos;
        if (runtext[--test] == 'e')
        {
            goto L0;
        }
                        
        L1:
        offset = 1;
        goto Advance;
                        
        L0:
        if (runtext[--test] != 'd')
        {
            goto L1;
        }
        if (runtext[--test] != 'c')
        {
            goto L1;
        }
        if (runtext[--test] != 'b')
        {
            goto L1;
        }
        if (runtext[--test] != 'a')
        {
            goto L1;
        }
                        
        base.runtextpos = test;
        return true;
    }
                    
    // No match
    ReturnFalse:
    base.runtextpos = runtextend;
    return false;
}
```

After:
```C#
protected override bool FindFirstChar()
{
    string runtext = base.runtext!;
    int runtextpos = base.runtextpos;
    int runtextend = base.runtextend;
    int ch;

    // Minimum required length check
    if (runtextpos <= runtextend - 6)
    {
        // Boyer-Moore prefix matching
        runtextpos += 5;
        while (runtextpos < runtextend)
        {
            ch = runtext[runtextpos];
            if (ch != 'f')
            {
                ch -= 'a';
                if ((uint)ch > ('f' - 'a'))
                {
                    runtextpos += 6;
                    continue;
                }
                runtextpos += "\u0005\u0004\u0003\u0002\u0001\0"[ch];
                continue;
            }

            int test = runtextpos;

            if (runtext[--test] != 'e' ||
                runtext[--test] != 'd' ||
                runtext[--test] != 'c' ||
                runtext[--test] != 'b' ||
                runtext[--test] != 'a')
            {
                runtextpos++;
                continue;
            }

            base.runtextpos = test;
            return true;
        }
    }

    // No match
    ReturnFalse:
    base.runtextpos = runtextend;
    return false;
}
```