### PR TITLE
[mono/win] Increase stack size (reserve) to 8MB

### DIFF
--- a/src/mono/CMakeLists.txt
+++ b/src/mono/CMakeLists.txt
@@ -254,6 +254,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   add_compile_options(/W3)   # set warning level 3
   add_compile_options(/EHsc) # set exception handling behavior
   add_compile_options(/FC)   # use full pathnames in diagnostics
+  add_link_options(/STACK:0x800000)  # set stack size to 8MB (default is 1MB)
   if(CMAKE_BUILD_TYPE STREQUAL "Release")
     add_compile_options(/Oi)   # enable intrinsics
     add_compile_options(/GF)   # enable string pooling


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/57141 in windows build.

Set the stack size (reserve) to 8MB, which is usually a default
on linux. This way we should get similar behavior on windows.

    > dumpbin.exe /headers artifacts\bin\mono\Browser.wasm.Debug\cross\browser-wasm\mono-aot-cross.exe|Select-String -Pattern stack

          800000 size of stack reserve
            1000 size of stack commit