### PR TITLE
Removing unused CallSiteKind items from Dependency Injection

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteKind.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteKind.cs
@@ -14,11 +14,5 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         IEnumerable,
 
         ServiceProvider,
-
-        Scope,
-
-        Transient,
-
-        Singleton
     }
 }


### PR DESCRIPTION
Removing Scope, Transient and Singleton from enum CallSiteKind.
Their CallSites were removed by 8e8650f9