### PR TITLE
Pick up a new build of Xunit

### DIFF
--- a/eng/CodeAnalysis.test.globalconfig
+++ b/eng/CodeAnalysis.test.globalconfig
@@ -1675,7 +1675,7 @@ dotnet_diagnostic.xUnit2012.severity = warning
 dotnet_diagnostic.xUnit2013.severity = none
 
 # xUnit2014: Do not use throws check to check for asynchronously thrown exception
-dotnet_diagnostic.xUnit2014.severity = warning
+dotnet_diagnostic.xUnit2014.severity = none
 
 # xUnit2015: Do not use typeof expression to check the exception type
 dotnet_diagnostic.xUnit2015.severity = warning

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -159,7 +159,8 @@
     <MicrosoftDotNetXHarnessTestRunnersXunitVersion>1.0.0-prerelease.21501.2</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
     <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.21501.2</MicrosoftDotNetXHarnessCLIVersion>
     <MicrosoftDotNetHotReloadUtilsGeneratorBuildToolVersion>1.0.2-alpha.0.21479.1</MicrosoftDotNetHotReloadUtilsGeneratorBuildToolVersion>
-    <XUnitVersion>2.4.2-pre.9</XUnitVersion>
+    <XUnitVersion>2.4.2-pre.13</XUnitVersion>
+    <XUnitAnalyzersVersion>0.12.0-pre.19</XUnitAnalyzersVersion>
     <XUnitRunnerVisualStudioVersion>2.4.2</XUnitRunnerVisualStudioVersion>
     <CoverletCollectorVersion>1.3.0</CoverletCollectorVersion>
     <NewtonsoftJsonVersion>12.0.3</NewtonsoftJsonVersion>

--- a/eng/testing/xunit/xunit.props
+++ b/eng/testing/xunit/xunit.props
@@ -10,6 +10,7 @@
 
     <!-- Excluding xunit.core/build as it enables deps file generation. -->
     <PackageReference Include="xunit" Version="$(XUnitVersion)" ExcludeAssets="build" />
+    <PackageReference Include="xunit.analyzers" Version="$(XUnitAnalyzersVersion)" ExcludeAssets="build" />
     <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsVersion)" />
   </ItemGroup>
 

--- a/src/libraries/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
@@ -320,7 +320,7 @@ namespace System.IO.Compression
                     }
                     else
                     {
-                        Assert.Equal(data2[i], (byte)0);
+                        Assert.Equal((byte)0, data2[i]);
                     }
                 }
             });

--- a/src/libraries/Microsoft.CSharp/tests/RuntimeBinderExceptionTests.cs
+++ b/src/libraries/Microsoft.CSharp/tests/RuntimeBinderExceptionTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Tests
                             CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
                         }));
             Func<CallSite, object, object, object, object> target = site.Target;
-            Assert.Throws<ArgumentException>(null, () => target.Invoke(site, "Ceci n'est pas un type", 2, 2));
+            AssertExtensions.Throws<ArgumentException>(null, () => target.Invoke(site, "Ceci n'est pas un type", 2, 2));
         }
 
         [Fact]

--- a/src/libraries/System.Collections.NonGeneric/tests/ReadOnlyCollectionBaseTests.cs
+++ b/src/libraries/System.Collections.NonGeneric/tests/ReadOnlyCollectionBaseTests.cs
@@ -139,7 +139,7 @@ namespace System.Collections.Tests
         public static void VirtualMethods()
         {
             VirtualTestReadOnlyCollection collectionBase = new VirtualTestReadOnlyCollection();
-            Assert.Equal(collectionBase.Count, int.MinValue);
+            Assert.Equal(int.MinValue, collectionBase.Count);
             Assert.Null(collectionBase.GetEnumerator());
         }
 

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/ContainerTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/ContainerTests.cs
@@ -400,7 +400,7 @@ namespace System.ComponentModel.Tests
             container.Add(component1, "Name1");
             container.Add(component2, "Name2");
 
-            Assert.Throws<ArgumentException>(null, () => component1.Site.Name = "Name2");
+            AssertExtensions.Throws<ArgumentException>(null, () => component1.Site.Name = "Name2");
         }
 
         [Fact]

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/Design/Serialization/MemberRelationshipServiceTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/Design/Serialization/MemberRelationshipServiceTests.cs
@@ -84,7 +84,7 @@ namespace System.ComponentModel.Design.Serialization.Tests
             MemberRelationship source = new MemberRelationship(owner, member);
 
             var service = new NotSupportingMemberRelationshipService();
-            Assert.Throws<ArgumentException>(null, () => service[source] = source);
+            AssertExtensions.Throws<ArgumentException>(null, () => service[source] = source);
         }
 
         private class TestClass

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/Design/ServiceContainerTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/Design/ServiceContainerTests.cs
@@ -224,9 +224,9 @@ namespace System.ComponentModel.Design.Tests
         public void AddService_ServiceInstanceNotInstanceOfType_ThrowsArgumentException()
         {
             var container = new ServiceContainer();
-            Assert.Throws<ArgumentException>(null, () => container.AddService(typeof(int), new object()));
-            Assert.Throws<ArgumentException>(null, () => container.AddService(typeof(int), new object(), true));
-            Assert.Throws<ArgumentException>(null, () => container.AddService(typeof(int), new object(), false));
+            AssertExtensions.Throws<ArgumentException>(null, () => container.AddService(typeof(int), new object()));
+            AssertExtensions.Throws<ArgumentException>(null, () => container.AddService(typeof(int), new object(), true));
+            AssertExtensions.Throws<ArgumentException>(null, () => container.AddService(typeof(int), new object(), false));
         }
 
         [Fact]

--- a/src/libraries/System.Data.Common/tests/System/Data/SqlTypes/SqlBytesTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/SqlTypes/SqlBytesTest.cs
@@ -66,9 +66,9 @@ namespace System.Data.Tests.SqlTypes
         {
             byte[] b = null;
             SqlBytes bytes = new SqlBytes();
-            Assert.Equal(bytes.MaxLength, -1);
+            Assert.Equal(-1, bytes.MaxLength);
             bytes = new SqlBytes(b);
-            Assert.Equal(bytes.MaxLength, -1);
+            Assert.Equal(-1, bytes.MaxLength);
             b = new byte[10];
             bytes = new SqlBytes(b);
             Assert.Equal(10, bytes.MaxLength);

--- a/src/libraries/System.Data.Common/tests/System/Data/SqlTypes/SqlCharsTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/SqlTypes/SqlCharsTest.cs
@@ -72,9 +72,9 @@ namespace System.Data.Tests.SqlTypes
         {
             char[] b = null;
             SqlChars chars = new SqlChars();
-            Assert.Equal(chars.MaxLength, -1);
+            Assert.Equal(-1, chars.MaxLength);
             chars = new SqlChars(b);
-            Assert.Equal(chars.MaxLength, -1);
+            Assert.Equal(-1, chars.MaxLength);
             b = new char[10];
             chars = new SqlChars(b);
             Assert.Equal(10, chars.MaxLength);

--- a/src/libraries/System.Data.Common/tests/System/Data/SqlTypes/SqlInt32Test.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/SqlTypes/SqlInt32Test.cs
@@ -56,9 +56,9 @@ namespace System.Data.Tests.SqlTypes
             x = new SqlInt32(a);
             y = new SqlInt32(b);
             z = x + y;
-            Assert.Equal(z.Value, a + b);
+            Assert.Equal(a + b, z.Value);
             z = SqlInt32.Add(x, y);
-            Assert.Equal(z.Value, a + b);
+            Assert.Equal(a + b, z.Value);
         }
 
         [Fact]
@@ -70,9 +70,9 @@ namespace System.Data.Tests.SqlTypes
             SqlInt32 x = new SqlInt32(a);
             SqlInt32 y = new SqlInt32(b);
             SqlInt32 z = x & y;
-            Assert.Equal(z.Value, a & b);
+            Assert.Equal(a & b, z.Value);
             z = SqlInt32.BitwiseAnd(x, y);
-            Assert.Equal(z.Value, a & b);
+            Assert.Equal(a & b, z.Value);
         }
 
         [Fact]
@@ -84,9 +84,9 @@ namespace System.Data.Tests.SqlTypes
             SqlInt32 x = new SqlInt32(a);
             SqlInt32 y = new SqlInt32(b);
             SqlInt32 z = x | y;
-            Assert.Equal(z.Value, a | b);
+            Assert.Equal(a | b, z.Value);
             z = SqlInt32.BitwiseOr(x, y);
-            Assert.Equal(z.Value, a | b);
+            Assert.Equal(a | b, z.Value);
         }
 
         [Fact]
@@ -98,9 +98,9 @@ namespace System.Data.Tests.SqlTypes
             SqlInt32 x = new SqlInt32(a);
             SqlInt32 y = new SqlInt32(b);
             SqlInt32 z = x / y;
-            Assert.Equal(z.Value, a / b);
+            Assert.Equal(a / b, z.Value);
             z = SqlInt32.Divide(x, y);
-            Assert.Equal(z.Value, a / b);
+            Assert.Equal(a / b, z.Value);
         }
 
         [Fact]
@@ -112,25 +112,25 @@ namespace System.Data.Tests.SqlTypes
             // Case 1: either is SqlInt32.Null
             x = SqlInt32.Null;
             y = new SqlInt32(5);
-            Assert.Equal(x == y, SqlBoolean.Null);
-            Assert.Equal(SqlInt32.Equals(x, y), SqlBoolean.Null);
+            Assert.Equal(SqlBoolean.Null, x == y);
+            Assert.Equal(SqlBoolean.Null, SqlInt32.Equals(x, y));
 
             // Case 2: both are SqlInt32.Null
             y = SqlInt32.Null;
-            Assert.Equal(x == y, SqlBoolean.Null);
-            Assert.Equal(SqlInt32.Equals(x, y), SqlBoolean.Null);
+            Assert.Equal(SqlBoolean.Null, x == y);
+            Assert.Equal(SqlBoolean.Null, SqlInt32.Equals(x, y));
 
             // Case 3: both are equal
             x = new SqlInt32(5);
             y = new SqlInt32(5);
-            Assert.Equal(x == y, SqlBoolean.True);
-            Assert.Equal(SqlInt32.Equals(x, y), SqlBoolean.True);
+            Assert.Equal(SqlBoolean.True, x == y);
+            Assert.Equal(SqlBoolean.True, SqlInt32.Equals(x, y));
 
             // Case 4: inequality
             x = new SqlInt32(5);
             y = new SqlInt32(6);
-            Assert.Equal(x == y, SqlBoolean.False);
-            Assert.Equal(SqlInt32.Equals(x, y), SqlBoolean.False);
+            Assert.Equal(SqlBoolean.False, x == y);
+            Assert.Equal(SqlBoolean.False, SqlInt32.Equals(x, y));
         }
 
         [Fact]
@@ -142,25 +142,25 @@ namespace System.Data.Tests.SqlTypes
             // Case 1: either is SqlInt32.Null
             x = SqlInt32.Null;
             y = new SqlInt32(5);
-            Assert.Equal(x > y, SqlBoolean.Null);
-            Assert.Equal(SqlInt32.GreaterThan(x, y), SqlBoolean.Null);
+            Assert.Equal(SqlBoolean.Null, x > y);
+            Assert.Equal(SqlBoolean.Null, SqlInt32.GreaterThan(x, y));
 
             // Case 2: both are SqlInt32.Null
             y = SqlInt32.Null;
-            Assert.Equal(x > y, SqlBoolean.Null);
-            Assert.Equal(SqlInt32.GreaterThan(x, y), SqlBoolean.Null);
+            Assert.Equal(SqlBoolean.Null, x > y);
+            Assert.Equal(SqlBoolean.Null, SqlInt32.GreaterThan(x, y));
 
             // Case 3: x > y
             x = new SqlInt32(5);
             y = new SqlInt32(4);
-            Assert.Equal(x > y, SqlBoolean.True);
-            Assert.Equal(SqlInt32.GreaterThan(x, y), SqlBoolean.True);
+            Assert.Equal(SqlBoolean.True, x > y);
+            Assert.Equal(SqlBoolean.True, SqlInt32.GreaterThan(x, y));
 
             // Case 4: x < y
             x = new SqlInt32(5);
             y = new SqlInt32(6);
-            Assert.Equal(x > y, SqlBoolean.False);
-            Assert.Equal(SqlInt32.GreaterThan(x, y), SqlBoolean.False);
+            Assert.Equal(SqlBoolean.False, x > y);
+            Assert.Equal(SqlBoolean.False, SqlInt32.GreaterThan(x, y));
         }
 
         [Fact]
@@ -172,31 +172,31 @@ namespace System.Data.Tests.SqlTypes
             // Case 1: either is SqlInt32.Null
             x = SqlInt32.Null;
             y = new SqlInt32(5);
