### PR TITLE
Fix inconsistencies in order of GeneratedDllImport fields

### DIFF
--- a/src/libraries/Common/src/Interop/Linux/System.Native/Interop.INotify.cs
+++ b/src/libraries/Common/src/Interop/Linux/System.Native/Interop.INotify.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_INotifyInit", SetLastError = true)]
         internal static partial SafeFileHandle INotifyInit();
 
-        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_INotifyAddWatch", SetLastError = true, CharSet = CharSet.Ansi)]
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_INotifyAddWatch", CharSet = CharSet.Ansi, SetLastError = true)]
         internal static partial int INotifyAddWatch(SafeFileHandle fd, string pathName, uint mask);
 
         [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_INotifyRemoveWatch", SetLastError = true)]

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Access.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Access.cs
@@ -15,7 +15,7 @@ internal static partial class Interop
             R_OK = 4,   /* Check for read */
         }
 
-        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Access", SetLastError = true, CharSet = CharSet.Ansi)]
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Access", CharSet = CharSet.Ansi, SetLastError = true)]
         internal static partial int Access(string path, AccessMode mode);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ForkAndExecProcess.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ForkAndExecProcess.cs
@@ -40,7 +40,7 @@ internal static partial class Interop
             }
         }
 
-        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ForkAndExecProcess", SetLastError = true, CharSet = CharSet.Ansi)]
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ForkAndExecProcess", CharSet = CharSet.Ansi, SetLastError = true)]
         private static unsafe partial int ForkAndExecProcess(
             string filename, byte** argv, byte** envp, string? cwd,
             int redirectStdin, int redirectStdout, int redirectStderr,

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetGroupList.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetGroupList.cs
@@ -43,7 +43,7 @@ internal static partial class Interop
             } while (true);
         }
 
-        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetGroupList", SetLastError = true, CharSet = CharSet.Ansi)]
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetGroupList", CharSet = CharSet.Ansi, SetLastError = true)]
         private static unsafe partial int GetGroupList(string name, uint group, uint* groups, int* ngroups);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetPeerUserName.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetPeerUserName.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetPeerUserName", SetLastError = true, CharSet = CharSet.Ansi)]
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetPeerUserName", CharSet = CharSet.Ansi, SetLastError = true)]
         internal static partial string GetPeerUserName(SafeHandle socket);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetPwUid.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetPwUid.cs
@@ -23,7 +23,7 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetPwUidR", SetLastError = false)]
         internal static unsafe partial int GetPwUidR(uint uid, out Passwd pwd, byte* buf, int bufLen);
 
-        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetPwNamR", SetLastError = false, CharSet = CharSet.Ansi)]
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetPwNamR", CharSet = CharSet.Ansi, SetLastError = false)]
         internal static unsafe partial int GetPwNamR(string name, out Passwd pwd, byte* buf, int bufLen);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Open.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Open.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Open", SetLastError = true, CharSet = CharSet.Ansi)]
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Open", CharSet = CharSet.Ansi, SetLastError = true)]
         internal static partial SafeFileHandle Open(string filename, OpenFlags flags, int mode);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.PathConf.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.PathConf.cs
@@ -20,7 +20,7 @@ internal static partial class Interop
             PC_VDISABLE         = 9,
         }
 
-        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_PathConf", SetLastError = true, CharSet = CharSet.Ansi)]
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_PathConf", CharSet = CharSet.Ansi, SetLastError = true)]
         private static partial int PathConf(string path, PathConfName name);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.RealPath.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.RealPath.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
         /// </summary>
         /// <param name="path">The path to the file system object</param>
         /// <returns>Returns the result string on success and null on failure</returns>
-        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_RealPath", SetLastError = true, CharSet = CharSet.Ansi)]
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_RealPath", CharSet = CharSet.Ansi, SetLastError = true)]
         internal static partial string RealPath(string path);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SNPrintF.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SNPrintF.cs
@@ -26,7 +26,7 @@ internal static partial class Interop
         /// success; if the return value is equal to the size then the result may have been truncated.
         /// On failure, returns a negative value.
         /// </returns>
-        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SNPrintF", SetLastError = true, CharSet = CharSet.Ansi)]
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SNPrintF", CharSet = CharSet.Ansi, SetLastError = true)]
         internal static unsafe partial int SNPrintF(byte* str, int size, string format, string arg1);
 
         /// <summary>
@@ -47,7 +47,7 @@ internal static partial class Interop
         /// success; if the return value is equal to the size then the result may have been truncated.
         /// On failure, returns a negative value.
         /// </returns>
-        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SNPrintF", SetLastError = true, CharSet = CharSet.Ansi)]
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SNPrintF", CharSet = CharSet.Ansi, SetLastError = true)]
         internal static unsafe partial int SNPrintF(byte* str, int size, string format, int arg1);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ShmOpen.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ShmOpen.cs
@@ -8,10 +8,10 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ShmOpen", SetLastError = true, CharSet = CharSet.Ansi)]
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ShmOpen", CharSet = CharSet.Ansi, SetLastError = true)]
         internal static partial SafeFileHandle ShmOpen(string name, OpenFlags flags, int mode);
 
