### PR TITLE
Optimize DateTime.Equals

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -688,7 +688,7 @@ namespace System
 
         public bool Equals(DateTime value)
         {
-            return Ticks == value.Ticks;
+            return this == value;
         }
 
         // Compares two DateTime values for equality. Returns true if
@@ -697,7 +697,7 @@ namespace System
         //
         public static bool Equals(DateTime t1, DateTime t2)
         {
-            return t1.Ticks == t2.Ticks;
+            return t1 == t2;
         }
 
         public static DateTime FromBinary(long dateData)
@@ -1401,9 +1401,9 @@ namespace System
 
         public static TimeSpan operator -(DateTime d1, DateTime d2) => new TimeSpan(d1.Ticks - d2.Ticks);
 
-        public static bool operator ==(DateTime d1, DateTime d2) => d1.Ticks == d2.Ticks;
+        public static bool operator ==(DateTime d1, DateTime d2) => ((d1._dateData ^ d2._dateData) << 2) == 0;
 
-        public static bool operator !=(DateTime d1, DateTime d2) => d1.Ticks != d2.Ticks;
+        public static bool operator !=(DateTime d1, DateTime d2) => ((d1._dateData ^ d2._dateData) << 2) != 0;
 
         public static bool operator <(DateTime t1, DateTime t2) => t1.Ticks < t2.Ticks;
 

--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -1403,7 +1403,7 @@ namespace System
 
         public static bool operator ==(DateTime d1, DateTime d2) => ((d1._dateData ^ d2._dateData) << 2) == 0;
 
-        public static bool operator !=(DateTime d1, DateTime d2) => ((d1._dateData ^ d2._dateData) << 2) != 0;
+        public static bool operator !=(DateTime d1, DateTime d2) => !(d1 == d2);
 
         public static bool operator <(DateTime t1, DateTime t2) => t1.Ticks < t2.Ticks;
 


### PR DESCRIPTION
A tiny improvement for `DateTime.Equals`:
```csharp
bool Test1(DateTime d1, DateTime d2) => d1 == d2;

// cmp against a constant
bool Test2(DateTime d1, DateTime d2) => d1 == new DateTime(637686893321649705);
```
Codegen diff: https://www.diffchecker.com/v4BfSbey
Could be done in JIT but it needs forward-sub feature for that first.

Self-contained benchmark: https://gist.github.com/EgorBo/e5642d9c2d362bb53880d3c9c87e5b95
```

|         Method |         d1 |         d2 |     Mean |    Error |   StdDev |
|--------------- |----------- |----------- |---------:|---------:|---------:|
|     Equals_new | MyDt[1000] | MyDt[1000] | 599.9 ns |  0.46 ns |  0.38 ns |
|     Equals_old | MyDt[1000] | MyDt[1000] | 651.8 ns |  0.70 ns |  0.62 ns |

|     Equals_new | MyDt[1000] | MyDt[1000] | 806.2 ns | 15.59 ns | 16.68 ns |
|     Equals_old | MyDt[1000] | MyDt[1000] | 859.2 ns |  2.34 ns |  2.19 ns |

| Equals_new_cns | MyDt[1000] | MyDt[1000] | 436.3 ns |  0.90 ns |  0.75 ns |
| Equals_old_cns | MyDt[1000] | MyDt[1000] | 855.7 ns | 13.78 ns | 12.89 ns |

| Equals_new_cns | MyDt[1000] | MyDt[1000] | 436.0 ns |  2.50 ns |  2.22 ns |
| Equals_old_cns | MyDt[1000] | MyDt[1000] | 875.0 ns | 16.63 ns | 17.80 ns |
```