### PR TITLE
fix for generation info in GCMemoryInfo 

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -44624,6 +44624,8 @@ bool gc_heap::is_pm_ratio_exceeded()
 
 void gc_heap::update_recorded_gen_data (last_recorded_gc_info* gc_info)
 {
+    memset (gc_info->gen_info, 0, sizeof (gc_info->gen_info));
+
 #ifdef MULTIPLE_HEAPS
     for (int i = 0; i < gc_heap::n_heaps; i++)
     {


### PR DESCRIPTION
apparently I didn't re-initialize the generation info so this always goes up monotonically. bad testing on my part. 