### PR TITLE
Update DllImportGenerator style to match repo conventions

### DIFF
--- a/src/libraries/Common/src/System/Runtime/InteropServices/ArrayMarshaller.cs
+++ b/src/libraries/Common/src/System/Runtime/InteropServices/ArrayMarshaller.cs
@@ -26,7 +26,7 @@ namespace System.Runtime.InteropServices.GeneratedMarshalling
         private IntPtr _allocatedMemory;
 
         public ArrayMarshaller(int sizeOfNativeElement)
-            :this()
+            : this()
         {
             _sizeOfNativeElement = sizeOfNativeElement;
         }

--- a/src/libraries/Common/src/System/Runtime/InteropServices/GeneratedMarshallingAttribute.cs
+++ b/src/libraries/Common/src/System/Runtime/InteropServices/GeneratedMarshallingAttribute.cs
@@ -57,7 +57,7 @@ namespace System.Runtime.InteropServices
         }
 
         public MarshalUsingAttribute(Type nativeType)
-            :this()
+            : this()
         {
             NativeType = nativeType;
         }

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Analyzers/ConvertToGeneratedDllImportFixer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Analyzers/ConvertToGeneratedDllImportFixer.cs
@@ -55,8 +55,7 @@ namespace Microsoft.Interop.Analyzers
                 return;
 
             // Make sure the method has the DllImportAttribute
-            AttributeData? dllImportAttr;
-            if (!TryGetAttribute(methodSymbol, dllImportAttrType, out dllImportAttr))
+            if (!TryGetAttribute(methodSymbol, dllImportAttrType, out AttributeData? dllImportAttr))
                 return;
 
             // Register code fixes with two options for the fix - using preprocessor or not.

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Analyzers/ManualTypeMarshallingAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Analyzers/ManualTypeMarshallingAnalyzer.cs
@@ -290,7 +290,7 @@ namespace Microsoft.Interop.Analyzers
                 }
                 else if (nativeMarshallingAttributeData is not null)
                 {
-                    AnalyzeNativeMarshalerType(context, type, nativeMarshallingAttributeData, isNativeMarshallingAttribute:true);
+                    AnalyzeNativeMarshalerType(context, type, nativeMarshallingAttributeData, isNativeMarshallingAttribute: true);
                 }
             }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Analyzers/ManualTypeMarshallingAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Analyzers/ManualTypeMarshallingAnalyzer.cs
@@ -225,13 +225,13 @@ namespace Microsoft.Interop.Analyzers
 
         private class PerCompilationAnalyzer
         {
-            private readonly INamedTypeSymbol GeneratedMarshallingAttribute;
-            private readonly INamedTypeSymbol BlittableTypeAttribute;
-            private readonly INamedTypeSymbol NativeMarshallingAttribute;
-            private readonly INamedTypeSymbol MarshalUsingAttribute;
-            private readonly INamedTypeSymbol GenericContiguousCollectionMarshallerAttribute;
-            private readonly INamedTypeSymbol SpanOfByte;
-            private readonly INamedTypeSymbol StructLayoutAttribute;
+            private readonly INamedTypeSymbol _generatedMarshallingAttribute;
+            private readonly INamedTypeSymbol _blittableTypeAttribute;
+            private readonly INamedTypeSymbol _nativeMarshallingAttribute;
+            private readonly INamedTypeSymbol _marshalUsingAttribute;
+            private readonly INamedTypeSymbol _genericContiguousCollectionMarshallerAttribute;
+            private readonly INamedTypeSymbol _spanOfByte;
+            private readonly INamedTypeSymbol _structLayoutAttribute;
 
             public PerCompilationAnalyzer(INamedTypeSymbol generatedMarshallingAttribute,
                                           INamedTypeSymbol blittableTypeAttribute,
@@ -241,13 +241,13 @@ namespace Microsoft.Interop.Analyzers
                                           INamedTypeSymbol spanOfByte,
                                           INamedTypeSymbol structLayoutAttribute)
             {
-                GeneratedMarshallingAttribute = generatedMarshallingAttribute;
-                BlittableTypeAttribute = blittableTypeAttribute;
-                NativeMarshallingAttribute = nativeMarshallingAttribute;
-                MarshalUsingAttribute = marshalUsingAttribute;
-                GenericContiguousCollectionMarshallerAttribute = genericContiguousCollectionMarshallerAttribute;
-                SpanOfByte = spanOfByte;
-                StructLayoutAttribute = structLayoutAttribute;
+                _generatedMarshallingAttribute = generatedMarshallingAttribute;
+                _blittableTypeAttribute = blittableTypeAttribute;
+                _nativeMarshallingAttribute = nativeMarshallingAttribute;
+                _marshalUsingAttribute = marshalUsingAttribute;
+                _genericContiguousCollectionMarshallerAttribute = genericContiguousCollectionMarshallerAttribute;
+                _spanOfByte = spanOfByte;
+                _structLayoutAttribute = structLayoutAttribute;
             }
 
             public void AnalyzeTypeDefinition(SymbolAnalysisContext context)
@@ -258,17 +258,17 @@ namespace Microsoft.Interop.Analyzers
                 AttributeData? nativeMarshallingAttributeData = null;
                 foreach (var attr in type.GetAttributes())
                 {
-                    if (SymbolEqualityComparer.Default.Equals(attr.AttributeClass, GeneratedMarshallingAttribute))
+                    if (SymbolEqualityComparer.Default.Equals(attr.AttributeClass, _generatedMarshallingAttribute))
                     {
                         // If the type has the GeneratedMarshallingAttribute,
                         // we let the source generator handle error checking.
                         return;
                     }
-                    else if (SymbolEqualityComparer.Default.Equals(attr.AttributeClass, BlittableTypeAttribute))
+                    else if (SymbolEqualityComparer.Default.Equals(attr.AttributeClass, _blittableTypeAttribute))
                     {
                         blittableTypeAttributeData = attr;
                     }
-                    else if (SymbolEqualityComparer.Default.Equals(attr.AttributeClass, NativeMarshallingAttribute))
+                    else if (SymbolEqualityComparer.Default.Equals(attr.AttributeClass, _nativeMarshallingAttribute))
                     {
                         nativeMarshallingAttributeData = attr;
                     }
@@ -281,7 +281,7 @@ namespace Microsoft.Interop.Analyzers
                             CannotHaveMultipleMarshallingAttributesRule,
                             type.ToDisplayString()));
                 }
