### PR TITLE
Enable running analyzers on DllImportGenerator and Microsoft.Interop.SourceGeneration

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -18,7 +18,7 @@
       unconditionally in Microsoft.NETCoreSdk.BundledVersions.props.
     -->
     <NETCoreAppMaximumVersion>$(MajorVersion).$(MinorVersion)</NETCoreAppMaximumVersion>
-    <EnableNETAnalyzers Condition="'$(EnableAnalyzers)' != 'true'">false</EnableNETAnalyzers>
+    <EnableNETAnalyzers Condition="'$(EnableNETAnalyzers)' == ''">$(RunAnalyzers)</EnableNETAnalyzers>
     <!-- SDK sets product to assembly but we want it to be our product name -->
     <Product>Microsoft%AE .NET</Product>
     <!-- Use the .NET product branding version for informational version description -->

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Analyzers/ConvertToGeneratedDllImportAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Analyzers/ConvertToGeneratedDllImportAnalyzer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Interop.Analyzers
     {
         private const string Category = "Interoperability";
 
-        public readonly static DiagnosticDescriptor ConvertToGeneratedDllImport =
+        public static readonly DiagnosticDescriptor ConvertToGeneratedDllImport =
             new DiagnosticDescriptor(
                 Ids.ConvertToGeneratedDllImport,
                 GetResourceString(nameof(Resources.ConvertToGeneratedDllImportTitle)),

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Analyzers/ConvertToGeneratedDllImportFixer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Analyzers/ConvertToGeneratedDllImportFixer.cs
@@ -276,7 +276,7 @@ namespace Microsoft.Interop.Analyzers
                 generator.AttributeArgument("CallConvs",
                     generator.ArrayCreationExpression(
                         generator.TypeExpression(editor.SemanticModel.Compilation.GetTypeByMetadataName(TypeNames.System_Type)),
-                        new [] { generator.TypeOfExpression(generator.TypeExpression(callingConventionType)) })));
+                        new[] { generator.TypeOfExpression(generator.TypeExpression(callingConventionType)) })));
 
             return true;
         }

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Analyzers/GeneratedDllImportAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Analyzers/GeneratedDllImportAnalyzer.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Interop.Analyzers
     public class GeneratedDllImportAnalyzer : DiagnosticAnalyzer
     {
         private const string Category = "Usage";
-        
-        public readonly static DiagnosticDescriptor GeneratedDllImportMissingModifiers =
+
+        public static readonly DiagnosticDescriptor GeneratedDllImportMissingModifiers =
             new DiagnosticDescriptor(
                 Ids.GeneratedDllImportMissingRequiredModifiers,
                 GetResourceString(nameof(Resources.GeneratedDllImportMissingModifiersTitle)),
@@ -28,7 +28,7 @@ namespace Microsoft.Interop.Analyzers
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.GeneratedDllImportMissingModifiersDescription)));
 
-        public readonly static DiagnosticDescriptor GeneratedDllImportContainingTypeMissingModifiers =
+        public static readonly DiagnosticDescriptor GeneratedDllImportContainingTypeMissingModifiers =
             new DiagnosticDescriptor(
                 Ids.GeneratedDllImportContaiingTypeMissingRequiredModifiers,
                 GetResourceString(nameof(Resources.GeneratedDllImportContainingTypeMissingModifiersTitle)),

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Analyzers/ManualTypeMarshallingAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Analyzers/ManualTypeMarshallingAnalyzer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Interop.Analyzers
     {
         private const string Category = "Usage";
 
-        public readonly static DiagnosticDescriptor BlittableTypeMustBeBlittableRule =
+        public static readonly DiagnosticDescriptor BlittableTypeMustBeBlittableRule =
             new DiagnosticDescriptor(
                 Ids.BlittableTypeMustBeBlittable,
                 "BlittableTypeMustBeBlittable",
@@ -27,7 +27,7 @@ namespace Microsoft.Interop.Analyzers
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.BlittableTypeMustBeBlittableDescription)));
 
-        public readonly static DiagnosticDescriptor CannotHaveMultipleMarshallingAttributesRule =
+        public static readonly DiagnosticDescriptor CannotHaveMultipleMarshallingAttributesRule =
             new DiagnosticDescriptor(
                 Ids.CannotHaveMultipleMarshallingAttributes,
                 "CannotHaveMultipleMarshallingAttributes",
@@ -37,7 +37,7 @@ namespace Microsoft.Interop.Analyzers
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.CannotHaveMultipleMarshallingAttributesDescription)));
 
-        public readonly static DiagnosticDescriptor NativeTypeMustBeNonNullRule =
+        public static readonly DiagnosticDescriptor NativeTypeMustBeNonNullRule =
             new DiagnosticDescriptor(
                 Ids.NativeTypeMustBeNonNull,
                 "NativeTypeMustBeNonNull",
@@ -47,7 +47,7 @@ namespace Microsoft.Interop.Analyzers
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.NativeTypeMustBeNonNullDescription)));
 
