### PR TITLE
Infra for regeneration of third-party-notices file

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -146,6 +146,7 @@
     <!-- Utility -->
     <SubsetName Include="publish" OnDemand="true" Description="Generate asset manifests and prepare to publish to BAR." />
     <SubsetName Include="RegenerateDownloadTable" OnDemand="true" Description="Regenerates the nightly build download table" />
+    <SubsetName Include="RegenerateThirdPartyNotices" Category="" OnDemand="true" Description="Regenerates the THIRD-PARTY-NOTICES.TXT file based on other repos' TPN files." />
 
   </ItemGroup>
 
@@ -358,6 +359,10 @@
   <!-- Utility -->
   <ItemGroup Condition="$(_subset.Contains('+regeneratedownloadtable+'))">
     <ProjectToBuild Include="$(RepositoryEngineeringDir)regenerate-download-table.proj" Pack="true" BuildInParallel="false" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(_subset.Contains('regeneratethirdpartynotices'))">
+    <ProjectToBuild Include="$(RepositoryEngineeringDir)regenerate-third-party-notices.proj" Pack="false" BuildInParallel="false" />
   </ItemGroup>
 
   <!-- Set default configurations. -->

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -146,7 +146,7 @@
     <!-- Utility -->
     <SubsetName Include="publish" OnDemand="true" Description="Generate asset manifests and prepare to publish to BAR." />
     <SubsetName Include="RegenerateDownloadTable" OnDemand="true" Description="Regenerates the nightly build download table" />
-    <SubsetName Include="RegenerateThirdPartyNotices" Category="" OnDemand="true" Description="Regenerates the THIRD-PARTY-NOTICES.TXT file based on other repos' TPN files." />
+    <SubsetName Include="RegenerateThirdPartyNotices" OnDemand="true" Description="Regenerates the THIRD-PARTY-NOTICES.TXT file based on other repos' TPN files." />
 
   </ItemGroup>
 

--- a/eng/regenerate-third-party-notices.proj
+++ b/eng/regenerate-third-party-notices.proj
@@ -24,6 +24,7 @@
       <!--
         Additional repos that should be included but don't have any third-party-notices files:
           dotnet/efcore
+          dotnet/emsdk
           dotnet/extensions
           dotnet/icu
           dotnet/sdk

--- a/eng/regenerate-third-party-notices.proj
+++ b/eng/regenerate-third-party-notices.proj
@@ -28,7 +28,7 @@
           dotnet/icu
           dotnet/sdk
           dotnet/windowsdesktop
-          mono/linker
+          dotnet/linker
       -->
 
       <TpnRepo Condition="'%(TpnRepo.Branch)' == ''" Branch="main" />

--- a/eng/regenerate-third-party-notices.proj
+++ b/eng/regenerate-third-party-notices.proj
@@ -1,11 +1,10 @@
-<Project>
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <UsingTask TaskName="RegenerateThirdPartyNotices" AssemblyFile="$(InstallerTasksAssemblyPath)" />
 
-  <Target Name="Build">
+  <Target Name="RegenerateThirdPartyNotices" AfterTargets="Build">
     <PropertyGroup>
-      <TpnFile>$(RepoRoot)src/installer/pkg/THIRD-PARTY-NOTICES.TXT</TpnFile>
+      <TpnFile>$(InstallerProjectRoot)pkg\THIRD-PARTY-NOTICES.TXT</TpnFile>
     </PropertyGroup>
 
     <!--
@@ -32,7 +31,7 @@
           mono/linker
       -->
 
-      <TpnRepo Condition="'%(TpnRepo.Branch)' == ''" Branch="master" />
+      <TpnRepo Condition="'%(TpnRepo.Branch)' == ''" Branch="main" />
 
       <PotentialTpnPath Include="THIRD-PARTY-NOTICES.TXT" />
       <PotentialTpnPath Include="THIRD-PARTY-NOTICES.txt" />
@@ -49,5 +48,4 @@
     <Message Text="$(MSBuildProjectName) -> $(TpnFile)" Importance="High" />
   </Target>
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.targets))\Directory.Build.targets" />
 </Project>

