### PR TITLE
Fix code heap reservation size

### DIFF
--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -2406,6 +2406,11 @@ HeapList* EEJitManager::NewCodeHeap(CodeHeapRequestInfo *pInfo, DomainCodeHeapLi
 #endif
 
     size_t reserveSize = initialRequestSize;
+
+#if defined(TARGET_AMD64) || defined(TARGET_ARM64)
+    reserveSize += JUMP_ALLOCATE_SIZE;
+#endif
+
     if (reserveSize < minReserveSize)
         reserveSize = minReserveSize;
     reserveSize = ALIGN_UP(reserveSize, VIRTUAL_ALLOC_RESERVE_GRANULARITY);

--- a/src/coreclr/vm/dynamicmethod.cpp
+++ b/src/coreclr/vm/dynamicmethod.cpp
@@ -398,6 +398,11 @@ HeapList* HostCodeHeap::InitializeHeapList(CodeHeapRequestInfo *pInfo)
 
     // Add TrackAllocation, HeapList and very conservative padding to make sure we have enough for the allocation
     ReserveBlockSize += sizeof(TrackAllocation) + HOST_CODEHEAP_SIZE_ALIGN + 0x100;
+
+#if defined(TARGET_AMD64) || defined(TARGET_ARM64)
+    ReserveBlockSize += JUMP_ALLOCATE_SIZE;
+#endif
+
     // reserve ReserveBlockSize rounded-up to VIRTUAL_ALLOC_RESERVE_GRANULARITY of memory
     ReserveBlockSize = ALIGN_UP(ReserveBlockSize, VIRTUAL_ALLOC_RESERVE_GRANULARITY);
 


### PR DESCRIPTION
When I've moved the heap metadata out of the actual code heaps some time
ago, I've forgotten to account for the personality routine slot
allocated at the beginning of the heaps. This was exposed by an assert when
executing under the JIT stress mode 2.

This change fixes it by adding accounting for those.

Close #59794