### PR TITLE
Loop Alignment support for Arm64

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2096,10 +2096,6 @@ void CodeGen::genGenerateCode(void** codePtr, uint32_t* nativeSizeOfCode)
     this->codePtr          = codePtr;
     this->nativeSizeOfCode = nativeSizeOfCode;
 
-#ifdef TARGET_ARM64
-    compiler->verbose = true;
-#endif
-
     DoPhase(this, PHASE_GENERATE_CODE, &CodeGen::genGenerateMachineCode);
     DoPhase(this, PHASE_EMIT_CODE, &CodeGen::genEmitMachineCode);
     DoPhase(this, PHASE_EMIT_GCEH, &CodeGen::genEmitUnwindDebugGCandEH);

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2096,6 +2096,10 @@ void CodeGen::genGenerateCode(void** codePtr, uint32_t* nativeSizeOfCode)
     this->codePtr          = codePtr;
     this->nativeSizeOfCode = nativeSizeOfCode;
 
+#ifdef TARGET_ARM64
+    compiler->verbose = true;
+#endif
+
     DoPhase(this, PHASE_GENERATE_CODE, &CodeGen::genGenerateMachineCode);
     DoPhase(this, PHASE_EMIT_CODE, &CodeGen::genEmitMachineCode);
     DoPhase(this, PHASE_EMIT_GCEH, &CodeGen::genEmitUnwindDebugGCandEH);

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2647,6 +2647,7 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
     opts.compJitAlignLoopMaxCodeSize    = DEFAULT_MAX_LOOPSIZE_FOR_ALIGN;
 #endif
 
+#ifdef TARGET_XARCH
     if (opts.compJitAlignLoopAdaptive)
     {
         opts.compJitAlignPaddingLimit = (opts.compJitAlignLoopBoundary >> 1) - 1;
@@ -2655,8 +2656,17 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
     {
         opts.compJitAlignPaddingLimit = opts.compJitAlignLoopBoundary - 1;
     }
+#elif TARGET_ARM64
+    // Since instructions of Arm64 are in multiple of 4, just have one padding limit
+    // for adaptive and non-adaptive alignment.
+    opts.compJitAlignPaddingLimit = (opts.compJitAlignLoopBoundary >> 1);
+#endif
 
     assert(isPow2(opts.compJitAlignLoopBoundary));
+#ifdef TARGET_ARM64
+    // The minimum encoding size for Arm64 is 4 bytes.
+    assert(opts.compJitAlignLoopBoundary >= 4);
+#endif
 
 #if REGEN_SHORTCUTS || REGEN_CALLPAT
     // We never want to have debugging enabled when regenerating GC encoding patterns

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2650,19 +2650,26 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
 #ifdef TARGET_XARCH
     if (opts.compJitAlignLoopAdaptive)
     {
+        // For adaptive alignment, padding limit is equal to the max instruction encoding
+        // size which is 15 bytes. Hence (32 >> 1) - 1 = 15 bytes.
         opts.compJitAlignPaddingLimit = (opts.compJitAlignLoopBoundary >> 1) - 1;
     }
     else
     {
+        // For non-adaptive alignment, padding limit is 1 less than the alignment boundary
+        // specified.
         opts.compJitAlignPaddingLimit = opts.compJitAlignLoopBoundary - 1;
     }
 #elif TARGET_ARM64
     if (opts.compJitAlignLoopAdaptive)
     {
+        // For adaptive alignment, padding limit is same as specified by the alignment
+        // boundary because all instructions are 4 bytes long. Hence (32 >> 1) = 16 bytes.
         opts.compJitAlignPaddingLimit = (opts.compJitAlignLoopBoundary >> 1);
     }
     else
     {
+        // For non-adaptive, padding limit is same as specified by the alignment.
         opts.compJitAlignPaddingLimit = opts.compJitAlignLoopBoundary;
     }
 #endif

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2657,9 +2657,14 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
         opts.compJitAlignPaddingLimit = opts.compJitAlignLoopBoundary - 1;
     }
 #elif TARGET_ARM64
-    // Since instructions of Arm64 are in multiple of 4, just have one padding limit
-    // for adaptive and non-adaptive alignment.
-    opts.compJitAlignPaddingLimit = (opts.compJitAlignLoopBoundary >> 1);
+    if (opts.compJitAlignLoopAdaptive)
+    {
+        opts.compJitAlignPaddingLimit = (opts.compJitAlignLoopBoundary >> 1);
+    }
+    else
+    {
+        opts.compJitAlignPaddingLimit = opts.compJitAlignLoopBoundary;
+    }
 #endif
 
     assert(isPow2(opts.compJitAlignLoopBoundary));

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -4844,7 +4844,7 @@ void emitter::emitLongLoopAlign(unsigned short alignmentBoundary)
 #elif defined(TARGET_ARM64)
     unsigned short nAlignInstr   = alignmentBoundary / INSTR_ENCODED_SIZE;
     unsigned short insAlignCount = nAlignInstr;
-    unsigned short paddingBytes = INSTR_ENCODED_SIZE;
+    unsigned short paddingBytes  = INSTR_ENCODED_SIZE;
 #endif
 
     unsigned short instrDescSize = nAlignInstr * sizeof(instrDescAlign);

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -4810,10 +4810,9 @@ void emitter::emitLoopAlign(unsigned short paddingBytes)
 
 #if defined(TARGET_XARCH)
     assert(paddingBytes <= MAX_ENCODED_SIZE);
-    paddingBytes       = min(paddingBytes, MAX_ENCODED_SIZE); // We may need to skip up to 15 bytes of code
     id->idCodeSize(paddingBytes);
 #elif defined(TARGET_ARM64)
-    assert(paddingBytes % INSTR_ENCODED_SIZE == 0);
+    assert(paddingBytes == INSTR_ENCODED_SIZE);
 #endif  
     
     id->idaIG = emitCurIG;

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -4797,6 +4797,35 @@ AGAIN:
 #if FEATURE_LOOP_ALIGN
 
 //-----------------------------------------------------------------------------
