### PR TITLE
Update workload localization file directory structure

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/Microsoft.NET.Workload.Mono.Toolchain.Manifest.pkgproj
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Manifest/Microsoft.NET.Workload.Mono.Toolchain.Manifest.pkgproj
@@ -23,7 +23,7 @@
 
     <ItemGroup>
       <File Include="localize/**/*">
-        <TargetPath>localize</TargetPath>
+        <TargetPath>data/localize</TargetPath>
       </File>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
Fixing a bug in https://github.com/dotnet/runtime/pull/59379, part of dotnet/sdk#20497

Workload/SDK logic only copies content in the `data` directory, so moving the localize directory into the proper location to be picked up and laid down on disk. 