### PR TITLE
Add runtime.osx-arm64.runtime.native.System.IO.Ports proj file for pa…

### DIFF
--- a/src/libraries/System.IO.Ports/pkg/runtime.osx-arm64.runtime.native.System.IO.Ports.proj
+++ b/src/libraries/System.IO.Ports/pkg/runtime.osx-arm64.runtime.native.System.IO.Ports.proj
@@ -1,0 +1,7 @@
+<Project>
+  <Import Project="runtime.native.System.IO.Ports.props" />
+  <PropertyGroup>
+    <!-- TODO: Remove when the package shipped. -->
+    <DisablePackageBaselineValidation>true</DisablePackageBaselineValidation>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Fixes #59972

Customer Impact

The native library for System.IO.Ports is current not built nor packaged for osx-arm64. The native library compiles cleanly and works correctly, but just isn't being built or packaged by the CI system.

This change adds a package project to build/package it, which also adds it as a dependency to the meta runtime.native.System.IO.Ports package

Testing

Tested on actual Apple Silicon hardware with various serial devices. Since no current M1 device offers native serial ports, all testing was conducted with various USB devices that convert to or present as serial ports. Works correctly.

Risk

Low. The alternative is that there is no support at all.

@ViktorHofer As requested