### PR TITLE
Fix Robocopy Verification

### DIFF
--- a/eng/testing/performance/performance-setup.ps1
+++ b/eng/testing/performance/performance-setup.ps1
@@ -39,7 +39,7 @@ function Verified-Move-Item {
     
     Move-Item -Path $Path -Destination $Destination
     if (!$?) {
-        Write-Output "Failed to move $Source to $Destination"
+        Write-Output "Failed to move $Path to $Destination"
         exit 1
     }
 }

--- a/eng/testing/performance/performance-setup.ps1
+++ b/eng/testing/performance/performance-setup.ps1
@@ -29,38 +29,48 @@ Param(
 )
 
 function Verified-Move-Item {
-	[Parameter(Mandatory)]
-	[string]$Path
-	[Parameter(Mandatory)]
-	[string]$Destination
-	
-	Move-Item -Path $Path -Destination $Destination
-	if (!$?) {
-		Write-Output "Failed to move $Source to $Destination"
-		exit 1
-	}
+    [CmdletBinding()]
+    param(
+        [Parameter(mandatory=$true)]
+        [string]$Path,
+        [Parameter(mandatory=$true)]
+        [string]$Destination
+    )
+    
+    Move-Item -Path $Path -Destination $Destination
+    if (!$?) {
+        Write-Output "Failed to move $Source to $Destination"
+        exit 1
+    }
 }
 
 function Verified-Copy-Item {
-	[Parameter(Mandatory)]
-	[string]$path
-	[Parameter(Mandatory)]
-	[string]$Destination
-	
-	Copy-Item -path $path $Destination
-	if (!$?) {
-		Write-Output "Failed to copy $Source to $Destination"
-		exit 1
-	}
+    [CmdletBinding()]
+    param(
+    [Parameter(mandatory=$true)]
+    [string]$Path,
+    [Parameter(mandatory=$true)]
+    [string]$Destination
+    )
+    
+    Copy-Item -path $path $Destination
+    if (!$?) {
+        Write-Output "Failed to copy $Path to $Destination"
+        exit 1
+    }
 }
 
 function Verify-Robocopy {
-	[Parameter(Mandatory)]
-	[string]$Source
-	if ($LASTEXITCODE -ne 0 -or !$?) {
-		Write-Output "Failed to copy ${Source}: exit code $LASTEXITCODE"
-		exit $LASTEXITCODE
-	}
+    [CmdletBinding()]
+    param(
+    [Parameter(mandatory=$true)]
+    [string]$Source
+    )
+    
+    if ($LASTEXITCODE -ne 0 -or !$?) {
+        Write-Output "Failed to copy ${Source}: exit code $LASTEXITCODE"
+        exit $LASTEXITCODE
+    }
 }
 
 $RunFromPerformanceRepo = ($Repository -eq "dotnet/performance") -or ($Repository -eq "dotnet-performance")

--- a/eng/testing/performance/performance-setup.ps1
+++ b/eng/testing/performance/performance-setup.ps1
@@ -67,10 +67,13 @@ function Verify-Robocopy {
         [string]$Source
     )
     
-    if ($LASTEXITCODE -ne 0 -or !$?) {
+    if ($LASTEXITCODE -eq 8 -or !$?) {
         Write-Output "Failed to copy ${Source}: exit code $LASTEXITCODE"
         exit $LASTEXITCODE
     }
+	else if ($LASTEXITCODE -gt 1) {
+		Write-Output "Unusual result when copying ${Source}: exit code $LASTEXITCODE"
+	}
 }
 
 $RunFromPerformanceRepo = ($Repository -eq "dotnet/performance") -or ($Repository -eq "dotnet-performance")

--- a/eng/testing/performance/performance-setup.ps1
+++ b/eng/testing/performance/performance-setup.ps1
@@ -47,13 +47,13 @@ function Verified-Move-Item {
 function Verified-Copy-Item {
     [CmdletBinding()]
     param(
-    [Parameter(mandatory=$true)]
-    [string]$Path,
-    [Parameter(mandatory=$true)]
-    [string]$Destination
+        [Parameter(mandatory=$true)]
+        [string]$Path,
+        [Parameter(mandatory=$true)]
+        [string]$Destination
     )
     
-    Copy-Item -path $path $Destination
+    Copy-Item -path $Path $Destination
     if (!$?) {
         Write-Output "Failed to copy $Path to $Destination"
         exit 1
@@ -63,8 +63,8 @@ function Verified-Copy-Item {
 function Verify-Robocopy {
     [CmdletBinding()]
     param(
-    [Parameter(mandatory=$true)]
-    [string]$Source
+        [Parameter(mandatory=$true)]
+        [string]$Source
     )
     
     if ($LASTEXITCODE -ne 0 -or !$?) {
@@ -198,7 +198,7 @@ if ($AndroidMono) {
     {
         mkdir $WorkItemDirectory
     }
-    Verified-Copy-Item -path "$SourceDirectory\artifacts\bin\AndroidSampleApp\arm64\Release\android-arm64\publish\apk\bin\HelloAndroid.apk" $PayloadDirectory
+    Verified-Copy-Item -Path "$SourceDirectory\artifacts\bin\AndroidSampleApp\arm64\Release\android-arm64\publish\apk\bin\HelloAndroid.apk" $PayloadDirectory
     $SetupArguments = $SetupArguments -replace $Architecture, 'arm64'
 }
 
@@ -208,9 +208,9 @@ if ($iOSMono) {
         mkdir $WorkItemDirectory
     }
     if($iOSLlvmBuild) {
-        Verified-Copy-Item -path "$SourceDirectory\iosHelloWorld\llvm" $PayloadDirectory\iosHelloWorld\llvm -Recurse
+        Verified-Copy-Item -Path "$SourceDirectory\iosHelloWorld\llvm" $PayloadDirectory\iosHelloWorld\llvm -Recurse
     } else {
-        Verified-Copy-Item -path "$SourceDirectory\iosHelloWorld\nollvm" $PayloadDirectory\iosHelloWorld\nollvm -Recurse
+        Verified-Copy-Item -Path "$SourceDirectory\iosHelloWorld\nollvm" $PayloadDirectory\iosHelloWorld\nollvm -Recurse
     }
 
     $SetupArguments = $SetupArguments -replace $Architecture, 'arm64'


### PR DESCRIPTION
The previously implemented verification for robocopy assumed 0 meant success.  This PR accounts for the actual meaning of the return codes as defined in https://docs.microsoft.com/en-us/troubleshoot/windows-server/backup-and-storage/return-codes-used-robocopy-utility