-                else if (blittableTypeAttributeData is not null && (!type.HasOnlyBlittableFields() || type.IsAutoLayout(StructLayoutAttribute)))
+                else if (blittableTypeAttributeData is not null && (!type.HasOnlyBlittableFields() || type.IsAutoLayout(_structLayoutAttribute)))
                 {
                     context.ReportDiagnostic(
                         blittableTypeAttributeData.CreateDiagnostic(
@@ -307,7 +307,7 @@ namespace Microsoft.Interop.Analyzers
 
             public void AnalyzeElement(SymbolAnalysisContext context)
             {
-                AttributeData? attrData = context.Symbol.GetAttributes().FirstOrDefault(attr => SymbolEqualityComparer.Default.Equals(MarshalUsingAttribute, attr.AttributeClass));
+                AttributeData? attrData = context.Symbol.GetAttributes().FirstOrDefault(attr => SymbolEqualityComparer.Default.Equals(_marshalUsingAttribute, attr.AttributeClass));
                 if (attrData is not null)
                 {
                     if (context.Symbol is IParameterSymbol param)
@@ -324,7 +324,7 @@ namespace Microsoft.Interop.Analyzers
             public void AnalyzeReturnType(SymbolAnalysisContext context)
             {
                 var method = (IMethodSymbol)context.Symbol;
-                AttributeData? attrData = method.GetReturnTypeAttributes().FirstOrDefault(attr => SymbolEqualityComparer.Default.Equals(MarshalUsingAttribute, attr.AttributeClass));
+                AttributeData? attrData = method.GetReturnTypeAttributes().FirstOrDefault(attr => SymbolEqualityComparer.Default.Equals(_marshalUsingAttribute, attr.AttributeClass));
                 if (attrData is not null)
                 {
                     AnalyzeNativeMarshalerType(context, method.ReturnType, attrData, isNativeMarshallingAttribute: false);
@@ -364,12 +364,12 @@ namespace Microsoft.Interop.Analyzers
                 DiagnosticDescriptor requiredShapeRule = NativeTypeMustHaveRequiredShapeRule;
 
                 ManualTypeMarshallingHelper.NativeTypeMarshallingVariant variant = ManualTypeMarshallingHelper.NativeTypeMarshallingVariant.Standard;
-                if (marshalerType.GetAttributes().Any(a => SymbolEqualityComparer.Default.Equals(GenericContiguousCollectionMarshallerAttribute, a.AttributeClass)))
+                if (marshalerType.GetAttributes().Any(a => SymbolEqualityComparer.Default.Equals(_genericContiguousCollectionMarshallerAttribute, a.AttributeClass)))
                 {
                     variant = ManualTypeMarshallingHelper.NativeTypeMarshallingVariant.ContiguousCollection;
                     requiredShapeRule = CollectionNativeTypeMustHaveRequiredShapeRule;
                     if (!ManualTypeMarshallingHelper.TryGetManagedValuesProperty(marshalerType, out _)
-                        || !ManualTypeMarshallingHelper.HasNativeValueStorageProperty(marshalerType, SpanOfByte))
+                        || !ManualTypeMarshallingHelper.HasNativeValueStorageProperty(marshalerType, _spanOfByte))
                     {
                         context.ReportDiagnostic(
                             GetDiagnosticLocations(context, marshalerType, nativeMarshalerAttributeData).CreateDiagnostic(
@@ -425,7 +425,7 @@ namespace Microsoft.Interop.Analyzers
 
                     hasConstructor = hasConstructor || ManualTypeMarshallingHelper.IsManagedToNativeConstructor(ctor, type, variant);
 
-                    if (!hasStackallocConstructor && ManualTypeMarshallingHelper.IsStackallocConstructor(ctor, type, SpanOfByte, variant))
+                    if (!hasStackallocConstructor && ManualTypeMarshallingHelper.IsStackallocConstructor(ctor, type, _spanOfByte, variant))
                     {
                         hasStackallocConstructor = true;
                         IFieldSymbol stackAllocSizeField = nativeType.GetMembers("StackBufferSize").OfType<IFieldSymbol>().FirstOrDefault();

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Comparers.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Comparers.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Interop
         /// <param name="elementComparer">The comparer instance for the collection elements.</param>
         public ImmutableArraySequenceEqualComparer(IEqualityComparer<T> elementComparer)
         {
-            this._elementComparer = elementComparer;
+            _elementComparer = elementComparer;
         }
 
         public bool Equals(ImmutableArray<T> x, ImmutableArray<T> y)
@@ -81,8 +81,8 @@ namespace Microsoft.Interop
 
         public CustomValueTupleElementComparer(IEqualityComparer<T> item1Comparer, IEqualityComparer<U> item2Comparer)
         {
-            this._item1Comparer = item1Comparer;
-            this._item2Comparer = item2Comparer;
+            _item1Comparer = item1Comparer;
+            _item2Comparer = item2Comparer;
         }
 
         public bool Equals((T, U) x, (T, U) y)

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Comparers.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Comparers.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Interop
     /// <typeparam name="T">The type of immutable array element.</typeparam>
     internal class ImmutableArraySequenceEqualComparer<T> : IEqualityComparer<ImmutableArray<T>>
     {
-        private readonly IEqualityComparer<T> elementComparer;
+        private readonly IEqualityComparer<T> _elementComparer;
 
         /// <summary>
         /// Creates an <see cref="ImmutableArraySequenceEqualComparer{T}"/> with a custom comparer for the elements of the collection.
@@ -47,12 +47,12 @@ namespace Microsoft.Interop
         /// <param name="elementComparer">The comparer instance for the collection elements.</param>
         public ImmutableArraySequenceEqualComparer(IEqualityComparer<T> elementComparer)
         {
-            this.elementComparer = elementComparer;
+            this._elementComparer = elementComparer;
         }
 
         public bool Equals(ImmutableArray<T> x, ImmutableArray<T> y)
         {
-            return x.SequenceEqual(y, elementComparer);
+            return x.SequenceEqual(y, _elementComparer);
         }
 
         public int GetHashCode(ImmutableArray<T> obj)
@@ -76,18 +76,18 @@ namespace Microsoft.Interop
 
     internal class CustomValueTupleElementComparer<T, U> : IEqualityComparer<(T, U)>
     {
-        private readonly IEqualityComparer<T> item1Comparer;
-        private readonly IEqualityComparer<U> item2Comparer;
+        private readonly IEqualityComparer<T> _item1Comparer;
+        private readonly IEqualityComparer<U> _item2Comparer;
 
         public CustomValueTupleElementComparer(IEqualityComparer<T> item1Comparer, IEqualityComparer<U> item2Comparer)
         {
-            this.item1Comparer = item1Comparer;
-            this.item2Comparer = item2Comparer;
+            this._item1Comparer = item1Comparer;
+            this._item2Comparer = item2Comparer;
         }
 
         public bool Equals((T, U) x, (T, U) y)
         {
-            return item1Comparer.Equals(x.Item1, y.Item1) && item2Comparer.Equals(x.Item2, y.Item2);
+            return _item1Comparer.Equals(x.Item1, y.Item1) && _item2Comparer.Equals(x.Item2, y.Item2);
         }
 
         public int GetHashCode((T, U) obj)

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Diagnostics/Events.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/Diagnostics/Events.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Interop.Diagnostics
         [Event(StartSourceGenerationEventId, Level = EventLevel.Informational, Keywords = Keywords.SourceGeneration)]
         public void SourceGenerationStart(int methodCount)
         {
-            this.WriteEvent(StartSourceGenerationEventId, methodCount);
+            WriteEvent(StartSourceGenerationEventId, methodCount);
         }
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace Microsoft.Interop.Diagnostics
         [Event(StopSourceGenerationEventId, Level = EventLevel.Informational, Keywords = Keywords.SourceGeneration)]
         public void SourceGenerationStop()
         {
-            this.WriteEvent(StopSourceGenerationEventId);
+            WriteEvent(StopSourceGenerationEventId);
         }
 
         private class StartStopEvent : IDisposable

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Interop
 
             public record ExecutedStepInfo(StepName Step, object Input);
 
-            private List<ExecutedStepInfo> _executedSteps = new();
+            private readonly List<ExecutedStepInfo> _executedSteps = new();
             public IEnumerable<ExecutedStepInfo> ExecutedSteps => _executedSteps;
 
             internal void RecordExecutedStep(ExecutedStepInfo step) => _executedSteps.Add(step);

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportGenerator.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Interop
         private const string GeneratedDllImport = nameof(GeneratedDllImport);
         private const string GeneratedDllImportAttribute = nameof(GeneratedDllImportAttribute);
 
-        private static readonly Version MinimumSupportedFrameworkVersion = new Version(5, 0);
+        private static readonly Version s_minimumSupportedFrameworkVersion = new Version(5, 0);
 
         internal sealed record IncrementalStubGenerationContext(DllImportStubContext StubContext, ImmutableArray<AttributeSyntax> ForwardedAttributes, GeneratedDllImportData DllImportData, ImmutableArray<Diagnostic> Diagnostics)
         {
@@ -57,10 +57,10 @@ namespace Microsoft.Interop
 
             public record ExecutedStepInfo(StepName Step, object Input);
 
-            private List<ExecutedStepInfo> executedSteps = new();
-            public IEnumerable<ExecutedStepInfo> ExecutedSteps => executedSteps;
+            private List<ExecutedStepInfo> _executedSteps = new();
+            public IEnumerable<ExecutedStepInfo> ExecutedSteps => _executedSteps;
 
-            internal void RecordExecutedStep(ExecutedStepInfo step) => executedSteps.Add(step);
+            internal void RecordExecutedStep(ExecutedStepInfo step) => _executedSteps.Add(step);
         }
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace Microsoft.Interop
                             Diagnostic.Create(
                                 GeneratorDiagnostics.TargetFrameworkNotSupported,
                                 Location.None,
-                                MinimumSupportedFrameworkVersion.ToString(2)));
+                                s_minimumSupportedFrameworkVersion.ToString(2)));
                     }
                 });
 
@@ -294,7 +294,7 @@ namespace Microsoft.Interop
                 // .NET Standard
                 "netstandard" => false,
                 // .NET Core (when version < 5.0) or .NET
-                "System.Runtime" or "System.Private.CoreLib" => version >= MinimumSupportedFrameworkVersion,
+                "System.Runtime" or "System.Private.CoreLib" => version >= s_minimumSupportedFrameworkVersion,
                 _ => false,
             };
         }

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportStubContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/DllImportStubContext.cs
@@ -25,9 +25,9 @@ namespace Microsoft.Interop
 
     internal sealed class DllImportStubContext : IEquatable<DllImportStubContext>
     {
-// We don't need the warnings around not setting the various
-// non-nullable fields/properties on this type in the constructor
-// since we always use a property initializer.
+        // We don't need the warnings around not setting the various
+        // non-nullable fields/properties on this type in the constructor
+        // since we always use a property initializer.
 #pragma warning disable 8618
         private DllImportStubContext()
         {

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/ForwarderMarshallingGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/ForwarderMarshallingGeneratorFactory.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Interop
 {
     internal class ForwarderMarshallingGeneratorFactory : IMarshallingGeneratorFactory
     {
-        private static readonly Forwarder Forwarder = new Forwarder();
+        private static readonly Forwarder s_forwarder = new Forwarder();
 
-        public IMarshallingGenerator Create(TypePositionInfo info, StubCodeContext context) => Forwarder;
+        public IMarshallingGenerator Create(TypePositionInfo info, StubCodeContext context) => s_forwarder;
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/GeneratorDiagnostics.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/GeneratorDiagnostics.cs
@@ -127,9 +127,9 @@ namespace Microsoft.Interop
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.TargetFrameworkNotSupportedDescription)));
 
-        private readonly List<Diagnostic> diagnostics = new List<Diagnostic>();
+        private readonly List<Diagnostic> _diagnostics = new List<Diagnostic>();
 
-        public IEnumerable<Diagnostic> Diagnostics => diagnostics;
+        public IEnumerable<Diagnostic> Diagnostics => _diagnostics;
 
         /// <summary>
         /// Report diagnostic for configuration that is not supported by the DLL import source generator
@@ -144,14 +144,14 @@ namespace Microsoft.Interop
         {
             if (unsupportedValue == null)
             {
-                diagnostics.Add(
+                _diagnostics.Add(
                     attributeData.CreateDiagnostic(
                         GeneratorDiagnostics.ConfigurationNotSupported,
                         configurationName));
             }
             else
             {
-                diagnostics.Add(
+                _diagnostics.Add(
                     attributeData.CreateDiagnostic(
                         GeneratorDiagnostics.ConfigurationValueNotSupported,
                         unsupportedValue,
@@ -191,7 +191,7 @@ namespace Microsoft.Interop
                 // Report the specific not-supported reason.
                 if (info.IsManagedReturnPosition)
                 {
-                    diagnostics.Add(
+                    _diagnostics.Add(
                         diagnosticLocation.CreateDiagnostic(
                             GeneratorDiagnostics.ReturnTypeNotSupportedWithDetails,
                             notSupportedDetails!,
@@ -199,7 +199,7 @@ namespace Microsoft.Interop
                 }
                 else
                 {
-                    diagnostics.Add(
+                    _diagnostics.Add(
                         diagnosticLocation.CreateDiagnostic(
                             GeneratorDiagnostics.ParameterTypeNotSupportedWithDetails,
                             notSupportedDetails!,
@@ -213,7 +213,7 @@ namespace Microsoft.Interop
                 // than when there is no attribute and the type itself is not supported.
                 if (info.IsManagedReturnPosition)
                 {
-                    diagnostics.Add(
+                    _diagnostics.Add(
                         diagnosticLocation.CreateDiagnostic(
                             GeneratorDiagnostics.ReturnConfigurationNotSupported,
                             nameof(System.Runtime.InteropServices.MarshalAsAttribute),
@@ -221,7 +221,7 @@ namespace Microsoft.Interop
                 }
                 else
                 {
-                    diagnostics.Add(
+                    _diagnostics.Add(
                         diagnosticLocation.CreateDiagnostic(
                             GeneratorDiagnostics.ParameterConfigurationNotSupported,
                             nameof(System.Runtime.InteropServices.MarshalAsAttribute),
@@ -233,7 +233,7 @@ namespace Microsoft.Interop
                 // Report that the type is not supported
                 if (info.IsManagedReturnPosition)
                 {
-                    diagnostics.Add(
+                    _diagnostics.Add(
                         diagnosticLocation.CreateDiagnostic(
                             GeneratorDiagnostics.ReturnTypeNotSupported,
                             info.ManagedType.DiagnosticFormattedName,
@@ -241,7 +241,7 @@ namespace Microsoft.Interop
                 }
                 else
                 {
-                    diagnostics.Add(
+                    _diagnostics.Add(
                         diagnosticLocation.CreateDiagnostic(
                             GeneratorDiagnostics.ParameterTypeNotSupported,
                             info.ManagedType.DiagnosticFormattedName,
@@ -255,7 +255,7 @@ namespace Microsoft.Interop
             string reasonResourceName,
             params string[] reasonArgs)
         {
-            diagnostics.Add(
+            _diagnostics.Add(
                 attributeData.CreateDiagnostic(
                     GeneratorDiagnostics.MarshallingAttributeConfigurationNotSupported,
                     new LocalizableResourceString(reasonResourceName, Resources.ResourceManager, typeof(Resources), reasonArgs)));
@@ -267,7 +267,7 @@ namespace Microsoft.Interop
         /// <param name="minimumSupportedVersion">Minimum supported version of .NET</param>
         public void ReportTargetFrameworkNotSupported(Version minimumSupportedVersion)
         {
-            diagnostics.Add(
+            _diagnostics.Add(
                 Diagnostic.Create(
                     TargetFrameworkNotSupported,
                     Location.None,

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/LanguageSupport.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/LanguageSupport.cs
@@ -7,5 +7,5 @@ namespace System.Runtime.CompilerServices
 {
     // Define IsExternalInit type to support records.
     internal class IsExternalInit
-    {}
+    { }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/NoPreserveSigMarshallingGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/NoPreserveSigMarshallingGeneratorFactory.cs
@@ -11,12 +11,12 @@ namespace Microsoft.Interop
 {
     internal class NoPreserveSigMarshallingGeneratorFactory : IMarshallingGeneratorFactory
     {
-        private static readonly HResultExceptionMarshaller HResultException = new HResultExceptionMarshaller();
-        private readonly IMarshallingGeneratorFactory inner;
+        private static readonly HResultExceptionMarshaller s_hResultException = new HResultExceptionMarshaller();
+        private readonly IMarshallingGeneratorFactory _inner;
 
         public NoPreserveSigMarshallingGeneratorFactory(IMarshallingGeneratorFactory inner)
         {
-            this.inner = inner;
+            this._inner = inner;
         }
 
         public IMarshallingGenerator Create(TypePositionInfo info, StubCodeContext context)
@@ -25,9 +25,9 @@ namespace Microsoft.Interop
             {
                 // Use marshaller for native HRESULT return / exception throwing
                 System.Diagnostics.Debug.Assert(info.ManagedType.Equals(SpecialTypeInfo.Int32));
-                return HResultException;
+                return s_hResultException;
             }
-            return inner.Create(info, context);
+            return _inner.Create(info, context);
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/NoPreserveSigMarshallingGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/NoPreserveSigMarshallingGeneratorFactory.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Interop
 
         public NoPreserveSigMarshallingGeneratorFactory(IMarshallingGeneratorFactory inner)
         {
-            this._inner = inner;
+            _inner = inner;
         }
 
         public IMarshallingGenerator Create(TypePositionInfo info, StubCodeContext context)

--- a/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/PInvokeStubCodeGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/DllImportGenerator/PInvokeStubCodeGenerator.cs
@@ -55,11 +55,11 @@ namespace Microsoft.Interop
         // Error code representing success. This maps to S_OK for Windows HRESULT semantics and 0 for POSIX errno semantics.
         private const int SuccessErrorCode = 0;
 
-        private readonly bool setLastError;
-        private readonly List<BoundGenerator> paramMarshallers;
-        private readonly BoundGenerator retMarshaller;
-        private readonly List<BoundGenerator> sortedMarshallers;
-        private readonly bool stubReturnsVoid;
+        private readonly bool _setLastError;
+        private readonly List<BoundGenerator> _paramMarshallers;
+        private readonly BoundGenerator _retMarshaller;
+        private readonly List<BoundGenerator> _sortedMarshallers;
+        private readonly bool _stubReturnsVoid;
 
         public PInvokeStubCodeGenerator(
             IEnumerable<TypePositionInfo> argTypes,
@@ -67,7 +67,7 @@ namespace Microsoft.Interop
             Action<TypePositionInfo, MarshallingNotSupportedException> marshallingNotSupportedCallback,
             IMarshallingGeneratorFactory generatorFactory)
         {
-            this.setLastError = setLastError;
+            this._setLastError = setLastError;
 
             List<BoundGenerator> allMarshallers = new();
             List<BoundGenerator> paramMarshallers = new();
@@ -98,17 +98,17 @@ namespace Microsoft.Interop
                 }
             }
 
-            this.stubReturnsVoid = managedRetMarshaller.TypeInfo.ManagedType == SpecialTypeInfo.Void;
+            this._stubReturnsVoid = managedRetMarshaller.TypeInfo.ManagedType == SpecialTypeInfo.Void;
 
-            if (!managedRetMarshaller.TypeInfo.IsNativeReturnPosition && !this.stubReturnsVoid)
+            if (!managedRetMarshaller.TypeInfo.IsNativeReturnPosition && !this._stubReturnsVoid)
             {
                 // If the managed ret marshaller isn't the native ret marshaller, then the managed ret marshaller
                 // is a parameter.
                 paramMarshallers.Add(managedRetMarshaller);
             }
 
-            this.retMarshaller = nativeRetMarshaller;
-            this.paramMarshallers = paramMarshallers;
+            this._retMarshaller = nativeRetMarshaller;
+            this._paramMarshallers = paramMarshallers;
 
             // We are doing a topological sort of our marshallers to ensure that each parameter/return value's
             // dependencies are unmarshalled before their dependents. This comes up in the case of contiguous
@@ -132,7 +132,7 @@ namespace Microsoft.Interop
             // the return value has dependencies on numRows and numColumns and numRows has a dependency on numColumns,
             // we want to unmarshal numColumns, then numRows, then the return value.
             // A topological sort ensures we get this order correct.
-            this.sortedMarshallers = MarshallerHelpers.GetTopologicallySortedElements(
+            this._sortedMarshallers = MarshallerHelpers.GetTopologicallySortedElements(
                 allMarshallers,
                 static m => GetInfoIndex(m.TypeInfo),
                 static m => GetInfoDependencies(m.TypeInfo))
@@ -214,7 +214,7 @@ namespace Microsoft.Interop
         {
             var setupStatements = new List<StatementSyntax>();
 
-            foreach (var marshaller in paramMarshallers)
+            foreach (var marshaller in _paramMarshallers)
             {
                 TypePositionInfo info = marshaller.TypeInfo;
                 if (info.IsManagedReturnPosition)
@@ -236,15 +236,15 @@ namespace Microsoft.Interop
                 AppendVariableDeclations(setupStatements, info, marshaller.Generator);
             }
 
-            bool invokeReturnsVoid = retMarshaller.TypeInfo.ManagedType == SpecialTypeInfo.Void;
+            bool invokeReturnsVoid = _retMarshaller.TypeInfo.ManagedType == SpecialTypeInfo.Void;
 
             // Stub return is not the same as invoke return
-            if (!stubReturnsVoid && !retMarshaller.TypeInfo.IsManagedReturnPosition)
+            if (!_stubReturnsVoid && !_retMarshaller.TypeInfo.IsManagedReturnPosition)
             {
                 // Stub return should be the last parameter for the invoke
-                Debug.Assert(paramMarshallers.Any() && paramMarshallers.Last().TypeInfo.IsManagedReturnPosition, "Expected stub return to be the last parameter for the invoke");
+                Debug.Assert(_paramMarshallers.Any() && _paramMarshallers.Last().TypeInfo.IsManagedReturnPosition, "Expected stub return to be the last parameter for the invoke");
 
-                (TypePositionInfo stubRetTypeInfo, IMarshallingGenerator stubRetGenerator) = paramMarshallers.Last();
+                (TypePositionInfo stubRetTypeInfo, IMarshallingGenerator stubRetGenerator) = _paramMarshallers.Last();
 
                 // Declare variables for stub return value
                 AppendVariableDeclations(setupStatements, stubRetTypeInfo, stubRetGenerator);
@@ -253,12 +253,12 @@ namespace Microsoft.Interop
             if (!invokeReturnsVoid)
             {
                 // Declare variables for invoke return value
-                AppendVariableDeclations(setupStatements, retMarshaller.TypeInfo, retMarshaller.Generator);
+                AppendVariableDeclations(setupStatements, _retMarshaller.TypeInfo, _retMarshaller.Generator);
             }
 
             // Do not manually handle SetLastError when generating forwarders.
             // We want the runtime to handle everything.
-            if (this.setLastError)
+            if (this._setLastError)
             {
                 // Declare variable for last error
                 setupStatements.Add(MarshallerHelpers.DeclareWithDefault(
@@ -304,7 +304,7 @@ namespace Microsoft.Interop
                 allStatements.AddRange(tryStatements);
             }
 
-            if (this.setLastError)
+            if (this._setLastError)
             {
                 // Marshal.SetLastPInvokeError(<lastError>);
                 allStatements.Add(ExpressionStatement(
@@ -318,7 +318,7 @@ namespace Microsoft.Interop
             }
 
             // Return
-            if (!stubReturnsVoid)
+            if (!_stubReturnsVoid)
                 allStatements.Add(ReturnStatement(IdentifierName(ReturnIdentifier)));
 
             // Wrap all statements in an unsafe block
@@ -331,7 +331,7 @@ namespace Microsoft.Interop
 
                 if (!invokeReturnsVoid && (stage is Stage.Setup or Stage.Cleanup))
                 {
-                    var retStatements = retMarshaller.Generator.Generate(retMarshaller.TypeInfo, this);
+                    var retStatements = _retMarshaller.Generator.Generate(_retMarshaller.TypeInfo, this);
                     statementsToUpdate.AddRange(retStatements);
                 }
 
@@ -340,7 +340,7 @@ namespace Microsoft.Interop
                     // For Unmarshal and GuaranteedUnmarshal stages, use the topologically sorted
                     // marshaller list to generate the marshalling statements
 
-                    foreach (var marshaller in sortedMarshallers)
+                    foreach (var marshaller in _sortedMarshallers)
                     {
                         statementsToUpdate.AddRange(marshaller.Generator.Generate(marshaller.TypeInfo, this));
                     }
@@ -348,7 +348,7 @@ namespace Microsoft.Interop
                 else
                 {
                     // Generate code for each parameter for the current stage in declaration order.
-                    foreach (var marshaller in paramMarshallers)
+                    foreach (var marshaller in _paramMarshallers)
                     {
                         var generatedStatements = marshaller.Generator.Generate(marshaller.TypeInfo, this);
                         statementsToUpdate.AddRange(generatedStatements);
@@ -373,7 +373,7 @@ namespace Microsoft.Interop
                 var fixedStatements = new List<FixedStatementSyntax>();
                 this.CurrentStage = Stage.Pin;
                 // Generate code for each parameter for the current stage
-                foreach (var marshaller in paramMarshallers)
+                foreach (var marshaller in _paramMarshallers)
                 {
                     var generatedStatements = marshaller.Generator.Generate(marshaller.TypeInfo, this);
                     // Collect all the fixed statements. These will be used in the Invoke stage.
@@ -388,7 +388,7 @@ namespace Microsoft.Interop
 
                 this.CurrentStage = Stage.Invoke;
                 // Generate code for each parameter for the current stage
-                foreach (var marshaller in paramMarshallers)
+                foreach (var marshaller in _paramMarshallers)
                 {
                     // Get arguments for invocation
                     ArgumentSyntax argSyntax = marshaller.Generator.AsArgument(marshaller.TypeInfo, this);
@@ -406,13 +406,13 @@ namespace Microsoft.Interop
                     invokeStatement = ExpressionStatement(
                         AssignmentExpression(
                             SyntaxKind.SimpleAssignmentExpression,
-                            IdentifierName(this.GetIdentifiers(retMarshaller.TypeInfo).native),
+                            IdentifierName(this.GetIdentifiers(_retMarshaller.TypeInfo).native),
                             invoke));
                 }
 
                 // Do not manually handle SetLastError when generating forwarders.
                 // We want the runtime to handle everything.
-                if (setLastError)
+                if (_setLastError)
                 {
                     // Marshal.SetLastSystemError(0);
                     var clearLastError = ExpressionStatement(
@@ -464,10 +464,10 @@ namespace Microsoft.Interop
             return (
                 ParameterList(
                     SeparatedList(
-                        paramMarshallers.Select(marshaler => marshaler.Generator.AsParameter(marshaler.TypeInfo)))),
-                retMarshaller.Generator.AsNativeType(retMarshaller.TypeInfo),
-                retMarshaller.Generator is IAttributedReturnTypeMarshallingGenerator attributedReturn
-                ? attributedReturn.GenerateAttributesForReturnType(retMarshaller.TypeInfo)
+                        _paramMarshallers.Select(marshaler => marshaler.Generator.AsParameter(marshaler.TypeInfo)))),
+                _retMarshaller.Generator.AsNativeType(_retMarshaller.TypeInfo),
+                _retMarshaller.Generator is IAttributedReturnTypeMarshallingGenerator attributedReturn
+                ? attributedReturn.GenerateAttributesForReturnType(_retMarshaller.TypeInfo)
                 : null
             );
         }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ContiguousCollectionElementMarshallingCodeContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ContiguousCollectionElementMarshallingCodeContext.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Interop
 {
     internal sealed class ContiguousCollectionElementMarshallingCodeContext : StubCodeContext
     {
-        private readonly string nativeSpanIdentifier;
+        private readonly string _nativeSpanIdentifier;
 
         public override bool SingleFrameSpansNativeContext => false;
 
@@ -37,7 +37,7 @@ namespace Microsoft.Interop
         {
             CurrentStage = currentStage;
             IndexerIdentifier = CalculateIndexerIdentifierBasedOnParentContext(parentContext);
-            this.nativeSpanIdentifier = nativeSpanIdentifier;
+            this._nativeSpanIdentifier = nativeSpanIdentifier;
             ParentContext = parentContext;
         }
 
@@ -51,13 +51,13 @@ namespace Microsoft.Interop
             var (_, native) = ParentContext!.GetIdentifiers(info);
             return (
                 $"{native}.ManagedValues[{IndexerIdentifier}]",
-                $"{nativeSpanIdentifier}[{IndexerIdentifier}]"
+                $"{_nativeSpanIdentifier}[{IndexerIdentifier}]"
             );
         }
 
         public override string GetAdditionalIdentifier(TypePositionInfo info, string name)
         {
-            return $"{nativeSpanIdentifier}__{IndexerIdentifier}__{name}";
+            return $"{_nativeSpanIdentifier}__{IndexerIdentifier}__{name}";
         }
 
         private static string CalculateIndexerIdentifierBasedOnParentContext(StubCodeContext? parentContext)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ContiguousCollectionElementMarshallingCodeContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ContiguousCollectionElementMarshallingCodeContext.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Interop
         {
             CurrentStage = currentStage;
             IndexerIdentifier = CalculateIndexerIdentifierBasedOnParentContext(parentContext);
-            this._nativeSpanIdentifier = nativeSpanIdentifier;
+            _nativeSpanIdentifier = nativeSpanIdentifier;
             ParentContext = parentContext;
         }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/LanguageSupport.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/LanguageSupport.cs
@@ -7,5 +7,5 @@ namespace System.Runtime.CompilerServices
 {
     // Define IsExternalInit type to support records.
     internal class IsExternalInit
-    {}
+    { }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManualTypeMarshallingHelper.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManualTypeMarshallingHelper.cs
@@ -127,11 +127,11 @@ namespace Microsoft.Interop
             return type.GetMembers(SetUnmarshalledCollectionLengthMethodName)
                 .OfType<IMethodSymbol>()
                 .Any(m => m is
-                    {
-                        IsStatic: false,
-                        Parameters: { Length: 1 },
-                        ReturnType: { SpecialType: SpecialType.System_Void }
-                    } && m.Parameters[0].Type.SpecialType == SpecialType.System_Int32);
+                {
+                    IsStatic: false,
+                    Parameters: { Length: 1 },
+                    ReturnType: { SpecialType: SpecialType.System_Void }
+                } && m.Parameters[0].Type.SpecialType == SpecialType.System_Int32);
         }
 
         public static bool HasNativeValueStorageProperty(ITypeSymbol type, ITypeSymbol spanOfByte)
@@ -139,7 +139,7 @@ namespace Microsoft.Interop
             return type
                 .GetMembers(NativeValueStoragePropertyName)
                 .OfType<IPropertySymbol>()
-                .Any(p => p is {IsStatic: false, GetMethod: not null, ReturnsByRef: false, ReturnsByRefReadonly: false }
+                .Any(p => p is { IsStatic: false, GetMethod: not null, ReturnsByRef: false, ReturnsByRefReadonly: false }
                     && SymbolEqualityComparer.Default.Equals(p.Type, spanOfByte));
         }
     }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ArrayMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ArrayMarshaller.cs
@@ -18,10 +18,10 @@ namespace Microsoft.Interop
 
         public ArrayMarshaller(IMarshallingGenerator manualMarshallingGenerator, TypeSyntax elementType, bool enablePinning, InteropGenerationOptions options)
         {
-            this._manualMarshallingGenerator = manualMarshallingGenerator;
-            this._elementType = elementType;
-            this._enablePinning = enablePinning;
-            this._options = options;
+            _manualMarshallingGenerator = manualMarshallingGenerator;
+            _elementType = elementType;
+            _enablePinning = enablePinning;
+            _options = options;
         }
 
         public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ArrayMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ArrayMarshaller.cs
@@ -11,17 +11,17 @@ namespace Microsoft.Interop
 {
     public sealed class ArrayMarshaller : IMarshallingGenerator
     {
-        private readonly IMarshallingGenerator manualMarshallingGenerator;
-        private readonly TypeSyntax elementType;
-        private readonly bool enablePinning;
-        private readonly InteropGenerationOptions options;
+        private readonly IMarshallingGenerator _manualMarshallingGenerator;
+        private readonly TypeSyntax _elementType;
+        private readonly bool _enablePinning;
+        private readonly InteropGenerationOptions _options;
 
         public ArrayMarshaller(IMarshallingGenerator manualMarshallingGenerator, TypeSyntax elementType, bool enablePinning, InteropGenerationOptions options)
         {
-            this.manualMarshallingGenerator = manualMarshallingGenerator;
-            this.elementType = elementType;
-            this.enablePinning = enablePinning;
-            this.options = options;
+            this._manualMarshallingGenerator = manualMarshallingGenerator;
+            this._elementType = elementType;
+            this._enablePinning = enablePinning;
+            this._options = options;
         }
 
         public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
@@ -31,17 +31,17 @@ namespace Microsoft.Interop
                 string identifier = context.GetIdentifiers(info).native;
                 return Argument(CastExpression(AsNativeType(info), IdentifierName(identifier)));
             }
-            return manualMarshallingGenerator.AsArgument(info, context);
+            return _manualMarshallingGenerator.AsArgument(info, context);
         }
 
         public TypeSyntax AsNativeType(TypePositionInfo info)
         {
-            return manualMarshallingGenerator.AsNativeType(info);
+            return _manualMarshallingGenerator.AsNativeType(info);
         }
 
         public ParameterSyntax AsParameter(TypePositionInfo info)
         {
-            return manualMarshallingGenerator.AsParameter(info);
+            return _manualMarshallingGenerator.AsParameter(info);
         }
 
         public IEnumerable<StatementSyntax> Generate(TypePositionInfo info, StubCodeContext context)
@@ -50,12 +50,12 @@ namespace Microsoft.Interop
             {
                 return GeneratePinningPath(info, context);
             }
-            return manualMarshallingGenerator.Generate(info, context);
+            return _manualMarshallingGenerator.Generate(info, context);
         }
 
         public bool SupportsByValueMarshalKind(ByValueContentsMarshalKind marshalKind, StubCodeContext context)
         {
-            if (context.SingleFrameSpansNativeContext && enablePinning)
+            if (context.SingleFrameSpansNativeContext && _enablePinning)
             {
                 return false;
             }
@@ -68,19 +68,19 @@ namespace Microsoft.Interop
             {
                 return false;
             }
-            return manualMarshallingGenerator.UsesNativeIdentifier(info, context);
+            return _manualMarshallingGenerator.UsesNativeIdentifier(info, context);
         }
 
         private bool IsPinningPathSupported(TypePositionInfo info, StubCodeContext context)
         {
-            return context.SingleFrameSpansNativeContext && enablePinning && !info.IsByRef && !info.IsManagedReturnPosition;
+            return context.SingleFrameSpansNativeContext && _enablePinning && !info.IsByRef && !info.IsManagedReturnPosition;
         }
 
         private IEnumerable<StatementSyntax> GeneratePinningPath(TypePositionInfo info, StubCodeContext context)
         {
             var (managedIdentifer, nativeIdentifier) = context.GetIdentifiers(info);
             string byRefIdentifier = $"__byref_{managedIdentifer}";
-            TypeSyntax arrayElementType = elementType;
+            TypeSyntax arrayElementType = _elementType;
             if (context.CurrentStage == StubCodeContext.Stage.Marshal)
             {
                 // [COMPAT] We use explicit byref calculations here instead of just using a fixed statement
@@ -133,7 +133,7 @@ namespace Microsoft.Interop
                                 PrefixUnaryExpression(SyntaxKind.AddressOfExpression,
                                 InvocationExpression(
                                     MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                        ParseTypeName(TypeNames.Unsafe(options)),
+                                        ParseTypeName(TypeNames.Unsafe(_options)),
                                         GenericName("As").AddTypeArgumentListArguments(
                                             arrayElementType,
                                             PredefinedType(Token(SyntaxKind.ByteKeyword)))))

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/AttributedMarshallingModelGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/AttributedMarshallingModelGeneratorFactory.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Interop
         public AttributedMarshallingModelGeneratorFactory(IMarshallingGeneratorFactory innerMarshallingGenerator, InteropGenerationOptions options)
         {
             Options = options;
-            this._innerMarshallingGenerator = innerMarshallingGenerator;
+            _innerMarshallingGenerator = innerMarshallingGenerator;
             ElementMarshallingGeneratorFactory = this;
         }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/AttributedMarshallingModelGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/AttributedMarshallingModelGeneratorFactory.cs
@@ -14,15 +14,15 @@ namespace Microsoft.Interop
 {
     public class AttributedMarshallingModelGeneratorFactory : IMarshallingGeneratorFactory
     {
-        private static readonly BlittableMarshaller Blittable = new BlittableMarshaller();
-        private static readonly Forwarder Forwarder = new Forwarder();
+        private static readonly BlittableMarshaller s_blittable = new BlittableMarshaller();
+        private static readonly Forwarder s_forwarder = new Forwarder();
 
-        private readonly IMarshallingGeneratorFactory innerMarshallingGenerator;
+        private readonly IMarshallingGeneratorFactory _innerMarshallingGenerator;
 
         public AttributedMarshallingModelGeneratorFactory(IMarshallingGeneratorFactory innerMarshallingGenerator, InteropGenerationOptions options)
         {
             Options = options;
-            this.innerMarshallingGenerator = innerMarshallingGenerator;
+            this._innerMarshallingGenerator = innerMarshallingGenerator;
             ElementMarshallingGeneratorFactory = this;
         }
 
@@ -39,9 +39,9 @@ namespace Microsoft.Interop
             return info.MarshallingAttributeInfo switch
             {
                 NativeMarshallingAttributeInfo marshalInfo => CreateCustomNativeTypeMarshaller(info, context, marshalInfo),
-                BlittableTypeAttributeInfo => Blittable,
-                GeneratedNativeMarshallingAttributeInfo => Forwarder,
-                _ => innerMarshallingGenerator.Create(info, context)
+                BlittableTypeAttributeInfo => s_blittable,
+                GeneratedNativeMarshallingAttributeInfo => s_forwarder,
+                _ => _innerMarshallingGenerator.Create(info, context)
             };
         }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ByValueContentsMarshalKindValidator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ByValueContentsMarshalKindValidator.cs
@@ -12,16 +12,16 @@ namespace Microsoft.Interop
     /// </summary>
     public class ByValueContentsMarshalKindValidator : IMarshallingGeneratorFactory
     {
-        private readonly IMarshallingGeneratorFactory inner;
+        private readonly IMarshallingGeneratorFactory _inner;
 
         public ByValueContentsMarshalKindValidator(IMarshallingGeneratorFactory inner)
         {
-            this.inner = inner;
+            this._inner = inner;
         }
 
         public IMarshallingGenerator Create(TypePositionInfo info, StubCodeContext context)
         {
-            return ValidateByValueMarshalKind(info, context, inner.Create(info, context));
+            return ValidateByValueMarshalKind(info, context, _inner.Create(info, context));
         }
 
         private static IMarshallingGenerator ValidateByValueMarshalKind(TypePositionInfo info, StubCodeContext context, IMarshallingGenerator generator)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ByValueContentsMarshalKindValidator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ByValueContentsMarshalKindValidator.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Interop
 
         public ByValueContentsMarshalKindValidator(IMarshallingGeneratorFactory inner)
         {
-            this._inner = inner;
+            _inner = inner;
         }
 
         public IMarshallingGenerator Create(TypePositionInfo info, StubCodeContext context)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CharMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CharMarshaller.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Interop
 {
     public sealed class Utf16CharMarshaller : IMarshallingGenerator
     {
-        private static readonly PredefinedTypeSyntax NativeType = PredefinedType(Token(SyntaxKind.UShortKeyword));
+        private static readonly PredefinedTypeSyntax s_nativeType = PredefinedType(Token(SyntaxKind.UShortKeyword));
 
         public Utf16CharMarshaller()
         {
@@ -50,7 +50,7 @@ namespace Microsoft.Interop
         public TypeSyntax AsNativeType(TypePositionInfo info)
         {
             Debug.Assert(info.ManagedType is SpecialTypeInfo(_, _, SpecialType.System_Char));
-            return NativeType;
+            return s_nativeType;
         }
 
         public ParameterSyntax AsParameter(TypePositionInfo info)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CustomNativeTypeMarshallingGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CustomNativeTypeMarshallingGenerator.cs
@@ -14,23 +14,23 @@ namespace Microsoft.Interop
     /// </summary>
     internal sealed class CustomNativeTypeMarshallingGenerator : IMarshallingGenerator
     {
-        private readonly ICustomNativeTypeMarshallingStrategy nativeTypeMarshaller;
-        private readonly bool enableByValueContentsMarshalling;
+        private readonly ICustomNativeTypeMarshallingStrategy _nativeTypeMarshaller;
+        private readonly bool _enableByValueContentsMarshalling;
 
         public CustomNativeTypeMarshallingGenerator(ICustomNativeTypeMarshallingStrategy nativeTypeMarshaller, bool enableByValueContentsMarshalling)
         {
-            this.nativeTypeMarshaller = nativeTypeMarshaller;
-            this.enableByValueContentsMarshalling = enableByValueContentsMarshalling;
+            this._nativeTypeMarshaller = nativeTypeMarshaller;
+            this._enableByValueContentsMarshalling = enableByValueContentsMarshalling;
         }
 
         public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
         {
-            return nativeTypeMarshaller.AsArgument(info, context);
+            return _nativeTypeMarshaller.AsArgument(info, context);
         }
 
         public TypeSyntax AsNativeType(TypePositionInfo info)
         {
-            return nativeTypeMarshaller.AsNativeType(info);
+            return _nativeTypeMarshaller.AsNativeType(info);
         }
 
         public ParameterSyntax AsParameter(TypePositionInfo info)
@@ -49,28 +49,28 @@ namespace Microsoft.Interop
             switch (context.CurrentStage)
             {
                 case StubCodeContext.Stage.Setup:
-                    return nativeTypeMarshaller.GenerateSetupStatements(info, context);
+                    return _nativeTypeMarshaller.GenerateSetupStatements(info, context);
                 case StubCodeContext.Stage.Marshal:
                     if (!info.IsManagedReturnPosition && info.RefKind != RefKind.Out)
                     {
-                        return nativeTypeMarshaller.GenerateMarshalStatements(info, context, nativeTypeMarshaller.GetNativeTypeConstructorArguments(info, context));
+                        return _nativeTypeMarshaller.GenerateMarshalStatements(info, context, _nativeTypeMarshaller.GetNativeTypeConstructorArguments(info, context));
                     }
                     break;
                 case StubCodeContext.Stage.Pin:
                     if (!info.IsByRef || info.RefKind == RefKind.In)
                     {
-                        return nativeTypeMarshaller.GeneratePinStatements(info, context);
+                        return _nativeTypeMarshaller.GeneratePinStatements(info, context);
                     }
                     break;
                 case StubCodeContext.Stage.Unmarshal:
                     if (info.IsManagedReturnPosition || (info.IsByRef && info.RefKind != RefKind.In)
-                        || (enableByValueContentsMarshalling && !info.IsByRef && info.ByValueContentsMarshalKind.HasFlag(ByValueContentsMarshalKind.Out)))
+                        || (_enableByValueContentsMarshalling && !info.IsByRef && info.ByValueContentsMarshalKind.HasFlag(ByValueContentsMarshalKind.Out)))
                     {
-                        return nativeTypeMarshaller.GenerateUnmarshalStatements(info, context);
+                        return _nativeTypeMarshaller.GenerateUnmarshalStatements(info, context);
                     }
                     break;
                 case StubCodeContext.Stage.Cleanup:
-                    return nativeTypeMarshaller.GenerateCleanupStatements(info, context);
+                    return _nativeTypeMarshaller.GenerateCleanupStatements(info, context);
                 default:
                     break;
             }
@@ -80,12 +80,12 @@ namespace Microsoft.Interop
 
         public bool SupportsByValueMarshalKind(ByValueContentsMarshalKind marshalKind, StubCodeContext context)
         {
-            return enableByValueContentsMarshalling;
+            return _enableByValueContentsMarshalling;
         }
 
         public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context)
         {
-            return nativeTypeMarshaller.UsesNativeIdentifier(info, context);
+            return _nativeTypeMarshaller.UsesNativeIdentifier(info, context);
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CustomNativeTypeMarshallingGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/CustomNativeTypeMarshallingGenerator.cs
@@ -19,8 +19,8 @@ namespace Microsoft.Interop
 
         public CustomNativeTypeMarshallingGenerator(ICustomNativeTypeMarshallingStrategy nativeTypeMarshaller, bool enableByValueContentsMarshalling)
         {
-            this._nativeTypeMarshaller = nativeTypeMarshaller;
-            this._enableByValueContentsMarshalling = enableByValueContentsMarshalling;
+            _nativeTypeMarshaller = nativeTypeMarshaller;
+            _enableByValueContentsMarshalling = enableByValueContentsMarshalling;
         }
 
         public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/Forwarder.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/Forwarder.cs
@@ -41,13 +41,13 @@ namespace Microsoft.Interop
                 && collectionMarshalling.ElementMarshallingInfo is NoMarshallingInfo or MarshalAsInfo { UnmanagedType: not UnmanagedType.CustomMarshaler }
                 && info.ManagedType is IArrayTypeSymbol)
             {
-                List<AttributeArgumentSyntax> marshalAsArguments = new List<AttributeArgumentSyntax>();
-                marshalAsArguments.Add(
+                List<AttributeArgumentSyntax> marshalAsArguments = new List<AttributeArgumentSyntax>
+                {
                     AttributeArgument(
                         CastExpression(ParseTypeName(TypeNames.System_Runtime_InteropServices_UnmanagedType),
                         LiteralExpression(SyntaxKind.NumericLiteralExpression,
                             Literal((int)UnmanagedType.LPArray))))
-                    );
+                };
 
                 if (collectionMarshalling.ElementCountInfo is SizeAndParamIndexInfo countInfo)
                 {

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/HResultExceptionMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/HResultExceptionMarshaller.cs
@@ -14,12 +14,12 @@ namespace Microsoft.Interop
 {
     public sealed class HResultExceptionMarshaller : IMarshallingGenerator
     {
-        private static readonly TypeSyntax NativeType = PredefinedType(Token(SyntaxKind.IntKeyword));
+        private static readonly TypeSyntax s_nativeType = PredefinedType(Token(SyntaxKind.IntKeyword));
 
         public TypeSyntax AsNativeType(TypePositionInfo info)
         {
             Debug.Assert(info.ManagedType is SpecialTypeInfo(_, _, SpecialType.System_Int32));
-            return NativeType;
+            return s_nativeType;
         }
 
         // Should only be used for return value

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
@@ -41,11 +41,11 @@ namespace Microsoft.Interop
     /// </summary>
     internal sealed class SimpleCustomNativeTypeMarshalling : ICustomNativeTypeMarshallingStrategy
     {
-        private readonly TypeSyntax nativeTypeSyntax;
+        private readonly TypeSyntax _nativeTypeSyntax;
 
         public SimpleCustomNativeTypeMarshalling(TypeSyntax nativeTypeSyntax)
         {
-            this.nativeTypeSyntax = nativeTypeSyntax;
+            this._nativeTypeSyntax = nativeTypeSyntax;
         }
 
         public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
@@ -64,7 +64,7 @@ namespace Microsoft.Interop
 
         public TypeSyntax AsNativeType(TypePositionInfo info)
         {
-            return nativeTypeSyntax;
+            return _nativeTypeSyntax;
         }
 
         public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context)
@@ -151,13 +151,13 @@ namespace Microsoft.Interop
     /// </summary>
     internal sealed class CustomNativeTypeWithValuePropertyMarshalling : ICustomNativeTypeMarshallingStrategy
     {
-        private readonly ICustomNativeTypeMarshallingStrategy innerMarshaller;
-        private readonly TypeSyntax valuePropertyType;
+        private readonly ICustomNativeTypeMarshallingStrategy _innerMarshaller;
+        private readonly TypeSyntax _valuePropertyType;
 
         public CustomNativeTypeWithValuePropertyMarshalling(ICustomNativeTypeMarshallingStrategy innerMarshaller, TypeSyntax valuePropertyType)
         {
-            this.innerMarshaller = innerMarshaller;
-            this.valuePropertyType = valuePropertyType;
+            this._innerMarshaller = innerMarshaller;
+            this._valuePropertyType = valuePropertyType;
         }
 
         public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
@@ -176,7 +176,7 @@ namespace Microsoft.Interop
 
         public TypeSyntax AsNativeType(TypePositionInfo info)
         {
-            return valuePropertyType;
+            return _valuePropertyType;
         }
 
         public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context)
@@ -196,7 +196,7 @@ namespace Microsoft.Interop
                 yield return GenerateValuePropertyAssignment(info, context, subContext);
             }
 
-            foreach (var statement in innerMarshaller.GenerateCleanupStatements(info, subContext))
+            foreach (var statement in _innerMarshaller.GenerateCleanupStatements(info, subContext))
             {
                 yield return statement;
             }
@@ -205,7 +205,7 @@ namespace Microsoft.Interop
         public IEnumerable<StatementSyntax> GenerateMarshalStatements(TypePositionInfo info, StubCodeContext context, IEnumerable<ArgumentSyntax> nativeTypeConstructorArguments)
         {
             var subContext = new CustomNativeTypeWithValuePropertyStubContext(context);
-            foreach (var statement in innerMarshaller.GenerateMarshalStatements(info, subContext, nativeTypeConstructorArguments))
+            foreach (var statement in _innerMarshaller.GenerateMarshalStatements(info, subContext, nativeTypeConstructorArguments))
             {
                 yield return statement;
             }
@@ -238,7 +238,7 @@ namespace Microsoft.Interop
 
             yield return GenerateValuePropertyAssignment(info, context, subContext);
 
-            foreach (var statement in innerMarshaller.GenerateUnmarshalStatements(info, subContext))
+            foreach (var statement in _innerMarshaller.GenerateUnmarshalStatements(info, subContext))
             {
                 yield return statement;
             }
@@ -247,7 +247,7 @@ namespace Microsoft.Interop
         public IEnumerable<ArgumentSyntax> GetNativeTypeConstructorArguments(TypePositionInfo info, StubCodeContext context)
         {
             var subContext = new CustomNativeTypeWithValuePropertyStubContext(context);
-            return innerMarshaller.GetNativeTypeConstructorArguments(info, subContext);
+            return _innerMarshaller.GetNativeTypeConstructorArguments(info, subContext);
         }
 
         public IEnumerable<StatementSyntax> GenerateSetupStatements(TypePositionInfo info, StubCodeContext context)
@@ -255,12 +255,12 @@ namespace Microsoft.Interop
             var subContext = new CustomNativeTypeWithValuePropertyStubContext(context);
             yield return LocalDeclarationStatement(
                 VariableDeclaration(
-                    innerMarshaller.AsNativeType(info),
+                    _innerMarshaller.AsNativeType(info),
                     SingletonSeparatedList(
                         VariableDeclarator(subContext.GetIdentifiers(info).native)
                         .WithInitializer(EqualsValueClause(LiteralExpression(SyntaxKind.DefaultLiteralExpression))))));
 
-            foreach (var statement in innerMarshaller.GenerateSetupStatements(info, subContext))
+            foreach (var statement in _innerMarshaller.GenerateSetupStatements(info, subContext))
             {
                 yield return statement;
             }
@@ -269,7 +269,7 @@ namespace Microsoft.Interop
         public IEnumerable<StatementSyntax> GeneratePinStatements(TypePositionInfo info, StubCodeContext context)
         {
             var subContext = new CustomNativeTypeWithValuePropertyStubContext(context);
-            return innerMarshaller.GeneratePinStatements(info, subContext);
+            return _innerMarshaller.GeneratePinStatements(info, subContext);
         }
     }
 
@@ -278,26 +278,26 @@ namespace Microsoft.Interop
     /// </summary>
     internal sealed class StackallocOptimizationMarshalling : ICustomNativeTypeMarshallingStrategy
     {
-        private readonly ICustomNativeTypeMarshallingStrategy innerMarshaller;
+        private readonly ICustomNativeTypeMarshallingStrategy _innerMarshaller;
 
         public StackallocOptimizationMarshalling(ICustomNativeTypeMarshallingStrategy innerMarshaller)
         {
-            this.innerMarshaller = innerMarshaller;
+            this._innerMarshaller = innerMarshaller;
         }
 
         public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.AsArgument(info, context);
+            return _innerMarshaller.AsArgument(info, context);
         }
 
         public TypeSyntax AsNativeType(TypePositionInfo info)
         {
-            return innerMarshaller.AsNativeType(info);
+            return _innerMarshaller.AsNativeType(info);
         }
 
         public IEnumerable<StatementSyntax> GenerateCleanupStatements(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.GenerateCleanupStatements(info, context);
+            return _innerMarshaller.GenerateCleanupStatements(info, context);
         }
 
         public IEnumerable<StatementSyntax> GenerateMarshalStatements(TypePositionInfo info, StubCodeContext context, IEnumerable<ArgumentSyntax> nativeTypeConstructorArguments)
@@ -321,7 +321,7 @@ namespace Microsoft.Interop
                                             ))))))))));
             }
 
-            foreach (var statement in innerMarshaller.GenerateMarshalStatements(info, context, nativeTypeConstructorArguments))
+            foreach (var statement in _innerMarshaller.GenerateMarshalStatements(info, context, nativeTypeConstructorArguments))
             {
                 yield return statement;
             }
@@ -339,22 +339,22 @@ namespace Microsoft.Interop
 
         public IEnumerable<StatementSyntax> GeneratePinStatements(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.GeneratePinStatements(info, context);
+            return _innerMarshaller.GeneratePinStatements(info, context);
         }
 
         public IEnumerable<StatementSyntax> GenerateSetupStatements(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.GenerateSetupStatements(info, context);
+            return _innerMarshaller.GenerateSetupStatements(info, context);
         }
 
         public IEnumerable<StatementSyntax> GenerateUnmarshalStatements(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.GenerateUnmarshalStatements(info, context);
+            return _innerMarshaller.GenerateUnmarshalStatements(info, context);
         }
 
         public IEnumerable<ArgumentSyntax> GetNativeTypeConstructorArguments(TypePositionInfo info, StubCodeContext context)
         {
-            foreach (var arg in innerMarshaller.GetNativeTypeConstructorArguments(info, context))
+            foreach (var arg in _innerMarshaller.GetNativeTypeConstructorArguments(info, context))
             {
                 yield return arg;
             }
@@ -378,7 +378,7 @@ namespace Microsoft.Interop
 
         public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.UsesNativeIdentifier(info, context);
+            return _innerMarshaller.UsesNativeIdentifier(info, context);
         }
     }
 
@@ -387,26 +387,26 @@ namespace Microsoft.Interop
     /// </summary>
     internal sealed class FreeNativeCleanupStrategy : ICustomNativeTypeMarshallingStrategy
     {
-        private readonly ICustomNativeTypeMarshallingStrategy innerMarshaller;
+        private readonly ICustomNativeTypeMarshallingStrategy _innerMarshaller;
 
         public FreeNativeCleanupStrategy(ICustomNativeTypeMarshallingStrategy innerMarshaller)
         {
-            this.innerMarshaller = innerMarshaller;
+            this._innerMarshaller = innerMarshaller;
         }
 
         public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.AsArgument(info, context);
+            return _innerMarshaller.AsArgument(info, context);
         }
 
         public TypeSyntax AsNativeType(TypePositionInfo info)
         {
-            return innerMarshaller.AsNativeType(info);
+            return _innerMarshaller.AsNativeType(info);
         }
 
         public IEnumerable<StatementSyntax> GenerateCleanupStatements(TypePositionInfo info, StubCodeContext context)
         {
-            foreach (var statement in innerMarshaller.GenerateCleanupStatements(info, context))
+            foreach (var statement in _innerMarshaller.GenerateCleanupStatements(info, context))
             {
                 yield return statement;
             }
@@ -421,32 +421,32 @@ namespace Microsoft.Interop
 
         public IEnumerable<StatementSyntax> GenerateMarshalStatements(TypePositionInfo info, StubCodeContext context, IEnumerable<ArgumentSyntax> nativeTypeConstructorArguments)
         {
-            return innerMarshaller.GenerateMarshalStatements(info, context, nativeTypeConstructorArguments);
+            return _innerMarshaller.GenerateMarshalStatements(info, context, nativeTypeConstructorArguments);
         }
 
         public IEnumerable<StatementSyntax> GeneratePinStatements(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.GeneratePinStatements(info, context);
+            return _innerMarshaller.GeneratePinStatements(info, context);
         }
 
         public IEnumerable<StatementSyntax> GenerateSetupStatements(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.GenerateSetupStatements(info, context);
+            return _innerMarshaller.GenerateSetupStatements(info, context);
         }
 
         public IEnumerable<StatementSyntax> GenerateUnmarshalStatements(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.GenerateUnmarshalStatements(info, context);
+            return _innerMarshaller.GenerateUnmarshalStatements(info, context);
         }
 
         public IEnumerable<ArgumentSyntax> GetNativeTypeConstructorArguments(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.GetNativeTypeConstructorArguments(info, context);
+            return _innerMarshaller.GetNativeTypeConstructorArguments(info, context);
         }
 
         public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.UsesNativeIdentifier(info, context);
+            return _innerMarshaller.UsesNativeIdentifier(info, context);
         }
     }
 
@@ -455,13 +455,13 @@ namespace Microsoft.Interop
     /// </summary>
     internal sealed class PinnableMarshallerTypeMarshalling : ICustomNativeTypeMarshallingStrategy
     {
-        private readonly ICustomNativeTypeMarshallingStrategy innerMarshaller;
-        private readonly TypeSyntax valuePropertyType;
+        private readonly ICustomNativeTypeMarshallingStrategy _innerMarshaller;
+        private readonly TypeSyntax _valuePropertyType;
 
         public PinnableMarshallerTypeMarshalling(ICustomNativeTypeMarshallingStrategy innerMarshaller, TypeSyntax valuePropertyType)
         {
-            this.innerMarshaller = innerMarshaller;
-            this.valuePropertyType = valuePropertyType;
+            this._innerMarshaller = innerMarshaller;
+            this._valuePropertyType = valuePropertyType;
         }
 
         private bool CanPinMarshaller(TypePositionInfo info, StubCodeContext context)
@@ -471,12 +471,12 @@ namespace Microsoft.Interop
 
         public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.AsArgument(info, context);
+            return _innerMarshaller.AsArgument(info, context);
         }
 
         public TypeSyntax AsNativeType(TypePositionInfo info)
         {
-            return valuePropertyType;
+            return _valuePropertyType;
         }
 
         public IEnumerable<StatementSyntax> GenerateCleanupStatements(TypePositionInfo info, StubCodeContext context)
@@ -489,7 +489,7 @@ namespace Microsoft.Interop
                 yield return GenerateValuePropertyAssignment(info, context, subContext);
             }
 
-            foreach (var statement in innerMarshaller.GenerateCleanupStatements(info, subContext))
+            foreach (var statement in _innerMarshaller.GenerateCleanupStatements(info, subContext))
             {
                 yield return statement;
             }
@@ -498,7 +498,7 @@ namespace Microsoft.Interop
         public IEnumerable<StatementSyntax> GenerateMarshalStatements(TypePositionInfo info, StubCodeContext context, IEnumerable<ArgumentSyntax> nativeTypeConstructorArguments)
         {
             var subContext = new CustomNativeTypeWithValuePropertyStubContext(context);
-            foreach (var statement in innerMarshaller.GenerateMarshalStatements(info, subContext, nativeTypeConstructorArguments))
+            foreach (var statement in _innerMarshaller.GenerateMarshalStatements(info, subContext, nativeTypeConstructorArguments))
             {
                 yield return statement;
             }
@@ -522,7 +522,7 @@ namespace Microsoft.Interop
             var subContext = new CustomNativeTypeWithValuePropertyStubContext(context);
             yield return FixedStatement(
                 VariableDeclaration(
-                valuePropertyType,
+                _valuePropertyType,
                 SingletonSeparatedList(
                     VariableDeclarator(context.GetIdentifiers(info).native)
                         .WithInitializer(EqualsValueClause(
@@ -540,12 +540,12 @@ namespace Microsoft.Interop
             var subContext = new CustomNativeTypeWithValuePropertyStubContext(context);
             yield return LocalDeclarationStatement(
                 VariableDeclaration(
-                    innerMarshaller.AsNativeType(info),
+                    _innerMarshaller.AsNativeType(info),
                     SingletonSeparatedList(
                         VariableDeclarator(subContext.GetIdentifiers(info).native)
                         .WithInitializer(EqualsValueClause(LiteralExpression(SyntaxKind.DefaultLiteralExpression))))));
 
-            foreach (var statement in innerMarshaller.GenerateSetupStatements(info, subContext))
+            foreach (var statement in _innerMarshaller.GenerateSetupStatements(info, subContext))
             {
                 yield return statement;
             }
@@ -573,7 +573,7 @@ namespace Microsoft.Interop
                 yield return GenerateValuePropertyAssignment(info, context, subContext);
             }
 
-            foreach (var statement in innerMarshaller.GenerateUnmarshalStatements(info, subContext))
+            foreach (var statement in _innerMarshaller.GenerateUnmarshalStatements(info, subContext))
             {
                 yield return statement;
             }
@@ -582,7 +582,7 @@ namespace Microsoft.Interop
         public IEnumerable<ArgumentSyntax> GetNativeTypeConstructorArguments(TypePositionInfo info, StubCodeContext context)
         {
             var subContext = new CustomNativeTypeWithValuePropertyStubContext(context);
-            return innerMarshaller.GetNativeTypeConstructorArguments(info, subContext);
+            return _innerMarshaller.GetNativeTypeConstructorArguments(info, subContext);
         }
 
         public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context)
@@ -591,7 +591,7 @@ namespace Microsoft.Interop
             {
                 return false;
             }
-            return innerMarshaller.UsesNativeIdentifier(info, context);
+            return _innerMarshaller.UsesNativeIdentifier(info, context);
         }
     }
 
@@ -600,25 +600,25 @@ namespace Microsoft.Interop
     /// </summary>
     internal sealed class NumElementsExpressionMarshalling : ICustomNativeTypeMarshallingStrategy
     {
-        private readonly ICustomNativeTypeMarshallingStrategy innerMarshaller;
-        private readonly ExpressionSyntax numElementsExpression;
-        private readonly ExpressionSyntax sizeOfElementExpression;
+        private readonly ICustomNativeTypeMarshallingStrategy _innerMarshaller;
+        private readonly ExpressionSyntax _numElementsExpression;
+        private readonly ExpressionSyntax _sizeOfElementExpression;
 
         public NumElementsExpressionMarshalling(ICustomNativeTypeMarshallingStrategy innerMarshaller, ExpressionSyntax numElementsExpression, ExpressionSyntax sizeOfElementExpression)
         {
-            this.innerMarshaller = innerMarshaller;
-            this.numElementsExpression = numElementsExpression;
-            this.sizeOfElementExpression = sizeOfElementExpression;
+            this._innerMarshaller = innerMarshaller;
+            this._numElementsExpression = numElementsExpression;
+            this._sizeOfElementExpression = sizeOfElementExpression;
         }
 
         public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.AsArgument(info, context);
+            return _innerMarshaller.AsArgument(info, context);
         }
 
         public TypeSyntax AsNativeType(TypePositionInfo info)
         {
-            return innerMarshaller.AsNativeType(info);
+            return _innerMarshaller.AsNativeType(info);
         }
 
         public IEnumerable<StatementSyntax> GenerateCleanupStatements(TypePositionInfo info, StubCodeContext context)
@@ -634,7 +634,7 @@ namespace Microsoft.Interop
                 }
             }
 
-            foreach (var statement in innerMarshaller.GenerateCleanupStatements(info, context))
+            foreach (var statement in _innerMarshaller.GenerateCleanupStatements(info, context))
             {
                 yield return statement;
             }
@@ -642,17 +642,17 @@ namespace Microsoft.Interop
 
         public IEnumerable<StatementSyntax> GenerateMarshalStatements(TypePositionInfo info, StubCodeContext context, IEnumerable<ArgumentSyntax> nativeTypeConstructorArguments)
         {
-            return innerMarshaller.GenerateMarshalStatements(info, context, nativeTypeConstructorArguments);
+            return _innerMarshaller.GenerateMarshalStatements(info, context, nativeTypeConstructorArguments);
         }
 
         public IEnumerable<StatementSyntax> GeneratePinStatements(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.GeneratePinStatements(info, context);
+            return _innerMarshaller.GeneratePinStatements(info, context);
         }
 
         public IEnumerable<StatementSyntax> GenerateSetupStatements(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.GenerateSetupStatements(info, context);
+            return _innerMarshaller.GenerateSetupStatements(info, context);
         }
 
         private IEnumerable<StatementSyntax> GenerateUnmarshallerCollectionInitialization(TypePositionInfo info, StubCodeContext context)
@@ -662,7 +662,7 @@ namespace Microsoft.Interop
             {
                 yield return ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
                     IdentifierName(marshalerIdentifier),
-                    ImplicitObjectCreationExpression().AddArgumentListArguments(Argument(sizeOfElementExpression))));
+                    ImplicitObjectCreationExpression().AddArgumentListArguments(Argument(_sizeOfElementExpression))));
             }
 
             if (info.IsByRef || !info.ByValueContentsMarshalKind.HasFlag(ByValueContentsMarshalKind.Out))
@@ -673,7 +673,7 @@ namespace Microsoft.Interop
                             SyntaxKind.SimpleMemberAccessExpression,
                             IdentifierName(marshalerIdentifier),
                             IdentifierName(ManualTypeMarshallingHelper.SetUnmarshalledCollectionLengthMethodName)))
-                    .AddArgumentListArguments(Argument(numElementsExpression)));
+                    .AddArgumentListArguments(Argument(_numElementsExpression)));
             }
         }
 
@@ -689,7 +689,7 @@ namespace Microsoft.Interop
                 yield return statement;
             }
 
-            foreach (var statement in innerMarshaller.GenerateUnmarshalStatements(info, context))
+            foreach (var statement in _innerMarshaller.GenerateUnmarshalStatements(info, context))
             {
                 yield return statement;
             }
@@ -697,16 +697,16 @@ namespace Microsoft.Interop
 
         public IEnumerable<ArgumentSyntax> GetNativeTypeConstructorArguments(TypePositionInfo info, StubCodeContext context)
         {
-            foreach (var arg in innerMarshaller.GetNativeTypeConstructorArguments(info, context))
+            foreach (var arg in _innerMarshaller.GetNativeTypeConstructorArguments(info, context))
             {
                 yield return arg;
             }
-            yield return Argument(sizeOfElementExpression);
+            yield return Argument(_sizeOfElementExpression);
         }
 
         public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.UsesNativeIdentifier(info, context);
+            return _innerMarshaller.UsesNativeIdentifier(info, context);
         }
     }
 
@@ -715,34 +715,34 @@ namespace Microsoft.Interop
     /// </summary>
     internal sealed class ContiguousBlittableElementCollectionMarshalling : ICustomNativeTypeMarshallingStrategy
     {
-        private readonly ICustomNativeTypeMarshallingStrategy innerMarshaller;
-        private readonly TypeSyntax elementType;
+        private readonly ICustomNativeTypeMarshallingStrategy _innerMarshaller;
+        private readonly TypeSyntax _elementType;
 
         public ContiguousBlittableElementCollectionMarshalling(ICustomNativeTypeMarshallingStrategy innerMarshaller, TypeSyntax elementType)
         {
-            this.innerMarshaller = innerMarshaller;
-            this.elementType = elementType;
+            this._innerMarshaller = innerMarshaller;
+            this._elementType = elementType;
         }
 
         public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.AsArgument(info, context);
+            return _innerMarshaller.AsArgument(info, context);
         }
 
         public TypeSyntax AsNativeType(TypePositionInfo info)
         {
-            return innerMarshaller.AsNativeType(info);
+            return _innerMarshaller.AsNativeType(info);
         }
 
         public IEnumerable<StatementSyntax> GenerateCleanupStatements(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.GenerateCleanupStatements(info, context);
+            return _innerMarshaller.GenerateCleanupStatements(info, context);
         }
 
         public IEnumerable<StatementSyntax> GenerateMarshalStatements(TypePositionInfo info, StubCodeContext context, IEnumerable<ArgumentSyntax> nativeTypeConstructorArguments)
         {
             string nativeIdentifier = context.GetIdentifiers(info).native;
-            foreach (var statement in innerMarshaller.GenerateMarshalStatements(info, context, nativeTypeConstructorArguments))
+            foreach (var statement in _innerMarshaller.GenerateMarshalStatements(info, context, nativeTypeConstructorArguments))
             {
                 yield return statement;
             }
@@ -777,7 +777,7 @@ namespace Microsoft.Interop
                                             new[]
                                             {
                                                 PredefinedType(Token(SyntaxKind.ByteKeyword)),
-                                                elementType
+                                                _elementType
                                             })))))
                         .AddArgumentListArguments(
                             Argument(
@@ -789,12 +789,12 @@ namespace Microsoft.Interop
 
         public IEnumerable<StatementSyntax> GeneratePinStatements(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.GeneratePinStatements(info, context);
+            return _innerMarshaller.GeneratePinStatements(info, context);
         }
 
         public IEnumerable<StatementSyntax> GenerateSetupStatements(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.GenerateSetupStatements(info, context);
+            return _innerMarshaller.GenerateSetupStatements(info, context);
         }
 
         public IEnumerable<StatementSyntax> GenerateUnmarshalStatements(TypePositionInfo info, StubCodeContext context)
@@ -817,7 +817,7 @@ namespace Microsoft.Interop
                                                 new[]
                                                 {
                                                     PredefinedType(Token(SyntaxKind.ByteKeyword)),
-                                                    elementType
+                                                    _elementType
                                                 })))))
                             .AddArgumentListArguments(
                                 Argument(
@@ -833,7 +833,7 @@ namespace Microsoft.Interop
                             IdentifierName(nativeIdentifier),
                             IdentifierName(ManualTypeMarshallingHelper.ManagedValuesPropertyName)))));
 
-            foreach (var statement in innerMarshaller.GenerateUnmarshalStatements(info, context))
+            foreach (var statement in _innerMarshaller.GenerateUnmarshalStatements(info, context))
             {
                 yield return statement;
             }
@@ -841,12 +841,12 @@ namespace Microsoft.Interop
 
         public IEnumerable<ArgumentSyntax> GetNativeTypeConstructorArguments(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.GetNativeTypeConstructorArguments(info, context);
+            return _innerMarshaller.GetNativeTypeConstructorArguments(info, context);
         }
 
         public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.UsesNativeIdentifier(info, context);
+            return _innerMarshaller.UsesNativeIdentifier(info, context);
         }
     }
 
@@ -855,17 +855,17 @@ namespace Microsoft.Interop
     /// </summary>
     internal sealed class ContiguousNonBlittableElementCollectionMarshalling : ICustomNativeTypeMarshallingStrategy
     {
-        private readonly ICustomNativeTypeMarshallingStrategy innerMarshaller;
-        private readonly IMarshallingGenerator elementMarshaller;
-        private readonly TypePositionInfo elementInfo;
+        private readonly ICustomNativeTypeMarshallingStrategy _innerMarshaller;
+        private readonly IMarshallingGenerator _elementMarshaller;
+        private readonly TypePositionInfo _elementInfo;
 
         public ContiguousNonBlittableElementCollectionMarshalling(ICustomNativeTypeMarshallingStrategy innerMarshaller,
             IMarshallingGenerator elementMarshaller,
             TypePositionInfo elementInfo)
         {
-            this.innerMarshaller = innerMarshaller;
-            this.elementMarshaller = elementMarshaller;
-            this.elementInfo = elementInfo;
+            this._innerMarshaller = innerMarshaller;
+            this._elementMarshaller = elementMarshaller;
+            this._elementInfo = elementInfo;
         }
 
         private LocalDeclarationStatementSyntax GenerateNativeSpanDeclaration(TypePositionInfo info, StubCodeContext context)
@@ -876,7 +876,7 @@ namespace Microsoft.Interop
                 GenericName(
                     Identifier(TypeNames.System_Span),
                     TypeArgumentList(
-                        SingletonSeparatedList(elementMarshaller.AsNativeType(elementInfo).GetCompatibleGenericTypeParameterSyntax()))
+                        SingletonSeparatedList(_elementMarshaller.AsNativeType(_elementInfo).GetCompatibleGenericTypeParameterSyntax()))
                 ),
                 SingletonSeparatedList(
                     VariableDeclarator(Identifier(nativeSpanIdentifier))
@@ -893,7 +893,7 @@ namespace Microsoft.Interop
                                             new[]
                                             {
                                                 PredefinedType(Token(SyntaxKind.ByteKeyword)),
-                                                elementMarshaller.AsNativeType(elementInfo).GetCompatibleGenericTypeParameterSyntax()
+                                                _elementMarshaller.AsNativeType(_elementInfo).GetCompatibleGenericTypeParameterSyntax()
                                             })))))
                         .AddArgumentListArguments(
                             Argument(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
@@ -918,7 +918,7 @@ namespace Microsoft.Interop
                 ? $"{nativeIdentifier}.{ManualTypeMarshallingHelper.ManagedValuesPropertyName}"
                 : nativeSpanIdentifier;
 
-            TypePositionInfo localElementInfo = elementInfo with
+            TypePositionInfo localElementInfo = _elementInfo with
             {
                 InstanceIdentifier = info.InstanceIdentifier,
                 RefKind = info.IsByRef ? info.RefKind : info.ByValueContentsMarshalKind.GetRefKindForByValueContentsKind(),
@@ -926,15 +926,15 @@ namespace Microsoft.Interop
                 NativeIndex = info.NativeIndex
             };
 
-            List<StatementSyntax> elementStatements = elementMarshaller.Generate(localElementInfo, elementSubContext).ToList();
+            List<StatementSyntax> elementStatements = _elementMarshaller.Generate(localElementInfo, elementSubContext).ToList();
 
             if (elementStatements.Any())
             {
                 StatementSyntax marshallingStatement = Block(
-                    List(elementMarshaller.Generate(localElementInfo, elementSetupSubContext)
+                    List(_elementMarshaller.Generate(localElementInfo, elementSetupSubContext)
                         .Concat(elementStatements)));
 
-                if (elementMarshaller.AsNativeType(elementInfo) is PointerTypeSyntax elementNativeType)
+                if (_elementMarshaller.AsNativeType(_elementInfo) is PointerTypeSyntax elementNativeType)
                 {
                     PointerNativeTypeAssignmentRewriter rewriter = new(elementSubContext.GetIdentifiers(localElementInfo).native, elementNativeType);
                     marshallingStatement = (StatementSyntax)rewriter.Visit(marshallingStatement);
@@ -951,18 +951,18 @@ namespace Microsoft.Interop
 
         public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.AsArgument(info, context);
+            return _innerMarshaller.AsArgument(info, context);
         }
 
         public TypeSyntax AsNativeType(TypePositionInfo info)
         {
-            return innerMarshaller.AsNativeType(info);
+            return _innerMarshaller.AsNativeType(info);
         }
 
         public IEnumerable<StatementSyntax> GenerateCleanupStatements(TypePositionInfo info, StubCodeContext context)
         {
             yield return GenerateContentsMarshallingStatement(info, context, useManagedSpanForLength: false);
-            foreach (var statement in innerMarshaller.GenerateCleanupStatements(info, context))
+            foreach (var statement in _innerMarshaller.GenerateCleanupStatements(info, context))
             {
                 yield return statement;
             }
@@ -970,7 +970,7 @@ namespace Microsoft.Interop
 
         public IEnumerable<StatementSyntax> GenerateMarshalStatements(TypePositionInfo info, StubCodeContext context, IEnumerable<ArgumentSyntax> nativeTypeConstructorArguments)
         {
-            foreach (var statement in innerMarshaller.GenerateMarshalStatements(info, context, nativeTypeConstructorArguments))
+            foreach (var statement in _innerMarshaller.GenerateMarshalStatements(info, context, nativeTypeConstructorArguments))
             {
                 yield return statement;
             }
@@ -986,18 +986,18 @@ namespace Microsoft.Interop
 
         public IEnumerable<StatementSyntax> GeneratePinStatements(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.GeneratePinStatements(info, context);
+            return _innerMarshaller.GeneratePinStatements(info, context);
         }
 
         public IEnumerable<StatementSyntax> GenerateSetupStatements(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.GenerateSetupStatements(info, context);
+            return _innerMarshaller.GenerateSetupStatements(info, context);
         }
 
         public IEnumerable<StatementSyntax> GenerateUnmarshalStatements(TypePositionInfo info, StubCodeContext context)
         {
             yield return GenerateContentsMarshallingStatement(info, context, useManagedSpanForLength: false);
-            foreach (var statement in innerMarshaller.GenerateUnmarshalStatements(info, context))
+            foreach (var statement in _innerMarshaller.GenerateUnmarshalStatements(info, context))
             {
                 yield return statement;
             }
@@ -1005,12 +1005,12 @@ namespace Microsoft.Interop
 
         public IEnumerable<ArgumentSyntax> GetNativeTypeConstructorArguments(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.GetNativeTypeConstructorArguments(info, context);
+            return _innerMarshaller.GetNativeTypeConstructorArguments(info, context);
         }
 
         public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.UsesNativeIdentifier(info, context);
+            return _innerMarshaller.UsesNativeIdentifier(info, context);
         }
 
         /// <summary>
@@ -1020,25 +1020,25 @@ namespace Microsoft.Interop
         /// </summary>
         private class PointerNativeTypeAssignmentRewriter : CSharpSyntaxRewriter
         {
-            private readonly string nativeIdentifier;
-            private readonly PointerTypeSyntax nativeType;
+            private readonly string _nativeIdentifier;
+            private readonly PointerTypeSyntax _nativeType;
 
             public PointerNativeTypeAssignmentRewriter(string nativeIdentifier, PointerTypeSyntax nativeType)
             {
-                this.nativeIdentifier = nativeIdentifier;
-                this.nativeType = nativeType;
+                this._nativeIdentifier = nativeIdentifier;
+                this._nativeType = nativeType;
             }
 
             public override SyntaxNode VisitAssignmentExpression(AssignmentExpressionSyntax node)
             {
-                if (node.Left.ToString() == nativeIdentifier)
+                if (node.Left.ToString() == _nativeIdentifier)
                 {
                     return node.WithRight(
                         CastExpression(MarshallerHelpers.SystemIntPtrType, node.Right));
                 }
-                if (node.Right.ToString() == nativeIdentifier)
+                if (node.Right.ToString() == _nativeIdentifier)
                 {
-                    return node.WithRight(CastExpression(nativeType, node.Right));
+                    return node.WithRight(CastExpression(_nativeType, node.Right));
                 }
 
                 return node;

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Interop
 
         public SimpleCustomNativeTypeMarshalling(TypeSyntax nativeTypeSyntax)
         {
-            this._nativeTypeSyntax = nativeTypeSyntax;
+            _nativeTypeSyntax = nativeTypeSyntax;
         }
 
         public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
@@ -156,8 +156,8 @@ namespace Microsoft.Interop
 
         public CustomNativeTypeWithValuePropertyMarshalling(ICustomNativeTypeMarshallingStrategy innerMarshaller, TypeSyntax valuePropertyType)
         {
-            this._innerMarshaller = innerMarshaller;
-            this._valuePropertyType = valuePropertyType;
+            _innerMarshaller = innerMarshaller;
+            _valuePropertyType = valuePropertyType;
         }
 
         public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
@@ -282,7 +282,7 @@ namespace Microsoft.Interop
 
         public StackallocOptimizationMarshalling(ICustomNativeTypeMarshallingStrategy innerMarshaller)
         {
-            this._innerMarshaller = innerMarshaller;
+            _innerMarshaller = innerMarshaller;
         }
 
         public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
@@ -391,7 +391,7 @@ namespace Microsoft.Interop
 
         public FreeNativeCleanupStrategy(ICustomNativeTypeMarshallingStrategy innerMarshaller)
         {
-            this._innerMarshaller = innerMarshaller;
+            _innerMarshaller = innerMarshaller;
         }
 
         public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
@@ -460,8 +460,8 @@ namespace Microsoft.Interop
 
         public PinnableMarshallerTypeMarshalling(ICustomNativeTypeMarshallingStrategy innerMarshaller, TypeSyntax valuePropertyType)
         {
-            this._innerMarshaller = innerMarshaller;
-            this._valuePropertyType = valuePropertyType;
+            _innerMarshaller = innerMarshaller;
+            _valuePropertyType = valuePropertyType;
         }
 
         private bool CanPinMarshaller(TypePositionInfo info, StubCodeContext context)
@@ -606,9 +606,9 @@ namespace Microsoft.Interop
 
         public NumElementsExpressionMarshalling(ICustomNativeTypeMarshallingStrategy innerMarshaller, ExpressionSyntax numElementsExpression, ExpressionSyntax sizeOfElementExpression)
         {
-            this._innerMarshaller = innerMarshaller;
-            this._numElementsExpression = numElementsExpression;
-            this._sizeOfElementExpression = sizeOfElementExpression;
+            _innerMarshaller = innerMarshaller;
+            _numElementsExpression = numElementsExpression;
+            _sizeOfElementExpression = sizeOfElementExpression;
         }
 
         public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
@@ -720,8 +720,8 @@ namespace Microsoft.Interop
 
         public ContiguousBlittableElementCollectionMarshalling(ICustomNativeTypeMarshallingStrategy innerMarshaller, TypeSyntax elementType)
         {
-            this._innerMarshaller = innerMarshaller;
-            this._elementType = elementType;
+            _innerMarshaller = innerMarshaller;
+            _elementType = elementType;
         }
 
         public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
@@ -863,9 +863,9 @@ namespace Microsoft.Interop
             IMarshallingGenerator elementMarshaller,
             TypePositionInfo elementInfo)
         {
-            this._innerMarshaller = innerMarshaller;
-            this._elementMarshaller = elementMarshaller;
-            this._elementInfo = elementInfo;
+            _innerMarshaller = innerMarshaller;
+            _elementMarshaller = elementMarshaller;
+            _elementInfo = elementInfo;
         }
 
         private LocalDeclarationStatementSyntax GenerateNativeSpanDeclaration(TypePositionInfo info, StubCodeContext context)
@@ -1025,8 +1025,8 @@ namespace Microsoft.Interop
 
             public PointerNativeTypeAssignmentRewriter(string nativeIdentifier, PointerTypeSyntax nativeType)
             {
-                this._nativeIdentifier = nativeIdentifier;
-                this._nativeType = nativeType;
+                _nativeIdentifier = nativeIdentifier;
+                _nativeType = nativeType;
             }
 
             public override SyntaxNode VisitAssignmentExpression(AssignmentExpressionSyntax node)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallerHelpers.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallerHelpers.cs
@@ -192,12 +192,12 @@ namespace Microsoft.Interop
 
         private struct EdgeMap
         {
-            private readonly bool[] edgeMap;
+            private readonly bool[] _edgeMap;
 
             public EdgeMap(int numNodes)
             {
                 NodeCount = numNodes;
-                edgeMap = new bool[NodeCount * NodeCount];
+                _edgeMap = new bool[NodeCount * NodeCount];
             }
 
             /// <summary>
@@ -209,17 +209,17 @@ namespace Microsoft.Interop
             /// <returns>If there exists an edge that starts at <paramref name="from"/> and ends at <paramref name="to"/></returns>
             public bool this[int to, int from]
             {
-                get => edgeMap[to * NodeCount + from];
-                set => edgeMap[to * NodeCount + from] = value;
+                get => _edgeMap[to * NodeCount + from];
+                set => _edgeMap[to * NodeCount + from] = value;
             }
 
-            public bool AnyEdges => Array.IndexOf(edgeMap, true) != -1;
+            public bool AnyEdges => Array.IndexOf(_edgeMap, true) != -1;
 
             public int NodeCount { get; }
 
             public bool AnyIncomingEdge(int to)
             {
-                return Array.IndexOf(edgeMap, true, to * NodeCount, NodeCount) != -1;
+                return Array.IndexOf(_edgeMap, true, to * NodeCount, NodeCount) != -1;
             }
         }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGenerator.cs
@@ -97,8 +97,8 @@ namespace Microsoft.Interop
         /// <param name="context"><see cref="Microsoft.Interop.StubCodeContext"/> instance</param>
         public MarshallingNotSupportedException(TypePositionInfo info, StubCodeContext context)
         {
-            this.TypePositionInfo = info;
-            this.StubCodeContext = context;
+            TypePositionInfo = info;
+            StubCodeContext = context;
         }
 
         /// <summary>

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGeneratorFactory.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Interop
 
         public DefaultMarshallingGeneratorFactory(InteropGenerationOptions options)
         {
-            this.Options = options;
+            Options = options;
         }
 
         /// <summary>

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGeneratorFactory.cs
@@ -27,20 +27,20 @@ namespace Microsoft.Interop
 
     public sealed class DefaultMarshallingGeneratorFactory : IMarshallingGeneratorFactory
     {
-        private static readonly ByteBoolMarshaller ByteBool = new();
-        private static readonly WinBoolMarshaller WinBool = new();
-        private static readonly VariantBoolMarshaller VariantBool = new();
+        private static readonly ByteBoolMarshaller s_byteBool = new();
+        private static readonly WinBoolMarshaller s_winBool = new();
+        private static readonly VariantBoolMarshaller s_variantBool = new();
 
-        private static readonly Utf16CharMarshaller Utf16Char = new();
-        private static readonly Utf16StringMarshaller Utf16String = new();
-        private static readonly Utf8StringMarshaller Utf8String = new();
-        private static readonly AnsiStringMarshaller AnsiString = new AnsiStringMarshaller(Utf8String);
-        private static readonly PlatformDefinedStringMarshaller PlatformDefinedString = new PlatformDefinedStringMarshaller(Utf16String, Utf8String);
+        private static readonly Utf16CharMarshaller s_utf16Char = new();
+        private static readonly Utf16StringMarshaller s_utf16String = new();
+        private static readonly Utf8StringMarshaller s_utf8String = new();
+        private static readonly AnsiStringMarshaller s_ansiString = new AnsiStringMarshaller(s_utf8String);
+        private static readonly PlatformDefinedStringMarshaller s_platformDefinedString = new PlatformDefinedStringMarshaller(s_utf16String, s_utf8String);
 
-        private static readonly Forwarder Forwarder = new();
-        private static readonly BlittableMarshaller Blittable = new();
-        private static readonly DelegateMarshaller Delegate = new();
-        private static readonly SafeHandleMarshaller SafeHandle = new();
+        private static readonly Forwarder s_forwarder = new();
+        private static readonly BlittableMarshaller s_blittable = new();
+        private static readonly DelegateMarshaller s_delegate = new();
+        private static readonly SafeHandleMarshaller s_safeHandle = new();
         private InteropGenerationOptions Options { get; }
 
         public DefaultMarshallingGeneratorFactory(InteropGenerationOptions options)
@@ -73,7 +73,7 @@ namespace Microsoft.Interop
                     or { ManagedType: SpecialTypeInfo { SpecialType: SpecialType.System_UIntPtr }, MarshallingAttributeInfo: NoMarshallingInfo or MarshalAsInfo(UnmanagedType.SysUInt, _) }
                     or { ManagedType: SpecialTypeInfo { SpecialType: SpecialType.System_Single }, MarshallingAttributeInfo: NoMarshallingInfo or MarshalAsInfo(UnmanagedType.R4, _) }
                     or { ManagedType: SpecialTypeInfo { SpecialType: SpecialType.System_Double }, MarshallingAttributeInfo: NoMarshallingInfo or MarshalAsInfo(UnmanagedType.R8, _) }:
-                    return Blittable;
+                    return s_blittable;
 
                 // Enum with no marshalling info
                 case { ManagedType: EnumTypeInfo enumType, MarshallingAttributeInfo: NoMarshallingInfo }:
@@ -83,27 +83,27 @@ namespace Microsoft.Interop
                     {
                         throw new MarshallingNotSupportedException(info, context);
                     }
-                    return Blittable;
+                    return s_blittable;
 
                 // Pointer with no marshalling info
                 case { ManagedType: PointerTypeInfo(_, _, IsFunctionPointer: false), MarshallingAttributeInfo: NoMarshallingInfo }:
-                    return Blittable;
+                    return s_blittable;
 
                 // Function pointer with no marshalling info
                 case { ManagedType: PointerTypeInfo(_, _, IsFunctionPointer: true), MarshallingAttributeInfo: NoMarshallingInfo or MarshalAsInfo(UnmanagedType.FunctionPtr, _) }:
-                    return Blittable;
+                    return s_blittable;
 
                 case { ManagedType: SpecialTypeInfo { SpecialType: SpecialType.System_Boolean }, MarshallingAttributeInfo: NoMarshallingInfo }:
-                    return WinBool; // [Compat] Matching the default for the built-in runtime marshallers.
+                    return s_winBool; // [Compat] Matching the default for the built-in runtime marshallers.
                 case { ManagedType: SpecialTypeInfo { SpecialType: SpecialType.System_Boolean }, MarshallingAttributeInfo: MarshalAsInfo(UnmanagedType.I1 or UnmanagedType.U1, _) }:
-                    return ByteBool;
+                    return s_byteBool;
                 case { ManagedType: SpecialTypeInfo { SpecialType: SpecialType.System_Boolean }, MarshallingAttributeInfo: MarshalAsInfo(UnmanagedType.I4 or UnmanagedType.U4 or UnmanagedType.Bool, _) }:
-                    return WinBool;
+                    return s_winBool;
                 case { ManagedType: SpecialTypeInfo { SpecialType: SpecialType.System_Boolean }, MarshallingAttributeInfo: MarshalAsInfo(UnmanagedType.VariantBool, _) }:
-                    return VariantBool;
+                    return s_variantBool;
 
                 case { ManagedType: DelegateTypeInfo, MarshallingAttributeInfo: NoMarshallingInfo or MarshalAsInfo(UnmanagedType.FunctionPtr, _) }:
-                    return Delegate;
+                    return s_delegate;
 
                 case { MarshallingAttributeInfo: SafeHandleMarshallingInfo(_, bool isAbstract) }:
                     if (!context.AdditionalTemporaryStateLivesAcrossStages)
@@ -117,7 +117,7 @@ namespace Microsoft.Interop
                             NotSupportedDetails = Resources.SafeHandleByRefMustBeConcrete
                         };
                     }
-                    return SafeHandle;
+                    return s_safeHandle;
 
                 case { ManagedType: SpecialTypeInfo { SpecialType: SpecialType.System_Char } }:
                     return CreateCharMarshaller(info, context);
@@ -126,7 +126,7 @@ namespace Microsoft.Interop
                     return CreateStringMarshaller(info, context);
 
                 case { ManagedType: SpecialTypeInfo { SpecialType: SpecialType.System_Void } }:
-                    return Forwarder;
+                    return s_forwarder;
 
                 default:
                     throw new MarshallingNotSupportedException(info, context);
@@ -152,7 +152,7 @@ namespace Microsoft.Interop
                 {
                     case UnmanagedType.I2:
                     case UnmanagedType.U2:
-                        return Utf16Char;
+                        return s_utf16Char;
                 }
             }
             else if (marshalInfo is MarshallingInfoStringSupport marshalStringInfo)
@@ -160,7 +160,7 @@ namespace Microsoft.Interop
                 switch (marshalStringInfo.CharEncoding)
                 {
                     case CharEncoding.Utf16:
-                        return Utf16Char;
+                        return s_utf16Char;
                     case CharEncoding.Ansi:
                         throw new MarshallingNotSupportedException(info, context) // [Compat] ANSI is not supported for char
                         {
@@ -195,12 +195,12 @@ namespace Microsoft.Interop
                 switch (marshalAsInfo.UnmanagedType)
                 {
                     case UnmanagedType.LPStr:
-                        return AnsiString;
+                        return s_ansiString;
                     case UnmanagedType.LPTStr:
                     case UnmanagedType.LPWStr:
-                        return Utf16String;
+                        return s_utf16String;
                     case (UnmanagedType)0x30:// UnmanagedType.LPUTF8Str
-                        return Utf8String;
+                        return s_utf8String;
                 }
             }
             else if (marshalInfo is MarshallingInfoStringSupport marshalStringInfo)
@@ -208,13 +208,13 @@ namespace Microsoft.Interop
                 switch (marshalStringInfo.CharEncoding)
                 {
                     case CharEncoding.Ansi:
-                        return AnsiString;
+                        return s_ansiString;
                     case CharEncoding.Utf16:
-                        return Utf16String;
+                        return s_utf16String;
                     case CharEncoding.Utf8:
-                        return Utf8String;
+                        return s_utf8String;
                     case CharEncoding.PlatformDefined:
-                        return PlatformDefinedString;
+                        return s_platformDefinedString;
                 }
             }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/PinnableManagedValueMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/PinnableManagedValueMarshaller.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Interop
 
         public PinnableManagedValueMarshaller(IMarshallingGenerator manualMarshallingGenerator)
         {
-            this._manualMarshallingGenerator = manualMarshallingGenerator;
+            _manualMarshallingGenerator = manualMarshallingGenerator;
         }
 
         public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/PinnableManagedValueMarshaller.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/PinnableManagedValueMarshaller.cs
@@ -10,11 +10,11 @@ namespace Microsoft.Interop
 {
     public sealed class PinnableManagedValueMarshaller : IMarshallingGenerator
     {
-        private readonly IMarshallingGenerator manualMarshallingGenerator;
+        private readonly IMarshallingGenerator _manualMarshallingGenerator;
 
         public PinnableManagedValueMarshaller(IMarshallingGenerator manualMarshallingGenerator)
         {
-            this.manualMarshallingGenerator = manualMarshallingGenerator;
+            this._manualMarshallingGenerator = manualMarshallingGenerator;
         }
 
         public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
@@ -24,17 +24,17 @@ namespace Microsoft.Interop
                 string identifier = context.GetIdentifiers(info).native;
                 return Argument(CastExpression(AsNativeType(info), IdentifierName(identifier)));
             }
-            return manualMarshallingGenerator.AsArgument(info, context);
+            return _manualMarshallingGenerator.AsArgument(info, context);
         }
 
         public TypeSyntax AsNativeType(TypePositionInfo info)
         {
-            return manualMarshallingGenerator.AsNativeType(info);
+            return _manualMarshallingGenerator.AsNativeType(info);
         }
 
         public ParameterSyntax AsParameter(TypePositionInfo info)
         {
-            return manualMarshallingGenerator.AsParameter(info);
+            return _manualMarshallingGenerator.AsParameter(info);
         }
 
         public IEnumerable<StatementSyntax> Generate(TypePositionInfo info, StubCodeContext context)
@@ -43,12 +43,12 @@ namespace Microsoft.Interop
             {
                 return GeneratePinningPath(info, context);
             }
-            return manualMarshallingGenerator.Generate(info, context);
+            return _manualMarshallingGenerator.Generate(info, context);
         }
 
         public bool SupportsByValueMarshalKind(ByValueContentsMarshalKind marshalKind, StubCodeContext context)
         {
-            return manualMarshallingGenerator.SupportsByValueMarshalKind(marshalKind, context);
+            return _manualMarshallingGenerator.SupportsByValueMarshalKind(marshalKind, context);
         }
 
         public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context)
@@ -57,7 +57,7 @@ namespace Microsoft.Interop
             {
                 return false;
             }
-            return manualMarshallingGenerator.UsesNativeIdentifier(info, context);
+            return _manualMarshallingGenerator.UsesNativeIdentifier(info, context);
         }
         private static bool IsPinningPathSupported(TypePositionInfo info, StubCodeContext context)
         {

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StringMarshaller.Ansi.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StringMarshaller.Ansi.cs
@@ -14,13 +14,13 @@ namespace Microsoft.Interop
 {
     public sealed class AnsiStringMarshaller : ConditionalStackallocMarshallingGenerator
     {
-        private static readonly TypeSyntax NativeType = PointerType(PredefinedType(Token(SyntaxKind.ByteKeyword)));
+        private static readonly TypeSyntax s_nativeType = PointerType(PredefinedType(Token(SyntaxKind.ByteKeyword)));
 
-        private readonly Utf8StringMarshaller utf8StringMarshaller;
+        private readonly Utf8StringMarshaller _utf8StringMarshaller;
 
         public AnsiStringMarshaller(Utf8StringMarshaller utf8StringMarshaller)
         {
-            this.utf8StringMarshaller = utf8StringMarshaller;
+            this._utf8StringMarshaller = utf8StringMarshaller;
         }
 
         public override ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
@@ -42,7 +42,7 @@ namespace Microsoft.Interop
         public override TypeSyntax AsNativeType(TypePositionInfo info)
         {
             // byte*
-            return NativeType;
+            return s_nativeType;
         }
 
         public override ParameterSyntax AsParameter(TypePositionInfo info)
@@ -105,7 +105,7 @@ namespace Microsoft.Interop
                         yield return IfStatement(IsWindows,
                             windowsBlock,
                             ElseClause(
-                                Block(this.utf8StringMarshaller.Generate(info, context))));
+                                Block(this._utf8StringMarshaller.Generate(info, context))));
                     }
                     break;
                 case StubCodeContext.Stage.Unmarshal:
@@ -140,7 +140,7 @@ namespace Microsoft.Interop
                                                             IdentifierName(nativeIdentifier))))),
                                                 initializer: null))))),
                             ElseClause(
-                                Block(this.utf8StringMarshaller.Generate(info, context))));
+                                Block(this._utf8StringMarshaller.Generate(info, context))));
                     }
                     break;
                 case StubCodeContext.Stage.Cleanup:

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StringMarshaller.Ansi.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StringMarshaller.Ansi.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Interop
 
         public AnsiStringMarshaller(Utf8StringMarshaller utf8StringMarshaller)
         {
-            this._utf8StringMarshaller = utf8StringMarshaller;
+            _utf8StringMarshaller = utf8StringMarshaller;
         }
 
         public override ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
@@ -105,7 +105,7 @@ namespace Microsoft.Interop
                         yield return IfStatement(IsWindows,
                             windowsBlock,
                             ElseClause(
-                                Block(this._utf8StringMarshaller.Generate(info, context))));
+                                Block(_utf8StringMarshaller.Generate(info, context))));
                     }
                     break;
                 case StubCodeContext.Stage.Unmarshal:
