### PR TITLE
Seal internal types in runtime tasks

### DIFF
--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -933,7 +933,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
         return outItems;
     }
 
-    internal class PrecompileArguments
+    internal sealed class PrecompileArguments
     {
         public PrecompileArguments(string ResponseFilePath, IDictionary<string, string> EnvironmentVariables, string WorkingDir, ITaskItem AOTAssembly, IList<ProxyFile> ProxyFiles)
         {
@@ -952,7 +952,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
     }
 }
 
-internal class FileCache
+internal sealed class FileCache
 {
     private CompilerCache? _newCache;
     private CompilerCache? _oldCache;
@@ -1020,7 +1020,7 @@ internal class FileCache
     public ProxyFile NewFile(string targetFile) => new ProxyFile(targetFile, this);
 }
 
-internal class ProxyFile
+internal sealed class ProxyFile
 {
     public string TargetFile { get; }
     public string TempFile   { get; }
@@ -1093,7 +1093,7 @@ public enum MonoAotModulesTableLanguage
     ObjC
 }
 
-internal class CompilerCache
+internal sealed class CompilerCache
 {
     public CompilerCache() => FileHashes = new();
     public CompilerCache(IDictionary<string, string> oldHashes)

--- a/src/tasks/AppleAppBuilder/Xcode.cs
+++ b/src/tasks/AppleAppBuilder/Xcode.cs
@@ -111,7 +111,7 @@ public class XcodeBuildApp : Task
     }
 }
 
