### PR TITLE
Disable providervalidation runtime test on MonoVM.

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1486,6 +1486,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/gcdump/gcdump/**">
             <Issue>needs triage</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/providervalidation/**">
+            <Issue>https://github.com/dotnet/runtime/issues/59296</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/DllImportAttribute/DllImportPath/**">
             <Issue>needs triage</Issue>
         </ExcludeList>


### PR DESCRIPTION
Disable providervalidation runtime test on MonoVM while working on local repro, https://github.com/dotnet/runtime/issues/59296