### PR TITLE
Make Utf16CharMarshaller pin ref parameters

### DIFF
--- a/docs/design/libraries/DllImportGenerator/Compatibility.md
+++ b/docs/design/libraries/DllImportGenerator/Compatibility.md
@@ -69,6 +69,10 @@ Jagged arrays (arrays of arrays) are technically unsupported as was the case in 
 
 In the source-generated marshalling, arrays will be allocated on the stack (instead of through [`AllocCoTaskMem`](https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.marshal.alloccotaskmem)) if they are passed by value or by read-only reference if they contain at most 256 bytes of data. The built-in system does not support this optimization for arrays.
 
+### `in` keyword
+
+For some types - blittable or Unicode `char` - passed by read-only reference via the [`in` keyword](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/in-parameter-modifier), the built-in system simply pins the parameter. The generated marshalling code does the same. A consequence of this behaviour is that any modifications made by the invoked function will be reflected in the caller. It is left to the user to avoid the situation in which `in` is used for a parameter that will actually be modified by the invoked function.
+
 ### `LCIDConversion` support
 
 [`LCIDConversionAttribute`](`https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.lcidconversionattribute`) will not be supported for methods marked with `GeneratedDllImportAttribute`.

--- a/docs/design/libraries/DllImportGenerator/Compatibility.md
+++ b/docs/design/libraries/DllImportGenerator/Compatibility.md
@@ -71,7 +71,7 @@ In the source-generated marshalling, arrays will be allocated on the stack (inst
 
 ### `in` keyword
 
-For some types - blittable or Unicode `char` - passed by read-only reference via the [`in` keyword](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/in-parameter-modifier), the built-in system simply pins the parameter. The generated marshalling code does the same. A consequence of this behaviour is that any modifications made by the invoked function will be reflected in the caller. It is left to the user to avoid the situation in which `in` is used for a parameter that will actually be modified by the invoked function.
+For some types - blittable or Unicode `char` - passed by read-only reference via the [`in` keyword](https://docs.microsoft.com/dotnet/csharp/language-reference/keywords/in-parameter-modifier), the built-in system simply pins the parameter. The generated marshalling code does the same. A consequence of this behaviour is that any modifications made by the invoked function will be reflected in the caller. It is left to the user to avoid the situation in which `in` is used for a parameter that will actually be modified by the invoked function.
 
 ### `LCIDConversion` support
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CharMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CharMarshaller.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Interop
 
         public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context)
         {
-            return info.IsManagedReturnPosition || info.RefKind == RefKind.In || (info.IsByRef && !context.SingleFrameSpansNativeContext);
+            return info.IsManagedReturnPosition || (info.IsByRef && !context.SingleFrameSpansNativeContext);
         }
 
         public bool SupportsByValueMarshalKind(ByValueContentsMarshalKind marshalKind, StubCodeContext context) => false;
@@ -134,7 +134,7 @@ namespace Microsoft.Interop
         {
             return context.SingleFrameSpansNativeContext
                 && !info.IsManagedReturnPosition
-                && (info.IsByRef && info.RefKind != RefKind.In);
+                && info.IsByRef;
         }
 
         private static string PinnedIdentifier(string identifier) => $"{identifier}__pinned";

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CharMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CharMarshaller.cs
@@ -22,16 +22,29 @@ namespace Microsoft.Interop
 
         public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
         {
-            string identifier = context.GetIdentifiers(info).native;
-            if (info.IsByRef)
+            (string managedIdentifier, string nativeIdentifier) = context.GetIdentifiers(info);
+            if (!info.IsByRef)
             {
+                // (ushort)<managedIdentifier>
                 return Argument(
-                    PrefixUnaryExpression(
-                        SyntaxKind.AddressOfExpression,
-                        IdentifierName(identifier)));
+                    CastExpression(
+                        AsNativeType(info),
+                        IdentifierName(managedIdentifier)));
+            }
+            else if (IsPinningPathSupported(info, context))
+            {
+                // (ushort*)<pinned>
+                return Argument(
+                    CastExpression(
+                        PointerType(AsNativeType(info)),
+                        IdentifierName(PinnedIdentifier(info.InstanceIdentifier))));
             }
 
-            return Argument(IdentifierName(identifier));
+            // &<nativeIdentifier>
+            return Argument(
+                PrefixUnaryExpression(
+                    SyntaxKind.AddressOfExpression,
+                    IdentifierName(nativeIdentifier)));
         }
 
         public TypeSyntax AsNativeType(TypePositionInfo info)