--- a/eng/regenerate-third-party-notices.proj
+++ b/eng/regenerate-third-party-notices.proj
@@ -1,0 +1,53 @@
+<Project>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
+
+  <UsingTask TaskName="RegenerateThirdPartyNotices" AssemblyFile="$(InstallerTasksAssemblyPath)" />
+
+  <Target Name="Build">
+    <PropertyGroup>
+      <TpnFile>$(RepoRoot)src/installer/pkg/THIRD-PARTY-NOTICES.TXT</TpnFile>
+    </PropertyGroup>
+
+    <!--
+      Repo configuration. Upstreams, but also more: the TPN in Core-Setup serves many repos outside
+      its graph, because Core-Setup produces the installer that ends up placing the single TPN file
+      in the dotnet home directory.
+    -->
+    <ItemGroup>
+      <TpnRepo Include="dotnet/runtime" />
+      <TpnRepo Include="dotnet/aspnetcore" />
+      <TpnRepo Include="dotnet/installer" />
+      <TpnRepo Include="dotnet/roslyn-analyzers" />
+      <TpnRepo Include="dotnet/templating" />
+      <TpnRepo Include="dotnet/winforms" />
+      <TpnRepo Include="dotnet/wpf" />
+
+      <!--
+        Additional repos that should be included but don't have any third-party-notices files:
+          dotnet/efcore
+          dotnet/extensions
+          dotnet/icu
+          dotnet/sdk
+          dotnet/windowsdesktop
+          mono/linker
+      -->
+
+      <TpnRepo Condition="'%(TpnRepo.Branch)' == ''" Branch="master" />
+
+      <PotentialTpnPath Include="THIRD-PARTY-NOTICES.TXT" />
+      <PotentialTpnPath Include="THIRD-PARTY-NOTICES.txt" />
+      <PotentialTpnPath Include="THIRD-PARTY-NOTICES" />
+      <PotentialTpnPath Include="THIRDPARTYNOTICES.TXT" />
+      <PotentialTpnPath Include="THIRDPARTYNOTICES.txt" />
+    </ItemGroup>
+
+    <RegenerateThirdPartyNotices
+      TpnFile="$(TpnFile)"
+      PotentialTpnPaths="@(PotentialTpnPath)"
+      TpnRepos="@(TpnRepo)" />
+
+    <Message Text="$(MSBuildProjectName) -> $(TpnFile)" Importance="High" />
+  </Target>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.targets))\Directory.Build.targets" />
+</Project>

--- a/eng/regenerate-third-party-notices.proj
+++ b/eng/regenerate-third-party-notices.proj
@@ -9,8 +9,8 @@
     </PropertyGroup>
 
     <!--
-      Repo configuration. Upstreams, but also more: the TPN in Core-Setup serves many repos outside
-      its graph, because Core-Setup produces the installer that ends up placing the single TPN file
+      Repo configuration. Upstreams, but also more: the TPN in dotnet/runtime serves many repos outside
+      its graph, because dotnet/runtime produces the installer that ends up placing the single TPN file
       in the dotnet home directory.
     -->
     <ItemGroup>

