### PR TITLE
Move runtime rolling builds to run twice a day on main

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -6,7 +6,6 @@ trigger:
   batch: true
   branches:
     include:
-    - main
     - release/*.*
   paths:
     include:
@@ -23,6 +22,14 @@ trigger:
     - README.md
     - SECURITY.md
     - THIRD-PARTY-NOTICES.TXT
+
+schedules:
+  - cron: "0 8,20 * * *" # run at 8:00 and 20:00 (UTC) which is 00:00 and 12:00 (PST).
+    displayName:
+    branches:
+      include:
+      - main
+    always: false # run only if there were changes since the last successful scheduled run.
 
 pr:
   branches:

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -25,7 +25,7 @@ trigger:
 
 schedules:
   - cron: "0 8,20 * * *" # run at 8:00 and 20:00 (UTC) which is 00:00 and 12:00 (PST).
-    displayName:
+    displayName: Runtime default schedule
     branches:
       include:
       - main


### PR DESCRIPTION
In an effort to reduce the usage of build/test resources we are going to experiment running rolling builds just twice a day vs 6-8 times that was running with run per commit batch.

Currently we chose 00:00 and 12:00 PST to be in the middle of workday loads for each timezone. 

Release branches I left as per commit batch as I guess those are not that frequent and when doing servicing we do want to get more protection? If we want to change release branches as well, I can do that also 😄 

cc: @jkotas @stephentoub @danmoseley 