### PR TITLE
Improve value numbering for casts

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5425,7 +5425,14 @@ GenTree* Compiler::optExtractSideEffListFromConst(GenTree* tree)
     {
         // Do a sanity check to ensure persistent side effects aren't discarded and
         // tell gtExtractSideEffList to ignore the root of the tree.
-        assert(!gtNodeHasSideEffects(tree, GTF_PERSISTENT_SIDE_EFFECTS));
+        // We are relying here on an invariant that VN will only fold non-throwing expressions.
+        const bool ignoreExceptions = true;
+        const bool ignoreCctors     = false;
+        // We have to check "AsCall()->HasSideEffects()" here separately because "gtNodeHasSideEffects"
+        // also checks for side effects that arguments introduce (incosistently so, it otherwise only
+        // checks for the side effects the node itself has). TODO-Cleanup: change it to not do that?
+        assert(!gtNodeHasSideEffects(tree, GTF_PERSISTENT_SIDE_EFFECTS) ||
+               (tree->IsCall() && !tree->AsCall()->HasSideEffects(this, ignoreExceptions, ignoreCctors)));
 
         // Exception side effects may be ignored because the root is known to be a constant
         // (e.g. VN may evaluate a DIV/MOD node to a constant and the node may still
@@ -5620,6 +5627,13 @@ Compiler::fgWalkResult Compiler::optVNConstantPropCurStmt(BasicBlock* block, Sta
             }
             // Let's not conflict with CSE (to save the movw/movt).
             if (lclNumIsCSE(tree->AsLclVarCommon()->GetLclNum()))
+            {
+                return WALK_CONTINUE;
+            }
+            break;
+
+        case GT_CALL:
+            if (!tree->AsCall()->IsPure(this))
             {
                 return WALK_CONTINUE;
             }

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5494,6 +5494,9 @@ public:
     // Does value-numbering for a call.  We interpret some helper calls.
     void fgValueNumberCall(GenTreeCall* call);
 
+    // Does value-numbering for a helper representing a cast operation.
+    void fgValueNumberCastHelper(GenTreeCall* call);
+
     // Does value-numbering for a helper "call" that has a VN function symbol "vnf".
     void fgValueNumberHelperCallFunc(GenTreeCall* call, VNFunc vnf, ValueNumPair vnpExc);
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -15924,7 +15924,7 @@ void Compiler::gtExtractSideEffList(GenTree*  expr,
             {
                 if (m_compiler->gtNodeHasSideEffects(node, m_flags))
                 {
-                    m_sideEffects.Push(node);
+                    PushSideEffects(node);
                     if (node->OperIsBlk() && !node->OperIsStoreBlk())
                     {
                         JITDUMP("Replace an unused OBJ/BLK node [%06d] with a NULLCHECK\n", dspTreeID(node));
@@ -15941,7 +15941,7 @@ void Compiler::gtExtractSideEffList(GenTree*  expr,
                 // gtNodeHasSideEffects and make this check unconditionally.
                 if (node->OperIsAtomicOp())
                 {
-                    m_sideEffects.Push(node);
+                    PushSideEffects(node);
                     return Compiler::WALK_SKIP_SUBTREES;
                 }
 
@@ -15952,7 +15952,7 @@ void Compiler::gtExtractSideEffList(GenTree*  expr,
                         (node->gtGetOp1()->TypeGet() == TYP_STRUCT))
                     {
                         JITDUMP("Keep the GT_ADDR and GT_IND together:\n");
-                        m_sideEffects.Push(node);
+                        PushSideEffects(node);
                         return Compiler::WALK_SKIP_SUBTREES;
                     }
                 }
@@ -15969,7 +15969,7 @@ void Compiler::gtExtractSideEffList(GenTree*  expr,
                 // those need to be extracted as if they're side effects.
                 if (!UnmarkCSE(node))
                 {
-                    m_sideEffects.Push(node);
+                    PushSideEffects(node);
                     return Compiler::WALK_SKIP_SUBTREES;
                 }
 
@@ -16004,6 +16004,16 @@ void Compiler::gtExtractSideEffList(GenTree*  expr,
 #endif
                 return false;
             }
+        }
+
+        void PushSideEffects(GenTree* node)
+        {
+            // The extracted side effect will no longer be an argument, so unmark it.
+            // This is safe to do because the side effects will be visited in pre-order,
+            // aborting as soon as any tree is extracted. Thus if an argument for a call
+            // is being extracted, it is guaranteed that the call itself will not be.
+            node->gtFlags &= ~GTF_LATE_ARG;
+            m_sideEffects.Push(node);
         }
     };
 

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -9874,12 +9874,14 @@ VNFunc Compiler::fgValueNumberJitHelperMethodVNFunc(CorInfoHelpFunc helpFunc)
             vnf = VNFunc(GT_RSZ);
             break;
         case CORINFO_HELP_LMUL:
-        case CORINFO_HELP_LMUL_OVF:
             vnf = VNFunc(GT_MUL);
             break;
+        case CORINFO_HELP_LMUL_OVF:
+            vnf = VNF_MUL_OVF;
+            break;
         case CORINFO_HELP_ULMUL_OVF:
-            vnf = VNFunc(GT_MUL);
-            break; // Is this the right thing?
+            vnf = VNF_MUL_UN_OVF;
+            break;
         case CORINFO_HELP_LDIV:
             vnf = VNFunc(GT_DIV);
             break;

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -291,7 +291,7 @@ public:
 
     // Packs information about the cast into an integer constant represented by the returned value number,
     // to be used as the second operand of VNF_Cast & VNF_CastOvf.
-    ValueNum VNForCastOper(var_types castToType, bool srcIsUnsigned = false DEBUGARG(bool printResult = true));
+    ValueNum VNForCastOper(var_types castToType, bool srcIsUnsigned);
 
     // Unpacks the information stored by VNForCastOper in the constant represented by the value number.
     void GetCastOperFromVN(ValueNum vn, var_types* pCastToType, bool* pSrcIsUnsigned);
@@ -556,8 +556,12 @@ public:
                                                    rhs.GetConservative(), indType, block));
     }
 
-    // Compute the normal ValueNumber for a cast with no exceptions
-    ValueNum VNForCast(ValueNum srcVN, var_types castToType, var_types castFromType, bool srcIsUnsigned = false);
+    // Compute the ValueNumber for a cast
+    ValueNum VNForCast(ValueNum  srcVN,
+                       var_types castToType,
+                       var_types castFromType,
+                       bool      srcIsUnsigned    = false,
+                       bool      hasOverflowCheck = false);
 
     // Compute the ValueNumberPair for a cast
     ValueNumPair VNPairForCast(ValueNumPair srcVNPair,
@@ -897,6 +901,10 @@ public:
     // Prints a representation (comma-separated list of field names) on standard out.
     void vnDumpSimdType(Compiler* comp, VNFuncApp* simdType);
 #endif // FEATURE_SIMD
+
+    // Requires "castVN" to represent VNF_Cast or VNF_CastOvf.
+    // Prints the cast's representation mirroring GT_CAST's dump format.
+    void vnDumpCast(Compiler* comp, ValueNum castVN);
 
     // Returns the string name of "vnf".
     static const char* VNFuncName(VNFunc vnf);

--- a/src/coreclr/jit/valuenumfuncs.h
+++ b/src/coreclr/jit/valuenumfuncs.h
@@ -69,16 +69,6 @@ ValueNumFuncDef(InvalidCastExc, 2, false, false, false)     // CastClass check, 
 ValueNumFuncDef(NewArrOverflowExc, 1, false, false, false)  // Raises Integer overflow when Arg 0 is negative
 ValueNumFuncDef(HelperMultipleExc, 0, false, false, false)  // Represents one or more different exceptions that could be thrown by a Jit Helper method
 
-ValueNumFuncDef(Lng2Dbl, 1, false, false, false)
-ValueNumFuncDef(ULng2Dbl, 1, false, false, false)
-ValueNumFuncDef(Dbl2Int, 1, false, false, false)
-ValueNumFuncDef(Dbl2UInt, 1, false, false, false)
-ValueNumFuncDef(Dbl2Lng, 1, false, false, false)
-ValueNumFuncDef(Dbl2ULng, 1, false, false, false)
-ValueNumFuncDef(Dbl2IntOvf, 1, false, false, false)
-ValueNumFuncDef(Dbl2UIntOvf, 1, false, false, false)
-ValueNumFuncDef(Dbl2LngOvf, 1, false, false, false)
-ValueNumFuncDef(Dbl2ULngOvf, 1, false, false, false)
 ValueNumFuncDef(FltRound, 1, false, false, false)
 ValueNumFuncDef(DblRound, 1, false, false, false)
 


### PR DESCRIPTION
Now that we no longer fold overflowing conversions with implementation-defined behavior, it is possible to unify how the cast helpers are value numbered and how regular casts are numbered.

There are also changes that enable global constant propagation into calls, this was necessary to fix some of the regressions that showed up. The remaining regressions are due to #57033 (we propagate "just above" the helper and see it as a side effect).

Diffs: [`win-x64`](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-59841/win-x64.md), [`win-x86`](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-59841/win-x86.md), [`linux-arm`](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-59841/linux-arm.md)