### PR TITLE
Move the Libraries Enterprise Linux pipeline off Ubuntu 16.04

### DIFF
--- a/eng/pipelines/libraries/enterprise/linux.yml
+++ b/eng/pipelines/libraries/enterprise/linux.yml
@@ -19,7 +19,7 @@ pr:
       - src/libraries/System.Net.Security/*
 
 pool:
-  vmImage: 'ubuntu-16.04'
+  vmImage: 'ubuntu-18.04'
 
 variables:
   - template: ../variables.yml


### PR DESCRIPTION
Ubuntu 16.04 is out of support and Azure DevOps is going to remove the queue (they have a brownout today which is how I found this).