### PR TITLE
FileSystem.Unix: improve CopyFile.

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.CopyFile.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.CopyFile.cs
@@ -10,6 +10,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CopyFile", SetLastError = true)]
-        internal static partial int CopyFile(SafeFileHandle source, SafeFileHandle destination);
+        internal static partial int CopyFile(SafeFileHandle source, SafeFileHandle destination, long sourceLength);
     }
 }

--- a/src/libraries/Native/Unix/System.Native/pal_io.c
+++ b/src/libraries/Native/Unix/System.Native/pal_io.c
@@ -1143,14 +1143,6 @@ static int32_t CopyFile_ReadWrite(int inFd, int outFd, int64_t fileLength)
             assert(bytesWritten >= 0);
             bytesRead -= bytesWritten;
             offset += bytesWritten;
-            if (fileLength > 0)
-            {
-                fileLength -= bytesWritten;
-                if (fileLength == 0)
-                {
-                    break;
-                }
-            }
         }
     }
 

--- a/src/libraries/Native/Unix/System.Native/pal_io.c
+++ b/src/libraries/Native/Unix/System.Native/pal_io.c
@@ -1148,6 +1148,8 @@ static int32_t CopyFile_ReadWrite(int inFd, int outFd)
 
 int32_t SystemNative_CopyFile(intptr_t sourceFd, intptr_t destinationFd, int64_t sourceLength)
 {
+    (void)sourceLength; // unused on some platforms.
+
     int inFd = ToFileDescriptor(sourceFd);
     int outFd = ToFileDescriptor(destinationFd);
 

--- a/src/libraries/Native/Unix/System.Native/pal_io.c
+++ b/src/libraries/Native/Unix/System.Native/pal_io.c
@@ -61,6 +61,8 @@ extern int     getpeereid(int, uid_t *__restrict__, gid_t *__restrict__);
 #endif
 #endif
 
+// The portable build is performed on RHEL7 which doesn't define FICLONE yet.
+// Ensure FICLONE is defined for all Linux builds.
 #ifdef __linux__
 #ifndef FICLONE
 #define FICLONE _IOW(0x94, 9, int)
@@ -1172,8 +1174,8 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, intptr_t destinationFd, int64_t
     int ret;
     bool copied = false;
 
-    // Certain files (e.g. procfs) may return a size of 0 even though reading from then will
-    // produce data.  We use plain read/write for those.
+    // Certain files (e.g. procfs) may return a size of 0 even though reading them will
+    // produce data. We use plain read/write for those.
 #ifdef FICLONE
     if (sourceLength != 0)
     {

--- a/src/libraries/Native/Unix/System.Native/pal_io.c
+++ b/src/libraries/Native/Unix/System.Native/pal_io.c
@@ -1210,6 +1210,12 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, intptr_t destinationFd, int64_t
                     break;
                 }
             }
+            else if (sent == 0)
+            {
+                // The file was truncated (or maybe some other condition occurred).
+                // Perform the remaining copying using read/write.
+                break;
+            }
             else
             {
                 assert(sent <= sourceLength);
@@ -1217,7 +1223,7 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, intptr_t destinationFd, int64_t
             }
         } while (sourceLength > 0);
 
-        copied = true;
+        copied = sourceLength == 0;
     }
 #endif // HAVE_SENDFILE_4
 

--- a/src/libraries/Native/Unix/System.Native/pal_io.c
+++ b/src/libraries/Native/Unix/System.Native/pal_io.c
@@ -1182,12 +1182,6 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, intptr_t destinationFd, int64_t
         // Try copying data using a copy-on-write clone. This shares storage between the files.
         while ((ret = ioctl(outFd, FICLONE, inFd)) < 0 && errno == EINTR);
         copied = ret == 0;
-        if (!copied && errno != EOPNOTSUPP // not supported
-                    && errno != EXDEV      // not same file system
-                    && errno != ETXTBSY)   // swapfiles can't be reflinked
-        {
-            return -1;
-        }
     }
 #endif
 #if HAVE_SENDFILE_4

--- a/src/libraries/Native/Unix/System.Native/pal_io.c
+++ b/src/libraries/Native/Unix/System.Native/pal_io.c
@@ -1093,16 +1093,11 @@ int32_t SystemNative_Write(intptr_t fd, const void* buffer, int32_t bufferSize)
 
 #if !HAVE_FCOPYFILE
 // Read all data from inFd and write it to outFd