-            Assert.Equal(x >= y, SqlBoolean.Null);
-            Assert.Equal(SqlInt32.GreaterThanOrEqual(x, y), SqlBoolean.Null);
+            Assert.Equal(SqlBoolean.Null, x >= y);
+            Assert.Equal(SqlBoolean.Null, SqlInt32.GreaterThanOrEqual(x, y));
 
             // Case 2: both are SqlInt32.Null
             y = SqlInt32.Null;
-            Assert.Equal(x >= y, SqlBoolean.Null);
-            Assert.Equal(SqlInt32.GreaterThanOrEqual(x, y), SqlBoolean.Null);
+            Assert.Equal(SqlBoolean.Null, x >= y);
+            Assert.Equal(SqlBoolean.Null, SqlInt32.GreaterThanOrEqual(x, y));
 
             // Case 3: x > y
             x = new SqlInt32(5);
             y = new SqlInt32(4);
-            Assert.Equal(x >= y, SqlBoolean.True);
-            Assert.Equal(SqlInt32.GreaterThanOrEqual(x, y), SqlBoolean.True);
+            Assert.Equal(SqlBoolean.True, x >= y);
+            Assert.Equal(SqlBoolean.True, SqlInt32.GreaterThanOrEqual(x, y));
 
             // Case 4: x < y
             x = new SqlInt32(5);
             y = new SqlInt32(6);
-            Assert.Equal(x >= y, SqlBoolean.False);
-            Assert.Equal(SqlInt32.GreaterThanOrEqual(x, y), SqlBoolean.False);
+            Assert.Equal(SqlBoolean.False, x >= y);
+            Assert.Equal(SqlBoolean.False, SqlInt32.GreaterThanOrEqual(x, y));
 
             // Case 5: x == y
             x = new SqlInt32(5);
             y = new SqlInt32(5);
-            Assert.Equal(x >= y, SqlBoolean.True);
-            Assert.Equal(SqlInt32.GreaterThanOrEqual(x, y), SqlBoolean.True);
+            Assert.Equal(SqlBoolean.True, x >= y);
+            Assert.Equal(SqlBoolean.True, SqlInt32.GreaterThanOrEqual(x, y));
         }
 
         [Fact]
@@ -208,25 +208,25 @@ namespace System.Data.Tests.SqlTypes
             // Case 1: either is SqlInt32.Null
             x = SqlInt32.Null;
             y = new SqlInt32(5);
-            Assert.Equal(x < y, SqlBoolean.Null);
-            Assert.Equal(SqlInt32.LessThan(x, y), SqlBoolean.Null);
+            Assert.Equal(SqlBoolean.Null, x < y);
+            Assert.Equal(SqlBoolean.Null, SqlInt32.LessThan(x, y));
 
             // Case 2: both are SqlInt32.Null
             y = SqlInt32.Null;
-            Assert.Equal(x < y, SqlBoolean.Null);
-            Assert.Equal(SqlInt32.LessThan(x, y), SqlBoolean.Null);
+            Assert.Equal(SqlBoolean.Null, x < y);
+            Assert.Equal(SqlBoolean.Null, SqlInt32.LessThan(x, y));
 
             // Case 3: x > y
             x = new SqlInt32(5);
             y = new SqlInt32(4);
-            Assert.Equal(x < y, SqlBoolean.False);
-            Assert.Equal(SqlInt32.LessThan(x, y), SqlBoolean.False);
+            Assert.Equal(SqlBoolean.False, x < y);
+            Assert.Equal(SqlBoolean.False, SqlInt32.LessThan(x, y));
 
             // Case 4: x < y
             x = new SqlInt32(5);
             y = new SqlInt32(6);
-            Assert.Equal(x < y, SqlBoolean.True);
-            Assert.Equal(SqlInt32.LessThan(x, y), SqlBoolean.True);
+            Assert.Equal(SqlBoolean.True, x < y);
+            Assert.Equal(SqlBoolean.True, SqlInt32.LessThan(x, y));
         }
 
         [Fact]
@@ -238,31 +238,31 @@ namespace System.Data.Tests.SqlTypes
             // Case 1: either is SqlInt32.Null
             x = SqlInt32.Null;
             y = new SqlInt32(5);
-            Assert.Equal(x <= y, SqlBoolean.Null);
-            Assert.Equal(SqlInt32.LessThanOrEqual(x, y), SqlBoolean.Null);
+            Assert.Equal(SqlBoolean.Null, x <= y);
+            Assert.Equal(SqlBoolean.Null, SqlInt32.LessThanOrEqual(x, y));
 
             // Case 2: both are SqlInt32.Null
             y = SqlInt32.Null;
-            Assert.Equal(x <= y, SqlBoolean.Null);
-            Assert.Equal(SqlInt32.LessThanOrEqual(x, y), SqlBoolean.Null);
+            Assert.Equal(SqlBoolean.Null, x <= y);
+            Assert.Equal(SqlBoolean.Null, SqlInt32.LessThanOrEqual(x, y));
 
             // Case 3: x > y
             x = new SqlInt32(5);
             y = new SqlInt32(4);
-            Assert.Equal(x <= y, SqlBoolean.False);
-            Assert.Equal(SqlInt32.LessThanOrEqual(x, y), SqlBoolean.False);
+            Assert.Equal(SqlBoolean.False, x <= y);
+            Assert.Equal(SqlBoolean.False, SqlInt32.LessThanOrEqual(x, y));
 
             // Case 4: x < y
             x = new SqlInt32(5);
             y = new SqlInt32(6);
-            Assert.Equal(x <= y, SqlBoolean.True);
-            Assert.Equal(SqlInt32.LessThanOrEqual(x, y), SqlBoolean.True);
+            Assert.Equal(SqlBoolean.True, x <= y);
+            Assert.Equal(SqlBoolean.True, SqlInt32.LessThanOrEqual(x, y));
 
             // Case 5: x == y
             x = new SqlInt32(5);
             y = new SqlInt32(5);
-            Assert.Equal(x <= y, SqlBoolean.True);
-            Assert.Equal(SqlInt32.LessThanOrEqual(x, y), SqlBoolean.True);
+            Assert.Equal(SqlBoolean.True, x <= y);
+            Assert.Equal(SqlBoolean.True, SqlInt32.LessThanOrEqual(x, y));
         }
 
         [Fact]
@@ -274,9 +274,9 @@ namespace System.Data.Tests.SqlTypes
             SqlInt32 x = new SqlInt32(a);
             SqlInt32 y = new SqlInt32(b);
             SqlInt32 z = x % y;
-            Assert.Equal(z.Value, a % b);
+            Assert.Equal(a % b, z.Value);
             z = SqlInt32.Mod(x, y);
-            Assert.Equal(z.Value, a % b);
+            Assert.Equal(a % b, z.Value);
         }
 
         [Fact]
@@ -287,9 +287,9 @@ namespace System.Data.Tests.SqlTypes
             SqlInt32 x = new SqlInt32(a);
             SqlInt32 y = new SqlInt32(b);
             SqlInt32 z = x % y;
-            Assert.Equal(z.Value, a % b);
+            Assert.Equal(a % b, z.Value);
             z = SqlInt32.Modulus(x, y);
-            Assert.Equal(z.Value, a % b);
+            Assert.Equal(a % b, z.Value);
         }
 
         [Fact]
@@ -301,9 +301,9 @@ namespace System.Data.Tests.SqlTypes
             SqlInt32 x = new SqlInt32(a);
             SqlInt32 y = new SqlInt32(b);
             SqlInt32 z = x * y;
-            Assert.Equal(z.Value, a * b);
+            Assert.Equal(a * b, z.Value);
             z = SqlInt32.Multiply(x, y);
-            Assert.Equal(z.Value, a * b);
+            Assert.Equal(a * b, z.Value);
         }
 
         [Fact]
@@ -315,16 +315,16 @@ namespace System.Data.Tests.SqlTypes
             x = new SqlInt32(5);
             y = SqlInt32.Null;
 
-            Assert.Equal(x != y, SqlBoolean.Null);
-            Assert.Equal(SqlInt32.NotEquals(x, y), SqlBoolean.Null);
+            Assert.Equal(SqlBoolean.Null, x != y);
+            Assert.Equal(SqlBoolean.Null, SqlInt32.NotEquals(x, y));
 
             y = new SqlInt32(5);
-            Assert.Equal(x != y, SqlBoolean.False);
-            Assert.Equal(SqlInt32.NotEquals(x, y), SqlBoolean.False);
+            Assert.Equal(SqlBoolean.False, x != y);
+            Assert.Equal(SqlBoolean.False, SqlInt32.NotEquals(x, y));
 
             y = new SqlInt32(6);
-            Assert.Equal(x != y, SqlBoolean.True);
-            Assert.Equal(SqlInt32.NotEquals(x, y), SqlBoolean.True);
+            Assert.Equal(SqlBoolean.True, x != y);
+            Assert.Equal(SqlBoolean.True, SqlInt32.NotEquals(x, y));
         }
 
         [Fact]
@@ -334,9 +334,9 @@ namespace System.Data.Tests.SqlTypes
 
             SqlInt32 x = new SqlInt32(a);
             SqlInt32 z = ~x;
-            Assert.Equal(z.Value, ~a);
+            Assert.Equal(~a, z.Value);
             z = SqlInt32.OnesComplement(x);
-            Assert.Equal(z.Value, ~a);
+            Assert.Equal(~a, z.Value);
         }
 
         [Fact]
@@ -355,9 +355,9 @@ namespace System.Data.Tests.SqlTypes
             SqlInt32 x = new SqlInt32(a);
             SqlInt32 y = new SqlInt32(b);
             SqlInt32 z = x - y;
-            Assert.Equal(z.Value, a - b);
+            Assert.Equal(a - b, z.Value);
             z = SqlInt32.Subtract(x, y);
-            Assert.Equal(z.Value, a - b);
+            Assert.Equal(a - b, z.Value);
         }
 
         [Fact]
@@ -367,27 +367,27 @@ namespace System.Data.Tests.SqlTypes
 
             // Case 1: SqlInt32.Null -> SqlBoolean == SqlBoolean.Null
             x = SqlInt32.Null;
-            Assert.Equal(x.ToSqlBoolean(), SqlBoolean.Null);
+            Assert.Equal(SqlBoolean.Null, x.ToSqlBoolean());
 
             // Case 2: SqlInt32.Zero -> SqlBoolean == False
             x = SqlInt32.Zero;
-            Assert.Equal(x.ToSqlBoolean(), SqlBoolean.False);
+            Assert.Equal(SqlBoolean.False, x.ToSqlBoolean());
 
             // Case 3: SqlInt32(nonzero) -> SqlBoolean == True
             x = new SqlInt32(27);
-            Assert.Equal(x.ToSqlBoolean(), SqlBoolean.True);
+            Assert.Equal(SqlBoolean.True, x.ToSqlBoolean());
 
             // Case 4: SqlInt32.Null -> SqlByte == SqlByte.Null
             x = SqlInt32.Null;
-            Assert.Equal(x.ToSqlByte(), SqlByte.Null);
+            Assert.Equal(SqlByte.Null, x.ToSqlByte());
 
             // Case 5: Test non-null conversion to SqlByte
             x = new SqlInt32(27);
-            Assert.Equal(x.ToSqlByte().Value, (byte)27);
+            Assert.Equal((byte)27, x.ToSqlByte().Value);
 
             // Case 6: SqlInt32.Null -> SqlDecimal == SqlDecimal.Null
             x = SqlInt32.Null;
-            Assert.Equal(x.ToSqlDecimal(), SqlDecimal.Null);
+            Assert.Equal(SqlDecimal.Null, x.ToSqlDecimal());
 
             // Case 7: Test non-null conversion to SqlDecimal
             x = new SqlInt32(27);
@@ -395,7 +395,7 @@ namespace System.Data.Tests.SqlTypes
 
             // Case 8: SqlInt32.Null -> SqlDouble == SqlDouble.Null
             x = SqlInt32.Null;
-            Assert.Equal(x.ToSqlDouble(), SqlDouble.Null);
+            Assert.Equal(SqlDouble.Null, x.ToSqlDouble());
 
             // Case 9: Test non-null conversion to SqlDouble
             x = new SqlInt32(27);
@@ -403,15 +403,15 @@ namespace System.Data.Tests.SqlTypes
 
             // Case 10: SqlInt32.Null -> SqlInt16 == SqlInt16.Null
             x = SqlInt32.Null;
-            Assert.Equal(x.ToSqlInt16(), SqlInt16.Null);
+            Assert.Equal(SqlInt16.Null, x.ToSqlInt16());
 
             // Case 11: Test non-null conversion to SqlInt16
             x = new SqlInt32(27);