-        public readonly static DiagnosticDescriptor NativeTypeMustBeBlittableRule =
+        public static readonly DiagnosticDescriptor NativeTypeMustBeBlittableRule =
             new DiagnosticDescriptor(
                 Ids.NativeTypeMustBeBlittable,
                 "NativeTypeMustBeBlittable",
@@ -57,7 +57,7 @@ namespace Microsoft.Interop.Analyzers
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.BlittableTypeMustBeBlittableDescription)));
 
-        public readonly static DiagnosticDescriptor GetPinnableReferenceReturnTypeBlittableRule =
+        public static readonly DiagnosticDescriptor GetPinnableReferenceReturnTypeBlittableRule =
             new DiagnosticDescriptor(
                 Ids.GetPinnableReferenceReturnTypeBlittable,
                 "GetPinnableReferenceReturnTypeBlittable",
@@ -66,8 +66,8 @@ namespace Microsoft.Interop.Analyzers
                 DiagnosticSeverity.Error,
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.GetPinnableReferenceReturnTypeBlittableDescription)));
-    
-        public readonly static DiagnosticDescriptor NativeTypeMustBePointerSizedRule =
+
+        public static readonly DiagnosticDescriptor NativeTypeMustBePointerSizedRule =
             new DiagnosticDescriptor(
                 Ids.NativeTypeMustBePointerSized,
                 "NativeTypeMustBePointerSized",
@@ -77,7 +77,7 @@ namespace Microsoft.Interop.Analyzers
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.NativeTypeMustBePointerSizedDescription)));
 
-        public readonly static DiagnosticDescriptor NativeTypeMustHaveRequiredShapeRule =
+        public static readonly DiagnosticDescriptor NativeTypeMustHaveRequiredShapeRule =
             new DiagnosticDescriptor(
                 Ids.NativeTypeMustHaveRequiredShape,
                 "NativeTypeMustHaveRequiredShape",
@@ -87,7 +87,7 @@ namespace Microsoft.Interop.Analyzers
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.NativeTypeMustHaveRequiredShapeDescription)));
 
-        public readonly static DiagnosticDescriptor CollectionNativeTypeMustHaveRequiredShapeRule =
+        public static readonly DiagnosticDescriptor CollectionNativeTypeMustHaveRequiredShapeRule =
             new DiagnosticDescriptor(
                 Ids.NativeTypeMustHaveRequiredShape,
                 "NativeTypeMustHaveRequiredShape",
@@ -97,7 +97,7 @@ namespace Microsoft.Interop.Analyzers
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.CollectionNativeTypeMustHaveRequiredShapeDescription)));
 
-        public readonly static DiagnosticDescriptor ValuePropertyMustHaveSetterRule =
+        public static readonly DiagnosticDescriptor ValuePropertyMustHaveSetterRule =
             new DiagnosticDescriptor(
                 Ids.ValuePropertyMustHaveSetter,
                 "ValuePropertyMustHaveSetter",
@@ -107,7 +107,7 @@ namespace Microsoft.Interop.Analyzers
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.ValuePropertyMustHaveSetterDescription)));
 
-        public readonly static DiagnosticDescriptor ValuePropertyMustHaveGetterRule =
+        public static readonly DiagnosticDescriptor ValuePropertyMustHaveGetterRule =
             new DiagnosticDescriptor(
                 Ids.ValuePropertyMustHaveGetter,
                 "ValuePropertyMustHaveGetter",
@@ -117,7 +117,7 @@ namespace Microsoft.Interop.Analyzers
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.ValuePropertyMustHaveGetterDescription)));
 
-        public readonly static DiagnosticDescriptor GetPinnableReferenceShouldSupportAllocatingMarshallingFallbackRule =
+        public static readonly DiagnosticDescriptor GetPinnableReferenceShouldSupportAllocatingMarshallingFallbackRule =
             new DiagnosticDescriptor(
                 Ids.GetPinnableReferenceShouldSupportAllocatingMarshallingFallback,
                 "GetPinnableReferenceShouldSupportAllocatingMarshallingFallback",
@@ -127,7 +127,7 @@ namespace Microsoft.Interop.Analyzers
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.GetPinnableReferenceShouldSupportAllocatingMarshallingFallbackDescription)));
 
-        public readonly static DiagnosticDescriptor StackallocMarshallingShouldSupportAllocatingMarshallingFallbackRule =
+        public static readonly DiagnosticDescriptor StackallocMarshallingShouldSupportAllocatingMarshallingFallbackRule =
             new DiagnosticDescriptor(
                 Ids.StackallocMarshallingShouldSupportAllocatingMarshallingFallback,
                 "StackallocMarshallingShouldSupportAllocatingMarshallingFallback",
@@ -137,7 +137,7 @@ namespace Microsoft.Interop.Analyzers
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.StackallocMarshallingShouldSupportAllocatingMarshallingFallbackDescription)));
 
-        public readonly static DiagnosticDescriptor StackallocConstructorMustHaveStackBufferSizeConstantRule =
+        public static readonly DiagnosticDescriptor StackallocConstructorMustHaveStackBufferSizeConstantRule =
             new DiagnosticDescriptor(
                 Ids.StackallocConstructorMustHaveStackBufferSizeConstant,
                 "StackallocConstructorMustHaveStackBufferSizeConstant",
@@ -147,7 +147,7 @@ namespace Microsoft.Interop.Analyzers
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.StackallocConstructorMustHaveStackBufferSizeConstantDescription)));
 
