### PR TITLE
[QUIC] Fixed exception type for ConnectionShutdownInitiatedByTransport

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -283,6 +283,11 @@ namespace System.Net.Quic.Implementations.MsQuic
                 state.ConnectTcs = null;
             }
 
+            // To throw QuicConnectionAbortedException (instead of QuicOperationAbortedException) out of AcceptStreamAsync() since
+            // it wasn't our side who shutdown the connection.
+            // We should rather keep the Status and propagate it either in a different exception or as a different field of QuicConnectionAbortedException.
+            // See: https://github.com/dotnet/runtime/issues/60133
+            state.AbortErrorCode = 0;
             state.AcceptQueue.Writer.TryComplete();
             return MsQuicStatusCodes.Success;
         }


### PR DESCRIPTION
In case of a shutdown by a transport we would throw `QuicOperationAbortedException` out of `AcceptStreamAsync`, which would wrongly imply that it was our side who initiated the connection shutdown.
This is a quick safe fix to make the logic throw `QuicConnectionAbortedException` instead. 

However, we should properly propagate outside the information that it was transport and not the peer who closed the connection --> not closing the original issue.

Fixes #60133

Verified manually, now seeing in Kestrel log:
```
dbug: Microsoft.AspNetCore.Server.Kestrel.Transport.Quic[5]
      Connection id "0HMCADU0GKLVK" aborted by peer with error code 0.
      System.Net.Quic.QuicConnectionAbortedException: Connection aborted by peer (0).
         at System.Net.Quic.Implementations.MsQuic.MsQuicConnection.AcceptStreamAsync(CancellationToken cancellationToken)
         at System.Net.Quic.QuicConnection.AcceptStreamAsync(CancellationToken cancellationToken)
         at Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.Internal.QuicConnectionContext.AcceptAsync(CancellationToken cancellationToken)
dbug: Microsoft.AspNetCore.Server.Kestrel.Transport.Quic[6]
      Connection id "0HMCADU0GKLVK" aborted by application with error code 0 because: "The client closed the connection.".
```

cc @JamesNK @CarnaViire 