### PR TITLE
Add PEM exports to certificates

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.cs
@@ -483,7 +483,7 @@ namespace System
             {
                 if (!comparer.Equals(expected, actual[i]))
                 {
-                    throw new XunitException($"Expected {expected?.ToString() ?? "null"} at position {i}");
+                    throw new XunitException($"Expected {expected?.ToString() ?? "null"} at position {i}; actual {actual[i]?.ToString() ?? "null"}");
                 }
             }
         }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/ref/System.Security.Cryptography.X509Certificates.cs
@@ -268,6 +268,7 @@ namespace System.Security.Cryptography.X509Certificates
         public static System.Security.Cryptography.X509Certificates.X509Certificate2 CreateFromPem(System.ReadOnlySpan<char> certPem) { throw null; }
         public static System.Security.Cryptography.X509Certificates.X509Certificate2 CreateFromPem(System.ReadOnlySpan<char> certPem, System.ReadOnlySpan<char> keyPem) { throw null; }
         public static System.Security.Cryptography.X509Certificates.X509Certificate2 CreateFromPemFile(string certPemFilePath, string? keyPemFilePath = null) { throw null; }
+        public string ExportCertificatePem() { throw null; }
         public static System.Security.Cryptography.X509Certificates.X509ContentType GetCertContentType(byte[] rawData) { throw null; }
         public static System.Security.Cryptography.X509Certificates.X509ContentType GetCertContentType(System.ReadOnlySpan<byte> rawData) { throw null; }
         public static System.Security.Cryptography.X509Certificates.X509ContentType GetCertContentType(string fileName) { throw null; }
@@ -291,6 +292,7 @@ namespace System.Security.Cryptography.X509Certificates
         public override void Reset() { }
         public override string ToString() { throw null; }
         public override string ToString(bool verbose) { throw null; }
+        public bool TryExportCertificatePem(System.Span<char> destination, out int charsWritten) { throw null; }
         public bool Verify() { throw null; }
     }
     public partial class X509Certificate2Collection : System.Security.Cryptography.X509Certificates.X509CertificateCollection, System.Collections.Generic.IEnumerable<System.Security.Cryptography.X509Certificates.X509Certificate2>, System.Collections.IEnumerable
@@ -306,6 +308,10 @@ namespace System.Security.Cryptography.X509Certificates
         public bool Contains(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate) { throw null; }
         public byte[]? Export(System.Security.Cryptography.X509Certificates.X509ContentType contentType) { throw null; }
         public byte[]? Export(System.Security.Cryptography.X509Certificates.X509ContentType contentType, string? password) { throw null; }
+        public string ExportCertificatePems() { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("ios")]
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("tvos")]
+        public string ExportPkcs7Pem() { throw null; }
         public System.Security.Cryptography.X509Certificates.X509Certificate2Collection Find(System.Security.Cryptography.X509Certificates.X509FindType findType, object findValue, bool validOnly) { throw null; }
         public new System.Security.Cryptography.X509Certificates.X509Certificate2Enumerator GetEnumerator() { throw null; }
         public void Import(byte[] rawData) { }
@@ -323,6 +329,10 @@ namespace System.Security.Cryptography.X509Certificates
         public void RemoveRange(System.Security.Cryptography.X509Certificates.X509Certificate2Collection certificates) { }
         public void RemoveRange(System.Security.Cryptography.X509Certificates.X509Certificate2[] certificates) { }
         System.Collections.Generic.IEnumerator<System.Security.Cryptography.X509Certificates.X509Certificate2> System.Collections.Generic.IEnumerable<System.Security.Cryptography.X509Certificates.X509Certificate2>.GetEnumerator() { throw null; }
+        public bool TryExportCertificatePems(System.Span<char> destination, out int charsWritten) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("ios")]
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("tvos")]
+        public bool TryExportPkcs7Pem(System.Span<char> destination, out int charsWritten) { throw null; }
     }
     public sealed partial class X509Certificate2Enumerator : System.Collections.Generic.IEnumerator<System.Security.Cryptography.X509Certificates.X509Certificate2>, System.Collections.IEnumerator, System.IDisposable
     {

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
@@ -1124,6 +1124,70 @@ namespace System.Security.Cryptography.X509Certificates
             throw new CryptographicException(SR.Cryptography_X509_NoPemCertificate);
         }
 
