### PR TITLE
Fix some of the issues around pgo data collection of stack trace data

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -877,7 +877,7 @@ namespace ILCompiler.Reflection.ReadyToRun
             while (!curParser.IsNull())
             {
                 IAssemblyMetadata mdReader = GetGlobalMetadata();
-                var decoder = new R2RSignatureDecoder<TType, TMethod, TGenericContext>(provider, default(TGenericContext), mdReader.MetadataReader, this, (int)curParser.Offset);
+                var decoder = new R2RSignatureDecoder<TType, TMethod, TGenericContext>(provider, default(TGenericContext), mdReader?.MetadataReader, this, (int)curParser.Offset);
 
                 TMethod customMethod = decoder.ParseMethod();
 
@@ -887,7 +887,6 @@ namespace ILCompiler.Reflection.ReadyToRun
                 ReadyToRunMethod r2rMethod = _runtimeFunctionToMethod[runtimeFunctionId];
                 if (!Object.ReferenceEquals(customMethod, null) && !foundMethods.ContainsKey(customMethod))
                     foundMethods.Add(customMethod, r2rMethod);
-                foundMethods.Add(customMethod, r2rMethod);
                 curParser = allEntriesEnum.GetNext();
             }
         }

--- a/src/coreclr/tools/dotnet-pgo/ModuleLoadLogger.cs
+++ b/src/coreclr/tools/dotnet-pgo/ModuleLoadLogger.cs
@@ -18,13 +18,28 @@ namespace Microsoft.Diagnostics.Tools.Pgo
 
         Logger _logger;
 
+        [ThreadStatic]
+        private static int s_loadFailuresAreErrors = 0;
+
+        public class LoadFailuresAsErrors : IDisposable
+        {
+            public LoadFailuresAsErrors()
+            {
+                s_loadFailuresAreErrors++;
+            }
+            public void Dispose()
+            {
+                s_loadFailuresAreErrors--;
+            }
+        }
+
         public void LogModuleLoadFailure(string simpleName, string filePath)
         {
             if (_simpleNamesReported.Add(simpleName))
             {
                 string str = $"Failed to load assembly '{simpleName}' from '{filePath}'";
 
-                if (String.Compare("System.Private.CoreLib", simpleName, StringComparison.OrdinalIgnoreCase) == 0)
+                if (s_loadFailuresAreErrors != 0 || String.Compare("System.Private.CoreLib", simpleName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
                     _logger.PrintError(str);
                 }
@@ -41,7 +56,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
             {
                 string str = $"Failed to load assembly '{simpleName}'";
 
-                if (String.Compare("System.Private.CoreLib", simpleName, StringComparison.OrdinalIgnoreCase) == 0)
+                if (s_loadFailuresAreErrors != 0 || String.Compare("System.Private.CoreLib", simpleName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
                     _logger.PrintError(str);
                 }

--- a/src/coreclr/tools/dotnet-pgo/Program.cs
+++ b/src/coreclr/tools/dotnet-pgo/Program.cs
@@ -1014,7 +1014,9 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                                 filePathError = true;
                             }
                             else
-                                tsc.GetModuleFromPath(fileReference.FullName);
+                            {
+                                tsc.GetModuleFromPath(fileReference.FullName, throwIfNotLoadable: false);
+                            }
                         }
                         catch (Internal.TypeSystem.TypeSystemException.BadImageFormatException)
                         {
@@ -1133,7 +1135,8 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                             p,
                             tsc,
                             idParser,
-                            clrInstanceId.Value);
+                            clrInstanceId.Value,
+                            s_logger);
                     }
 
                     return methodMemMap;

--- a/src/coreclr/tools/dotnet-pgo/Program.cs
+++ b/src/coreclr/tools/dotnet-pgo/Program.cs
@@ -948,9 +948,11 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                     return -5;
                 }
 
-                if (!p.EventsInProcess.ByEventType<MethodJittingStartedTraceData>().Any())
+                if (!p.EventsInProcess.ByEventType<MethodJittingStartedTraceData>().Any() &&
+                    !p.EventsInProcess.ByEventType<R2RGetEntryPointTraceData>().Any() &&
+                    !p.EventsInProcess.ByEventType< SampledProfileTraceData>().Any())
                 {
-                    PrintError($"No managed jit starting data\nWas the trace collected with provider at least \"Microsoft-Windows-DotNETRuntime:0x4000080018:5\"?");
+                    PrintError($"No data in trace for process\nWas the trace collected with provider at least \"Microsoft-Windows-DotNETRuntime:0x4000080018:5\"?");
                     return -5;
                 }
 
