### PR TITLE
Socket: don't disconnect Socket for unknown/unsupported socket options.

### DIFF
--- a/src/libraries/Native/Unix/System.Native/pal_networking.c
+++ b/src/libraries/Native/Unix/System.Native/pal_networking.c
@@ -1655,7 +1655,7 @@ int32_t SystemNative_GetSocketErrorOption(intptr_t socket, int32_t* error)
     return Error_SUCCESS;
 }
 
-static int32_t TryGetPlatformSocketOption(int32_t socketOptionLevel, int32_t socketOptionName, int* optLevel, int* optName)
+static bool TryGetPlatformSocketOption(int32_t socketOptionLevel, int32_t socketOptionName, int* optLevel, int* optName)
 {
     switch (socketOptionLevel)
     {
@@ -1666,37 +1666,37 @@ static int32_t TryGetPlatformSocketOption(int32_t socketOptionLevel, int32_t soc
             {
                 case SocketOptionName_SO_DEBUG:
                     *optName = SO_DEBUG;
-                    return Error_SUCCESS;
+                    return true;
 
                 case SocketOptionName_SO_ACCEPTCONN:
                     *optName = SO_ACCEPTCONN;
-                    return Error_SUCCESS;
+                    return true;
 
                 case SocketOptionName_SO_REUSEADDR:
                     *optName = SO_REUSEADDR;
-                    return Error_SUCCESS;
+                    return true;
 
                 case SocketOptionName_SO_KEEPALIVE:
                     *optName = SO_KEEPALIVE;
-                    return Error_SUCCESS;
+                    return true;
 
                 case SocketOptionName_SO_DONTROUTE:
                     *optName = SO_DONTROUTE;
-                    return Error_SUCCESS;
+                    return true;
 
                 case SocketOptionName_SO_BROADCAST:
                     *optName = SO_BROADCAST;
-                    return Error_SUCCESS;
+                    return true;
 
                 // case SocketOptionName_SO_USELOOPBACK:
 
                 case SocketOptionName_SO_LINGER:
                     *optName = SO_LINGER;
-                    return Error_SUCCESS;
+                    return true;
 
                 case SocketOptionName_SO_OOBINLINE:
                     *optName = SO_OOBINLINE;
-                    return Error_SUCCESS;
+                    return true;
 
                 // case SocketOptionName_SO_DONTLINGER:
 
@@ -1704,40 +1704,40 @@ static int32_t TryGetPlatformSocketOption(int32_t socketOptionLevel, int32_t soc
 
                 case SocketOptionName_SO_SNDBUF:
                     *optName = SO_SNDBUF;
-                    return Error_SUCCESS;
+                    return true;
 
                 case SocketOptionName_SO_RCVBUF:
                     *optName = SO_RCVBUF;
-                    return Error_SUCCESS;
+                    return true;
 
                 case SocketOptionName_SO_SNDLOWAT:
                     *optName = SO_SNDLOWAT;
-                    return Error_SUCCESS;
+                    return true;
 
                 case SocketOptionName_SO_RCVLOWAT:
                     *optName = SO_RCVLOWAT;
-                    return Error_SUCCESS;
+                    return true;
 
                 case SocketOptionName_SO_SNDTIMEO:
                     *optName = SO_SNDTIMEO;
-                    return Error_SUCCESS;
+                    return true;
 
                 case SocketOptionName_SO_RCVTIMEO:
                     *optName = SO_RCVTIMEO;
-                    return Error_SUCCESS;
+                    return true;
 
                 case SocketOptionName_SO_ERROR:
                     *optName = SO_ERROR;
-                    return Error_SUCCESS;
+                    return true;
 
                 case SocketOptionName_SO_TYPE:
                     *optName = SO_TYPE;
-                    return Error_SUCCESS;
+                    return true;
 
                 // case SocketOptionName_SO_MAXCONN:
 
                 default:
-                    return Error_ENOPROTOOPT;
+                    return false;
             }
 
         case SocketOptionLevel_SOL_IP:
@@ -1747,76 +1747,76 @@ static int32_t TryGetPlatformSocketOption(int32_t socketOptionLevel, int32_t soc
             {
                 case SocketOptionName_SO_IP_OPTIONS:
                     *optName = IP_OPTIONS;
-                    return Error_SUCCESS;
+                    return true;
 
                 case SocketOptionName_SO_IP_HDRINCL:
                     *optName = IP_HDRINCL;
-                    return Error_SUCCESS;
+                    return true;
 
                 case SocketOptionName_SO_IP_TOS:
                     *optName = IP_TOS;
-                    return Error_SUCCESS;
+                    return true;
 
                 case SocketOptionName_SO_IP_TTL:
                     *optName = IP_TTL;
-                    return Error_SUCCESS;
+                    return true;
 
                 case SocketOptionName_SO_IP_MULTICAST_IF:
                     *optName = IP_MULTICAST_IF;
-                    return Error_SUCCESS;
+                    return true;
 
                 case SocketOptionName_SO_IP_MULTICAST_TTL:
                     *optName = IP_MULTICAST_TTL;
-                    return Error_SUCCESS;
+                    return true;
 
                 case SocketOptionName_SO_IP_MULTICAST_LOOP:
                     *optName = IP_MULTICAST_LOOP;
-                    return Error_SUCCESS;
+                    return true;
 
                 case SocketOptionName_SO_IP_ADD_MEMBERSHIP:
                     *optName = IP_ADD_MEMBERSHIP;
-                    return Error_SUCCESS;
+                    return true;
 
                 case SocketOptionName_SO_IP_DROP_MEMBERSHIP:
                     *optName = IP_DROP_MEMBERSHIP;
-                    return Error_SUCCESS;
+                    return true;
 
 #ifdef IP_MTU_DISCOVER
                 case SocketOptionName_SO_IP_DONTFRAGMENT:
                     *optName = IP_MTU_DISCOVER; // option values will also need to be translated
-                    return Error_SUCCESS;
+                    return true;
 #endif
 
 #ifdef IP_ADD_SOURCE_MEMBERSHIP
                 case SocketOptionName_SO_IP_ADD_SOURCE_MEMBERSHIP:
                     *optName = IP_ADD_SOURCE_MEMBERSHIP;
-                    return Error_SUCCESS;
+                    return true;
 #endif
 
 #ifdef IP_DROP_SOURCE_MEMBERSHIP
                 case SocketOptionName_SO_IP_DROP_SOURCE_MEMBERSHIP:
                     *optName = IP_DROP_SOURCE_MEMBERSHIP;
-                    return Error_SUCCESS;
+                    return true;
 #endif
 
 #ifdef IP_BLOCK_SOURCE
                 case SocketOptionName_SO_IP_BLOCK_SOURCE:
                     *optName = IP_BLOCK_SOURCE;
-                    return Error_SUCCESS;
+                    return true;
 #endif
 
 #ifdef IP_UNBLOCK_SOURCE
                 case SocketOptionName_SO_IP_UNBLOCK_SOURCE:
                     *optName = IP_UNBLOCK_SOURCE;
-                    return Error_SUCCESS;
+                    return true;
 #endif
 
                 case SocketOptionName_SO_IP_PKTINFO:
                     *optName = IP_PKTINFO;
-                    return Error_SUCCESS;
+                    return true;
 
                 default:
-                    return Error_ENOPROTOOPT;
+                    return false;
             }
 
         case SocketOptionLevel_SOL_IPV6:
@@ -1826,31 +1826,31 @@ static int32_t TryGetPlatformSocketOption(int32_t socketOptionLevel, int32_t soc
             {
                 case SocketOptionName_SO_IPV6_HOPLIMIT:
                     *optName = IPV6_HOPLIMIT;
-                    return Error_SUCCESS;
+                    return true;
 
                 // case SocketOptionName_SO_IPV6_PROTECTION_LEVEL:
 
                 case SocketOptionName_SO_IPV6_V6ONLY:
                     *optName = IPV6_V6ONLY;
-                    return Error_SUCCESS;
+                    return true;
 
                 case SocketOptionName_SO_IP_PKTINFO:
                     *optName = IPV6_RECVPKTINFO;
-                    return Error_SUCCESS;
+                    return true;
 
                 case SocketOptionName_SO_IP_MULTICAST_IF:
                     *optName = IPV6_MULTICAST_IF;
-                    return Error_SUCCESS;
+                    return true;
 
                 case SocketOptionName_SO_IP_MULTICAST_TTL:
                     *optName = IPV6_MULTICAST_HOPS;
-                    return Error_SUCCESS;
+                    return true;
                 case SocketOptionName_SO_IP_TTL:
                     *optName = IPV6_UNICAST_HOPS;
-                    return Error_SUCCESS;
+                    return true;
 
                 default:
-                    return Error_ENOPROTOOPT;
+                    return false;
             }
 
         case SocketOptionLevel_SOL_TCP:
@@ -1860,13 +1860,13 @@ static int32_t TryGetPlatformSocketOption(int32_t socketOptionLevel, int32_t soc
             {
                 case SocketOptionName_SO_TCP_NODELAY:
                     *optName = TCP_NODELAY;
-                    return Error_SUCCESS;
+                    return true;
 
                 // case SocketOptionName_SO_TCP_BSDURGENT:
 
                 case SocketOptionName_SO_TCP_KEEPALIVE_RETRYCOUNT:
                     *optName = TCP_KEEPCNT;
-                    return Error_SUCCESS;
+                    return true;
 
                 case SocketOptionName_SO_TCP_KEEPALIVE_TIME:
                     *optName =
@@ -1875,14 +1875,14 @@ static int32_t TryGetPlatformSocketOption(int32_t socketOptionLevel, int32_t soc
                     #else
                         TCP_KEEPIDLE;
                     #endif
-                    return Error_SUCCESS;
+                    return true;
 
                 case SocketOptionName_SO_TCP_KEEPALIVE_INTERVAL:
                     *optName = TCP_KEEPINTVL;
-                    return Error_SUCCESS;
+                    return true;
 
                 default:
-                    return Error_ENOPROTOOPT;
+                    return false;
             }
 
         case SocketOptionLevel_SOL_UDP:
@@ -1899,11 +1899,11 @@ static int32_t TryGetPlatformSocketOption(int32_t socketOptionLevel, int32_t soc
                 // case SocketOptionName_SO_UDP_UPDATECONNECTCONTEXT:
 
                 default:
-                    return Error_ENOPROTOOPT;
+                    return false;
             }
 
         default:
-            return Error_ENOTSUP;
+            return false;
     }
 }
 
@@ -2011,14 +2011,13 @@ int32_t SystemNative_GetSockOpt(
     }
 
     int optLevel, optName;
-    int err = TryGetPlatformSocketOption(socketOptionLevel, socketOptionName, &optLevel, &optName);
-    if (err != Error_SUCCESS)
+    if (!TryGetPlatformSocketOption(socketOptionLevel, socketOptionName, &optLevel, &optName))
     {
-        return err;
+        return Error_ENOTSUP;
     }
 
     socklen_t optLen = (socklen_t)*optionLen;
-    err = getsockopt(fd, optLevel, optName, optionValue, &optLen);
+    int err = getsockopt(fd, optLevel, optName, optionValue, &optLen);
 
     if (err != 0)
     {
@@ -2159,13 +2158,12 @@ SystemNative_SetSockOpt(intptr_t socket, int32_t socketOptionLevel, int32_t sock
 #endif
 
     int optLevel, optName;
-    int err = TryGetPlatformSocketOption(socketOptionLevel, socketOptionName, &optLevel, &optName);
-    if (err != Error_SUCCESS)
+    if (!TryGetPlatformSocketOption(socketOptionLevel, socketOptionName, &optLevel, &optName))
     {
-        return err;
+        return Error_ENOTSUP;
     }
 
-    err = setsockopt(fd, optLevel, optName, optionValue, (socklen_t)optionLen);
+    int err = setsockopt(fd, optLevel, optName, optionValue, (socklen_t)optionLen);
     return err == 0 ? Error_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 

--- a/src/libraries/Native/Unix/System.Native/pal_networking.c
+++ b/src/libraries/Native/Unix/System.Native/pal_networking.c
@@ -2013,7 +2013,7 @@ int32_t SystemNative_GetSockOpt(
     int optLevel, optName;
     if (!TryGetPlatformSocketOption(socketOptionLevel, socketOptionName, &optLevel, &optName))
     {
-        return Error_ENOTSUP;
+        return Error_ENOPROTOOPT;
     }
 
     socklen_t optLen = (socklen_t)*optionLen;
@@ -2160,7 +2160,7 @@ SystemNative_SetSockOpt(intptr_t socket, int32_t socketOptionLevel, int32_t sock
     int optLevel, optName;
     if (!TryGetPlatformSocketOption(socketOptionLevel, socketOptionName, &optLevel, &optName))
     {
-        return Error_ENOTSUP;
+        return Error_ENOPROTOOPT;
     }
 
     int err = setsockopt(fd, optLevel, optName, optionValue, (socklen_t)optionLen);

--- a/src/libraries/Native/Unix/System.Native/pal_networking.c
+++ b/src/libraries/Native/Unix/System.Native/pal_networking.c
@@ -1655,7 +1655,7 @@ int32_t SystemNative_GetSocketErrorOption(intptr_t socket, int32_t* error)
     return Error_SUCCESS;
 }
 
-static bool TryGetPlatformSocketOption(int32_t socketOptionLevel, int32_t socketOptionName, int* optLevel, int* optName)
+static int32_t TryGetPlatformSocketOption(int32_t socketOptionLevel, int32_t socketOptionName, int* optLevel, int* optName)
 {
     switch (socketOptionLevel)
     {
@@ -1666,37 +1666,37 @@ static bool TryGetPlatformSocketOption(int32_t socketOptionLevel, int32_t socket
             {
                 case SocketOptionName_SO_DEBUG:
                     *optName = SO_DEBUG;
-                    return true;
+                    return Error_SUCCESS;
 
                 case SocketOptionName_SO_ACCEPTCONN:
                     *optName = SO_ACCEPTCONN;
-                    return true;
+                    return Error_SUCCESS;
 
                 case SocketOptionName_SO_REUSEADDR:
                     *optName = SO_REUSEADDR;
-                    return true;
+                    return Error_SUCCESS;
 
                 case SocketOptionName_SO_KEEPALIVE:
                     *optName = SO_KEEPALIVE;
-                    return true;
+                    return Error_SUCCESS;
 
                 case SocketOptionName_SO_DONTROUTE:
                     *optName = SO_DONTROUTE;
-                    return true;
+                    return Error_SUCCESS;
 
                 case SocketOptionName_SO_BROADCAST:
                     *optName = SO_BROADCAST;
-                    return true;
+                    return Error_SUCCESS;
 
                 // case SocketOptionName_SO_USELOOPBACK:
 
                 case SocketOptionName_SO_LINGER:
                     *optName = SO_LINGER;
-                    return true;
+                    return Error_SUCCESS;
 
                 case SocketOptionName_SO_OOBINLINE:
                     *optName = SO_OOBINLINE;
-                    return true;
+                    return Error_SUCCESS;
 
                 // case SocketOptionName_SO_DONTLINGER:
 
@@ -1704,40 +1704,40 @@ static bool TryGetPlatformSocketOption(int32_t socketOptionLevel, int32_t socket
 
                 case SocketOptionName_SO_SNDBUF:
                     *optName = SO_SNDBUF;
-                    return true;
+                    return Error_SUCCESS;
 
                 case SocketOptionName_SO_RCVBUF:
                     *optName = SO_RCVBUF;
-                    return true;
+                    return Error_SUCCESS;
 
                 case SocketOptionName_SO_SNDLOWAT:
                     *optName = SO_SNDLOWAT;
-                    return true;
+                    return Error_SUCCESS;
 
                 case SocketOptionName_SO_RCVLOWAT:
                     *optName = SO_RCVLOWAT;
-                    return true;
+                    return Error_SUCCESS;
 
                 case SocketOptionName_SO_SNDTIMEO:
                     *optName = SO_SNDTIMEO;
-                    return true;
+                    return Error_SUCCESS;
 
                 case SocketOptionName_SO_RCVTIMEO:
                     *optName = SO_RCVTIMEO;
-                    return true;
+                    return Error_SUCCESS;
 
                 case SocketOptionName_SO_ERROR:
                     *optName = SO_ERROR;
-                    return true;
+                    return Error_SUCCESS;
 
                 case SocketOptionName_SO_TYPE:
                     *optName = SO_TYPE;
-                    return true;
+                    return Error_SUCCESS;
 
                 // case SocketOptionName_SO_MAXCONN:
 
                 default:
-                    return false;
+                    return Error_ENOPROTOOPT;
             }
 
         case SocketOptionLevel_SOL_IP:
@@ -1747,76 +1747,76 @@ static bool TryGetPlatformSocketOption(int32_t socketOptionLevel, int32_t socket
             {
                 case SocketOptionName_SO_IP_OPTIONS:
                     *optName = IP_OPTIONS;
-                    return true;
+                    return Error_SUCCESS;
 
                 case SocketOptionName_SO_IP_HDRINCL:
                     *optName = IP_HDRINCL;
-                    return true;
+                    return Error_SUCCESS;
 
                 case SocketOptionName_SO_IP_TOS:
                     *optName = IP_TOS;
-                    return true;
+                    return Error_SUCCESS;
 
                 case SocketOptionName_SO_IP_TTL:
                     *optName = IP_TTL;
-                    return true;
+                    return Error_SUCCESS;
 
                 case SocketOptionName_SO_IP_MULTICAST_IF:
                     *optName = IP_MULTICAST_IF;
-                    return true;
+                    return Error_SUCCESS;
 
                 case SocketOptionName_SO_IP_MULTICAST_TTL:
                     *optName = IP_MULTICAST_TTL;
-                    return true;
+                    return Error_SUCCESS;
 
                 case SocketOptionName_SO_IP_MULTICAST_LOOP:
                     *optName = IP_MULTICAST_LOOP;
-                    return true;
+                    return Error_SUCCESS;
 
                 case SocketOptionName_SO_IP_ADD_MEMBERSHIP:
                     *optName = IP_ADD_MEMBERSHIP;
-                    return true;
+                    return Error_SUCCESS;
 
                 case SocketOptionName_SO_IP_DROP_MEMBERSHIP:
                     *optName = IP_DROP_MEMBERSHIP;
-                    return true;
+                    return Error_SUCCESS;
 
 #ifdef IP_MTU_DISCOVER
                 case SocketOptionName_SO_IP_DONTFRAGMENT:
                     *optName = IP_MTU_DISCOVER; // option values will also need to be translated
-                    return true;
+                    return Error_SUCCESS;
 #endif
 
 #ifdef IP_ADD_SOURCE_MEMBERSHIP
                 case SocketOptionName_SO_IP_ADD_SOURCE_MEMBERSHIP:
                     *optName = IP_ADD_SOURCE_MEMBERSHIP;
-                    return true;
+                    return Error_SUCCESS;
 #endif
 
 #ifdef IP_DROP_SOURCE_MEMBERSHIP
                 case SocketOptionName_SO_IP_DROP_SOURCE_MEMBERSHIP:
                     *optName = IP_DROP_SOURCE_MEMBERSHIP;
-                    return true;
+                    return Error_SUCCESS;
 #endif
 
 #ifdef IP_BLOCK_SOURCE
                 case SocketOptionName_SO_IP_BLOCK_SOURCE:
                     *optName = IP_BLOCK_SOURCE;
-                    return true;
+                    return Error_SUCCESS;
 #endif
 
 #ifdef IP_UNBLOCK_SOURCE
                 case SocketOptionName_SO_IP_UNBLOCK_SOURCE:
                     *optName = IP_UNBLOCK_SOURCE;
-                    return true;
+                    return Error_SUCCESS;
 #endif
 
                 case SocketOptionName_SO_IP_PKTINFO:
                     *optName = IP_PKTINFO;
-                    return true;
+                    return Error_SUCCESS;
 
                 default:
-                    return false;
+                    return Error_ENOPROTOOPT;
             }
 
         case SocketOptionLevel_SOL_IPV6:
@@ -1826,31 +1826,31 @@ static bool TryGetPlatformSocketOption(int32_t socketOptionLevel, int32_t socket
             {
                 case SocketOptionName_SO_IPV6_HOPLIMIT:
                     *optName = IPV6_HOPLIMIT;
-                    return true;
+                    return Error_SUCCESS;
 
                 // case SocketOptionName_SO_IPV6_PROTECTION_LEVEL:
 
                 case SocketOptionName_SO_IPV6_V6ONLY:
                     *optName = IPV6_V6ONLY;
-                    return true;
+                    return Error_SUCCESS;
 
                 case SocketOptionName_SO_IP_PKTINFO:
                     *optName = IPV6_RECVPKTINFO;
-                    return true;
+                    return Error_SUCCESS;
 
                 case SocketOptionName_SO_IP_MULTICAST_IF:
                     *optName = IPV6_MULTICAST_IF;
-                    return true;
+                    return Error_SUCCESS;
 
                 case SocketOptionName_SO_IP_MULTICAST_TTL:
                     *optName = IPV6_MULTICAST_HOPS;
-                    return true;
+                    return Error_SUCCESS;
                 case SocketOptionName_SO_IP_TTL:
                     *optName = IPV6_UNICAST_HOPS;
-                    return true;
+                    return Error_SUCCESS;
 
                 default:
-                    return false;
+                    return Error_ENOPROTOOPT;
             }
 
         case SocketOptionLevel_SOL_TCP:
@@ -1860,13 +1860,13 @@ static bool TryGetPlatformSocketOption(int32_t socketOptionLevel, int32_t socket
             {
                 case SocketOptionName_SO_TCP_NODELAY:
                     *optName = TCP_NODELAY;
-                    return true;
+                    return Error_SUCCESS;
 
                 // case SocketOptionName_SO_TCP_BSDURGENT:
 
                 case SocketOptionName_SO_TCP_KEEPALIVE_RETRYCOUNT:
                     *optName = TCP_KEEPCNT;
-                    return true;
+                    return Error_SUCCESS;
 
                 case SocketOptionName_SO_TCP_KEEPALIVE_TIME:
                     *optName =
@@ -1875,14 +1875,14 @@ static bool TryGetPlatformSocketOption(int32_t socketOptionLevel, int32_t socket
                     #else
                         TCP_KEEPIDLE;
                     #endif
-                    return true;
+                    return Error_SUCCESS;
 
                 case SocketOptionName_SO_TCP_KEEPALIVE_INTERVAL:
                     *optName = TCP_KEEPINTVL;
-                    return true;
+                    return Error_SUCCESS;
 
                 default:
-                    return false;
+                    return Error_ENOPROTOOPT;
             }
 
         case SocketOptionLevel_SOL_UDP:
@@ -1899,11 +1899,11 @@ static bool TryGetPlatformSocketOption(int32_t socketOptionLevel, int32_t socket
                 // case SocketOptionName_SO_UDP_UPDATECONNECTCONTEXT:
 
                 default:
-                    return false;
+                    return Error_ENOPROTOOPT;
             }
 
         default:
-            return false;
+            return Error_ENOTSUP;
     }
 }
 
@@ -2011,13 +2011,14 @@ int32_t SystemNative_GetSockOpt(
     }
 
     int optLevel, optName;
-    if (!TryGetPlatformSocketOption(socketOptionLevel, socketOptionName, &optLevel, &optName))
+    int err = TryGetPlatformSocketOption(socketOptionLevel, socketOptionName, &optLevel, &optName);
+    if (err != Error_SUCCESS)
     {
-        return Error_ENOPROTOOPT;
+        return err;
     }
 
     socklen_t optLen = (socklen_t)*optionLen;
-    int err = getsockopt(fd, optLevel, optName, optionValue, &optLen);
+    err = getsockopt(fd, optLevel, optName, optionValue, &optLen);
 
     if (err != 0)
     {
@@ -2158,12 +2159,13 @@ SystemNative_SetSockOpt(intptr_t socket, int32_t socketOptionLevel, int32_t sock
 #endif
 
     int optLevel, optName;
-    if (!TryGetPlatformSocketOption(socketOptionLevel, socketOptionName, &optLevel, &optName))
+    int err = TryGetPlatformSocketOption(socketOptionLevel, socketOptionName, &optLevel, &optName);
+    if (err != Error_SUCCESS)
     {
-        return Error_ENOPROTOOPT;
+        return err;
     }
 
-    int err = setsockopt(fd, optLevel, optName, optionValue, (socklen_t)optionLen);
+    err = setsockopt(fd, optLevel, optName, optionValue, (socklen_t)optionLen);
     return err == 0 ? Error_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -3693,8 +3693,7 @@ namespace System.Net.Sockets
         private void UpdateStatusAfterSocketOptionErrorAndThrowException(SocketError error, [CallerMemberName] string? callerName = null)
         {
             // Don't disconnect socket for unknown options.
-            bool noDisconnect = error == SocketError.ProtocolOption ||
-                                error == SocketError.OperationNotSupported;
+            bool noDisconnect = error == SocketError.ProtocolOption;
             UpdateStatusAfterSocketErrorAndThrowException(error, callerName, noDisconnect);
         }
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -3693,7 +3693,8 @@ namespace System.Net.Sockets
         private void UpdateStatusAfterSocketOptionErrorAndThrowException(SocketError error, [CallerMemberName] string? callerName = null)
         {
             // Don't disconnect socket for unknown options.
-            bool disconnectOnFailure = error != SocketError.ProtocolOption;
+            bool disconnectOnFailure = error != SocketError.ProtocolOption &&
+                                       error != SocketError.OperationNotSupported;
             UpdateStatusAfterSocketErrorAndThrowException(error, disconnectOnFailure, callerName);
         }
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -1933,7 +1933,7 @@ namespace System.Net.Sockets
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
             {
-                UpdateStatusAfterSocketErrorAndThrowException(errorCode);
+                UpdateStatusAfterSocketOptionErrorAndThrowException(errorCode);
             }
         }
 
@@ -2015,7 +2015,7 @@ namespace System.Net.Sockets
 
             if (errorCode != SocketError.Success)
             {
-                UpdateStatusAfterSocketErrorAndThrowException(errorCode);
+                UpdateStatusAfterSocketOptionErrorAndThrowException(errorCode);
             }
         }
 
@@ -2051,7 +2051,7 @@ namespace System.Net.Sockets
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
             {
-                UpdateStatusAfterSocketErrorAndThrowException(errorCode);
+                UpdateStatusAfterSocketOptionErrorAndThrowException(errorCode);
             }
 
             return optionValue;
@@ -2076,7 +2076,7 @@ namespace System.Net.Sockets
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
             {
-                UpdateStatusAfterSocketErrorAndThrowException(errorCode);
+                UpdateStatusAfterSocketOptionErrorAndThrowException(errorCode);
             }
         }
 
@@ -2100,7 +2100,7 @@ namespace System.Net.Sockets
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
             {
-                UpdateStatusAfterSocketErrorAndThrowException(errorCode);
+                UpdateStatusAfterSocketOptionErrorAndThrowException(errorCode);
             }
 
             if (optionLength != realOptionLength)
@@ -2136,7 +2136,7 @@ namespace System.Net.Sockets
 
             if (errorCode != SocketError.Success)
             {
-                UpdateStatusAfterSocketErrorAndThrowException(errorCode);
+                UpdateStatusAfterSocketOptionErrorAndThrowException(errorCode);
             }
 
             return realOptionLength;
@@ -3432,7 +3432,7 @@ namespace System.Net.Sockets
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
             {
-                UpdateStatusAfterSocketErrorAndThrowException(errorCode);
+                UpdateStatusAfterSocketOptionErrorAndThrowException(errorCode);
             }
         }
 
@@ -3445,7 +3445,7 @@ namespace System.Net.Sockets
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
             {
-                UpdateStatusAfterSocketErrorAndThrowException(errorCode);
+                UpdateStatusAfterSocketOptionErrorAndThrowException(errorCode);
             }
         }
 
@@ -3472,7 +3472,7 @@ namespace System.Net.Sockets
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
             {
-                UpdateStatusAfterSocketErrorAndThrowException(errorCode);
+                UpdateStatusAfterSocketOptionErrorAndThrowException(errorCode);
             }
         }
 
@@ -3486,7 +3486,7 @@ namespace System.Net.Sockets
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
             {
-                UpdateStatusAfterSocketErrorAndThrowException(errorCode);
+                UpdateStatusAfterSocketOptionErrorAndThrowException(errorCode);
             }
 
             return lingerOption;
@@ -3502,7 +3502,7 @@ namespace System.Net.Sockets
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
             {
-                UpdateStatusAfterSocketErrorAndThrowException(errorCode);
+                UpdateStatusAfterSocketOptionErrorAndThrowException(errorCode);
             }
 
             return multicastOption;
@@ -3519,7 +3519,7 @@ namespace System.Net.Sockets
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
             {
-                UpdateStatusAfterSocketErrorAndThrowException(errorCode);
+                UpdateStatusAfterSocketOptionErrorAndThrowException(errorCode);
             }
 
             return multicastOption;
@@ -3690,11 +3690,19 @@ namespace System.Net.Sockets
             }
         }
 
-        private void UpdateStatusAfterSocketErrorAndThrowException(SocketError error, [CallerMemberName] string? callerName = null)
+        private void UpdateStatusAfterSocketOptionErrorAndThrowException(SocketError error, [CallerMemberName] string? callerName = null)
+        {
+            // Don't disconnect socket for unknown options.
+            bool noDisconnect = error == SocketError.ProtocolOption ||
+                                error == SocketError.OperationNotSupported;
+            UpdateStatusAfterSocketErrorAndThrowException(error, callerName, noDisconnect);
+        }
+
+        private void UpdateStatusAfterSocketErrorAndThrowException(SocketError error, [CallerMemberName] string? callerName = null, bool noDisconnect = false)
         {
             // Update the internal state of this socket according to the error before throwing.
             var socketException = new SocketException((int)error);
-            UpdateStatusAfterSocketError(socketException);
+            UpdateStatusAfterSocketError(socketException, noDisconnect);
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, socketException, memberName: callerName);
             throw socketException;
         }
@@ -3702,18 +3710,18 @@ namespace System.Net.Sockets
         // UpdateStatusAfterSocketError(socketException) - updates the status of a connected socket
         // on which a failure occurred. it'll go to winsock and check if the connection
         // is still open and if it needs to update our internal state.
-        internal void UpdateStatusAfterSocketError(SocketException socketException)
+        internal void UpdateStatusAfterSocketError(SocketException socketException, bool noDisconnect = false)
         {
-            UpdateStatusAfterSocketError(socketException.SocketErrorCode);
+            UpdateStatusAfterSocketError(socketException.SocketErrorCode, noDisconnect);
         }
 
-        internal void UpdateStatusAfterSocketError(SocketError errorCode)
+        internal void UpdateStatusAfterSocketError(SocketError errorCode, bool noDisconnect = false)
         {
             // If we already know the socket is disconnected
             // we don't need to do anything else.
-            if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"errorCode:{errorCode}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"errorCode:{errorCode},noDisconnect:{noDisconnect}");
 
-            if (_isConnected && (_handle.IsInvalid || (errorCode != SocketError.WouldBlock &&
+            if (!noDisconnect && _isConnected && (_handle.IsInvalid || (errorCode != SocketError.WouldBlock &&
                     errorCode != SocketError.IOPending && errorCode != SocketError.NoBufferSpaceAvailable &&
                     errorCode != SocketError.TimedOut)))
             {

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -27,7 +27,7 @@ namespace System.Net.Sockets.Tests
                 }
                 else
                 {
-                    Assert.Throws<SocketException>(() => socket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseUnicastPort));
+                    SocketException se = Assert.Throws<SocketException>(() => socket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseUnicastPort));
                 }
             }
         }
@@ -45,7 +45,7 @@ namespace System.Net.Sockets.Tests
                 }
                 else
                 {
-                    Assert.Throws<SocketException>(() => socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseUnicastPort, 1));
+                    SocketException se = Assert.Throws<SocketException>(() => socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseUnicastPort, 1));
                 }
             }
         }
@@ -60,7 +60,7 @@ namespace System.Net.Sockets.Tests
             {
                 socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, new MulticastOption(groupIp, interfaceIndex));
 
-                Assert.Throws<SocketException>(() => socket.GetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership));
+                SocketException se = Assert.Throws<SocketException>(() => socket.GetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership));
             }
         }
 
