### PR TITLE
Fixes based on feedback for the original #59929

### DIFF
--- a/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
@@ -590,7 +590,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 Directory.CreateDirectory(dotnetWithMockHostFxr);
                 string expectedErrorCode = Constants.ErrorCode.FrameworkMissingFailure.ToString("x");
 
-                var dotnetBuilder = new DotNetBuilder(dotnetWithMockHostFxr, sharedTestState.RepoDirectories.BuiltDotnet, "hostfxrFrameworkMissingFailure")
+                var dotnetBuilder = new DotNetBuilder(dotnetWithMockHostFxr, sharedTestState.RepoDirectories.BuiltDotnet, "mockhostfxrFrameworkMissingFailure")
                     .RemoveHostFxr()
                     .AddMockHostFxr(new Version(2, 2, 0));
                 var dotnet = dotnetBuilder.Build();

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundledAppWithSubDirs.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundledAppWithSubDirs.cs
@@ -69,7 +69,7 @@ namespace AppHost.Bundle.Tests
                 Directory.CreateDirectory(dotnetWithMockHostFxr);
                 string expectedErrorCode = Constants.ErrorCode.BundleExtractionFailure.ToString("x");
 
-                var dotnetBuilder = new DotNetBuilder(dotnetWithMockHostFxr, sharedTestState.RepoDirectories.BuiltDotnet, "hostfxrFrameworkMissingFailure")
+                var dotnetBuilder = new DotNetBuilder(dotnetWithMockHostFxr, sharedTestState.RepoDirectories.BuiltDotnet, "mockhostfxrBundleVersionFailure")
                     .RemoveHostFxr()
                     .AddMockHostFxr(new Version(5, 0, 0));
                 var dotnet = dotnetBuilder.Build();
@@ -87,7 +87,8 @@ namespace AppHost.Bundle.Tests
                     .WaitForExit(true)
                     .Should().Fail()
                     .And.HaveStdErrContaining("Bundle header version compatibility check failed.")
-                    .And.HaveStdErrContaining($"Showing error dialog for application: '{Path.GetFileName(singleFile)}' - error code: 0x{expectedErrorCode}");
+                    .And.HaveStdErrContaining($"Showing error dialog for application: '{Path.GetFileName(singleFile)}' - error code: 0x{expectedErrorCode}")
+                    .And.HaveStdErrContaining("apphost_version=");
             }
         }
 

--- a/src/native/corehost/apphost/apphost.windows.cpp
+++ b/src/native/corehost/apphost/apphost.windows.cpp
@@ -112,6 +112,8 @@ namespace
                 {
                     dialogMsg = pal::string_t(_X("To run this application, you must install .NET Desktop Runtime ")) + _STRINGIFY(COMMON_HOST_PKG_VER) + _X(" (") + get_arch() + _X(").\n\n");
                     url = get_download_url();
+                    url.append(_X("&apphost_version="));
+                    url.append(_STRINGIFY(COMMON_HOST_PKG_VER));
                 }
             }
 

--- a/src/native/corehost/bundle/header.cpp
+++ b/src/native/corehost/bundle/header.cpp
@@ -29,7 +29,7 @@ header_t header_t::read(reader_t& reader)
     if (!fixed_header->is_valid())
     {
         trace::error(_X("Failure processing application bundle."));
-        trace::error(_X("Bundle header version compatibility check failed."));
+        trace::error(_X("Bundle header version compatibility check failed. Header version: %d.%d"), fixed_header->major_version, fixed_header->minor_version);
 
         throw StatusCode::BundleExtractionFailure;
     }

--- a/src/native/corehost/test/mockhostfxr/mockhostfxr.cpp
+++ b/src/native/corehost/test/mockhostfxr/mockhostfxr.cpp
@@ -18,7 +18,7 @@ SHARED_API int HOSTFXR_CALLTYPE hostfxr_main_startupinfo(const int argc, const p
 {
     trace_hostfxr_entry_point(_X("hostfxr_main_startupinfo"));
 
-    const pal::string_t dotnet_folder = get_directory(dotnet_root);
+    const pal::string_t dotnet_folder = get_filename(dotnet_root);
 
     if (pal::strcmp(dotnet_folder.c_str(), _X("mockhostfxrFrameworkMissingFailure")) == 0)
     {
@@ -38,7 +38,7 @@ SHARED_API int HOSTFXR_CALLTYPE hostfxr_main_bundle_startupinfo(const int argc, 
 {
     trace_hostfxr_entry_point(_X("hostfxr_main_bundle_startupinfo"));
 
-    const pal::string_t dotnet_folder = get_directory(dotnet_root);
+    const pal::string_t dotnet_folder = get_filename(dotnet_root);
 
     if (pal::strcmp(dotnet_folder.c_str(), _X("mockhostfxrBundleVersionFailure")) == 0)
     {

--- a/src/native/corehost/test/mockhostfxr/mockhostfxr.cpp
+++ b/src/native/corehost/test/mockhostfxr/mockhostfxr.cpp
@@ -20,7 +20,7 @@ SHARED_API int HOSTFXR_CALLTYPE hostfxr_main_startupinfo(const int argc, const p
 
     const pal::string_t dotnet_folder = get_directory(dotnet_root);
 
-    if (pal::strcmp(dotnet_folder.c_str(), _X("hostfxrFrameworkMissingFailure")))
+    if (pal::strcmp(dotnet_folder.c_str(), _X("mockhostfxrFrameworkMissingFailure")) == 0)
     {
         return StatusCode::FrameworkMissingFailure;
     }
@@ -40,7 +40,7 @@ SHARED_API int HOSTFXR_CALLTYPE hostfxr_main_bundle_startupinfo(const int argc, 
 
     const pal::string_t dotnet_folder = get_directory(dotnet_root);
 
-    if (pal::strcmp(dotnet_folder.c_str(), _X("mockhostfxrBundleVersionFailure")))
+    if (pal::strcmp(dotnet_folder.c_str(), _X("mockhostfxrBundleVersionFailure")) == 0)
     {
         trace::error(_X("Failure processing application bundle."));
         trace::error(_X("Bundle header version compatibility check failed."));


### PR DESCRIPTION
Adds apphost_version to the URL (most important fix)
Adds version info to the error message for 6.0

Cleans up some stuff in tests