### PR TITLE
[wasm] rationalize internal exports

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -218,6 +218,7 @@
     <PlatformManifestFileEntry Include="icudt_optimal.dat" IsNative="true" />
     <PlatformManifestFileEntry Include="icudt_optimal_no_CJK.dat" IsNative="true" />
     <PlatformManifestFileEntry Include="runtime.iffe.js" IsNative="true" />
+    <PlatformManifestFileEntry Include="dotnet.d.ts" IsNative="true" />
     <PlatformManifestFileEntry Include="library-dotnet.js" IsNative="true" />
     <PlatformManifestFileEntry Include="pal_random.js" IsNative="true" />
     <PlatformManifestFileEntry Include="corebindings.c" IsNative="true" />

--- a/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
+++ b/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
@@ -98,7 +98,7 @@ internal static partial class Interop
         {
         }
 
-        // Called by the AOT profiler to save profile data into Module.aot_profile_data
+        // Called by the AOT profiler to save profile data into INTERNAL.aot_profile_data
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public static unsafe void DumpAotProfileData(ref byte buf, int len, string extraArg)
         {

--- a/src/libraries/Native/Unix/System.Native/pal_random.js
+++ b/src/libraries/Native/Unix/System.Native/pal_random.js
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-var DotNetEntropyLib = {
+const DotNetEntropyLib = {
     $DOTNETENTROPY: {
         // batchedQuotaMax is the max number of bytes as specified by the api spec.
         // If the byteLength of array is greater than 65536, throw a QuotaExceededError and terminate the algorithm.
@@ -10,13 +10,13 @@ var DotNetEntropyLib = {
         getBatchedRandomValues: function (buffer, bufferLength) {
             // for modern web browsers
             // map the work array to the memory buffer passed with the length
-            for (var i = 0; i < bufferLength; i += this.batchedQuotaMax) {
-                var view = new Uint8Array(Module.HEAPU8.buffer, buffer + i, Math.min(bufferLength - i, this.batchedQuotaMax));
+            for (let i = 0; i < bufferLength; i += this.batchedQuotaMax) {
+                const view = new Uint8Array(Module.HEAPU8.buffer, buffer + i, Math.min(bufferLength - i, this.batchedQuotaMax));
                 crypto.getRandomValues(view)
             }
         }
     },
-    dotnet_browser_entropy : function (buffer, bufferLength) {
+    dotnet_browser_entropy: function (buffer, bufferLength) {
         // check that we have crypto available
         if (typeof crypto === 'object' && typeof crypto['getRandomValues'] === 'function') {
             DOTNETENTROPY.getBatchedRandomValues(buffer, bufferLength)

--- a/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
+++ b/src/libraries/System.Private.Runtime.InteropServices.JavaScript/tests/System/Runtime/InteropServices/JavaScript/MarshalTests.cs
@@ -283,7 +283,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             HelperMarshal._intValue = 0;
             Runtime.InvokeJS(@$"
-                var invoke_int = Module.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
+                var invoke_int = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
                 invoke_int (200);
             ");
 
@@ -295,7 +295,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             HelperMarshal._intPtrValue = IntPtr.Zero;
             Runtime.InvokeJS(@$"
-                var invoke_int_ptr = Module.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeIntPtr"");
+                var invoke_int_ptr = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeIntPtr"");
                 invoke_int_ptr (42);
             ");
             Assert.Equal(42, (int)HelperMarshal._intPtrValue);
@@ -306,7 +306,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             HelperMarshal._marshaledIntPtrValue = IntPtr.Zero;
             Runtime.InvokeJS(@$"
-                var invokeMarshalIntPtr = Module.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeMarshalIntPtr"");
+                var invokeMarshalIntPtr = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeMarshalIntPtr"");
                 var r = invokeMarshalIntPtr ();
 
                 if (r != 42) throw `Invalid int_ptr value`;
@@ -319,7 +319,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             HelperMarshal._intValue = 0;
             Runtime.InvokeJS(@$"
-                Module.mono_call_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"", [ 300 ]);
+                INTERNAL.call_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"", [ 300 ]);
             ");
 
             Assert.Equal(300, HelperMarshal._intValue);
@@ -330,7 +330,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             HelperMarshal._intValue = 0;
             Runtime.InvokeJS(@$"
-                var invoke_int = Module.mono_method_resolve (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
+                var invoke_int = INTERNAL.mono_method_resolve (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
                 App.call_test_method (""InvokeInt"", [ invoke_int ]);
             ");
 
@@ -629,7 +629,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
 
             HelperMarshal._intValue = 1;
             Runtime.InvokeJS(@$"
-                var invoke_int = Module.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
+                var invoke_int = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
                 invoke_int ();
             ");
             Assert.Equal(0, HelperMarshal._intValue);
@@ -640,7 +640,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             HelperMarshal._intValue = 0;
             Runtime.InvokeJS(@$"
-                var invoke_int = Module.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
+                var invoke_int = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
                 invoke_int (200, 400);
             ");
             Assert.Equal(200, HelperMarshal._intValue);
@@ -654,13 +654,13 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
 
             HelperMarshal._intValue = 0;
             Runtime.InvokeJS(@$"
-                var invoke_int = Module.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
+                var invoke_int = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
                 invoke_int (""200"");
             ");
             Assert.Equal(200, HelperMarshal._intValue);
 
             Runtime.InvokeJS(@$"
-                var invoke_int = Module.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
+                var invoke_int = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
                 invoke_int (400.5);
             ");
             Assert.Equal(400, HelperMarshal._intValue);
@@ -671,14 +671,14 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             HelperMarshal._intValue = 100;
             Runtime.InvokeJS(@$"
-                var invoke_int = Module.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
+                var invoke_int = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
                 invoke_int (""hello"");
             ");
             Assert.Equal(0, HelperMarshal._intValue);
 
             // In this case at the very least, the leading "7" is not turned into the number 7
             Runtime.InvokeJS(@$"
-                var invoke_int = Module.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
+                var invoke_int = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeInt"");
                 invoke_int (""7apples"");
             ");
             Assert.Equal(0, HelperMarshal._intValue);
@@ -689,7 +689,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             HelperMarshal._uintValue = 0;
             Runtime.InvokeJS(@$"
-                var invoke_uint = Module.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeUInt"");
+                var invoke_uint = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeUInt"");
                 invoke_uint (0xFFFFFFFE);
             ");
 
@@ -702,9 +702,9 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             HelperMarshal._uintValue = 0;
             HelperMarshal._enumValue = TestEnum.BigValue;
             Runtime.InvokeJS(@$"
-                var get_value = Module.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}GetEnumValue"");
+                var get_value = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}GetEnumValue"");
                 var e = get_value ();
-                var invoke_uint = Module.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeUInt"");
+                var invoke_uint = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}InvokeUInt"");
                 invoke_uint (e);
             ");
             Assert.Equal((uint)TestEnum.BigValue, HelperMarshal._uintValue);
@@ -715,7 +715,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             HelperMarshal._enumValue = TestEnum.Zero;
             Runtime.InvokeJS(@$"
-                var set_enum = Module.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}SetEnumValue"", ""j"");
+                var set_enum = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}SetEnumValue"", ""j"");
                 set_enum (0xFFFFFFFE);
             ");
             Assert.Equal(TestEnum.BigValue, HelperMarshal._enumValue);
@@ -728,7 +728,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             // HACK: We're explicitly telling the bindings layer to pass an int here, not an enum
             // Because we know the enum is : uint, this is compatible, so it works.
             Runtime.InvokeJS(@$"
-                var set_enum = Module.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}SetEnumValue"", ""i"");
+                var set_enum = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}SetEnumValue"", ""i"");
                 set_enum (0xFFFFFFFE);
             ");
             Assert.Equal(TestEnum.BigValue, HelperMarshal._enumValue);
@@ -740,7 +740,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             HelperMarshal._enumValue = TestEnum.Zero;
             var exc = Assert.Throws<JSException>( () => 
                 Runtime.InvokeJS(@$"
-                    var set_enum = Module.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}SetEnumValue"", ""j"");
+                    var set_enum = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}SetEnumValue"", ""j"");
                     set_enum (""BigValue"");
                 ")
             );
@@ -752,7 +752,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             var exc = Assert.Throws<JSException>( () => 
                 Runtime.InvokeJS(@$"
-                    var get_u64 = Module.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}GetUInt64"", """");
+                    var get_u64 = INTERNAL.mono_bind_static_method (""{HelperMarshal.INTEROP_CLASS}GetUInt64"", """");
                     var u64 = get_u64();
                 ")
             );
