### PR TITLE
[wasm][debugger] Fix debug compilation using cmake

### DIFF
--- a/src/mono/wasm/runtime/CMakeLists.txt
+++ b/src/mono/wasm/runtime/CMakeLists.txt
@@ -7,10 +7,7 @@ add_executable(dotnet corebindings.c driver.c pinvoke.c)
 target_include_directories(dotnet PUBLIC ${MONO_INCLUDES} ${MONO_OBJ_INCLUDES})
 target_compile_options(dotnet PUBLIC @${NATIVE_BIN_DIR}/src/emcc-default.rsp -DCORE_BINDINGS -DGEN_PINVOKE=1)
 
-set_source_files_properties(corebindings.c PROPERTIES COMPILE_FLAGS ${CONFIGURATION_EMCC_FLAGS})
-set_source_files_properties(driver.c PROPERTIES COMPILE_FLAGS ${CONFIGURATION_EMCC_FLAGS})
-set_source_files_properties(pinvoke.c PROPERTIES COMPILE_FLAGS ${CONFIGURATION_EMCC_FLAGS})
-
+set_target_properties(dotnet PROPERTIES COMPILE_FLAGS ${CONFIGURATION_EMCC_FLAGS})
 
 target_link_libraries(dotnet
     ${ICU_LIB_DIR}/libicuuc.a

--- a/src/mono/wasm/runtime/CMakeLists.txt
+++ b/src/mono/wasm/runtime/CMakeLists.txt
@@ -5,7 +5,13 @@ project(mono-wasm-runtime C)
 add_executable(dotnet corebindings.c driver.c pinvoke.c)
 
 target_include_directories(dotnet PUBLIC ${MONO_INCLUDES} ${MONO_OBJ_INCLUDES})
-target_compile_options(dotnet PUBLIC @${NATIVE_BIN_DIR}/src/emcc-default.rsp ${CONFIGURATION_EMCC_FLAGS} -DCORE_BINDINGS -DGEN_PINVOKE=1)
+target_compile_options(dotnet PUBLIC @${NATIVE_BIN_DIR}/src/emcc-default.rsp -DCORE_BINDINGS -DGEN_PINVOKE=1)
+
+set_source_files_properties(corebindings.c PROPERTIES COMPILE_FLAGS ${CONFIGURATION_EMCC_FLAGS})
+set_source_files_properties(driver.c PROPERTIES COMPILE_FLAGS ${CONFIGURATION_EMCC_FLAGS})
+set_source_files_properties(pinvoke.c PROPERTIES COMPILE_FLAGS ${CONFIGURATION_EMCC_FLAGS})
+
+
 target_link_libraries(dotnet
     ${ICU_LIB_DIR}/libicuuc.a
     ${ICU_LIB_DIR}/libicui18n.a

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -148,7 +148,7 @@
     </ItemGroup>
     <PropertyGroup>
       <PInvokeTableFile>$(ArtifactsObjDir)wasm/pinvoke-table.h</PInvokeTableFile>
-      <CMakeConfigurationEmccFlags Condition="'$(Configuration)' == 'Debug'">-g;-Os;-s;-DDEBUG=1</CMakeConfigurationEmccFlags>
+      <CMakeConfigurationEmccFlags Condition="'$(Configuration)' == 'Debug'">-g -Os -s -DDEBUG=1</CMakeConfigurationEmccFlags>
       <CMakeConfigurationEmccFlags Condition="'$(Configuration)' == 'Release'">-Oz</CMakeConfigurationEmccFlags>
       <CMakeBuildRuntimeConfigureCmd>emcmake cmake $(MSBuildThisFileDirectory)runtime -DCONFIGURATION_EMCC_FLAGS=&quot;$(CMakeConfigurationEmccFlags)&quot; -DMONO_INCLUDES=&quot;$(MonoArtifactsPath)include/mono-2.0&quot; -DMONO_OBJ_INCLUDES=&quot;$(MonoObjDir.TrimEnd('\/'))&quot; -DICU_LIB_DIR=&quot;$(ICULibDir.TrimEnd('\/'))&quot; -DMONO_ARTIFACTS_DIR=&quot;$(MonoArtifactsPath.TrimEnd('\/'))&quot; -DNATIVE_BIN_DIR=&quot;$(NativeBinDir.TrimEnd('\/'))&quot; -DSYSTEM_NATIVE_DIR=&quot;$(RepoRoot)src/libraries/Native/Unix/System.Native&quot; -DEMSDK_PATH=&quot;$(EMSDK_PATH.TrimEnd('\/'))&quot; -DSOURCE_DIR=&quot;$(MSBuildThisFileDirectory.TrimEnd('\/'))/runtime&quot;</CMakeBuildRuntimeConfigureCmd>
       <CMakeBuildRuntimeConfigureCmd Condition="'$(OS)' == 'Windows_NT'">call &quot;$(RepositoryEngineeringDir)native\init-vs-env.cmd&quot; &amp;&amp; call &quot;$([MSBuild]::NormalizePath('$(EMSDK_PATH)', 'emsdk_env.bat'))&quot; &amp;&amp; $(CMakeBuildRuntimeConfigureCmd)</CMakeBuildRuntimeConfigureCmd>


### PR DESCRIPTION
Debugger tests were broken when running with runtime compiled in debug mode since this commit
https://github.com/dotnet/runtime/commit/909880b5a7a737f86d388f263e0bfa8c2ddb186c

I'm not a cmake expert so might be a better way to pass the compiler flags.


Getting errors like this:
`"value": "System.AggregateException: One or more errors occurred. (Object reference not set to an instance of an object.)\n ---> System.NullReferenceException: Object reference not set to an instance of an object.\n   at System.IO.StreamWriter.CheckAsyncTaskInProgress() in T:\\thays\\runtime_wasm_main\\runtime\\src\\libraries\\System.Private.CoreLib\\src\\System\\IO\\StreamWriter.cs:line 53\n   at System.IO.StreamWriter.set_AutoFlush(Boolean value) in T:\\thays\\runtime_wasm_main\\runtime\\src\\libraries\\System.Private.CoreLib\\src\\System\\IO\\StreamWriter.cs:line 342\n   at System.Console.CreateOutputWriter(Stream outputStream) in T:\\thays\\runtime_wasm_main\\runtime\\src\\libraries\\System.Console\\src\\System\\Console.cs:line 237\n   at System.Console.<get_Out>g__EnsureInitialized|26_0() in T:\\thays\\runtime_wasm_main\\runtime\\src\\libraries\\System.Console\\src\\System\\Console.cs:line 207\n   at System.Console.get_Out() in T:\\thays\\runtime_wasm_main\\runtime\\src\\libraries\\System.Console\\src\\System\\Console.cs:line 199\n   at System.Console.WriteLine(String value) in T:\\thays\\runtime_wasm_main\\runtime\\src\\libraries\\System.Console\\src\\System\\Console.cs:line 807\n   at InspectTask.RunInspectTask() in T:\\thays\\runtime_wasm_main\\runtime\\src\\mono\\wasm\\debugger\\tests\\debugger-test\\debugger-test2.cs:line 99\n   --- End of inner exception stack trace ---"`

And this:
```
"exception": {
      "type": "string",
      "value": "System.AggregateException: One or more errors occurred. (RangeError: Maximum call stack size exceeded)\n ---> System.Net.Http.HttpRequestException: RangeError: Maximum call stack size exceeded\n ---> System.Runtime.InteropServices.JavaScript.JSException: RangeError: Maximum call stack size exceeded\n   at System.Runtime.InteropServices.JavaScript.JSObject.Invoke(String method, Object[] args) in T:\\thays\\runtime_wasm_main\\runtime\\src\\libraries\\System.Private.Runtime.InteropServices.JavaScript\\src\\System\\Runtime\\InteropServices\\JavaScript\\JSObject.cs:line 43\n   at System.Net.Http.BrowserHttpHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) in T:\\thays\\runtime_wasm_main\\runtime\\src\\libraries\\System.Net.Http\\src\\System\\Net\\Http\\BrowserHttpHandler\\BrowserHttpHandler.cs:line 252\n   --- End of inner exception stack trace ---\n   at System.Net.Http.BrowserHttpHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) in T:\\thays\\runtime_wasm_main\\runtime\\src\\libraries\\System.Net.Http\\src\\System\\Net\\Http\\BrowserHttpHandler\\BrowserHttpHandler.cs:line 332\n   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken) 
```