### PR TITLE
Support passing total code size through when doing SPMI diffs

### DIFF
--- a/src/coreclr/ToolBox/superpmi/superpmi-shared/standardpch.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi-shared/standardpch.h
@@ -68,12 +68,14 @@
 #ifdef TARGET_UNIX
 #include "clr_std/string"
 #include "clr_std/algorithm"
+#include "clr_std/vector"
 #else // !TARGET_UNIX
 #ifndef USE_STL
 #define USE_STL
 #endif // USE_STL
 #include <string>
 #include <algorithm>
+#include <vector>
 #endif // !TARGET_UNIX
 
 #ifdef USE_MSVCDIS

--- a/src/coreclr/ToolBox/superpmi/superpmi/CMakeLists.txt
+++ b/src/coreclr/ToolBox/superpmi/superpmi/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SUPERPMI_SOURCES
     jitdebugger.cpp
     jitinstance.cpp
     methodstatsemitter.cpp
+    metricssummary.cpp
     neardiffer.cpp
     parallelsuperpmi.cpp
     superpmi.cpp

--- a/src/coreclr/ToolBox/superpmi/superpmi/CMakeLists.txt
+++ b/src/coreclr/ToolBox/superpmi/superpmi/CMakeLists.txt
@@ -12,9 +12,6 @@ if(CLR_CMAKE_HOST_WIN32)
   set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreaded)
 endif(CLR_CMAKE_HOST_WIN32)
 
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 include_directories(.)
 include_directories(../superpmi-shared)
 

--- a/src/coreclr/ToolBox/superpmi/superpmi/CMakeLists.txt
+++ b/src/coreclr/ToolBox/superpmi/superpmi/CMakeLists.txt
@@ -12,6 +12,9 @@ if(CLR_CMAKE_HOST_WIN32)
   set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreaded)
 endif(CLR_CMAKE_HOST_WIN32)
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 include_directories(.)
 include_directories(../superpmi-shared)
 

--- a/src/coreclr/ToolBox/superpmi/superpmi/commandline.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/commandline.cpp
@@ -81,6 +81,16 @@ void CommandLine::DumpHelp(const char* program)
     printf("         t - method throughput time\n");
     printf("         * - all available method stats\n");
     printf("\n");
+    printf(" -metricsSummary <file name>, -baseMetricsSummary <file name.csv>\n");
+    printf("     Emit a summary of metrics to the specified file\n");
+    printf("     Currently includes:\n");
+    printf("       Total number of successful SPMI compiles\n");
+    printf("       Total number of failing SPMI compiles\n");
+    printf("       Total amount of ASM code in bytes\n");
+    printf("\n");
+    printf(" -diffMetricsSummary <file name>\n");
+    printf("     Same as above, but emit for the diff/second JIT");
+    printf("\n");
     printf(" -a[pplyDiff]\n");
     printf("     Compare the compile result generated from the provided JIT with the\n");
     printf("     compile result stored with the MC. If two JITs are provided, this\n");
@@ -373,6 +383,26 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
                 }
 
                 o->methodStatsTypes = argv[i];
