### PR TITLE
Don't regress SkipLocalsInit optimization on <= NET6

### DIFF
--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -219,7 +219,7 @@
   </Choose>
 
   <PropertyGroup>
-    <SkipLocalsInit Condition="'$(SkipLocalsInit)' == '' and '$(MSBuildProjectExtension)' == '.csproj' and '$(IsNETCoreAppSrc)' == 'true' and ($([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', '$(NetCoreAppCurrent)')))">true</SkipLocalsInit>
+    <SkipLocalsInit Condition="'$(SkipLocalsInit)' == '' and '$(MSBuildProjectExtension)' == '.csproj' and '$(IsNETCoreAppSrc)' == 'true' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">true</SkipLocalsInit>
   </PropertyGroup>
 
   <!--Instructs compiler not to emit .locals init, using SkipLocalsInitAttribute.-->


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/54964

net6.0 assets which are part of the Microsoft.NETCore.App shared framework and ship inside a package need to keep the SkipLocalsInit optimization to avoid regressing perf. This would happen when referencing one of the 7.0 packages but consuming the net6.0 asset in it. The higher assembly version of the net6.0 asset would win over the same asset in the shared framework and without this fix, the SkipLocalsInit optimization would be lost.