-        public readonly static DiagnosticDescriptor RefValuePropertyUnsupportedRule =
+        public static readonly DiagnosticDescriptor RefValuePropertyUnsupportedRule =
             new DiagnosticDescriptor(
                 Ids.RefValuePropertyUnsupported,
                 "RefValuePropertyUnsupported",
@@ -157,7 +157,7 @@ namespace Microsoft.Interop.Analyzers
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.RefValuePropertyUnsupportedDescription)));
 
-        public readonly static DiagnosticDescriptor NativeGenericTypeMustBeClosedOrMatchArityRule =
+        public static readonly DiagnosticDescriptor NativeGenericTypeMustBeClosedOrMatchArityRule =
             new DiagnosticDescriptor(
                 Ids.NativeGenericTypeMustBeClosedOrMatchArity,
                 "NativeGenericTypeMustBeClosedOrMatchArity",
@@ -167,7 +167,7 @@ namespace Microsoft.Interop.Analyzers
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.NativeGenericTypeMustBeClosedOrMatchArityDescription)));
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => 
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
             ImmutableArray.Create(
                 BlittableTypeMustBeBlittableRule,
                 CannotHaveMultipleMarshallingAttributesRule,
@@ -223,7 +223,7 @@ namespace Microsoft.Interop.Analyzers
             }
         }
 
-        class PerCompilationAnalyzer
+        private class PerCompilationAnalyzer
         {
             private readonly INamedTypeSymbol GeneratedMarshallingAttribute;
             private readonly INamedTypeSymbol BlittableTypeAttribute;

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Comparers.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Comparers.cs
@@ -16,12 +16,12 @@ namespace Microsoft.Interop
         /// Comparer for the set of all of the generated stubs and diagnostics generated for each of them.
         /// </summary>
         public static readonly IEqualityComparer<ImmutableArray<(string, ImmutableArray<Diagnostic>)>> GeneratedSourceSet = new ImmutableArraySequenceEqualComparer<(string, ImmutableArray<Diagnostic>)>(new CustomValueTupleElementComparer<string, ImmutableArray<Diagnostic>>(EqualityComparer<string>.Default, new ImmutableArraySequenceEqualComparer<Diagnostic>(EqualityComparer<Diagnostic>.Default)));
-        
+
         /// <summary>
         /// Comparer for an individual generated stub source as a string and the generated diagnostics for the stub.
         /// </summary>
         public static readonly IEqualityComparer<(string, ImmutableArray<Diagnostic>)> GeneratedSource = new CustomValueTupleElementComparer<string, ImmutableArray<Diagnostic>>(EqualityComparer<string>.Default, new ImmutableArraySequenceEqualComparer<Diagnostic>(EqualityComparer<Diagnostic>.Default));
-        
+
         /// <summary>
         /// Comparer for an individual generated stub source as a syntax tree and the generated diagnostics for the stub.
         /// </summary>

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.cs
@@ -15,6 +15,8 @@ using System.Text;
 using System.Threading;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+
 namespace Microsoft.Interop
 {
     [Generator]
@@ -73,7 +75,7 @@ namespace Microsoft.Interop
                 .CreateSyntaxProvider(
                     static (node, ct) => ShouldVisitNode(node),
                     static (context, ct) =>
-                        new 
+                        new
                         {
                             Syntax = (MethodDeclarationSyntax)context.Node,
                             Symbol = (IMethodSymbol)context.SemanticModel.GetDeclaredSymbol(context.Node, ct)!
@@ -184,7 +186,7 @@ namespace Microsoft.Interop
                     context.AddSource("GeneratedDllImports.g.cs", data.Item1);
                 });
         }
-        
+
         private static List<AttributeSyntax> GenerateSyntaxForForwardedAttributes(AttributeData? suppressGCTransitionAttribute, AttributeData? unmanagedCallConvAttribute)
         {
             const string CallConvsField = "CallConvs";
@@ -412,7 +414,7 @@ namespace Microsoft.Interop
             }
 
             Debug.Assert(generatedDllImportAttr is not null);
-            
+
             var generatorDiagnostics = new GeneratorDiagnostics();
 
             // Process the GeneratedDllImport attribute
@@ -427,7 +429,7 @@ namespace Microsoft.Interop
             {
                 generatorDiagnostics.ReportConfigurationNotSupported(generatedDllImportAttr!, nameof(GeneratedDllImportData.ThrowOnUnmappableChar));
             }
-            
+
             if (stubDllImportData.IsUserDefined.HasFlag(DllImportMember.CallingConvention))
             {
                 generatorDiagnostics.ReportConfigurationNotSupported(generatedDllImportAttr!, nameof(GeneratedDllImportData.CallingConvention));
@@ -640,7 +642,7 @@ namespace Microsoft.Interop
         }
 
         private static bool ShouldVisitNode(SyntaxNode syntaxNode)
-        { 
+        {
             // We only support C# method declarations.
             if (syntaxNode.Language != LanguageNames.CSharp
                 || !syntaxNode.IsKind(SyntaxKind.MethodDeclaration))

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.csproj
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.csproj
@@ -11,6 +11,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>Microsoft.Interop</RootNamespace>
     <IsRoslynComponent>true</IsRoslynComponent>
+    <RunAnalyzers>true</RunAnalyzers>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGeneratorOptions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGeneratorOptions.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.Interop
 {
-    record DllImportGeneratorOptions(bool GenerateForwarders, bool UseMarshalType, bool UseInternalUnsafeType)
+    internal record DllImportGeneratorOptions(bool GenerateForwarders, bool UseMarshalType, bool UseInternalUnsafeType)
     {
         public DllImportGeneratorOptions(AnalyzerConfigOptions options)
             : this(options.GenerateForwarders(), options.UseMarshalType(), options.UseInternalUnsafeType())

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportStubContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportStubContext.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Interop
                 // Use the declaring syntax as a basis for this type declaration.
                 // Since we're generating source for the method, we know that the current type
                 // has to be declared in source.
-                TypeDeclarationSyntax typeDecl = (TypeDeclarationSyntax)currType.DeclaringSyntaxReferences[0].GetSyntax();
+                TypeDeclarationSyntax typeDecl = (TypeDeclarationSyntax)currType.DeclaringSyntaxReferences[0].GetSyntax(token);
                 // Remove current members, attributes, and base list so we don't double declare them.
                 typeDecl = typeDecl.WithMembers(List<MemberDeclarationSyntax>())
                                    .WithAttributeLists(List<AttributeListSyntax>())
@@ -264,7 +264,7 @@ namespace Microsoft.Interop
                     return true;
                 }
             }
-            
+
             // We check the module case earlier, so we don't need to do it here.
 
             return false;

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/ForwarderMarshallingGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/ForwarderMarshallingGeneratorFactory.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 namespace Microsoft.Interop
 {
-    class ForwarderMarshallingGeneratorFactory : IMarshallingGeneratorFactory
+    internal class ForwarderMarshallingGeneratorFactory : IMarshallingGeneratorFactory
     {
         private static readonly Forwarder Forwarder = new Forwarder();
 

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/GeneratorDiagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/GeneratorDiagnostics.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Interop
 
         private const string Category = "SourceGeneration";
 
-        public readonly static DiagnosticDescriptor ParameterTypeNotSupported =
+        public static readonly DiagnosticDescriptor ParameterTypeNotSupported =
             new DiagnosticDescriptor(
                 Ids.TypeNotSupported,
                 GetResourceString(nameof(Resources.TypeNotSupportedTitle)),
@@ -37,7 +37,7 @@ namespace Microsoft.Interop
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.TypeNotSupportedDescription)));
 
-        public readonly static DiagnosticDescriptor ReturnTypeNotSupported =
+        public static readonly DiagnosticDescriptor ReturnTypeNotSupported =
             new DiagnosticDescriptor(
                 Ids.TypeNotSupported,
                 GetResourceString(nameof(Resources.TypeNotSupportedTitle)),
@@ -47,7 +47,7 @@ namespace Microsoft.Interop
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.TypeNotSupportedDescription)));
 
-        public readonly static DiagnosticDescriptor ParameterTypeNotSupportedWithDetails =
+        public static readonly DiagnosticDescriptor ParameterTypeNotSupportedWithDetails =
             new DiagnosticDescriptor(
                 Ids.TypeNotSupported,
                 GetResourceString(nameof(Resources.TypeNotSupportedTitle)),
@@ -57,7 +57,7 @@ namespace Microsoft.Interop
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.TypeNotSupportedDescription)));
 