+            }
+            else if ((_strnicmp(&argv[i][1], "metricsSummary", argLen) == 0) || (_strnicmp(&argv[i][1], "baseMetricsSummary", argLen) == 0))
+            {
+                if (++i >= argc)
+                {
+                    DumpHelp(argv[0]);
+                    return false;
+                }
+
+                o->baseMetricsSummaryFile = argv[i];
+            }
+            else if ((_strnicmp(&argv[i][1], "diffMetricsSummary", argLen) == 0))
+            {
+                if (++i >= argc)
+                {
+                    DumpHelp(argv[0]);
+                    return false;
+                }
+
+                o->diffMetricsSummaryFile = argv[i];
             }
             else if ((_strnicmp(&argv[i][1], "applyDiff", argLen) == 0))
             {

--- a/src/coreclr/ToolBox/superpmi/superpmi/commandline.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi/commandline.h
@@ -36,6 +36,8 @@ public:
             , indexes(nullptr)
             , hash(nullptr)
             , methodStatsTypes(nullptr)
+            , baseMetricsSummaryFile(nullptr)
+            , diffMetricsSummaryFile(nullptr)
             , mclFilename(nullptr)
             , diffMCLFilename(nullptr)
             , targetArchitecture(nullptr)
@@ -67,6 +69,8 @@ public:
         int*  indexes;
         char* hash;
         char* methodStatsTypes;
+        char* baseMetricsSummaryFile;
+        char* diffMetricsSummaryFile;
         char* mclFilename;
         char* diffMCLFilename;
         char* targetArchitecture;

--- a/src/coreclr/ToolBox/superpmi/superpmi/jitinstance.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi/jitinstance.h
@@ -60,7 +60,7 @@ public:
 
     bool resetConfig(MethodContext* firstContext);
 
-    Result CompileMethod(MethodContext* MethodToCompile, int mcIndex, bool collectThroughput);
+    Result CompileMethod(MethodContext* MethodToCompile, int mcIndex, bool collectThroughput, class MetricsSummary* summary);
 
     const WCHAR* getForceOption(const WCHAR* key);
     const WCHAR* getOption(const WCHAR* key);

--- a/src/coreclr/ToolBox/superpmi/superpmi/methodstatsemitter.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi/methodstatsemitter.h
@@ -24,4 +24,5 @@ public:
     void Emit(int methodNumber, MethodContext* mc, ULONGLONG firstTime, ULONGLONG secondTime);
     void SetStatsTypes(char* types);
 };
+
 #endif

--- a/src/coreclr/ToolBox/superpmi/superpmi/metricssummary.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/metricssummary.cpp
@@ -44,7 +44,7 @@ bool MetricsSummary::SaveToFile(const char* path)
         sprintf_s(buffer, sizeof(buffer), "Successful compiles,Failing compiles,Code bytes\n%d,%d,%lld\n",
             SuccessfulCompiles, FailingCompiles, NumCodeBytes);
     DWORD numWritten;
-    if (!WriteFile(file.get(), buffer, static_cast<DWORD>(len), &numWritten, nullptr) || numWritten != len)
+    if (!WriteFile(file.get(), buffer, static_cast<DWORD>(len), &numWritten, nullptr) || numWritten != static_cast<DWORD>(len))
     {
         return false;
     }

--- a/src/coreclr/ToolBox/superpmi/superpmi/metricssummary.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/metricssummary.cpp
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "standardpch.h"
+#include "metricssummary.h"
+#include "logging.h"
+
+#include <fstream>
+#include <inttypes.h>
+
+bool MetricsSummary::SaveToFile(const char* path)
+{
+    FILE* file = fopen(path, "w");
+    if (file == nullptr)
+    {
+        return false;
+    }
+
+    fprintf(file, "Successful compiles,Failing compiles,Code bytes\n");
+    fprintf(file, "%d,%d,%" PRId64 "\n", SuccessfulCompiles, FailingCompiles, NumCodeBytes);
+    fclose(file);
+    return true;
+}
+
+bool MetricsSummary::LoadFromFile(const char* path, MetricsSummary* result)
+{
+    FILE* file = fopen(path, "r");
+    if (file == nullptr)
+    {
+        return false;
+    }
+
+    fscanf(file, "Successful compiles,Failing compiles,Code bytes\n");
+    if (fscanf(file, "%d,%d,%" SCNd64 "\n", &result->SuccessfulCompiles, &result->FailingCompiles, &result->NumCodeBytes) != 3)
+    {
+        return false;
+    }
+
+    fclose(file);
+    return true;
+}
+
+void MetricsSummary::AggregateFrom(const MetricsSummary& other)
+{
+    SuccessfulCompiles += other.SuccessfulCompiles;
+    FailingCompiles += other.FailingCompiles;
+    NumCodeBytes += other.NumCodeBytes;
+}

--- a/src/coreclr/ToolBox/superpmi/superpmi/metricssummary.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi/metricssummary.h
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#ifndef _MetricsSummary
+#define _MetricsSummary
+
+class MetricsSummary
+{
+public:
+    int SuccessfulCompiles;
+    int FailingCompiles;
+    int64_t NumCodeBytes;
+
+    MetricsSummary()
+        : SuccessfulCompiles(0)
+        , FailingCompiles(0)
+        , NumCodeBytes(0)
+    {
+    }
+
+    bool SaveToFile(const char* path);
+    static bool LoadFromFile(const char* path, MetricsSummary* result);
+    void AggregateFrom(const MetricsSummary& other);
+};
+
+#endif

