### PR TITLE
Add PreciseRefCountsRequired method 

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5361,6 +5361,8 @@ public:
     // rather than the "use" SSA number recorded in the tree "lcl".
     inline unsigned GetSsaNumForLocalVarDef(GenTree* lcl);
 
+    inline bool PreciseRefCountsRequired();
+
     // Performs SSA conversion.
     void fgSsaBuild();
 

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -1794,7 +1794,7 @@ inline unsigned Compiler::lvaGrabTempWithImplicitUse(bool shortLifetime DEBUGARG
 inline void LclVarDsc::incRefCnts(weight_t weight, Compiler* comp, RefCountState state, bool propagate)
 {
     // In minopts and debug codegen, we don't maintain normal ref counts.
-    if ((state == RCS_NORMAL) && comp->opts.OptimizationDisabled())
+    if ((state == RCS_NORMAL) && !comp->PreciseRefCountsRequired())
     {
         // Note, at least, that there is at least one reference.
         lvImplicitlyReferenced = 1;
@@ -4231,6 +4231,11 @@ unsigned Compiler::GetSsaNumForLocalVarDef(GenTree* lcl)
     {
         return lcl->AsLclVarCommon()->GetSsaNum();
     }
+}
+
+inline bool Compiler::PreciseRefCountsRequired()
+{
+    return opts.OptimizationEnabled();
 }
 
 template <typename TVisitor>

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -4373,8 +4373,8 @@ void Compiler::lvaMarkLocalVars()
     const bool isRecompute = false;
     lvaComputeRefCounts(isRecompute, setSlotNumbers);
 
-    // If we're not optimizing, we're done.
-    if (opts.OptimizationDisabled())
+    // If we don't need precise reference counts, e.g. we're not optimizing, we're done.
+    if (!PreciseRefCountsRequired())
     {
         return;
     }
@@ -4394,7 +4394,7 @@ void Compiler::lvaMarkLocalVars()
     }
 
 #if ASSERTION_PROP
-    assert(opts.OptimizationEnabled());
+    assert(PreciseRefCountsRequired());
 
     // Note: optAddCopies() depends on lvaRefBlks, which is set in lvaMarkLocalVars(BasicBlock*), called above.
     optAddCopies();
@@ -4432,7 +4432,7 @@ void Compiler::lvaComputeRefCounts(bool isRecompute, bool setSlotNumbers)
     //
     // On first compute: mark all locals as implicitly referenced and untracked.
     // On recompute: do nothing.
-    if (opts.OptimizationDisabled())
+    if (!PreciseRefCountsRequired())
     {
         if (isRecompute)
         {

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -170,8 +170,8 @@ void Compiler::fgLocalVarLivenessInit()
 {
     JITDUMP("In fgLocalVarLivenessInit\n");
 
-    // Sort locals first, if we're optimizing
-    if (opts.OptimizationEnabled())
+    // Sort locals first, if precise reference counts are required, e.g. we're optimizing
+    if (PreciseRefCountsRequired())
     {
         lvaSortByRefCount();
     }


### PR DESCRIPTION
This PR adds a `PreciseRefCountsRequierd ` to better describe the intention when deciding whether to calculate precise ref counts for liveness.  It is the fallout from the NativeAOT-LLVM branch in the runtimelab repo where an SSA phase is run which requires precise ref counts regardless of optimisation settings.

See https://github.com/dotnet/runtimelab/pull/1598 and https://github.com/dotnet/runtimelab/pull/1598#discussion_r721477772

Thanks for reviewing.

