### PR TITLE
Some Antigen pipeline fixes

### DIFF
--- a/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
+++ b/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
@@ -132,8 +132,6 @@ jobs:
         archiveExtension: $(archiveExtension)
         artifactName: 'Antigen_Issues_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
         displayName: ${{ format('Upload artifacts Antigen issues for {0}-{1}', parameters.osGroup, parameters.archType ) }}
-      continueOnError: true
-      condition: always()
 
     # Always upload the available issues-summary.txt files
     - task: CopyFiles@2

--- a/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
+++ b/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
@@ -54,12 +54,12 @@ jobs:
     - HelixApiAccessToken: ''
     - HelixPreCommand: ''
 
-    - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
-      - name: RunReason
-        value: 'PR'
-    - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+    - ${{ if in(variables['Build.Reason'], 'Schedule') }}:
       - name: RunReason
         value: 'Scheduled'
+    - ${{ if notin(variables['Build.Reason'], 'Schedule') }}:
+      - name: RunReason
+        value: 'PR'
     - ${{ if eq(parameters.osGroup, 'windows') }}:
       - name: PythonScript
         value: 'py -3'

--- a/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
+++ b/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
@@ -71,6 +71,8 @@ jobs:
         value: '$(Build.SourcesDirectory)\artifacts\helixresults\'
       - name: IssuesSummaryLocation
         value: '$(Build.SourcesDirectory)\artifacts\issues_summary\'
+      - name: AntigenLogsLocation
+        value: '$(Build.SourcesDirectory)\artifacts\antigen_logs\'
 
     - ${{ if ne(parameters.osGroup, 'windows') }}:
       - name: PythonScript
@@ -83,6 +85,8 @@ jobs:
         value: '$(Build.SourcesDirectory)/artifacts/helixresults/'
       - name: IssuesSummaryLocation
         value: '$(Build.SourcesDirectory)/artifacts/issues_summary/'
+      - name: AntigenLogsLocation
+        value: '$(Build.SourcesDirectory)/artifacts/antigen_logs/'
     workspace:
       clean: all
     pool:
@@ -146,6 +150,24 @@ jobs:
       inputs:
         targetPath: $(IssuesSummaryLocation)
         artifactName: 'Issues_Summary_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
+      continueOnError: true
+      condition: always()
+
+    # Always upload the available Antigen.log files
+    - task: CopyFiles@2
+      displayName: Copying Antigen.logs of all partitions
+      inputs:
+        sourceFolder: '$(IssuesLocation)'
+        contents: '**/Antigen-*.log'
+        targetFolder: '$(AntigenLogsLocation)'
+      continueOnError: true
+      condition: always()
+
+    - task: PublishPipelineArtifact@1
+      displayName: Publish Antigen.log files
+      inputs:
+        targetPath: $(AntigenLogsLocation)
+        artifactName: 'Antigen_Logs_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
       continueOnError: true
       condition: always()
 

--- a/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
+++ b/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
@@ -121,6 +121,8 @@ jobs:
         archiveExtension: $(archiveExtension)
         artifactName: 'Antigen_Issues_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
         displayName: ${{ format('Upload artifacts Antigen issues for {0}-{1}', parameters.osGroup, parameters.archType ) }}
+      continueOnError: true
+      condition: always()
 
     # Always upload the available issues-summary.txt files
     - task: CopyFiles@2
@@ -129,20 +131,25 @@ jobs:
         sourceFolder: '$(IssuesLocation)'
         contents: '**/issues-summary-*.txt'
         targetFolder: '$(IssuesSummaryLocation)'
+      continueOnError: true
+      condition: always()
 
     - task: PublishPipelineArtifact@1
       displayName: Publish issues-summary.txt files
       inputs:
         targetPath: $(IssuesSummaryLocation)
         artifactName: 'Issues_Summary_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
+      continueOnError: true
+      condition: always()
 
     - script: $(PythonScript) $(Build.SourcesDirectory)/src/coreclr/scripts/antigen_unique_issues.py -issues_directory $(IssuesSummaryLocation)
       displayName: ${{ format('Print unique issues ({0})', parameters.osGroup) }}
       continueOnError: true
+      condition: always()
 
     - task: PublishPipelineArtifact@1
       displayName: Publish Antigen build logs
       inputs:
         targetPath: $(Build.SourcesDirectory)/artifacts/log
-        artifactName: 'Antigen_BuildLogs__$(archType)_$(buildConfig)'
+        artifactName: 'Antigen_BuildLogs_$(osGroup)_$(archType)_$(buildConfig)'
       condition: always()

