### PR TITLE
Enable doc generation for source-build

### DIFF
--- a/Build.proj
+++ b/Build.proj
@@ -10,7 +10,7 @@
   <Import Project="$(RepositoryEngineeringDir)SubsetValidation.targets" />
 
   <!-- Upfront restore hooks -->
-  <Import Project="$(RepositoryEngineeringDir)restore\docs.targets" Condition="'$(DotNetBuildFromSource)' != 'true'" />
+  <Import Project="$(RepositoryEngineeringDir)restore\docs.targets" />
   <Import Project="$(RepositoryEngineeringDir)restore\optimizationData.targets" Condition="'$(DotNetBuildFromSource)' != 'true'" />
 
   <Target Name="BuildLocalTasks"


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/2404 and https://github.com/dotnet/source-build/issues/2394.

When building source-build the xml doc files are missing from the resulting ref packs.  This change removes a check that was preventing the xml doc from being generated during source build.