### PR TITLE
Replace memset + malloc with calloc

### DIFF
--- a/src/coreclr/pal/src/libunwind/src/coredump/_UCD_create.c
+++ b/src/coreclr/pal/src/libunwind/src/coredump/_UCD_create.c
@@ -84,7 +84,7 @@ _UCD_create(const char *filename)
 #define elf_header64 elf_header.h64
   bool _64bits;
 
-  struct UCD_info *ui = memset(malloc(sizeof(*ui)), 0, sizeof(*ui));
+  struct UCD_info *ui = calloc(1, sizeof(*ui));
   ui->edi.di_cache.format = -1;
   ui->edi.di_debug.format = -1;
 #if UNW_TARGET_IA64


### PR DESCRIPTION
Calling calloc is much more efficient than calling malloc and then memset