### PR TITLE
Prefer readonlyspan properties over readonly array fields

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -190,3 +190,5 @@ indent_size = 2
 end_of_line = lf
 [*.{cmd,bat}]
 end_of_line = crlf
+
+dotnet_diagnostic.CA1850.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -191,4 +191,3 @@ end_of_line = lf
 [*.{cmd,bat}]
 end_of_line = crlf
 
-dotnet_diagnostic.CA1850.severity = warning

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
@@ -388,7 +388,7 @@ namespace System.IO.Compression
                             }
                             else
                             {
-                                if (symbol < 0 || symbol >= ExtraLengthBits.Length)
+                                if ((uint)symbol >= ExtraLengthBits.Length)
                                 {
                                     throw new InvalidDataException(SR.GenericInvalidData);
                                 }

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
@@ -10,7 +10,7 @@ namespace System.IO.Compression
         // const tables used in decoding:
 
         // Extra bits for length code 257 - 285.
-        private static readonly byte[] s_extraLengthBits =
+        private static ReadOnlySpan<byte> ExtraLengthBits => new byte[]
         {
             0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3,
             3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 16
@@ -33,9 +33,9 @@ namespace System.IO.Compression
         };
 
         // code lengths for code length alphabet is stored in following order
-        private static readonly byte[] s_codeOrder = { 16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15 };
+        private static ReadOnlySpan<byte> CodeOrder => new byte[] { 16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15 };
 
-        private static readonly byte[] s_staticDistanceTreeTable =
+        private static ReadOnlySpan<byte> StaticDistanceTreeTable => new byte[]
         {
             0x00, 0x10, 0x08, 0x18, 0x04, 0x14, 0x0c, 0x1c, 0x02, 0x12, 0x0a, 0x1a,
             0x06, 0x16, 0x0e, 0x1e, 0x01, 0x11, 0x09, 0x19, 0x05, 0x15, 0x0d, 0x1d,
@@ -388,11 +388,11 @@ namespace System.IO.Compression
                             }
                             else
                             {
-                                if (symbol < 0 || symbol >= s_extraLengthBits.Length)
+                                if (symbol < 0 || symbol >= ExtraLengthBits.Length)
                                 {
                                     throw new InvalidDataException(SR.GenericInvalidData);
                                 }
-                                _extraBits = s_extraLengthBits[symbol];
+                                _extraBits = ExtraLengthBits[symbol];
                                 Debug.Assert(_extraBits != 0, "We handle other cases separately!");
                             }
                             _length = symbol;
@@ -431,7 +431,7 @@ namespace System.IO.Compression
                             _distanceCode = _input.GetBits(5);
                             if (_distanceCode >= 0)
                             {
-                                _distanceCode = s_staticDistanceTreeTable[_distanceCode];
+                                _distanceCode = StaticDistanceTreeTable[_distanceCode];
                             }
                         }
 
@@ -544,13 +544,13 @@ namespace System.IO.Compression
                         {
                             return false;
                         }
-                        _codeLengthTreeCodeLength[s_codeOrder[_loopCounter]] = (byte)bits;
+                        _codeLengthTreeCodeLength[CodeOrder[_loopCounter]] = (byte)bits;
                         ++_loopCounter;
                     }
 
-                    for (int i = _codeLengthCodeCount; i < s_codeOrder.Length; i++)
+                    for (int i = _codeLengthCodeCount; i < CodeOrder.Length; i++)
                     {
-                        _codeLengthTreeCodeLength[s_codeOrder[i]] = 0;
+                        _codeLengthTreeCodeLength[CodeOrder[i]] = 0;
                     }
 
                     // create huffman tree for code length

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpResponseStream.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpResponseStream.Windows.cs
@@ -303,7 +303,7 @@ namespace System.Net
                 {
                     flags |= Interop.HttpApi.HTTP_FLAGS.HTTP_SEND_RESPONSE_FLAG_DISCONNECT;
                 }
