### PR TITLE
Revert bind single elements to array in configuration binder

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -19,7 +19,6 @@ namespace Microsoft.Extensions.Configuration
         private const string TrimmingWarningMessage = "In case the type is non-primitive, the trimmer cannot statically analyze the object's type so its members may be trimmed.";
         private const string InstanceGetTypeTrimmingWarningMessage = "Cannot statically analyze the type of instance so its members may be trimmed";
         private const string PropertyTrimmingWarningMessage = "Cannot statically analyze property.PropertyType so its members may be trimmed.";
-        private const string BindSingleElementsToArraySwitch = "Microsoft.Extensions.Configuration.BindSingleElementsToArray";
 
         /// <summary>
         /// Attempts to bind the configuration instance to a new instance of type T.
@@ -363,7 +362,7 @@ namespace Microsoft.Extensions.Configuration
                 return convertedValue;
             }
 
-            if (config != null && (config.GetChildren().Any() || (configValue != null && ShouldBindSingleElementsToArray())))
+            if (config != null && config.GetChildren().Any())
             {
                 // If we don't have an instance, try to create one
                 if (instance == null)
@@ -496,7 +495,7 @@ namespace Microsoft.Extensions.Configuration
             Type itemType = collectionType.GenericTypeArguments[0];
             MethodInfo addMethod = collectionType.GetMethod("Add", DeclaredOnlyLookup);
 
-            foreach (IConfigurationSection section in GetChildrenOrSelf(config))
+            foreach (IConfigurationSection section in config.GetChildren())
             {
                 try
                 {
@@ -519,7 +518,7 @@ namespace Microsoft.Extensions.Configuration
         [RequiresUnreferencedCode("Cannot statically analyze what the element type is of the Array so its members may be trimmed.")]
         private static Array BindArray(Array source, IConfiguration config, BinderOptions options)
         {
-            IConfigurationSection[] children = GetChildrenOrSelf(config).ToArray();
+            IConfigurationSection[] children = config.GetChildren().ToArray();
             int arrayLength = source.Length;
             Type elementType = source.GetType().GetElementType();
             var newArray = Array.CreateInstance(elementType, arrayLength + children.Length);
@@ -702,38 +701,6 @@ namespace Microsoft.Extensions.Configuration
             }
 
             return property.Name;
-        }
-
-        private static IEnumerable<IConfigurationSection> GetChildrenOrSelf(IConfiguration config)
-        {
-            if (!ShouldBindSingleElementsToArray())
-            {
-                return config.GetChildren();
-            }
-
-            IEnumerable<IConfigurationSection> children;
-            // If configuration's children is an array, the configuration key will be a number
-            if (config.GetChildren().Any(a => long.TryParse(a.Key, out _)))
-            {
-                children = config.GetChildren();
-            }
-            else
-            {
-                children = new[] { config as IConfigurationSection };
-            }
-
-            return children;
-        }
-
-        private static bool ShouldBindSingleElementsToArray()
-        {
-            if (AppContext.TryGetSwitch(BindSingleElementsToArraySwitch, out bool bindSingleElementsToArray))
-            {
-                return bindSingleElementsToArray;
-            }
-
-            // Enable this switch by default.
-            return true;
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -21,9 +21,6 @@ namespace Microsoft.Extensions.Configuration
         private const string PropertyTrimmingWarningMessage = "Cannot statically analyze property.PropertyType so its members may be trimmed.";
         private const string BindSingleElementsToArraySwitch = "Microsoft.Extensions.Configuration.BindSingleElementsToArray";
 
-        // Enable this switch by default.
-        private static bool ShouldBindSingleElementsToArray { get; } = AppContext.TryGetSwitch(BindSingleElementsToArraySwitch, out bool verifyCanBindSingleElementsToArray) ? verifyCanBindSingleElementsToArray : true;
-
         /// <summary>
         /// Attempts to bind the configuration instance to a new instance of type T.
         /// If this configuration section has a value, that will be used.
@@ -366,7 +363,7 @@ namespace Microsoft.Extensions.Configuration
                 return convertedValue;
             }
 
-            if (config != null && (config.GetChildren().Any() || (configValue != null && ShouldBindSingleElementsToArray)))
+            if (config != null && (config.GetChildren().Any() || (configValue != null && ShouldBindSingleElementsToArray())))
             {
                 // If we don't have an instance, try to create one
                 if (instance == null)
@@ -709,7 +706,7 @@ namespace Microsoft.Extensions.Configuration
 
         private static IEnumerable<IConfigurationSection> GetChildrenOrSelf(IConfiguration config)
         {
-            if (!ShouldBindSingleElementsToArray)
+            if (!ShouldBindSingleElementsToArray())
             {
                 return config.GetChildren();
             }
@@ -726,6 +723,17 @@ namespace Microsoft.Extensions.Configuration
             }
 
             return children;
+        }
+
+        private static bool ShouldBindSingleElementsToArray()
+        {
+            if (AppContext.TryGetSwitch(BindSingleElementsToArraySwitch, out bool bindSingleElementsToArray))
+            {
+                return bindSingleElementsToArray;
+            }
+
+            // Enable this switch by default.
+            return true;
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
@@ -936,58 +936,6 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
                 exception.Message);
         }
 
-        [Fact]
-        public void CanBindSingleElementToCollection()
-        {
-            var dic = new Dictionary<string, string>
-            {
-                {"MyString", "hello world"},
-                {"Nested:Integer", "11"},
-            };
-
-            var configurationBuilder = new ConfigurationBuilder();
-            configurationBuilder.AddInMemoryCollection(dic);
-            IConfiguration config = configurationBuilder.Build();
-
-            var stringArr = config.GetSection("MyString").Get<string[]>();
-            Assert.Equal("hello world", stringArr[0]);
-            Assert.Equal(1, stringArr.Length);
-
-            var stringAsStr = config.GetSection("MyString").Get<string>();
-            Assert.Equal("hello world", stringAsStr);
-
-            var nested = config.GetSection("Nested").Get<NestedOptions>();
-            Assert.Equal(11, nested.Integer);
-
-            var nestedAsArray = config.GetSection("Nested").Get<NestedOptions[]>();
-            Assert.Equal(11, nestedAsArray[0].Integer);
-            Assert.Equal(1, nestedAsArray.Length);
-        }
-
-        [Fact]
-        public void CannotBindSingleElementToCollectionWhenSwitchSet()
-        {
-            AppContext.SetSwitch("Microsoft.Extensions.Configuration.BindSingleElementsToArray", false);
-
-            var dic = new Dictionary<string, string>
-            {
-                {"MyString", "hello world"},
-                {"Nested:Integer", "11"},
-            };
-
-            var configurationBuilder = new ConfigurationBuilder();
-            configurationBuilder.AddInMemoryCollection(dic);
-            IConfiguration config = configurationBuilder.Build();
-
-            var stringArr = config.GetSection("MyString").Get<string[]>();
-            Assert.Null(stringArr);
-
-            var stringAsStr = config.GetSection("MyString").Get<string>();
-            Assert.Equal("hello world", stringAsStr);
-
-            AppContext.SetSwitch("Microsoft.Extensions.Configuration.BindSingleElementsToArray", true);
-        }
-
         private interface ISomeInterface
         {
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Microsoft.Extensions.Configuration.Binder.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Microsoft.Extensions.Configuration.Binder.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
-    <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The change we introduced in: https://github.com/dotnet/runtime/pull/57204 and https://github.com/dotnet/runtime/pull/57872 have raised two breaks in RC1, I think we are very late in the cycle to introduce more risk and try to fix those issues. 

https://github.com/dotnet/runtime/issues/58852
https://github.com/dotnet/runtime/issues/58330

We should revert this change and then try to do it again on 7.0.0 considering both issues that have been raised.

We should port this to 6.0 branch as well.

cc: @ericstj @danmoseley @vidommet 