--- a/src/coreclr/ToolBox/superpmi/superpmi/metricssummary.h
+++ b/src/coreclr/ToolBox/superpmi/superpmi/metricssummary.h
@@ -9,7 +9,7 @@ class MetricsSummary
 public:
     int SuccessfulCompiles;
     int FailingCompiles;
-    int64_t NumCodeBytes;
+    long long NumCodeBytes;
 
     MetricsSummary()
         : SuccessfulCompiles(0)
@@ -19,7 +19,7 @@ public:
     }
 
     bool SaveToFile(const char* path);
-    static bool LoadFromFile(const char* path, MetricsSummary* result);
+    static bool LoadFromFile(const char* path, MetricsSummary* metrics);
     void AggregateFrom(const MetricsSummary& other);
 };
 

--- a/src/coreclr/ToolBox/superpmi/superpmi/parallelsuperpmi.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/parallelsuperpmi.cpp
@@ -8,6 +8,7 @@
 #include "lightweightmap.h"
 #include "commandline.h"
 #include "errorhandling.h"
+#include "metricssummary.h"
 
 #define MAX_LOG_LINE_SIZE 0x1000 // 4 KB
 
@@ -293,6 +294,35 @@ Cleanup:
     }
 }
 
+static bool ProcessChildMetrics(const char* baseMetricsSummaryPath, const char* diffMetricsSummaryPath, MetricsSummary* baseMetrics, MetricsSummary* diffMetrics)
+{
+    if (baseMetricsSummaryPath != nullptr)
+    {
+        MetricsSummary childBaseMetrics;
+        if (!MetricsSummary::LoadFromFile(baseMetricsSummaryPath, &childBaseMetrics))
+        {
+            LogError("Couldn't load base metrics summary created by child process");
+            return false;
+        }
+
+        baseMetrics->AggregateFrom(childBaseMetrics);
+    }
+
+    if (diffMetricsSummaryPath != nullptr)
+    {
+        MetricsSummary childDiffMetrics;
+        if (!MetricsSummary::LoadFromFile(diffMetricsSummaryPath, &childDiffMetrics))
+        {
+            LogError("Couldn't load diff metrics summary created by child process");
+            return false;
+        }
+
+        diffMetrics->AggregateFrom(childDiffMetrics);
+    }
+
+    return true;
+}
+
 #ifndef TARGET_UNIX // TODO-Porting: handle Ctrl-C signals gracefully on Unix
 BOOL WINAPI CtrlHandler(DWORD fdwCtrlType)
 {
@@ -309,15 +339,39 @@ int __cdecl compareInt(const void* arg1, const void* arg2)
     return (*(const int*)arg1) - (*(const int*)arg2);
 }
 
