### PR TITLE
Syndication test fixes for wasm.

### DIFF
--- a/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/Atom10FeedFormatterTests.cs
+++ b/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/Atom10FeedFormatterTests.cs
@@ -437,7 +437,7 @@ namespace System.ServiceModel.Syndication.Tests
 
                 Assert.Equal("updated", elements[2].Name.LocalName);
                 DateTimeOffset now = DateTimeOffset.UtcNow;
-                Assert.True(now > DateTimeOffset.ParseExact(elements[2].Value, "yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture));
+                Assert.True(now >= DateTimeOffset.ParseExact(elements[2].Value, "yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture));
             }
         }
 

--- a/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/Atom10ItemFormatterTests.cs
+++ b/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/Atom10ItemFormatterTests.cs
@@ -334,7 +334,7 @@ namespace System.ServiceModel.Syndication.Tests
 
                 Assert.Equal("updated", elements[2].Name.LocalName);
                 DateTimeOffset now = DateTimeOffset.UtcNow;
-                Assert.True(now > DateTimeOffset.ParseExact(elements[2].Value, "yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture));
+                Assert.True(now >= DateTimeOffset.ParseExact(elements[2].Value, "yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture));
             }
         }
 


### PR DESCRIPTION
There is a pair of Atom10 tests in System.ServiceModel.Syndication which are
comparing timestamps from the beginning of the test to timestamps from the
end, expecting them to be strictly greater between the two. But on some
platforms (wasm) the test may execute faster than the granularity of DateTime,
so two equal timestamps should be fine as well.