### PR TITLE
[release/6.0] Add osx-arm64.runtime.native.System.IO.Ports

### DIFF
--- a/src/libraries/System.IO.Ports/pkg/runtime.osx-arm64.runtime.native.System.IO.Ports.proj
+++ b/src/libraries/System.IO.Ports/pkg/runtime.osx-arm64.runtime.native.System.IO.Ports.proj
@@ -1,0 +1,6 @@
+<Project>
+  <Import Project="runtime.native.System.IO.Ports.props" />
+  <PropertyGroup>
+    <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
+  </PropertyGroup>
+</Project>

--- a/src/libraries/System.IO.Ports/pkg/runtime.osx-arm64.runtime.native.System.IO.Ports.proj
+++ b/src/libraries/System.IO.Ports/pkg/runtime.osx-arm64.runtime.native.System.IO.Ports.proj
@@ -1,6 +1,7 @@
 <Project>
   <Import Project="runtime.native.System.IO.Ports.props" />
   <PropertyGroup>
+    <!-- TODO: Remove when the package shipped. -->
     <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/59972

This change adds a package project to build/package it, which also adds it as a dependency to the meta runtime.native.System.IO.Ports package.

## Customer Impact

.NET 6 advertises Apple Silicon support. Not having this means that part of that support is missing. In particular, myself and many others develop for .NET on Apple hw, which is moving fairly quickly to Apple Silicon. Not having this means that I have to use a Linux VM or a remote system if I want to communicate with external devices.

In my specific case, I built electronics that interface with .NET servers and clients using USB, which shows up as a virtual serial port. Not having that functionality on my development machine is quite annoying.

## Testing

Tested on actual Apple Silicon hardware with various serial devices. Since no current M1 device offers native serial ports, all testing was conducted with various USB devices that convert to or present as serial ports. Works correctly.

## Risk

Low. The alternative is that there is no support at all.
