### PR TITLE
Clean-up crossgen's NuGet dependencies et. al.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -88,6 +88,7 @@
     <StyleCopAnalyzersVersion>1.2.0-beta.304</StyleCopAnalyzersVersion>
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
     <SystemCollectionsVersion>4.3.0</SystemCollectionsVersion>
+    <SystemCollectionsImmutableVersion>5.0.0</SystemCollectionsImmutableVersion>
     <SystemComponentModelAnnotationsVersion>5.0.0</SystemComponentModelAnnotationsVersion>
     <SystemDataSqlClientVersion>4.8.2</SystemDataSqlClientVersion>
     <SystemDataDataSetExtensionsVersion>4.5.0</SystemDataDataSetExtensionsVersion>

--- a/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/ILCompiler.DependencyAnalysisFramework.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/ILCompiler.DependencyAnalysisFramework.csproj
@@ -16,11 +16,8 @@
     <Configurations>Debug;Release;Checked</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Xml.ReaderWriter">
-      <Version>4.3.0</Version>
-    </PackageReference>
     <PackageReference Include="System.Collections.Immutable">
-      <Version>1.3.1</Version>
+      <Version>$(SystemCollectionsImmutableVersion)</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun/ILCompiler.TypeSystem.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.ReadyToRun/ILCompiler.TypeSystem.ReadyToRun.csproj
@@ -26,9 +26,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IO.MemoryMappedFiles">
-      <Version>4.3.0</Version>
-    </PackageReference>
     <PackageReference Include="System.Reflection.Metadata">
       <Version>$(SystemReflectionMetadataVersion)</Version>
     </PackageReference>


### PR DESCRIPTION
This PR removes two unnecessary NuGet packages from crossgen-related projects and updates another one to its latest stable version, helping uncluttering the projects' dependency tree. Furthermore, it optimizes a function in crossgen's entry point to use spans, eliminating allocations.