### PR TITLE
Partially disable test

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/Enumeration/SpecialDirectoryTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Enumeration/SpecialDirectoryTests.cs
@@ -60,7 +60,14 @@ namespace System.IO.Tests.Enumeration
         {
             // Files that begin with periods are considered hidden on Unix
             string[] paths = GetNames(TestDirectory, new EnumerationOptions { ReturnSpecialDirectories = true, AttributesToSkip = 0 });
-            Assert.Contains(".", paths);
+
+            if (!PlatformDetection.IsWindows10Version22000OrGreater)
+            {
+                // Sometimes this is not returned - presumably an OS bug.
+                // This occurs often on Windows 11, very rarely otherwise.
+                Assert.Contains(".", paths);
+            }
+
             Assert.Contains("..", paths);
         }
     }


### PR DESCRIPTION
Fixes #33148

Sometimes file enumeration does not return the special "." directory. On Windows 11 this is now happening far more often. Disabling this part on there. My assumption is that this is not high priority to investigate as any app can assume it's there.