### PR TITLE
FileSystemEntry.Unix: ensure properties are available when file is deleted.

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.cs
@@ -270,28 +270,6 @@ namespace System
         }
 
         /// <summary>
-        /// Validate that a given value is equal to another value.
-        /// </summary>
-        /// <param name="expected">The expected value.</param>
-        /// <param name="actual">The value to be compared against.</param>
-        public static void EqualTo<T>(T expected, T actual, string userMessage = null)
-        {
-            if (expected == null && actual == null)
-                return;
-
-            bool equal = expected != null && expected switch
-            {
-                IEquatable<T> equatable => equatable.Equals(actual),
-                IComparable<T> comparableT => comparableT.CompareTo(actual) == 0,
-                IComparable comparable => comparable.CompareTo(actual) == 0,
-                _ => throw new NotSupportedException($"{nameof(EqualTo)} is not supported for {typeof(T)}.")
-            };
-
-            if (!equal)
-                throw new XunitException(AddOptionalUserMessage($"Expected: {expected} is not equal to {actual}", userMessage));
-        }
-
-        /// <summary>
         /// Validate that a given value is greater than another value.
         /// </summary>
         /// <param name="actual">The value that should be greater than <paramref name="greaterThan"/>.</param>

--- a/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.cs
@@ -277,7 +277,7 @@ namespace System
         public static void EqualTo<T>(T expected, T actual, string userMessage = null)
         {
             if (expected == null && actual == null)
-				return;
+                return;
 
             bool equal = expected != null && expected switch
             {

--- a/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.cs
@@ -270,6 +270,28 @@ namespace System
         }
 
         /// <summary>
+        /// Validate that a given value is equal to another value.
+        /// </summary>
+        /// <param name="expected">The expected value.</param>
+        /// <param name="actual">The value to be compared against.</param>
+        public static void EqualTo<T>(T expected, T actual, string userMessage = null)
+        {
+            if (expected == null && actual == null)
+				return;
+
+            bool equal = expected != null && expected switch
+            {
+                IEquatable<T> equatable => equatable.Equals(actual),
+                IComparable<T> comparableT => comparableT.CompareTo(actual) == 0,
+                IComparable comparable => comparable.CompareTo(actual) == 0,
+                _ => throw new NotSupportedException($"{nameof(EqualTo)} is not supported for {typeof(T)}.")
+            };
+
+            if (!equal)
+                throw new XunitException(AddOptionalUserMessage($"Expected: {expected} is not equal to {actual}", userMessage));
+        }
+
+        /// <summary>
         /// Validate that a given value is greater than another value.
         /// </summary>
         /// <param name="actual">The value that should be greater than <paramref name="greaterThan"/>.</param>

--- a/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
@@ -92,45 +92,45 @@ namespace System.IO.Tests.Enumeration
                 entry = enumerator.Current;
 
                 // Names and paths.
-                AssertExtensions.EqualTo(expected.Name, entry.FileName, "Name");
-                AssertExtensions.EqualTo(testDirectory.FullName, entry.Directory, "Directory");
-                AssertExtensions.EqualTo(expected.FullName, entry.FullPath, "FullPath");
-                AssertExtensions.EqualTo(expected.FullName, entry.SpecifiedFullPath, "SpecifiedFullPath");
+                Assert.Equal(expected.Name, entry.FileName);
+                Assert.Equal(testDirectory.FullName, entry.Directory);
+                Assert.Equal(expected.FullName, entry.FullPath);
+                Assert.Equal(expected.FullName, entry.SpecifiedFullPath);
 
                 // Values determined during enumeration.
                 if (PlatformDetection.IsBrowser)
                 {
                     // For Browser, all items are typed as DT_UNKNOWN.
-                    AssertExtensions.EqualTo(false, entry.IsDirectory, "IsDirectory");
-                    AssertExtensions.EqualTo(entry.FileName.StartsWith('.') ? FileAttributes.Hidden : FileAttributes.Normal, entry.Attributes, "Attributes");
+                    Assert.False(entry.IsDirectory);
+                    Assert.Equal(entry.FileName.StartsWith('.') ? FileAttributes.Hidden : FileAttributes.Normal, entry.Attributes);
                 }
                 else
                 {
-                    AssertExtensions.EqualTo(expected is DirectoryInfo, entry.IsDirectory, "IsDirectory");
-                    AssertExtensions.EqualTo(expected.Attributes, entry.Attributes, "Attributes");
+                    Assert.Equal(expected is DirectoryInfo, entry.IsDirectory);
+                    Assert.Equal(expected.Attributes, entry.Attributes);
                 }
 
                 if (PlatformDetection.IsWindows)
                 {
-                    AssertExtensions.EqualTo((expected.Attributes & FileAttributes.Hidden) != 0, entry.IsHidden, "IsHidden");
-                    AssertExtensions.EqualTo(expected.CreationTimeUtc, entry.CreationTimeUtc, "CreationTimeUtc");
-                    AssertExtensions.EqualTo(expected.LastAccessTimeUtc, entry.LastAccessTimeUtc, "LastAccessTimeUtc");
-                    AssertExtensions.EqualTo(expected.LastWriteTimeUtc, entry.LastWriteTimeUtc, "LastWriteTimeUtc");
+                    Assert.Equal((expected.Attributes & FileAttributes.Hidden) != 0, entry.IsHidden);
+                    Assert.Equal(expected.CreationTimeUtc, entry.CreationTimeUtc);
+                    Assert.Equal(expected.LastAccessTimeUtc, entry.LastAccessTimeUtc);
+                    Assert.Equal(expected.LastWriteTimeUtc, entry.LastWriteTimeUtc);
                     if (expected is FileInfo fileInfo)
                     {
-                        AssertExtensions.EqualTo(fileInfo.Length, entry.Length, "Length");
+                        Assert.Equal(fileInfo.Length, entry.Length);
                     }
                 }
                 else
                 {
                     // On Unix, these values were not determined during enumeration.
                     // Because the file was deleted, the values can no longer be retrieved and sensible defaults are returned.
-                    AssertExtensions.EqualTo(entry.FileName.StartsWith('.'), entry.IsHidden, "IsHidden");
+                    Assert.Equal(entry.FileName.StartsWith('.'), entry.IsHidden);
                     DateTimeOffset defaultTime = new DateTimeOffset(DateTime.FromFileTimeUtc(0));
-                    AssertExtensions.EqualTo(defaultTime, entry.CreationTimeUtc, "CreationTimeUtc");
-                    AssertExtensions.EqualTo(defaultTime, entry.LastAccessTimeUtc, "LastAccessTimeUtc");
-                    AssertExtensions.EqualTo(defaultTime, entry.LastWriteTimeUtc, "LastWriteTimeUtc");
-                    AssertExtensions.EqualTo(0, entry.Length, "Length");
+                    Assert.Equal(defaultTime, entry.CreationTimeUtc);
+                    Assert.Equal(defaultTime, entry.LastAccessTimeUtc);
+                    Assert.Equal(defaultTime, entry.LastWriteTimeUtc);
+                    Assert.Equal(0, entry.Length);
                 }
 
                 Assert.False(enumerator.MoveNext(), "Move final");

--- a/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
@@ -110,9 +110,10 @@ namespace System.IO.Tests.Enumeration
                 {
                     // Because the item is deleted, we can no longer retrieve these values and defaults are returned instead.
                     Assert.Equal(entry.FileName.StartsWith('.'), entry.IsHidden);
-                    Assert.Equal(new DateTimeOffset(DateTime.FromFileTimeUtc(0)), entry.CreationTimeUtc);
-                    Assert.Equal(new DateTimeOffset(DateTime.FromFileTimeUtc(0)), entry.LastAccessTimeUtc);
-                    Assert.Equal(new DateTimeOffset(DateTime.FromFileTimeUtc(0)), entry.LastWriteTimeUtc);
+                    DateTimeOffset defaultOffset = new DateTimeOffset(DateTime.FromFileTimeUtc(0));
+                    Assert.Equal(defaultOffset, entry.CreationTimeUtc);
+                    Assert.Equal(defaultOffset, entry.LastAccessTimeUtc);
+                    Assert.Equal(defaultOffset, entry.LastWriteTimeUtc);
                     Assert.Equal(0, entry.Length);
                 }
 

--- a/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
@@ -85,7 +85,12 @@ namespace System.IO.Tests.Enumeration
                 FileSystemInfo expected = entry.FileName == item1 ? item2Info : item1Info;
                 Assert.True(enumerator.MoveNext(), "Move second");
                 entry = enumerator.Current;
+
+                // Names and paths.
                 AssertExtensions.EqualTo(expected.Name, entry.FileName, "Name");
+                AssertExtensions.EqualTo(testDirectory.FullName, entry.Directory, "Directory");
+                AssertExtensions.EqualTo(expected.FullName, entry.FullPath, "FullPath");
+                AssertExtensions.EqualTo(expected.FullName, entry.SpecifiedFullPath, "SpecifiedFullPath");
 
                 // Values determined during enumeration.
                 if (PlatformDetection.IsBrowser)
@@ -100,10 +105,6 @@ namespace System.IO.Tests.Enumeration
                     AssertExtensions.EqualTo(expected.Attributes, entry.Attributes, "Attributes");
                 }
 
