### PR TITLE
Sort oper allocation counts table

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -214,7 +214,7 @@ unsigned char GenTree::s_gtTrueSizes[GT_COUNT + 1]{
 #endif // NODEBASH_STATS || MEASURE_NODE_SIZE || COUNT_AST_OPERS
 
 #if COUNT_AST_OPERS
-LONG GenTree::s_gtNodeCounts[GT_COUNT + 1] = {0};
+unsigned GenTree::s_gtNodeCounts[GT_COUNT + 1] = {0};
 #endif // COUNT_AST_OPERS
 
 /* static */
@@ -509,8 +509,8 @@ void GenTree::DumpNodeSizes(FILE* fp)
 {
     // Dump the sizes of the various GenTree flavors
 
-    fprintf(fp, "Small tree node size = %3u bytes\n", TREE_NODE_SZ_SMALL);
-    fprintf(fp, "Large tree node size = %3u bytes\n", TREE_NODE_SZ_LARGE);
+    fprintf(fp, "Small tree node size = %zu bytes\n", TREE_NODE_SZ_SMALL);
+    fprintf(fp, "Large tree node size = %zu bytes\n", TREE_NODE_SZ_LARGE);
     fprintf(fp, "\n");
 
     // Verify that node sizes are set kosherly and dump sizes

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1877,7 +1877,7 @@ public:
     static unsigned char s_gtTrueSizes[];
 #endif
 #if COUNT_AST_OPERS
-    static LONG s_gtNodeCounts[];
+    static unsigned s_gtNodeCounts[];
 #endif
 
     static void InitNodeSize();


### PR DESCRIPTION
Sort the table output for `COUNT_AST_OPERS`, improving its legibility.

Sample output of the new table when CG-ing x64 CoreLib:

```scala
GenTree operator counts (approximate):

    GT_LCL_VAR              812975 (23.1%)  72 bytes each
    GT_CNS_INT              443558 (12.6%)  72 bytes each
    GT_ASG                  300295 ( 8.5%)  64 bytes each
    GT_CALL                 197311 ( 5.6%) 144 bytes each
    GT_IL_OFFSET            185497 ( 5.3%)  48 bytes each
    GT_IND                  182090 ( 5.2%)  64 bytes each
    GT_PUTARG_REG           141099 ( 4.0%)  64 bytes each
    GT_ADDR                 137819 ( 3.9%)  64 bytes each
    GT_ARGPLACE             128510 ( 3.6%)  56 bytes each
    GT_ADD                  114240 ( 3.2%)  64 bytes each
    GT_FIELD                111934 ( 3.2%)  88 bytes each
    GT_NOP                   97413 ( 2.8%)  48 bytes each
    GT_CAST                  73225 ( 2.1%)  72 bytes each
    GT_RET_EXPR              68020 ( 1.9%)  72 bytes each
    GT_JTRUE                 63943 ( 1.8%)  64 bytes each
    GT_COMMA                 56130 ( 1.6%)  64 bytes each
    GT_PHI_ARG               51581 ( 1.5%)  72 bytes each
    GT_RETURN                38862 ( 1.1%)  64 bytes each
    GT_EQ                    36072 ( 1.0%)  64 bytes each
    GT_STOREIND              31268 ( 0.9%)  72 bytes each
    GT_NE                    29118 ( 0.8%)  64 bytes each
    GT_OBJ                   24266 ( 0.7%)  80 bytes each
    GT_PHI                   23213 ( 0.7%)  56 bytes each
    All other GT_xxx ...    175143 ( 5.0%) ...  4.7% small +  0.3% large
    -----------------------------------------------------
    Total    .......       3523582 --ALL-- ... 91.0% small +  9.0% large
```