### PR TITLE
Fix Errors in performance-setup Scripts From PR 59483

### DIFF
--- a/eng/testing/performance/performance-setup.ps1
+++ b/eng/testing/performance/performance-setup.ps1
@@ -58,7 +58,7 @@ function Verify-Robocopy {
 	[Parameter(Mandatory)]
 	[string]$Source
 	if ($LASTEXITCODE -ne 0 -or !$?) {
-		Write-Output "Failed to copy $Source: exit code $LASTEXITCODE"
+		Write-Output "Failed to copy ${Source}: exit code $LASTEXITCODE"
 		exit $LASTEXITCODE
 	}
 }

--- a/eng/testing/performance/performance-setup.sh
+++ b/eng/testing/performance/performance-setup.sh
@@ -288,7 +288,8 @@ else
 	if [ "$?" -ne "0" ]; then
 		echo "git clone failed with code $?"
 		exit 1
-
+	fi
+	
     docs_directory=$performance_directory/docs
     verified_mv $docs_directory $workitem_directory
 fi


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/59483 was merged to resolve issues with performance setup scripts not returning a nonzero exit code when they encountered failures, but some errors were found after it was merged.  This PR is to address those errors.