-        public readonly static DiagnosticDescriptor ReturnTypeNotSupportedWithDetails =
+        public static readonly DiagnosticDescriptor ReturnTypeNotSupportedWithDetails =
             new DiagnosticDescriptor(
                 Ids.TypeNotSupported,
                 GetResourceString(nameof(Resources.TypeNotSupportedTitle)),
@@ -67,7 +67,7 @@ namespace Microsoft.Interop
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.TypeNotSupportedDescription)));
 
-        public readonly static DiagnosticDescriptor ParameterConfigurationNotSupported =
+        public static readonly DiagnosticDescriptor ParameterConfigurationNotSupported =
             new DiagnosticDescriptor(
                 Ids.ConfigurationNotSupported,
                 GetResourceString(nameof(Resources.ConfigurationNotSupportedTitle)),
@@ -77,7 +77,7 @@ namespace Microsoft.Interop
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.ConfigurationNotSupportedDescription)));
 
-        public readonly static DiagnosticDescriptor ReturnConfigurationNotSupported =
+        public static readonly DiagnosticDescriptor ReturnConfigurationNotSupported =
             new DiagnosticDescriptor(
                 Ids.ConfigurationNotSupported,
                 GetResourceString(nameof(Resources.ConfigurationNotSupportedTitle)),
@@ -87,7 +87,7 @@ namespace Microsoft.Interop
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.ConfigurationNotSupportedDescription)));
 
-        public readonly static DiagnosticDescriptor ConfigurationNotSupported =
+        public static readonly DiagnosticDescriptor ConfigurationNotSupported =
             new DiagnosticDescriptor(
                 Ids.ConfigurationNotSupported,
                 GetResourceString(nameof(Resources.ConfigurationNotSupportedTitle)),
@@ -97,7 +97,7 @@ namespace Microsoft.Interop
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.ConfigurationNotSupportedDescription)));
 
