### PR TITLE
Fix GetGenerationWithRange when we have a gen 2 object in the ephemeral segment (#60189)

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -43088,6 +43088,7 @@ unsigned int GCHeap::GetGenerationWithRange (Object* object, uint8_t** ppStart, 
         }
         if (generation == -1)
         {
+            generation = max_generation;
             *ppStart = heap_segment_mem (hs);
             *ppAllocated = *ppReserved = generation_allocation_start (hp->generation_of (max_generation - 1));
         }


### PR DESCRIPTION
Backporting https://github.com/dotnet/runtime/pull/60189

## Customer Impact
Since the GetObjectGeneration() API returned -1 instead of 2 for a Gen 2 object lying on the ephemeral heap segment. A less defensive ICorProfiler implementation might index into the -1 entry of an array and leading to buffer underflow. Even for a defensive implementation, we would have wrong statistics.

After the change, we will output 2 as the correct generation number.

## Testing
The diagnostics team confirmed the change fixed the problem through their automated testing.

## Risk
Low – this is a new code path introduced in .NET 6.