### PR TITLE
Test fix: FileStream DeleteOnClose run on OuterLoop with longer timeout

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/FileStream/DeleteOnClose.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/DeleteOnClose.cs
@@ -10,6 +10,7 @@ namespace System.IO.Tests
     public class FileStream_DeleteOnClose : FileSystemTest
     {
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsFileLockingEnabled), nameof(PlatformDetection.IsThreadingSupported))]
+        [OuterLoop]
         public async Task OpenOrCreate_DeleteOnClose_UsableAsMutex()
         {
             var cts = new CancellationTokenSource();
@@ -69,7 +70,7 @@ namespace System.IO.Tests
             }
 
             // Wait for 1000 locks.
-            cts.CancelAfter(TimeSpan.FromSeconds(60)); // Test timeout.
+            cts.CancelAfter(TimeSpan.FromSeconds(120)); // Test timeout (reason for outerloop)
             Volatile.Write(ref locksRemaining, 500);
             await Task.WhenAll(tasks);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/60147

A new unit test was added in  https://github.com/dotnet/runtime/pull/55327 to fix a Unix-only bug. This PR ensures the test is limited to only run on Unix, in both `System.IO.FileSystem.Tests.csproj` and in `System.IO.FileSystem.Net5Compat.Tests.csproj`.

Pending confirmation from @tmds that this unit test was only intended to be run on Unix.