### PR TITLE
Fix a macro usage and cleanup stale comment

### DIFF
--- a/eng/native/gen-buildsys.sh
+++ b/eng/native/gen-buildsys.sh
@@ -116,7 +116,6 @@ fi
 # We have to be able to build with CMake 3.6.2, so we can't use the -S or -B options
 pushd "$2"
 
-# Include CMAKE_USER_MAKE_RULES_OVERRIDE as uninitialized since it will hold its value in the CMake cache otherwise can cause issues when branch switching
 $cmake_command \
   --no-warn-unused-cli \
   -G "$generator" \

--- a/src/coreclr/tools/StressLogAnalyzer/StressLogPlugin/util.h
+++ b/src/coreclr/tools/StressLogAnalyzer/StressLogPlugin/util.h
@@ -19,11 +19,11 @@ typedef void* CRITSEC_COOKIE;
 // Unix L"" is UTF32, and on windows it's UTF16.  Because of built-in assumptions on the size
 // of string literals, it's important to match behaviour between Unix and Windows.  Unix will be defined
 // as u"" (char16_t)
-#ifdef PLATFORM_UNIX
+#ifdef TARGET_UNIX
 #define W(str)  u##str
-#else // PLATFORM_UNIX
+#else // TARGET_UNIX
 #define W(str)  L##str
-#endif // PLATFORM_UNIX
+#endif // TARGET_UNIX
 
 //*****************************************************************************
 //


### PR DESCRIPTION
In fcd862e06413a000f9cafa9d2f359226c60b9b42, the OS and arch definitions were consolidated. 57bfe474518ab5b7cfe6bf7424a79ce3af9d6657 brought back a usage of `PLATFORM_UNIX` which is not defined in runtime repo anymore.

PR replaces it with `TARGET_UNIX` and also cleans up a stale comment about `CMAKE_USER_MAKE_RULES_OVERRIDE` (which is obsolete since https://github.com/dotnet/runtime/commit/f1890a75f5afc6fbd8e4e0ef966523578a8d2813).