-        public readonly static DiagnosticDescriptor ConfigurationValueNotSupported =
+        public static readonly DiagnosticDescriptor ConfigurationValueNotSupported =
             new DiagnosticDescriptor(
                 Ids.ConfigurationNotSupported,
                 GetResourceString(nameof(Resources.ConfigurationNotSupportedTitle)),
@@ -107,7 +107,7 @@ namespace Microsoft.Interop
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.ConfigurationNotSupportedDescription)));
 
-        public readonly static DiagnosticDescriptor MarshallingAttributeConfigurationNotSupported =
+        public static readonly DiagnosticDescriptor MarshallingAttributeConfigurationNotSupported =
             new DiagnosticDescriptor(
                 Ids.ConfigurationNotSupported,
                 GetResourceString(nameof(Resources.ConfigurationNotSupportedTitle)),
@@ -117,7 +117,7 @@ namespace Microsoft.Interop
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.ConfigurationNotSupportedDescription)));
 
-        public readonly static DiagnosticDescriptor TargetFrameworkNotSupported =
+        public static readonly DiagnosticDescriptor TargetFrameworkNotSupported =
             new DiagnosticDescriptor(
                 Ids.TargetFrameworkNotSupported,
                 GetResourceString(nameof(Resources.TargetFrameworkNotSupportedTitle)),

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/NoPreserveSigMarshallingGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/NoPreserveSigMarshallingGeneratorFactory.cs
@@ -9,7 +9,7 @@ using System.Text;
 
 namespace Microsoft.Interop
 {
-    class NoPreserveSigMarshallingGeneratorFactory : IMarshallingGeneratorFactory
+    internal class NoPreserveSigMarshallingGeneratorFactory : IMarshallingGeneratorFactory
     {
         private static readonly HResultExceptionMarshaller HResultException = new HResultExceptionMarshaller();
         private readonly IMarshallingGeneratorFactory inner;

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/PInvokeStubCodeGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/PInvokeStubCodeGenerator.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Interop
                 }
                 return info.ManagedIndex;
             }
-            
+
             BoundGenerator CreateGenerator(TypePositionInfo p)
             {
                 try

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManualTypeMarshallingHelper.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManualTypeMarshallingHelper.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Interop
             return type
                 .GetMembers(NativeValueStoragePropertyName)
                 .OfType<IPropertySymbol>()
-                .Any(p => p is {IsStatic: false, GetMethod: not null, ReturnsByRef: false, ReturnsByRefReadonly: false } 
+                .Any(p => p is {IsStatic: false, GetMethod: not null, ReturnsByRef: false, ReturnsByRefReadonly: false }
                     && SymbolEqualityComparer.Default.Equals(p.Type, spanOfByte));
         }
     }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ArrayMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ArrayMarshaller.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Interop
             TypeSyntax arrayElementType = elementType;
             if (context.CurrentStage == StubCodeContext.Stage.Marshal)
             {
-                // [COMPAT] We use explicit byref calculations here instead of just using a fixed statement 
+                // [COMPAT] We use explicit byref calculations here instead of just using a fixed statement
                 // since a fixed statement converts a zero-length array to a null pointer.
                 // Many native APIs, such as GDI+, ICU, etc. validate that an array parameter is non-null
                 // even when the passed in array length is zero. To avoid breaking customers that want to move

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/BlittableMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/BlittableMarshaller.cs
@@ -35,7 +35,6 @@ namespace Microsoft.Interop
             else if (context.SingleFrameSpansNativeContext && !info.IsManagedReturnPosition)
             {
                 return Argument(IdentifierName(context.GetIdentifiers(info).native));
-                
             }
             return Argument(
                     PrefixUnaryExpression(
@@ -102,7 +101,7 @@ namespace Microsoft.Interop
         {
             return info.IsByRef && !info.IsManagedReturnPosition && !context.SingleFrameSpansNativeContext;
         }
-        
+
         public bool SupportsByValueMarshalKind(ByValueContentsMarshalKind marshalKind, StubCodeContext context) => false;
     }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/BoolMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/BoolMarshaller.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Interop
         }
 
         public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context) => true;
-        
+
         public bool SupportsByValueMarshalKind(ByValueContentsMarshalKind marshalKind, StubCodeContext context) => false;
     }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CharMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CharMarshaller.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Interop
         }
 
         public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context) => true;
-        
+
         public bool SupportsByValueMarshalKind(ByValueContentsMarshalKind marshalKind, StubCodeContext context) => false;
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ConditionalStackallocMarshallingGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ConditionalStackallocMarshallingGenerator.cs
@@ -45,12 +45,12 @@ namespace Microsoft.Interop
         }
 
         protected IEnumerable<StatementSyntax> GenerateConditionalAllocationSyntax(
-            TypePositionInfo info, 
+            TypePositionInfo info,
             StubCodeContext context,
             int stackallocMaxSize)
         {
             (_, string nativeIdentifier) = context.GetIdentifiers(info);
-            
+
             string allocationMarkerIdentifier = GetAllocationMarkerIdentifier(info, context);
             string byteLenIdentifier = GetByteLengthIdentifier(info, context);
             string stackAllocPtrIdentifier = GetStackAllocIdentifier(info, context);
@@ -210,7 +210,7 @@ namespace Microsoft.Interop
         protected abstract ExpressionSyntax GenerateFreeExpression(
             TypePositionInfo info,
             StubCodeContext context);
-        
+
         /// <summary>
         /// Generate code to check if the managed value is not null.
         /// </summary>

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/DelegateMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/DelegateMarshaller.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Interop
         }
 
         public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context) => true;
