### PR TITLE
Fix null termination for generated marshalling of read-only ref string

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.Tests/SetLastErrorTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/DllImportGenerator.Tests/SetLastErrorTests.cs
@@ -33,7 +33,7 @@ namespace DllImportGenerator.IntegrationTests
             [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "set_error", SetLastError = true)]
             public static partial int SetError(int error, byte shouldSetError);
 
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "set_error_return_string", SetLastError = true)]
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "set_error", SetLastError = true)]
             [return: MarshalUsing(typeof(SetLastErrorMarshaller))]
             public static partial int SetError_CustomMarshallingSetsError(int error, byte shouldSetError);
 


### PR DESCRIPTION
Not sure how we managed to not hit test failures in runtimelab, but:
- `StringTests.UnicodeStringByRef` was failing for `Reverse_In` because we weren't null terminating
- `SetError_CustomMarshallingSetsError` was calling the wrong function

cc @AaronRobinsonMSFT @jkoritzinsky