### PR TITLE
Re-enable Windows test that verifies DriveInfo.VolumeLabel setter fails on SUBST'd drive

### DIFF
--- a/src/libraries/Common/tests/System/IO/VirtualDriveHelper.Windows.cs
+++ b/src/libraries/Common/tests/System/IO/VirtualDriveHelper.Windows.cs
@@ -1,0 +1,160 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+public class VirtualDriveHelper : IDisposable
+{
+    // Temporary Windows directory that can be mounted to a drive letter using the subst command
+    private string? _virtualDriveTargetDir = null;
+    // Windows drive letter that points to a mounted directory using the subst command
+    private char _virtualDriveLetter = default;
+
+    /// <summary>
+    /// If there is a SUBST'ed drive, Dispose unmounts it to free the drive letter.
+    /// </summary>
+    public void Dispose()
+    {
+        try
+        {
+            if (VirtualDriveLetter != default)
+            {
+                DeleteVirtualDrive(VirtualDriveLetter);
+                Directory.Delete(VirtualDriveTargetDir, recursive: true);
+            }
+        }
+        catch { } // avoid exceptions on dispose
+    }
+
+    /// <summary>
+    /// Returns the path of a folder that is to be mounted using SUBST.
+    /// </summary>
+    public string VirtualDriveTargetDir
+    {
+        get
+        {
+            if (_virtualDriveTargetDir == null)
+            {
+                // Create a folder inside the temp directory so that it can be mounted to a drive letter with subst
+                _virtualDriveTargetDir = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
+                Directory.CreateDirectory(_virtualDriveTargetDir);
+            }
+
+            return _virtualDriveTargetDir;
+        }
+    }
+
+    /// <summary>
+    /// Returns the drive letter of a drive letter that represents a mounted folder using SUBST.
+    /// </summary>
+    public char VirtualDriveLetter
+    {
+        get
+        {
+            if (_virtualDriveLetter == default)
+            {
+                // Mount the folder to a drive letter
+                _virtualDriveLetter = CreateVirtualDrive(VirtualDriveTargetDir);
+            }
+            return _virtualDriveLetter;
+        }
+    }
+
+    ///<summary>
+    /// On Windows, mounts a folder to an assigned virtual drive letter using the subst command.
+    /// subst is not available in Windows Nano.
+    /// </summary>
+    public char CreateVirtualDrive(string targetDir)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        char driveLetter = GetNextAvailableDriveLetter();
+        bool success = RunProcess(CreateProcessStartInfo("cmd", "/c", SubstPath, $"{driveLetter}:", targetDir));
+        if (!success || !DriveInfo.GetDrives().Any(x => x.Name[0] == driveLetter))
+        {
+            throw new InvalidOperationException($"Could not create virtual drive {driveLetter}: with subst");
+        }
+        return driveLetter;
+
+        // Finds the next unused drive letter and returns it.
+        char GetNextAvailableDriveLetter()
+        {
+            List<char> existingDrives = DriveInfo.GetDrives().Select(x => x.Name[0]).ToList();
+
+            // A,B are reserved, C is usually reserved
+            IEnumerable<int> range = Enumerable.Range('D', 'Z' - 'D');
+            IEnumerable<char> castRange = range.Select(x => Convert.ToChar(x));
+            IEnumerable<char> allDrivesLetters = castRange.Except(existingDrives);
+
+            if (!allDrivesLetters.Any())
+            {
+                throw new ArgumentOutOfRangeException("No drive letters available");
+            }
+
+            return allDrivesLetters.First();
+        }
+    }
+
+    /// <summary>
+    /// On Windows, unassigns the specified virtual drive letter from its mounted folder.
+    /// </summary>
+    public void DeleteVirtualDrive(char driveLetter)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        bool success = RunProcess(CreateProcessStartInfo("cmd", "/c", SubstPath, "/d", $"{driveLetter}:"));
+        if (!success || DriveInfo.GetDrives().Any(x => x.Name[0] == driveLetter))
+        {
+            throw new InvalidOperationException($"Could not delete virtual drive {driveLetter}: with subst");
+        }
+    }
+
+    private static ProcessStartInfo CreateProcessStartInfo(string fileName, params string[] arguments)
+    {
+        var info = new ProcessStartInfo
+        {
+            FileName = fileName,
+            UseShellExecute = false,
+            RedirectStandardOutput = true
+        };
+
+        foreach (var argument in arguments)
+        {
+            info.ArgumentList.Add(argument);
+        }
+
+        return info;
+    }
+
+    private static bool RunProcess(ProcessStartInfo startInfo)
+    {
+        var process = Process.Start(startInfo);
+        process.WaitForExit();
+        return process.ExitCode == 0;
+    }
+
+    private string SubstPath
+    {
+        get
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                throw new PlatformNotSupportedException();
+            }
+
+            string systemRoot = Environment.GetEnvironmentVariable("SystemRoot") ?? @"C:\Windows";
+            string system32 = Path.Join(systemRoot, "System32");
+            return Path.Join(system32, "subst.exe");
+        }
+    }   
+}