@@ -52,12 +65,36 @@ namespace Microsoft.Interop
         public IEnumerable<StatementSyntax> Generate(TypePositionInfo info, StubCodeContext context)
         {
             (string managedIdentifier, string nativeIdentifier) = context.GetIdentifiers(info);
+
+            if (IsPinningPathSupported(info, context))
+            {
+                if (context.CurrentStage == StubCodeContext.Stage.Pin)
+                {
+                    // fixed (char* <pinned> = &<managed>)
+                    yield return FixedStatement(
+                        VariableDeclaration(
+                            PointerType(PredefinedType(Token(SyntaxKind.CharKeyword))),
+                            SingletonSeparatedList(
+                                VariableDeclarator(Identifier(PinnedIdentifier(info.InstanceIdentifier)))
+                                    .WithInitializer(EqualsValueClause(
+                                        PrefixUnaryExpression(
+                                            SyntaxKind.AddressOfExpression,
+                                            IdentifierName(Identifier(managedIdentifier)))
+                                    ))
+                            )
+                        ),
+                        EmptyStatement()
+                    );
+                }
+                yield break;
+            }
+
             switch (context.CurrentStage)
             {
                 case StubCodeContext.Stage.Setup:
                     break;
                 case StubCodeContext.Stage.Marshal:
-                    if (info.RefKind != RefKind.Out)
+                    if (info.IsByRef && info.RefKind != RefKind.Out)
                     {
                         yield return ExpressionStatement(
                             AssignmentExpression(
@@ -86,8 +123,20 @@ namespace Microsoft.Interop
             }
         }
 
-        public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context) => true;
+        public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context)
+        {
+            return info.IsManagedReturnPosition || info.RefKind == RefKind.In || (info.IsByRef && !context.SingleFrameSpansNativeContext);
+        }
 
         public bool SupportsByValueMarshalKind(ByValueContentsMarshalKind marshalKind, StubCodeContext context) => false;
+
+        private bool IsPinningPathSupported(TypePositionInfo info, StubCodeContext context)
+        {
+            return context.SingleFrameSpansNativeContext
+                && !info.IsManagedReturnPosition
+                && (info.IsByRef && info.RefKind != RefKind.In);
+        }
+
+        private static string PinnedIdentifier(string identifier) => $"{identifier}__pinned";
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.Tests/CharacterTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.Tests/CharacterTests.cs
@@ -75,7 +75,7 @@ namespace DllImportGenerator.IntegrationTests
 
             result = initial;
             NativeExportsNE.ReturnUIntAsUnicode_In(value, in result);
-            Assert.Equal(initial, result); // Should not be updated when using 'in'
+            Assert.Equal(expected, result); // Value is updated even when passed with 'in' keyword (matches built-in system)
         }
 
         [Theory]

--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.Tests/CharacterTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.Tests/CharacterTests.cs
@@ -1,7 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 using Xunit;
@@ -32,6 +34,9 @@ namespace DllImportGenerator.IntegrationTests
         [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "char_return_as_uint", CharSet = CharSet.Ansi)]
         [return: MarshalAs(UnmanagedType.I2)]
         public static partial char ReturnI2AsI2IgnoreCharSet([MarshalAs(UnmanagedType.I2)] char input);
