### PR TITLE
Avoid resetting gen0 bricks for background_sweep (#59106)

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -33109,8 +33109,6 @@ void gc_heap::background_mark_phase ()
 #endif //MULTIPLE_HEAPS
     }
 
-    gen0_bricks_cleared = FALSE;
-
     dprintf (2, ("end of bgc mark: loh: %d, poh: %d, soh: %d",
                  generation_size (loh_generation),
                  generation_size (poh_generation),


### PR DESCRIPTION
Backporting https://github.com/dotnet/runtime/pull/59106

## Customer Impact
Exchange reported that they are hitting occasionally long gen 1 GC that hurts their tail latencies, having this change available in .NET 6 will allow them to have the fix right away once they upgrade to .NET 6.
They used to be able to reproduce this occasionally long GC in around 20 minutes, with the fix, they don’t detect that anymore in 6 hours.

## Testing
This change went through 48 hours of stress testing on both workstation and server GC, and also many runs on the Exchange perf tests.

## Risk
Low – given we have done a lot of testing.