@@ -1036,7 +1038,63 @@ namespace Microsoft.Diagnostics.Tools.Pgo
 
                 TraceRuntimeDescToTypeSystemDesc idParser = new TraceRuntimeDescToTypeSystemDesc(p, tsc, clrInstanceId.Value);
 
-                SortedDictionary<int, ProcessedMethodData> methodsToAttemptToPrepare = new SortedDictionary<int, ProcessedMethodData>();
+                int mismatchErrors = 0;
+                foreach (var e in p.EventsInProcess.ByEventType<ModuleLoadUnloadTraceData>())
+                {
+                    ModuleDesc loadedModule = idParser.ResolveModuleID(e.ModuleID, false);
+                    if (loadedModule == null)
+                    {
+                        PrintWarning($"Unable to find loaded module {e.ModuleILFileName} to verify match");
+                        continue;
+                    }
+
+                    EcmaModule ecmaModule = loadedModule as EcmaModule;
+                    if (ecmaModule == null)
+                    {
+                        continue;
+                    }
+
+                    bool matched = false;
+                    bool mismatch = false;
+                    foreach (var debugEntry in ecmaModule.PEReader.ReadDebugDirectory())
+                    {
+                        if (debugEntry.Type == DebugDirectoryEntryType.CodeView)
+                        {
+                            var codeViewData = ecmaModule.PEReader.ReadCodeViewDebugDirectoryData(debugEntry);
+                            if (codeViewData.Path.EndsWith("ni.pdb"))
+                                continue;
+                            if (codeViewData.Guid != e.ManagedPdbSignature)
+                            {
+                                PrintError($"Dll mismatch between assembly located at \"{e.ModuleILPath}\" during trace collection and module \"{tsc.PEReaderToFilePath(ecmaModule.PEReader)}\"");
+                                mismatchErrors++;
+                                mismatch = true;
+                                continue;
+                            }
+                            else
+                            {
+                                matched = true;
+                            }
+                        }
+                    }
+
+                    if (!matched && !mismatch)
+                    {
+                        PrintMessage($"Unable to validate match between assembly located at \"{e.ModuleILPath}\" during trace collection and module \"{tsc.PEReaderToFilePath(ecmaModule.PEReader)}\"");
+                    }
+
+                    // TODO find some way to match on MVID as only some dlls have managed pdbs, and this won't find issues with embedded pdbs
+                }
+
+                if (mismatchErrors != 0)
+                {
+                    PrintError($"{mismatchErrors} mismatch error(s) found");
+                    return -1;
+                }
+
+                // Now that the modules are validated run Init to prepare for the rest of execution
+                idParser.Init();
+
+                SortedDictionary<long, ProcessedMethodData> methodsToAttemptToPrepare = new SortedDictionary<long, ProcessedMethodData>();
 
                 if (commandLineOptions.ProcessR2REvents)
                 {
@@ -1158,6 +1216,9 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                     MethodMemoryMap mmap = GetMethodMemMap();
                     foreach (var e in p.EventsInProcess.ByEventType<SampledProfileTraceData>())
                     {
+                        if ((e.TimeStampRelativeMSec < commandLineOptions.ExcludeEventsBefore) && (e.TimeStampRelativeMSec > commandLineOptions.ExcludeEventsAfter))
+                            continue;
+
                         var callstack = e.CallStack();
                         if (callstack == null)
                             continue;
@@ -1194,7 +1255,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                             if (!methodsListedToPrepare.Contains(nextMethod))
                             {
                                 methodsListedToPrepare.Add(nextMethod);
-                                methodsToAttemptToPrepare.Add((int)e.EventIndex, new ProcessedMethodData(e.TimeStampRelativeMSec, nextMethod, "SampleMethodCaller"));
+                                methodsToAttemptToPrepare.Add(0x100000000 + (int)e.EventIndex, new ProcessedMethodData(e.TimeStampRelativeMSec, nextMethod, "SampleMethodCaller"));
                             }
 
                             if (!callGraph.TryGetValue(nextMethod, out var innerDictionary))

--- a/src/coreclr/tools/dotnet-pgo/TraceRuntimeDescToTypeSystemDesc.cs
+++ b/src/coreclr/tools/dotnet-pgo/TraceRuntimeDescToTypeSystemDesc.cs
@@ -252,8 +252,11 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                     }
                 }
             }