--- a/src/installer/pkg/THIRD-PARTY-NOTICES.TXT
+++ b/src/installer/pkg/THIRD-PARTY-NOTICES.TXT
@@ -1305,3 +1305,198 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+License for fastmod (https://github.com/lemire/fastmod) and ibm-fpgen (https://github.com/nigeltao/parse-number-fxx-test-data)
+--------------------------------------
+
+   Copyright 2018 Daniel Lemire
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+License notice for Angular v8.0
+--------------------------------------------
+The MIT License (MIT)
+=====================
+
+Copyright (c) 2010-2019 Google LLC. http://angular.io/license
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+License notice for corefx
+
+License notice for JavaScript queues
+-------------------------------------
+
+CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED HEREUNDER.
+
+Statement of Purpose
+The laws of most jurisdictions throughout the world automatically confer exclusive Copyright and Related Rights (defined below) upon the creator and subsequent owner(s) (each and all, an "owner") of an original work of authorship and/or a database (each, a "Work").
+Certain owners wish to permanently relinquish those rights to a Work for the purpose of contributing to a commons of creative, cultural and scientific works ("Commons") that the public can reliably and without fear of later claims of infringement build upon, modify, incorporate in other works, reuse and redistribute as freely as possible in any form whatsoever and for any purposes, including without limitation commercial purposes. These owners may contribute to the Commons to promote the ideal of a free culture and the further production of creative, cultural and scientific works, or to gain reputation or greater distribution for their Work in part through the use and efforts of others.
+For these and/or other purposes and motivations, and without any expectation of additional consideration or compensation, the person associating CC0 with a Work (the "Affirmer"), to the extent that he or she is an owner of Copyright and Related Rights in the Work, voluntarily elects to apply CC0 to the Work and publicly distribute the Work under its terms, with knowledge of his or her Copyright and Related Rights in the Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be protected by copyright and related or neighboring rights ("Copyright and Related Rights"). Copyright and Related Rights include, but are not limited to, the following:
+the right to reproduce, adapt, distribute, perform, display, communicate, and translate a Work;
+moral rights retained by the original author(s) and/or performer(s);
+publicity and privacy rights pertaining to a person's image or likeness depicted in a Work;
+rights protecting against unfair competition in regards to a Work, subject to the limitations in paragraph 4(a), below;
+rights protecting the extraction, dissemination, use and reuse of data in a Work;
+database rights (such as those arising under Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, and under any national implementation thereof, including any amended or successor version of such directive); and
+other similar, equivalent or corresponding rights throughout the world based on applicable law or treaty, and any national implementations thereof.
+2. Waiver. To the greatest extent permitted by, but not in contravention of, applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and unconditionally waives, abandons, and surrenders all of Affirmer's Copyright and Related Rights and associated claims and causes of action, whether now known or unknown (including existing as well as future claims and causes of action), in the Work (i) in all territories worldwide, (ii) for the maximum duration provided by applicable law or treaty (including future time extensions), (iii) in any current or future medium and for any number of copies, and (iv) for any purpose whatsoever, including without limitation commercial, advertising or promotional purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each member of the public at large and to the detriment of Affirmer's heirs and successors, fully intending that such Waiver shall not be subject to revocation, rescission, cancellation, termination, or any other legal or equitable action to disrupt the quiet enjoyment of the Work by the public as contemplated by Affirmer's express Statement of Purpose.
+3. Public License Fallback. Should any part of the Waiver for any reason be judged legally invalid or ineffective under applicable law, then the Waiver shall be preserved to the maximum extent permitted taking into account Affirmer's express Statement of Purpose. In addition, to the extent the Waiver is so judged Affirmer hereby grants to each affected person a royalty-free, non transferable, non sublicensable, non exclusive, irrevocable and unconditional license to exercise Affirmer's Copyright and Related Rights in the Work (i) in all territories worldwide, (ii) for the maximum duration provided by applicable law or treaty (including future time extensions), (iii) in any current or future medium and for any number of copies, and (iv) for any purpose whatsoever, including without limitation commercial, advertising or promotional purposes (the "License"). The License shall be deemed effective as of the date CC0 was applied by Affirmer to the Work. Should any part of the License for any reason be judged legally invalid or ineffective under applicable law, such partial invalidity or ineffectiveness shall not invalidate the remainder of the License, and in such case Affirmer hereby affirms that he or she will not (i) exercise any of his or her remaining Copyright and Related Rights in the Work or (ii) assert any associated claims and causes of action with respect to the Work, in either case contrary to Affirmer's express Statement of Purpose.
+4. Limitations and Disclaimers.
+a. No trademark or patent rights held by Affirmer are waived, abandoned, surrendered, licensed or otherwise affected by this document.
+b. Affirmer offers the Work as-is and makes no representations or warranties of any kind concerning the Work, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non infringement, or the absence of latent or other defects, accuracy, or the present or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law.
+c. Affirmer disclaims responsibility for clearing rights of other persons that may apply to the Work or any use thereof, including without limitation any person's Copyright and Related Rights in the Work. Further, Affirmer disclaims responsibility for obtaining any necessary consents, permissions or other rights required for any use of the Work.
+d. Affirmer understands and acknowledges that Creative Commons is not a party to this document and has no duty or obligation with respect to this CC0 or use of the Work.
+
+License notice for MSBuild Locator
+-------------------------------------
+
+https://github.com/Microsoft/MSBuildLocator
+
+Copyright (c) 2018 .NET Foundation and Contributors
+
+This software is licensed subject to the MIT license, available at 
+https://opensource.org/licenses/MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+License notice for Newtonsoft.Json
+===================================
+
+The MIT License (MIT)
+
+Copyright (c) 2007 James Newton-King
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+License notice for NuGet.Client
+-------------------------------
+
+In reference to: https://github.com/dotnet/templating/blob/main/build/nuget.exe
+
+https://github.com/NuGet/NuGet.Client/blob/dev/LICENSE.txt
+
+Copyright (c) .NET Foundation. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+these files except in compliance with the License. You may obtain a copy of the
+License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+License notice for Roslyn Clr Heap Allocation Analyzer
+-------------------------------------
+
+https://github.com/Microsoft/RoslynClrHeapAllocationAnalyzer
+
+Copyright (c) 2018 Microsoft Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at 
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+License notice for StyleCop Analyzers
+-------------------------------------
+
+The MIT License (MIT)
+
+Copyright (c) Tunnel Vision Laboratories, LLC
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------
+
+The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/tasks/installer.tasks/StaticFileRegeneration/EnumerableExtensions.cs
+++ b/src/tasks/installer.tasks/StaticFileRegeneration/EnumerableExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/tasks/installer.tasks/StaticFileRegeneration/EnumerableExtensions.cs
+++ b/src/tasks/installer.tasks/StaticFileRegeneration/EnumerableExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    internal static class EnumerableExtensions
+    {
+        public static IEnumerable<T> NullAsEmpty<T>(this IEnumerable<T> source)
+        {
+            return source ?? Enumerable.Empty<T>();
+        }
+    }
+}

