### PR TITLE
[wasm][debugger] Fix reusing buffer for debugger

### DIFF
--- a/src/mono/wasm/runtime/src/mono/debug.ts
+++ b/src/mono/wasm/runtime/src/mono/debug.ts
@@ -52,7 +52,8 @@ function mono_wasm_malloc_and_set_debug_buffer(command_parameters: string) {
         _debugger_buffer_len = Math.max(command_parameters.length, _debugger_buffer_len, 256);
         _debugger_buffer = Module._malloc(_debugger_buffer_len);
     }
-    _debugger_heap_bytes = new Uint8Array(Module.HEAPU8.buffer, _debugger_buffer, _debugger_buffer_len);    
+    //reset _debugger_heap_bytes because Module.HEAPU8.buffer can be reallocated 
+    _debugger_heap_bytes = new Uint8Array(Module.HEAPU8.buffer, _debugger_buffer, _debugger_buffer_len);
     _debugger_heap_bytes.set(_base64_to_uint8(command_parameters));
 }
 

--- a/src/mono/wasm/runtime/src/mono/debug.ts
+++ b/src/mono/wasm/runtime/src/mono/debug.ts
@@ -51,8 +51,8 @@ function mono_wasm_malloc_and_set_debug_buffer(command_parameters: string) {
             Module._free(_debugger_buffer);
         _debugger_buffer_len = Math.max(command_parameters.length, _debugger_buffer_len, 256);
         _debugger_buffer = Module._malloc(_debugger_buffer_len);
-        _debugger_heap_bytes = new Uint8Array(Module.HEAPU8.buffer, _debugger_buffer, _debugger_buffer_len);
     }
+    _debugger_heap_bytes = new Uint8Array(Module.HEAPU8.buffer, _debugger_buffer, _debugger_buffer_len);    
     _debugger_heap_bytes.set(_base64_to_uint8(command_parameters));
 }
 


### PR DESCRIPTION
When the wasm linear memory has to grow it invalidates existing views into the heap. To avoid this issue make sure to always create a new view into the heap for the debugger command immediately before use.