### PR TITLE
Use `.maxstack 8` in the `System.Runtime.CompilerServices.Unsafe` IL code.

### DIFF
--- a/src/libraries/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.il
+++ b/src/libraries/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.il
@@ -64,7 +64,7 @@
   .method public hidebysig static !!T Read<T>(void* source) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 1
+        .maxstack 8
         ldarg.0
         ldobj !!T
         ret
@@ -73,7 +73,7 @@
   .method public hidebysig static !!T ReadUnaligned<T>(void* source) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 1
+        .maxstack 8
         ldarg.0
         unaligned. 0x1
         ldobj !!T
@@ -83,7 +83,7 @@
   .method public hidebysig static !!T ReadUnaligned<T>(uint8& source) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 1
+        .maxstack 8
         ldarg.0
         unaligned. 0x1
         ldobj !!T
@@ -94,7 +94,7 @@
                                                  !!T 'value') cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 2
+        .maxstack 8
         ldarg.0
         ldarg.1
         stobj !!T
@@ -105,7 +105,7 @@
                                                  !!T 'value') cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 2
+        .maxstack 8
         ldarg.0
         ldarg.1
         unaligned. 0x01
@@ -117,7 +117,7 @@
                                                  !!T 'value') cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 2
+        .maxstack 8
         ldarg.0
         ldarg.1
         unaligned. 0x01
@@ -129,7 +129,7 @@
                                                 !!T& source) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 2
+        .maxstack 8
         ldarg.0
         ldarg.1
         ldobj !!T
@@ -141,7 +141,7 @@
                                                 void* source) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 2
+        .maxstack 8
         ldarg.0
         ldarg.1
         ldobj !!T
@@ -152,7 +152,7 @@
   .method public hidebysig static void* AsPointer<T>(!!T& 'value') cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 1
+        .maxstack 8
         ldarg.0
         conv.u
         ret
@@ -161,14 +161,14 @@
   .method public hidebysig static void SkipInit<T> ([out] !!T& 'value') cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 0
+        .maxstack 8
         ret
   } // end of method Unsafe::SkipInit
 
   .method public hidebysig static int32 SizeOf<T>() cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 1
+        .maxstack 8
         sizeof !!T
         ret
   } // end of method Unsafe::SizeOf
@@ -176,7 +176,7 @@
   .method public hidebysig static void CopyBlock(void* destination, void* source, uint32 byteCount) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 3
+        .maxstack 8
         ldarg.0
         ldarg.1
         ldarg.2
@@ -187,7 +187,7 @@
   .method public hidebysig static void CopyBlock(uint8& destination, uint8& source, uint32 byteCount) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 3
+        .maxstack 8
         ldarg.0
         ldarg.1
         ldarg.2
@@ -198,7 +198,7 @@
   .method public hidebysig static void CopyBlockUnaligned(void* destination, void* source, uint32 byteCount) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 3
+        .maxstack 8
         ldarg.0
         ldarg.1
         ldarg.2
@@ -210,7 +210,7 @@
   .method public hidebysig static void CopyBlockUnaligned(uint8& destination, uint8& source, uint32 byteCount) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 3
+        .maxstack 8
         ldarg.0
         ldarg.1
         ldarg.2
@@ -222,7 +222,7 @@
   .method public hidebysig static void InitBlock(void* startAddress, uint8 'value', uint32 byteCount) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 3
+        .maxstack 8
         ldarg.0
         ldarg.1
         ldarg.2
@@ -233,7 +233,7 @@
   .method public hidebysig static void InitBlock(uint8& startAddress, uint8 'value', uint32 byteCount) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 3
+        .maxstack 8
         ldarg.0
         ldarg.1
         ldarg.2
@@ -244,7 +244,7 @@
   .method public hidebysig static void InitBlockUnaligned(void* startAddress, uint8 'value', uint32 byteCount) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 3
+        .maxstack 8
         ldarg.0
         ldarg.1
         ldarg.2
@@ -256,7 +256,7 @@
   .method public hidebysig static void InitBlockUnaligned(uint8& startAddress, uint8 'value', uint32 byteCount) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 3
+        .maxstack 8
         ldarg.0
         ldarg.1
         ldarg.2
@@ -268,7 +268,7 @@
   .method public hidebysig static !!T As<class T>(object o) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 1
+        .maxstack 8
         ldarg.0
         ret
   } // end of method Unsafe::As
@@ -281,12 +281,12 @@
 // and
 // https://github.com/dotnet/coreclr/pull/11218
 #ifdef netcoreapp
-        .maxstack 1
+        .maxstack 8
         ldarg.0
         ret
 #else
         .locals (int32&)
-        .maxstack 1
+        .maxstack 8
         ldarg.0
         // Roundtrip via a local to avoid type mismatch on return that the JIT inliner chokes on.
         stloc.0
@@ -304,7 +304,7 @@
 #else
         .custom instance void System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = ( 01 00 00 00 )
 #endif
-        .maxstack 1
+        .maxstack 8
         ldarg.0
         ret
   } // end of method Unsafe::AsRef