-                fixed (void* pBuffer = &ChunkTerminator[0])
+                fixed (void* pBuffer = &MemoryMarshal.GetReference(ChunkTerminator))
                 {
                     Interop.HttpApi.HTTP_DATA_CHUNK* pDataChunk = null;
                     if (_httpContext.Response.BoundaryType == BoundaryType.Chunked)

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpResponseStream.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpResponseStream.Windows.cs
@@ -281,7 +281,7 @@ namespace System.Net
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "dataWritten:" + dataWritten + " _leftToWrite:" + _leftToWrite + " _closed:" + _closed);
         }
 
-        private static readonly byte[] s_chunkTerminator = new byte[] { (byte)'0', (byte)'\r', (byte)'\n', (byte)'\r', (byte)'\n' };
+        private static ReadOnlySpan<byte> ChunkTerminator => new byte[] { (byte)'0', (byte)'\r', (byte)'\n', (byte)'\r', (byte)'\n' };
 
         private void DisposeCore()
         {
@@ -303,7 +303,7 @@ namespace System.Net
                 {
                     flags |= Interop.HttpApi.HTTP_FLAGS.HTTP_SEND_RESPONSE_FLAG_DISCONNECT;
                 }
-                fixed (void* pBuffer = &s_chunkTerminator[0])
+                fixed (void* pBuffer = &ChunkTerminator[0])
                 {
                     Interop.HttpApi.HTTP_DATA_CHUNK* pDataChunk = null;
                     if (_httpContext.Response.BoundaryType == BoundaryType.Chunked)
@@ -311,7 +311,7 @@ namespace System.Net
                         Interop.HttpApi.HTTP_DATA_CHUNK dataChunk = default;
                         dataChunk.DataChunkType = Interop.HttpApi.HTTP_DATA_CHUNK_TYPE.HttpDataChunkFromMemory;
                         dataChunk.pBuffer = (byte*)pBuffer;
-                        dataChunk.BufferLength = (uint)s_chunkTerminator.Length;
+                        dataChunk.BufferLength = (uint)ChunkTerminator.Length;
                         pDataChunk = &dataChunk;
                     }
                     if (!sentHeaders)

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlUTF8TextWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlUTF8TextWriter.cs
@@ -69,7 +69,7 @@ namespace System.Xml
             (byte)'e', (byte)'n', (byte)'c', (byte)'o', (byte)'d', (byte)'i', (byte)'n', (byte)'g', (byte)'=', (byte)'"', (byte)'u', (byte)'t', (byte)'f', (byte)'-', (byte)'8', (byte)'"',
             (byte)'?', (byte)'>'
         };
-        private static readonly byte[] s_digits =
+        private static ReadOnlySpan<byte> Digits => new byte[]
         {
             (byte) '0', (byte) '1', (byte) '2', (byte) '3', (byte) '4', (byte) '5', (byte) '6', (byte) '7',
             (byte) '8', (byte) '9', (byte) 'A', (byte) 'B', (byte) 'C', (byte) 'D', (byte) 'E', (byte) 'F'
@@ -638,7 +638,7 @@ namespace System.Xml
             do
             {
                 count++;
-                chars[--offset] = s_digits[(int)(value & 0x0F)];
+                chars[--offset] = Digits[(int)(value & 0x0F)];
                 value /= 16;
             }
             while (value != 0);

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/ISCIIEncoding.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/ISCIIEncoding.cs
@@ -255,7 +255,7 @@ namespace System.Text
                         $"[ISCIIEncoding.GetBytes]Expected indicTwoBytes from 1-3, not {(indicTwoBytes >> 12)}");
 
                     // Already did buffer checking, but...
-                    if (!buffer.AddByte(s_SecondIndicByte[indicTwoBytes >> 12]))
+                    if (!buffer.AddByte(SecondIndicByte[indicTwoBytes >> 12]))
                         break;
                 }
             }
@@ -1936,7 +1936,7 @@ namespace System.Text
         // This is used if the UnicodeToIndic table 4 high bits are set, this is
         // the value of the second Indic byte when applicable.
         ////////////////////////////////////////////////////////////////////////////
-        private static readonly byte[] s_SecondIndicByte =
+        private static ReadOnlySpan<byte> SecondIndicByte => new byte[]
         {
             0x00,
             0xe9,


### PR DESCRIPTION
While working on [this analyzer issue](https://github.com/dotnet/runtime/issues/33780) I ran the analyzer against dotnet/runtime and found several violations. I've fixed them.