### PR TITLE
[wasm] Fix typedef for non-void interp entry callbacks

### DIFF
--- a/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
+++ b/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
@@ -326,7 +326,7 @@ public class PInvokeTableGenerator : Task
             sb.Append($" (*WasmInterpEntrySig_{cb_index}) (");
             int pindex = 0;
             if (method.ReturnType.Name != "Void") {
-                sb.Append("int");
+                sb.Append("int*");
                 pindex++;
             }
             foreach (var p in method.GetParameters()) {


### PR DESCRIPTION
For UnmanagedCallersOnly methods that return non-void, pass the address of the
return variable to the interp entry method.