### PR TITLE
Fix benign assert in gtNewTempAssign

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -15498,7 +15498,7 @@ GenTree* Compiler::gtNewTempAssign(
         //     the field was transformed as IND opr GT_LCL_FLD;
         // 2. we are propagation `ASG(struct V01, 0)` to `RETURN(struct V01)`, `CNT_INT` doesn't `structHnd`;
         // in these cases, we can use the type of the merge return for the assignment.
-        assert(val->OperIs(GT_IND, GT_LCL_FLD, GT_CNS_INT));
+        assert(val->gtEffectiveVal(true)->OperIs(GT_IND, GT_LCL_FLD, GT_CNS_INT));
         assert(tmp == genReturnLocal);
         valStructHnd = lvaGetStruct(genReturnLocal);
         assert(valStructHnd != NO_CLASS_HANDLE);
@@ -15510,7 +15510,7 @@ GenTree* Compiler::gtNewTempAssign(
     }
     else if (varTypeIsStruct(varDsc) && ((valStructHnd != NO_CLASS_HANDLE) || varTypeIsSIMD(valTyp)))
     {
-        // The struct value may be be a child of a GT_COMMA.
+        // The struct value may be be a child of a GT_COMMA due to explicit null checks of indirs/fields.
         GenTree* valx = val->gtEffectiveVal(/*commaOnly*/ true);
 
         if (valStructHnd != NO_CLASS_HANDLE)

--- a/src/tests/JIT/Regression/JitBlue/Runtime_59871/Runtime_59871.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_59871/Runtime_59871.cs
@@ -9,7 +9,7 @@ public class Runtime_59871
     public static int Main()
     {
         Foo(new Runtime_59871());
-		return 100;
+        return 100;
     }
 
     static DateTime Foo(Runtime_59871 p)

--- a/src/tests/JIT/Regression/JitBlue/Runtime_59871/Runtime_59871.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_59871/Runtime_59871.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Runtime.InteropServices;
+
+public class Runtime_59871
+{
+    LargeStruct _large;
+    Union _field;
+
+    public static int Main()
+    {
+        Foo(new Runtime_59871());
+		return 100;
+    }
+
+    static DateTime Foo(Runtime_59871 p)
+    {
+        switch (Environment.TickCount % 4)
+        {
+            case 0: return p._field.DateTime;
+            case 1: return p._field.DateTime;
+            case 2: return p._field.DateTime;
+            case 3: return p._field.DateTime;
+        }
+
+        return p._field.DateTime;
+    }
+
+    unsafe struct LargeStruct
+    {
+        public fixed byte F[0x10000];
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 8)]
+    struct Union
+    {
+        [FieldOffset(0)]
+        public long Int64;
+        [FieldOffset(0)]
+        public DateTime DateTime;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_59871/Runtime_59871.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_59871/Runtime_59871.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+	<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_59871/Runtime_59871.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_59871/Runtime_59871.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-	<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
The later part of this method correctly handles the GT_COMMA case, so we
just need to fix the assert.

Fix #59871