--- a/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
+++ b/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
@@ -54,6 +54,12 @@ jobs:
     - HelixApiAccessToken: ''
     - HelixPreCommand: ''
 
+    - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
+      - name: RunReason
+        value: 'PR'
+    - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+      - name: RunReason
+        value: 'Scheduled'
     - ${{ if eq(parameters.osGroup, 'windows') }}:
       - name: PythonScript
         value: 'py -3'
@@ -110,6 +116,7 @@ jobs:
         osGroup: ${{ parameters.osGroup }}
         RunConfiguration: '$(RunConfiguration)'
         ToolName: '$(ToolName)'
+        RunReason: '$(RunReason)'
         continueOnError: true
 
     - template: /eng/pipelines/common/upload-artifact-step.yml

--- a/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
+++ b/eng/pipelines/coreclr/templates/jit-run-exploratory-job.yml
@@ -178,5 +178,5 @@ jobs:
       displayName: Publish Antigen build logs
       inputs:
         targetPath: $(Build.SourcesDirectory)/artifacts/log
-        artifactName: 'Antigen_BuildLogs_$(osGroup)_$(archType)_$(buildConfig)'
+        artifactName: 'Antigen_BuildLogs_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
       condition: always()

--- a/src/coreclr/scripts/antigen_run.py
+++ b/src/coreclr/scripts/antigen_run.py
@@ -30,6 +30,7 @@ parser.add_argument("-antigen_directory", help="Path to antigen tool")
 parser.add_argument("-output_directory", help="Path to output directory")
 parser.add_argument("-partition", help="Partition name")
 parser.add_argument("-core_root", help="path to CORE_ROOT directory")
+parser.add_argument("-run_duration", help="Run duration in minutes")
 is_windows = platform.system() == "Windows"
 
 
@@ -71,6 +72,10 @@ def setup_args(args):
                         lambda core_root: os.path.isdir(core_root),
                         "core_root doesn't exist")
 
+    coreclr_args.verify(args,
+                        "run_duration",
+                        lambda unused: True,
+                        "Unable to set run_duration")
     return coreclr_args
 
 
@@ -179,7 +184,7 @@ def main(main_args):
     core_root = coreclr_args.core_root
     tag_name = "{}-{}".format(coreclr_args.run_configuration, coreclr_args.partition)
     output_directory = coreclr_args.output_directory
-    run_duration = 120 # Run for 2 hours
+    run_duration = coreclr_args.run_duration
 
     path_to_corerun = os.path.join(core_root, "corerun")
     path_to_tool = os.path.join(antigen_directory, "Antigen")

--- a/src/coreclr/scripts/antigen_run.py
+++ b/src/coreclr/scripts/antigen_run.py
@@ -208,7 +208,7 @@ def main(main_args):
 
         # Copy issues for upload
         print("Copying issues to " + output_directory)
-        copy_issues(temp_location, output_directory, tag_name, antigen_log)
+        copy_issues(temp_location, output_directory, tag_name)
 
 if __name__ == "__main__":
     args = parser.parse_args()

--- a/src/coreclr/scripts/antigen_run.py
+++ b/src/coreclr/scripts/antigen_run.py
@@ -169,7 +169,16 @@ def copy_issues(issues_directory, upload_directory, tag_name):
         except PermissionError as pe_error:
             print('Ignoring PermissionError: {0}'.format(pe_error))
 
+        src_antigen_log = os.path.join(issues_directory, get_antigen_filename(tag_name))
+        dst_antigen_log = os.path.join(upload_directory, get_antigen_filename(tag_name))
+        print("Copying {} to {}".format(src_antigen_log, dst_antigen_log))
+        try:
+            shutil.copy2(src_antigen_log, dst_antigen_log)
+        except PermissionError as pe_error:
+            print('Ignoring PermissionError: {0}'.format(pe_error))
 
