### PR TITLE
Fix a few more ASAN-exposed issues

### DIFF
--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -674,8 +674,8 @@ PCODE MethodDesc::JitCompileCode(PrepareCodeConfig* pConfig)
 
         const char *description = "jit lock";
         INDEBUG(description = m_pszDebugMethodName;)
-            ReleaseHolder<JitListLockEntry> pEntry(JitListLockEntry::Find(
-                pJitLock, version, description));
+        ReleaseHolder<JitListLockEntry> pEntry(JitListLockEntry::Find(
+            pJitLock, version, description));
 
         // We have an entry now, we can release the global lock
         pJitLock.Release();

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -670,10 +670,12 @@ PCODE MethodDesc::JitCompileCode(PrepareCodeConfig* pConfig)
             return pCode;
         }
 
+        NativeCodeVersion version = pConfig->GetCodeVersion();
+
         const char *description = "jit lock";
         INDEBUG(description = m_pszDebugMethodName;)
             ReleaseHolder<JitListLockEntry> pEntry(JitListLockEntry::Find(
-                pJitLock, pConfig->GetCodeVersion(), description));
+                pJitLock, version, description));
 
         // We have an entry now, we can release the global lock
         pJitLock.Release();

--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -93,6 +93,9 @@ BOOL ReadyToRunInfo::TryLookupTypeTokenFromName(const NameHandle *pName, mdToken
 
     LPCUTF8 pszName = NULL;
     LPCUTF8 pszNameSpace = NULL;
+    // Reserve stack space for parsing out the namespace in a name-based lookup
+    // at this scope so the stack space is in scope for all usages in this method.
+    CQuickBytes szNamespace;
 
     //
     // Compute the hashcode of the type (hashcode based on type name and namespace name)
@@ -105,7 +108,7 @@ BOOL ReadyToRunInfo::TryLookupTypeTokenFromName(const NameHandle *pName, mdToken
 
         pszName = pName->GetName();
         pszNameSpace = "";
-
+        
         if (pName->GetNameSpace() != NULL)
         {
             pszNameSpace = pName->GetNameSpace();
@@ -113,7 +116,6 @@ BOOL ReadyToRunInfo::TryLookupTypeTokenFromName(const NameHandle *pName, mdToken
         else
         {
             LPCUTF8 p;
-            CQuickBytes szNamespace;
 
             if ((p = ns::FindSep(pszName)) != NULL)
             {

--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -95,7 +95,7 @@ BOOL ReadyToRunInfo::TryLookupTypeTokenFromName(const NameHandle *pName, mdToken
     LPCUTF8 pszNameSpace = NULL;
     // Reserve stack space for parsing out the namespace in a name-based lookup
     // at this scope so the stack space is in scope for all usages in this method.
-    CQuickBytes szNamespace;
+    CQuickBytes namespaceBuffer;
 
     //
     // Compute the hashcode of the type (hashcode based on type name and namespace name)
@@ -121,7 +121,7 @@ BOOL ReadyToRunInfo::TryLookupTypeTokenFromName(const NameHandle *pName, mdToken
                 SIZE_T d = p - pszName;
 
                 FAULT_NOT_FATAL();
-                pszNameSpace = szNamespace.SetStringNoThrow(pszName, d);
+                pszNameSpace = namespaceBuffer.SetStringNoThrow(pszName, d);
 
                 if (pszNameSpace == NULL)
                     return FALSE;

--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -108,7 +108,6 @@ BOOL ReadyToRunInfo::TryLookupTypeTokenFromName(const NameHandle *pName, mdToken
 
         pszName = pName->GetName();
         pszNameSpace = "";
-        
         if (pName->GetNameSpace() != NULL)
         {
             pszNameSpace = pName->GetNameSpace();

--- a/src/coreclr/vm/threadstatics.cpp
+++ b/src/coreclr/vm/threadstatics.cpp
@@ -464,7 +464,7 @@ void    ThreadLocalModule::EnsureDynamicClassIndex(DWORD dwID)
 
     // If this allocation fails, we throw. If it succeeds,
     // then we are good to go
-    pNewDynamicClassTable = (DynamicClassInfo*)(void*)new BYTE[sizeof(DynamicClassInfo) * aDynamicEntries];
+    pNewDynamicClassTable = new DynamicClassInfo[aDynamicEntries];
 
     // Zero out the dynamic class table
     memset(pNewDynamicClassTable, 0, sizeof(DynamicClassInfo) * aDynamicEntries);
@@ -487,7 +487,7 @@ void    ThreadLocalModule::EnsureDynamicClassIndex(DWORD dwID)
     m_aDynamicEntries = aDynamicEntries;
 
     if (pOldDynamicClassTable != NULL)
-        delete pOldDynamicClassTable;
+        delete[] pOldDynamicClassTable;
 }
 
 void    ThreadLocalModule::AllocateDynamicClass(MethodTable *pMT)


### PR DESCRIPTION
Fix another alloc/dealloc mismatch in threadstatics.cpp.

Fix a use-after-scope bug in R2R token lookup.

Create a temporary copy of the NativeCodeVersion struct outside the expression to make sure that the implicit ref lives long enough (it needs to outlive the expression).