### PR TITLE
Fix WebSocket cancel test for non-browser

### DIFF
--- a/src/libraries/System.Net.WebSockets.Client/tests/CancelTest.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/CancelTest.cs
@@ -22,7 +22,7 @@ namespace System.Net.WebSockets.Client.Tests
                 var cts = new CancellationTokenSource(100);
 
                 var ub = new UriBuilder(server);
-                ub.Query = "delay20sec";
+                ub.Query = PlatformDetection.IsBrowser ? "delay20sec" : "delay10sec";
 
                 var ex = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => cws.ConnectAsync(ub.Uri, cts.Token));
                 Assert.True(WebSocketState.Closed == cws.State, $"Actual {cws.State} when {ex}");


### PR DESCRIPTION
Non-browser WS server used for `ConnectAsync_Cancel_ThrowsCancellationException` doesn't support "delay20sec", only "delay10sec". This basically reverts the change in this line from https://github.com/dotnet/runtime/pull/58199 for non-browser platforms.

Contributes to https://github.com/dotnet/runtime/issues/58355

/cc @pavelsavara @ManickaP 