### PR TITLE
Fix GetGenerationWithRange when we have a gen 2 object in the ephemeral segment

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -43371,6 +43371,7 @@ unsigned int GCHeap::GetGenerationWithRange (Object* object, uint8_t** ppStart, 
         }
         if (generation == -1)
         {
+            generation = max_generation;
             *ppStart = heap_segment_mem (hs);
             *ppAllocated = *ppReserved = generation_allocation_start (hp->generation_of (max_generation - 1));
         }


### PR DESCRIPTION
This fixes a case where the `GCHeap::GetGenerationWithRange` returns -1.
@dotnet/dotnet-diag 