--- a/src/tasks/installer.tasks/StaticFileRegeneration/RegenerateThirdPartyNotices.cs
+++ b/src/tasks/installer.tasks/StaticFileRegeneration/RegenerateThirdPartyNotices.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
 using System;

--- a/src/tasks/installer.tasks/StaticFileRegeneration/RegenerateThirdPartyNotices.cs
+++ b/src/tasks/installer.tasks/StaticFileRegeneration/RegenerateThirdPartyNotices.cs
@@ -1,0 +1,190 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class RegenerateThirdPartyNotices : BuildTask
+    {
+        private const string GitHubRawContentBaseUrl = "https://raw.githubusercontent.com/";
+
+        private static readonly char[] NewlineChars = { '\n', '\r' };
+
+        /// <summary>
+        /// The Third Party Notices file (TPN file) to regenerate.
+        /// </summary>
+        [Required]
+        public string TpnFile { get; set; }
+
+        /// <summary>
+        /// Potential names for the file in various repositories. Each one is tried for each repo.
+        /// </summary>
+        [Required]
+        public string[] PotentialTpnPaths { get; set; }
+
+        /// <summary>
+        /// %(Identity): The "{organization}/{name}" of a repo to gather TPN info from.
+        /// %(Branch): The branch to pull from.
+        /// </summary>
+        [Required]
+        public ITaskItem[] TpnRepos { get; set; }
+
+        public override bool Execute()
+        {
+            using (var client = new HttpClient())
+            {
+                ExecuteAsync(client).Wait();
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+
+        public async Task ExecuteAsync(HttpClient client)
+        {
+            var results = await Task.WhenAll(TpnRepos
+                .SelectMany(item =>
+                {
+                    string repo = item.ItemSpec;
+                    string branch = item.GetMetadata("Branch")
+                        ?? throw new ArgumentException($"{item.ItemSpec} specifies no Branch.");
+
+                    return PotentialTpnPaths.Select(path => new
+                    {
+                        Repo = repo,
+                        Branch = branch,
+                        PotentialPath = path,
+                        Url = $"{GitHubRawContentBaseUrl}{repo}/{branch}/{path}"
+                    });
+                })
+                .Select(async c =>
+                {
+                    TpnDocument content = null;
+
+                    Log.LogMessage(
+                        MessageImportance.High,
+                        $"Getting {c.Url}");
+
+                    HttpResponseMessage response = await client.GetAsync(c.Url);
+
+                    if (response.StatusCode != HttpStatusCode.NotFound)
+                    {
+                        response.EnsureSuccessStatusCode();
+
+                        string tpnContent = await response.Content.ReadAsStringAsync();
+
+                        try
+                        {
+                            content = TpnDocument.Parse(tpnContent.Split(NewlineChars));
+                        }
+                        catch
+                        {
+                            Log.LogError($"Failed to parse response from {c.Url}");
+                            throw;
+                        }
+
+                        Log.LogMessage($"Got content from URL: {c.Url}");
+                    }
+                    else
+                    {
+                        Log.LogMessage($"Checked for content, but does not exist: {c.Url}");
+                    }
+
+                    return new
+                    {
+                        c.Repo,
+                        c.Branch,
+                        c.PotentialPath,
+                        c.Url,
+                        Content = content
+                    };
+                }));
+
+            foreach (var r in results.Where(r => r.Content != null).OrderBy(r => r.Repo))
+            {
+                Log.LogMessage(
+                    MessageImportance.High,
+                    $"Found TPN: {r.Repo} [{r.Branch}] {r.PotentialPath}");
+            }
+
+            // Ensure we found one (and only one) TPN file for each repo.
+            foreach (var miscount in results
+                .GroupBy(r => r.Repo)
+                .Where(g => g.Count(r => r.Content != null) != 1))
+            {
+                Log.LogError($"Unable to find exactly one TPN for {miscount.Key}");
+            }
+
+            if (Log.HasLoggedErrors)
+            {
+                return;
+            }
+
+            TpnDocument existingTpn = TpnDocument.Parse(File.ReadAllLines(TpnFile));
+
+            Log.LogMessage(
+                MessageImportance.High,
+                $"Existing TPN file preamble: {existingTpn.Preamble.Substring(0, 10)}...");
+
+            foreach (var s in existingTpn.Sections.OrderBy(s => s.Header.SingleLineName))
+            {
+                Log.LogMessage(
+                    MessageImportance.High,
+                    $"{s.Header.StartLine + 1}:{s.Header.StartLine + s.Header.LineLength} {s.Header.Format} '{s.Header.SingleLineName}'");
+            }
+
+            TpnDocument[] otherTpns = results
+                .Select(r => r.Content)
+                .Where(r => r != null)
+                .ToArray();
+
+            TpnSection[] newSections = otherTpns
+                .SelectMany(o => o.Sections)
+                .Except(existingTpn.Sections, new TpnSection.ByHeaderNameComparer())
+                .OrderBy(s => s.Header.Name)
+                .ToArray();
+
+            foreach (TpnSection existing in results
+                .SelectMany(r => (r.Content?.Sections.Except(newSections)).NullAsEmpty())
+                .Where(s => !newSections.Contains(s))
+                .OrderBy(s => s.Header.Name))
+            {
+                Log.LogMessage(
+                    MessageImportance.High,
+                    $"Found already-imported section: '{existing.Header.SingleLineName}'");
+            }
+
+            foreach (var s in newSections)
+            {
+                Log.LogMessage(
+                    MessageImportance.High,
+                    $"New section to import: '{s.Header.SingleLineName}' of " +
+                    string.Join(
+                        ", ",
+                        results
+                            .Where(r => r.Content?.Sections.Contains(s) == true)
+                            .Select(r => r.Url)) +
+                    $" line {s.Header.StartLine}");
+            }
+
+            Log.LogMessage(MessageImportance.High, $"Importing {newSections.Length} sections...");
+
+            var newTpn = new TpnDocument
+            {
+                Preamble = existingTpn.Preamble,
+                Sections = existingTpn.Sections.Concat(newSections)
+            };
+
+            File.WriteAllText(TpnFile, newTpn.ToString());
+
+            Log.LogMessage(MessageImportance.High, $"Wrote new TPN contents to {TpnFile}.");
+        }
+    }
+}

--- a/src/tasks/installer.tasks/StaticFileRegeneration/TpnDocument.cs
+++ b/src/tasks/installer.tasks/StaticFileRegeneration/TpnDocument.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/tasks/installer.tasks/StaticFileRegeneration/TpnDocument.cs
+++ b/src/tasks/installer.tasks/StaticFileRegeneration/TpnDocument.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class TpnDocument
+    {
+        public static TpnDocument Parse(string[] lines)
+        {
+            var headers = TpnSectionHeader.ParseAll(lines).ToArray();
+
+            var sections = headers
+                .Select((h, i) =>
+                {
+                    int headerEndLine = h.StartLine + h.LineLength + 1;
+                    int linesUntilNext = lines.Length - headerEndLine;
+
+                    if (i + 1 < headers.Length)
+                    {
+                        linesUntilNext = headers[i + 1].StartLine - headerEndLine;
+                    }
+
+                    return new TpnSection
+                    {
+                        Header = h,
+                        Content = string.Join(
+                            Environment.NewLine,
+                            lines
+                                .Skip(headerEndLine)
+                                .Take(linesUntilNext)
+                                // Skip lines in the content that could be confused for separators.
+                                .Where(line => !TpnSectionHeader.IsSeparatorLine(line))
+                                // Trim empty line at the end of the section.
+                                .Reverse()
+                                .SkipWhile(line => string.IsNullOrWhiteSpace(line))
+                                .Reverse())
+                    };
+                })
+                .ToArray();
+
+            if (sections.Length == 0)
+            {
+                throw new ArgumentException($"No sections found.");
+            }
+
+            return new TpnDocument
+            {
+                Preamble = string.Join(
+                    Environment.NewLine,
+                    lines.Take(sections.First().Header.StartLine)),
+
+                Sections = sections
+            };
+        }
+
+        public string Preamble { get; set; }
+
+        public IEnumerable<TpnSection> Sections { get; set; }
+
+        public override string ToString() =>
+            Preamble + Environment.NewLine +
+            string.Join(Environment.NewLine + Environment.NewLine, Sections) +
+            Environment.NewLine;
+    }
+}

