### PR TITLE
Building sourcebuild leg with portable flag

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -125,7 +125,6 @@ jobs:
         parameters:
           platform:
             buildScript: $(_sclEnableCommand) $(Build.SourcesDirectory)$(dir)build$(scriptExt)
-            nonPortable: true
 
     - ${{ if in(parameters.osGroup, 'OSX', 'iOS', 'tvOS', 'MacCatalyst') }}:
       - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh ${{ parameters.osGroup }} ${{ parameters.archType }} azDO


### PR DESCRIPTION
Internal build https://dev.azure.com/dnceng/internal/_build/results?buildId=1393957&view=results

Portable builds are required for downstream consumption