### PR TITLE
fixes to get Quic working on macOS

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
@@ -38,6 +38,9 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DecodeX509")]
         internal static extern SafeX509Handle DecodeX509(ref byte buf, int len);
 
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DecodeX509")]
+        internal static extern SafeX509Handle DecodeX509(IntPtr buf, int len);
+
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509DerSize")]
         internal static extern int GetX509DerSize(SafeX509Handle x);
 

--- a/src/libraries/Common/src/System/Net/Security/CertificateValidation.OSX.cs
+++ b/src/libraries/Common/src/System/Net/Security/CertificateValidation.OSX.cs
@@ -4,6 +4,7 @@
 using Microsoft.Win32.SafeHandles;
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 
 namespace System.Net.Security
@@ -12,9 +13,8 @@ namespace System.Net.Security
     {
         private static readonly IdnMapping s_idnMapping = new IdnMapping();
 
-        internal static SslPolicyErrors BuildChainAndVerifyProperties(X509Chain chain, X509Certificate2 remoteCertificate, bool checkCertName, bool isServer, string? hostName, IntPtr certificateBuffer, int bufferLength ) => BuildChainAndVerifyProperties(chain, remoteCertificate, checkCertName, isServer, hostName);
-
-        internal static SslPolicyErrors BuildChainAndVerifyProperties(X509Chain chain, X509Certificate2 remoteCertificate, bool checkCertName, bool isServer, string? hostName)
+        // WARNING: This function will do the verification using OpenSSL. If the intention is to use OS function, caller should use CertificatePal interface.
+        internal static SslPolicyErrors BuildChainAndVerifyProperties(X509Chain chain, X509Certificate2 remoteCertificate, bool checkCertName, bool isServer, string? hostName, IntPtr certificateBuffer, int bufferLength = 0)
         {
             SslPolicyErrors errors = chain.Build(remoteCertificate) ?
                 SslPolicyErrors.None :
@@ -30,8 +30,20 @@ namespace System.Net.Security
                 return errors | SslPolicyErrors.RemoteCertificateNameMismatch;
             }
 
+            SafeX509Handle certHandle;
+            if (certificateBuffer != IntPtr.Zero && bufferLength > 0)
+            {
+                certHandle = Interop.Crypto.DecodeX509(certificateBuffer, bufferLength);
+            }
+            else
+            {
+                // We dont't have DER encoded buffer.
+                byte[] der = remoteCertificate.Export(X509ContentType.Cert);
+                certHandle = Interop.Crypto.DecodeX509(Marshal.UnsafeAddrOfPinnedArrayElement(der, 0), der.Length);
+            }
+
             int hostNameMatch;
-            using (SafeX509Handle certHandle = Interop.Crypto.X509UpRef(remoteCertificate.Handle))
+            using (certHandle)
             {
                 IPAddress? hostnameAsIp;
                 if (IPAddress.TryParse(hostName, out hostnameAsIp))

--- a/src/libraries/Common/src/System/Net/Security/CertificateValidation.Unix.cs
+++ b/src/libraries/Common/src/System/Net/Security/CertificateValidation.Unix.cs
@@ -12,7 +12,8 @@ namespace System.Net.Security
     {
         private static readonly IdnMapping s_idnMapping = new IdnMapping();
 
-        internal static SslPolicyErrors BuildChainAndVerifyProperties(X509Chain chain, X509Certificate2 remoteCertificate, bool checkCertName, bool isServer, string? hostName, IntPtr certificateBuffer, int bufferLength ) => BuildChainAndVerifyProperties(chain, remoteCertificate, checkCertName, isServer, hostName);
+        internal static SslPolicyErrors BuildChainAndVerifyProperties(X509Chain chain, X509Certificate2 remoteCertificate, bool checkCertName, bool isServer, string? hostName, IntPtr certificateBuffer, int bufferLength)
+            => BuildChainAndVerifyProperties(chain, remoteCertificate, checkCertName, isServer, hostName);
 
         internal static SslPolicyErrors BuildChainAndVerifyProperties(X509Chain chain, X509Certificate2 remoteCertificate, bool checkCertName, bool isServer, string? hostName)
         {

--- a/src/libraries/Common/src/System/Net/Security/CertificateValidation.Windows.cs
+++ b/src/libraries/Common/src/System/Net/Security/CertificateValidation.Windows.cs
@@ -13,6 +13,8 @@ namespace System.Net
 {
     internal static partial class CertificateValidation
     {
+        internal static SslPolicyErrors BuildChainAndVerifyProperties(X509Chain chain, X509Certificate2 remoteCertificate, bool checkCertName, bool isServer, string? hostName, IntPtr certificateBuffer, int bufferLength ) => BuildChainAndVerifyProperties(chain, remoteCertificate, checkCertName, isServer, hostName);
+
         internal static SslPolicyErrors BuildChainAndVerifyProperties(X509Chain chain, X509Certificate2 remoteCertificate, bool checkCertName, bool isServer, string? hostName)
         {
             SslPolicyErrors sslPolicyErrors = SslPolicyErrors.None;

--- a/src/libraries/Common/src/System/Net/Security/CertificateValidation.Windows.cs
+++ b/src/libraries/Common/src/System/Net/Security/CertificateValidation.Windows.cs
@@ -13,7 +13,8 @@ namespace System.Net
 {
     internal static partial class CertificateValidation
     {
-        internal static SslPolicyErrors BuildChainAndVerifyProperties(X509Chain chain, X509Certificate2 remoteCertificate, bool checkCertName, bool isServer, string? hostName, IntPtr certificateBuffer, int bufferLength ) => BuildChainAndVerifyProperties(chain, remoteCertificate, checkCertName, isServer, hostName);
+        internal static SslPolicyErrors BuildChainAndVerifyProperties(X509Chain chain, X509Certificate2 remoteCertificate, bool checkCertName, bool isServer, string? hostName, IntPtr certificateBuffer, int bufferLength)
+            => BuildChainAndVerifyProperties(chain, remoteCertificate, checkCertName, isServer, hostName);
 
         internal static SslPolicyErrors BuildChainAndVerifyProperties(X509Chain chain, X509Certificate2 remoteCertificate, bool checkCertName, bool isServer, string? hostName)
         {

--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -3,6 +3,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-Linux;$(NetCoreAppCurrent)-OSX;$(NetCoreAppCurrent)-FreeBSD;$(NetCoreAppCurrent)</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <DefineConstants Condition="'$(TargetsFreeBSD)' == 'true' or '$(TargetsOSX)' == 'true'">$(DefineConstants);SOCKADDR_HAS_LENGTH</DefineConstants>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>
@@ -76,21 +77,23 @@
     <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeBioHandle.Unix.cs" Link="Common\Microsoft\Win32\SafeHandles\SafeBioHandle.Unix.cs" />
     <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs" Link="Common\Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs" />
     <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeHandleCache.cs" Link="Common\Microsoft\Win32\SafeHandles\SafeHandleCache.cs" />
-    <Compile Include="$(CommonPath)System\Net\Security\CertificateValidation.Unix.cs" Link="Common\System\Net\Security\CertificateValidation.Unix.cs" />
   </ItemGroup>
   <!-- Linux specific files -->
   <ItemGroup Condition="'$(TargetsLinux)' == 'true'">
     <Compile Include="$(CommonPath)Interop\Linux\Interop.Libraries.cs" Link="Common\Interop\Linux\Interop.Libraries.cs" />
     <Compile Include="System\Net\Quic\Implementations\MsQuic\Interop\MsQuicStatusCodes.Linux.cs" />
+    <Compile Include="$(CommonPath)System\Net\Security\CertificateValidation.Unix.cs" Link="Common\System\Net\Security\CertificateValidation.Unix.cs" />
   </ItemGroup>
   <!-- FreeBSD specific files -->
   <ItemGroup Condition="'$(TargetsFreeBSD)' == 'true' ">
+    <Compile Include="$(CommonPath)System\Net\Security\CertificateValidation.Unix.cs" Link="Common\System\Net\Security\CertificateValidation.Unix.cs" />
     <Compile Include="$(CommonPath)Interop\FreeBSD\Interop.Libraries.cs" Link="Common\Interop\FreeBSD\Interop.Libraries.cs" />
     <!-- Assume similarity with OSX for now -->
     <Compile Include="System\Net\Quic\Implementations\MsQuic\Interop\MsQuicStatusCodes.OSX.cs" />
   </ItemGroup>
   <!-- OSX specific files -->
   <ItemGroup Condition=" '$(TargetsOSX)' == 'true'">
+    <Compile Include="$(CommonPath)System\Net\Security\CertificateValidation.OSX.cs" Link="Common\System\Net\Security\CertificateValidation.OSX.cs" />
     <Compile Include="$(CommonPath)Interop\OSX\Interop.Libraries.cs" Link="Common\Interop\OSX\Interop.Libraries.cs" />
     <Compile Include="System\Net\Quic\Implementations\MsQuic\Interop\MsQuicStatusCodes.OSX.cs" />
   </ItemGroup>

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicAddressHelpers.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Internal/MsQuicAddressHelpers.cs
@@ -11,7 +11,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
     {
         internal static unsafe IPEndPoint INetToIPEndPoint(ref SOCKADDR_INET inetAddress)
         {
-            if (inetAddress.si_family == (ushort)QUIC_ADDRESS_FAMILY.INET)
+            if (inetAddress.si_family == QUIC_ADDRESS_FAMILY.INET)
             {
                 return new IPEndPoint(new IPAddress(MemoryMarshal.CreateReadOnlySpan<byte>(ref inetAddress.Ipv4.sin_addr[0], 4)), (ushort)IPAddress.NetworkToHostOrder((short)inetAddress.Ipv4.sin_port));
             }
@@ -30,11 +30,11 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
                 {
                     case AddressFamily.InterNetwork:
                         endpoint.Address.TryWriteBytes(MemoryMarshal.CreateSpan<byte>(ref socketAddress.Ipv4.sin_addr[0], 4), out _);
-                        socketAddress.Ipv4.sin_family = (ushort)QUIC_ADDRESS_FAMILY.INET;
+                        socketAddress.Ipv4.sin_family = QUIC_ADDRESS_FAMILY.INET;
                         break;
                     case AddressFamily.InterNetworkV6:
                         endpoint.Address.TryWriteBytes(MemoryMarshal.CreateSpan<byte>(ref socketAddress.Ipv6.sin6_addr[0], 16), out _);
-                        socketAddress.Ipv6.sin6_family = (ushort)QUIC_ADDRESS_FAMILY.INET6;
+                        socketAddress.Ipv6.sin6_family = QUIC_ADDRESS_FAMILY.INET6;
                         break;
                     default:
                         throw new ArgumentException(SR.net_quic_addressfamily_notsupported);

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicEnums.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicEnums.cs
@@ -203,7 +203,11 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         IDEAL_SEND_BUFFER_SIZE = 8,
     }
 
+#if SOCKADDR_HAS_LENGTH
+    internal enum QUIC_ADDRESS_FAMILY : byte
+#else
     internal enum QUIC_ADDRESS_FAMILY : ushort
+#endif
     {
         UNSPEC = 0,
         INET = 2,

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicNativeMethods.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/Interop/MsQuicNativeMethods.cs
@@ -582,7 +582,10 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         [StructLayout(LayoutKind.Sequential)]
         internal struct SOCKADDR_IN
         {
-            internal ushort sin_family;
+#if SOCKADDR_HAS_LENGTH
+            internal byte sin_len;
+#endif
+            internal QUIC_ADDRESS_FAMILY sin_family;
             internal ushort sin_port;
             internal fixed byte sin_addr[4];
         }
@@ -591,7 +594,10 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         [StructLayout(LayoutKind.Sequential)]
         internal struct SOCKADDR_IN6
         {
-            internal ushort sin6_family;
+#if SOCKADDR_HAS_LENGTH
+            internal byte sin6_len;
+#endif
+            internal QUIC_ADDRESS_FAMILY sin6_family;
             internal ushort sin6_port;
             internal uint sin6_flowinfo;
             internal fixed byte sin6_addr[16];
@@ -606,8 +612,12 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
             internal SOCKADDR_IN Ipv4;
             [FieldOffset(0)]
             internal SOCKADDR_IN6 Ipv6;
+#if SOCKADDR_HAS_LENGTH
+            [FieldOffset(1)]
+#else
             [FieldOffset(0)]
-            internal ushort si_family;
+#endif
+            internal QUIC_ADDRESS_FAMILY si_family;
         }
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -391,6 +391,8 @@ namespace System.Net.Quic.Implementations.MsQuic
             X509Chain? chain = null;
             X509Certificate2? certificate = null;
             X509Certificate2Collection? additionalCertificates = null;
+            IntPtr certificateBuffer = IntPtr.Zero;
+            int certificateLength = 0;
 
             try
             {
@@ -406,6 +408,8 @@ namespace System.Net.Quic.Implementations.MsQuic
                         {
                             ReadOnlySpan<QuicBuffer> quicBuffer = new ReadOnlySpan<QuicBuffer>((void*)connectionEvent.Data.PeerCertificateReceived.PlatformCertificateHandle, sizeof(QuicBuffer));
                             certificate = new X509Certificate2(new ReadOnlySpan<byte>(quicBuffer[0].Buffer, (int)quicBuffer[0].Length));
+                            certificateBuffer = (IntPtr) quicBuffer[0].Buffer;
+                            certificateLength = (int)quicBuffer[0].Length;
 
                             if (connectionEvent.Data.PeerCertificateReceived.PlatformCertificateChainHandle != IntPtr.Zero)
                             {
@@ -437,7 +441,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                         chain.ChainPolicy.ExtraStore.AddRange(additionalCertificates);
                     }
 
-                    sslPolicyErrors |= CertificateValidation.BuildChainAndVerifyProperties(chain, certificate, true, state.IsServer, state.TargetHost);
+                    sslPolicyErrors |= CertificateValidation.BuildChainAndVerifyProperties(chain, certificate, true, state.IsServer, state.TargetHost, certificateBuffer, certificateLength);
                 }
 
                 if (!state.RemoteCertificateRequired)

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -408,7 +408,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                         {
                             ReadOnlySpan<QuicBuffer> quicBuffer = new ReadOnlySpan<QuicBuffer>((void*)connectionEvent.Data.PeerCertificateReceived.PlatformCertificateHandle, sizeof(QuicBuffer));
                             certificate = new X509Certificate2(new ReadOnlySpan<byte>(quicBuffer[0].Buffer, (int)quicBuffer[0].Length));
-                            certificateBuffer = (IntPtr) quicBuffer[0].Buffer;
+                            certificateBuffer = (IntPtr)quicBuffer[0].Buffer;
                             certificateLength = (int)quicBuffer[0].Length;
 
                             if (connectionEvent.Data.PeerCertificateReceived.PlatformCertificateChainHandle != IntPtr.Zero)

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -58,6 +58,7 @@ namespace System.Net.Quic.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/46837", TestPlatforms.OSX)]
         public async Task ConnectWithCertificateChain()
         {
             (X509Certificate2 certificate, X509Certificate2Collection chain) = System.Net.Security.Tests.TestHelper.GenerateCertificates("localhost", longChain: true);


### PR DESCRIPTION
fixes #58849

There were two basic problems. 
1) is the issue reported in #58849
BSD derivatives like macOS/OSX and FreeBSD has different `sockaddr` layout. We may look at it more how to share Socket PAL but for now this is minimal fix.

2) tests were crashing in certificate validation. 
When  #56175 was done, we purposely ignored macOS as the CertificatePal requires native SSL context. 
While the code allowed everything to build, passing X509Certificate.Handle to OpenSSL does not work since the underlying code is different. To make this work, we play the portable game again e.g. we create `X509*` aka SafeX509Handle from DER encode ASN. That may make it different from SslStream but it will make it consistent with Linux. Alternatively we can create the Apple's SSL context or find some other primitives how to get validation working. 


on my local run, all tests can now pass on macOS 10.15

```
  ----- start Tue Sep 28 15:05:46 PDT 2021 =============== To repro directly: =====================================================
  pushd /Users/furt/github/wfurt-runtime/artifacts/bin/System.Net.Quic.Functional.Tests/net7.0-Unix-Debug
  /Users/furt/github/wfurt-runtime/artifacts/bin/testhost/net7.0-OSX-Debug-x64/dotnet exec --runtimeconfig System.Net.Quic.Functional.Tests.runtimeconfig.json --depsfile System.Net.Quic.Functional.Tests.deps.json xunit.console.dll System.Net.Quic.Functional.Tests.dll -xml testResults.xml -nologo -notrait category=OuterLoop -notrait category=failing -verbose -nocolor -parallel none
  popd
  ===========================================================================================================
  ~/github/wfurt-runtime/artifacts/bin/System.Net.Quic.Functional.Tests/net7.0-Unix-Debug ~/github/wfurt-runtime/src/libraries/System.Net.Quic/tests/FunctionalTests
    Discovering: System.Net.Quic.Functional.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.Net.Quic.Functional.Tests (found 139 of 150 test cases)
    Starting:    System.Net.Quic.Functional.Tests (parallel test collections = off, max threads = 16)
      System.Net.Quic.Tests.QuicListenerTests_MockProvider.Listener_Backlog_Success [STARTING]
      System.Net.Quic.Tests.QuicListenerTests_MockProvider.Listener_Backlog_Success [FINISHED] Time: 0.8646661s
...

    Finished:    System.Net.Quic.Functional.Tests
  === TEST EXECUTION SUMMARY ===
     System.Net.Quic.Functional.Tests  Total: 546, Errors: 0, Failed: 0, Skipped: 0, Time: 41.846s
```