-                AssertExtensions.EqualTo(testDirectory.FullName, entry.Directory, "Directory");
-                AssertExtensions.EqualTo(expected.FullName, entry.FullPath, "FullPath");
-                AssertExtensions.EqualTo(expected.FullName, entry.SpecifiedFullPath, "SpecifiedFullPath");
-
                 if (PlatformDetection.IsWindows)
                 {
                     AssertExtensions.EqualTo((expected.Attributes & FileAttributes.Hidden) != 0, entry.IsHidden, "IsHidden");
@@ -117,7 +118,8 @@ namespace System.IO.Tests.Enumeration
                 }
                 else
                 {
-                    // Because the item is deleted, we can no longer retrieve these values and defaults are returned instead.
+                    // On Unix, these values were not determined during enumeration.
+                    // Because the file was deleted, the values can no longer be retrieved and sensible defaults are returned.
                     AssertExtensions.EqualTo(entry.FileName.StartsWith('.'), entry.IsHidden, "IsHidden");
                     DateTimeOffset defaultTime = new DateTimeOffset(DateTime.FromFileTimeUtc(0));
                     AssertExtensions.EqualTo(defaultTime, entry.CreationTimeUtc, "CreationTimeUtc");

--- a/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
@@ -88,8 +88,18 @@ namespace System.IO.Tests.Enumeration
                 AssertExtensions.EqualTo(expected.Name, entry.FileName, "Name");
 
                 // Values determined during enumeration.
-                AssertExtensions.EqualTo(expected is DirectoryInfo, entry.IsDirectory, "IsDirectory");
-                AssertExtensions.EqualTo(expected.Attributes, entry.Attributes, "Attributes");
+                if (PlatformDetection.IsBrowser)
+                {
+                    // For Browser, all items are typed as DT_UNKNOWN.
+                    AssertExtensions.EqualTo(false, entry.IsDirectory, "IsDirectory");
+                    AssertExtensions.EqualTo(entry.FileName.StartsWith('.') ? FileAttributes.Hidden : FileAttributes.Normal, entry.Attributes, "Attributes");
+                }
+                else
+                {
+                    AssertExtensions.EqualTo(expected is DirectoryInfo, entry.IsDirectory, "IsDirectory");
+                    AssertExtensions.EqualTo(expected.Attributes, entry.Attributes, "Attributes");
+                }
+
                 AssertExtensions.EqualTo(testDirectory.FullName, entry.Directory, "Directory");
                 AssertExtensions.EqualTo(expected.FullName, entry.FullPath, "FullPath");
                 AssertExtensions.EqualTo(expected.FullName, entry.SpecifiedFullPath, "SpecifiedFullPath");

--- a/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
@@ -55,7 +55,7 @@ namespace System.IO.Tests.Enumeration
                 fileOne.Attributes &= ~(FileAttributes.Archive | FileAttributes.NotContentIndexed);
             }
 