-        
+
         public bool SupportsByValueMarshalKind(ByValueContentsMarshalKind marshalKind, StubCodeContext context) => false;
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/Forwarder.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/Forwarder.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Interop
                             Literal((int)marshalAs.UnmanagedType)))))));
                 return true;
             }
-            
+
             if (info.MarshallingAttributeInfo is NativeContiguousCollectionMarshallingInfo collectionMarshalling
                 && collectionMarshalling.UseDefaultMarshalling
                 && collectionMarshalling.ElementCountInfo is NoCountInfo or SizeAndParamIndexInfo
@@ -112,7 +112,7 @@ namespace Microsoft.Interop
         }
 
         public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context) => false;
-        
+
         public bool SupportsByValueMarshalKind(ByValueContentsMarshalKind marshalKind, StubCodeContext context) => true;
 
         public AttributeListSyntax? GenerateAttributesForReturnType(TypePositionInfo info)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/HResultExceptionMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/HResultExceptionMarshaller.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Interop
         }
 
         public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context) => false;
-        
+
         public bool SupportsByValueMarshalKind(ByValueContentsMarshalKind marshalKind, StubCodeContext context) => false;
     }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Interop
     /// <summary>
     /// The base interface for implementing various different aspects of the custom native type and collection marshalling specs.
     /// </summary>
