### PR TITLE
Use ProductVersion in how-to-debug-dump

### DIFF
--- a/eng/testing/debug-dump-template.md
+++ b/eng/testing/debug-dump-template.md
@@ -61,8 +61,8 @@ Open WinDbg and open the dump with `File>Open Dump`.
 ```
 
 ```
-!setclrpath %WOUTDIR%\shared\Microsoft.NETCore.App\7.0.0
-.sympath+ %WOUTDIR%\shared\Microsoft.NETCore.App\7.0.0
+!setclrpath %WOUTDIR%\shared\Microsoft.NETCore.App\%PRODUCTVERSION%
+.sympath+ %WOUTDIR%\shared\Microsoft.NETCore.App\%PRODUCTVERSION%
 ```
 
 Now you can use regular SOS commands like `!dumpstack`, `!pe`, etc.
@@ -82,8 +82,8 @@ If prompted, open a new command prompt to pick up the updated PATH.
 ```cmd
 dotnet-dump analyze ^
   <win-path-to-dump> ^
-  --command "setclrpath %WOUTDIR%\shared\Microsoft.NETCore.App\7.0.0" ^
-  "setsymbolserver -directory %WOUTDIR%\shared\Microsoft.NETCore.App\7.0.0"
+  --command "setclrpath %WOUTDIR%\shared\Microsoft.NETCore.App\%PRODUCTVERSION%" ^
+  "setsymbolserver -directory %WOUTDIR%\shared\Microsoft.NETCore.App\%PRODUCTVERSION%"
 ```
 
 Now you can use regular SOS commands like `dumpstack`, `pe`, etc.
@@ -95,7 +95,7 @@ dotnet tool uninstall --global dotnet-dump
 ---
 ## If it's a Linux dump on Windows...
 
-Download the [Cross DAC Binaries](https://dev.azure.com/dnceng/public/_apis/build/builds/%BUILDID%/artifacts?artifactName=CoreCLRCrossDacArtifacts&api-version=6.0&%24format=zip), open it and choose the flavor that matches the dump you are to debug, and copy those files to `%WOUTDIR%\shared\Microsoft.NETCore.App\7.0.0`.
+Download the [Cross DAC Binaries](https://dev.azure.com/dnceng/public/_apis/build/builds/%BUILDID%/artifacts?artifactName=CoreCLRCrossDacArtifacts&api-version=6.0&%24format=zip), open it and choose the flavor that matches the dump you are to debug, and copy those files to `%WOUTDIR%\shared\Microsoft.NETCore.App\%PRODUCTVERSION%`.
 
 Now you can debug with WinDbg or `dotnet-dump` as if it was a Windows dump. See above.
 
@@ -109,9 +109,9 @@ Install or update LLDB if necessary ([instructions here](https://github.com/dotn
 Load the dump:
 ```sh
 lldb --core <lin-path-to-dump> \
-  %LOUTDIR%/shared/Microsoft.NETCore.App/7.0.0/dotnet \
-  -o "setclrpath %LOUTDIR%/shared/Microsoft.NETCore.App/7.0.0" \
-  -o "setsymbolserver -directory %LOUTDIR%/shared/Microsoft.NETCore.App/7.0.0"
+  %LOUTDIR%/shared/Microsoft.NETCore.App/%PRODUCTVERSION%/dotnet \
+  -o "setclrpath %LOUTDIR%/shared/Microsoft.NETCore.App/%PRODUCTVERSION%" \
+  -o "setsymbolserver -directory %LOUTDIR%/shared/Microsoft.NETCore.App/%PRODUCTVERSION%"
 ```
 
 If you want to load native symbols
@@ -130,8 +130,8 @@ If prompted, open a new command prompt to pick up the updated PATH.
 ```sh
 dotnet-dump analyze \
   <lin-path-to-dump> \