+def get_antigen_filename(tag_name):
+    return "Antigen-{}.log".format(tag_name)
 
 def main(main_args):
     """Main entrypoint
@@ -194,11 +203,12 @@ def main(main_args):
 
     # Run tool such that issues are placed in a temp folder
     with TempDir() as temp_location:
-        run_command([path_to_tool, "-c", path_to_corerun, "-o", temp_location, "-d", str(run_duration)], _exit_on_fail=True, _long_running= True)
+        antigen_log = path.join(temp_location, get_antigen_filename(tag_name))
+        run_command([path_to_tool, "-c", path_to_corerun, "-o", temp_location, "-d", str(run_duration)], _exit_on_fail=True, _output_file= antigen_log)
 
         # Copy issues for upload
         print("Copying issues to " + output_directory)
-        copy_issues(temp_location, output_directory, tag_name)
+        copy_issues(temp_location, output_directory, tag_name, antigen_log)
 
 if __name__ == "__main__":
     args = parser.parse_args()

--- a/src/coreclr/scripts/antigen_run.py
+++ b/src/coreclr/scripts/antigen_run.py
@@ -201,14 +201,17 @@ def main(main_args):
         path_to_corerun += ".exe"
         path_to_tool += ".exe"
 
-    # Run tool such that issues are placed in a temp folder
-    with TempDir() as temp_location:
-        antigen_log = path.join(temp_location, get_antigen_filename(tag_name))
-        run_command([path_to_tool, "-c", path_to_corerun, "-o", temp_location, "-d", str(run_duration)], _exit_on_fail=True, _output_file= antigen_log)
+    try:
+        # Run tool such that issues are placed in a temp folder
+        with TempDir() as temp_location:
+            antigen_log = path.join(temp_location, get_antigen_filename(tag_name))
+            run_command([path_to_tool, "-c", path_to_corerun, "-o", temp_location, "-d", str(run_duration)], _exit_on_fail=True, _output_file= antigen_log)
 
-        # Copy issues for upload
-        print("Copying issues to " + output_directory)
-        copy_issues(temp_location, output_directory, tag_name)
+            # Copy issues for upload
+            print("Copying issues to " + output_directory)
+            copy_issues(temp_location, output_directory, tag_name)
+    except PermissionError as pe:
+        print("Got error: %s", pe)
 
 if __name__ == "__main__":
     args = parser.parse_args()

--- a/src/coreclr/scripts/antigen_run.py
+++ b/src/coreclr/scripts/antigen_run.py
@@ -194,6 +194,8 @@ def main(main_args):
     tag_name = "{}-{}".format(coreclr_args.run_configuration, coreclr_args.partition)
     output_directory = coreclr_args.output_directory
     run_duration = coreclr_args.run_duration
+    if not run_duration:
+        run_duration = 60
 
     path_to_corerun = os.path.join(core_root, "corerun")
     path_to_tool = os.path.join(antigen_directory, "Antigen")

--- a/src/coreclr/scripts/exploratory.proj
+++ b/src/coreclr/scripts/exploratory.proj
@@ -37,14 +37,14 @@
   </PropertyGroup>
 
   <!-- For Scheduled= 3 hours. For PRs= 1 hour -->
-  <ItemGroup Condition=" '$(RunReason)' == 'Scheduled' ">
+  <PropertyGroup Condition=" '$(RunReason)' == 'Scheduled' ">
       <WorkItemTimeout>3:15</WorkItemTimeout>
       <RunDuration>180</RunDuration>
-  </ItemGroup>
-  <ItemGroup Condition=" '$(RunReason)' == 'PR' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(RunReason)' != 'Scheduled' ">
       <WorkItemTimeout>1:15</WorkItemTimeout>
       <RunDuration>60</RunDuration>
-  </ItemGroup>
+  </PropertyGroup>
 
   <ItemGroup Condition=" '$(AGENT_OS)' == 'Windows_NT' ">
     <HelixPreCommand Include="taskkill.exe /f /im corerun.exe"/>

--- a/src/coreclr/scripts/exploratory.proj
+++ b/src/coreclr/scripts/exploratory.proj
@@ -79,7 +79,7 @@
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
       <Command>$(WorkItemCommand) -partition %(PartitionName)</Command>
       <Timeout>$(WorkItemTimeout)</Timeout>
-      <DownloadFilesFromResults>AllIssues-$(RunConfiguration)-%(PartitionName).zip;issues-summary-$(RunConfiguration)-%(PartitionName).txt</DownloadFilesFromResults>
+      <DownloadFilesFromResults>AllIssues-$(RunConfiguration)-%(PartitionName).zip;issues-summary-$(RunConfiguration)-%(PartitionName).txt;Antigen-$(RunConfiguration)-%(PartitionName).log</DownloadFilesFromResults>
     </HelixWorkItem>
   </ItemGroup>
 

--- a/src/coreclr/scripts/exploratory.proj
+++ b/src/coreclr/scripts/exploratory.proj
@@ -28,7 +28,6 @@
   <PropertyGroup>
     <EnableAzurePipelinesReporter>false</EnableAzurePipelinesReporter>
     <EnableXUnitReporter>false</EnableXUnitReporter>
-    <WorkItemTimeout>2:30</WorkItemTimeout>
     <Creator>$(_Creator)</Creator>
     <HelixAccessToken>$(_HelixAccessToken)</HelixAccessToken>
     <HelixBuild>$(_HelixBuild)</HelixBuild>
@@ -36,6 +35,16 @@
     <HelixTargetQueues>$(_HelixTargetQueues)</HelixTargetQueues>
     <HelixType>$(_HelixType)</HelixType>
   </PropertyGroup>
+
+  <!-- For Scheduled= 3 hours. For PRs= 1 hour -->
+  <ItemGroup Condition=" '$(RunReason)' == 'Scheduled' ">
+      <WorkItemTimeout>3:15</WorkItemTimeout>
+      <RunDuration>180</RunDuration>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(RunReason)' == 'PR' ">
+      <WorkItemTimeout>1:15</WorkItemTimeout>
+      <RunDuration>60</RunDuration>
+  </ItemGroup>
 
   <ItemGroup Condition=" '$(AGENT_OS)' == 'Windows_NT' ">
     <HelixPreCommand Include="taskkill.exe /f /im corerun.exe"/>
@@ -48,7 +57,7 @@
   <PropertyGroup>
     <HelixPreCommands>@(HelixPreCommand)</HelixPreCommands>
     <HelixPostCommands>@(HelixPostCommand)</HelixPostCommands>
-    <WorkItemCommand>$(Python) $(CoreRoot)$(FileSeparatorChar)antigen_run.py -run_configuration $(RunConfiguration) -output_directory $(OutputDirectory) -antigen_directory $(ToolPath) -core_root $(CoreRoot)</WorkItemCommand>
+    <WorkItemCommand>$(Python) $(CoreRoot)$(FileSeparatorChar)antigen_run.py -run_configuration $(RunConfiguration) -output_directory $(OutputDirectory) -antigen_directory $(ToolPath) -core_root $(CoreRoot) -run_duration $(RunDuration) </WorkItemCommand>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coreclr/scripts/superpmi_setup.py
+++ b/src/coreclr/scripts/superpmi_setup.py
@@ -312,7 +312,7 @@ def first_fit(sorted_by_size, max_size):
     return partitions
 
 
-def run_command(command_to_run, _cwd=None, _exit_on_fail=False, _long_running=False):
+def run_command(command_to_run, _cwd=None, _exit_on_fail=False, _output_file=None):
     """ Runs the command.
 
     Args:
