### PR TITLE
[release/6.0] SafeFileHandle.Unix: don't DeleteOnClose when lock is not successful.

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/FileStream/SafeFileHandle.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/SafeFileHandle.cs
@@ -78,6 +78,18 @@ namespace System.IO.Tests
             await ThrowWhenHandlePositionIsChanged(useAsync: true);
         }
 
+        [Fact]
+        public void DeleteOnClose_FailedShareDoesNotDeleteFile()
+        {
+            string fileName = GetTestFilePath();
+
+            using SafeFileHandle handle = File.OpenHandle(fileName, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None);
+
+            Assert.Throws<IOException>(() => File.OpenHandle(fileName, FileMode.Open, FileAccess.Write, FileShare.None, FileOptions.DeleteOnClose));
+
+            Assert.True(File.Exists(fileName));
+        }
+
         private async Task ThrowWhenHandlePositionIsChanged(bool useAsync)
         {
             string fileName = GetTestFilePath();

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/SafeFileHandle.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/SafeFileHandle.cs
@@ -78,7 +78,7 @@ namespace System.IO.Tests
             await ThrowWhenHandlePositionIsChanged(useAsync: true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsFileLockingEnabled))]
         public void DeleteOnClose_FailedShareDoesNotDeleteFile()
         {
             string fileName = GetTestFilePath();


### PR DESCRIPTION
# Description

In https://github.com/dotnet/runtime/pull/55153 DeleteOnClose handling moved from FileStream to SafeFileHandle.

This unintentionally caused DeleteOnClose to be applied even when FileShare locking fails. As on Windows, DeleteOnClose should not take effect when sharing prevents the file from being opened.

This also swaps the order of unlink and LOCK_UN in Dispose as it was prior to https://github.com/dotnet/runtime/pull/55153.
Either order should be fine.

# Customer impact

Unintentional deleting of file.

# Testing

Existing and new unit test.

# Risk

Low. Behaves the same as previous versions of .NET.

Fixes https://github.com/dotnet/runtime/issues/59995.