### PR TITLE
Update WCF dependencies on the compat pack (#59764)

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -12,6 +12,10 @@
       <Uri>https://github.com/dotnet/emsdk</Uri>
       <Sha>885a25579f723c790c1d91e4fc4939390429ccbc</Sha>
     </Dependency>
+    <Dependency Name="System.ServiceModel.Primitives" Version="4.9.0-rc2.21473.1">
+      <Uri>https://github.com/dotnet/wcf</Uri>
+      <Sha>7f504aabb1988e9a093c1e74d8040bd52feb2f01</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.21473.5">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -110,7 +110,7 @@
     <SystemSecurityCryptographyCngVersion>5.0.0</SystemSecurityCryptographyCngVersion>
     <SystemSecurityCryptographyOpenSslVersion>5.0.0</SystemSecurityCryptographyOpenSslVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>
-    <ServiceModelVersion>4.8.1</ServiceModelVersion>
+    <SystemServiceModelPrimitivesVersion>4.9.0-rc2.21473.1</SystemServiceModelPrimitivesVersion>
     <SystemTextJsonVersion>6.0.0-rc.1.21415.6</SystemTextJsonVersion>
     <SystemRuntimeCompilerServicesUnsafeVersion>6.0.0-rc.1.21415.6</SystemRuntimeCompilerServicesUnsafeVersion>
     <SystemThreadingTasksExtensionsVersion>4.5.4</SystemThreadingTasksExtensionsVersion>

--- a/src/libraries/Microsoft.Windows.Compatibility/src/Microsoft.Windows.Compatibility.csproj
+++ b/src/libraries/Microsoft.Windows.Compatibility/src/Microsoft.Windows.Compatibility.csproj
@@ -51,8 +51,9 @@
                                      System.ServiceModel.Duplex;
                                      System.ServiceModel.Http;
                                      System.ServiceModel.NetTcp;
-                                     System.ServiceModel.Security"
-                      Version="$(ServiceModelVersion)" />
+                                     System.ServiceModel.Security;
+                                     System.Web.Services.Description"
+                      Version="$(SystemServiceModelPrimitivesVersion)" />
   </ItemGroup>
 
   <!-- Packages which are inbox in NET6 and shouldn't and can't be referenced anymore. -->


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/59764 to release/6.0

## Description

Updating to the RC1 packages of WCF + adding a new WCF package. This helps us prepare for when the WCF 6.0 stable packages are ready we will just take a dependency update via darc.

## Testing

Validated the nuspec is correct and also that the new package can be restored.

## Risk

Low. 

cc: @danmoseley 