+        /// <summary>
+        /// Exports the public X.509 certificate, encoded as PEM.
+        /// </summary>
+        /// <returns>
+        /// The PEM encoding of the certificate.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        /// The certificate is corrupt, in an invalid state, or could not be exported
+        /// to PEM.
+        /// </exception>
+        /// <remarks>
+        /// <p>
+        ///   A PEM-encoded X.509 certificate will begin with <c>-----BEGIN CERTIFICATE-----</c>
+        ///   and end with <c>-----END CERTIFICATE-----</c>, with the base64 encoded DER
+        ///   contents of the certificate between the PEM boundaries.
+        /// </p>
+        /// <p>
+        ///   The certificate is encoded according to the IETF RFC 7468 &quot;strict&quot;
+        ///   encoding rules.
+        /// </p>
+        /// </remarks>
+        public string ExportCertificatePem()
+        {
+            int pemSize = PemEncoding.GetEncodedSize(PemLabels.X509Certificate.Length, RawDataMemory.Length);
+
+            return string.Create(pemSize, this, static (destination, cert) => {
+                if (!cert.TryExportCertificatePem(destination, out int charsWritten) ||
+                    charsWritten != destination.Length)
+                {
+                    Debug.Fail("Pre-allocated buffer was not the correct size.");
+                    throw new CryptographicException();
+                }
+            });
+        }
+
+        /// <summary>
+        /// Attempts to export the public X.509 certificate, encoded as PEM.
+        /// </summary>
+        /// <param name="destination">The buffer to receive the PEM encoded certificate.</param>
+        /// <param name="charsWritten">When this method returns, the total number of characters written to <paramref name="destination" />.</param>
+        /// <returns>
+        ///   <see langword="true"/> if <paramref name="destination"/> was large enough to receive the encoded PEM;
+        ///   otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        /// The certificate is corrupt, in an invalid state, or could not be exported
+        /// to PEM.
+        /// </exception>
+        /// <remarks>
+        /// <p>
+        ///   A PEM-encoded X.509 certificate will begin with <c>-----BEGIN CERTIFICATE-----</c>
+        ///   and end with <c>-----END CERTIFICATE-----</c>, with the base64 encoded DER
+        ///   contents of the certificate between the PEM boundaries.
+        /// </p>
+        /// <p>
+        ///   The certificate is encoded according to the IETF RFC 7468 &quot;strict&quot;
+        ///   encoding rules.
+        /// </p>
+        /// </remarks>
+        public bool TryExportCertificatePem(Span<char> destination, out int charsWritten)
+        {
+            return PemEncoding.TryWrite(PemLabels.X509Certificate, RawDataMemory.Span, destination, out charsWritten);
+        }
+
         private static X509Certificate2 ExtractKeyFromPem<TAlg>(
             ReadOnlySpan<char> keyPem,
             string[] labels,

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2Collection.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2Collection.cs
@@ -549,6 +549,10 @@ namespace System.Security.Cryptography.X509Certificates
                 ReadOnlyMemory<byte> certData = this[i].RawDataMemory;
                 int certSize = PemEncoding.GetEncodedSize(PemLabels.X509Certificate.Length, certData.Length);
 
+                // If we ran out of space in the destination, return false. It's okay
+                // that we may have successfully written data to the destination
+                // already. Since certificates only contain "public" information,
+                // we don't need to clear what has been written already.
                 if (buffer.Length < certSize)
                 {
                     charsWritten = 0;
@@ -574,6 +578,8 @@ namespace System.Security.Cryptography.X509Certificates
                         return false;
                     }
 
+                    // Always use Unix line endings between certificates to match the
+                    // behavior of PemEncoding.TryWrite, which is following RFC 7468.
                     buffer[0] = '\n';
                     buffer = buffer.Slice(1);
                     written++;

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2Collection.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2Collection.cs
@@ -6,6 +6,7 @@ using Internal.Cryptography.Pal;
 using Microsoft.Win32.SafeHandles;
 using System.Diagnostics;
 using System.Formats.Asn1;
+using System.Runtime.Versioning;
 using System.Security.Cryptography.X509Certificates.Asn1;
 using System.Collections.Generic;
 
@@ -411,6 +412,196 @@ namespace System.Security.Cryptography.X509Certificates
                     RemoveAt(Count - 1);
                 }
                 throw;
