### PR TITLE
Do not throw StackOverflow exception from `ChangeToken.OnChange`

### DIFF
--- a/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/ChangeToken.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Extensions.Primitives
 
             private void RegisterChangeTokenCallback(IChangeToken? token)
             {
-                if (token is null)
+                if (token is null || token.HasChanged)
                 {
                     return;
                 }

--- a/src/libraries/Microsoft.Extensions.Primitives/tests/ChangeTokenTest.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/tests/ChangeTokenTest.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Extensions.Primitives
             };
 
             var count = 0;
-            Action consumer = () => ++count;
+            Action consumer = () => ++ count;
 
             using (ChangeToken.OnChange(producer, consumer))
             {

--- a/src/libraries/Microsoft.Extensions.Primitives/tests/ChangeTokenTest.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/tests/ChangeTokenTest.cs
@@ -90,9 +90,10 @@ namespace Microsoft.Extensions.Primitives
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/60183")]
         public void ReusingOnceFiredChangeTokenShouldNotThrow()
         {
+            // See: https://github.com/dotnet/runtime/issues/60183
+
             var cancellationTokenSource = new CancellationTokenSource();
             var cancellationChangeToken = new CancellationChangeToken(cancellationTokenSource.Token);
 

--- a/src/libraries/Microsoft.Extensions.Primitives/tests/ChangeTokenTest.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/tests/ChangeTokenTest.cs
@@ -153,7 +153,6 @@ namespace Microsoft.Extensions.Primitives
             cancellationTokenSource.Cancel();
 
             var x = 0;
-
             Func<IChangeToken> producer = () =>
             {
                 ++ x;
@@ -178,6 +177,35 @@ namespace Microsoft.Extensions.Primitives
             }
 
             Assert.Equal(3, fired);
+        }
+
+        [Fact]
+        public void OnChangeFiresCallbackForEveryChangeOccurrence()
+        {
+            var cancellationTokenSource = new CancellationTokenSource();
+            var cancellationChangeToken = new CancellationChangeToken(cancellationTokenSource.Token);
+
+            Func<IChangeToken> producer = () =>
+            {
+                cancellationTokenSource = new CancellationTokenSource();
+                cancellationChangeToken = new CancellationChangeToken(cancellationTokenSource.Token);
+
+                return cancellationChangeToken;
+            };
+
+            var fired = 0;
+            Action consumer = () => ++ fired;
+
+            using (ChangeToken.OnChange(producer, consumer))
+            {
+                cancellationTokenSource.Cancel();
+                cancellationTokenSource.Cancel();
+                cancellationTokenSource.Cancel();
+                cancellationTokenSource.Cancel();
+                cancellationTokenSource.Cancel();
+            }
+
+            Assert.Equal(5, fired);
         }
 
         [Fact]


### PR DESCRIPTION
If the `IChangeToken` has already been fired, `HasChanged` is `true` - do not re-register. This avoids having an infinite loop, which results in a `StackOverflowException`. The first new unit test `ReusingOnceFiredChangeTokenShouldNotThrow`, if ran without the changes to `ChangeToken` exemplifies the bug.

- Add missing triple slash comments for the `<returns>` of both `OnChange` overloads.
- Consistently name static readonly field, `s_` prefix,
- Fix typo in comments.
- Add mechanism to detect infinite loop, where registration from a callback calls itself.
- Add three new unit tests validating missing scenarios, and one that specifically exhibited the `StackOverflowException`.

Fixes #60183

/cc @davidfowl @eerhardt