-            Assert.Equal(x.ToSqlInt16().Value, (short)27);
+            Assert.Equal((short)27, x.ToSqlInt16().Value);
 
             // Case 12: SqlInt32.Null -> SqlInt64 == SqlInt64.Null
             x = SqlInt32.Null;
-            Assert.Equal(x.ToSqlInt64(), SqlInt64.Null);
+            Assert.Equal(SqlInt64.Null, x.ToSqlInt64());
 
             // Case 13: Test non-null conversion to SqlInt64
             x = new SqlInt32(27);
@@ -419,7 +419,7 @@ namespace System.Data.Tests.SqlTypes
 
             // Case 14: SqlInt32.Null -> SqlMoney == SqlMoney.Null
             x = SqlInt32.Null;
-            Assert.Equal(x.ToSqlMoney(), SqlMoney.Null);
+            Assert.Equal(SqlMoney.Null, x.ToSqlMoney());
 
             // Case 15: Test non-null conversion to SqlMoney
             x = new SqlInt32(27);
@@ -427,7 +427,7 @@ namespace System.Data.Tests.SqlTypes
 
             // Case 16: SqlInt32.Null -> SqlSingle == SqlSingle.Null
             x = SqlInt32.Null;
-            Assert.Equal(x.ToSqlSingle(), SqlSingle.Null);
+            Assert.Equal(SqlSingle.Null, x.ToSqlSingle());
 
             // Case 17: Test non-null conversion to SqlSingle
             x = new SqlInt32(27);
@@ -443,9 +443,9 @@ namespace System.Data.Tests.SqlTypes
             SqlInt32 x = new SqlInt32(a);
             SqlInt32 y = new SqlInt32(b);
             SqlInt32 z = x ^ y;
-            Assert.Equal(z.Value, a ^ b);
+            Assert.Equal(a ^ b, z.Value);
             z = SqlInt32.Xor(x, y);
-            Assert.Equal(z.Value, a ^ b);
+            Assert.Equal(a ^ b, z.Value);
         }
 
         [Fact]

--- a/src/libraries/System.Drawing.Common/tests/Drawing2D/MatrixTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Drawing2D/MatrixTests.cs
@@ -910,7 +910,7 @@ namespace System.Drawing.Drawing2D.Tests
             {
                 try
                 {
-                    Assert.Equal(expected[i], actual[i], 3);
+                    Assert.Equal((double)expected[i], (double)actual[i], 3);
                 }
                 catch
                 {

--- a/src/libraries/System.Drawing.Common/tests/FontFamilyTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/FontFamilyTests.cs
@@ -69,7 +69,7 @@ namespace System.Drawing.Tests
         {
             using (var fontCollection = new PrivateFontCollection())
             {
-                Assert.Throws<ArgumentException>(null, () => new FontFamily("Times New Roman", fontCollection));
+                AssertExtensions.Throws<ArgumentException>(null, () => new FontFamily("Times New Roman", fontCollection));
             }
         }
 

--- a/src/libraries/System.Drawing.Common/tests/FontTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/FontTests.cs
@@ -557,7 +557,7 @@ namespace System.Drawing.Tests
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                Assert.Equal(font.GetHeight(graphics.DpiY), font.GetHeight(graphics), 5);
+                Assert.Equal((double)font.GetHeight(graphics.DpiY), font.GetHeight(graphics), 5);
             }
         }
 
@@ -574,7 +574,7 @@ namespace System.Drawing.Tests
             using (FontFamily family = FontFamily.GenericSansSerif)
             using (var font = new Font(family, 10))
             {
-                Assert.Equal(expected, font.GetHeight(dpi), 5);
+                Assert.Equal((double)expected, font.GetHeight(dpi), 5);
             }
         }
 

--- a/src/libraries/System.Drawing.Common/tests/ImageTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/ImageTests.cs
@@ -121,7 +121,7 @@ namespace System.Drawing.Tests
         public void GetPropertyItem_NoSuchPropertyItemEmptyMemoryBitmap_ThrowsArgumentException(int propid)
         {
             using var bitmap = new Bitmap(1, 1);
-            Assert.Throws<ArgumentException>(null, () => bitmap.GetPropertyItem(propid));
+            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.GetPropertyItem(propid));
         }
 
         [Theory]
@@ -131,7 +131,7 @@ namespace System.Drawing.Tests
         public void GetPropertyItem_NoSuchPropertyItemEmptyImageBitmapBmp_ThrowsArgumentException(int propid)
         {
             using var bitmap = new Bitmap(Helpers.GetTestBitmapPath("almogaver1bit.bmp"));
-            Assert.Throws<ArgumentException>(null, () => bitmap.GetPropertyItem(propid));
+            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.GetPropertyItem(propid));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -149,17 +149,17 @@ namespace System.Drawing.Tests
 
             bitmap.RemovePropertyItem(PropertyTagExifUserComment);
             Assert.Equal(new int[] { PropertyTagChrominanceTable, PropertyTagLuminanceTable }, bitmap.PropertyIdList);
-            Assert.Throws<ArgumentException>(null, () => bitmap.GetPropertyItem(PropertyTagExifUserComment));
-            Assert.Throws<ArgumentException>(null, () => bitmap.RemovePropertyItem(PropertyTagExifUserComment));
+            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.GetPropertyItem(PropertyTagExifUserComment));
+            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.RemovePropertyItem(PropertyTagExifUserComment));
             
             bitmap.RemovePropertyItem(PropertyTagLuminanceTable);
             Assert.Equal(new int[] { PropertyTagChrominanceTable }, bitmap.PropertyIdList);
-            Assert.Throws<ArgumentException>(null, () => bitmap.GetPropertyItem(PropertyTagLuminanceTable));
-            Assert.Throws<ArgumentException>(null, () => bitmap.RemovePropertyItem(PropertyTagLuminanceTable));
+            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.GetPropertyItem(PropertyTagLuminanceTable));
+            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.RemovePropertyItem(PropertyTagLuminanceTable));
             
             bitmap.RemovePropertyItem(PropertyTagChrominanceTable);
             Assert.Empty(bitmap.PropertyIdList);
-            Assert.Throws<ArgumentException>(null, () => bitmap.GetPropertyItem(PropertyTagChrominanceTable));
+            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.GetPropertyItem(PropertyTagChrominanceTable));
             Assert.Throws<ExternalException>(() => bitmap.RemovePropertyItem(PropertyTagChrominanceTable));
         }
 
@@ -170,17 +170,17 @@ namespace System.Drawing.Tests
             using var bitmap = new Bitmap(Helpers.GetTestBitmapPath("nature24bits.jpg"));
             bitmap.RemovePropertyItem(PropertyTagExifUserComment);
             Assert.Equal(new int[] { PropertyTagChrominanceTable, PropertyTagLuminanceTable }, bitmap.PropertyIdList);
-            Assert.Throws<ArgumentException>(null, () => bitmap.GetPropertyItem(PropertyTagExifUserComment));
-            Assert.Throws<ArgumentException>(null, () => bitmap.RemovePropertyItem(PropertyTagExifUserComment));
+            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.GetPropertyItem(PropertyTagExifUserComment));
+            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.RemovePropertyItem(PropertyTagExifUserComment));
             
             bitmap.RemovePropertyItem(PropertyTagLuminanceTable);
             Assert.Equal(new int[] { PropertyTagChrominanceTable }, bitmap.PropertyIdList);
-            Assert.Throws<ArgumentException>(null, () => bitmap.GetPropertyItem(PropertyTagLuminanceTable));
-            Assert.Throws<ArgumentException>(null, () => bitmap.RemovePropertyItem(PropertyTagLuminanceTable));
+            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.GetPropertyItem(PropertyTagLuminanceTable));
+            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.RemovePropertyItem(PropertyTagLuminanceTable));
             
             bitmap.RemovePropertyItem(PropertyTagChrominanceTable);
             Assert.Empty(bitmap.PropertyIdList);
-            Assert.Throws<ArgumentException>(null, () => bitmap.GetPropertyItem(PropertyTagChrominanceTable));
+            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.GetPropertyItem(PropertyTagChrominanceTable));
             Assert.Throws<ExternalException>(() => bitmap.RemovePropertyItem(PropertyTagChrominanceTable));
         }
 
@@ -222,7 +222,7 @@ namespace System.Drawing.Tests
             bitmap.SetPropertyItem(item2);
             bitmap.SetPropertyItem(item3);
             
-            Assert.Throws<ArgumentException>(null, () => bitmap.RemovePropertyItem(propid));
+            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.RemovePropertyItem(propid));
         }
   
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
@@ -233,7 +233,7 @@ namespace System.Drawing.Tests
         public void RemovePropertyItem_NoSuchPropertyNotEmptyBitmapJpg_ThrowsArgumentException(int propid)
         {
             using var bitmap = new Bitmap(Helpers.GetTestBitmapPath("nature24bits.jpg"));
-            Assert.Throws<ArgumentException>(null, () => bitmap.RemovePropertyItem(propid));
+            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.RemovePropertyItem(propid));
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]

--- a/src/libraries/System.Drawing.Common/tests/Printing/PrinterSettingsTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Printing/PrinterSettingsTests.cs
@@ -479,10 +479,10 @@ namespace System.Drawing.Printing.Tests
             using (Graphics graphic = printerSettings.CreateMeasurementGraphics())
             {
                 Assert.NotNull(graphic);
-                Assert.Equal(printerSettings.DefaultPageSettings.Bounds.X, graphic.VisibleClipBounds.X, 0);
-                Assert.Equal(printerSettings.DefaultPageSettings.Bounds.Y, graphic.VisibleClipBounds.Y, 0);
-                Assert.Equal(printerSettings.DefaultPageSettings.PrintableArea.Height, graphic.VisibleClipBounds.Height, 0);
-                Assert.Equal(printerSettings.DefaultPageSettings.PrintableArea.Width, graphic.VisibleClipBounds.Width, 0);
+                Assert.Equal((double)printerSettings.DefaultPageSettings.Bounds.X, graphic.VisibleClipBounds.X, 0);
+                Assert.Equal((double)printerSettings.DefaultPageSettings.Bounds.Y, graphic.VisibleClipBounds.Y, 0);
+                Assert.Equal((double)printerSettings.DefaultPageSettings.PrintableArea.Height, graphic.VisibleClipBounds.Height, 0);
+                Assert.Equal((double)printerSettings.DefaultPageSettings.PrintableArea.Width, graphic.VisibleClipBounds.Width, 0);
             }
         }
 
@@ -494,8 +494,8 @@ namespace System.Drawing.Printing.Tests
             using (Graphics graphic = printerSettings.CreateMeasurementGraphics(true))
             {
                 Assert.NotNull(graphic);
-                Assert.Equal(printerSettings.DefaultPageSettings.PrintableArea.Height, graphic.VisibleClipBounds.Height, 0);
-                Assert.Equal(printerSettings.DefaultPageSettings.PrintableArea.Width, graphic.VisibleClipBounds.Width, 0);
+                Assert.Equal((double)printerSettings.DefaultPageSettings.PrintableArea.Height, graphic.VisibleClipBounds.Height, 0);
+                Assert.Equal((double)printerSettings.DefaultPageSettings.PrintableArea.Width, graphic.VisibleClipBounds.Width, 0);
             }
         }
 
@@ -508,10 +508,10 @@ namespace System.Drawing.Printing.Tests
             using (Graphics graphic = printerSettings.CreateMeasurementGraphics(pageSettings))
             {
                 Assert.NotNull(graphic);
-                Assert.Equal(printerSettings.DefaultPageSettings.Bounds.X, graphic.VisibleClipBounds.X, 0);
-                Assert.Equal(printerSettings.DefaultPageSettings.Bounds.Y, graphic.VisibleClipBounds.Y, 0);
-                Assert.Equal(printerSettings.DefaultPageSettings.PrintableArea.Height, graphic.VisibleClipBounds.Height, 0);
-                Assert.Equal(printerSettings.DefaultPageSettings.PrintableArea.Width, graphic.VisibleClipBounds.Width, 0);
+                Assert.Equal((double)printerSettings.DefaultPageSettings.Bounds.X, graphic.VisibleClipBounds.X, 0);
+                Assert.Equal((double)printerSettings.DefaultPageSettings.Bounds.Y, graphic.VisibleClipBounds.Y, 0);
+                Assert.Equal((double)printerSettings.DefaultPageSettings.PrintableArea.Height, graphic.VisibleClipBounds.Height, 0);
+                Assert.Equal((double)printerSettings.DefaultPageSettings.PrintableArea.Width, graphic.VisibleClipBounds.Width, 0);
             }
         }
 