+            }
+        }
+
+        /// <summary>
+        /// Exports the X.509 public certificates as a PKCS7 certificate collection, encoded as PEM.
+        /// </summary>
+        /// <returns>The PEM encoded PKCS7 collection.</returns>
+        /// <exception cref="CryptographicException">
+        /// A certificate is corrupt, in an invalid state, or could not be exported
+        /// to PEM.
+        /// </exception>
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        public string ExportPkcs7Pem()
+        {
+            byte[]? pkcs7 = Export(X509ContentType.Pkcs7);
+
+            if (pkcs7 is null)
+            {
+                throw new CryptographicException(SR.Cryptography_X509_ExportFailed);
+            }
+
+            int encodedSize = PemEncoding.GetEncodedSize(PemLabels.Pkcs7Certificate.Length, pkcs7.Length);
+
+            return string.Create(encodedSize, pkcs7, static (destination, pkcs7) => {
+                if (!PemEncoding.TryWrite(PemLabels.Pkcs7Certificate, pkcs7, destination, out int written) ||
+                    written != destination.Length)
+                {
+                    Debug.Fail("Pre-allocated buffer was not the correct size.");
+                    throw new CryptographicException();
+                }
+            });
+        }
+
+        /// <summary>
+        /// Attempts to export the X.509 public certificates as a PKCS7 certificate collection, encoded as PEM.
+        /// </summary>
+        /// <param name="destination">The buffer to receive the PEM encoded PKCS7 collection.</param>
+        /// <param name="charsWritten">When this method returns, the total number of characters written to <paramref name="destination" />.</param>
+        /// <returns>
+        ///   <see langword="true"/> if <paramref name="destination"/> was large enough to receive PEM encoded PKCS7
+        ///   certificate collection; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        /// A certificate is corrupt, in an invalid state, or could not be exported
+        /// to PEM.
+        /// </exception>
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("tvos")]
+        public bool TryExportPkcs7Pem(Span<char> destination, out int charsWritten)
+        {
+            byte[]? pkcs7 = Export(X509ContentType.Pkcs7);
+
+            if (pkcs7 is null)
+            {
+                throw new CryptographicException(SR.Cryptography_X509_ExportFailed);
+            }
+
+            return PemEncoding.TryWrite(PemLabels.Pkcs7Certificate, pkcs7, destination, out charsWritten);
+        }
+
+        /// <summary>
+        /// Exports the public X.509 certificates, encoded as PEM.
+        /// </summary>
+        /// <returns>
+        /// The PEM encoding of the certificates.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        /// A certificate is corrupt, in an invalid state, or could not be exported
+        /// to PEM.
+        /// </exception>
+        /// <exception cref="OverflowException">
+        /// The combined size of encoding all certificates exceeds <see cref="int.MaxValue" />.
+        /// </exception>
+        /// <remarks>
+        /// <p>
+        ///   A PEM-encoded X.509 certificate collection will contain certificates
+        ///   where each certificate begins with <c>-----BEGIN CERTIFICATE-----</c>
+        ///   and ends with <c>-----END CERTIFICATE-----</c>, with the base64 encoded DER
+        ///   contents of the certificate between the PEM boundaries. Each certificate is
+        ///   separated by a single line-feed character.
+        /// </p>
+        /// <p>
+        ///   Certificates are encoded according to the IETF RFC 7468 &quot;strict&quot;
+        ///   encoding rules.
+        /// </p>
+        /// </remarks>
+        public string ExportCertificatePems()
+        {
+            int size = GetCertificatePemsSize();
+
+            return string.Create(size, this, static (destination, col) => {
+                if (!col.TryExportCertificatePems(destination, out int charsWritten) ||
+                    charsWritten != destination.Length)
+                {
+                    Debug.Fail("Pre-allocated buffer was not the correct size.");
+                    throw new CryptographicException();
+                }
+            });
+        }
+
+        /// <summary>
+        /// Attempts to export the public X.509 certificates, encoded as PEM.
+        /// </summary>
+        /// <param name="destination">The buffer to receive the PEM encoded certificates.</param>
+        /// <param name="charsWritten">When this method returns, the total number of characters written to <paramref name="destination" />.</param>
+        /// <returns>
+        ///   <see langword="true"/> if <paramref name="destination"/> was large enough to receive the encoded PEMs;
+        ///   otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        /// A certificate is corrupt, in an invalid state, or could not be exported
+        /// to PEM.
+        /// </exception>
+        /// <remarks>
+        /// <p>
+        ///   A PEM-encoded X.509 certificate collection will contain certificates
+        ///   where each certificate begins with <c>-----BEGIN CERTIFICATE-----</c>
+        ///   and ends with <c>-----END CERTIFICATE-----</c>, with the base64 encoded DER
+        ///   contents of the certificate between the PEM boundaries. Each certificate is
+        ///   separated by a single line-feed character.
+        /// </p>
+        /// <p>
+        ///   Certificates are encoded according to the IETF RFC 7468 &quot;strict&quot;
+        ///   encoding rules.
+        /// </p>
+        /// </remarks>
+        public bool TryExportCertificatePems(Span<char> destination, out int charsWritten)
+        {
+            Span<char> buffer = destination;
+            int written = 0;
+
+            for (int i = 0; i < Count; i++)
+            {
+                ReadOnlyMemory<byte> certData = this[i].RawDataMemory;
+                int certSize = PemEncoding.GetEncodedSize(PemLabels.X509Certificate.Length, certData.Length);
+
+                if (buffer.Length < certSize)
+                {
+                    charsWritten = 0;
+                    return false;
+                }
+
+                if (!PemEncoding.TryWrite(PemLabels.X509Certificate, certData.Span, buffer, out int certWritten) ||
+                    certWritten != certSize)
+                {
+                    Debug.Fail("Presized buffer is too small or did not write the correct amount.");
+                    throw new CryptographicException();
+                }
+
+                buffer = buffer.Slice(certWritten);
+                written += certWritten;
+
+                // write a new line if not the last certificate.
+                if (i < Count - 1)
+                {
+                    if (buffer.IsEmpty)
+                    {
+                        charsWritten = 0;
+                        return false;
+                    }
+
+                    buffer[0] = '\n';
+                    buffer = buffer.Slice(1);
+                    written++;
+                }
+            }
+
+            charsWritten = written;
+            return true;
+        }
+
+        private int GetCertificatePemsSize()
+        {
+            checked
+            {
+                int size = 0;
+
+                for (int i = 0; i < Count; i++)
+                {
+                    size += PemEncoding.GetEncodedSize(PemLabels.X509Certificate.Length, this[i].RawDataMemory.Length);
+
+                    // Add a \n character between each certificate, except the last one.
+                    if (i < Count - 1)
+                    {
+                        size += 1;
+                    }
+                }
+
+                return size;
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -1725,8 +1725,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Equal("PKCS7", new string(pemActual[fields.Label]));
                 byte[] data = Convert.FromBase64String(new string(actualBase64));
 
-                using ImportedCollection imported = Cert.Import(data);
-                Assert.Equal(expected.ToArray(), imported.Collection.ToArray(), new X509Certificate2EqualityComparer());
+                (int locationOffset, int locationLength) = fields.Location.GetOffsetAndLength(pemActual.Length);
+                Assert.Equal(0, locationOffset);
+                Assert.Equal(pemActual.Length, locationLength);
+
+                using (ImportedCollection imported = Cert.Import(data))
+                {
+                    Assert.Equal(expected.ToArray(), imported.Collection.ToArray(), new X509Certificate2EqualityComparer());
+                }
             }
 
             string pkcs7Pem = collection.ExportPkcs7Pem();

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -1567,7 +1567,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         public static void TryExportCertificatePems_Empty()
         {
             X509Certificate2Collection cc = new X509Certificate2Collection();
-           AssertPemExport(cc, string.Empty);
+            AssertPemExport(cc, string.Empty);
         }
 
         [Fact]

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -1573,18 +1573,12 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Fact]
         public static void ExportCertificatePems_SingleCert()
         {
-            const string SinglePem = "-----BEGIN CERTIFICATE-----\n" +
-                "MIIBETCBuaADAgECAgkA9StU5ZnBmM4wCgYIKoZIzj0EAwIwDzENMAsGA1UEAxME\n" +
-                "dGlueTAeFw0yMTA5MTUyMjAyNDNaFw0yMTA5MTUyMjAyNDNaMA8xDTALBgNVBAMT\n" +
-                "BHRpbnkwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQZ+baUXzzLi+p3cZEf4f23\n" +
-                "L/2Dbn5UB/uMCB7L71rWf3UwuCA3Is5uPci/3PQYLNwDkP3m3ZzxyzVCgFVqqYFg\n" +
-                "MAoGCCqGSM49BAMCA0cAMEQCIHafyKHQhv+03DaOJpuotD+jNu0Nc9pUI9OA8pUY\n" +
-                "3+qJAiBsqKjtc8LuGtUoqGvxLLQJwJ2QNY/qyEGtaImlqTYg5w==\n" +
-                "-----END CERTIFICATE-----";
-            using ImportedCollection ic = Cert.ImportFromPem(SinglePem);
-            X509Certificate2Collection cc = ic.Collection;
-            AssertPemExport(cc, SinglePem);
-            AssertPkcs7PemExport(cc);
+            using (ImportedCollection ic = Cert.ImportFromPem(TestData.CertRfc7468Wrapped))
+            {
+                X509Certificate2Collection cc = ic.Collection;
+                AssertPemExport(cc, TestData.CertRfc7468Wrapped);
+                AssertPkcs7PemExport(cc);
+            }
         }
 
         [Fact]
