### PR TITLE
[release/6.0] Define SystemReflectionMetadataStaticVersion to workaround source-build issues.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -97,6 +97,8 @@
     <SystemNetPrimitivesVersion>4.3.1</SystemNetPrimitivesVersion>
     <SystemNumericsVectorsVersion>4.5.0</SystemNumericsVectorsVersion>
     <SystemReflectionMetadataVersion>5.0.0</SystemReflectionMetadataVersion>
+    <!-- Static version does not get updated with the latest version during source-builds. -->
+    <SystemReflectionMetadataStaticVersion>5.0.0</SystemReflectionMetadataStaticVersion>
     <SystemReflectionEmitVersion>4.7.0</SystemReflectionEmitVersion>
     <SystemReflectionEmitILGenerationVersion>4.7.0</SystemReflectionEmitILGenerationVersion>
     <SystemReflectionEmitLightweightVersion>4.7.0</SystemReflectionEmitLightweightVersion>

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun/ILCompiler.TypeSystem.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun/ILCompiler.TypeSystem.ReadyToRun.csproj
@@ -30,7 +30,7 @@
       <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.Reflection.Metadata">
-      <Version>$(SystemReflectionMetadataVersion)</Version>
+      <Version>$(SystemReflectionMetadataStaticVersion)</Version>
     </PackageReference>
     <PackageReference Condition = "'$(EnableDiaSymReaderUse)' == 'true'" Include="Microsoft.DiaSymReader">
       <Version>1.3.0</Version>


### PR DESCRIPTION
This fixes the underlying issue that manifested itself as https://github.com/dotnet/runtime/issues/58800.  

The core issue is that when building in source-build, the SystemReflectionMetadataVersion gets overridden to the source-built version (6.0) which causes assembly resolution issues impacting crossgen2.  The long term solution is a [7.0 source-build feature](https://github.com/dotnet/source-build/issues/2482) which would eliminate the SystemReflectionMetadataVersion override because the dependency is not defined in the repo's Version.Details.xml file.