+        }
 
-
+        // Call before any api other than ResolveModuleID will work
+        public void Init()
+        {
             // Fill in all the types
             foreach (var entry in _types)
             {

--- a/src/coreclr/tools/dotnet-pgo/TraceRuntimeDescToTypeSystemDesc.cs
+++ b/src/coreclr/tools/dotnet-pgo/TraceRuntimeDescToTypeSystemDesc.cs
@@ -93,15 +93,15 @@ namespace Microsoft.Diagnostics.Tools.Pgo
 
         class ModuleDescInfo
         {
-            public ModuleDescInfo(long id, TraceManagedModule traceManagedModule)
+            public ModuleDescInfo(long id, string assemblyName)
             {
                 ID = id;
-                TraceManagedModule = traceManagedModule;
+                AssemblyName = assemblyName;
             }
 
             public readonly long ID;
             public ModuleDesc Module;
-            public readonly TraceManagedModule TraceManagedModule;
+            public readonly string AssemblyName;
         }
 
         private readonly Dictionary<long, MethodDescInfo> _methods = new Dictionary<long, MethodDescInfo>();
@@ -222,9 +222,11 @@ namespace Microsoft.Diagnostics.Tools.Pgo
             }
 
             Dictionary<long, int> assemblyToCLRInstanceIDMap = new Dictionary<long, int>();
+            Dictionary<long, string> assemblyToFullyQualifiedAssemblyName = new Dictionary<long, string>();
             foreach (var assemblyLoadTrace in _traceProcess.EventsInProcess.ByEventType<AssemblyLoadUnloadTraceData>())
             {
                 assemblyToCLRInstanceIDMap[assemblyLoadTrace.AssemblyID] = assemblyLoadTrace.ClrInstanceID;
+                assemblyToFullyQualifiedAssemblyName[assemblyLoadTrace.AssemblyID] = assemblyLoadTrace.FullyQualifiedAssemblyName;
             }
 
             foreach (var moduleFile in _traceProcess.LoadedModules)
@@ -240,16 +242,8 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                     if (clrInstanceIDModule != _clrInstanceID)
                         continue;
 
-                    if (managedModule.ModuleFile != null)
-                    {
-                        ModuleDescInfo currentInfo;
-                        if (_modules.TryGetValue(managedModule.ModuleID, out currentInfo))
-                        {
-                            continue;
-                        }
-                        currentInfo = new ModuleDescInfo(managedModule.ModuleID, managedModule);
-                        _modules.Add(managedModule.ModuleID, currentInfo);
-                    }
+                    var currentInfo = new ModuleDescInfo(managedModule.ModuleID, assemblyToFullyQualifiedAssemblyName[managedModule.AssemblyID]);
+                    _modules.Add(managedModule.ModuleID, currentInfo);
                 }
             }
         }
@@ -274,14 +268,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                     if (minfo.Module != null)
                         return minfo.Module;
 
-                    string simpleName = minfo.TraceManagedModule.Name;
-
-                    if (!File.Exists(minfo.TraceManagedModule.FilePath) && minfo.TraceManagedModule.FilePath.EndsWith(".il.dll") && simpleName.EndsWith(".il"))
-                    {
-                        simpleName = simpleName.Substring(0, simpleName.Length - 3);
-                    }
-
-                    minfo.Module = _context.ResolveAssembly(new AssemblyName(simpleName), throwIfNotFound);
+                    minfo.Module = _context.ResolveAssembly(new AssemblyName(minfo.AssemblyName), throwIfNotFound);
                     return minfo.Module;
                 }
                 else

--- a/src/coreclr/tools/dotnet-pgo/TraceTypeSystemContext.cs
+++ b/src/coreclr/tools/dotnet-pgo/TraceTypeSystemContext.cs
@@ -181,9 +181,9 @@ namespace Microsoft.Diagnostics.Tools.Pgo
             }
         }
 
-        public EcmaModule GetModuleFromPath(string filePath)
+        public EcmaModule GetModuleFromPath(string filePath, bool throwIfNotLoadable = true)
         {
-            return GetOrAddModuleFromPath(filePath, null, true);
+            return GetOrAddModuleFromPath(filePath, null, true, throwIfNotLoadable: throwIfNotLoadable);
         }
 
         public EcmaModule GetMetadataOnlyModuleFromPath(string filePath)
