### PR TITLE
[metadata] Replace uses of MonoType:byref by a getter

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -5023,7 +5023,7 @@ buffer_add_value_full (Buffer *buf, MonoType *t, void *addr, MonoDomain *domain,
 	MonoObject *obj;
 	gboolean boxed_vtype = FALSE;
 
-	if (mono_type_is_byref_internal (t)) {
+	if (m_type_is_byref (t)) {
 		if (!(*(void**)addr)) {
 			/* This can happen with compiler generated locals */
 			//PRINT_MSG ("%s\n", mono_type_full_name (t));
@@ -5699,7 +5699,7 @@ set_var (MonoType *t, MonoDebugVarInfo *var, MonoContext *ctx, MonoDomain *domai
 		host_mgreg_t v;
 		gboolean is_signed = FALSE;
 
-		if (mono_type_is_byref_internal (t)) {
+		if (m_type_is_byref (t)) {
 			addr = (guint8 *)mono_arch_context_get_int_reg (ctx, reg);
 
 			if (addr) {
@@ -5709,7 +5709,7 @@ set_var (MonoType *t, MonoDebugVarInfo *var, MonoContext *ctx, MonoDomain *domai
 			break;
 		}
 
-		if (!mono_type_is_byref_internal (t) && (t->type == MONO_TYPE_I1 || t->type == MONO_TYPE_I2 || t->type == MONO_TYPE_I4 || t->type == MONO_TYPE_I8))
+		if (!m_type_is_byref (t) && (t->type == MONO_TYPE_I1 || t->type == MONO_TYPE_I2 || t->type == MONO_TYPE_I4 || t->type == MONO_TYPE_I8))
 			is_signed = TRUE;
 
 		switch (size) {
@@ -5754,7 +5754,7 @@ set_var (MonoType *t, MonoDebugVarInfo *var, MonoContext *ctx, MonoDomain *domai
 
 		//PRINT_MSG ("[R%d+%d] = %p\n", reg, var->offset, addr);
 
-		if (mono_type_is_byref_internal (t)) {
+		if (m_type_is_byref (t)) {
 			addr = *(guint8**)addr;
 
 			if (!addr)
@@ -6103,7 +6103,7 @@ mono_do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, gu
 			if (args [i] && ((MonoObject*)args [i])->vtable->domain != domain)
 				NOT_IMPLEMENTED;
 
-			if (mono_type_is_byref_internal (sig->params [i])) {
+			if (m_type_is_byref (sig->params [i])) {
 				arg_buf [i] = g_newa (guint8, sizeof (gpointer));
 				*(gpointer*)arg_buf [i] = args [i];
 				args [i] = arg_buf [i];
@@ -6178,7 +6178,7 @@ mono_do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, gu
 				buffer_add_value (buf, mono_get_void_type_dbg (), NULL, domain);
 			}
 		} else if (MONO_TYPE_IS_REFERENCE (sig->ret)) {
-			if (mono_type_is_byref_internal (sig->ret)) {
+			if (m_type_is_byref (sig->ret)) {
 				MonoType* ret_byval = m_class_get_byval_arg (mono_class_from_mono_type_internal (sig->ret));
 				buffer_add_value (buf, ret_byval, &res, domain);
 			} else {
@@ -6195,7 +6195,7 @@ mono_do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, gu
 			} else {
 				g_assert (res);
 
-				if (mono_type_is_byref_internal (sig->ret)) {
+				if (m_type_is_byref (sig->ret)) {
 					MonoType* ret_byval = m_class_get_byval_arg (mono_class_from_mono_type_internal (sig->ret));
 					buffer_add_value (buf, ret_byval, mono_object_unbox_internal (res), domain);
 				} else {
@@ -6213,7 +6213,7 @@ mono_do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, gu
 			for (i = 0; i < nargs; ++i) {
 				if (MONO_TYPE_IS_REFERENCE (sig->params [i]))
 					buffer_add_value (buf, sig->params [i], &args [i], domain);
-				else if (mono_type_is_byref_internal (sig->params [i]))
+				else if (m_type_is_byref (sig->params [i]))
 					/* add_value () does an indirection */
 					buffer_add_value (buf, sig->params [i], &arg_buf [i], domain);
 				else
@@ -7892,7 +7892,7 @@ type_commands_internal (int command, MonoClass *klass, MonoDomain *domain, guint
 			b |= (1 << 0);
 		if (type->type == MONO_TYPE_PTR || type->type == MONO_TYPE_FNPTR)
 			b |= (1 << 1);
-		if (!mono_type_is_byref_internal (type) && (((type->type >= MONO_TYPE_BOOLEAN) && (type->type <= MONO_TYPE_R8)) || (type->type == MONO_TYPE_I) || (type->type == MONO_TYPE_U)))
+		if (!m_type_is_byref (type) && (((type->type >= MONO_TYPE_BOOLEAN) && (type->type <= MONO_TYPE_R8)) || (type->type == MONO_TYPE_I) || (type->type == MONO_TYPE_U)))
 			b |= (1 << 2);
 		if (type->type == MONO_TYPE_VALUETYPE)
 			b |= (1 << 3);

--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -5023,7 +5023,7 @@ buffer_add_value_full (Buffer *buf, MonoType *t, void *addr, MonoDomain *domain,
 	MonoObject *obj;
 	gboolean boxed_vtype = FALSE;
 
-	if (t->byref) {
+	if (mono_type_is_byref_internal (t)) {
 		if (!(*(void**)addr)) {
 			/* This can happen with compiler generated locals */
 			//PRINT_MSG ("%s\n", mono_type_full_name (t));
@@ -5699,7 +5699,7 @@ set_var (MonoType *t, MonoDebugVarInfo *var, MonoContext *ctx, MonoDomain *domai
 		host_mgreg_t v;
 		gboolean is_signed = FALSE;
 
-		if (t->byref) {
+		if (mono_type_is_byref_internal (t)) {
 			addr = (guint8 *)mono_arch_context_get_int_reg (ctx, reg);
 
 			if (addr) {
@@ -5709,7 +5709,7 @@ set_var (MonoType *t, MonoDebugVarInfo *var, MonoContext *ctx, MonoDomain *domai
 			break;
 		}
 
-		if (!t->byref && (t->type == MONO_TYPE_I1 || t->type == MONO_TYPE_I2 || t->type == MONO_TYPE_I4 || t->type == MONO_TYPE_I8))
+		if (!mono_type_is_byref_internal (t) && (t->type == MONO_TYPE_I1 || t->type == MONO_TYPE_I2 || t->type == MONO_TYPE_I4 || t->type == MONO_TYPE_I8))
 			is_signed = TRUE;
 
 		switch (size) {
@@ -5754,7 +5754,7 @@ set_var (MonoType *t, MonoDebugVarInfo *var, MonoContext *ctx, MonoDomain *domai
 
 		//PRINT_MSG ("[R%d+%d] = %p\n", reg, var->offset, addr);
 
-		if (t->byref) {
+		if (mono_type_is_byref_internal (t)) {
 			addr = *(guint8**)addr;
 
 			if (!addr)
@@ -6103,7 +6103,7 @@ mono_do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, gu
 			if (args [i] && ((MonoObject*)args [i])->vtable->domain != domain)
 				NOT_IMPLEMENTED;
 
-			if (sig->params [i]->byref) {
+			if (mono_type_is_byref_internal (sig->params [i])) {
 				arg_buf [i] = g_newa (guint8, sizeof (gpointer));
 				*(gpointer*)arg_buf [i] = args [i];
 				args [i] = arg_buf [i];
@@ -6178,7 +6178,7 @@ mono_do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, gu
 				buffer_add_value (buf, mono_get_void_type_dbg (), NULL, domain);
 			}
 		} else if (MONO_TYPE_IS_REFERENCE (sig->ret)) {
-			if (sig->ret->byref) {
+			if (mono_type_is_byref_internal (sig->ret)) {
 				MonoType* ret_byval = m_class_get_byval_arg (mono_class_from_mono_type_internal (sig->ret));
 				buffer_add_value (buf, ret_byval, &res, domain);
 			} else {
@@ -6195,7 +6195,7 @@ mono_do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, gu
 			} else {
 				g_assert (res);
 
-				if (sig->ret->byref) {
+				if (mono_type_is_byref_internal (sig->ret)) {
 					MonoType* ret_byval = m_class_get_byval_arg (mono_class_from_mono_type_internal (sig->ret));
 					buffer_add_value (buf, ret_byval, mono_object_unbox_internal (res), domain);
 				} else {
@@ -6213,7 +6213,7 @@ mono_do_invoke_method (DebuggerTlsData *tls, Buffer *buf, InvokeData *invoke, gu
 			for (i = 0; i < nargs; ++i) {
 				if (MONO_TYPE_IS_REFERENCE (sig->params [i]))
 					buffer_add_value (buf, sig->params [i], &args [i], domain);
-				else if (sig->params [i]->byref)
+				else if (mono_type_is_byref_internal (sig->params [i]))
 					/* add_value () does an indirection */
 					buffer_add_value (buf, sig->params [i], &arg_buf [i], domain);
 				else
@@ -7892,7 +7892,7 @@ type_commands_internal (int command, MonoClass *klass, MonoDomain *domain, guint
 			b |= (1 << 0);
 		if (type->type == MONO_TYPE_PTR || type->type == MONO_TYPE_FNPTR)
 			b |= (1 << 1);
-		if (!type->byref && (((type->type >= MONO_TYPE_BOOLEAN) && (type->type <= MONO_TYPE_R8)) || (type->type == MONO_TYPE_I) || (type->type == MONO_TYPE_U)))
+		if (!mono_type_is_byref_internal (type) && (((type->type >= MONO_TYPE_BOOLEAN) && (type->type <= MONO_TYPE_R8)) || (type->type == MONO_TYPE_I) || (type->type == MONO_TYPE_U)))
 			b |= (1 << 2);
 		if (type->type == MONO_TYPE_VALUETYPE)
 			b |= (1 << 3);

--- a/src/mono/mono/component/debugger-engine.c
+++ b/src/mono/mono/component/debugger-engine.c
@@ -1733,7 +1733,7 @@ mono_de_set_interp_var (MonoType *t, gpointer addr, guint8 *val_buf)
 {
 	int size;
 
-	if (mono_type_is_byref_internal (t)) {
+	if (m_type_is_byref (t)) {
 		addr = *(gpointer*)addr;
 		if (!addr)
 			return ERR_INVALID_OBJECT;

--- a/src/mono/mono/component/debugger-engine.c
+++ b/src/mono/mono/component/debugger-engine.c
@@ -1733,7 +1733,7 @@ mono_de_set_interp_var (MonoType *t, gpointer addr, guint8 *val_buf)
 {
 	int size;
 
-	if (t->byref) {
+	if (mono_type_is_byref_internal (t)) {
 		addr = *(gpointer*)addr;
 		if (!addr)
 			return ERR_INVALID_OBJECT;

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -1805,7 +1805,7 @@ type_has_references (MonoClass *klass, MonoType *ftype)
 {
 	if (MONO_TYPE_IS_REFERENCE (ftype) || IS_GC_REFERENCE (klass, ftype) || ((MONO_TYPE_ISSTRUCT (ftype) && class_has_references (mono_class_from_mono_type_internal (ftype)))))
 		return TRUE;
-	if (!mono_type_is_byref_internal (ftype) && (ftype->type == MONO_TYPE_VAR || ftype->type == MONO_TYPE_MVAR)) {
+	if (!m_type_is_byref (ftype) && (ftype->type == MONO_TYPE_VAR || ftype->type == MONO_TYPE_MVAR)) {
 		MonoGenericParam *gparam = ftype->data.generic_param;
 
 		if (gparam->gshared_constraint)
@@ -1974,7 +1974,7 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 		if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
 			continue;
 		if (blittable) {
-			if (mono_type_is_byref_internal (field->type) || MONO_TYPE_IS_REFERENCE (field->type)) {
+			if (m_type_is_byref (field->type) || MONO_TYPE_IS_REFERENCE (field->type)) {
 				blittable = FALSE;
 			} else if (mono_type_is_generic_parameter (field->type) &&
 				   mono_class_is_gparam_with_nonblittable_parent (mono_class_from_mono_type_internal (field->type))) {

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -493,7 +493,7 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 
 		if (mono_metadata_token_table (parent_token) == MONO_TABLE_TYPESPEC) {
 			/*WARNING: this must satisfy mono_metadata_type_hash*/
-			klass->this_arg.byref = 1;
+			klass->this_arg.byref__ = 1;
 			klass->this_arg.data.klass = klass;
 			klass->this_arg.type = MONO_TYPE_CLASS;
 			klass->_byval_arg.data.klass = klass;
@@ -846,7 +846,7 @@ mono_class_create_generic_inst (MonoGenericClass *gclass)
 	klass->_byval_arg.type = MONO_TYPE_GENERICINST;
 	klass->this_arg.type = m_class_get_byval_arg (klass)->type;
 	klass->this_arg.data.generic_class = klass->_byval_arg.data.generic_class = gclass;
-	klass->this_arg.byref = TRUE;
+	klass->this_arg.byref__ = TRUE;
 	klass->enumtype = gklass->enumtype;
 	klass->valuetype = gklass->valuetype;
 
@@ -1148,7 +1148,7 @@ mono_class_create_bounded_array (MonoClass *eclass, guint32 rank, gboolean bound
 		klass->_byval_arg.data.klass = eclass;
 	}
 	klass->this_arg = klass->_byval_arg;
-	klass->this_arg.byref = 1;
+	klass->this_arg.byref__ = 1;
 
 	if (rank > 32) {
 		ERROR_DECL (prepared_error);
@@ -1321,7 +1321,7 @@ make_generic_param_class (MonoGenericParam *param)
 	klass->this_arg.type = t;
 	CHECKED_METADATA_WRITE_PTR ( klass->this_arg.data.generic_param ,  param );
 	CHECKED_METADATA_WRITE_PTR ( klass->_byval_arg.data.generic_param , param );
-	klass->this_arg.byref = TRUE;
+	klass->this_arg.byref__ = TRUE;
 
 	/* We don't use type_token for VAR since only classes can use it (not arrays, pointer, VARs, etc) */
 	klass->sizes.generic_param_token = !is_anonymous ? pinfo->token : 0;
@@ -1464,7 +1464,7 @@ mono_class_create_ptr (MonoType *type)
 
 	result->this_arg.type = result->_byval_arg.type = MONO_TYPE_PTR;
 	result->this_arg.data.type = result->_byval_arg.data.type = m_class_get_byval_arg (el_class);
-	result->this_arg.byref = TRUE;
+	result->this_arg.byref__ = TRUE;
 
 	mono_class_setup_supertypes (result);
 
@@ -1529,7 +1529,7 @@ mono_class_create_fnptr (MonoMethodSignature *sig)
 	result->cast_class = result->element_class = result;
 	result->this_arg.type = result->_byval_arg.type = MONO_TYPE_FNPTR;
 	result->this_arg.data.method = result->_byval_arg.data.method = sig;
-	result->this_arg.byref = TRUE;
+	result->this_arg.byref__ = TRUE;
 	result->blittable = TRUE;
 	result->inited = TRUE;
 
@@ -1805,7 +1805,7 @@ type_has_references (MonoClass *klass, MonoType *ftype)
 {
 	if (MONO_TYPE_IS_REFERENCE (ftype) || IS_GC_REFERENCE (klass, ftype) || ((MONO_TYPE_ISSTRUCT (ftype) && class_has_references (mono_class_from_mono_type_internal (ftype)))))
 		return TRUE;
-	if (!ftype->byref && (ftype->type == MONO_TYPE_VAR || ftype->type == MONO_TYPE_MVAR)) {
+	if (!mono_type_is_byref_internal (ftype) && (ftype->type == MONO_TYPE_VAR || ftype->type == MONO_TYPE_MVAR)) {
 		MonoGenericParam *gparam = ftype->data.generic_param;
 
 		if (gparam->gshared_constraint)
@@ -1974,7 +1974,7 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 		if (field->type->attrs & FIELD_ATTRIBUTE_STATIC)
 			continue;
 		if (blittable) {
-			if (field->type->byref || MONO_TYPE_IS_REFERENCE (field->type)) {
+			if (mono_type_is_byref_internal (field->type) || MONO_TYPE_IS_REFERENCE (field->type)) {
 				blittable = FALSE;
 			} else if (mono_type_is_generic_parameter (field->type) &&
 				   mono_class_is_gparam_with_nonblittable_parent (mono_class_from_mono_type_internal (field->type))) {
@@ -3102,7 +3102,7 @@ mono_class_setup_mono_type (MonoClass *klass)
 	const char *nspace = klass->name_space;
 	gboolean is_corlib = mono_is_corlib_image (klass->image);
 
-	klass->this_arg.byref = 1;
+	klass->this_arg.byref__ = 1;
 	klass->this_arg.data.klass = klass;
 	klass->this_arg.type = MONO_TYPE_CLASS;
 	klass->_byval_arg.data.klass = klass;

--- a/src/mono/mono/metadata/class-setup-vtable.c
+++ b/src/mono/mono/metadata/class-setup-vtable.c
@@ -1421,10 +1421,10 @@ vtable_slot_has_preserve_base_overrides_attribute (MonoClass *klass, int slot, M
 static gboolean
 is_ok_for_covariant_ret (MonoType *type_impl, MonoType *type_decl)
 {
-	if (mono_type_is_byref_internal (type_impl) ^ mono_type_is_byref_internal (type_decl))
+	if (m_type_is_byref (type_impl) ^ m_type_is_byref (type_decl))
 		return FALSE;
 
-	if (mono_type_is_byref_internal (type_impl)) {
+	if (m_type_is_byref (type_impl)) {
 		return mono_byref_type_is_assignable_from (type_decl, type_impl, TRUE);
 	}
 

--- a/src/mono/mono/metadata/class-setup-vtable.c
+++ b/src/mono/mono/metadata/class-setup-vtable.c
@@ -1421,10 +1421,10 @@ vtable_slot_has_preserve_base_overrides_attribute (MonoClass *klass, int slot, M
 static gboolean
 is_ok_for_covariant_ret (MonoType *type_impl, MonoType *type_decl)
 {
-	if (type_impl->byref ^ type_decl->byref)
+	if (mono_type_is_byref_internal (type_impl) ^ mono_type_is_byref_internal (type_decl))
 		return FALSE;
 
-	if (type_impl->byref) {
+	if (mono_type_is_byref_internal (type_impl)) {
 		return mono_byref_type_is_assignable_from (type_decl, type_impl, TRUE);
 	}
 

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -283,7 +283,7 @@ _mono_type_get_assembly_name (MonoClass *klass, GString *str)
 static void
 mono_type_name_check_byref (MonoType *type, GString *str)
 {
-	if (mono_type_is_byref_internal (type))
+	if (m_type_is_byref (type))
 		g_string_append_c (str, '&');
 }
 
@@ -575,9 +575,9 @@ mono_type_get_name (MonoType *type)
 MonoType*
 mono_type_get_underlying_type (MonoType *type)
 {
-	if (type->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (type->data.klass) && !mono_type_is_byref_internal (type))
+	if (type->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (type->data.klass) && !m_type_is_byref (type))
 		return mono_class_enum_basetype_internal (type->data.klass);
-	if (type->type == MONO_TYPE_GENERICINST && m_class_is_enumtype (type->data.generic_class->container_class) && !mono_type_is_byref_internal (type))
+	if (type->type == MONO_TYPE_GENERICINST && m_class_is_enumtype (type->data.generic_class->container_class) && !m_type_is_byref (type))
 		return mono_class_enum_basetype_internal (type->data.generic_class->container_class);
 	return type;
 }
@@ -1691,7 +1691,7 @@ MonoType*
 mono_type_get_basic_type_from_generic (MonoType *type)
 {
 	/* When we do generic sharing we let type variables stand for reference/primitive types. */
-	if (!mono_type_is_byref_internal (type) && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR) &&
+	if (!m_type_is_byref (type) && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR) &&
 		(!type->data.generic_param->gshared_constraint || type->data.generic_param->gshared_constraint->type == MONO_TYPE_OBJECT))
 		return mono_get_object_type ();
 	return type;
@@ -3782,8 +3782,8 @@ mono_type_get_underlying_type_ignore_byref (MonoType *type)
 gboolean
 mono_byref_type_is_assignable_from (MonoType *type, MonoType *ctype, gboolean signature_assignment)
 {
-	g_assert (mono_type_is_byref_internal (type));
-	g_assert (mono_type_is_byref_internal (ctype));
+	g_assert (m_type_is_byref (type));
+	g_assert (m_type_is_byref (ctype));
 	MonoType *t = mono_type_get_underlying_type_ignore_byref (type);
 	MonoType *ot = mono_type_get_underlying_type_ignore_byref (ctype);
 

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -283,7 +283,7 @@ _mono_type_get_assembly_name (MonoClass *klass, GString *str)
 static void
 mono_type_name_check_byref (MonoType *type, GString *str)
 {
-	if (type->byref)
+	if (mono_type_is_byref_internal (type))
 		g_string_append_c (str, '&');
 }
 
@@ -575,9 +575,9 @@ mono_type_get_name (MonoType *type)
 MonoType*
 mono_type_get_underlying_type (MonoType *type)
 {
-	if (type->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (type->data.klass) && !type->byref)
+	if (type->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (type->data.klass) && !mono_type_is_byref_internal (type))
 		return mono_class_enum_basetype_internal (type->data.klass);
-	if (type->type == MONO_TYPE_GENERICINST && m_class_is_enumtype (type->data.generic_class->container_class) && !type->byref)
+	if (type->type == MONO_TYPE_GENERICINST && m_class_is_enumtype (type->data.generic_class->container_class) && !mono_type_is_byref_internal (type))
 		return mono_class_enum_basetype_internal (type->data.generic_class->container_class);
 	return type;
 }
@@ -708,7 +708,7 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 		 * ->byref and ->attrs from @type are propagated to the returned type.
 		 */
 		nt = mono_metadata_type_dup_with_cmods (image, inst->type_argv [num], type);
-		nt->byref = type->byref;
+		nt->byref__ = type->byref__;
 		nt->attrs = type->attrs;
 		return nt;
 	}
@@ -750,7 +750,7 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 #endif
 
 		nt = mono_metadata_type_dup_with_cmods (image, inst->type_argv [num], type);
-		nt->byref = type->byref || inst->type_argv[num]->byref;
+		nt->byref__ = type->byref__ || inst->type_argv[num]->byref__;
 		nt->attrs = type->attrs;
 #ifdef DEBUG_INFLATE_CMODS
 		if (append_cmods) {
@@ -1691,7 +1691,7 @@ MonoType*
 mono_type_get_basic_type_from_generic (MonoType *type)
 {
 	/* When we do generic sharing we let type variables stand for reference/primitive types. */
-	if (!type->byref && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR) &&
+	if (!mono_type_is_byref_internal (type) && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR) &&
 		(!type->data.generic_param->gshared_constraint || type->data.generic_param->gshared_constraint->type == MONO_TYPE_OBJECT))
 		return mono_get_object_type ();
 	return type;
@@ -3782,8 +3782,8 @@ mono_type_get_underlying_type_ignore_byref (MonoType *type)
 gboolean
 mono_byref_type_is_assignable_from (MonoType *type, MonoType *ctype, gboolean signature_assignment)
 {
-	g_assert (type->byref);
-	g_assert (ctype->byref);
+	g_assert (mono_type_is_byref_internal (type));
+	g_assert (mono_type_is_byref_internal (ctype));
 	MonoType *t = mono_type_get_underlying_type_ignore_byref (type);
 	MonoType *ot = mono_type_get_underlying_type_ignore_byref (ctype);
 

--- a/src/mono/mono/metadata/debug-helpers.c
+++ b/src/mono/mono/metadata/debug-helpers.c
@@ -235,7 +235,7 @@ mono_type_get_desc (GString *res, MonoType *type, gboolean include_namespace)
 	if (type->has_cmods) {
 		mono_custom_modifiers_get_desc (res, type, include_namespace);
 	}
-	if (type->byref)
+	if (mono_type_is_byref_internal (type))
 		g_string_append_c (res, '&');
 }
 

--- a/src/mono/mono/metadata/debug-helpers.c
+++ b/src/mono/mono/metadata/debug-helpers.c
@@ -235,7 +235,7 @@ mono_type_get_desc (GString *res, MonoType *type, gboolean include_namespace)
 	if (type->has_cmods) {
 		mono_custom_modifiers_get_desc (res, type, include_namespace);
 	}
-	if (mono_type_is_byref_internal (type))
+	if (m_type_is_byref (type))
 		g_string_append_c (res, '&');
 }
 

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -160,7 +160,7 @@ type_array_from_modifiers (MonoType *type, int optional, MonoError *error);
 static inline MonoBoolean
 is_generic_parameter (MonoType *type)
 {
-	return !mono_type_is_byref_internal (type) && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR);
+	return !m_type_is_byref (type) && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR);
 }
 
 #ifdef HOST_WIN32
@@ -708,7 +708,7 @@ ves_icall_System_Array_InternalCreate (MonoArray *volatile* result, MonoType* ty
 		goto exit;
 	}
 
-	if (mono_type_is_byref_internal (type) || m_class_is_byreflike (klass)) {
+	if (m_type_is_byref (type) || m_class_is_byreflike (klass)) {
 		mono_error_set_not_supported (error, NULL);
 		goto exit;
 	}
@@ -1092,7 +1092,7 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_GetUninitializedObjectI
 		return NULL_HANDLE;
 	}
 
-	if (mono_class_is_array (klass) || mono_class_is_pointer (klass) || mono_type_is_byref_internal (handle)) {
+	if (mono_class_is_array (klass) || mono_class_is_pointer (klass) || m_type_is_byref (handle)) {
 		mono_error_set_argument (error, NULL, NULL);
 		return NULL_HANDLE;
 	}
@@ -1709,10 +1709,10 @@ ves_icall_RuntimeTypeHandle_type_is_assignable_from (MonoReflectionTypeHandle re
 	MonoType *ctype = MONO_HANDLE_GETVAL (ref_c, type);
 	MonoClass *klassc = mono_class_from_mono_type_internal (ctype);
 
-	if (mono_type_is_byref_internal (type) ^ mono_type_is_byref_internal (ctype))
+	if (m_type_is_byref (type) ^ m_type_is_byref (ctype))
 		return FALSE;
 
-	if (mono_type_is_byref_internal (type)) {
+	if (m_type_is_byref (type)) {
 		return mono_byref_type_is_assignable_from (type, ctype, FALSE);
 	}
 
@@ -1732,12 +1732,12 @@ ves_icall_RuntimeTypeHandle_is_subclass_of (MonoType *childType, MonoType *baseT
 	childClass = mono_class_from_mono_type_internal (childType);
 	baseClass = mono_class_from_mono_type_internal (baseType);
 
-	if (G_UNLIKELY (mono_type_is_byref_internal (childType))) {
-		result = !mono_type_is_byref_internal (baseType) && baseClass == mono_defaults.object_class;
+	if (G_UNLIKELY (m_type_is_byref (childType))) {
+		result = !m_type_is_byref (baseType) && baseClass == mono_defaults.object_class;
 		goto done;
 	}
 
-	if (G_UNLIKELY (mono_type_is_byref_internal (baseType))) {
+	if (G_UNLIKELY (m_type_is_byref (baseType))) {
 		result = FALSE;
 		goto done;
 	}
@@ -1792,7 +1792,7 @@ ves_icall_RuntimeTypeHandle_GetAttributes (MonoReflectionTypeHandle ref_type, Mo
 {
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
-	if (mono_type_is_byref_internal (type) || type->type == MONO_TYPE_PTR || type->type == MONO_TYPE_FNPTR)
+	if (m_type_is_byref (type) || type->type == MONO_TYPE_PTR || type->type == MONO_TYPE_FNPTR)
 		return TYPE_ATTRIBUTE_NOT_PUBLIC;
 
 	MonoClass *klass = mono_class_from_mono_type_internal (type);
@@ -2022,7 +2022,7 @@ ves_icall_RuntimeFieldInfo_SetValueInternal (MonoReflectionFieldHandle field, Mo
 	gboolean isref = FALSE;
 	MonoGCHandle value_gchandle = 0;
 	gchar *v = NULL;
-	if (!mono_type_is_byref_internal (type)) {
+	if (!m_type_is_byref (type)) {
 		switch (type->type) {
 		case MONO_TYPE_U1:
 		case MONO_TYPE_I1:
@@ -2684,7 +2684,7 @@ ves_icall_RuntimeTypeHandle_GetElementType (MonoReflectionTypeHandle ref_type, M
 {
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
-	if (!mono_type_is_byref_internal (type) && type->type == MONO_TYPE_SZARRAY)
+	if (!m_type_is_byref (type) && type->type == MONO_TYPE_SZARRAY)
 		return mono_type_get_object_handle (m_class_get_byval_arg (type->data.klass), error);
 
 	MonoClass *klass = mono_class_from_mono_type_internal (type);
@@ -2693,7 +2693,7 @@ ves_icall_RuntimeTypeHandle_GetElementType (MonoReflectionTypeHandle ref_type, M
 
 	// GetElementType should only return a type for:
 	// Array Pointer PassedByRef
-	if (mono_type_is_byref_internal (type))
+	if (m_type_is_byref (type))
 		return mono_type_get_object_handle (m_class_get_byval_arg (klass), error);
 	else if (m_class_get_element_class (klass) && MONO_CLASS_IS_ARRAY (klass))
 		return mono_type_get_object_handle (m_class_get_byval_arg (m_class_get_element_class (klass)), error);
@@ -2708,7 +2708,7 @@ ves_icall_RuntimeTypeHandle_GetBaseType (MonoReflectionTypeHandle ref_type, Mono
 {
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
-	if (mono_type_is_byref_internal (type))
+	if (m_type_is_byref (type))
 		return MONO_HANDLE_CAST (MonoReflectionType, NULL_HANDLE);
 
 	MonoClass *klass = mono_class_from_mono_type_internal (type);
@@ -2723,7 +2723,7 @@ ves_icall_RuntimeTypeHandle_GetCorElementType (MonoReflectionTypeHandle ref_type
 {
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
-	if (mono_type_is_byref_internal (type))
+	if (m_type_is_byref (type))
 		return MONO_TYPE_BYREF;
 	else
 		return (guint32)type->type;
@@ -2745,7 +2745,7 @@ ves_icall_RuntimeTypeHandle_IsByRefLike (MonoReflectionTypeHandle ref_type, Mono
 {
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 	/* .NET Core says byref types are not IsByRefLike */
-	if (mono_type_is_byref_internal (type))
+	if (m_type_is_byref (type))
 		return FALSE;
 	MonoClass *klass = mono_class_from_mono_type_internal (type);
 	return m_class_is_byreflike (klass);
@@ -2791,7 +2791,7 @@ ves_icall_RuntimeType_get_DeclaringType (MonoReflectionTypeHandle ref_type, Mono
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 	MonoClass *klass;
 
-	if (mono_type_is_byref_internal (type))
+	if (m_type_is_byref (type))
 		return MONO_HANDLE_CAST (MonoReflectionType, NULL_HANDLE);
 	if (type->type == MONO_TYPE_VAR) {
 		MonoGenericContainer *param = mono_type_get_generic_param_owner (type);
@@ -2818,7 +2818,7 @@ ves_icall_RuntimeType_get_Name (MonoReflectionTypeHandle reftype, MonoError *err
 	// Determining exactly when to do so is fairly difficult, so for now we don't bother to avoid regressions
 	const char *klass_name = m_class_get_name (klass);
 
-	if (mono_type_is_byref_internal (type)) {
+	if (m_type_is_byref (type)) {
 		char *n = g_strdup_printf ("%s&", klass_name);
 		MonoStringHandle res = mono_string_new_handle (n, error);
 
@@ -2927,7 +2927,7 @@ ves_icall_RuntimeTypeHandle_IsGenericTypeDefinition (MonoReflectionTypeHandle re
 		return FALSE;
 
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
-	if (mono_type_is_byref_internal (type))
+	if (m_type_is_byref (type))
 		return FALSE;
 
 	MonoClass *klass = mono_class_from_mono_type_internal (type);
@@ -2942,7 +2942,7 @@ ves_icall_RuntimeTypeHandle_GetGenericTypeDefinition_impl (MonoReflectionTypeHan
 
 	MonoReflectionTypeHandle ret = MONO_HANDLE_NEW (MonoReflectionType, NULL);
 
-	if (mono_type_is_byref_internal (type))
+	if (m_type_is_byref (type))
 		goto leave;
 
 	MonoClass *klass;
@@ -3016,7 +3016,7 @@ ves_icall_RuntimeTypeHandle_HasInstantiation (MonoReflectionTypeHandle ref_type,
 		return FALSE;
 
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
-	if (mono_type_is_byref_internal (type))
+	if (m_type_is_byref (type))
 		return FALSE;
 
 	klass = mono_class_from_mono_type_internal (type);
@@ -3085,7 +3085,7 @@ ves_icall_RuntimeType_get_DeclaringMethod (MonoReflectionTypeHandle ref_type, Mo
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 	MonoReflectionMethodHandle ret = MONO_HANDLE_NEW (MonoReflectionMethod, NULL);
 
-	if (mono_type_is_byref_internal (type) || (type->type != MONO_TYPE_MVAR && type->type != MONO_TYPE_VAR)) {
+	if (m_type_is_byref (type) || (type->type != MONO_TYPE_MVAR && type->type != MONO_TYPE_VAR)) {
 		mono_error_set_invalid_operation (error, "DeclaringMethod can only be used on generic arguments");
 		goto leave;
 	}
@@ -3416,7 +3416,7 @@ ves_icall_InternalInvoke (MonoReflectionMethodHandle method_handle, MonoObjectHa
 		goto return_null;
 	}
 
-	if (mono_type_is_byref_internal (sig->ret)) {
+	if (m_type_is_byref (sig->ret)) {
 		MonoType* ret_byval = m_class_get_byval_arg (mono_class_from_mono_type_internal (sig->ret));
 		if (ret_byval->type == MONO_TYPE_VOID) {
 			exception = mono_exception_from_name_msg (mono_defaults.corlib, "System", "NotSupportedException", "ByRef to void return values are not supported in reflection invocation");
@@ -3749,7 +3749,7 @@ ves_icall_RuntimeType_GetFields_native (MonoReflectionTypeHandle ref_type, char 
 	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
-	if (mono_type_is_byref_internal (type)) {
+	if (m_type_is_byref (type)) {
 		return g_ptr_array_new ();
 	}
 
@@ -3942,7 +3942,7 @@ ves_icall_RuntimeType_GetMethodsByName_native (MonoReflectionTypeHandle ref_type
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
 	MonoClass *klass = mono_class_from_mono_type_internal (type);
-	if (mono_type_is_byref_internal (type)) {
+	if (m_type_is_byref (type)) {
 		return g_ptr_array_new ();
 	}
 
@@ -3953,7 +3953,7 @@ GPtrArray*
 ves_icall_RuntimeType_GetConstructors_native (MonoReflectionTypeHandle ref_type, guint32 bflags, MonoError *error)
 {
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
-	if (mono_type_is_byref_internal (type)) {
+	if (m_type_is_byref (type)) {
 		return g_ptr_array_new ();
 	}
 
@@ -4072,7 +4072,7 @@ ves_icall_RuntimeType_GetPropertiesByName_native (MonoReflectionTypeHandle ref_t
 	bflags |= BFLAGS_NonPublic;
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
-	if (mono_type_is_byref_internal (type)) {
+	if (m_type_is_byref (type)) {
 		return g_ptr_array_new ();
 	}
 
@@ -4182,7 +4182,7 @@ ves_icall_RuntimeType_GetEvents_native (MonoReflectionTypeHandle ref_type, char 
 {
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
-	if (mono_type_is_byref_internal (type)) {
+	if (m_type_is_byref (type)) {
 		return g_ptr_array_new ();
 	}
 
@@ -4253,7 +4253,7 @@ ves_icall_RuntimeType_GetNestedTypes_native (MonoReflectionTypeHandle ref_type, 
 {
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
-	if (mono_type_is_byref_internal (type)) {
+	if (m_type_is_byref (type)) {
 		return g_ptr_array_new ();
 	}
 
@@ -6047,7 +6047,7 @@ check_for_invalid_array_type (MonoType *type, MonoError *error)
 
 	error_init (error);
 
-	if (mono_type_is_byref_internal (type))
+	if (m_type_is_byref (type))
 		allowed = FALSE;
 	else if (type->type == MONO_TYPE_TYPEDBYREF)
 		allowed = FALSE;

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -160,7 +160,7 @@ type_array_from_modifiers (MonoType *type, int optional, MonoError *error);
 static inline MonoBoolean
 is_generic_parameter (MonoType *type)
 {
-	return !type->byref && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR);
+	return !mono_type_is_byref_internal (type) && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR);
 }
 
 #ifdef HOST_WIN32
@@ -708,7 +708,7 @@ ves_icall_System_Array_InternalCreate (MonoArray *volatile* result, MonoType* ty
 		goto exit;
 	}
 
-	if (type->byref || m_class_is_byreflike (klass)) {
+	if (mono_type_is_byref_internal (type) || m_class_is_byreflike (klass)) {
 		mono_error_set_not_supported (error, NULL);
 		goto exit;
 	}
@@ -1092,7 +1092,7 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_GetUninitializedObjectI
 		return NULL_HANDLE;
 	}
 
-	if (mono_class_is_array (klass) || mono_class_is_pointer (klass) || handle->byref) {
+	if (mono_class_is_array (klass) || mono_class_is_pointer (klass) || mono_type_is_byref_internal (handle)) {
 		mono_error_set_argument (error, NULL, NULL);
 		return NULL_HANDLE;
 	}
@@ -1709,10 +1709,10 @@ ves_icall_RuntimeTypeHandle_type_is_assignable_from (MonoReflectionTypeHandle re
 	MonoType *ctype = MONO_HANDLE_GETVAL (ref_c, type);
 	MonoClass *klassc = mono_class_from_mono_type_internal (ctype);
 
-	if (type->byref ^ ctype->byref)
+	if (mono_type_is_byref_internal (type) ^ mono_type_is_byref_internal (ctype))
 		return FALSE;
 
-	if (type->byref) {
+	if (mono_type_is_byref_internal (type)) {
 		return mono_byref_type_is_assignable_from (type, ctype, FALSE);
 	}
 
@@ -1732,12 +1732,12 @@ ves_icall_RuntimeTypeHandle_is_subclass_of (MonoType *childType, MonoType *baseT
 	childClass = mono_class_from_mono_type_internal (childType);
 	baseClass = mono_class_from_mono_type_internal (baseType);
 
-	if (G_UNLIKELY (childType->byref)) {
-		result = !baseType->byref && baseClass == mono_defaults.object_class;
+	if (G_UNLIKELY (mono_type_is_byref_internal (childType))) {
+		result = !mono_type_is_byref_internal (baseType) && baseClass == mono_defaults.object_class;
 		goto done;
 	}
 
-	if (G_UNLIKELY (baseType->byref)) {
+	if (G_UNLIKELY (mono_type_is_byref_internal (baseType))) {
 		result = FALSE;
 		goto done;
 	}
@@ -1792,7 +1792,7 @@ ves_icall_RuntimeTypeHandle_GetAttributes (MonoReflectionTypeHandle ref_type, Mo
 {
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
-	if (type->byref || type->type == MONO_TYPE_PTR || type->type == MONO_TYPE_FNPTR)
+	if (mono_type_is_byref_internal (type) || type->type == MONO_TYPE_PTR || type->type == MONO_TYPE_FNPTR)
 		return TYPE_ATTRIBUTE_NOT_PUBLIC;
 
 	MonoClass *klass = mono_class_from_mono_type_internal (type);
@@ -2022,7 +2022,7 @@ ves_icall_RuntimeFieldInfo_SetValueInternal (MonoReflectionFieldHandle field, Mo
 	gboolean isref = FALSE;
 	MonoGCHandle value_gchandle = 0;
 	gchar *v = NULL;
-	if (!type->byref) {
+	if (!mono_type_is_byref_internal (type)) {
 		switch (type->type) {
 		case MONO_TYPE_U1:
 		case MONO_TYPE_I1:
@@ -2684,7 +2684,7 @@ ves_icall_RuntimeTypeHandle_GetElementType (MonoReflectionTypeHandle ref_type, M
 {
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
-	if (!type->byref && type->type == MONO_TYPE_SZARRAY)
+	if (!mono_type_is_byref_internal (type) && type->type == MONO_TYPE_SZARRAY)
 		return mono_type_get_object_handle (m_class_get_byval_arg (type->data.klass), error);
 
 	MonoClass *klass = mono_class_from_mono_type_internal (type);
@@ -2693,7 +2693,7 @@ ves_icall_RuntimeTypeHandle_GetElementType (MonoReflectionTypeHandle ref_type, M
 
 	// GetElementType should only return a type for:
 	// Array Pointer PassedByRef
-	if (type->byref)
+	if (mono_type_is_byref_internal (type))
 		return mono_type_get_object_handle (m_class_get_byval_arg (klass), error);
 	else if (m_class_get_element_class (klass) && MONO_CLASS_IS_ARRAY (klass))
 		return mono_type_get_object_handle (m_class_get_byval_arg (m_class_get_element_class (klass)), error);
@@ -2708,7 +2708,7 @@ ves_icall_RuntimeTypeHandle_GetBaseType (MonoReflectionTypeHandle ref_type, Mono
 {
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
-	if (type->byref)
+	if (mono_type_is_byref_internal (type))
 		return MONO_HANDLE_CAST (MonoReflectionType, NULL_HANDLE);
 
 	MonoClass *klass = mono_class_from_mono_type_internal (type);
@@ -2723,7 +2723,7 @@ ves_icall_RuntimeTypeHandle_GetCorElementType (MonoReflectionTypeHandle ref_type
 {
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
-	if (type->byref)
+	if (mono_type_is_byref_internal (type))
 		return MONO_TYPE_BYREF;
 	else
 		return (guint32)type->type;
@@ -2745,7 +2745,7 @@ ves_icall_RuntimeTypeHandle_IsByRefLike (MonoReflectionTypeHandle ref_type, Mono
 {
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 	/* .NET Core says byref types are not IsByRefLike */
-	if (type->byref)
+	if (mono_type_is_byref_internal (type))
 		return FALSE;
 	MonoClass *klass = mono_class_from_mono_type_internal (type);
 	return m_class_is_byreflike (klass);
@@ -2791,7 +2791,7 @@ ves_icall_RuntimeType_get_DeclaringType (MonoReflectionTypeHandle ref_type, Mono
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 	MonoClass *klass;
 
-	if (type->byref)
+	if (mono_type_is_byref_internal (type))
 		return MONO_HANDLE_CAST (MonoReflectionType, NULL_HANDLE);
 	if (type->type == MONO_TYPE_VAR) {
 		MonoGenericContainer *param = mono_type_get_generic_param_owner (type);
@@ -2818,7 +2818,7 @@ ves_icall_RuntimeType_get_Name (MonoReflectionTypeHandle reftype, MonoError *err
 	// Determining exactly when to do so is fairly difficult, so for now we don't bother to avoid regressions
 	const char *klass_name = m_class_get_name (klass);
 
-	if (type->byref) {
+	if (mono_type_is_byref_internal (type)) {
 		char *n = g_strdup_printf ("%s&", klass_name);
 		MonoStringHandle res = mono_string_new_handle (n, error);
 
@@ -2927,7 +2927,7 @@ ves_icall_RuntimeTypeHandle_IsGenericTypeDefinition (MonoReflectionTypeHandle re
 		return FALSE;
 
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
-	if (type->byref)
+	if (mono_type_is_byref_internal (type))
 		return FALSE;
 
 	MonoClass *klass = mono_class_from_mono_type_internal (type);
@@ -2942,7 +2942,7 @@ ves_icall_RuntimeTypeHandle_GetGenericTypeDefinition_impl (MonoReflectionTypeHan
 
 	MonoReflectionTypeHandle ret = MONO_HANDLE_NEW (MonoReflectionType, NULL);
 
-	if (type->byref)
+	if (mono_type_is_byref_internal (type))
 		goto leave;
 
 	MonoClass *klass;
@@ -3016,7 +3016,7 @@ ves_icall_RuntimeTypeHandle_HasInstantiation (MonoReflectionTypeHandle ref_type,
 		return FALSE;
 
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
-	if (type->byref)
+	if (mono_type_is_byref_internal (type))
 		return FALSE;
 
 	klass = mono_class_from_mono_type_internal (type);
@@ -3085,7 +3085,7 @@ ves_icall_RuntimeType_get_DeclaringMethod (MonoReflectionTypeHandle ref_type, Mo
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 	MonoReflectionMethodHandle ret = MONO_HANDLE_NEW (MonoReflectionMethod, NULL);
 
-	if (type->byref || (type->type != MONO_TYPE_MVAR && type->type != MONO_TYPE_VAR)) {
+	if (mono_type_is_byref_internal (type) || (type->type != MONO_TYPE_MVAR && type->type != MONO_TYPE_VAR)) {
 		mono_error_set_invalid_operation (error, "DeclaringMethod can only be used on generic arguments");
 		goto leave;
 	}
@@ -3416,7 +3416,7 @@ ves_icall_InternalInvoke (MonoReflectionMethodHandle method_handle, MonoObjectHa
 		goto return_null;
 	}
 
-	if (sig->ret->byref) {
+	if (mono_type_is_byref_internal (sig->ret)) {
 		MonoType* ret_byval = m_class_get_byval_arg (mono_class_from_mono_type_internal (sig->ret));
 		if (ret_byval->type == MONO_TYPE_VOID) {
 			exception = mono_exception_from_name_msg (mono_defaults.corlib, "System", "NotSupportedException", "ByRef to void return values are not supported in reflection invocation");
@@ -3749,7 +3749,7 @@ ves_icall_RuntimeType_GetFields_native (MonoReflectionTypeHandle ref_type, char 
 	error_init (error);
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
-	if (type->byref) {
+	if (mono_type_is_byref_internal (type)) {
 		return g_ptr_array_new ();
 	}
 
@@ -3942,7 +3942,7 @@ ves_icall_RuntimeType_GetMethodsByName_native (MonoReflectionTypeHandle ref_type
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
 	MonoClass *klass = mono_class_from_mono_type_internal (type);
-	if (type->byref) {
+	if (mono_type_is_byref_internal (type)) {
 		return g_ptr_array_new ();
 	}
 
@@ -3953,7 +3953,7 @@ GPtrArray*
 ves_icall_RuntimeType_GetConstructors_native (MonoReflectionTypeHandle ref_type, guint32 bflags, MonoError *error)
 {
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
-	if (type->byref) {
+	if (mono_type_is_byref_internal (type)) {
 		return g_ptr_array_new ();
 	}
 
@@ -4072,7 +4072,7 @@ ves_icall_RuntimeType_GetPropertiesByName_native (MonoReflectionTypeHandle ref_t
 	bflags |= BFLAGS_NonPublic;
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
-	if (type->byref) {
+	if (mono_type_is_byref_internal (type)) {
 		return g_ptr_array_new ();
 	}
 
@@ -4182,7 +4182,7 @@ ves_icall_RuntimeType_GetEvents_native (MonoReflectionTypeHandle ref_type, char 
 {
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
-	if (type->byref) {
+	if (mono_type_is_byref_internal (type)) {
 		return g_ptr_array_new ();
 	}
 
@@ -4253,7 +4253,7 @@ ves_icall_RuntimeType_GetNestedTypes_native (MonoReflectionTypeHandle ref_type, 
 {
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
-	if (type->byref) {
+	if (mono_type_is_byref_internal (type)) {
 		return g_ptr_array_new ();
 	}
 
@@ -6047,7 +6047,7 @@ check_for_invalid_array_type (MonoType *type, MonoError *error)
 
 	error_init (error);
 
-	if (type->byref)
+	if (mono_type_is_byref_internal (type))
 		allowed = FALSE;
 	else if (type->type == MONO_TYPE_TYPEDBYREF)
 		allowed = FALSE;

--- a/src/mono/mono/metadata/marshal-ilgen.c
+++ b/src/mono/mono/metadata/marshal-ilgen.c
@@ -1162,7 +1162,7 @@ emit_struct_conv_full (MonoMethodBuilder *mb, MonoClass *klass, gboolean to_obje
 			int t;
 
 			//XXX a byref field!?!? that's not allowed! and worse, it might miss a WB
-			g_assert (!mono_type_is_byref_internal (ftype));
+			g_assert (!m_type_is_byref (ftype));
 			if (ftype->type == MONO_TYPE_I || ftype->type == MONO_TYPE_U) {
 				mono_mb_emit_ldloc (mb, 1);
 				mono_mb_emit_ldloc (mb, 0);
@@ -1442,7 +1442,7 @@ mono_mb_emit_restore_result (MonoMethodBuilder *mb, MonoType *return_type)
 	MonoType *t = mono_type_get_underlying_type (return_type);
 	MonoType *int_type = mono_get_int_type ();
 
-	if (mono_type_is_byref_internal (return_type))
+	if (m_type_is_byref (return_type))
 		return_type = int_type;
 
 	switch (t->type) {
@@ -1542,7 +1542,7 @@ emit_invoke_call (MonoMethodBuilder *mb, MonoMethod *method,
 			mono_mb_emit_byte (mb, CEE_ADD);
 		}
 
-		if (mono_type_is_byref_internal (t)) {
+		if (m_type_is_byref (t)) {
 			mono_mb_emit_byte (mb, CEE_LDIND_I);
 			/* A Nullable<T> type don't have a boxed form, it's either null or a boxed T.
 			 * So to make this work we unbox it to a local variablee and push a reference to that.
@@ -1628,7 +1628,7 @@ handle_enum:
 		mono_mb_emit_calli (mb, callsig);
 	}
 
-	if (mono_type_is_byref_internal (sig->ret)) {
+	if (m_type_is_byref (sig->ret)) {
 		/* perform indirect load and return by value */
 		int pos;
 		mono_mb_emit_byte (mb, CEE_DUP);
@@ -1638,7 +1638,7 @@ handle_enum:
 
 		int ldind_op;
 		MonoType* ret_byval = m_class_get_byval_arg (mono_class_from_mono_type_internal (sig->ret));
-		g_assert (!mono_type_is_byref_internal (ret_byval));
+		g_assert (!m_type_is_byref (ret_byval));
 		// TODO: Handle null references
 		ldind_op = mono_type_to_ldind (ret_byval);
 		/* taken from similar code in mini-generic-sharing.c
@@ -1701,7 +1701,7 @@ handle_enum:
 		 * Box the result and put it back into the array, the caller will have
 		 * to obtain it from there.
 		 */
-		if (mono_type_is_byref_internal (t) && t->type == MONO_TYPE_GENERICINST && mono_class_is_nullable (mono_class_from_mono_type_internal (t))) {
+		if (m_type_is_byref (t) && t->type == MONO_TYPE_GENERICINST && mono_class_is_nullable (mono_class_from_mono_type_internal (t))) {
 			mono_mb_emit_ldarg (mb, 1);			
 			mono_mb_emit_icon (mb, TARGET_SIZEOF_VOID_P * i);
 			mono_mb_emit_byte (mb, CEE_ADD);
@@ -2184,7 +2184,7 @@ emit_native_wrapper_ilgen (MonoImage *image, MonoMethodBuilder *mb, MonoMethodSi
 	gc_safe_transition_builder_cleanup (&gc_safe_transition_builder);
 
 	/* convert the result */
-	if (!mono_type_is_byref_internal (sig->ret)) {
+	if (!m_type_is_byref (sig->ret)) {
 		MonoMarshalSpec *spec = mspecs [0];
 		type = sig->ret->type;
 
@@ -2446,7 +2446,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 		if (m_class_is_blittable (eklass)) {
 			mono_mb_emit_ldarg (mb, argnum);
-			if (mono_type_is_byref_internal (t))
+			if (m_type_is_byref (t))
 				mono_mb_emit_byte (mb, CEE_LDIND_I);
 			mono_mb_emit_icall_id (mb, conv_to_icall (MONO_MARSHAL_CONV_ARRAY_LPARRAY, NULL));
 			mono_mb_emit_stloc (mb, conv_arg);
@@ -2481,7 +2481,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 			src_var = mono_mb_add_local (mb, object_type);
 			mono_mb_emit_ldarg (mb, argnum);
-			if (mono_type_is_byref_internal (t))
+			if (m_type_is_byref (t))
 				mono_mb_emit_byte (mb, CEE_LDIND_I);
 			mono_mb_emit_stloc (mb, src_var);
 
@@ -2584,18 +2584,18 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 			param_type = m->sig->params [param_num];
 
-			if (mono_type_is_byref_internal (param_type) && param_type->type != MONO_TYPE_I4) {
+			if (m_type_is_byref (param_type) && param_type->type != MONO_TYPE_I4) {
 				char *msg = g_strdup ("Not implemented.");
 				mono_mb_emit_exception_marshal_directive (mb, msg);
 				break;
 			}
 
-			if (mono_type_is_byref_internal (t) ) {
+			if (m_type_is_byref (t) ) {
 				mono_mb_emit_ldarg (mb, argnum);
 
 				/* Create the managed array */
 				mono_mb_emit_ldarg (mb, param_num);
-				if (mono_type_is_byref_internal (m->sig->params [param_num]))
+				if (m_type_is_byref (m->sig->params [param_num]))
 					// FIXME: Support other types
 					mono_mb_emit_byte (mb, CEE_LDIND_I4);
 				mono_mb_emit_byte (mb, CEE_CONV_OVF_I);
@@ -2621,7 +2621,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 			/* Check null */
 			mono_mb_emit_ldarg (mb, argnum);
-			if (mono_type_is_byref_internal (t))
+			if (m_type_is_byref (t))
 				mono_mb_emit_byte (mb, CEE_LDIND_I);
 			label1 = mono_mb_emit_branch (mb, CEE_BRFALSE);
 
@@ -2635,7 +2635,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			label2 = mono_mb_get_label (mb);
 			mono_mb_emit_ldloc (mb, index_var);
 			mono_mb_emit_ldarg (mb, argnum);
-			if (mono_type_is_byref_internal (t))
+			if (m_type_is_byref (t))
 				mono_mb_emit_byte (mb, CEE_LDIND_REF);
 			mono_mb_emit_byte (mb, CEE_LDLEN);
 			label3 = mono_mb_emit_branch (mb, CEE_BGE);
@@ -2650,7 +2650,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 				/* dest */
 				mono_mb_emit_ldarg (mb, argnum);
-				if (mono_type_is_byref_internal (t))
+				if (m_type_is_byref (t))
 					mono_mb_emit_byte (mb, CEE_LDIND_I);
 				mono_mb_emit_ldloc (mb, index_var);
 				mono_mb_emit_byte (mb, CEE_LDELEM_REF);
@@ -2686,7 +2686,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 					/* set dst_ptr */
 					mono_mb_emit_ldarg (mb, argnum);
-					if (mono_type_is_byref_internal (t))
+					if (m_type_is_byref (t))
 						mono_mb_emit_byte (mb, CEE_LDIND_REF);
 					mono_mb_emit_ldloc (mb, index_var);
 					mono_mb_emit_op (mb, CEE_LDELEMA, eklass);
@@ -2718,7 +2718,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			/* free memory allocated (if any) by MONO_MARSHAL_CONV_ARRAY_LPARRAY */
 
 			mono_mb_emit_ldarg (mb, argnum);
-			if (mono_type_is_byref_internal (t))
+			if (m_type_is_byref (t))
 				mono_mb_emit_byte (mb, CEE_LDIND_REF);
 			mono_mb_emit_ldloc (mb, conv_arg);
 			mono_mb_emit_icall_id (mb, conv_to_icall (MONO_MARSHAL_FREE_LPARRAY, NULL));
@@ -2728,7 +2728,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	}
 
 	case MARSHAL_ACTION_PUSH:
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			mono_mb_emit_ldloc_addr (mb, conv_arg);
 		else
 			mono_mb_emit_ldloc (mb, conv_arg);
@@ -2750,7 +2750,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		conv_arg = mono_mb_add_local (mb, object_type);
 		*conv_arg_type = int_type;
 
-		if (mono_type_is_byref_internal (t)) {
+		if (m_type_is_byref (t)) {
 			char *msg = g_strdup ("Byref array marshalling to managed code is not implemented.");
 			mono_mb_emit_exception_marshal_directive (mb, msg);
 			return conv_arg;
@@ -2952,7 +2952,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			break;
 		
 		/* These are already checked in CONV_IN */
-		g_assert (!mono_type_is_byref_internal (t));
+		g_assert (!m_type_is_byref (t));
 		g_assert (spec->native == MONO_NATIVE_LPARRAY);
 		g_assert (t->attrs & PARAM_ATTRIBUTE_OUT);
 
@@ -3071,7 +3071,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		MonoMarshalConv conv = MONO_MARSHAL_CONV_INVALID;
 		gboolean is_string = FALSE;
 		
-		g_assert (!mono_type_is_byref_internal (t));
+		g_assert (!m_type_is_byref (t));
 
 		mono_marshal_load_type_info (eklass);
 
@@ -3239,14 +3239,14 @@ emit_marshal_boolean_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		guint8 ldc_op = CEE_LDC_I4_1;
 
 		local_type = mono_marshal_boolean_conv_in_get_local_type (spec, &ldc_op);
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			*conv_arg_type = int_type;
 		else
 			*conv_arg_type = local_type;
 		conv_arg = mono_mb_add_local (mb, local_type);
 		
 		mono_mb_emit_ldarg (mb, argnum);
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			mono_mb_emit_byte (mb, CEE_LDIND_I1);
 		label_false = mono_mb_emit_branch (mb, CEE_BRFALSE);
 		mono_mb_emit_byte (mb, ldc_op);
@@ -3259,7 +3259,7 @@ emit_marshal_boolean_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	case MARSHAL_ACTION_CONV_OUT:
 	{
 		int label_false, label_end;
-		if (!mono_type_is_byref_internal (t))
+		if (!m_type_is_byref (t))
 			break;
 
 		mono_mb_emit_ldarg (mb, argnum);
@@ -3278,7 +3278,7 @@ emit_marshal_boolean_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	}
 
 	case MARSHAL_ACTION_PUSH:
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			mono_mb_emit_ldloc_addr (mb, conv_arg);
 		else if (conv_arg)
 			mono_mb_emit_ldloc (mb, conv_arg);
@@ -3299,7 +3299,7 @@ emit_marshal_boolean_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		conv_arg_class = mono_marshal_boolean_managed_conv_in_get_conv_arg_class (spec, &ldop);
 		conv_arg = mono_mb_add_local (mb, boolean_type);
 
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			*conv_arg_type = m_class_get_this_arg (conv_arg_class);
 		else
 			*conv_arg_type = m_class_get_byval_arg (conv_arg_class);
@@ -3308,7 +3308,7 @@ emit_marshal_boolean_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		mono_mb_emit_ldarg (mb, argnum);
 		
 		/* Check null */
-		if (mono_type_is_byref_internal (t)) {
+		if (m_type_is_byref (t)) {
 			label_null = mono_mb_emit_branch (mb, CEE_BRFALSE);
 			mono_mb_emit_ldarg (mb, argnum);
 			mono_mb_emit_byte (mb, ldop);
@@ -3320,7 +3320,7 @@ emit_marshal_boolean_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		mono_mb_emit_stloc (mb, conv_arg);
 		mono_mb_patch_branch (mb, label_false);
 
-		if (mono_type_is_byref_internal (t)) 
+		if (m_type_is_byref (t)) 
 			mono_mb_patch_branch (mb, label_null);
 		break;
 	}
@@ -3330,7 +3330,7 @@ emit_marshal_boolean_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		guint8 ldc_op = CEE_LDC_I4_1;
 		int label_null,label_false, label_end;
 
-		if (!mono_type_is_byref_internal (t))
+		if (!m_type_is_byref (t))
 			break;
 		if (spec) {
 			switch (spec->native) {
@@ -4463,7 +4463,7 @@ emit_thunk_invoke_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 
 			/* byref args & and the "this" arg must remain a ptr.
 			   Otherwise make a copy of the value type */
-			if (!(mono_type_is_byref_internal (csig->params [i]) || (i == 0 && sig->hasthis)))
+			if (!(m_type_is_byref (csig->params [i]) || (i == 0 && sig->hasthis)))
 				mono_mb_emit_op (mb, CEE_LDOBJ, klass);
 
 			csig->params [i] = object_type;
@@ -4634,23 +4634,23 @@ emit_marshal_custom_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		mono_mb_emit_byte (mb, CEE_LDNULL);
 		mono_mb_emit_stloc (mb, conv_arg);
 
-		if (mono_type_is_byref_internal (t) && (t->attrs & PARAM_ATTRIBUTE_OUT))
+		if (m_type_is_byref (t) && (t->attrs & PARAM_ATTRIBUTE_OUT))
 			break;
 
 		/* Minic MS.NET behavior */
-		if (!mono_type_is_byref_internal (t) && (t->attrs & PARAM_ATTRIBUTE_OUT) && !(t->attrs & PARAM_ATTRIBUTE_IN))
+		if (!m_type_is_byref (t) && (t->attrs & PARAM_ATTRIBUTE_OUT) && !(t->attrs & PARAM_ATTRIBUTE_IN))
 			break;
 
 		/* Check for null */
 		mono_mb_emit_ldarg (mb, argnum);
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			mono_mb_emit_byte (mb, CEE_LDIND_I);
 		pos2 = mono_mb_emit_branch (mb, CEE_BRFALSE);
 
 		emit_marshal_custom_get_instance (mb, mklass, spec);
 				
 		mono_mb_emit_ldarg (mb, argnum);
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			mono_mb_emit_byte (mb, CEE_LDIND_REF);
 
 		if (t->type == MONO_TYPE_VALUETYPE) {
@@ -4674,7 +4674,7 @@ emit_marshal_custom_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		mono_mb_emit_ldloc (mb, conv_arg);
 		pos2 = mono_mb_emit_branch (mb, CEE_BRFALSE);
 
-		if (mono_type_is_byref_internal (t)) {
+		if (m_type_is_byref (t)) {
 			mono_mb_emit_ldarg (mb, argnum);
 
 			emit_marshal_custom_get_instance (mb, mklass, spec);
@@ -4702,7 +4702,7 @@ emit_marshal_custom_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		break;
 
 	case MARSHAL_ACTION_PUSH:
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			mono_mb_emit_ldloc_addr (mb, conv_arg);
 		else
 			mono_mb_emit_ldloc (mb, conv_arg);
@@ -4739,19 +4739,19 @@ emit_marshal_custom_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		mono_mb_emit_byte (mb, CEE_LDNULL);
 		mono_mb_emit_stloc (mb, conv_arg);
 
-		if (mono_type_is_byref_internal (t) && t->attrs & PARAM_ATTRIBUTE_OUT)
+		if (m_type_is_byref (t) && t->attrs & PARAM_ATTRIBUTE_OUT)
 			break;
 
 		/* Check for null */
 		mono_mb_emit_ldarg (mb, argnum);
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			mono_mb_emit_byte (mb, CEE_LDIND_I);
 		pos2 = mono_mb_emit_branch (mb, CEE_BRFALSE);
 
 		emit_marshal_custom_get_instance (mb, mklass, spec);
 				
 		mono_mb_emit_ldarg (mb, argnum);
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			mono_mb_emit_byte (mb, CEE_LDIND_I);
 				
 		mono_mb_emit_op (mb, CEE_CALLVIRT, marshal_native_to_managed);
@@ -4761,7 +4761,7 @@ emit_marshal_custom_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		break;
 
 	case MARSHAL_ACTION_MANAGED_CONV_RESULT:
-		g_assert (!mono_type_is_byref_internal (t));
+		g_assert (!m_type_is_byref (t));
 
 		loc1 = mono_mb_add_local (mb, object_type);
 			
@@ -4793,7 +4793,7 @@ emit_marshal_custom_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		mono_mb_emit_ldloc (mb, conv_arg);
 		pos2 = mono_mb_emit_branch (mb, CEE_BRFALSE);
 
-		if (mono_type_is_byref_internal (t)) {
+		if (m_type_is_byref (t)) {
 			mono_mb_emit_ldarg (mb, argnum);
 
 			emit_marshal_custom_get_instance (mb, mklass, spec);
@@ -4832,7 +4832,7 @@ emit_marshal_asany_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		MonoMarshalNative encoding = mono_marshal_get_string_encoding (m->piinfo, NULL);
 
 		g_assert (t->type == MONO_TYPE_OBJECT);
-		g_assert (!mono_type_is_byref_internal (t));
+		g_assert (!m_type_is_byref (t));
 
 		conv_arg = mono_mb_add_local (mb, int_type);
 		mono_mb_emit_ldarg (mb, argnum);
@@ -4888,13 +4888,13 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 			conv_arg = mono_mb_add_local (mb, double_type);
 
-			if (mono_type_is_byref_internal (t)) {
+			if (m_type_is_byref (t)) {
 				mono_mb_emit_ldarg (mb, argnum);
 				pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
 			}
 
-			if (!(mono_type_is_byref_internal (t) && !(t->attrs & PARAM_ATTRIBUTE_IN) && (t->attrs & PARAM_ATTRIBUTE_OUT))) {
-				if (!mono_type_is_byref_internal (t))
+			if (!(m_type_is_byref (t) && !(t->attrs & PARAM_ATTRIBUTE_IN) && (t->attrs & PARAM_ATTRIBUTE_OUT))) {
+				if (!m_type_is_byref (t))
 					m->csig->params [argnum - m->csig->hasthis] = double_type;
 
 				MONO_STATIC_POINTER_INIT (MonoMethod, to_oadate)
@@ -4907,7 +4907,7 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 				mono_mb_emit_stloc (mb, conv_arg);
 			}
 
-			if (mono_type_is_byref_internal (t))
+			if (m_type_is_byref (t))
 				mono_mb_patch_branch (mb, pos);
 			break;
 		}
@@ -4918,7 +4918,7 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		conv_arg = mono_mb_add_local (mb, int_type);
 			
 		/* store the address of the source into local variable 0 */
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			mono_mb_emit_ldarg (mb, argnum);
 		else
 			mono_mb_emit_ldarg_addr (mb, argnum);
@@ -4932,12 +4932,12 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		mono_mb_emit_byte (mb, CEE_LOCALLOC);
 		mono_mb_emit_stloc (mb, conv_arg);
 
-		if (mono_type_is_byref_internal (t)) {
+		if (m_type_is_byref (t)) {
 			mono_mb_emit_ldloc (mb, 0);
 			pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
 		}
 
-		if (!(mono_type_is_byref_internal (t) && !(t->attrs & PARAM_ATTRIBUTE_IN) && (t->attrs & PARAM_ATTRIBUTE_OUT))) {
+		if (!(m_type_is_byref (t) && !(t->attrs & PARAM_ATTRIBUTE_IN) && (t->attrs & PARAM_ATTRIBUTE_OUT))) {
 			/* set dst_ptr */
 			mono_mb_emit_ldloc (mb, conv_arg);
 			mono_mb_emit_stloc (mb, 1);
@@ -4946,14 +4946,14 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			emit_struct_conv (mb, klass, FALSE);
 		}
 
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			mono_mb_patch_branch (mb, pos);
 		break;
 
 	case MARSHAL_ACTION_PUSH:
 		if (spec && spec->native == MONO_NATIVE_LPSTRUCT) {
 			/* FIXME: */
-			g_assert (!mono_type_is_byref_internal (t));
+			g_assert (!m_type_is_byref (t));
 
 			/* Have to change the signature since the vtype is passed byref */
 			m->csig->params [argnum - m->csig->hasthis] = int_type;
@@ -4966,7 +4966,7 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		}
 
 		if (klass == date_time_class) {
-			if (mono_type_is_byref_internal (t))
+			if (m_type_is_byref (t))
 				mono_mb_emit_ldloc_addr (mb, conv_arg);
 			else
 				mono_mb_emit_ldloc (mb, conv_arg);
@@ -4978,7 +4978,7 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			break;
 		}			
 		mono_mb_emit_ldloc (mb, conv_arg);
-		if (!mono_type_is_byref_internal (t)) {
+		if (!m_type_is_byref (t)) {
 			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
 			mono_mb_emit_op (mb, CEE_MONO_LDNATIVEOBJ, klass);
 		}
@@ -4988,7 +4988,7 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		if (klass == date_time_class) {
 			/* Convert from an OLE DATE type */
 
-			if (!mono_type_is_byref_internal (t))
+			if (!m_type_is_byref (t))
 				break;
 
 			if (!((t->attrs & PARAM_ATTRIBUTE_IN) && !(t->attrs & PARAM_ATTRIBUTE_OUT))) {
@@ -5010,7 +5010,7 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		if (mono_class_is_explicit_layout (klass) || m_class_is_blittable (klass) || m_class_is_enumtype (klass))
 			break;
 
-		if (mono_type_is_byref_internal (t)) {
+		if (m_type_is_byref (t)) {
 			/* dst = argument */
 			mono_mb_emit_ldarg (mb, argnum);
 			mono_mb_emit_stloc (mb, 1);
@@ -5030,7 +5030,7 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 		emit_struct_free (mb, klass, conv_arg);
 		
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			mono_mb_patch_branch (mb, pos);
 		break;
 
@@ -5064,13 +5064,13 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		if (t->attrs & PARAM_ATTRIBUTE_OUT)
 			break;
 
-		if (mono_type_is_byref_internal (t)) 
+		if (m_type_is_byref (t)) 
 			mono_mb_emit_ldarg (mb, argnum);
 		else
 			mono_mb_emit_ldarg_addr (mb, argnum);
 		mono_mb_emit_stloc (mb, 0);
 
-		if (mono_type_is_byref_internal (t)) {
+		if (m_type_is_byref (t)) {
 			mono_mb_emit_ldloc (mb, 0);
 			pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
 		}			
@@ -5081,14 +5081,14 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		/* emit valuetype conversion code */
 		emit_struct_conv (mb, klass, TRUE);
 
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			mono_mb_patch_branch (mb, pos);
 		break;
 
 	case MARSHAL_ACTION_MANAGED_CONV_OUT:
 		if (mono_class_is_explicit_layout (klass) || m_class_is_blittable (klass) || m_class_is_enumtype (klass))
 			break;
-		if (mono_type_is_byref_internal (t) && (t->attrs & PARAM_ATTRIBUTE_IN) && !(t->attrs & PARAM_ATTRIBUTE_OUT))
+		if (m_type_is_byref (t) && (t->attrs & PARAM_ATTRIBUTE_IN) && !(t->attrs & PARAM_ATTRIBUTE_OUT))
 			break;
 
 		/* Check for null */
@@ -5171,7 +5171,7 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		*conv_arg_type = int_type;
 		conv_arg = mono_mb_add_local (mb, int_type);
 
-		if (mono_type_is_byref_internal (t)) {
+		if (m_type_is_byref (t)) {
 			if (t->attrs & PARAM_ATTRIBUTE_OUT)
 				break;
 
@@ -5201,7 +5201,7 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 		if (encoding == MONO_NATIVE_VBBYREFSTR) {
 
-			if (!mono_type_is_byref_internal (t)) {
+			if (!m_type_is_byref (t)) {
 				char *msg = g_strdup ("VBByRefStr marshalling requires a ref parameter.");
 				mono_mb_emit_exception_marshal_directive (mb, msg);
 				break;
@@ -5217,7 +5217,7 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			 * Have to allocate a new string with the same length as the original, and
 			 * copy the contents of the buffer pointed to by CONV_ARG into it.
 			 */
-			g_assert (mono_type_is_byref_internal (t));
+			g_assert (m_type_is_byref (t));
 			mono_mb_emit_ldarg (mb, argnum);
 			mono_mb_emit_ldloc (mb, conv_arg);
 			mono_mb_emit_ldarg (mb, argnum);
@@ -5225,7 +5225,7 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			mono_mb_emit_managed_call (mb, m, NULL);
 			mono_mb_emit_icall (mb, mono_string_new_len_wrapper);
 			mono_mb_emit_byte (mb, CEE_STIND_REF);
-		} else if (mono_type_is_byref_internal (t) && (t->attrs & PARAM_ATTRIBUTE_OUT || !(t->attrs & PARAM_ATTRIBUTE_IN))) {
+		} else if (m_type_is_byref (t) && (t->attrs & PARAM_ATTRIBUTE_OUT || !(t->attrs & PARAM_ATTRIBUTE_IN))) {
 			int stind_op;
 			mono_mb_emit_ldarg (mb, argnum);
 			mono_mb_emit_ldloc (mb, conv_arg);
@@ -5241,7 +5241,7 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		break;
 
 	case MARSHAL_ACTION_PUSH:
-		if (mono_type_is_byref_internal (t) && encoding != MONO_NATIVE_VBBYREFSTR)
+		if (m_type_is_byref (t) && encoding != MONO_NATIVE_VBBYREFSTR)
 			mono_mb_emit_ldloc_addr (mb, conv_arg);
 		else
 			mono_mb_emit_ldloc (mb, conv_arg);
@@ -5271,7 +5271,7 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 		*conv_arg_type = int_type;
 
-		if (mono_type_is_byref_internal (t)) {
+		if (m_type_is_byref (t)) {
 			if (t->attrs & PARAM_ATTRIBUTE_OUT)
 				break;
 		}
@@ -5284,14 +5284,14 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		}
 
 		mono_mb_emit_ldarg (mb, argnum);
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			mono_mb_emit_byte (mb, CEE_LDIND_I);
 		mono_mb_emit_icall_id (mb, conv_to_icall (conv, NULL));
 		mono_mb_emit_stloc (mb, conv_arg);
 		break;
 
 	case MARSHAL_ACTION_MANAGED_CONV_OUT:
-		if (mono_type_is_byref_internal (t)) {
+		if (m_type_is_byref (t)) {
 			if (conv_arg) {
 				int stind_op;
 				mono_mb_emit_ldarg (mb, argnum);
@@ -5350,7 +5350,7 @@ emit_marshal_safehandle_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		mono_mb_emit_icon (mb, 0);
 		mono_mb_emit_stloc (mb, dar_release_slot);
 
-		if (mono_type_is_byref_internal (t)) {
+		if (m_type_is_byref (t)) {
 			int old_handle_value_slot = mono_mb_add_local (mb, int_type);
 
 			if (!is_in (t)) {
@@ -5389,7 +5389,7 @@ emit_marshal_safehandle_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	}
 
 	case MARSHAL_ACTION_PUSH:
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			mono_mb_emit_ldloc_addr (mb, conv_arg);
 		else 
 			mono_mb_emit_ldloc (mb, conv_arg);
@@ -5403,7 +5403,7 @@ emit_marshal_safehandle_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		if (!sh_dangerous_release)
 			init_safe_handle ();
 
-		if (mono_type_is_byref_internal (t)) {
+		if (m_type_is_byref (t)) {
 			/* If there was SafeHandle on input we have to release the reference to it */
 			if (is_in (t)) {
 				mono_mb_emit_ldloc (mb, dar_release_slot);
@@ -5534,7 +5534,7 @@ emit_marshal_handleref_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		conv_arg = mono_mb_add_local (mb, int_type);
 		*conv_arg_type = int_type;
 
-		if (mono_type_is_byref_internal (t)) {
+		if (m_type_is_byref (t)) {
 			char *msg = g_strdup ("HandleRefs can not be returned from unmanaged code (or passed by ref)");
 			mono_mb_emit_exception_marshal_directive (mb, msg);
 			break;
@@ -5605,7 +5605,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		}
 
 		if (m_class_is_delegate (klass)) {
-			if (mono_type_is_byref_internal (t)) {
+			if (m_type_is_byref (t)) {
 				if (!(t->attrs & PARAM_ATTRIBUTE_OUT)) {
 					char *msg = g_strdup_printf ("Byref marshalling of delegates is not implemented.");
 					mono_mb_emit_exception_marshal_directive (mb, msg);
@@ -5622,7 +5622,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			MonoMarshalConv conv = mono_marshal_get_stringbuilder_to_ptr_conv (m->piinfo, spec);
 
 #if 0			
-			if (mono_type_is_byref_internal (t)) {
+			if (m_type_is_byref (t)) {
 				if (!(t->attrs & PARAM_ATTRIBUTE_OUT)) {
 					char *msg = g_strdup_printf ("Byref marshalling of stringbuilders is not implemented.");
 					mono_mb_emit_exception_marshal_directive (mb, msg);
@@ -5631,7 +5631,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			}
 #endif
 
-			if (mono_type_is_byref_internal (t) && !(t->attrs & PARAM_ATTRIBUTE_IN) && (t->attrs & PARAM_ATTRIBUTE_OUT))
+			if (m_type_is_byref (t) && !(t->attrs & PARAM_ATTRIBUTE_IN) && (t->attrs & PARAM_ATTRIBUTE_OUT))
 				break;
 
 			if (conv == MONO_MARSHAL_CONV_INVALID) {
@@ -5641,7 +5641,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			}
 
 			mono_mb_emit_ldarg (mb, argnum);
-			if (mono_type_is_byref_internal (t))
+			if (m_type_is_byref (t))
 				mono_mb_emit_byte (mb, CEE_LDIND_I);
 
 			mono_mb_emit_icall_id (mb, conv_to_icall (conv, NULL));
@@ -5663,7 +5663,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			mono_mb_emit_byte (mb, CEE_LDNULL);
 			mono_mb_emit_stloc (mb, conv_arg);
 
-			if (mono_type_is_byref_internal (t)) {
+			if (m_type_is_byref (t)) {
 				/* we dont need any conversions for out parameters */
 				if (t->attrs & PARAM_ATTRIBUTE_OUT)
 					break;
@@ -5688,7 +5688,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			mono_mb_emit_byte (mb, CEE_LOCALLOC);
 			mono_mb_emit_stloc (mb, conv_arg);
 
-			if (mono_type_is_byref_internal (t)) {
+			if (m_type_is_byref (t)) {
 				/* Need to store the original buffer so we can free it later */
 				m->orig_conv_args [argnum] = mono_mb_add_local (mb, int_type);
 				mono_mb_emit_ldloc (mb, conv_arg);
@@ -5722,7 +5722,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 			g_assert (encoding != -1);
 
-			if (mono_type_is_byref_internal (t)) {
+			if (m_type_is_byref (t)) {
 				//g_assert (!(t->attrs & PARAM_ATTRIBUTE_OUT));
 
 				need_free = TRUE;
@@ -5760,7 +5760,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		}
 
 		if (m_class_is_delegate (klass)) {
-			if (mono_type_is_byref_internal (t)) {
+			if (m_type_is_byref (t)) {
 				mono_mb_emit_ldarg (mb, argnum);
 				mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
 				mono_mb_emit_op (mb, CEE_MONO_CLASSCONST, klass);
@@ -5771,7 +5771,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			break;
 		}
 
-		if (mono_type_is_byref_internal (t) && (t->attrs & PARAM_ATTRIBUTE_OUT)) {
+		if (m_type_is_byref (t) && (t->attrs & PARAM_ATTRIBUTE_OUT)) {
 			/* allocate a new object */
 			mono_mb_emit_ldarg (mb, argnum);
 			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
@@ -5782,7 +5782,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		/* dst = *argument */
 		mono_mb_emit_ldarg (mb, argnum);
 
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			mono_mb_emit_byte (mb, CEE_LDIND_I);
 
 		mono_mb_emit_stloc (mb, 1);
@@ -5790,7 +5790,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		mono_mb_emit_ldloc (mb, 1);
 		pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
 
-		if (mono_type_is_byref_internal (t) || (t->attrs & PARAM_ATTRIBUTE_OUT)) {
+		if (m_type_is_byref (t) || (t->attrs & PARAM_ATTRIBUTE_OUT)) {
 			mono_mb_emit_ldloc (mb, 1);
 			mono_mb_emit_icon (mb, MONO_ABI_SIZEOF (MonoObject));
 			mono_mb_emit_byte (mb, CEE_ADD);
@@ -5835,7 +5835,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		break;
 
 	case MARSHAL_ACTION_PUSH:
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			mono_mb_emit_ldloc_addr (mb, conv_arg);
 		else
 			mono_mb_emit_ldloc (mb, conv_arg);
@@ -5843,7 +5843,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 	case MARSHAL_ACTION_CONV_RESULT:
 		if (m_class_is_delegate (klass)) {
-			g_assert (!mono_type_is_byref_internal (t));
+			g_assert (!m_type_is_byref (t));
 			mono_mb_emit_stloc (mb, 0);
 			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
 			mono_mb_emit_op (mb, CEE_MONO_CLASSCONST, klass);
@@ -5900,7 +5900,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
 			mono_mb_emit_op (mb, CEE_MONO_CLASSCONST, klass);
 			mono_mb_emit_ldarg (mb, argnum);
-			if (mono_type_is_byref_internal (t))
+			if (m_type_is_byref (t))
 				mono_mb_emit_byte (mb, CEE_LDIND_I);
 			mono_mb_emit_icall_id (mb, conv_to_icall (MONO_MARSHAL_CONV_FTN_DEL, NULL));
 			mono_mb_emit_stloc (mb, conv_arg);
@@ -5915,7 +5915,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			// FIXME:
 			g_assert (encoding == MONO_NATIVE_LPSTR || encoding == MONO_NATIVE_UTF8STR);
 
-			g_assert (!mono_type_is_byref_internal (t));
+			g_assert (!m_type_is_byref (t));
 			g_assert (encoding != -1);
 
 			mono_mb_emit_ldarg (mb, argnum);
@@ -5938,7 +5938,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 		/* Set src */
 		mono_mb_emit_ldarg (mb, argnum);
-		if (mono_type_is_byref_internal (t)) {
+		if (m_type_is_byref (t)) {
 			int pos2;
 
 			/* Check for NULL and raise an exception */
@@ -5975,7 +5975,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 	case MARSHAL_ACTION_MANAGED_CONV_OUT:
 		if (m_class_is_delegate (klass)) {
-			if (mono_type_is_byref_internal (t)) {
+			if (m_type_is_byref (t)) {
 				int stind_op;
 				mono_mb_emit_ldarg (mb, argnum);
 				mono_mb_emit_ldloc (mb, conv_arg);
@@ -5985,7 +5985,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			}
 		}
 
-		if (mono_type_is_byref_internal (t)) {
+		if (m_type_is_byref (t)) {
 			/* Check for null */
 			mono_mb_emit_ldloc (mb, conv_arg);
 			pos = mono_mb_emit_branch (mb, CEE_BRTRUE);
@@ -6100,16 +6100,16 @@ emit_marshal_variant_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	case MARSHAL_ACTION_CONV_IN: {
 		conv_arg = mono_mb_add_local (mb, variant_type);
 		
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			*conv_arg_type = variant_type_byref;
 		else
 			*conv_arg_type = variant_type;
 
-		if (mono_type_is_byref_internal (t) && !(t->attrs & PARAM_ATTRIBUTE_IN) && t->attrs & PARAM_ATTRIBUTE_OUT)
+		if (m_type_is_byref (t) && !(t->attrs & PARAM_ATTRIBUTE_IN) && t->attrs & PARAM_ATTRIBUTE_OUT)
 			break;
 
 		mono_mb_emit_ldarg (mb, argnum);
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			mono_mb_emit_byte(mb, CEE_LDIND_REF);
 		mono_mb_emit_ldloc_addr (mb, conv_arg);
 		mono_mb_emit_managed_call (mb, mono_get_Marshal_GetNativeVariantForObject (), NULL);
@@ -6117,7 +6117,7 @@ emit_marshal_variant_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	}
 
 	case MARSHAL_ACTION_CONV_OUT: {
-		if (mono_type_is_byref_internal (t) && (t->attrs & PARAM_ATTRIBUTE_OUT || !(t->attrs & PARAM_ATTRIBUTE_IN))) {
+		if (m_type_is_byref (t) && (t->attrs & PARAM_ATTRIBUTE_OUT || !(t->attrs & PARAM_ATTRIBUTE_IN))) {
 			mono_mb_emit_ldarg (mb, argnum);
 			mono_mb_emit_ldloc_addr (mb, conv_arg);
 			mono_mb_emit_managed_call (mb, mono_get_Marshal_GetObjectForNativeVariant (), NULL);
@@ -6130,7 +6130,7 @@ emit_marshal_variant_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	}
 
 	case MARSHAL_ACTION_PUSH:
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			mono_mb_emit_ldloc_addr (mb, conv_arg);
 		else
 			mono_mb_emit_ldloc (mb, conv_arg);
@@ -6145,15 +6145,15 @@ emit_marshal_variant_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	case MARSHAL_ACTION_MANAGED_CONV_IN: {
 		conv_arg = mono_mb_add_local (mb, object_type);
 
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			*conv_arg_type = variant_type_byref;
 		else
 			*conv_arg_type = variant_type;
 
-		if (mono_type_is_byref_internal (t) && !(t->attrs & PARAM_ATTRIBUTE_IN) && t->attrs & PARAM_ATTRIBUTE_OUT)
+		if (m_type_is_byref (t) && !(t->attrs & PARAM_ATTRIBUTE_IN) && t->attrs & PARAM_ATTRIBUTE_OUT)
 			break;
 
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			mono_mb_emit_ldarg (mb, argnum);
 		else
 			mono_mb_emit_ldarg_addr (mb, argnum);
@@ -6163,7 +6163,7 @@ emit_marshal_variant_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	}
 
 	case MARSHAL_ACTION_MANAGED_CONV_OUT: {
-		if (mono_type_is_byref_internal (t) && (t->attrs & PARAM_ATTRIBUTE_OUT || !(t->attrs & PARAM_ATTRIBUTE_IN))) {
+		if (m_type_is_byref (t) && (t->attrs & PARAM_ATTRIBUTE_OUT || !(t->attrs & PARAM_ATTRIBUTE_IN))) {
 			mono_mb_emit_ldloc (mb, conv_arg);
 			mono_mb_emit_ldarg (mb, argnum);
 			mono_mb_emit_managed_call (mb, mono_get_Marshal_GetNativeVariantForObject (), NULL);
@@ -6297,7 +6297,7 @@ emit_managed_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethodSignature *invoke_s
 		MonoType *t = sig->params [i];
 
 		if (tmp_locals [i]) {
-			if (mono_type_is_byref_internal (t))
+			if (m_type_is_byref (t))
 				mono_mb_emit_ldloc_addr (mb, tmp_locals [i]);
 			else
 				mono_mb_emit_ldloc (mb, tmp_locals [i]);
@@ -6322,7 +6322,7 @@ emit_managed_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethodSignature *invoke_s
 
 	if (mspecs [0] && mspecs [0]->native == MONO_NATIVE_CUSTOM) {
 		mono_emit_marshal (m, 0, sig->ret, mspecs [0], 0, NULL, MARSHAL_ACTION_MANAGED_CONV_RESULT);
-	} else if (!mono_type_is_byref_internal (sig->ret)) { 
+	} else if (!m_type_is_byref (sig->ret)) { 
 		switch (sig->ret->type) {
 		case MONO_TYPE_VOID:
 			break;
@@ -6369,7 +6369,7 @@ emit_managed_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethodSignature *invoke_s
 		if (spec && spec->native == MONO_NATIVE_CUSTOM) {
 			mono_emit_marshal (m, i, t, mspecs [i + 1], tmp_locals [i], NULL, MARSHAL_ACTION_MANAGED_CONV_OUT);
 		}
-		else if (mono_type_is_byref_internal (t)) {
+		else if (m_type_is_byref (t)) {
 			switch (t->type) {
 			case MONO_TYPE_CLASS:
 			case MONO_TYPE_VALUETYPE:
@@ -6552,18 +6552,18 @@ signature_param_uses_handles (MonoMethodSignature *sig, MonoMethodSignature *gen
 	 * like string& since the C code for the icall has to work uniformly
 	 * for both valuetypes and reference types.
 	 */
-	if (generic_sig && mono_type_is_byref_internal (generic_sig->params [param]) &&
+	if (generic_sig && m_type_is_byref (generic_sig->params [param]) &&
 	    (generic_sig->params [param]->type == MONO_TYPE_VAR || generic_sig->params [param]->type == MONO_TYPE_MVAR))
 		return ICALL_HANDLES_WRAP_VALUETYPE_REF;
 
 	if (MONO_TYPE_IS_REFERENCE (sig->params [param])) {
 		if (mono_signature_param_is_out (sig, param))
 			return ICALL_HANDLES_WRAP_OBJ_OUT;
-		else if (mono_type_is_byref_internal (sig->params [param]))
+		else if (m_type_is_byref (sig->params [param]))
 			return ICALL_HANDLES_WRAP_OBJ_INOUT;
 		else
 			return ICALL_HANDLES_WRAP_OBJ;
-	} else if (mono_type_is_byref_internal (sig->params [param]))
+	} else if (m_type_is_byref (sig->params [param]))
 		return ICALL_HANDLES_WRAP_VALUETYPE_REF;
 	else
 		return ICALL_HANDLES_WRAP_NONE;

--- a/src/mono/mono/metadata/marshal-ilgen.c
+++ b/src/mono/mono/metadata/marshal-ilgen.c
@@ -1162,7 +1162,7 @@ emit_struct_conv_full (MonoMethodBuilder *mb, MonoClass *klass, gboolean to_obje
 			int t;
 
 			//XXX a byref field!?!? that's not allowed! and worse, it might miss a WB
-			g_assert (!ftype->byref);
+			g_assert (!mono_type_is_byref_internal (ftype));
 			if (ftype->type == MONO_TYPE_I || ftype->type == MONO_TYPE_U) {
 				mono_mb_emit_ldloc (mb, 1);
 				mono_mb_emit_ldloc (mb, 0);
@@ -1442,7 +1442,7 @@ mono_mb_emit_restore_result (MonoMethodBuilder *mb, MonoType *return_type)
 	MonoType *t = mono_type_get_underlying_type (return_type);
 	MonoType *int_type = mono_get_int_type ();
 
-	if (return_type->byref)
+	if (mono_type_is_byref_internal (return_type))
 		return_type = int_type;
 
 	switch (t->type) {
@@ -1542,7 +1542,7 @@ emit_invoke_call (MonoMethodBuilder *mb, MonoMethod *method,
 			mono_mb_emit_byte (mb, CEE_ADD);
 		}
 
-		if (t->byref) {
+		if (mono_type_is_byref_internal (t)) {
 			mono_mb_emit_byte (mb, CEE_LDIND_I);
 			/* A Nullable<T> type don't have a boxed form, it's either null or a boxed T.
 			 * So to make this work we unbox it to a local variablee and push a reference to that.
@@ -1628,7 +1628,7 @@ handle_enum:
 		mono_mb_emit_calli (mb, callsig);
 	}
 
-	if (sig->ret->byref) {
+	if (mono_type_is_byref_internal (sig->ret)) {
 		/* perform indirect load and return by value */
 		int pos;
 		mono_mb_emit_byte (mb, CEE_DUP);
@@ -1638,7 +1638,7 @@ handle_enum:
 
 		int ldind_op;
 		MonoType* ret_byval = m_class_get_byval_arg (mono_class_from_mono_type_internal (sig->ret));
-		g_assert (!ret_byval->byref);
+		g_assert (!mono_type_is_byref_internal (ret_byval));
 		// TODO: Handle null references
 		ldind_op = mono_type_to_ldind (ret_byval);
 		/* taken from similar code in mini-generic-sharing.c
@@ -1701,7 +1701,7 @@ handle_enum:
 		 * Box the result and put it back into the array, the caller will have
 		 * to obtain it from there.
 		 */
-		if (t->byref && t->type == MONO_TYPE_GENERICINST && mono_class_is_nullable (mono_class_from_mono_type_internal (t))) {
+		if (mono_type_is_byref_internal (t) && t->type == MONO_TYPE_GENERICINST && mono_class_is_nullable (mono_class_from_mono_type_internal (t))) {
 			mono_mb_emit_ldarg (mb, 1);			
 			mono_mb_emit_icon (mb, TARGET_SIZEOF_VOID_P * i);
 			mono_mb_emit_byte (mb, CEE_ADD);
@@ -2184,7 +2184,7 @@ emit_native_wrapper_ilgen (MonoImage *image, MonoMethodBuilder *mb, MonoMethodSi
 	gc_safe_transition_builder_cleanup (&gc_safe_transition_builder);
 
 	/* convert the result */
-	if (!sig->ret->byref) {
+	if (!mono_type_is_byref_internal (sig->ret)) {
 		MonoMarshalSpec *spec = mspecs [0];
 		type = sig->ret->type;
 
@@ -2446,7 +2446,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 		if (m_class_is_blittable (eklass)) {
 			mono_mb_emit_ldarg (mb, argnum);
-			if (t->byref)
+			if (mono_type_is_byref_internal (t))
 				mono_mb_emit_byte (mb, CEE_LDIND_I);
 			mono_mb_emit_icall_id (mb, conv_to_icall (MONO_MARSHAL_CONV_ARRAY_LPARRAY, NULL));
 			mono_mb_emit_stloc (mb, conv_arg);
@@ -2481,7 +2481,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 			src_var = mono_mb_add_local (mb, object_type);
 			mono_mb_emit_ldarg (mb, argnum);
-			if (t->byref)
+			if (mono_type_is_byref_internal (t))
 				mono_mb_emit_byte (mb, CEE_LDIND_I);
 			mono_mb_emit_stloc (mb, src_var);
 
@@ -2584,18 +2584,18 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 			param_type = m->sig->params [param_num];
 
-			if (param_type->byref && param_type->type != MONO_TYPE_I4) {
+			if (mono_type_is_byref_internal (param_type) && param_type->type != MONO_TYPE_I4) {
 				char *msg = g_strdup ("Not implemented.");
 				mono_mb_emit_exception_marshal_directive (mb, msg);
 				break;
 			}
 
-			if (t->byref ) {
+			if (mono_type_is_byref_internal (t) ) {
 				mono_mb_emit_ldarg (mb, argnum);
 
 				/* Create the managed array */
 				mono_mb_emit_ldarg (mb, param_num);
-				if (m->sig->params [param_num]->byref)
+				if (mono_type_is_byref_internal (m->sig->params [param_num]))
 					// FIXME: Support other types
 					mono_mb_emit_byte (mb, CEE_LDIND_I4);
 				mono_mb_emit_byte (mb, CEE_CONV_OVF_I);
@@ -2621,7 +2621,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 			/* Check null */
 			mono_mb_emit_ldarg (mb, argnum);
-			if (t->byref)
+			if (mono_type_is_byref_internal (t))
 				mono_mb_emit_byte (mb, CEE_LDIND_I);
 			label1 = mono_mb_emit_branch (mb, CEE_BRFALSE);
 
@@ -2635,7 +2635,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			label2 = mono_mb_get_label (mb);
 			mono_mb_emit_ldloc (mb, index_var);
 			mono_mb_emit_ldarg (mb, argnum);
-			if (t->byref)
+			if (mono_type_is_byref_internal (t))
 				mono_mb_emit_byte (mb, CEE_LDIND_REF);
 			mono_mb_emit_byte (mb, CEE_LDLEN);
 			label3 = mono_mb_emit_branch (mb, CEE_BGE);
@@ -2650,7 +2650,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 				/* dest */
 				mono_mb_emit_ldarg (mb, argnum);
-				if (t->byref)
+				if (mono_type_is_byref_internal (t))
 					mono_mb_emit_byte (mb, CEE_LDIND_I);
 				mono_mb_emit_ldloc (mb, index_var);
 				mono_mb_emit_byte (mb, CEE_LDELEM_REF);
@@ -2686,7 +2686,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 					/* set dst_ptr */
 					mono_mb_emit_ldarg (mb, argnum);
-					if (t->byref)
+					if (mono_type_is_byref_internal (t))
 						mono_mb_emit_byte (mb, CEE_LDIND_REF);
 					mono_mb_emit_ldloc (mb, index_var);
 					mono_mb_emit_op (mb, CEE_LDELEMA, eklass);
@@ -2718,7 +2718,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			/* free memory allocated (if any) by MONO_MARSHAL_CONV_ARRAY_LPARRAY */
 
 			mono_mb_emit_ldarg (mb, argnum);
-			if (t->byref)
+			if (mono_type_is_byref_internal (t))
 				mono_mb_emit_byte (mb, CEE_LDIND_REF);
 			mono_mb_emit_ldloc (mb, conv_arg);
 			mono_mb_emit_icall_id (mb, conv_to_icall (MONO_MARSHAL_FREE_LPARRAY, NULL));
@@ -2728,7 +2728,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	}
 
 	case MARSHAL_ACTION_PUSH:
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			mono_mb_emit_ldloc_addr (mb, conv_arg);
 		else
 			mono_mb_emit_ldloc (mb, conv_arg);
@@ -2750,7 +2750,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		conv_arg = mono_mb_add_local (mb, object_type);
 		*conv_arg_type = int_type;
 
-		if (t->byref) {
+		if (mono_type_is_byref_internal (t)) {
 			char *msg = g_strdup ("Byref array marshalling to managed code is not implemented.");
 			mono_mb_emit_exception_marshal_directive (mb, msg);
 			return conv_arg;
@@ -2952,7 +2952,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			break;
 		
 		/* These are already checked in CONV_IN */
-		g_assert (!t->byref);
+		g_assert (!mono_type_is_byref_internal (t));
 		g_assert (spec->native == MONO_NATIVE_LPARRAY);
 		g_assert (t->attrs & PARAM_ATTRIBUTE_OUT);
 
@@ -3071,7 +3071,7 @@ emit_marshal_array_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		MonoMarshalConv conv = MONO_MARSHAL_CONV_INVALID;
 		gboolean is_string = FALSE;
 		
-		g_assert (!t->byref);
+		g_assert (!mono_type_is_byref_internal (t));
 
 		mono_marshal_load_type_info (eklass);
 
@@ -3239,14 +3239,14 @@ emit_marshal_boolean_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		guint8 ldc_op = CEE_LDC_I4_1;
 
 		local_type = mono_marshal_boolean_conv_in_get_local_type (spec, &ldc_op);
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			*conv_arg_type = int_type;
 		else
 			*conv_arg_type = local_type;
 		conv_arg = mono_mb_add_local (mb, local_type);
 		
 		mono_mb_emit_ldarg (mb, argnum);
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			mono_mb_emit_byte (mb, CEE_LDIND_I1);
 		label_false = mono_mb_emit_branch (mb, CEE_BRFALSE);
 		mono_mb_emit_byte (mb, ldc_op);
@@ -3259,7 +3259,7 @@ emit_marshal_boolean_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	case MARSHAL_ACTION_CONV_OUT:
 	{
 		int label_false, label_end;
-		if (!t->byref)
+		if (!mono_type_is_byref_internal (t))
 			break;
 
 		mono_mb_emit_ldarg (mb, argnum);
@@ -3278,7 +3278,7 @@ emit_marshal_boolean_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	}
 
 	case MARSHAL_ACTION_PUSH:
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			mono_mb_emit_ldloc_addr (mb, conv_arg);
 		else if (conv_arg)
 			mono_mb_emit_ldloc (mb, conv_arg);
@@ -3299,7 +3299,7 @@ emit_marshal_boolean_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		conv_arg_class = mono_marshal_boolean_managed_conv_in_get_conv_arg_class (spec, &ldop);
 		conv_arg = mono_mb_add_local (mb, boolean_type);
 
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			*conv_arg_type = m_class_get_this_arg (conv_arg_class);
 		else
 			*conv_arg_type = m_class_get_byval_arg (conv_arg_class);
@@ -3308,7 +3308,7 @@ emit_marshal_boolean_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		mono_mb_emit_ldarg (mb, argnum);
 		
 		/* Check null */
-		if (t->byref) {
+		if (mono_type_is_byref_internal (t)) {
 			label_null = mono_mb_emit_branch (mb, CEE_BRFALSE);
 			mono_mb_emit_ldarg (mb, argnum);
 			mono_mb_emit_byte (mb, ldop);
@@ -3320,7 +3320,7 @@ emit_marshal_boolean_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		mono_mb_emit_stloc (mb, conv_arg);
 		mono_mb_patch_branch (mb, label_false);
 
-		if (t->byref) 
+		if (mono_type_is_byref_internal (t)) 
 			mono_mb_patch_branch (mb, label_null);
 		break;
 	}
@@ -3330,7 +3330,7 @@ emit_marshal_boolean_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		guint8 ldc_op = CEE_LDC_I4_1;
 		int label_null,label_false, label_end;
 
-		if (!t->byref)
+		if (!mono_type_is_byref_internal (t))
 			break;
 		if (spec) {
 			switch (spec->native) {
@@ -4463,7 +4463,7 @@ emit_thunk_invoke_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *method, Mono
 
 			/* byref args & and the "this" arg must remain a ptr.
 			   Otherwise make a copy of the value type */
-			if (!(csig->params [i]->byref || (i == 0 && sig->hasthis)))
+			if (!(mono_type_is_byref_internal (csig->params [i]) || (i == 0 && sig->hasthis)))
 				mono_mb_emit_op (mb, CEE_LDOBJ, klass);
 
 			csig->params [i] = object_type;
@@ -4634,23 +4634,23 @@ emit_marshal_custom_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		mono_mb_emit_byte (mb, CEE_LDNULL);
 		mono_mb_emit_stloc (mb, conv_arg);
 
-		if (t->byref && (t->attrs & PARAM_ATTRIBUTE_OUT))
+		if (mono_type_is_byref_internal (t) && (t->attrs & PARAM_ATTRIBUTE_OUT))
 			break;
 
 		/* Minic MS.NET behavior */
-		if (!t->byref && (t->attrs & PARAM_ATTRIBUTE_OUT) && !(t->attrs & PARAM_ATTRIBUTE_IN))
+		if (!mono_type_is_byref_internal (t) && (t->attrs & PARAM_ATTRIBUTE_OUT) && !(t->attrs & PARAM_ATTRIBUTE_IN))
 			break;
 
 		/* Check for null */
 		mono_mb_emit_ldarg (mb, argnum);
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			mono_mb_emit_byte (mb, CEE_LDIND_I);
 		pos2 = mono_mb_emit_branch (mb, CEE_BRFALSE);
 
 		emit_marshal_custom_get_instance (mb, mklass, spec);
 				
 		mono_mb_emit_ldarg (mb, argnum);
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			mono_mb_emit_byte (mb, CEE_LDIND_REF);
 
 		if (t->type == MONO_TYPE_VALUETYPE) {
@@ -4674,7 +4674,7 @@ emit_marshal_custom_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		mono_mb_emit_ldloc (mb, conv_arg);
 		pos2 = mono_mb_emit_branch (mb, CEE_BRFALSE);
 
-		if (t->byref) {
+		if (mono_type_is_byref_internal (t)) {
 			mono_mb_emit_ldarg (mb, argnum);
 
 			emit_marshal_custom_get_instance (mb, mklass, spec);
@@ -4702,7 +4702,7 @@ emit_marshal_custom_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		break;
 
 	case MARSHAL_ACTION_PUSH:
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			mono_mb_emit_ldloc_addr (mb, conv_arg);
 		else
 			mono_mb_emit_ldloc (mb, conv_arg);
@@ -4739,19 +4739,19 @@ emit_marshal_custom_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		mono_mb_emit_byte (mb, CEE_LDNULL);
 		mono_mb_emit_stloc (mb, conv_arg);
 
-		if (t->byref && t->attrs & PARAM_ATTRIBUTE_OUT)
+		if (mono_type_is_byref_internal (t) && t->attrs & PARAM_ATTRIBUTE_OUT)
 			break;
 
 		/* Check for null */
 		mono_mb_emit_ldarg (mb, argnum);
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			mono_mb_emit_byte (mb, CEE_LDIND_I);
 		pos2 = mono_mb_emit_branch (mb, CEE_BRFALSE);
 
 		emit_marshal_custom_get_instance (mb, mklass, spec);
 				
 		mono_mb_emit_ldarg (mb, argnum);
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			mono_mb_emit_byte (mb, CEE_LDIND_I);
 				
 		mono_mb_emit_op (mb, CEE_CALLVIRT, marshal_native_to_managed);
@@ -4761,7 +4761,7 @@ emit_marshal_custom_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		break;
 
 	case MARSHAL_ACTION_MANAGED_CONV_RESULT:
-		g_assert (!t->byref);
+		g_assert (!mono_type_is_byref_internal (t));
 
 		loc1 = mono_mb_add_local (mb, object_type);
 			
@@ -4793,7 +4793,7 @@ emit_marshal_custom_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		mono_mb_emit_ldloc (mb, conv_arg);
 		pos2 = mono_mb_emit_branch (mb, CEE_BRFALSE);
 
-		if (t->byref) {
+		if (mono_type_is_byref_internal (t)) {
 			mono_mb_emit_ldarg (mb, argnum);
 
 			emit_marshal_custom_get_instance (mb, mklass, spec);
@@ -4832,7 +4832,7 @@ emit_marshal_asany_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		MonoMarshalNative encoding = mono_marshal_get_string_encoding (m->piinfo, NULL);
 
 		g_assert (t->type == MONO_TYPE_OBJECT);
-		g_assert (!t->byref);
+		g_assert (!mono_type_is_byref_internal (t));
 
 		conv_arg = mono_mb_add_local (mb, int_type);
 		mono_mb_emit_ldarg (mb, argnum);
@@ -4888,13 +4888,13 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 			conv_arg = mono_mb_add_local (mb, double_type);
 
-			if (t->byref) {
+			if (mono_type_is_byref_internal (t)) {
 				mono_mb_emit_ldarg (mb, argnum);
 				pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
 			}
 
-			if (!(t->byref && !(t->attrs & PARAM_ATTRIBUTE_IN) && (t->attrs & PARAM_ATTRIBUTE_OUT))) {
-				if (!t->byref)
+			if (!(mono_type_is_byref_internal (t) && !(t->attrs & PARAM_ATTRIBUTE_IN) && (t->attrs & PARAM_ATTRIBUTE_OUT))) {
+				if (!mono_type_is_byref_internal (t))
 					m->csig->params [argnum - m->csig->hasthis] = double_type;
 
 				MONO_STATIC_POINTER_INIT (MonoMethod, to_oadate)
@@ -4907,7 +4907,7 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 				mono_mb_emit_stloc (mb, conv_arg);
 			}
 
-			if (t->byref)
+			if (mono_type_is_byref_internal (t))
 				mono_mb_patch_branch (mb, pos);
 			break;
 		}
@@ -4918,7 +4918,7 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		conv_arg = mono_mb_add_local (mb, int_type);
 			
 		/* store the address of the source into local variable 0 */
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			mono_mb_emit_ldarg (mb, argnum);
 		else
 			mono_mb_emit_ldarg_addr (mb, argnum);
@@ -4932,12 +4932,12 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		mono_mb_emit_byte (mb, CEE_LOCALLOC);
 		mono_mb_emit_stloc (mb, conv_arg);
 
-		if (t->byref) {
+		if (mono_type_is_byref_internal (t)) {
 			mono_mb_emit_ldloc (mb, 0);
 			pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
 		}
 
-		if (!(t->byref && !(t->attrs & PARAM_ATTRIBUTE_IN) && (t->attrs & PARAM_ATTRIBUTE_OUT))) {
+		if (!(mono_type_is_byref_internal (t) && !(t->attrs & PARAM_ATTRIBUTE_IN) && (t->attrs & PARAM_ATTRIBUTE_OUT))) {
 			/* set dst_ptr */
 			mono_mb_emit_ldloc (mb, conv_arg);
 			mono_mb_emit_stloc (mb, 1);
@@ -4946,14 +4946,14 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			emit_struct_conv (mb, klass, FALSE);
 		}
 
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			mono_mb_patch_branch (mb, pos);
 		break;
 
 	case MARSHAL_ACTION_PUSH:
 		if (spec && spec->native == MONO_NATIVE_LPSTRUCT) {
 			/* FIXME: */
-			g_assert (!t->byref);
+			g_assert (!mono_type_is_byref_internal (t));
 
 			/* Have to change the signature since the vtype is passed byref */
 			m->csig->params [argnum - m->csig->hasthis] = int_type;
@@ -4966,7 +4966,7 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		}
 
 		if (klass == date_time_class) {
-			if (t->byref)
+			if (mono_type_is_byref_internal (t))
 				mono_mb_emit_ldloc_addr (mb, conv_arg);
 			else
 				mono_mb_emit_ldloc (mb, conv_arg);
@@ -4978,7 +4978,7 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			break;
 		}			
 		mono_mb_emit_ldloc (mb, conv_arg);
-		if (!t->byref) {
+		if (!mono_type_is_byref_internal (t)) {
 			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
 			mono_mb_emit_op (mb, CEE_MONO_LDNATIVEOBJ, klass);
 		}
@@ -4988,7 +4988,7 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		if (klass == date_time_class) {
 			/* Convert from an OLE DATE type */
 
-			if (!t->byref)
+			if (!mono_type_is_byref_internal (t))
 				break;
 
 			if (!((t->attrs & PARAM_ATTRIBUTE_IN) && !(t->attrs & PARAM_ATTRIBUTE_OUT))) {
@@ -5010,7 +5010,7 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		if (mono_class_is_explicit_layout (klass) || m_class_is_blittable (klass) || m_class_is_enumtype (klass))
 			break;
 
-		if (t->byref) {
+		if (mono_type_is_byref_internal (t)) {
 			/* dst = argument */
 			mono_mb_emit_ldarg (mb, argnum);
 			mono_mb_emit_stloc (mb, 1);
@@ -5030,7 +5030,7 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 		emit_struct_free (mb, klass, conv_arg);
 		
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			mono_mb_patch_branch (mb, pos);
 		break;
 
@@ -5064,13 +5064,13 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		if (t->attrs & PARAM_ATTRIBUTE_OUT)
 			break;
 
-		if (t->byref) 
+		if (mono_type_is_byref_internal (t)) 
 			mono_mb_emit_ldarg (mb, argnum);
 		else
 			mono_mb_emit_ldarg_addr (mb, argnum);
 		mono_mb_emit_stloc (mb, 0);
 
-		if (t->byref) {
+		if (mono_type_is_byref_internal (t)) {
 			mono_mb_emit_ldloc (mb, 0);
 			pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
 		}			
@@ -5081,14 +5081,14 @@ emit_marshal_vtype_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		/* emit valuetype conversion code */
 		emit_struct_conv (mb, klass, TRUE);
 
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			mono_mb_patch_branch (mb, pos);
 		break;
 
 	case MARSHAL_ACTION_MANAGED_CONV_OUT:
 		if (mono_class_is_explicit_layout (klass) || m_class_is_blittable (klass) || m_class_is_enumtype (klass))
 			break;
-		if (t->byref && (t->attrs & PARAM_ATTRIBUTE_IN) && !(t->attrs & PARAM_ATTRIBUTE_OUT))
+		if (mono_type_is_byref_internal (t) && (t->attrs & PARAM_ATTRIBUTE_IN) && !(t->attrs & PARAM_ATTRIBUTE_OUT))
 			break;
 
 		/* Check for null */
@@ -5171,7 +5171,7 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		*conv_arg_type = int_type;
 		conv_arg = mono_mb_add_local (mb, int_type);
 
-		if (t->byref) {
+		if (mono_type_is_byref_internal (t)) {
 			if (t->attrs & PARAM_ATTRIBUTE_OUT)
 				break;
 
@@ -5201,7 +5201,7 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 		if (encoding == MONO_NATIVE_VBBYREFSTR) {
 
-			if (!t->byref) {
+			if (!mono_type_is_byref_internal (t)) {
 				char *msg = g_strdup ("VBByRefStr marshalling requires a ref parameter.");
 				mono_mb_emit_exception_marshal_directive (mb, msg);
 				break;
@@ -5217,7 +5217,7 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			 * Have to allocate a new string with the same length as the original, and
 			 * copy the contents of the buffer pointed to by CONV_ARG into it.
 			 */
-			g_assert (t->byref);
+			g_assert (mono_type_is_byref_internal (t));
 			mono_mb_emit_ldarg (mb, argnum);
 			mono_mb_emit_ldloc (mb, conv_arg);
 			mono_mb_emit_ldarg (mb, argnum);
@@ -5225,7 +5225,7 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			mono_mb_emit_managed_call (mb, m, NULL);
 			mono_mb_emit_icall (mb, mono_string_new_len_wrapper);
 			mono_mb_emit_byte (mb, CEE_STIND_REF);
-		} else if (t->byref && (t->attrs & PARAM_ATTRIBUTE_OUT || !(t->attrs & PARAM_ATTRIBUTE_IN))) {
+		} else if (mono_type_is_byref_internal (t) && (t->attrs & PARAM_ATTRIBUTE_OUT || !(t->attrs & PARAM_ATTRIBUTE_IN))) {
 			int stind_op;
 			mono_mb_emit_ldarg (mb, argnum);
 			mono_mb_emit_ldloc (mb, conv_arg);
@@ -5241,7 +5241,7 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		break;
 
 	case MARSHAL_ACTION_PUSH:
-		if (t->byref && encoding != MONO_NATIVE_VBBYREFSTR)
+		if (mono_type_is_byref_internal (t) && encoding != MONO_NATIVE_VBBYREFSTR)
 			mono_mb_emit_ldloc_addr (mb, conv_arg);
 		else
 			mono_mb_emit_ldloc (mb, conv_arg);
@@ -5271,7 +5271,7 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 		*conv_arg_type = int_type;
 
-		if (t->byref) {
+		if (mono_type_is_byref_internal (t)) {
 			if (t->attrs & PARAM_ATTRIBUTE_OUT)
 				break;
 		}
@@ -5284,14 +5284,14 @@ emit_marshal_string_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		}
 
 		mono_mb_emit_ldarg (mb, argnum);
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			mono_mb_emit_byte (mb, CEE_LDIND_I);
 		mono_mb_emit_icall_id (mb, conv_to_icall (conv, NULL));
 		mono_mb_emit_stloc (mb, conv_arg);
 		break;
 
 	case MARSHAL_ACTION_MANAGED_CONV_OUT:
-		if (t->byref) {
+		if (mono_type_is_byref_internal (t)) {
 			if (conv_arg) {
 				int stind_op;
 				mono_mb_emit_ldarg (mb, argnum);
@@ -5350,7 +5350,7 @@ emit_marshal_safehandle_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		mono_mb_emit_icon (mb, 0);
 		mono_mb_emit_stloc (mb, dar_release_slot);
 
-		if (t->byref) {
+		if (mono_type_is_byref_internal (t)) {
 			int old_handle_value_slot = mono_mb_add_local (mb, int_type);
 
 			if (!is_in (t)) {
@@ -5389,7 +5389,7 @@ emit_marshal_safehandle_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	}
 
 	case MARSHAL_ACTION_PUSH:
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			mono_mb_emit_ldloc_addr (mb, conv_arg);
 		else 
 			mono_mb_emit_ldloc (mb, conv_arg);
@@ -5403,7 +5403,7 @@ emit_marshal_safehandle_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		if (!sh_dangerous_release)
 			init_safe_handle ();
 
-		if (t->byref){
+		if (mono_type_is_byref_internal (t)) {
 			/* If there was SafeHandle on input we have to release the reference to it */
 			if (is_in (t)) {
 				mono_mb_emit_ldloc (mb, dar_release_slot);
@@ -5534,7 +5534,7 @@ emit_marshal_handleref_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		conv_arg = mono_mb_add_local (mb, int_type);
 		*conv_arg_type = int_type;
 
-		if (t->byref){
+		if (mono_type_is_byref_internal (t)) {
 			char *msg = g_strdup ("HandleRefs can not be returned from unmanaged code (or passed by ref)");
 			mono_mb_emit_exception_marshal_directive (mb, msg);
 			break;
@@ -5605,7 +5605,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		}
 
 		if (m_class_is_delegate (klass)) {
-			if (t->byref) {
+			if (mono_type_is_byref_internal (t)) {
 				if (!(t->attrs & PARAM_ATTRIBUTE_OUT)) {
 					char *msg = g_strdup_printf ("Byref marshalling of delegates is not implemented.");
 					mono_mb_emit_exception_marshal_directive (mb, msg);
@@ -5622,7 +5622,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			MonoMarshalConv conv = mono_marshal_get_stringbuilder_to_ptr_conv (m->piinfo, spec);
 
 #if 0			
-			if (t->byref) {
+			if (mono_type_is_byref_internal (t)) {
 				if (!(t->attrs & PARAM_ATTRIBUTE_OUT)) {
 					char *msg = g_strdup_printf ("Byref marshalling of stringbuilders is not implemented.");
 					mono_mb_emit_exception_marshal_directive (mb, msg);
@@ -5631,7 +5631,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			}
 #endif
 
-			if (t->byref && !(t->attrs & PARAM_ATTRIBUTE_IN) && (t->attrs & PARAM_ATTRIBUTE_OUT))
+			if (mono_type_is_byref_internal (t) && !(t->attrs & PARAM_ATTRIBUTE_IN) && (t->attrs & PARAM_ATTRIBUTE_OUT))
 				break;
 
 			if (conv == MONO_MARSHAL_CONV_INVALID) {
@@ -5641,7 +5641,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			}
 
 			mono_mb_emit_ldarg (mb, argnum);
-			if (t->byref)
+			if (mono_type_is_byref_internal (t))
 				mono_mb_emit_byte (mb, CEE_LDIND_I);
 
 			mono_mb_emit_icall_id (mb, conv_to_icall (conv, NULL));
@@ -5663,7 +5663,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			mono_mb_emit_byte (mb, CEE_LDNULL);
 			mono_mb_emit_stloc (mb, conv_arg);
 
-			if (t->byref) {
+			if (mono_type_is_byref_internal (t)) {
 				/* we dont need any conversions for out parameters */
 				if (t->attrs & PARAM_ATTRIBUTE_OUT)
 					break;
@@ -5688,7 +5688,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			mono_mb_emit_byte (mb, CEE_LOCALLOC);
 			mono_mb_emit_stloc (mb, conv_arg);
 
-			if (t->byref) {
+			if (mono_type_is_byref_internal (t)) {
 				/* Need to store the original buffer so we can free it later */
 				m->orig_conv_args [argnum] = mono_mb_add_local (mb, int_type);
 				mono_mb_emit_ldloc (mb, conv_arg);
@@ -5722,7 +5722,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 			g_assert (encoding != -1);
 
-			if (t->byref) {
+			if (mono_type_is_byref_internal (t)) {
 				//g_assert (!(t->attrs & PARAM_ATTRIBUTE_OUT));
 
 				need_free = TRUE;
@@ -5760,7 +5760,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		}
 
 		if (m_class_is_delegate (klass)) {
-			if (t->byref) {
+			if (mono_type_is_byref_internal (t)) {
 				mono_mb_emit_ldarg (mb, argnum);
 				mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
 				mono_mb_emit_op (mb, CEE_MONO_CLASSCONST, klass);
@@ -5771,7 +5771,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			break;
 		}
 
-		if (t->byref && (t->attrs & PARAM_ATTRIBUTE_OUT)) {
+		if (mono_type_is_byref_internal (t) && (t->attrs & PARAM_ATTRIBUTE_OUT)) {
 			/* allocate a new object */
 			mono_mb_emit_ldarg (mb, argnum);
 			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
@@ -5782,7 +5782,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		/* dst = *argument */
 		mono_mb_emit_ldarg (mb, argnum);
 
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			mono_mb_emit_byte (mb, CEE_LDIND_I);
 
 		mono_mb_emit_stloc (mb, 1);
@@ -5790,7 +5790,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		mono_mb_emit_ldloc (mb, 1);
 		pos = mono_mb_emit_branch (mb, CEE_BRFALSE);
 
-		if (t->byref || (t->attrs & PARAM_ATTRIBUTE_OUT)) {
+		if (mono_type_is_byref_internal (t) || (t->attrs & PARAM_ATTRIBUTE_OUT)) {
 			mono_mb_emit_ldloc (mb, 1);
 			mono_mb_emit_icon (mb, MONO_ABI_SIZEOF (MonoObject));
 			mono_mb_emit_byte (mb, CEE_ADD);
@@ -5835,7 +5835,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 		break;
 
 	case MARSHAL_ACTION_PUSH:
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			mono_mb_emit_ldloc_addr (mb, conv_arg);
 		else
 			mono_mb_emit_ldloc (mb, conv_arg);
@@ -5843,7 +5843,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 	case MARSHAL_ACTION_CONV_RESULT:
 		if (m_class_is_delegate (klass)) {
-			g_assert (!t->byref);
+			g_assert (!mono_type_is_byref_internal (t));
 			mono_mb_emit_stloc (mb, 0);
 			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
 			mono_mb_emit_op (mb, CEE_MONO_CLASSCONST, klass);
@@ -5900,7 +5900,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
 			mono_mb_emit_op (mb, CEE_MONO_CLASSCONST, klass);
 			mono_mb_emit_ldarg (mb, argnum);
-			if (t->byref)
+			if (mono_type_is_byref_internal (t))
 				mono_mb_emit_byte (mb, CEE_LDIND_I);
 			mono_mb_emit_icall_id (mb, conv_to_icall (MONO_MARSHAL_CONV_FTN_DEL, NULL));
 			mono_mb_emit_stloc (mb, conv_arg);
@@ -5915,7 +5915,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			// FIXME:
 			g_assert (encoding == MONO_NATIVE_LPSTR || encoding == MONO_NATIVE_UTF8STR);
 
-			g_assert (!t->byref);
+			g_assert (!mono_type_is_byref_internal (t));
 			g_assert (encoding != -1);
 
 			mono_mb_emit_ldarg (mb, argnum);
@@ -5938,7 +5938,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 		/* Set src */
 		mono_mb_emit_ldarg (mb, argnum);
-		if (t->byref) {
+		if (mono_type_is_byref_internal (t)) {
 			int pos2;
 
 			/* Check for NULL and raise an exception */
@@ -5975,7 +5975,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 	case MARSHAL_ACTION_MANAGED_CONV_OUT:
 		if (m_class_is_delegate (klass)) {
-			if (t->byref) {
+			if (mono_type_is_byref_internal (t)) {
 				int stind_op;
 				mono_mb_emit_ldarg (mb, argnum);
 				mono_mb_emit_ldloc (mb, conv_arg);
@@ -5985,7 +5985,7 @@ emit_marshal_object_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 			}
 		}
 
-		if (t->byref) {
+		if (mono_type_is_byref_internal (t)) {
 			/* Check for null */
 			mono_mb_emit_ldloc (mb, conv_arg);
 			pos = mono_mb_emit_branch (mb, CEE_BRTRUE);
@@ -6100,16 +6100,16 @@ emit_marshal_variant_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	case MARSHAL_ACTION_CONV_IN: {
 		conv_arg = mono_mb_add_local (mb, variant_type);
 		
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			*conv_arg_type = variant_type_byref;
 		else
 			*conv_arg_type = variant_type;
 
-		if (t->byref && !(t->attrs & PARAM_ATTRIBUTE_IN) && t->attrs & PARAM_ATTRIBUTE_OUT)
+		if (mono_type_is_byref_internal (t) && !(t->attrs & PARAM_ATTRIBUTE_IN) && t->attrs & PARAM_ATTRIBUTE_OUT)
 			break;
 
 		mono_mb_emit_ldarg (mb, argnum);
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			mono_mb_emit_byte(mb, CEE_LDIND_REF);
 		mono_mb_emit_ldloc_addr (mb, conv_arg);
 		mono_mb_emit_managed_call (mb, mono_get_Marshal_GetNativeVariantForObject (), NULL);
@@ -6117,7 +6117,7 @@ emit_marshal_variant_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	}
 
 	case MARSHAL_ACTION_CONV_OUT: {
-		if (t->byref && (t->attrs & PARAM_ATTRIBUTE_OUT || !(t->attrs & PARAM_ATTRIBUTE_IN))) {
+		if (mono_type_is_byref_internal (t) && (t->attrs & PARAM_ATTRIBUTE_OUT || !(t->attrs & PARAM_ATTRIBUTE_IN))) {
 			mono_mb_emit_ldarg (mb, argnum);
 			mono_mb_emit_ldloc_addr (mb, conv_arg);
 			mono_mb_emit_managed_call (mb, mono_get_Marshal_GetObjectForNativeVariant (), NULL);
@@ -6130,7 +6130,7 @@ emit_marshal_variant_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	}
 
 	case MARSHAL_ACTION_PUSH:
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			mono_mb_emit_ldloc_addr (mb, conv_arg);
 		else
 			mono_mb_emit_ldloc (mb, conv_arg);
@@ -6145,15 +6145,15 @@ emit_marshal_variant_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	case MARSHAL_ACTION_MANAGED_CONV_IN: {
 		conv_arg = mono_mb_add_local (mb, object_type);
 
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			*conv_arg_type = variant_type_byref;
 		else
 			*conv_arg_type = variant_type;
 
-		if (t->byref && !(t->attrs & PARAM_ATTRIBUTE_IN) && t->attrs & PARAM_ATTRIBUTE_OUT)
+		if (mono_type_is_byref_internal (t) && !(t->attrs & PARAM_ATTRIBUTE_IN) && t->attrs & PARAM_ATTRIBUTE_OUT)
 			break;
 
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			mono_mb_emit_ldarg (mb, argnum);
 		else
 			mono_mb_emit_ldarg_addr (mb, argnum);
@@ -6163,7 +6163,7 @@ emit_marshal_variant_ilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	}
 
 	case MARSHAL_ACTION_MANAGED_CONV_OUT: {
-		if (t->byref && (t->attrs & PARAM_ATTRIBUTE_OUT || !(t->attrs & PARAM_ATTRIBUTE_IN))) {
+		if (mono_type_is_byref_internal (t) && (t->attrs & PARAM_ATTRIBUTE_OUT || !(t->attrs & PARAM_ATTRIBUTE_IN))) {
 			mono_mb_emit_ldloc (mb, conv_arg);
 			mono_mb_emit_ldarg (mb, argnum);
 			mono_mb_emit_managed_call (mb, mono_get_Marshal_GetNativeVariantForObject (), NULL);
@@ -6297,7 +6297,7 @@ emit_managed_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethodSignature *invoke_s
 		MonoType *t = sig->params [i];
 
 		if (tmp_locals [i]) {
-			if (t->byref)
+			if (mono_type_is_byref_internal (t))
 				mono_mb_emit_ldloc_addr (mb, tmp_locals [i]);
 			else
 				mono_mb_emit_ldloc (mb, tmp_locals [i]);
@@ -6322,7 +6322,7 @@ emit_managed_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethodSignature *invoke_s
 
 	if (mspecs [0] && mspecs [0]->native == MONO_NATIVE_CUSTOM) {
 		mono_emit_marshal (m, 0, sig->ret, mspecs [0], 0, NULL, MARSHAL_ACTION_MANAGED_CONV_RESULT);
-	} else if (!sig->ret->byref) { 
+	} else if (!mono_type_is_byref_internal (sig->ret)) { 
 		switch (sig->ret->type) {
 		case MONO_TYPE_VOID:
 			break;
@@ -6369,7 +6369,7 @@ emit_managed_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethodSignature *invoke_s
 		if (spec && spec->native == MONO_NATIVE_CUSTOM) {
 			mono_emit_marshal (m, i, t, mspecs [i + 1], tmp_locals [i], NULL, MARSHAL_ACTION_MANAGED_CONV_OUT);
 		}
-		else if (t->byref) {
+		else if (mono_type_is_byref_internal (t)) {
 			switch (t->type) {
 			case MONO_TYPE_CLASS:
 			case MONO_TYPE_VALUETYPE:

--- a/src/mono/mono/metadata/marshal-noilgen.c
+++ b/src/mono/mono/metadata/marshal-noilgen.c
@@ -52,7 +52,7 @@ emit_marshal_boolean_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	MonoType *int_type = mono_get_int_type ();
 	switch (action) {
 	case MARSHAL_ACTION_CONV_IN:
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			*conv_arg_type = int_type;
 		else
 			*conv_arg_type = mono_marshal_boolean_conv_in_get_local_type (spec, NULL);
@@ -60,7 +60,7 @@ emit_marshal_boolean_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 	case MARSHAL_ACTION_MANAGED_CONV_IN: {
 		MonoClass* conv_arg_class = mono_marshal_boolean_managed_conv_in_get_conv_arg_class (spec, NULL);
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			*conv_arg_type = m_class_get_this_arg (conv_arg_class);
 		else
 			*conv_arg_type = m_class_get_byval_arg (conv_arg_class);
@@ -199,7 +199,7 @@ emit_managed_wrapper_noilgen (MonoMethodBuilder *mb, MonoMethodSignature *invoke
 		}
 	}
 
-	if (!mono_type_is_byref_internal (sig->ret)) {
+	if (!m_type_is_byref (sig->ret)) {
 		switch (sig->ret->type) {
 		case MONO_TYPE_STRING:
 			csig->ret = int_type;

--- a/src/mono/mono/metadata/marshal-noilgen.c
+++ b/src/mono/mono/metadata/marshal-noilgen.c
@@ -52,7 +52,7 @@ emit_marshal_boolean_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 	MonoType *int_type = mono_get_int_type ();
 	switch (action) {
 	case MARSHAL_ACTION_CONV_IN:
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			*conv_arg_type = int_type;
 		else
 			*conv_arg_type = mono_marshal_boolean_conv_in_get_local_type (spec, NULL);
@@ -60,7 +60,7 @@ emit_marshal_boolean_noilgen (EmitMarshalContext *m, int argnum, MonoType *t,
 
 	case MARSHAL_ACTION_MANAGED_CONV_IN: {
 		MonoClass* conv_arg_class = mono_marshal_boolean_managed_conv_in_get_conv_arg_class (spec, NULL);
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			*conv_arg_type = m_class_get_this_arg (conv_arg_class);
 		else
 			*conv_arg_type = m_class_get_byval_arg (conv_arg_class);
@@ -199,7 +199,7 @@ emit_managed_wrapper_noilgen (MonoMethodBuilder *mb, MonoMethodSignature *invoke
 		}
 	}
 
-	if (!sig->ret->byref) {
+	if (!mono_type_is_byref_internal (sig->ret)) {
 		switch (sig->ret->type) {
 		case MONO_TYPE_STRING:
 			csig->ret = int_type;

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -1158,7 +1158,7 @@ mono_string_new_len_wrapper_impl (const char *text, guint length, MonoError *err
 guint
 mono_type_to_ldind (MonoType *type)
 {
-	if (mono_type_is_byref_internal (type))
+	if (m_type_is_byref (type))
 		return CEE_LDIND_I;
 
 handle_enum:
@@ -1215,7 +1215,7 @@ handle_enum:
 guint
 mono_type_to_stind (MonoType *type)
 {
-	if (mono_type_is_byref_internal (type))
+	if (m_type_is_byref (type))
 		return MONO_TYPE_IS_REFERENCE (type) ? CEE_STIND_REF : CEE_STIND_I;
 
 handle_enum:
@@ -2297,7 +2297,7 @@ mono_marshal_get_string_ctor_signature (MonoMethod *method)
 static MonoType*
 get_runtime_invoke_type (MonoType *t, gboolean ret)
 {
-	if (mono_type_is_byref_internal (t)) {
+	if (m_type_is_byref (t)) {
 		if (t->type == MONO_TYPE_GENERICINST && mono_class_is_nullable (mono_class_from_mono_type_internal (t)))
 			return t;
 
@@ -3693,7 +3693,7 @@ mono_marshal_emit_managed_wrapper (MonoMethodBuilder *mb, MonoMethodSignature *i
 static gboolean
 type_is_blittable (MonoType *type)
 {
-	if (mono_type_is_byref_internal (type))
+	if (m_type_is_byref (type))
 		return FALSE;
 	type = mono_type_get_underlying_type (type);
 	switch (type->type) {
@@ -5441,7 +5441,7 @@ mono_type_native_stack_size (MonoType *t, guint32 *align)
 	if (!align)
 		align = &tmp;
 
-	if (mono_type_is_byref_internal (t)) {
+	if (m_type_is_byref (t)) {
 		*align = TARGET_SIZEOF_VOID_P;
 		return TARGET_SIZEOF_VOID_P;
 	}

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -1158,7 +1158,7 @@ mono_string_new_len_wrapper_impl (const char *text, guint length, MonoError *err
 guint
 mono_type_to_ldind (MonoType *type)
 {
-	if (type->byref)
+	if (mono_type_is_byref_internal (type))
 		return CEE_LDIND_I;
 
 handle_enum:
@@ -1215,7 +1215,7 @@ handle_enum:
 guint
 mono_type_to_stind (MonoType *type)
 {
-	if (type->byref)
+	if (mono_type_is_byref_internal (type))
 		return MONO_TYPE_IS_REFERENCE (type) ? CEE_STIND_REF : CEE_STIND_I;
 
 handle_enum:
@@ -2297,7 +2297,7 @@ mono_marshal_get_string_ctor_signature (MonoMethod *method)
 static MonoType*
 get_runtime_invoke_type (MonoType *t, gboolean ret)
 {
-	if (t->byref) {
+	if (mono_type_is_byref_internal (t)) {
 		if (t->type == MONO_TYPE_GENERICINST && mono_class_is_nullable (mono_class_from_mono_type_internal (t)))
 			return t;
 
@@ -3693,7 +3693,7 @@ mono_marshal_emit_managed_wrapper (MonoMethodBuilder *mb, MonoMethodSignature *i
 static gboolean
 type_is_blittable (MonoType *type)
 {
-	if (type->byref)
+	if (mono_type_is_byref_internal (type))
 		return FALSE;
 	type = mono_type_get_underlying_type (type);
 	switch (type->type) {
@@ -5441,7 +5441,7 @@ mono_type_native_stack_size (MonoType *t, guint32 *align)
 	if (!align)
 		align = &tmp;
 
-	if (t->byref) {
+	if (mono_type_is_byref_internal (t)) {
 		*align = TARGET_SIZEOF_VOID_P;
 		return TARGET_SIZEOF_VOID_P;
 	}
@@ -5934,7 +5934,7 @@ mono_marshal_get_thunk_invoke_wrapper (MonoMethod *method)
 
 	/* setup exception param as byref+[out] */
 	csig->params [param_count - 1] = mono_metadata_type_dup (image, m_class_get_byval_arg (mono_defaults.exception_class));
-	csig->params [param_count - 1]->byref = 1;
+	csig->params [param_count - 1]->byref__ = 1;
 	csig->params [param_count - 1]->attrs = PARAM_ATTRIBUTE_OUT;
 
 	/* convert struct return to object */

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -33,7 +33,7 @@ struct _MonoType {
 	unsigned int attrs    : 16; /* param attributes or field flags */
 	MonoTypeEnum type     : 8;
 	unsigned int has_cmods : 1;  
-	unsigned int byref__    : 1; /* don't access directly, use mono_type_is_byref_internal */
+	unsigned int byref__    : 1; /* don't access directly, use m_type_is_byref */
 	unsigned int pinned   : 1;  /* valid when included in a local var signature */
 };
 
@@ -1183,13 +1183,13 @@ mono_type_get_signature_internal (MonoType *type)
 }
 
 /**
- * mono_type_is_byref_internal:
+ * m_type_is_byref:
  * \param type the \c MonoType operated on
  * \returns TRUE if \p type represents a type passed by reference,
  * FALSE otherwise.
  */
 static inline gboolean
-mono_type_is_byref_internal (const MonoType *type)
+m_type_is_byref (const MonoType *type)
 {
 	return type->byref__;
 }

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -1188,8 +1188,8 @@ mono_type_get_signature_internal (MonoType *type)
  * \returns TRUE if \p type represents a type passed by reference,
  * FALSE otherwise.
  */
-static inline mono_bool
-mono_type_is_byref_internal (MonoType *type)
+static inline gboolean
+mono_type_is_byref_internal (const MonoType *type)
 {
 	return type->byref__;
 }

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -33,7 +33,7 @@ struct _MonoType {
 	unsigned int attrs    : 16; /* param attributes or field flags */
 	MonoTypeEnum type     : 8;
 	unsigned int has_cmods : 1;  
-	unsigned int byref    : 1;
+	unsigned int byref__    : 1; /* don't access directly, use mono_type_is_byref_internal */
 	unsigned int pinned   : 1;  /* valid when included in a local var signature */
 };
 
@@ -1191,7 +1191,7 @@ mono_type_get_signature_internal (MonoType *type)
 static inline mono_bool
 mono_type_is_byref_internal (MonoType *type)
 {
-	return type->byref;
+	return type->byref__;
 }
 
 /**

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -1850,7 +1850,7 @@ mono_type_hash (gconstpointer data)
 	if (type->type == MONO_TYPE_GENERICINST)
 		return mono_generic_class_hash (type->data.generic_class);
 	else
-		return type->type | (mono_type_is_byref_internal (type) << 8) | (type->attrs << 9);
+		return type->type | ((m_type_is_byref (type) ? 1 : 0) << 8) | (type->attrs << 9);
 }
 
 static gint
@@ -1859,7 +1859,7 @@ mono_type_equal (gconstpointer ka, gconstpointer kb)
 	const MonoType *a = (const MonoType *) ka;
 	const MonoType *b = (const MonoType *) kb;
 	
-	if (a->type != b->type || mono_type_is_byref_internal (a) != mono_type_is_byref_internal (b) || a->attrs != b->attrs || a->pinned != b->pinned)
+	if (a->type != b->type || m_type_is_byref (a) != m_type_is_byref (b) || a->attrs != b->attrs || a->pinned != b->pinned)
 		return 0;
 	/* need other checks */
 	return 1;
@@ -2101,7 +2101,7 @@ mono_metadata_parse_type_internal (MonoImage *m, MonoGenericContainer *container
 	if (!type->has_cmods && !transient) {
 		/* no need to free type here, because it is on the stack */
 		if ((type->type == MONO_TYPE_CLASS || type->type == MONO_TYPE_VALUETYPE) && !type->pinned && !type->attrs) {
-			MonoType *ret = mono_type_is_byref_internal (type) ? m_class_get_this_arg (type->data.klass) : m_class_get_byval_arg (type->data.klass);
+			MonoType *ret = m_type_is_byref (type) ? m_class_get_this_arg (type->data.klass) : m_class_get_byval_arg (type->data.klass);
 
 			/* Consider the case:
 
@@ -5100,7 +5100,7 @@ mono_type_size (MonoType *t, int *align)
 		*align = 1;
 		return 0;
 	}
-	if (mono_type_is_byref_internal (t)) {
+	if (m_type_is_byref (t)) {
 		*align = MONO_ABI_ALIGNOF (gpointer);
 		return MONO_ABI_SIZEOF (gpointer);
 	}
@@ -5215,7 +5215,7 @@ mono_type_stack_size_internal (MonoType *t, int *align, gboolean allow_open)
 	if (!align)
 		align = &tmp;
 
-	if (mono_type_is_byref_internal (t)) {
+	if (m_type_is_byref (t)) {
 		*align = stack_slot_align;
 		return stack_slot_size;
 	}
@@ -5408,7 +5408,7 @@ mono_metadata_type_hash (MonoType *t1)
 {
 	guint hash = t1->type;
 
-	hash |= mono_type_is_byref_internal (t1) << 6; /* do not collide with t1->type values */
+	hash |= (m_type_is_byref (t1) ? 1 : 0) << 6; /* do not collide with t1->type values */
 	switch (t1->type) {
 	case MONO_TYPE_VALUETYPE:
 	case MONO_TYPE_CLASS:
@@ -5423,7 +5423,7 @@ mono_metadata_type_hash (MonoType *t1)
 		 * inserted in a bunch of hash tables before been finished.
 		 */
 		if (image_is_dynamic (m_class_get_image (klass)))
-			return (mono_type_is_byref_internal (t1) << 6) | mono_metadata_str_hash (m_class_get_name (klass));
+			return ((m_type_is_byref (t1) ? 1 : 0) << 6) | mono_metadata_str_hash (m_class_get_name (klass));
 		return ((hash << 5) - hash) ^ mono_metadata_str_hash (m_class_get_name (klass));
 	}
 	case MONO_TYPE_PTR:
@@ -5598,7 +5598,7 @@ mono_metadata_custom_modifiers_equal (MonoType *t1, MonoType *t2, gboolean signa
 static gboolean
 do_mono_metadata_type_equal (MonoType *t1, MonoType *t2, gboolean signature_only)
 {
-	if (t1->type != t2->type || mono_type_is_byref_internal (t1) != mono_type_is_byref_internal (t2))
+	if (t1->type != t2->type || m_type_is_byref (t1) != m_type_is_byref (t2))
 		return FALSE;
 
 	gboolean cmod_reject = FALSE;
@@ -6552,7 +6552,7 @@ mono_type_to_unmanaged (MonoType *type, MonoMarshalSpec *mspec, gboolean as_fiel
 
 	*conv = MONO_MARSHAL_CONV_NONE;
 
-	if (mono_type_is_byref_internal (type))
+	if (m_type_is_byref (type))
 		return MONO_NATIVE_UINT;
 
 handle_enum:
@@ -7147,7 +7147,7 @@ mono_type_is_byref (MonoType *type)
 {
 	mono_bool result;
 	MONO_ENTER_GC_UNSAFE; // FIXME slow
-	result = mono_type_is_byref_internal (type);
+	result = m_type_is_byref (type);
 	MONO_EXIT_GC_UNSAFE;
 	return result;
 }
@@ -7239,7 +7239,7 @@ mono_type_get_modifiers (MonoType *type, gboolean *is_required, gpointer *iter)
 mono_bool
 mono_type_is_struct (MonoType *type)
 {
-	return (!mono_type_is_byref_internal (type) && ((type->type == MONO_TYPE_VALUETYPE &&
+	return (!m_type_is_byref (type) && ((type->type == MONO_TYPE_VALUETYPE &&
 		!m_class_is_enumtype (type->data.klass)) || (type->type == MONO_TYPE_TYPEDBYREF) ||
 		((type->type == MONO_TYPE_GENERICINST) && 
 		mono_metadata_generic_class_is_valuetype (type->data.generic_class) &&
@@ -7254,7 +7254,7 @@ mono_type_is_struct (MonoType *type)
 mono_bool
 mono_type_is_void (MonoType *type)
 {
-	return (type && (type->type == MONO_TYPE_VOID) && !mono_type_is_byref_internal (type));
+	return (type && (type->type == MONO_TYPE_VOID) && !m_type_is_byref (type));
 }
 
 /**
@@ -7265,7 +7265,7 @@ mono_type_is_void (MonoType *type)
 mono_bool
 mono_type_is_pointer (MonoType *type)
 {
-	return (type && ((mono_type_is_byref_internal (type) || (type->type == MONO_TYPE_I) || type->type == MONO_TYPE_STRING)
+	return (type && ((m_type_is_byref (type) || (type->type == MONO_TYPE_I) || type->type == MONO_TYPE_STRING)
 		|| (type->type == MONO_TYPE_SZARRAY) || (type->type == MONO_TYPE_CLASS) ||
 		(type->type == MONO_TYPE_U) || (type->type == MONO_TYPE_OBJECT) ||
 		(type->type == MONO_TYPE_ARRAY) || (type->type == MONO_TYPE_PTR) ||
@@ -7295,7 +7295,7 @@ mono_type_is_reference (MonoType *type)
 mono_bool
 mono_type_is_generic_parameter (MonoType *type)
 {
-	return !mono_type_is_byref_internal (type) && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR);
+	return !m_type_is_byref (type) && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR);
 }
 
 /**
@@ -7736,7 +7736,7 @@ mono_guid_signature_append_type (GString *res, MonoType *type)
 	default:
 		break;
 	}
-	if (mono_type_is_byref_internal (type)) g_string_append_c (res, '&');
+	if (m_type_is_byref (type)) g_string_append_c (res, '&');
 }
 
 static void

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -1850,7 +1850,7 @@ mono_type_hash (gconstpointer data)
 	if (type->type == MONO_TYPE_GENERICINST)
 		return mono_generic_class_hash (type->data.generic_class);
 	else
-		return type->type | (type->byref << 8) | (type->attrs << 9);
+		return type->type | (mono_type_is_byref_internal (type) << 8) | (type->attrs << 9);
 }
 
 static gint
@@ -1859,7 +1859,7 @@ mono_type_equal (gconstpointer ka, gconstpointer kb)
 	const MonoType *a = (const MonoType *) ka;
 	const MonoType *b = (const MonoType *) kb;
 	
-	if (a->type != b->type || a->byref != b->byref || a->attrs != b->attrs || a->pinned != b->pinned)
+	if (a->type != b->type || mono_type_is_byref_internal (a) != mono_type_is_byref_internal (b) || a->attrs != b->attrs || a->pinned != b->pinned)
 		return 0;
 	/* need other checks */
 	return 1;
@@ -2088,7 +2088,7 @@ mono_metadata_parse_type_internal (MonoImage *m, MonoGenericContainer *container
 	g_assert (count == 0);
 
 	type->attrs = opt_attrs;
-	type->byref = byref;
+	type->byref__ = byref;
 	type->pinned = pinned ? 1 : 0;
 
 	if (!do_mono_metadata_parse_type (type, m, container, transient, ptr, &ptr, error))
@@ -2101,7 +2101,7 @@ mono_metadata_parse_type_internal (MonoImage *m, MonoGenericContainer *container
 	if (!type->has_cmods && !transient) {
 		/* no need to free type here, because it is on the stack */
 		if ((type->type == MONO_TYPE_CLASS || type->type == MONO_TYPE_VALUETYPE) && !type->pinned && !type->attrs) {
-			MonoType *ret = type->byref ? m_class_get_this_arg (type->data.klass) : m_class_get_byval_arg (type->data.klass);
+			MonoType *ret = mono_type_is_byref_internal (type) ? m_class_get_this_arg (type->data.klass) : m_class_get_byval_arg (type->data.klass);
 
 			/* Consider the case:
 
@@ -5100,7 +5100,7 @@ mono_type_size (MonoType *t, int *align)
 		*align = 1;
 		return 0;
 	}
-	if (t->byref) {
+	if (mono_type_is_byref_internal (t)) {
 		*align = MONO_ABI_ALIGNOF (gpointer);
 		return MONO_ABI_SIZEOF (gpointer);
 	}
@@ -5215,7 +5215,7 @@ mono_type_stack_size_internal (MonoType *t, int *align, gboolean allow_open)
 	if (!align)
 		align = &tmp;
 
-	if (t->byref) {
+	if (mono_type_is_byref_internal (t)) {
 		*align = stack_slot_align;
 		return stack_slot_size;
 	}
@@ -5408,7 +5408,7 @@ mono_metadata_type_hash (MonoType *t1)
 {
 	guint hash = t1->type;
 
-	hash |= t1->byref << 6; /* do not collide with t1->type values */
+	hash |= mono_type_is_byref_internal (t1) << 6; /* do not collide with t1->type values */
 	switch (t1->type) {
 	case MONO_TYPE_VALUETYPE:
 	case MONO_TYPE_CLASS:
@@ -5423,7 +5423,7 @@ mono_metadata_type_hash (MonoType *t1)
 		 * inserted in a bunch of hash tables before been finished.
 		 */
 		if (image_is_dynamic (m_class_get_image (klass)))
-			return (t1->byref << 6) | mono_metadata_str_hash (m_class_get_name (klass));
+			return (mono_type_is_byref_internal (t1) << 6) | mono_metadata_str_hash (m_class_get_name (klass));
 		return ((hash << 5) - hash) ^ mono_metadata_str_hash (m_class_get_name (klass));
 	}
 	case MONO_TYPE_PTR:
@@ -5598,7 +5598,7 @@ mono_metadata_custom_modifiers_equal (MonoType *t1, MonoType *t2, gboolean signa
 static gboolean
 do_mono_metadata_type_equal (MonoType *t1, MonoType *t2, gboolean signature_only)
 {
-	if (t1->type != t2->type || t1->byref != t2->byref)
+	if (t1->type != t2->type || mono_type_is_byref_internal (t1) != mono_type_is_byref_internal (t2))
 		return FALSE;
 
 	gboolean cmod_reject = FALSE;
@@ -6552,7 +6552,7 @@ mono_type_to_unmanaged (MonoType *type, MonoMarshalSpec *mspec, gboolean as_fiel
 
 	*conv = MONO_MARSHAL_CONV_NONE;
 
-	if (type->byref)
+	if (mono_type_is_byref_internal (type))
 		return MONO_NATIVE_UINT;
 
 handle_enum:
@@ -7239,7 +7239,7 @@ mono_type_get_modifiers (MonoType *type, gboolean *is_required, gpointer *iter)
 mono_bool
 mono_type_is_struct (MonoType *type)
 {
-	return (!type->byref && ((type->type == MONO_TYPE_VALUETYPE &&
+	return (!mono_type_is_byref_internal (type) && ((type->type == MONO_TYPE_VALUETYPE &&
 		!m_class_is_enumtype (type->data.klass)) || (type->type == MONO_TYPE_TYPEDBYREF) ||
 		((type->type == MONO_TYPE_GENERICINST) && 
 		mono_metadata_generic_class_is_valuetype (type->data.generic_class) &&
@@ -7254,7 +7254,7 @@ mono_type_is_struct (MonoType *type)
 mono_bool
 mono_type_is_void (MonoType *type)
 {
-	return (type && (type->type == MONO_TYPE_VOID) && !type->byref);
+	return (type && (type->type == MONO_TYPE_VOID) && !mono_type_is_byref_internal (type));
 }
 
 /**
@@ -7265,7 +7265,7 @@ mono_type_is_void (MonoType *type)
 mono_bool
 mono_type_is_pointer (MonoType *type)
 {
-	return (type && ((type->byref || (type->type == MONO_TYPE_I) || type->type == MONO_TYPE_STRING)
+	return (type && ((mono_type_is_byref_internal (type) || (type->type == MONO_TYPE_I) || type->type == MONO_TYPE_STRING)
 		|| (type->type == MONO_TYPE_SZARRAY) || (type->type == MONO_TYPE_CLASS) ||
 		(type->type == MONO_TYPE_U) || (type->type == MONO_TYPE_OBJECT) ||
 		(type->type == MONO_TYPE_ARRAY) || (type->type == MONO_TYPE_PTR) ||
@@ -7295,7 +7295,7 @@ mono_type_is_reference (MonoType *type)
 mono_bool
 mono_type_is_generic_parameter (MonoType *type)
 {
-	return !type->byref && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR);
+	return !mono_type_is_byref_internal (type) && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR);
 }
 
 /**
@@ -7736,7 +7736,7 @@ mono_guid_signature_append_type (GString *res, MonoType *type)
 	default:
 		break;
 	}
-	if (type->byref) g_string_append_c (res, '&');
+	if (mono_type_is_byref_internal (type)) g_string_append_c (res, '&');
 }
 
 static void

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -848,7 +848,7 @@ compute_class_bitmap (MonoClass *klass, gsize *bitmap, int size, int offset, int
 					continue;
 			}
 			/* FIXME: should not happen, flag as type load error */
-			if (mono_type_is_byref_internal (field->type))
+			if (m_type_is_byref (field->type))
 				break;
 
 			if (static_fields && field->offset == -1)
@@ -2654,7 +2654,7 @@ mono_copy_value (MonoType *type, void *dest, void *value, int deref_pointer)
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	int t;
-	if (mono_type_is_byref_internal (type)) {
+	if (m_type_is_byref (type)) {
 		/* object fields cannot be byref, so we don't need a
 		   wbarrier here */
 		gpointer *p = (gpointer*)dest;
@@ -2997,7 +2997,7 @@ mono_field_get_value_object_checked (MonoClassField *field, MonoObject *obj, Mon
 	case MONO_TYPE_I8:
 	case MONO_TYPE_R8:
 	case MONO_TYPE_VALUETYPE:
-		is_ref = mono_type_is_byref_internal (type);
+		is_ref = m_type_is_byref (type);
 		break;
 	case MONO_TYPE_GENERICINST:
 		is_ref = !mono_type_generic_inst_is_valuetype (type);
@@ -4556,7 +4556,7 @@ invoke_array_extract_argument (MonoArray *params, int i, MonoType *t, MonoObject
 					/* The runtime invoke wrapper needs the original boxed vtype, it does handle byref values as well. */
 					*pa_obj = mono_array_get_internal (params, MonoObject*, i);
 					result = *pa_obj;
-					if (mono_type_is_byref_internal (t))
+					if (m_type_is_byref (t))
 						*has_byref_nullables = TRUE;
 				} else {
 					/* MS seems to create the objects if a null is passed in */
@@ -4568,7 +4568,7 @@ invoke_array_extract_argument (MonoArray *params, int i, MonoType *t, MonoObject
 						was_null = TRUE;
 					}
 
-					if (mono_type_is_byref_internal (t)) {
+					if (m_type_is_byref (t)) {
 						/*
 						 * We can't pass the unboxed vtype byref to the callee, since
 						 * that would mean the callee would be able to modify boxed
@@ -4583,7 +4583,7 @@ invoke_array_extract_argument (MonoArray *params, int i, MonoType *t, MonoObject
 					}
 					*pa_obj = mono_array_get_internal (params, MonoObject*, i);
 					result = mono_object_unbox_internal (*pa_obj);
-					if (!mono_type_is_byref_internal (t) && was_null)
+					if (!m_type_is_byref (t) && was_null)
 						mono_array_setref_internal (params, i, NULL);
 				}
 				break;
@@ -4592,7 +4592,7 @@ invoke_array_extract_argument (MonoArray *params, int i, MonoType *t, MonoObject
 			case MONO_TYPE_CLASS:
 			case MONO_TYPE_ARRAY:
 			case MONO_TYPE_SZARRAY:
-				if (mono_type_is_byref_internal (t)) {
+				if (m_type_is_byref (t)) {
 					result = mono_array_addr_internal (params, MonoObject*, i);
 					// FIXME: I need to check this code path
 				} else {
@@ -4601,7 +4601,7 @@ invoke_array_extract_argument (MonoArray *params, int i, MonoType *t, MonoObject
 				}
 				break;
 			case MONO_TYPE_GENERICINST:
-				if (mono_type_is_byref_internal (t))
+				if (m_type_is_byref (t))
 					t = m_class_get_this_arg (t->data.generic_class->container_class);
 				else
 					t = m_class_get_byval_arg (t->data.generic_class->container_class);
@@ -4875,7 +4875,7 @@ mono_runtime_try_invoke_array (MonoMethod *method, void *obj, MonoArray *params,
 			} else {
 				box_args [0] = NULL;
 			}
-			if (mono_type_is_byref_internal (sig->ret)) {
+			if (m_type_is_byref (sig->ret)) {
 				// byref is already unboxed by the invoke code
 				MonoType *tmpret = mono_metadata_type_dup (NULL, sig->ret);
 				tmpret->byref__ = FALSE;
@@ -4902,7 +4902,7 @@ mono_runtime_try_invoke_array (MonoMethod *method, void *obj, MonoArray *params,
 			for (i = 0; i < mono_array_length_internal (params); i++) {
 				MonoType *t = sig->params [i];
 
-				if (mono_type_is_byref_internal (t) && t->type == MONO_TYPE_GENERICINST && mono_class_is_nullable (mono_class_from_mono_type_internal (t)))
+				if (m_type_is_byref (t) && t->type == MONO_TYPE_GENERICINST && mono_class_is_nullable (mono_class_from_mono_type_internal (t)))
 					mono_array_setref_internal (params, i, pa [i]);
 			}
 		}

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -848,7 +848,7 @@ compute_class_bitmap (MonoClass *klass, gsize *bitmap, int size, int offset, int
 					continue;
 			}
 			/* FIXME: should not happen, flag as type load error */
-			if (field->type->byref)
+			if (mono_type_is_byref_internal (field->type))
 				break;
 
 			if (static_fields && field->offset == -1)
@@ -2654,7 +2654,7 @@ mono_copy_value (MonoType *type, void *dest, void *value, int deref_pointer)
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	int t;
-	if (type->byref) {
+	if (mono_type_is_byref_internal (type)) {
 		/* object fields cannot be byref, so we don't need a
 		   wbarrier here */
 		gpointer *p = (gpointer*)dest;
@@ -2997,7 +2997,7 @@ mono_field_get_value_object_checked (MonoClassField *field, MonoObject *obj, Mon
 	case MONO_TYPE_I8:
 	case MONO_TYPE_R8:
 	case MONO_TYPE_VALUETYPE:
-		is_ref = type->byref;
+		is_ref = mono_type_is_byref_internal (type);
 		break;
 	case MONO_TYPE_GENERICINST:
 		is_ref = !mono_type_generic_inst_is_valuetype (type);
@@ -4556,7 +4556,7 @@ invoke_array_extract_argument (MonoArray *params, int i, MonoType *t, MonoObject
 					/* The runtime invoke wrapper needs the original boxed vtype, it does handle byref values as well. */
 					*pa_obj = mono_array_get_internal (params, MonoObject*, i);
 					result = *pa_obj;
-					if (t->byref)
+					if (mono_type_is_byref_internal (t))
 						*has_byref_nullables = TRUE;
 				} else {
 					/* MS seems to create the objects if a null is passed in */
@@ -4568,7 +4568,7 @@ invoke_array_extract_argument (MonoArray *params, int i, MonoType *t, MonoObject
 						was_null = TRUE;
 					}
 
-					if (t->byref) {
+					if (mono_type_is_byref_internal (t)) {
 						/*
 						 * We can't pass the unboxed vtype byref to the callee, since
 						 * that would mean the callee would be able to modify boxed
@@ -4583,7 +4583,7 @@ invoke_array_extract_argument (MonoArray *params, int i, MonoType *t, MonoObject
 					}
 					*pa_obj = mono_array_get_internal (params, MonoObject*, i);
 					result = mono_object_unbox_internal (*pa_obj);
-					if (!t->byref && was_null)
+					if (!mono_type_is_byref_internal (t) && was_null)
 						mono_array_setref_internal (params, i, NULL);
 				}
 				break;
@@ -4592,7 +4592,7 @@ invoke_array_extract_argument (MonoArray *params, int i, MonoType *t, MonoObject
 			case MONO_TYPE_CLASS:
 			case MONO_TYPE_ARRAY:
 			case MONO_TYPE_SZARRAY:
-				if (t->byref) {
+				if (mono_type_is_byref_internal (t)) {
 					result = mono_array_addr_internal (params, MonoObject*, i);
 					// FIXME: I need to check this code path
 				} else {
@@ -4601,7 +4601,7 @@ invoke_array_extract_argument (MonoArray *params, int i, MonoType *t, MonoObject
 				}
 				break;
 			case MONO_TYPE_GENERICINST:
-				if (t->byref)
+				if (mono_type_is_byref_internal (t))
 					t = m_class_get_this_arg (t->data.generic_class->container_class);
 				else
 					t = m_class_get_byval_arg (t->data.generic_class->container_class);
@@ -4875,10 +4875,10 @@ mono_runtime_try_invoke_array (MonoMethod *method, void *obj, MonoArray *params,
 			} else {
 				box_args [0] = NULL;
 			}
-			if (sig->ret->byref) {
+			if (mono_type_is_byref_internal (sig->ret)) {
 				// byref is already unboxed by the invoke code
 				MonoType *tmpret = mono_metadata_type_dup (NULL, sig->ret);
-				tmpret->byref = FALSE;
+				tmpret->byref__ = FALSE;
 				MonoReflectionTypeHandle type_h = mono_type_get_object_handle (tmpret, error);
 				box_args [1] = MONO_HANDLE_RAW (type_h);
 				mono_metadata_free_type (tmpret);
@@ -4902,7 +4902,7 @@ mono_runtime_try_invoke_array (MonoMethod *method, void *obj, MonoArray *params,
 			for (i = 0; i < mono_array_length_internal (params); i++) {
 				MonoType *t = sig->params [i];
 
-				if (t->byref && t->type == MONO_TYPE_GENERICINST && mono_class_is_nullable (mono_class_from_mono_type_internal (t)))
+				if (mono_type_is_byref_internal (t) && t->type == MONO_TYPE_GENERICINST && mono_class_is_nullable (mono_class_from_mono_type_internal (t)))
 					mono_array_setref_internal (params, i, pa [i]);
 			}
 		}

--- a/src/mono/mono/metadata/reflection.c
+++ b/src/mono/mono/metadata/reflection.c
@@ -403,11 +403,11 @@ mono_type_normalize (MonoType *type)
 	}
 
 	if (is_denorm_gtd)
-		return type->byref == m_class_get_byval_arg (gtd)->byref ? m_class_get_byval_arg (gtd) : m_class_get_this_arg (gtd);
+		return mono_type_is_byref_internal (type) == mono_type_is_byref_internal (m_class_get_byval_arg (gtd)) ? m_class_get_byval_arg (gtd) : m_class_get_this_arg (gtd);
 
 	if (requires_rebind) {
 		MonoClass *klass = mono_class_bind_generic_parameters (gtd, ginst->type_argc, argv, gclass->is_dynamic);
-		return type->byref == m_class_get_byval_arg (klass)->byref ? m_class_get_byval_arg (klass) : m_class_get_this_arg (klass);
+		return mono_type_is_byref_internal (type) == mono_type_is_byref_internal (m_class_get_byval_arg (klass)) ? m_class_get_byval_arg (klass) : m_class_get_this_arg (klass);
 	}
 
 	return type;
@@ -450,7 +450,7 @@ mono_type_get_object_checked (MonoType *type, MonoError *error)
 	 * expects that is can be freed.
 	 * Using the right type from 
 	 */
-	type = m_class_get_byval_arg (klass)->byref == type->byref ? m_class_get_byval_arg (klass) : m_class_get_this_arg (klass);
+	type = mono_type_is_byref_internal (m_class_get_byval_arg (klass)) == mono_type_is_byref_internal (type) ? m_class_get_byval_arg (klass) : m_class_get_this_arg (klass);
 
 	/* We don't want to return types with custom modifiers to the managed
 	 * world since they're hard to distinguish from plain types using the
@@ -463,7 +463,7 @@ mono_type_get_object_checked (MonoType *type, MonoError *error)
 	g_assert (!type->has_cmods);
 
 	/* void is very common */
-	if (!type->byref && type->type == MONO_TYPE_VOID && domain->typeof_void)
+	if (!mono_type_is_byref_internal (type) && type->type == MONO_TYPE_VOID && domain->typeof_void)
 		return (MonoReflectionType*)domain->typeof_void;
 
 	/*
@@ -531,7 +531,7 @@ mono_type_get_object_checked (MonoType *type, MonoError *error)
 		goto leave;
 	}
 
-	if (mono_class_has_ref_info (klass) && !m_class_was_typebuilder (klass) && !type->byref) {
+	if (mono_class_has_ref_info (klass) && !m_class_was_typebuilder (klass) && !mono_type_is_byref_internal (type)) {
 		res = &mono_class_get_ref_info_raw (klass)->type; /* FIXME use handles */
 		goto leave;
 	}
@@ -547,7 +547,7 @@ mono_type_get_object_checked (MonoType *type, MonoError *error)
 		res = cached;
 	} else {
 		mono_g_hash_table_insert_internal (memory_manager->type_hash, type, res);
-		if (type->type == MONO_TYPE_VOID && !type->byref)
+		if (type->type == MONO_TYPE_VOID && !mono_type_is_byref_internal (type))
 			domain->typeof_void = (MonoObject*)res;
 	}
 	mono_mem_manager_unlock (memory_manager);

--- a/src/mono/mono/metadata/reflection.c
+++ b/src/mono/mono/metadata/reflection.c
@@ -403,11 +403,11 @@ mono_type_normalize (MonoType *type)
 	}
 
 	if (is_denorm_gtd)
-		return mono_type_is_byref_internal (type) == mono_type_is_byref_internal (m_class_get_byval_arg (gtd)) ? m_class_get_byval_arg (gtd) : m_class_get_this_arg (gtd);
+		return m_type_is_byref (type) == m_type_is_byref (m_class_get_byval_arg (gtd)) ? m_class_get_byval_arg (gtd) : m_class_get_this_arg (gtd);
 
 	if (requires_rebind) {
 		MonoClass *klass = mono_class_bind_generic_parameters (gtd, ginst->type_argc, argv, gclass->is_dynamic);
-		return mono_type_is_byref_internal (type) == mono_type_is_byref_internal (m_class_get_byval_arg (klass)) ? m_class_get_byval_arg (klass) : m_class_get_this_arg (klass);
+		return m_type_is_byref (type) == m_type_is_byref (m_class_get_byval_arg (klass)) ? m_class_get_byval_arg (klass) : m_class_get_this_arg (klass);
 	}
 
 	return type;
@@ -450,7 +450,7 @@ mono_type_get_object_checked (MonoType *type, MonoError *error)
 	 * expects that is can be freed.
 	 * Using the right type from 
 	 */
-	type = mono_type_is_byref_internal (m_class_get_byval_arg (klass)) == mono_type_is_byref_internal (type) ? m_class_get_byval_arg (klass) : m_class_get_this_arg (klass);
+	type = m_type_is_byref (m_class_get_byval_arg (klass)) == m_type_is_byref (type) ? m_class_get_byval_arg (klass) : m_class_get_this_arg (klass);
 
 	/* We don't want to return types with custom modifiers to the managed
 	 * world since they're hard to distinguish from plain types using the
@@ -463,7 +463,7 @@ mono_type_get_object_checked (MonoType *type, MonoError *error)
 	g_assert (!type->has_cmods);
 
 	/* void is very common */
-	if (!mono_type_is_byref_internal (type) && type->type == MONO_TYPE_VOID && domain->typeof_void)
+	if (!m_type_is_byref (type) && type->type == MONO_TYPE_VOID && domain->typeof_void)
 		return (MonoReflectionType*)domain->typeof_void;
 
 	/*
@@ -531,7 +531,7 @@ mono_type_get_object_checked (MonoType *type, MonoError *error)
 		goto leave;
 	}
 
-	if (mono_class_has_ref_info (klass) && !m_class_was_typebuilder (klass) && !mono_type_is_byref_internal (type)) {
+	if (mono_class_has_ref_info (klass) && !m_class_was_typebuilder (klass) && !m_type_is_byref (type)) {
 		res = &mono_class_get_ref_info_raw (klass)->type; /* FIXME use handles */
 		goto leave;
 	}
@@ -547,7 +547,7 @@ mono_type_get_object_checked (MonoType *type, MonoError *error)
 		res = cached;
 	} else {
 		mono_g_hash_table_insert_internal (memory_manager->type_hash, type, res);
-		if (type->type == MONO_TYPE_VOID && !mono_type_is_byref_internal (type))
+		if (type->type == MONO_TYPE_VOID && !m_type_is_byref (type))
 			domain->typeof_void = (MonoObject*)res;
 	}
 	mono_mem_manager_unlock (memory_manager);

--- a/src/mono/mono/metadata/sre-encode.c
+++ b/src/mono/mono/metadata/sre-encode.c
@@ -162,10 +162,10 @@ encode_type (MonoDynamicImage *assembly, MonoType *type, SigBuffer *buf)
 		return;
 	}
 		
-	if (mono_type_is_byref_internal (type))
+	if (m_type_is_byref (type))
 		sigbuffer_add_value (buf, MONO_TYPE_BYREF);
 
-	switch (mono_type_is_byref_internal (type)) {
+	switch (m_type_is_byref (type)) {
 	case MONO_TYPE_VOID:
 	case MONO_TYPE_BOOLEAN:
 	case MONO_TYPE_CHAR:

--- a/src/mono/mono/metadata/sre-encode.c
+++ b/src/mono/mono/metadata/sre-encode.c
@@ -162,10 +162,10 @@ encode_type (MonoDynamicImage *assembly, MonoType *type, SigBuffer *buf)
 		return;
 	}
 		
-	if (type->byref)
+	if (mono_type_is_byref_internal (type))
 		sigbuffer_add_value (buf, MONO_TYPE_BYREF);
 
-	switch (type->type){
+	switch (mono_type_is_byref_internal (type)) {
 	case MONO_TYPE_VOID:
 	case MONO_TYPE_BOOLEAN:
 	case MONO_TYPE_CHAR:

--- a/src/mono/mono/metadata/sre-encode.c
+++ b/src/mono/mono/metadata/sre-encode.c
@@ -165,7 +165,7 @@ encode_type (MonoDynamicImage *assembly, MonoType *type, SigBuffer *buf)
 	if (m_type_is_byref (type))
 		sigbuffer_add_value (buf, MONO_TYPE_BYREF);
 
-	switch (m_type_is_byref (type)) {
+	switch (type->type){
 	case MONO_TYPE_VOID:
 	case MONO_TYPE_BOOLEAN:
 	case MONO_TYPE_CHAR:

--- a/src/mono/mono/mini/abcremoval.c
+++ b/src/mono/mono/mini/abcremoval.c
@@ -1245,7 +1245,7 @@ process_block (MonoCompile *cfg, MonoBasicBlock *bb, MonoVariableRelationsEvalua
 static MonoIntegerValueKind
 type_to_value_kind (MonoType *type)
 {
-	if (type->byref)
+	if (mono_type_is_byref_internal (type))
 		return MONO_UNKNOWN_INTEGER_VALUE;
 	switch (type->type) {
 	case MONO_TYPE_I1:

--- a/src/mono/mono/mini/abcremoval.c
+++ b/src/mono/mono/mini/abcremoval.c
@@ -1245,7 +1245,7 @@ process_block (MonoCompile *cfg, MonoBasicBlock *bb, MonoVariableRelationsEvalua
 static MonoIntegerValueKind
 type_to_value_kind (MonoType *type)
 {
-	if (mono_type_is_byref_internal (type))
+	if (m_type_is_byref (type))
 		return MONO_UNKNOWN_INTEGER_VALUE;
 	switch (type->type) {
 	case MONO_TYPE_I1:

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -3581,7 +3581,7 @@ encode_type (MonoAotCompile *acfg, MonoType *t, guint8 *buf, guint8 **endbuf)
 		*p = MONO_TYPE_PINNED;
 		++p;
 	}
-	if (t->byref) {
+	if (mono_type_is_byref_internal (t)) {
 		*p = MONO_TYPE_BYREF;
 		++p;
 	}
@@ -8765,14 +8765,14 @@ get_concrete_sig (MonoMethodSignature *sig)
 
 	//printf ("%s\n", mono_signature_full_name (sig));
 
-	if (sig->ret->byref)
+	if (mono_type_is_byref_internal (sig->ret))
 		copy->ret = m_class_get_this_arg (mono_defaults.int_class);
 	else
 		copy->ret = mini_get_underlying_type (sig->ret);
 	if (!is_concrete_type (copy->ret))
 		concrete = FALSE;
 	for (i = 0; i < sig->param_count; ++i) {
-		if (sig->params [i]->byref) {
+		if (mono_type_is_byref_internal (sig->params [i])) {
 			MonoType *t = m_class_get_byval_arg (mono_class_from_mono_type_internal (sig->params [i]));
 			t = mini_get_underlying_type (t);
 			copy->params [i] = m_class_get_this_arg (mono_class_from_mono_type_internal (t));
@@ -9342,7 +9342,7 @@ mono_aot_get_method_name (MonoCompile *cfg)
 static gboolean
 append_mangled_type (GString *s, MonoType *t)
 {
-	if (t->byref)
+	if (mono_type_is_byref_internal (t))
 		g_string_append_printf (s, "b");
 	switch (t->type) {
 	case MONO_TYPE_VOID:
@@ -10612,7 +10612,7 @@ mono_aot_type_hash (MonoType *t1)
 {
 	guint hash = t1->type;
 
-	hash |= t1->byref << 6; /* do not collide with t1->type values */
+	hash |= mono_type_is_byref_internal (t1) << 6; /* do not collide with t1->type values */
 	switch (t1->type) {
 	case MONO_TYPE_VALUETYPE:
 	case MONO_TYPE_CLASS:

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -3581,7 +3581,7 @@ encode_type (MonoAotCompile *acfg, MonoType *t, guint8 *buf, guint8 **endbuf)
 		*p = MONO_TYPE_PINNED;
 		++p;
 	}
-	if (mono_type_is_byref_internal (t)) {
+	if (m_type_is_byref (t)) {
 		*p = MONO_TYPE_BYREF;
 		++p;
 	}
@@ -8765,14 +8765,14 @@ get_concrete_sig (MonoMethodSignature *sig)
 
 	//printf ("%s\n", mono_signature_full_name (sig));
 
-	if (mono_type_is_byref_internal (sig->ret))
+	if (m_type_is_byref (sig->ret))
 		copy->ret = m_class_get_this_arg (mono_defaults.int_class);
 	else
 		copy->ret = mini_get_underlying_type (sig->ret);
 	if (!is_concrete_type (copy->ret))
 		concrete = FALSE;
 	for (i = 0; i < sig->param_count; ++i) {
-		if (mono_type_is_byref_internal (sig->params [i])) {
+		if (m_type_is_byref (sig->params [i])) {
 			MonoType *t = m_class_get_byval_arg (mono_class_from_mono_type_internal (sig->params [i]));
 			t = mini_get_underlying_type (t);
 			copy->params [i] = m_class_get_this_arg (mono_class_from_mono_type_internal (t));
@@ -9342,7 +9342,7 @@ mono_aot_get_method_name (MonoCompile *cfg)
 static gboolean
 append_mangled_type (GString *s, MonoType *t)
 {
-	if (mono_type_is_byref_internal (t))
+	if (m_type_is_byref (t))
 		g_string_append_printf (s, "b");
 	switch (t->type) {
 	case MONO_TYPE_VOID:
@@ -10612,7 +10612,7 @@ mono_aot_type_hash (MonoType *t1)
 {
 	guint hash = t1->type;
 
-	hash |= mono_type_is_byref_internal (t1) << 6; /* do not collide with t1->type values */
+	hash |= m_type_is_byref (t1) << 6; /* do not collide with t1->type values */
 	switch (t1->type) {
 	case MONO_TYPE_VALUETYPE:
 	case MONO_TYPE_CLASS:

--- a/src/mono/mono/mini/aot-runtime-wasm.c
+++ b/src/mono/mono/mini/aot-runtime-wasm.c
@@ -16,7 +16,7 @@
 static char
 type_to_c (MonoType *t)
 {
-	if (mono_type_is_byref_internal (t))
+	if (m_type_is_byref (t))
 		return 'I';
 
 handle_enum:

--- a/src/mono/mono/mini/aot-runtime-wasm.c
+++ b/src/mono/mono/mini/aot-runtime-wasm.c
@@ -16,7 +16,7 @@
 static char
 type_to_c (MonoType *t)
 {
-	if (t->byref)
+	if (mono_type_is_byref_internal (t))
 		return 'I';
 
 handle_enum:

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -710,7 +710,7 @@ decode_type (MonoAotModule *module, guint8 *buf, guint8 **endbuf, MonoError *err
 			t->pinned = TRUE;
 			++p;
 		} else if (*p == MONO_TYPE_BYREF) {
-			t->byref = TRUE;
+			t->byref__ = TRUE;
 			++p;
 		} else {
 			break;

--- a/src/mono/mono/mini/dwarfwriter.c
+++ b/src/mono/mono/mini/dwarfwriter.c
@@ -1144,7 +1144,7 @@ get_type_die (MonoDwarfWriter *w, MonoType *t)
 	int j;
 	const char *tdie;
 
-	if (mono_type_is_byref_internal (t)) {
+	if (m_type_is_byref (t)) {
 		if (t->type == MONO_TYPE_VALUETYPE) {
 			tdie = (const char *)g_hash_table_lookup (w->class_to_pointer_die, klass);
 		}
@@ -1203,7 +1203,7 @@ emit_type (MonoDwarfWriter *w, MonoType *t)
 	int j;
 	const char *tdie;
 
-	if (mono_type_is_byref_internal (t)) {
+	if (m_type_is_byref (t)) {
 		if (t->type == MONO_TYPE_VALUETYPE) {
 			tdie = emit_class_dwarf_info (w, klass, TRUE);
 			if (tdie)

--- a/src/mono/mono/mini/dwarfwriter.c
+++ b/src/mono/mono/mini/dwarfwriter.c
@@ -1144,7 +1144,7 @@ get_type_die (MonoDwarfWriter *w, MonoType *t)
 	int j;
 	const char *tdie;
 
-	if (t->byref) {
+	if (mono_type_is_byref_internal (t)) {
 		if (t->type == MONO_TYPE_VALUETYPE) {
 			tdie = (const char *)g_hash_table_lookup (w->class_to_pointer_die, klass);
 		}
@@ -1203,7 +1203,7 @@ emit_type (MonoDwarfWriter *w, MonoType *t)
 	int j;
 	const char *tdie;
 
-	if (t->byref) {
+	if (mono_type_is_byref_internal (t)) {
 		if (t->type == MONO_TYPE_VALUETYPE) {
 			tdie = emit_class_dwarf_info (w, klass, TRUE);
 			if (tdie)

--- a/src/mono/mono/mini/interp/interp-internals.h
+++ b/src/mono/mono/mini/interp/interp-internals.h
@@ -279,7 +279,7 @@ static inline int
 mint_type(MonoType *type_)
 {
 	MonoType *type = mini_native_type_replace_type (type_);
-	if (mono_type_is_byref_internal (type))
+	if (m_type_is_byref (type))
 		return MINT_TYPE_I;
 enum_type:
 	switch (type->type) {

--- a/src/mono/mono/mini/interp/interp-internals.h
+++ b/src/mono/mono/mini/interp/interp-internals.h
@@ -279,7 +279,7 @@ static inline int
 mint_type(MonoType *type_)
 {
 	MonoType *type = mini_native_type_replace_type (type_);
-	if (type->byref)
+	if (mono_type_is_byref_internal (type))
 		return MINT_TYPE_I;
 enum_type:
 	switch (type->type) {

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -748,7 +748,7 @@ static int
 stackval_from_data (MonoType *type, stackval *result, const void *data, gboolean pinvoke)
 {
 	type = mini_native_type_replace_type (type);
-	if (mono_type_is_byref_internal (type)) {
+	if (m_type_is_byref (type)) {
 		result->data.p = *(gpointer*)data;
 		return MINT_STACK_SLOT_SIZE;
 	}
@@ -835,7 +835,7 @@ static int
 stackval_to_data (MonoType *type, stackval *val, void *data, gboolean pinvoke)
 {
 	type = mini_native_type_replace_type (type);
-	if (mono_type_is_byref_internal (type)) {
+	if (m_type_is_byref (type)) {
 		gpointer *p = (gpointer*)data;
 		*p = val->data.p;
 		return MINT_STACK_SLOT_SIZE;
@@ -1258,7 +1258,7 @@ static InterpMethodArguments* build_args_from_sig (MonoMethodSignature *sig, Int
 		margs->ilen++;
 
 	for (int i = 0; i < sig->param_count; i++) {
-		guint32 ptype = mono_type_is_byref_internal (sig->params [i]) ? MONO_TYPE_PTR : sig->params [i]->type;
+		guint32 ptype = m_type_is_byref (sig->params [i]) ? MONO_TYPE_PTR : sig->params [i]->type;
 		switch (ptype) {
 		case MONO_TYPE_BOOLEAN:
 		case MONO_TYPE_CHAR:
@@ -1332,7 +1332,7 @@ static InterpMethodArguments* build_args_from_sig (MonoMethodSignature *sig, Int
 		MonoType *type = sig->params [i];
 		guint32 ptype;
 retry:
-		ptype = mono_type_is_byref_internal (type) ? MONO_TYPE_PTR : type->type;
+		ptype = m_type_is_byref (type) ? MONO_TYPE_PTR : type->type;
 		switch (ptype) {
 		case MONO_TYPE_BOOLEAN:
 		case MONO_TYPE_CHAR:
@@ -2031,7 +2031,7 @@ interp_entry (InterpEntryData *data)
 	else
 		params = data->args;
 	for (i = 0; i < sig->param_count; ++i) {
-		if (mono_type_is_byref_internal (sig->params [i])) {
+		if (m_type_is_byref (sig->params [i])) {
 			sp_args->data.p = params [i];
 			sp_args++;
 		} else {
@@ -2366,7 +2366,7 @@ init_jit_call_info (InterpMethod *rmethod, MonoError *error)
 		for (int i = 0; i < rmethod->param_count; ++i) {
 			MonoType *t = rmethod->param_types [i];
 			int mt = mint_type (t);
-			if (mono_type_is_byref_internal (sig->params [i])) {
+			if (m_type_is_byref (sig->params [i])) {
 				cinfo->arginfo [i] = JIT_ARG_BYVAL;
 			} else if (mt == MINT_TYPE_O) {
 				cinfo->arginfo [i] = JIT_ARG_BYREF;

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -748,7 +748,7 @@ static int
 stackval_from_data (MonoType *type, stackval *result, const void *data, gboolean pinvoke)
 {
 	type = mini_native_type_replace_type (type);
-	if (type->byref) {
+	if (mono_type_is_byref_internal (type)) {
 		result->data.p = *(gpointer*)data;
 		return MINT_STACK_SLOT_SIZE;
 	}
@@ -835,7 +835,7 @@ static int
 stackval_to_data (MonoType *type, stackval *val, void *data, gboolean pinvoke)
 {
 	type = mini_native_type_replace_type (type);
-	if (type->byref) {
+	if (mono_type_is_byref_internal (type)) {
 		gpointer *p = (gpointer*)data;
 		*p = val->data.p;
 		return MINT_STACK_SLOT_SIZE;
@@ -1258,7 +1258,7 @@ static InterpMethodArguments* build_args_from_sig (MonoMethodSignature *sig, Int
 		margs->ilen++;
 
 	for (int i = 0; i < sig->param_count; i++) {
-		guint32 ptype = sig->params [i]->byref ? MONO_TYPE_PTR : sig->params [i]->type;
+		guint32 ptype = mono_type_is_byref_internal (sig->params [i]) ? MONO_TYPE_PTR : sig->params [i]->type;
 		switch (ptype) {
 		case MONO_TYPE_BOOLEAN:
 		case MONO_TYPE_CHAR:
@@ -1332,7 +1332,7 @@ static InterpMethodArguments* build_args_from_sig (MonoMethodSignature *sig, Int
 		MonoType *type = sig->params [i];
 		guint32 ptype;
 retry:
-		ptype = type->byref ? MONO_TYPE_PTR : type->type;
+		ptype = mono_type_is_byref_internal (type) ? MONO_TYPE_PTR : type->type;
 		switch (ptype) {
 		case MONO_TYPE_BOOLEAN:
 		case MONO_TYPE_CHAR:
@@ -2031,7 +2031,7 @@ interp_entry (InterpEntryData *data)
 	else
 		params = data->args;
 	for (i = 0; i < sig->param_count; ++i) {
-		if (sig->params [i]->byref) {
+		if (mono_type_is_byref_internal (sig->params [i])) {
 			sp_args->data.p = params [i];
 			sp_args++;
 		} else {
@@ -2366,7 +2366,7 @@ init_jit_call_info (InterpMethod *rmethod, MonoError *error)
 		for (int i = 0; i < rmethod->param_count; ++i) {
 			MonoType *t = rmethod->param_types [i];
 			int mt = mint_type (t);
-			if (sig->params [i]->byref) {
+			if (mono_type_is_byref_internal (sig->params [i])) {
 				cinfo->arginfo [i] = JIT_ARG_BYVAL;
 			} else if (mt == MINT_TYPE_O) {
 				cinfo->arginfo [i] = JIT_ARG_BYREF;

--- a/src/mono/mono/mini/intrinsics.c
+++ b/src/mono/mono/mini/intrinsics.c
@@ -658,7 +658,7 @@ emit_jit_helpers_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSi
 static gboolean
 byref_arg_is_reference (MonoType *t)
 {
-	g_assert (t->byref);
+	g_assert (mono_type_is_byref_internal (t));
 
 	return mini_type_is_reference (m_class_get_byval_arg (mono_class_from_mono_type_internal (t)));
 }
@@ -1019,7 +1019,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 		gboolean is_enter = FALSE;
 		gboolean is_v4 = FALSE;
 
-		if (!strcmp (cmethod->name, "Enter") && fsig->param_count == 2 && fsig->params [1]->byref) {
+		if (!strcmp (cmethod->name, "Enter") && fsig->param_count == 2 && mono_type_is_byref_internal (fsig->params [1])) {
 			is_enter = TRUE;
 			is_v4 = TRUE;
 		}
@@ -1058,7 +1058,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 			return ins;
 		} else if (strcmp (cmethod->name, "MemoryBarrier") == 0 && fsig->param_count == 0) {
 			return mini_emit_memory_barrier (cfg, MONO_MEMORY_BARRIER_SEQ);
-		} else if (!strcmp (cmethod->name, "VolatileRead") && fsig->param_count == 1 && fsig->params [0]->byref) {
+		} else if (!strcmp (cmethod->name, "VolatileRead") && fsig->param_count == 1 && mono_type_is_byref_internal (fsig->params [0])) {
 			guint32 opcode = 0;
 			gboolean is_ref = byref_arg_is_reference (fsig->params [0]);
 
@@ -1132,7 +1132,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 
 				return ins;
 			}
-		} else if (!strcmp (cmethod->name, "VolatileWrite") && fsig->param_count == 2 && fsig->params [0]->byref) {
+		} else if (!strcmp (cmethod->name, "VolatileWrite") && fsig->param_count == 2 && mono_type_is_byref_internal (fsig->params [0])) {
 			guint32 opcode = 0;
 			gboolean is_ref = byref_arg_is_reference (fsig->params [0]);
 
@@ -1295,7 +1295,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 				MONO_ADD_INS (cfg->cbb, ins);
 			}
 		}
-		else if (strcmp (cmethod->name, "Exchange") == 0 && fsig->param_count == 2 && fsig->params [0]->byref) {
+		else if (strcmp (cmethod->name, "Exchange") == 0 && fsig->param_count == 2 && mono_type_is_byref_internal (fsig->params [0])) {
 			MonoInst *f2i = NULL, *i2f;
 			guint32 opcode, f2i_opcode, i2f_opcode;
 			gboolean is_ref = byref_arg_is_reference (fsig->params [0]);
@@ -1545,7 +1545,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 			gboolean is_ref;
 			gboolean is_float = t->type == MONO_TYPE_R4 || t->type == MONO_TYPE_R8;
 
-			g_assert (t->byref);
+			g_assert (mono_type_is_byref_internal (t));
 			is_ref = byref_arg_is_reference (t);
 			if (t->type == MONO_TYPE_I1)
 				opcode = OP_ATOMIC_LOAD_I1;
@@ -1626,7 +1626,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 			MonoType *t = fsig->params [0];
 			gboolean is_ref;
 
-			g_assert (t->byref);
+			g_assert (mono_type_is_byref_internal (t));
 			is_ref = byref_arg_is_reference (t);
 			if (t->type == MONO_TYPE_I1)
 				opcode = OP_ATOMIC_STORE_I1;

--- a/src/mono/mono/mini/intrinsics.c
+++ b/src/mono/mono/mini/intrinsics.c
@@ -658,7 +658,7 @@ emit_jit_helpers_intrinsics (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSi
 static gboolean
 byref_arg_is_reference (MonoType *t)
 {
-	g_assert (mono_type_is_byref_internal (t));
+	g_assert (m_type_is_byref (t));
 
 	return mini_type_is_reference (m_class_get_byval_arg (mono_class_from_mono_type_internal (t)));
 }
@@ -1019,7 +1019,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 		gboolean is_enter = FALSE;
 		gboolean is_v4 = FALSE;
 
-		if (!strcmp (cmethod->name, "Enter") && fsig->param_count == 2 && mono_type_is_byref_internal (fsig->params [1])) {
+		if (!strcmp (cmethod->name, "Enter") && fsig->param_count == 2 && m_type_is_byref (fsig->params [1])) {
 			is_enter = TRUE;
 			is_v4 = TRUE;
 		}
@@ -1058,7 +1058,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 			return ins;
 		} else if (strcmp (cmethod->name, "MemoryBarrier") == 0 && fsig->param_count == 0) {
 			return mini_emit_memory_barrier (cfg, MONO_MEMORY_BARRIER_SEQ);
-		} else if (!strcmp (cmethod->name, "VolatileRead") && fsig->param_count == 1 && mono_type_is_byref_internal (fsig->params [0])) {
+		} else if (!strcmp (cmethod->name, "VolatileRead") && fsig->param_count == 1 && m_type_is_byref (fsig->params [0])) {
 			guint32 opcode = 0;
 			gboolean is_ref = byref_arg_is_reference (fsig->params [0]);
 
@@ -1132,7 +1132,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 
 				return ins;
 			}
-		} else if (!strcmp (cmethod->name, "VolatileWrite") && fsig->param_count == 2 && mono_type_is_byref_internal (fsig->params [0])) {
+		} else if (!strcmp (cmethod->name, "VolatileWrite") && fsig->param_count == 2 && m_type_is_byref (fsig->params [0])) {
 			guint32 opcode = 0;
 			gboolean is_ref = byref_arg_is_reference (fsig->params [0]);
 
@@ -1295,7 +1295,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 				MONO_ADD_INS (cfg->cbb, ins);
 			}
 		}
-		else if (strcmp (cmethod->name, "Exchange") == 0 && fsig->param_count == 2 && mono_type_is_byref_internal (fsig->params [0])) {
+		else if (strcmp (cmethod->name, "Exchange") == 0 && fsig->param_count == 2 && m_type_is_byref (fsig->params [0])) {
 			MonoInst *f2i = NULL, *i2f;
 			guint32 opcode, f2i_opcode, i2f_opcode;
 			gboolean is_ref = byref_arg_is_reference (fsig->params [0]);
@@ -1545,7 +1545,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 			gboolean is_ref;
 			gboolean is_float = t->type == MONO_TYPE_R4 || t->type == MONO_TYPE_R8;
 
-			g_assert (mono_type_is_byref_internal (t));
+			g_assert (m_type_is_byref (t));
 			is_ref = byref_arg_is_reference (t);
 			if (t->type == MONO_TYPE_I1)
 				opcode = OP_ATOMIC_LOAD_I1;
@@ -1626,7 +1626,7 @@ mini_emit_inst_for_method (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSign
 			MonoType *t = fsig->params [0];
 			gboolean is_ref;
 
-			g_assert (mono_type_is_byref_internal (t));
+			g_assert (m_type_is_byref (t));
 			is_ref = byref_arg_is_reference (t);
 			if (t->type == MONO_TYPE_I1)
 				opcode = OP_ATOMIC_STORE_I1;

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -301,7 +301,7 @@ mono_alloc_ireg_copy (MonoCompile *cfg, guint32 vreg)
 guint
 mono_type_to_regmove (MonoCompile *cfg, MonoType *type)
 {
-	if (mono_type_is_byref_internal (type))
+	if (m_type_is_byref (type))
 		return OP_MOVE;
 
 	type = mini_get_underlying_type (type);
@@ -806,7 +806,7 @@ mini_type_to_eval_stack_type (MonoCompile *cfg, MonoType *type, MonoInst *inst)
 
 	type = mini_get_underlying_type (type);
 	inst->klass = klass = mono_class_from_mono_type_internal (type);
-	if (mono_type_is_byref_internal (type)) {
+	if (m_type_is_byref (type)) {
 		inst->type = STACK_MP;
 		return;
 	}
@@ -1307,13 +1307,13 @@ check_values_to_signature (MonoInst *args, MonoType *this_ins, MonoMethodSignatu
 		case STACK_INV:
 			return 0;
 		case STACK_MP:
-			if (mono_type_is_byref_internal (!sig->params [i]))
+			if (m_type_is_byref (!sig->params [i]))
 				return 0;
 			continue;
 		case STACK_OBJ:
-			if (mono_type_is_byref_internal (sig->params [i]))
+			if (m_type_is_byref (sig->params [i]))
 				return 0;
-			switch (mono_type_is_byref_internal (sig->params [i])) {
+			switch (m_type_is_byref (sig->params [i])) {
 			case MONO_TYPE_CLASS:
 			case MONO_TYPE_STRING:
 			case MONO_TYPE_OBJECT:
@@ -1325,7 +1325,7 @@ check_values_to_signature (MonoInst *args, MonoType *this_ins, MonoMethodSignatu
 			}
 			continue;
 		case STACK_R8:
-			if (mono_type_is_byref_internal (sig->params [i]))
+			if (m_type_is_byref (sig->params [i]))
 				return 0;
 			if (sig->params [i]->type != MONO_TYPE_R4 && sig->params [i]->type != MONO_TYPE_R8)
 				return 0;
@@ -1842,7 +1842,7 @@ target_type_is_incompatible (MonoCompile *cfg, MonoType *target, MonoInst *arg)
 	MonoType *simple_type;
 	MonoClass *klass;
 
-	if (mono_type_is_byref_internal (target)) {
+	if (m_type_is_byref (target)) {
 		/* FIXME: check that the pointed to types match */
 		if (arg->type == STACK_MP) {
 			/* This is needed to handle gshared types + ldaddr. We lower the types so we can handle enums and other typedef-like types. */
@@ -2025,7 +2025,7 @@ check_call_signature (MonoCompile *cfg, MonoMethodSignature *sig, MonoInst **arg
 		args++;
 	}
 	for (i = 0; i < sig->param_count; ++i) {
-		if (mono_type_is_byref_internal (sig->params [i])) {
+		if (m_type_is_byref (sig->params [i])) {
 			if (args [i]->type != STACK_MP && args [i]->type != STACK_PTR)
 				return TRUE;
 			continue;
@@ -2237,7 +2237,7 @@ static MonoInst*
 mono_emit_widen_call_res (MonoCompile *cfg, MonoInst *ins, MonoMethodSignature *fsig)
 {
 	if (!MONO_TYPE_IS_VOID (fsig->ret)) {
-		if ((fsig->pinvoke || LLVM_ENABLED) && !mono_type_is_byref_internal (fsig->ret)) {
+		if ((fsig->pinvoke || LLVM_ENABLED) && !m_type_is_byref (fsig->ret)) {
 			int widen_op = -1;
 
 			/* 
@@ -3678,7 +3678,7 @@ handle_constrained_gsharedvt_call (MonoCompile *cfg, MonoMethod *cmethod, MonoMe
 		} else {
 			supported = TRUE;
 			for (int i = 0; i < fsig->param_count; ++i) {
-				if (!(mono_type_is_byref_internal (fsig->params [i]) || MONO_TYPE_IS_PRIMITIVE (fsig->params [i]) || MONO_TYPE_IS_REFERENCE (fsig->params [i]) || MONO_TYPE_ISSTRUCT (fsig->params [i]) || mini_is_gsharedvt_type (fsig->params [i])))
+				if (!(m_type_is_byref (fsig->params [i]) || MONO_TYPE_IS_PRIMITIVE (fsig->params [i]) || MONO_TYPE_IS_REFERENCE (fsig->params [i]) || MONO_TYPE_ISSTRUCT (fsig->params [i]) || mini_is_gsharedvt_type (fsig->params [i])))
 					supported = FALSE;
 			}
 		}
@@ -3998,7 +3998,7 @@ mono_method_check_inlining (MonoCompile *cfg, MonoMethod *method)
 		if (sig->ret && sig->ret->type == MONO_TYPE_R4)
 			return FALSE;
 		for (i = 0; i < sig->param_count; ++i)
-			if (!mono_type_is_byref_internal (sig->params [i]) && sig->params [i]->type == MONO_TYPE_R4)
+			if (!m_type_is_byref (sig->params [i]) && sig->params [i]->type == MONO_TYPE_R4)
 				return FALSE;
 	}
 #endif
@@ -4469,7 +4469,7 @@ mini_emit_init_rvar (MonoCompile *cfg, int dreg, MonoType *rtype)
 	rtype = mini_get_underlying_type (rtype);
 	t = rtype->type;
 
-	if (mono_type_is_byref_internal (rtype)) {
+	if (m_type_is_byref (rtype)) {
 		MONO_EMIT_NEW_PCONST (cfg, dreg, NULL);
 	} else if (t >= MONO_TYPE_BOOLEAN && t <= MONO_TYPE_U4) {
 		MONO_EMIT_NEW_ICONST (cfg, dreg, 0);
@@ -4505,7 +4505,7 @@ emit_dummy_init_rvar (MonoCompile *cfg, int dreg, MonoType *rtype)
 	rtype = mini_get_underlying_type (rtype);
 	t = rtype->type;
 
-	if (mono_type_is_byref_internal (rtype)) {
+	if (m_type_is_byref (rtype)) {
 		MONO_EMIT_NEW_DUMMY_INIT (cfg, dreg, OP_DUMMY_PCONST);
 	} else if (t >= MONO_TYPE_BOOLEAN && t <= MONO_TYPE_U4) {
 		MONO_EMIT_NEW_DUMMY_INIT (cfg, dreg, OP_DUMMY_ICONST);
@@ -5149,7 +5149,7 @@ set_exception_type_from_invalid_il (MonoCompile *cfg, MonoMethod *method, guchar
 guint32
 mono_type_to_stloc_coerce (MonoType *type)
 {
-	if (mono_type_is_byref_internal (type))
+	if (m_type_is_byref (type))
 		return 0;
 
 	type = mini_get_underlying_type (type);
@@ -5478,7 +5478,7 @@ is_supported_tailcall (MonoCompile *cfg, const guint8 *ip, MonoMethod *method, M
 	}
 
 	for (int i = 0; i < fsig->param_count; ++i) {
-		if (IS_NOT_SUPPORTED_TAILCALL (mono_type_is_byref_internal (fsig->params [i]) || fsig->params [i]->type == MONO_TYPE_PTR || fsig->params [i]->type == MONO_TYPE_FNPTR)) {
+		if (IS_NOT_SUPPORTED_TAILCALL (m_type_is_byref (fsig->params [i]) || fsig->params [i]->type == MONO_TYPE_PTR || fsig->params [i]->type == MONO_TYPE_FNPTR)) {
 			tailcall_calli = FALSE;
 			tailcall = FALSE; // These can point to the current method's stack. Emit range check?
 			goto exit;
@@ -5822,7 +5822,7 @@ emit_setret (MonoCompile *cfg, MonoInst *val)
 		}
 	} else {
 #ifdef MONO_ARCH_SOFT_FLOAT_FALLBACK
-		if (COMPILE_SOFT_FLOAT (cfg) && !mono_type_is_byref_internal (ret_type) && ret_type->type == MONO_TYPE_R4) {
+		if (COMPILE_SOFT_FLOAT (cfg) && !m_type_is_byref (ret_type) && ret_type->type == MONO_TYPE_R4) {
 			MonoInst *conv;
 
 			MonoInst *iargs [ ] = { val };
@@ -6453,7 +6453,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 		mono_debug_init_method (cfg, cfg->cbb, breakpoint_id);
 
 	for (n = 0; n < header->num_locals; ++n) {
-		if (header->locals [n]->type == MONO_TYPE_VOID && !mono_type_is_byref_internal (header->locals [n]))
+		if (header->locals [n]->type == MONO_TYPE_VOID && !m_type_is_byref (header->locals [n]))
 			UNVERIFIED;
 	}
 	class_inits = NULL;
@@ -8747,8 +8747,8 @@ calli_end:
 			 */
 			if (cfg->cbb->out_of_line && m_class_get_image (cmethod->klass) == mono_defaults.corlib &&
 				is_exception_class (cmethod->klass) && n <= 2 &&
-			    ((n < 1) || (!mono_type_is_byref_internal (fsig->params [0]) && fsig->params [0]->type == MONO_TYPE_STRING)) && 
-			    ((n < 2) || (!mono_type_is_byref_internal (fsig->params [1]) && fsig->params [1]->type == MONO_TYPE_STRING))) {
+			    ((n < 1) || (!m_type_is_byref (fsig->params [0]) && fsig->params [0]->type == MONO_TYPE_STRING)) && 
+			    ((n < 2) || (!m_type_is_byref (fsig->params [1]) && fsig->params [1]->type == MONO_TYPE_STRING))) {
 				MonoInst *iargs [3];
 
 				sp -= n;

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -301,7 +301,7 @@ mono_alloc_ireg_copy (MonoCompile *cfg, guint32 vreg)
 guint
 mono_type_to_regmove (MonoCompile *cfg, MonoType *type)
 {
-	if (type->byref)
+	if (mono_type_is_byref_internal (type))
 		return OP_MOVE;
 
 	type = mini_get_underlying_type (type);
@@ -806,7 +806,7 @@ mini_type_to_eval_stack_type (MonoCompile *cfg, MonoType *type, MonoInst *inst)
 
 	type = mini_get_underlying_type (type);
 	inst->klass = klass = mono_class_from_mono_type_internal (type);
-	if (type->byref) {
+	if (mono_type_is_byref_internal (type)) {
 		inst->type = STACK_MP;
 		return;
 	}
@@ -1307,13 +1307,13 @@ check_values_to_signature (MonoInst *args, MonoType *this_ins, MonoMethodSignatu
 		case STACK_INV:
 			return 0;
 		case STACK_MP:
-			if (!sig->params [i]->byref)
+			if (mono_type_is_byref_internal (!sig->params [i]))
 				return 0;
 			continue;
 		case STACK_OBJ:
-			if (sig->params [i]->byref)
+			if (mono_type_is_byref_internal (sig->params [i]))
 				return 0;
-			switch (sig->params [i]->type) {
+			switch (mono_type_is_byref_internal (sig->params [i])) {
 			case MONO_TYPE_CLASS:
 			case MONO_TYPE_STRING:
 			case MONO_TYPE_OBJECT:
@@ -1325,7 +1325,7 @@ check_values_to_signature (MonoInst *args, MonoType *this_ins, MonoMethodSignatu
 			}
 			continue;
 		case STACK_R8:
-			if (sig->params [i]->byref)
+			if (mono_type_is_byref_internal (sig->params [i]))
 				return 0;
 			if (sig->params [i]->type != MONO_TYPE_R4 && sig->params [i]->type != MONO_TYPE_R8)
 				return 0;
@@ -1842,7 +1842,7 @@ target_type_is_incompatible (MonoCompile *cfg, MonoType *target, MonoInst *arg)
 	MonoType *simple_type;
 	MonoClass *klass;
 
-	if (target->byref) {
+	if (mono_type_is_byref_internal (target)) {
 		/* FIXME: check that the pointed to types match */
 		if (arg->type == STACK_MP) {
 			/* This is needed to handle gshared types + ldaddr. We lower the types so we can handle enums and other typedef-like types. */
@@ -2025,7 +2025,7 @@ check_call_signature (MonoCompile *cfg, MonoMethodSignature *sig, MonoInst **arg
 		args++;
 	}
 	for (i = 0; i < sig->param_count; ++i) {
-		if (sig->params [i]->byref) {
+		if (mono_type_is_byref_internal (sig->params [i])) {
 			if (args [i]->type != STACK_MP && args [i]->type != STACK_PTR)
 				return TRUE;
 			continue;
@@ -2237,7 +2237,7 @@ static MonoInst*
 mono_emit_widen_call_res (MonoCompile *cfg, MonoInst *ins, MonoMethodSignature *fsig)
 {
 	if (!MONO_TYPE_IS_VOID (fsig->ret)) {
-		if ((fsig->pinvoke || LLVM_ENABLED) && !fsig->ret->byref) {
+		if ((fsig->pinvoke || LLVM_ENABLED) && !mono_type_is_byref_internal (fsig->ret)) {
 			int widen_op = -1;
 
 			/* 
@@ -3678,7 +3678,7 @@ handle_constrained_gsharedvt_call (MonoCompile *cfg, MonoMethod *cmethod, MonoMe
 		} else {
 			supported = TRUE;
 			for (int i = 0; i < fsig->param_count; ++i) {
-				if (!(fsig->params [i]->byref || MONO_TYPE_IS_PRIMITIVE (fsig->params [i]) || MONO_TYPE_IS_REFERENCE (fsig->params [i]) || MONO_TYPE_ISSTRUCT (fsig->params [i]) || mini_is_gsharedvt_type (fsig->params [i])))
+				if (!(mono_type_is_byref_internal (fsig->params [i]) || MONO_TYPE_IS_PRIMITIVE (fsig->params [i]) || MONO_TYPE_IS_REFERENCE (fsig->params [i]) || MONO_TYPE_ISSTRUCT (fsig->params [i]) || mini_is_gsharedvt_type (fsig->params [i])))
 					supported = FALSE;
 			}
 		}
@@ -3998,7 +3998,7 @@ mono_method_check_inlining (MonoCompile *cfg, MonoMethod *method)
 		if (sig->ret && sig->ret->type == MONO_TYPE_R4)
 			return FALSE;
 		for (i = 0; i < sig->param_count; ++i)
-			if (!sig->params [i]->byref && sig->params [i]->type == MONO_TYPE_R4)
+			if (!mono_type_is_byref_internal (sig->params [i]) && sig->params [i]->type == MONO_TYPE_R4)
 				return FALSE;
 	}
 #endif
@@ -4469,7 +4469,7 @@ mini_emit_init_rvar (MonoCompile *cfg, int dreg, MonoType *rtype)
 	rtype = mini_get_underlying_type (rtype);
 	t = rtype->type;
 
-	if (rtype->byref) {
+	if (mono_type_is_byref_internal (rtype)) {
 		MONO_EMIT_NEW_PCONST (cfg, dreg, NULL);
 	} else if (t >= MONO_TYPE_BOOLEAN && t <= MONO_TYPE_U4) {
 		MONO_EMIT_NEW_ICONST (cfg, dreg, 0);
@@ -4505,7 +4505,7 @@ emit_dummy_init_rvar (MonoCompile *cfg, int dreg, MonoType *rtype)
 	rtype = mini_get_underlying_type (rtype);
 	t = rtype->type;
 
-	if (rtype->byref) {
+	if (mono_type_is_byref_internal (rtype)) {
 		MONO_EMIT_NEW_DUMMY_INIT (cfg, dreg, OP_DUMMY_PCONST);
 	} else if (t >= MONO_TYPE_BOOLEAN && t <= MONO_TYPE_U4) {
 		MONO_EMIT_NEW_DUMMY_INIT (cfg, dreg, OP_DUMMY_ICONST);
@@ -5149,7 +5149,7 @@ set_exception_type_from_invalid_il (MonoCompile *cfg, MonoMethod *method, guchar
 guint32
 mono_type_to_stloc_coerce (MonoType *type)
 {
-	if (type->byref)
+	if (mono_type_is_byref_internal (type))
 		return 0;
 
 	type = mini_get_underlying_type (type);
@@ -5478,7 +5478,7 @@ is_supported_tailcall (MonoCompile *cfg, const guint8 *ip, MonoMethod *method, M
 	}
 
 	for (int i = 0; i < fsig->param_count; ++i) {
-		if (IS_NOT_SUPPORTED_TAILCALL (fsig->params [i]->byref || fsig->params [i]->type == MONO_TYPE_PTR || fsig->params [i]->type == MONO_TYPE_FNPTR)) {
+		if (IS_NOT_SUPPORTED_TAILCALL (mono_type_is_byref_internal (fsig->params [i]) || fsig->params [i]->type == MONO_TYPE_PTR || fsig->params [i]->type == MONO_TYPE_FNPTR)) {
 			tailcall_calli = FALSE;
 			tailcall = FALSE; // These can point to the current method's stack. Emit range check?
 			goto exit;
@@ -5822,7 +5822,7 @@ emit_setret (MonoCompile *cfg, MonoInst *val)
 		}
 	} else {
 #ifdef MONO_ARCH_SOFT_FLOAT_FALLBACK
-		if (COMPILE_SOFT_FLOAT (cfg) && !ret_type->byref && ret_type->type == MONO_TYPE_R4) {
+		if (COMPILE_SOFT_FLOAT (cfg) && !mono_type_is_byref_internal (ret_type) && ret_type->type == MONO_TYPE_R4) {
 			MonoInst *conv;
 
 			MonoInst *iargs [ ] = { val };
@@ -6453,7 +6453,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 		mono_debug_init_method (cfg, cfg->cbb, breakpoint_id);
 
 	for (n = 0; n < header->num_locals; ++n) {
-		if (header->locals [n]->type == MONO_TYPE_VOID && !header->locals [n]->byref)
+		if (header->locals [n]->type == MONO_TYPE_VOID && !mono_type_is_byref_internal (header->locals [n]))
 			UNVERIFIED;
 	}
 	class_inits = NULL;
@@ -8747,8 +8747,8 @@ calli_end:
 			 */
 			if (cfg->cbb->out_of_line && m_class_get_image (cmethod->klass) == mono_defaults.corlib &&
 				is_exception_class (cmethod->klass) && n <= 2 &&
-				((n < 1) || (!fsig->params [0]->byref && fsig->params [0]->type == MONO_TYPE_STRING)) && 
-				((n < 2) || (!fsig->params [1]->byref && fsig->params [1]->type == MONO_TYPE_STRING))) {
+			    ((n < 1) || (!mono_type_is_byref_internal (fsig->params [0]) && fsig->params [0]->type == MONO_TYPE_STRING)) && 
+			    ((n < 2) || (!mono_type_is_byref_internal (fsig->params [1]) && fsig->params [1]->type == MONO_TYPE_STRING))) {
 				MonoInst *iargs [3];
 
 				sp -= n;

--- a/src/mono/mono/mini/mini-amd64-gsharedvt.c
+++ b/src/mono/mono/mini/mini-amd64-gsharedvt.c
@@ -450,7 +450,7 @@ mono_arch_get_gsharedvt_call_info (MonoMemoryManager *mem_manager, gpointer addr
 		/* Compute return value marshalling */
 		switch (cinfo->ret.storage) {
 		case ArgInIReg:
-			if (!gsharedvt_in || sig->ret->byref) {
+			if (!gsharedvt_in || mono_type_is_byref_internal (sig->ret)) {
 				info->ret_marshal = GSHAREDVT_RET_IREGS_1;
 			} else {
 				MonoType *ret = sig->ret;

--- a/src/mono/mono/mini/mini-amd64-gsharedvt.c
+++ b/src/mono/mono/mini/mini-amd64-gsharedvt.c
@@ -450,7 +450,7 @@ mono_arch_get_gsharedvt_call_info (MonoMemoryManager *mem_manager, gpointer addr
 		/* Compute return value marshalling */
 		switch (cinfo->ret.storage) {
 		case ArgInIReg:
-			if (!gsharedvt_in || mono_type_is_byref_internal (sig->ret)) {
+			if (!gsharedvt_in || m_type_is_byref (sig->ret)) {
 				info->ret_marshal = GSHAREDVT_RET_IREGS_1;
 			} else {
 				MonoType *ret = sig->ret;

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -2246,7 +2246,7 @@ mono_arch_emit_call (MonoCompile *cfg, MonoCallInst *call)
 		t = mini_get_underlying_type (t);
 		//XXX what about ArgGSharedVtOnStack here?
 		if (ainfo->storage == ArgOnStack && !MONO_TYPE_ISSTRUCT (t)) {
-			if (!mono_type_is_byref_internal (t)) {
+			if (!m_type_is_byref (t)) {
 				if (t->type == MONO_TYPE_R4)
 					MONO_EMIT_NEW_STORE_MEMBASE (cfg, OP_STORER4_MEMBASE_REG, AMD64_RSP, ainfo->offset, in->dreg);
 				else if (t->type == MONO_TYPE_R8)
@@ -2632,7 +2632,7 @@ mono_arch_dyn_call_prepare (MonoMethodSignature *sig)
 		MonoType *t = sig->params [aindex];
 		ArgInfo *ainfo = &cinfo->args [aindex + sig->hasthis];
 
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			continue;
 
 		switch (t->type) {
@@ -2764,7 +2764,7 @@ mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, g
 			slot = general_param_reg_to_index [ainfo->reg];
 		}
 
-		if (mono_type_is_byref_internal (t)) {
+		if (m_type_is_byref (t)) {
 			p->regs [slot] = PTR_TO_GREG (*(arg));
 			continue;
 		}

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -2246,7 +2246,7 @@ mono_arch_emit_call (MonoCompile *cfg, MonoCallInst *call)
 		t = mini_get_underlying_type (t);
 		//XXX what about ArgGSharedVtOnStack here?
 		if (ainfo->storage == ArgOnStack && !MONO_TYPE_ISSTRUCT (t)) {
-			if (!t->byref) {
+			if (!mono_type_is_byref_internal (t)) {
 				if (t->type == MONO_TYPE_R4)
 					MONO_EMIT_NEW_STORE_MEMBASE (cfg, OP_STORER4_MEMBASE_REG, AMD64_RSP, ainfo->offset, in->dreg);
 				else if (t->type == MONO_TYPE_R8)
@@ -2632,7 +2632,7 @@ mono_arch_dyn_call_prepare (MonoMethodSignature *sig)
 		MonoType *t = sig->params [aindex];
 		ArgInfo *ainfo = &cinfo->args [aindex + sig->hasthis];
 
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			continue;
 
 		switch (t->type) {
@@ -2764,7 +2764,7 @@ mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, g
 			slot = general_param_reg_to_index [ainfo->reg];
 		}
 
-		if (t->byref) {
+		if (mono_type_is_byref_internal (t)) {
 			p->regs [slot] = PTR_TO_GREG (*(arg));
 			continue;
 		}

--- a/src/mono/mono/mini/mini-arm-gsharedvt.c
+++ b/src/mono/mono/mini/mini-arm-gsharedvt.c
@@ -287,13 +287,13 @@ mono_arch_get_gsharedvt_call_info (MonoMemoryManager *mem_manager, gpointer addr
 	if (var_ret) {
 		switch (cinfo->ret.storage) {
 		case RegTypeGeneral:
-			if (gsharedvt_in && !sig->ret->byref && sig->ret->type == MONO_TYPE_I1)
+			if (gsharedvt_in && !mono_type_is_byref_internal (sig->ret) && sig->ret->type == MONO_TYPE_I1)
 				info->ret_marshal = GSHAREDVT_RET_I1;
-			else if (gsharedvt_in && !sig->ret->byref && (sig->ret->type == MONO_TYPE_U1 || sig->ret->type == MONO_TYPE_BOOLEAN))
+			else if (gsharedvt_in && !mono_type_is_byref_internal (sig->ret) && (sig->ret->type == MONO_TYPE_U1 || sig->ret->type == MONO_TYPE_BOOLEAN))
 				info->ret_marshal = GSHAREDVT_RET_U1;
-			else if (gsharedvt_in && !sig->ret->byref && sig->ret->type == MONO_TYPE_I2)
+			else if (gsharedvt_in && !mono_type_is_byref_internal (sig->ret) && sig->ret->type == MONO_TYPE_I2)
 				info->ret_marshal = GSHAREDVT_RET_I2;
-			else if (gsharedvt_in && !sig->ret->byref && (sig->ret->type == MONO_TYPE_U2 || sig->ret->type == MONO_TYPE_CHAR))
+			else if (gsharedvt_in && !mono_type_is_byref_internal (sig->ret) && (sig->ret->type == MONO_TYPE_U2 || sig->ret->type == MONO_TYPE_CHAR))
 				info->ret_marshal = GSHAREDVT_RET_U2;
 			else
 				info->ret_marshal = GSHAREDVT_RET_IREG;

--- a/src/mono/mono/mini/mini-arm-gsharedvt.c
+++ b/src/mono/mono/mini/mini-arm-gsharedvt.c
@@ -287,13 +287,13 @@ mono_arch_get_gsharedvt_call_info (MonoMemoryManager *mem_manager, gpointer addr
 	if (var_ret) {
 		switch (cinfo->ret.storage) {
 		case RegTypeGeneral:
-			if (gsharedvt_in && !mono_type_is_byref_internal (sig->ret) && sig->ret->type == MONO_TYPE_I1)
+			if (gsharedvt_in && !m_type_is_byref (sig->ret) && sig->ret->type == MONO_TYPE_I1)
 				info->ret_marshal = GSHAREDVT_RET_I1;
-			else if (gsharedvt_in && !mono_type_is_byref_internal (sig->ret) && (sig->ret->type == MONO_TYPE_U1 || sig->ret->type == MONO_TYPE_BOOLEAN))
+			else if (gsharedvt_in && !m_type_is_byref (sig->ret) && (sig->ret->type == MONO_TYPE_U1 || sig->ret->type == MONO_TYPE_BOOLEAN))
 				info->ret_marshal = GSHAREDVT_RET_U1;
-			else if (gsharedvt_in && !mono_type_is_byref_internal (sig->ret) && sig->ret->type == MONO_TYPE_I2)
+			else if (gsharedvt_in && !m_type_is_byref (sig->ret) && sig->ret->type == MONO_TYPE_I2)
 				info->ret_marshal = GSHAREDVT_RET_I2;
-			else if (gsharedvt_in && !mono_type_is_byref_internal (sig->ret) && (sig->ret->type == MONO_TYPE_U2 || sig->ret->type == MONO_TYPE_CHAR))
+			else if (gsharedvt_in && !m_type_is_byref (sig->ret) && (sig->ret->type == MONO_TYPE_U2 || sig->ret->type == MONO_TYPE_CHAR))
 				info->ret_marshal = GSHAREDVT_RET_U2;
 			else
 				info->ret_marshal = GSHAREDVT_RET_IREG;

--- a/src/mono/mono/mini/mini-arm.c
+++ b/src/mono/mono/mini/mini-arm.c
@@ -954,7 +954,7 @@ mono_arch_is_soft_float (void)
 static gboolean
 is_regsize_var (MonoType *t)
 {
-	if (t->byref)
+	if (mono_type_is_byref_internal (t))
 		return TRUE;
 	t = mini_get_underlying_type (t);
 	switch (t->type) {
@@ -1239,7 +1239,7 @@ is_hfa (MonoType *t, int *out_nfields, int *out_esize)
 			prev_ftype = ftype;
 			nfields += nested_nfields;
 		} else {
-			if (!(!ftype->byref && (ftype->type == MONO_TYPE_R4 || ftype->type == MONO_TYPE_R8)))
+			if (!(!mono_type_is_byref_internal (ftype) && (ftype->type == MONO_TYPE_R4 || ftype->type == MONO_TYPE_R8)))
 				return FALSE;
 			if (prev_ftype && prev_ftype->type != ftype->type)
 				return FALSE;
@@ -1412,7 +1412,7 @@ get_call_info (MonoMemPool *mp, MonoMethodSignature *sig)
 			add_general (&gr, &stack_size, &cinfo->sig_cookie, TRUE);
 		}
 		DEBUG(g_print("param %d: ", i));
-		if (sig->params [i]->byref) {
+		if (mono_type_is_byref_internal (sig->params [i])) {
                         DEBUG(g_print("byref\n"));
 			add_general (&gr, &stack_size, ainfo, TRUE);
 			n++;
@@ -2463,7 +2463,7 @@ mono_arch_emit_call (MonoCompile *cfg, MonoCallInst *call)
 		switch (ainfo->storage) {
 		case RegTypeGeneral:
 		case RegTypeIRegPair:
-			if (!t->byref && ((t->type == MONO_TYPE_I8) || (t->type == MONO_TYPE_U8))) {
+			if (!mono_type_is_byref_internal (t) && ((t->type == MONO_TYPE_I8) || (t->type == MONO_TYPE_U8))) {
 				MONO_INST_NEW (cfg, ins, OP_MOVE);
 				ins->dreg = mono_alloc_ireg (cfg);
 				ins->sreg1 = MONO_LVREG_LS (in->dreg);
@@ -2475,7 +2475,7 @@ mono_arch_emit_call (MonoCompile *cfg, MonoCallInst *call)
 				ins->sreg1 = MONO_LVREG_MS (in->dreg);
 				MONO_ADD_INS (cfg->cbb, ins);
 				mono_call_inst_add_outarg_reg (cfg, call, ins->dreg, ainfo->reg + 1, FALSE);
-			} else if (!t->byref && ((t->type == MONO_TYPE_R8) || (t->type == MONO_TYPE_R4))) {
+			} else if (!mono_type_is_byref_internal (t) && ((t->type == MONO_TYPE_R8) || (t->type == MONO_TYPE_R4))) {
 				if (ainfo->size == 4) {
 					if (IS_SOFT_FLOAT) {
 						/* mono_emit_call_args () have already done the r8->r4 conversion */
@@ -2547,9 +2547,9 @@ mono_arch_emit_call (MonoCompile *cfg, MonoCallInst *call)
 			MONO_ADD_INS (cfg->cbb, ins);
 			break;
 		case RegTypeBase:
-			if (!t->byref && ((t->type == MONO_TYPE_I8) || (t->type == MONO_TYPE_U8))) {
+			if (!mono_type_is_byref_internal (t) && ((t->type == MONO_TYPE_I8) || (t->type == MONO_TYPE_U8))) {
 				MONO_EMIT_NEW_STORE_MEMBASE (cfg, OP_STOREI8_MEMBASE_REG, ARMREG_SP, ainfo->offset, in->dreg);
-			} else if (!t->byref && ((t->type == MONO_TYPE_R4) || (t->type == MONO_TYPE_R8))) {
+			} else if (!mono_type_is_byref_internal (t) && ((t->type == MONO_TYPE_R4) || (t->type == MONO_TYPE_R8))) {
 				if (t->type == MONO_TYPE_R8) {
 					MONO_EMIT_NEW_STORE_MEMBASE (cfg, OP_STORER8_MEMBASE_REG, ARMREG_SP, ainfo->offset, in->dreg);
 				} else {
@@ -2563,14 +2563,14 @@ mono_arch_emit_call (MonoCompile *cfg, MonoCallInst *call)
 			}
 			break;
 		case RegTypeBaseGen:
-			if (!t->byref && ((t->type == MONO_TYPE_I8) || (t->type == MONO_TYPE_U8))) {
+			if (!mono_type_is_byref_internal (t) && ((t->type == MONO_TYPE_I8) || (t->type == MONO_TYPE_U8))) {
 				MONO_EMIT_NEW_STORE_MEMBASE (cfg, OP_STORE_MEMBASE_REG, ARMREG_SP, ainfo->offset, (G_BYTE_ORDER == G_BIG_ENDIAN) ? MONO_LVREG_LS (in->dreg) : MONO_LVREG_MS (in->dreg));
 				MONO_INST_NEW (cfg, ins, OP_MOVE);
 				ins->dreg = mono_alloc_ireg (cfg);
 				ins->sreg1 = G_BYTE_ORDER == G_BIG_ENDIAN ? MONO_LVREG_MS (in->dreg) : MONO_LVREG_LS (in->dreg);
 				MONO_ADD_INS (cfg->cbb, ins);
 				mono_call_inst_add_outarg_reg (cfg, call, ins->dreg, ARMREG_R3, FALSE);
-			} else if (!t->byref && (t->type == MONO_TYPE_R8)) {
+			} else if (!mono_type_is_byref_internal (t) && (t->type == MONO_TYPE_R8)) {
 				int creg;
 
 				/* This should work for soft-float as well */
@@ -2760,7 +2760,7 @@ mono_arch_emit_setret (MonoCompile *cfg, MonoMethod *method, MonoInst *val)
 {
 	MonoType *ret = mini_get_underlying_type (mono_method_signature_internal (method)->ret);
 
-	if (!ret->byref) {
+	if (!mono_type_is_byref_internal (ret)) {
 		if (ret->type == MONO_TYPE_I8 || ret->type == MONO_TYPE_U8) {
 			MonoInst *ins;
 
@@ -2873,7 +2873,7 @@ dyn_call_supported (CallInfo *cinfo, MonoMethodSignature *sig)
 	for (i = 0; i < sig->param_count; ++i) {
 		MonoType *t = sig->params [i];
 
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			continue;
 
 		t = mini_get_underlying_type (t);
@@ -2987,7 +2987,7 @@ mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, g
 			g_assert_not_reached ();
 		}
 
-		if (t->byref) {
+		if (mono_type_is_byref_internal (t)) {
 			p->regs [slot] = (host_mgreg_t)(gsize)*arg;
 			continue;
 		}

--- a/src/mono/mono/mini/mini-arm.c
+++ b/src/mono/mono/mini/mini-arm.c
@@ -954,7 +954,7 @@ mono_arch_is_soft_float (void)
 static gboolean
 is_regsize_var (MonoType *t)
 {
-	if (mono_type_is_byref_internal (t))
+	if (m_type_is_byref (t))
 		return TRUE;
 	t = mini_get_underlying_type (t);
 	switch (t->type) {
@@ -1239,7 +1239,7 @@ is_hfa (MonoType *t, int *out_nfields, int *out_esize)
 			prev_ftype = ftype;
 			nfields += nested_nfields;
 		} else {
-			if (!(!mono_type_is_byref_internal (ftype) && (ftype->type == MONO_TYPE_R4 || ftype->type == MONO_TYPE_R8)))
+			if (!(!m_type_is_byref (ftype) && (ftype->type == MONO_TYPE_R4 || ftype->type == MONO_TYPE_R8)))
 				return FALSE;
 			if (prev_ftype && prev_ftype->type != ftype->type)
 				return FALSE;
@@ -1412,7 +1412,7 @@ get_call_info (MonoMemPool *mp, MonoMethodSignature *sig)
 			add_general (&gr, &stack_size, &cinfo->sig_cookie, TRUE);
 		}
 		DEBUG(g_print("param %d: ", i));
-		if (mono_type_is_byref_internal (sig->params [i])) {
+		if (m_type_is_byref (sig->params [i])) {
                         DEBUG(g_print("byref\n"));
 			add_general (&gr, &stack_size, ainfo, TRUE);
 			n++;
@@ -2463,7 +2463,7 @@ mono_arch_emit_call (MonoCompile *cfg, MonoCallInst *call)
 		switch (ainfo->storage) {
 		case RegTypeGeneral:
 		case RegTypeIRegPair:
-			if (!mono_type_is_byref_internal (t) && ((t->type == MONO_TYPE_I8) || (t->type == MONO_TYPE_U8))) {
+			if (!m_type_is_byref (t) && ((t->type == MONO_TYPE_I8) || (t->type == MONO_TYPE_U8))) {
 				MONO_INST_NEW (cfg, ins, OP_MOVE);
 				ins->dreg = mono_alloc_ireg (cfg);
 				ins->sreg1 = MONO_LVREG_LS (in->dreg);
@@ -2475,7 +2475,7 @@ mono_arch_emit_call (MonoCompile *cfg, MonoCallInst *call)
 				ins->sreg1 = MONO_LVREG_MS (in->dreg);
 				MONO_ADD_INS (cfg->cbb, ins);
 				mono_call_inst_add_outarg_reg (cfg, call, ins->dreg, ainfo->reg + 1, FALSE);
-			} else if (!mono_type_is_byref_internal (t) && ((t->type == MONO_TYPE_R8) || (t->type == MONO_TYPE_R4))) {
+			} else if (!m_type_is_byref (t) && ((t->type == MONO_TYPE_R8) || (t->type == MONO_TYPE_R4))) {
 				if (ainfo->size == 4) {
 					if (IS_SOFT_FLOAT) {
 						/* mono_emit_call_args () have already done the r8->r4 conversion */
@@ -2547,9 +2547,9 @@ mono_arch_emit_call (MonoCompile *cfg, MonoCallInst *call)
 			MONO_ADD_INS (cfg->cbb, ins);
 			break;
 		case RegTypeBase:
-			if (!mono_type_is_byref_internal (t) && ((t->type == MONO_TYPE_I8) || (t->type == MONO_TYPE_U8))) {
+			if (!m_type_is_byref (t) && ((t->type == MONO_TYPE_I8) || (t->type == MONO_TYPE_U8))) {
 				MONO_EMIT_NEW_STORE_MEMBASE (cfg, OP_STOREI8_MEMBASE_REG, ARMREG_SP, ainfo->offset, in->dreg);
-			} else if (!mono_type_is_byref_internal (t) && ((t->type == MONO_TYPE_R4) || (t->type == MONO_TYPE_R8))) {
+			} else if (!m_type_is_byref (t) && ((t->type == MONO_TYPE_R4) || (t->type == MONO_TYPE_R8))) {
 				if (t->type == MONO_TYPE_R8) {
 					MONO_EMIT_NEW_STORE_MEMBASE (cfg, OP_STORER8_MEMBASE_REG, ARMREG_SP, ainfo->offset, in->dreg);
 				} else {
@@ -2563,14 +2563,14 @@ mono_arch_emit_call (MonoCompile *cfg, MonoCallInst *call)
 			}
 			break;
 		case RegTypeBaseGen:
-			if (!mono_type_is_byref_internal (t) && ((t->type == MONO_TYPE_I8) || (t->type == MONO_TYPE_U8))) {
+			if (!m_type_is_byref (t) && ((t->type == MONO_TYPE_I8) || (t->type == MONO_TYPE_U8))) {
 				MONO_EMIT_NEW_STORE_MEMBASE (cfg, OP_STORE_MEMBASE_REG, ARMREG_SP, ainfo->offset, (G_BYTE_ORDER == G_BIG_ENDIAN) ? MONO_LVREG_LS (in->dreg) : MONO_LVREG_MS (in->dreg));
 				MONO_INST_NEW (cfg, ins, OP_MOVE);
 				ins->dreg = mono_alloc_ireg (cfg);
 				ins->sreg1 = G_BYTE_ORDER == G_BIG_ENDIAN ? MONO_LVREG_MS (in->dreg) : MONO_LVREG_LS (in->dreg);
 				MONO_ADD_INS (cfg->cbb, ins);
 				mono_call_inst_add_outarg_reg (cfg, call, ins->dreg, ARMREG_R3, FALSE);
-			} else if (!mono_type_is_byref_internal (t) && (t->type == MONO_TYPE_R8)) {
+			} else if (!m_type_is_byref (t) && (t->type == MONO_TYPE_R8)) {
 				int creg;
 
 				/* This should work for soft-float as well */
@@ -2760,7 +2760,7 @@ mono_arch_emit_setret (MonoCompile *cfg, MonoMethod *method, MonoInst *val)
 {
 	MonoType *ret = mini_get_underlying_type (mono_method_signature_internal (method)->ret);
 
-	if (!mono_type_is_byref_internal (ret)) {
+	if (!m_type_is_byref (ret)) {
 		if (ret->type == MONO_TYPE_I8 || ret->type == MONO_TYPE_U8) {
 			MonoInst *ins;
 
@@ -2873,7 +2873,7 @@ dyn_call_supported (CallInfo *cinfo, MonoMethodSignature *sig)
 	for (i = 0; i < sig->param_count; ++i) {
 		MonoType *t = sig->params [i];
 
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			continue;
 
 		t = mini_get_underlying_type (t);
@@ -2987,7 +2987,7 @@ mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, g
 			g_assert_not_reached ();
 		}
 
-		if (mono_type_is_byref_internal (t)) {
+		if (m_type_is_byref (t)) {
 			p->regs [slot] = (host_mgreg_t)(gsize)*arg;
 			continue;
 		}

--- a/src/mono/mono/mini/mini-arm64-gsharedvt.c
+++ b/src/mono/mono/mini/mini-arm64-gsharedvt.c
@@ -345,7 +345,7 @@ mono_arch_get_gsharedvt_call_info (MonoMemoryManager *mem_manager, gpointer addr
 	if (var_ret) {
 		switch (cinfo->ret.storage) {
 		case ArgInIReg:
-			if (!gsharedvt_in || sig->ret->byref) {
+			if (!gsharedvt_in || mono_type_is_byref_internal (sig->ret)) {
 				info->ret_marshal = GSHAREDVT_RET_I8;
 			} else {
 				MonoType *rtype = mini_get_underlying_type (sig->ret);

--- a/src/mono/mono/mini/mini-arm64-gsharedvt.c
+++ b/src/mono/mono/mini/mini-arm64-gsharedvt.c
@@ -345,7 +345,7 @@ mono_arch_get_gsharedvt_call_info (MonoMemoryManager *mem_manager, gpointer addr
 	if (var_ret) {
 		switch (cinfo->ret.storage) {
 		case ArgInIReg:
-			if (!gsharedvt_in || mono_type_is_byref_internal (sig->ret)) {
+			if (!gsharedvt_in || m_type_is_byref (sig->ret)) {
 				info->ret_marshal = GSHAREDVT_RET_I8;
 			} else {
 				MonoType *rtype = mini_get_underlying_type (sig->ret);

--- a/src/mono/mono/mini/mini-arm64.c
+++ b/src/mono/mono/mini/mini-arm64.c
@@ -1182,7 +1182,7 @@ is_hfa (MonoType *t, int *out_nfields, int *out_esize, int *field_offsets)
 			}
 			nfields += nested_nfields;
 		} else {
-			if (!(!mono_type_is_byref_internal (ftype) && (ftype->type == MONO_TYPE_R4 || ftype->type == MONO_TYPE_R8)))
+			if (!(!m_type_is_byref (ftype) && (ftype->type == MONO_TYPE_R4 || ftype->type == MONO_TYPE_R8)))
 				return FALSE;
 			if (prev_ftype && prev_ftype->type != ftype->type)
 				return FALSE;
@@ -1720,7 +1720,7 @@ mono_arch_dyn_call_prepare (MonoMethodSignature *sig)
 	for (aindex = 0; aindex < sig->param_count; aindex++) {
 		MonoType *t = info->param_types [aindex];
 
-		if (mono_type_is_byref_internal (t))
+		if (m_type_is_byref (t))
 			continue;
 
 		switch (t->type) {
@@ -1819,7 +1819,7 @@ mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, g
 			slot = ainfo->reg;
 		}
 
-		if (mono_type_is_byref_internal (t)) {
+		if (m_type_is_byref (t)) {
 			p->regs [slot] = (host_mgreg_t)*arg;
 			continue;
 		}

--- a/src/mono/mono/mini/mini-arm64.c
+++ b/src/mono/mono/mini/mini-arm64.c
@@ -1182,7 +1182,7 @@ is_hfa (MonoType *t, int *out_nfields, int *out_esize, int *field_offsets)
 			}
 			nfields += nested_nfields;
 		} else {
-			if (!(!ftype->byref && (ftype->type == MONO_TYPE_R4 || ftype->type == MONO_TYPE_R8)))
+			if (!(!mono_type_is_byref_internal (ftype) && (ftype->type == MONO_TYPE_R4 || ftype->type == MONO_TYPE_R8)))
 				return FALSE;
 			if (prev_ftype && prev_ftype->type != ftype->type)
 				return FALSE;
@@ -1720,7 +1720,7 @@ mono_arch_dyn_call_prepare (MonoMethodSignature *sig)
 	for (aindex = 0; aindex < sig->param_count; aindex++) {
 		MonoType *t = info->param_types [aindex];
 
-		if (t->byref)
+		if (mono_type_is_byref_internal (t))
 			continue;
 
 		switch (t->type) {
@@ -1819,7 +1819,7 @@ mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, g
 			slot = ainfo->reg;
 		}
 
-		if (t->byref) {
+		if (mono_type_is_byref_internal (t)) {
 			p->regs [slot] = (host_mgreg_t)*arg;
 			continue;
 		}

--- a/src/mono/mono/mini/mini-codegen.c
+++ b/src/mono/mono/mini/mini-codegen.c
@@ -2751,7 +2751,7 @@ mini_type_is_hfa (MonoType *t, int *out_nfields, int *out_esize)
 			prev_ftype = ftype;
 			nfields += nested_nfields;
 		} else {
-			if (!(!mono_type_is_byref_internal (ftype) && (ftype->type == MONO_TYPE_R4 || ftype->type == MONO_TYPE_R8)))
+			if (!(!m_type_is_byref (ftype) && (ftype->type == MONO_TYPE_R4 || ftype->type == MONO_TYPE_R8)))
 				return FALSE;
 			if (prev_ftype && prev_ftype->type != ftype->type)
 				return FALSE;

--- a/src/mono/mono/mini/mini-codegen.c
+++ b/src/mono/mono/mini/mini-codegen.c
@@ -2751,7 +2751,7 @@ mini_type_is_hfa (MonoType *t, int *out_nfields, int *out_esize)
 			prev_ftype = ftype;
 			nfields += nested_nfields;
 		} else {
-			if (!(!ftype->byref && (ftype->type == MONO_TYPE_R4 || ftype->type == MONO_TYPE_R8)))
+			if (!(!mono_type_is_byref_internal (ftype) && (ftype->type == MONO_TYPE_R4 || ftype->type == MONO_TYPE_R8)))
 				return FALSE;
 			if (prev_ftype && prev_ftype->type != ftype->type)
 				return FALSE;

--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -1260,7 +1260,7 @@ get_wrapper_shared_vtype (MonoType *t)
 static MonoType*
 get_wrapper_shared_type_full (MonoType *t, gboolean is_field)
 {
-	if (mono_type_is_byref_internal (t))
+	if (m_type_is_byref (t))
 		return m_class_get_this_arg (mono_defaults.int_class);
 	t = mini_get_underlying_type (t);
 
@@ -1381,7 +1381,7 @@ get_wrapper_shared_type_reg (MonoType *t, gboolean pinvoke)
 	MonoType *orig_t = t;
 
 	t = get_wrapper_shared_type (t);
-	if (mono_type_is_byref_internal (t))
+	if (m_type_is_byref (t))
 		return t;
 
 	switch (t->type) {
@@ -1507,7 +1507,7 @@ mini_get_gsharedvt_in_sig_wrapper (MonoMethodSignature *sig)
 	}
 	for (i = 0; i < sig->param_count; i++) {
 		gsharedvt_sig->params [pindex] = sig->params [i];
-		if (!mono_type_is_byref_internal (sig->params [i])) {
+		if (!m_type_is_byref (sig->params [i])) {
 			gsharedvt_sig->params [pindex] = mono_metadata_type_dup (NULL, gsharedvt_sig->params [pindex]);
 			gsharedvt_sig->params [pindex]->byref__ = 1;
 		}
@@ -1534,7 +1534,7 @@ mini_get_gsharedvt_in_sig_wrapper (MonoMethodSignature *sig)
 	if (sig->ret->type != MONO_TYPE_VOID)
 		mono_mb_emit_ldloc_addr (mb, retval_var);
 	for (i = 0; i < sig->param_count; i++) {
-		if (mono_type_is_byref_internal (sig->params [i]))
+		if (m_type_is_byref (sig->params [i]))
 			mono_mb_emit_ldarg (mb, i + (sig->hasthis == TRUE));
 		else
 			mono_mb_emit_ldarg_addr (mb, i + (sig->hasthis == TRUE));
@@ -1621,7 +1621,7 @@ mini_get_gsharedvt_out_sig_wrapper (MonoMethodSignature *sig)
 	for (i = 0; i < sig->param_count; i++) {
 		csig->params [pindex] = sig->params [i];
 		param_names [pindex] = g_strdup_printf ("%d", i);
-		if (!mono_type_is_byref_internal (sig->params [i])) {
+		if (!m_type_is_byref (sig->params [i])) {
 			csig->params [pindex] = mono_metadata_type_dup (NULL, csig->params [pindex]);
 			csig->params [pindex]->byref__ = 1;
 		}
@@ -1655,7 +1655,7 @@ mini_get_gsharedvt_out_sig_wrapper (MonoMethodSignature *sig)
 	if (sig->hasthis)
 		mono_mb_emit_ldarg (mb, 0);
 	for (i = 0; i < sig->param_count; i++) {
-		if (mono_type_is_byref_internal (sig->params [i])) {
+		if (m_type_is_byref (sig->params [i])) {
 			mono_mb_emit_ldarg (mb, args_start + i);
 		} else {
 			ldind_op = mono_type_to_ldind (sig->params [i]);
@@ -1769,7 +1769,7 @@ mini_get_interp_in_wrapper (MonoMethodSignature *sig)
 	memcpy (csig, sig, mono_metadata_signature_size (sig));
 
 	for (i = 0; i < sig->param_count; i++) {
-		if (mono_type_is_byref_internal (sig->params [i]))
+		if (m_type_is_byref (sig->params [i]))
 			csig->params [i] = m_class_get_this_arg (mono_defaults.int_class);
 	}
 
@@ -1804,7 +1804,7 @@ mini_get_interp_in_wrapper (MonoMethodSignature *sig)
 		}
 		for (i = 0; i < sig->param_count; i++) {
 			entry_sig->params [pindex] = sig->params [i];
-			if (!mono_type_is_byref_internal (sig->params [i])) {
+			if (!m_type_is_byref (sig->params [i])) {
 				entry_sig->params [pindex] = mono_metadata_type_dup (NULL, entry_sig->params [pindex]);
 				entry_sig->params [pindex]->byref__ = 1;
 			}
@@ -1852,7 +1852,7 @@ mini_get_interp_in_wrapper (MonoMethodSignature *sig)
 			mono_mb_emit_ldloc (mb, args_var);
 			mono_mb_emit_icon (mb, TARGET_SIZEOF_VOID_P * i);
 			mono_mb_emit_byte (mb, CEE_ADD);
-			if (mono_type_is_byref_internal (sig->params [i]))
+			if (m_type_is_byref (sig->params [i]))
 				mono_mb_emit_ldarg (mb, i + (sig->hasthis == TRUE));
 			else
 				mono_mb_emit_ldarg_addr (mb, i + (sig->hasthis == TRUE));
@@ -1878,7 +1878,7 @@ mini_get_interp_in_wrapper (MonoMethodSignature *sig)
 		else if (sig->ret->type != MONO_TYPE_VOID)
 			mono_mb_emit_ldloc_addr (mb, retval_var);
 		for (i = 0; i < sig->param_count; i++) {
-			if (mono_type_is_byref_internal (sig->params [i]))
+			if (m_type_is_byref (sig->params [i]))
 				mono_mb_emit_ldarg (mb, i + (sig->hasthis == TRUE));
 			else
 				mono_mb_emit_ldarg_addr (mb, i + (sig->hasthis == TRUE));
@@ -3218,10 +3218,10 @@ type_is_sharable (MonoType *type, gboolean allow_type_vars, gboolean allow_parti
 		return TRUE;
 
 	/* Allow non ref arguments if they are primitive types or enums (partial sharing). */
-	if (allow_partial && !mono_type_is_byref_internal (type) && (((type->type >= MONO_TYPE_BOOLEAN) && (type->type <= MONO_TYPE_R8)) || (type->type == MONO_TYPE_I) || (type->type == MONO_TYPE_U) || (type->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (type->data.klass))))
+	if (allow_partial && !m_type_is_byref (type) && (((type->type >= MONO_TYPE_BOOLEAN) && (type->type <= MONO_TYPE_R8)) || (type->type == MONO_TYPE_I) || (type->type == MONO_TYPE_U) || (type->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (type->data.klass))))
 		return TRUE;
 
-	if (allow_partial && !mono_type_is_byref_internal (type) && type->type == MONO_TYPE_GENERICINST && MONO_TYPE_ISSTRUCT (type)) {
+	if (allow_partial && !m_type_is_byref (type) && type->type == MONO_TYPE_GENERICINST && MONO_TYPE_ISSTRUCT (type)) {
 		MonoGenericClass *gclass = type->data.generic_class;
 
 		if (gclass->context.class_inst && !mini_generic_inst_is_sharable (gclass->context.class_inst, allow_type_vars, allow_partial))
@@ -3723,9 +3723,9 @@ mini_class_get_context (MonoClass *klass)
 static MonoType*
 mini_get_basic_type_from_generic (MonoType *type)
 {
-	if (!mono_type_is_byref_internal (type) && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR) && mini_is_gsharedvt_type (type))
+	if (!m_type_is_byref (type) && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR) && mini_is_gsharedvt_type (type))
 		return type;
-	else if (!mono_type_is_byref_internal (type) && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR)) {
+	else if (!m_type_is_byref (type) && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR)) {
 		MonoType *constraint = type->data.generic_param->gshared_constraint;
 		/* The gparam constraint encodes the type this gparam can represent */
 		if (!constraint) {
@@ -3753,9 +3753,9 @@ mini_type_get_underlying_type (MonoType *type)
 {
 	type = mini_native_type_replace_type (type);
 
-	if (mono_type_is_byref_internal (type))
+	if (m_type_is_byref (type))
 		return mono_get_int_type ();
-	if (!mono_type_is_byref_internal (type) && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR) && mini_is_gsharedvt_type (type))
+	if (!m_type_is_byref (type) && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR) && mini_is_gsharedvt_type (type))
 		return type;
 	type = mini_get_basic_type_from_generic (mono_type_get_underlying_type (type));
 	switch (type->type) {
@@ -4054,7 +4054,7 @@ get_shared_type (MonoType *t, MonoType *type)
 {
 	MonoTypeEnum ttype;
 
-	if (!mono_type_is_byref_internal (type) && type->type == MONO_TYPE_GENERICINST && MONO_TYPE_ISSTRUCT (type)) {
+	if (!m_type_is_byref (type) && type->type == MONO_TYPE_GENERICINST && MONO_TYPE_ISSTRUCT (type)) {
 		ERROR_DECL (error);
 		MonoGenericClass *gclass = type->data.generic_class;
 		MonoGenericContext context;
@@ -4356,7 +4356,7 @@ mini_is_gsharedvt_type (MonoType *t)
 {
 	int i;
 
-	if (mono_type_is_byref_internal (t))
+	if (m_type_is_byref (t))
 		return FALSE;
 	if ((t->type == MONO_TYPE_VAR || t->type == MONO_TYPE_MVAR) && t->data.generic_param->gshared_constraint && t->data.generic_param->gshared_constraint->type == MONO_TYPE_VALUETYPE)
 		return TRUE;
@@ -4446,7 +4446,7 @@ is_variable_size (MonoType *t)
 {
 	int i;
 
-	if (mono_type_is_byref_internal (t))
+	if (m_type_is_byref (t))
 		return FALSE;
 
 	if (t->type == MONO_TYPE_VAR || t->type == MONO_TYPE_MVAR) {

--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -1260,7 +1260,7 @@ get_wrapper_shared_vtype (MonoType *t)
 static MonoType*
 get_wrapper_shared_type_full (MonoType *t, gboolean is_field)
 {
-	if (t->byref)
+	if (mono_type_is_byref_internal (t))
 		return m_class_get_this_arg (mono_defaults.int_class);
 	t = mini_get_underlying_type (t);
 
@@ -1381,7 +1381,7 @@ get_wrapper_shared_type_reg (MonoType *t, gboolean pinvoke)
 	MonoType *orig_t = t;
 
 	t = get_wrapper_shared_type (t);
-	if (t->byref)
+	if (mono_type_is_byref_internal (t))
 		return t;
 
 	switch (t->type) {
@@ -1507,9 +1507,9 @@ mini_get_gsharedvt_in_sig_wrapper (MonoMethodSignature *sig)
 	}
 	for (i = 0; i < sig->param_count; i++) {
 		gsharedvt_sig->params [pindex] = sig->params [i];
-		if (!sig->params [i]->byref) {
+		if (!mono_type_is_byref_internal (sig->params [i])) {
 			gsharedvt_sig->params [pindex] = mono_metadata_type_dup (NULL, gsharedvt_sig->params [pindex]);
-			gsharedvt_sig->params [pindex]->byref = 1;
+			gsharedvt_sig->params [pindex]->byref__ = 1;
 		}
 		pindex ++;
 	}
@@ -1534,7 +1534,7 @@ mini_get_gsharedvt_in_sig_wrapper (MonoMethodSignature *sig)
 	if (sig->ret->type != MONO_TYPE_VOID)
 		mono_mb_emit_ldloc_addr (mb, retval_var);
 	for (i = 0; i < sig->param_count; i++) {
-		if (sig->params [i]->byref)
+		if (mono_type_is_byref_internal (sig->params [i]))
 			mono_mb_emit_ldarg (mb, i + (sig->hasthis == TRUE));
 		else
 			mono_mb_emit_ldarg_addr (mb, i + (sig->hasthis == TRUE));
@@ -1621,9 +1621,9 @@ mini_get_gsharedvt_out_sig_wrapper (MonoMethodSignature *sig)
 	for (i = 0; i < sig->param_count; i++) {
 		csig->params [pindex] = sig->params [i];
 		param_names [pindex] = g_strdup_printf ("%d", i);
-		if (!sig->params [i]->byref) {
+		if (!mono_type_is_byref_internal (sig->params [i])) {
 			csig->params [pindex] = mono_metadata_type_dup (NULL, csig->params [pindex]);
-			csig->params [pindex]->byref = 1;
+			csig->params [pindex]->byref__ = 1;
 		}
 		pindex ++;
 	}
@@ -1655,7 +1655,7 @@ mini_get_gsharedvt_out_sig_wrapper (MonoMethodSignature *sig)
 	if (sig->hasthis)
 		mono_mb_emit_ldarg (mb, 0);
 	for (i = 0; i < sig->param_count; i++) {
-		if (sig->params [i]->byref) {
+		if (mono_type_is_byref_internal (sig->params [i])) {
 			mono_mb_emit_ldarg (mb, args_start + i);
 		} else {
 			ldind_op = mono_type_to_ldind (sig->params [i]);
@@ -1769,7 +1769,7 @@ mini_get_interp_in_wrapper (MonoMethodSignature *sig)
 	memcpy (csig, sig, mono_metadata_signature_size (sig));
 
 	for (i = 0; i < sig->param_count; i++) {
-		if (sig->params [i]->byref)
+		if (mono_type_is_byref_internal (sig->params [i]))
 			csig->params [i] = m_class_get_this_arg (mono_defaults.int_class);
 	}
 
@@ -1804,9 +1804,9 @@ mini_get_interp_in_wrapper (MonoMethodSignature *sig)
 		}
 		for (i = 0; i < sig->param_count; i++) {
 			entry_sig->params [pindex] = sig->params [i];
-			if (!sig->params [i]->byref) {
+			if (!mono_type_is_byref_internal (sig->params [i])) {
 				entry_sig->params [pindex] = mono_metadata_type_dup (NULL, entry_sig->params [pindex]);
-				entry_sig->params [pindex]->byref = 1;
+				entry_sig->params [pindex]->byref__ = 1;
 			}
 			pindex ++;
 		}
@@ -1852,7 +1852,7 @@ mini_get_interp_in_wrapper (MonoMethodSignature *sig)
 			mono_mb_emit_ldloc (mb, args_var);
 			mono_mb_emit_icon (mb, TARGET_SIZEOF_VOID_P * i);
 			mono_mb_emit_byte (mb, CEE_ADD);
-			if (sig->params [i]->byref)
+			if (mono_type_is_byref_internal (sig->params [i]))
 				mono_mb_emit_ldarg (mb, i + (sig->hasthis == TRUE));
 			else
 				mono_mb_emit_ldarg_addr (mb, i + (sig->hasthis == TRUE));
@@ -1878,7 +1878,7 @@ mini_get_interp_in_wrapper (MonoMethodSignature *sig)
 		else if (sig->ret->type != MONO_TYPE_VOID)
 			mono_mb_emit_ldloc_addr (mb, retval_var);
 		for (i = 0; i < sig->param_count; i++) {
-			if (sig->params [i]->byref)
+			if (mono_type_is_byref_internal (sig->params [i]))
 				mono_mb_emit_ldarg (mb, i + (sig->hasthis == TRUE));
 			else
 				mono_mb_emit_ldarg_addr (mb, i + (sig->hasthis == TRUE));
@@ -3218,10 +3218,10 @@ type_is_sharable (MonoType *type, gboolean allow_type_vars, gboolean allow_parti
 		return TRUE;
 
 	/* Allow non ref arguments if they are primitive types or enums (partial sharing). */
-	if (allow_partial && !type->byref && (((type->type >= MONO_TYPE_BOOLEAN) && (type->type <= MONO_TYPE_R8)) || (type->type == MONO_TYPE_I) || (type->type == MONO_TYPE_U) || (type->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (type->data.klass))))
+	if (allow_partial && !mono_type_is_byref_internal (type) && (((type->type >= MONO_TYPE_BOOLEAN) && (type->type <= MONO_TYPE_R8)) || (type->type == MONO_TYPE_I) || (type->type == MONO_TYPE_U) || (type->type == MONO_TYPE_VALUETYPE && m_class_is_enumtype (type->data.klass))))
 		return TRUE;
 
-	if (allow_partial && !type->byref && type->type == MONO_TYPE_GENERICINST && MONO_TYPE_ISSTRUCT (type)) {
+	if (allow_partial && !mono_type_is_byref_internal (type) && type->type == MONO_TYPE_GENERICINST && MONO_TYPE_ISSTRUCT (type)) {
 		MonoGenericClass *gclass = type->data.generic_class;
 
 		if (gclass->context.class_inst && !mini_generic_inst_is_sharable (gclass->context.class_inst, allow_type_vars, allow_partial))
@@ -3723,9 +3723,9 @@ mini_class_get_context (MonoClass *klass)
 static MonoType*
 mini_get_basic_type_from_generic (MonoType *type)
 {
-	if (!type->byref && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR) && mini_is_gsharedvt_type (type))
+	if (!mono_type_is_byref_internal (type) && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR) && mini_is_gsharedvt_type (type))
 		return type;
-	else if (!type->byref && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR)) {
+	else if (!mono_type_is_byref_internal (type) && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR)) {
 		MonoType *constraint = type->data.generic_param->gshared_constraint;
 		/* The gparam constraint encodes the type this gparam can represent */
 		if (!constraint) {
@@ -3753,9 +3753,9 @@ mini_type_get_underlying_type (MonoType *type)
 {
 	type = mini_native_type_replace_type (type);
 
-	if (type->byref)
+	if (mono_type_is_byref_internal (type))
 		return mono_get_int_type ();
-	if (!type->byref && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR) && mini_is_gsharedvt_type (type))
+	if (!mono_type_is_byref_internal (type) && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR) && mini_is_gsharedvt_type (type))
 		return type;
 	type = mini_get_basic_type_from_generic (mono_type_get_underlying_type (type));
 	switch (type->type) {
@@ -4054,7 +4054,7 @@ get_shared_type (MonoType *t, MonoType *type)
 {
 	MonoTypeEnum ttype;
 
-	if (!type->byref && type->type == MONO_TYPE_GENERICINST && MONO_TYPE_ISSTRUCT (type)) {
+	if (!mono_type_is_byref_internal (type) && type->type == MONO_TYPE_GENERICINST && MONO_TYPE_ISSTRUCT (type)) {
 		ERROR_DECL (error);
 		MonoGenericClass *gclass = type->data.generic_class;
 		MonoGenericContext context;
@@ -4356,7 +4356,7 @@ mini_is_gsharedvt_type (MonoType *t)
 {
 	int i;
 
-	if (t->byref)
+	if (mono_type_is_byref_internal (t))
 		return FALSE;
 	if ((t->type == MONO_TYPE_VAR || t->type == MONO_TYPE_MVAR) && t->data.generic_param->gshared_constraint && t->data.generic_param->gshared_constraint->type == MONO_TYPE_VALUETYPE)
 		return TRUE;
@@ -4446,7 +4446,7 @@ is_variable_size (MonoType *t)
 {
 	int i;
 
-	if (t->byref)
+	if (mono_type_is_byref_internal (t))
 		return FALSE;
 
 	if (t->type == MONO_TYPE_VAR || t->type == MONO_TYPE_MVAR) {

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -751,7 +751,7 @@ inst_c1_type (const MonoInst *ins)
 static LLVMTypeRef
 type_to_llvm_type (EmitContext *ctx, MonoType *t)
 {
-	if (mono_type_is_byref_internal (t))
+	if (m_type_is_byref (t))
 		return ThisType ();
 
 	t = mini_get_underlying_type (t);
@@ -845,7 +845,7 @@ static gboolean
 type_is_unsigned (EmitContext *ctx, MonoType *t)
 {
 	t = mini_get_underlying_type (t);
-	if (mono_type_is_byref_internal (t))
+	if (m_type_is_byref (t))
 		return FALSE;
 	return primitive_type_is_unsigned (t->type);
 }
@@ -1414,7 +1414,7 @@ emit_volatile_load (EmitContext *ctx, int vreg)
 
 	v = mono_llvm_build_load (ctx->builder, ctx->addresses [vreg], "", TRUE);
 	t = ctx->vreg_cli_types [vreg];
-	if (t && !mono_type_is_byref_internal (t)) {
+	if (t && !m_type_is_byref (t)) {
 		/* 
 		 * Might have to zero extend since llvm doesn't have 
 		 * unsigned types.
@@ -3912,7 +3912,7 @@ emit_entry_bb (EmitContext *ctx, LLVMBuilderRef builder)
 		default: {
 			LLVMTypeRef t;
 			/* Needed to avoid phi argument mismatch errors since operations on pointers produce i32/i64 */
-			if (mono_type_is_byref_internal (ainfo->type))
+			if (m_type_is_byref (ainfo->type))
 				t = IntPtrType ();
 			else
 				t = type_to_llvm_type (ctx, ainfo->type);
@@ -11126,7 +11126,7 @@ get_llvm_call_info (MonoCompile *cfg, MonoMethodSignature *sig)
 		}
 
 		for (i = 0; i < sig->param_count; ++i) {
-			if (mono_type_is_byref_internal (sig->params [i]))
+			if (m_type_is_byref (sig->params [i]))
 				linfo->args [pindex].storage = LLVMArgNormal;
 			else if (mini_is_gsharedvt_variable_type (sig->params [i]))
 				linfo->args [pindex].storage = LLVMArgGsharedvtVariable;

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -751,7 +751,7 @@ inst_c1_type (const MonoInst *ins)
 static LLVMTypeRef
 type_to_llvm_type (EmitContext *ctx, MonoType *t)
 {
-	if (t->byref)
+	if (mono_type_is_byref_internal (t))
 		return ThisType ();
 
 	t = mini_get_underlying_type (t);
@@ -845,7 +845,7 @@ static gboolean
 type_is_unsigned (EmitContext *ctx, MonoType *t)
 {
 	t = mini_get_underlying_type (t);
-	if (t->byref)
+	if (mono_type_is_byref_internal (t))
 		return FALSE;
 	return primitive_type_is_unsigned (t->type);
 }
@@ -1414,7 +1414,7 @@ emit_volatile_load (EmitContext *ctx, int vreg)
 
 	v = mono_llvm_build_load (ctx->builder, ctx->addresses [vreg], "", TRUE);
 	t = ctx->vreg_cli_types [vreg];
-	if (t && !t->byref) {
+	if (t && !mono_type_is_byref_internal (t)) {
 		/* 
 		 * Might have to zero extend since llvm doesn't have 
 		 * unsigned types.
@@ -3912,7 +3912,7 @@ emit_entry_bb (EmitContext *ctx, LLVMBuilderRef builder)
 		default: {
 			LLVMTypeRef t;
 			/* Needed to avoid phi argument mismatch errors since operations on pointers produce i32/i64 */
-			if (ainfo->type->byref)
+			if (mono_type_is_byref_internal (ainfo->type))
 				t = IntPtrType ();
 			else
 				t = type_to_llvm_type (ctx, ainfo->type);
@@ -11126,7 +11126,7 @@ get_llvm_call_info (MonoCompile *cfg, MonoMethodSignature *sig)
 		}
 
 		for (i = 0; i < sig->param_count; ++i) {
-			if (sig->params [i]->byref)
+			if (mono_type_is_byref_internal (sig->params [i]))
 				linfo->args [pindex].storage = LLVMArgNormal;
 			else if (mini_is_gsharedvt_variable_type (sig->params [i]))
 				linfo->args [pindex].storage = LLVMArgGsharedvtVariable;

--- a/src/mono/mono/mini/mini-native-types.c
+++ b/src/mono/mono/mini/mini-native-types.c
@@ -95,9 +95,9 @@ mini_magic_type_size (MonoCompile *cfg, MonoType *type)
 		return 4;
 	else if (type->type == MONO_TYPE_I8 || type->type == MONO_TYPE_U8)
 		return 8;
-	else if (type->type == MONO_TYPE_R4 && !mono_type_is_byref_internal (type) && (!cfg || cfg->r4fp))
+	else if (type->type == MONO_TYPE_R4 && !m_type_is_byref (type) && (!cfg || cfg->r4fp))
 		return 4;
-	else if (type->type == MONO_TYPE_R8 && !mono_type_is_byref_internal (type))
+	else if (type->type == MONO_TYPE_R8 && !m_type_is_byref (type))
 		return 8;
 	return TARGET_SIZEOF_VOID_P;
 }
@@ -471,12 +471,12 @@ mini_native_type_replace_type (MonoType *type)
 	klass = type->data.klass;
 
 	if (mono_class_is_magic_int (klass))
-		return mono_type_is_byref_internal (type) ? m_class_get_this_arg (mono_defaults.int_class) : mono_get_int_type ();
+		return m_type_is_byref (type) ? m_class_get_this_arg (mono_defaults.int_class) : mono_get_int_type ();
 	if (mono_class_is_magic_float (klass))
 #if TARGET_SIZEOF_VOID_P == 8
-		return mono_type_is_byref_internal (type) ? m_class_get_this_arg (mono_defaults.double_class) : m_class_get_byval_arg (mono_defaults.double_class);
+		return m_type_is_byref (type) ? m_class_get_this_arg (mono_defaults.double_class) : m_class_get_byval_arg (mono_defaults.double_class);
 #else
-		return mono_type_is_byref_internal (type) ? m_class_get_this_arg (mono_defaults.single_class) : m_class_get_byval_arg (mono_defaults.single_class);
+		return m_type_is_byref (type) ? m_class_get_this_arg (mono_defaults.single_class) : m_class_get_byval_arg (mono_defaults.single_class);
 #endif
 	return type;
 }

--- a/src/mono/mono/mini/mini-native-types.c
+++ b/src/mono/mono/mini/mini-native-types.c
@@ -95,9 +95,9 @@ mini_magic_type_size (MonoCompile *cfg, MonoType *type)
 		return 4;
 	else if (type->type == MONO_TYPE_I8 || type->type == MONO_TYPE_U8)
 		return 8;
-	else if (type->type == MONO_TYPE_R4 && !type->byref && (!cfg || cfg->r4fp))
+	else if (type->type == MONO_TYPE_R4 && !mono_type_is_byref_internal (type) && (!cfg || cfg->r4fp))
 		return 4;
-	else if (type->type == MONO_TYPE_R8 && !type->byref)
+	else if (type->type == MONO_TYPE_R8 && !mono_type_is_byref_internal (type))
 		return 8;
 	return TARGET_SIZEOF_VOID_P;
 }
@@ -471,12 +471,12 @@ mini_native_type_replace_type (MonoType *type)
 	klass = type->data.klass;
 
 	if (mono_class_is_magic_int (klass))
-		return type->byref ? m_class_get_this_arg (mono_defaults.int_class) : mono_get_int_type ();
+		return mono_type_is_byref_internal (type) ? m_class_get_this_arg (mono_defaults.int_class) : mono_get_int_type ();
 	if (mono_class_is_magic_float (klass))
 #if TARGET_SIZEOF_VOID_P == 8
-		return type->byref ? m_class_get_this_arg (mono_defaults.double_class) : m_class_get_byval_arg (mono_defaults.double_class);
+		return mono_type_is_byref_internal (type) ? m_class_get_this_arg (mono_defaults.double_class) : m_class_get_byval_arg (mono_defaults.double_class);
 #else
-		return type->byref ? m_class_get_this_arg (mono_defaults.single_class) : m_class_get_byval_arg (mono_defaults.single_class);
+		return mono_type_is_byref_internal (type) ? m_class_get_this_arg (mono_defaults.single_class) : m_class_get_byval_arg (mono_defaults.single_class);
 #endif
 	return type;
 }

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -3039,7 +3039,7 @@ create_runtime_invoke_info (MonoMethod *method, gpointer compiled_method, gboole
 		for (i = 0; i < sig->param_count; ++i) {
 			MonoType *t = sig->params [i];
 
-			if (t->byref && t->type == MONO_TYPE_GENERICINST && mono_class_is_nullable (mono_class_from_mono_type_internal (t)))
+			if (mono_type_is_byref_internal (t) && t->type == MONO_TYPE_GENERICINST && mono_class_is_nullable (mono_class_from_mono_type_internal (t)))
 				supported = FALSE;
 		}
 
@@ -3186,7 +3186,7 @@ mono_llvmonly_runtime_invoke (MonoMethod *method, RuntimeInvokeInfo *info, void 
 	if (sig->hasthis)
 		args [pindex ++] = &obj;
 	if (sig->ret->type != MONO_TYPE_VOID) {
-		if (info->ret_box_class && !sig->ret->byref &&
+		if (info->ret_box_class && !mono_type_is_byref_internal (sig->ret) &&
 		    (sig->ret->type == MONO_TYPE_VALUETYPE ||
 		     (sig->ret->type == MONO_TYPE_GENERICINST && !MONO_TYPE_IS_REFERENCE (sig->ret)))) {
 			// if the return type is a struct, allocate enough stack space to hold it
@@ -3219,7 +3219,7 @@ mono_llvmonly_runtime_invoke (MonoMethod *method, RuntimeInvokeInfo *info, void 
 			params [i] = nullable_buf;
 		}
 
-		if (!t->byref && (MONO_TYPE_IS_REFERENCE (t) || t->type == MONO_TYPE_PTR)) {
+		if (!mono_type_is_byref_internal (t) && (MONO_TYPE_IS_REFERENCE (t) || t->type == MONO_TYPE_PTR)) {
 			param_refs [i] = params [i];
 			params [i] = &(param_refs [i]);
 		}
@@ -3234,7 +3234,7 @@ mono_llvmonly_runtime_invoke (MonoMethod *method, RuntimeInvokeInfo *info, void 
 	if (exc && *exc)
 		return NULL;
 
-	if (sig->ret->byref) {
+	if (mono_type_is_byref_internal (sig->ret)) {
 		if (*(gpointer*)retval == NULL) {
 			MonoClass *klass = mono_class_get_nullbyrefreturn_ex_class ();
 			MonoObject *ex = mono_object_new_checked (klass, error);
@@ -3246,14 +3246,14 @@ mono_llvmonly_runtime_invoke (MonoMethod *method, RuntimeInvokeInfo *info, void 
 
 	if (sig->ret->type != MONO_TYPE_VOID) {
 		if (info->ret_box_class) {
-			if (sig->ret->byref) {
+			if (mono_type_is_byref_internal (sig->ret)) {
 				return mono_value_box_checked (info->ret_box_class, *(gpointer*)retval, error);
 			} else {
 				MonoObject *ret = mono_value_box_checked (info->ret_box_class, retval, error);
 				return ret;
 			}
 		} else {
-			if (sig->ret->byref)
+			if (mono_type_is_byref_internal (sig->ret))
 				return **(MonoObject***)retval;
 			else
 				return *(MonoObject**)retval;
@@ -3417,7 +3417,7 @@ mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 		guint8 *retval = NULL;
 
 		/* if the return type is a struct and it's too big, allocate more space for it */
-		if (info->ret_box_class && !sig->ret->byref &&
+		if (info->ret_box_class && !mono_type_is_byref_internal (sig->ret) &&
 		    (sig->ret->type == MONO_TYPE_VALUETYPE ||
 		     (sig->ret->type == MONO_TYPE_GENERICINST && !MONO_TYPE_IS_REFERENCE (sig->ret)))) {
 			MonoClass *ret_klass = mono_class_from_mono_type_internal (sig->ret);
@@ -3438,7 +3438,7 @@ mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 		for (i = 0; i < sig->param_count; ++i) {
 			MonoType *t = sig->params [i];
 
-			if (t->byref) {
+			if (mono_type_is_byref_internal (t)) {
 				args [pindex ++] = &params [i];
 			} else if (MONO_TYPE_IS_REFERENCE (t) || t->type == MONO_TYPE_PTR) {
 				args [pindex ++] = &params [i];
@@ -3464,7 +3464,7 @@ mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 			return NULL;
 		}
 
-		if (sig->ret->byref) {
+		if (mono_type_is_byref_internal (sig->ret)) {
 			if (*(gpointer*)retval == NULL) {
 				MonoClass *klass = mono_class_get_nullbyrefreturn_ex_class ();
 				MonoObject *ex = mono_object_new_checked (klass, error);
@@ -3475,14 +3475,14 @@ mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 		}
 
 		if (info->ret_box_class) {
-			if (sig->ret->byref) {
+			if (mono_type_is_byref_internal (sig->ret)) {
 				return mono_value_box_checked (info->ret_box_class, *(gpointer*)retval, error);
 			} else {
 				MonoObject *boxed_ret = mono_value_box_checked (info->ret_box_class, retval, error);
 				return boxed_ret;
 			}
 		} else {
-			if (sig->ret->byref)
+			if (mono_type_is_byref_internal (sig->ret))
 				return **(MonoObject***)retval;
 			else
 				return *(MonoObject**)retval;

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -3039,7 +3039,7 @@ create_runtime_invoke_info (MonoMethod *method, gpointer compiled_method, gboole
 		for (i = 0; i < sig->param_count; ++i) {
 			MonoType *t = sig->params [i];
 
-			if (mono_type_is_byref_internal (t) && t->type == MONO_TYPE_GENERICINST && mono_class_is_nullable (mono_class_from_mono_type_internal (t)))
+			if (m_type_is_byref (t) && t->type == MONO_TYPE_GENERICINST && mono_class_is_nullable (mono_class_from_mono_type_internal (t)))
 				supported = FALSE;
 		}
 
@@ -3186,7 +3186,7 @@ mono_llvmonly_runtime_invoke (MonoMethod *method, RuntimeInvokeInfo *info, void 
 	if (sig->hasthis)
 		args [pindex ++] = &obj;
 	if (sig->ret->type != MONO_TYPE_VOID) {
-		if (info->ret_box_class && !mono_type_is_byref_internal (sig->ret) &&
+		if (info->ret_box_class && !m_type_is_byref (sig->ret) &&
 		    (sig->ret->type == MONO_TYPE_VALUETYPE ||
 		     (sig->ret->type == MONO_TYPE_GENERICINST && !MONO_TYPE_IS_REFERENCE (sig->ret)))) {
 			// if the return type is a struct, allocate enough stack space to hold it
@@ -3219,7 +3219,7 @@ mono_llvmonly_runtime_invoke (MonoMethod *method, RuntimeInvokeInfo *info, void 
 			params [i] = nullable_buf;
 		}
 
-		if (!mono_type_is_byref_internal (t) && (MONO_TYPE_IS_REFERENCE (t) || t->type == MONO_TYPE_PTR)) {
+		if (!m_type_is_byref (t) && (MONO_TYPE_IS_REFERENCE (t) || t->type == MONO_TYPE_PTR)) {
 			param_refs [i] = params [i];
 			params [i] = &(param_refs [i]);
 		}
@@ -3234,7 +3234,7 @@ mono_llvmonly_runtime_invoke (MonoMethod *method, RuntimeInvokeInfo *info, void 
 	if (exc && *exc)
 		return NULL;
 
-	if (mono_type_is_byref_internal (sig->ret)) {
+	if (m_type_is_byref (sig->ret)) {
 		if (*(gpointer*)retval == NULL) {
 			MonoClass *klass = mono_class_get_nullbyrefreturn_ex_class ();
 			MonoObject *ex = mono_object_new_checked (klass, error);
@@ -3246,14 +3246,14 @@ mono_llvmonly_runtime_invoke (MonoMethod *method, RuntimeInvokeInfo *info, void 
 
 	if (sig->ret->type != MONO_TYPE_VOID) {
 		if (info->ret_box_class) {
-			if (mono_type_is_byref_internal (sig->ret)) {
+			if (m_type_is_byref (sig->ret)) {
 				return mono_value_box_checked (info->ret_box_class, *(gpointer*)retval, error);
 			} else {
 				MonoObject *ret = mono_value_box_checked (info->ret_box_class, retval, error);
 				return ret;
 			}
 		} else {
-			if (mono_type_is_byref_internal (sig->ret))
+			if (m_type_is_byref (sig->ret))
 				return **(MonoObject***)retval;
 			else
 				return *(MonoObject**)retval;
@@ -3417,7 +3417,7 @@ mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 		guint8 *retval = NULL;
 
 		/* if the return type is a struct and it's too big, allocate more space for it */
-		if (info->ret_box_class && !mono_type_is_byref_internal (sig->ret) &&
+		if (info->ret_box_class && !m_type_is_byref (sig->ret) &&
 		    (sig->ret->type == MONO_TYPE_VALUETYPE ||
 		     (sig->ret->type == MONO_TYPE_GENERICINST && !MONO_TYPE_IS_REFERENCE (sig->ret)))) {
 			MonoClass *ret_klass = mono_class_from_mono_type_internal (sig->ret);
@@ -3438,7 +3438,7 @@ mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 		for (i = 0; i < sig->param_count; ++i) {
 			MonoType *t = sig->params [i];
 
-			if (mono_type_is_byref_internal (t)) {
+			if (m_type_is_byref (t)) {
 				args [pindex ++] = &params [i];
 			} else if (MONO_TYPE_IS_REFERENCE (t) || t->type == MONO_TYPE_PTR) {
 				args [pindex ++] = &params [i];
@@ -3464,7 +3464,7 @@ mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 			return NULL;
 		}
 
-		if (mono_type_is_byref_internal (sig->ret)) {
+		if (m_type_is_byref (sig->ret)) {
 			if (*(gpointer*)retval == NULL) {
 				MonoClass *klass = mono_class_get_nullbyrefreturn_ex_class ();
 				MonoObject *ex = mono_object_new_checked (klass, error);
@@ -3475,14 +3475,14 @@ mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 		}
 
 		if (info->ret_box_class) {
-			if (mono_type_is_byref_internal (sig->ret)) {
+			if (m_type_is_byref (sig->ret)) {
 				return mono_value_box_checked (info->ret_box_class, *(gpointer*)retval, error);
 			} else {
 				MonoObject *boxed_ret = mono_value_box_checked (info->ret_box_class, retval, error);
 				return boxed_ret;
 			}
 		} else {
-			if (mono_type_is_byref_internal (sig->ret))
+			if (m_type_is_byref (sig->ret))
 				return **(MonoObject***)retval;
 			else
 				return *(MonoObject**)retval;

--- a/src/mono/mono/mini/mini-trampolines.c
+++ b/src/mono/mono/mini/mini-trampolines.c
@@ -1024,7 +1024,7 @@ mono_delegate_trampoline (host_mgreg_t *regs, guint8 *code, gpointer *arg, guint
 			if (sig->hasthis && m_class_is_valuetype (method->klass)) {
 				gboolean need_unbox = TRUE;
 
-				if (tramp_info->invoke_sig->param_count > sig->param_count && mono_type_is_byref_internal (tramp_info->invoke_sig->params [0]))
+				if (tramp_info->invoke_sig->param_count > sig->param_count && m_type_is_byref (tramp_info->invoke_sig->params [0]))
 					need_unbox = FALSE;
 
 				if (need_unbox) {

--- a/src/mono/mono/mini/mini-trampolines.c
+++ b/src/mono/mono/mini/mini-trampolines.c
@@ -1024,7 +1024,7 @@ mono_delegate_trampoline (host_mgreg_t *regs, guint8 *code, gpointer *arg, guint
 			if (sig->hasthis && m_class_is_valuetype (method->klass)) {
 				gboolean need_unbox = TRUE;
 
-				if (tramp_info->invoke_sig->param_count > sig->param_count && tramp_info->invoke_sig->params [0]->byref)
+				if (tramp_info->invoke_sig->param_count > sig->param_count && mono_type_is_byref_internal (tramp_info->invoke_sig->params [0]))
 					need_unbox = FALSE;
 
 				if (need_unbox) {

--- a/src/mono/mono/mini/mini-wasm.c
+++ b/src/mono/mono/mini/mini-wasm.c
@@ -272,7 +272,7 @@ mono_arch_emit_setret (MonoCompile *cfg, MonoMethod *method, MonoInst *val)
 {
 	MonoType *ret = mini_get_underlying_type (mono_method_signature_internal (method)->ret);
 
-	if (!ret->byref) {
+	if (!m_type_is_byref (ret)) {
 		if (ret->type == MONO_TYPE_R4) {
 			MONO_EMIT_NEW_UNALU (cfg, cfg->r4fp ? OP_RMOVE : OP_FMOVE, cfg->ret->dreg, val->dreg);
 			return;

--- a/src/mono/mono/mini/mini-x86-gsharedvt.c
+++ b/src/mono/mono/mini/mini-x86-gsharedvt.c
@@ -160,13 +160,13 @@ mono_arch_get_gsharedvt_call_info (MonoMemoryManager *mem_manager, gpointer addr
 	if (var_ret) {
 		switch (cinfo->ret.storage) {
 		case ArgInIReg:
-			if (gsharedvt_in && !sig->ret->byref && sig->ret->type == MONO_TYPE_I1)
+			if (gsharedvt_in && !mono_type_is_byref_internal (sig->ret) && sig->ret->type == MONO_TYPE_I1)
 				info->ret_marshal = GSHAREDVT_RET_I1;
-			else if (gsharedvt_in && !sig->ret->byref && (sig->ret->type == MONO_TYPE_U1 || sig->ret->type == MONO_TYPE_BOOLEAN))
+			else if (gsharedvt_in && !mono_type_is_byref_internal (sig->ret) && (sig->ret->type == MONO_TYPE_U1 || sig->ret->type == MONO_TYPE_BOOLEAN))
 				info->ret_marshal = GSHAREDVT_RET_U1;
-			else if (gsharedvt_in && !sig->ret->byref && sig->ret->type == MONO_TYPE_I2)
+			else if (gsharedvt_in && !mono_type_is_byref_internal (sig->ret) && sig->ret->type == MONO_TYPE_I2)
 				info->ret_marshal = GSHAREDVT_RET_I2;
-			else if (gsharedvt_in && !sig->ret->byref && (sig->ret->type == MONO_TYPE_U2 || sig->ret->type == MONO_TYPE_CHAR))
+			else if (gsharedvt_in && !mono_type_is_byref_internal (sig->ret) && (sig->ret->type == MONO_TYPE_U2 || sig->ret->type == MONO_TYPE_CHAR))
 				info->ret_marshal = GSHAREDVT_RET_U2;
 			else if (cinfo->ret.is_pair)
  				info->ret_marshal = GSHAREDVT_RET_IREGS;

--- a/src/mono/mono/mini/mini-x86-gsharedvt.c
+++ b/src/mono/mono/mini/mini-x86-gsharedvt.c
@@ -160,13 +160,13 @@ mono_arch_get_gsharedvt_call_info (MonoMemoryManager *mem_manager, gpointer addr
 	if (var_ret) {
 		switch (cinfo->ret.storage) {
 		case ArgInIReg:
-			if (gsharedvt_in && !mono_type_is_byref_internal (sig->ret) && sig->ret->type == MONO_TYPE_I1)
+			if (gsharedvt_in && !m_type_is_byref (sig->ret) && sig->ret->type == MONO_TYPE_I1)
 				info->ret_marshal = GSHAREDVT_RET_I1;
-			else if (gsharedvt_in && !mono_type_is_byref_internal (sig->ret) && (sig->ret->type == MONO_TYPE_U1 || sig->ret->type == MONO_TYPE_BOOLEAN))
+			else if (gsharedvt_in && !m_type_is_byref (sig->ret) && (sig->ret->type == MONO_TYPE_U1 || sig->ret->type == MONO_TYPE_BOOLEAN))
 				info->ret_marshal = GSHAREDVT_RET_U1;
-			else if (gsharedvt_in && !mono_type_is_byref_internal (sig->ret) && sig->ret->type == MONO_TYPE_I2)
+			else if (gsharedvt_in && !m_type_is_byref (sig->ret) && sig->ret->type == MONO_TYPE_I2)
 				info->ret_marshal = GSHAREDVT_RET_I2;
-			else if (gsharedvt_in && !mono_type_is_byref_internal (sig->ret) && (sig->ret->type == MONO_TYPE_U2 || sig->ret->type == MONO_TYPE_CHAR))
+			else if (gsharedvt_in && !m_type_is_byref (sig->ret) && (sig->ret->type == MONO_TYPE_U2 || sig->ret->type == MONO_TYPE_CHAR))
 				info->ret_marshal = GSHAREDVT_RET_U2;
 			else if (cinfo->ret.is_pair)
  				info->ret_marshal = GSHAREDVT_RET_IREGS;

--- a/src/mono/mono/mini/mini-x86.c
+++ b/src/mono/mono/mini/mini-x86.c
@@ -456,7 +456,7 @@ get_call_info_internal (CallInfo *cinfo, MonoMethodSignature *sig)
 			add_general (&gr, param_regs, &stack_size, &cinfo->sig_cookie);
 		}
 
-		if (mono_type_is_byref_internal (sig->params [i])) {
+		if (m_type_is_byref (sig->params [i])) {
 			add_general (&gr, param_regs, &stack_size, ainfo);
 			continue;
 		}
@@ -1331,7 +1331,7 @@ collect_fp_stack_space (MonoMethodSignature *sig, int start_arg, int *fp_arg_set
 
 	for (; start_arg < sig->param_count; ++start_arg) {
 		t = mini_get_underlying_type (sig->params [start_arg]);
-		if (!mono_type_is_byref_internal (t) && t->type == MONO_TYPE_R8) {
+		if (!m_type_is_byref (t) && t->type == MONO_TYPE_R8) {
 			fp_space += sizeof (double);
 			*fp_arg_setup = start_arg;
 		} else {
@@ -1612,7 +1612,7 @@ mono_arch_emit_call (MonoCompile *cfg, MonoCallInst *call)
 		} else {
 			switch (ainfo->storage) {
 			case ArgOnStack:
-				if (!mono_type_is_byref_internal (t)) {
+				if (!m_type_is_byref (t)) {
 					if (t->type == MONO_TYPE_R4) {
 						MONO_EMIT_NEW_STORE_MEMBASE (cfg, OP_STORER4_MEMBASE_REG, X86_ESP, ainfo->offset, in->dreg);
 						argsize = 4;
@@ -1747,7 +1747,7 @@ mono_arch_emit_setret (MonoCompile *cfg, MonoMethod *method, MonoInst *val)
 {
 	MonoType *ret = mini_get_underlying_type (mono_method_signature_internal (method)->ret);
 
-	if (!mono_type_is_byref_internal (ret)) {
+	if (!m_type_is_byref (ret)) {
 		if (ret->type == MONO_TYPE_R4) {
 			if (COMPILE_LLVM (cfg))
 				MONO_EMIT_NEW_UNALU (cfg, OP_FMOVE, cfg->ret->dreg, val->dreg);

--- a/src/mono/mono/mini/mini-x86.c
+++ b/src/mono/mono/mini/mini-x86.c
@@ -456,7 +456,7 @@ get_call_info_internal (CallInfo *cinfo, MonoMethodSignature *sig)
 			add_general (&gr, param_regs, &stack_size, &cinfo->sig_cookie);
 		}
 
-		if (sig->params [i]->byref) {
+		if (mono_type_is_byref_internal (sig->params [i])) {
 			add_general (&gr, param_regs, &stack_size, ainfo);
 			continue;
 		}
@@ -1331,7 +1331,7 @@ collect_fp_stack_space (MonoMethodSignature *sig, int start_arg, int *fp_arg_set
 
 	for (; start_arg < sig->param_count; ++start_arg) {
 		t = mini_get_underlying_type (sig->params [start_arg]);
-		if (!t->byref && t->type == MONO_TYPE_R8) {
+		if (!mono_type_is_byref_internal (t) && t->type == MONO_TYPE_R8) {
 			fp_space += sizeof (double);
 			*fp_arg_setup = start_arg;
 		} else {
@@ -1612,7 +1612,7 @@ mono_arch_emit_call (MonoCompile *cfg, MonoCallInst *call)
 		} else {
 			switch (ainfo->storage) {
 			case ArgOnStack:
-				if (!t->byref) {
+				if (!mono_type_is_byref_internal (t)) {
 					if (t->type == MONO_TYPE_R4) {
 						MONO_EMIT_NEW_STORE_MEMBASE (cfg, OP_STORER4_MEMBASE_REG, X86_ESP, ainfo->offset, in->dreg);
 						argsize = 4;
@@ -1747,7 +1747,7 @@ mono_arch_emit_setret (MonoCompile *cfg, MonoMethod *method, MonoInst *val)
 {
 	MonoType *ret = mini_get_underlying_type (mono_method_signature_internal (method)->ret);
 
-	if (!ret->byref) {
+	if (!mono_type_is_byref_internal (ret)) {
 		if (ret->type == MONO_TYPE_R4) {
 			if (COMPILE_LLVM (cfg))
 				MONO_EMIT_NEW_UNALU (cfg, OP_FMOVE, cfg->ret->dreg, val->dreg);

--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -440,7 +440,7 @@ guint
 mini_type_to_stind (MonoCompile* cfg, MonoType *type)
 {
 	type = mini_get_underlying_type (type);
-	if (cfg->gshared && !type->byref && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR)) {
+	if (cfg->gshared && !mono_type_is_byref_internal (type) && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR)) {
 		g_assert (mini_type_var_is_vt (type));
 		return CEE_STOBJ;
 	}
@@ -625,8 +625,8 @@ set_vreg_to_inst (MonoCompile *cfg, int vreg, MonoInst *inst)
 	cfg->vreg_to_inst [vreg] = inst;
 }
 
-#define mono_type_is_long(type) (!(type)->byref && ((mono_type_get_underlying_type (type)->type == MONO_TYPE_I8) || (mono_type_get_underlying_type (type)->type == MONO_TYPE_U8)))
-#define mono_type_is_float(type) (!(type)->byref && (((type)->type == MONO_TYPE_R8) || ((type)->type == MONO_TYPE_R4)))
+#define mono_type_is_long(type) (!mono_type_is_byref_internal (type) && ((mono_type_get_underlying_type (type)->type == MONO_TYPE_I8) || (mono_type_get_underlying_type (type)->type == MONO_TYPE_U8)))
+#define mono_type_is_float(type) (!mono_type_is_byref_internal (type) && (((type)->type == MONO_TYPE_R8) || ((type)->type == MONO_TYPE_R4)))
 
 MonoInst*
 mono_compile_create_var_for_vreg (MonoCompile *cfg, MonoType *type, int opcode, int vreg)
@@ -660,7 +660,7 @@ mono_compile_create_var_for_vreg (MonoCompile *cfg, MonoType *type, int opcode, 
 		mono_cfg_set_exception (cfg, MONO_EXCEPTION_TYPE_LOAD);
 
 	if (cfg->compute_gc_maps) {
-		if (type->byref) {
+		if (mono_type_is_byref_internal (type)) {
 			mono_mark_vreg_as_mp (cfg, vreg);
 		} else {
 			if ((MONO_TYPE_ISSTRUCT (type) && m_class_has_references (inst->klass)) || mini_type_is_reference (type)) {
@@ -753,7 +753,7 @@ mono_compile_create_var (MonoCompile *cfg, MonoType *type, int opcode)
 {
 	int dreg;
 
-	if (type->type == MONO_TYPE_VALUETYPE && !type->byref) {
+	if (type->type == MONO_TYPE_VALUETYPE && !mono_type_is_byref_internal (type)) {
 		MonoClass *klass = mono_class_from_mono_type_internal (type);
 		if (m_class_is_enumtype (klass) && m_class_get_image (klass) == mono_get_corlib () && !strcmp (m_class_get_name (klass), "StackCrawlMark")) {
 			if (!(cfg->method->flags & METHOD_ATTRIBUTE_REQSECOBJ))

--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -440,7 +440,7 @@ guint
 mini_type_to_stind (MonoCompile* cfg, MonoType *type)
 {
 	type = mini_get_underlying_type (type);
-	if (cfg->gshared && !mono_type_is_byref_internal (type) && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR)) {
+	if (cfg->gshared && !m_type_is_byref (type) && (type->type == MONO_TYPE_VAR || type->type == MONO_TYPE_MVAR)) {
 		g_assert (mini_type_var_is_vt (type));
 		return CEE_STOBJ;
 	}
@@ -625,8 +625,8 @@ set_vreg_to_inst (MonoCompile *cfg, int vreg, MonoInst *inst)
 	cfg->vreg_to_inst [vreg] = inst;
 }
 
-#define mono_type_is_long(type) (!mono_type_is_byref_internal (type) && ((mono_type_get_underlying_type (type)->type == MONO_TYPE_I8) || (mono_type_get_underlying_type (type)->type == MONO_TYPE_U8)))
-#define mono_type_is_float(type) (!mono_type_is_byref_internal (type) && (((type)->type == MONO_TYPE_R8) || ((type)->type == MONO_TYPE_R4)))
+#define mono_type_is_long(type) (!m_type_is_byref (type) && ((mono_type_get_underlying_type (type)->type == MONO_TYPE_I8) || (mono_type_get_underlying_type (type)->type == MONO_TYPE_U8)))
+#define mono_type_is_float(type) (!m_type_is_byref (type) && (((type)->type == MONO_TYPE_R8) || ((type)->type == MONO_TYPE_R4)))
 
 MonoInst*
 mono_compile_create_var_for_vreg (MonoCompile *cfg, MonoType *type, int opcode, int vreg)
@@ -660,7 +660,7 @@ mono_compile_create_var_for_vreg (MonoCompile *cfg, MonoType *type, int opcode, 
 		mono_cfg_set_exception (cfg, MONO_EXCEPTION_TYPE_LOAD);
 
 	if (cfg->compute_gc_maps) {
-		if (mono_type_is_byref_internal (type)) {
+		if (m_type_is_byref (type)) {
 			mono_mark_vreg_as_mp (cfg, vreg);
 		} else {
 			if ((MONO_TYPE_ISSTRUCT (type) && m_class_has_references (inst->klass)) || mini_type_is_reference (type)) {
@@ -753,7 +753,7 @@ mono_compile_create_var (MonoCompile *cfg, MonoType *type, int opcode)
 {
 	int dreg;
 
-	if (type->type == MONO_TYPE_VALUETYPE && !mono_type_is_byref_internal (type)) {
+	if (type->type == MONO_TYPE_VALUETYPE && !m_type_is_byref (type)) {
 		MonoClass *klass = mono_class_from_mono_type_internal (type);
 		if (m_class_is_enumtype (klass) && m_class_get_image (klass) == mono_get_corlib () && !strcmp (m_class_get_name (klass), "StackCrawlMark")) {
 			if (!(cfg->method->flags & METHOD_ATTRIBUTE_REQSECOBJ))

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -138,8 +138,8 @@ typedef struct SeqPointInfo SeqPointInfo;
 #define printf g_print
 #endif
 
-#define MONO_TYPE_IS_PRIMITIVE(t) ((!(t)->byref && ((((t)->type >= MONO_TYPE_BOOLEAN && (t)->type <= MONO_TYPE_R8) || ((t)->type >= MONO_TYPE_I && (t)->type <= MONO_TYPE_U)))))
-#define MONO_TYPE_IS_VECTOR_PRIMITIVE(t) ((!(t)->byref && ((((t)->type >= MONO_TYPE_I1 && (t)->type <= MONO_TYPE_R8) || ((t)->type >= MONO_TYPE_I && (t)->type <= MONO_TYPE_U)))))
+#define MONO_TYPE_IS_PRIMITIVE(t) ((!mono_type_is_byref_internal ((t)) && ((((t)->type >= MONO_TYPE_BOOLEAN && (t)->type <= MONO_TYPE_R8) || ((t)->type >= MONO_TYPE_I && (t)->type <= MONO_TYPE_U)))))
+#define MONO_TYPE_IS_VECTOR_PRIMITIVE(t) ((!mono_type_is_byref_internal ((t)) && ((((t)->type >= MONO_TYPE_I1 && (t)->type <= MONO_TYPE_R8) || ((t)->type >= MONO_TYPE_I && (t)->type <= MONO_TYPE_U)))))
 //XXX this ignores if t is byref
 #define MONO_TYPE_IS_PRIMITIVE_SCALAR(t) ((((((t)->type >= MONO_TYPE_BOOLEAN && (t)->type <= MONO_TYPE_U8) || ((t)->type >= MONO_TYPE_I && (t)->type <= MONO_TYPE_U)))))
 

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -138,8 +138,8 @@ typedef struct SeqPointInfo SeqPointInfo;
 #define printf g_print
 #endif
 
-#define MONO_TYPE_IS_PRIMITIVE(t) ((!mono_type_is_byref_internal ((t)) && ((((t)->type >= MONO_TYPE_BOOLEAN && (t)->type <= MONO_TYPE_R8) || ((t)->type >= MONO_TYPE_I && (t)->type <= MONO_TYPE_U)))))
-#define MONO_TYPE_IS_VECTOR_PRIMITIVE(t) ((!mono_type_is_byref_internal ((t)) && ((((t)->type >= MONO_TYPE_I1 && (t)->type <= MONO_TYPE_R8) || ((t)->type >= MONO_TYPE_I && (t)->type <= MONO_TYPE_U)))))
+#define MONO_TYPE_IS_PRIMITIVE(t) ((!m_type_is_byref ((t)) && ((((t)->type >= MONO_TYPE_BOOLEAN && (t)->type <= MONO_TYPE_R8) || ((t)->type >= MONO_TYPE_I && (t)->type <= MONO_TYPE_U)))))
+#define MONO_TYPE_IS_VECTOR_PRIMITIVE(t) ((!m_type_is_byref ((t)) && ((((t)->type >= MONO_TYPE_I1 && (t)->type <= MONO_TYPE_R8) || ((t)->type >= MONO_TYPE_I && (t)->type <= MONO_TYPE_U)))))
 //XXX this ignores if t is byref
 #define MONO_TYPE_IS_PRIMITIVE_SCALAR(t) ((((((t)->type >= MONO_TYPE_BOOLEAN && (t)->type <= MONO_TYPE_U8) || ((t)->type >= MONO_TYPE_I && (t)->type <= MONO_TYPE_U)))))
 

--- a/src/mono/mono/mini/ssa.c
+++ b/src/mono/mono/mini/ssa.c
@@ -437,7 +437,7 @@ mono_ssa_compute (MonoCompile *cfg)
 				break;
 			}
 
- 			if (var->inst_vtype->byref)
+ 			if (mono_type_is_byref_internal (var->inst_vtype))
  				ins->klass = mono_defaults.int_class;
  			else
  				ins->klass = var->klass;

--- a/src/mono/mono/mini/ssa.c
+++ b/src/mono/mono/mini/ssa.c
@@ -437,7 +437,7 @@ mono_ssa_compute (MonoCompile *cfg)
 				break;
 			}
 
- 			if (mono_type_is_byref_internal (var->inst_vtype))
+ 			if (m_type_is_byref (var->inst_vtype))
  				ins->klass = mono_defaults.int_class;
  			else
  				ins->klass = var->klass;

--- a/src/mono/mono/mini/trace.c
+++ b/src/mono/mono/mini/trace.c
@@ -213,7 +213,7 @@ mono_trace_enter_method (MonoMethod *method, MonoJitInfo *ji, MonoProfilerCallCo
 
 		MonoType *type = sig->params [i];
 
-		if (mono_type_is_byref_internal (type)) {
+		if (m_type_is_byref (type)) {
 			printf ("[BYREF:%p]", *(gpointer*)buf);
 			mini_profiler_context_free_buffer (buf);
 			break;

--- a/src/mono/mono/mini/trace.c
+++ b/src/mono/mono/mini/trace.c
@@ -213,7 +213,7 @@ mono_trace_enter_method (MonoMethod *method, MonoJitInfo *ji, MonoProfilerCallCo
 
 		MonoType *type = sig->params [i];
 
-		if (type->byref) {
+		if (mono_type_is_byref_internal (type)) {
 			printf ("[BYREF:%p]", *(gpointer*)buf);
 			mini_profiler_context_free_buffer (buf);
 			break;

--- a/src/mono/mono/profiler/aot.c
+++ b/src/mono/mono/profiler/aot.c
@@ -673,7 +673,7 @@ prof_save (MonoProfiler *prof, FILE* file)
 
 		sig = mono_method_signature_checked (send_method, error);
 		mono_error_assert_ok (error);
-		if (sig->param_count != 3 || !sig->params [0]->byref || sig->params [0]->type != MONO_TYPE_U1 || sig->params [1]->type != MONO_TYPE_I4 || sig->params [2]->type != MONO_TYPE_STRING) {
+		if (sig->param_count != 3 || !mono_type_is_byref_internal (sig->params [0]) || sig->params [0]->type != MONO_TYPE_U1 || sig->params [1]->type != MONO_TYPE_I4 || sig->params [2]->type != MONO_TYPE_STRING) {
 			mono_profiler_printf_err ("Method '%s' should have signature void (byte&,int,string).", prof->send_to_str);
 			exit (1);
 		}

--- a/src/mono/mono/profiler/aot.c
+++ b/src/mono/mono/profiler/aot.c
@@ -673,7 +673,7 @@ prof_save (MonoProfiler *prof, FILE* file)
 
 		sig = mono_method_signature_checked (send_method, error);
 		mono_error_assert_ok (error);
-		if (sig->param_count != 3 || !mono_type_is_byref_internal (sig->params [0]) || sig->params [0]->type != MONO_TYPE_U1 || sig->params [1]->type != MONO_TYPE_I4 || sig->params [2]->type != MONO_TYPE_STRING) {
+		if (sig->param_count != 3 || !m_type_is_byref (sig->params [0]) || sig->params [0]->type != MONO_TYPE_U1 || sig->params [1]->type != MONO_TYPE_I4 || sig->params [2]->type != MONO_TYPE_STRING) {
 			mono_profiler_printf_err ("Method '%s' should have signature void (byte&,int,string).", prof->send_to_str);
 			exit (1);
 		}


### PR DESCRIPTION
Call `m_type_is_byref` instead of accessing the byref bit directly.

No functional change. (I hope).

This is in preparation for exploring alternative representations of ref types.