### PR TITLE
Fix Unix ARM64 RtlRestoreContext implementation

### DIFF
--- a/src/coreclr/pal/src/arch/arm64/context2.S
+++ b/src/coreclr/pal/src/arch/arm64/context2.S
@@ -204,12 +204,11 @@ LOCAL_LABEL(No_Restore_CONTEXT_INTEGER):
     ldr w17, [x16, CONTEXT_Cpsr]
     msr nzcv, x17
     ldp fp, lr, [x16, CONTEXT_Fp]
-    ldr x17, [x16, CONTEXT_Sp]
-    mov sp, x17
-    ldr x17, [x16, CONTEXT_Pc]
+    ldp x16, x17, [x16, CONTEXT_Sp] // Context_Pc is right after Context_Sp
+    mov sp, x16
     br x17
 
 LOCAL_LABEL(No_Restore_CONTEXT_CONTROL):
-   ret
+    ret
 
 LEAF_END RtlRestoreContext, _TEXT


### PR DESCRIPTION
The RtlRestoreContext sets SP before reading out PC from the
context. That can lead to a corruption of the PC in the context
if an async signal is delivered to the thread  or the thread is
interrupted by any other mean after the SP is set and before
the value of PC is extracted from the context.

This change fixes it by setting the SP after both PC and SP values
are read from the context data structure.