### PR TITLE
[release/6.0] Update signed wix version for arm64 fixes

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -193,7 +193,7 @@
     <MicrosoftNETRuntimeEmscriptenVersion>$(MicrosoftNETWorkloadEmscriptenManifest60100Version)</MicrosoftNETRuntimeEmscriptenVersion>
     <!-- workloads -->
     <SwixPackageVersion>1.1.87-gba258badda</SwixPackageVersion>
-    <WixPackageVersion>1.0.0-v3.14.0.4118</WixPackageVersion>
+    <WixPackageVersion>1.0.0-v3.14.0.5722</WixPackageVersion>
     <MonoWorkloadManifestVersion>6.0.0-preview.5.21275.7</MonoWorkloadManifestVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Tell mode packaging related tooling update.

Updated WiX build that contains changes to better support x64 emulation on arm64. This is needed for 6.0.

Fixes the mono workload side of https://github.com/dotnet/runtime/issues/60003