### PR TITLE
XARCH: Eliminate redundant mov to/from mem.

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -4495,6 +4495,12 @@ bool emitter::IsRedundantMov(
         return false;
     }
 
+    // Skip optimization if current instruction creates a GC live value.
+    if (EA_IS_GCREF_OR_BYREF(size))
+    {
+        return false;
+    }
+
     bool hasSideEffect = HasSideEffect(ins, size);
 
     // Check if we are already in the correct register and don't have a side effect
@@ -7140,6 +7146,12 @@ bool emitter::IsRedundantStackMov(instruction ins, insFormat fmt, emitAttr size,
     if (!emitComp->opts.OptimizationEnabled())
     {
         // The remaining move elisions should only happen if optimizations are enabled
+        return false;
+    }
+
+    // Skip optimization if current instruction creates a GC live value.
+    if (EA_IS_GCREF_OR_BYREF(size))
+    {
         return false;
     }
 

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -107,6 +107,8 @@ bool IsRedundantMov(
     instruction ins, insFormat fmt, emitAttr size, regNumber dst, regNumber src, bool canIgnoreSideEffects);
 bool EmitMovsxAsCwde(instruction ins, emitAttr size, regNumber dst, regNumber src);
 
+bool IsRedundantMov_S_R(instruction ins, insFormat fmt, emitAttr size, regNumber ireg, int varx, int offs);
+
 static bool IsJccInstruction(instruction ins);
 static bool IsJmpInstruction(instruction ins);
 

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -103,11 +103,12 @@ code_t AddRexPrefix(instruction ins, code_t code);
 bool EncodedBySSE38orSSE3A(instruction ins);
 bool Is4ByteSSEInstruction(instruction ins);
 static bool IsMovInstruction(instruction ins);
+bool HasSideEffect(instruction ins, emitAttr size);
 bool IsRedundantMov(
     instruction ins, insFormat fmt, emitAttr size, regNumber dst, regNumber src, bool canIgnoreSideEffects);
 bool EmitMovsxAsCwde(instruction ins, emitAttr size, regNumber dst, regNumber src);
 
-bool IsRedundantMov_S_R(instruction ins, insFormat fmt, emitAttr size, regNumber ireg, int varx, int offs);
+bool IsRedundantStackMov(instruction ins, insFormat fmt, emitAttr size, regNumber ireg, int varx, int offs);
 
 static bool IsJccInstruction(instruction ins);
 static bool IsJmpInstruction(instruction ins);


### PR DESCRIPTION
Optimize redundant mov instructions like:

IN002f: 000141 mov      qword ptr [V08 rsp+78H], rax
IN0030: 000146 mov      rax, qword ptr [V08 rsp+78H]
see comment ([link](https://github.com/dotnet/runtime/issues/12984#issuecomment-888525339))

This commit will essentially mirror what we do for Register->Register movs but with slight modifications to customize it for mem<->reg mov.
There are a couple of further optimizations to be revisited for both this and the existing IsRedundantMov() implementation(These are already mentioned as comments in existing impl)

1. Neither will work for sse on targets with avx encoding since it cannot be determined the current way it's implemented if the upper bits have been modified.
2. Currently, we check if both instructions(curr and predecessor) are equivalent. We can extend it for some other cases like aligned/unaligned(movups/movaps for eg.)

An example code snippet to reproduce this
`
    [MethodImpl(MethodImplOptions.AggressiveOptimization)]

    static unsafe double fmaTest4()

    {
        vec b;
 
       var a = Vector256.AsDouble(Vector256.Create(3f));

        var c = Vector256.AsDouble(Vector256.Create(2f));

        var d = Vector256.AsDouble(Vector256.Create(3f));

        c = Fma.MultiplyAdd(Avx.LoadVector256((double*)&a), Avx.LoadVector256((double*)&b), Avx.LoadVector256((double*)&c));

        return Avx.Add(Avx.LoadVector256((double*)&c), Avx.LoadVector256((double*)&d)).ToScalar();

    }`