@@ -806,7 +806,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             HelperMarshal._stringResource = HelperMarshal._stringResource2 = null;
             Runtime.InvokeJS(@"
-                var sym = BINDING.mono_intern_string(""interned string 3"");
+                var sym = INTERNAL.mono_intern_string(""interned string 3"");
                 App.call_test_method (""InvokeString"", [ sym ], ""s"");
                 App.call_test_method (""InvokeString2"", [ sym ], ""s"");
             ");
@@ -823,7 +823,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 var s = ""long interned string"";
                 for (var i = 0; i < 1024; i++)
                     s += String(i % 10);
-                var sym = BINDING.mono_intern_string(s);
+                var sym = INTERNAL.mono_intern_string(s);
                 App.call_test_method (""InvokeString"", [ sym ], ""S"");
                 App.call_test_method (""InvokeString2"", [ sym ], ""s"");
             ");
@@ -837,7 +837,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             HelperMarshal._stringResource = null;
             Runtime.InvokeJS(@"
                 for (var i = 0; i < 10240; i++)
-                    BINDING.mono_intern_string('s' + i);
+                    INTERNAL.mono_intern_string('s' + i);
                 App.call_test_method (""InvokeString"", [ 's5000' ], ""S"");
             ");
             Assert.Equal("s5000", HelperMarshal._stringResource);
@@ -864,8 +864,8 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             HelperMarshal._stringResource = HelperMarshal._stringResource2 = null;
             var fqn = "[System.Private.Runtime.InteropServices.JavaScript.Tests]System.Runtime.InteropServices.JavaScript.Tests.HelperMarshal:StoreArgumentAndReturnLiteral";
             Runtime.InvokeJS(
-                $"var a = BINDING.bind_static_method('{fqn}')('test');\r\n" +
-                $"var b = BINDING.bind_static_method('{fqn}')(a);\r\n" +
+                $"var a = INTERNAL.mono_bind_static_method('{fqn}')('test');\r\n" +
+                $"var b = INTERNAL.mono_bind_static_method('{fqn}')(a);\r\n" +
                 "App.call_test_method ('InvokeString2', [ b ]);"
             );
             Assert.Equal("s: 1 length: 1", HelperMarshal._stringResource);

--- a/src/mono/mono/component/mini-wasm-debugger.c
+++ b/src/mono/mono/component/mini-wasm-debugger.c
@@ -68,8 +68,8 @@ void wasm_debugger_log (int level, const gchar *format, ...)
 		var message = Module.UTF8ToString ($1);
 		var namespace = "Debugger.Debug";
 
-		if (MONO["logging"] && MONO.logging["debugger"]) {
-			MONO.logging.debugger (level, message);
+		if (INTERNAL["logging"] && INTERNAL.logging["debugger"]) {
+			INTERNAL.logging.debugger (level, message);
 			return;
 		}
 
@@ -375,7 +375,7 @@ mono_wasm_send_dbg_command_with_parms (int id, MdbgProtCommandSet command_set, i
 	m_dbgprot_buffer_add_data (&bufWithParms, data, size);
 	if (!write_value_to_buffer(&bufWithParms, valtype, newvalue)) {
 		EM_ASM ({
-			MONO.mono_wasm_add_dbg_command_received ($0, $1, $2, $3);
+			INTERNAL.mono_wasm_add_dbg_command_received ($0, $1, $2, $3);
 		}, 0, id, 0, 0);
 		return TRUE;
 	}
@@ -403,7 +403,7 @@ mono_wasm_send_dbg_command (int id, MdbgProtCommandSet command_set, int command,
 	else
 		error = mono_process_dbg_packet (id, command_set, command, &no_reply, data, data + size, &buf);
 	EM_ASM ({
-		MONO.mono_wasm_add_dbg_command_received ($0, $1, $2, $3);
+		INTERNAL.mono_wasm_add_dbg_command_received ($0, $1, $2, $3);
 	}, error == MDBGPROT_ERR_NONE, id, buf.buf, buf.p-buf.buf);
 	
 	buffer_free (&buf);
@@ -414,7 +414,7 @@ static gboolean
 receive_debugger_agent_message (void *data, int len)
 {
 	EM_ASM ({
-		MONO.mono_wasm_add_dbg_command_received (1, -1, $0, $1);
+		INTERNAL.mono_wasm_add_dbg_command_received (1, -1, $0, $1);
 	}, data, len);
 	mono_wasm_save_thread_context();
 	mono_wasm_fire_debugger_agent_message ();	

--- a/src/mono/sample/mbr/browser/index.html
+++ b/src/mono/sample/mbr/browser/index.html
@@ -18,12 +18,12 @@
         init: function () {
 	  var outElement = document.getElementById("out");
           document.getElementById("update").addEventListener("click", function () {
-	    BINDING.call_static_method("[WasmDelta] Sample.Test:Update", []);
+	    INTERNAL.call_static_method("[WasmDelta] Sample.Test:Update", []);
 	    console.log ("applied update");
-	    var ret = BINDING.call_static_method("[WasmDelta] Sample.Test:TestMeaning", []);
+	    var ret = INTERNAL.call_static_method("[WasmDelta] Sample.Test:TestMeaning", []);
 	    outElement.innerHTML = ret;
 	  })
-          var ret = BINDING.call_static_method("[WasmDelta] Sample.Test:TestMeaning", []);
+          var ret = INTERNAL.call_static_method("[WasmDelta] Sample.Test:TestMeaning", []);
 	  outElement.innerHTML = ret;
           console.log ("ready");
         },

--- a/src/mono/sample/mbr/browser/runtime.js
+++ b/src/mono/sample/mbr/browser/runtime.js
@@ -2,30 +2,30 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 "use strict";
-var Module = { 
+var Module = {
     config: null,
 
-    preInit: async function() {
-        await MONO.mono_wasm_load_config("./mono-config.json"); // sets Module.config implicitly
+    preInit: async function () {
+        await MONO.mono_wasm_load_config("./mono-config.json"); // sets MONO.config implicitly
     },
 
     // Called when the runtime is initialized and wasm is ready
     onRuntimeInitialized: function () {
-        if (!Module.config || Module.config.error) {
+        if (!MONO.config || MONO.config.error) {
             console.log("An error occured while loading the config file");
             return;
         }
 
-        Module.config.loaded_cb = function () {
-            App.init ();
+        MONO.config.loaded_cb = function () {
+            App.init();
         };
-        Module.config.environment_variables = {
+        MONO.config.environment_variables = {
             "DOTNET_MODIFIABLE_ASSEMBLIES": "debug"
         };
-        Module.config.fetch_file_cb = function (asset) {
-            return fetch (asset, { credentials: 'same-origin' });
+        MONO.config.fetch_file_cb = function (asset) {
+            return fetch(asset, { credentials: 'same-origin' });
         }
 
-        MONO.mono_load_runtime_and_bcl_args (Module.config);
+        MONO.mono_load_runtime_and_bcl_args(MONO.config);
     },
 };

--- a/src/mono/sample/wasm/browser-bench/index.html
+++ b/src/mono/sample/wasm/browser-bench/index.html
@@ -37,7 +37,7 @@
       };
 
       function yieldBench () {
-        let promise = BINDING.call_static_method("[Wasm.Browser.Bench.Sample] Sample.Test:RunBenchmark", []);
+        let promise = INTERNAL.call_static_method("[Wasm.Browser.Bench.Sample] Sample.Test:RunBenchmark", []);
         promise.then(ret => {
           document.getElementById("out").innerHTML += ret;
           if (ret.length > 0) {
@@ -52,7 +52,7 @@
       var App = {
         init: function () {
           if (tasks != '')
-            BINDING.call_static_method("[Wasm.Browser.Bench.Sample] Sample.Test:SetTasks", tasks);
+            INTERNAL.call_static_method("[Wasm.Browser.Bench.Sample] Sample.Test:SetTasks", tasks);
           yieldBench ();
         }
       };

--- a/src/mono/sample/wasm/browser-bench/runtime.js
+++ b/src/mono/sample/wasm/browser-bench/runtime.js
@@ -2,46 +2,44 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 "use strict";
-var Module = { 
+var Module = {
     config: null,
 
-    preInit: async function() {
-        await MONO.mono_wasm_load_config("./mono-config.json"); // sets Module.config implicitly
+    preInit: async function () {
+        await MONO.mono_wasm_load_config("./mono-config.json"); // sets MONO.config implicitly
     },
 
     // Called when the runtime is initialized and wasm is ready
     onRuntimeInitialized: function () {
-        if (!Module.config || Module.config.error) {
+        if (!MONO.config || MONO.config.error) {
             console.log("An error occured while loading the config file");
             return;
         }
 
-        Module.config.loaded_cb = function () {
+        MONO.config.loaded_cb = function () {
             try {
-                App.init ();
+                App.init();
             } catch (error) {
                 test_exit(1);
                 throw (error);
             }
         };
-        Module.config.fetch_file_cb = function (asset) {
-            return fetch (asset, { credentials: 'same-origin' });
+        MONO.config.fetch_file_cb = function (asset) {
+            return fetch(asset, { credentials: 'same-origin' });
         }
 
-        if (Module.config.enable_profiler)
-        {
-            Module.config.aot_profiler_options = {
-                write_at:"Sample.Test::StopProfile",
+        if (MONO.config.enable_profiler) {
+            MONO.config.aot_profiler_options = {
+                write_at: "Sample.Test::StopProfile",
                 send_to: "System.Runtime.InteropServices.JavaScript.Runtime::DumpAotProfileData"
             }
         }
 
-        try
-        {
-            MONO.mono_load_runtime_and_bcl_args (Module.config);
+        try {
+            MONO.mono_load_runtime_and_bcl_args(MONO.config);
         } catch (error) {
             test_exit(1);
-            throw(error);
+            throw (error);
         }
     },
 };

--- a/src/mono/sample/wasm/browser-profile/README.md
+++ b/src/mono/sample/wasm/browser-profile/README.md
@@ -27,16 +27,16 @@ var Module = {
 
 3. Call the `write_at` method at the end of the app, either in C# or in JS. To call the `write_at` method in JS, make use of bindings:
 
-`BINDING.call_static_method("<[ProjectName] Namespace.Class::StopProfile">, []);`
+`INTERNAL.call_static_method("<[ProjectName] Namespace.Class::StopProfile">, []);`
 
-When the `write_at` method is called, the `send_to` method `DumpAotProfileData` stores the profile data into `Module.aot_profile_data`
+When the `write_at` method is called, the `send_to` method `DumpAotProfileData` stores the profile data into `INTERNAL.aot_profile_data`
 
-4. Download `Module.aot_profile_data` in JS, using something similar to:
+4. Download `INTERNAL.aot_profile_data` in JS, using something similar to:
 
 ```
 function saveProfile() {
   var a = document.createElement('a');
-  var blob = new Blob([Module.aot_profile_data]);
+  var blob = new Blob([INTERNAL.aot_profile_data]);
   a.href = URL.createObjectURL(blob);
   a.download = "data.aotprofile";
   // Append anchor to body.

--- a/src/mono/sample/wasm/browser-profile/runtime.js
+++ b/src/mono/sample/wasm/browser-profile/runtime.js
@@ -2,22 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 "use strict";
-var Module = { 
+var Module = {
     is_testing: false,
     config: null,
 
-    preInit: async function() {
-        await MONO.mono_wasm_load_config("./mono-config.json"); // sets Module.config implicitly
+    preInit: async function () {
+        await MONO.mono_wasm_load_config("./mono-config.json"); // sets MONO.config implicitly
     },
 
     // Called when the runtime is initialized and wasm is ready
     onRuntimeInitialized: function () {
-        if (!Module.config || Module.config.error) {
+        if (!MONO.config || MONO.config.error) {
             console.log("An error occured while loading the config file");
             return;
         }
 
-        Module.config.loaded_cb = function () {
+        MONO.config.loaded_cb = function () {
             try {
                 Module.init();
             } catch (error) {
@@ -25,70 +25,67 @@ var Module = {
                 throw (error);
             }
         };
-        Module.config.fetch_file_cb = function (asset) {
-            return fetch (asset, { credentials: 'same-origin' });
+        MONO.config.fetch_file_cb = function (asset) {
+            return fetch(asset, { credentials: 'same-origin' });
         }
 
-        if (Module.config.enable_profiler)
-        {
-            Module.config.aot_profiler_options = {
-                write_at:"Sample.Test::StopProfile",
+        if (MONO.config.enable_profiler) {
+            MONO.config.aot_profiler_options = {
+                write_at: "Sample.Test::StopProfile",
                 send_to: "System.Runtime.InteropServices.JavaScript.Runtime::DumpAotProfileData"
             }
         }
 
-        try
-        {
-            MONO.mono_load_runtime_and_bcl_args (Module.config);
+        try {
+            MONO.mono_load_runtime_and_bcl_args(MONO.config);
         } catch (error) {
             Module.test_exit(1);
-            throw(error);
+            throw (error);
         }
     },
 
     init: function () {
         console.log("not ready yet")
-        var ret = BINDING.call_static_method("[Wasm.BrowserProfile.Sample] Sample.Test:TestMeaning", []);
+        const ret = INTERNAL.call_static_method("[Wasm.BrowserProfile.Sample] Sample.Test:TestMeaning", []);
         document.getElementById("out").innerHTML = ret;
-        console.log ("ready");
+        console.log("ready");
 
-        if (Module.is_testing)
-        {
-          console.debug(`ret: ${ret}`);
-          let exit_code = ret == 42 ? 0 : 1;
-          Module.test_exit(exit_code);
+        if (Module.is_testing) {
+            console.debug(`ret: ${ret}`);
+            let exit_code = ret == 42 ? 0 : 1;
+            Module.test_exit(exit_code);
         }
 
-        if (Module.config.enable_profiler) {
-          BINDING.call_static_method("[Wasm.BrowserProfile.Sample] Sample.Test:StopProfile", []);
-          Module.saveProfile();
+        if (MONO.config.enable_profiler) {
+            INTERNAL.call_static_method("[Wasm.BrowserProfile.Sample] Sample.Test:StopProfile", []);
+            Module.saveProfile();
         }
     },
 
-    onLoad: function() {
-        var url = new URL(decodeURI(window.location));
-        let args = url.searchParams.getAll('arg');
+    onLoad: function () {
+        const url = new URL(decodeURI(window.location));
+        const args = url.searchParams.getAll('arg');
         Module.is_testing = args !== undefined && (args.find(arg => arg == '--testing') !== undefined);
     },
-  
-    test_exit: function(exit_code) {
+
+    test_exit: function (exit_code) {
         if (!Module.is_testing) {
             console.log(`test_exit: ${exit_code}`);
             return;
         }
 
         /* Set result in a tests_done element, to be read by xharness */
-        var tests_done_elem = document.createElement("label");
+        const tests_done_elem = document.createElement("label");
         tests_done_elem.id = "tests_done";
         tests_done_elem.innerHTML = exit_code.toString();
         document.body.appendChild(tests_done_elem);
 
         console.log(`WASM EXIT ${exit_code}`);
     },
-  
+
     saveProfile: function () {
-        var a = document.createElement('a');
-        var blob = new Blob([Module.aot_profile_data]);
+        const a = document.createElement('a');
+        const blob = new Blob([INTERNAL.aot_profile_data]);
         a.href = URL.createObjectURL(blob);
         a.download = "data.aotprofile";
         // Append anchor to body.

--- a/src/mono/sample/wasm/browser/index.html
+++ b/src/mono/sample/wasm/browser/index.html
@@ -36,7 +36,7 @@
 
       var App = {
         init: function () {
-          var ret = BINDING.call_static_method("[Wasm.Browser.Sample] Sample.Test:TestMeaning", []);
+          var ret = INTERNAL.call_static_method("[Wasm.Browser.Sample] Sample.Test:TestMeaning", []);
           document.getElementById("out").innerHTML = ret;
 
           if (is_testing)

--- a/src/mono/sample/wasm/browser/runtime.js
+++ b/src/mono/sample/wasm/browser/runtime.js
@@ -2,39 +2,38 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 "use strict";
-var Module = { 
+var Module = {
 
     config: null,
 
-    preInit: async function() {
-        await MONO.mono_wasm_load_config("./mono-config.json"); // sets Module.config implicitly
+    preInit: async function () {
+        await MONO.mono_wasm_load_config("./mono-config.json"); // sets MONO.config implicitly
     },
 
     // Called when the runtime is initialized and wasm is ready
     onRuntimeInitialized: function () {
-        if (!Module.config || Module.config.error) {
+        if (!MONO.config || MONO.config.error) {
             console.log("No config found");
             return;
         }
 
-        Module.config.loaded_cb = function () {
+        MONO.config.loaded_cb = function () {
             try {
-                App.init ();
+                App.init();
             } catch (error) {
                 test_exit(1);
                 throw (error);
             }
         };
-        Module.config.fetch_file_cb = function (asset) {
-            return fetch (asset, { credentials: 'same-origin' });
+        MONO.config.fetch_file_cb = function (asset) {
+            return fetch(asset, { credentials: 'same-origin' });
         }
 
-        try
-        {
-            MONO.mono_load_runtime_and_bcl_args (Module.config);
+        try {
+            MONO.mono_load_runtime_and_bcl_args(MONO.config);
         } catch (error) {
             test_exit(1);
-            throw(error);
+            throw (error);
         }
     },
 };

--- a/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/DevToolsHelper.cs
@@ -172,33 +172,31 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         public MonoCommands(string expression) => this.expression = expression;
 
-        public static MonoCommands GetExceptionObject() => new MonoCommands("MONO.mono_wasm_get_exception_object()");
+        public static MonoCommands GetDebuggerAgentBufferReceived() => new MonoCommands("INTERNAL.mono_wasm_get_dbg_command_info()");
 
-        public static MonoCommands GetDebuggerAgentBufferReceived() => new MonoCommands("MONO.mono_wasm_get_dbg_command_info()");
+        public static MonoCommands IsRuntimeReady() => new MonoCommands("INTERNAL.mono_wasm_runtime_is_ready");
 
-        public static MonoCommands IsRuntimeReady() => new MonoCommands("MONO.mono_wasm_runtime_is_ready");
-
-        public static MonoCommands GetLoadedFiles() => new MonoCommands("MONO.mono_wasm_get_loaded_files()");
+        public static MonoCommands GetLoadedFiles() => new MonoCommands("INTERNAL.mono_wasm_get_loaded_files()");
 
         public static MonoCommands SendDebuggerAgentCommand(int id, int command_set, int command, string command_parameters)
         {
-            return new MonoCommands($"MONO.mono_wasm_send_dbg_command ({id}, {command_set}, {command},'{command_parameters}')");
+            return new MonoCommands($"INTERNAL.mono_wasm_send_dbg_command ({id}, {command_set}, {command},'{command_parameters}')");
         }
 
         public static MonoCommands SendDebuggerAgentCommandWithParms(int id, int command_set, int command, string command_parameters, int len, int type, string parm)
         {
-            return new MonoCommands($"MONO.mono_wasm_send_dbg_command_with_parms ({id}, {command_set}, {command},'{command_parameters}', {len}, {type}, '{parm}')");
+            return new MonoCommands($"INTERNAL.mono_wasm_send_dbg_command_with_parms ({id}, {command_set}, {command},'{command_parameters}', {len}, {type}, '{parm}')");
         }
 
-        public static MonoCommands CallFunctionOn(JToken args) => new MonoCommands($"MONO.mono_wasm_call_function_on ({args.ToString()})");
+        public static MonoCommands CallFunctionOn(JToken args) => new MonoCommands($"INTERNAL.mono_wasm_call_function_on ({args})");
 
-        public static MonoCommands GetDetails(int objectId, JToken args = null) => new MonoCommands($"MONO.mono_wasm_get_details ({objectId}, {(args ?? "{ }")})");
+        public static MonoCommands GetDetails(int objectId, JToken args = null) => new MonoCommands($"INTERNAL.mono_wasm_get_details ({objectId}, {(args ?? "{ }")})");
 
-        public static MonoCommands Resume() => new MonoCommands($"MONO.mono_wasm_debugger_resume ()");
+        public static MonoCommands Resume() => new MonoCommands($"INTERNAL.mono_wasm_debugger_resume ()");
 
-        public static MonoCommands DetachDebugger() => new MonoCommands($"MONO.mono_wasm_detach_debugger()");
+        public static MonoCommands DetachDebugger() => new MonoCommands($"INTERNAL.mono_wasm_detach_debugger()");
 
-        public static MonoCommands ReleaseObject(DotnetObjectId objectId) => new MonoCommands($"MONO.mono_wasm_release_object('{objectId}')");
+        public static MonoCommands ReleaseObject(DotnetObjectId objectId) => new MonoCommands($"INTERNAL.mono_wasm_release_object('{objectId}')");
     }
 
     internal enum MonoErrorCodes

--- a/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/BreakpointTests.cs
@@ -35,7 +35,7 @@ namespace DebuggerTests
         {
             // Test that js breakpoints get set correctly
             // 13 24
-            // 13 31
+            // 13 33
             var bp1_res = await SetBreakpoint("/debugger-driver.html", 13, 24);
 
             Assert.EndsWith("debugger-driver.html", bp1_res.Value["breakpointId"].ToString());
@@ -47,7 +47,7 @@ namespace DebuggerTests
             Assert.Equal(13, loc["lineNumber"]);
             Assert.Equal(24, loc["columnNumber"]);
 
-            var bp2_res = await SetBreakpoint("/debugger-driver.html", 13, 31);
+            var bp2_res = await SetBreakpoint("/debugger-driver.html", 13, 33);
 
             Assert.EndsWith("debugger-driver.html", bp2_res.Value["breakpointId"].ToString());
             Assert.Equal(1, bp2_res.Value["locations"]?.Value<JArray>()?.Count);
@@ -56,14 +56,14 @@ namespace DebuggerTests
 
             Assert.NotNull(loc2["scriptId"]);
             Assert.Equal(13, loc2["lineNumber"]);
-            Assert.Equal(31, loc2["columnNumber"]);
+            Assert.Equal(33, loc2["columnNumber"]);
         }
 
         [Fact]
         public async Task CreateJS0Breakpoint()
         {
             // 13 24
-            // 13 31
+            // 13 33
             var bp1_res = await SetBreakpoint("/debugger-driver.html", 13, 0);
 
             Assert.EndsWith("debugger-driver.html", bp1_res.Value["breakpointId"].ToString());
@@ -75,7 +75,7 @@ namespace DebuggerTests
             Assert.Equal(13, loc["lineNumber"]);
             Assert.Equal(24, loc["columnNumber"]);
 
-            var bp2_res = await SetBreakpoint("/debugger-driver.html", 13, 31);
+            var bp2_res = await SetBreakpoint("/debugger-driver.html", 13, 33);
 
             Assert.EndsWith("debugger-driver.html", bp2_res.Value["breakpointId"].ToString());
             Assert.Equal(1, bp2_res.Value["locations"]?.Value<JArray>()?.Count);
@@ -84,7 +84,7 @@ namespace DebuggerTests
 
             Assert.NotNull(loc2["scriptId"]);
             Assert.Equal(13, loc2["lineNumber"]);
-            Assert.Equal(31, loc2["columnNumber"]);
+            Assert.Equal(33, loc2["columnNumber"]);
         }
 
         [Theory]

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -41,7 +41,12 @@ namespace DebuggerTests
         static protected string FindTestPath()
         {
             var asm_dir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            var test_app_path = Path.Combine(asm_dir, "..", "..", "..", "debugger-test", "Debug", "publish");
+#if DEBUG
+            var config="Debug";
+#else
+            var config="Release";
+#endif            
+            var test_app_path = Path.Combine(asm_dir, "..", "..", "..", "debugger-test", config, "publish");
             if (File.Exists(Path.Combine(test_app_path, "debugger-driver.html")))
                 return test_app_path;
 

--- a/src/mono/wasm/debugger/DebuggerTestSuite/MonoJsTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/MonoJsTests.cs
@@ -14,40 +14,16 @@ namespace DebuggerTests
     public class MonoJsTests : DebuggerTestBase
     {
         [Fact]
-        public async Task InvalidScopeId()
-        {
-            var bp1_res = await SetBreakpointInMethod("debugger-test.dll", "Math", "IntAdd", 3);
-            await EvaluateAndCheck(
-                "window.setTimeout(function() { invoke_static_method('[debugger-test] Math:IntAdd', 1, 2); })",
-                null, -1, -1, "IntAdd");
-
-            var varIds = new[]
-            {
-                    new { index = 0, name = "one" },
-                };
-
-            var scopeId = "-12";
-            var expression = $"MONO.mono_wasm_get_variables({scopeId}, {JsonConvert.SerializeObject(varIds)})";
-            var res = await cli.SendCommand($"Runtime.evaluate", JObject.FromObject(new { expression, returnByValue = true }), token);
-            Assert.False(res.IsOk);
-
-            scopeId = "30000";
-            expression = $"MONO.mono_wasm_get_variables({scopeId}, {JsonConvert.SerializeObject(varIds)})";
-            res = await cli.SendCommand($"Runtime.evaluate", JObject.FromObject(new { expression, returnByValue = true }), token);
-            Assert.False(res.IsOk);
-        }
-
-        [Fact]
         public async Task BadRaiseDebugEventsTest()
         {
             var bad_expressions = new[]
             {
-                    "MONO.mono_wasm_raise_debug_event('')",
-                    "MONO.mono_wasm_raise_debug_event(undefined)",
-                    "MONO.mono_wasm_raise_debug_event({})",
+                    "INTERNAL.mono_wasm_raise_debug_event('')",
+                    "INTERNAL.mono_wasm_raise_debug_event(undefined)",
+                    "INTERNAL.mono_wasm_raise_debug_event({})",
 
-                    "MONO.mono_wasm_raise_debug_event({eventName:'foo'}, '')",
-                    "MONO.mono_wasm_raise_debug_event({eventName:'foo'}, 12)"
+                    "INTERNAL.mono_wasm_raise_debug_event({eventName:'foo'}, '')",
+                    "INTERNAL.mono_wasm_raise_debug_event({eventName:'foo'}, 12)"
                 };
 
             foreach (var expression in bad_expressions)
@@ -82,7 +58,7 @@ namespace DebuggerTests
             });
 
             var trace_str = trace.HasValue ? $"trace: {trace.ToString().ToLower()}" : String.Empty;
-            var expression = $"MONO.mono_wasm_raise_debug_event({{ eventName:'qwe' }}, {{ {trace_str} }})";
+            var expression = $"INTERNAL.mono_wasm_raise_debug_event({{ eventName:'qwe' }}, {{ {trace_str} }})";
             var res = await cli.SendCommand($"Runtime.evaluate", JObject.FromObject(new { expression }), token);
             Assert.True(res.IsOk, $"Expected to pass for {expression}");
 
@@ -163,7 +139,7 @@ namespace DebuggerTests
                 pdb_base64 = Convert.ToBase64String(bytes);
             }
 
-            var expression = $@"MONO.mono_wasm_raise_debug_event({{
+            var expression = $@"INTERNAL.mono_wasm_raise_debug_event({{
                     eventName: 'AssemblyLoaded',
                     assembly_name: '{asm_name}',
                     assembly_b64: '{asm_base64}',

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-driver.html
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-driver.html
@@ -6,14 +6,14 @@
 	<script type='text/javascript'>
 		var App = {
 			init: function () {
-				this.int_add = Module.mono_bind_static_method ("[debugger-test] Math:IntAdd");
-				this.use_complex = Module.mono_bind_static_method ("[debugger-test] Math:UseComplex");
-				this.delegates_test = Module.mono_bind_static_method ("[debugger-test] Math:DelegatesTest");
-				this.generic_types_test = Module.mono_bind_static_method ("[debugger-test] Math:GenericTypesTest");
-				this.outer_method = Module.mono_bind_static_method ("[debugger-test] Math:OuterMethod");
-				this.async_method = Module.mono_bind_static_method ("[debugger-test] Math/NestedInMath:AsyncTest");
-				this.method_with_structs = Module.mono_bind_static_method ("[debugger-test] DebuggerTests.ValueTypesTest:MethodWithLocalStructs");
-				this.run_all = Module.mono_bind_static_method ("[debugger-test] DebuggerTest:run_all");
+				this.int_add = INTERNAL.mono_bind_static_method ("[debugger-test] Math:IntAdd");
+				this.use_complex = INTERNAL.mono_bind_static_method ("[debugger-test] Math:UseComplex");
+				this.delegates_test = INTERNAL.mono_bind_static_method ("[debugger-test] Math:DelegatesTest");
+				this.generic_types_test = INTERNAL.mono_bind_static_method ("[debugger-test] Math:GenericTypesTest");
+				this.outer_method = INTERNAL.mono_bind_static_method ("[debugger-test] Math:OuterMethod");
+				this.async_method = INTERNAL.mono_bind_static_method ("[debugger-test] Math/NestedInMath:AsyncTest");
+				this.method_with_structs = INTERNAL.mono_bind_static_method ("[debugger-test] DebuggerTests.ValueTypesTest:MethodWithLocalStructs");
+				this.run_all = INTERNAL.mono_bind_static_method ("[debugger-test] DebuggerTest:run_all");
 				this.static_method_table = {};
 				console.log ("ready");
 			},
@@ -21,7 +21,7 @@
 		function invoke_static_method (method_name, ...args) {
 			var method = App.static_method_table [method_name];
 			if (method == undefined)
-				method = App.static_method_table [method_name] = Module.mono_bind_static_method (method_name);
+				method = App.static_method_table [method_name] = INTERNAL.mono_bind_static_method (method_name);
 
 			return method (...args);
 		}
@@ -29,7 +29,7 @@
 		async function invoke_static_method_async (method_name, ...args) {
 			var method = App.static_method_table [method_name];
 			if (method == undefined) {
-				method = App.static_method_table [method_name] = Module.mono_bind_static_method (method_name);
+				method = App.static_method_table [method_name] = INTERNAL.mono_bind_static_method (method_name);
 			}
 
 			return await method (...args);

--- a/src/mono/wasm/debugger/tests/debugger-test/other.js
+++ b/src/mono/wasm/debugger/tests/debugger-test/other.js
@@ -4,7 +4,7 @@
 "use strict";
 
 function big_array_js_test (len) {
-	var big = new Array(len);
+	const big = new Array(len);
 	for (let i=0; i < len; i ++) {
 		big[i]=i + 1000;
 	}
@@ -12,7 +12,7 @@ function big_array_js_test (len) {
 };
 
 function object_js_test () {
-	var obj = {
+	const obj = {
 		a_obj: { aa: 5, ab: 'foo' },
 		b_arr: [ 10, 12 ]
 	};
@@ -21,7 +21,7 @@ function object_js_test () {
 };
 
 function getters_js_test () {
-	var ptd = {
+	const ptd = {
 		get Int () { return 5; },
 		get String () { return "foobar"; },
 		get DT () { return "dt"; },
@@ -53,7 +53,7 @@ function exceptions_test () {
 }
 
 function negative_cfo_test (str_value = null) {
-	var ptd = {
+	const ptd = {
 		get Int () { return 5; },
 		get String () { return "foobar"; },
 		get DT () { return "dt"; },
@@ -98,6 +98,6 @@ function get_properties_test () {
 
 function malloc_to_reallocate_test () {
 	//need to allocate this buffer size to force wasm linear memory to grow 
-	var _debugger_buffer = Module._malloc(4500000);
+	const _debugger_buffer = Module._malloc(4500000);
 	Module._free(_debugger_buffer);
 }

--- a/src/mono/wasm/debugger/tests/debugger-test/runtime-debugger.js
+++ b/src/mono/wasm/debugger/tests/debugger-test/runtime-debugger.js
@@ -4,25 +4,25 @@
 "use strict";
 
 var Module = {
-    config: null,
+	config: null,
 
-    preInit: async function() {
-        await MONO.mono_wasm_load_config("./mono-config.json"); // sets Module.config implicitly
-    },
+	preInit: async function () {
+		await MONO.mono_wasm_load_config("./mono-config.json"); // sets MONO.config implicitly
+	},
 
-    // Called when the runtime is initialized and wasm is ready
-    onRuntimeInitialized: function () {
-		if (!Module.config || Module.config.error) {
-            console.log("An error occured while loading the config file");
-            return;
-        }
+	// Called when the runtime is initialized and wasm is ready
+	onRuntimeInitialized: function () {
+		if (!MONO.config || MONO.config.error) {
+			console.log("An error occured while loading the config file");
+			return;
+		}
 
-		Module.config.loaded_cb = function () {
-			App.init ();
+		MONO.config.loaded_cb = function () {
+			App.init();
 		};
 		// For custom logging patch the functions below
 		/*
-		MONO.logging = {
+		INTERNAL.logging = {
 			trace: function (domain, log_level, message, isFatal, dataPtr) {},
 			debugger: function (level, message) {}
 		};
@@ -30,9 +30,9 @@ var Module = {
 		MONO.mono_wasm_setenv ("MONO_LOG_MASK", "all");
 		*/
 
-		Module.config.environment_variables = {
+		MONO.config.environment_variables = {
 			"DOTNET_MODIFIABLE_ASSEMBLIES": "debug"
 		};
-		MONO.mono_load_runtime_and_bcl_args (Module.config)
+		MONO.mono_load_runtime_and_bcl_args(MONO.config)
 	},
 };

--- a/src/mono/wasm/runtime-test.js
+++ b/src/mono/wasm/runtime-test.js
@@ -7,95 +7,96 @@
 "use strict";
 
 //glue code to deal with the differences between chrome, ch, d8, jsc and sm.
-var is_browser = typeof window != "undefined";
+const is_browser = typeof window != "undefined";
+const is_node = !is_browser && typeof process != 'undefined';
 
 // if the engine doesn't provide a console
 if (typeof (console) === "undefined") {
-	var console = {
-		log: globalThis.print,
-		clear: function () { }
-	};
+    globalThis.console = {
+        log: globalThis.print,
+        clear: function () { }
+    };
 }
 globalThis.testConsole = console;
 
 //define arguments for later
-var allRuntimeArguments = null;
+let allRuntimeArguments = null;
 try {
-	if (is_browser) {
-		// We expect to be run by tests/runtime/run.js which passes in the arguments using http parameters
-		const url = new URL(decodeURI(window.location));
-		allRuntimeArguments = [];
-		for (let param of url.searchParams) {
-			if (param[0] == "arg") {
-				allRuntimeArguments.push(param[1]);
-			}
-		}
+    if (is_browser) {
+        // We expect to be run by tests/runtime/run.js which passes in the arguments using http parameters
+        const url = new URL(decodeURI(window.location));
+        allRuntimeArguments = [];
+        for (let param of url.searchParams) {
+            if (param[0] == "arg") {
+                allRuntimeArguments.push(param[1]);
+            }
+        }
 
-	} else if (typeof arguments !== "undefined" && typeof arguments !== "null") {
-		allRuntimeArguments = arguments;
-	} else if (typeof process !== 'undefined' && typeof process.argv !== "undefined") {
-		allRuntimeArguments = process.argv.slice(2);
-	} else if (typeof scriptArgs !== "undefined") {
-		allRuntimeArguments = scriptArgs;
-	} else if (typeof WScript !== "undefined" && WScript.Arguments) {
-		allRuntimeArguments = WScript.Arguments;
-	} else {
-		allRuntimeArguments = [];
-	}
+    } else if (typeof arguments !== "undefined" && typeof arguments !== "null") {
+        allRuntimeArguments = arguments;
+    } else if (typeof process !== 'undefined' && typeof process.argv !== "undefined") {
+        allRuntimeArguments = process.argv.slice(2);
+    } else if (typeof scriptArgs !== "undefined") {
+        allRuntimeArguments = scriptArgs;
+    } else if (typeof WScript !== "undefined" && WScript.Arguments) {
+        allRuntimeArguments = WScript.Arguments;
+    } else {
+        allRuntimeArguments = [];
+    }
 } catch (e) {
-	console.log(e);
+    console.log(e);
 }
 
-function proxyMethod (prefix, func, asJson) {
-	return function() {
-		const args = [...arguments];
-		var payload= args[0];
-		if(payload === undefined) payload = 'undefined';
-		else if(payload === null) payload = 'null';
-		else if(typeof payload === 'function') payload = payload.toString();
-		else if(typeof payload !== 'string') {
-			try{
-				payload = JSON.stringify(payload);
-			}catch(e){
-				payload = payload.toString();
-			}
-		}
+function proxyMethod(prefix, func, asJson) {
+    return function () {
+        const args = [...arguments];
+        let payload = args[0];
+        if (payload === undefined) payload = 'undefined';
+        else if (payload === null) payload = 'null';
+        else if (typeof payload === 'function') payload = payload.toString();
+        else if (typeof payload !== 'string') {
+            try {
+                payload = JSON.stringify(payload);
+            } catch (e) {
+                payload = payload.toString();
+            }
+        }
 
-		if (asJson) {
-			func (JSON.stringify({
-				method: prefix,
-				payload: payload,
-				arguments: args
-			}));
-		} else {
-			func([prefix + payload, ...args.slice(1)]);
-		}
-	};
+        if (asJson) {
+            func(JSON.stringify({
+                method: prefix,
+                payload: payload,
+                arguments: args
+            }));
+        } else {
+            func([prefix + payload, ...args.slice(1)]);
+        }
+    };
 };
 
-var methods = ["debug", "trace", "warn", "info", "error"];
-for (var m of methods) {
-	if (typeof(console[m]) != "function") {
-		console[m] = proxyMethod(`console.${m}: `, console.log, false);
-	}
+const methods = ["debug", "trace", "warn", "info", "error"];
+for (let m of methods) {
+    if (typeof (console[m]) != "function") {
+        console[m] = proxyMethod(`console.${m}: `, console.log, false);
+    }
 }
 
-function proxyJson (func) {
-	for (var m of ["log", ...methods])
-		console[m] = proxyMethod(`console.${m}`,func, true);
+function proxyJson(func) {
+    for (let m of ["log", ...methods])
+        console[m] = proxyMethod(`console.${m}`, func, true);
 }
 
 if (is_browser) {
-	const consoleUrl = `${window.location.origin}/console`.replace('http://', 'ws://');
+    const consoleUrl = `${window.location.origin}/console`.replace('http://', 'ws://');
 
-	let consoleWebSocket = new WebSocket(consoleUrl);
-	consoleWebSocket.onopen = function(event) {
-		proxyJson(function (msg) { consoleWebSocket.send (msg); });
-		globalThis.testConsole.log("browser: Console websocket connected.");
-	};
-	consoleWebSocket.onerror = function(event) {
-		console.log(`websocket error: ${event}`);
-	};
+    let consoleWebSocket = new WebSocket(consoleUrl);
+    consoleWebSocket.onopen = function (event) {
+        proxyJson(function (msg) { consoleWebSocket.send(msg); });
+        globalThis.testConsole.log("browser: Console websocket connected.");
+    };
+    consoleWebSocket.onerror = function (event) {
+        console.log(`websocket error: ${event}`);
+    };
 }
 //proxyJson(console.log);
 
@@ -104,294 +105,275 @@ let print = globalThis.testConsole.log;
 let printErr = globalThis.testConsole.error;
 
 if (typeof crypto === 'undefined') {
-	// **NOTE** this is a simple insecure polyfill for testing purposes only
-	// /dev/random doesn't work on js shells, so define our own
-	// See library_fs.js:createDefaultDevices ()
-	var crypto = {
-		getRandomValues: function (buffer) {
-			for (var i = 0; i < buffer.length; i++)
-				buffer [i] = (Math.random () * 256) | 0;
-		}
-	}
+    // **NOTE** this is a simple insecure polyfill for testing purposes only
+    // /dev/random doesn't work on js shells, so define our own
+    // See library_fs.js:createDefaultDevices ()
+    globalThis.crypto = {
+        getRandomValues: function (buffer) {
+            for (let i = 0; i < buffer.length; i++)
+                buffer[i] = (Math.random() * 256) | 0;
+        }
+    }
 }
 
 if (typeof performance == 'undefined') {
-	// performance.now() is used by emscripten and doesn't work in JSC
-	var performance = {
-		now: function () {
-			return Date.now ();
-		}
-	}
+    // performance.now() is used by emscripten and doesn't work in JSC
+    globalThis.performance = {
+        now: function () {
+            return Date.now();
+        }
+    }
 }
 
 //end of all the nice shell glue code.
 
-function test_exit (exit_code) {
-	if (is_browser) {
-		// Notify the selenium script
-		Module.exit_code = exit_code;
-		Module.print ("WASM EXIT " + exit_code);
-		var tests_done_elem = document.createElement ("label");
-		tests_done_elem.id = "tests_done";
-		tests_done_elem.innerHTML = exit_code.toString ();
-		document.body.appendChild (tests_done_elem);
-	} else {
-		Module.wasm_exit (exit_code);
-	}
+function test_exit(exit_code) {
+    if (is_browser) {
+        // Notify the selenium script
+        Module.exit_code = exit_code;
+        Module.print("WASM EXIT " + exit_code);
+        const tests_done_elem = document.createElement("label");
+        tests_done_elem.id = "tests_done";
+        tests_done_elem.innerHTML = exit_code.toString();
+        document.body.appendChild(tests_done_elem);
+    } else {
+        INTERNAL.mono_wasm_exit(exit_code);
+    }
 }
 
-function fail_exec (reason) {
-	Module.print (reason);
-	test_exit (1);
+function fail_exec(reason) {
+    Module.print(reason);
+    test_exit(1);
 }
 
-function inspect_object (o) {
-	var r = "";
-	for(var p in o) {
-		var t = typeof o[p];
-		r += "'" + p + "' => '" + t + "', ";
-	}
-	return r;
+function inspect_object(o) {
+    const r = "";
+    for (let p in o) {
+        const t = typeof o[p];
+        r += "'" + p + "' => '" + t + "', ";
+    }
+    return r;
 }
 
 // Preprocess arguments
 console.info("Arguments: " + allRuntimeArguments);
-var profilers = [];
-var setenv = {};
-var runtime_args = [];
-var enable_gc = true;
-var enable_zoneinfo = false;
-var working_dir='/';
+const profilers = [];
+const setenv = {};
+const runtime_args = [];
+let enable_gc = true;
+let working_dir = '/';
 while (allRuntimeArguments !== undefined && allRuntimeArguments.length > 0) {
-	if (allRuntimeArguments [0].startsWith ("--profile=")) {
-		var arg = allRuntimeArguments [0].substring ("--profile=".length);
+    if (allRuntimeArguments[0].startsWith("--profile=")) {
+        const arg = allRuntimeArguments[0].substring("--profile=".length);
 
-		profilers.push (arg);
+        profilers.push(arg);
 
-		allRuntimeArguments = allRuntimeArguments.slice (1);
-	} else if (allRuntimeArguments [0].startsWith ("--setenv=")) {
-		var arg = allRuntimeArguments [0].substring ("--setenv=".length);
-		var parts = arg.split ('=');
-		if (parts.length != 2)
-			fail_exec ("Error: malformed argument: '" + allRuntimeArguments [0]);
-		setenv [parts [0]] = parts [1];
-		allRuntimeArguments = allRuntimeArguments.slice (1);
-	} else if (allRuntimeArguments [0].startsWith ("--runtime-arg=")) {
-		var arg = allRuntimeArguments [0].substring ("--runtime-arg=".length);
-		runtime_args.push (arg);
-		allRuntimeArguments = allRuntimeArguments.slice (1);
-	} else if (allRuntimeArguments [0] == "--disable-on-demand-gc") {
-		enable_gc = false;
-		allRuntimeArguments = allRuntimeArguments.slice (1);
-	} else if (allRuntimeArguments [0].startsWith ("--working-dir=")) {
-		var arg = allRuntimeArguments [0].substring ("--working-dir=".length);
-		working_dir = arg;
-		allRuntimeArguments = allRuntimeArguments.slice (1);
-	} else {
-		break;
-	}
+        allRuntimeArguments = allRuntimeArguments.slice(1);
+    } else if (allRuntimeArguments[0].startsWith("--setenv=")) {
+        const arg = allRuntimeArguments[0].substring("--setenv=".length);
+        const parts = arg.split('=');
+        if (parts.length != 2)
+            fail_exec("Error: malformed argument: '" + allRuntimeArguments[0]);
+        setenv[parts[0]] = parts[1];
+        allRuntimeArguments = allRuntimeArguments.slice(1);
+    } else if (allRuntimeArguments[0].startsWith("--runtime-arg=")) {
+        const arg = allRuntimeArguments[0].substring("--runtime-arg=".length);
+        runtime_args.push(arg);
+        allRuntimeArguments = allRuntimeArguments.slice(1);
+    } else if (allRuntimeArguments[0] == "--disable-on-demand-gc") {
+        enable_gc = false;
+        allRuntimeArguments = allRuntimeArguments.slice(1);
+    } else if (allRuntimeArguments[0].startsWith("--working-dir=")) {
+        const arg = allRuntimeArguments[0].substring("--working-dir=".length);
+        working_dir = arg;
+        allRuntimeArguments = allRuntimeArguments.slice(1);
+    } else {
+        break;
+    }
 }
 
 // cheap way to let the testing infrastructure know we're running in a browser context (or not)
 setenv["IsBrowserDomSupported"] = is_browser.toString().toLowerCase();
 
-function writeContentToFile(content, path)
-{
-	var stream = FS.open(path, 'w+');
-	FS.write(stream, content, 0, content.length, 0);
-	FS.close(stream);
+function writeContentToFile(content, path) {
+    const stream = FS.open(path, 'w+');
+    FS.write(stream, content, 0, content.length, 0);
+    FS.close(stream);
 }
 
-function loadScript (url)
-{
-	if (is_browser) {
-		var script = document.createElement ("script");
-		script.src = url;
-		document.head.appendChild (script);
-	} else {
-		load (url);
-	}
+function loadScript(url) {
+    if (is_browser) {
+        const script = document.createElement("script");
+        script.src = url;
+        document.head.appendChild(script);
+    } else {
+        load(url);
+    }
 }
 
 var Module = {
-	mainScriptUrlOrBlob: "dotnet.js",
-	config: null,
-	print,
-	printErr,
+    mainScriptUrlOrBlob: "dotnet.js",
+    config: null,
+    print,
+    printErr,
 
-    preInit: async function() {
-        await MONO.mono_wasm_load_config("./mono-config.json"); // sets Module.config implicitly
+    preInit: async function () {
+        await MONO.mono_wasm_load_config("./mono-config.json"); // sets MONO.config implicitly
     },
 
-	onAbort: function(x) {
-		print ("ABORT: " + x);
-		var err = new Error();
-		print ("Stacktrace: \n");
-		print (err.stack);
-		test_exit (1);
-	},
+    onAbort: function (x) {
+        print("ABORT: " + x);
+        const err = new Error();
+        print("Stacktrace: \n");
+        print(err.stack);
+        test_exit(1);
+    },
 
-	onRuntimeInitialized: function () {
-		// Have to set env vars here to enable setting MONO_LOG_LEVEL etc.
-		for (var variable in setenv) {
-			MONO.mono_wasm_setenv (variable, setenv [variable]);
-		}
+    onRuntimeInitialized: function () {
+        // Have to set env vars here to enable setting MONO_LOG_LEVEL etc.
+        for (let variable in setenv) {
+            MONO.mono_wasm_setenv(variable, setenv[variable]);
+        }
 
-		if (!enable_gc) {
-			Module.ccall ('mono_wasm_enable_on_demand_gc', 'void', ['number'], [0]);
-		}
+        if (!enable_gc) {
+            INTERNAL.mono_wasm_enable_on_demand_gc(0);
+        }
 
-		Module.config.loaded_cb = function () {
-			let wds = FS.stat (working_dir);
-			if (wds === undefined || !FS.isDir (wds.mode)) {
-				fail_exec (`Could not find working directory ${working_dir}`);
-				return;
-			}
+        MONO.config.loaded_cb = function () {
+            let wds = FS.stat(working_dir);
+            if (wds === undefined || !FS.isDir(wds.mode)) {
+                fail_exec(`Could not find working directory ${working_dir}`);
+                return;
+            }
 
-			FS.chdir (working_dir);
-			App.init ();
-		};
-		Module.config.fetch_file_cb = function (asset) {
-			// console.log("fetch_file_cb('" + asset + "')");
-			// for testing purposes add BCL assets to VFS until we special case File.Open
-			// to identify when an assembly from the BCL is being open and resolve it correctly.
-			/*
-			var content = new Uint8Array (read (asset, 'binary'));
-			var path = asset.substr(Module.config.deploy_prefix.length);
-			writeContentToFile(content, path);
-			*/
+            FS.chdir(working_dir);
+            App.init();
+        };
+        MONO.config.fetch_file_cb = function (asset) {
+            // console.log("fetch_file_cb('" + asset + "')");
+            // for testing purposes add BCL assets to VFS until we special case File.Open
+            // to identify when an assembly from the BCL is being open and resolve it correctly.
+            /*
+            const content = new Uint8Array (read (asset, 'binary'));
+            const path = asset.substr(MONO.config.deploy_prefix.length);
+            writeContentToFile(content, path);
+            */
 
-			if (typeof window != 'undefined') {
-				return fetch (asset, { credentials: 'same-origin' });
-			} else {
-				// The default mono_load_runtime_and_bcl defaults to using
-				// fetch to load the assets.  It also provides a way to set a
-				// fetch promise callback.
-				// Here we wrap the file read in a promise and fake a fetch response
-				// structure.
-				return new Promise ((resolve, reject) => {
-					var bytes = null, error = null;
-					try {
-						bytes = read (asset, 'binary');
-					} catch (exc) {
-						console.log('v8 file read failed ' + asset + ' ' + exc)
-						error = exc;
-					}
-					var response = { ok: (bytes && !error), url: asset,
-						arrayBuffer: function () {
-							return new Promise ((resolve2, reject2) => {
-								if (error)
-									reject2 (error);
-								else
-									resolve2 (new Uint8Array (bytes));
-						}
-					)}
-					}
-					resolve (response);
-				})
-			}
-		};
+            if (typeof window != 'undefined') {
+                return fetch(asset, { credentials: 'same-origin' });
+            } else {
+                // The default mono_load_runtime_and_bcl defaults to using
+                // fetch to load the assets.  It also provides a way to set a
+                // fetch promise callback.
+                // Here we wrap the file read in a promise and fake a fetch response
+                // structure.
+                return new Promise((resolve, reject) => {
+                    let bytes = null, error = null;
+                    try {
+                        bytes = read(asset, 'binary');
+                    } catch (exc) {
+                        console.log('v8 file read failed ' + asset + ' ' + exc)
+                        error = exc;
+                    }
+                    const response = {
+                        ok: (bytes && !error), url: asset,
+                        arrayBuffer: function () {
+                            return new Promise((resolve2, reject2) => {
+                                if (error)
+                                    reject2(error);
+                                else
+                                    resolve2(new Uint8Array(bytes));
+                            }
+                            )
+                        }
+                    }
+                    resolve(response);
+                })
+            }
+        };
 
-		MONO.mono_load_runtime_and_bcl_args (Module.config);
-	},
+        MONO.mono_load_runtime_and_bcl_args(MONO.config);
+    },
 };
-loadScript ("dotnet.js");
+loadScript("dotnet.js");
 
 const IGNORE_PARAM_COUNT = -1;
 
-var App = {
-	init: function () {
-		var wasm_set_main_args = Module.cwrap ('mono_wasm_set_main_args', 'void', ['number', 'number']);
-		var wasm_strdup = Module.cwrap ('mono_wasm_strdup', 'number', ['string']);
+const App = {
+    init: function () {
+        console.info("Initializing.....");
 
-		Module.wasm_exit = Module.cwrap ('mono_wasm_exit', 'void', ['number']);
+        for (let i = 0; i < profilers.length; ++i) {
+            const init = Module.cwrap('mono_wasm_load_profiler_' + profilers[i], 'void', ['string'])
 
-		console.info("Initializing.....");
+            init("");
+        }
 
-		for (var i = 0; i < profilers.length; ++i) {
-			var init = Module.cwrap ('mono_wasm_load_profiler_' + profilers [i], 'void', ['string'])
+        if (allRuntimeArguments.length == 0) {
+            fail_exec("Missing required --run argument");
+            return;
+        }
 
-			init ("");
-		}
+        if (allRuntimeArguments[0] == "--regression") {
+            let res = 0;
+            try {
+                res = INTERNAL.mono_wasm_exec_regression(10, allRuntimeArguments[1]);
+                Module.print("REGRESSION RESULT: " + res);
+            } catch (e) {
+                Module.print("ABORT: " + e);
+                print(e.stack);
+                res = 1;
+            }
 
-		if (allRuntimeArguments.length == 0) {
-			fail_exec ("Missing required --run argument");
-			return;
-		}
+            if (res)
+                fail_exec("REGRESSION TEST FAILED");
 
-		if (allRuntimeArguments[0] == "--regression") {
-			var exec_regression = Module.cwrap ('mono_wasm_exec_regression', 'number', ['number', 'string'])
+            return;
+        }
 
-			var res = 0;
-				try {
-					res = exec_regression (10, allRuntimeArguments[1]);
-					Module.print ("REGRESSION RESULT: " + res);
-				} catch (e) {
-					Module.print ("ABORT: " + e);
-					print (e.stack);
-					res = 1;
-				}
+        if (runtime_args.length > 0)
+            INTERNAL.mono_wasm_set_runtime_options(runtime_args);
 
-			if (res)
-				fail_exec ("REGRESSION TEST FAILED");
+        if (allRuntimeArguments[0] == "--run") {
+            // Run an exe
+            if (allRuntimeArguments.length == 1) {
+                fail_exec("Error: Missing main executable argument.");
+                return;
+            }
 
-			return;
-		}
+            const main_assembly_name = allRuntimeArguments[1];
+            const app_args = allRuntimeArguments.slice(2);
+            INTERNAL.mono_wasm_set_main_args(allRuntimeArguments[1], app_args);
 
-		if (runtime_args.length > 0)
-			MONO.mono_wasm_set_runtime_options (runtime_args);
+            // Automatic signature isn't working correctly
+            let result = BINDING.call_assembly_entry_point(main_assembly_name, [app_args], "m");
+            let onError = function (error) {
+                console.error(error);
+                if (error.stack)
+                    console.error(error.stack);
 
-		if (allRuntimeArguments[0] == "--run") {
-			// Run an exe
-			if (allRuntimeArguments.length == 1) {
-				fail_exec ("Error: Missing main executable argument.");
-				return;
-			}
+                test_exit(1);
+            }
+            try {
+                result.then(test_exit).catch(onError);
+            } catch (error) {
+                onError(error);
+            }
 
-			var main_assembly_name = allRuntimeArguments[1];
-			var app_args = allRuntimeArguments.slice (2);
+        } else {
+            fail_exec("Unhandled argument: " + allRuntimeArguments[0]);
+        }
+    },
+    call_test_method: function (method_name, args, signature) {
+        if ((arguments.length > 2) && (typeof (signature) !== "string"))
+            throw new Error("Invalid number of arguments for call_test_method");
 
-			var main_argc = allRuntimeArguments.length - 2 + 1;
-			var main_argv = Module._malloc (main_argc * 4);
-			var aindex = 0;
-			Module.setValue (main_argv + (aindex * 4), wasm_strdup (allRuntimeArguments [1]), "i32")
-			aindex += 1;
-			for (var i = 2; i < allRuntimeArguments.length; ++i) {
-				Module.setValue (main_argv + (aindex * 4), wasm_strdup (allRuntimeArguments [i]), "i32");
-				aindex += 1;
-			}
-			wasm_set_main_args (main_argc, main_argv);
-
-			// Automatic signature isn't working correctly
-			let result = Module.mono_call_assembly_entry_point (main_assembly_name, [app_args], "m");
-			let onError = function (error)
-			{
-				console.error (error);
-				if (error.stack)
-					console.error (error.stack);
-
-				test_exit (1);
-			}
-			try {
-				result.then (test_exit).catch (onError);
-			} catch (error) {
-				onError(error);
-			}
-
-		} else {
-			fail_exec ("Unhandled argument: " + allRuntimeArguments [0]);
-		}
-	},
-	call_test_method: function (method_name, args, signature) {
-		if ((arguments.length > 2) && (typeof (signature) !== "string"))
-			throw new Error("Invalid number of arguments for call_test_method");
-
-		var fqn = "[System.Private.Runtime.InteropServices.JavaScript.Tests]System.Runtime.InteropServices.JavaScript.Tests.HelperMarshal:" + method_name;
-		try {
-			return BINDING.call_static_method(fqn, args || [], signature);
-		} catch (exc) {
-			console.error("exception thrown in", fqn);
-			throw exc;
-		}
-	}
+        const fqn = "[System.Private.Runtime.InteropServices.JavaScript.Tests]System.Runtime.InteropServices.JavaScript.Tests.HelperMarshal:" + method_name;
+        try {
+            return INTERNAL.call_static_method(fqn, args || [], signature);
+        } catch (exc) {
+            console.error("exception thrown in", fqn);
+            throw exc;
+        }
+    }
 };

--- a/src/mono/wasm/runtime/CMakeLists.txt
+++ b/src/mono/wasm/runtime/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.14.5)
 
 project(mono-wasm-runtime C)
 
+set(CMAKE_EXECUTABLE_SUFFIX ".js")
 add_executable(dotnet corebindings.c driver.c pinvoke.c)
 
 target_include_directories(dotnet PUBLIC ${MONO_INCLUDES} ${MONO_OBJ_INCLUDES})
@@ -23,7 +24,6 @@ target_link_libraries(dotnet
     ${NATIVE_BIN_DIR}/libSystem.IO.Compression.Native.a)
 
 set_target_properties(dotnet PROPERTIES
-    CMAKE_EXECUTABLE_SUFFIX ".js"
     LINK_DEPENDS "${NATIVE_BIN_DIR}/src/emcc-default.rsp;${NATIVE_BIN_DIR}/src/runtime.iffe.js;${SOURCE_DIR}/library-dotnet.js;${SYSTEM_NATIVE_DIR}/pal_random.js"
     LINK_FLAGS "@${NATIVE_BIN_DIR}/src/emcc-default.rsp ${CONFIGURATION_EMCC_FLAGS} -DENABLE_NETCORE=1 --pre-js ${NATIVE_BIN_DIR}/src/runtime.iffe.js --js-library ${SOURCE_DIR}/library-dotnet.js --js-library ${SYSTEM_NATIVE_DIR}/pal_random.js"
     RUNTIME_OUTPUT_DIRECTORY "${NATIVE_BIN_DIR}")

--- a/src/mono/wasm/runtime/buffers.ts
+++ b/src/mono/wasm/runtime/buffers.ts
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-import { JSHandle, MonoArray, MonoObject, MonoString } from "./types";
+import { Int32Ptr, JSHandle, MonoArray, MonoObject, MonoString, VoidPtr } from "./types";
 import { Module } from "./modules";
 import { mono_wasm_get_jsobj_from_js_handle } from "./gc-handles";
 import { wrap_error } from "./method-calls";

--- a/src/mono/wasm/runtime/cancelable-promise.ts
+++ b/src/mono/wasm/runtime/cancelable-promise.ts
@@ -3,7 +3,7 @@
 
 import { mono_wasm_get_jsobj_from_js_handle } from "./gc-handles";
 import { wrap_error } from "./method-calls";
-import { JSHandle, MonoString } from "./types";
+import { Int32Ptr, JSHandle, MonoString } from "./types";
 
 export const _are_promises_supported = ((typeof Promise === "object") || (typeof Promise === "function")) && (typeof Promise.resolve === "function");
 const promise_control_symbol = Symbol.for("wasm promise_control");

--- a/src/mono/wasm/runtime/corebindings.c
+++ b/src/mono/wasm/runtime/corebindings.c
@@ -35,7 +35,7 @@ extern MonoString* mono_wasm_web_socket_abort (int webSocket_js_handle, int *is_
 // Note: code snippet is not a function definition. Instead it must create and return a function instance.
 EM_JS(MonoObject*, compile_function, (int snippet_ptr, int len, int *is_exception), {
 	try {
-		var data = MONO.string_decoder.decode (snippet_ptr, snippet_ptr + len);
+		var data = INTERNAL.string_decoder.decode (snippet_ptr, snippet_ptr + len);
 		var wrapper = '(function () { ' + data + ' })';
 		var funcFactory = eval(wrapper);
 		var func = funcFactory();

--- a/src/mono/wasm/runtime/cs-to-js.ts
+++ b/src/mono/wasm/runtime/cs-to-js.ts
@@ -3,7 +3,7 @@
 
 import { mono_wasm_new_root, WasmRoot } from "./roots";
 import {
-    GCHandle, JSHandleDisposed, MonoArray,
+    GCHandle, Int32Ptr, JSHandleDisposed, MonoArray,
     MonoArrayNull, MonoObject, MonoObjectNull, MonoString
 } from "./types";
 import { Module, runtimeHelpers } from "./modules";

--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-import { MonoArray, MonoAssembly, MonoClass, MonoMethod, MonoObject, MonoString } from "./types";
+import { CharPtr, CharPtrPtr, Int32Ptr, MonoArray, MonoAssembly, MonoClass, MonoMethod, MonoObject, MonoString, VoidPtr } from "./types";
 import { Module } from "./modules";
 
 const fn_signatures: [ident: string, returnType: string | null, argTypes?: string[], opts?: any][] = [
@@ -48,6 +48,13 @@ const fn_signatures: [ident: string, returnType: string | null, argTypes?: strin
 
     //DOTNET
     ["mono_wasm_string_from_js", "number", ["string"]],
+
+    //INTERNAL
+    ["mono_wasm_exit", "void", ["number"]],
+    ["mono_wasm_set_main_args", "void", ["number", "number"]],
+    ["mono_wasm_enable_on_demand_gc", "void", ["number"]],
+    ["mono_profiler_init_aot", "void", ["number"]],
+    ["mono_wasm_exec_regression", "number", ["number", "string"]],
 ];
 
 export interface t_Cwraps {
@@ -68,7 +75,6 @@ export interface t_Cwraps {
     mono_wasm_add_assembly(name: string, data: VoidPtr, size: number): number;
     mono_wasm_add_satellite_assembly(name: string, culture: string, data: VoidPtr, size: number): void;
     mono_wasm_load_runtime(unused: string, debug_level: number): void;
-    mono_wasm_exit(exit_code: number): number;
 
     // BINDING
     mono_wasm_assembly_load(name: string): MonoAssembly
@@ -94,6 +100,13 @@ export interface t_Cwraps {
 
     //DOTNET
     mono_wasm_string_from_js(str: string): MonoString
+
+    //INTERNAL
+    mono_wasm_exit(exit_code: number): number;
+    mono_wasm_enable_on_demand_gc(enable: number): void;
+    mono_wasm_set_main_args(argc: number, argv: VoidPtr): void;
+    mono_profiler_init_aot(desc: string): void;
+    mono_wasm_exec_regression(verbose_level: number, image: string): number;
 }
 
 const wrapped_c_functions: t_Cwraps = <any>{};

--- a/src/mono/wasm/runtime/debug.ts
+++ b/src/mono/wasm/runtime/debug.ts
@@ -4,6 +4,7 @@
 import { Module, runtimeHelpers } from "./modules";
 import { toBase64StringImpl } from "./base64";
 import cwraps from "./cwraps";
+import { VoidPtr } from "./types";
 
 let commands_received: CommandResponse;
 let _call_function_res_cache: any = {};

--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -105,7 +105,7 @@ mono_wasm_invoke_js (MonoString *str, int *is_exception)
 	int *p_native_res_len = &native_res_len;
 
 	mono_unichar2 *native_res = (mono_unichar2*)EM_ASM_INT ({
-		var js_str = MONO.string_decoder.copy ($0);
+		var js_str = INTERNAL.string_decoder.copy ($0);
 
 		try {
 			var res = eval (js_str);
@@ -154,8 +154,8 @@ wasm_trace_logger (const char *log_domain, const char *log_level, const char *me
 		var domain = Module.UTF8ToString ($3); // is this always Mono?
 		var dataPtr = $4;
 
-		if (MONO["logging"] && MONO.logging["trace"]) {
-			MONO.logging.trace(domain, log_level, message, isFatal, dataPtr);
+		if (INTERNAL["logging"] && INTERNAL.logging["trace"]) {
+			INTERNAL.logging.trace(domain, log_level, message, isFatal, dataPtr);
 			return;
 		}
 
@@ -747,21 +747,6 @@ EMSCRIPTEN_KEEPALIVE char *
 mono_wasm_string_get_utf8 (MonoString *str)
 {
 	return mono_string_to_utf8 (str); //XXX JS is responsible for freeing this
-}
-
-// Deprecated
-EMSCRIPTEN_KEEPALIVE void
-mono_wasm_string_convert (MonoString *str)
-{
-	if (str == NULL)
-		return;
-
-	mono_unichar2 *native_val = mono_string_chars (str);
-	int native_len = mono_string_length (str) * 2;
-
-	EM_ASM ({
-		MONO.string_decoder.decode($0, $0 + $1, true);
-	}, (int)native_val, native_len);
 }
 
 EMSCRIPTEN_KEEPALIVE MonoString *

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -61,15 +61,16 @@ export const MONO: MONO = <any>{
     mono_wasm_load_data_archive,
     mono_wasm_load_config,
     mono_load_runtime_and_bcl_args,
+    mono_wasm_new_root_buffer,
+    mono_wasm_new_root,
+    mono_wasm_release_roots,
+
     config: runtimeHelpers.config,
     loaded_files: runtimeHelpers.loaded_files,
 
     // generated bindings closure `library_mono`
-    mono_wasm_new_root_buffer,
     mono_wasm_new_root_buffer_from_pointer,
-    mono_wasm_new_root,
     mono_wasm_new_roots,
-    mono_wasm_release_roots,
 };
 
 export const BINDING: BINDING = <any>{
@@ -227,6 +228,10 @@ export interface MONO {
     mono_wasm_load_icu_data: typeof mono_wasm_load_icu_data;
     mono_wasm_load_config: typeof mono_wasm_load_config;
     mono_load_runtime_and_bcl_args: typeof mono_load_runtime_and_bcl_args;
+    mono_wasm_new_root_buffer: typeof mono_wasm_new_root_buffer;
+    mono_wasm_new_root: typeof mono_wasm_new_root;
+    mono_wasm_release_roots: typeof mono_wasm_release_roots;
+
     loaded_files: string[];
     config: MonoConfig | MonoConfigError,
 }

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -50,6 +50,7 @@ import { mono_wasm_add_event_listener, mono_wasm_remove_event_listener } from ".
 import { mono_wasm_release_cs_owned_object } from "./gc-handles";
 import { mono_wasm_web_socket_open, mono_wasm_web_socket_send, mono_wasm_web_socket_receive, mono_wasm_web_socket_close, mono_wasm_web_socket_abort } from "./web-socket";
 import cwraps from "./cwraps";
+import { ArgsMarshalString } from "./method-binding";
 
 export const MONO: MONO = <any>{
     // current "public" MONO API
@@ -124,14 +125,17 @@ function export_to_emscripten(dotnet: any, mono: any, binding: any, internal: an
 // the methods would be visible to EMCC linker
 // --- keep in sync with library-dotnet.js ---
 const linker_exports = {
-    //MonoSupportLib
+    // mini-wasm.c
     mono_set_timeout,
+
+    // mini-wasm-debugger.c
     mono_wasm_asm_loaded,
     mono_wasm_fire_debugger_agent_message,
-    schedule_background_exec,
-    mono_wasm_setenv,
 
-    //DotNetSupportLib 
+    // mono-threads-wasm.c
+    schedule_background_exec,
+
+    // also keep in sync with driver.c
     mono_wasm_invoke_js_blazor,
     mono_wasm_invoke_js_marshalled,
     mono_wasm_invoke_js_unmarshalled,
@@ -164,7 +168,10 @@ const linker_exports = {
 
     // backward compatibility, sync with EmscriptenModuleMono
     // https://github.com/search?q=mono_bind_static_method&type=Code
-    mono_bind_static_method,
+    mono_bind_static_method: (fqn: string, signature: ArgsMarshalString): Function => {
+        console.warn("Module.mono_bind_static_method is obsolete, please use BINDING.bind_static_method instead");
+        return mono_bind_static_method(fqn, signature);
+    },
 };
 export const DOTNET: any = {
 };

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -70,8 +70,6 @@ export const MONO: MONO = <any>{
     mono_wasm_new_root,
     mono_wasm_new_roots,
     mono_wasm_release_roots,
-
-    // EM_JS,EM_ASM,EM_ASM_INT macros
 };
 
 export const BINDING: BINDING = <any>{

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -21,13 +21,12 @@ import {
     mono_wasm_fire_debugger_agent_message,
 } from "./debug";
 import { runtimeHelpers, setLegacyModules } from "./modules";
-import { MonoConfig, MonoConfigError } from "./types";
+import { MonoArray, MonoConfig, MonoConfigError, MonoObject } from "./types";
 import {
     mono_load_runtime_and_bcl_args, mono_wasm_load_config,
     mono_wasm_setenv, mono_wasm_set_runtime_options,
     mono_wasm_load_data_archive, mono_wasm_asm_loaded,
-    mono_bindings_init,
-    mono_wasm_invoke_js_blazor, mono_wasm_invoke_js_marshalled, mono_wasm_invoke_js_unmarshalled
+    mono_wasm_invoke_js_blazor, mono_wasm_invoke_js_marshalled, mono_wasm_invoke_js_unmarshalled, mono_wasm_set_main_args
 } from "./startup";
 import { mono_set_timeout, schedule_background_exec } from "./scheduling";
 import { mono_wasm_load_icu_data, mono_wasm_get_icudt_name } from "./icu";
@@ -38,9 +37,8 @@ import {
     _unbox_mono_obj_root_with_known_nonprimitive_type
 } from "./cs-to-js";
 import {
-    call_static_method, mono_bind_assembly_entry_point,
-    mono_bind_static_method, mono_call_assembly_entry_point,
-    mono_method_get_call_signature, call_method, mono_method_resolve,
+    call_static_method, mono_bind_static_method, mono_call_assembly_entry_point,
+    mono_method_resolve,
     mono_wasm_get_by_index, mono_wasm_get_global_object, mono_wasm_get_object_property,
     mono_wasm_invoke_js_with_args, mono_wasm_set_by_index, mono_wasm_set_object_property,
     _get_args_root_buffer_for_method_call, _get_buffer_for_method_call,
@@ -50,7 +48,6 @@ import { mono_wasm_typed_array_copy_to, mono_wasm_typed_array_from, mono_wasm_ty
 import { mono_wasm_cancel_promise } from "./cancelable-promise";
 import { mono_wasm_add_event_listener, mono_wasm_remove_event_listener } from "./event-listener";
 import { mono_wasm_release_cs_owned_object } from "./gc-handles";
-import { mono_bind_method } from "./method-binding";
 import { mono_wasm_web_socket_open, mono_wasm_web_socket_send, mono_wasm_web_socket_receive, mono_wasm_web_socket_close, mono_wasm_web_socket_abort } from "./web-socket";
 import cwraps from "./cwraps";
 
@@ -61,10 +58,10 @@ export const MONO: MONO = <any>{
     mono_wasm_load_icu_data,
     mono_wasm_runtime_ready,
     mono_wasm_load_data_archive,
+    mono_wasm_load_config,
+    mono_load_runtime_and_bcl_args,
+    config: runtimeHelpers.config,
     loaded_files: runtimeHelpers.loaded_files,
-
-    // EM_JS macro
-    string_decoder,
 
     // generated bindings closure `library_mono`
     mono_wasm_new_root_buffer,
@@ -72,27 +69,8 @@ export const MONO: MONO = <any>{
     mono_wasm_new_root,
     mono_wasm_new_roots,
     mono_wasm_release_roots,
-    //mono.mono_wasm_get_icudt_name = mono_wasm_get_icudt_name,
 
-    // used in debugger
-    mono_wasm_get_loaded_files,
-    mono_wasm_add_dbg_command_received,
-    mono_wasm_send_dbg_command_with_parms,
-    mono_wasm_send_dbg_command,
-    mono_wasm_get_dbg_command_info,
-    mono_wasm_get_details,
-    mono_wasm_release_object,
-    mono_wasm_call_function_on,
-    mono_wasm_debugger_resume,
-    mono_wasm_detach_debugger,
-    mono_wasm_raise_debug_event,
-    mono_wasm_runtime_is_ready: runtimeHelpers.mono_wasm_runtime_is_ready,
-
-    // used in tests
-    mono_load_runtime_and_bcl_args,
-    mono_wasm_load_config,
-    mono_wasm_set_runtime_options,
-    config: runtimeHelpers.config,
+    // EM_JS,EM_ASM,EM_ASM_INT macros
 };
 
 export const BINDING: BINDING = <any>{
@@ -109,6 +87,7 @@ export const BINDING: BINDING = <any>{
     unbox_mono_obj,
 
     // generated bindings closure `binding_support`
+    // todo use the methods directly in the closure, not via BINDING
     _get_args_root_buffer_for_method_call,
     _get_buffer_for_method_call,
     invoke_method: cwraps.mono_wasm_invoke_method,
@@ -116,55 +95,41 @@ export const BINDING: BINDING = <any>{
     mono_wasm_try_unbox_primitive_and_get_type: cwraps.mono_wasm_try_unbox_primitive_and_get_type,
     _unbox_mono_obj_root_with_known_nonprimitive_type,
     _teardown_after_call,
-
-    // tests
-    call_static_method,
-    mono_intern_string,
-
-    // startup
-    BINDING_ASM: "[System.Private.Runtime.InteropServices.JavaScript]System.Runtime.InteropServices.JavaScript.Runtime",
 };
 
 // this is executed early during load of emscripten runtime
 // it exports methods to global objects MONO, BINDING and Module in backward compatible way
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export function export_to_emscripten(mono: any, binding: any, dotnet: any, module: t_ModuleExtension): void {
+function export_to_emscripten(dotnet: any, mono: any, binding: any, internal: any, module: any): void {
     // we want to have same instance of MONO, BINDING and Module in dotnet iffe
-    setLegacyModules(mono, binding, module);
+    setLegacyModules(dotnet, mono, binding, internal, module);
 
     // here we merge methods to it from the local objects
+    Object.assign(dotnet, DOTNET);
     Object.assign(mono, MONO);
     Object.assign(binding, BINDING);
-    Object.assign(module, _linker_exports);
+    Object.assign(internal, INTERNAL);
+    Object.assign(module, linker_exports);
 
     // here we merge objects used in tests
-    Object.assign(module, {
-        // config,
-        call_static_method,
-        mono_call_static_method: call_static_method
-    });
+    if (!module.no_global_exports) {
+        (<any>globalThis).DOTNET = dotnet;
+        (<any>globalThis).MONO = mono;
+        (<any>globalThis).BINDING = binding;
+        (<any>globalThis).INTERNAL = internal;
+        (<any>globalThis).Module = module;
+    }
 }
 
 // the methods would be visible to EMCC linker
 // --- keep in sync with library-dotnet.js ---
-export const _linker_exports = {
+const linker_exports = {
     //MonoSupportLib
     mono_set_timeout,
     mono_wasm_asm_loaded,
     mono_wasm_fire_debugger_agent_message,
     schedule_background_exec,
     mono_wasm_setenv,
-
-    //BindingSupportLib
-    mono_bindings_init,// TODO remove
-    mono_bind_method,// TODO remove
-    mono_method_invoke: call_method,// TODO remove, rename this
-    mono_method_get_call_signature,// TODO remove
-    mono_method_resolve,// tests
-    mono_bind_static_method,// tests
-    mono_bind_assembly_entry_point,// TODO remove
-    mono_call_assembly_entry_point,// tests
-    mono_intern_string,// TODO remove
 
     //DotNetSupportLib 
     mono_wasm_invoke_js_blazor,
@@ -197,6 +162,50 @@ export const _linker_exports = {
     mono_wasm_load_icu_data,
     mono_wasm_get_icudt_name,
 };
+export const DOTNET: any = {
+};
+
+export const INTERNAL: any = {
+    // startup
+    BINDING_ASM: "[System.Private.Runtime.InteropServices.JavaScript]System.Runtime.InteropServices.JavaScript.Runtime",
+    export_to_emscripten,
+
+    // linker
+    linker_exports: linker_exports,
+
+    // tests
+    call_static_method,
+    mono_wasm_exit: cwraps.mono_wasm_exit,
+    mono_wasm_enable_on_demand_gc: cwraps.mono_wasm_enable_on_demand_gc,
+    mono_profiler_init_aot: cwraps.mono_profiler_init_aot,
+    mono_wasm_set_runtime_options,
+    mono_wasm_set_main_args: mono_wasm_set_main_args,
+    mono_wasm_strdup: cwraps.mono_wasm_strdup,
+    mono_wasm_exec_regression: cwraps.mono_wasm_exec_regression,
+    mono_method_resolve,//MarshalTests.cs
+    mono_bind_static_method,// MarshalTests.cs
+    mono_intern_string,// MarshalTests.cs
+
+    // EM_JS,EM_ASM,EM_ASM_INT macros
+    string_decoder,
+    logging: undefined,
+
+    // used in EM_ASM macros in debugger
+    mono_wasm_add_dbg_command_received,
+
+    // used in debugger DevToolsHelper.cs
+    mono_wasm_get_loaded_files,
+    mono_wasm_send_dbg_command_with_parms,
+    mono_wasm_send_dbg_command,
+    mono_wasm_get_dbg_command_info,
+    mono_wasm_get_details,
+    mono_wasm_release_object,
+    mono_wasm_call_function_on,
+    mono_wasm_debugger_resume,
+    mono_wasm_detach_debugger,
+    mono_wasm_raise_debug_event,
+    mono_wasm_runtime_is_ready: runtimeHelpers.mono_wasm_runtime_is_ready,
+};
 
 // this represents visibility in the javascript
 // like https://github.com/dotnet/aspnetcore/blob/main/src/Components/Web.JS/src/Platform/Mono/MonoTypes.ts
@@ -206,14 +215,17 @@ export interface MONO {
     mono_wasm_load_data_archive: typeof mono_wasm_load_data_archive;
     mono_wasm_load_bytes_into_heap: typeof mono_wasm_load_bytes_into_heap;
     mono_wasm_load_icu_data: typeof mono_wasm_load_icu_data;
+    mono_wasm_load_config: typeof mono_wasm_load_config;
+    mono_load_runtime_and_bcl_args: typeof mono_load_runtime_and_bcl_args;
     loaded_files: string[];
+    config: MonoConfig | MonoConfigError,
 }
 
 // this represents visibility in the javascript
 // like https://github.com/dotnet/aspnetcore/blob/main/src/Components/Web.JS/src/Platform/Mono/MonoTypes.ts
 export interface BINDING {
-    mono_obj_array_new: typeof cwraps.mono_wasm_obj_array_new,
-    mono_obj_array_set: typeof cwraps.mono_wasm_obj_array_set,
+    mono_obj_array_new: (size: number) => MonoArray,
+    mono_obj_array_set: (array: MonoArray, idx: number, obj: MonoObject) => void,
     js_string_to_mono_string: typeof js_string_to_mono_string,
     js_typed_array_to_array: typeof js_typed_array_to_array,
     js_to_mono_obj: typeof js_to_mono_obj,
@@ -222,12 +234,4 @@ export interface BINDING {
     bind_static_method: typeof mono_bind_static_method,
     call_assembly_entry_point: typeof mono_call_assembly_entry_point,
     unbox_mono_obj: typeof unbox_mono_obj
-}
-
-// how we extended wasm Module
-export type t_ModuleExtension = t_Module & {
-    config?: MonoConfig | MonoConfigError,
-
-    //tests
-    mono_call_static_method: typeof call_static_method
 }

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -110,7 +110,15 @@ function export_to_emscripten(dotnet: any, mono: any, binding: any, internal: an
     Object.assign(mono, MONO);
     Object.assign(binding, BINDING);
     Object.assign(internal, INTERNAL);
-    Object.assign(module, linker_exports);
+
+    // backward compatibility, sync with EmscriptenModuleMono
+    Object.assign(module, {
+        // https://github.com/search?q=mono_bind_static_method&type=Code
+        mono_bind_static_method: (fqn: string, signature: ArgsMarshalString): Function => {
+            console.warn("Module.mono_bind_static_method is obsolete, please use BINDING.bind_static_method instead");
+            return mono_bind_static_method(fqn, signature);
+        },
+    });
 
     // here we expose objects used in tests to global namespace
     if (!module.no_global_exports) {
@@ -165,13 +173,6 @@ const linker_exports = {
     //  also keep in sync with pal_icushim_static.c
     mono_wasm_load_icu_data,
     mono_wasm_get_icudt_name,
-
-    // backward compatibility, sync with EmscriptenModuleMono
-    // https://github.com/search?q=mono_bind_static_method&type=Code
-    mono_bind_static_method: (fqn: string, signature: ArgsMarshalString): Function => {
-        console.warn("Module.mono_bind_static_method is obsolete, please use BINDING.bind_static_method instead");
-        return mono_bind_static_method(fqn, signature);
-    },
 };
 export const DOTNET: any = {
 };

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -111,7 +111,7 @@ function export_to_emscripten(dotnet: any, mono: any, binding: any, internal: an
     Object.assign(internal, INTERNAL);
     Object.assign(module, linker_exports);
 
-    // here we merge objects used in tests
+    // here we expose objects used in tests to global namespace
     if (!module.no_global_exports) {
         (<any>globalThis).DOTNET = dotnet;
         (<any>globalThis).MONO = mono;
@@ -161,6 +161,10 @@ const linker_exports = {
     //  also keep in sync with pal_icushim_static.c
     mono_wasm_load_icu_data,
     mono_wasm_get_icudt_name,
+
+    // backward compatibility, sync with EmscriptenModuleMono
+    // https://github.com/search?q=mono_bind_static_method&type=Code
+    mono_bind_static_method,
 };
 export const DOTNET: any = {
 };

--- a/src/mono/wasm/runtime/icu.ts
+++ b/src/mono/wasm/runtime/icu.ts
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import cwraps from "./cwraps";
-import { GlobalizationMode } from "./types";
+import { GlobalizationMode, VoidPtr } from "./types";
 
 let num_icu_assets_loaded_successfully = 0;
 

--- a/src/mono/wasm/runtime/js-to-cs.ts
+++ b/src/mono/wasm/runtime/js-to-cs.ts
@@ -14,7 +14,7 @@ import { wrap_error } from "./method-calls";
 import { js_string_to_mono_string, js_string_to_mono_string_interned } from "./strings";
 import { isThenable } from "./cancelable-promise";
 import { has_backing_array_buffer } from "./buffers";
-import { JSHandle, MonoArray, MonoMethod, MonoObject, MonoObjectNull, MonoString, wasm_type_symbol } from "./types";
+import { Int32Ptr, JSHandle, MonoArray, MonoMethod, MonoObject, MonoObjectNull, MonoString, wasm_type_symbol } from "./types";
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function _js_to_mono_uri(should_add_in_flight: boolean, js_obj: any): MonoObject {

--- a/src/mono/wasm/runtime/library-dotnet.js
+++ b/src/mono/wasm/runtime/library-dotnet.js
@@ -57,6 +57,9 @@ const linked_functions = [
     // pal_icushim_static.c
     "mono_wasm_load_icu_data",
     "mono_wasm_get_icudt_name",
+
+    // backward compatibility
+    "mono_bind_static_method",
 ];
 
 // -- this javascript file is evaluated by emcc during compilation! --

--- a/src/mono/wasm/runtime/library-dotnet.js
+++ b/src/mono/wasm/runtime/library-dotnet.js
@@ -60,9 +60,6 @@ const linked_functions = [
     // pal_icushim_static.c
     "mono_wasm_load_icu_data",
     "mono_wasm_get_icudt_name",
-
-    // backward compatibility
-    "mono_bind_static_method",
 ];
 
 // -- this javascript file is evaluated by emcc during compilation! --

--- a/src/mono/wasm/runtime/library-dotnet.js
+++ b/src/mono/wasm/runtime/library-dotnet.js
@@ -4,15 +4,17 @@
 
 "use strict";
 
-var DotNetSupportLib = {
+const DotNetSupportLib = {
     // this will become globalThis.DOTNET
     $DOTNET: {},
     // this will become globalThis.MONO
     $MONO: {},
     // this will become globalThis.BINDING
     $BINDING: {},
+    // this will become globalThis.INTERNAL
+    $INTERNAL: {},
     // this line will be executed on runtime, populating the objects with methods
-    $DOTNET__postset: "__dotnet_runtime.export_to_emscripten (MONO, BINDING, DOTNET, Module);",
+    $DOTNET__postset: "__dotnet_runtime.INTERNAL.export_to_emscripten (DOTNET, MONO, BINDING, INTERNAL, Module);",
 };
 
 // the methods would be visible to EMCC linker
@@ -24,17 +26,6 @@ const linked_functions = [
     "mono_wasm_fire_debugger_agent_message",
     "schedule_background_exec",
     "mono_wasm_setenv",
-
-    //BindingSupportLib
-    "mono_bindings_init",
-    "mono_bind_method",
-    "mono_method_invoke",
-    "mono_method_get_call_signature",
-    "mono_method_resolve",
-    "mono_bind_static_method",
-    "mono_bind_assembly_entry_point",
-    "mono_call_assembly_entry_point",
-    "mono_intern_string",
 
     //DotNetSupportLib
     "mono_wasm_invoke_js_blazor",
@@ -70,12 +61,13 @@ const linked_functions = [
 
 // -- this javascript file is evaluated by emcc during compilation! --
 // we generate simple proxy for each exported function so that emcc will include them in the final output
-for (var linked_function of linked_functions) {
-    const fn_template = `return __dotnet_runtime._linker_exports.${linked_function}.apply(__dotnet_runtime, arguments)`;
+for (let linked_function of linked_functions) {
+    const fn_template = `return __dotnet_runtime.INTERNAL.linker_exports.${linked_function}.apply(__dotnet_runtime, arguments)`;
     DotNetSupportLib[linked_function] = new Function(fn_template);
 }
 
+autoAddDeps(DotNetSupportLib, "$DOTNET");
 autoAddDeps(DotNetSupportLib, "$MONO");
 autoAddDeps(DotNetSupportLib, "$BINDING");
-autoAddDeps(DotNetSupportLib, "$DOTNET");
+autoAddDeps(DotNetSupportLib, "$INTERNAL");
 mergeInto(LibraryManager.library, DotNetSupportLib);

--- a/src/mono/wasm/runtime/library-dotnet.js
+++ b/src/mono/wasm/runtime/library-dotnet.js
@@ -20,14 +20,17 @@ const DotNetSupportLib = {
 // the methods would be visible to EMCC linker
 // --- keep in sync with exports.ts ---
 const linked_functions = [
-    //MonoSupportLib
+    // mini-wasm.c
     "mono_set_timeout",
+
+    // mini-wasm-debugger.c
     "mono_wasm_asm_loaded",
     "mono_wasm_fire_debugger_agent_message",
-    "schedule_background_exec",
-    "mono_wasm_setenv",
 
-    //DotNetSupportLib
+    // mono-threads-wasm.c
+    "schedule_background_exec",
+
+    // driver.c
     "mono_wasm_invoke_js_blazor",
     "mono_wasm_invoke_js_marshalled",
     "mono_wasm_invoke_js_unmarshalled",

--- a/src/mono/wasm/runtime/method-binding.ts
+++ b/src/mono/wasm/runtime/method-binding.ts
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { WasmRootBuffer } from "./roots";
-import { MonoClass, MonoMethod, MonoObject, coerceNull, VoidPtrNull } from "./types";
+import { MonoClass, MonoMethod, MonoObject, coerceNull, VoidPtrNull, VoidPtr } from "./types";
 import { BINDING, MONO, runtimeHelpers } from "./modules";
 import { js_to_mono_enum, _js_to_mono_obj, _js_to_mono_uri } from "./js-to-cs";
 import { js_string_to_mono_string, js_string_to_mono_string_interned } from "./strings";

--- a/src/mono/wasm/runtime/method-calls.ts
+++ b/src/mono/wasm/runtime/method-calls.ts
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { mono_wasm_new_root, mono_wasm_new_root_buffer, WasmRoot, WasmRootBuffer } from "./roots";
-import { JSHandle, MonoArray, MonoMethod, MonoObject, MonoObjectNull, MonoString, coerceNull as coerceNull, VoidPtrNull } from "./types";
+import { JSHandle, MonoArray, MonoMethod, MonoObject, MonoObjectNull, MonoString, coerceNull as coerceNull, VoidPtrNull, VoidPtr, Int32Ptr } from "./types";
 import { Module, runtimeHelpers } from "./modules";
 import { _mono_array_root_to_js_array, _unbox_mono_obj_root } from "./cs-to-js";
 import { get_js_obj, mono_wasm_get_jsobj_from_js_handle } from "./gc-handles";

--- a/src/mono/wasm/runtime/modules.ts
+++ b/src/mono/wasm/runtime/modules.ts
@@ -42,5 +42,6 @@ export const runtimeHelpers: RuntimeHelpers = <any>{
     set config(value: MonoConfig) {
         monoConfig = value;
         MONO.config = value;
+        Module.config = value;
     },
 };

--- a/src/mono/wasm/runtime/modules.ts
+++ b/src/mono/wasm/runtime/modules.ts
@@ -1,29 +1,31 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-/* eslint-disable no-var */
 /* eslint-disable @typescript-eslint/triple-slash-reference */
 /// <reference path="./types/emscripten.d.ts" />
 /// <reference path="./types/v8.d.ts" />
 
-import { t_ModuleExtension } from "./exports";
-import { MonoConfig, t_RuntimeHelpers } from "./types";
+import { EmscriptenModuleMono, MonoConfig, RuntimeHelpers } from "./types";
 
-export var Module: t_Module & t_ModuleExtension;
-export var MONO: any;
-export var BINDING: any;
+export let Module: EmscriptenModule & EmscriptenModuleMono;
+export let MONO: any;
+export let BINDING: any;
+export let DOTNET: any;
+export let INTERNAL: any;
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export function setLegacyModules(mono: any, binding: any, module: t_Module & t_ModuleExtension) {
-    Module = module;
+export function setLegacyModules(dotnet: any, mono: any, binding: any, internal: any, module: EmscriptenModule & EmscriptenModuleMono) {
+    DOTNET = dotnet;
     MONO = mono;
     BINDING = binding;
+    INTERNAL = internal;
+    Module = module;
 }
 
 let monoConfig: MonoConfig;
 let runtime_is_ready = false;
 
-export const runtimeHelpers: t_RuntimeHelpers = <any>{
+export const runtimeHelpers: RuntimeHelpers = <any>{
     namespace: "System.Runtime.InteropServices.JavaScript",
     classname: "Runtime",
     loaded_files: [],
@@ -32,7 +34,7 @@ export const runtimeHelpers: t_RuntimeHelpers = <any>{
     },
     set mono_wasm_runtime_is_ready(value: boolean) {
         runtime_is_ready = value;
-        MONO.mono_wasm_runtime_is_ready = value;
+        INTERNAL.mono_wasm_runtime_is_ready = value;
     },
     get config() {
         return monoConfig;
@@ -40,6 +42,5 @@ export const runtimeHelpers: t_RuntimeHelpers = <any>{
     set config(value: MonoConfig) {
         monoConfig = value;
         MONO.config = value;
-        Module.config = value;
     },
 };

--- a/src/mono/wasm/runtime/package-lock.json
+++ b/src/mono/wasm/runtime/package-lock.json
@@ -995,6 +995,15 @@
         "yallist": "^4.0.0"
       }
     },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -1185,6 +1194,16 @@
         "fsevents": "~2.3.2"
       }
     },
+    "rollup-plugin-dts": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-4.0.0.tgz",
+      "integrity": "sha512-tgUC8CxVgtlLDVloUEA9uACVaxjJHuYxlDSTp1LdCexA0bJx+RuMi45RjdLG9RTCgZlV5YBh3O7P2u6dS1KlnA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.14.5",
+        "magic-string": "^0.25.7"
+      }
+    },
     "rollup-plugin-terser": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
@@ -1311,6 +1330,12 @@
           "dev": true
         }
       }
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/src/mono/wasm/runtime/package.json
+++ b/src/mono/wasm/runtime/package.json
@@ -19,10 +19,11 @@
   "license": "MIT",
   "devDependencies": {
     "@rollup/plugin-typescript": "8.2.5",
-    "@typescript-eslint/eslint-plugin": "^4.31.2",
-    "@typescript-eslint/parser": "^4.31.2",
-    "eslint": "^7.32.0",
+    "@typescript-eslint/eslint-plugin": "4.31.2",
+    "@typescript-eslint/parser": "4.31.2",
+    "eslint": "7.32.0",
     "rollup": "2.56.3",
+    "rollup-plugin-dts": "4.0.0",
     "rollup-plugin-terser": "7.0.2",
     "tslib": "2.3.1",
     "typescript": "4.4.3"

--- a/src/mono/wasm/runtime/profiler.ts
+++ b/src/mono/wasm/runtime/profiler.ts
@@ -10,7 +10,7 @@ import { AOTProfilerOptions, CoverageProfilerOptions } from "./types";
 // <METHODNAME> should be in the format <CLASS>::<METHODNAME>.
 // write_at defaults to 'WebAssembly.Runtime::StopProfile'.
 // send_to defaults to 'WebAssembly.Runtime::DumpAotProfileData'.
-// DumpAotProfileData stores the data into Module.aot_profile_data.
+// DumpAotProfileData stores the data into INTERNAL.aot_profile_data.
 //
 export function mono_wasm_init_aot_profiler(options: AOTProfilerOptions): void {
     if (options == null)
@@ -27,7 +27,7 @@ export function mono_wasm_init_aot_profiler(options: AOTProfilerOptions): void {
 // <METHODNAME> should be in the format <CLASS>::<METHODNAME>.
 // write_at defaults to 'WebAssembly.Runtime::StopProfile'.
 // send_to defaults to 'WebAssembly.Runtime::DumpCoverageProfileData'.
-// DumpCoverageProfileData stores the data into Module.coverage_profile_data.
+// DumpCoverageProfileData stores the data into INTERNAL.coverage_profile_data.
 export function mono_wasm_init_coverage_profiler(options: CoverageProfilerOptions): void {
     if (options == null)
         options = {};

--- a/src/mono/wasm/runtime/roots.ts
+++ b/src/mono/wasm/runtime/roots.ts
@@ -3,6 +3,7 @@
 
 import cwraps from "./cwraps";
 import { Module } from "./modules";
+import { VoidPtr, ManagedPointer, NativePointer } from "./types";
 
 const maxScratchRoots = 8192;
 let _scratch_root_buffer: WasmRootBuffer | null = null;

--- a/src/mono/wasm/runtime/strings.ts
+++ b/src/mono/wasm/runtime/strings.ts
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { mono_wasm_new_root_buffer, WasmRootBuffer } from "./roots";
-import { MonoString, MonoStringNull } from "./types";
+import { CharPtr, MonoString, MonoStringNull, NativePointer } from "./types";
 import { Module } from "./modules";
 import cwraps from "./cwraps";
 import { mono_wasm_new_root } from "./roots";

--- a/src/mono/wasm/runtime/tsconfig.json
+++ b/src/mono/wasm/runtime/tsconfig.json
@@ -11,7 +11,6 @@
       "dom"
     ],
     "strict": true,
-    "allowJs": true,
     "outDir": "bin",
   },
   "exclude": [

--- a/src/mono/wasm/runtime/types.ts
+++ b/src/mono/wasm/runtime/types.ts
@@ -171,5 +171,9 @@ export type CoverageProfilerOptions = {
 // how we extended emscripten Module
 export type EmscriptenModuleMono = EmscriptenModule & {
     no_global_exports?: boolean,
+
+    // backward compatibility
     config?: MonoConfig | MonoConfigError,
+    // backward compatibility https://github.com/search?q=mono_bind_static_method&type=Code
+    mono_bind_static_method: (fqn: string, signature: string) => Function,
 }

--- a/src/mono/wasm/runtime/types.ts
+++ b/src/mono/wasm/runtime/types.ts
@@ -3,6 +3,32 @@
 
 import { bind_runtime_method } from "./method-binding";
 
+export type TypedArray = Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array;
+
+export interface ManagedPointer {
+    __brandManagedPointer: "ManagedPointer"
+}
+
+export interface NativePointer {
+    __brandNativePointer: "NativePointer"
+}
+
+export interface VoidPtr extends NativePointer {
+    __brand: "VoidPtr"
+}
+
+export interface CharPtr extends NativePointer {
+    __brand: "CharPtr"
+}
+
+export interface Int32Ptr extends NativePointer {
+    __brand: "Int32Ptr"
+}
+
+export interface CharPtrPtr extends NativePointer {
+    __brand: "CharPtrPtr"
+}
+
 export type GCHandle = {
     __brand: "GCHandle"
 }
@@ -104,7 +130,7 @@ export const enum AssetBehaviours {
     VFS = "vfs", // load asset into the virtual filesystem (for fopen, File.Open, etc)
 }
 
-export type t_RuntimeHelpers = {
+export type RuntimeHelpers = {
     get_call_sig: MonoMethod;
     runtime_namespace: string;
     runtime_classname: string;
@@ -134,10 +160,16 @@ export const enum GlobalizationMode {
 
 export type AOTProfilerOptions = {
     write_at?: string, // should be in the format <CLASS>::<METHODNAME>, default: 'WebAssembly.Runtime::StopProfile'
-    send_to?: string // should be in the format <CLASS>::<METHODNAME>, default: 'WebAssembly.Runtime::DumpAotProfileData' (DumpAotProfileData stores the data into Module.aot_profile_data.)
+    send_to?: string // should be in the format <CLASS>::<METHODNAME>, default: 'WebAssembly.Runtime::DumpAotProfileData' (DumpAotProfileData stores the data into INTERNAL.aot_profile_data.)
 }
 
 export type CoverageProfilerOptions = {
     write_at?: string, // should be in the format <CLASS>::<METHODNAME>, default: 'WebAssembly.Runtime::StopProfile'
-    send_to?: string // should be in the format <CLASS>::<METHODNAME>, default: 'WebAssembly.Runtime::DumpCoverageProfileData' (DumpCoverageProfileData stores the data into Module.coverage_profile_data.)
+    send_to?: string // should be in the format <CLASS>::<METHODNAME>, default: 'WebAssembly.Runtime::DumpCoverageProfileData' (DumpCoverageProfileData stores the data into INTERNAL.coverage_profile_data.)
+}
+
+// how we extended emscripten Module
+export type EmscriptenModuleMono = EmscriptenModule & {
+    no_global_exports?: boolean,
+    config?: MonoConfig | MonoConfigError,
 }

--- a/src/mono/wasm/runtime/types/emscripten.d.ts
+++ b/src/mono/wasm/runtime/types/emscripten.d.ts
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 declare interface ManagedPointer {
-    __brandbase: "ManagedPointer"
+    __brandManagedPointer: "ManagedPointer"
 }
 
 declare interface NativePointer {
-    __brandbase: "NativePointer"
+    __brandNativePointer: "NativePointer"
 }
 
 declare interface VoidPtr extends NativePointer {
@@ -34,9 +34,9 @@ declare function mergeInto(a: object, b: object): void;
 // TODO, what's wrong with EXPORTED_RUNTIME_METHODS ?
 declare function locateFile(path: string, prefix?: string): string;
 
-declare let Module: t_Module;
+declare let Module: EmscriptenModule;
 
-declare interface t_Module {
+declare interface EmscriptenModule {
     HEAP8: Int8Array,
     HEAP16: Int16Array;
     HEAP32: Int32Array;

--- a/src/mono/wasm/runtime/web-socket.ts
+++ b/src/mono/wasm/runtime/web-socket.ts
@@ -10,7 +10,7 @@ import { mono_wasm_get_jsobj_from_js_handle, mono_wasm_get_js_handle } from "./g
 import { _wrap_js_thenable_as_task } from "./js-to-cs";
 import { wrap_error } from "./method-calls";
 import { conv_string } from "./strings";
-import { JSHandle, MonoArray, MonoObject, MonoObjectNull, MonoString } from "./types";
+import { Int32Ptr, JSHandle, MonoArray, MonoObject, MonoObjectNull, MonoString } from "./types";
 
 const wasm_ws_pending_send_buffer = Symbol.for("wasm ws_pending_send_buffer");
 const wasm_ws_pending_send_buffer_offset = Symbol.for("wasm ws_pending_send_buffer_offset");

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -71,7 +71,6 @@
       <_EmccCommonFlags Include="--source-map-base http://example.com" />
 
       <_EmccCommonFlags Include="-s STRICT_JS=1" />      
-
       <_EmccCommonFlags Include="-s MODULARIZE=1" Condition="'$(WasmEnableES6)' != 'false'" />
       <_EmccCommonFlags Include="-s EXPORT_ES6=1" Condition="'$(WasmEnableES6)' != 'false'" />
     </ItemGroup>
@@ -207,6 +206,7 @@
     </ItemGroup>
 
     <Copy SourceFiles="$(NativeBinDir)dotnet.js;
+                       $(NativeBinDir)src\dotnet.d.ts;
                        $(NativeBinDir)dotnet.wasm;
                        $(NativeBinDir)dotnet.timezones.blat"
           DestinationFolder="$(MicrosoftNetCoreAppRuntimePackNativeDir)"

--- a/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/index.html
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/index.html
@@ -36,7 +36,7 @@
 
       var App = {
         init: function () {
-          var exit_code = BINDING.call_static_method("[WebAssembly.Browser.HotReload.Test] Sample.Test:TestMeaning", []);
+          var exit_code = INTERNAL.call_static_method("[WebAssembly.Browser.HotReload.Test] Sample.Test:TestMeaning", []);
           document.getElementById("out").innerHTML = exit_code;
 
           if (is_testing)

--- a/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/runtime.js
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/runtime.js
@@ -1,47 +1,46 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-var Module = { 
+var Module = {
 
     config: null,
 
-    preInit: async function() {
-        await MONO.mono_wasm_load_config("./mono-config.json"); // sets Module.config implicitly
+    preInit: async function () {
+        await MONO.mono_wasm_load_config("./mono-config.json"); // sets MONO.config implicitly
     },
 
     onRuntimeInitialized: function () {
-        if (!Module.config || Module.config.error) {
+        if (!MONO.config || MONO.config.error) {
             console.log("No config found");
             test_exit(1);
-            throw(Module.config.error);
+            throw (MONO.config.error);
         }
-        
-        Module.config.loaded_cb = function () {
+
+        MONO.config.loaded_cb = function () {
             try {
-                App.init ();
+                App.init();
             } catch (error) {
                 test_exit(1);
                 throw (error);
             }
         };
-        Module.config.fetch_file_cb = function (asset) {
-            return fetch (asset, { credentials: 'same-origin' });
+        MONO.config.fetch_file_cb = function (asset) {
+            return fetch(asset, { credentials: 'same-origin' });
         }
 
-        if (Module.config.environment_variables !== undefined) {
-            console.log ("expected environment variables to be undefined, but they're: ", Module.config.environment_variables);
+        if (MONO.config.environment_variables !== undefined) {
+            console.log("expected environment variables to be undefined, but they're: ", MONO.config.environment_variables);
             test_exit(1);
         }
-        Module.config.environment_variables = {
+        MONO.config.environment_variables = {
             "DOTNET_MODIFIABLE_ASSEMBLIES": "debug"
         };
 
-        try
-        {
-            MONO.mono_load_runtime_and_bcl_args (Module.config);
+        try {
+            MONO.mono_load_runtime_and_bcl_args(MONO.config);
         } catch (error) {
             test_exit(1);
-            throw(error);
+            throw (error);
         }
     },
 };

--- a/src/tests/FunctionalTests/WebAssembly/Browser/RuntimeConfig/index.html
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/RuntimeConfig/index.html
@@ -36,7 +36,7 @@
 
       var App = {
         init: function () {
-          var exit_code = BINDING.call_static_method("[WebAssembly.Browser.RuntimeConfig.Test] Sample.Test:TestMeaning", []);
+          var exit_code = INTERNAL.call_static_method("[WebAssembly.Browser.RuntimeConfig.Test] Sample.Test:TestMeaning", []);
           document.getElementById("out").innerHTML = exit_code;
 
           if (is_testing)

--- a/src/tests/FunctionalTests/WebAssembly/Browser/RuntimeConfig/runtime.js
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/RuntimeConfig/runtime.js
@@ -1,39 +1,38 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-var Module = { 
+var Module = {
 
     config: null,
 
-    preInit: async function() {
-        await MONO.mono_wasm_load_config("./mono-config.json"); // sets Module.config implicitly
+    preInit: async function () {
+        await MONO.mono_wasm_load_config("./mono-config.json"); // sets MONO.config implicitly
     },
 
     onRuntimeInitialized: function () {
-        if (!Module.config || Module.config.error) {
+        if (!MONO.config || MONO.config.error) {
             console.log("No config found");
             test_exit(1);
-            throw(Module.config.error);
+            throw (MONO.config.error);
         }
-        
-        Module.config.loaded_cb = function () {
+
+        MONO.config.loaded_cb = function () {
             try {
-                App.init ();
+                App.init();
             } catch (error) {
                 test_exit(1);
                 throw (error);
             }
         };
-        Module.config.fetch_file_cb = function (asset) {
-            return fetch (asset, { credentials: 'same-origin' });
+        MONO.config.fetch_file_cb = function (asset) {
+            return fetch(asset, { credentials: 'same-origin' });
         }
 
-        try
-        {
-            MONO.mono_load_runtime_and_bcl_args (Module.config);
+        try {
+            MONO.mono_load_runtime_and_bcl_args(MONO.config);
         } catch (error) {
             test_exit(1);
-            throw(error);
+            throw (error);
         }
     },
 };


### PR DESCRIPTION
- reduce `BINDING` and `MONO` exports to [minimal scope necessary](https://github.com/dotnet/runtime/blob/368b27d8c2d5025db6044d7854aadd79f89cb4e8/src/mono/wasm/runtime/exports.ts#L212) - as [used by Blazor](https://github.com/dotnet/aspnetcore/blob/main/src/Components/Web.JS/src/Platform/Mono/MonoTypes.ts)
- introduce `globalThis.INTERNAL` and move all exported methods which we only use internally or for testing
- fix all internal usages in tests
- produce `dotnet.d.ts` and include it in the workload
- moved `Module.config` to `MONO.config`
- added `mono_load_runtime_and_bcl_args` into `MONO` export
- add `mono_wasm_new_root_buffer`, `mono_wasm_new_root`, `mono_wasm_release_roots` to the `MONO` export
- removed obsolete debugger test `InvalidScopeId`
- introduced `INTERNAL.mono_wasm_set_main_args`