### PR TITLE
Block out the test Interop/PInvoke/Generics/GenericTest on arm64 pending investigation

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -238,6 +238,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/Runtime_56953/Runtime_56953/*">
             <Issue>https://github.com/dotnet/runtime/issues/57515</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/Generics/GenericsTest/*">
+            <Issue>https://github.com/dotnet/runtime/issues/60036</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- Windows all architecture excludes -->


### PR DESCRIPTION
/cc @dotnet/crossgen-contrib 

Mitigates: #60036