@@ -524,8 +524,8 @@ namespace System.Drawing.Printing.Tests
             using (Graphics graphic = printerSettings.CreateMeasurementGraphics(pageSettings, true))
             {
                 Assert.NotNull(graphic);
-                Assert.Equal(printerSettings.DefaultPageSettings.PrintableArea.Height, graphic.VisibleClipBounds.Height, 0);
-                Assert.Equal(printerSettings.DefaultPageSettings.PrintableArea.Width, graphic.VisibleClipBounds.Width, 0);
+                Assert.Equal((double)printerSettings.DefaultPageSettings.PrintableArea.Height, graphic.VisibleClipBounds.Height, 0);
+                Assert.Equal((double)printerSettings.DefaultPageSettings.PrintableArea.Width, graphic.VisibleClipBounds.Width, 0);
             }
         }
 

--- a/src/libraries/System.Drawing.Common/tests/SystemPensTest.cs
+++ b/src/libraries/System.Drawing.Common/tests/SystemPensTest.cs
@@ -77,7 +77,7 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => pen.StartCap = LineCap.RoundAnchor);
             using (var matrix = new Matrix())
             {
-                Assert.Throws<ArgumentException>(null, () => pen.Transform = matrix);
+                AssertExtensions.Throws<ArgumentException>(null, () => pen.Transform = matrix);
             }
             AssertExtensions.Throws<ArgumentException>(null, () => pen.Width = 10);
         }

--- a/src/libraries/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
@@ -1794,11 +1794,11 @@ namespace MonoTests.System.Drawing
                 string_format.Alignment = StringAlignment.Far;
                 SizeF far = g.MeasureString(text, font, int.MaxValue, string_format);
 
-                Assert.Equal(near.Width, center.Width, 1);
-                Assert.Equal(near.Height, center.Height, 1);
+                Assert.Equal((double)near.Width, center.Width, 1);
+                Assert.Equal((double)near.Height, center.Height, 1);
 
-                Assert.Equal(center.Width, far.Width, 1);
-                Assert.Equal(center.Height, far.Height, 1);
+                Assert.Equal((double)center.Width, far.Width, 1);
+                Assert.Equal((double)center.Height, far.Height, 1);
             }
         }
 
@@ -1821,11 +1821,11 @@ namespace MonoTests.System.Drawing
                 string_format.Alignment = StringAlignment.Far;
                 SizeF far = g.MeasureString(text, font, int.MaxValue, string_format);
 
-                Assert.Equal(near.Width, center.Width, 0);
-                Assert.Equal(near.Height, center.Height, 0);
+                Assert.Equal((double)near.Width, center.Width, 0);
+                Assert.Equal((double)near.Height, center.Height, 0);
 
-                Assert.Equal(center.Width, far.Width, 0);
-                Assert.Equal(center.Height, far.Height, 0);
+                Assert.Equal((double)center.Width, far.Width, 0);
+                Assert.Equal((double)center.Height, far.Height, 0);
             }
         }
 
@@ -1846,11 +1846,11 @@ namespace MonoTests.System.Drawing
                 string_format.LineAlignment = StringAlignment.Far;
                 SizeF far = g.MeasureString(text, font, int.MaxValue, string_format);
 
-                Assert.Equal(near.Width, center.Width, 1);
-                Assert.Equal(near.Height, center.Height, 1);
+                Assert.Equal((double)near.Width, center.Width, 1);
+                Assert.Equal((double)near.Height, center.Height, 1);
 
-                Assert.Equal(center.Width, far.Width, 1);
-                Assert.Equal(center.Height, far.Height, 1);
+                Assert.Equal((double)center.Width, far.Width, 1);
+                Assert.Equal((double)center.Height, far.Height, 1);
             }
         }
 
@@ -1873,11 +1873,11 @@ namespace MonoTests.System.Drawing
                 string_format.LineAlignment = StringAlignment.Far;
                 SizeF far = g.MeasureString(text, font, int.MaxValue, string_format);
 
-                Assert.Equal(near.Width, center.Width, 1);
-                Assert.Equal(near.Height, center.Height, 1);
+                Assert.Equal((double)near.Width, center.Width, 1);
+                Assert.Equal((double)near.Height, center.Height, 1);
 
-                Assert.Equal(center.Width, far.Width, 1);
-                Assert.Equal(center.Height, far.Height, 1);
+                Assert.Equal((double)center.Width, far.Width, 1);
+                Assert.Equal((double)center.Height, far.Height, 1);
             }
         }
 
@@ -1895,7 +1895,7 @@ namespace MonoTests.System.Drawing
 
                 // in pixels
                 Assert.True(size2.Width < size.Width);
-                Assert.Equal(size2.Height, size.Height);
+                Assert.Equal((double)size2.Height, size.Height);
 
                 Assert.Equal(1, lines);
                 // documentation seems to suggest chars is total length
@@ -1920,8 +1920,8 @@ namespace MonoTests.System.Drawing
                 {
                     s += " ";
                     size = g.MeasureString(s, font);
-                    Assert.Equal(expected.Height, size.Height, 1);
-                    Assert.Equal(expected.Width, size.Width, 1);
+                    Assert.Equal((double)expected.Height, size.Height, 1);
+                    Assert.Equal((double)expected.Width, size.Width, 1);
                 }
 
                 s = "a";
@@ -1932,8 +1932,8 @@ namespace MonoTests.System.Drawing
                 for (int i = 1; i < 10; i++)
                 {
                     size = g.MeasureString(s, font);
-                    Assert.Equal(expected.Height, size.Height, 1);
-                    Assert.Equal(expected.Width + i * space_width, size.Width, 1);
+                    Assert.Equal((double)expected.Height, size.Height, 1);
+                    Assert.Equal((double)expected.Width + i * space_width, size.Width, 1);
                     s = " " + s;
                 }
 
@@ -1943,8 +1943,8 @@ namespace MonoTests.System.Drawing
                 {
                     s = s + " ";
                     size = g.MeasureString(s, font);
-                    Assert.Equal(expected.Height, size.Height, 1);
-                    Assert.Equal(expected.Width, size.Width, 1);
+                    Assert.Equal((double)expected.Height, size.Height, 1);
+                    Assert.Equal((double)expected.Width, size.Width, 1);
                 }
             }
         }
@@ -2076,7 +2076,7 @@ namespace MonoTests.System.Drawing
                 string_format.HotkeyPrefix = HotkeyPrefix.Hide;
                 regions = g.MeasureCharacterRanges(text, font, layout_rect, string_format);
                 RectangleF bounds_hide = regions[0].GetBounds(g);
-                Assert.Equal(bounds_hide.Width, bounds_show.Width);
+                Assert.Equal((double)bounds_hide.Width, bounds_show.Width);
             }
         }
 
@@ -2125,8 +2125,8 @@ namespace MonoTests.System.Drawing
                     RectangleF sb = small[i].GetBounds(gfx);
                     Assert.Equal(sb.X, zb.X);
                     Assert.Equal(sb.Y, zb.Y);
-                    Assert.Equal(sb.Width, zb.Width);
-                    Assert.Equal(sb.Height, zb.Height);
+                    Assert.Equal((double)sb.Width, zb.Width);
+                    Assert.Equal((double)sb.Height, zb.Height);
                 }
 
                 Region[] max = Measure_Helper(gfx, new RectangleF(0, 0, float.MaxValue, float.MaxValue));
@@ -2137,8 +2137,8 @@ namespace MonoTests.System.Drawing
                     RectangleF mb = max[i].GetBounds(gfx);
                     Assert.Equal(mb.X, zb.X);
                     Assert.Equal(mb.Y, zb.Y);
-                    Assert.Equal(mb.Width, zb.Width);
-                    Assert.Equal(mb.Height, zb.Height);
+                    Assert.Equal((double)mb.Width, zb.Width);
+                    Assert.Equal((double)mb.Height, zb.Height);
                 }
             }
         }
@@ -2316,15 +2316,15 @@ namespace MonoTests.System.Drawing
                 RectangleF clip = g.VisibleClipBounds;
                 Assert.Equal(0, clip.X);
                 Assert.Equal(0, clip.Y);
-                Assert.Equal(32, clip.Width, 4);
-                Assert.Equal(32, clip.Height, 4);
+                Assert.Equal(32.0, clip.Width, 4);
+                Assert.Equal(32.0, clip.Height, 4);
 
                 g.RotateTransform(90);
                 RectangleF rotclip = g.VisibleClipBounds;
                 Assert.Equal(0, rotclip.X);
-                Assert.Equal(-32, rotclip.Y, 4);
-                Assert.Equal(32, rotclip.Width, 4);
-                Assert.Equal(32, rotclip.Height, 4);
+                Assert.Equal(-32.0, rotclip.Y, 4);
+                Assert.Equal(32.0, rotclip.Width, 4);
+                Assert.Equal(32.0, rotclip.Height, 4);
             }
         }
 
@@ -2363,15 +2363,15 @@ namespace MonoTests.System.Drawing
                 g.RotateTransform(90);
                 RectangleF rotclipbound = g.ClipBounds;
                 Assert.Equal(0, rotclipbound.X);
-                Assert.Equal(-200, rotclipbound.Y, 4);
-                Assert.Equal(200, rotclipbound.Width, 4);
-                Assert.Equal(200, rotclipbound.Height, 4);
+                Assert.Equal(-200.0, rotclipbound.Y, 4);
+                Assert.Equal(200.0, rotclipbound.Width, 4);
+                Assert.Equal(200.0, rotclipbound.Height, 4);
 
                 RectangleF rotclip = g.VisibleClipBounds;
                 Assert.Equal(0, rotclip.X);
-                Assert.Equal(-100, rotclip.Y, 4);
-                Assert.Equal(100, rotclip.Width, 4);
-                Assert.Equal(100, rotclip.Height, 4);
+                Assert.Equal(-100.0, rotclip.Y, 4);
+                Assert.Equal(100.0, rotclip.Width, 4);
+                Assert.Equal(100.0, rotclip.Height, 4);
             }
         }
 
@@ -2390,15 +2390,15 @@ namespace MonoTests.System.Drawing
                 RectangleF vcb = g.VisibleClipBounds;
                 Assert.Equal(0, vcb.X);
                 Assert.Equal(0, vcb.Y);
-                Assert.Equal(100, vcb.Width, 4);
-                Assert.Equal(50, vcb.Height, 4);
+                Assert.Equal(100.0, vcb.Width, 4);
+                Assert.Equal(50.0, vcb.Height, 4);
 
                 g.RotateTransform(90);
                 RectangleF rvcb = g.VisibleClipBounds;
                 Assert.Equal(0, rvcb.X);
-                Assert.Equal(-100, rvcb.Y, 4);
-                Assert.Equal(50.0f, rvcb.Width, 4);
-                Assert.Equal(100, rvcb.Height, 4);
+                Assert.Equal(-100.0, rvcb.Y, 4);
+                Assert.Equal(50.0, rvcb.Width, 4);
+                Assert.Equal(100.0, rvcb.Height, 4);
             }
         }
 

--- a/src/libraries/System.Drawing.Common/tests/mono/System.Imaging/MetafileTest.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Imaging/MetafileTest.cs
@@ -441,21 +441,21 @@ namespace MonoTests.System.Drawing.Imaging
                     g.MultiplyTransform(m);
                     // check
                     float[] elements = g.Transform.Elements;
-                    Assert.Equal(-1f, elements[0], 5);
-                    Assert.Equal(0f, elements[1], 5);
-                    Assert.Equal(0f, elements[2], 5);
-                    Assert.Equal(-1f, elements[3], 5);
-                    Assert.Equal(-2f, elements[4], 5);
-                    Assert.Equal(-3f, elements[5], 5);
+                    Assert.Equal(-1.0, elements[0], 5);
+                    Assert.Equal(0.0, elements[1], 5);
+                    Assert.Equal(0.0, elements[2], 5);
+                    Assert.Equal(-1.0, elements[3], 5);
+                    Assert.Equal(-2.0, elements[4], 5);
+                    Assert.Equal(-3.0, elements[5], 5);
 
                     g.Transform = m;
                     elements = g.Transform.Elements;
-                    Assert.Equal(0f, elements[0], 5);
-                    Assert.Equal(0.5f, elements[1], 5);
-                    Assert.Equal(-2f, elements[2], 5);
-                    Assert.Equal(0f, elements[3], 5);
-                    Assert.Equal(-4f, elements[4], 5);
-                    Assert.Equal(-1f, elements[5], 5);
+                    Assert.Equal(0.0, elements[0], 5);
+                    Assert.Equal(0.5, elements[1], 5);
+                    Assert.Equal(-2.0, elements[2], 5);
+                    Assert.Equal(0.0, elements[3], 5);
+                    Assert.Equal(-4.0, elements[4], 5);
+                    Assert.Equal(-1.0, elements[5], 5);
 
                     g.ResetTransform();
                     Assert.True(g.Transform.IsIdentity);

