### PR TITLE
Fix issue in decommit_ephemeral_segment_pages (segment case).

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -38748,7 +38748,7 @@ void gc_heap::decommit_ephemeral_segment_pages()
 
     dynamic_data* dd0 = dynamic_data_of (0);
 
-    ptrdiff_t desired_allocation = estimate_gen_growth (soh_gen0) +
+    ptrdiff_t desired_allocation = dd_new_allocation (dd0) +
                                    estimate_gen_growth (soh_gen1) +
                                    loh_size_threshold;
 


### PR DESCRIPTION
We assume that we can use half the free list space in gen 0 for new allocation. If that is too optimistic, we may allocate into decommitted memory and crash in the allocator. That is because there is a race condition between the allocating thread and the decommitting thread - we decided to avoid that by making sure we would never decommit memory that we may allocate in gen 0.

There are two reasons why assuming we can use half the free list space for new allocations may be too optimistic:
 - if we allocate large objects in gen 0, we may not have free spaces of the necessary size available.
- when background GC goes into background_ephemeral_sweep, it deletes and rebuilds the free list for gen 0. A thread trying to allocate during that time may see a completely empty free list.

We used to do this correctly by not taking into account the free list space in gen 0 at all. But as we made changes for regions, that seemed unnecessarily pessimistic, but as we changed the logic, we failed to honor the invariants the allocator relies on.

The fix essentially goes back to the older logic where the free list space in gen 0 is not taken into account. We can do better than this, but it's more complicated.
