### PR TITLE
Don't create a symbols archive in a PGO build.

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.Composite.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.Composite.sfxproj
@@ -7,7 +7,7 @@
     <ArchiveName>dotnet-runtime-internal-composite</ArchiveName>
     <OverridePackageId>$(SharedFrameworkName).Composite</OverridePackageId>
     <OverridePackageId Condition="'$(PgoInstrument)' != ''">$(SharedFrameworkName).Composite.PGO</OverridePackageId>
-    <CreateSymbolsArchive>true</CreateSymbolsArchive>
+    <CreateSymbolsArchive Condition="'$(PgoInstrument)' == ''">true</CreateSymbolsArchive>
     <SymbolsArchiveName>dotnet-runtime-composite-symbols</SymbolsArchiveName>
     <UseTemplatedPlatformManifest>true</UseTemplatedPlatformManifest>
     <ForcePublishReadyToRunComposite>true</ForcePublishReadyToRunComposite>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.sfxproj
@@ -8,7 +8,7 @@
     <InstallerName Condition="'$(TargetOS)' != 'OSX'">dotnet-runtime</InstallerName>
     <InstallerName Condition="'$(TargetOS)' == 'OSX'">dotnet-runtime-internal</InstallerName>
     <OverridePackageId Condition="'$(PgoInstrument)' != ''">$(SharedFrameworkName).PGO</OverridePackageId>
-    <CreateSymbolsArchive>true</CreateSymbolsArchive>
+    <CreateSymbolsArchive Condition="'$(PgoInstrument)' == ''">true</CreateSymbolsArchive>
     <SymbolsArchiveName>dotnet-runtime-symbols</SymbolsArchiveName>
     <VSInsertionShortComponentName>NetCore.SharedFramework</VSInsertionShortComponentName>
     <UseTemplatedPlatformManifest>true</UseTemplatedPlatformManifest>


### PR DESCRIPTION
Fixes having duplicate artifacts which was causing official build failures.

Official build: https://dev.azure.com/dnceng/internal/_build/results?buildId=1406827&view=results