### PR TITLE
[release/6.0-rc2][wasm][debugger] Fix reuse buffer

### DIFF
--- a/src/mono/wasm/runtime/library_mono.js
+++ b/src/mono/wasm/runtime/library_mono.js
@@ -589,8 +589,8 @@ var MonoSupportLib = {
 					Module._free (this._debugger_buffer);
 				this._debugger_buffer_len = Math.max(command_parameters.length, this._debugger_buffer_len, 256);
 				this._debugger_buffer = Module._malloc (this._debugger_buffer_len);
-				this._debugger_heap_bytes = new Uint8Array (Module.HEAPU8.buffer, this._debugger_buffer, this._debugger_buffer_len);
 			}
+			this._debugger_heap_bytes = new Uint8Array (Module.HEAPU8.buffer, this._debugger_buffer, this._debugger_buffer_len);
 			this._debugger_heap_bytes.set(this._base64_to_uint8 (command_parameters));
 		},
 


### PR DESCRIPTION
Backport of #59773 to release/6.0

When the wasm linear memory has to grow it invalidates existing views into the heap.  To avoid this issue make sure to always create a new view into the heap for the debugger command immediately before use.

## Customer Impact
Debugging will eventually fail once the runtime allocates enough memory to require growing the Wasm memory buffer.

## Testing
Tested manually on Blazor
Tested on debugger-tests

## Risk
Low risk, it's reseting the `_debugger_heap_bytes` always before the usage to avoid using an invalid pointer in the case that Module.HEAPU8.buffer is reallocated.