@@ -115,7 +115,7 @@ namespace System.Net.Sockets.Tests
             int interfaceIndex = 31415;
             using (Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
             {
-                Assert.Throws<SocketException>(() =>
+                SocketException se = Assert.Throws<SocketException>(() =>
                     s.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastInterface, IPAddress.HostToNetworkOrder(interfaceIndex)));
             }
         }
@@ -222,7 +222,7 @@ namespace System.Net.Sockets.Tests
             int interfaceIndex = 31415;
             using (Socket s = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp))
             {
-                Assert.Throws<SocketException>(() =>
+                SocketException se = Assert.Throws<SocketException>(() =>
                                                s.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.MulticastInterface, interfaceIndex));
             }
         }
@@ -569,11 +569,11 @@ namespace System.Net.Sockets.Tests
             using (socket1)
             using (socket2)
             {
-                Assert.True(socket1.Connected);
+                SocketException se = Assert.Throws<SocketException>(() => socket1.GetSocketOption((SocketOptionLevel)(-1), (SocketOptionName)(-1)));
+                Assert.True(se.SocketErrorCode == SocketError.ProtocolOption ||
+                            se.SocketErrorCode == SocketError.OperationNotSupported, $"SocketError: {se.SocketErrorCode}");
 
-                Assert.Throws<SocketException>(() => socket1.GetSocketOption((SocketOptionLevel)(-1), (SocketOptionName)(-1)));
-
-                Assert.True(socket1.Connected);
+                Assert.True(socket1.Connected, "Connected");
             }
         }
 