-static int32_t CopyFile_ReadWrite(int inFd, int outFd, int64_t fileLength)
+static int32_t CopyFile_ReadWrite(int inFd, int outFd)
 {
-    // Allocate a buffer.
-    size_t bufferLength = 80 * 1024 * sizeof(char);
-    if (fileLength > 0 && fileLength < (int64_t)bufferLength)
-    {
-        // Limit buffer to file length if it is smaller.
-        bufferLength = (size_t)fileLength;
-    }
-    char* buffer = (char*)malloc(bufferLength);
+    // Allocate a buffer
+    const int BufferLength = 80 * 1024 * sizeof(char);
+    char* buffer = (char*)malloc(BufferLength);
     if (buffer == NULL)
     {
         return -1;
@@ -1113,7 +1108,7 @@ static int32_t CopyFile_ReadWrite(int inFd, int outFd, int64_t fileLength)
     {
         // Read up to what will fit in our buffer.  We're done if we get back 0 bytes.
         ssize_t bytesRead;
-        while ((bytesRead = read(inFd, buffer, bufferLength)) < 0 && errno == EINTR);
+        while ((bytesRead = read(inFd, buffer, BufferLength)) < 0 && errno == EINTR);
         if (bytesRead == -1)
         {
             int tmp = errno;
@@ -1214,7 +1209,7 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, intptr_t destinationFd, int64_t
 #endif // HAVE_SENDFILE_4
 
     // Perform a manual copy.
-    if (!copied && CopyFile_ReadWrite(inFd, outFd, sourceLength) != 0)
+    if (!copied && CopyFile_ReadWrite(inFd, outFd) != 0)
     {
         return -1;
     }

--- a/src/libraries/Native/Unix/System.Native/pal_io.c
+++ b/src/libraries/Native/Unix/System.Native/pal_io.c
@@ -1164,9 +1164,9 @@ int32_t SystemNative_CopyFile(intptr_t sourceFd, intptr_t destinationFd, int64_t
     // Certain files (e.g. procfs) may return a size of 0 even though reading them will
     // produce data. We use plain read/write for those.
 #ifdef FICLONE
+    // Try copying data using a copy-on-write clone. This shares storage between the files.
     if (sourceLength != 0)
     {
-        // Try copying data using a copy-on-write clone. This shares storage between the files.
         while ((ret = ioctl(outFd, FICLONE, inFd)) < 0 && errno == EINTR);
         copied = ret == 0;
     }

--- a/src/libraries/Native/Unix/System.Native/pal_io.h
+++ b/src/libraries/Native/Unix/System.Native/pal_io.h
@@ -675,7 +675,7 @@ PALEXPORT int32_t SystemNative_Write(intptr_t fd, const void* buffer, int32_t bu
  *
  * Returns 0 on success; otherwise, returns -1 and sets errno.
  */
-PALEXPORT int32_t SystemNative_CopyFile(intptr_t sourceFd, intptr_t destinationFd);
+PALEXPORT int32_t SystemNative_CopyFile(intptr_t sourceFd, intptr_t destinationFd, int64_t sourceLength);
 
 /**
 * Initializes a new inotify instance and returns a file

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Win32.SafeHandles
                 Interop.ErrorInfo error = Interop.Sys.GetLastErrorInfo();
                 handle.Dispose();
 
-                if (createOpenException?.Invoke(error, flags, path) is { } ex)
+                if (createOpenException?.Invoke(error, flags, path) is Exception ex)
                 {
                     throw ex;
                 }

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -57,12 +57,8 @@ namespace Microsoft.Win32.SafeHandles
 
         internal void EnsureThreadPoolBindingInitialized() { /* nop */ }
 
-        /// <summary>Opens the specified file with the requested flags and mode.</summary>
-        /// <param name="path">The path to the file.</param>
-        /// <param name="flags">The flags with which to open the file.</param>
-        /// <param name="mode">The mode for opening the file.</param>
-        /// <returns>A SafeFileHandle for the opened file.</returns>
-        private static SafeFileHandle Open(string path, Interop.Sys.OpenFlags flags, int mode)
+        private static SafeFileHandle Open(string path, Interop.Sys.OpenFlags flags, int mode,
+                                           Func<Interop.ErrorInfo, Interop.Sys.OpenFlags, string, Exception?>? createOpenException)
         {
             Debug.Assert(path != null);
             SafeFileHandle handle = Interop.Sys.Open(path, flags, mode);
@@ -72,6 +68,11 @@ namespace Microsoft.Win32.SafeHandles
             {
                 Interop.ErrorInfo error = Interop.Sys.GetLastErrorInfo();
                 handle.Dispose();
+
+                if (createOpenException?.Invoke(error, flags, path) is { } ex)
+                {
+                    throw ex;
+                }
 
                 // If we fail to open the file due to a path not existing, we need to know whether to blame
                 // the file itself or its directory.  If we're creating the file, then we blame the directory,
@@ -155,30 +156,52 @@ namespace Microsoft.Win32.SafeHandles
             }
         }
 
-        internal static SafeFileHandle Open(string fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, long preallocationSize)
-        {
-            // Translate the arguments into arguments for an open call.
-            Interop.Sys.OpenFlags openFlags = PreOpenConfigurationFromOptions(mode, access, share, options);
-
-            // If the file gets created a new, we'll select the permissions for it.  Most Unix utilities by default use 666 (read and
-            // write for all), so we do the same (even though this doesn't match Windows, where by default it's possible to write out
-            // a file and then execute it). No matter what we choose, it'll be subject to the umask applied by the system, such that the
-            // actual permissions will typically be less than what we select here.
-            const Interop.Sys.Permissions OpenPermissions =
+        // If the file gets created a new, we'll select the permissions for it.  Most Unix utilities by default use 666 (read and
+        // write for all), so we do the same (even though this doesn't match Windows, where by default it's possible to write out
+        // a file and then execute it). No matter what we choose, it'll be subject to the umask applied by the system, such that the
+        // actual permissions will typically be less than what we select here.
+        private const Interop.Sys.Permissions DefaultOpenPermissions =
                 Interop.Sys.Permissions.S_IRUSR | Interop.Sys.Permissions.S_IWUSR |
                 Interop.Sys.Permissions.S_IRGRP | Interop.Sys.Permissions.S_IWGRP |
                 Interop.Sys.Permissions.S_IROTH | Interop.Sys.Permissions.S_IWOTH;
+
+        // Specialized Open that returns the file length and permissions of the opened file.
+        // This information is retrieved from the 'stat' syscall that must be performed to ensure the path is not a directory.
+        internal static SafeFileHandle OpenReadOnly(string fullPath, FileOptions options, out long fileLength, out Interop.Sys.Permissions filePermissions)
+        {
+            SafeFileHandle handle = Open(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read, options, preallocationSize: 0, DefaultOpenPermissions, out fileLength, out filePermissions, null);
+            Debug.Assert(fileLength >= 0);
+            return handle;
+        }
+
+        internal static SafeFileHandle Open(string fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, long preallocationSize,
+                                            Interop.Sys.Permissions openPermissions = DefaultOpenPermissions,
+                                            Func<Interop.ErrorInfo, Interop.Sys.OpenFlags, string, Exception?>? createOpenException = null)
+        {
+            long fileLength;
+            Interop.Sys.Permissions filePermissions;
+            return Open(fullPath, mode, access, share, options, preallocationSize, openPermissions, out fileLength, out filePermissions, null);
+        }
+
+        private static SafeFileHandle Open(string fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, long preallocationSize,
+                                            Interop.Sys.Permissions openPermissions,
+                                            out long fileLength,
+                                            out Interop.Sys.Permissions filePermissions,
+                                            Func<Interop.ErrorInfo, Interop.Sys.OpenFlags, string, Exception?>? createOpenException = null)
+        {
+            // Translate the arguments into arguments for an open call.
+            Interop.Sys.OpenFlags openFlags = PreOpenConfigurationFromOptions(mode, access, share, options);
 
             SafeFileHandle? safeFileHandle = null;
             try
             {
                 while (true)
                 {
-                    safeFileHandle = Open(fullPath, openFlags, (int)OpenPermissions);
+                    safeFileHandle = Open(fullPath, openFlags, (int)openPermissions, createOpenException);
 
                     // When Init return false, the path has changed to another file entry, and
                     // we need to re-open the path to reflect that.
-                    if (safeFileHandle.Init(fullPath, mode, access, share, options, preallocationSize))
+                    if (safeFileHandle.Init(fullPath, mode, access, share, options, preallocationSize, out fileLength, out filePermissions))
                     {
                         return safeFileHandle;
                     }
@@ -275,10 +298,13 @@ namespace Microsoft.Win32.SafeHandles
             return flags;
         }
 
-        private bool Init(string path, FileMode mode, FileAccess access, FileShare share, FileOptions options, long preallocationSize)
+        private bool Init(string path, FileMode mode, FileAccess access, FileShare share, FileOptions options, long preallocationSize,
+                          out long fileLength, out Interop.Sys.Permissions filePermissions)
         {
             Interop.Sys.FileStatus status = default;
             bool statusHasValue = false;
+            fileLength = -1;
+            filePermissions = 0;
 
             // Make sure our handle is not a directory.
             // We can omit the check when write access is requested. open will have failed with EISDIR.
@@ -300,6 +326,9 @@ namespace Microsoft.Win32.SafeHandles
                     _canSeek = NullableBool.True;
                     Debug.Assert(Interop.Sys.LSeek(this, 0, Interop.Sys.SeekWhence.SEEK_CUR) >= 0);
                 }
+
+                fileLength = status.Size;
+                filePermissions = (Interop.Sys.Permissions)(status.Mode & (int)Interop.Sys.Permissions.Mask);
             }
 
             IsAsync = (options & FileOptions.Asynchronous) != 0;

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
@@ -21,8 +21,8 @@ namespace System.IO
             Interop.Sys.Permissions filePermissions;
             using SafeFileHandle src = SafeFileHandle.OpenReadOnly(sourceFullPath, FileOptions.None, out fileLength, out filePermissions);
             using SafeFileHandle dst = SafeFileHandle.Open(destFullPath, overwrite ? FileMode.Create : FileMode.CreateNew,
-                                                           FileAccess.ReadWrite, FileShare.None, FileOptions.None, preallocationSize: 0,
-                                                           openPermissions: filePermissions, CreateOpenException);
+                                            FileAccess.ReadWrite, FileShare.None, FileOptions.None, preallocationSize: 0, openPermissions: filePermissions,
+                                            (Interop.ErrorInfo error, Interop.Sys.OpenFlags flags, string path) => CreateOpenException(error, flags, path));
 
             Interop.CheckIo(Interop.Sys.CopyFile(src, dst, fileLength));
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
@@ -11,25 +11,30 @@ namespace System.IO
     /// <summary>Provides an implementation of FileSystem for Unix systems.</summary>
     internal static partial class FileSystem
     {
-        internal const int DefaultBufferSize = 4096;
-
         // On Linux, the maximum number of symbolic links that are followed while resolving a pathname is 40.
         // See: https://man7.org/linux/man-pages/man7/path_resolution.7.html
         private const int MaxFollowedLinks = 40;
 
         public static void CopyFile(string sourceFullPath, string destFullPath, bool overwrite)
         {
-            // If the destination path points to a directory, we throw to match Windows behaviour
-            if (DirectoryExists(destFullPath))
-            {
-                throw new IOException(SR.Format(SR.Arg_FileIsDirectory_Name, destFullPath));
-            }
+            long fileLength;
+            Interop.Sys.Permissions filePermissions;
+            using SafeFileHandle src = SafeFileHandle.OpenReadOnly(sourceFullPath, FileOptions.None, out fileLength, out filePermissions);
+            using SafeFileHandle dst = SafeFileHandle.Open(destFullPath, overwrite ? FileMode.Create : FileMode.CreateNew,
+                                                           FileAccess.ReadWrite, FileShare.None, FileOptions.None, preallocationSize: 0,
+                                                           openPermissions: filePermissions, CreateOpenException);
 
-            // Copy the contents of the file from the source to the destination, creating the destination in the process
-            using (SafeFileHandle src = File.OpenHandle(sourceFullPath, FileMode.Open, FileAccess.Read, FileShare.Read, FileOptions.None))
-            using (SafeFileHandle dst = File.OpenHandle(destFullPath, overwrite ? FileMode.Create : FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, FileOptions.None))
+            Interop.CheckIo(Interop.Sys.CopyFile(src, dst, fileLength));
+
+            static Exception? CreateOpenException(Interop.ErrorInfo error, Interop.Sys.OpenFlags flags, string path)
             {
-                Interop.CheckIo(Interop.Sys.CopyFile(src, dst));
+                // If the destination path points to a directory, we throw to match Windows behaviour.
+                if (error.Error == Interop.Error.EEXIST && DirectoryExists(path))
+                {
+                    return new IOException(SR.Format(SR.Arg_FileIsDirectory_Name, path));
+                }
+
+                return null; // Let SafeFileHandle create the exception for this error.
             }
         }
 


### PR DESCRIPTION
Like the upcoming version of GNU coreutils 'cp' prefer a copy-on-write clone.
This shares the physical storage between files, which means no data needs to copied.
CoW-clones are supported by a number of Linux file systems, like Btrfs, XFS, and overlayfs.

Eliminate a 'stat' call that is always performed for checking if the target is a directory
by only performing the check when the 'open' syscall reports an error.

Eliminate a 'stat' call for retrieving the file size of the source by passing through
the length that was retrieved when checking the opened file is not a directory.

Create the destination with file permissions that match the source.
We still need to fchmod due to umask being applied to the open mode.

When performing a manual copy, limit the allocated buffer for small files.
And, avoid the last 'read' call by checking when we've copied the expected nr of bytes.