### PR TITLE
Update CODEOWNERS to remove JSON area and to add Obsoletions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,6 @@
 /src/libraries/Common/src/Interop/                                  @dotnet/platform-deps-team
 /src/libraries/Common/src/System/Net/Http/aspnetcore/               @dotnet/http
 /src/libraries/Common/tests/Tests/System/Net/aspnetcore/            @dotnet/http
-/src/libraries/System.Text.Json/                                    @steveharter @layomia @eiriktsarpalis
 
 # CoreCLR Code Owners
 
@@ -55,3 +54,8 @@
 /src/mono/mono/utils/mono-threads* @lambdageek @vargaz
 
 /src/mono/dlls @thaystg @lambdageek
+
+# Obsoletions / Custom Diagnostics
+
+/docs/project/list-of-diagnostics.md                @jeffhandley
+/src/libraries/Common/src/System/Obsoletions.cs     @jeffhandley


### PR DESCRIPTION
Added myself to get tagged as a reviewer any time obsoletions are changed. And removing the JSON area tagging per request from @eiriktsarpalis.