### PR TITLE
Pin compiler version to workaround package validation loading missmatching roslyn versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -51,6 +51,8 @@
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>4.0.0-4.final</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
     <MicrosoftCodeAnalysisCSharpVersion>4.0.0-4.final</MicrosoftCodeAnalysisCSharpVersion>
     <MicrosoftCodeAnalysisNetAnalyzersVersion>7.0.0-preview1.21502.1</MicrosoftCodeAnalysisNetAnalyzersVersion>
+    <!-- Pin compiler version to workaround issue: https://github.com/dotnet/runtime/issues/59908 -->
+    <MicrosoftNetCompilersToolsetVersion>4.0.0-5.21453.15</MicrosoftNetCompilersToolsetVersion>
     <!-- SDK dependencies -->
     <MicrosoftDotNetCompatibilityVersion>1.0.0-rc.1.21459.41</MicrosoftDotNetCompatibilityVersion>
     <!-- Arcade dependencies -->


### PR DESCRIPTION
This mitigates: https://github.com/dotnet/runtime/issues/59908

There was a breaking change in between these 2 versions where an abstract and an interface member were added and unfortunately there is a race condition (I haven't found where), that sometimes `Microsoft.CodeAnalysis` is loaded from the SDK before we call the package validation task, and [then in the package validation task](https://github.com/dotnet/sdk/blob/8e652a081d0dd2c68ca377e5b7514a6b73e05ebd/src/Compatibility/Microsoft.DotNet.Compatibility/ValidatePackage.cs#L106-L120) we load `Microsoft.CodeAnalysis.CSharp` from the compiler package, which depends on these new members defined on `Microsoft.CodeAnalysis` but since we are loading it from the SDK for some reason, those members are not found and hence the crash.

![PackageValidationError](https://user-images.githubusercontent.com/22899328/136093177-36fd5374-7d7c-4d2a-923a-5ad2fe52f2cb.png)

Pinning the compiler version to unblock CI while I make more progress on the investigation
