### PR TITLE
Don't cache commandline in coreclr diagnostics server

### DIFF
--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -1109,50 +1109,6 @@ _rt_coreclr_hash_map_iterator_value (CONST_ITERATOR_TYPE *iterator)
 
 static
 inline
-char *
-diagnostics_command_line_get (void)
-{
-	STATIC_CONTRACT_NOTHROW;
-	return ep_rt_utf16_to_utf8_string (reinterpret_cast<const ep_char16_t *>(GetCommandLineForDiagnostics ()), -1);
-}
-
-static
-inline
-ep_char8_t **
-diagnostics_command_line_get_ref (void)
-{
-	STATIC_CONTRACT_NOTHROW;
-
-	extern ep_char8_t *_ep_rt_coreclr_diagnostics_cmd_line;
-	return &_ep_rt_coreclr_diagnostics_cmd_line;
-}
-
-static
-inline
-void
-diagnostics_command_line_lazy_init (void)
-{
-	STATIC_CONTRACT_NOTHROW;
-
-	//TODO: Real lazy init implementation.
-	if (!*diagnostics_command_line_get_ref ())
-		*diagnostics_command_line_get_ref () = diagnostics_command_line_get ();
-}
-
-static
-inline
-void
-diagnostics_command_line_lazy_clean (void)
-{
-	STATIC_CONTRACT_NOTHROW;
-
-	//TODO: Real lazy clean up implementation.
-	ep_rt_utf8_string_free (*diagnostics_command_line_get_ref ());
-	*diagnostics_command_line_get_ref () = NULL;
-}
-
-static
-inline
 ep_rt_lock_handle_t *
 ep_rt_coreclr_config_lock_get (void)
 {
@@ -1316,7 +1272,6 @@ void
 ep_rt_shutdown (void)
 {
 	STATIC_CONTRACT_NOTHROW;
-	diagnostics_command_line_lazy_clean ();
 }
 
 static
@@ -2711,8 +2666,22 @@ ep_rt_diagnostics_command_line_get (void)
 {
 	STATIC_CONTRACT_NOTHROW;
 
-	diagnostics_command_line_lazy_init ();
-	return *diagnostics_command_line_get_ref ();
+	// In coreclr, this value can change over time, specifically before vs after suspension in diagnostics server.
+	// The host initalizes the runtime in two phases, init and exec assembly. On non-Windows platforms the commandline returned by the runtime
+	// is different during each phase. We suspend during init where the runtime has populated the commandline with a
+	// mock value (the full path of the executing assembly) and the actual value isn't populated till the exec assembly phase.
+	// On Windows this does not apply as the value is retrieved directly from the OS any time it is requested. 
+	// As a result, we cannot actually cache this value. We need to return the _current_ value.
+	// This function needs to handle freeing the string in order to make it consistent with Mono's version.
+	// To that end, we'll "cache" it here so we free the previous string when we get it again.
+	extern ep_char8_t *_ep_rt_coreclr_diagnostics_cmd_line;
+
+	if (_ep_rt_coreclr_diagnostics_cmd_line)
+		ep_rt_utf8_string_free(_ep_rt_coreclr_diagnostics_cmd_line);
+
+	_ep_rt_coreclr_diagnostics_cmd_line = ep_rt_utf16_to_utf8_string (reinterpret_cast<const ep_char16_t *>(GetCommandLineForDiagnostics ()), -1);
+
+	return _ep_rt_coreclr_diagnostics_cmd_line;
 }
 
 /*


### PR DESCRIPTION
When we switched to the C implementation of the diagnostics server and eventpipe in .net6, we added some caching around some values that we return in IPC commands. Some of these values, however, actually changed depending on when the IPC command was sent. Specifically, the entry point assembly and commandline reported by the runtime are different at the suspension point than after execution has started for non-Windows platforms. This is due to a limitation of hosting infrastructure and the PAL on non-Windows platforms. If these values are requested while suspended, then the mock values will be cached for the rest of execution which is a regression from .net5 behavior.

I'm intending to port this back to .net6 in servicing. There is a larger change required to make the values correct at the suspension point which requires changes at the hosting layer.

CC @dotnet/dotnet-diag @jander-msft 