-        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ShmUnlink", SetLastError = true, CharSet = CharSet.Ansi)]
+        [GeneratedDllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ShmUnlink", CharSet = CharSet.Ansi, SetLastError = true)]
         internal static partial int ShmUnlink(string name);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ConvertSdToStringSd.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ConvertSdToStringSd.cs
@@ -10,11 +10,11 @@ internal static partial class Interop
     {
 #if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "ConvertSecurityDescriptorToStringSecurityDescriptorW",
-            CallingConvention = CallingConvention.Winapi, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
+            CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static partial bool ConvertSdToStringSd(
 #else
         [DllImport(Interop.Libraries.Advapi32, EntryPoint = "ConvertSecurityDescriptorToStringSecurityDescriptorW",
-            CallingConvention = CallingConvention.Winapi, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
+            CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static extern bool ConvertSdToStringSd(
 #endif
             byte[] securityDescriptor,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ConvertStringSdToSd.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ConvertStringSdToSd.cs
@@ -10,11 +10,11 @@ internal static partial class Interop
     {
 #if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "ConvertStringSecurityDescriptorToSecurityDescriptorW",
-            CallingConvention = CallingConvention.Winapi, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
+            CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static partial bool ConvertStringSdToSd(
 #else
         [DllImport(Interop.Libraries.Advapi32, EntryPoint = "ConvertStringSecurityDescriptorToSecurityDescriptorW",
-            CallingConvention = CallingConvention.Winapi, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
+            CallingConvention = CallingConvention.Winapi, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static extern bool ConvertStringSdToSd(
 #endif
             string stringSd,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ConvertStringSidToSid.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.ConvertStringSidToSid.cs
@@ -9,10 +9,10 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "ConvertStringSidToSidW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "ConvertStringSidToSidW", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static partial int ConvertStringSidToSid(
 #else
-        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "ConvertStringSidToSidW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "ConvertStringSidToSidW", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern int ConvertStringSidToSid(
 #endif
             string stringSid,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CreateProcessWithLogon.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CreateProcessWithLogon.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-        [GeneratedDllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true, EntryPoint = "CreateProcessWithLogonW")]
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "CreateProcessWithLogonW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static unsafe partial bool CreateProcessWithLogonW(
             string userName,
             string domain,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CreateWellKnownSid.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CreateWellKnownSid.cs
@@ -9,10 +9,10 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "CreateWellKnownSid", SetLastError = true, CharSet = CharSet.Unicode)]
+        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "CreateWellKnownSid", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static partial int CreateWellKnownSid(
 #else
-        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "CreateWellKnownSid", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "CreateWellKnownSid", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern int CreateWellKnownSid(
 #endif
             int sidType,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptAcquireContext.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptAcquireContext.cs
@@ -21,10 +21,10 @@ internal static partial class Interop
         }
 
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Advapi32, SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "CryptAcquireContextW")]
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "CryptAcquireContextW", CharSet = CharSet.Unicode, SetLastError = true)]
         public static partial bool CryptAcquireContext(
 #else
-        [DllImport(Libraries.Advapi32, SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "CryptAcquireContextW")]
+        [DllImport(Libraries.Advapi32, EntryPoint = "CryptAcquireContextW", CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern bool CryptAcquireContext(
 #endif
             out SafeProvHandle phProv,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptSignHash.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.CryptSignHash.cs
@@ -24,7 +24,7 @@ internal static partial class Interop
             CRYPT_X931_FORMAT = 0x00000004,  // Not supported
         }
 
-        [GeneratedDllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CryptSignHashW")]
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "CryptSignHashW", CharSet = CharSet.Unicode, SetLastError = true)]
         public static partial bool CryptSignHash(
             SafeHashHandle hHash,
             KeySpec dwKeySpec,
@@ -33,7 +33,7 @@ internal static partial class Interop
             byte[]? pbSignature,
             ref int pdwSigLen);
 
-        [GeneratedDllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CryptVerifySignatureW")]
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "CryptVerifySignatureW", CharSet = CharSet.Unicode, SetLastError = true)]
         public static partial bool CryptVerifySignature(
             SafeHashHandle hHash,
             byte[] pbSignature,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.EncryptDecrypt.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.EncryptDecrypt.cs
@@ -12,10 +12,10 @@ internal static partial class Interop
         /// WARNING: This method does not implicitly handle long paths. Use EncryptFile.
         /// </summary>
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "EncryptFileW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "EncryptFileW", CharSet = CharSet.Unicode, SetLastError = true)]
         private static partial bool EncryptFilePrivate(string lpFileName);
 #else
-        [DllImport(Libraries.Advapi32, EntryPoint = "EncryptFileW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.Advapi32, EntryPoint = "EncryptFileW", CharSet = CharSet.Unicode, SetLastError = true)]
         private static extern bool EncryptFilePrivate(string lpFileName);
 #endif
 
@@ -29,10 +29,10 @@ internal static partial class Interop
         /// WARNING: This method does not implicitly handle long paths. Use DecryptFile.
         /// </summary>
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "DecryptFileW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "DecryptFileW", CharSet = CharSet.Unicode, SetLastError = true)]
         private static partial bool DecryptFileFilePrivate(
 #else
-        [DllImport(Libraries.Advapi32, EntryPoint = "DecryptFileW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.Advapi32, EntryPoint = "DecryptFileW", CharSet = CharSet.Unicode, SetLastError = true)]
         private static extern bool DecryptFileFilePrivate(
 #endif
             string lpFileName,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetSecurityDescriptorLength.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetSecurityDescriptorLength.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
         [DllImport(Interop.Libraries.Advapi32, EntryPoint = "GetSecurityDescriptorLength", CallingConvention = CallingConvention.Winapi,
-            ExactSpelling = true, CharSet = CharSet.Unicode)]
+            CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static extern /*DWORD*/ uint GetSecurityDescriptorLength(IntPtr byteArray);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetSecurityInfoByName.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetSecurityInfoByName.cs
@@ -9,10 +9,10 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "GetNamedSecurityInfoW", SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "GetNamedSecurityInfoW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static partial uint GetSecurityInfoByName(
 #else
-        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "GetNamedSecurityInfoW", SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "GetNamedSecurityInfoW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static extern /*DWORD*/ uint GetSecurityInfoByName(
 #endif
             string name,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetWindowsAccountDomainSid.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.GetWindowsAccountDomainSid.cs
@@ -9,10 +9,10 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "GetWindowsAccountDomainSid", SetLastError = true, CharSet = CharSet.Unicode)]
+        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "GetWindowsAccountDomainSid", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static partial int GetWindowsAccountDomainSid(
 #else
-        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "GetWindowsAccountDomainSid", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "GetWindowsAccountDomainSid", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern int GetWindowsAccountDomainSid(
 #endif
             byte[] sid,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.IsEqualDomainSid.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.IsEqualDomainSid.cs
@@ -9,10 +9,10 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "EqualDomainSid", SetLastError = true, CharSet = CharSet.Unicode)]
+        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "EqualDomainSid", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static partial int IsEqualDomainSid(
 #else
-        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "EqualDomainSid", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "EqualDomainSid", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern int IsEqualDomainSid(
 #endif
             byte[] sid1,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.IsWellKnownSid.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.IsWellKnownSid.cs
@@ -9,10 +9,10 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "IsWellKnownSid", SetLastError = true, CharSet = CharSet.Unicode)]
+        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "IsWellKnownSid", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static partial int IsWellKnownSid(
 #else
-        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "IsWellKnownSid", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "IsWellKnownSid", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern int IsWellKnownSid(
 #endif
             byte[] sid,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.LookupPrivilegeValue.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.LookupPrivilegeValue.cs
@@ -8,10 +8,10 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "LookupPrivilegeValueW")]
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "LookupPrivilegeValueW", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static partial bool LookupPrivilegeValue(
 #else
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false, EntryPoint = "LookupPrivilegeValueW")]
+        [DllImport(Libraries.Advapi32, EntryPoint = "LookupPrivilegeValueW", CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
         internal static extern bool LookupPrivilegeValue(
 #endif
             [MarshalAs(UnmanagedType.LPTStr)] string? lpSystemName, [MarshalAs(UnmanagedType.LPTStr)] string lpName, out LUID lpLuid);

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.LsaLookupSids.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.LsaLookupSids.cs
@@ -10,10 +10,10 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "LsaLookupSids", SetLastError = true, CharSet = CharSet.Unicode)]
+        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "LsaLookupSids", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static partial uint LsaLookupSids(
 #else
-        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "LsaLookupSids", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "LsaLookupSids", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern uint LsaLookupSids(
 #endif
             SafeLsaPolicyHandle handle,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.LsaOpenPolicy.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.LsaOpenPolicy.cs
@@ -10,10 +10,10 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "LsaOpenPolicy", SetLastError = true, CharSet = CharSet.Unicode)]
+        [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "LsaOpenPolicy", CharSet = CharSet.Unicode, SetLastError = true)]
         private static partial uint LsaOpenPolicy(
 #else
-        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "LsaOpenPolicy", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Interop.Libraries.Advapi32, EntryPoint = "LsaOpenPolicy", CharSet = CharSet.Unicode, SetLastError = true)]
         private static extern uint LsaOpenPolicy(
 #endif
             ref UNICODE_STRING SystemName,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegConnectRegistry.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegConnectRegistry.cs
@@ -15,10 +15,10 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, EntryPoint = "RegConnectRegistryW")]
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegConnectRegistryW", CharSet = CharSet.Unicode)]
         internal static partial int RegConnectRegistry(
 #else
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegConnectRegistryW")]
+        [DllImport(Libraries.Advapi32, EntryPoint = "RegConnectRegistryW", CharSet = CharSet.Unicode, BestFitMapping = false)]
         internal static extern int RegConnectRegistry(
 #endif
             string machineName,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegCreateKeyEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegCreateKeyEx.cs
@@ -15,10 +15,10 @@ internal static partial class Interop
         // Note: RegCreateKeyEx won't set the last error on failure - it returns
         // an error code if it fails.
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, EntryPoint = "RegCreateKeyExW", ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegCreateKeyExW", CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static partial int RegCreateKeyEx(
 #else
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegCreateKeyExW", ExactSpelling = true)]
+        [DllImport(Libraries.Advapi32, EntryPoint = "RegCreateKeyExW", BestFitMapping = false, CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static extern int RegCreateKeyEx(
 #endif
             SafeRegistryHandle hKey,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegDeleteKeyEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegDeleteKeyEx.cs
@@ -13,10 +13,10 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, EntryPoint = "RegDeleteKeyExW", ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegDeleteKeyExW", CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static partial int RegDeleteKeyEx(
 #else
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegDeleteKeyExW", ExactSpelling = true)]
+        [DllImport(Libraries.Advapi32, EntryPoint = "RegDeleteKeyExW", BestFitMapping = false, CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static extern int RegDeleteKeyEx(
 #endif
             SafeRegistryHandle hKey,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegDeleteValue.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegDeleteValue.cs
@@ -13,10 +13,10 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, EntryPoint = "RegDeleteValueW", ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegDeleteValueW", CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static partial int RegDeleteValue(
 #else
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegDeleteValueW", ExactSpelling = true)]
+        [DllImport(Libraries.Advapi32, EntryPoint = "RegDeleteValueW", BestFitMapping = false, CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static extern int RegDeleteValue(
 #endif
             SafeRegistryHandle hKey,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegOpenKeyEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegOpenKeyEx.cs
@@ -14,10 +14,10 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, EntryPoint = "RegOpenKeyExW", ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegOpenKeyExW", CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static partial int RegOpenKeyEx(
 #else
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegOpenKeyExW", ExactSpelling = true)]
+        [DllImport(Libraries.Advapi32, EntryPoint = "RegOpenKeyExW", CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static extern int RegOpenKeyEx(
 #endif
             SafeRegistryHandle hKey,
@@ -28,10 +28,10 @@ internal static partial class Interop
 
 
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, EntryPoint = "RegOpenKeyExW", ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegOpenKeyExW", CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static partial int RegOpenKeyEx(
 #else
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegOpenKeyExW", ExactSpelling = true)]
+        [DllImport(Libraries.Advapi32, EntryPoint = "RegOpenKeyExW", BestFitMapping = false, CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static extern int RegOpenKeyEx(
 #endif
             IntPtr hKey,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegSetValueEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegSetValueEx.cs
@@ -13,10 +13,10 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, EntryPoint = "RegSetValueExW", ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegSetValueExW", CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static partial int RegSetValueEx(
 #else
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegSetValueExW", ExactSpelling = true)]
+        [DllImport(Libraries.Advapi32, EntryPoint = "RegSetValueExW", BestFitMapping = false, CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static extern int RegSetValueEx(
 #endif
             SafeRegistryHandle hKey,
@@ -27,10 +27,10 @@ internal static partial class Interop
             int cbData);
 
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, EntryPoint = "RegSetValueExW", ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegSetValueExW", CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static partial int RegSetValueEx(
 #else
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegSetValueExW", ExactSpelling = true)]
+        [DllImport(Libraries.Advapi32, EntryPoint = "RegSetValueExW", BestFitMapping = false, CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static extern int RegSetValueEx(
 #endif
             SafeRegistryHandle hKey,
@@ -41,10 +41,10 @@ internal static partial class Interop
             int cbData);
 
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, EntryPoint = "RegSetValueExW", ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegSetValueExW", CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static partial int RegSetValueEx(
 #else
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegSetValueExW", ExactSpelling = true)]
+        [DllImport(Libraries.Advapi32, EntryPoint = "RegSetValueExW", BestFitMapping = false, CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static extern int RegSetValueEx(
 #endif
             SafeRegistryHandle hKey,
@@ -55,10 +55,10 @@ internal static partial class Interop
             int cbData);
 
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, EntryPoint = "RegSetValueExW", ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegSetValueExW", CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static partial int RegSetValueEx(
 #else
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegSetValueExW", ExactSpelling = true)]
+        [DllImport(Libraries.Advapi32, EntryPoint = "RegSetValueExW", BestFitMapping = false, CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static extern int RegSetValueEx(
 #endif
             SafeRegistryHandle hKey,
@@ -69,10 +69,10 @@ internal static partial class Interop
             int cbData);
 
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, EntryPoint = "RegSetValueExW", ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "RegSetValueExW", CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static partial int RegSetValueEx(
 #else
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegSetValueExW", ExactSpelling = true)]
+        [DllImport(Libraries.Advapi32, EntryPoint = "RegSetValueExW", BestFitMapping = false, CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static extern int RegSetValueEx(
 #endif
             SafeRegistryHandle hKey,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RevertToSelf.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RevertToSelf.cs
@@ -9,10 +9,10 @@ internal static partial class Interop
     internal static partial class Advapi32
     {
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Interop.Libraries.Advapi32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        [GeneratedDllImport(Interop.Libraries.Advapi32, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static partial bool RevertToSelf();
 #else
-        [DllImport(Interop.Libraries.Advapi32, SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        [DllImport(Interop.Libraries.Advapi32, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static extern bool RevertToSelf();
 #endif
     }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.SetSecurityInfoByHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.SetSecurityInfoByHandle.cs
@@ -10,11 +10,11 @@ internal static partial class Interop
     {
 #if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "SetSecurityInfo", CallingConvention = CallingConvention.Winapi,
-            SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
+            CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static partial uint SetSecurityInfoByHandle(
 #else
         [DllImport(Interop.Libraries.Advapi32, EntryPoint = "SetSecurityInfo", CallingConvention = CallingConvention.Winapi,
-            SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
+            CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static extern /*DWORD*/ uint SetSecurityInfoByHandle(
 #endif
             SafeHandle handle,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.SetSecurityInfoByName.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.SetSecurityInfoByName.cs
@@ -10,11 +10,11 @@ internal static partial class Interop
     {
 #if DLLIMPORTGENERATOR_ENABLED
         [GeneratedDllImport(Interop.Libraries.Advapi32, EntryPoint = "SetNamedSecurityInfoW", CallingConvention = CallingConvention.Winapi,
-            SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
+            CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static partial uint SetSecurityInfoByName(
 #else
         [DllImport(Interop.Libraries.Advapi32, EntryPoint = "SetNamedSecurityInfoW", CallingConvention = CallingConvention.Winapi,
-            SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
+            CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static extern /*DWORD*/ uint SetSecurityInfoByName(
 #endif
             string name,

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Cng.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Cng.cs
@@ -127,7 +127,7 @@ namespace Internal.NativeCrypto
             [GeneratedDllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
             public static partial NTSTATUS BCryptSetProperty(SafeAlgorithmHandle hObject, string pszProperty, string pbInput, int cbInput, int dwFlags);
 
-            [GeneratedDllImport(Libraries.BCrypt, CharSet = CharSet.Unicode, EntryPoint = "BCryptSetProperty")]
+            [GeneratedDllImport(Libraries.BCrypt, EntryPoint = "BCryptSetProperty", CharSet = CharSet.Unicode)]
             private static partial NTSTATUS BCryptSetIntPropertyPrivate(SafeBCryptHandle hObject, string pszProperty, ref int pdwInput, int cbInput, int dwFlags);
 
             public static unsafe NTSTATUS BCryptSetIntProperty(SafeBCryptHandle hObject, string pszProperty, ref int pdwInput, int dwFlags)

--- a/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertNameToStr.cs
+++ b/src/libraries/Common/src/Interop/Windows/Crypt32/Interop.CertNameToStr.cs
@@ -8,10 +8,10 @@ internal static partial class Interop
     internal static partial class Crypt32
     {
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CertNameToStrW")]
+        [GeneratedDllImport(Libraries.Crypt32, EntryPoint = "CertNameToStrW", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static unsafe partial int CertNameToStr(
 #else
-        [DllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CertNameToStrW")]
+        [DllImport(Libraries.Crypt32, EntryPoint = "CertNameToStrW", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern unsafe int CertNameToStr(
 #endif
             int dwCertEncodingType,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CopyFileEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CopyFileEx.cs
@@ -13,10 +13,10 @@ internal static partial class Interop
         /// WARNING: This method does not implicitly handle long paths. Use CopyFileEx.
         /// </summary>
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "CopyFileExW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "CopyFileExW", CharSet = CharSet.Unicode, SetLastError = true)]
         private static partial bool CopyFileExPrivate(
 #else
-        [DllImport(Libraries.Kernel32, EntryPoint = "CopyFileExW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "CopyFileExW", CharSet = CharSet.Unicode, SetLastError = true)]
         private static extern bool CopyFileExPrivate(
 #endif
             string src,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateDirectory.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateDirectory.cs
@@ -13,10 +13,10 @@ internal static partial class Interop
         /// WARNING: This method does not implicitly handle long paths. Use CreateDirectory.
         /// </summary>
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "CreateDirectoryW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "CreateDirectoryW", CharSet = CharSet.Unicode, SetLastError = true)]
         private static partial bool CreateDirectoryPrivate(
 #else
-        [DllImport(Libraries.Kernel32, EntryPoint = "CreateDirectoryW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "CreateDirectoryW", CharSet = CharSet.Unicode, SetLastError = true)]
         private static extern bool CreateDirectoryPrivate(
 #endif
             string path,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateFile.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateFile.cs
@@ -14,10 +14,10 @@ internal static partial class Interop
         /// WARNING: This method does not implicitly handle long paths. Use CreateFile.
         /// </summary>
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "CreateFileW", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "CreateFileW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         private static unsafe partial SafeFileHandle CreateFilePrivate(
 #else
-        [DllImport(Libraries.Kernel32, EntryPoint = "CreateFileW", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "CreateFileW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         private static unsafe extern SafeFileHandle CreateFilePrivate(
 #endif
             string lpFileName,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateFile_IntPtr.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateFile_IntPtr.cs
@@ -13,10 +13,10 @@ internal static partial class Interop
         /// WARNING: This method does not implicitly handle long paths. Use CreateFile.
         /// </summary>
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "CreateFileW", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "CreateFileW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         private static unsafe partial IntPtr CreateFilePrivate_IntPtr(
 #else
-        [DllImport(Libraries.Kernel32, EntryPoint = "CreateFileW", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "CreateFileW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         private static unsafe extern IntPtr CreateFilePrivate_IntPtr(
 #endif
             string lpFileName,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateNamedPipe.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateNamedPipe.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [GeneratedDllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CreateNamedPipeW")]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "CreateNamedPipeW", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static partial SafePipeHandle CreateNamedPipe(
             string pipeName,
             int openMode,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateProcess.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.CreateProcess.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [GeneratedDllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CreateProcessW")]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "CreateProcessW", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static unsafe partial bool CreateProcess(
             string? lpApplicationName,
             char* lpCommandLine,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DeleteFile.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DeleteFile.cs
@@ -13,10 +13,10 @@ internal static partial class Interop
         /// WARNING: This method does not implicitly handle long paths. Use DeleteFile.
         /// </summary>
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "DeleteFileW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "DeleteFileW", CharSet = CharSet.Unicode, SetLastError = true)]
         private static partial bool DeleteFilePrivate(string path);
 #else
-        [DllImport(Libraries.Kernel32, EntryPoint = "DeleteFileW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "DeleteFileW", CharSet = CharSet.Unicode, SetLastError = true)]
         private static extern bool DeleteFilePrivate(string path);
 #endif
 

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DeleteVolumeMountPoint.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.DeleteVolumeMountPoint.cs
@@ -13,10 +13,10 @@ internal static partial class Interop
         /// WARNING: This method does not implicitly handle long paths. Use DeleteVolumeMountPoint.
         /// </summary>
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "DeleteVolumeMountPointW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "DeleteVolumeMountPointW", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static partial bool DeleteVolumeMountPointPrivate(string mountPoint);
 #else
-        [DllImport(Libraries.Kernel32, EntryPoint = "DeleteVolumeMountPointW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "DeleteVolumeMountPointW", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern bool DeleteVolumeMountPointPrivate(string mountPoint);
 #endif
 

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.EnumProcessModules.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.EnumProcessModules.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [GeneratedDllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "K32EnumProcessModules")]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "K32EnumProcessModules", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static partial bool EnumProcessModules(SafeProcessHandle handle, IntPtr[]? modules, int size, out int needed);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.EnumProcesses.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.EnumProcesses.cs
@@ -7,7 +7,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [GeneratedDllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "K32EnumProcesses")]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "K32EnumProcesses", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static partial bool EnumProcesses(int[] processIds, int size, out int needed);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FillConsoleOutputAttribute.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FillConsoleOutputAttribute.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [GeneratedDllImport(Libraries.Kernel32, SetLastError = true, CharSet = CharSet.Unicode)]
+        [GeneratedDllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true)]
         internal static partial bool FillConsoleOutputAttribute(IntPtr hConsoleOutput, short wColorAttribute, int numCells, COORD startCoord, out int pNumBytesWritten);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FillConsoleOutputCharacter.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FillConsoleOutputCharacter.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [GeneratedDllImport(Libraries.Kernel32, SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "FillConsoleOutputCharacterW")]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "FillConsoleOutputCharacterW", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static partial bool FillConsoleOutputCharacter(IntPtr hConsoleOutput, char character, int nLength, COORD dwWriteCoord, out int pNumCharsWritten);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FormatMessage.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FormatMessage.cs
@@ -16,10 +16,10 @@ internal static partial class Interop
         private const int ERROR_INSUFFICIENT_BUFFER = 0x7A;
 
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, EntryPoint = "FormatMessageW", SetLastError = true, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "FormatMessageW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         private static unsafe partial int FormatMessage(
 #else
-        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, EntryPoint = "FormatMessageW", SetLastError = true, BestFitMapping = true, ExactSpelling = true)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "FormatMessageW", BestFitMapping = true, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         private static extern unsafe int FormatMessage(
 #endif
             int dwFlags,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetConsoleTitle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetConsoleTitle.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [GeneratedDllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static unsafe partial uint GetConsoleTitleW(char* title, uint nSize);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetFileAttributesEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetFileAttributesEx.cs
@@ -12,10 +12,10 @@ internal static partial class Interop
         /// WARNING: This method does not implicitly handle long paths. Use GetFileAttributesEx.
         /// </summary>
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "GetFileAttributesExW", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "GetFileAttributesExW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         private static partial bool GetFileAttributesExPrivate(
 #else
-        [DllImport(Libraries.Kernel32, EntryPoint = "GetFileAttributesExW", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "GetFileAttributesExW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         private static extern bool GetFileAttributesExPrivate(
 #endif
             string? name,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetFullPathNameW.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetFullPathNameW.cs
@@ -12,10 +12,10 @@ internal static partial class Interop
         /// WARNING: This method does not implicitly handle long paths. Use GetFullPathName or PathHelper.
         /// </summary>
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static partial uint GetFullPathNameW(
 #else
-        [DllImport(Libraries.Kernel32, SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false, ExactSpelling = true)]
+        [DllImport(Libraries.Kernel32, BestFitMapping = false, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static extern uint GetFullPathNameW(
 #endif
             ref char lpFileName,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetLongPathNameW.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetLongPathNameW.cs
@@ -11,10 +11,10 @@ internal static partial class Interop
         /// WARNING: This method does not implicitly handle long paths. Use GetFullPath/PathHelper.
         /// </summary>
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static partial uint GetLongPathNameW(
 #else
-        [DllImport(Libraries.Kernel32, SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false, ExactSpelling = true)]
+        [DllImport(Libraries.Kernel32, BestFitMapping = false, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static extern uint GetLongPathNameW(
 #endif
             ref char lpszShortPath,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetModuleBaseName.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetModuleBaseName.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [GeneratedDllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "K32GetModuleBaseNameW")]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "K32GetModuleBaseNameW", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static partial int GetModuleBaseName(SafeProcessHandle processHandle, IntPtr moduleHandle, [Out] char[] baseName, int size);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetModuleFileNameEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetModuleFileNameEx.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [GeneratedDllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "K32GetModuleFileNameExW")]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "K32GetModuleFileNameExW", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static partial int GetModuleFileNameEx(SafeProcessHandle processHandle, IntPtr moduleHandle, [Out] char[] baseName, int size);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetModuleInformation.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetModuleInformation.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [GeneratedDllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "K32GetModuleInformation")]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "K32GetModuleInformation", CharSet = CharSet.Unicode, SetLastError = true)]
         private static partial bool GetModuleInformation(SafeProcessHandle processHandle, IntPtr moduleHandle, out NtModuleInfo ntModuleInfo, int size);
 
         internal static unsafe bool GetModuleInformation(SafeProcessHandle processHandle, IntPtr moduleHandle, out NtModuleInfo ntModuleInfo) =>

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetNamedPipeHandleState.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetNamedPipeHandleState.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [GeneratedDllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static unsafe partial bool GetNamedPipeHandleStateW(
             SafePipeHandle hNamedPipe,
             uint* lpState,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.LoadLibraryEx_IntPtr.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.LoadLibraryEx_IntPtr.cs
@@ -11,7 +11,7 @@ internal static partial class Interop
         internal const int LOAD_LIBRARY_AS_DATAFILE = 0x00000002;
         internal const int LOAD_LIBRARY_SEARCH_SYSTEM32 = 0x00000800;
 
-        [GeneratedDllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, EntryPoint = "LoadLibraryExW", SetLastError = true, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "LoadLibraryExW", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static partial IntPtr LoadLibraryEx(string libFilename, IntPtr reserved, int flags);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.MoveFileEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.MoveFileEx.cs
@@ -16,10 +16,10 @@ internal static partial class Interop
         /// WARNING: This method does not implicitly handle long paths. Use MoveFile.
         /// </summary>
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "MoveFileExW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "MoveFileExW", CharSet = CharSet.Unicode, SetLastError = true)]
         private static partial bool MoveFileExPrivate(
 #else
-        [DllImport(Libraries.Kernel32, EntryPoint = "MoveFileExW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "MoveFileExW", CharSet = CharSet.Unicode, SetLastError = true)]
         private static extern bool MoveFileExPrivate(
 #endif
             string src, string dst, uint flags);

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.PeekConsoleInput.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.PeekConsoleInput.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [GeneratedDllImport(Libraries.Kernel32, SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "PeekConsoleInputW")]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "PeekConsoleInputW", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static partial bool PeekConsoleInput(IntPtr hConsoleInput, out InputRecord buffer, int numInputRecords_UseOne, out int numEventsRead);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ReadConsole.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ReadConsole.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [GeneratedDllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "ReadConsoleW")]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "ReadConsoleW", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static unsafe partial bool ReadConsole(
             IntPtr hConsoleInput,
             byte* lpBuffer,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ReadConsoleInput.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ReadConsoleInput.cs
@@ -32,9 +32,7 @@ internal static partial class Interop
 
     internal static partial class Kernel32
     {
-
-        [GeneratedDllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "ReadConsoleInputW")]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "ReadConsoleInputW", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static partial bool ReadConsoleInput(IntPtr hConsoleInput, out InputRecord buffer, int numInputRecords_UseOne, out int numEventsRead);
-
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ReadConsoleOutput.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ReadConsoleOutput.cs
@@ -15,7 +15,7 @@ internal static partial class Interop
             private short attributes;
         }
 
-        [GeneratedDllImport(Libraries.Kernel32, SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "ReadConsoleOutputW")]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "ReadConsoleOutputW", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static unsafe partial bool ReadConsoleOutput(IntPtr hConsoleOutput, CHAR_INFO* pBuffer, COORD bufferSize, COORD bufferCoord, ref SMALL_RECT readRegion);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.RemoveDirectory.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.RemoveDirectory.cs
@@ -13,10 +13,10 @@ internal static partial class Interop
         /// WARNING: This method does not implicitly handle long paths. Use RemoveDirectory.
         /// </summary>
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "RemoveDirectoryW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "RemoveDirectoryW", CharSet = CharSet.Unicode, SetLastError = true)]
         private static partial bool RemoveDirectoryPrivate(string path);
 #else
-        [DllImport(Libraries.Kernel32, EntryPoint = "RemoveDirectoryW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "RemoveDirectoryW", CharSet = CharSet.Unicode, SetLastError = true)]
         private static extern bool RemoveDirectoryPrivate(string path);
 #endif
 

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ReplaceFile.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ReplaceFile.cs
@@ -10,10 +10,10 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "ReplaceFileW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "ReplaceFileW", CharSet = CharSet.Unicode, SetLastError = true)]
         private static partial bool ReplaceFilePrivate(
 #else
-        [DllImport(Libraries.Kernel32, EntryPoint = "ReplaceFileW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "ReplaceFileW", CharSet = CharSet.Unicode, SetLastError = true)]
         private static extern bool ReplaceFilePrivate(
 #endif
             string replacedFileName, string replacementFileName, string? backupFileName,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetConsoleTitle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetConsoleTitle.cs
@@ -7,7 +7,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [GeneratedDllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "SetConsoleTitleW")]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "SetConsoleTitleW", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static partial bool SetConsoleTitle(string title);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetFileAttributes.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetFileAttributes.cs
@@ -12,10 +12,10 @@ internal static partial class Interop
         /// WARNING: This method does not implicitly handle long paths. Use SetFileAttributes.
         /// </summary>
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "SetFileAttributesW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "SetFileAttributesW", CharSet = CharSet.Unicode, SetLastError = true)]
         private static partial bool SetFileAttributesPrivate(
 #else
-        [DllImport(Libraries.Kernel32, EntryPoint = "SetFileAttributesW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "SetFileAttributesW", CharSet = CharSet.Unicode, SetLastError = true)]
         private static extern bool SetFileAttributesPrivate(
 #endif
             string name,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetFileInformationByHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetFileInformationByHandle.cs
@@ -10,10 +10,10 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, SetLastError = true, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Kernel32, ExactSpelling = true, SetLastError = true)]
         internal static unsafe partial bool SetFileInformationByHandle(
 #else
-        [DllImport(Libraries.Kernel32, SetLastError = true, ExactSpelling = true)]
+        [DllImport(Libraries.Kernel32, ExactSpelling = true, SetLastError = true)]
         internal static unsafe extern bool SetFileInformationByHandle(
 #endif
             SafeFileHandle hFile,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetThreadErrorMode.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetThreadErrorMode.cs
@@ -9,10 +9,10 @@ internal static partial class Interop
     {
         [SuppressGCTransition]
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, SetLastError = true, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Kernel32, ExactSpelling = true, SetLastError = true)]
         internal static partial bool SetThreadErrorMode(
 #else
-        [DllImport(Libraries.Kernel32, SetLastError = true, ExactSpelling = true)]
+        [DllImport(Libraries.Kernel32, ExactSpelling = true, SetLastError = true)]
         internal static extern bool SetThreadErrorMode(
 #endif
             uint dwNewMode,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.VirtualAlloc.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.VirtualAlloc.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [GeneratedDllImport(Libraries.Kernel32, SetLastError = true, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Kernel32, ExactSpelling = true, SetLastError = true)]
         internal static partial IntPtr VirtualAlloc(SafeHandle lpAddress, UIntPtr dwSize, int flAllocationType, int flProtect);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.VirtualQuery.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.VirtualQuery.cs
@@ -9,10 +9,10 @@ internal static partial class Interop
     internal static partial class Kernel32
     {
 #if DLLIMPORTGENERATOR_ENABLED
-        [GeneratedDllImport(Libraries.Kernel32, SetLastError = true, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.Kernel32, ExactSpelling = true, SetLastError = true)]
         internal static partial UIntPtr VirtualQuery(
 #else
-        [DllImport(Libraries.Kernel32, SetLastError = true, ExactSpelling = true)]
+        [DllImport(Libraries.Kernel32, ExactSpelling = true, SetLastError = true)]
         internal static extern UIntPtr VirtualQuery(
 #endif
             SafeHandle lpAddress,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.WaitNamedPipe.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.WaitNamedPipe.cs
@@ -7,7 +7,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [GeneratedDllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "WaitNamedPipeW")]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "WaitNamedPipeW", CharSet = CharSet.Unicode, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool WaitNamedPipe(string? name, int timeout);
     }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.WriteConsole.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.WriteConsole.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [GeneratedDllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "WriteConsoleW")]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "WriteConsoleW", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static unsafe partial bool WriteConsole(
             IntPtr hConsoleOutput,
             byte* lpBuffer,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.WriteConsoleOutput.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.WriteConsoleOutput.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [GeneratedDllImport(Libraries.Kernel32, SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "WriteConsoleOutputW")]
+        [GeneratedDllImport(Libraries.Kernel32, EntryPoint = "WriteConsoleOutputW", CharSet = CharSet.Unicode, SetLastError = true)]
         internal static unsafe partial bool WriteConsoleOutput(IntPtr hConsoleOutput, CHAR_INFO* buffer, COORD bufferSize, COORD bufferCoord, ref SMALL_RECT writeRegion);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Shell32/Interop.ShellExecuteExW.cs
+++ b/src/libraries/Common/src/Interop/Windows/Shell32/Interop.ShellExecuteExW.cs
@@ -50,7 +50,7 @@ internal static partial class Interop
         internal const uint SEE_MASK_NOCLOSEPROCESS = 0x00000040;
         internal const uint SEE_MASK_FLAG_NO_UI = 0x00000400;
 
-        [GeneratedDllImport(Libraries.Shell32, ExactSpelling = true, CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Libraries.Shell32, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static unsafe partial bool ShellExecuteExW(
             SHELLEXECUTEINFO* pExecInfo);
     }

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/Interop.SSPI.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/Interop.SSPI.cs
@@ -391,7 +391,7 @@ internal static partial class Interop
             out int pkgnum,
             out SafeFreeContextBuffer_SECURITY handle);
 
-        [GeneratedDllImport(Interop.Libraries.SspiCli, ExactSpelling = true, CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Interop.Libraries.SspiCli, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static unsafe partial int AcquireCredentialsHandleW(
             string? principal,
             string moduleName,
@@ -403,7 +403,7 @@ internal static partial class Interop
             ref CredHandle handlePtr,
             out long timeStamp);
 
-        [GeneratedDllImport(Interop.Libraries.SspiCli, ExactSpelling = true, CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Interop.Libraries.SspiCli, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static unsafe partial int AcquireCredentialsHandleW(
             string? principal,
             string moduleName,
@@ -415,7 +415,7 @@ internal static partial class Interop
             ref CredHandle handlePtr,
             out long timeStamp);
 
-        [GeneratedDllImport(Interop.Libraries.SspiCli, ExactSpelling = true, CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Interop.Libraries.SspiCli, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static unsafe partial int AcquireCredentialsHandleW(
             string? principal,
             string moduleName,
@@ -427,7 +427,7 @@ internal static partial class Interop
             ref CredHandle handlePtr,
             out long timeStamp);
 
-        [GeneratedDllImport(Interop.Libraries.SspiCli, ExactSpelling = true, CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Interop.Libraries.SspiCli, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static unsafe partial int AcquireCredentialsHandleW(
             string? principal,
             string moduleName,
@@ -468,7 +468,7 @@ internal static partial class Interop
         internal static partial SECURITY_STATUS SspiFreeAuthIdentity(
             IntPtr authData);
 
-        [GeneratedDllImport(Interop.Libraries.SspiCli, ExactSpelling = true, CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Interop.Libraries.SspiCli, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static partial SECURITY_STATUS SspiEncodeStringsAsAuthIdentity(
             string userName,
             string domainName,
@@ -476,7 +476,7 @@ internal static partial class Interop
             out SafeSspiAuthDataHandle authData);
 
         // TODO: Switch to use GeneratedDllImport once we annotate blittable types used in interop in CoreLib (like Guid)
-        [DllImport(Interop.Libraries.SspiCli, ExactSpelling = true, CharSet = CharSet.Unicode, SetLastError = true)]
+        [DllImport(Interop.Libraries.SspiCli, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static extern SECURITY_STATUS SetCredentialsAttributesW(
             in CredHandle handlePtr,
             long ulAttribute,

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.GetWindowTextLengthW.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.GetWindowTextLengthW.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [GeneratedDllImport(Libraries.User32, SetLastError = true, ExactSpelling = true)]
+        [GeneratedDllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
         public static partial int GetWindowTextLengthW(IntPtr hWnd);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.GetWindowTextW.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.GetWindowTextW.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [GeneratedDllImport(Libraries.User32, ExactSpelling = true, SetLastError = true, CharSet = CharSet.Unicode)]
+        [GeneratedDllImport(Libraries.User32, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         public static unsafe partial int GetWindowTextW(IntPtr hWnd, char* lpString, int nMaxCount);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Version/Interop.GetFileVersionInfoEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Version/Interop.GetFileVersionInfoEx.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Version
     {
-        [GeneratedDllImport(Libraries.Version, CharSet = CharSet.Unicode, EntryPoint = "GetFileVersionInfoExW")]
+        [GeneratedDllImport(Libraries.Version, EntryPoint = "GetFileVersionInfoExW", CharSet = CharSet.Unicode)]
         internal static partial bool GetFileVersionInfoEx(
                     uint dwFlags,
                     string lpwstrFilename,

--- a/src/libraries/Common/src/Interop/Windows/Version/Interop.GetFileVersionInfoSizeEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Version/Interop.GetFileVersionInfoSizeEx.cs
@@ -7,7 +7,7 @@ internal static partial class Interop
 {
     internal static partial class Version
     {
-        [GeneratedDllImport(Libraries.Version, CharSet = CharSet.Unicode, EntryPoint = "GetFileVersionInfoSizeExW")]
+        [GeneratedDllImport(Libraries.Version, EntryPoint = "GetFileVersionInfoSizeExW", CharSet = CharSet.Unicode)]
         internal static partial uint GetFileVersionInfoSizeEx(uint dwFlags, string lpwstrFilename, out uint lpdwHandle);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Version/Interop.VerQueryValue.cs
+++ b/src/libraries/Common/src/Interop/Windows/Version/Interop.VerQueryValue.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Version
     {
-        [GeneratedDllImport(Libraries.Version, CharSet = CharSet.Unicode, EntryPoint = "VerQueryValueW")]
+        [GeneratedDllImport(Libraries.Version, EntryPoint = "VerQueryValueW", CharSet = CharSet.Unicode)]
         internal static partial bool VerQueryValue(IntPtr pBlock, string lpSubBlock, out IntPtr lplpBuffer, out uint puLen);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/WinSock/Interop.GetAddrInfoExW.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/Interop.GetAddrInfoExW.cs
@@ -17,7 +17,7 @@ internal static partial class Interop
 
         internal const int NS_ALL = 0;
 
-        [GeneratedDllImport(Libraries.Ws2_32, ExactSpelling = true, CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Libraries.Ws2_32, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static unsafe partial int GetAddrInfoExW(
             string pName,
             string? pServiceName,

--- a/src/libraries/Common/src/Interop/Windows/WinSock/Interop.GetAddrInfoW.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/Interop.GetAddrInfoW.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Winsock
     {
-        [GeneratedDllImport(Interop.Libraries.Ws2_32, ExactSpelling = true, CharSet = CharSet.Unicode, SetLastError = true)]
+        [GeneratedDllImport(Interop.Libraries.Ws2_32, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
         internal static unsafe partial int GetAddrInfoW(
             string pNameName,
             string? pServiceName,

--- a/src/libraries/Common/src/Interop/Windows/WinSock/Interop.WSAIoctl.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/Interop.WSAIoctl.cs
@@ -22,7 +22,7 @@ internal static partial class Interop
             [In] IntPtr shouldBeNull,
             [In] IntPtr shouldBeNull2);
 
-        [GeneratedDllImport(Interop.Libraries.Ws2_32, SetLastError = true, EntryPoint = "WSAIoctl")]
+        [GeneratedDllImport(Interop.Libraries.Ws2_32, EntryPoint = "WSAIoctl", SetLastError = true)]
         internal static partial SocketError WSAIoctl_Blocking(
             SafeSocketHandle socketHandle,
             int ioControlCode,

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Interop.crypt32.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Interop.crypt32.cs
@@ -77,7 +77,7 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
         public static partial bool CertGetCertificateContextProperty(SafeCertContextHandle pCertContext, CertContextPropId dwPropId, out IntPtr pvData, ref int pcbData);
 
-        [GeneratedDllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CertGetCertificateContextProperty")]
+        [GeneratedDllImport(Libraries.Crypt32, EntryPoint = "CertGetCertificateContextProperty", CharSet = CharSet.Unicode, SetLastError = true)]
         public static unsafe partial bool CertGetCertificateContextPropertyString(SafeCertContextHandle pCertContext, CertContextPropId dwPropId, byte* pvData, ref int pcbData);
 
         [GeneratedDllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
@@ -114,7 +114,7 @@ internal static partial class Interop
             }
         }
 
-        [GeneratedDllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CertGetNameStringW")]
+        [GeneratedDllImport(Libraries.Crypt32, EntryPoint = "CertGetNameStringW", CharSet = CharSet.Unicode, SetLastError = true)]
         private static unsafe partial int CertGetNameString(SafeCertContextHandle pCertContext, CertNameType dwType, CertNameFlags dwFlags, in CertNameStringType pvTypePara, char* pszNameString, int cchNameString);
 
         [GeneratedDllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
@@ -126,7 +126,7 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.Crypt32, SetLastError = true)]
         internal static partial SafeCertStoreHandle CertDuplicateStore(IntPtr hCertStore);
 
-        [GeneratedDllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CertDuplicateCertificateContext")]
+        [GeneratedDllImport(Libraries.Crypt32, EntryPoint = "CertDuplicateCertificateContext", CharSet = CharSet.Unicode, SetLastError = true)]
         public static partial SafeCertContextHandleWithKeyContainerDeletion CertDuplicateCertificateContextWithKeyContainerDeletion(IntPtr pCertContext);
 
         public static SafeCertStoreHandle CertOpenStore(CertStoreProvider lpszStoreProvider, CertEncodingType dwMsgAndCertEncodingType, IntPtr hCryptProv, CertStoreFlags dwFlags, string? pvPara)
@@ -192,7 +192,7 @@ internal static partial class Interop
         [GeneratedDllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true)]
         public static partial bool PFXExportCertStore(SafeCertStoreHandle hStore, ref CRYPTOAPI_BLOB pPFX, SafePasswordHandle szPassword, PFXExportFlags dwFlags);
 
-        [GeneratedDllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CertStrToNameW")]
+        [GeneratedDllImport(Libraries.Crypt32, EntryPoint = "CertStrToNameW", CharSet = CharSet.Unicode, SetLastError = true)]
         public static partial bool CertStrToName(CertEncodingType dwCertEncodingType, string pszX500, CertNameStrTypeAndFlags dwStrType, IntPtr pvReserved, byte[]? pbEncoded, ref int pcbEncoded, IntPtr ppszError);
 
         public static bool CryptDecodeObject(CertEncodingType dwCertEncodingType, CryptDecodeObjectStructType lpszStructType, byte[] pbEncoded, int cbEncoded, CryptDecodeObjectFlags dwFlags, byte[]? pvStructInfo, ref int pcbStructInfo)
@@ -208,10 +208,10 @@ internal static partial class Interop
             return CryptDecodeObjectPointer(dwCertEncodingType, (IntPtr)lpszStructType, pbEncoded, cbEncoded, dwFlags, pvStructInfo, ref pcbStructInfo);
         }
 
-        [GeneratedDllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CryptDecodeObject")]
+        [GeneratedDllImport(Libraries.Crypt32, EntryPoint = "CryptDecodeObject", CharSet = CharSet.Unicode, SetLastError = true)]
         private static unsafe partial bool CryptDecodeObjectPointer(CertEncodingType dwCertEncodingType, IntPtr lpszStructType, byte[] pbEncoded, int cbEncoded, CryptDecodeObjectFlags dwFlags, void* pvStructInfo, ref int pcbStructInfo);
 
-        [GeneratedDllImport(Libraries.Crypt32, CharSet = CharSet.Unicode, SetLastError = true, EntryPoint = "CryptDecodeObject")]
+        [GeneratedDllImport(Libraries.Crypt32, EntryPoint = "CryptDecodeObject", CharSet = CharSet.Unicode, SetLastError = true)]
         public static unsafe partial bool CryptDecodeObjectPointer(CertEncodingType dwCertEncodingType, [MarshalAs(UnmanagedType.LPStr)] string lpszStructType, byte[] pbEncoded, int cbEncoded, CryptDecodeObjectFlags dwFlags, void* pvStructInfo, ref int pcbStructInfo);
 
         public static unsafe bool CryptEncodeObject(CertEncodingType dwCertEncodingType, CryptDecodeObjectStructType lpszStructType, void* pvStructInfo, byte[]? pbEncoded, ref int pcbEncoded)

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Interop.cryptoapi.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/Native/Interop.cryptoapi.cs
@@ -14,7 +14,7 @@ internal static partial class Interop
 {
     public static partial class cryptoapi
     {
-        [GeneratedDllImport(Libraries.Advapi32, SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "CryptAcquireContextW")]
+        [GeneratedDllImport(Libraries.Advapi32, EntryPoint = "CryptAcquireContextW", CharSet = CharSet.Unicode, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static unsafe partial bool CryptAcquireContext(out IntPtr psafeProvHandle, char* pszContainer, char* pszProvider, int dwProvType, CryptAcquireContextFlags dwFlags);
     }


### PR DESCRIPTION
The most common ordering I saw for existing `DllImport`s based on some simple regex searches was `EntryPoint` and then remaining ones in alphabetical order, so I went with that.

cc @AaronRobinsonMSFT @jkoritzinsky 