### PR TITLE
Remove assert preventing empty PKCS7 exports

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Android/StorePal.ExportPal.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Android/StorePal.ExportPal.cs
@@ -39,7 +39,6 @@ namespace Internal.Cryptography.Pal
                     }
                 }
 
-                Debug.Assert(certHandles.Length > 0);
                 return Interop.AndroidCrypto.X509ExportPkcs7(certHandles);
             }
 


### PR DESCRIPTION
An empty PKCS7 collection is valid, so don't require the certHandles count to be greater than 0.

Before:

```
DOTNET  : ((null) warning) Process terminated due to "   at System.Diagnostics.DebugProvider.Fail(String message, String detailMessage)
DOTNET  :    at System.Diagnostics.Debug.Fail(String message, String detailMessage)
DOTNET  :    at System.Diagnostics.Debug.Assert(Boolean condition, String message, String detailMessage)
DOTNET  :    at System.Diagnostics.Debug.Assert(Boolean condition)
```

After:

```
[PASS] System.Security.Cryptography.X509Certificates.Tests.CollectionTests.ExportPkcs7_Empty
```