### PR TITLE
Stop running runtime tests on Android arm64 in main build

### DIFF
--- a/eng/pipelines/runtime-staging.yml
+++ b/eng/pipelines/runtime-staging.yml
@@ -418,12 +418,13 @@ jobs:
           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
           eq(variables['isFullMatrix'], true))
       # don't run tests on PRs until we can get significantly more devices
-      ${{ if eq(variables['isFullMatrix'], true) }}:
-        # extra steps, run tests
-        extraStepsTemplate: /eng/pipelines/common/templates/runtimes/android-runtime-and-send-to-helix.yml
-        extraStepsParameters:
-          creator: dotnet-bot
-          testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+      # Turn off the testing for now, until https://github.com/dotnet/xharness/issues/663 gets resolved
+      # ${{ if eq(variables['isFullMatrix'], true) }}:
+      #   # extra steps, run tests
+      #   extraStepsTemplate: /eng/pipelines/common/templates/runtimes/android-runtime-and-send-to-helix.yml
+      #   extraStepsParameters:
+      #     creator: dotnet-bot
+      #     testRunNamePrefixSuffix: Mono_$(_BuildConfig)
 
 # Run disabled installer tests on Linux x64
 - template: /eng/pipelines/common/platform-matrix.yml


### PR DESCRIPTION
Temporarily disable runtime tests running on Android arm64. Will re-enable once https://github.com/dotnet/xharness/issues/663 is resolved.

cc: @greenEkatherine @premun 