-            using (var enumerator = new DefaultFileAttributes(testDirectory.FullName, new EnumerationOptions()))
+            using (var enumerator = new DefaultFileAttributes(testDirectory.FullName, new EnumerationOptions() { AttributesToSkip = 0 }))
             {
                 Assert.True(enumerator.MoveNext());
                 Assert.Equal(fileOne.Name, enumerator.Current);
@@ -104,7 +104,7 @@ namespace System.IO.Tests.Enumeration
                 subDirectory.Attributes &= ~FileAttributes.NotContentIndexed;
             }
 
-            using (var enumerator = new DefaultDirectoryAttributes(testDirectory.FullName, new EnumerationOptions()))
+            using (var enumerator = new DefaultDirectoryAttributes(testDirectory.FullName, new EnumerationOptions() { AttributesToSkip = 0 }))
             {
                 Assert.True(enumerator.MoveNext());
                 Assert.Equal(subDirectory.Name, enumerator.Current);

--- a/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
@@ -113,10 +113,7 @@ namespace System.IO.Tests.Enumeration
                     Assert.Equal(new DateTimeOffset(DateTime.FromFileTimeUtc(0)), entry.CreationTimeUtc);
                     Assert.Equal(new DateTimeOffset(DateTime.FromFileTimeUtc(0)), entry.LastAccessTimeUtc);
                     Assert.Equal(new DateTimeOffset(DateTime.FromFileTimeUtc(0)), entry.LastWriteTimeUtc);
-                    if (expected is FileInfo fileInfo)
-                    {
-                        Assert.Equal(0, entry.Length);
-                    }
+                    Assert.Equal(0, entry.Length);
                 }
 
                 Assert.False(enumerator.MoveNext());

