### PR TITLE
Use Span.Fill in String(Char, Int32) constructor 

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/String.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.cs
@@ -320,10 +320,12 @@ namespace System
                 throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_NegativeCount);
             }
 
-            char[] arr = new char[count];
-            Span<char> s = new(arr);
-            s.Fill(c);
-            return new(s);
+            string result = FastAllocateString(count);
+            if (c != '\0')
+            {
+                  MemoryMarshal.CreateSpan(ref result._firstChar, count).Fill(c);
+            }
+            return result;
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]

--- a/src/libraries/System.Private.CoreLib/src/System/String.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.cs
@@ -323,7 +323,7 @@ namespace System
             string result = FastAllocateString(count);
             if (c != '\0')
             {
-                  MemoryMarshal.CreateSpan(ref result._firstChar, count).Fill(c);
+                SpanHelpers.Fill(ref result._firstChar, (uint)count, c);
             }
             return result;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/String.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.cs
@@ -320,38 +320,10 @@ namespace System
                 throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_NegativeCount);
             }
 
-            string result = FastAllocateString(count);
-
-            if (c != '\0') // Fast path null char string
-            {
-                unsafe
-                {
-                    fixed (char* dest = &result._firstChar)
-                    {
-                        uint cc = (uint)((c << 16) | c);
-                        uint* dmem = (uint*)dest;
-                        if (count >= 4)
-                        {
-                            count -= 4;
-                            do
-                            {
-                                dmem[0] = cc;
-                                dmem[1] = cc;
-                                dmem += 2;
-                                count -= 4;
-                            } while (count >= 0);
-                        }
-                        if ((count & 2) != 0)
-                        {
-                            *dmem = cc;
-                            dmem++;
-                        }
-                        if ((count & 1) != 0)
-                            ((char*)dmem)[0] = c;
-                    }
-                }
-            }
-            return result;
+            char[] arr = new char[count];
+            Span<char> s = new(arr);
+            s.Fill(c);
+            return new(s);
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]


### PR DESCRIPTION
Fix for Use Span<Char>.Fill in String(Char, Int32) constructor #57993