### PR TITLE
Update WCF dependencies on the compat pack

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -12,6 +12,10 @@
       <Uri>https://github.com/dotnet/emsdk</Uri>
       <Sha>9f2345b3c5f43dbf34790e21657ae1f2445cd06a</Sha>
     </Dependency>
+    <Dependency Name="System.ServiceModel.Primitives" Version="4.9.0-rc2.21473.1">
+      <Uri>https://github.com/dotnet/wcf</Uri>
+      <Sha>7f504aabb1988e9a093c1e74d8040bd52feb2f01</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.21463.4">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -110,7 +110,7 @@
     <SystemSecurityCryptographyCngVersion>5.0.0</SystemSecurityCryptographyCngVersion>
     <SystemSecurityCryptographyOpenSslVersion>5.0.0</SystemSecurityCryptographyOpenSslVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>
-    <ServiceModelVersion>4.8.1</ServiceModelVersion>
+    <SystemServiceModelPrimitivesVersion>4.9.0-rc2.21473.1</SystemServiceModelPrimitivesVersion>
     <SystemTextJsonVersion>7.0.0-alpha.1.21463.1</SystemTextJsonVersion>
     <SystemRuntimeCompilerServicesUnsafeVersion>7.0.0-alpha.1.21463.1</SystemRuntimeCompilerServicesUnsafeVersion>
     <SystemThreadingTasksExtensionsVersion>4.5.4</SystemThreadingTasksExtensionsVersion>

--- a/src/libraries/Microsoft.Windows.Compatibility/src/Microsoft.Windows.Compatibility.csproj
+++ b/src/libraries/Microsoft.Windows.Compatibility/src/Microsoft.Windows.Compatibility.csproj
@@ -50,8 +50,9 @@
                                      System.ServiceModel.Duplex;
                                      System.ServiceModel.Http;
                                      System.ServiceModel.NetTcp;
-                                     System.ServiceModel.Security"
-                      Version="$(ServiceModelVersion)" />
+                                     System.ServiceModel.Security;
+                                     System.Web.Services.Description"
+                      Version="$(SystemServiceModelPrimitivesVersion)" />
   </ItemGroup>
 
   <!-- Packages which are inbox on frameworks newer than .NET Standard 2.0. -->


### PR DESCRIPTION
We will update to the latest GA packages once they are ready.

Also, adding a new package which is a full façade to .NET Framework: `System.Web.Services.Description`.

I will also port this to 6.0

FYI: @mconnew @HongGit 