--- a/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Enumeration/AttributeTests.cs
@@ -72,7 +72,7 @@ namespace System.IO.Tests.Enumeration
             using (var enumerator = new GetPropertiesEnumerator(testDirectory.FullName, new EnumerationOptions() { AttributesToSkip = 0 }))
             {
                 // Move to the first item.
-                Assert.True(enumerator.MoveNext());
+                Assert.True(enumerator.MoveNext(), "Move first");
                 FileSystemEntryProperties entry = enumerator.Current;
 
                 Assert.True(entry.FileName == item1 || entry.FileName == item2, "Unexpected item");
@@ -83,41 +83,40 @@ namespace System.IO.Tests.Enumeration
 
                 // Move to the second item.
                 FileSystemInfo expected = entry.FileName == item1 ? item2Info : item1Info;
-                Assert.True(enumerator.MoveNext());
+                Assert.True(enumerator.MoveNext(), "Move second");
                 entry = enumerator.Current;
-                Assert.Equal(expected.Name, entry.FileName);
+                AssertExtensions.EqualTo(expected.Name, entry.FileName, "Name");
 
                 // Values determined during enumeration.
-                Assert.Equal(expected is DirectoryInfo, entry.IsDirectory);
-                Assert.Equal(expected.Attributes, entry.Attributes);
-                Assert.Equal(testDirectory.FullName, entry.Directory);
-                Assert.Equal(expected.FullName, entry.FullPath);
-                Assert.Equal(expected.FullName, entry.SpecifiedFullPath);
+                AssertExtensions.EqualTo(expected is DirectoryInfo, entry.IsDirectory, "IsDirectory");
+                AssertExtensions.EqualTo(expected.Attributes, entry.Attributes, "Attributes");
+                AssertExtensions.EqualTo(testDirectory.FullName, entry.Directory, "Directory");
+                AssertExtensions.EqualTo(expected.FullName, entry.FullPath, "FullPath");
+                AssertExtensions.EqualTo(expected.FullName, entry.SpecifiedFullPath, "SpecifiedFullPath");
 
                 if (PlatformDetection.IsWindows)
                 {
-                    Assert.Equal((expected.Attributes & FileAttributes.Hidden) != 0, entry.IsHidden);
-                    Assert.Equal(expected.CreationTimeUtc, entry.CreationTimeUtc);
-                    Assert.Equal(expected.LastAccessTimeUtc, entry.LastAccessTimeUtc);
-                    Assert.Equal(expected.LastWriteTimeUtc, entry.LastWriteTimeUtc);
-                    Assert.Equal((expected.Attributes & FileAttributes.Hidden) != 0, entry.IsHidden);
+                    AssertExtensions.EqualTo((expected.Attributes & FileAttributes.Hidden) != 0, entry.IsHidden, "IsHidden");
+                    AssertExtensions.EqualTo(expected.CreationTimeUtc, entry.CreationTimeUtc, "CreationTimeUtc");
+                    AssertExtensions.EqualTo(expected.LastAccessTimeUtc, entry.LastAccessTimeUtc, "LastAccessTimeUtc");
+                    AssertExtensions.EqualTo(expected.LastWriteTimeUtc, entry.LastWriteTimeUtc, "LastWriteTimeUtc");
                     if (expected is FileInfo fileInfo)
                     {
-                        Assert.Equal(fileInfo.Length, entry.Length);
+                        AssertExtensions.EqualTo(fileInfo.Length, entry.Length, "Length");
                     }
                 }
                 else
                 {
                     // Because the item is deleted, we can no longer retrieve these values and defaults are returned instead.
-                    Assert.Equal(entry.FileName.StartsWith('.'), entry.IsHidden);
-                    DateTimeOffset defaultOffset = new DateTimeOffset(DateTime.FromFileTimeUtc(0));
-                    Assert.Equal(defaultOffset, entry.CreationTimeUtc);
-                    Assert.Equal(defaultOffset, entry.LastAccessTimeUtc);
-                    Assert.Equal(defaultOffset, entry.LastWriteTimeUtc);
-                    Assert.Equal(0, entry.Length);
+                    AssertExtensions.EqualTo(entry.FileName.StartsWith('.'), entry.IsHidden, "IsHidden");
+                    DateTimeOffset defaultTime = new DateTimeOffset(DateTime.FromFileTimeUtc(0));
+                    AssertExtensions.EqualTo(defaultTime, entry.CreationTimeUtc, "CreationTimeUtc");
+                    AssertExtensions.EqualTo(defaultTime, entry.LastAccessTimeUtc, "LastAccessTimeUtc");
+                    AssertExtensions.EqualTo(defaultTime, entry.LastWriteTimeUtc, "LastWriteTimeUtc");
+                    AssertExtensions.EqualTo(0, entry.Length, "Length");
                 }
 
-                Assert.False(enumerator.MoveNext());
+                Assert.False(enumerator.MoveNext(), "Move final");
             }
 
             static FileSystemInfo CreateItem(DirectoryInfo testDirectory, string item)