@@ -1606,11 +1600,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 "MAoGCCqGSM49BAMCA0cAMEQCIHIweJarpnxQ88gAtGbBq6iFWjGhXP0mfxJtrJKd\n" +
                 "WqzGAiBqbvlwpNMDKYGB7fwthHKn4SzxQaHYj27TdRuitsNCHg==\n" +
                 "-----END CERTIFICATE-----";
-            using ImportedCollection ic = Cert.ImportFromPem(MultiPem);
-            X509Certificate2Collection cc = ic.Collection;
-            Assert.Equal(2, cc.Count);
-            AssertPemExport(cc, MultiPem);
-            AssertPkcs7PemExport(cc);
+
+            using (ImportedCollection ic = Cert.ImportFromPem(MultiPem))
+            {
+                X509Certificate2Collection cc = ic.Collection;
+                Assert.Equal(2, cc.Count);
+                AssertPemExport(cc, MultiPem);
+                AssertPkcs7PemExport(cc);
+            }
         }
 
         private static void TestExportSingleCert_SecureStringPassword(X509ContentType ct)

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -58,6 +58,8 @@
     <Compile Include="CertificateCreation\DSAX509SignatureGenerator.cs" />
     <Compile Include="CertificateCreation\EccTestData.cs" />
     <Compile Include="CertificateCreation\ECDsaX509SignatureGeneratorTests.cs" />
