### PR TITLE
[hack] Add script to run local Roslyn build on non-Windows

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -278,7 +278,8 @@
     <!-- default to allowing all language features -->
     <LangVersion>preview</LangVersion>
     <LangVersion Condition="'$(MSBuildProjectExtension)' == '.vbproj'">latest</LangVersion>
-    <CscToolExe>$(MSBuildThisFileDirectory)\runcsc.bat</CscToolExe>
+    <CscToolExe Condition="'$(_hostOS)' == 'Windows'">$(MSBuildThisFileDirectory)\runcsc.bat</CscToolExe>
+    <CscToolExe Condition="'$(_hostOS)' != 'Windows'">$(MSBuildThisFileDirectory)\runcsc.sh</CscToolExe>
     <!-- Enables Strict mode for Roslyn compiler -->
     <Features>strict;nullablePublicOnly</Features>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/runcsc.sh
+++ b/runcsc.sh
@@ -1,0 +1,3 @@
+#! /bin/sh
+b=`dirname $0`
+exec ${b}/dotnet.sh ${b}/../roslyn/artifacts/bin/csc/Release/netcoreapp3.1/csc.dll "$@"


### PR DESCRIPTION
tested on macOS. Shoudl work on Linux, too.

Build roslyn with
```
./build.sh --restore --build -c Release
```
then build the runtime with
```
./build.sh clr.native+mono+libs -c Release
```
(or your preferred subsets)