### PR TITLE
[Mono]: Fix hfa type field count to handle more cases under LLVM.

### DIFF
--- a/src/mono/mono/mini/mini-codegen.c
+++ b/src/mono/mono/mini/mini-codegen.c
@@ -2761,8 +2761,8 @@ mini_type_is_hfa (MonoType *t, int *out_nfields, int *out_esize)
 	}
 	if (nfields == 0)
 		return FALSE;
-	*out_nfields = nfields;
 	*out_esize = prev_ftype->type == MONO_TYPE_R4 ? 4 : 8;
+	*out_nfields = mono_class_value_size (klass, NULL) / *out_esize;
 	return TRUE;
 }
 


### PR DESCRIPTION
Current way of calculating fields for hfa types was not correct, incorrectly describe some hfa types in LLVM.

One scenario where it breaks is when using explicit struct layout having several fields starting at the same offset. Our current
implementation would count each field meaning that the struct of floats or doubles described to LLVM would not match the size
of allocated object, since it would count fields starting on the same offset twice, causing issue in p/invokes on platforms
where the platform ABI push value types onto stack.

An example:

```
StructLayout(LayoutKind.Explicit)]
public struct Vector2
{
  private unsafe struct F2
  {
    public fixed float data[2];
  }

  [FieldOffset(0)]
  private F2 V;

  [FieldOffset(0)]
  public float V1;

  [FieldOffset(4)]
  public float V2;
}

```
The old implementation would describe the above struct like this to LLVM:

`type { float, float, float }`

incorrectly adding an additional float, creating a 12 byte struct instead of 8 bytes.

Any construction using

`private fixed float x[12];`

would also incorrectly be calculated as one field instead of 12 in this case.

The way `mini_type_is_hfa` works is that it will make sure the type is only made up of floats or doubles and not a combination of them or any other type. Instead of using the field count calculated through this schema (that sees all field types, but inaccurately count them in some scenarios), we could use types value size (since its all floats or all doubles) and then get number of fields based on type size (float or double). Implementation of mono_class_value_size will correctly handle size in cases where we have explicit layout as above and shared with how none LLVM AOT:ed code views the same type.