### PR TITLE
Fix runtime-staging trigger and one bug

### DIFF
--- a/eng/pipelines/runtime-staging.yml
+++ b/eng/pipelines/runtime-staging.yml
@@ -1,3 +1,27 @@
+# Setting batch to true, triggers one build at a time.
+# if there is a push while a build in progress, it will wait,
+# until the running build finishes, and produce a build with all the changes
+# that happened during the last build.
+trigger:
+  batch: true
+  branches:
+    include:
+    - release/*.*
+  paths:
+    include:
+    - '*'
+    exclude:
+    - eng/Version.Details.xml
+    - .github/*
+    - docs/*
+    - CODE-OF-CONDUCT.md
+    - CONTRIBUTING.md
+    - LICENSE.TXT
+    - PATENTS.TXT
+    - README.md
+    - SECURITY.md
+    - THIRD-PARTY-NOTICES.TXT
+
 schedules:
   - cron: "0 7,19 * * *" # run at 7:00 and 19:00 (UTC) which is 23:00 and 11:00 (PST).
     displayName: Runtime-staging default schedule
@@ -160,7 +184,6 @@ jobs:
       extraStepsTemplate: /eng/pipelines/libraries/helix.yml
       extraStepsParameters:
         creator: dotnet-bot
-        interpreter: true
         testRunNamePrefixSuffix: Mono_$(_BuildConfig)
         condition: >-
           or(


### PR DESCRIPTION
We were triggering the runtime-staging jobs for all branches rather than just PRs and the scheduled runs on main.
Fix it to only run for pushes on release branches, like runtime.yml.

I also noticed a small bug where we had `interpreter: true` in the "iOS/tvOS devices - Full AOT + AggressiveTrimming" job, that was probably a copy/paste mistake.