### PR TITLE
Fix TimeZones Test failure

### DIFF
--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -3113,7 +3113,7 @@ namespace System.Tests
                 string tzResourceFilePath = Path.Join(Environment.SystemDirectory, cultureName, "tzres.dll.mui");
                 if (!File.Exists(tzResourceFilePath))
                 {
-                    // If Windows installed a UI language and not including the time zone resources DLL for that language,
+                    // If Windows installed a UI language but did not include the time zone resources DLL for that language,
                     // then skip this language as .NET will not be able to get the localized resources for that language.
                     return 1;
                 }

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -3110,6 +3110,14 @@ namespace System.Tests
                 // native string is null terminated
                 var cultureName = new string(lpUiLanguageString);
 
+                string tzResourceFilePath = Path.Join(Environment.SystemDirectory, cultureName, "tzres.dll.mui");
+                if (!File.Exists(tzResourceFilePath))
+                {
+                    // If Windows installed a UI language and not including the time zone resources DLL for that language,
+                    // then skip this language as .NET will not be able to get the localized resources for that language.
+                    return 1;
+                }
+
                 try
                 {
                     var handle = GCHandle.FromIntPtr(lParam);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/60119

Recently, Helix started to use `Windows 7 N` image in the CI run. This image includes a lot of installed UI languages. The time zone display names depends on the installed localized resources on the path `%SystemDirectory%\[Language]\tzres.dll.mui`. For example, if Japanese UI language is installed, Windows will install the file `%SystemDirectory%\ja-JP\tzres.dll.mui`. We found on the Windows 7 image, Windows not necessary installing this file for specific language. `zh-HK` is the one we encountered which caused the test failure. 

The fix here is to make the test tolerate this case. The test still working properly and validating all installed UI languages time zone display names.