@@ -584,12 +584,12 @@ namespace System.Net.Sockets.Tests
             using (socket1)
             using (socket2)
             {
-                Assert.True(socket1.Connected);
-
                 var optionValue = new byte[4];
-                Assert.Throws<SocketException>(() => socket1.GetSocketOption((SocketOptionLevel)(-1), (SocketOptionName)(-1), optionValue));
+                SocketException se = Assert.Throws<SocketException>(() => socket1.GetSocketOption((SocketOptionLevel)(-1), (SocketOptionName)(-1), optionValue));
+                Assert.True(se.SocketErrorCode == SocketError.ProtocolOption ||
+                            se.SocketErrorCode == SocketError.OperationNotSupported, $"SocketError: {se.SocketErrorCode}");
 
-                Assert.True(socket1.Connected);
+                Assert.True(socket1.Connected, "Connected");
             }
         }
 
@@ -600,11 +600,11 @@ namespace System.Net.Sockets.Tests
             using (socket1)
             using (socket2)
             {
-                Assert.True(socket1.Connected);
+                SocketException se = Assert.Throws<SocketException>(() => socket1.GetSocketOption((SocketOptionLevel)(-1), (SocketOptionName)(-1), optionLength: 4));
+                Assert.True(se.SocketErrorCode == SocketError.ProtocolOption ||
+                            se.SocketErrorCode == SocketError.OperationNotSupported, $"SocketError: {se.SocketErrorCode}");
 
-                Assert.Throws<SocketException>(() => socket1.GetSocketOption((SocketOptionLevel)(-1), (SocketOptionName)(-1), optionLength: 4));
-
-                Assert.True(socket1.Connected);
+                Assert.True(socket1.Connected, "Connected");
             }
         }
 
