### PR TITLE
Fix NRT warnings in source generated code

### DIFF
--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
@@ -644,6 +644,7 @@ namespace System.Text.Json.SourceGeneration
                 bool hasInitOnlyProperties = false;
                 bool hasTypeFactoryConverter = false;
                 bool hasPropertyFactoryConverters = false;
+                bool canContainNullableReferenceAnnotations = type.CanContainNullableReferenceTypeAnnotations();
 
                 IList<CustomAttributeData> attributeDataList = CustomAttributeData.GetCustomAttributes(type);
                 foreach (CustomAttributeData attributeData in attributeDataList)
@@ -1010,6 +1011,7 @@ namespace System.Text.Json.SourceGeneration
                     converterInstatiationLogic,
                     implementsIJsonOnSerialized : implementsIJsonOnSerialized,
                     implementsIJsonOnSerializing : implementsIJsonOnSerializing,
+                    canContainNullableReferenceAnnotations: canContainNullableReferenceAnnotations,
                     hasTypeFactoryConverter : hasTypeFactoryConverter,
                     hasPropertyFactoryConverters : hasPropertyFactoryConverters);
 

--- a/src/libraries/System.Text.Json/gen/Reflection/TypeExtensions.cs
+++ b/src/libraries/System.Text.Json/gen/Reflection/TypeExtensions.cs
@@ -109,6 +109,30 @@ namespace System.Text.Json.Reflection
             return false;
         }
 
