### PR TITLE
Fix test sensitivity to PKCS7 certificate ordering

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -1744,7 +1744,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
                 using (ImportedCollection imported = Cert.Import(data))
                 {
-                    Assert.Equal(expected.ToArray(), imported.Collection.ToArray(), new X509Certificate2EqualityComparer());
+                    X509Certificate2[] expectedCollection = expected.OrderBy(c => c.Thumbprint).ToArray();
+                    X509Certificate2[] actualCollection = imported.Collection.OrderBy(c => c.Thumbprint).ToArray();
+                    Assert.Equal(expectedCollection, actualCollection, new X509Certificate2EqualityComparer());
                 }
             }
 


### PR DESCRIPTION
Android exports PKCS7 certificates in a different order, and the xunit assertion is sensitive to order. So we sort them first.

Fixes #59777.

After this PR and #59812 is merged, the X509Certificates test suite back to fully passing on Android.