@@ -615,11 +615,11 @@ namespace System.Net.Sockets.Tests
             using (socket1)
             using (socket2)
             {
-                Assert.True(socket1.Connected);
+                SocketException se = Assert.Throws<SocketException>(() => socket1.SetSocketOption((SocketOptionLevel)(-1), (SocketOptionName)(-1), optionValue: 1));
+                Assert.True(se.SocketErrorCode == SocketError.ProtocolOption ||
+                            se.SocketErrorCode == SocketError.OperationNotSupported, $"SocketError: {se.SocketErrorCode}");
 
-                Assert.Throws<SocketException>(() => socket1.SetSocketOption((SocketOptionLevel)(-1), (SocketOptionName)(-1), optionValue: 1));
-
-                Assert.True(socket1.Connected);
+                Assert.True(socket1.Connected, "Connected");
             }
         }
 
@@ -630,12 +630,12 @@ namespace System.Net.Sockets.Tests
             using (socket1)
             using (socket2)
             {
-                Assert.True(socket1.Connected);
-
                 var optionValue = new byte[4];
-                Assert.Throws<SocketException>(() => socket1.SetSocketOption((SocketOptionLevel)(-1), (SocketOptionName)(-1), optionValue));
+                SocketException se = Assert.Throws<SocketException>(() => socket1.SetSocketOption((SocketOptionLevel)(-1), (SocketOptionName)(-1), optionValue));
+                Assert.True(se.SocketErrorCode == SocketError.ProtocolOption ||
+                            se.SocketErrorCode == SocketError.OperationNotSupported, $"SocketError: {se.SocketErrorCode}");
 
-                Assert.True(socket1.Connected);
+                Assert.True(socket1.Connected, "Connected");
             }
         }
 