--- a/src/libraries/Common/tests/System/IO/VirtualDriveHelper.Windows.cs
+++ b/src/libraries/Common/tests/System/IO/VirtualDriveHelper.Windows.cs
@@ -1,160 +1,148 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
+using System.Runtime.Versioning;
 
-public class VirtualDriveHelper : IDisposable
+namespace System.IO.FileSystem
 {
-    // Temporary Windows directory that can be mounted to a drive letter using the subst command
-    private string? _virtualDriveTargetDir = null;
-    // Windows drive letter that points to a mounted directory using the subst command
-    private char _virtualDriveLetter = default;
-
-    /// <summary>
-    /// If there is a SUBST'ed drive, Dispose unmounts it to free the drive letter.
-    /// </summary>
-    public void Dispose()
+    // Adds test helper APIs to manipulate Windows virtual drives via SUBST.
+    [SupportedOSPlatform("windows")]
+    public class VirtualDriveHelper : IDisposable
     {
-        try
+        // Temporary Windows directory that can be mounted to a drive letter using the subst command
+        private string? _virtualDriveTargetDir = null;
+        // Windows drive letter that points to a mounted directory using the subst command
+        private char _virtualDriveLetter = default;
+
+        /// <summary>
+        /// If there is a SUBST'ed drive, Dispose unmounts it to free the drive letter.
+        /// </summary>
+        public void Dispose()
         {
-            if (VirtualDriveLetter != default)
+            try
             {
-                DeleteVirtualDrive(VirtualDriveLetter);
-                Directory.Delete(VirtualDriveTargetDir, recursive: true);
+                if (VirtualDriveLetter != default)
+                {
+                    DeleteVirtualDrive(VirtualDriveLetter);
+                    Directory.Delete(VirtualDriveTargetDir, recursive: true);
+                }
+            }
+            catch { } // avoid exceptions on dispose
+        }
+
+        /// <summary>
+        /// Returns the path of a folder that is to be mounted using SUBST.
+        /// </summary>
+        public string VirtualDriveTargetDir
+        {
+            get
+            {
+                if (_virtualDriveTargetDir == null)
+                {
+                    // Create a folder inside the temp directory so that it can be mounted to a drive letter with subst
+                    _virtualDriveTargetDir = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
+                    Directory.CreateDirectory(_virtualDriveTargetDir);
+                }
+
+                return _virtualDriveTargetDir;
             }
         }
-        catch { } // avoid exceptions on dispose
-    }
 
-    /// <summary>
-    /// Returns the path of a folder that is to be mounted using SUBST.
-    /// </summary>
-    public string VirtualDriveTargetDir
-    {
-        get
+        /// <summary>
+        /// Returns the drive letter of a drive letter that represents a mounted folder using SUBST.
+        /// </summary>
+        public char VirtualDriveLetter
         {
-            if (_virtualDriveTargetDir == null)
+            get
             {
-                // Create a folder inside the temp directory so that it can be mounted to a drive letter with subst
-                _virtualDriveTargetDir = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
-                Directory.CreateDirectory(_virtualDriveTargetDir);
+                if (_virtualDriveLetter == default)
+                {
+                    // Mount the folder to a drive letter
+                    _virtualDriveLetter = CreateVirtualDrive(VirtualDriveTargetDir);
+                }
+                return _virtualDriveLetter;
+            }
+        }
+
+        ///<summary>
+        /// On Windows, mounts a folder to an assigned virtual drive letter using the subst command.
+        /// subst is not available in Windows Nano.
+        /// </summary>
+        private static char CreateVirtualDrive(string targetDir)
+        {
+            char driveLetter = GetNextAvailableDriveLetter();
+            bool success = RunProcess(CreateProcessStartInfo("cmd", "/c", SubstPath, $"{driveLetter}:", targetDir));
+            if (!success || !DriveInfo.GetDrives().Any(x => x.Name[0] == driveLetter))
+            {
+                throw new InvalidOperationException($"Could not create virtual drive {driveLetter}: with subst");
+            }
+            return driveLetter;
+
+            // Finds the next unused drive letter and returns it.
+            char GetNextAvailableDriveLetter()
+            {
+                List<char> existingDrives = DriveInfo.GetDrives().Select(x => x.Name[0]).ToList();
+
+                // A,B are reserved, C is usually reserved
+                IEnumerable<int> range = Enumerable.Range('D', 'Z' - 'D');
+                IEnumerable<char> castRange = range.Select(x => Convert.ToChar(x));
+                IEnumerable<char> allDrivesLetters = castRange.Except(existingDrives);
+
+                if (!allDrivesLetters.Any())
+                {
+                    throw new ArgumentOutOfRangeException("No drive letters available");
+                }
+
+                return allDrivesLetters.First();
+            }
+        }
+
+        /// <summary>
+        /// On Windows, unassigns the specified virtual drive letter from its mounted folder.
+        /// </summary>
+        private static void DeleteVirtualDrive(char driveLetter)
+        {
+            bool success = RunProcess(CreateProcessStartInfo("cmd", "/c", SubstPath, "/d", $"{driveLetter}:"));
+            if (!success || DriveInfo.GetDrives().Any(x => x.Name[0] == driveLetter))
+            {
+                throw new InvalidOperationException($"Could not delete virtual drive {driveLetter}: with subst");
+            }
+        }
+
+        private static ProcessStartInfo CreateProcessStartInfo(string fileName, params string[] arguments)
+        {
+            var info = new ProcessStartInfo
+            {
+                FileName = fileName,
+                UseShellExecute = false,
+                RedirectStandardOutput = true
+            };
+
+            foreach (var argument in arguments)
+            {
+                info.ArgumentList.Add(argument);
             }
 
-            return _virtualDriveTargetDir;
+            return info;
         }
-    }
 
-    /// <summary>
-    /// Returns the drive letter of a drive letter that represents a mounted folder using SUBST.
-    /// </summary>
-    public char VirtualDriveLetter
-    {
-        get
+        private static bool RunProcess(ProcessStartInfo startInfo)
         {
-            if (_virtualDriveLetter == default)
+            using var process = Process.Start(startInfo);
+            process.WaitForExit();
+            return process.ExitCode == 0;
+        }
+
+        private static string SubstPath
+        {
+            get
             {
-                // Mount the folder to a drive letter
-                _virtualDriveLetter = CreateVirtualDrive(VirtualDriveTargetDir);
+                string systemRoot = Environment.GetEnvironmentVariable("SystemRoot") ?? @"C:\Windows";
+                return Path.Join(systemRoot, "System32", "subst.exe");
             }
-            return _virtualDriveLetter;
         }
     }
-
-    ///<summary>
-    /// On Windows, mounts a folder to an assigned virtual drive letter using the subst command.
-    /// subst is not available in Windows Nano.
-    /// </summary>
-    public char CreateVirtualDrive(string targetDir)
-    {
-        if (!OperatingSystem.IsWindows())
-        {
-            throw new PlatformNotSupportedException();
-        }
-
-        char driveLetter = GetNextAvailableDriveLetter();
-        bool success = RunProcess(CreateProcessStartInfo("cmd", "/c", SubstPath, $"{driveLetter}:", targetDir));
-        if (!success || !DriveInfo.GetDrives().Any(x => x.Name[0] == driveLetter))
-        {
-            throw new InvalidOperationException($"Could not create virtual drive {driveLetter}: with subst");
-        }
-        return driveLetter;
-
-        // Finds the next unused drive letter and returns it.
-        char GetNextAvailableDriveLetter()
-        {
-            List<char> existingDrives = DriveInfo.GetDrives().Select(x => x.Name[0]).ToList();
-
-            // A,B are reserved, C is usually reserved
-            IEnumerable<int> range = Enumerable.Range('D', 'Z' - 'D');
-            IEnumerable<char> castRange = range.Select(x => Convert.ToChar(x));
-            IEnumerable<char> allDrivesLetters = castRange.Except(existingDrives);
-
-            if (!allDrivesLetters.Any())
-            {
-                throw new ArgumentOutOfRangeException("No drive letters available");
-            }
-
-            return allDrivesLetters.First();
-        }
-    }
-
-    /// <summary>
-    /// On Windows, unassigns the specified virtual drive letter from its mounted folder.
-    /// </summary>
-    public void DeleteVirtualDrive(char driveLetter)
-    {
-        if (!OperatingSystem.IsWindows())
-        {
-            throw new PlatformNotSupportedException();
-        }
-
-        bool success = RunProcess(CreateProcessStartInfo("cmd", "/c", SubstPath, "/d", $"{driveLetter}:"));
-        if (!success || DriveInfo.GetDrives().Any(x => x.Name[0] == driveLetter))
-        {
-            throw new InvalidOperationException($"Could not delete virtual drive {driveLetter}: with subst");
-        }
-    }
-
-    private static ProcessStartInfo CreateProcessStartInfo(string fileName, params string[] arguments)
-    {
-        var info = new ProcessStartInfo
-        {
-            FileName = fileName,
-            UseShellExecute = false,
-            RedirectStandardOutput = true
-        };
-
-        foreach (var argument in arguments)
-        {
-            info.ArgumentList.Add(argument);
-        }
-
-        return info;
-    }
-
-    private static bool RunProcess(ProcessStartInfo startInfo)
-    {
-        var process = Process.Start(startInfo);
-        process.WaitForExit();
-        return process.ExitCode == 0;
-    }
-
-    private string SubstPath
-    {
-        get
-        {
-            if (!OperatingSystem.IsWindows())
-            {
-                throw new PlatformNotSupportedException();
-            }
-
-            string systemRoot = Environment.GetEnvironmentVariable("SystemRoot") ?? @"C:\Windows";
-            string system32 = Path.Join(systemRoot, "System32");
-            return Path.Join(system32, "subst.exe");
-        }
-    }   
 }

