### PR TITLE
Make upgrade install new host first, then uninstall old

### DIFF
--- a/src/installer/pkg/sfx/installers/dotnet-host.proj
+++ b/src/installer/pkg/sfx/installers/dotnet-host.proj
@@ -11,6 +11,7 @@
     <RegKeyProductName>sharedhost</RegKeyProductName>
     <WixDependencyKeyName>Dotnet_CLI_SharedHost</WixDependencyKeyName>
     <OutputFilesCandleVariable>HostSrc</OutputFilesCandleVariable>
+    <MajorUpgradeSchedule>afterInstallExecute</MajorUpgradeSchedule>
     <VersionInstallerName>false</VersionInstallerName>
     <UseBrandingNameInLinuxPackageDescription>true</UseBrandingNameInLinuxPackageDescription>
     <MacOSComponentNamePackType>sharedhost</MacOSComponentNamePackType>


### PR DESCRIPTION
This should preserve the ordering of PATH, since the old MSI will never
remove its entry.

Requires https://github.com/dotnet/arcade/pull/8025