@@ -312,7 +312,7 @@
   .method public hidebysig static !!TTo& As<TFrom, TTo>(!!TFrom& source) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 1
+        .maxstack 8
         ldarg.0
         ret
   } // end of method Unsafe::As
@@ -320,7 +320,7 @@
   .method public hidebysig static !!T& Unbox<valuetype .ctor ([CORE_ASSEMBLY]System.ValueType) T> (object 'box') cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 1
+        .maxstack 8
         ldarg.0
         unbox !!T
         ret
@@ -329,7 +329,7 @@
   .method public hidebysig static !!T& Add<T>(!!T& source, int32 elementOffset) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 3
+        .maxstack 8
         ldarg.0
         ldarg.1
         sizeof !!T
@@ -342,7 +342,7 @@
   .method public hidebysig static void* Add<T>(void* source, int32 elementOffset) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 3
+        .maxstack 8
         ldarg.0
         ldarg.1
         sizeof !!T
@@ -355,7 +355,7 @@
   .method public hidebysig static !!T& Add<T>(!!T& source, native int elementOffset) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 3
+        .maxstack 8
         ldarg.0
         ldarg.1
         sizeof !!T
@@ -371,7 +371,7 @@
                 01 00 00 00
             )
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 3
+        .maxstack 8
         ldarg.0
         ldarg.1
         sizeof !!T
@@ -383,7 +383,7 @@
   .method public hidebysig static !!T& AddByteOffset<T>(!!T& source, native int byteOffset) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 2
+        .maxstack 8
         ldarg.0
         ldarg.1
         add
@@ -397,7 +397,7 @@
                 01 00 00 00
             )
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 2
+        .maxstack 8
         ldarg.0
         ldarg.1
         add
@@ -407,7 +407,7 @@
   .method public hidebysig static !!T& Subtract<T>(!!T& source, int32 elementOffset) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 3
+        .maxstack 8
         ldarg.0
         ldarg.1
         sizeof !!T
@@ -420,7 +420,7 @@
   .method public hidebysig static void* Subtract<T>(void* source, int32 elementOffset) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 3
+        .maxstack 8
         ldarg.0
         ldarg.1
         sizeof !!T
@@ -433,7 +433,7 @@
   .method public hidebysig static !!T& Subtract<T>(!!T& source, native int elementOffset) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 3
+        .maxstack 8
         ldarg.0
         ldarg.1
         sizeof !!T
@@ -449,7 +449,7 @@
                 01 00 00 00
             )
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 3
+        .maxstack 8
         ldarg.0
         ldarg.1
         sizeof !!T
@@ -461,7 +461,7 @@
   .method public hidebysig static !!T& SubtractByteOffset<T>(!!T& source, native int byteOffset) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 2
+        .maxstack 8
         ldarg.0
         ldarg.1
         sub
@@ -475,7 +475,7 @@
                 01 00 00 00
             )
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 2
+        .maxstack 8
         ldarg.0
         ldarg.1
         sub
@@ -485,7 +485,7 @@
   .method public hidebysig static native int ByteOffset<T>(!!T& origin, !!T& target) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 2
+        .maxstack 8
         ldarg.1
         ldarg.0
         sub
@@ -495,7 +495,7 @@
   .method public hidebysig static bool AreSame<T>(!!T& left, !!T& right) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 2
+        .maxstack 8
         ldarg.0
         ldarg.1
         ceq
@@ -505,7 +505,7 @@
   .method public hidebysig static bool IsAddressGreaterThan<T>(!!T& left, !!T& right) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 2
+        .maxstack 8
         ldarg.0
         ldarg.1
         cgt.un
@@ -515,7 +515,7 @@
   .method public hidebysig static bool IsAddressLessThan<T>(!!T& left, !!T& right) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 2
+        .maxstack 8
         ldarg.0
         ldarg.1
         clt.un
@@ -525,7 +525,7 @@
   .method public hidebysig static bool IsNullRef<T>(!!T& source) cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 2
+        .maxstack 8
         ldarg.0
         ldc.i4.0
         conv.u
@@ -536,7 +536,7 @@
   .method public hidebysig static !!T& NullRef<T>() cil managed aggressiveinlining
   {
         .custom instance void System.Runtime.Versioning.NonVersionableAttribute::.ctor() = ( 01 00 00 00 )
-        .maxstack 1
+        .maxstack 8
         ldc.i4.0
         conv.u
         ret
@@ -553,7 +553,7 @@
   .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
-        .maxstack 1
+        .maxstack 8
         ldarg.0
         call instance void [CORE_ASSEMBLY]System.Attribute::.ctor()
         ret
@@ -569,7 +569,7 @@
   .method public hidebysig specialname rtspecialname
           instance void .ctor () cil managed
   {
-        .maxstack 1
+        .maxstack 8
         ldarg.0
         call instance void [CORE_ASSEMBLY]System.Attribute::.ctor()
         ret


### PR DESCRIPTION
It allows using the tiny method header encoding and shrinks the generated assembly by 495 bytes (11 bytes saved per method, times 45 methods whose `.maxstack` was changed).