-// 'arrWorkerMCLPath' is an array of strings of size 'workerCount'.
-void MergeWorkerMCLs(char* mclFilename, char** arrWorkerMCLPath, int workerCount)
+struct PerWorkerData
+{
+    HANDLE hStdOutput;
+    HANDLE hStdError;
+
+    char* failingMCListPath;
+    char* diffMCListPath;
+    char* stdOutputPath;
+    char* stdErrorPath;
+    char* baseMetricsSummaryPath;
+    char* diffMetricsSummaryPath;
+
+    PerWorkerData()
+        : hStdOutput(INVALID_HANDLE_VALUE)
+        , hStdError(INVALID_HANDLE_VALUE)
+        , failingMCListPath(nullptr)
+        , diffMCListPath(nullptr)
+        , stdOutputPath(nullptr)
+        , stdErrorPath(nullptr)
+        , baseMetricsSummaryPath(nullptr)
+        , diffMetricsSummaryPath(nullptr)
+    {
+    }
+};
+
+void MergeWorkerMCLs(char* mclFilename, PerWorkerData* workerData, int workerCount, char* PerWorkerData::*mclPath)
 {
     int **MCL = new int *[workerCount], *MCLCount = new int[workerCount], totalCount = 0;
 
     for (int i = 0; i < workerCount; i++)
     {
         // Read the next partial MCL file
-        ReadMCLToArray(arrWorkerMCLPath[i], &MCL[i], &MCLCount[i]);
+        ReadMCLToArray(workerData[i].*mclPath, &MCL[i], &MCLCount[i]);
 
         totalCount += MCLCount[i];
     }
@@ -474,14 +528,7 @@ int doParallelSuperPMI(CommandLine::Options& o)
         LogVerbose(" diffMCLFilename=%s", o.diffMCLFilename);
     LogVerbose(" workerCount=%d, skipCleanup=%d.", o.workerCount, o.skipCleanup);
 
-    HANDLE* hProcesses = new HANDLE[o.workerCount];
-    HANDLE* hStdOutput = new HANDLE[o.workerCount];
-    HANDLE* hStdError  = new HANDLE[o.workerCount];
-
-    char** arrFailingMCListPath = new char*[o.workerCount];
-    char** arrDiffMCListPath    = new char*[o.workerCount];
-    char** arrStdOutputPath     = new char*[o.workerCount];
-    char** arrStdErrorPath      = new char*[o.workerCount];
+    PerWorkerData* perWorkerData = new PerWorkerData[o.workerCount];
 
     // Add a random number to the temporary file names to allow multiple parallel SuperPMI to happen at once.
     unsigned int randNumber = 0;
@@ -493,51 +540,71 @@ int doParallelSuperPMI(CommandLine::Options& o)
 
     for (int i = 0; i < o.workerCount; i++)
     {
+        PerWorkerData& wd = perWorkerData[i];
         if (o.mclFilename != nullptr)
         {
-            arrFailingMCListPath[i] = new char[MAX_PATH];
-            sprintf_s(arrFailingMCListPath[i], MAX_PATH, "%sParallelSuperPMI-%u-%d.mcl", tempPath, randNumber, i);
-        }
-        else
-        {
-            arrFailingMCListPath[i] = nullptr;
+            wd.failingMCListPath = new char[MAX_PATH];
+            sprintf_s(wd.failingMCListPath, MAX_PATH, "%sParallelSuperPMI-%u-%d.mcl", tempPath, randNumber, i);
         }
 
         if (o.diffMCLFilename != nullptr)
         {
-            arrDiffMCListPath[i] = new char[MAX_PATH];
-            sprintf_s(arrDiffMCListPath[i], MAX_PATH, "%sParallelSuperPMI-Diff-%u-%d.mcl", tempPath, randNumber, i);
+            wd.diffMCListPath = new char[MAX_PATH];
+            sprintf_s(wd.diffMCListPath, MAX_PATH, "%sParallelSuperPMI-Diff-%u-%d.mcl", tempPath, randNumber, i);
         }
-        else
+
+        if (o.baseMetricsSummaryFile != nullptr)
         {
-            arrDiffMCListPath[i] = nullptr;
+            wd.baseMetricsSummaryPath = new char[MAX_PATH];
+            sprintf_s(wd.baseMetricsSummaryPath, MAX_PATH, "%sParallelSuperPMI-BaseMetricsSummary-%u-%d.txt", tempPath, randNumber, i);
         }
 
-        arrStdOutputPath[i] = new char[MAX_PATH];
-        arrStdErrorPath[i]  = new char[MAX_PATH];
+        if (o.diffMetricsSummaryFile != nullptr)
+        {
+            wd.diffMetricsSummaryPath = new char[MAX_PATH];
+            sprintf_s(wd.diffMetricsSummaryPath, MAX_PATH, "%sParallelSuperPMI-DiffMetricsSummary-%u-%d.txt", tempPath, randNumber, i);
+        }
 
-        sprintf_s(arrStdOutputPath[i], MAX_PATH, "%sParallelSuperPMI-stdout-%u-%d.txt", tempPath, randNumber, i);
-        sprintf_s(arrStdErrorPath[i], MAX_PATH, "%sParallelSuperPMI-stderr-%u-%d.txt", tempPath, randNumber, i);
+        wd.stdOutputPath = new char[MAX_PATH];
+        wd.stdErrorPath  = new char[MAX_PATH];
+
+        sprintf_s(wd.stdOutputPath, MAX_PATH, "%sParallelSuperPMI-stdout-%u-%d.txt", tempPath, randNumber, i);
+        sprintf_s(wd.stdErrorPath, MAX_PATH, "%sParallelSuperPMI-stderr-%u-%d.txt", tempPath, randNumber, i);
     }
 
     char cmdLine[MAX_CMDLINE_SIZE];
     cmdLine[0] = '\0';
     int bytesWritten;
 
+    HANDLE* hProcesses = new HANDLE[o.workerCount];
     for (int i = 0; i < o.workerCount; i++)
     {
         bytesWritten = sprintf_s(cmdLine, MAX_CMDLINE_SIZE, "%s -stride %d %d", spmiFilename, i + 1, o.workerCount);
 
-        if (o.mclFilename != nullptr)
+        PerWorkerData& wd = perWorkerData[i];
+
+        if (wd.failingMCListPath != nullptr)
         {
             bytesWritten += sprintf_s(cmdLine + bytesWritten, MAX_CMDLINE_SIZE - bytesWritten, " -failingMCList %s",
-                                      arrFailingMCListPath[i]);
+                                      wd.failingMCListPath);
         }
 
-        if (o.diffMCLFilename != nullptr)
+        if (wd.diffMCListPath != nullptr)
         {
             bytesWritten += sprintf_s(cmdLine + bytesWritten, MAX_CMDLINE_SIZE - bytesWritten, " -diffMCList %s",
-                                      arrDiffMCListPath[i]);
+                                      wd.diffMCListPath);
+        }
+
+        if (wd.baseMetricsSummaryPath != nullptr)
+        {
+            bytesWritten += sprintf_s(cmdLine + bytesWritten, MAX_CMDLINE_SIZE - bytesWritten, " -baseMetricsSummary %s",
+                                      wd.baseMetricsSummaryPath);
+        }
+
+        if (wd.diffMetricsSummaryPath != nullptr)
+        {
+            bytesWritten += sprintf_s(cmdLine + bytesWritten, MAX_CMDLINE_SIZE - bytesWritten, " -diffMetricsSummary %s",
+                                      wd.diffMetricsSummaryPath);
         }
 
         if (o.failureLimit > 0)