+//
+//  The next instruction will be a loop head entry point
+//  So insert an alignment instruction here to ensure that
+//  we can properly align the code.
+//
+void emitter::emitLoopAlign(unsigned short paddingBytes)
+{
+    /* Insert a pseudo-instruction to ensure that we align
+       the next instruction properly */
+    instrDescAlign* id = emitNewInstrAlign();
+
+#if defined(TARGET_XARCH)
+    assert(paddingBytes <= MAX_ENCODED_SIZE);
+    paddingBytes       = min(paddingBytes, MAX_ENCODED_SIZE); // We may need to skip up to 15 bytes of code
+    id->idCodeSize(paddingBytes);
+#elif defined(TARGET_ARM64)
+    assert(paddingBytes % MAX1_ENCODED_SIZE == 0);
+#endif  
+    
+    id->idaIG = emitCurIG;
+
+    /* Append this instruction to this IG's alignment list */
+    id->idaNext = emitCurIGAlignList;
+
+    emitCurIGsize += paddingBytes;
+    emitCurIGAlignList = id;
+}
+
+//-----------------------------------------------------------------------------
 // emitLoopAlignment: Insert an align instruction at the end of emitCurIG and
 //                    mark it as IGF_LOOP_ALIGN to indicate that next IG  is a
 //                    loop needing alignment.
@@ -4805,6 +4834,7 @@ void emitter::emitLoopAlignment()
 {
     unsigned short paddingBytes;
 
+#if defined(TARGET_XARCH)
     if ((emitComp->opts.compJitAlignLoopBoundary > 16) && (!emitComp->opts.compJitAlignLoopAdaptive))
     {
         paddingBytes = emitComp->opts.compJitAlignLoopBoundary;
@@ -4815,6 +4845,17 @@ void emitter::emitLoopAlignment()
         paddingBytes = MAX_ENCODED_SIZE;
         emitLoopAlign(paddingBytes);
     }
+#elif defined(TARGET_ARM64)
+    if (emitComp->opts.compJitAlignLoopAdaptive)
+    {
+        paddingBytes = emitComp->opts.compJitAlignLoopBoundary >> 1;
+    }
+    else
+    {
+        paddingBytes = emitComp->opts.compJitAlignLoopBoundary;
+    }
+    emitLongLoopAlign(paddingBytes);
+#endif
 
     // Mark this IG as need alignment so during emitter we can check the instruction count heuristics of
     // all IGs that follows this IG and participate in a loop.
@@ -5126,26 +5167,42 @@ void emitter::emitLoopAlignAdjustments()
                 alignIG->igFlags &= ~IGF_LOOP_ALIGN;
             }
 
+#ifdef TARGET_XARCH
             if (emitComp->opts.compJitAlignLoopAdaptive)
             {
                 assert(actualPaddingNeeded < MAX_ENCODED_SIZE);
                 alignInstr->idCodeSize(actualPaddingNeeded);
             }
             else
