### PR TITLE
Use local version of Roslyn to build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -278,6 +278,7 @@
     <!-- default to allowing all language features -->
     <LangVersion>preview</LangVersion>
     <LangVersion Condition="'$(MSBuildProjectExtension)' == '.vbproj'">latest</LangVersion>
+    <CscToolExe>$(MSBuildThisFileDirectory)\runcsc.bat</CscToolExe>
     <!-- Enables Strict mode for Roslyn compiler -->
     <Features>strict;nullablePublicOnly</Features>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/runcsc.bat
+++ b/runcsc.bat
@@ -1,0 +1,1 @@
+@call %~dp0\dotnet.cmd %~dp0\..\roslyn\artifacts\bin\csc\Release\netcoreapp3.1\csc.dll %*


### PR DESCRIPTION
This works on Windows. We'll need something subtly different on Unix.

Once this is checked in you'll need to:
1. clone a roslyn repo next to the runtime repo
2. Build a release version of that repo with a command like "build.cmd -restore -deployExtensions -launch -c Release"
3. Then do whatever you want to do in the repo