### PR TITLE
fallocate sets errno on error, posix_fallocate did not

### DIFF
--- a/src/libraries/Native/Unix/System.Native/pal_io.c
+++ b/src/libraries/Native/Unix/System.Native/pal_io.c
@@ -1015,7 +1015,7 @@ int32_t SystemNative_FAllocate(intptr_t fd, int64_t offset, int64_t length)
     int fileDescriptor = ToFileDescriptor(fd);
     int32_t result;
 #if HAVE_FALLOCATE // Linux
-    while ((result = fallocate(fileDescriptor, FALLOC_FL_KEEP_SIZE, (off_t)offset, (off_t)length)) == EINTR);
+    while ((result = fallocate(fileDescriptor, FALLOC_FL_KEEP_SIZE, (off_t)offset, (off_t)length)) == -1 && errno == EINTR);
 #elif defined(F_PREALLOCATE) // macOS
     fstore_t fstore;
     fstore.fst_flags = F_ALLOCATEALL; // Allocate all requested space or no space at all.


### PR DESCRIPTION
minor issue that I've found when reviewing #59338

> On success, fallocate() returns zero.  On error, -1 is returned
       and errno is set to indicate the error.

> posix_fallocate() returns zero on success, or an error number on
       failure.  Note that errno is not set.