### PR TITLE
[HTTP/3] Set EOS for 0-length response payload

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -485,6 +485,8 @@ namespace System.Net.Http
                     case null:
                         // Done receiving: copy over trailing headers.
                         CopyTrailersToResponseMessage(_response!);
+
+                        _responseDataPayloadRemaining = -1; // Set to -1 to indicate EOS.
                         return;
                     case Http3FrameType.Data:
                         // The sum of data frames must equal content length. Because this method is only
@@ -500,7 +502,7 @@ namespace System.Net.Http
                         }
                         break;
                     default:
-                        Debug.Fail($"Recieved unexpected frame type {frameType}.");
+                        Debug.Fail($"Received unexpected frame type {frameType}.");
                         return;
                 }
             }


### PR DESCRIPTION
Since we issue `AbortRead` from `Http3RequestStream.Dispose` in case we haven't consumed the stream till the end, we need to set the EOF for an empty response content as well.
This is the same logic as we do in normal DATA frame reading logic. Once EOS is reached, we set `_responseDataPayloadRemaining` to -1.

Discovered and the fix validated while working #56310.