### PR TITLE
Fix nullable warning in HttpConnectionBase

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -35,6 +35,7 @@ namespace System.Net.Http
                 {
                     cache = lastValue = descriptor.GetHeaderValue(value, encoding);
                 }
+                Debug.Assert(cache is not null);
                 return lastValue;
             }
         }


### PR DESCRIPTION
Very recently we started enforcing nullability attributes on local functions in the compiler. The flow analysis can't tell that `cache` is not null when exiting here, so without the change we get the following new warning:
`src\libraries\System.Net.Http\src\System\Net\Http\SocketsHttpHandler\HttpConnectionBase.cs(38,17): error CS8777: Parameter 'cache' must have a non-null value when exiting.`

BTW, it seems like nullability warnings are treated as errors locally at least in this project. It feels like warn-as-error is better used only for CI and official builds--local builds should be allowed to proceed in the presence of warnings. Just my 2 cents.

cc @jcouv