### PR TITLE
Check BackgroundService.ExecuteTask for null

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
@@ -81,27 +81,29 @@ namespace Microsoft.Extensions.Hosting.Internal
         {
             // backgroundService.ExecuteTask may not be set (e.g. if the derived class doesn't call base.StartAsync)
             Task backgroundTask = backgroundService.ExecuteTask;
-            if (backgroundTask != null)
+            if (backgroundTask == null)
             {
-                try
-                {
-                    await backgroundTask.ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    // When the host is being stopped, it cancels the background services.
-                    // This isn't an error condition, so don't log it as an error.
-                    if (_stopCalled && backgroundTask.IsCanceled && ex is OperationCanceledException)
-                    {
-                        return;
-                    }
+                return;
+            }
 
-                    _logger.BackgroundServiceFaulted(ex);
-                    if (_options.BackgroundServiceExceptionBehavior == BackgroundServiceExceptionBehavior.StopHost)
-                    {
-                        _logger.BackgroundServiceStoppingHost(ex);
-                        _applicationLifetime.StopApplication();
-                    }
+            try
+            {
+                await backgroundTask.ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // When the host is being stopped, it cancels the background services.
+                // This isn't an error condition, so don't log it as an error.
+                if (_stopCalled && backgroundTask.IsCanceled && ex is OperationCanceledException)
+                {
+                    return;
+                }
+
+                _logger.BackgroundServiceFaulted(ex);
+                if (_options.BackgroundServiceExceptionBehavior == BackgroundServiceExceptionBehavior.StopHost)
+                {
+                    _logger.BackgroundServiceStoppingHost(ex);
+                    _applicationLifetime.StopApplication();
                 }
             }
         }

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
@@ -1394,6 +1394,36 @@ namespace Microsoft.Extensions.Hosting.Internal
             }
         }
 
+        /// <summary>
+        /// Tests that when a BackgroundService does not call base, the Host still starts and stops successfully.
+        /// </summary>
+        [Fact]
+        public async Task StartOnBackgroundServiceThatDoesNotCallBase()
+        {
+            TestLoggerProvider logger = new TestLoggerProvider();
+
+            using IHost host = CreateBuilder()
+                .ConfigureLogging(logging =>
+                {
+                    logging.AddProvider(logger);
+                })
+                .ConfigureServices(services =>
+                {
+                    services.AddHostedService<BackgroundServiceDoesNotCallBase>();
+                })
+                .Build();
+
+            host.Start();
+            await host.StopAsync();
+
+            foreach (LogEvent logEvent in logger.GetEvents())
+            {
+                Assert.True(logEvent.LogLevel <= LogLevel.Information, "All logged events should be les than or equal to Information. No Warnings or Errors.");
+
+                Assert.NotEqual("BackgroundServiceFaulted", logEvent.EventId.Name);
+            }
+        }
+
         private IHostBuilder CreateBuilder(IConfiguration config = null)
         {
             return new HostBuilder().ConfigureHostConfiguration(builder => builder.AddConfiguration(config ?? new ConfigurationBuilder().Build()));
@@ -1561,6 +1591,15 @@ namespace Microsoft.Extensions.Hosting.Internal
                     await Task.Delay(1000, stoppingToken);
                 }
             }
+        }
+
+        private class BackgroundServiceDoesNotCallBase : BackgroundService
+        {
+            public override Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+            protected override Task ExecuteAsync(CancellationToken stoppingToken) => Task.CompletedTask;
+
+            public override Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
@@ -1418,7 +1418,7 @@ namespace Microsoft.Extensions.Hosting.Internal
 
             foreach (LogEvent logEvent in logger.GetEvents())
             {
-                Assert.True(logEvent.LogLevel <= LogLevel.Information, "All logged events should be les than or equal to Information. No Warnings or Errors.");
+                Assert.True(logEvent.LogLevel <= LogLevel.Information, "All logged events should be less than or equal to Information. No Warnings or Errors.");
 
                 Assert.NotEqual("BackgroundServiceFaulted", logEvent.EventId.Name);
             }


### PR DESCRIPTION
In some scenarios, derived classes might not have called base.StartAsync, and ExecuteTask will still be null. Ensure we don't fail in those cases.

Fix #60131

My plan is to backport this to 6.0.