### PR TITLE
Fix for GitHub issue #59432 and the corresponding regression test

### DIFF
--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -1206,7 +1206,7 @@ MethodTableBuilder::bmtInterfaceEntry::CreateSlotTable(
         MethodDesc *pDeclMD = it.GetDeclMethodDesc();
         if (!pDeclMD->IsVirtual())
         {
-            break;
+            continue;
         }
 
         bmtRTMethod * pCurMethod = new (pStackingAllocator)

--- a/src/tests/Loader/classloader/StaticVirtualMethods/RegressionTests/GitHub_59432.cs
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/RegressionTests/GitHub_59432.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+class Program
+{
+    static int Main()
+    {
+        Console.WriteLine("Start");
+        SomeClass someInstance = new();
+        CalledMethod();
+        Console.WriteLine("Done");
+        return 100;
+    }
+
+    static void CalledMethod()
+    {
+        SomeClass.SomeStaticMethodInClass();
+    }
+}
+
+interface ISomeInterface
+{
+    static int SomeStaticMethod() => 42;
+    static abstract int SomeStaticAbstractMethod();
+}
+
+class SomeClass : ISomeInterface
+{
+    static int ISomeInterface.SomeStaticAbstractMethod() => 42;
+    public static int SomeStaticMethodInClass() => 42;
+}

--- a/src/tests/Loader/classloader/StaticVirtualMethods/RegressionTests/GitHub_59432.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/RegressionTests/GitHub_59432.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Turns out there was a subtle bug in the interface slot map population
that got triggered by a suitable combination of non-virtual and
virtual interface methods.

Thanks

Tomas

Fixes: https://github.com/dotnet/runtime/issues/59432