### PR TITLE
Fix a build break

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -64,7 +64,7 @@ GenTree* Compiler::fgMorphIntoHelperCall(GenTree* tree, int helper, GenTreeCall:
 
     GenTreeCall* call           = tree->AsCall();
     call->gtCallType            = CT_HELPER;
-    call->gtReturnType          = static_cast<unsigned char>(tree->TypeGet());
+    call->gtReturnType          = tree->TypeGet();
     call->gtCallMethHnd         = eeFindHelper(helper);
     call->gtCallThisArg         = nullptr;
     call->gtCallArgs            = args;


### PR DESCRIPTION
The other casts around `gtReturnType` should be cleaned up as well, but that is left for another day.

This should presumably be merged with some expedience as it affects the CI.

Closes #60221

@dotnet/jit-contrib