### PR TITLE
Enable host.pkg subset in source-build

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -66,8 +66,8 @@
     <DefaultLibrariesSubsets>$(DefaultLibrariesSubsets)libs.ref+libs.src</DefaultLibrariesSubsets>
     <DefaultLibrariesSubsets Condition="'$(DotNetBuildFromSource)' != 'true'">$(DefaultLibrariesSubsets)+libs.pretest</DefaultLibrariesSubsets>
 
-    <DefaultHostSubsets>host.native+host.tools</DefaultHostSubsets>
-    <DefaultHostSubsets Condition="'$(DotNetBuildFromSource)' != 'true'">$(DefaultHostSubsets)+host.pkg+host.tests</DefaultHostSubsets>
+    <DefaultHostSubsets>host.native+host.tools+host.pkg</DefaultHostSubsets>
+    <DefaultHostSubsets Condition="'$(DotNetBuildFromSource)' != 'true'">$(DefaultHostSubsets)+host.tests</DefaultHostSubsets>
     <DefaultHostSubsets Condition="'$(RuntimeFlavor)' != '$(PrimaryRuntimeFlavor)'"></DefaultHostSubsets>
     <DefaultHostSubsets Condition="'$(RuntimeFlavor)' != '$(PrimaryRuntimeFlavor)' and '$(TargetsMobile)' != 'true'">host.native</DefaultHostSubsets>
 


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/2421

microsoft.netcore.dotnethostresolver and microsoft.netcore.dotnetapphost are missing from source-build which is introducing prebuilts.  This is a regression from 5.0 introduced by the ArPow source-build restructuring.
