### PR TITLE
Fix: CTS.TryReset() concurrency issue #60182

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
@@ -392,11 +392,12 @@ namespace System.Threading
             // to transition from canceled to non-canceled.
             if (_state == NotCanceledState)
             {
+                bool reset;
+
                 // If there is no timer, then we're free to reset.  If there is a timer, then we need to first try
                 // to reset it to be infinite so that it won't fire, and then recognize that it could have already
                 // fired by the time we successfully changed it, and so check to see whether that's possibly the case.
                 // If we successfully reset it and it never fired, then we can be sure it won't trigger cancellation.
-                bool reset = false;
                 if (_timer is TimerQueueTimer timer)
                 {
                     try
@@ -405,11 +406,16 @@ namespace System.Threading
                     }
                     catch (ObjectDisposedException)
                     {
-                        // Just eat the exception. There is no other way to tell that 
-                        // the timer has been disposed, and even if there were, there 
-                        // would not be a good way to deal with the observe/dispose 
-                        // race condition. 
+                        // Just eat the exception. There is no other way to tell that
+                        // the timer has been disposed, and even if there were, there
+                        // would not be a good way to deal with the observe/dispose
+                        // race condition.
+                        reset = false;
                     }
+                }
+                else
+                {
+                    reset = true;
                 }
 
                 if (reset)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/CancellationTokenSource.cs
@@ -396,9 +396,21 @@ namespace System.Threading
                 // to reset it to be infinite so that it won't fire, and then recognize that it could have already
                 // fired by the time we successfully changed it, and so check to see whether that's possibly the case.
                 // If we successfully reset it and it never fired, then we can be sure it won't trigger cancellation.
-                bool reset =
-                    _timer is not TimerQueueTimer timer ||
-                    (timer.Change(Timeout.UnsignedInfinite, Timeout.UnsignedInfinite) && !timer._everQueued);
+                bool reset = false;
+                if (_timer is TimerQueueTimer timer)
+                {
+                    try
+                    {
+                        reset = timer.Change(Timeout.UnsignedInfinite, Timeout.UnsignedInfinite) && !timer._everQueued;
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        // Just eat the exception. There is no other way to tell that 
+                        // the timer has been disposed, and even if there were, there 
+                        // would not be a good way to deal with the observe/dispose 
+                        // race condition. 
+                    }
+                }
 
                 if (reset)
                 {


### PR DESCRIPTION
PR contains a fix for #60182

Also, the fix resolves potential concurrency between `Cancel` and `TryReset` as follows:
* If `Cancel` happens before `TryReset` then CTS will be canceled normally
* If `TryReset` happens before `Cancel` then `Cancel` will have no effect