### PR TITLE
Remove dead code

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -9071,14 +9071,6 @@ void cTreeFlags(Compiler* comp, GenTree* tree)
 #endif
                 break;
 
-            case GT_NOP:
-
-                if (tree->gtFlags & GTF_NOP_DEATH)
-                {
-                    chars += printf("[NOP_DEATH]");
-                }
-                break;
-
             case GT_NO_OP:
                 break;
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3009,7 +3009,7 @@ public:
     // For binary opers.
     GenTree* gtNewOperNode(genTreeOps oper, var_types type, GenTree* op1, GenTree* op2);
 
-    GenTreeQmark* gtNewQmarkNode(var_types type, GenTree* cond, GenTree* colon);
+    GenTreeQmark* gtNewQmarkNode(var_types type, GenTree* cond, GenTreeColon* colon);
 
     GenTree* gtNewLargeOperNode(genTreeOps oper,
                                 var_types  type = TYP_I_IMPL,

--- a/src/coreclr/jit/decomposelongs.cpp
+++ b/src/coreclr/jit/decomposelongs.cpp
@@ -325,7 +325,7 @@ GenTree* DecomposeLongs::FinalizeDecomposition(LIR::Use& use,
 
     Range().InsertAfter(insertResultAfter, gtLong);
 
-    use.ReplaceWith(m_compiler, gtLong);
+    use.ReplaceWith(gtLong);
 
     return gtLong->gtNext;
 }
@@ -1075,7 +1075,7 @@ GenTree* DecomposeLongs::DecomposeShift(LIR::Use& use)
                 gtLong->SetUnusedValue();
             }
             Range().Remove(shift);
-            use.ReplaceWith(m_compiler, gtLong);
+            use.ReplaceWith(gtLong);
             return next;
         }
 
@@ -1370,7 +1370,7 @@ GenTree* DecomposeLongs::DecomposeShift(LIR::Use& use)
         Range().InsertAfter(shift, LIR::SeqTree(m_compiler, call));
 
         Range().Remove(shift);
-        use.ReplaceWith(m_compiler, call);
+        use.ReplaceWith(call);
         return call;
     }
 }
@@ -1449,7 +1449,7 @@ GenTree* DecomposeLongs::DecomposeRotate(LIR::Use& use)
         GenTree* next = tree->gtNext;
         // Remove tree and don't do anything else.
         Range().Remove(tree);
-        use.ReplaceWith(m_compiler, gtLong);
+        use.ReplaceWith(gtLong);
         return next;
     }
     else
