### PR TITLE
Regression Fix - Update HostFactoryResolver, set the app name via an argument

### DIFF
--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -144,6 +145,14 @@ namespace Microsoft.Extensions.Hosting
             {
                 return args =>
                 {
+                    static bool IsApplicationNameArg(string arg)
+                        => arg.Equals("--applicationName", StringComparison.OrdinalIgnoreCase) ||
+                            arg.Equals("/applicationName", StringComparison.OrdinalIgnoreCase);
+
+                    args = args.Any(arg => IsApplicationNameArg(arg)) || assembly.FullName is null
+                        ? args
+                        : args.Concat(new[] { "--applicationName", assembly.FullName }).ToArray();
+
                     var host = hostFactory(args);
                     return GetServiceProvider(host);
                 };

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/ApplicationNameSetFromAgrument/ApplicationNameSetFromAgrument.csproj
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/ApplicationNameSetFromAgrument/ApplicationNameSetFromAgrument.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
+    <EnableDefaultItems>true</EnableDefaultItems>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MockHostTypes\MockHostTypes.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/ApplicationNameSetFromAgrument/Program.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/ApplicationNameSetFromAgrument/Program.cs
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+var host = new HostBuilder().ConfigureAppConfiguration(builder => builder.AddCommandLine(args)).Build();

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/HostFactoryResolverTests.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/HostFactoryResolverTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Extensions.Configuration;
 using MockHostTypes;
 using System;
 using System.Diagnostics.CodeAnalysis;
@@ -250,6 +251,17 @@ namespace Microsoft.Extensions.Hosting.Tests
 
             Assert.NotNull(factory);
             Assert.IsAssignableFrom<IServiceProvider>(factory(Array.Empty<string>()));
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        public void ApplicationNameSetFromAgrument()
+        {
+            Assembly assembly = Assembly.Load("ApplicationNameSetFromAgrument");
+            var factory = HostFactoryResolver.ResolveServiceProviderFactory(assembly, s_WaitTimeout);
+            IServiceProvider? serviceProvider = factory(Array.Empty<string>());
+
+            var configuration = (IConfiguration)serviceProvider.GetService(typeof(IConfiguration));
+            Assert.Contains("ApplicationNameSetFromAgrument", configuration["applicationName"]);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/Microsoft.Extensions.HostFactoryResolver.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/Microsoft.Extensions.HostFactoryResolver.Tests.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="ApplicationNameSetFromAgrument\ApplicationNameSetFromAgrument.csproj" />
     <ProjectReference Include="BuildWebHostInvalidSignature\BuildWebHostInvalidSignature.csproj" />
     <ProjectReference Include="BuildWebHostPatternTestSite\BuildWebHostPatternTestSite.csproj" />
     <ProjectReference Include="CreateHostBuilderInvalidSignature\CreateHostBuilderInvalidSignature.csproj" />


### PR DESCRIPTION
Based on original PR: dotnet/efcore#26198
Dupe of PR: https://github.com/dotnet/runtime/pull/59743
Fixes reported issue: https://github.com/dotnet/runtime/issues/59745

Updates HostFactoryResolver to account for lack of application name with new host pattern and adds test.

### Description

Changes to the templates for 6.0 required a new mechanism for tools to discover and use registered services in an ASP.NET Core or any other app based on a hosted service provider. This new mechanism results in a host setup that does not by default have an application name available. This in turn results in user secrets not being found, and so any tooling that is using user secrets will fail. This was discovered using EF Core which supports obtaining the database connection string from user secrets.

The fix is to set a default application name based on the assembly when using this new mechanism to discover services.

### Customer impact

EF Core database operations executed from the command line may fail, or worse, use the wrong connection string and update the wrong database.

### How found

Customer reported on RC1.

### Regression

Yes and no. It's a regression to the experience when the new templates or the patterns shipped in those templates are used. It is not technically a regression if the application is still using the patterns from previous versions.

### Testing

Testing is tricky here because this runtime package is consumed as source in EF Core. This is what we have done and plan to do:

* We have manually tested end-to-end with EF Core by including the updated source in an EF Core local build.
* We have added unit tests as part of this PR.
* We have unit tests in EF Core that will validate that the change flows into EF Core correctly. See https://github.com/dotnet/efcore/pull/26204.
* Once the change has made its way into EF Core, we will test again end-to-end using a daily build of the EF Core GA package.
* We will do a final end-to-end test once the GA build for validation is available.

### Risk

Low. Simple code change to add a default application name on in the new code path introduced in 6.0.