### PR TITLE
[loader] Look for P/Invoke libs next to the managed assembly

### DIFF
--- a/src/mono/mono/metadata/native-library.c
+++ b/src/mono/mono/metadata/native-library.c
@@ -1048,7 +1048,7 @@ retry_with_libcoreclr:
 			mono_custom_attrs_free (cinfo);
 	}
 	if (flags < 0)
-		flags = 0;
+		flags = DLLIMPORTSEARCHPATH_ASSEMBLY_DIRECTORY;
 	module = netcore_lookup_native_library (alc, image, new_scope, flags);
 
 	if (!module) {


### PR DESCRIPTION
If there's a P/Invoke to a library, direct `netcore_probe_for_module` to look in `NATIVE_DLL_SEARCH_DIRECTORIES`, followed by the directory containing the managed assembly.

Fixes https://github.com/dotnet/runtime/issues/59766