### PR TITLE
Acknowledge community triagers in area-owners.md

### DIFF
--- a/docs/area-owners.md
+++ b/docs/area-owners.md
@@ -158,3 +158,10 @@ Note: Editing this file doesn't update the mapping used by the `@msftbot` issue 
 |------------------|---------------|-----------------------------------------------------|--------------|
 | arch-wasm        | @lewing       | @lewing @BrzVlad                                    |              |
 
+## Community Triagers
+
+The repo has a number of community members carrying the triager role. While not necessarily associated with a specific area they might be able to assist with certain issues and pull requests. Currently, the following community members are triagers:
+
+* @huoyaoyuan
+* @SingleAccretion
+* @tmds

--- a/docs/area-owners.md
+++ b/docs/area-owners.md
@@ -165,3 +165,4 @@ The repo has a number of community members carrying the triager role. While not 
 * @huoyaoyuan
 * @SingleAccretion
 * @tmds
+* @vcsjones

--- a/docs/area-owners.md
+++ b/docs/area-owners.md
@@ -160,7 +160,7 @@ Note: Editing this file doesn't update the mapping used by the `@msftbot` issue 
 
 ## Community Triagers
 
-The repo has a number of community members carrying the triager role. While not necessarily associated with a specific area they might be able to assist with labeling certain issues and pull requests. Currently, the following community members are triagers:
+The repo has a number of community members carrying the triager role. While not necessarily associated with a specific area, they may assist with labeling issues and pull requests. Currently, the following community members are triagers:
 
 * @huoyaoyuan
 * @SingleAccretion

--- a/docs/area-owners.md
+++ b/docs/area-owners.md
@@ -160,7 +160,7 @@ Note: Editing this file doesn't update the mapping used by the `@msftbot` issue 
 
 ## Community Triagers
 
-The repo has a number of community members carrying the triager role. While not necessarily associated with a specific area they might be able to assist with certain issues and pull requests. Currently, the following community members are triagers:
+The repo has a number of community members carrying the triager role. While not necessarily associated with a specific area they might be able to assist with labeling certain issues and pull requests. Currently, the following community members are triagers:
 
 * @huoyaoyuan
 * @SingleAccretion


### PR DESCRIPTION
While triage is technically not an area, it felt less appropriate to create a separate document simply to acknowledge community triagers.