@@ -140,7 +140,7 @@ namespace Microsoft.Interop
                                                             IdentifierName(nativeIdentifier))))),
                                                 initializer: null))))),
                             ElseClause(
-                                Block(this._utf8StringMarshaller.Generate(info, context))));
+                                Block(_utf8StringMarshaller.Generate(info, context))));
                     }
                     break;
                 case StubCodeContext.Stage.Cleanup:

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StringMarshaller.PlatformDefined.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StringMarshaller.PlatformDefined.cs
@@ -22,14 +22,14 @@ namespace Microsoft.Interop
 
         public PlatformDefinedStringMarshaller(IMarshallingGenerator windowsMarshaller, IMarshallingGenerator nonWindowsMarshaller)
         {
-            this._windowsMarshaller = windowsMarshaller;
-            this._nonWindowsMarshaller = nonWindowsMarshaller;
+            _windowsMarshaller = windowsMarshaller;
+            _nonWindowsMarshaller = nonWindowsMarshaller;
         }
 
         public override ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
         {
-            var windowsExpr = this._windowsMarshaller.AsArgument(info, context).Expression;
-            var nonWindowsExpr = this._nonWindowsMarshaller.AsArgument(info, context).Expression;
+            var windowsExpr = _windowsMarshaller.AsArgument(info, context).Expression;
+            var nonWindowsExpr = _nonWindowsMarshaller.AsArgument(info, context).Expression;
 
             // If the Windows and non-Windows syntax are equivalent, just return one of them.
             if (windowsExpr.IsEquivalentTo(nonWindowsExpr))
@@ -73,9 +73,9 @@ namespace Microsoft.Interop
                 case StubCodeContext.Stage.Marshal:
                     if (info.RefKind != RefKind.Out)
                     {
-                        if (this.TryGetConditionalBlockForStatements(
-                                this._windowsMarshaller.Generate(info, context),
-                                this._nonWindowsMarshaller.Generate(info, context),
+                        if (TryGetConditionalBlockForStatements(
+                                _windowsMarshaller.Generate(info, context),
+                                _nonWindowsMarshaller.Generate(info, context),
                                 out StatementSyntax marshal))
                         {
                             yield return marshal;
@@ -86,19 +86,19 @@ namespace Microsoft.Interop
                     // [Compat] The built-in system could determine the platform at runtime and pin only on
                     // the platform on which is is needed. In the generated source, if pinning is needed for
                     // any platform, it is done on every platform.
-                    foreach (var s in this._windowsMarshaller.Generate(info, context))
+                    foreach (var s in _windowsMarshaller.Generate(info, context))
                         yield return s;
 
-                    foreach (var s in this._nonWindowsMarshaller.Generate(info, context))
+                    foreach (var s in _nonWindowsMarshaller.Generate(info, context))
                         yield return s;
 
                     break;
                 case StubCodeContext.Stage.Unmarshal:
                     if (info.IsManagedReturnPosition || (info.IsByRef && info.RefKind != RefKind.In))
                     {
-                        if (this.TryGetConditionalBlockForStatements(
-                                this._windowsMarshaller.Generate(info, context),
-                                this._nonWindowsMarshaller.Generate(info, context),
+                        if (TryGetConditionalBlockForStatements(
+                                _windowsMarshaller.Generate(info, context),
+                                _nonWindowsMarshaller.Generate(info, context),
                                 out StatementSyntax unmarshal))
                         {
                             yield return unmarshal;

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StringMarshaller.PlatformDefined.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StringMarshaller.PlatformDefined.cs
@@ -15,21 +15,21 @@ namespace Microsoft.Interop
 {
     public sealed class PlatformDefinedStringMarshaller : ConditionalStackallocMarshallingGenerator
     {
-        private static readonly TypeSyntax NativeType = PointerType(PredefinedType(Token(SyntaxKind.VoidKeyword)));
+        private static readonly TypeSyntax s_nativeType = PointerType(PredefinedType(Token(SyntaxKind.VoidKeyword)));
 
-        private readonly IMarshallingGenerator windowsMarshaller;
-        private readonly IMarshallingGenerator nonWindowsMarshaller;
+        private readonly IMarshallingGenerator _windowsMarshaller;
+        private readonly IMarshallingGenerator _nonWindowsMarshaller;
 
         public PlatformDefinedStringMarshaller(IMarshallingGenerator windowsMarshaller, IMarshallingGenerator nonWindowsMarshaller)
         {
-            this.windowsMarshaller = windowsMarshaller;
-            this.nonWindowsMarshaller = nonWindowsMarshaller;
+            this._windowsMarshaller = windowsMarshaller;
+            this._nonWindowsMarshaller = nonWindowsMarshaller;
         }
 
         public override ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
         {
-            var windowsExpr = this.windowsMarshaller.AsArgument(info, context).Expression;
-            var nonWindowsExpr = this.nonWindowsMarshaller.AsArgument(info, context).Expression;
+            var windowsExpr = this._windowsMarshaller.AsArgument(info, context).Expression;
+            var nonWindowsExpr = this._nonWindowsMarshaller.AsArgument(info, context).Expression;
 
             // If the Windows and non-Windows syntax are equivalent, just return one of them.
             if (windowsExpr.IsEquivalentTo(nonWindowsExpr))
@@ -46,7 +46,7 @@ namespace Microsoft.Interop
         public override TypeSyntax AsNativeType(TypePositionInfo info)
         {
             // void*
-            return NativeType;
+            return s_nativeType;
         }
 
         public override ParameterSyntax AsParameter(TypePositionInfo info)
@@ -74,8 +74,8 @@ namespace Microsoft.Interop
                     if (info.RefKind != RefKind.Out)
                     {
                         if (this.TryGetConditionalBlockForStatements(
-                                this.windowsMarshaller.Generate(info, context),
-                                this.nonWindowsMarshaller.Generate(info, context),
+                                this._windowsMarshaller.Generate(info, context),
+                                this._nonWindowsMarshaller.Generate(info, context),
                                 out StatementSyntax marshal))
                         {
                             yield return marshal;
@@ -86,10 +86,10 @@ namespace Microsoft.Interop
                     // [Compat] The built-in system could determine the platform at runtime and pin only on
                     // the platform on which is is needed. In the generated source, if pinning is needed for
                     // any platform, it is done on every platform.
-                    foreach (var s in this.windowsMarshaller.Generate(info, context))
+                    foreach (var s in this._windowsMarshaller.Generate(info, context))
                         yield return s;
 
-                    foreach (var s in this.nonWindowsMarshaller.Generate(info, context))
+                    foreach (var s in this._nonWindowsMarshaller.Generate(info, context))
                         yield return s;
 
                     break;
@@ -97,8 +97,8 @@ namespace Microsoft.Interop
                     if (info.IsManagedReturnPosition || (info.IsByRef && info.RefKind != RefKind.In))
                     {
                         if (this.TryGetConditionalBlockForStatements(
-                                this.windowsMarshaller.Generate(info, context),
-                                this.nonWindowsMarshaller.Generate(info, context),
+                                this._windowsMarshaller.Generate(info, context),
+                                this._nonWindowsMarshaller.Generate(info, context),
                                 out StatementSyntax unmarshal))
                         {
                             yield return unmarshal;

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StringMarshaller.Utf16.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StringMarshaller.Utf16.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Interop
         // so the threshold for optimized allocation is based on that length.
         private const int StackAllocBytesThreshold = 260 * sizeof(ushort);
 
-        private static readonly TypeSyntax NativeType = PointerType(PredefinedType(Token(SyntaxKind.UShortKeyword)));
+        private static readonly TypeSyntax s_nativeType = PointerType(PredefinedType(Token(SyntaxKind.UShortKeyword)));
 
         private static string PinnedIdentifier(string nativeIdentifier) => $"{nativeIdentifier}__pinned";
 
@@ -49,7 +49,7 @@ namespace Microsoft.Interop
         public override TypeSyntax AsNativeType(TypePositionInfo info)
         {
             // ushort*
-            return NativeType;
+            return s_nativeType;
         }
 
         public override ParameterSyntax AsParameter(TypePositionInfo info)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StringMarshaller.Utf8.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/StringMarshaller.Utf8.cs
@@ -26,8 +26,8 @@ namespace Microsoft.Interop
         // maximum number of bytes per 'char' is 3.
         private const int MaxByteCountPerChar = 3;
 
-        private static readonly TypeSyntax NativeType = PointerType(PredefinedType(Token(SyntaxKind.ByteKeyword)));
-        private static readonly TypeSyntax UTF8EncodingType = ParseTypeName("System.Text.Encoding.UTF8");
+        private static readonly TypeSyntax s_nativeType = PointerType(PredefinedType(Token(SyntaxKind.ByteKeyword)));
+        private static readonly TypeSyntax s_utf8EncodingType = ParseTypeName("System.Text.Encoding.UTF8");
 
         public override ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
         {
@@ -43,7 +43,7 @@ namespace Microsoft.Interop
             return Argument(IdentifierName(identifier));
         }
 
-        public override TypeSyntax AsNativeType(TypePositionInfo info) => NativeType;
+        public override TypeSyntax AsNativeType(TypePositionInfo info) => s_nativeType;
 
         public override ParameterSyntax AsParameter(TypePositionInfo info)
         {
@@ -155,7 +155,7 @@ namespace Microsoft.Interop
                         InvocationExpression(
                             MemberAccessExpression(
                                 SyntaxKind.SimpleMemberAccessExpression,
-                                UTF8EncodingType,
+                                s_utf8EncodingType,
                                 IdentifierName("GetBytes")),
                             ArgumentList(
                                 SeparatedList(new ArgumentSyntax[] {

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshallingAttributeInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshallingAttributeInfo.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Interop
         // Add a constructor that can only be called by derived types in the same assembly
         // to enforce that this type cannot be extended by users of this library.
         private protected MarshallingInfo()
-        {}
+        { }
     }
 
     public sealed record NoMarshallingInfo : MarshallingInfo
@@ -87,7 +87,7 @@ namespace Microsoft.Interop
 
     public abstract record CountInfo
     {
-        private protected CountInfo() {}
+        private protected CountInfo() { }
     }
 
     public sealed record NoCountInfo : CountInfo

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshallingAttributeInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/MarshallingAttributeInfo.cs
@@ -449,8 +449,8 @@ namespace Microsoft.Interop
             ref int maxIndirectionLevelUsed)
         {
             object unmanagedTypeObj = attrData.ConstructorArguments[0].Value!;
-            UnmanagedType unmanagedType = unmanagedTypeObj is short
-                ? (UnmanagedType)(short)unmanagedTypeObj
+            UnmanagedType unmanagedType = unmanagedTypeObj is short unmanagedTypeAsShort
+                ? (UnmanagedType)unmanagedTypeAsShort
                 : (UnmanagedType)unmanagedTypeObj;
             if (!Enum.IsDefined(typeof(UnmanagedType), unmanagedType)
                 || unmanagedType == UnmanagedType.CustomMarshaler

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypePositionInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypePositionInfo.cs
@@ -57,8 +57,8 @@ namespace Microsoft.Interop
 
         public ByValueContentsMarshalKind ByValueContentsMarshalKind { get; init; }
 
-        public bool IsManagedReturnPosition { get => this.ManagedIndex == ReturnIndex; }
-        public bool IsNativeReturnPosition { get => this.NativeIndex == ReturnIndex; }
+        public bool IsManagedReturnPosition { get => ManagedIndex == ReturnIndex; }
+        public bool IsNativeReturnPosition { get => NativeIndex == ReturnIndex; }
 
         public int ManagedIndex { get; init; } = UnsetIndex;
         public int NativeIndex { get; init; } = UnsetIndex;

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeSymbolExtensions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypeSymbolExtensions.cs
@@ -56,23 +56,23 @@ namespace Microsoft.Interop
         }
 
         private static bool IsSpecialTypeBlittable(SpecialType specialType)
-         => specialType switch
-         {
-            SpecialType.System_Void
-            or SpecialType.System_SByte
-            or SpecialType.System_Byte
-            or SpecialType.System_Int16
-            or SpecialType.System_UInt16
-            or SpecialType.System_Int32
-            or SpecialType.System_UInt32
-            or SpecialType.System_Int64
-            or SpecialType.System_UInt64
-            or SpecialType.System_Single
-            or SpecialType.System_Double
-            or SpecialType.System_IntPtr
-            or SpecialType.System_UIntPtr => true,
-            _ => false
-         };
+            => specialType switch
+            {
+                SpecialType.System_Void
+                or SpecialType.System_SByte
+                or SpecialType.System_Byte
+                or SpecialType.System_Int16
+                or SpecialType.System_UInt16
+                or SpecialType.System_Int32
+                or SpecialType.System_UInt32
+                or SpecialType.System_Int64
+                or SpecialType.System_UInt64
+                or SpecialType.System_Single
+                or SpecialType.System_Double
+                or SpecialType.System_IntPtr
+                or SpecialType.System_UIntPtr => true,
+                _ => false
+            };
 
         public static bool IsConsideredBlittable(this ITypeSymbol type) => IsConsideredBlittable(type, ImmutableHashSet.Create<ITypeSymbol>(SymbolEqualityComparer.Default));
 


### PR DESCRIPTION
Make `DllImportGenerator` and `Microsoft.Interop.SourceGeneration` match libraries' coding conventions. Specific violations:
- `IDE0003`: Remove this or Me qualification
- `IDE0018`: Inline variable declaration
- `IDE0020`: Use pattern matching to avoid is check followed by a cast
- `IDE0028`: Use collection initializers
- `IDE0044`: Add readonly modifier
- `IDE0055`: Fix formatting
- `IDE1006`: Naming rule violation

cc @AaronRobinsonMSFT @jkoritzinsky 