### PR TITLE
Add support for cloning loops with `<=` conditions

### DIFF
--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -534,7 +534,6 @@ void LoopCloneContext::EvaluateConditions(unsigned loopNum, bool* pAllTrue, bool
 
                 // Since this will force us to abort loop cloning, there is no need compute an accurate `allTrue`,
                 // so we can break out of the loop now.
-                // REVIEW: it appears we never hit this condition in any test.
                 break;
             }
         }
@@ -1417,6 +1416,7 @@ void Compiler::optDebugLogLoopCloning(BasicBlock* block, Statement* insertBefore
 void Compiler::optPerformStaticOptimizations(unsigned loopNum, LoopCloneContext* context DEBUGARG(bool dynamicPath))
 {
     JitExpandArrayStack<LcOptInfo*>* optInfos = context->GetLoopOptInfo(loopNum);
+    assert(optInfos != nullptr);
     for (unsigned i = 0; i < optInfos->Size(); ++i)
     {
         LcOptInfo* optInfo = optInfos->Get(i);
@@ -2566,7 +2566,7 @@ PhaseStatus Compiler::optCloneLoops()
             {
                 context.CancelLoopOptInfo(i);
             }
-            if (allTrue)
+            else if (allTrue)
             {
                 // Perform static optimizations on the fast path since we always
                 // have to take the cloned path.

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -1009,7 +1009,7 @@ LC_Deref* LC_Deref::Find(JitExpandArrayStack<LC_Deref*>* children, unsigned lcl)
 // Operation:
 //     Inspect the loop cloning optimization candidates and populate the conditions necessary
 //     for each optimization candidate. Checks if the loop stride is "> 0" if the loop
-//     condition is "less than". If the initializer is "var" init then adds condition
+//     condition is `<` or `<=`. If the initializer is "var" init then adds condition
 //     "var >= 0", and if the loop is var limit then, "var >= 0" and "var <= a.len"
 //     are added to "context". These conditions are checked in the pre-header block
 //     and the cloning choice is made.
@@ -1026,7 +1026,7 @@ bool Compiler::optDeriveLoopCloningConditions(unsigned loopNum, LoopCloneContext
     LoopDsc*                         loop     = &optLoopTable[loopNum];
     JitExpandArrayStack<LcOptInfo*>* optInfos = context->GetLoopOptInfo(loopNum);
 
-    if (loop->lpTestOper() == GT_LT)
+    if (GenTree::StaticOperIs(loop->lpTestOper(), GT_LT, GT_LE))
     {
         // Stride conditions
         if (loop->lpIterConst() <= 0)
@@ -1112,6 +1112,21 @@ bool Compiler::optDeriveLoopCloningConditions(unsigned loopNum, LoopCloneContext
             return false;
         }
 
+        // GT_LT loop test: limit <= arrLen
+        // GT_LE loop test: limit < arrLen
+        genTreeOps opLimitCondition;
+        switch (loop->lpTestOper())
+        {
+            case GT_LT:
+                opLimitCondition = GT_LE;
+                break;
+            case GT_LE:
+                opLimitCondition = GT_LT;
+                break;
+            default:
+                unreached();
+        }
+
         for (unsigned i = 0; i < optInfos->Size(); ++i)
         {
             LcOptInfo* optInfo = optInfos->Get(i);
@@ -1119,11 +1134,10 @@ bool Compiler::optDeriveLoopCloningConditions(unsigned loopNum, LoopCloneContext
             {
                 case LcOptInfo::LcJaggedArray:
                 {
-                    // limit <= arrLen
                     LcJaggedArrayOptInfo* arrIndexInfo = optInfo->AsLcJaggedArrayOptInfo();
                     LC_Array     arrLen(LC_Array::Jagged, &arrIndexInfo->arrIndex, arrIndexInfo->dim, LC_Array::ArrLen);
                     LC_Ident     arrLenIdent = LC_Ident(arrLen);
-                    LC_Condition cond(GT_LE, LC_Expr(ident), LC_Expr(arrLenIdent));
+                    LC_Condition cond(opLimitCondition, LC_Expr(ident), LC_Expr(arrLenIdent));
                     context->EnsureConditions(loopNum)->Push(cond);
 
                     // Ensure that this array must be dereference-able, before executing the actual condition.
@@ -1133,13 +1147,15 @@ bool Compiler::optDeriveLoopCloningConditions(unsigned loopNum, LoopCloneContext
                 break;
                 case LcOptInfo::LcMdArray:
                 {
-                    // limit <= mdArrLen
                     LcMdArrayOptInfo* mdArrInfo = optInfo->AsLcMdArrayOptInfo();
-                    LC_Condition      cond(GT_LE, LC_Expr(ident),
-                                      LC_Expr(LC_Ident(LC_Array(LC_Array::MdArray, mdArrInfo->GetArrIndexForDim(
-                                                                                       getAllocator(CMK_LoopClone)),
-                                                                mdArrInfo->dim, LC_Array::None))));
+                    LC_Array          arrLen(LC_Array(LC_Array::MdArray,
+                                             mdArrInfo->GetArrIndexForDim(getAllocator(CMK_LoopClone)), mdArrInfo->dim,
+                                             LC_Array::None));
+                    LC_Ident     arrLenIdent = LC_Ident(arrLen);
+                    LC_Condition cond(opLimitCondition, LC_Expr(ident), LC_Expr(arrLenIdent));
                     context->EnsureConditions(loopNum)->Push(cond);
+
+                    // TODO: ensure array is dereference-able?
                 }
                 break;
 
@@ -1148,11 +1164,14 @@ bool Compiler::optDeriveLoopCloningConditions(unsigned loopNum, LoopCloneContext
                     return false;
             }
         }
+
         JITDUMP("Conditions: ");
         DBEXEC(verbose, context->PrintConditions(loopNum));
         JITDUMP("\n");
+
         return true;
     }
+
     return false;
 }
 


### PR DESCRIPTION
Loop cloning currently only handles loops using `<` limit comparison,
e.g., in loops like `for (i = c; i < n; i++)`. This change allows
for loop cloning for loops using `<=`. This happens frequently in the BenchF
benchmarks (which maybe had their origin long ago in 1-based array Fortran code?),
and some in the BenchI benchmarks. In real world code, it happens
in Visual Basic code.

There are perf wins and losses, with the usual existing issues for loop cloning.
For one case, BenchI.XPosMatrix, I see a loss due to various things, including:
1. Unfortunate register allocation and/or missing copy prop, leading to lots of
unnecessary copies.
2. Hitting jcc erratum
3. CSE leads to un-contained array length load in array bounds check

Even so, there is one fewer bounds check than the baseline. We could remove one more,
but a limitation in recognizing multi-dimensional jagged array components prevents loop
cloning from recognizing a legal-to-remove bounds check (https://github.com/dotnet/runtime/issues/54074).