### PR TITLE
Fix license header in a few new files

### DIFF
--- a/src/coreclr/tools/Common/Compiler/Logging/CompilerGeneratedState.cs
+++ b/src/coreclr/tools/Common/Compiler/Logging/CompilerGeneratedState.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 

--- a/src/coreclr/tools/Common/Compiler/Logging/ReferenceSource/CompilerGeneratedState.cs
+++ b/src/coreclr/tools/Common/Compiler/Logging/ReferenceSource/CompilerGeneratedState.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using Mono.Cecil;

--- a/src/coreclr/tools/Common/Compiler/Logging/ReferenceSource/MessageContainer.cs
+++ b/src/coreclr/tools/Common/Compiler/Logging/ReferenceSource/MessageContainer.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;

--- a/src/coreclr/tools/Common/Compiler/Logging/ReferenceSource/MessageOrigin.cs
+++ b/src/coreclr/tools/Common/Compiler/Logging/ReferenceSource/MessageOrigin.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;

--- a/src/libraries/System.Collections/tests/Generic/List/List.Generic.Tests.EnsureCapacity.cs
+++ b/src/libraries/System.Collections/tests/Generic/List/List.Generic.Tests.EnsureCapacity.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using Xunit;

--- a/src/tests/JIT/Math/Functions/DivideByConst.cs
+++ b/src/tests/JIT/Math/Functions/DivideByConst.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Runtime.CompilerServices;