@@ -553,26 +620,26 @@ int doParallelSuperPMI(CommandLine::Options& o)
         sa.lpSecurityDescriptor = NULL;
         sa.bInheritHandle       = TRUE; // Let newly created stdout/stderr handles be inherited.
 
-        LogDebug("stdout %i=%s", i, arrStdOutputPath[i]);
-        hStdOutput[i] = CreateFileA(arrStdOutputPath[i], GENERIC_WRITE, FILE_SHARE_READ, &sa, CREATE_ALWAYS,
+        LogDebug("stdout %i=%s", i, wd.stdOutputPath);
+        wd.hStdOutput = CreateFileA(wd.stdOutputPath, GENERIC_WRITE, FILE_SHARE_READ, &sa, CREATE_ALWAYS,
                                     FILE_ATTRIBUTE_NORMAL, NULL);
-        if (hStdOutput[i] == INVALID_HANDLE_VALUE)
+        if (wd.hStdOutput == INVALID_HANDLE_VALUE)
         {
-            LogError("Unable to open '%s'. GetLastError()=%u", arrStdOutputPath[i], GetLastError());
+            LogError("Unable to open '%s'. GetLastError()=%u", wd.stdOutputPath, GetLastError());
             return -1;
         }
 
-        LogDebug("stderr %i=%s", i, arrStdErrorPath[i]);
-        hStdError[i] = CreateFileA(arrStdErrorPath[i], GENERIC_WRITE, FILE_SHARE_READ, &sa, CREATE_ALWAYS,
+        LogDebug("stderr %i=%s", i, wd.stdErrorPath);
+        wd.hStdError = CreateFileA(wd.stdErrorPath, GENERIC_WRITE, FILE_SHARE_READ, &sa, CREATE_ALWAYS,
                                    FILE_ATTRIBUTE_NORMAL, NULL);
-        if (hStdError[i] == INVALID_HANDLE_VALUE)
+        if (wd.hStdError == INVALID_HANDLE_VALUE)
         {
-            LogError("Unable to open '%s'. GetLastError()=%u", arrStdErrorPath[i], GetLastError());
+            LogError("Unable to open '%s'. GetLastError()=%u", wd.stdErrorPath, GetLastError());
             return -1;
         }
 
         // Create a SuperPMI worker process and redirect its output to file
-        if (!StartProcess(cmdLine, hStdOutput[i], hStdError[i], &hProcesses[i]))
+        if (!StartProcess(cmdLine, wd.hStdOutput, wd.hStdError, &hProcesses[i]))
         {
             return -1;
         }
@@ -583,8 +650,8 @@ int doParallelSuperPMI(CommandLine::Options& o)
     // Close stdout/stderr
     for (int i = 0; i < o.workerCount; i++)
     {
-        CloseHandle(hStdOutput[i]);
-        CloseHandle(hStdError[i]);
+        CloseHandle(perWorkerData[i].hStdOutput);
+        CloseHandle(perWorkerData[i].hStdError);
     }
 
     SpmiResult result = SpmiResult::Success;
@@ -626,13 +693,18 @@ int doParallelSuperPMI(CommandLine::Options& o)
         bool usageError = false; // variable to flag if we hit a usage error in SuperPMI
 
         int loaded = 0, jitted = 0, failed = 0, excluded = 0, missing = 0, diffs = 0;
+        MetricsSummary baseMetrics;
+        MetricsSummary diffMetrics;
 
         // Read the stderr files and log them as errors
         // Read the stdout files and parse them for counts and log any MISSING or ISSUE errors
         for (int i = 0; i < o.workerCount; i++)
         {
-            ProcessChildStdErr(arrStdErrorPath[i]);
-            ProcessChildStdOut(o, arrStdOutputPath[i], &loaded, &jitted, &failed, &excluded, &missing, &diffs, &usageError);
+            PerWorkerData& wd = perWorkerData[i];
+            ProcessChildStdErr(wd.stdErrorPath);
+            ProcessChildStdOut(o, wd.stdOutputPath, &loaded, &jitted, &failed, &excluded, &missing, &diffs, &usageError);
+            ProcessChildMetrics(wd.baseMetricsSummaryPath, wd.diffMetricsSummaryPath, &baseMetrics, &diffMetrics);
+
             if (usageError)
                 break;
         }
@@ -640,13 +712,23 @@ int doParallelSuperPMI(CommandLine::Options& o)
         if (o.mclFilename != nullptr && !usageError)
         {
             // Concat the resulting .mcl files
-            MergeWorkerMCLs(o.mclFilename, arrFailingMCListPath, o.workerCount);
+            MergeWorkerMCLs(o.mclFilename, perWorkerData, o.workerCount, &PerWorkerData::failingMCListPath);
         }
 
         if (o.diffMCLFilename != nullptr && !usageError)
         {
             // Concat the resulting diff .mcl files
-            MergeWorkerMCLs(o.diffMCLFilename, arrDiffMCListPath, o.workerCount);
+            MergeWorkerMCLs(o.diffMCLFilename, perWorkerData, o.workerCount, &PerWorkerData::diffMCListPath);
+        }
+
+        if (o.baseMetricsSummaryFile != nullptr && !usageError)
+        {
+            baseMetrics.SaveToFile(o.baseMetricsSummaryFile);
+        }
+
+        if (o.diffMetricsSummaryFile != nullptr && !usageError)
+        {
+            diffMetrics.SaveToFile(o.diffMetricsSummaryFile);
         }
 
         if (!usageError)
@@ -670,16 +752,25 @@ int doParallelSuperPMI(CommandLine::Options& o)
         // Delete all temporary files generated
         for (int i = 0; i < o.workerCount; i++)
         {
-            if (arrFailingMCListPath[i] != nullptr)
+            PerWorkerData& wd = perWorkerData[i];
+            if (wd.failingMCListPath != nullptr)
             {
-                DeleteFile(arrFailingMCListPath[i]);
+                DeleteFile(wd.failingMCListPath);
             }
-            if (arrDiffMCListPath[i] != nullptr)
+            if (wd.diffMCListPath != nullptr)
             {
-                DeleteFile(arrDiffMCListPath[i]);
+                DeleteFile(wd.diffMCListPath);
             }
-            DeleteFile(arrStdOutputPath[i]);
-            DeleteFile(arrStdErrorPath[i]);
+            if (wd.baseMetricsSummaryPath != nullptr)
+            {
+                DeleteFile(wd.baseMetricsSummaryPath);
+            }
+            if (wd.diffMetricsSummaryPath != nullptr)
+            {
+                DeleteFile(wd.diffMetricsSummaryPath);
+            }
+            DeleteFile(wd.stdOutputPath);
+            DeleteFile(wd.stdErrorPath);
         }
     }
 

--- a/src/coreclr/ToolBox/superpmi/superpmi/superpmi.cpp
+++ b/src/coreclr/ToolBox/superpmi/superpmi/superpmi.cpp
@@ -18,6 +18,7 @@
 #include "mclist.h"
 #include "methodstatsemitter.h"
 #include "spmiutil.h"
+#include "metricssummary.h"
 
 extern int doParallelSuperPMI(CommandLine::Options& o);
 
@@ -264,6 +265,9 @@ int __cdecl main(int argc, char* argv[])
         }
     }
 