@@ -646,12 +646,12 @@ namespace System.Net.Sockets.Tests
             using (socket1)
             using (socket2)
             {
-                Assert.True(socket1.Connected);
-
                 bool optionValue = true;
-                Assert.Throws<SocketException>(() => socket1.SetSocketOption((SocketOptionLevel)(-1), (SocketOptionName)(-1), optionValue));
+                SocketException se = Assert.Throws<SocketException>(() => socket1.SetSocketOption((SocketOptionLevel)(-1), (SocketOptionName)(-1), optionValue));
+                Assert.True(se.SocketErrorCode == SocketError.ProtocolOption ||
+                            se.SocketErrorCode == SocketError.OperationNotSupported, $"SocketError: {se.SocketErrorCode}");
 
-                Assert.True(socket1.Connected);
+                Assert.True(socket1.Connected, "Connected");
             }
         }
 
@@ -662,12 +662,12 @@ namespace System.Net.Sockets.Tests
             using (socket1)
             using (socket2)
             {
-                Assert.True(socket1.Connected);
-
                 var optionValue = new byte[4];
-                Assert.Throws<SocketException>(() => socket1.GetRawSocketOption(-1, -1, optionValue));
+                SocketException se = Assert.Throws<SocketException>(() => socket1.GetRawSocketOption(-1, -1, optionValue));
+                Assert.True(se.SocketErrorCode == SocketError.ProtocolOption ||
+                            se.SocketErrorCode == SocketError.OperationNotSupported, $"SocketError: {se.SocketErrorCode}");
 
-                Assert.True(socket1.Connected);
+                Assert.True(socket1.Connected, "Connected");
             }
         }
 