-  --command "setclrpath %LOUTDIR%/shared/Microsoft.NETCore.App/7.0.0" \
-  "setsymbolserver -directory %LOUTDIR%/shared/Microsoft.NETCore.App/7.0.0"
+  --command "setclrpath %LOUTDIR%/shared/Microsoft.NETCore.App/%PRODUCTVERSION%" \
+  "setsymbolserver -directory %LOUTDIR%/shared/Microsoft.NETCore.App/%PRODUCTVERSION%"
 ```
 
 ---

--- a/eng/testing/gen-debug-dump-docs.py
+++ b/eng/testing/gen-debug-dump-docs.py
@@ -10,6 +10,7 @@ template_dir = os.getcwd()
 out_dir = template_dir
 idx = 0
 args_len = len(sys.argv)
+product_ver = ''
 while idx < args_len:
     arg = sys.argv[idx]
     idx += 1
@@ -61,6 +62,14 @@ while idx < args_len:
         dump_dir = sys.argv[idx]
         idx += 1
 
+    if arg == '-productver':
+        if idx >= args_len or sys.argv[idx].startswith('-'):
+            print("Must specify a value for -productver")
+            exit(1)
+
+        product_ver = sys.argv[idx]
+        idx += 1
+
 dump_names = []
 if dump_dir != '':
     for filename in os.listdir(dump_dir):
@@ -83,6 +92,10 @@ if job_id == '':
     print("ERROR: unespecified required argument -jobid")
     exit(1)
 
+if product_ver == '':
+    print("ERROR: unespecified required argument -productver")
+    exit(1)
+
 replace_string = ''
 dir_separator = '/' if platform.system() != 'Windows' else '\\'
 unix_user_folder = '$HOME/helix_payload/'
@@ -96,6 +109,7 @@ with open(source_file, 'r') as f:
     replace_string = file_text.replace('%JOBID%', job_id)
     replace_string = replace_string.replace('%WORKITEM%', workitem)
     replace_string = replace_string.replace('%BUILDID%', build_id)
+    replace_string = replace_string.replace('%PRODUCTVERSION%', product_ver)
     replace_string = replace_string.replace('%LOUTDIR%', unix_user_folder + workitem)
     replace_string = replace_string.replace('%WOUTDIR%', windows_user_folder + workitem)
 

--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -293,17 +293,17 @@
 
     <ItemGroup Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS' or '$(TargetOS)' == 'iOSSimulator' or '$(TargetOS)' == 'tvOSSimulator' or '$(TargetOS)' == 'MacCatalyst'">
       <!-- Create work items for test apps -->
-      <XHarnessAppBundleToTest 
+      <XHarnessAppBundleToTest
         Include="$([System.IO.Directory]::GetDirectories('$(TestArchiveTestsRoot)', '*.app', System.IO.SearchOption.AllDirectories))">
         <TestTarget>$(AppleTestTarget)</TestTarget>
       </XHarnessAppBundleToTest>
 
-      <!-- 
+      <!--
         Create work items for run-only apps
 
         Note: We're excluding iOS and tvOS device runonly as mlaunch does not seem to return and times out.
       -->
-      <XHarnessAppBundleToTest 
+      <XHarnessAppBundleToTest
         Condition="Exists('$(TestArchiveRoot)runonly') and '$(TargetOS)' != 'tvOS' and '$(TargetOS)' != 'iOS'"
         Include="$([System.IO.Directory]::GetDirectories('$(TestArchiveRoot)runonly', '*.app', System.IO.SearchOption.AllDirectories))" >
         <!-- The sample app doesn't need test runner -->

--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -361,11 +361,11 @@
     <PropertyGroup Condition="'$(RuntimeFlavor)' == 'CoreCLR' and '$(BUILD_BUILDID)' != ''">
       <HelixPostCommands Condition="'$(TargetsWindows)' == 'true'">
         $(HelixPostCommands);
-        %HELIX_PYTHONPATH% %HELIX_CORRELATION_PAYLOAD%\gen-debug-dump-docs.py -buildid $(BUILD_BUILDID) -workitem %HELIX_WORKITEM_FRIENDLYNAME% -jobid %HELIX_CORRELATION_ID% -outdir %HELIX_WORKITEM_UPLOAD_ROOT% -templatedir %HELIX_CORRELATION_PAYLOAD% -dumpdir %HELIX_DUMP_FOLDER%
+        %HELIX_PYTHONPATH% %HELIX_CORRELATION_PAYLOAD%\gen-debug-dump-docs.py -buildid $(BUILD_BUILDID) -workitem %HELIX_WORKITEM_FRIENDLYNAME% -jobid %HELIX_CORRELATION_ID% -outdir %HELIX_WORKITEM_UPLOAD_ROOT% -templatedir %HELIX_CORRELATION_PAYLOAD% -dumpdir %HELIX_DUMP_FOLDER% -productver $(ProductVersion)
       </HelixPostCommands>
       <HelixPostCommands Condition="'$(TargetsWindows)' != 'true'">
         $(HelixPostCommands);
-        $HELIX_PYTHONPATH $HELIX_CORRELATION_PAYLOAD/gen-debug-dump-docs.py -buildid $(BUILD_BUILDID) -workitem $HELIX_WORKITEM_FRIENDLYNAME -jobid $HELIX_CORRELATION_ID -outdir $HELIX_WORKITEM_UPLOAD_ROOT -templatedir $HELIX_CORRELATION_PAYLOAD -dumpdir $HELIX_DUMP_FOLDER
+        $HELIX_PYTHONPATH $HELIX_CORRELATION_PAYLOAD/gen-debug-dump-docs.py -buildid $(BUILD_BUILDID) -workitem $HELIX_WORKITEM_FRIENDLYNAME -jobid $HELIX_CORRELATION_ID -outdir $HELIX_WORKITEM_UPLOAD_ROOT -templatedir $HELIX_CORRELATION_PAYLOAD -dumpdir $HELIX_DUMP_FOLDER -productver $(ProductVersion)
       </HelixPostCommands>
     </PropertyGroup>
 


### PR DESCRIPTION
Passing `-productver` to `gen-debug-dump-docs.py` would prevent us from updating generated guide when version is globally updated.

cc @safern