### PR TITLE
[release/5.0] Disable FromHwnd* tests failing on CI

### DIFF
--- a/src/libraries/System.Drawing.Common/tests/GraphicsTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/GraphicsTests.cs
@@ -258,6 +258,7 @@ namespace System.Drawing.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/51097")]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Hwnd_TestData))]
         public void FromHwnd_ValidHwnd_ReturnsExpected(IntPtr hWnd)
@@ -270,6 +271,7 @@ namespace System.Drawing.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/22221", TestPlatforms.AnyUnix)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/51097")]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Hwnd_TestData))]
         public void FromHwndInternal_ValidHwnd_ReturnsExpected(IntPtr hWnd)


### PR DESCRIPTION
These tests have been conflicting on main and currently just hit it on the release/5.0 branch. Let's disable them on release/5.0 to not block PRs.