### PR TITLE
Add ISMETHOD and ISMETHODHASH macros

### DIFF
--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4754,12 +4754,10 @@ struct GenTreeCall final : public GenTree
 
     void ResetArgInfo();
 
-    GenTreeCallFlags gtCallMoreFlags; // in addition to gtFlags
-
-    unsigned char gtCallType : 3;   // value from the gtCallTypes enumeration
-    unsigned char gtReturnType : 5; // exact return type
-
-    CORINFO_CLASS_HANDLE gtRetClsHnd; // The return type handle of the call if it is a struct; always available
+    GenTreeCallFlags     gtCallMoreFlags;  // in addition to gtFlags
+    gtCallTypes          gtCallType : 3;   // value from the gtCallTypes enumeration
+    var_types            gtReturnType : 5; // exact return type
+    CORINFO_CLASS_HANDLE gtRetClsHnd;      // The return type handle of the call if it is a struct; always available
 
     union {
         // only used for CALLI unmanaged calls (CT_INDIRECT)

--- a/src/coreclr/jit/jit.h
+++ b/src/coreclr/jit/jit.h
@@ -529,6 +529,7 @@ const bool dspGCtbls = true;
     if (JitTls::GetCompiler()->verbose)                                                                                \
         JitTls::GetCompiler()->fgTableDispBasicBlock(b);
 #define VERBOSE JitTls::GetCompiler()->verbose
+// Development-time only macros, simplify guards for specified IL methods one wants to debug/add log messages for
 #define ISMETHOD(name) (strcmp(JitTls::GetCompiler()->impInlineRoot()->info.compMethodName, name) == 0)
 #define ISMETHODHASH(hash) (JitTls::GetCompiler()->impInlineRoot()->info.compMethodHash() == hash)
 #else // !DEBUG
@@ -544,8 +545,6 @@ const bool dspGCtbls = true;
 #define DISPTREERANGE(range, t)
 #define DISPBLOCK(b)
 #define VERBOSE 0
-#define ISMETHOD(name)
-#define ISMETHODHASH(hash)
 #endif // !DEBUG
 
 /*****************************************************************************

--- a/src/coreclr/jit/jit.h
+++ b/src/coreclr/jit/jit.h
@@ -530,7 +530,7 @@ const bool dspGCtbls = true;
         JitTls::GetCompiler()->fgTableDispBasicBlock(b);
 #define VERBOSE JitTls::GetCompiler()->verbose
 #define ISMETHOD(name) !strcmp(JitTls::GetCompiler()->info.compMethodName, name)
-#define ISMETHODHASH(hash) !strcmp(JitTls::GetCompiler()->info.compMethodHash, hash)
+#define ISMETHODHASH(hash) (JitTls::GetCompiler()->impInlineRoot()->info.compMethodHash() == hash)
 #else // !DEBUG
 #define JITDUMP(...)
 #define JITDUMPEXEC(x)

--- a/src/coreclr/jit/jit.h
+++ b/src/coreclr/jit/jit.h
@@ -529,6 +529,8 @@ const bool dspGCtbls = true;
     if (JitTls::GetCompiler()->verbose)                                                                                \
         JitTls::GetCompiler()->fgTableDispBasicBlock(b);
 #define VERBOSE JitTls::GetCompiler()->verbose
+#define ISMETHOD(name) !strcmp(JitTls::GetCompiler()->info.compMethodName, name)
+#define ISMETHODHASH(hash) !strcmp(JitTls::GetCompiler()->info.compMethodHash, hash)
 #else // !DEBUG
 #define JITDUMP(...)
 #define JITDUMPEXEC(x)
@@ -542,6 +544,8 @@ const bool dspGCtbls = true;
 #define DISPTREERANGE(range, t)
 #define DISPBLOCK(b)
 #define VERBOSE 0
+#define ISMETHOD(name)
+#define ISMETHODHASH(hash)
 #endif // !DEBUG
 
 /*****************************************************************************

--- a/src/coreclr/jit/jit.h
+++ b/src/coreclr/jit/jit.h
@@ -529,7 +529,7 @@ const bool dspGCtbls = true;
     if (JitTls::GetCompiler()->verbose)                                                                                \
         JitTls::GetCompiler()->fgTableDispBasicBlock(b);
 #define VERBOSE JitTls::GetCompiler()->verbose
-#define ISMETHOD(name) !strcmp(JitTls::GetCompiler()->impInlineRoot()->info.compMethodName, name)
+#define ISMETHOD(name) (strcmp(JitTls::GetCompiler()->impInlineRoot()->info.compMethodName, name) == 0)
 #define ISMETHODHASH(hash) (JitTls::GetCompiler()->impInlineRoot()->info.compMethodHash() == hash)
 #else // !DEBUG
 #define JITDUMP(...)

--- a/src/coreclr/jit/jit.h
+++ b/src/coreclr/jit/jit.h
@@ -529,7 +529,7 @@ const bool dspGCtbls = true;
     if (JitTls::GetCompiler()->verbose)                                                                                \
         JitTls::GetCompiler()->fgTableDispBasicBlock(b);
 #define VERBOSE JitTls::GetCompiler()->verbose
-#define ISMETHOD(name) !strcmp(JitTls::GetCompiler()->info.compMethodName, name)
+#define ISMETHOD(name) !strcmp(JitTls::GetCompiler()->impInlineRoot()->info.compMethodName, name)
 #define ISMETHODHASH(hash) (JitTls::GetCompiler()->impInlineRoot()->info.compMethodHash() == hash)
 #else // !DEBUG
 #define JITDUMP(...)


### PR DESCRIPTION
This PR adds `ISMETHOD` and `ISMETHODHASH` macros so one can do something like:
```c
if (ISMETHOD("Main"))
{
; // break or some printf when JIT compiles "Main" function
}
```
Same for `ISMETHODHASH(424242)` which is useful when one debugs superpmi failures

@dotnet/jit-contrib @SingleAccretion do you find it useful? I personally write such strcmp quite often 🙂 

Also, this PR changes types for `gtCallType` and `gtReturnType` to corresponding enums for better intellisense (enums have the same underlying type - unsigned char)