@@ -320,7 +320,7 @@ def run_command(command_to_run, _cwd=None, _exit_on_fail=False, _long_running=Fa
         _cwd (string): Current working directory.
         _exit_on_fail (bool): If it should exit on failure.
     Returns:
-        (string, string, int): Returns a tuple of stdout, stderr, and command return code if _long_running= False
+        (string, string, int): Returns a tuple of stdout, stderr, and command return code if _output_file= None
         Otherwise stdout, stderr are empty.
     """
     print("Running: " + " ".join(command_to_run))
@@ -328,17 +328,18 @@ def run_command(command_to_run, _cwd=None, _exit_on_fail=False, _long_running=Fa
     command_stderr = ""
     return_code = 1
 
-    output_type = subprocess.STDOUT if _long_running else subprocess.PIPE
+    output_type = subprocess.STDOUT if _output_file else subprocess.PIPE
     with subprocess.Popen(command_to_run, stdout=subprocess.PIPE, stderr=output_type, cwd=_cwd) as proc:
 
-        # For long running command, continuosly print the output
-        if _long_running:
+        # For long running command, continuously print the output
+        if _output_file:
             while True:
-                output = proc.stdout.readline()
-                if proc.poll() is not None:
-                    break
-                if output:
-                    print(output.strip().decode("utf-8"))
+                with open(_output_file, 'a') as of:
+                    output = proc.stdout.readline()
+                    if proc.poll() is not None:
+                        break
+                    if output:
+                        of.write(output.strip().decode("utf-8") + "\n")
         else:
             command_stdout, command_stderr = proc.communicate()
             if len(command_stdout) > 0:


### PR DESCRIPTION
- Include the name of OS in the artifacts folder so we don't get error when linux-x64 uploads the artifacts and then windows-x64 complains that artifacts already present
- Set 2 different durations depending on RunReason. For PR triggered, it will be just for 1 hour and for weekly scheduled run, it will be for 3 hours.
- Capture the output in `Antigen.log` and upload it as one of the artifacts for easy debugging.