### PR TITLE
Make libraries tests use the same config as the matching libraries build.

### DIFF
--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -64,7 +64,7 @@ jobs:
         - ${{ format('{0}_{1}_product_build_{2}{3}_{4}_{5}', parameters.runtimeFlavor, parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.liveRuntimeBuildConfig) }}
 
       variables:
-        - librariesTestsArtifactName: ${{ format('libraries_test_assets_{0}_{1}_{2}', parameters.osGroup, parameters.archType, parameters.buildConfig) }}
+        - librariesTestsArtifactName: ${{ format('libraries_test_assets_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
         - _subset: libs+libs.tests
         - _buildAction: ''
         - _additionalBuildArguments: ''

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -66,19 +66,16 @@ jobs:
 
       variables:
         - librariesTestsArtifactName: ${{ format('libraries_test_assets_{0}_{1}_{2}', parameters.osGroup, parameters.archType, parameters.buildConfig) }}
-        - _subset: libs
+        - _subset: libs+libs.tests
         - _buildAction: ''
         - _additionalBuildArguments: ''
         - ${{ parameters.variables }}
 
         # Tests only run for 'allConfiguration' and 'net48' build-jobs
-        # If platform is in testBuildPlatforms we build tests as well.
-        - ${{ if or(eq(parameters.runTests, true), containsValue(parameters.testBuildPlatforms, parameters.platform)) }}:
-          - _subset: libs+libs.tests
-          - ${{ if eq(parameters.useHelix, false) }}:
-            - _buildAction: -restore -build -test
-          - ${{ if eq(parameters.useHelix, true) }}:
-            - _additionalBuildArguments: /p:ArchiveTests=true
+        - ${{ if eq(parameters.useHelix, false) }}:
+          - _buildAction: -restore -build -test
+        - ${{ if eq(parameters.useHelix, true) }}:
+          - _additionalBuildArguments: /p:ArchiveTests=true
 
         - ${{ parameters.variables }}
 
@@ -102,7 +99,7 @@ jobs:
                 $(_additionalBuildArguments)
           displayName: Restore and Build Product
 
-        - ${{ if in(parameters.osGroup, 'OSX', 'iOS', 'tvOS') }}: 
+        - ${{ if in(parameters.osGroup, 'OSX', 'iOS', 'tvOS') }}:
           - script: |
               du -sh $(Build.SourcesDirectory)/*
               df -h
@@ -122,17 +119,16 @@ jobs:
               tarCompression: $(tarCompression)
               artifactName: $(librariesBuildArtifactName)
               displayName: Build Assets
-          
-          - ${{ if containsValue(parameters.testBuildPlatforms, parameters.platform) }}:
-            - template: /eng/pipelines/common/upload-artifact-step.yml
-              parameters:
-                rootFolder: $(Build.SourcesDirectory)/artifacts/helix
-                includeRootFolder: true
-                archiveType: $(archiveType)
-                archiveExtension: $(archiveExtension)
-                tarCompression: $(tarCompression)
-                artifactName: $(librariesTestsArtifactName)
-                displayName: Test Assets
+
+          - template: /eng/pipelines/common/upload-artifact-step.yml
+            parameters:
+              rootFolder: $(Build.SourcesDirectory)/artifacts/helix
+              includeRootFolder: true
+              archiveType: $(archiveType)
+              archiveExtension: $(archiveExtension)
+              tarCompression: $(tarCompression)
+              artifactName: $(librariesTestsArtifactName)
+              displayName: Test Assets
 
           # Save AllConfigurations artifacts using the prepare-signed-artifacts format. The
           # platform-specific jobs' nupkgs automatically flow through the matching platform-specific
@@ -145,7 +141,7 @@ jobs:
                   or(
                      eq(variables['_librariesBuildProducedPackages'], true),
                      eq(variables['Build.SourceBranchName'], 'main'),
-                     eq(variables['System.PullRequest.TargetBranch'], 'main')) 
+                     eq(variables['System.PullRequest.TargetBranch'], 'main'))
 
         - ${{ if and(eq(parameters.runTests, true), eq(parameters.useHelix, true)) }}:
           - template: /eng/pipelines/libraries/helix.yml

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -28,7 +28,9 @@ parameters:
   shouldContinueOnError: false
   variables: {}
   pool: ''
+  # Run tests as part of the build job (instead of running them in a separate job)
   runTests: false
+  # Package up the test builds so they can be sent to Helix
   useHelix: true
   testScope: ''
 
@@ -71,7 +73,7 @@ jobs:
         - ${{ parameters.variables }}
 
         # Tests only run for 'allConfiguration' and 'net48' build-jobs
-        - ${{ if eq(parameters.useHelix, false) }}:
+        - ${{ if eq(parameters.runTests, true) }}:
           - _buildAction: -restore -build -test
         - ${{ if eq(parameters.useHelix, true) }}:
           - _additionalBuildArguments: /p:ArchiveTests=true
@@ -119,15 +121,17 @@ jobs:
               artifactName: $(librariesBuildArtifactName)
               displayName: Build Assets
 
-          - template: /eng/pipelines/common/upload-artifact-step.yml
-            parameters:
-              rootFolder: $(Build.SourcesDirectory)/artifacts/helix
-              includeRootFolder: true
-              archiveType: $(archiveType)
-              archiveExtension: $(archiveExtension)
-              tarCompression: $(tarCompression)
-              artifactName: $(librariesTestsArtifactName)
-              displayName: Test Assets
+          # Upload test assets if we are sending tests to Helix and not running them directly in this job.
+          - ${{ if and(eq(parameters.runTests, false), eq(parameters.useHelix, true)) }}:
+            - template: /eng/pipelines/common/upload-artifact-step.yml
+              parameters:
+                rootFolder: $(Build.SourcesDirectory)/artifacts/helix
+                includeRootFolder: true
+                archiveType: $(archiveType)
+                archiveExtension: $(archiveExtension)
+                tarCompression: $(tarCompression)
+                artifactName: $(librariesTestsArtifactName)
+                displayName: Test Assets
 
           # Save AllConfigurations artifacts using the prepare-signed-artifacts format. The
           # platform-specific jobs' nupkgs automatically flow through the matching platform-specific

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -31,7 +31,6 @@ parameters:
   runTests: false
   useHelix: true
   testScope: ''
-  testBuildPlatforms: []
 
 jobs:
   - template: /eng/pipelines/libraries/base-job.yml

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -73,7 +73,8 @@ jobs:
         - ${{ parameters.variables }}
 
         # Tests only run for 'allConfiguration' and 'net48' build-jobs
-        - ${{ if eq(parameters.runTests, true) }}:
+        # Only pass -test for when we aren't running tests using Helix.
+        - ${{ if and(eq(parameters.runTests, true), eq(parameters.useHelix, false)) }}:
           - _buildAction: -restore -build -test
         - ${{ if eq(parameters.useHelix, true) }}:
           - _additionalBuildArguments: /p:ArchiveTests=true

--- a/eng/pipelines/libraries/run-test-job.yml
+++ b/eng/pipelines/libraries/run-test-job.yml
@@ -15,9 +15,6 @@ parameters:
   runtimeVariant: ''
   testScope: ''
   helixQueues: []
-  dependsOnTestBuildConfiguration: Debug
-  dependsOnTestArchitecture: x64
-  dependsOnTestOsSubgroup: ''
   dependOnEvaluatePaths: false
   condition: true
   shouldContinueOnError: false
@@ -58,7 +55,7 @@ jobs:
       ${{ if startsWith(parameters.pool.queue, 'BuildPool.Ubuntu') }}:
         pool:
           vmImage: 'ubuntu-latest'
-      
+
       ${{ if not(startsWith(parameters.pool.queue, 'BuildPool.Ubuntu')) }}:
         pool: ${{ parameters.pool }}
 
@@ -69,14 +66,11 @@ jobs:
       - ${{ if eq(parameters.dependsOn[0], '') }}:
         - ${{ if notIn(parameters.framework, 'allConfigurations', 'net48') }}:
           - ${{ format('libraries_build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
-          # tests are built as part of product build
-          - ${{ if or(ne(parameters.archType, parameters.dependsOnTestArchitecture), ne(parameters.buildConfig, parameters.dependsOnTestBuildConfiguration), ne(parameters.osSubgroup, parameters.dependsOnTestOsSubgroup)) }}:
-            - ${{ format('libraries_build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.dependsOnTestOsSubgroup, parameters.dependsOnTestArchitecture, parameters.dependsOnTestBuildConfiguration) }}
         - ${{ if ne(parameters.liveRuntimeBuildConfig, '') }}:
           - ${{ format('{0}_{1}_product_build_{2}{3}_{4}_{5}', parameters.runtimeFlavor, parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.liveRuntimeBuildConfig) }}
 
       variables:
-        - librariesTestsArtifactName: ${{ format('libraries_test_assets_{0}_{1}_{2}', parameters.osGroup, parameters.dependsOnTestArchitecture, parameters.dependsOnTestBuildConfiguration) }}
+        - librariesTestsArtifactName: ${{ format('libraries_test_assets_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
         - _archiveTestsParameter: /p:ArchiveTests=true
 
         - ${{ parameters.variables }}

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -796,23 +796,23 @@ jobs:
 
 #
 # Libraries Build that only run when coreclr is changed
+# Only do this on PR builds since we use the Release builds for these test runs in CI
+# and those are already built above
 #
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/libraries/build-job.yml
-    buildConfig: Debug
-    platforms:
-      - Linux_arm
-      - Linux_musl_arm
-      - Linux_musl_arm64
-    jobParameters:
-      liveRuntimeBuildConfig: release
-      # Don't run on isFullMatrix as we need the Release libraries build then,
-      # which is already handled above.
-      condition: >-
-        and(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-          eq(variables['isFullMatrix'], false))
+
+- ${{ if eq(variables['isFullMatrix'], true) }}:
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/libraries/build-job.yml
+      buildConfig: Debug
+      platforms:
+        - Linux_arm
+        - Linux_musl_arm
+        - Linux_musl_arm64
+      jobParameters:
+        liveRuntimeBuildConfig: release
+        condition: >-
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true)
 
 #
 # Libraries Build that only run when libraries is changed

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -783,10 +783,6 @@ jobs:
     jobTemplate: /eng/pipelines/libraries/build-job.yml
     buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
     platforms:
-    - ${{ if eq(variables['isFullMatrix'], false) }}:
-      - Linux_arm
-      - Linux_musl_arm
-      - Linux_musl_arm64
     - Linux_arm64
     - Linux_musl_x64
     - Linux_x64
@@ -797,6 +793,26 @@ jobs:
     jobParameters:
       testScope: innerloop
       liveRuntimeBuildConfig: release
+
+#
+# Libraries Build that only run when coreclr is changed
+#
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/libraries/build-job.yml
+    buildConfig: Debug
+    platforms:
+      - Linux_arm
+      - Linux_musl_arm
+      - Linux_musl_arm64
+    jobParameters:
+      liveRuntimeBuildConfig: release
+      # Don't run on isFullMatrix as we need the Release libraries build then,
+      # which is already handled above.
+      condition: >-
+        and(
+          eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+          eq(variables['isFullMatrix'], false))
 
 #
 # Libraries Build that only run when libraries is changed

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1152,7 +1152,7 @@ jobs:
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
     jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-    buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+    buildConfig: Release
     platforms:
     - windows_x86
     - ${{ if eq(variables['isFullMatrix'], true) }}:

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -792,10 +792,6 @@ jobs:
     - FreeBSD_x64
     jobParameters:
       testScope: innerloop
-      testBuildPlatforms:
-      - Linux_x64
-      - windows_x64
-      - OSX_x64
       liveRuntimeBuildConfig: release
 
 #
@@ -1116,8 +1112,6 @@ jobs:
       runtimeDisplayName: mono
       testScope: innerloop
       liveRuntimeBuildConfig: release
-      dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}
-      dependsOnTestArchitecture: x64
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
@@ -1145,8 +1139,6 @@ jobs:
       runtimeDisplayName: mono_interpreter
       testScope: innerloop
       liveRuntimeBuildConfig: release
-      dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}
-      dependsOnTestArchitecture: x64
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
@@ -1160,7 +1152,7 @@ jobs:
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
     jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-    buildConfig: Release
+    buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
     platforms:
     - windows_x86
     - ${{ if eq(variables['isFullMatrix'], true) }}:
@@ -1171,8 +1163,6 @@ jobs:
       isFullMatrix: ${{ variables.isFullMatrix }}
       testScope: innerloop
       liveRuntimeBuildConfig: release
-      dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}
-      dependsOnTestArchitecture: x64
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
@@ -1201,8 +1191,6 @@ jobs:
       isFullMatrix: ${{ variables.isFullMatrix }}
       testScope: innerloop
       liveRuntimeBuildConfig: release
-      dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}
-      dependsOnTestArchitecture: x64
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
@@ -1215,7 +1203,7 @@ jobs:
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
     jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-    buildConfig: Release
+    buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
     platforms:
     # - windows_arm return this when https://github.com/dotnet/runtime/issues/1097 is fixed.
     - Linux_arm
@@ -1227,8 +1215,6 @@ jobs:
     jobParameters:
       testScope: innerloop
       liveRuntimeBuildConfig: checked
-      dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}
-      dependsOnTestArchitecture: x64
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
@@ -1251,8 +1237,6 @@ jobs:
     jobParameters:
       testScope: innerloop
       liveRuntimeBuildConfig: checked
-      dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}
-      dependsOnTestArchitecture: x64
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
@@ -1269,8 +1253,6 @@ jobs:
     jobParameters:
       testScope: innerloop
       liveRuntimeBuildConfig: checked
-      dependsOnTestBuildConfiguration: ${{ variables.debugOnPrReleaseOnRolling }}
-      dependsOnTestArchitecture: x64
       condition: >-
         or(
           eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -800,7 +800,7 @@ jobs:
 # and those are already built above
 #
 
-- ${{ if eq(variables['isFullMatrix'], true) }}:
+- ${{ if eq(variables['isFullMatrix'], false) }}:
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
       jobTemplate: /eng/pipelines/libraries/build-job.yml

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -783,6 +783,10 @@ jobs:
     jobTemplate: /eng/pipelines/libraries/build-job.yml
     buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
     platforms:
+    - ${{ if eq(variables['isFullMatrix'], false) }}:
+      - Linux_arm
+      - Linux_musl_arm
+      - Linux_musl_arm64
     - Linux_arm64
     - Linux_musl_x64
     - Linux_x64


### PR DESCRIPTION
This change is useful in two ways:

1. It simplifies our CI build dependency graph so that we don't have a windows x86 job depending on a windows x64 job to finish first. This also allows us to possibly find and fix any bugs in CI that would pop up from this part of linearizing our builds (which we've chatted about a few times previously).
2. It unblocks #59579 which introduces an arch-dependent native component into the libraries tests with DNNE.