### PR TITLE
Ignore nop-statements between tailcall and ret

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_58827/Runtime_58827.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_58827/Runtime_58827.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+class B
+{
+    public B z() => this;
+    public bool T() => true;
+    public virtual bool F(B b, int x) => x == 0;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool G(B b, int x)
+    {
+        var bb = z();
+        return bb?.T() == true && F(b, x);
+    }
+
+    public bool H(B b, int x) => G(b, x);
+    public bool I(B b, int x) => F(b, x + 1);
+    public bool J(B b, int x) => I(b, x);
+    public bool K(B b, int x) => J(b, x);
+}
+
+class X : B
+{
+    static int y = 0;
+
+    public override bool F(B b, int x)
+    {
+        if (x == 0) return true;
+        return b.H(b, x - 1);
+    }
+
+    [MethodImpl(MethodImplOptions.NoOptimization)]
+    public static int Main()
+    {
+        var x = new X();
+
+        for (int i = 0; i < 50; i++)
+        {
+            _ = x.K(x, i);
+            Thread.Sleep(15);
+        }
+
+        return x.K(x, y) ? 100 : -1;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_58827/Runtime_58827.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_58827/Runtime_58827.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+    <!-- This test requires PGO -->
+    <CLRTestBatchPreCommands><![CDATA[
+      $(CLRTestBatchPreCommands)
+      set DOTNET_TieredCompilation=1
+      set DOTNET_TC_QuickJitForLoops=1
+      set DOTNET_TieredPGO=1
+      ]]></CLRTestBatchPreCommands>
+          <BashCLRTestPreCommands><![CDATA[
+      $(BashCLRTestPreCommands)
+      export DOTNET_TieredCompilation=1
+      export DOTNET_TC_QuickJitForLoops=1
+      export DOTNET_TieredPGO=1
+      ]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/58827

I can remove the whole validation thing if @jakobbotsch @AndyAyersMS both are fine with it (I personally am)