### PR TITLE
[mono] Increase the number of preallocated trampolines for Mono FullAOT runtime test runs

### DIFF
--- a/src/tests/run.proj
+++ b/src/tests/run.proj
@@ -606,6 +606,12 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
 
     <ItemGroup>
       <MonoAotOption Condition="'$(MonoFullAot)' == 'true'" Include="full" />
+      <MonoAotOption Condition="'$(MonoFullAot)' == 'true'" Include="nimt-trampolines=2000" />
+      <MonoAotOption Condition="'$(MonoFullAot)' == 'true'" Include="ntrampolines=10000" />
+      <MonoAotOption Condition="'$(MonoFullAot)' == 'true'" Include="nrgctx-fetch-trampolines=256" />
+      <MonoAotOption Condition="'$(MonoFullAot)' == 'true'" Include="ngsharedvt-trampolines=4400" />
+      <MonoAotOption Condition="'$(MonoFullAot)' == 'true'" Include="nftnptr-arg-trampolines=4000" />
+      <MonoAotOption Condition="'$(MonoFullAot)' == 'true'" Include="nrgctx-trampolines=21000" />
       <MonoAotOption Include="llvm" />
       <MonoAotOption Include="llvm-path=$(MonoLlvmPath)" />
       <MonoAotOption Condition="'$(__MonoToolPrefix)' != ''" Include="tool-prefix=$(__MonoToolPrefix)" />


### PR DESCRIPTION
I have no justification for these numbers; they were pulled from MonoAOTCompiler.props. It might be a good idea to port the "infinite trampoline" hack to non-Apple platforms.