### PR TITLE
Do not flush serializer buffers before first IAsyncEnumerable element is fetched

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -18,7 +18,7 @@ namespace System.Text.Json
         // needs to be expanded\doubled because it is not large enough to write the current property or element.
         // We check for flush after each JSON property and element is written to the buffer.
         // Once the buffer is expanded to contain the largest single element\property, a 90% thresold
-        // means the buffer may be expanded a maximum of 4 times: 1-(1\(2^4))==.9375.
+        // means the buffer may be expanded a maximum of 4 times: 1-(1/(2^4))==.9375.
         private const float FlushThreshold = .90f;
 
         /// <summary>
@@ -332,6 +332,7 @@ namespace System.Text.Json
 
                             if (state.SuppressFlush)
                             {
+                                Debug.Assert(state.PendingTask is not null);
                                 state.SuppressFlush = false;
                             }
                             else

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -332,6 +332,7 @@ namespace System.Text.Json
 
                             if (state.SuppressFlush)
                             {
+                                Debug.Assert(!isFinalBlock);
                                 Debug.Assert(state.PendingTask is not null);
                                 state.SuppressFlush = false;
                             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -19,7 +19,7 @@ namespace System.Text.Json
         // We check for flush after each JSON property and element is written to the buffer.
         // Once the buffer is expanded to contain the largest single element\property, a 90% thresold
         // means the buffer may be expanded a maximum of 4 times: 1-(1\(2^4))==.9375.
-        private const float FlushThreshold = .9f;
+        private const float FlushThreshold = .90f;
 
         /// <summary>
         /// Converts the provided value to UTF-8 encoded JSON text and write it to the <see cref="System.IO.Stream"/>.
@@ -329,8 +329,16 @@ namespace System.Text.Json
                         try
                         {
                             isFinalBlock = WriteCore(converter, writer, value, options, ref state);
-                            await bufferWriter.WriteToStreamAsync(utf8Json, cancellationToken).ConfigureAwait(false);
-                            bufferWriter.Clear();
+
+                            if (state.SuppressFlush)
+                            {
+                                state.SuppressFlush = false;
+                            }
+                            else
+                            {
+                                await bufferWriter.WriteToStreamAsync(utf8Json, cancellationToken).ConfigureAwait(false);
+                                bufferWriter.Clear();
+                            }
                         }
                         finally
                         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -41,6 +41,12 @@ namespace System.Text.Json
         public CancellationToken CancellationToken;
 
         /// <summary>
+        /// In the case of async serialization, used by resumable converters to signal that
+        /// the current buffer contents should not be flushed to the underlying stream.
+        /// </summary>
+        public bool SuppressFlush;
+
+        /// <summary>
         /// Stores a pending task that a resumable converter depends on to continue work.
         /// It must be awaited by the root context before serialization is resumed.
         /// </summary>


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/36977

See https://github.com/dotnet/aspnetcore/issues/36977#issuecomment-931084414 for an explanation of the issue. 

I ran the benchmark suite against the changes and no performance regression was recorded.

Should consider servicing in 6.0.