### PR TITLE
Override `corehost_resolve_component_dependencies` and `corehost_set_error_writer` PInvokes in singlefile scenario.

### DIFF
--- a/src/installer/tests/Assets/TestProjects/AppWithSubDirs/Program.cs
+++ b/src/installer/tests/Assets/TestProjects/AppWithSubDirs/Program.cs
@@ -12,6 +12,21 @@ namespace AppWithSubDirs
         {
             string baseDir = Path.Combine(AppContext.BaseDirectory, "Sentence");
 
+            // singlefile app redirects a number of known internal PInvokes to their implementations
+            // which are statically linked into the host.
+            // Use of File IO, Console APIs and the like uses and tests those mechanisms extensively.
+            //
+            // There are also two PInvokes in the hostpolicy itself. Test them here.
+            // We are not looking for a success, just that we can get to these methods -
+            // we should not see errors like "Unable to find an entry point".
+            try
+            {
+                new System.Runtime.Loader.AssemblyDependencyResolver("qwerty");
+            }
+            catch (InvalidOperationException ex) when (ex.Message.Contains("Failed to locate managed application"))
+            {
+            }
+
             string Part(string dir="", string subdir="", string subsubdir="")
             {
                 return File.ReadAllText(Path.Combine(baseDir, dir, subdir, subsubdir, "word"));

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleTestBase.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleTestBase.cs
@@ -25,7 +25,7 @@ namespace AppHost.Bundle.Tests
             var publishedHostPath = BundleHelper.GetHostPath(testFixture);
             HostWriter.CreateAppHost(singleFileHost,
                                      publishedHostPath,
-                                     BundleHelper.GetAppPath(testFixture));
+                                     BundleHelper.GetAppName(testFixture));
             return publishedHostPath;
         }
 
@@ -37,7 +37,7 @@ namespace AppHost.Bundle.Tests
             var publishedHostPath = BundleHelper.GetHostPath(testFixture);
             HostWriter.CreateAppHost(appHost,
                                      publishedHostPath,
-                                     BundleHelper.GetAppPath(testFixture));
+                                     BundleHelper.GetAppName(testFixture));
             return publishedHostPath;
         }
 

--- a/src/native/corehost/hostpolicy.h
+++ b/src/native/corehost/hostpolicy.h
@@ -37,4 +37,15 @@ typedef int(HOSTPOLICY_CALLTYPE *corehost_initialize_fn)(
     uint32_t options,
     corehost_context_contract *handle);
 
+typedef void(HOSTPOLICY_CALLTYPE* corehost_resolve_component_dependencies_result_fn)(
+    const pal::char_t* assembly_paths,
+    const pal::char_t* native_search_paths,
+    const pal::char_t* resource_search_paths);
+
+SHARED_API corehost_error_writer_fn HOSTPOLICY_CALLTYPE corehost_set_error_writer(corehost_error_writer_fn error_writer);
+
+SHARED_API int HOSTPOLICY_CALLTYPE corehost_resolve_component_dependencies(
+    const pal::char_t* component_main_assembly_path,
+    corehost_resolve_component_dependencies_result_fn result);
+
 #endif //__HOSTPOLICY_H__

--- a/src/native/corehost/hostpolicy/hostpolicy.cpp
+++ b/src/native/corehost/hostpolicy/hostpolicy.cpp
@@ -824,11 +824,6 @@ SHARED_API int HOSTPOLICY_CALLTYPE corehost_unload()
     return StatusCode::Success;
 }
 
-typedef void(HOSTPOLICY_CALLTYPE *corehost_resolve_component_dependencies_result_fn)(
-    const pal::char_t* assembly_paths,
-    const pal::char_t* native_search_paths,
-    const pal::char_t* resource_search_paths);
-
 SHARED_API int HOSTPOLICY_CALLTYPE corehost_resolve_component_dependencies(
     const pal::char_t *component_main_assembly_path,
     corehost_resolve_component_dependencies_result_fn result)

--- a/src/native/corehost/hostpolicy/hostpolicy_context.cpp
+++ b/src/native/corehost/hostpolicy/hostpolicy_context.cpp
@@ -90,12 +90,12 @@ namespace
         {
             if (strcmp(entrypointName, "corehost_resolve_component_dependencies") == 0)
             {
-                return corehost_resolve_component_dependencies;
+                return (void*)corehost_resolve_component_dependencies;
             }
 
             if (strcmp(entrypointName, "corehost_set_error_writer") == 0)
             {
-                return corehost_set_error_writer;
+                return (void*)corehost_set_error_writer;
             }
         }
 

--- a/src/native/corehost/hostpolicy/hostpolicy_context.cpp
+++ b/src/native/corehost/hostpolicy/hostpolicy_context.cpp
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #include "hostpolicy_context.h"
+#include "hostpolicy.h"
 
 #include "deps_resolver.h"
 #include <error_codes.h>
@@ -55,11 +56,15 @@ namespace
     const void* STDMETHODCALLTYPE pinvoke_override(const char* libraryName, const char* entrypointName)
     {
 #if defined(_WIN32)
+        const char* hostPolicyLib = "hostpolicy.dll";
+
         if (strcmp(libraryName, "System.IO.Compression.Native") == 0)
         {
             return CompressionResolveDllImport(entrypointName);
         }
 #else
+        const char* hostPolicyLib = "libhostpolicy";
+
         if (strcmp(libraryName, "libSystem.IO.Compression.Native") == 0)
         {
             return CompressionResolveDllImport(entrypointName);
@@ -80,6 +85,19 @@ namespace
             return CryptoResolveDllImport(entrypointName);
         }
 #endif
+        // there are two PInvokes in the hostpolicy itself, redirect them here.
+        if (strcmp(libraryName, hostPolicyLib) == 0)
+        {
+            if (strcmp(entrypointName, "corehost_resolve_component_dependencies") == 0)
+            {
+                return corehost_resolve_component_dependencies;
+            }
+
+            if (strcmp(entrypointName, "corehost_set_error_writer") == 0)
+            {
+                return corehost_set_error_writer;
+            }
+        }
 
 #if defined(TARGET_OSX)
         if (strcmp(libraryName, "libSystem.Security.Cryptography.Native.Apple") == 0)


### PR DESCRIPTION
Re: https://github.com/dotnet/runtime/issues/59961

When we embed native runtime/helpers statically in the singlefile host, the host also adds PInvoke overrides, so that PInvokes would still work and use embedded implementation.

What we missed is that the host component itself (hostpolicy) has 2 exported functions accessible from managed libraries via PInvokes. This change adds overrides for these as well.