### PR TITLE
Fix retry when downloading clang tools

### DIFF
--- a/eng/formatting/download-tools.ps1
+++ b/eng/formatting/download-tools.ps1
@@ -1,3 +1,4 @@
+. "$PSScriptRoot/../common/tools.ps1" # for Retry function
 
 function DownloadClangTool {
     param (
@@ -10,29 +11,13 @@ function DownloadClangTool {
     $baseUri = "https://clrjit.blob.core.windows.net/clang-tools/windows"
 
     if (-not $(ls $downloadOutputPath | Where-Object { $_.Name -eq "$toolName.exe" })) {
-        $baseBackoffSeconds = 2;
 
-        $success = $false
-        for ($i = 0; $i -lt 5; $i++) {
-            Write-Output "Attempting download of '$baseUri/$toolName.exe'"
-            try {
-                # Pass -PassThru as otherwise Invoke-WebRequest leaves a corrupted file if the download fails. With -PassThru the download is buffered first.
-                # -UseBasicParsing is necessary for older PowerShells when Internet Explorer might not be installed/configured
-                $null = Invoke-WebRequest -Uri "$baseUri/$toolName.exe" -OutFile $(Join-Path $downloadOutputPath -ChildPath "$toolName.exe") -PassThru -UseBasicParsing
-                $success = $true
-                break
-            }
-            catch {
-                Write-Output $_
-            }
-			
-            Write-Output "Download attempt $($i+1) failed. Trying again in $($baseBackoffSeconds + $baseBackoffSeconds * $i) seconds"
-            Start-Sleep -Seconds $($baseBackoffSeconds + $baseBackoffSeconds * $i)
-        }
-        if (-not $success) {
-            Write-Output "Failed to download $toolName"
-            throw [System.IO.IOException] "Could not download $toolName"
-        }
+        Retry({
+            Write-Output "Downloading '$baseUri/$toolName.exe'"
+            # Pass -PassThru as otherwise Invoke-WebRequest leaves a corrupted file if the download fails. With -PassThru the download is buffered first.
+            # -UseBasicParsing is necessary for older PowerShells when Internet Explorer might not be installed/configured
+            $null = Invoke-WebRequest -Uri "$baseUri/$toolName.exe" -OutFile $(Join-Path $downloadOutputPath -ChildPath "$toolName.exe") -PassThru -UseBasicParsing
+        })
     }
 }
 

--- a/eng/formatting/download-tools.ps1
+++ b/eng/formatting/download-tools.ps1
@@ -17,7 +17,8 @@ function DownloadClangTool {
             Write-Output "Attempting download of '$baseUri/$toolName.exe'"
             try {
                 # Pass -PassThru as otherwise Invoke-WebRequest leaves a corrupted file if the download fails. With -PassThru the download is buffered first.
-                $null = Invoke-WebRequest -Uri "$baseUri/$toolName.exe" -OutFile $(Join-Path $downloadOutputPath -ChildPath "$toolName.exe") -PassThru
+                # -UseBasicParsing is necessary for older PowerShells when Internet Explorer might not be installed/configured
+                $null = Invoke-WebRequest -Uri "$baseUri/$toolName.exe" -OutFile $(Join-Path $downloadOutputPath -ChildPath "$toolName.exe") -PassThru -UseBasicParsing
                 $success = $true
                 break
             }


### PR DESCRIPTION
Invoke-WebRequest throws an exception when the download fails, so we
should use try-catch instead of status code to check failure.

In addition pass -PassThru to avoid leaving a corrupted download file in
case the download fails. This will buffer the download and write it once
at the end.

Fix #57196

I used [clumsy](https://github.com/jagt/clumsy) to verify that this works. In those tests I also noticed that on PowerShell 7, Invoke-WebRequest with -OutFile but without -PassThru sometimes does not detect when the download fails. It seems to work reliably with -PassThru though. There is already an issue for it: https://github.com/PowerShell/PowerShell/issues/16122