### PR TITLE
Increase timeout for ConsoleLifetimeExitTests.EnsureEnvironmentExitDoesntHang

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/ConsoleLifetimeExitTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/ConsoleLifetimeExitTests.cs
@@ -139,9 +139,9 @@ namespace Microsoft.Extensions.Hosting.Tests
                         services.AddHostedService<EnsureEnvironmentExitDoesntHangWorker>();
                     })
                     .RunConsoleAsync();
-            }, new RemoteInvokeOptions() { TimeOut = 10_000 }); // give a 10 second time out, so if this does hang, it doesn't hang for the full timeout
+            }, new RemoteInvokeOptions() { TimeOut = 30_000 }); // give a 10 second time out, so if this does hang, it doesn't hang for the full timeout
 
-            Assert.True(remoteHandle.Process.WaitForExit(10_000), "The hosted process should have exited within 10 seconds");
+            Assert.True(remoteHandle.Process.WaitForExit(30_000), "The hosted process should have exited within 10 seconds");
 
             // SIGTERM is only handled on net6.0+, so the workaround to "clobber" the exit code is still in place on NetFramework
             int expectedExitCode = PlatformDetection.IsNetFramework ? 0 : 125;

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/ConsoleLifetimeExitTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/ConsoleLifetimeExitTests.cs
@@ -139,9 +139,9 @@ namespace Microsoft.Extensions.Hosting.Tests
                         services.AddHostedService<EnsureEnvironmentExitDoesntHangWorker>();
                     })
                     .RunConsoleAsync();
-            }, new RemoteInvokeOptions() { TimeOut = 30_000 }); // give a 10 second time out, so if this does hang, it doesn't hang for the full timeout
+            }, new RemoteInvokeOptions() { TimeOut = 30_000 }); // give a 30 second time out, so if this does hang, it doesn't hang for the full timeout
 
-            Assert.True(remoteHandle.Process.WaitForExit(30_000), "The hosted process should have exited within 10 seconds");
+            Assert.True(remoteHandle.Process.WaitForExit(30_000), "The hosted process should have exited within 30 seconds");
 
             // SIGTERM is only handled on net6.0+, so the workaround to "clobber" the exit code is still in place on NetFramework
             int expectedExitCode = PlatformDetection.IsNetFramework ? 0 : 125;


### PR DESCRIPTION
Increases timeout for ConsoleLifetimeExitTests.EnsureEnvironmentExitDoesntHang up to 30s

Currently test is failing on slow configurations (see issue for more details)

Related to: https://github.com/dotnet/runtime/issues/57908
It's hard to tell this will fix the issue. We can possibly close it and watch out if failure ever occurs again
