### PR TITLE
Change loop cloning conditions codegen

### DIFF
--- a/src/coreclr/jit/loopcloning.h
+++ b/src/coreclr/jit/loopcloning.h
@@ -585,7 +585,7 @@ struct LC_Condition
     }
 
     // Convert this conditional operation into a GenTree.
-    GenTree* ToGenTree(Compiler* comp, BasicBlock* bb);
+    GenTree* ToGenTree(Compiler* comp, BasicBlock* bb, bool invert);
 };
 
 /**


### PR DESCRIPTION
Add an option, statically determined at compile time,
to generate loop cloning loop choice conditions into one block
per condition instead of using bitwise and operators to always
execute all non-dependent conditions in a single block.

This leads to code size reduction in the condition code, as well
as making it easier to understand.