@@ -133,7 +132,7 @@ namespace System.IO.Tests.Enumeration
                 else
                 {
                     // use the last char to have different lengths for different files.
-                    Assert.True(item == "file1" || item == "file2");
+                    Assert.True(item == "file1" || item == "file2", "File names");
                     int length = (int)item[item.Length - 1];
                     File.WriteAllBytes(fullPath, new byte[length]);
                     var info = new FileInfo(fullPath);

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEntry.Unix.cs
@@ -10,7 +10,7 @@ namespace System.IO.Enumeration
     /// </summary>
     public unsafe ref partial struct FileSystemEntry
    {
-        internal Interop.Sys.DirectoryEntry _directoryEntry;
+        private Interop.Sys.DirectoryEntry _directoryEntry;
         private FileStatus _status;
         private Span<char> _pathBuffer;
         private ReadOnlySpan<char> _fullPath;
@@ -32,38 +32,34 @@ namespace System.IO.Enumeration
             entry._pathBuffer = pathBuffer;
             entry._fullPath = ReadOnlySpan<char>.Empty;
             entry._fileName = ReadOnlySpan<char>.Empty;
-
             entry._status.InvalidateCaches();
+            entry._status.InitiallyDirectory = false;
 
             bool isDirectory = directoryEntry.InodeType == Interop.Sys.NodeType.DT_DIR;
             bool isSymlink   = directoryEntry.InodeType == Interop.Sys.NodeType.DT_LNK;
             bool isUnknown   = directoryEntry.InodeType == Interop.Sys.NodeType.DT_UNKNOWN;
 
-            // Some operating systems don't have the inode type in the dirent structure,
-            // so we use DT_UNKNOWN as a sentinel value. As such, check if the dirent is a
-            // symlink or a directory.
-            if (isUnknown)
+            if (isDirectory)
             {
-                isSymlink = entry.IsSymbolicLink;
-                // Need to fail silently in case we are enumerating
-                isDirectory = entry._status.IsDirectory(entry.FullPath, continueOnError: true);
+                entry._status.InitiallyDirectory = true;
             }
-            // Same idea as the directory check, just repeated for (and tweaked due to the
-            // nature of) symlinks.
-            // Whether we had the dirent structure or not, we treat a symlink to a directory as a directory,
-            // so we need to reflect that in our isDirectory variable.
             else if (isSymlink)
             {
-                // Need to fail silently in case we are enumerating
-                isDirectory = entry._status.IsDirectory(entry.FullPath, continueOnError: true);
+                entry._status.InitiallyDirectory = entry._status.IsDirectory(entry.FullPath, continueOnError: true);
+            }
+            else if (isUnknown)
+            {
+                entry._status.InitiallyDirectory = entry._status.IsDirectory(entry.FullPath, continueOnError: true);
+                if (entry._status.IsSymbolicLink(entry.FullPath, continueOnError: true))
+                {
+                    entry._directoryEntry.InodeType = Interop.Sys.NodeType.DT_LNK;
+                }
             }
 
-            entry._status.InitiallyDirectory = isDirectory;
-
             FileAttributes attributes = default;
-            if (isSymlink)
+            if (entry.IsSymbolicLink)
                 attributes |= FileAttributes.ReparsePoint;
-            if (isDirectory)
+            if (entry.IsDirectory)
                 attributes |= FileAttributes.Directory;
 
             return attributes;
@@ -119,15 +115,41 @@ namespace System.IO.Enumeration
 
         // Windows never fails getting attributes, length, or time as that information comes back
         // with the native enumeration struct. As such we must not throw here.
-        public FileAttributes Attributes => _status.GetAttributes(FullPath, FileName);
+        public FileAttributes Attributes
+        {
+            get
+            {
+                FileAttributes attributes = _status.GetAttributes(FullPath, FileName, continueOnError: true);
+                if (attributes != (FileAttributes)(-1))
+                {
+                    return attributes;
+                }
+
+                // File was removed before we retrieved attributes.
+                // Return what we know.
+                attributes = default;
+
+                if (IsSymbolicLink)
+                    attributes |= FileAttributes.ReparsePoint;
+
+                if (IsDirectory)
+                    attributes |= FileAttributes.Directory;
+
+                if (FileStatus.IsNameHidden(FileName))
+                    attributes |= FileAttributes.Hidden;
+
+                return attributes != default ? attributes : FileAttributes.Normal;
+            }
+        }
         public long Length => _status.GetLength(FullPath, continueOnError: true);
         public DateTimeOffset CreationTimeUtc => _status.GetCreationTime(FullPath, continueOnError: true);
         public DateTimeOffset LastAccessTimeUtc => _status.GetLastAccessTime(FullPath, continueOnError: true);
         public DateTimeOffset LastWriteTimeUtc => _status.GetLastWriteTime(FullPath, continueOnError: true);
+        public bool IsHidden => _status.IsHidden(FullPath, FileName, continueOnError: true);
+        internal bool IsReadOnly => _status.IsReadOnly(FullPath, continueOnError: true);
+
         public bool IsDirectory => _status.InitiallyDirectory;
-        public bool IsHidden => _status.IsHidden(FullPath, FileName);
-        internal bool IsReadOnly => _status.IsReadOnly(FullPath);
-        internal bool IsSymbolicLink => _status.IsSymbolicLink(FullPath);
+        internal bool IsSymbolicLink => _directoryEntry.InodeType == Interop.Sys.NodeType.DT_LNK;
 
         public FileSystemInfo ToFileSystemInfo()
         {

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStatus.Unix.cs
@@ -327,7 +327,7 @@ namespace System.IO
         internal long GetLength(ReadOnlySpan<char> path, bool continueOnError = false)
         {
             EnsureCachesInitialized(path, continueOnError);
-            return _fileCache.Size;
+            return IsFileCacheInitialized ? _fileCache.Size : 0;
         }
 
         // Tries to refresh the lstat cache (_fileCache).

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStatus.Unix.cs
@@ -326,6 +326,9 @@ namespace System.IO
 
         internal long GetLength(ReadOnlySpan<char> path, bool continueOnError = false)
         {
+            // For symbolic links, on Windows, Length returns zero and not the target file size.
+            // On Unix, it returns the length of the path stored in the link.
+
             EnsureCachesInitialized(path, continueOnError);
             return IsFileCacheInitialized ? _fileCache.Size : 0;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStatus.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStatus.Unix.cs
@@ -123,7 +123,7 @@ namespace System.IO
             return HasHiddenFlag;
         }
 
-        internal bool IsNameHidden(ReadOnlySpan<char> fileName) => fileName.Length > 0 && fileName[0] == '.';
+        internal static bool IsNameHidden(ReadOnlySpan<char> fileName) => fileName.Length > 0 && fileName[0] == '.';
 
         // Returns true if the path points to a directory, or if the path is a symbolic link
         // that points to a directory
@@ -139,9 +139,9 @@ namespace System.IO
             return HasSymbolicLinkFlag;
         }
 
-        internal FileAttributes GetAttributes(ReadOnlySpan<char> path, ReadOnlySpan<char> fileName)
+        internal FileAttributes GetAttributes(ReadOnlySpan<char> path, ReadOnlySpan<char> fileName, bool continueOnError = false)
         {
-            EnsureCachesInitialized(path);
+            EnsureCachesInitialized(path, continueOnError);
 
             if (!_exists)
                 return (FileAttributes)(-1);


### PR DESCRIPTION
When the file no longer exists, we create attributes based on what we know.

The test for this was passing because it cached the attributes before the
item was deleted due to enumerating with skipping FileAttributes.Hidden.

@carlossanlop ptal.