@@ -678,12 +678,12 @@ namespace System.Net.Sockets.Tests
             using (socket1)
             using (socket2)
             {
-                Assert.True(socket1.Connected);
-
                 var optionValue = new byte[4];
-                Assert.Throws<SocketException>(() => socket1.SetRawSocketOption(-1, -1, optionValue));
+                SocketException se = Assert.Throws<SocketException>(() => socket1.SetRawSocketOption(-1, -1, optionValue));
+                Assert.True(se.SocketErrorCode == SocketError.ProtocolOption ||
+                            se.SocketErrorCode == SocketError.OperationNotSupported, $"SocketError: {se.SocketErrorCode}");
 
-                Assert.True(socket1.Connected);
+                Assert.True(socket1.Connected, "Connected");
             }
         }
     }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -562,6 +562,130 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [Fact]
+        public void GetUnsupportedSocketOption_DoesNotDisconnectSocket()
+        {
+            (Socket socket1, Socket socket2) = SocketTestExtensions.CreateConnectedSocketPair();
+            using (socket1)
+            using (socket2)
+            {
+                Assert.True(socket1.Connected);
+
+                Assert.Throws<SocketException>(() => socket1.GetSocketOption((SocketOptionLevel)(-1), (SocketOptionName)(-1)));
+
+                Assert.True(socket1.Connected);
+            }
+        }
+
+        [Fact]
+        public void GetUnsupportedSocketOptionBytesArg_DoesNotDisconnectSocket()
+        {
+            (Socket socket1, Socket socket2) = SocketTestExtensions.CreateConnectedSocketPair();
+            using (socket1)
+            using (socket2)
+            {
+                Assert.True(socket1.Connected);
+
+                var optionValue = new byte[4];
+                Assert.Throws<SocketException>(() => socket1.GetSocketOption((SocketOptionLevel)(-1), (SocketOptionName)(-1), optionValue));
+
+                Assert.True(socket1.Connected);
+            }
+        }
+
+        [Fact]
+        public void GetUnsupportedSocketOptionLengthArg_DoesNotDisconnectSocket()
+        {
+            (Socket socket1, Socket socket2) = SocketTestExtensions.CreateConnectedSocketPair();
+            using (socket1)
+            using (socket2)
+            {
+                Assert.True(socket1.Connected);
+
+                Assert.Throws<SocketException>(() => socket1.GetSocketOption((SocketOptionLevel)(-1), (SocketOptionName)(-1), optionLength: 4));
+
+                Assert.True(socket1.Connected);
+            }
+        }
+
+        [Fact]
+        public void SetUnsupportedSocketOptionIntArg_DoesNotDisconnectSocket()
+        {
+            (Socket socket1, Socket socket2) = SocketTestExtensions.CreateConnectedSocketPair();
+            using (socket1)
+            using (socket2)
+            {
+                Assert.True(socket1.Connected);
+
+                Assert.Throws<SocketException>(() => socket1.SetSocketOption((SocketOptionLevel)(-1), (SocketOptionName)(-1), optionValue: 1));
+
+                Assert.True(socket1.Connected);
+            }
+        }
+
+        [Fact]
+        public void SetUnsupportedSocketOptionBytesArg_DoesNotDisconnectSocket()
+        {
+            (Socket socket1, Socket socket2) = SocketTestExtensions.CreateConnectedSocketPair();
+            using (socket1)
+            using (socket2)
+            {
+                Assert.True(socket1.Connected);
+
+                var optionValue = new byte[4];
+                Assert.Throws<SocketException>(() => socket1.SetSocketOption((SocketOptionLevel)(-1), (SocketOptionName)(-1), optionValue));
+
+                Assert.True(socket1.Connected);
+            }
+        }
+
+        [Fact]
+        public void SetUnsupportedSocketOptionBoolArg_DoesNotDisconnectSocket()
+        {
+            (Socket socket1, Socket socket2) = SocketTestExtensions.CreateConnectedSocketPair();
+            using (socket1)
+            using (socket2)
+            {
+                Assert.True(socket1.Connected);
+
+                bool optionValue = true;
+                Assert.Throws<SocketException>(() => socket1.SetSocketOption((SocketOptionLevel)(-1), (SocketOptionName)(-1), optionValue));
+
+                Assert.True(socket1.Connected);
+            }
+        }
+
+        [Fact]
+        public void GetUnsupportedRawSocketOption_DoesNotDisconnectSocket()
+        {
+            (Socket socket1, Socket socket2) = SocketTestExtensions.CreateConnectedSocketPair();
+            using (socket1)
+            using (socket2)
+            {
+                Assert.True(socket1.Connected);
+
+                var optionValue = new byte[4];
+                Assert.Throws<SocketException>(() => socket1.GetRawSocketOption(-1, -1, optionValue));
+
+                Assert.True(socket1.Connected);
+            }
+        }
+
+        [Fact]
+        public void SetUnsupportedRawSocketOption_DoesNotDisconnectSocket()
+        {
+            (Socket socket1, Socket socket2) = SocketTestExtensions.CreateConnectedSocketPair();
+            using (socket1)
+            using (socket2)
+            {
+                Assert.True(socket1.Connected);
+
+                var optionValue = new byte[4];
+                Assert.Throws<SocketException>(() => socket1.SetRawSocketOption(-1, -1, optionValue));
+
+                Assert.True(socket1.Connected);
+            }
+        }
     }
 
     [Collection("NoParallelTests")]

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -27,7 +27,7 @@ namespace System.Net.Sockets.Tests
                 }
                 else
                 {
-                    SocketException se = Assert.Throws<SocketException>(() => socket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseUnicastPort));
+                    Assert.Throws<SocketException>(() => socket.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseUnicastPort));
                 }
             }
         }
