### PR TITLE
Add a Reverse P/Invoke scenario for profiler transition tests.

### DIFF
--- a/src/tests/profiler/native/transitions/transitions.h
+++ b/src/tests/profiler/native/transitions/transitions.h
@@ -8,7 +8,7 @@
 class Transitions : public Profiler
 {
 public:
-    Transitions();
+    Transitions() = default;
     virtual ~Transitions() = default;
 
     static GUID GetClsid();
@@ -19,8 +19,20 @@ public:
 
 private:
     std::atomic<int> _failures;
-    std::atomic<bool> _sawEnter;
-    std::atomic<bool> _sawLeave;
 
-    bool FunctionIsTargetFunction(FunctionID functionID);
+    struct TransitionInstance
+    {
+        TransitionInstance()
+            : UnmanagedToManaged{ (COR_PRF_TRANSITION_REASON)-1 }
+            , ManagedToUnmanaged{ (COR_PRF_TRANSITION_REASON)-1 }
+        { }
+
+        COR_PRF_TRANSITION_REASON UnmanagedToManaged;
+        COR_PRF_TRANSITION_REASON ManagedToUnmanaged;
+    };
+
+    TransitionInstance _pinvoke;
+    TransitionInstance _reversePinvoke;
+
+    bool FunctionIsTargetFunction(FunctionID functionID, TransitionInstance** inst);
 };

--- a/src/tests/profiler/transitions/transitions.cs
+++ b/src/tests/profiler/transitions/transitions.cs
@@ -6,16 +6,22 @@ using System.Runtime.InteropServices;
 
 namespace Profiler.Tests
 {
-    class GCTests
+    unsafe class Transitions
     {
         static readonly Guid TransitionsGuid = new Guid("027AD7BB-578E-4921-B29F-B540363D83EC");
 
-        [DllImport("Profiler")]
-        public static extern void DoPInvoke(int i);
-
-        public static int RunTest(String[] args) 
+        [UnmanagedCallersOnly]
+        private static int DoReversePInvoke(int i)
         {
-            DoPInvoke(13);
+            return i;
+        }
+
+        [DllImport("Profiler")]
+        public static extern void DoPInvoke(delegate* unmanaged<int,int> callback, int i);
+
+        public static int RunTest(String[] args)
+        {
+            DoPInvoke(&DoReversePInvoke, 13);
 
             return 100;
         }


### PR DESCRIPTION
Add test to validate we don't regress #59919 - see https://github.com/dotnet/runtime/issues/59917.

/cc @davmason @k15tfu @jkoritzinsky