+        public static bool CanContainNullableReferenceTypeAnnotations(this Type type)
+        {
+            // Returns true iff Type instance has potential for receiving nullable reference type annotations,
+            // i.e. the type is a reference type or contains generic parameters that are reference types.
+
+            if (!type.IsValueType)
+            {
+                return true;
+            }
+
+            if (type.IsGenericType)
+            {
+                foreach (var genericParam in type.GetGenericArguments())
+                {
+                    if (CanContainNullableReferenceTypeAnnotations(genericParam))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
         public static bool IsObjectType(this Type type) => type.FullName == "System.Object";
 
         public static bool IsStringType(this Type type) => type.FullName == "System.String";

--- a/src/libraries/System.Text.Json/gen/Reflection/TypeExtensions.cs
+++ b/src/libraries/System.Text.Json/gen/Reflection/TypeExtensions.cs
@@ -121,7 +121,7 @@ namespace System.Text.Json.Reflection
 
             if (type.IsGenericType)
             {
-                foreach (var genericParam in type.GetGenericArguments())
+                foreach (Type genericParam in type.GetGenericArguments())
                 {
                     if (CanContainNullableReferenceTypeAnnotations(genericParam))
                     {

--- a/src/libraries/System.Text.Json/gen/TypeGenerationSpec.cs
+++ b/src/libraries/System.Text.Json/gen/TypeGenerationSpec.cs
@@ -72,6 +72,11 @@ namespace System.Text.Json.SourceGeneration
         public bool HasPropertyFactoryConverters { get; private set; }
         public bool HasTypeFactoryConverter { get; private set; }
 
+        // The spec is derived from cached `System.Type` instances, which are generally annotation-agnostic.
+        // Hence we can only record the potential for nullable annotations being possible for the runtime type.
+        // TODO: consider deriving the generation spec from the Roslyn symbols directly.
+        public bool CanContainNullableReferenceAnnotations { get; private set; }
+
         public string? ImmutableCollectionBuilderName
         {
             get
@@ -114,6 +119,7 @@ namespace System.Text.Json.SourceGeneration
             bool implementsIJsonOnSerialized,
             bool implementsIJsonOnSerializing,
             bool hasTypeFactoryConverter,
+            bool canContainNullableReferenceAnnotations,
             bool hasPropertyFactoryConverters)
         {
             GenerationMode = generationMode;
@@ -136,6 +142,7 @@ namespace System.Text.Json.SourceGeneration
             ConverterInstantiationLogic = converterInstantiationLogic;
             ImplementsIJsonOnSerialized = implementsIJsonOnSerialized;
             ImplementsIJsonOnSerializing = implementsIJsonOnSerializing;
+            CanContainNullableReferenceAnnotations = canContainNullableReferenceAnnotations;
             HasTypeFactoryConverter = hasTypeFactoryConverter;
             HasPropertyFactoryConverters = hasPropertyFactoryConverters;
         }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/ContextClasses.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/ContextClasses.cs
@@ -34,6 +34,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         public JsonTypeInfo<string> String { get; }
         public JsonTypeInfo<(string Label1, int Label2, bool)> ValueTupleStringInt32Boolean { get; }
         public JsonTypeInfo<RealWorldContextTests.ClassWithEnumAndNullable> ClassWithEnumAndNullable { get; }
+        public JsonTypeInfo<RealWorldContextTests.ClassWithNullableProperties> ClassWithNullableProperties { get; }
         public JsonTypeInfo<ClassWithCustomConverter> ClassWithCustomConverter { get; }
         public JsonTypeInfo<StructWithCustomConverter> StructWithCustomConverter { get; }
         public JsonTypeInfo<ClassWithCustomConverterFactory> ClassWithCustomConverterFactory { get; }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/MetadataAndSerializationContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/MetadataAndSerializationContextTests.cs
@@ -28,6 +28,7 @@ namespace System.Text.Json.SourceGeneration.Tests
     [JsonSerializable(typeof(string))]
     [JsonSerializable(typeof((string Label1, int Label2, bool)))]
     [JsonSerializable(typeof(RealWorldContextTests.ClassWithEnumAndNullable))]
+    [JsonSerializable(typeof(RealWorldContextTests.ClassWithNullableProperties))]
     [JsonSerializable(typeof(ClassWithCustomConverter))]
     [JsonSerializable(typeof(StructWithCustomConverter))]
     [JsonSerializable(typeof(ClassWithCustomConverterFactory))]
@@ -72,6 +73,7 @@ namespace System.Text.Json.SourceGeneration.Tests
             Assert.Null(MetadataAndSerializationContext.Default.String.SerializeHandler);
             Assert.NotNull(MetadataAndSerializationContext.Default.ValueTupleStringInt32Boolean.SerializeHandler);
             Assert.NotNull(MetadataAndSerializationContext.Default.ClassWithEnumAndNullable.SerializeHandler);
+            Assert.NotNull(MetadataAndSerializationContext.Default.ClassWithNullableProperties.SerializeHandler);
             Assert.NotNull(MetadataAndSerializationContext.Default.ClassWithCustomConverter);
             Assert.NotNull(MetadataAndSerializationContext.Default.StructWithCustomConverter);
             Assert.NotNull(MetadataAndSerializationContext.Default.ClassWithCustomConverterFactory);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/MetadataContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/MetadataContextTests.cs
@@ -27,6 +27,7 @@ namespace System.Text.Json.SourceGeneration.Tests
     [JsonSerializable(typeof(string), GenerationMode = JsonSourceGenerationMode.Metadata)]
     [JsonSerializable(typeof((string Label1, int Label2, bool)), GenerationMode = JsonSourceGenerationMode.Metadata)]
     [JsonSerializable(typeof(RealWorldContextTests.ClassWithEnumAndNullable), GenerationMode = JsonSourceGenerationMode.Metadata)]
+    [JsonSerializable(typeof(RealWorldContextTests.ClassWithNullableProperties), GenerationMode = JsonSourceGenerationMode.Metadata)]
     [JsonSerializable(typeof(ClassWithCustomConverter), GenerationMode = JsonSourceGenerationMode.Metadata)]
     [JsonSerializable(typeof(StructWithCustomConverter), GenerationMode = JsonSourceGenerationMode.Metadata)]
     [JsonSerializable(typeof(ClassWithCustomConverterFactory), GenerationMode = JsonSourceGenerationMode.Metadata)]
@@ -69,6 +70,7 @@ namespace System.Text.Json.SourceGeneration.Tests
             Assert.Null(MetadataWithPerTypeAttributeContext.Default.String.SerializeHandler);
             Assert.Null(MetadataWithPerTypeAttributeContext.Default.ValueTupleStringInt32Boolean.SerializeHandler);
             Assert.Null(MetadataWithPerTypeAttributeContext.Default.ClassWithEnumAndNullable.SerializeHandler);
+            Assert.Null(MetadataWithPerTypeAttributeContext.Default.ClassWithNullableProperties.SerializeHandler);
             Assert.Null(MetadataWithPerTypeAttributeContext.Default.ClassWithCustomConverter.SerializeHandler);
             Assert.Null(MetadataWithPerTypeAttributeContext.Default.StructWithCustomConverter.SerializeHandler);
             Assert.Null(MetadataWithPerTypeAttributeContext.Default.ClassWithCustomConverterFactory.SerializeHandler);
@@ -104,6 +106,7 @@ namespace System.Text.Json.SourceGeneration.Tests
     [JsonSerializable(typeof(string))]
     [JsonSerializable(typeof((string Label1, int Label2, bool)))]
     [JsonSerializable(typeof(RealWorldContextTests.ClassWithEnumAndNullable))]
+    [JsonSerializable(typeof(RealWorldContextTests.ClassWithNullableProperties))]
     [JsonSerializable(typeof(ClassWithCustomConverter))]
     [JsonSerializable(typeof(StructWithCustomConverter))]
     [JsonSerializable(typeof(ClassWithCustomConverterFactory))]
@@ -169,6 +172,7 @@ namespace System.Text.Json.SourceGeneration.Tests
             Assert.Null(MetadataContext.Default.String.SerializeHandler);
             Assert.Null(MetadataContext.Default.ValueTupleStringInt32Boolean.SerializeHandler);
             Assert.Null(MetadataContext.Default.ClassWithEnumAndNullable.SerializeHandler);
+            Assert.Null(MetadataContext.Default.ClassWithNullableProperties.SerializeHandler);
             Assert.Null(MetadataContext.Default.ClassWithCustomConverter.SerializeHandler);
             Assert.Null(MetadataContext.Default.StructWithCustomConverter.SerializeHandler);
             Assert.Null(MetadataContext.Default.ClassWithCustomConverterFactory.SerializeHandler);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/MixedModeContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/MixedModeContextTests.cs
@@ -28,6 +28,7 @@ namespace System.Text.Json.SourceGeneration.Tests
     [JsonSerializable(typeof(string), GenerationMode = JsonSourceGenerationMode.Metadata | JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof((string Label1, int Label2, bool)), GenerationMode = JsonSourceGenerationMode.Metadata | JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(RealWorldContextTests.ClassWithEnumAndNullable), GenerationMode = JsonSourceGenerationMode.Metadata | JsonSourceGenerationMode.Serialization)]
+    [JsonSerializable(typeof(RealWorldContextTests.ClassWithNullableProperties), GenerationMode = JsonSourceGenerationMode.Metadata | JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(ClassWithCustomConverter), GenerationMode = JsonSourceGenerationMode.Metadata | JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(StructWithCustomConverter), GenerationMode = JsonSourceGenerationMode.Metadata | JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(ClassWithCustomConverterFactory), GenerationMode = JsonSourceGenerationMode.Metadata | JsonSourceGenerationMode.Serialization)]
@@ -71,6 +72,7 @@ namespace System.Text.Json.SourceGeneration.Tests
             Assert.Null(MixedModeContext.Default.String.SerializeHandler);
             Assert.NotNull(MixedModeContext.Default.ValueTupleStringInt32Boolean.SerializeHandler);
             Assert.NotNull(MixedModeContext.Default.ClassWithEnumAndNullable.SerializeHandler);
+            Assert.NotNull(MixedModeContext.Default.ClassWithNullableProperties.SerializeHandler);
             Assert.Null(MixedModeContext.Default.ClassWithCustomConverter.SerializeHandler);
             Assert.Null(MixedModeContext.Default.StructWithCustomConverter.SerializeHandler);
             Assert.Null(MixedModeContext.Default.ClassWithCustomConverterFactory.SerializeHandler);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/RealWorldContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/RealWorldContextTests.cs
@@ -784,6 +784,8 @@ namespace System.Text.Json.SourceGeneration.Tests
             public GenericStruct<int[]?> NullableArrayParameter { get; set; }
             public GenericStruct<MyPoco?> NullablePocoParameter { get; set; }
 
+            public (string? x, int y)? NullableArgumentOfNullableStruct { get; set; }
+
             public record MyPoco { }
             public struct GenericStruct<T> { }
         }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/RealWorldContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/RealWorldContextTests.cs
@@ -734,6 +734,60 @@ namespace System.Text.Json.SourceGeneration.Tests
             public DayOfWeek? NullableDay { get; set; }
         }
 
+        [Fact]
+        public virtual void ClassWithNullableProperties_Roundtrip()
+        {
+            RunTest(new ClassWithNullableProperties
+            {
+                Uri = new Uri("http://contoso.com"),
+                Array = new int[] { 42 },
+                Poco = new ClassWithNullableProperties.MyPoco(),
+
+                NullableUri = new Uri("http://contoso.com"),
+                NullableArray = new int[] { 42 },
+                NullablePoco = new ClassWithNullableProperties.MyPoco()
+            });
+
+            RunTest(new ClassWithNullableProperties());
+
+            void RunTest(ClassWithNullableProperties expected)
+            {
+                string json = JsonSerializer.Serialize(expected, DefaultContext.ClassWithNullableProperties);
+                ClassWithNullableProperties actual = JsonSerializer.Deserialize(json, DefaultContext.ClassWithNullableProperties);
+
+                Assert.Equal(expected.Uri, actual.Uri);
+                Assert.Equal(expected.Array, actual.Array);
+                Assert.Equal(expected.Poco, actual.Poco);
+
+                Assert.Equal(expected.NullableUri, actual.NullableUri);
+                Assert.Equal(expected.NullableArray, actual.NullableArray);
+                Assert.Equal(expected.NullablePoco, actual.NullablePoco);
+
+                Assert.Equal(expected.NullableUriParameter, actual.NullableUriParameter);
+                Assert.Equal(expected.NullableArrayParameter, actual.NullableArrayParameter);
+                Assert.Equal(expected.NullablePocoParameter, actual.NullablePocoParameter);
+            }
+        }
+
+        public class ClassWithNullableProperties
+        {
+            public Uri Uri { get; set; }
+            public int[] Array { get; set; }
+            public MyPoco Poco { get; set; }
+
+            public Uri? NullableUri { get; set; }
+            public int[]? NullableArray { get; set; }
+            public MyPoco? NullablePoco { get; set; }
+
+            // struct types containing nullable reference types as generic parameters
+            public GenericStruct<Uri?> NullableUriParameter { get; set; }
+            public GenericStruct<int[]?> NullableArrayParameter { get; set; }
+            public GenericStruct<MyPoco?> NullablePocoParameter { get; set; }
+
+            public record MyPoco { }
+            public struct GenericStruct<T> { }
+        }
+
         private const string ExceptionMessageFromCustomContext = "Exception thrown from custom context.";
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/SerializationContextTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/SerializationContextTests.cs
@@ -28,6 +28,7 @@ namespace System.Text.Json.SourceGeneration.Tests
     [JsonSerializable(typeof(string))]
     [JsonSerializable(typeof((string Label1, int Label2, bool)))]
     [JsonSerializable(typeof(RealWorldContextTests.ClassWithEnumAndNullable))]
+    [JsonSerializable(typeof(RealWorldContextTests.ClassWithNullableProperties))]
     [JsonSerializable(typeof(ClassWithCustomConverter))]
     [JsonSerializable(typeof(StructWithCustomConverter))]
     [JsonSerializable(typeof(ClassWithCustomConverterFactory))]
@@ -64,6 +65,7 @@ namespace System.Text.Json.SourceGeneration.Tests
     [JsonSerializable(typeof(string), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof((string Label1, int Label2, bool)), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(RealWorldContextTests.ClassWithEnumAndNullable), GenerationMode = JsonSourceGenerationMode.Serialization)]
+    [JsonSerializable(typeof(RealWorldContextTests.ClassWithNullableProperties), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(ClassWithCustomConverter), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(StructWithCustomConverter), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(ClassWithCustomConverterFactory), GenerationMode = JsonSourceGenerationMode.Serialization)]
@@ -101,6 +103,7 @@ namespace System.Text.Json.SourceGeneration.Tests
     [JsonSerializable(typeof(string), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof((string Label1, int Label2, bool)), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(RealWorldContextTests.ClassWithEnumAndNullable), GenerationMode = JsonSourceGenerationMode.Serialization)]
+    [JsonSerializable(typeof(RealWorldContextTests.ClassWithNullableProperties), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(ClassWithCustomConverter), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(StructWithCustomConverter), GenerationMode = JsonSourceGenerationMode.Serialization)]
     [JsonSerializable(typeof(ClassWithCustomConverterFactory), GenerationMode = JsonSourceGenerationMode.Serialization)]
@@ -366,6 +369,41 @@ namespace System.Text.Json.SourceGeneration.Tests
                 ClassWithEnumAndNullable actual = JsonSerializer.Deserialize(json, ((ITestContext)MetadataWithPerTypeAttributeContext.Default).ClassWithEnumAndNullable);
                 Assert.Equal(expected.Day, actual.Day);
                 Assert.Equal(expected.NullableDay, actual.NullableDay);
+            }
+        }
+
+        [Fact]
+        public override void ClassWithNullableProperties_Roundtrip()
+        {
+            RunTest(new ClassWithNullableProperties
+            {
+                Uri = new Uri("http://contoso.com"),
+                Array = new int[] { 42 },
+                Poco = new ClassWithNullableProperties.MyPoco(),
+
+                NullableUri = new Uri("http://contoso.com"),
+                NullableArray = new int[] { 42 },
+                NullablePoco = new ClassWithNullableProperties.MyPoco()
+            });
+
+            RunTest(new ClassWithNullableProperties());
+
+            void RunTest(ClassWithNullableProperties expected)
+            {
+                string json = JsonSerializer.Serialize(expected, DefaultContext.ClassWithNullableProperties);
+                ClassWithNullableProperties actual = JsonSerializer.Deserialize(json, ((ITestContext)MetadataWithPerTypeAttributeContext.Default).ClassWithNullableProperties);
+
+                Assert.Equal(expected.Uri, actual.Uri);
+                Assert.Equal(expected.Array, actual.Array);
+                Assert.Equal(expected.Poco, actual.Poco);
+
+                Assert.Equal(expected.NullableUri, actual.NullableUri);
+                Assert.Equal(expected.NullableArray, actual.NullableArray);
+                Assert.Equal(expected.NullablePoco, actual.NullablePoco);
+
+                Assert.Equal(expected.NullableUriParameter, actual.NullableUriParameter);
+                Assert.Equal(expected.NullableArrayParameter, actual.NullableArrayParameter);
+                Assert.Equal(expected.NullablePocoParameter, actual.NullablePocoParameter);
             }
         }
 


### PR DESCRIPTION
Addresses an issue where STJ source generated code can result in warnings in cases where member types contain nullable reference type annotations. Also updates the annotations for fast-path serialize methods so that the input value type is nullable for the case of reference types.

Note that the implementation intentionally does not take [Roslyn nullability metadata](https://docs.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.itypesymbol.nullableannotation?view=roslyn-dotnet-3.11.0) into account when inserting suppresions. This is due to a restriction in our current sourcegen infrastructure which abstracts the Roslyn symbols as System.Reflection types: since nullability metadata is not available in that layer it ends up being erased. We should consider changing this in .NET 7.0.0.

Should be considered for 6.0.0 servicing.

Fix #59464.