### PR TITLE
Do not check options values if options haven't been initialized in BindingDoesNotThrowIfReloadedDuringBinding test

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
@@ -979,16 +979,21 @@ IniKey1=IniValue2");
 
                 MyOptions options = null;
 
+                bool optionsInitialized = false;
                 while (!cts.IsCancellationRequested)
                 {
                     options = config.Get<MyOptions>();
+                    optionsInitialized = true;
                 }
 
-                Assert.Equal("CmdValue1", options.CmdKey1);
-                Assert.Equal("IniValue1", options.IniKey1);
-                Assert.Equal("JsonValue1", options.JsonKey1);
-                Assert.Equal("MemValue1", options.MemKey1);
-                Assert.Equal("XmlValue1", options.XmlKey1);
+                if (optionsInitialized)
+                {
+                    Assert.Equal("CmdValue1", options.CmdKey1);
+                    Assert.Equal("IniValue1", options.IniKey1);
+                    Assert.Equal("JsonValue1", options.JsonKey1);
+                    Assert.Equal("MemValue1", options.MemKey1);
+                    Assert.Equal("XmlValue1", options.XmlKey1);
+                }
             }
         }
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/59800

This test is failing in the rolling  builds. This excludes possibility this is a test issue. If this shows up again it means a product issue.