--- a/src/tasks/installer.tasks/StaticFileRegeneration/TpnSection.cs
+++ b/src/tasks/installer.tasks/StaticFileRegeneration/TpnSection.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/tasks/installer.tasks/StaticFileRegeneration/TpnSection.cs
+++ b/src/tasks/installer.tasks/StaticFileRegeneration/TpnSection.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class TpnSection
+    {
+        public class ByHeaderNameComparer : EqualityComparer<TpnSection>
+        {
+            public override bool Equals(TpnSection x, TpnSection y) =>
+                string.Equals(x.Header.Name, y.Header.Name, StringComparison.OrdinalIgnoreCase);
+
+            public override int GetHashCode(TpnSection obj) => obj.Header.Name.GetHashCode();
+        }
+
+        public TpnSectionHeader Header { get; set; }
+        public string Content { get; set; }
+
+        public override string ToString() =>
+            Header + Environment.NewLine + Environment.NewLine + Content;
+    }
+}

--- a/src/tasks/installer.tasks/StaticFileRegeneration/TpnSectionHeader.cs
+++ b/src/tasks/installer.tasks/StaticFileRegeneration/TpnSectionHeader.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/tasks/installer.tasks/StaticFileRegeneration/TpnSectionHeader.cs
+++ b/src/tasks/installer.tasks/StaticFileRegeneration/TpnSectionHeader.cs
@@ -1,0 +1,176 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class TpnSectionHeader
+    {
+        private static readonly char[] SectionSeparatorChars = { '-', '=' };
+        private static readonly Regex NumberListPrefix = new Regex(@"^[0-9]+\.\t(?<name>.*)$");
+
+        public static bool IsSeparatorLine(string line)
+        {
+            return line.Length > 2 && line.All(c => SectionSeparatorChars.Contains(c));
+        }
+
+        public static IEnumerable<TpnSectionHeader> ParseAll(string[] lines)
+        {
+            // A separator line can't represent a section if it's on the first or last few lines.
+            for (int i = 1; i < lines.Length - 2; i++)
+            {
+                string lineAbove = lines[i - 1].Trim();
+                string line = lines[i].Trim();
+                string lineBelow = lines[i + 1].Trim();
+
+                if (line.Length > 2 &&
+                    IsSeparatorLine(line) &&
+                    string.IsNullOrEmpty(lineBelow))
+                {
+                    // 'line' is a separator line. Check around to see what kind it is.
+
+                    if (string.IsNullOrEmpty(lineAbove))
+                    {
+                        var header = ParseSeparatedOrNull(lines, i);
+                        if (header != null)
+                        {
+                            yield return header;
+                        }
+                    }
+                    else
+                    {
+                        var header = ParseUnderlined(lines, i);
+                        yield return header;
+                    }
+                }
+
+                var numberedHeader = ParseNumberedOrNull(lines, i);
+                if (numberedHeader != null)
+                {
+                    yield return numberedHeader;
+                }
+            }
+        }
+
+        public string Name { get; set; }
+        public string SeparatorLine { get; set; }
+
+        public TpnSectionHeaderFormat Format { get; set; }
+
+        public int StartLine { get; set; }
+        public int LineLength { get; set; }
+
+        public string SingleLineName => Name.Replace('\n', ' ').Replace('\r', ' ');
+
+        public override string ToString()
+        {
+            switch (Format)
+            {
+                case TpnSectionHeaderFormat.Separated:
+                    return
+                        SeparatorLine + Environment.NewLine +
+                        Environment.NewLine +
+                        Name;
+
+                case TpnSectionHeaderFormat.Underlined:
+                    return
+                        Name + Environment.NewLine +
+                        SeparatorLine;
+
+                case TpnSectionHeaderFormat.Numbered:
+                    return SeparatorLine;
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        private static TpnSectionHeader ParseSeparatedOrNull(string[] lines, int i)
+        {
+            string[] nameLines = lines
+                .Skip(i + 2)
+                .TakeWhile(s => !string.IsNullOrWhiteSpace(s))
+                .Select(s => s.Trim())
+                .ToArray();
+
+            string name = string.Join(Environment.NewLine, nameLines);
+
+            // If there's a separator line as the last line in the name, this line doesn't indicate
+            // a section. It needs to be handled by ParseUnderlined instead.
+            if (nameLines.Any(IsSeparatorLine))
+            {
+                if (nameLines.Take(nameLines.Length - 1).Any(IsSeparatorLine))
+                {
+                    throw new ArgumentException(
+                        $"Separator line detected inside name '{name}'");
+                }
+            }
+            else
+            {
+                return new TpnSectionHeader
+                {
+                    Name = name,
+
+                    SeparatorLine = lines[i],
+                    Format = TpnSectionHeaderFormat.Separated,
+
+                    StartLine = i,
+                    LineLength = 2 + nameLines.Length
+                };
+            }
+
+            return null;
+        }
+
+        private static TpnSectionHeader ParseUnderlined(string[] lines, int i)
+        {
+            string[] nameLines = lines
+                .Take(i)
+                .Reverse()
+                .TakeWhile(s => !string.IsNullOrWhiteSpace(s))
+                .Reverse()
+                .Select(s => s.Trim())
+                .ToArray();
+
+            int nameStartLine = i - nameLines.Length;
+
+            return new TpnSectionHeader
+            {
+                Name = string.Join(Environment.NewLine, nameLines),
+
+                SeparatorLine = lines[i],
+                Format = TpnSectionHeaderFormat.Underlined,
+
+                StartLine = nameStartLine,
+                LineLength = nameLines.Length + 1
+            };
+        }
+        private static TpnSectionHeader ParseNumberedOrNull(string[] lines, int i)
+        {
+            Match numberListMatch;
+
+            if (string.IsNullOrWhiteSpace(lines[i - 1]) &&
+                string.IsNullOrWhiteSpace(lines[i + 1]) &&
+                (numberListMatch = NumberListPrefix.Match(lines[i])).Success)
+            {
+                return new TpnSectionHeader
+                {
+                    Name = numberListMatch.Groups["name"].Value,
+
+                    SeparatorLine = lines[i],
+                    Format = TpnSectionHeaderFormat.Numbered,
+
+                    StartLine = i,
+                    LineLength = 1
+                };
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/tasks/installer.tasks/StaticFileRegeneration/TpnSectionHeaderFormat.cs
+++ b/src/tasks/installer.tasks/StaticFileRegeneration/TpnSectionHeaderFormat.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public enum TpnSectionHeaderFormat
+    {
+        /// <summary>
+        /// {blank line}
+        /// {3+ section separator chars}
+        /// {blank line}
+        /// {name}
+        /// </summary>
+        Separated,
+
+        /// <summary>
+        /// {blank line}
+        /// {name (multiline)}
+        /// {3+ section separator chars}
+        /// {blank line}
+        /// </summary>
+        Underlined,
+
+        /// <summary>
+        /// {blank line}
+        /// {number}.{tab}{name}
+        /// {blank line}
+        /// </summary>
+        Numbered
+    }
+}

--- a/src/tasks/installer.tasks/StaticFileRegeneration/TpnSectionHeaderFormat.cs
+++ b/src/tasks/installer.tasks/StaticFileRegeneration/TpnSectionHeaderFormat.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.DotNet.Build.Tasks
 {


### PR DESCRIPTION
This is based on infra originally implemented by @dagood https://github.com/dagood/core-setup/compare/bac3b0dc8ec9e0d4d2441524ed2bca24f8bab748...100d6dc55309b01856a15bd991c784f31154f63a

It regenerates TPN file under src/installer/pkg, with content from dotnet/runtime and other repos. We used the same infra for .NET 5 release, but it was never merged into runtime repo.