### PR TITLE
Fix dependency of GenerateLayout on RestorePackages

### DIFF
--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -30,10 +30,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <TestBuildSteps Include="RestorePackages" />
     <TestBuildSteps Include="ManagedBuild" />
     <TestBuildSteps Include="CheckTestBuildStep" />
     <TestBuildSteps Include="GenerateLayout" />
-    <TestBuildSteps Include="RestorePackages" />
     <TestBuildSteps Include="BuildTestWrappers" />
     <TestBuildSteps Include="CrossgenFramework" />
     <TestBuildSteps Include="CreateAndroidApps" />
@@ -468,7 +468,7 @@
 
   <Target Name="GenerateLayout"
       DependsOnTargets="CreateTestOverlay"
-      AfterTargets="ManagedBuild"
+      AfterTargets="ManagedBuild;RestorePackages"
       Condition="'$(__BuildTestWrappersOnly)' != '1' and '$(__CopyNativeTestBinaries)' != '1' and '$(__SkipGenerateLayout)' != '1' and !$(MonoAot) and !$(MonoFullAot)" />
 
   <Target Name="BuildTestWrappers"


### PR DESCRIPTION
Parker Bibus pinged me earlier today to report a bug caused by my
test cleanup - using generatelayoutonly without previously
building the managed tests ends up failing the build due to
unrestored packages. This was due to the fact that I overlooked
that CopyDependenciesToCoreRoot needs the support projects to be
restored; in usual scenarios, they usually got restored as part
of another build step like managed test build so that I didn't hit
that in my local and lab testing.

Thanks

Tomas

/cc @dotnet/runtime-infrastructure 