+    MetricsSummary baseMetrics;
+    MetricsSummary diffMetrics;
+
     while (true)
     {
         MethodContextBuffer mcb = reader->GetNextMethodContext();
@@ -360,7 +364,7 @@ int __cdecl main(int argc, char* argv[])
 
         jittedCount++;
         st3.Start();
-        res = jit->CompileMethod(mc, reader->GetMethodContextIndex(), collectThroughput);
+        res = jit->CompileMethod(mc, reader->GetMethodContextIndex(), collectThroughput, &baseMetrics);
         st3.Stop();
         LogDebug("Method %d compiled in %fms, result %d", reader->GetMethodContextIndex(), st3.GetMilliseconds(), res);
 
@@ -378,7 +382,7 @@ int __cdecl main(int argc, char* argv[])
             mc->cr = new CompileResult();
 
             st4.Start();
-            res2 = jit2->CompileMethod(mc, reader->GetMethodContextIndex(), collectThroughput);
+            res2 = jit2->CompileMethod(mc, reader->GetMethodContextIndex(), collectThroughput, &diffMetrics);
             st4.Stop();
             LogDebug("Method %d compiled by JIT2 in %fms, result %d", reader->GetMethodContextIndex(),
                      st4.GetMilliseconds(), res2);
@@ -602,6 +606,16 @@ int __cdecl main(int argc, char* argv[])
 
     st2.Stop();
     LogVerbose("Total time: %fms", st2.GetMilliseconds());
+
+    if (o.baseMetricsSummaryFile != nullptr)
+    {
+        baseMetrics.SaveToFile(o.baseMetricsSummaryFile);
+    }
+
+    if (o.diffMetricsSummaryFile != nullptr)
+    {
+        diffMetrics.SaveToFile(o.diffMetricsSummaryFile);
+    }
 
     if (methodStatsEmitter != nullptr)
     {

--- a/src/coreclr/inc/clr_std/vector
+++ b/src/coreclr/inc/clr_std/vector
@@ -373,6 +373,11 @@ namespace std
                 m_size -= elements;
                 return iterator(m_pelements + (position - begin()));
             }
+            
+            T* data()
+            {
+                return m_pelements;
+            }
 
             const T* data() const
             {


### PR DESCRIPTION
Currently the total code bytes shown for the base/diff is misleading
when SPMI is used because SPMI generates only .dasm files for method
contexts with diffs. This change:

* Adds -baseMetricsSummary and -diffMetricsSummary to SPMI, which
  specifies a file path to output metrics. Currently that's just the
  number of failing/succeeding compiles, and the total number of code
  bytes, but the hope is to use this for other metrics as well.
* Adds --override-total-base-metric and --override-total-diff-metric to
  jit-analyze, to support overriding the computed total base and total
  diff metric, since they are misleading when .dasm files are only
  created for differences
* Supports this from the superpmi.py wrapper script for asmdiffs when no
  explicit metric is provided: in this case, the script will get the
  metrics from SPMI and pass them to jit-analyze to override the
  computed totals.

The net result is that the displayed results from jit-analyze after SPMI
runs are less misleading and should be more comparable to similar PMI
runs.