+#endif
             {
                 unsigned paddingToAdj = actualPaddingNeeded;
 
 #ifdef DEBUG
+#if defined(TARGET_XARCH)
                 int instrAdjusted =
                     (emitComp->opts.compJitAlignLoopBoundary + (MAX_ENCODED_SIZE - 1)) / MAX_ENCODED_SIZE;
-#endif
+#elif defined(TARGET_ARM64)
+                unsigned short instrAdjusted = (emitComp->opts.compJitAlignLoopBoundary >> 1) / MAX1_ENCODED_SIZE;
+#endif  // TARGET_XARCH
+#endif  // DEBUG
                 // Adjust the padding amount in all align instructions in this IG
                 instrDescAlign *alignInstrToAdj = alignInstr, *prevAlignInstr = nullptr;
                 for (; alignInstrToAdj != nullptr && alignInstrToAdj->idaIG == alignInstr->idaIG;
                      alignInstrToAdj = alignInstrToAdj->idaNext)
                 {
-                    unsigned newPadding = min(paddingToAdj, MAX_ENCODED_SIZE);
+                    
+#if defined(TARGET_XARCH)
+                    unsigned newPadding = min(paddingToAdj, MAX_ENCODED_SIZE); //TODO: Move this outside ifdef once MAX_ENCODED_SIZE is same for arm64
                     alignInstrToAdj->idCodeSize(newPadding);
+#elif defined(TARGET_ARM64)
+                    unsigned newPadding = min(paddingToAdj, MAX1_ENCODED_SIZE); // TODO: Move this outside ifdef once
+                                                                               // MAX_ENCODED_SIZE is same for arm64
+                    if (newPadding == 0)
+                    {
+                        alignInstrToAdj->idInsOpt(INS_OPTS_NONE);
+                    }
+#endif
                     paddingToAdj -= newPadding;
                     prevAlignInstr = alignInstrToAdj;
 #ifdef DEBUG
@@ -5191,7 +5248,7 @@ void emitter::emitLoopAlignAdjustments()
 }
 
 //-----------------------------------------------------------------------------
-//  emitCalculatePaddingForLoopAlignment: Calculate the padding to insert at the
+//  emitCalculatePaddingForLoopAlignment: Calculate the padding amount to insert at the
 //    end of 'ig' so the loop that starts after 'ig' is aligned.
 //
 //  Arguments:
@@ -5268,16 +5325,25 @@ unsigned emitter::emitCalculatePaddingForLoopAlignment(insGroup* ig, size_t offs
     if (emitComp->opts.compJitAlignLoopAdaptive)
     {
         // adaptive loop alignment
-        unsigned nMaxPaddingBytes = (1 << (maxLoopBlocksAllowed - minBlocksNeededForLoop + 1)) - 1;
+        unsigned nMaxPaddingBytes = (1 << (maxLoopBlocksAllowed - minBlocksNeededForLoop + 1));
+#ifdef TARGET_XARCH
+        // Max padding for adaptive alignment has alignmentBoundary of 32 bytes with
+        // max padding limit of 15 bytes ((alignmentBoundary >> 1) - 1)
+        nMaxPaddingBytes -= 1;
+#endif
         unsigned nPaddingBytes    = (-(int)(size_t)offset) & (alignmentBoundary - 1);
 
         // Check if the alignment exceeds maxPadding limit
         if (nPaddingBytes > nMaxPaddingBytes)
         {
+#ifdef TARGET_XARCH
             // Cannot align to 32B, so try to align to 16B boundary.
+            // Only applicable for xarch since for arm64, it is recommended to align at
+            // 32B only.
             alignmentBoundary >>= 1;
             nMaxPaddingBytes = 1 << (maxLoopBlocksAllowed - minBlocksNeededForLoop + 1);
             nPaddingBytes    = (-(int)(size_t)offset) & (alignmentBoundary - 1);
+#endif
 
             // Check if the loop is already at new alignment boundary
             if (nPaddingBytes == 0)
@@ -5705,6 +5771,7 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
     memset(&args, 0, sizeof(args));
 
 #ifdef TARGET_ARM64
+
     // For arm64, we want to allocate JIT data always adjacent to code similar to what native compiler does.
     // This way allows us to use a single `ldr` to access such data like float constant/jmp table.
     if (emitTotalColdCodeSize > 0)

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -4813,8 +4813,8 @@ void emitter::emitLoopAlign(unsigned short paddingBytes)
     id->idCodeSize(paddingBytes);
 #elif defined(TARGET_ARM64)
     assert(paddingBytes == INSTR_ENCODED_SIZE);
-#endif  
-    
+#endif
+
     id->idaIG = emitCurIG;
 
     /* Append this instruction to this IG's alignment list */
@@ -5182,20 +5182,19 @@ void emitter::emitLoopAlignAdjustments()
                 int instrAdjusted =
                     (emitComp->opts.compJitAlignLoopBoundary + (MAX_ENCODED_SIZE - 1)) / MAX_ENCODED_SIZE;
 #elif defined(TARGET_ARM64)
-                unsigned short instrAdjusted = (emitComp->opts.compJitAlignLoopBoundary >> 1) /
-                                                       INSTR_ENCODED_SIZE;
+                unsigned short instrAdjusted = (emitComp->opts.compJitAlignLoopBoundary >> 1) / INSTR_ENCODED_SIZE;
                 if (!emitComp->opts.compJitAlignLoopAdaptive)
                 {
                     instrAdjusted = emitComp->opts.compJitAlignLoopBoundary / INSTR_ENCODED_SIZE;
                 }
-#endif  // TARGET_XARCH & TARGET_ARM64
-#endif  // DEBUG
+#endif // TARGET_XARCH & TARGET_ARM64
+#endif // DEBUG
                 // Adjust the padding amount in all align instructions in this IG
                 instrDescAlign *alignInstrToAdj = alignInstr, *prevAlignInstr = nullptr;
                 for (; alignInstrToAdj != nullptr && alignInstrToAdj->idaIG == alignInstr->idaIG;
                      alignInstrToAdj = alignInstrToAdj->idaNext)
                 {
-                    
+
 #if defined(TARGET_XARCH)
                     unsigned newPadding = min(paddingToAdj, MAX_ENCODED_SIZE);
                     alignInstrToAdj->idCodeSize(newPadding);
@@ -5334,7 +5333,7 @@ unsigned emitter::emitCalculatePaddingForLoopAlignment(insGroup* ig, size_t offs
         // max padding limit of 15 bytes ((alignmentBoundary >> 1) - 1)
         nMaxPaddingBytes -= 1;
 #endif
-        unsigned nPaddingBytes    = (-(int)(size_t)offset) & (alignmentBoundary - 1);
+        unsigned nPaddingBytes = (-(int)(size_t)offset) & (alignmentBoundary - 1);
 
         // Check if the alignment exceeds maxPadding limit
         if (nPaddingBytes > nMaxPaddingBytes)

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -583,7 +583,7 @@ protected:
         instruction _idIns : 10;
 #define MAX_ENCODED_SIZE 15
 #elif defined(TARGET_ARM64)
-#define MAX1_ENCODED_SIZE 4
+#define INSTR_ENCODED_SIZE 4
         static_assert_no_msg(INS_count <= 512);
         instruction _idIns : 9;
 #else  // !(defined(TARGET_XARCH) || defined(TARGET_ARM64))

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -583,6 +583,7 @@ protected:
         instruction _idIns : 10;
 #define MAX_ENCODED_SIZE 15
 #elif defined(TARGET_ARM64)
+#define MAX1_ENCODED_SIZE 4
         static_assert_no_msg(INS_count <= 512);
         instruction _idIns : 9;
 #else  // !(defined(TARGET_XARCH) || defined(TARGET_ARM64))
@@ -890,6 +891,12 @@ protected:
         }
 
 #elif defined(TARGET_ARM64)
+
+        inline bool idIsEmptyAlign() const
+        {
+            return (idIns() == INS_align) && (idInsOpt() == INS_OPTS_NONE);
+        }
+
         unsigned idCodeSize() const
         {
             int size = 4;
@@ -911,6 +918,12 @@ protected:
                     {
                         // adrp + ldr
                         size = 8;
+                    }
+                    break;
+                case IF_SN_0A:
+                    if (idIsEmptyAlign())
+                    {
+                        size = 0;
                     }
                     break;
                 default:
@@ -1371,7 +1384,11 @@ protected:
         instrDescAlign* idaNext; // next align in the group/method
         insGroup*       idaIG;   // containing group
     };
-#endif
+
+    void emitLoopAlign(unsigned short paddingBytes);
+    void emitLongLoopAlign(unsigned short alignmentBoundary);
+
+#endif // FEATURE_LOOP_ALIGN
 
 #if !defined(TARGET_ARM64) // This shouldn't be needed for ARM32, either, but I don't want to touch the ARM32 JIT.
     struct instrDescLbl : instrDescJmp
@@ -2569,6 +2586,11 @@ inline emitter::instrDescAlign* emitter::emitNewInstrAlign()
 {
     instrDescAlign* newInstr = emitAllocInstrAlign();
     newInstr->idIns(INS_align);
+
+#ifdef TARGET_ARM64
+    newInstr->idInsFmt(IF_SN_0A);
+    newInstr->idInsOpt(INS_OPTS_ALIGN);
+#endif
     return newInstr;
 }
 #endif

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -81,6 +81,38 @@ const emitJumpKind emitReverseJumpKinds[] = {
     return emitReverseJumpKinds[jumpKind];
 }
 
+#if FEATURE_LOOP_ALIGN
+//-----------------------------------------------------------------------------
+//
+//  The next instruction will be a loop head entry point
+//  So insert alignment instruction(s) here to ensure that
+//  we can properly align the code.
+//
+//  This emits more than one `INS_align` instruction depending on the
+//  alignmentBoundary parameter.
+//
+void emitter::emitLongLoopAlign(unsigned short alignmentBoundary)
+{
+    unsigned short nAlignInstr   = alignmentBoundary / MAX1_ENCODED_SIZE;
+    unsigned short instrDescSize = nAlignInstr * sizeof(instrDescAlign);
+
+    // Ensure that all align instructions fall in same IG.
+    if (emitCurIGfreeNext + instrDescSize >= emitCurIGfreeEndp)
+    {
+        emitForceNewIG = true;
+    }
+
+    /* Insert a pseudo-instruction to ensure that we align
+    the next instruction properly */
+
+    while (nAlignInstr)
+    {
+        emitLoopAlign(MAX1_ENCODED_SIZE);
+        nAlignInstr--;
+    }
+}
+#endif
+
 /*****************************************************************************
  *
  *  Return the allocated size (in bytes) of the given instruction descriptor.
@@ -138,7 +170,15 @@ size_t emitter::emitSizeOfInsDsc(instrDesc* id)
         if (id->idIsLargeDsp())
             return sizeof(instrDescDsp);
         else
+        {
+#if FEATURE_LOOP_ALIGN
+            if (id->idIns() == INS_align)
+            {
+                return sizeof(instrDescAlign);
+            }
+#endif
             return sizeof(instrDesc);
+        }
     }
 }
 
@@ -11415,9 +11455,39 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             break;
 
         case IF_SN_0A: // SN_0A   ................ ................
-            code = emitInsCode(ins, fmt);
-            dst += emitOutput_Instr(dst, code);
+        {
+            bool skipIns = false;
+#if FEATURE_LOOP_ALIGN
+            if (id->idIns() == INS_align)
+            {
+                // IG can be marked as not needing alignment after emitting align instruction.
+                // Alternatively, there are fewer align instructions needed than emitted.
+                // If that is the case, skip outputting alignment.
+                if (!ig->isLoopAlign() || id->idIsEmptyAlign())
+                {
+                    skipIns = true;
+                }
+
+#ifdef DEBUG
+                if (!ig->isLoopAlign())
+                {
+                    // Validate if the state is correctly updated
+                    assert(id->idIsEmptyAlign());
+                }
+#endif
+                sz  = sizeof(instrDescAlign);
+                ins = INS_nop;
+            }
+#endif // FEATURE_LOOP_ALIGN
+
+            if (!skipIns)
+            {
+                code = emitInsCode(ins, fmt);
+                dst += emitOutput_Instr(dst, code);
+            }
+
             break;
+        }
 
         case IF_SI_0A: // SI_0A   ...........iiiii iiiiiiiiiii.....               imm16
             imm = emitGetInsSC(id);
@@ -11564,7 +11634,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 
     /* All instructions are expected to generate code */
 
-    assert(*dp != dst);
+    assert(*dp != dst || id->idIsEmptyAlign());
 
     *dp = dst;
 

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -93,7 +93,7 @@ const emitJumpKind emitReverseJumpKinds[] = {
 //
 void emitter::emitLongLoopAlign(unsigned short alignmentBoundary)
 {
-    unsigned short nAlignInstr   = alignmentBoundary / MAX1_ENCODED_SIZE;
+    unsigned short nAlignInstr   = alignmentBoundary / INSTR_ENCODED_SIZE;
     unsigned short instrDescSize = nAlignInstr * sizeof(instrDescAlign);
 
     // Ensure that all align instructions fall in same IG.
@@ -107,7 +107,7 @@ void emitter::emitLongLoopAlign(unsigned short alignmentBoundary)
 
     while (nAlignInstr)
     {
-        emitLoopAlign(MAX1_ENCODED_SIZE);
+        emitLoopAlign(INSTR_ENCODED_SIZE);
         nAlignInstr--;
     }
 }
@@ -13354,7 +13354,7 @@ void emitter::emitDispIns(
         case IF_SN_0A: // SN_0A   ................ ................
             if (ins == INS_align)
             {
-                printf("[%d bytes]", id->idIsEmptyAlign() ? 0 : MAX1_ENCODED_SIZE);
+                printf("[%d bytes]", id->idIsEmptyAlign() ? 0 : INSTR_ENCODED_SIZE);
             }
             break;
 

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -13352,6 +13352,10 @@ void emitter::emitDispIns(
             break;
 
         case IF_SN_0A: // SN_0A   ................ ................
+            if (ins == INS_align)
+            {
+                printf("[%d bytes]", id->idIsEmptyAlign() ? 0 : MAX1_ENCODED_SIZE);
+            }
             break;
 
         case IF_SI_0A: // SI_0A   ...........iiiii iiiiiiiiiii.....               imm16

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -81,38 +81,6 @@ const emitJumpKind emitReverseJumpKinds[] = {
     return emitReverseJumpKinds[jumpKind];
 }
 
-#if FEATURE_LOOP_ALIGN
-//-----------------------------------------------------------------------------
-//
-//  The next instruction will be a loop head entry point
-//  So insert alignment instruction(s) here to ensure that
-//  we can properly align the code.
-//
-//  This emits more than one `INS_align` instruction depending on the
-//  alignmentBoundary parameter.
-//
-void emitter::emitLongLoopAlign(unsigned short alignmentBoundary)
-{
-    unsigned short nAlignInstr   = alignmentBoundary / INSTR_ENCODED_SIZE;
-    unsigned short instrDescSize = nAlignInstr * sizeof(instrDescAlign);
-
-    // Ensure that all align instructions fall in same IG.
-    if (emitCurIGfreeNext + instrDescSize >= emitCurIGfreeEndp)
-    {
-        emitForceNewIG = true;
-    }
-
-    /* Insert a pseudo-instruction to ensure that we align
-    the next instruction properly */
-
-    while (nAlignInstr)
-    {
-        emitLoopAlign(INSTR_ENCODED_SIZE);
-        nAlignInstr--;
-    }
-}
-#endif
-
 /*****************************************************************************
  *
  *  Return the allocated size (in bytes) of the given instruction descriptor.

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -14591,8 +14591,17 @@ emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(ins
             break;
 
         case IF_SN_0A: // bkpt, brk, nop
-            result.insThroughput = PERFSCORE_THROUGHPUT_2X;
-            result.insLatency    = PERFSCORE_LATENCY_ZERO;
+            if (id->idIsEmptyAlign())
+            {
+                // We're not going to generate any instruction, so it doesn't count for PerfScore.
+                result.insThroughput = PERFSCORE_THROUGHPUT_ZERO;
+                result.insLatency    = PERFSCORE_LATENCY_ZERO;
+            }
+            else
+            {
+                result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+                result.insLatency    = PERFSCORE_LATENCY_ZERO;
+            }
             break;
 
         case IF_SI_0B: // dmb, dsb, isb

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -2768,40 +2768,6 @@ emitter::instrDesc* emitter::emitNewInstrAmdCns(emitAttr size, ssize_t dsp, int 
     }
 }
 
-//-----------------------------------------------------------------------------
-//
-//  The next instruction will be a loop head entry point
-//  So insert alignment instruction(s) here to ensure that
-//  we can properly align the code.
-//
-//  This emits more than one `INS_align` instruction depending on the
-//  alignmentBoundary parameter.
-//
-void emitter::emitLongLoopAlign(unsigned short alignmentBoundary)
-{
-    unsigned short nPaddingBytes    = alignmentBoundary - 1;
-    unsigned short nAlignInstr      = (nPaddingBytes + (MAX_ENCODED_SIZE - 1)) / MAX_ENCODED_SIZE;
-    unsigned short instrDescSize    = nAlignInstr * sizeof(instrDescAlign);
-    unsigned short insAlignCount    = nPaddingBytes / MAX_ENCODED_SIZE;
-    unsigned short lastInsAlignSize = nPaddingBytes % MAX_ENCODED_SIZE;
-
-    // Ensure that all align instructions fall in same IG.
-    if (emitCurIGfreeNext + instrDescSize >= emitCurIGfreeEndp)
-    {
-        emitForceNewIG = true;
-    }
-
-    /* Insert a pseudo-instruction to ensure that we align
-    the next instruction properly */
-
-    while (insAlignCount)
-    {
-        emitLoopAlign(MAX_ENCODED_SIZE);
-        insAlignCount--;
-    }
-    emitLoopAlign(lastInsAlignSize);
-}
-
 /*****************************************************************************
  *
  *  Add a NOP instruction of the given size.

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -2771,30 +2771,6 @@ emitter::instrDesc* emitter::emitNewInstrAmdCns(emitAttr size, ssize_t dsp, int 
 //-----------------------------------------------------------------------------
 //
 //  The next instruction will be a loop head entry point
-//  So insert an alignment instruction here to ensure that
-//  we can properly align the code.
-//
-void emitter::emitLoopAlign(unsigned short paddingBytes)
-{
-    /* Insert a pseudo-instruction to ensure that we align
-       the next instruction properly */
-
-    assert(paddingBytes <= MAX_ENCODED_SIZE);
-    paddingBytes       = min(paddingBytes, MAX_ENCODED_SIZE); // We may need to skip up to 15 bytes of code
-    instrDescAlign* id = emitNewInstrAlign();
-    id->idCodeSize(paddingBytes);
-    id->idaIG = emitCurIG;
-
-    /* Append this instruction to this IG's alignment list */
-    id->idaNext = emitCurIGAlignList;
-
-    emitCurIGsize += paddingBytes;
-    emitCurIGAlignList = id;
-}
-
-//-----------------------------------------------------------------------------
-//
-//  The next instruction will be a loop head entry point
 //  So insert alignment instruction(s) here to ensure that
 //  we can properly align the code.
 //

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -306,10 +306,6 @@ inline emitAttr emitDecodeScale(unsigned ensz)
 /************************************************************************/
 
 public:
-void emitLoopAlign(unsigned short paddingBytes);
-
-void emitLongLoopAlign(unsigned short alignmentBoundary);
-
 void emitIns(instruction ins);
 
 void emitIns(instruction ins, emitAttr attr);

--- a/src/coreclr/jit/instr.h
+++ b/src/coreclr/jit/instr.h
@@ -220,6 +220,8 @@ enum insOpts : unsigned
 
     INS_OPTS_S_TO_H,      // Single to Half
     INS_OPTS_D_TO_H,      // Double to Half
+
+    INS_OPTS_ALIGN        // Align instruction
 };
 
 enum insCond : unsigned

--- a/src/coreclr/jit/instr.h
+++ b/src/coreclr/jit/instr.h
@@ -219,9 +219,11 @@ enum insOpts : unsigned
     INS_OPTS_H_TO_D,      // Half to Double
 
     INS_OPTS_S_TO_H,      // Single to Half
-    INS_OPTS_D_TO_H,      // Double to Half
+    INS_OPTS_D_TO_H       // Double to Half
 
-    INS_OPTS_ALIGN        // Align instruction
+#if FEATURE_LOOP_ALIGN
+    , INS_OPTS_ALIGN      // Align instruction
+#endif
 };
 
 enum insCond : unsigned

--- a/src/coreclr/jit/instrsarm64.h
+++ b/src/coreclr/jit/instrsarm64.h
@@ -1970,7 +1970,8 @@ INST1(tbx_3regs,   "tbx",          0,      IF_DV_3C,  0x0E005000)
 
 INST1(tbx_4regs,   "tbx",          0,      IF_DV_3C,  0x0E007000)
                                    //  tbx    Vd,{Vn,Vn+1,Vn+2,Vn+3},Vm DV_3C  0Q001110000mmmmm 011100nnnnnddddd   0E00 7000   Vd,Vn,Vm   (vector)
-
+INST1(align,       "align",        0,      IF_SN_0A,  BAD_CODE)
+                                   //  align                          SN_0A
 // clang-format on
 
 /*****************************************************************************/

--- a/src/coreclr/jit/instrsarm64.h
+++ b/src/coreclr/jit/instrsarm64.h
@@ -1970,8 +1970,11 @@ INST1(tbx_3regs,   "tbx",          0,      IF_DV_3C,  0x0E005000)
 
 INST1(tbx_4regs,   "tbx",          0,      IF_DV_3C,  0x0E007000)
                                    //  tbx    Vd,{Vn,Vn+1,Vn+2,Vn+3},Vm DV_3C  0Q001110000mmmmm 011100nnnnnddddd   0E00 7000   Vd,Vn,Vm   (vector)
+
+#if FEATURE_LOOP_ALIGN
 INST1(align,       "align",        0,      IF_SN_0A,  BAD_CODE)
                                    //  align                          SN_0A
+#endif
 // clang-format on
 
 /*****************************************************************************/

--- a/src/coreclr/jit/jit.h
+++ b/src/coreclr/jit/jit.h
@@ -701,7 +701,7 @@ private:
 #define CLFLG_STRUCTPROMOTE 0x00000
 #endif
 
-#ifdef TARGET_XARCH
+#if defined(TARGET_XARCH) || defined(TARGET_ARM64)
 #define FEATURE_LOOP_ALIGN 1
 #else
 #define FEATURE_LOOP_ALIGN 0


### PR DESCRIPTION
Add support for loop alignment for Arm64. This is an extension of adaptive loop alignment work done for xarch in #44370 .

The loop alignment is adaptive and the padding amount will be adjusted based on the number of blocks needed to fit the loop. Since the instruction encoding size for Arm64 is 4 bytes, 4 `NOP` will be added for a loop that can fit in single chunk of 32 bytes, and the padding amount will reduce as the loop size increases.

| Max Pad (bytes) | Minimum 32B blocks needed to fit the loop |
|-----------------|-------------------------------------------|
| 16              | 1 (32 bytes)                              |
| 12              | 2 (64 bytes)                              |
| 8               | 3 (96 bytes)                              |
| 4               | 4 (128 bytes)                             |

Benchmarks windows/arm64 diffs:
```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 221276
Total bytes of diff: 223752
Total bytes of delta: 2476 (1.12% of base)
Total relative delta: 9.88
    diff is a regression.
    relative diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          48 : 12587.dasm (3.28% of base)
          32 : 2381.dasm (8.89% of base)
          32 : 2757.dasm (2.69% of base)
          24 : 1201.dasm (2.37% of base)
          24 : 18571.dasm (1.14% of base)
          20 : 9146.dasm (1.71% of base)
          16 : 11289.dasm (19.05% of base)
          16 : 13071.dasm (4.17% of base)
          16 : 14407.dasm (4.71% of base)
          16 : 11879.dasm (4.71% of base)
          16 : 21920.dasm (4.71% of base)
          16 : 265.dasm (1.38% of base)
          16 : 12059.dasm (1.02% of base)
          16 : 4135.dasm (2.41% of base)
          16 : 13231.dasm (5.80% of base)
          16 : 17237.dasm (5.80% of base)
          16 : 19061.dasm (4.71% of base)
          16 : 1602.dasm (2.48% of base)
          16 : 21369.dasm (4.71% of base)
          16 : 22459.dasm (4.88% of base)

293 total files with Code Size differences (0 improved, 293 regressed), 1 unchanged.

Top method regressions (bytes):
          48 ( 3.28% of base) : 12587.dasm - BenchmarksGame.FannkuchRedux_9:Run(int,int)
          32 ( 2.69% of base) : 2757.dasm - System.Number:TryParseInt64IntegerStyle(System.ReadOnlySpan`1[Char],int,System.Globalization.NumberFormatInfo,byref):int
          32 ( 8.89% of base) : 2381.dasm - System.Xml.XmlStreamNodeWriter:UnsafeGetUTF8Chars(long,int,System.Byte[],int):int:this
          24 ( 2.37% of base) : 1201.dasm - System.Text.RegularExpressions.RegexBoyerMoore:.ctor(System.String,bool,bool,System.Globalization.CultureInfo):this
          24 ( 1.14% of base) : 18571.dasm - System.Threading.ReaderWriterLockSlim:TryEnterWriteLockCore(TimeoutTracker):bool:this
          20 ( 1.71% of base) : 9146.dasm - System.Number:TryParseUInt64IntegerStyle(System.ReadOnlySpan`1[Char],int,System.Globalization.NumberFormatInfo,byref):int
          16 ( 1.02% of base) : 12059.dasm - BenchmarksGame.FannkuchRedux_5:run(int,int,int)
          16 ( 2.37% of base) : 21241.dasm - BenchmarksGame.SpectralNorm_1:Bench(int):double:this
          16 ( 0.76% of base) : 23328.dasm - Benchstone.BenchI.Puzzle:DoIt():bool:this
          16 ( 1.47% of base) : 10517.dasm - DecCalc:VarDecMul(byref,byref)
          16 ( 5.80% of base) : 13231.dasm - System.Buffers.Text.Utf8Parser:TryParseByteD(System.ReadOnlySpan`1[Byte],byref,byref):bool
          16 ( 4.17% of base) : 13071.dasm - System.Buffers.Text.Utf8Parser:TryParseUInt16D(System.ReadOnlySpan`1[Byte],byref,byref):bool
          16 ( 2.41% of base) : 4135.dasm - System.Buffers.Text.Utf8Parser:TryParseUInt32D(System.ReadOnlySpan`1[Byte],byref,byref):bool
          16 (19.05% of base) : 11289.dasm - System.Collections.IndexerSet`1[Int32][System.Int32]:Span():int:this
          16 ( 4.71% of base) : 14822.dasm - System.MathBenchmarks.Double:AbsTest()
          16 ( 4.71% of base) : 21369.dasm - System.MathBenchmarks.Double:CeilingTest()
          16 ( 4.71% of base) : 21920.dasm - System.MathBenchmarks.Double:FloorTest()
          16 ( 4.88% of base) : 22459.dasm - System.MathBenchmarks.Double:ILogBTest()
          16 ( 4.71% of base) : 11879.dasm - System.MathBenchmarks.Double:RoundTest()
          16 ( 4.71% of base) : 13485.dasm - System.MathBenchmarks.Double:SqrtTest()

Top method regressions (percentages):
          12 (21.43% of base) : 18878.dasm - System.Diagnostics.Tracing.EventSource:GetDispatcher(System.Diagnostics.Tracing.EventListener):System.Diagnostics.Tracing.EventDispatcher:this
          16 (19.05% of base) : 11289.dasm - System.Collections.IndexerSet`1[Int32][System.Int32]:Span():int:this
          12 (17.65% of base) : 12576.dasm - System.Xml.Linq.XElement:Attribute(System.Xml.Linq.XName):System.Xml.Linq.XAttribute:this
           8 (16.67% of base) : 19693.dasm - System.Collections.Concurrent.ConcurrentStack`1[__Canon][System.__Canon]:get_Count():int:this
           8 (16.67% of base) : 14274.dasm - System.Collections.Concurrent.ConcurrentStack`1[Int32][System.Int32]:get_Count():int:this
          12 (13.64% of base) : 22676.dasm - System.Collections.IterateFor`1[Int32][System.Int32]:ReadOnlySpan():int:this
          12 (13.64% of base) : 22412.dasm - System.Collections.IterateFor`1[Int32][System.Int32]:Span():int:this
          12 (13.64% of base) : 19362.dasm - System.Collections.IterateForEach`1[Int32][System.Int32]:ReadOnlySpan():int:this
          12 (13.64% of base) : 18995.dasm - System.Collections.IterateForEach`1[Int32][System.Int32]:Span():int:this
           8 (13.33% of base) : 22034.dasm - Benchstone.BenchF.DMath:Fact(double):double
           8 (13.33% of base) : 22035.dasm - Benchstone.BenchF.DMath:Power(double,double):double
          12 (13.04% of base) : 17238.dasm - System.Reflection.BlobUtilities:WriteBytes(System.Byte[],int,ubyte,int)
           8 (12.50% of base) : 12681.dasm - Span.IndexerBench:TestIndexer1(System.Span`1[Byte]):ubyte
           8 (12.50% of base) : 13060.dasm - Span.IndexerBench:TestIndexer2(System.Span`1[Byte]):ubyte
           8 (12.50% of base) : 13330.dasm - Span.IndexerBench:TestIndexer3(System.Span`1[Byte]):ubyte
           8 (12.50% of base) : 18057.dasm - Span.IndexerBench:TestReadOnlyIndexer1(System.ReadOnlySpan`1[Byte]):ubyte
           8 (12.50% of base) : 18954.dasm - Span.IndexerBench:TestReadOnlyIndexer2(System.ReadOnlySpan`1[Byte]):ubyte
           8 (12.50% of base) : 11224.dasm - Span.IndexerBench:TestRef(System.Span`1[Byte]):ubyte
           8 (11.76% of base) : 14723.dasm - Span.IndexerBench:TestIndexer6(System.Span`1[Byte],Span.Sink):ubyte
          12 (11.54% of base) : 21117.dasm - System.Collections.IndexerSetReverse`1[Int32][System.Int32]:Span():int:this

293 total methods with Code Size differences (0 improved, 293 regressed), 1 unchanged.

```

</details>

--------------------------------------------------------------------------------



Libraries windows/arm64 diffs:

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 547924
Total bytes of diff: 555328
Total bytes of delta: 7404 (1.35% of base)
Total relative delta: 41.93
    diff is a regression.
    relative diff is a regression.
```
<details>

<summary>Detail diffs</summary>

```


Top file regressions (bytes):
          64 : 6462.dasm (1.75% of base)
          32 : 116552.dasm (8.89% of base)
          32 : 145813.dasm (7.92% of base)
          28 : 213124.dasm (1.77% of base)
          28 : 110271.dasm (6.14% of base)
          28 : 204842.dasm (7.69% of base)
          24 : 100302.dasm (1.50% of base)
          24 : 98371.dasm (9.68% of base)
          24 : 100294.dasm (8.57% of base)
          24 : 99802.dasm (10.71% of base)
          24 : 90757.dasm (0.93% of base)
          24 : 92581.dasm (9.38% of base)
          24 : 98133.dasm (9.68% of base)
          24 : 99568.dasm (10.71% of base)
          24 : 101605.dasm (1.32% of base)
          24 : 222436.dasm (2.37% of base)
          20 : 90768.dasm (0.75% of base)
          20 : 170368.dasm (1.38% of base)
          20 : 172208.dasm (0.98% of base)
          20 : 21798.dasm (6.58% of base)

956 total files with Code Size differences (0 improved, 956 regressed), 2 unchanged.

Top method regressions (bytes):
          64 ( 1.75% of base) : 6462.dasm - <StartupCode$FSharp-Core>.$Quotations:eq@197(Microsoft.FSharp.Quotations.Tree,Microsoft.FSharp.Quotations.Tree):bool
          32 ( 7.92% of base) : 145813.dasm - Microsoft.CSharp.RuntimeBinder.SymbolTable:FindMethodFromMemberInfo(System.Reflection.MemberInfo):Microsoft.CSharp.RuntimeBinder.Semantics.MethodSymbol
          32 ( 8.89% of base) : 116552.dasm - System.Xml.XmlStreamNodeWriter:UnsafeGetUTF8Chars(long,int,System.Byte[],int):int:this
          28 ( 6.14% of base) : 110271.dasm - System.Data.SqlTypes.SqlBinary:PerformCompareByte(System.Byte[],System.Byte[]):int
          28 ( 7.69% of base) : 204842.dasm - System.Net.WebSockets.ManagedWebSocket:ApplyMask(System.Span`1[Byte],int,int):int
          28 ( 1.77% of base) : 213124.dasm - System.Numerics.BigInteger:.ctor(System.ReadOnlySpan`1[Byte],bool,bool):this
          24 ( 1.32% of base) : 101605.dasm - <>c__DisplayClass32_0:<SetupCallbacks>b__46(Microsoft.Diagnostics.Tracing.Parsers.ClrPrivate.MulticoreJitPrivateTraceData):this
          24 (10.71% of base) : 99568.dasm - Microsoft.Diagnostics.Tracing.Parsers.ApplicationServer.Multidata42TemplateATraceData:PayloadValue(int):System.Object:this
          24 (10.71% of base) : 99802.dasm - Microsoft.Diagnostics.Tracing.Parsers.ApplicationServer.Multidata79TemplateATraceData:PayloadValue(int):System.Object:this
          24 ( 9.68% of base) : 98371.dasm - Microsoft.Diagnostics.Tracing.Parsers.ClrPrivate.DynamicTypeUseStringAndIntPrivateTraceData:PayloadValue(int):System.Object:this
          24 ( 9.68% of base) : 98133.dasm - Microsoft.Diagnostics.Tracing.Parsers.ClrPrivate.ModuleTransparencyCalculationTraceData:PayloadValue(int):System.Object:this
          24 ( 9.38% of base) : 92581.dasm - Microsoft.Diagnostics.Tracing.Parsers.LinuxKernel.ProcessStartTraceData:PayloadValue(int):System.Object:this
          24 ( 8.57% of base) : 100294.dasm - Microsoft.Diagnostics.Tracing.Parsers.MicrosoftAntimalwareEngine.MessageUfsScanStart32Args_V1TraceData:PayloadValue(int):System.Object:this
          24 ( 1.50% of base) : 100302.dasm - Microsoft.Diagnostics.Tracing.Parsers.MicrosoftAntimalwareEngine.MetaStoreTaskMetaStoreActionArgsTraceData:ToXml(System.Text.StringBuilder):System.Text.StringBuilder:this
          24 ( 0.93% of base) : 90757.dasm - Microsoft.Diagnostics.Tracing.Parsers.MicrosoftWindowsTCPIP.IpDadFailedArgs:ToXml(System.Text.StringBuilder):System.Text.StringBuilder:this
          24 ( 2.37% of base) : 222436.dasm - System.Text.RegularExpressions.RegexBoyerMoore:.ctor(System.String,bool,bool,System.Globalization.CultureInfo):this
          20 ( 1.63% of base) : 235147.dasm - ArraySerializer:Deserialize(Xunit.Abstractions.IXunitSerializationInfo):this
          20 ( 6.58% of base) : 21798.dasm - Microsoft.CodeAnalysis.CSharp.Binder:CreateSourceIndicesArray(int,int):System.Int32[]
          20 ( 0.70% of base) : 97675.dasm - Microsoft.Diagnostics.Tracing.Parsers.Clr.ResolutionAttemptedTraceData:ToXml(System.Text.StringBuilder):System.Text.StringBuilder:this
          20 ( 1.27% of base) : 100328.dasm - Microsoft.Diagnostics.Tracing.Parsers.MicrosoftAntimalwareEngine.PersistedStoreTaskPersistedStoreAnalyzeFileArgsTraceData:ToXml(System.Text.StringBuilder):System.Text.StringBuilder:this

Top method regressions (percentages):
          16 (36.36% of base) : 229123.dasm - Internal.JitInterface.MemoryHelper:FillMemory(long,ubyte,int)
          16 (36.36% of base) : 166457.dasm - System.ComponentModel.EventHandlerList:Find(System.Object):ListEntry:this
          16 (33.33% of base) : 82923.dasm - Microsoft.Diagnostics.Tracing.EventPipeEventMetaDataHeader:ClearMemory(long,int)
          16 (30.77% of base) : 174245.dasm - FilterAndTransform:Reverse(TransformSpec):TransformSpec
          16 (26.67% of base) : 130330.dasm - System.Xml.Xsl.XsltOld.DocumentScope:ResolveAtom(System.String):System.String:this
          12 (25.00% of base) : 174742.dasm - System.Diagnostics.Metrics.Counter`1[Vector`1][System.Numerics.Vector`1[System.Single]]:Add(System.Numerics.Vector`1[Single],System.ReadOnlySpan`1[[System.Collections.Generic.KeyValuePair`2[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Object, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]):this
          12 (25.00% of base) : 174809.dasm - System.Diagnostics.Metrics.Instrument`1[Vector`1][System.Numerics.Vector`1[System.Single]]:RecordMeasurement(System.Numerics.Vector`1[Single],System.ReadOnlySpan`1[[System.Collections.Generic.KeyValuePair`2[[System.String, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Object, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]):this
          16 (23.53% of base) : 146733.dasm - Microsoft.CSharp.RuntimeBinder.Semantics.Symbol:LookupNext(long):Microsoft.CSharp.RuntimeBinder.Semantics.Symbol:this
          16 (22.22% of base) : 92551.dasm - Microsoft.Diagnostics.Tracing.Parsers.MicrosoftWindowsNDISPacketCapture.PacketFragmentArgs:IsPrintable(long,long):bool
          12 (21.43% of base) : 74506.dasm - Microsoft.CodeAnalysis.RealParser:CountSignificantBits(ubyte):int
          12 (21.43% of base) : 206494.dasm - System.Xml.Linq.XElement:RemoveAttributesSkipNotify():this
          12 (20.00% of base) : 798.dasm - Microsoft.FSharp.Collections.ListDebugView`1[__Canon][System.__Canon]:get__FullList():System.__Canon[]:this
          12 (20.00% of base) : 797.dasm - Microsoft.FSharp.Collections.ListDebugView`1[__Canon][System.__Canon]:get_Items():System.__Canon[]:this
          12 (20.00% of base) : 803.dasm - Microsoft.FSharp.Collections.ListDebugView`1[Byte][System.Byte]:get__FullList():System.Byte[]:this
          12 (20.00% of base) : 802.dasm - Microsoft.FSharp.Collections.ListDebugView`1[Byte][System.Byte]:get_Items():System.Byte[]:this
          12 (18.75% of base) : 15261.dasm - System.MemoryExtensions:ClampStart(System.ReadOnlySpan`1[Int32],int):int
          12 (18.75% of base) : 15264.dasm - System.MemoryExtensions:ClampStart(System.ReadOnlySpan`1[Int64],long):int
          12 (17.65% of base) : 206572.dasm - System.Xml.Linq.XElement:Attribute(System.Xml.Linq.XName):System.Xml.Linq.XAttribute:this
          16 (16.67% of base) : 82945.dasm - Microsoft.Diagnostics.Tracing.TraceEventSource:GetContainerID(long):System.String:this
           8 (16.67% of base) : 162472.dasm - NodeKeyValueCollection:System.Collections.ICollection.get_Count():int:this

956 total methods with Code Size differences (0 improved, 956 regressed), 2 unchanged.

```

</details>

--------------------------------------------------------------------------------

It is worth noting that because of fixed size encoding of arm64, very few methods benefit from loop alignment. For example, below is the diff for xarch.

x64:
| Collection | Methods affected | Total padding (in bytes) |
|------------|------------------|--------------------------|
| Benchmarks | 470              | 4908                     |
| Libraries  | 1637             | 14967                    |

arm64:

| Collection | Methods affected | Total padding (in bytes) |
|------------|------------------|--------------------------|
| Benchmarks | 293              | 2476                     |
| Libraries  | 956              | 7404                     |

Finally, as expected, the allocation size regression is same as code size regression we see above and there is no mismatch because there is we do not over-estimation the instruction sizes for arm64.

I tried to measure performance for some of the benchmarks that asmdiff pointed out and I didn't notice any significant performance and stability difference (cc @TamarChristinaArm ), but the plan is to merge this in and monitor the perf lab to see if it impacts benchmarks over the time. If we see that it adversely affects the benchmarks, we will revert this feature for arm64.