### PR TITLE
Arm64: Align methods containing loops to 32B

### DIFF
--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -5657,8 +5657,8 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
     }
 #endif
 
-#ifdef TARGET_XARCH
-    // For x64/x86, align methods that are "optimizations enabled" to 32 byte boundaries if
+#if defined(TARGET_XARCH) || defined(TARGET_ARM64)
+    // For x64/x86/arm64, align methods that are "optimizations enabled" to 32 byte boundaries if
     // they are larger than 16 bytes and contain a loop.
     //
     if (emitComp->opts.OptimizationEnabled() && !emitComp->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_PREJIT) &&

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -6389,7 +6389,12 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
 #endif
 
     unsigned actualCodeSize = emitCurCodeOffs(cp);
+
+#if defined(TARGET_ARM64)
+    assert(emitTotalCodeSize == actualCodeSize);
+#else
     assert(emitTotalCodeSize >= actualCodeSize);
+#endif
 
 #if EMITTER_STATS
     totAllocdSize += emitTotalCodeSize;

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -12160,7 +12160,6 @@ void emitter::emitDispInsHex(instrDesc* id, BYTE* code, size_t sz)
         }
         else
         {
-            assert(id->idCodeSize() == sz);
             printf("              ");
         }
     }


### PR DESCRIPTION
From [Arm Neoverse N1 Software Optimization Guide](https://developer.arm.com/documentation/swog309707/a) it is beneficial to align methods at 32B boundary. This will further work well when we start loop alignment at 32B boundaries.

![image](https://user-images.githubusercontent.com/12488060/135528748-27013a93-ae1a-4449-a585-50fbf9be8430.png)

As a continuation of https://github.com/dotnet/runtime/pull/2249, align bigger methods having loops to 32B alignment boundary.

- I have also added a tighter check on the code size we emit for Arm64 to make sure that there is no misestimation happening for Arm64. 
- There was an assert that would validate the `idCodeSize()` before printing the instruction which was necessary because the callers never pass the `sz` and it 