--- a/src/libraries/Common/tests/System/IO/VirtualDriveHelper.Windows.cs
+++ b/src/libraries/Common/tests/System/IO/VirtualDriveHelper.Windows.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.Versioning;
 
-namespace System.IO.FileSystem
+namespace System.IO
 {
     // Adds test helper APIs to manipulate Windows virtual drives via SUBST.
     [SupportedOSPlatform("windows")]

--- a/src/libraries/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Unix.Tests.cs
+++ b/src/libraries/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Unix.Tests.cs
@@ -5,7 +5,7 @@ using System;
 using System.Linq;
 using Xunit;
 
-namespace System.IO.FileSystem.DriveInfoTests
+namespace System.IO.FileSystem.Tests
 {
     public partial class DriveInfoUnixTests
     {

--- a/src/libraries/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Windows.Tests.cs
+++ b/src/libraries/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Windows.Tests.cs
@@ -9,27 +9,9 @@ using System.Security;
 using System.Text;
 using Xunit;
 
-namespace System.IO.FileSystem.DriveInfoTests
+namespace System.IO.FileSystem.Tests
 {
-    // Separate class from the rest of the DriveInfo tests to prevent adding an extra virtual drive to GetDrives().
-    public class DriveInfoVirtualDriveTests : IDisposable
-    {
-        private VirtualDriveHelper VirtualDrive { get; } = new VirtualDriveHelper();
-
-        public void Dispose() => VirtualDrive.Dispose();
-
-        // Cannot set the volume label on a SUBST'ed folder
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsSubstAvailable))]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        public void SetVolumeLabel_OnVirtualDrive_Throws()
-        {
-            char letter = VirtualDrive.VirtualDriveLetter; // Trigger calling subst
-            DriveInfo drive = DriveInfo.GetDrives().Where(d => d.RootDirectory.FullName[0] == letter).FirstOrDefault();
-            Assert.NotNull(drive);
-            Assert.Throws<IOException>(() => drive.VolumeLabel = "impossible");
-        }
-    }
-
+    [PlatformSpecific(TestPlatforms.Windows)]
     public class DriveInfoWindowsTests
     {
         [Theory]
@@ -52,7 +34,6 @@ namespace System.IO.FileSystem.DriveInfoTests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
         public void TestConstructor()
         {
             string[] variableInput = { "{0}", "{0}", "{0}:", "{0}:", @"{0}:\", @"{0}:\\", "{0}://" };
@@ -71,7 +52,6 @@ namespace System.IO.FileSystem.DriveInfoTests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
         public void TestGetDrives()
         {
             var validExpectedDrives = GetValidDriveLettersOnMachine();
@@ -114,7 +94,6 @@ namespace System.IO.FileSystem.DriveInfoTests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
         public void TestDriveFormat()
         {
             DriveInfo validDrive = DriveInfo.GetDrives().Where(d => d.DriveType == DriveType.Fixed).First();
@@ -141,7 +120,6 @@ namespace System.IO.FileSystem.DriveInfoTests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
         public void TestDriveType()
         {
             var validDrive = DriveInfo.GetDrives().Where(d => d.DriveType == DriveType.Fixed).First();
@@ -154,7 +132,6 @@ namespace System.IO.FileSystem.DriveInfoTests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
         public void TestValidDiskSpaceProperties()
         {
             bool win32Result;
@@ -186,7 +163,6 @@ namespace System.IO.FileSystem.DriveInfoTests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
         public void TestInvalidDiskProperties()
         {
             string invalidDriveName = GetInvalidDriveLettersOnMachine().First().ToString();
@@ -206,7 +182,6 @@ namespace System.IO.FileSystem.DriveInfoTests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
         public void GetVolumeLabel_Returns_CorrectLabel()
         {
             void DoDriveCheck()
@@ -242,7 +217,6 @@ namespace System.IO.FileSystem.DriveInfoTests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
         public void SetVolumeLabel_Roundtrips()
         {
             DriveInfo drive = DriveInfo.GetDrives().Where(d => d.DriveType == DriveType.Fixed).First();
@@ -263,7 +237,6 @@ namespace System.IO.FileSystem.DriveInfoTests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
         public void VolumeLabelOnNetworkOrCdRom_Throws()
         {
             // Test setting the volume label on a Network or CD-ROM

--- a/src/libraries/System.IO.FileSystem.DriveInfo/tests/System.IO.FileSystem.DriveInfo.Tests.csproj
+++ b/src/libraries/System.IO.FileSystem.DriveInfo/tests/System.IO.FileSystem.DriveInfo.Tests.csproj
@@ -5,6 +5,7 @@
   <ItemGroup>
     <Compile Include="DriveInfo.Unix.Tests.cs" Condition="'$(TargetsUnix)' == 'true' or '$(TargetsBrowser)' == 'true'" />
     <Compile Include="DriveInfo.Windows.Tests.cs" Condition="'$(TargetsWindows)' == 'true'" />
+    <Compile Include="VirtualDrives.Windows.Tests.cs" Condition="'$(TargetsWindows)' == 'true'" />
     <Compile Include="$(CommonTestPath)System\IO\VirtualDriveHelper.Windows.cs" Link="Common\System\IO\VirtualDriveHelper.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.IO.FileSystem.DriveInfo/tests/System.IO.FileSystem.DriveInfo.Tests.csproj
+++ b/src/libraries/System.IO.FileSystem.DriveInfo/tests/System.IO.FileSystem.DriveInfo.Tests.csproj
@@ -5,5 +5,6 @@
   <ItemGroup>
     <Compile Include="DriveInfo.Unix.Tests.cs" Condition="'$(TargetsUnix)' == 'true' or '$(TargetsBrowser)' == 'true'" />
     <Compile Include="DriveInfo.Windows.Tests.cs" Condition="'$(TargetsWindows)' == 'true'" />
+    <Compile Include="$(CommonTestPath)System\IO\VirtualDriveHelper.Windows.cs" Link="Common\System\IO\VirtualDriveHelper.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.IO.FileSystem.DriveInfo/tests/VirtualDrives.Windows.Tests.cs
+++ b/src/libraries/System.IO.FileSystem.DriveInfo/tests/VirtualDrives.Windows.Tests.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Text;
+using Xunit;
+
+namespace System.IO.FileSystem.Tests
+{
+    // Separate class from the rest of the DriveInfo tests to prevent adding an extra virtual drive to GetDrives().
+    public class DriveInfoVirtualDriveTests
+    {
+        // Cannot set the volume label on a SUBST'ed folder
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsSubstAvailable))]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void SetVolumeLabel_OnVirtualDrive_Throws()
+        {
+            using VirtualDriveHelper virtualDrive = new();
+            char letter = virtualDrive.VirtualDriveLetter; // Trigger calling subst
+            DriveInfo drive = DriveInfo.GetDrives().Where(d => d.RootDirectory.FullName[0] == letter).FirstOrDefault();
+            Assert.NotNull(drive);
+            Assert.Throws<IOException>(() => drive.VolumeLabel = "impossible");
+        }
+    }
+}

--- a/src/libraries/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/libraries/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -97,6 +97,7 @@
     <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.cs" Link="Common\System\Text\ValueStringBuilder.cs" />
     <Compile Include="$(CommonPath)System\IO\PathInternal.cs" Link="Common\System\IO\PathInternal.cs" />
     <Compile Include="$(CommonPath)System\IO\PathInternal.Windows.cs" Link="Common\System\IO\PathInternal.Windows.cs" />
+    <Compile Include="$(CommonTestPath)System\IO\VirtualDriveHelper.Windows.cs" Link="Common\System\IO\VirtualDriveHelper.Windows.cs" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.ServiceProcess.ServiceController\src\System.ServiceProcess.ServiceController.csproj" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.IO.FileSystem.AccessControl\src\System.IO.FileSystem.AccessControl.csproj" />
   </ItemGroup>

--- a/src/libraries/System.IO.FileSystem/tests/VirtualDriveSymbolicLinks.Windows.cs
+++ b/src/libraries/System.IO.FileSystem/tests/VirtualDriveSymbolicLinks.Windows.cs
@@ -11,17 +11,11 @@ namespace System.IO.Tests
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsSubstAvailable))]
     public class VirtualDrive_SymbolicLinks : BaseSymbolicLinks
     {
+        private VirtualDriveHelper VirtualDrive { get; } = new VirtualDriveHelper();
+
         protected override void Dispose(bool disposing)
         {
-            try
-            {
-                if (VirtualDriveLetter != default)
-                {
-                    MountHelper.DeleteVirtualDrive(VirtualDriveLetter);
-                    Directory.Delete(VirtualDriveTargetDir, recursive: true);
-                }
-            }
-            catch { } // avoid exceptions on dispose
+            VirtualDrive.Dispose();
             base.Dispose(disposing);
         }
 
@@ -210,38 +204,6 @@ namespace System.IO.Tests
             Assert.Equal(expectedTargetDirectoryInfoFullName, targetFileInfoFromDirectory.FullName);
         }
 
-        private string GetVirtualOrRealPath(bool condition) => condition ? $"{VirtualDriveLetter}:" : VirtualDriveTargetDir;
-
-        // Temporary Windows directory that can be mounted to a drive letter using the subst command
-        private string? _virtualDriveTargetDir = null;
-        private string VirtualDriveTargetDir
-        {
-            get
-            {
-                if (_virtualDriveTargetDir == null)
-                {
-                    // Create a folder inside the temp directory so that it can be mounted to a drive letter with subst
-                    _virtualDriveTargetDir = Path.Join(Path.GetTempPath(), GetRandomDirName());
-                    Directory.CreateDirectory(_virtualDriveTargetDir);
-                }
-
-                return _virtualDriveTargetDir;
-            }
-        }
-
-        // Windows drive letter that points to a mounted directory using the subst command
-        private char _virtualDriveLetter = default;
-        private char VirtualDriveLetter
-        {
-            get
-            {
-                if (_virtualDriveLetter == default)
-                {
-                    // Mount the folder to a drive letter
-                    _virtualDriveLetter = MountHelper.CreateVirtualDrive(VirtualDriveTargetDir);
-                }
-                return _virtualDriveLetter;
-            }
-        }
+        private string GetVirtualOrRealPath(bool condition) => condition ? $"{VirtualDrive.VirtualDriveLetter}:" : VirtualDrive.VirtualDriveTargetDir;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/14027

I'm reusing code I recently added to verify SUBST with symbolic links. I moved it to its own class for virtual drive manipulation on Windows.