-    interface ICustomNativeTypeMarshallingStrategy
+    internal interface ICustomNativeTypeMarshallingStrategy
     {
         TypeSyntax AsNativeType(TypePositionInfo info);
 
@@ -630,7 +630,7 @@ namespace Microsoft.Interop
             {
                 foreach (var statement in GenerateUnmarshallerCollectionInitialization(info, context))
                 {
-                    yield return statement;    
+                    yield return statement;
                 }
             }
 
@@ -686,7 +686,7 @@ namespace Microsoft.Interop
             // and NativeValueStorage spans when the actual collection value is unmarshalled from native to the marshaller.
             foreach (var statement in GenerateUnmarshallerCollectionInitialization(info, context))
             {
-                yield return statement;    
+                yield return statement;
             }
 
             foreach (var statement in innerMarshaller.GenerateUnmarshalStatements(info, context))
@@ -974,7 +974,7 @@ namespace Microsoft.Interop
             {
                 yield return statement;
             }
-            
+
             if (!info.IsByRef && info.ByValueContentsMarshalKind == ByValueContentsMarshalKind.Out)
             {
                 // If the parameter is marshalled by-value [Out], then we don't marshal the contents of the collection.

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallerHelpers.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallerHelpers.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Interop
 
             // Now that we have initialized our map of edges and we have our list of nodes,
             // we'll use Khan's algorithm to calculate a topological sort of the elements.
-            // Algorithm adapted from A. B. Kahn. 1962. Topological sorting of large networks. Commun. ACM 5, 11 (Nov. 1962), 558–562. DOI:https://doi.org/10.1145/368996.369025
+            // Algorithm adapted from A. B. Kahn. 1962. Topological sorting of large networks. Commun. ACM 5, 11 (Nov. 1962), 558ï¿½562. DOI:https://doi.org/10.1145/368996.369025
 
             // L is the sorted list
             List<T> L = new(elements.Count);
@@ -245,7 +245,7 @@ namespace Microsoft.Interop
             {
                 string methodName = encoding switch
                 {
-                    CharEncoding.Utf8 => "StringToCoTaskMemUTF8", // Not in .NET Standard 2.0, so we use the hard-coded name 
+                    CharEncoding.Utf8 => "StringToCoTaskMemUTF8", // Not in .NET Standard 2.0, so we use the hard-coded name
                     CharEncoding.Utf16 => nameof(System.Runtime.InteropServices.Marshal.StringToCoTaskMemUni),
                     CharEncoding.Ansi => nameof(System.Runtime.InteropServices.Marshal.StringToCoTaskMemAnsi),
                     _ => throw new System.ArgumentOutOfRangeException(nameof(encoding))

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallerHelpers.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallerHelpers.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Interop
 
             // Now that we have initialized our map of edges and we have our list of nodes,
             // we'll use Khan's algorithm to calculate a topological sort of the elements.
-            // Algorithm adapted from A. B. Kahn. 1962. Topological sorting of large networks. Commun. ACM 5, 11 (Nov. 1962), 558�562. DOI:https://doi.org/10.1145/368996.369025
+            // Algorithm adapted from A. B. Kahn. 1962. Topological sorting of large networks. Commun. ACM 5, 11 (Nov. 1962), 558-562. DOI:https://doi.org/10.1145/368996.369025
 
             // L is the sorted list
             List<T> L = new(elements.Count);

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGeneratorFactory.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Interop
                 // Enum with no marshalling info
                 case { ManagedType: EnumTypeInfo enumType, MarshallingAttributeInfo: NoMarshallingInfo }:
                     // Check that the underlying type is not bool or char. C# does not allow this, but ECMA-335 does.
-                    var underlyingSpecialType = enumType.UnderlyingType; 
+                    var underlyingSpecialType = enumType.UnderlyingType;
                     if (underlyingSpecialType == SpecialType.System_Boolean || underlyingSpecialType == SpecialType.System_Char)
                     {
                         throw new MarshallingNotSupportedException(info, context);
@@ -117,7 +117,7 @@ namespace Microsoft.Interop
                             NotSupportedDetails = Resources.SafeHandleByRefMustBeConcrete
                         };
                     }
-                    return new SafeHandleMarshaller();
+                    return SafeHandle;
 
                 case { ManagedType: SpecialTypeInfo { SpecialType: SpecialType.System_Char } }:
                     return CreateCharMarshaller(info, context);

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/SafeHandleMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/SafeHandleMarshaller.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Interop
                             .WithArgumentList(
                                 ArgumentList(
                                     SeparatedList(
-                                        new []{
+                                        new[]{
                                             Argument(
                                                 TypeOfExpression(
                                                     info.ManagedType.Syntax)),
@@ -151,7 +151,7 @@ namespace Microsoft.Interop
                                         .WithRefKindKeyword(Token(SyntaxKind.RefKeyword))))));
 
 
-                        ExpressionSyntax assignHandleToNativeExpression = 
+                        ExpressionSyntax assignHandleToNativeExpression =
                             AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
                                 IdentifierName(nativeIdentifier),
                                 InvocationExpression(
@@ -179,7 +179,7 @@ namespace Microsoft.Interop
                                 ParseTypeName(TypeNames.System_Runtime_InteropServices_Marshal),
                                 IdentifierName("InitHandle")),
                             ArgumentList(SeparatedList(
-                                new []
+                                new[]
                                 {
                                     Argument(IdentifierName(newHandleObjectIdentifier)),
                                     Argument(IdentifierName(nativeIdentifier))
@@ -208,7 +208,7 @@ namespace Microsoft.Interop
                                         IdentifierName(managedIdentifier),
                                         IdentifierName(nameof(SafeHandle.DangerousRelease))),
                                     ArgumentList())));
-                                
+
                         // Do not unmarshal the handle if the value didn't change.
                         yield return IfStatement(
                             BinaryExpression(SyntaxKind.NotEqualsExpression,
@@ -241,7 +241,7 @@ namespace Microsoft.Interop
         }
 
         public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context) => true;
-        
+
         public bool SupportsByValueMarshalKind(ByValueContentsMarshalKind marshalKind, StubCodeContext context) => false;
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StringMarshaller.Ansi.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StringMarshaller.Ansi.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Interop
         }
 
         public override bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context) => true;
-        
+
         public override bool SupportsByValueMarshalKind(ByValueContentsMarshalKind marshalKind, StubCodeContext context) => false;
 
         // This marshaller only uses the conditional allocaction base for setup and cleanup.

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StringMarshaller.PlatformDefined.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StringMarshaller.PlatformDefined.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Interop
             if (windowsExpr.IsEquivalentTo(nonWindowsExpr))
                 return Argument(windowsExpr);
 
-            // OperatingSystem.IsWindows() ? << Windows code >> : << non-Windows code >> 
+            // OperatingSystem.IsWindows() ? << Windows code >> : << non-Windows code >>
             return Argument(
                 ConditionalExpression(
                     IsWindows,
@@ -88,10 +88,10 @@ namespace Microsoft.Interop
                     // any platform, it is done on every platform.
                     foreach (var s in this.windowsMarshaller.Generate(info, context))
                         yield return s;
-                    
+
                     foreach (var s in this.nonWindowsMarshaller.Generate(info, context))
                         yield return s;
-                    
+
                     break;
                 case StubCodeContext.Stage.Unmarshal:
                     if (info.IsManagedReturnPosition || (info.IsByRef && info.RefKind != RefKind.In))
@@ -112,7 +112,7 @@ namespace Microsoft.Interop
         }
 
         public override bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context) => true;
-        
+
         public override bool SupportsByValueMarshalKind(ByValueContentsMarshalKind marshalKind, StubCodeContext context) => false;
 
         // This marshaller only uses the conditional allocaction base for setup and cleanup.

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StringMarshaller.Utf16.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StringMarshaller.Utf16.cs
@@ -128,16 +128,16 @@ namespace Microsoft.Interop
                     }
                     break;
                 case StubCodeContext.Stage.Cleanup:
-                    yield return GenerateConditionalAllocationFreeSyntax(info ,context);
+                    yield return GenerateConditionalAllocationFreeSyntax(info, context);
 
                     break;
             }
         }
 
         public override bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context) => true;
-        
+
         public override bool SupportsByValueMarshalKind(ByValueContentsMarshalKind marshalKind, StubCodeContext context) => false;
