### PR TITLE
Add flag to include all intermediate certificates

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
@@ -11,6 +11,7 @@ namespace System.Net.Security
     public partial class SslStreamCertificateContext
     {
         private const bool TrimRootCertificate = true;
+        private const bool SupportsAddAllAdditionalCertificates = true;
         internal readonly ConcurrentDictionary<SslProtocols, SafeSslContextHandle> SslContexts;
 
         private SslStreamCertificateContext(X509Certificate2 target, X509Certificate2[] intermediates, SslCertificateTrust? trust)

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.OSX.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.OSX.cs
@@ -9,6 +9,7 @@ namespace System.Net.Security
     {
         // No leaf, no root.
         private const bool TrimRootCertificate = true;
+        private const bool SupportsAddAllAdditionalCertificates = true;
 
         private SslStreamCertificateContext(X509Certificate2 target, X509Certificate2[] intermediates, SslCertificateTrust? trust)
         {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Windows.cs
@@ -9,6 +9,7 @@ namespace System.Net.Security
     {
         // No leaf, include root.
         private const bool TrimRootCertificate = false;
+        private const bool SupportsAddAllAdditionalCertificates = false;
 
         internal static SslStreamCertificateContext Create(X509Certificate2 target)
         {


### PR DESCRIPTION
This patch adds the enableAddAllCerficiatesIfSupported flag to the
SSLStreamCertificateContext.Create() method. This flag is optional and
never change the API specification. If this flag is not set, it will not
change the behavior at all.

Background
----------

SSL negotiation in modern HTTPS web servers requires the multiple trust
paths of SSL intermediate certificates. An example of this is the cross
root certificate technique which is recently widely used including Let's
Encrypt. Cross-root certificates are required to support both legacy and
modern SSL clients. In particular, this patch is needed to resolve the
problem that has been occurring since September 30, 2021 with the
expiration of Let's Encrypt's older CAs. The previous implementation of
SSLStreamCertificateContext.Create() always uses X509Chain.Build() to
create an SSL intermediate certificate chain, even if the developer
specifies multiple intermediate certificates in the
additionalCertificates argument. So only single trust chain will be
left, and all other chains will be deleted. In other words, even if a
developer carefully builds multiple intermediate certificate chains
manually with the additionalCertificates parameter, the previous
SSLStreamCertificateContext.Create() function always leaves only a
single chain out of the multiple chains, and all other chains will
disappear. Therefore the current .NET's SslStream and Kestrel Web Server
implementations are unable to provide the fundamental functionality that
is supported by popular SSL web servers (e.g. Nginx) for modern SSL
applications.

Solution
--------

To solve the above problem, I have created this patch. This patch
introduces the enforceAddAllCerficiatesIfSupported flag. By setting the
additionalCertificates flag to true, it will force all certificates
specified in additionalCertificates to be presented to the counterpart
host as intermediate certificates during SSL negotiation. You can force
OpenSSL PAL to present all certificates specified in
additionalCertificates to the other host as intermediate certificates
during SSL negotiation by setting additionalCertificates to true. In
this case, OpenSSL will present the intermediate certificates to the
counterpart host in the order of the certificates specified in the
additionalCertificates. Thus, the developer can control the order of
intermediate certificates with additionalCertificates. If there are
duplicates in the certificate collection specified by the developer in
additionalCertificates, the duplicates will be automatically removed.

Actual test with Let's Encrypt cross-signing certificate chains
---------------------------------------------------------------

I have tested this SSL improvement in practice using the intermediate
certificate chain that comes with SSL certificates issued by Let's
Encrypt, and it works correctly. This patch is only available for Linux
and OSX using the OpenSSL PAL. Unfortunately, the Win32 platform does
not use OpenSSL PAL and cannot support multiple trust paths due to the
specification of the SSL certificate chain abstracted by the OS.
enforceAddAllCerficiatesIfSupported parameter is simply ignored on
Win32 platforms for safety.