### PR TITLE
Fix Time Zone when running with Globalization Invariant Mode

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.FullGlobalizationData.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.FullGlobalizationData.Unix.cs
@@ -24,6 +24,11 @@ namespace System
         // Main function that is called during construction to populate the three display names
         private static void TryPopulateTimeZoneDisplayNamesFromGlobalizationData(string timeZoneId, TimeSpan baseUtcOffset, ref string? standardDisplayName, ref string? daylightDisplayName, ref string? displayName)
         {
+            if (GlobalizationMode.Invariant)
+            {
+                return;
+            }
+
             // Determine the culture to use
             CultureInfo uiCulture = CultureInfo.CurrentUICulture;
             if (uiCulture.Name.Length == 0)

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2545,13 +2545,10 @@ namespace System.Tests
         [PlatformSpecific(TestPlatforms.AnyUnix)]
         public static void TimeZoneInfo_LocalZoneWithInvariantMode()
         {
-            bool runningInInvariantMode = false;
-            try { CultureInfo.GetCultureInfo("en-US"); } catch { runningInInvariantMode = true; }
-
             string hostTZId = TimeZoneInfo.Local.Id;
 
             ProcessStartInfo psi = new ProcessStartInfo() {  UseShellExecute = false };
-            psi.Environment.Add("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", runningInInvariantMode ? "0" : "1");
+            psi.Environment.Add("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", PlatformDetection.IsInvariantGlobalization ? "0" : "1");
 
             RemoteExecutor.Invoke((tzId, hostIsRunningInInvariantMode) =>
             {
@@ -2564,7 +2561,7 @@ namespace System.Tests
 
                 Assert.Equal(tzId, TimeZoneInfo.Local.Id);
 
-            }, hostTZId, runningInInvariantMode.ToString(), new RemoteInvokeOptions { StartInfo =  psi}).Dispose();
+            }, hostTZId, PlatformDetection.IsInvariantGlobalization.ToString(), new RemoteInvokeOptions { StartInfo =  psi}).Dispose();
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2555,6 +2555,8 @@ namespace System.Tests
 
                 if (!hostInvariantMode)
                 {
+                    // If hostInvariantMode is false, means the child process should enable the globalization invariant mode.
+                    // We validate here that by trying to create a culture which should throws in such mode.
                     Assert.Throws<CultureNotFoundException>(() => CultureInfo.GetCultureInfo("en-US"));
                 }
 

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -2542,7 +2542,6 @@ namespace System.Tests
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]
         public static void TimeZoneInfo_LocalZoneWithInvariantMode()
         {
             string hostTZId = TimeZoneInfo.Local.Id;


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/59636

When enabling the globalization invariant mode on Linux, we'll always fallback to `UTC` time zone which is wrong and a regression from .NET 5.0. We have some docker containers (e.g. Alpine) which enable the globalization invariant mode by default on the whole image; the problem will be obvious there.

In .NET 6.0 we have introduced the [Globalization Invariant Mode Breaking Change](https://docs.microsoft.com/en-us/dotnet/core/compatibility/globalization/6.0/culture-creation-invariant-mode). This breaking change causes throwing exception when enabling the globalization invariant mode and creating any culture other than Invariant culture. 
If the globalization invariant mode is enabled and trying to get the local time zone when running on Linux platform, the creation process will try to initialize the display names of the time zone. This initialization tries to reset the UI culture to `en-US` if it is set to Invariant culture. When we have the globalization invariant mode is on, the UI culture will always be Invariant and cause the time zone initialization to fallback to `en-US` which will throw exception because it is not allowed to create any other cultures in the Invariant mode. We catch the exception and then fallback to use `UTC` time zone instead of the actual time zone set on the running machine.

The fix is simple and not risky which is avoid creating any culture during time zone initialization when the globalization invariant mode is on.