### PR TITLE
Move more pipelines to scheduled rather than rolling

### DIFF
--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -24,7 +24,7 @@ trigger:
     - eng/pipelines/runtime.yml
 
 schedules:
-  - cron: "0 7,19 * * *" # run at 9:00, 18:00 and 01:00 (UTC) which is 2:00, 11:00 and 18:00 (PST).
+  - cron: "0 9,18,1 * * *" # run at 9:00, 18:00 and 01:00 (UTC) which is 2:00, 11:00 and 18:00 (PST).
     displayName: runtime-coreclr-outerloop default schedule
     branches:
       include:

--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -2,7 +2,6 @@ trigger:
   batch: true
   branches:
     include:
-    - main
     - release/*.*
   paths:
     include:
@@ -23,6 +22,14 @@ trigger:
     - eng/pipelines/installer/*
     - eng/pipelines/libraries/*
     - eng/pipelines/runtime.yml
+
+schedules:
+  - cron: "0 7,19 * * *" # run at 9:00, 18:00 and 01:00 (UTC) which is 2:00, 11:00 and 18:00 (PST).
+    displayName: runtime-coreclr-outerloop default schedule
+    branches:
+      include:
+      - main
+    always: false # run only if there were changes since the last successful scheduled run.
 
 jobs:
 

--- a/eng/pipelines/runtime-linker-tests.yml
+++ b/eng/pipelines/runtime-linker-tests.yml
@@ -1,3 +1,6 @@
+# The purpose of this pipeline is to run the trimming tests. These tests ensure trimming is
+# done correctly and also that our APIs are trimming safe.
+
 trigger:
   batch: true
   branches:

--- a/eng/pipelines/runtime-linker-tests.yml
+++ b/eng/pipelines/runtime-linker-tests.yml
@@ -1,12 +1,7 @@
-# The purpose of this pipeline is to exercise local developer workflow in the consolidated
-# runtime repo. In particular, it is supposed to run the root "build" script just like any
-# normal developer normally would and monitor regressions w.r.t. this fundamental scenario.
-
 trigger:
   batch: true
   branches:
     include:
-    - main
     - release/*.*
   paths:
     include:
@@ -22,6 +17,14 @@ trigger:
     - README.md
     - SECURITY.md
     - THIRD-PARTY-NOTICES.TXT
+  
+schedules:
+  - cron: "0 7,19 * * *" # run at 7:00 and 19:00 (UTC) which is 23:00 and 11:00 (PST).
+    displayName: Runtime-linker-tests default schedule
+    branches:
+      include:
+      - main
+    always: false # run only if there were changes since the last successful scheduled run.
 
 pr:
   branches:

--- a/eng/pipelines/runtime-staging.yml
+++ b/eng/pipelines/runtime-staging.yml
@@ -1,27 +1,10 @@
-# Setting batch to true, triggers one build at a time.
-# if there is a push while a build in progress, it will wait,
-# until the running build finishes, and produce a build with all the changes
-# that happened during the last build.
-trigger:
-  batch: true
-  branches:
-    include:
-    - main
-  paths:
-    include:
-    - '*'
-    - docs/manpages/*
-    exclude:
-    - eng/Version.Details.xml
-    - .github/*
-    - docs/*
-    - CODE-OF-CONDUCT.md
-    - CONTRIBUTING.md
-    - LICENSE.TXT
-    - PATENTS.TXT
-    - README.md
-    - SECURITY.md
-    - THIRD-PARTY-NOTICES.TXT
+schedules:
+  - cron: "0 7,19 * * *" # run at 7:00 and 19:00 (UTC) which is 23:00 and 11:00 (PST).
+    displayName: Runtime-staging default schedule
+    branches:
+      include:
+      - main
+    always: false # run only if there were changes since the last successful scheduled run.
 
 pr:
   branches:


### PR DESCRIPTION
Follow up for: https://github.com/dotnet/runtime/pull/59884

Setting scheduled for the linker-tests, runtime-staging and coreclr outerloop.