+
+        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "char_reverse_buffer_ref", CharSet = CharSet.Unicode)]
+        public static partial void ReverseBuffer(ref char buffer, int len);
     }
 
     public class CharacterTests
@@ -80,6 +85,18 @@ namespace DllImportGenerator.IntegrationTests
             char expected = (char)expectedUInt;
             Assert.Equal(expected, NativeExportsNE.ReturnU2AsU2IgnoreCharSet(value));
             Assert.Equal(expected, NativeExportsNE.ReturnI2AsI2IgnoreCharSet(value));
+        }
+
+        [Fact]
+        public void ValidateRefCharAsBuffer()
+        {
+            char[] chars = CharacterMappings().Select(o => (char)o[0]).ToArray();
+            char[] expected = new char[chars.Length];
+            Array.Copy(chars, expected, chars.Length);
+            Array.Reverse(expected);
+
+            NativeExportsNE.ReverseBuffer(ref MemoryMarshal.GetArrayDataReference(chars), chars.Length);
+            Assert.Equal(expected, chars);
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/Characters.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/Characters.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Runtime.InteropServices;
 
 namespace NativeExports
@@ -23,6 +24,13 @@ namespace NativeExports
         public static void ReturnUIntAsRefUInt(uint input, uint* res)
         {
             *res = input;
+        }
+
+        [UnmanagedCallersOnly(EntryPoint = "char_reverse_buffer_ref")]
+        public static void ReverseBuffer(ushort *buffer, int len)
+        {
+            var span = new Span<ushort>(buffer, len);
+            span.Reverse();
         }
     }
 }


### PR DESCRIPTION
Make our char marshaller pin ref/out instead of copy just the char to a local.

`ref char` parameters are being used as string buffers in parts of the libraries. 

Before:
```C#
internal static unsafe partial char Method(char p, in char pIn, ref char cRef, out char pOut)
{
    unsafe
    {
        ushort __p_gen_native = default;
        ushort __pIn_gen_native = default;
        ushort __cRef_gen_native = default;
        pOut = default;
        ushort __pOut_gen_native = default;
        char __retVal = default;
        ushort __retVal_gen_native = default;
        //
        // Marshal
        //
        __p_gen_native = p;
        __pIn_gen_native = pIn;
        __cRef_gen_native = cRef;
        __retVal_gen_native = __PInvoke__(__p_gen_native, &__pIn_gen_native, &__cRef_gen_native, &__pOut_gen_native);
        //
        // Unmarshal
        //
        __retVal = (char)__retVal_gen_native;
        pOut = (char)__pOut_gen_native;
        cRef = (char)__cRef_gen_native;
        return __retVal;
    }

    [System.Runtime.InteropServices.DllImportAttribute("DNE", EntryPoint = "Method", CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
    extern static unsafe ushort __PInvoke__(ushort p, ushort* pIn, ushort* cRef, ushort* pOut);
}
```

After:
```C#
internal static unsafe partial char Method(char p, in char pIn, ref char cRef, out char pOut)
{
    unsafe
    {
        ushort __pIn_gen_native = default;
        pOut = default;
        char __retVal = default;
        ushort __retVal_gen_native = default;
        //
        // Marshal
        //
        __pIn_gen_native = pIn;
        fixed (char* cRef__pinned = &cRef)
        {
            fixed (char* pOut__pinned = &pOut)
                __retVal_gen_native = __PInvoke__((ushort)p, &__pIn_gen_native, (ushort*)cRef__pinned, (ushort*)pOut__pinned);
        }

        //
        // Unmarshal
        //
        __retVal = (char)__retVal_gen_native;
        return __retVal;
    }

    [System.Runtime.InteropServices.DllImportAttribute("DNE", EntryPoint = "Method", CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
    extern static unsafe ushort __PInvoke__(ushort p, ushort* pIn, ushort* cRef, ushort* pOut);
}
```

cc @AaronRobinsonMSFT @jkoritzinsky 