--- a/src/libraries/System.IO.UnmanagedMemoryStream/tests/UmsSafeBuffer.cs
+++ b/src/libraries/System.IO.UnmanagedMemoryStream/tests/UmsSafeBuffer.cs
@@ -95,7 +95,7 @@ namespace System.IO.Tests
             using (var buffer = new TestSafeBuffer(length))
             {
                 var stream = new UnmanagedMemoryStream(buffer, 0, (long)buffer.ByteLength, FileAccess.Write);
-                Assert.Equal(stream.Length, length);
+                Assert.Equal(length, stream.Length);
 
                 var bytes = ArrayHelpers.CreateByteArray(length);
                 var copy = bytes.Copy();
@@ -116,7 +116,7 @@ namespace System.IO.Tests
             using (var buffer = new TestSafeBuffer(length))
             {
                 var stream = new UnmanagedMemoryStream(buffer, 0, (long)buffer.ByteLength, FileAccess.ReadWrite);
-                Assert.Equal(stream.Length, length);
+                Assert.Equal(length, stream.Length);
 
                 var bytes = ArrayHelpers.CreateByteArray(length);
                 for (int index = 0; index < length; index++)

--- a/src/libraries/System.IO/tests/IndentedTextWriter.cs
+++ b/src/libraries/System.IO/tests/IndentedTextWriter.cs
@@ -312,7 +312,7 @@ namespace System.CodeDom.Tests
             Assert.Same(sw, itw.InnerWriter);
             Assert.Equal(sw.NewLine, itw.NewLine);
 
-            Assert.Equal(new string(' ', 4), IndentedTextWriter.DefaultTabString);
+            Assert.Equal("    ", IndentedTextWriter.DefaultTabString);
         }
 
         [Fact]

--- a/src/libraries/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
+++ b/src/libraries/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
@@ -1401,7 +1401,7 @@ namespace System.Linq.Expressions.Tests
         [Fact]
         public void CatchesMustReturnVoidWithVoidBody()
         {
-            Assert.Throws<ArgumentException>(null, () =>
+            AssertExtensions.Throws<ArgumentException>(null, () =>
                 Expression.TryCatch(
                     Expression.Empty(),
                     Expression.Catch(typeof(InvocationExpression), Expression.Constant("hello")),

--- a/src/libraries/System.Memory/tests/MemoryMarshal/AsReadOnlyRef.cs
+++ b/src/libraries/System.Memory/tests/MemoryMarshal/AsReadOnlyRef.cs
@@ -22,7 +22,7 @@ namespace System.SpanTests
             Array.Fill<byte>(array, 0x42);
             ref readonly TestHelpers.TestStructExplicit asStruct = ref MemoryMarshal.AsRef<TestHelpers.TestStructExplicit>(new ReadOnlySpan<byte>(array));
 
-            Assert.Equal(asStruct.UI1, (uint)0x42424242);
+            Assert.Equal((uint)0x42424242, asStruct.UI1);
         }
 
         [Fact]

--- a/src/libraries/System.Memory/tests/MemoryMarshal/AsRef.cs
+++ b/src/libraries/System.Memory/tests/MemoryMarshal/AsRef.cs
@@ -22,7 +22,7 @@ namespace System.SpanTests
             Array.Fill<byte>(array, 0x42);
             ref TestHelpers.TestStructExplicit asStruct = ref MemoryMarshal.AsRef<TestHelpers.TestStructExplicit>(new Span<byte>(array));
 
-            Assert.Equal(asStruct.UI1, (uint)0x42424242);
+            Assert.Equal((uint)0x42424242, asStruct.UI1);
         }
 
         [Fact]

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -2236,9 +2236,9 @@ namespace System.Net.Http.Functional.Tests
 
                 await Task.WhenAll(handleRequestTasks).WaitAsync(TestHelper.PassingTestTimeout).ConfigureAwait(false);
 
-                Assert.Equal(handleRequestTasks[0].Result.Count, MaxConcurrentStreams);
-                Assert.Equal(handleRequestTasks[1].Result.Count, MaxConcurrentStreams);
-                Assert.Equal(handleRequestTasks[2].Result.Count, MaxConcurrentStreams);
+                Assert.Equal(MaxConcurrentStreams, handleRequestTasks[0].Result.Count);
+                Assert.Equal(MaxConcurrentStreams, handleRequestTasks[1].Result.Count);
+                Assert.Equal(MaxConcurrentStreams, handleRequestTasks[2].Result.Count);
 
                 await connection0.ShutdownIgnoringErrorsAsync(handleRequestTasks[0].Result.LastStreamId).ConfigureAwait(false);
                 await connection2.ShutdownIgnoringErrorsAsync(handleRequestTasks[2].Result.LastStreamId).ConfigureAwait(false);
@@ -2259,9 +2259,9 @@ namespace System.Net.Http.Functional.Tests
 
                 await Task.WhenAll(finalHandleTasks).WaitAsync(TestHelper.PassingTestTimeout).ConfigureAwait(false);
 
-                Assert.Equal(finalHandleTasks[0].Result.Count, MaxConcurrentStreams);
-                Assert.Equal(finalHandleTasks[1].Result.Count, MaxConcurrentStreams);
-                Assert.Equal(finalHandleTasks[2].Result.Count, MaxConcurrentStreams);
+                Assert.Equal(MaxConcurrentStreams, finalHandleTasks[0].Result.Count);
+                Assert.Equal(MaxConcurrentStreams, finalHandleTasks[1].Result.Count);
+                Assert.Equal(MaxConcurrentStreams, finalHandleTasks[2].Result.Count);
 
                 await Task.WhenAll(sendTasks).WaitAsync(TestHelper.PassingTestTimeout).ConfigureAwait(false);
 

--- a/src/libraries/System.Net.Mail/tests/Functional/ContentDispositionTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/ContentDispositionTest.cs
@@ -261,7 +261,7 @@ namespace System.Net.Mime.Tests
             cd.Parameters["creation-date"] = ValidDateTimeLocal;
 
             Assert.Equal(DateTimeKind.Local, cd.CreationDate.Kind);
-            Assert.Equal(cd.Parameters["creation-date"], ValidDateTimeLocal);
+            Assert.Equal(ValidDateTimeLocal, cd.Parameters["creation-date"]);
         }
 
         [Fact]

--- a/src/libraries/System.Net.Requests/tests/FtpWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/FtpWebRequestTest.cs
@@ -40,9 +40,9 @@ namespace System.Net.Tests
             Assert.NotNull(request.Headers);
             Assert.Equal(0, request.Headers.Count);
             Assert.True(request.KeepAlive);
-            Assert.Equal(request.Method, WebRequestMethods.Ftp.DownloadFile);
+            Assert.Equal(WebRequestMethods.Ftp.DownloadFile, request.Method);
             Assert.Null(request.Proxy);
-            Assert.Equal(request.ReadWriteTimeout, 5 * 60 * 1000);
+            Assert.Equal(5 * 60 * 1000, request.ReadWriteTimeout);
             Assert.Null(request.RenameTo);
             Assert.Equal("ftp", request.RequestUri.Scheme);
             Assert.Equal("foo.com", request.RequestUri.Host);

--- a/src/libraries/System.Numerics.Vectors/tests/Vector2Tests.cs
+++ b/src/libraries/System.Numerics.Vectors/tests/Vector2Tests.cs
@@ -844,8 +844,8 @@ namespace System.Numerics.Tests
         public void Vector2ConstructorTest3()
         {
             Vector2 target = new Vector2(float.NaN, float.MaxValue);
-            Assert.Equal(target.X, float.NaN);
-            Assert.Equal(target.Y, float.MaxValue);
+            Assert.Equal(float.NaN, target.X);
+            Assert.Equal(float.MaxValue, target.Y);
         }
 
         // A test for Vector2f (float)

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -546,13 +546,13 @@ namespace System.PrivateUri.Tests
             int i;
 
             i = Uri.Compare(uri1, uri2, UriComponents.AbsoluteUri, UriFormat.UriEscaped, StringComparison.CurrentCulture);
-            Assert.Equal(i, -1);
+            Assert.Equal(-1, i);
 
             i = Uri.Compare(uri1, uri2, UriComponents.Query, UriFormat.UriEscaped, StringComparison.CurrentCulture);
             Assert.Equal(0, i);
 
             i = Uri.Compare(uri1, uri2, UriComponents.Query | UriComponents.Fragment, UriFormat.UriEscaped, StringComparison.CurrentCulture);
-            Assert.Equal(i, -1);
+            Assert.Equal(-1, i);
 
             Assert.False(uri1.Equals(uri2));
 

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
@@ -58,12 +58,12 @@ public static partial class XmlSerializerTests
     [Fact]
     public static void Xml_CharAsRoot()
     {
-        Assert.StrictEqual(SerializeAndDeserialize<char>(char.MinValue,
+        Assert.StrictEqual(char.MinValue, SerializeAndDeserialize<char>(char.MinValue,
 @"<?xml version=""1.0""?>
-<char>0</char>"), char.MinValue);
-        Assert.StrictEqual(SerializeAndDeserialize<char>(char.MaxValue,
+<char>0</char>"));
+        Assert.StrictEqual(char.MaxValue, SerializeAndDeserialize<char>(char.MaxValue,
 @"<?xml version=""1.0""?>
-<char>65535</char>"), char.MaxValue);
+<char>65535</char>"));
         Assert.StrictEqual('a', SerializeAndDeserialize<char>('a',
 @"<?xml version=""1.0""?>
 <char>97</char>"));
@@ -81,12 +81,12 @@ public static partial class XmlSerializerTests
         Assert.StrictEqual(10, SerializeAndDeserialize<byte>(10,
 @"<?xml version=""1.0""?>
 <unsignedByte>10</unsignedByte>"));
-        Assert.StrictEqual(SerializeAndDeserialize<byte>(byte.MinValue,
+        Assert.StrictEqual(byte.MinValue, SerializeAndDeserialize<byte>(byte.MinValue,
 @"<?xml version=""1.0""?>
-<unsignedByte>0</unsignedByte>"), byte.MinValue);
-        Assert.StrictEqual(SerializeAndDeserialize<byte>(byte.MaxValue,
+<unsignedByte>0</unsignedByte>"));
+        Assert.StrictEqual(byte.MaxValue, SerializeAndDeserialize<byte>(byte.MaxValue,
 @"<?xml version=""1.0""?>
-<unsignedByte>255</unsignedByte>"), byte.MaxValue);
+<unsignedByte>255</unsignedByte>"));
     }
 
     [Fact]
@@ -128,46 +128,46 @@ public static partial class XmlSerializerTests
     [Fact]
     public static void Xml_DoubleAsRoot()
     {
-        Assert.StrictEqual(SerializeAndDeserialize<double>(-1.2,
+        Assert.StrictEqual(-1.2, SerializeAndDeserialize<double>(-1.2,
 @"<?xml version=""1.0""?>
-<double>-1.2</double>"), -1.2);
+<double>-1.2</double>"));
         Assert.StrictEqual(0, SerializeAndDeserialize<double>(0,
 @"<?xml version=""1.0""?>
 <double>0</double>"));
         Assert.StrictEqual(2.3, SerializeAndDeserialize<double>(2.3,
 @"<?xml version=""1.0""?>
 <double>2.3</double>"));
-        Assert.StrictEqual(SerializeAndDeserialize<double>(double.MinValue,
+        Assert.StrictEqual(double.MinValue, SerializeAndDeserialize<double>(double.MinValue,
 @"<?xml version=""1.0""?>
-<double>-1.7976931348623157E+308</double>"), double.MinValue);
-        Assert.StrictEqual(SerializeAndDeserialize<double>(double.MaxValue,
+<double>-1.7976931348623157E+308</double>"));
+        Assert.StrictEqual(double.MaxValue, SerializeAndDeserialize<double>(double.MaxValue,
 @"<?xml version=""1.0""?>
-<double>1.7976931348623157E+308</double>"), double.MaxValue);
+<double>1.7976931348623157E+308</double>"));
     }
 
     [Fact]
     public static void Xml_FloatAsRoot()
     {
-        Assert.StrictEqual(SerializeAndDeserialize<float>((float)-1.2,
+        Assert.StrictEqual((float)-1.2, SerializeAndDeserialize<float>((float)-1.2,
 @"<?xml version=""1.0""?>
-<float>-1.2</float>"), (float)-1.2);
-        Assert.StrictEqual(SerializeAndDeserialize<float>((float)0,
+<float>-1.2</float>"));
+        Assert.StrictEqual((float)0, SerializeAndDeserialize<float>((float)0,
 @"<?xml version=""1.0""?>
-<float>0</float>"), (float)0);
-        Assert.StrictEqual(SerializeAndDeserialize<float>((float)2.3,
+<float>0</float>"));
+        Assert.StrictEqual((float)2.3, SerializeAndDeserialize<float>((float)2.3,
 @"<?xml version=""1.0""?>
-<float>2.3</float>"), (float)2.3);
+<float>2.3</float>"));
     }
 
     [Fact]
     public static void Xml_FloatAsRoot_NotNetFramework()
     {
-        Assert.StrictEqual(SerializeAndDeserialize<float>(float.MinValue,
+        Assert.StrictEqual(float.MinValue, SerializeAndDeserialize<float>(float.MinValue,
 @"<?xml version=""1.0""?>
-<float>-3.4028235E+38</float>"), float.MinValue);
-        Assert.StrictEqual(SerializeAndDeserialize<float>(float.MaxValue,
+<float>-3.4028235E+38</float>"));
+        Assert.StrictEqual(float.MaxValue, SerializeAndDeserialize<float>(float.MaxValue,
 @"<?xml version=""1.0""?>
-<float>3.4028235E+38</float>"), float.MaxValue);
+<float>3.4028235E+38</float>"));
     }
 
     [Fact]
@@ -229,8 +229,8 @@ public static partial class XmlSerializerTests
         Assert.StrictEqual(SerializeAndDeserialize<XmlQualifiedName>(new XmlQualifiedName("abc", "def"),
 @"<?xml version=""1.0""?>
 <QName xmlns:q1=""def"">q1:abc</QName>"), new XmlQualifiedName("abc", "def"));
-        Assert.StrictEqual(SerializeAndDeserialize<XmlQualifiedName>(XmlQualifiedName.Empty,
-@"<?xml version=""1.0""?><QName xmlns="""" />"), XmlQualifiedName.Empty);
+        Assert.StrictEqual(XmlQualifiedName.Empty, SerializeAndDeserialize<XmlQualifiedName>(XmlQualifiedName.Empty,
+@"<?xml version=""1.0""?><QName xmlns="""" />"));
     }
 
     [Fact]

--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/MetadataReaderTests.cs
@@ -127,7 +127,7 @@ namespace System.Reflection.Metadata.Tests
 
             //find index for mscorlib
             int mscorlibIndex = IndexOf(peImage, Encoding.ASCII.GetBytes("mscorlib"), headers.MetadataStartOffset);
-            Assert.NotEqual(mscorlibIndex, -1);
+            Assert.NotEqual(-1, mscorlibIndex);
             //mutate mscorlib
             peImage[mscorlibIndex + headers.MetadataStartOffset] = 0xFF;
 
@@ -146,10 +146,10 @@ namespace System.Reflection.Metadata.Tests
             // mutate CLR to reach MetadataKind.WindowsMetadata
             // find CLR
             int clrIndex = IndexOf(peImage, Encoding.ASCII.GetBytes("CLR"), headers.MetadataStartOffset);
-            Assert.NotEqual(clrIndex, -1);
+            Assert.NotEqual(-1, clrIndex);
             //find 5, This is the streamcount and is the last thing that should be read befor the test.
             int fiveIndex = IndexOf(peImage, new byte[] {5}, headers.MetadataStartOffset + clrIndex);
-            Assert.NotEqual(fiveIndex, -1);
+            Assert.NotEqual(-1, fiveIndex);
 
             peImage[clrIndex + headers.MetadataStartOffset] = 0xFF;
 
@@ -173,7 +173,7 @@ namespace System.Reflection.Metadata.Tests
 
             //find 5, This is the streamcount we'll change to one to leave out loops.
             int fiveIndex = IndexOf(peImage, new byte[] { 5 }, headers.MetadataStartOffset);
-            Assert.NotEqual(fiveIndex, -1);
+            Assert.NotEqual(-1, fiveIndex);
             Array.Copy(BitConverter.GetBytes((ushort)1), 0, peImage, fiveIndex + headers.MetadataStartOffset, BitConverter.GetBytes((ushort)1).Length);
 
             string[] streamNames= new string[]
@@ -206,7 +206,7 @@ namespace System.Reflection.Metadata.Tests
 
             //0x900001447 is the external table mask from PortablePdbs.DocumentsPdb
             int externalTableMaskIndex = IndexOf(peImage, new byte[] { 0x47, 0x14, 0, 0, 9, 0, 0, 0 }, 0);
-            Assert.NotEqual(externalTableMaskIndex, -1);
+            Assert.NotEqual(-1, externalTableMaskIndex);
 
             Array.Copy(new byte[] { 0x48, 0x14, 0, 0, 9, 0, 0, 0 }, 0, peImage, externalTableMaskIndex, 8);
             Assert.Throws<BadImageFormatException>(() => new MetadataReader((byte*)pinned.AddrOfPinnedObject(), peImage.Length));
@@ -219,13 +219,13 @@ namespace System.Reflection.Metadata.Tests
             GCHandle pinned = GetPinnedPEImage(peImage);
             //Find COR20Constants.StringStreamName to be changed to COR20Constants.MinimalDeltaMetadataTableStreamName
             int stringIndex = IndexOf(peImage, Encoding.ASCII.GetBytes(COR20Constants.StringStreamName), 0);
-            Assert.NotEqual(stringIndex, -1);
+            Assert.NotEqual(-1, stringIndex);
             //find remainingBytes to be increased because we are changing to uncompressed
             int remainingBytesIndex = IndexOf(peImage, BitConverter.GetBytes(180), 0);
-            Assert.NotEqual(remainingBytesIndex, -1);
+            Assert.NotEqual(-1, remainingBytesIndex);
             //find compressed to change to uncompressed
             int compressedIndex = IndexOf(peImage, Encoding.ASCII.GetBytes(COR20Constants.CompressedMetadataTableStreamName), 0);
-            Assert.NotEqual(compressedIndex, -1);
+            Assert.NotEqual(-1, compressedIndex);
 
             Array.Copy(Encoding.ASCII.GetBytes(COR20Constants.MinimalDeltaMetadataTableStreamName), 0, peImage, stringIndex, Encoding.ASCII.GetBytes(COR20Constants.MinimalDeltaMetadataTableStreamName).Length);
             peImage[stringIndex + COR20Constants.MinimalDeltaMetadataTableStreamName.Length] = (byte)0;
@@ -248,10 +248,10 @@ namespace System.Reflection.Metadata.Tests
 
             //0x0570 is the remaining bytes from NetModule.AppCS
             int remainingBytesIndex = IndexOf(peImage, new byte[] { 0x70, 0x05, 0, 0 }, headers.MetadataStartOffset);
-            Assert.NotEqual(remainingBytesIndex, -1);
+            Assert.NotEqual(-1, remainingBytesIndex);
             //0xcc90da21757 is the presentTables from NetModule.AppCS, must be after remainingBytesIndex
             int presentTablesIndex = IndexOf(peImage, new byte[] { 0x57, 0x17, 0xa2, 0x0d, 0xc9, 0x0c, 0, 0 }, headers.MetadataStartOffset + remainingBytesIndex);
-            Assert.NotEqual(presentTablesIndex, -1);
+            Assert.NotEqual(-1, presentTablesIndex);
 
             //Set this.ModuleTable.NumberOfRows to 0
             Array.Copy(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0 }, 0, peImage, presentTablesIndex + remainingBytesIndex + headers.MetadataStartOffset + 16, 8);

--- a/src/libraries/System.Reflection.Metadata/tests/Utilities/CompressedIntegerTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Utilities/CompressedIntegerTests.cs
@@ -323,7 +323,7 @@ namespace System.Reflection.Metadata.Tests
                 {
                     Assert.Equal(0, reader.Offset);
                     Assert.Throws<BadImageFormatException>(() => reader.ReadCompressedInteger());
-                    Assert.Equal(value, BlobReader.InvalidCompressedInteger);
+                    Assert.Equal(BlobReader.InvalidCompressedInteger, value);
                     Assert.Equal(0, reader.Offset);
                 }
 

--- a/src/libraries/System.Reflection/tests/ParameterInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/ParameterInfoTests.cs
@@ -104,7 +104,7 @@ namespace System.Reflection.Tests
             ParameterInfo p = GetParameterInfo(typeof(ParameterInfoMetadata), "Foo1", 0);
             object raw = p.RawDefaultValue;
             Assert.Equal(typeof(int), raw.GetType());
-            Assert.Equal<int>((int)raw, (int)BindingFlags.DeclaredOnly);
+            Assert.Equal<int>((int)BindingFlags.DeclaredOnly, (int)raw);
         }
 
         [Fact]
@@ -114,7 +114,7 @@ namespace System.Reflection.Tests
             ParameterInfo p = GetParameterInfo(typeof(ParameterInfoMetadata), "Foo2", 0);
             object raw = p.RawDefaultValue;
             Assert.Equal(typeof(int), raw.GetType());
-            Assert.Equal<int>((int)raw, (int)BindingFlags.IgnoreCase);
+            Assert.Equal<int>((int)BindingFlags.IgnoreCase, (int)raw);
         }
 
         [Fact]
@@ -123,7 +123,7 @@ namespace System.Reflection.Tests
             ParameterInfo p = GetParameterInfo(typeof(ParameterInfoMetadata), "Foo3", 0);
             object raw = p.RawDefaultValue;
             Assert.Equal(typeof(int), raw.GetType());
-            Assert.Equal<int>((int)raw, (int)BindingFlags.FlattenHierarchy);
+            Assert.Equal<int>((int)BindingFlags.FlattenHierarchy, (int)raw);
         }
 
         [Theory]

--- a/src/libraries/System.Resources.Extensions/tests/BinaryResourceWriterUnitTest.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryResourceWriterUnitTest.cs
@@ -69,36 +69,36 @@ namespace System.Resources.Extensions.Tests
             {
                 writer.AddResource("duplicate", "value");
 
-                Assert.Throws<ArgumentException>(null, () => writer.AddResource("duplicate", "value"));
-                Assert.Throws<ArgumentException>(null, () => writer.AddResource("duplicate", new object()));
-                Assert.Throws<ArgumentException>(null, () => writer.AddResource("duplicate", new byte[0]));
+                AssertExtensions.Throws<ArgumentException>(null, () => writer.AddResource("duplicate", "value"));
+                AssertExtensions.Throws<ArgumentException>(null, () => writer.AddResource("duplicate", new object()));
+                AssertExtensions.Throws<ArgumentException>(null, () => writer.AddResource("duplicate", new byte[0]));
 
                 using (var stream = new MemoryStream())
                 {
-                    Assert.Throws<ArgumentException>(null, () => writer.AddResource("duplicate", stream));
-                    Assert.Throws<ArgumentException>(null, () => writer.AddResource("duplicate", stream, true));
-                    Assert.Throws<ArgumentException>(null, () => writer.AddActivatorResource("duplicate", stream, "System.DayOfWeek", false));
+                    AssertExtensions.Throws<ArgumentException>(null, () => writer.AddResource("duplicate", stream));
+                    AssertExtensions.Throws<ArgumentException>(null, () => writer.AddResource("duplicate", stream, true));
+                    AssertExtensions.Throws<ArgumentException>(null, () => writer.AddActivatorResource("duplicate", stream, "System.DayOfWeek", false));
                 }
 
-                Assert.Throws<ArgumentException>(null, () => writer.AddBinaryFormattedResource("duplicate", new byte[1], "System.DayOfWeek"));
-                Assert.Throws<ArgumentException>(null, () => writer.AddTypeConverterResource("duplicate", new byte[1], "System.DayOfWeek"));
-                Assert.Throws<ArgumentException>(null, () => writer.AddResource("duplicate", "Monday", "System.DayOfWeek"));
+                AssertExtensions.Throws<ArgumentException>(null, () => writer.AddBinaryFormattedResource("duplicate", new byte[1], "System.DayOfWeek"));
+                AssertExtensions.Throws<ArgumentException>(null, () => writer.AddTypeConverterResource("duplicate", new byte[1], "System.DayOfWeek"));
+                AssertExtensions.Throws<ArgumentException>(null, () => writer.AddResource("duplicate", "Monday", "System.DayOfWeek"));
 
 
-                Assert.Throws<ArgumentException>(null, () => writer.AddResource("Duplicate", "value"));
-                Assert.Throws<ArgumentException>(null, () => writer.AddResource("dUplicate", new object()));
-                Assert.Throws<ArgumentException>(null, () => writer.AddResource("duPlicate", new byte[0]));
+                AssertExtensions.Throws<ArgumentException>(null, () => writer.AddResource("Duplicate", "value"));
+                AssertExtensions.Throws<ArgumentException>(null, () => writer.AddResource("dUplicate", new object()));
+                AssertExtensions.Throws<ArgumentException>(null, () => writer.AddResource("duPlicate", new byte[0]));
 
                 using (var stream = new MemoryStream())
                 {
-                    Assert.Throws<ArgumentException>(null, () => writer.AddResource("dupLicate", stream));
-                    Assert.Throws<ArgumentException>(null, () => writer.AddResource("duplIcate", stream, true));
-                    Assert.Throws<ArgumentException>(null, () => writer.AddActivatorResource("dupliCate", stream, "System.DayOfWeek", false));
+                    AssertExtensions.Throws<ArgumentException>(null, () => writer.AddResource("dupLicate", stream));
+                    AssertExtensions.Throws<ArgumentException>(null, () => writer.AddResource("duplIcate", stream, true));
+                    AssertExtensions.Throws<ArgumentException>(null, () => writer.AddActivatorResource("dupliCate", stream, "System.DayOfWeek", false));
                 }
 
-                Assert.Throws<ArgumentException>(null, () => writer.AddBinaryFormattedResource("duplicAte", new byte[1], "System.DayOfWeek"));
-                Assert.Throws<ArgumentException>(null, () => writer.AddTypeConverterResource("duplicaTe", new byte[1], "System.DayOfWeek"));
-                Assert.Throws<ArgumentException>(null, () => writer.AddResource("duplicatE", "Monday", "System.DayOfWeek"));
+                AssertExtensions.Throws<ArgumentException>(null, () => writer.AddBinaryFormattedResource("duplicAte", new byte[1], "System.DayOfWeek"));
+                AssertExtensions.Throws<ArgumentException>(null, () => writer.AddTypeConverterResource("duplicaTe", new byte[1], "System.DayOfWeek"));
+                AssertExtensions.Throws<ArgumentException>(null, () => writer.AddResource("duplicatE", "Monday", "System.DayOfWeek"));
             }
         }
 

--- a/src/libraries/System.Runtime.Extensions/tests/System/IO/PathTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/IO/PathTests.cs
@@ -157,7 +157,7 @@ namespace System.IO.Tests
             for (int i = 0; i < 100; i++)
             {
                 string s = Path.GetRandomFileName();
-                Assert.Equal(s.Length, 8 + 1 + 3);
+                Assert.Equal(8 + 1 + 3, s.Length);
                 Assert.Equal('.', s[8]);
                 Assert.Equal(-1, s.IndexOfAny(invalidChars));
                 Assert.True(fileNames.Add(s));

--- a/src/libraries/System.Runtime.Extensions/tests/System/IO/PathTests_Unix.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/IO/PathTests_Unix.cs
@@ -158,7 +158,7 @@ namespace System.IO.Tests
         [Fact]
         public void GetFullPath_ThrowsOnEmbeddedNulls()
         {
-            Assert.Throws<ArgumentException>(null, () => Path.GetFullPath("/gi\0t", "/foo/bar"));
+            AssertExtensions.Throws<ArgumentException>(null, () => Path.GetFullPath("/gi\0t", "/foo/bar"));
         }
 
         public static TheoryData<string, string> TestData_TrimEndingDirectorySeparator => new TheoryData<string, string>

--- a/src/libraries/System.Runtime.Extensions/tests/System/IO/PathTests_Windows.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/IO/PathTests_Windows.cs
@@ -616,7 +616,7 @@ namespace System.IO.Tests
         [Fact]
         public void GetFullPath_ThrowsOnEmbeddedNulls()
         {
-            Assert.Throws<ArgumentException>(null, () => Path.GetFullPath("/gi\0t", @"C:\foo\bar"));
+            AssertExtensions.Throws<ArgumentException>(null, () => Path.GetFullPath("/gi\0t", @"C:\foo\bar"));
         }
 
         public static TheoryData<string, string> TestData_TrimEndingDirectorySeparator => new TheoryData<string, string>

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SafeBufferTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/SafeBufferTests.cs
@@ -64,8 +64,8 @@ namespace System.Runtime.InteropServices.Tests
             var buffer = new SubBuffer(true);
             buffer.Initialize(4);
 
-            Assert.Throws<ArgumentException>(null, () => buffer.Read<int>(byteOffset));
-            Assert.Throws<ArgumentException>(null, () => buffer.Write<int>(byteOffset, 2));
+            AssertExtensions.Throws<ArgumentException>(null, () => buffer.Read<int>(byteOffset));
+            AssertExtensions.Throws<ArgumentException>(null, () => buffer.Write<int>(byteOffset, 2));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime.Loader/tests/DefaultContext/DefaultLoadContextTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/DefaultContext/DefaultLoadContextTest.cs
@@ -151,7 +151,7 @@ namespace System.Runtime.Loader.Tests
             Assert.Equal(assemblyExpected, assemblyExpectedFromLoad);
 
             // And make sure the simple name matches
-            Assert.Equal(assemblyExpected.GetName().Name, TestAssemblyName);
+            Assert.Equal(TestAssemblyName, assemblyExpected.GetName().Name);
 
             // Unwire the Resolving event.
             AssemblyLoadContext.Default.Resolving -= ResolveAssemblyAgain;

--- a/src/libraries/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/libraries/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -50,47 +50,47 @@ public static partial class DataContractJsonSerializerTests
     public static void DCJS_CharAsRoot()
     {
         // Special characters
-        Assert.StrictEqual(SerializeAndDeserialize<char>((char)0x2f, @"""\/"""), (char)0x2f); // Expected output string is: \/
-        Assert.StrictEqual(SerializeAndDeserialize<char>((char)0x5c, @"""\\"""), (char)0x5c); // \\
-        Assert.StrictEqual(SerializeAndDeserialize<char>((char)0x27, @"""'"""), (char)0x27); // '
-        Assert.StrictEqual(SerializeAndDeserialize<char>((char)0x22, @"""\"""""), (char)0x22); // \"
+        Assert.StrictEqual((char)0x2f, SerializeAndDeserialize<char>((char)0x2f, @"""\/""")); // Expected output string is: \/
+        Assert.StrictEqual((char)0x5c, SerializeAndDeserialize<char>((char)0x5c, @"""\\""")); // \\
+        Assert.StrictEqual((char)0x27, SerializeAndDeserialize<char>((char)0x27, @"""'""")); // '
+        Assert.StrictEqual((char)0x22, SerializeAndDeserialize<char>((char)0x22, @"""\""""")); // \"
 
         // There are 5 ranges of characters that have output in the form of "\u<code>".
         // The following tests the start and end character and at least one character in each range
         // and also in between the ranges.
 
         // #1. 0x0000 - 0x001F
-        Assert.StrictEqual(SerializeAndDeserialize<char>(char.MinValue, @"""\u0000"""), char.MinValue);
-        Assert.StrictEqual(SerializeAndDeserialize<char>((char)0x10, @"""\u0010"""), (char)0x10);
-        Assert.StrictEqual(SerializeAndDeserialize<char>((char)0x1f, @"""\u001f"""), (char)0x1f);
+        Assert.StrictEqual(char.MinValue, SerializeAndDeserialize<char>(char.MinValue, @"""\u0000"""));
+        Assert.StrictEqual((char)0x10, SerializeAndDeserialize<char>((char)0x10, @"""\u0010"""));
+        Assert.StrictEqual((char)0x1f, SerializeAndDeserialize<char>((char)0x1f, @"""\u001f"""));
 
         // Between #1 and #2
         Assert.StrictEqual('a', SerializeAndDeserialize<char>('a', @"""a""")); // 0x0061
 
         // #2. 0x0085
-        Assert.StrictEqual(SerializeAndDeserialize<char>((char)0x85, @"""\u0085"""), (char)0x85);
+        Assert.StrictEqual((char)0x85, SerializeAndDeserialize<char>((char)0x85, @"""\u0085"""));
 
         // Between #2 and #3
         Assert.StrictEqual('\u00F1', SerializeAndDeserialize<char>('\u00F1', "\"\u00F1\"")); // 0x00F1
 
         // #3. 0x2028 - 0x2029
-        Assert.StrictEqual(SerializeAndDeserialize<char>((char)0x2028, @"""\u2028"""), (char)0x2028);
-        Assert.StrictEqual(SerializeAndDeserialize<char>((char)0x2029, @"""\u2029"""), (char)0x2029);
+        Assert.StrictEqual((char)0x2028, SerializeAndDeserialize<char>((char)0x2028, @"""\u2028"""));
+        Assert.StrictEqual((char)0x2029, SerializeAndDeserialize<char>((char)0x2029, @"""\u2029"""));
 
         // Between #3 and #4
         Assert.StrictEqual('?', SerializeAndDeserialize<char>('?', @"""?""")); // 0x6F22
 
         // #4. 0xD800 - 0xDFFF
-        Assert.StrictEqual(SerializeAndDeserialize<char>((char)0xd800, @"""\ud800"""), (char)0xd800);
-        Assert.StrictEqual(SerializeAndDeserialize<char>((char)0xdabc, @"""\udabc"""), (char)0xdabc);
-        Assert.StrictEqual(SerializeAndDeserialize<char>((char)0xdfff, @"""\udfff"""), (char)0xdfff);
+        Assert.StrictEqual((char)0xd800, SerializeAndDeserialize<char>((char)0xd800, @"""\ud800"""));
+        Assert.StrictEqual((char)0xdabc, SerializeAndDeserialize<char>((char)0xdabc, @"""\udabc"""));
+        Assert.StrictEqual((char)0xdfff, SerializeAndDeserialize<char>((char)0xdfff, @"""\udfff"""));
 
         // Between #4 and #5
-        Assert.StrictEqual(SerializeAndDeserialize<char>((char)0xeabc, "\"\uEABC\""), (char)0xeabc);
+        Assert.StrictEqual((char)0xeabc, SerializeAndDeserialize<char>((char)0xeabc, "\"\uEABC\""));
 
         // #5. 0xFFFE - 0xFFFF
-        Assert.StrictEqual(SerializeAndDeserialize<char>((char)0xfffe, @"""\ufffe"""), (char)0xfffe);
-        Assert.StrictEqual(SerializeAndDeserialize<char>(char.MaxValue, @"""\uffff"""), char.MaxValue);
+        Assert.StrictEqual((char)0xfffe, SerializeAndDeserialize<char>((char)0xfffe, @"""\ufffe"""));
+        Assert.StrictEqual(char.MaxValue, SerializeAndDeserialize<char>(char.MaxValue, @"""\uffff"""));
     }
 
     [Fact]
@@ -108,8 +108,8 @@ public static partial class DataContractJsonSerializerTests
     public static void DCJS_ByteAsRoot()
     {
         Assert.StrictEqual(10, SerializeAndDeserialize<byte>(10, "10"));
-        Assert.StrictEqual(SerializeAndDeserialize<byte>(byte.MinValue, "0"), byte.MinValue);
-        Assert.StrictEqual(SerializeAndDeserialize<byte>(byte.MaxValue, "255"), byte.MaxValue);
+        Assert.StrictEqual(byte.MinValue, SerializeAndDeserialize<byte>(byte.MinValue, "0"));
+        Assert.StrictEqual(byte.MaxValue, SerializeAndDeserialize<byte>(byte.MaxValue, "255"));
     }
 
     [Fact]
@@ -139,26 +139,26 @@ public static partial class DataContractJsonSerializerTests
     [Fact]
     public static void DCJS_DoubleAsRoot()
     {
-        Assert.StrictEqual(SerializeAndDeserialize<double>(-1.2, "-1.2"), -1.2);
+        Assert.StrictEqual(-1.2, SerializeAndDeserialize<double>(-1.2, "-1.2"));
         Assert.StrictEqual(0, SerializeAndDeserialize<double>(0, "0"));
         Assert.StrictEqual(2.3, SerializeAndDeserialize<double>(2.3, "2.3"));
-        Assert.StrictEqual(SerializeAndDeserialize<double>(double.MinValue, "-1.7976931348623157E+308"), double.MinValue);
-        Assert.StrictEqual(SerializeAndDeserialize<double>(double.MaxValue, "1.7976931348623157E+308"), double.MaxValue);
+        Assert.StrictEqual(double.MinValue, SerializeAndDeserialize<double>(double.MinValue, "-1.7976931348623157E+308"));
+        Assert.StrictEqual(double.MaxValue, SerializeAndDeserialize<double>(double.MaxValue, "1.7976931348623157E+308"));
     }
 
     [Fact]
     public static void DCJS_FloatAsRoot()
     {
-        Assert.StrictEqual(SerializeAndDeserialize<float>((float)-1.2, "-1.2"), (float)-1.2);
-        Assert.StrictEqual(SerializeAndDeserialize<float>((float)0, "0"), (float)0);
-        Assert.StrictEqual(SerializeAndDeserialize<float>((float)2.3, "2.3"), (float)2.3);
+        Assert.StrictEqual((float)-1.2, SerializeAndDeserialize<float>((float)-1.2, "-1.2"));
+        Assert.StrictEqual((float)0, SerializeAndDeserialize<float>((float)0, "0"));
+        Assert.StrictEqual((float)2.3, SerializeAndDeserialize<float>((float)2.3, "2.3"));
     }
 
     [Fact]
     public static void DCJS_FloatAsRoot_NotNetFramework()
     {
-        Assert.StrictEqual(SerializeAndDeserialize<float>(float.MinValue, "-3.4028235E+38"), float.MinValue);
-        Assert.StrictEqual(SerializeAndDeserialize<float>(float.MaxValue, "3.4028235E+38"), float.MaxValue);
+        Assert.StrictEqual(float.MinValue, SerializeAndDeserialize<float>(float.MinValue, "-3.4028235E+38"));
+        Assert.StrictEqual(float.MaxValue, SerializeAndDeserialize<float>(float.MaxValue, "3.4028235E+38"));
     }
 
     [Fact]

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -84,8 +84,8 @@ public static partial class DataContractSerializerTests
     [Fact]
     public static void DCS_CharAsRoot()
     {
-        Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<char>(char.MinValue, @"<char xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">0</char>"), char.MinValue);
-        Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<char>(char.MaxValue, @"<char xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">65535</char>"), char.MaxValue);
+        Assert.StrictEqual(char.MinValue, DataContractSerializerHelper.SerializeAndDeserialize<char>(char.MinValue, @"<char xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">0</char>"));
+        Assert.StrictEqual(char.MaxValue, DataContractSerializerHelper.SerializeAndDeserialize<char>(char.MaxValue, @"<char xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">65535</char>"));
         Assert.StrictEqual('a', DataContractSerializerHelper.SerializeAndDeserialize<char>('a', @"<char xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">97</char>"));
         Assert.StrictEqual('\u00F1', DataContractSerializerHelper.SerializeAndDeserialize<char>('\u00F1', @"<char xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">241</char>"));
         Assert.StrictEqual('\u6F22', DataContractSerializerHelper.SerializeAndDeserialize<char>('\u6F22', @"<char xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">28450</char>"));
@@ -95,8 +95,8 @@ public static partial class DataContractSerializerTests
     public static void DCS_ByteAsRoot()
     {
         Assert.StrictEqual(10, DataContractSerializerHelper.SerializeAndDeserialize<byte>(10, @"<unsignedByte xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">10</unsignedByte>"));
-        Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<byte>(byte.MinValue, @"<unsignedByte xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">0</unsignedByte>"), byte.MinValue);
-        Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<byte>(byte.MaxValue, @"<unsignedByte xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">255</unsignedByte>"), byte.MaxValue);
+        Assert.StrictEqual(byte.MinValue, DataContractSerializerHelper.SerializeAndDeserialize<byte>(byte.MinValue, @"<unsignedByte xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">0</unsignedByte>"));
+        Assert.StrictEqual(byte.MaxValue, DataContractSerializerHelper.SerializeAndDeserialize<byte>(byte.MaxValue, @"<unsignedByte xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">255</unsignedByte>"));
     }
 
     [Fact]
@@ -123,26 +123,26 @@ public static partial class DataContractSerializerTests
     [Fact]
     public static void DCS_DoubleAsRoot()
     {
-        Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<double>(-1.2, @"<double xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">-1.2</double>"), -1.2);
+        Assert.StrictEqual(-1.2, DataContractSerializerHelper.SerializeAndDeserialize<double>(-1.2, @"<double xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">-1.2</double>"));
         Assert.StrictEqual(0, DataContractSerializerHelper.SerializeAndDeserialize<double>(0, @"<double xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">0</double>"));
         Assert.StrictEqual(2.3, DataContractSerializerHelper.SerializeAndDeserialize<double>(2.3, @"<double xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">2.3</double>"));
-        Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<double>(double.MinValue, @"<double xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">-1.7976931348623157E+308</double>"), double.MinValue);
-        Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<double>(double.MaxValue, @"<double xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">1.7976931348623157E+308</double>"), double.MaxValue);
+        Assert.StrictEqual(double.MinValue, DataContractSerializerHelper.SerializeAndDeserialize<double>(double.MinValue, @"<double xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">-1.7976931348623157E+308</double>"));
+        Assert.StrictEqual(double.MaxValue, DataContractSerializerHelper.SerializeAndDeserialize<double>(double.MaxValue, @"<double xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">1.7976931348623157E+308</double>"));
     }
 
     [Fact]
     public static void DCS_FloatAsRoot()
     {
-        Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<float>((float)-1.2, @"<float xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">-1.2</float>"), (float)-1.2);
-        Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<float>((float)0, @"<float xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">0</float>"), (float)0);
-        Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<float>((float)2.3, @"<float xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">2.3</float>"), (float)2.3);
+        Assert.StrictEqual((float)-1.2, DataContractSerializerHelper.SerializeAndDeserialize<float>((float)-1.2, @"<float xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">-1.2</float>"));
+        Assert.StrictEqual((float)0, DataContractSerializerHelper.SerializeAndDeserialize<float>((float)0, @"<float xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">0</float>"));
+        Assert.StrictEqual((float)2.3, DataContractSerializerHelper.SerializeAndDeserialize<float>((float)2.3, @"<float xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">2.3</float>"));
     }
 
     [Fact]
     public static void DCS_FloatAsRoot_NotNetFramework()
     {
-        Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<float>(float.MinValue, @"<float xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">-3.4028235E+38</float>"), float.MinValue);
-        Assert.StrictEqual(DataContractSerializerHelper.SerializeAndDeserialize<float>(float.MaxValue, @"<float xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">3.4028235E+38</float>"), float.MaxValue);
+        Assert.StrictEqual(float.MinValue, DataContractSerializerHelper.SerializeAndDeserialize<float>(float.MinValue, @"<float xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">-3.4028235E+38</float>"));
+        Assert.StrictEqual(float.MaxValue, DataContractSerializerHelper.SerializeAndDeserialize<float>(float.MaxValue, @"<float xmlns=""http://schemas.microsoft.com/2003/10/Serialization/"">3.4028235E+38</float>"));
     }
 
     [Fact]

--- a/src/libraries/System.Runtime/tests/System/IO/EndOfStreamExceptionTests.cs
+++ b/src/libraries/System.Runtime/tests/System/IO/EndOfStreamExceptionTests.cs
@@ -35,8 +35,8 @@ namespace System.Tests
             EndOfStreamException i = new EndOfStreamException(exceptionMessage, ex);
 
             Assert.Equal(exceptionMessage, i.Message);
-            Assert.Equal(i.InnerException.Message, innerExceptionMessage);
-            Assert.Equal(i.InnerException.HResult, ex.HResult);
+            Assert.Equal(innerExceptionMessage, i.InnerException.Message);
+            Assert.Equal(ex.HResult, i.InnerException.HResult);
             Assert.Equal(COR_E_ENDOFSTREAM, unchecked((uint)i.HResult));
         }
     }

--- a/src/libraries/System.Runtime/tests/System/NullReferenceExceptionTests.cs
+++ b/src/libraries/System.Runtime/tests/System/NullReferenceExceptionTests.cs
@@ -36,8 +36,8 @@ namespace System.Tests
             NullReferenceException i = new NullReferenceException(exceptionMessage, ex);
 
             Assert.Equal(exceptionMessage, i.Message);
-            Assert.Equal(i.InnerException.Message, innerExceptionMessage);
-            Assert.Equal(i.InnerException.HResult, ex.HResult);
+            Assert.Equal(innerExceptionMessage, i.InnerException.Message);
+            Assert.Equal(ex.HResult, i.InnerException.HResult);
             Assert.Equal(E_POINTER, unchecked((uint)i.HResult));
         }
     }

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignerInfoTests.netcoreapp.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignerInfoTests.netcoreapp.cs
@@ -547,7 +547,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
 
             Assert.Equal(expectedToken.GetSerialNumber().ByteArrayToHex(), actualToken.GetSerialNumber().ByteArrayToHex());
             Assert.Equal(expectedToken.Timestamp, actualToken.Timestamp);
-            Assert.Equal(expectedToken.HashAlgorithmId.Value, Oids.Sha256);
+            Assert.Equal(Oids.Sha256, expectedToken.HashAlgorithmId.Value);
             Assert.Equal(expectedToken.HashAlgorithmId.Value, actualToken.HashAlgorithmId.Value);
         }
 

--- a/src/libraries/System.Security.Cryptography.Xml/tests/DSAKeyValueTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/DSAKeyValueTest.cs
@@ -108,16 +108,16 @@ namespace System.Security.Cryptography.Xml.Tests
             dsaKeyValue.LoadXml(xmlDoc.DocumentElement);
 
             var parameters = dsaKeyValue.Key.ExportParameters(false);
-            Assert.Equal(Convert.ToBase64String(parameters.P), pValue);
-            Assert.Equal(Convert.ToBase64String(parameters.Q), qValue);
-            Assert.Equal(Convert.ToBase64String(parameters.G), gValue);
-            Assert.Equal(Convert.ToBase64String(parameters.Y), yValue);
+            Assert.Equal(pValue, Convert.ToBase64String(parameters.P));
+            Assert.Equal(qValue, Convert.ToBase64String(parameters.Q));
+            Assert.Equal(gValue, Convert.ToBase64String(parameters.G));
+            Assert.Equal(yValue, Convert.ToBase64String(parameters.Y));
 
             // Not all providers support round-tripping the seed value.
             // Seed and PGenCounter are round-tripped together.
             if (parameters.Seed != null)
             {
-                Assert.Equal(Convert.ToBase64String(parameters.Seed), seedValue);
+                Assert.Equal(seedValue, Convert.ToBase64String(parameters.Seed));
                 Assert.Equal(BitConverter.GetBytes(parameters.Counter)[0], Convert.FromBase64String(pgenCounterValue)[0]);
             }
         }

--- a/src/libraries/System.Security.Cryptography.Xml/tests/XmlLicenseEncryptedRef.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/XmlLicenseEncryptedRef.cs
@@ -49,7 +49,7 @@ namespace System.Security.Cryptography.Xml.Tests
                     KeyInfoEncryptedKey encryptedKeyInfo = clause as KeyInfoEncryptedKey;
                     EncryptedKey encryptedKey = encryptedKeyInfo.EncryptedKey;
 
-                    Assert.Equal(encryptedKey.EncryptionMethod.KeyAlgorithm, EncryptedXml.XmlEncRSAOAEPUrl);
+                    Assert.Equal(EncryptedXml.XmlEncRSAOAEPUrl, encryptedKey.EncryptionMethod.KeyAlgorithm);
                     Assert.Equal(1, encryptedKey.KeyInfo.Count);
                     Assert.NotEqual(0, _asymmetricKeys.Count);
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/BitStackTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/BitStackTests.cs
@@ -128,7 +128,7 @@ namespace System.Text.Json.Tests
                 Assert.Equal(expectedDepth, bitStack.CurrentDepth);
             }
 
-            Assert.Equal(expectedDepth, IterationCapacity * 2);
+            Assert.Equal(IterationCapacity * 2, expectedDepth);
 
             // Loop backwards when popping.
             for (int i = bitLength - 1; i >= bitLength - IterationCapacity; i--)

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonNodeOperatorTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/JsonNode/JsonNodeOperatorTests.cs
@@ -181,6 +181,7 @@ namespace System.Text.Json.Nodes.Tests
         [Fact]
         public static void ImplicitOperators_FromNullableValues()
         {
+            #pragma warning disable xUnit2002
             Assert.NotNull((JsonValue?)(byte?)42);
             Assert.NotNull((JsonValue?)(short?)42);
             Assert.NotNull((JsonValue?)(int?)42);
@@ -194,6 +195,7 @@ namespace System.Text.Json.Nodes.Tests
             Assert.NotNull((JsonValue?)(float?)42);
             Assert.NotNull((JsonValue?)(double?)42);
             Assert.NotNull((JsonValue?)(decimal?)42);
+            #pragma warning restore xUnit2002
             Assert.NotNull((JsonValue?)(DateTime?)new DateTime(2019, 1, 30, 12, 1, 2, DateTimeKind.Utc));
             Assert.NotNull((JsonValue?)(DateTimeOffset?)new DateTimeOffset(2019, 1, 30, 12, 1, 2, new TimeSpan(1, 0, 0)));
             Assert.NotNull((JsonValue?)(Guid?)new Guid("1B33498A-7B7D-4DDA-9C13-F6AA4AB449A6"));

--- a/src/libraries/System.Threading.Tasks.Dataflow/tests/Dataflow/DataflowBlockExtensionTests.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/tests/Dataflow/DataflowBlockExtensionTests.cs
@@ -1763,7 +1763,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             source.Complete();
 
             await encapsulated.Completion;
-            Assert.Equal(messagesReceived, messagesSent);
+            Assert.Equal(messagesSent, messagesReceived);
         }
 
         [Fact]


### PR DESCRIPTION
This is the latest pre-release of Xunit 2.x.  It contains updated asserts library and manually updated to the latest analyzers.

The analyzers found some new issues with our tests, which I have fixed.  There are a few issues I worked around.

xunit/xunit#2393
xunit/xunit#2394
xunit/xunit#2395

Reviewable commit-by-commit.