### PR TITLE
Reenable ExportCertificatePems_MultiCert test on Android

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -1583,7 +1583,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/59777", TestPlatforms.Android)]
         public static void ExportCertificatePems_MultiCert()
         {
             const string MultiPem = "-----BEGIN CERTIFICATE-----\n" +


### PR DESCRIPTION
The issue https://github.com/dotnet/runtime/issues/59777 was fixed.