### PR TITLE
Remove 3 active issues

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/Base/InfoGetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Base/InfoGetSetTimes.cs
@@ -12,23 +12,6 @@ namespace System.IO.Tests
         protected abstract void InvokeCreate(T item);
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/30108")]
-        public void DoesntExistThenCreate_ReturnsDefaultValues()
-        {
-            T item = GetMissingItem();
-            InvokeCreate(item);
-
-            Assert.All(TimeFunctions(), (function) =>
-            {
-                Assert.Equal(
-                    function.Kind == DateTimeKind.Local
-                        ? DateTime.FromFileTime(0).Ticks
-                        : DateTime.FromFileTimeUtc(0).Ticks,
-                    function.Getter(item).Ticks);
-            });
-        }
-
-        [Fact]
         public void ExistsThenDelete_ReturnsDefaultValues()
         {
             // Because we haven't hit the property the item should be in

--- a/src/libraries/System.IO.FileSystem/tests/Directory/EnumerableTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/EnumerableTests.cs
@@ -13,7 +13,7 @@ namespace System.IO.Tests
         [Fact]
         // we don't guarantee thread safety of enumerators in general, but on Windows we
         // currently are thread safe, and this test will help ensure that if we change that
-        // it's a conscious decision. Discussed in #24295.
+        // it's a conscious decision. Discussed in https://github.com/dotnet/runtime/issues/24295.
         [PlatformSpecific(TestPlatforms.Windows)]
         public void FileEnumeratorIsThreadSafe()
         {

--- a/src/libraries/System.IO.FileSystem/tests/Directory/EnumerableTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/EnumerableTests.cs
@@ -11,7 +11,10 @@ namespace System.IO.Tests
     public class EnumerableTests : FileSystemTest
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/24295", TestPlatforms.AnyUnix)]
+        // we don't guarantee thread safety of enumerators in general, but on Windows we
+        // currently are thread safe, and this test will help ensure that if we change that
+        // it's a conscious decision. Discussed in #24295.
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void FileEnumeratorIsThreadSafe()
         {
             string directory = Directory.CreateDirectory(GetTestFilePath()).FullName;

--- a/src/libraries/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -148,7 +148,7 @@ namespace System.IO.Tests
             Assert.Equal(ticks, dateTime.Ticks);
         }
 
-        // Linux kernels no longer have long max date time support. Discussed in #43166.
+        // Linux kernels no longer have long max date time support. Discussed in https://github.com/dotnet/runtime/issues/43166.
         [PlatformSpecific(~TestPlatforms.Linux)]
         [ConditionalFact(nameof(SupportsLongMaxDateTime))]
         public void SetDateTimeMax()

--- a/src/libraries/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -148,7 +148,8 @@ namespace System.IO.Tests
             Assert.Equal(ticks, dateTime.Ticks);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/43166", TestPlatforms.Linux)]
+        // Linux kernels no longer have long max date time support. Discussed in #43166.
+        [PlatformSpecific(~TestPlatforms.Linux)]
         [ConditionalFact(nameof(SupportsLongMaxDateTime))]
         public void SetDateTimeMax()
         {


### PR DESCRIPTION
Fix #30108. remove the test: I cannot see how this test could pass. when you create a directory/file, it does not have default values for its various time attributes.
Fix #24295. We do not plan to make the enumerator thread safe. It happens to be thread safe on Windows, so leaving the test for Windows so that if we do change this for some reason, we can document it in case anyone depends on it.
Fix #43166. Per discussion, this cannot be made to work on modern Linux distros.