-        
+
         protected override ExpressionSyntax GenerateAllocationExpression(
             TypePositionInfo info,
             StubCodeContext context,
@@ -155,7 +155,7 @@ namespace Microsoft.Interop
             // +1 for null terminator
             // *2 for number of bytes per char
             // int <byteLen> = (<managed>.Length + 1) * 2;
-            return 
+            return
                 BinaryExpression(
                     SyntaxKind.MultiplyExpression,
                     ParenthesizedExpression(
@@ -176,7 +176,7 @@ namespace Microsoft.Interop
             SyntaxToken stackAllocPtrIdentifier)
         {
             // ((ReadOnlySpan<char>)<managed>).CopyTo(new Span<char>(<stackAllocPtr>, <managed>.Length + 1));
-            return                                 
+            return
                 ExpressionStatement(
                     InvocationExpression(
                         MemberAccessExpression(
@@ -189,14 +189,14 @@ namespace Microsoft.Interop
                                 IdentifierName(context.GetIdentifiers(info).managed))),
                             IdentifierName("CopyTo")),
                         ArgumentList(
-                            SeparatedList(new [] {
+                            SeparatedList(new[] {
                                 Argument(
                                     ObjectCreationExpression(
                                         GenericName(Identifier(TypeNames.System_Span),
                                             TypeArgumentList(SingletonSeparatedList<TypeSyntax>(
                                                 PredefinedType(Token(SyntaxKind.CharKeyword))))),
                                         ArgumentList(
-                                            SeparatedList(new []{
+                                            SeparatedList(new[]{
                                                 Argument(IdentifierName(stackAllocPtrIdentifier)),
                                                 Argument(IdentifierName(byteLengthIdentifier))})),
                                         initializer: null))}))));

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StringMarshaller.Utf8.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StringMarshaller.Utf8.cs
@@ -103,9 +103,9 @@ namespace Microsoft.Interop
         }
 
         public override bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context) => true;
-        
+
         public override bool SupportsByValueMarshalKind(ByValueContentsMarshalKind marshalKind, StubCodeContext context) => false;
-        
+
         protected override ExpressionSyntax GenerateAllocationExpression(
             TypePositionInfo info,
             StubCodeContext context,

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshallingAttributeInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshallingAttributeInfo.cs
@@ -322,7 +322,7 @@ namespace Microsoft.Interop
             return NoMarshallingInfo.Instance;
         }
 
-        CountInfo CreateCountInfo(AttributeData marshalUsingData, ImmutableHashSet<string> inspectedElements)
+        private CountInfo CreateCountInfo(AttributeData marshalUsingData, ImmutableHashSet<string> inspectedElements)
         {
             int? constSize = null;
             string? elementName = null;
@@ -442,7 +442,7 @@ namespace Microsoft.Interop
             return null;
         }
 
-        MarshallingInfo CreateInfoFromMarshalAs(
+        private MarshallingInfo CreateInfoFromMarshalAs(
             ITypeSymbol type,
             AttributeData attrData,
             ImmutableHashSet<string> inspectedElements,
@@ -559,7 +559,7 @@ namespace Microsoft.Interop
                 ElementMarshallingInfo: elementMarshallingInfo);
         }
 
-        MarshallingInfo CreateNativeMarshallingInfo(
+        private MarshallingInfo CreateNativeMarshallingInfo(
             ITypeSymbol type,
             AttributeData attrData,
             bool isMarshalUsingAttribute,
@@ -695,7 +695,7 @@ namespace Microsoft.Interop
                 UseDefaultMarshalling: !isMarshalUsingAttribute);
         }
 
-        bool TryCreateTypeBasedMarshallingInfo(
+        private bool TryCreateTypeBasedMarshallingInfo(
             ITypeSymbol type,
             CountInfo parsedCountInfo,
             int indirectionLevel,

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj
@@ -5,6 +5,7 @@
     <Packable>false</Packable>
     <Nullable>enable</Nullable>
     <RootNamespace>Microsoft.Interop</RootNamespace>
+    <RunAnalyzers>true</RunAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Properties/AssemblyInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/StubCodeContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/StubCodeContext.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Interop
             /// Perform any cleanup required
             /// </summary>
             Cleanup,
-            
+
             /// <summary>
             /// Keep alive any managed objects that need to stay alive across the call.
             /// </summary>

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeNames.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeNames.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Interop
         }
 
         public const string System_Runtime_InteropServices_UnmanagedType = "System.Runtime.InteropServices.UnmanagedType";
-        
+
         public const string System_Runtime_InteropServices_MemoryMarshal = "System.Runtime.InteropServices.MemoryMarshal";
 
         public const string System_Runtime_InteropServices_GeneratedMarshalling_ArrayMarshaller_Metadata = "System.Runtime.InteropServices.GeneratedMarshalling.ArrayMarshaller`1";


### PR DESCRIPTION
- Set `EnableNETAnalyzers` based on `RunAnalyzers`
- Turn on analyzers in `DllImportGenerator` and `Microsoft.Interop.SourceGeneration` projects
- Fix errors (or warnings treated as errors) from analyzers

This change only fixes the violations that are warnings/errors - will do another pass for the IDE suggestions (naming, for example).

cc @AaronRobinsonMSFT @jkoritzinsky 