@@ -196,7 +196,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
             return GetOrAddModuleFromPath(filePath, moduleData, false);
         }
 
-        private EcmaModule GetOrAddModuleFromPath(string filePath, byte[] moduleData, bool useForBinding)
+        private EcmaModule GetOrAddModuleFromPath(string filePath, byte[] moduleData, bool useForBinding, bool throwIfNotLoadable = true)
         {
             // This method is not expected to be called frequently. Linear search is acceptable.
             foreach (var entry in ModuleHashtable.Enumerator.Get(_moduleHashtable))
@@ -208,10 +208,13 @@ namespace Microsoft.Diagnostics.Tools.Pgo
             bool succeeded = false;
             try
             {
-                EcmaModule returnValue = AddModule(filePath, null, moduleData, useForBinding);
-                _moduleLoadLogger.LogModuleLoadSuccess(returnValue.Assembly.GetName().Name, filePath);
-                succeeded = true;
-                return returnValue;
+                EcmaModule returnValue = AddModule(filePath, null, moduleData, useForBinding, throwIfNotLoadable: throwIfNotLoadable);
+                if (returnValue != null)
+                {
+                    _moduleLoadLogger.LogModuleLoadSuccess(returnValue.Assembly.GetName().Name, filePath);
+                    succeeded = true;
+                    return returnValue;
+                }
             }
             finally
             {
@@ -220,6 +223,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                     _moduleLoadLogger.LogModuleLoadFailure(Path.GetFileNameWithoutExtension(filePath), filePath);
                 }
             }
+            return null;
         }
 
         public static unsafe PEReader OpenPEFile(string filePath, byte[] moduleBytes, out MemoryMappedViewAccessor mappedViewAccessor)
@@ -268,13 +272,17 @@ namespace Microsoft.Diagnostics.Tools.Pgo
             }
         }
 
-        private EcmaModule AddModule(string filePath, string expectedSimpleName, byte[] moduleDataBytes, bool useForBinding)
+        private EcmaModule AddModule(string filePath, string expectedSimpleName, byte[] moduleDataBytes, bool useForBinding, bool throwIfNotLoadable = true)
         {
             MemoryMappedViewAccessor mappedViewAccessor = null;
             PdbSymbolReader pdbReader = null;
             try
             {
                 PEReader peReader = OpenPEFile(filePath, moduleDataBytes, out mappedViewAccessor);
+                if ((!peReader.HasMetadata) && !throwIfNotLoadable)
+                {
+                    return null;
+                }
                 pdbReader = OpenAssociatedSymbolFile(filePath, peReader);
 
                 EcmaModule module = EcmaModule.Create(this, peReader, containingAssembly: null, pdbReader);
@@ -315,6 +323,10 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                 }
 
                 return module;
+            }
+            catch when (!throwIfNotLoadable)
+            {
+                return null;
             }
             finally
             {
@@ -375,12 +387,14 @@ namespace Microsoft.Diagnostics.Tools.Pgo
 
         IAssemblyMetadata IAssemblyResolver.FindAssembly(MetadataReader metadataReader, AssemblyReferenceHandle assemblyReferenceHandle, string parentFile)
         {
+            using var triggerErrors = new ModuleLoadLogger.LoadFailuresAsErrors();
             EcmaAssembly ecmaAssembly = (EcmaAssembly)this.GetModuleForSimpleName(metadataReader.GetString(metadataReader.GetAssemblyReference(assemblyReferenceHandle).Name), false);
             return new StandaloneAssemblyMetadata(ecmaAssembly.PEReader);
         }
 
         IAssemblyMetadata IAssemblyResolver.FindAssembly(string simpleName, string parentFile)
         {
+            using var triggerErrors = new ModuleLoadLogger.LoadFailuresAsErrors();
             EcmaAssembly ecmaAssembly = (EcmaAssembly)this.GetModuleForSimpleName(simpleName, false);
             return new StandaloneAssemblyMetadata(ecmaAssembly.PEReader);
         }


### PR DESCRIPTION
- Improve assembly name acquisition in dotnet-pgo
  - Use assembly name from AssemblyLoad event, and do not attempt to figure it out from the Module load event
- Collect MemoryRegionInfo for all method regions, not just the first.
- Add a concept to check a guid associated with the associated dll files to avoid data tearing
- Improve parsing of instantiated method signatures when reading an R2R file
  - Handle the subtly different format which is use for type signatures in the InstantiationMethodSignature portion of an R2R file