### PR TITLE
Do not enregister Return SP check variable

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4665,7 +4665,8 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
 #if defined(DEBUG) && defined(TARGET_XARCH)
         if (opts.compStackCheckOnRet)
         {
-            lvaReturnSpCheck                  = lvaGrabTempWithImplicitUse(false DEBUGARG("ReturnSpCheck"));
+            lvaReturnSpCheck = lvaGrabTempWithImplicitUse(false DEBUGARG("ReturnSpCheck"));
+            lvaSetVarDoNotEnregister(lvaReturnSpCheck, DoNotEnregisterReason::ReturnSpCheck);
             lvaTable[lvaReturnSpCheck].lvType = TYP_I_IMPL;
         }
 #endif // defined(DEBUG) && defined(TARGET_XARCH)
@@ -9825,6 +9826,10 @@ void Compiler::EnregisterStats::RecordLocal(const LclVarDsc* varDsc)
                 m_blockOpRet++;
                 break;
 
+            case DoNotEnregisterReason::ReturnSpCheck:
+                m_returnSpCheck++;
+                break;
+
             default:
                 unreached();
                 break;
@@ -9945,6 +9950,7 @@ void Compiler::EnregisterStats::Dump(FILE* fout) const
     PRINT_STATS(m_oneAsgRetyping, notEnreg);
     PRINT_STATS(m_swizzleArg, notEnreg);
     PRINT_STATS(m_blockOpRet, notEnreg);
+    PRINT_STATS(m_returnSpCheck, notEnreg);
 
     fprintf(fout, "\nAddr exposed details:\n");
     if (m_addrExposed == 0)

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -388,7 +388,8 @@ enum class DoNotEnregisterReason
     StoreBlkSrc,    // the local is used as STORE_BLK source.
     OneAsgRetyping, // fgMorphOneAsgBlockOp prevents this local from being enregister.
     SwizzleArg,     // the local is passed using LCL_FLD as another type.
-    BlockOpRet      // the struct is returned and it promoted or there is a cast.
+    BlockOpRet,     // the struct is returned and it promoted or there is a cast.
+    ReturnSpCheck   // the local is used to do SP check
 };
 
 enum class AddressExposedReason
@@ -10301,6 +10302,7 @@ public:
         unsigned m_oneAsgRetyping;
         unsigned m_swizzleArg;
         unsigned m_blockOpRet;
+        unsigned m_returnSpCheck;
         unsigned m_liveInOutHndlr;
         unsigned m_depField;
         unsigned m_noRegVars;

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -2664,6 +2664,10 @@ void Compiler::lvaSetVarDoNotEnregister(unsigned varNum DEBUGARG(DoNotEnregister
             JITDUMP("return uses a block op\n");
             break;
 
+        case DoNotEnregisterReason::ReturnSpCheck:
+            JITDUMP("Used for SP check\n");
+            break;
+
         default:
             unreached();
             break;


### PR DESCRIPTION
Antigen found an issue that when `COMPlus_JitStackChecks=1` was used, we hit the following assert. The `ReturnSpCheck` should be marked as DoNotEnregister.

```
Assert failure(PID 51312 [0x0000c870], Thread: 49364 [0xc0d4]): Assertion failed 'lvaStackPointerVar != 0xCCCCCCCC && compiler->lvaTable[lvaStackPointerVar].lvDoNotEnregister && compiler->lvaTable[lvaStackPointerVar].lvOnFrame' in 'ILStubClass:IL_STUB_ReversePInvoke(long,int,ubyte,long,long,long,long)' during 'Generate code' (IL size 98)

    File: D:\git\runtime\src\coreclr\jit\codegencommon.cpp Line: 11699
    Image: D:\git\runtime\artifacts\tests\coreclr\windows.x64.Checked\tests\Core_Root\corerun.exe
```