### PR TITLE
Fix type layout diagnostics in the CoreCLR runtime

### DIFF
--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -13640,10 +13640,10 @@ BOOL LoadDynamicInfoEntry(Module *currentModule,
 
 #ifdef _DEBUG
                     {
+                        TypeLayoutCheck(pMT, pBlob, /* printDiff */ TRUE);
                         StackScratchBuffer buf;
                         _ASSERTE_MSG(false, fatalErrorString.GetUTF8(buf));
                         // Run through the type layout logic again, after the assert, makes debugging easy
-                        TypeLayoutCheck(pMT, pBlob, /* printDiff */ TRUE);
                     }
 #endif
 

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -13632,6 +13632,9 @@ BOOL LoadDynamicInfoEntry(Module *currentModule,
                 }
                 else
                 {
+                    // Run through the type layout logic again to report the mismatch in lab logs and make debugging easy
+                    TypeLayoutCheck(pMT, pBlob, /* printDiff */ TRUE);
+
                     // Verification failures are failfast events
                     DefineFullyQualifiedNameForClassW();
                     SString fatalErrorString;
@@ -13640,10 +13643,8 @@ BOOL LoadDynamicInfoEntry(Module *currentModule,
 
 #ifdef _DEBUG
                     {
-                        TypeLayoutCheck(pMT, pBlob, /* printDiff */ TRUE);
                         StackScratchBuffer buf;
                         _ASSERTE_MSG(false, fatalErrorString.GetUTF8(buf));
-                        // Run through the type layout logic again, after the assert, makes debugging easy
                     }
 #endif
 


### PR DESCRIPTION
In my change from the summer I added provisions to the type layout
check to support printing the differences as an aid for investigation
of this class of failures; I however put the diff display after the
assertion so that it actually doesn't get hit as the assertion tears
down the process. This change fixes the ordering and should let us
review the particular mismatch that occurs in the arm64 runs
(https://github.com/dotnet/runtime/issues/60036).

Thanks

Tomas

/cc @dotnet/crossgen-contrib 