### PR TITLE
Use the short form of an opcode in `ILGenerator.EmitWriteLine`.

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/ILGenerator.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/ILGenerator.cs
@@ -1210,7 +1210,7 @@ namespace System.Reflection.Emit
             }
             else
             {
-                Emit(OpCodes.Ldarg, (short)0); // Load the this ref.
+                Emit(OpCodes.Ldarg_0); // Load the this ref.
                 Emit(OpCodes.Ldfld, fld);
             }
             Type[] parameterTypes = new Type[1];


### PR DESCRIPTION
`ILGenerator.Emit(short)` does not use short forms if applicable; only the int overload does, but here we can directly use `ldarg.0`.