-internal class Xcode
+internal sealed class Xcode
 {
     private string RuntimeIdentifier { get; set; }
     private string Target { get; set; }

--- a/src/tasks/Crossgen2Tasks/CommonFilePulledFromSdkRepo/BuildErrorException.cs
+++ b/src/tasks/Crossgen2Tasks/CommonFilePulledFromSdkRepo/BuildErrorException.cs
@@ -10,7 +10,7 @@ namespace Microsoft.NET.Build.Tasks
     /// Represents an error that is neither avoidable in all cases nor indicative of a bug in this library.
     /// It will be logged as a plain build error without the exception type or stack.
     /// </summary>
-    internal class BuildErrorException : Exception
+    internal sealed class BuildErrorException : Exception
     {
         public BuildErrorException()
         {

--- a/src/tasks/Crossgen2Tasks/CommonFilePulledFromSdkRepo/RuntimeGraphCache.cs
+++ b/src/tasks/Crossgen2Tasks/CommonFilePulledFromSdkRepo/RuntimeGraphCache.cs
@@ -10,7 +10,7 @@ using NuGet.RuntimeModel;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    internal class RuntimeGraphCache
+    internal sealed class RuntimeGraphCache
     {
         private IBuildEngine4 _buildEngine;
         private Logger _log;

--- a/src/tasks/WasmAppBuilder/IcallTableGenerator.cs
+++ b/src/tasks/WasmAppBuilder/IcallTableGenerator.cs
@@ -276,7 +276,7 @@ public class IcallTableGenerator : Task
         return sb.ToString ();
     }
 
-    private class Icall : IComparable<Icall>
+    private sealed class Icall : IComparable<Icall>
     {
         public Icall (string name, string func, bool handles)
         {
@@ -298,7 +298,7 @@ public class IcallTableGenerator : Task
         }
     }
 
-    private class IcallClass
+    private sealed class IcallClass
     {
         public IcallClass (string name)
         {

--- a/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
+++ b/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
@@ -424,7 +424,7 @@ public class PInvokeTableGenerator : Task
     private static void Error (string msg) => throw new LogAsErrorException(msg);
 }
 
-internal class PInvoke : IEquatable<PInvoke>
+internal sealed class PInvoke : IEquatable<PInvoke>
 {
     public PInvoke(string entryPoint, string module, MethodInfo method)
     {
@@ -447,7 +447,7 @@ internal class PInvoke : IEquatable<PInvoke>
     public override string ToString() => $"{{ EntryPoint: {EntryPoint}, Module: {Module}, Method: {Method}, Skip: {Skip} }}";
 }
 
-internal class PInvokeComparer : IEqualityComparer<PInvoke>
+internal sealed class PInvokeComparer : IEqualityComparer<PInvoke>
 {
     public bool Equals(PInvoke? x, PInvoke? y)
     {
@@ -463,7 +463,7 @@ internal class PInvokeComparer : IEqualityComparer<PInvoke>
         => $"{pinvoke.EntryPoint}{pinvoke.Module}{pinvoke.Method}".GetHashCode();
 }
 
-internal class PInvokeCallback
+internal sealed class PInvokeCallback
 {
     public PInvokeCallback(MethodInfo method)
     {

--- a/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
+++ b/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
@@ -59,7 +59,7 @@ public class WasmAppBuilder : Task
     // </summary>
     public ITaskItem[]? ExtraConfig { get; set; }
 
-    private class WasmAppConfig
+    private sealed class WasmAppConfig
     {
         [JsonPropertyName("assembly_root")]
         public string AssemblyRoot { get; set; } = "managed";
@@ -86,12 +86,12 @@ public class WasmAppBuilder : Task
         public string Name { get; init; }
     }
 
-    private class AssemblyEntry : AssetEntry
+    private sealed class AssemblyEntry : AssetEntry
     {
         public AssemblyEntry(string name) : base(name, "assembly") {}
     }
 
-    private class SatelliteAssemblyEntry : AssetEntry
+    private sealed class SatelliteAssemblyEntry : AssetEntry
     {
         public SatelliteAssemblyEntry(string name, string culture) : base(name, "resource")
         {
@@ -102,14 +102,14 @@ public class WasmAppBuilder : Task
         public string CultureName { get; set; }
     }
 
-    private class VfsEntry : AssetEntry
+    private sealed class VfsEntry : AssetEntry
     {
         public VfsEntry(string name) : base(name, "vfs") {}
         [JsonPropertyName("virtual_path")]
         public string? VirtualPath { get; set; }
     }
 
-    private class IcuData : AssetEntry
+    private sealed class IcuData : AssetEntry
     {
         public IcuData(string name) : base(name, "icu") {}
         [JsonPropertyName("load_remote")]

--- a/src/tasks/WasmAppBuilder/WasmLoadAssembliesAndReferences.cs
+++ b/src/tasks/WasmAppBuilder/WasmLoadAssembliesAndReferences.cs
@@ -90,7 +90,7 @@ public class WasmLoadAssembliesAndReferences : Task
     }
 }
 
-internal class SearchPathsAssemblyResolver : MetadataAssemblyResolver
+internal sealed class SearchPathsAssemblyResolver : MetadataAssemblyResolver
 {
     private readonly string[] _searchPaths;
 

--- a/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
+++ b/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
@@ -196,7 +196,7 @@ namespace Microsoft.Workload.Build.Tasks
             return first ?? Path.Combine(parentDir, dirName);
         }
 
-        private record ManifestInformation(
+        private sealed record ManifestInformation(
             object Version,
             string Description,
 
@@ -207,7 +207,7 @@ namespace Microsoft.Workload.Build.Tasks
             object Data
         );
 
-        private record WorkloadInformation(
+        private sealed record WorkloadInformation(
             bool Abstract,
             string Kind,
             string Description,
@@ -217,7 +217,7 @@ namespace Microsoft.Workload.Build.Tasks
             List<string> Platforms
         );
 
-        private record PackVersionInformation(
+        private sealed record PackVersionInformation(
             string Kind,
             string Version,
             [property: JsonPropertyName("alias-to")]
@@ -225,7 +225,7 @@ namespace Microsoft.Workload.Build.Tasks
         );
     }
 
-    internal record PackageReference(string Name,
+    internal sealed record PackageReference(string Name,
                                      string Version,
                                      string OutputDir,
                                      string relativeSourceDir = "");

--- a/src/tasks/WorkloadBuildTasks/PackageInstaller.cs
+++ b/src/tasks/WorkloadBuildTasks/PackageInstaller.cs
@@ -13,7 +13,7 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.Workload.Build.Tasks
 {
-    internal class PackageInstaller
+    internal sealed class PackageInstaller
     {
         private readonly string _tempDir;
         private string _nugetConfigContents;


### PR DESCRIPTION
While working on [this analyzer](https://github.com/dotnet/runtime/issues/49944) ([PR](https://github.com/dotnet/roslyn-analyzers/pull/5594)) I ran the analyzer against dotnet/runtime and found these violations in several projects in src/tasks.