--- a/src/tests/JIT/Math/Functions/Double/AbsDouble.cs
+++ b/src/tests/JIT/Math/Functions/Double/AbsDouble.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/AcosDouble.cs
+++ b/src/tests/JIT/Math/Functions/Double/AcosDouble.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/Acosh.cs
+++ b/src/tests/JIT/Math/Functions/Double/Acosh.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/AsinDouble.cs
+++ b/src/tests/JIT/Math/Functions/Double/AsinDouble.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/Asinh.cs
+++ b/src/tests/JIT/Math/Functions/Double/Asinh.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/Atan2Double.cs
+++ b/src/tests/JIT/Math/Functions/Double/Atan2Double.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/AtanDouble.cs
+++ b/src/tests/JIT/Math/Functions/Double/AtanDouble.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/Atanh.cs
+++ b/src/tests/JIT/Math/Functions/Double/Atanh.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/Cbrt.cs
+++ b/src/tests/JIT/Math/Functions/Double/Cbrt.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/CeilingDouble.cs
+++ b/src/tests/JIT/Math/Functions/Double/CeilingDouble.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/CopySignDouble.cs
+++ b/src/tests/JIT/Math/Functions/Double/CopySignDouble.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/CosDouble.cs
+++ b/src/tests/JIT/Math/Functions/Double/CosDouble.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/CoshDouble.cs
+++ b/src/tests/JIT/Math/Functions/Double/CoshDouble.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/ExpDouble.cs
+++ b/src/tests/JIT/Math/Functions/Double/ExpDouble.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/FloorDouble.cs
+++ b/src/tests/JIT/Math/Functions/Double/FloorDouble.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/FusedMultiplyAdd.cs
+++ b/src/tests/JIT/Math/Functions/Double/FusedMultiplyAdd.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/ILogB.cs
+++ b/src/tests/JIT/Math/Functions/Double/ILogB.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/Log10Double.cs
+++ b/src/tests/JIT/Math/Functions/Double/Log10Double.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/Log2.cs
+++ b/src/tests/JIT/Math/Functions/Double/Log2.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/LogDouble.cs
+++ b/src/tests/JIT/Math/Functions/Double/LogDouble.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/MaxDouble.cs
+++ b/src/tests/JIT/Math/Functions/Double/MaxDouble.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/MinDouble.cs
+++ b/src/tests/JIT/Math/Functions/Double/MinDouble.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/PowDouble.cs
+++ b/src/tests/JIT/Math/Functions/Double/PowDouble.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/RoundDouble.cs
+++ b/src/tests/JIT/Math/Functions/Double/RoundDouble.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/ScaleB.cs
+++ b/src/tests/JIT/Math/Functions/Double/ScaleB.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/SinDouble.cs
+++ b/src/tests/JIT/Math/Functions/Double/SinDouble.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/SinhDouble.cs
+++ b/src/tests/JIT/Math/Functions/Double/SinhDouble.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/SqrtDouble.cs
+++ b/src/tests/JIT/Math/Functions/Double/SqrtDouble.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/TanDouble.cs
+++ b/src/tests/JIT/Math/Functions/Double/TanDouble.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Double/TanhDouble.cs
+++ b/src/tests/JIT/Math/Functions/Double/TanhDouble.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/MathTests.cs
+++ b/src/tests/JIT/Math/Functions/MathTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace System.MathBenchmarks
 {

--- a/src/tests/JIT/Math/Functions/Program.cs
+++ b/src/tests/JIT/Math/Functions/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace System.MathBenchmarks
 {

--- a/src/tests/JIT/Math/Functions/Single/AbsSingle.cs
+++ b/src/tests/JIT/Math/Functions/Single/AbsSingle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/AcosSingle.cs
+++ b/src/tests/JIT/Math/Functions/Single/AcosSingle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/Acosh.cs
+++ b/src/tests/JIT/Math/Functions/Single/Acosh.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/AsinSingle.cs
+++ b/src/tests/JIT/Math/Functions/Single/AsinSingle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/Asinh.cs
+++ b/src/tests/JIT/Math/Functions/Single/Asinh.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/Atan2Single.cs
+++ b/src/tests/JIT/Math/Functions/Single/Atan2Single.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/AtanSingle.cs
+++ b/src/tests/JIT/Math/Functions/Single/AtanSingle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/Atanh.cs
+++ b/src/tests/JIT/Math/Functions/Single/Atanh.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/Cbrt.cs
+++ b/src/tests/JIT/Math/Functions/Single/Cbrt.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/CeilingSingle.cs
+++ b/src/tests/JIT/Math/Functions/Single/CeilingSingle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/CopySignSingle.cs
+++ b/src/tests/JIT/Math/Functions/Single/CopySignSingle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/CosSingle.cs
+++ b/src/tests/JIT/Math/Functions/Single/CosSingle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/CoshSingle.cs
+++ b/src/tests/JIT/Math/Functions/Single/CoshSingle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/ExpSingle.cs
+++ b/src/tests/JIT/Math/Functions/Single/ExpSingle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/FloorSingle.cs
+++ b/src/tests/JIT/Math/Functions/Single/FloorSingle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/FusedMultiplyAdd.cs
+++ b/src/tests/JIT/Math/Functions/Single/FusedMultiplyAdd.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/ILogB.cs
+++ b/src/tests/JIT/Math/Functions/Single/ILogB.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/Log10Single.cs
+++ b/src/tests/JIT/Math/Functions/Single/Log10Single.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/Log2.cs
+++ b/src/tests/JIT/Math/Functions/Single/Log2.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/LogSingle.cs
+++ b/src/tests/JIT/Math/Functions/Single/LogSingle.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/MaxSingle.cs
+++ b/src/tests/JIT/Math/Functions/Single/MaxSingle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/MinSingle.cs
+++ b/src/tests/JIT/Math/Functions/Single/MinSingle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/PowSingle.cs
+++ b/src/tests/JIT/Math/Functions/Single/PowSingle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/RoundSingle.cs
+++ b/src/tests/JIT/Math/Functions/Single/RoundSingle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/ScaleB.cs
+++ b/src/tests/JIT/Math/Functions/Single/ScaleB.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/SinSingle.cs
+++ b/src/tests/JIT/Math/Functions/Single/SinSingle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/SinhSingle.cs
+++ b/src/tests/JIT/Math/Functions/Single/SinhSingle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/SqrtSingle.cs
+++ b/src/tests/JIT/Math/Functions/Single/SqrtSingle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/TanSingle.cs
+++ b/src/tests/JIT/Math/Functions/Single/TanSingle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/Math/Functions/Single/TanhSingle.cs
+++ b/src/tests/JIT/Math/Functions/Single/TanhSingle.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/src/tests/JIT/opt/perf/doublenegate/GitHub_57470.cs
+++ b/src/tests/JIT/opt/perf/doublenegate/GitHub_57470.cs
@@ -1,6 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+
 //
 // This file is auto-generated.
 // Seed: -1


### PR DESCRIPTION
Some new code files have brought back the old (three-liner) header since https://github.com/dotnet/runtime/commit/3b6600cbefe6b96706c5315ce184accbb4501f3b was merged.

cc @stephentoub