+    <Compile Include="$(CommonPath)Internal\Cryptography\PemEnumerator.cs"
+             Link="Common\Internal\Cryptography\PemEnumerator.cs" />
     <Compile Include="CertificateCreation\PrivateKeyAssociationTests.cs" />
     <Compile Include="CertificateCreation\RSAPkcs1X509SignatureGeneratorTests.cs" />
     <Compile Include="CertificateCreation\RSAPssX509SignatureGeneratorTests.cs" />

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/TestData.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/TestData.cs
@@ -2910,5 +2910,17 @@ voLmcK+XtmehjMVy7OSSFICNKybLBOvO8paydhCb1J0klkLPAoAjgP2cEd+KueeR
 yJpx+jD1MsjIEXIn5jtjXdUHd0JJmHWAyHdNzmhXrXC7JLnj4ri7xMAV3GZGDpAn
 YvvL0LiXzFyomg==
 -----END PUBLIC KEY-----";
+
+        // This string is for tests that are sensitive to the exact formatting
+        // and line breaks of the PEM.
+        public const string CertRfc7468Wrapped =
+            "-----BEGIN CERTIFICATE-----\n" +
+            "MIIBETCBuaADAgECAgkA9StU5ZnBmM4wCgYIKoZIzj0EAwIwDzENMAsGA1UEAxME\n" +
+            "dGlueTAeFw0yMTA5MTUyMjAyNDNaFw0yMTA5MTUyMjAyNDNaMA8xDTALBgNVBAMT\n" +
+            "BHRpbnkwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQZ+baUXzzLi+p3cZEf4f23\n" +
+            "L/2Dbn5UB/uMCB7L71rWf3UwuCA3Is5uPci/3PQYLNwDkP3m3ZzxyzVCgFVqqYFg\n" +
+            "MAoGCCqGSM49BAMCA0cAMEQCIHafyKHQhv+03DaOJpuotD+jNu0Nc9pUI9OA8pUY\n" +
+            "3+qJAiBsqKjtc8LuGtUoqGvxLLQJwJ2QNY/qyEGtaImlqTYg5w==\n" +
+            "-----END CERTIFICATE-----";
     }
 }


### PR DESCRIPTION
This implements PEM export on X509Certificate2 and X509Certificate2Collection.

Contributes to #51630.