@@ -1863,7 +1863,7 @@ GenTree* DecomposeLongs::OptimizeCastFromDecomposedLong(GenTreeCast* cast, GenTr
         LIR::Use useOfCast;
         if (Range().TryGetUse(cast, &useOfCast))
         {
-            useOfCast.ReplaceWith(m_compiler, loSrc);
+            useOfCast.ReplaceWith(loSrc);
         }
         else
         {

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -526,10 +526,10 @@ void BlockCountInstrumentor::InstrumentMethodEntry(Schema& schema, BYTE* profile
 
     // Compare Basic-Block count value against zero
     //
-    GenTree*   relop = m_comp->gtNewOperNode(GT_NE, typ, valueNode, m_comp->gtNewIconNode(0, typ));
-    GenTree*   colon = new (m_comp, GT_COLON) GenTreeColon(TYP_VOID, m_comp->gtNewNothingNode(), call);
-    GenTree*   cond  = m_comp->gtNewQmarkNode(TYP_VOID, relop, colon);
-    Statement* stmt  = m_comp->gtNewStmt(cond);
+    GenTree*      relop = m_comp->gtNewOperNode(GT_NE, typ, valueNode, m_comp->gtNewIconNode(0, typ));
+    GenTreeColon* colon = new (m_comp, GT_COLON) GenTreeColon(TYP_VOID, m_comp->gtNewNothingNode(), call);
+    GenTreeQmark* cond  = m_comp->gtNewQmarkNode(TYP_VOID, relop, colon);
+    Statement*    stmt  = m_comp->gtNewStmt(cond);
 
     // Add this check into the scratch block entry so we only do the check once per call.
     // If we put it in block we may be putting it inside a loop.

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -2804,7 +2804,7 @@ void Compiler::fgAddInternal()
         // Stick the conditional call at the start of the method
 
         fgEnsureFirstBBisScratch();
-        fgNewStmtAtEnd(fgFirstBB, gtNewQmarkNode(TYP_VOID, guardCheckCond, callback));
+        fgNewStmtAtEnd(fgFirstBB, gtNewQmarkNode(TYP_VOID, guardCheckCond, callback->AsColon()));
     }
 
 #if !defined(FEATURE_EH_FUNCLETS)

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -4148,13 +4148,6 @@ void Compiler::fgSetTreeSeqHelper(GenTree* tree, bool isLIR)
             noway_assert(!"DYN_BLK nodes should be sequenced as a special case");
             break;
 
-        case GT_INDEX_ADDR:
-            // Evaluate the array first, then the index....
-            assert((tree->gtFlags & GTF_REVERSE_OPS) == 0);
-            fgSetTreeSeqHelper(tree->AsIndexAddr()->Arr(), isLIR);
-            fgSetTreeSeqHelper(tree->AsIndexAddr()->Index(), isLIR);
-            break;
-
         default:
 #ifdef DEBUG
             gtDispTree(tree);

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -5987,7 +5987,7 @@ GenTree* Compiler::gtNewOperNode(genTreeOps oper, var_types type, GenTree* op1, 
     return node;
 }
 
-GenTreeQmark* Compiler::gtNewQmarkNode(var_types type, GenTree* cond, GenTree* colon)
+GenTreeQmark* Compiler::gtNewQmarkNode(var_types type, GenTree* cond, GenTreeColon* colon)
 {
     compQmarkUsed = true;
     cond->gtFlags |= GTF_RELOP_QMARK;
@@ -5999,13 +5999,6 @@ GenTreeQmark* Compiler::gtNewQmarkNode(var_types type, GenTree* cond, GenTree* c
     }
 #endif
     return result;
-}
-
-GenTreeQmark::GenTreeQmark(var_types type, GenTree* cond, GenTree* colonOp) : GenTreeOp(GT_QMARK, type, cond, colonOp)
-{
-    // These must follow a specific form.
-    assert(cond != nullptr && cond->TypeGet() == TYP_INT);
-    assert(colonOp != nullptr && colonOp->OperGet() == GT_COLON);
 }
 
 GenTreeIntCon* Compiler::gtNewIconNode(ssize_t value, var_types type)
@@ -7882,7 +7875,8 @@ GenTree* Compiler::gtCloneExpr(
                 break;
 
             case GT_QMARK:
-                copy = new (this, GT_QMARK) GenTreeQmark(tree->TypeGet(), tree->AsOp()->gtOp1, tree->AsOp()->gtOp2);
+                copy = new (this, GT_QMARK)
+                    GenTreeQmark(tree->TypeGet(), tree->AsOp()->gtGetOp1(), tree->AsOp()->gtGetOp2()->AsColon());
                 break;
 
             case GT_OBJ:

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4980,7 +4980,12 @@ struct GenTreeFptrVal : public GenTree
 /* gtQmark */
 struct GenTreeQmark : public GenTreeOp
 {
-    GenTreeQmark(var_types type, GenTree* cond, GenTree* colonOp);
+    GenTreeQmark(var_types type, GenTree* cond, GenTreeColon* colon)
+    {
+        // These must follow a specific form.
+        assert((cond != nullptr) && cond->TypeIs(TYP_INT));
+        assert((colon != nullptr) && colon->OperIs(GT_COLON));
+    }
 
 #if DEBUGGABLE_GENTREE
     GenTreeQmark() : GenTreeOp()

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -485,8 +485,6 @@ enum GenTreeFlags : unsigned int
 
     GTF_MEMORYBARRIER_LOAD      = 0x40000000, // GT_MEMORYBARRIER -- Load barrier
 
-    GTF_NOP_DEATH               = 0x40000000, // GT_NOP -- operand dies here
-
     GTF_FLD_VOLATILE            = 0x40000000, // GT_FIELD/GT_CLS_VAR -- same as GTF_IND_VOLATILE
     GTF_FLD_INITCLASS           = 0x20000000, // GT_FIELD/GT_CLS_VAR -- field access requires preceding class/static init helper
 
@@ -4982,12 +4980,10 @@ struct GenTreeFptrVal : public GenTree
 /* gtQmark */
 struct GenTreeQmark : public GenTreeOp
 {
-    // The "Compiler*" argument is not a DEBUGARG here because we use it to keep track of the set of
-    // (possible) QMark nodes.
-    GenTreeQmark(var_types type, GenTree* cond, GenTree* colonOp, class Compiler* comp);
+    GenTreeQmark(var_types type, GenTree* cond, GenTree* colonOp);
 
 #if DEBUGGABLE_GENTREE
-    GenTreeQmark() : GenTreeOp(GT_QMARK, TYP_INT, nullptr, nullptr)
+    GenTreeQmark() : GenTreeOp()
     {
     }
 #endif

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4980,7 +4980,7 @@ struct GenTreeFptrVal : public GenTree
 /* gtQmark */
 struct GenTreeQmark : public GenTreeOp
 {
-    GenTreeQmark(var_types type, GenTree* cond, GenTreeColon* colon)
+    GenTreeQmark(var_types type, GenTree* cond, GenTreeColon* colon) : GenTreeOp(GT_QMARK, type, cond, colon)
     {
         // These must follow a specific form.
         assert((cond != nullptr) && cond->TypeIs(TYP_INT));

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -2337,10 +2337,10 @@ GenTree* Compiler::impRuntimeLookupToTree(CORINFO_RESOLVED_TOKEN* pResolvedToken
         indir->gtFlags |= GTF_IND_NONFAULTING;
         indir->gtFlags |= GTF_IND_INVARIANT;
 
-        slot           = gtNewLclvNode(slotLclNum, TYP_I_IMPL);
-        GenTree* asg   = gtNewAssignNode(slot, indir);
-        GenTree* colon = new (this, GT_COLON) GenTreeColon(TYP_VOID, gtNewNothingNode(), asg);
-        GenTree* qmark = gtNewQmarkNode(TYP_VOID, relop, colon);
+        slot                = gtNewLclvNode(slotLclNum, TYP_I_IMPL);
+        GenTree*      asg   = gtNewAssignNode(slot, indir);
+        GenTreeColon* colon = new (this, GT_COLON) GenTreeColon(TYP_VOID, gtNewNothingNode(), asg);
+        GenTreeQmark* qmark = gtNewQmarkNode(TYP_VOID, relop, colon);
         impAppendTree(qmark, (unsigned)CHECK_SPILL_NONE, impCurStmtOffs);
 
         return gtNewLclvNode(slotLclNum, TYP_I_IMPL);
@@ -11245,7 +11245,7 @@ GenTree* Compiler::impCastClassOrIsInstToTree(GenTree*                op1,
     //                condFalse  condTrue
     //
     temp    = new (this, GT_COLON) GenTreeColon(TYP_REF, condTrue, condFalse);
-    qmarkMT = gtNewQmarkNode(TYP_REF, condMT, temp);
+    qmarkMT = gtNewQmarkNode(TYP_REF, condMT, temp->AsColon());
 
     if (isCastClass && impIsClassExact(pResolvedToken->hClass) && condTrue->OperIs(GT_CALL))
     {
@@ -11264,7 +11264,7 @@ GenTree* Compiler::impCastClassOrIsInstToTree(GenTree*                op1,
     //                qmarkMT   op1Copy
     //
     temp      = new (this, GT_COLON) GenTreeColon(TYP_REF, gtClone(op1), qmarkMT);
-    qmarkNull = gtNewQmarkNode(TYP_REF, condNull, temp);
+    qmarkNull = gtNewQmarkNode(TYP_REF, condNull, temp->AsColon());
     qmarkNull->gtFlags |= GTF_QMARK_CAST_INSTOF;
 
     // Make QMark node a top level node by spilling it.
@@ -16120,7 +16120,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     op1 = gtNewHelperCallNode(helper, TYP_VOID, gtNewCallArgs(op2, op1));
 
                     op1 = new (this, GT_COLON) GenTreeColon(TYP_VOID, gtNewNothingNode(), op1);
-                    op1 = gtNewQmarkNode(TYP_VOID, condBox, op1);
+                    op1 = gtNewQmarkNode(TYP_VOID, condBox, op1->AsColon());
 
                     // QMARK nodes cannot reside on the evaluation stack. Because there
                     // may be other trees on the evaluation stack that side-effect the

--- a/src/coreclr/jit/lir.cpp
+++ b/src/coreclr/jit/lir.cpp
@@ -154,7 +154,7 @@ void LIR::Use::AssertIsValid() const
 //
 //    GenTree* constantOne = compiler->gtNewIconNode(1);
 //    range.InsertAfter(opEq.Def(), constantOne);
-//    opEq.ReplaceWith(compiler, constantOne);
+//    opEq.ReplaceWith(constantOne);
 //
 // Which would produce something like the following LIR:
 //
@@ -179,13 +179,11 @@ void LIR::Use::AssertIsValid() const
 //          *  jmpTrue   void
 //
 // Arguments:
-//    compiler - The Compiler context.
 //    replacement - The replacement node.
 //
-void LIR::Use::ReplaceWith(Compiler* compiler, GenTree* replacement)
+void LIR::Use::ReplaceWith(GenTree* replacement)
 {
     assert(IsInitialized());
-    assert(compiler != nullptr);
     assert(replacement != nullptr);
     assert(IsDummyUse() || m_range->Contains(m_user));
     assert(m_range->Contains(replacement));
@@ -273,7 +271,7 @@ unsigned LIR::Use::ReplaceWithLclVar(Compiler* compiler, unsigned lclNum, GenTre
 
     m_range->InsertAfter(node, store, load);
 
-    ReplaceWith(compiler, load);
+    ReplaceWith(load);
 
     JITDUMP("ReplaceWithLclVar created store :\n");
     DISPNODE(store);

--- a/src/coreclr/jit/lir.h
+++ b/src/coreclr/jit/lir.h
@@ -73,7 +73,7 @@ public:
         void AssertIsValid() const;
         bool IsDummyUse() const;
 
-        void ReplaceWith(Compiler* compiler, GenTree* replacement);
+        void ReplaceWith(GenTree* replacement);
         unsigned ReplaceWithLclVar(Compiler* compiler, unsigned lclNum = BAD_VAR_NUM, GenTree** assign = nullptr);
     };
 

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -2690,7 +2690,7 @@ GenTree* Lowering::OptimizeConstCompare(GenTree* cmp)
             {
                 cc = new (comp, GT_SETCC) GenTreeCC(GT_SETCC, condition, TYP_INT);
                 BlockRange().InsertAfter(cmp, cc);
-                cmpUse.ReplaceWith(comp, cc);
+                cmpUse.ReplaceWith(cc);
             }
 
             cc->gtFlags |= GTF_USE_FLAGS;
@@ -2954,7 +2954,7 @@ GenTreeCC* Lowering::LowerNodeCC(GenTree* node, GenCondition condition)
             {
                 cc = new (comp, GT_SETCC) GenTreeCC(GT_SETCC, condition, TYP_INT);
                 BlockRange().InsertAfter(node, cc);
-                use.ReplaceWith(comp, cc);
+                use.ReplaceWith(cc);
             }
         }
     }
@@ -5102,7 +5102,7 @@ GenTree* Lowering::LowerAdd(GenTreeOp* node)
             DISPNODE(op1);
             if (BlockRange().TryGetUse(node, &use))
             {
-                use.ReplaceWith(comp, op1);
+                use.ReplaceWith(op1);
             }
             else
             {
@@ -5671,7 +5671,7 @@ GenTree* Lowering::LowerConstIntDivOrMod(GenTree* node)
     BlockRange().Remove(divMod);
 
     // replace the original divmod node with the new divmod tree
-    use.ReplaceWith(comp, newDivMod);
+    use.ReplaceWith(newDivMod);
 
     return newDivMod->gtNext;
 }
@@ -5932,7 +5932,7 @@ GenTree* Lowering::LowerArrElem(GenTree* node)
     LIR::Use arrElemUse;
     if (BlockRange().TryGetUse(arrElem, &arrElemUse))
     {
-        arrElemUse.ReplaceWith(comp, leaNode);
+        arrElemUse.ReplaceWith(leaNode);
     }
     else
     {

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -2879,7 +2879,7 @@ void Lowering::LowerHWIntrinsicGetElement(GenTreeHWIntrinsic* node)
 
         if (foundUse)
         {
-            use.ReplaceWith(comp, cast);
+            use.ReplaceWith(cast);
         }
         LowerNode(cast);
     }
@@ -3961,7 +3961,7 @@ void Lowering::LowerHWIntrinsicToScalar(GenTreeHWIntrinsic* node)
 
         if (foundUse)
         {
-            use.ReplaceWith(comp, cast);
+            use.ReplaceWith(cast);
         }
         LowerNode(cast);
     }

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -6231,7 +6231,7 @@ void LinearScan::insertCopyOrReload(BasicBlock* block, GenTree* tree, unsigned m
         // Insert the copy/reload after the spilled node and replace the use of the original node with a use
         // of the copy/reload.
         blockRange.InsertAfter(tree, newNode);
-        treeUse.ReplaceWith(compiler, newNode);
+        treeUse.ReplaceWith(newNode);
     }
 }
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -14896,18 +14896,6 @@ GenTree* Compiler::fgMorphTree(GenTree* tree, MorphAddrContext* mac)
             tree->gtFlags |= tree->AsDynBlk()->gtDynamicSize->gtFlags & GTF_ALL_EFFECT;
             break;
 
-        case GT_INDEX_ADDR:
-            GenTreeIndexAddr* indexAddr;
-            indexAddr          = tree->AsIndexAddr();
-            indexAddr->Index() = fgMorphTree(indexAddr->Index());
-            indexAddr->Arr()   = fgMorphTree(indexAddr->Arr());
-
-            tree->gtFlags &= ~GTF_CALL;
-
-            tree->gtFlags |= indexAddr->Index()->gtFlags & GTF_ALL_EFFECT;
-            tree->gtFlags |= indexAddr->Arr()->gtFlags & GTF_ALL_EFFECT;
-            break;
-
         default:
 #ifdef DEBUG
             gtDispTree(tree);

--- a/src/coreclr/jit/rationalize.cpp
+++ b/src/coreclr/jit/rationalize.cpp
@@ -84,7 +84,7 @@ void Rationalizer::RewriteIndir(LIR::Use& use)
                     JITDUMP("Rewriting GT_IND(GT_ADD(LCL_VAR_ADDR,0)) to LCL_VAR\n");
                     lclVarNode->SetOper(GT_LCL_VAR);
                     lclVarNode->gtType = indir->TypeGet();
-                    use.ReplaceWith(comp, lclVarNode);
+                    use.ReplaceWith(lclVarNode);
                     BlockRange().Remove(addr);
                     BlockRange().Remove(addr->gtGetOp2());
                     BlockRange().Remove(indir);
@@ -168,7 +168,7 @@ void Rationalizer::RewriteSIMDIndir(LIR::Use& use)
         }
 
         addr->gtType = simdType;
-        use.ReplaceWith(comp, addr);
+        use.ReplaceWith(addr);
     }
     else if (addr->OperIs(GT_ADDR) && addr->AsUnOp()->gtGetOp1()->OperIsSimdOrHWintrinsic())
     {
@@ -180,7 +180,7 @@ void Rationalizer::RewriteSIMDIndir(LIR::Use& use)
         BlockRange().Remove(indir);
         BlockRange().Remove(addr);
 
-        use.ReplaceWith(comp, addr->AsUnOp()->gtGetOp1());
+        use.ReplaceWith(addr->AsUnOp()->gtGetOp1());
     }
 #endif // FEATURE_SIMD
 }
@@ -450,7 +450,7 @@ void Rationalizer::RewriteAssignment(LIR::Use& use)
             // Remove the GT_IND node and replace the assignment node with the store
             BlockRange().Remove(location);
             BlockRange().InsertBefore(assignment, store);
-            use.ReplaceWith(comp, store);
+            use.ReplaceWith(store);
             BlockRange().Remove(assignment);
         }
         break;
@@ -501,7 +501,7 @@ void Rationalizer::RewriteAssignment(LIR::Use& use)
             // (now in its store form).
             BlockRange().Remove(storeBlk);
             BlockRange().InsertBefore(assignment, storeBlk);
-            use.ReplaceWith(comp, storeBlk);
+            use.ReplaceWith(storeBlk);
             BlockRange().Remove(assignment);
             DISPTREERANGE(BlockRange(), use.Def());
             JITDUMP("\n");
@@ -544,7 +544,7 @@ void Rationalizer::RewriteAddress(LIR::Use& use)
         location->gtType = TYP_BYREF;
         copyFlags(location, address, GTF_ALL_EFFECT);
 
-        use.ReplaceWith(comp, location);
+        use.ReplaceWith(location);
         BlockRange().Remove(address);
     }
     else if (locationOp == GT_CLS_VAR)
@@ -553,14 +553,14 @@ void Rationalizer::RewriteAddress(LIR::Use& use)
         location->gtType = TYP_BYREF;
         copyFlags(location, address, GTF_ALL_EFFECT);
 
-        use.ReplaceWith(comp, location);
+        use.ReplaceWith(location);
         BlockRange().Remove(address);
 
         JITDUMP("Rewriting GT_ADDR(GT_CLS_VAR) to GT_CLS_VAR_ADDR:\n");
     }
     else if (location->OperIsIndir())
     {
-        use.ReplaceWith(comp, location->gtGetOp1());
+        use.ReplaceWith(location->gtGetOp1());
         BlockRange().Remove(location);
         BlockRange().Remove(address);
 
@@ -621,7 +621,7 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, Compiler::Ge
 
         case GT_BOX:
             // GT_BOX at this level just passes through so get rid of it
-            use.ReplaceWith(comp, node->gtGetOp1());
+            use.ReplaceWith(node->gtGetOp1());
             BlockRange().Remove(node);
             break;
 
@@ -641,7 +641,7 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, Compiler::Ge
             // NOP.
             if (node->gtGetOp1() != nullptr)
             {
-                use.ReplaceWith(comp, node->gtGetOp1());
+                use.ReplaceWith(node->gtGetOp1());
                 BlockRange().Remove(node);
                 node = node->gtGetOp1();
             }
@@ -673,7 +673,7 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, Compiler::Ge
             GenTree* replacement = node->gtGetOp2();
             if (!use.IsDummyUse())
             {
-                use.ReplaceWith(comp, replacement);
+                use.ReplaceWith(replacement);
                 node = replacement;
             }
             else
@@ -702,8 +702,6 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, Compiler::Ge
 
         case GT_ARGPLACE:
             // Remove argplace and list nodes from the execution order.
-            //
-            // TODO: remove phi args and phi nodes as well?
             BlockRange().Remove(node);
             break;
 
@@ -724,7 +722,7 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, Compiler::Ge
                 node->gtType = TYP_BYREF;
 
                 BlockRange().InsertAfter(node, ind);
-                use.ReplaceWith(comp, ind);
+                use.ReplaceWith(ind);
 
                 // TODO: JIT dump
             }
@@ -766,7 +764,7 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, Compiler::Ge
                 GenTree* ind = comp->gtNewOperNode(GT_IND, simdType, address);
 
                 BlockRange().InsertBefore(simdNode, address, ind);
-                use.ReplaceWith(comp, ind);
+                use.ReplaceWith(ind);
                 BlockRange().Remove(simdNode);
 
                 DISPTREERANGE(BlockRange(), use.Def());


### PR DESCRIPTION
 - Delete unused `GTF_NOP_DEATH`.
 - Delete dead code handling `GT_INDEX_ADDR` as a `GTK_SPECIAL` node, it has always been `GTK_BINOP`.
 - Remove the unused `Compiler*` parameter from `GenTreeQmark`'s constructor.
 - Remove the unused `Compiler*` parameter from `LIR::Use::ReplaceWith`, ever so slightly improving its performance.

There are a handful of expected diffs ([`win-x64`](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-60095/win-x64.md), [`win-arm64`](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-60095/win-arm64.md), [`win-x86`](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-60095/win-x86.md), [`linux-arm`](https://github.com/SingleAccretion/diffs-repository/blob/main/runtime-60095/linux-arm.md)) with this change, they are due to proper costing for `INDEX_ADDR` causing `fgMorphArgs` to make different decisions:

```diff
 ***** BB07
 STMT00021 (IL 0x097...0x0A8)
-N014 ( 33, 22) [000136] --CXG-------              *  CALL      void   hackishModuleName.hackishMethodName
-N008 ( 10,  8) [000135] ---X-------- arg1 in rdx  +--*  ADD       int
-N003 (  3,  2) [000130] ------------              |  +--*  LCL_VAR   int    V04 loc2
-N007 (  6,  5) [000134] ---X--------              |  \--*  IND       int
-N006 (  4,  3) [000133] -------N----              |     \--*  ADD       byref
-N004 (  3,  2) [000131] ------------              |        +--*  LCL_VAR   ref    V02 loc0
-N005 (  1,  1) [000132] ------------              |        \--*  CNS_INT   long   8
-N013 (  9,  7) [000257] ---XG------- arg0 in rcx  \--*  ADD       byref
-N011 (  7,  5) [000258] ---XG-------                 +--*  INDEX_ADDR byref
-N009 (  3,  2) [000124] ------------                 |  +--*  LCL_VAR   ref    V02 loc0
-N010 (  3,  2) [000125] ------------                 |  \--*  LCL_VAR   int    V05 loc3
-N012 (  1,  1) [000256] ------------                 \--*  CNS_INT   long   8 field offset Fseq[hackishFieldName]
+N014 ( 38, 30) [000136] --CXG-------              *  CALL      void   hackishModuleName.hackishMethodName
+N007 ( 14, 15) [000257] ---XG------- arg0 in rcx  +--*  ADD       byref
+N005 ( 12, 13) [000258] ---XG-------              |  +--*  INDEX_ADDR byref
+N003 (  3,  2) [000124] ------------              |  |  +--*  LCL_VAR   ref    V02 loc0
+N004 (  3,  2) [000125] ------------              |  |  \--*  LCL_VAR   int    V05 loc3
+N006 (  1,  1) [000256] ------------              |  \--*  CNS_INT   long   8 field offset Fseq[hackishFieldName]
+N013 ( 10,  8) [000135] ---X-------- arg1 in rdx  \--*  ADD       int
+N008 (  3,  2) [000130] ------------                 +--*  LCL_VAR   int    V04 loc2
+N012 (  6,  5) [000134] ---X--------                 \--*  IND       int
+N011 (  4,  3) [000133] -------N----                    \--*  ADD       byref
+N009 (  3,  2) [000131] ------------                       +--*  LCL_VAR   ref    V02 loc0
+N010 (  1,  1) [000132] ------------                       \--*  CNS_INT   long   8
```
ARM/ARM64 diffs specifically are due to [this condition](https://github.com/dotnet/runtime/blob/74ba1330fa5dbdc084493cdae014a69431bdaa6b/src/coreclr/jit/morph.cpp#L1277):
```diff
                [000866] --CXG+------              \--*  CALL      struct hackishModuleName.hackishMethodName
-               [001806] -c-XG------- arg0 x0,x1      \--*  FIELD_LIST struct
-               [001807] ---XG------- ofs 0              +--*  IND       long
-     (  8,  7) [001803] ---XG-------                    |  \--*  INDEX_ADDR byref
-     (  6,  4) [000861] ---XG-------                    |     +--*  IND       ref
-     (  5,  5) [001802] -------N----                    |     |  \--*  ADD       byref
-     (  3,  2) [000860] ------------                    |     |     +--*  LCL_VAR   ref    V00 loc0
-     (  1,  2) [001801] ------------                    |     |     \--*  CNS_INT   long   8 field offset Fseq[hackishFieldName]
-     (  1,  2) [000862] ------------                    |     \--*  CNS_INT   int    0
-               [001816] ---XG------- ofs 8              \--*  IND       long
-               [001815] ---XG-------                       \--*  ADD       byref
-     (  8,  7) [001808] ---XG-------                          +--*  INDEX_ADDR byref
-     (  6,  4) [001809] ---XG-------                          |  +--*  IND       ref
-     (  5,  5) [001810] -------N----                          |  |  \--*  ADD       byref
-     (  3,  2) [001811] ------------                          |  |     +--*  LCL_VAR   ref    V00 loc0
-     (  1,  2) [001812] ------------                          |  |     \--*  CNS_INT   long   8 field offset Fseq[hackishFieldName]
-     (  1,  2) [001813] ------------                          |  \--*  CNS_INT   int    0
-               [001814] ------------                          \--*  CNS_INT   long   8
+               [001767] -A-XG-----L- arg0 SETUP      +--*  ASG       struct (copy)
+               [001765] D------N----                 |  +--*  LCL_VAR   struct<System.Decimal, 16> V156 tmp146
+     ( 19, 19) [000865] ---XG--N----                 |  \--*  IND       struct
+     ( 13, 15) [001763] ---XG-------                 |     \--*  INDEX_ADDR byref
+     (  6,  4) [000861] ---XG-------                 |        +--*  IND       ref
+     (  5,  5) [001762] -------N----                 |        |  \--*  ADD       byref
+     (  3,  2) [000860] ------------                 |        |     +--*  LCL_VAR   ref    V00 loc0
+     (  1,  2) [001761] ------------                 |        |     \--*  CNS_INT   long   8 field offset Fseq[hackishFieldName]
+     (  1,  2) [000862] ------------                 |        \--*  CNS_INT   int    0
+               [001769] -c---------- arg0 x0,x1      \--*  FIELD_LIST struct
+               [001770] ------------ ofs 0              +--*  LCL_FLD   long   V156 tmp146      [+0]
+               [001771] ------------ ofs 8              \--*  LCL_FLD   long   V156 tmp146      [+8]
```