### PR TITLE
Update how-to-debug-dump template

### DIFF
--- a/eng/testing/debug-dump-template.md
+++ b/eng/testing/debug-dump-template.md
@@ -107,16 +107,11 @@ Install or update LLDB if necessary ([instructions here](https://github.com/dotn
 
 Load the dump:
 ```sh
-lldb --core <lin-path-to-dump> %LOUTDIR%/shared/Microsoft.NETCore.App/7.0.0/dotnet
+lldb --core <lin-path-to-dump> \
+  %LOUTDIR%/shared/Microsoft.NETCore.App/7.0.0/dotnet \
+  -o "setclrpath %LOUTDIR%/shared/Microsoft.NETCore.App/7.0.0" \
+  -o "setsymbolserver -directory %LOUTDIR%/shared/Microsoft.NETCore.App/7.0.0"
 ```
-
-Within lldb:
-```gdb
-setclrpath /home/<YOUR USERNAME>/helix_payload/%WORKITEM%/shared/Microsoft.NETCore.App/7.0.0
-sethostruntime /usr/bin/dotnet
-setsymbolserver -directory /home/<YOUR USERNAME>/helix_payload/%WORKITEM%/shared/Microsoft.NETCore.App/7.0.0
-```
-note: on macOS change `/home/<YOUR USERNAME>` to `/Users/<your yourname>`.
 
 If you want to load native symbols
 ```gdb
@@ -132,14 +127,11 @@ dotnet tool update --global dotnet-dump
 ```
 If prompted, open a new command prompt to pick up the updated PATH.
 ```sh
-dotnet-dump analyze <lin-path-to-dump>
+dotnet-dump analyze \
+  <lin-path-to-dump> \
+  --command "setclrpath %LOUTDIR%/shared/Microsoft.NETCore.App/7.0.0" \
+  "setsymbolserver -directory %LOUTDIR%/shared/Microsoft.NETCore.App/7.0.0"
 ```
-Within dotnet-dump:
-```sh
-setclrpath /home/<YOUR USERNAME>/helix_payload/%WORKITEM%/shared/Microsoft.NETCore.App/7.0.0
-setsymbolserver -directory /home/<YOUR USERNAME>/helix_payload/%WORKITEM%/shared/Microsoft.NETCore.App/7.0.0
-```
-note: on macOS change `/home/<YOUR USERNAME>` to `/Users/<your yourname>`.
 
 ---
 ## If it's a macOS dump

--- a/eng/testing/debug-dump-template.md
+++ b/eng/testing/debug-dump-template.md
@@ -58,8 +58,8 @@ Open WinDbg and open the dump with `File>Open Dump`.
 ```
 
 ```
-!setclrpath %WOUTDIR%\shared\Microsoft.NETCore.App\6.0.0
-.sympath+ %WOUTDIR%\shared\Microsoft.NETCore.App\6.0.0
+!setclrpath %WOUTDIR%\shared\Microsoft.NETCore.App\7.0.0
+.sympath+ %WOUTDIR%\shared\Microsoft.NETCore.App\7.0.0
 ```
 
 Now you can use regular SOS commands like `!dumpstack`, `!pe`, etc.
@@ -81,8 +81,8 @@ dotnet-dump analyze <win-path-to-dump>
 ```
 Within dotnet-dump:
 ```sh
-setclrpath %WOUTDIR%\shared\Microsoft.NETCore.App\6.0.0
-setsymbolserver -directory %WOUTDIR%\shared\Microsoft.NETCore.App\6.0.0
+setclrpath %WOUTDIR%\shared\Microsoft.NETCore.App\7.0.0
+setsymbolserver -directory %WOUTDIR%\shared\Microsoft.NETCore.App\7.0.0
 ```
 
 Now you can use regular SOS commands like `dumpstack`, `pe`, etc.
@@ -94,7 +94,7 @@ dotnet tool uninstall --global dotnet-dump
 ---
 ## If it's a Linux dump on Windows...
 
-Download the [Cross DAC Binaries](https://dev.azure.com/dnceng/public/_apis/build/builds/%BUILDID%/artifacts?artifactName=CoreCLRCrossDacArtifacts&api-version=6.0&%24format=zip), open it and choose the flavor that matches the dump you are to debug, and copy those files to `%WOUTDIR%\shared\Microsoft.NETCore.App\6.0.0`.
+Download the [Cross DAC Binaries](https://dev.azure.com/dnceng/public/_apis/build/builds/%BUILDID%/artifacts?artifactName=CoreCLRCrossDacArtifacts&api-version=6.0&%24format=zip), open it and choose the flavor that matches the dump you are to debug, and copy those files to `%WOUTDIR%\shared\Microsoft.NETCore.App\7.0.0`.
 
 Now you can debug with WinDbg or `dotnet-dump` as if it was a Windows dump. See above.
 
@@ -107,17 +107,19 @@ Install or update LLDB if necessary ([instructions here](https://github.com/dotn
 
 Load the dump:
 ```sh
-lldb --core <lin-path-to-dump> %LOUTDIR%/shared/Microsoft.NETCore.App/6.0.0/dotnet
+lldb --core <lin-path-to-dump> %LOUTDIR%/shared/Microsoft.NETCore.App/7.0.0/dotnet
 ```
 
 Within lldb:
-```
-setclrpath %LOUTDIR%/shared/Microsoft.NETCore.App/6.0.0
+```gdb
+setclrpath /home/<YOUR USERNAME>/helix_payload/%WORKITEM%/shared/Microsoft.NETCore.App/7.0.0
 sethostruntime /usr/bin/dotnet
-setsymbolserver -directory %LOUTDIR%/shared/Microsoft.NETCore.App/6.0.0
+setsymbolserver -directory /home/<YOUR USERNAME>/helix_payload/%WORKITEM%/shared/Microsoft.NETCore.App/7.0.0
 ```
+note: on macOS change `/home/<YOUR USERNAME>` to `/Users/<your yourname>`.
+
 If you want to load native symbols
-```
+```gdb
 loadsymbols
 ```
 
@@ -134,9 +136,10 @@ dotnet-dump analyze <lin-path-to-dump>
 ```
 Within dotnet-dump:
 ```sh
-setclrpath %LOUTDIR%/shared/Microsoft.NETCore.App/6.0.0
-setsymbolserver -directory %LOUTDIR%/shared/Microsoft.NETCore.App/6.0.0
+setclrpath /home/<YOUR USERNAME>/helix_payload/%WORKITEM%/shared/Microsoft.NETCore.App/7.0.0
+setsymbolserver -directory /home/<YOUR USERNAME>/helix_payload/%WORKITEM%/shared/Microsoft.NETCore.App/7.0.0
 ```
+note: on macOS change `/home/<YOUR USERNAME>` to `/Users/<your yourname>`.
 
 ---
 ## If it's a macOS dump

--- a/eng/testing/debug-dump-template.md
+++ b/eng/testing/debug-dump-template.md
@@ -82,8 +82,8 @@ If prompted, open a new command prompt to pick up the updated PATH.
 ```cmd
 dotnet-dump analyze ^
   <win-path-to-dump> ^
-  --command "setclrpath %WOUTDIR%/shared/Microsoft.NETCore.App/7.0.0" ^
-  "setsymbolserver -directory %WOUTDIR%/shared/Microsoft.NETCore.App/7.0.0"
+  --command "setclrpath %WOUTDIR%\shared\Microsoft.NETCore.App\7.0.0" ^
+  "setsymbolserver -directory %WOUTDIR%\shared\Microsoft.NETCore.App\7.0.0"
 ```
 
 Now you can use regular SOS commands like `dumpstack`, `pe`, etc.

--- a/eng/testing/debug-dump-template.md
+++ b/eng/testing/debug-dump-template.md
@@ -6,11 +6,13 @@ dotnet tool install --global runfo
 dotnet tool update --global runfo
 ```
 If prompted, open a new command prompt to pick up the updated PATH.
-```sh
-# On Windows
-# assumes %WOUTDIR% does not exist
+Windows:
+```cmd
+:: assumes %WOUTDIR% does not exist
 runfo get-helix-payload -j %JOBID% -w %WORKITEM% -o %WOUTDIR%
-# On Linux and macOS
+```
+Linux and macOS:
+```sh
 # assumes %LOUTDIR% does not exist
 runfo get-helix-payload -j %JOBID% -w %WORKITEM% -o %LOUTDIR%
 ```
@@ -21,23 +23,24 @@ Any dump files published by helix will be downloaded.
 
 Now extract the files:
 
-```sh
-# On Windows
+Windows:
+```cmd
 for /f %i in ('dir /s/b %WOUTDIR%\*zip') do tar -xf %i -C %WOUTDIR%
-
-# On Linux and macOS
+```
+Linux and macOS
+```sh
 # obtain `unzip` if necessary; eg `sudo apt-get install unzip` or `sudo dnf install unzip`
 find %LOUTDIR% -name '*zip' -exec unzip -d %LOUTDIR% {} \;
 ```
 
 Now use the [dotnet-sos global tool](https://docs.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-sos) to install the SOS debugging extension.
-```sh
+```cmd
 dotnet tool install --global dotnet-sos
 dotnet tool update --global dotnet-sos
 ```
 If prompted, open a new command prompt to pick up the updated PATH.
-```sh
-# Install only one: the one matching your dump
+```cmd
+:: Install only one: the one matching your dump
 dotnet sos install --architecture Arm
 dotnet sos install --architecture Arm64
 dotnet sos install --architecture x86
@@ -71,23 +74,21 @@ Currently this is not possible because mscordbi.dll is not signed.
 ## ... and you want to debug with dotnet-dump
 
 Install the [dotnet-dump global tool](https://docs.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-dump).
-```sh
+```cmd
 dotnet tool install --global dotnet-dump
 dotnet tool update --global dotnet-dump
 ```
 If prompted, open a new command prompt to pick up the updated PATH.
-```sh
-dotnet-dump analyze <win-path-to-dump>
-```
-Within dotnet-dump:
-```sh
-setclrpath %WOUTDIR%\shared\Microsoft.NETCore.App\7.0.0
-setsymbolserver -directory %WOUTDIR%\shared\Microsoft.NETCore.App\7.0.0
+```cmd
+dotnet-dump analyze ^
+  <win-path-to-dump> ^
+  --command "setclrpath %WOUTDIR%/shared/Microsoft.NETCore.App/7.0.0" ^
+  "setsymbolserver -directory %WOUTDIR%/shared/Microsoft.NETCore.App/7.0.0"
 ```
 
 Now you can use regular SOS commands like `dumpstack`, `pe`, etc.
 If you are debugging a 32 bit dump using 64 bit dotnet, you will get an error `SOS does not support the current target architecture`. In that case replace dotnet-dump with the 32 bit version:
-```sh
+```cmd
 dotnet tool uninstall --global dotnet-dump
 "C:\Program Files (x86)\dotnet\dotnet.exe" tool install --global dotnet-dump
 ```

--- a/eng/testing/gen-debug-dump-docs.py
+++ b/eng/testing/gen-debug-dump-docs.py
@@ -17,23 +17,23 @@ while idx < args_len:
         if idx >= args_len or sys.argv[idx].startswith('-'):
             print("Must specify a value for -buildid")
             exit(1)
-        
+
         build_id = sys.argv[idx]
         idx += 1
-    
+
     if arg == '-jobid':
         if idx >= args_len or sys.argv[idx].startswith('-'):
             print("Must specify a value for -jobid")
             exit(1)
-        
+
         job_id = sys.argv[idx]
         idx += 1
-    
+
     if arg == '-workitem':
         if idx >= args_len or sys.argv[idx].startswith('-'):
             print("Must specify a value for -workitem")
             exit(1)
-        
+
         workitem = sys.argv[idx]
         idx += 1
 
@@ -41,7 +41,7 @@ while idx < args_len:
         if idx >= args_len or sys.argv[idx].startswith('-'):
             print("Must specify a value for -templatedir")
             exit(1)
-        
+
         template_dir = sys.argv[idx]
         idx += 1
 
@@ -49,7 +49,7 @@ while idx < args_len:
         if idx >= args_len or sys.argv[idx].startswith('-'):
             print("Must specify a value for -outdir")
             exit(1)
-        
+
         out_dir = sys.argv[idx]
         idx += 1
 
@@ -57,7 +57,7 @@ while idx < args_len:
         if idx >= args_len or sys.argv[idx].startswith('-'):
             print("Must specify a value for -dumpdir")
             exit(1)
-        
+
         dump_dir = sys.argv[idx]
         idx += 1
 
@@ -85,7 +85,7 @@ if job_id == '':
 
 replace_string = ''
 dir_separator = '/' if platform.system() != 'Windows' else '\\'
-unix_user_folder = '~/helix_payload/'
+unix_user_folder = '$HOME/helix_payload/'
 windows_user_folder = 'c:\\helix_payload\\'
 source_file = template_dir + dir_separator + 'debug-dump-template.md'
 with open(source_file, 'r') as f:


### PR DESCRIPTION
Shell shortcuts such as `~` are not resolved in `dotnet-dump` and `lddb` REPL. Following the instructions as is result in a cryptic error (from `dotnet-dump` as well as `dontet-sos`):

```gdb
...
(lldb) setsymbolserver -directory ~/helix_payload/System.Text.Json.Tests/shared/Microsoft.NETCore.App/7.0.0
Added symbol directory path: ~/helix_payload/System.Text.Json.Tests/shared/Microsoft.NETCore.App/7.0.0
(lldb) clrstack
Failed to load data access module, 0x80004002
Can not load or initialize libmscordaccore.so. The target runtime may not be initialized.

For more information see https://go.microsoft.com/fwlink/?linkid=2135652
ClrStack  failed
```
This PR changes the template, pointing user to pass options on command line.

Another thing to note that `setclrpath` understands the relative paths (based off of `$(pwd)`), but `setsymbolserver` requires absolute path in all cases. I will look into fixing the behavior upstream.

Also changed 6.0.0 to 7.0.0 to keep the instructions current.