@@ -45,7 +45,7 @@ namespace System.Net.Sockets.Tests
                 }
                 else
                 {
-                    SocketException se = Assert.Throws<SocketException>(() => socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseUnicastPort, 1));
+                    Assert.Throws<SocketException>(() => socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseUnicastPort, 1));
                 }
             }
         }
@@ -60,7 +60,7 @@ namespace System.Net.Sockets.Tests
             {
                 socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership, new MulticastOption(groupIp, interfaceIndex));
 
-                SocketException se = Assert.Throws<SocketException>(() => socket.GetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership));
+                Assert.Throws<SocketException>(() => socket.GetSocketOption(SocketOptionLevel.IP, SocketOptionName.AddMembership));
             }
         }
 
@@ -115,7 +115,7 @@ namespace System.Net.Sockets.Tests
             int interfaceIndex = 31415;
             using (Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
             {
-                SocketException se = Assert.Throws<SocketException>(() =>
+                Assert.Throws<SocketException>(() =>
                     s.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastInterface, IPAddress.HostToNetworkOrder(interfaceIndex)));
             }
         }
@@ -222,7 +222,7 @@ namespace System.Net.Sockets.Tests
             int interfaceIndex = 31415;
             using (Socket s = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp))
             {
-                SocketException se = Assert.Throws<SocketException>(() =>
+                Assert.Throws<SocketException>(() =>
                                                s.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.MulticastInterface, interfaceIndex));
             }
         }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -569,7 +569,7 @@ namespace System.Net.Sockets.Tests
             using (socket1)
             using (socket2)
             {
-                SocketException se = Assert.Throws<SocketException>(() => socket1.GetSocketOption((SocketOptionLevel)(-1), (SocketOptionName)(-1)));
+                SocketException se = Assert.Throws<SocketException>(() => socket1.GetSocketOption(SocketOptionLevel.Socket, (SocketOptionName)(-1)));
                 Assert.True(se.SocketErrorCode == SocketError.ProtocolOption ||
                             se.SocketErrorCode == SocketError.OperationNotSupported, $"SocketError: {se.SocketErrorCode}");
 
@@ -585,7 +585,7 @@ namespace System.Net.Sockets.Tests
             using (socket2)
             {
                 var optionValue = new byte[4];
-                SocketException se = Assert.Throws<SocketException>(() => socket1.GetSocketOption((SocketOptionLevel)(-1), (SocketOptionName)(-1), optionValue));
+                SocketException se = Assert.Throws<SocketException>(() => socket1.GetSocketOption(SocketOptionLevel.Socket, (SocketOptionName)(-1), optionValue));
                 Assert.True(se.SocketErrorCode == SocketError.ProtocolOption ||
                             se.SocketErrorCode == SocketError.OperationNotSupported, $"SocketError: {se.SocketErrorCode}");
 
@@ -600,7 +600,7 @@ namespace System.Net.Sockets.Tests
             using (socket1)
             using (socket2)
             {
-                SocketException se = Assert.Throws<SocketException>(() => socket1.GetSocketOption((SocketOptionLevel)(-1), (SocketOptionName)(-1), optionLength: 4));
+                SocketException se = Assert.Throws<SocketException>(() => socket1.GetSocketOption(SocketOptionLevel.Socket, (SocketOptionName)(-1), optionLength: 4));
                 Assert.True(se.SocketErrorCode == SocketError.ProtocolOption ||
                             se.SocketErrorCode == SocketError.OperationNotSupported, $"SocketError: {se.SocketErrorCode}");
 
@@ -615,7 +615,7 @@ namespace System.Net.Sockets.Tests
             using (socket1)
             using (socket2)
             {
-                SocketException se = Assert.Throws<SocketException>(() => socket1.SetSocketOption((SocketOptionLevel)(-1), (SocketOptionName)(-1), optionValue: 1));
+                SocketException se = Assert.Throws<SocketException>(() => socket1.SetSocketOption(SocketOptionLevel.Socket, (SocketOptionName)(-1), optionValue: 1));
                 Assert.True(se.SocketErrorCode == SocketError.ProtocolOption ||
                             se.SocketErrorCode == SocketError.OperationNotSupported, $"SocketError: {se.SocketErrorCode}");
 
@@ -631,7 +631,7 @@ namespace System.Net.Sockets.Tests
             using (socket2)
             {
                 var optionValue = new byte[4];
-                SocketException se = Assert.Throws<SocketException>(() => socket1.SetSocketOption((SocketOptionLevel)(-1), (SocketOptionName)(-1), optionValue));
+                SocketException se = Assert.Throws<SocketException>(() => socket1.SetSocketOption(SocketOptionLevel.Socket, (SocketOptionName)(-1), optionValue));
                 Assert.True(se.SocketErrorCode == SocketError.ProtocolOption ||
                             se.SocketErrorCode == SocketError.OperationNotSupported, $"SocketError: {se.SocketErrorCode}");
 
@@ -647,7 +647,7 @@ namespace System.Net.Sockets.Tests
             using (socket2)
             {
                 bool optionValue = true;
-                SocketException se = Assert.Throws<SocketException>(() => socket1.SetSocketOption((SocketOptionLevel)(-1), (SocketOptionName)(-1), optionValue));
+                SocketException se = Assert.Throws<SocketException>(() => socket1.SetSocketOption(SocketOptionLevel.Socket, (SocketOptionName)(-1), optionValue));
                 Assert.True(se.SocketErrorCode == SocketError.ProtocolOption ||
                             se.SocketErrorCode == SocketError.OperationNotSupported, $"SocketError: {se.SocketErrorCode}");
 
@@ -663,7 +663,7 @@ namespace System.Net.Sockets.Tests
             using (socket2)
             {
                 var optionValue = new byte[4];
-                SocketException se = Assert.Throws<SocketException>(() => socket1.GetRawSocketOption(-1, -1, optionValue));
+                SocketException se = Assert.Throws<SocketException>(() => socket1.GetRawSocketOption(SOL_SOCKET, -1, optionValue));
                 Assert.True(se.SocketErrorCode == SocketError.ProtocolOption ||
                             se.SocketErrorCode == SocketError.OperationNotSupported, $"SocketError: {se.SocketErrorCode}");
 
@@ -679,13 +679,15 @@ namespace System.Net.Sockets.Tests
             using (socket2)
             {
                 var optionValue = new byte[4];
-                SocketException se = Assert.Throws<SocketException>(() => socket1.SetRawSocketOption(-1, -1, optionValue));
+                SocketException se = Assert.Throws<SocketException>(() => socket1.SetRawSocketOption(SOL_SOCKET, -1, optionValue));
                 Assert.True(se.SocketErrorCode == SocketError.ProtocolOption ||
                             se.SocketErrorCode == SocketError.OperationNotSupported, $"SocketError: {se.SocketErrorCode}");
 
                 Assert.True(socket1.Connected, "Connected");
             }
         }
+
+        private static int SOL_SOCKET = OperatingSystem.IsLinux() ? 1 : (int)SocketOptionLevel.Socket;
     }
 
     [Collection("NoParallelTests")]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/59055.

@antonfirsov @dotnet/ncl ptal.